### PR TITLE
Enable more Pydocstyle rules

### DIFF
--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -1585,7 +1585,6 @@ def _create_empty_categorical_column(
 def pandas_categorical_as_column(
     categorical: ColumnLike, codes: ColumnLike = None
 ) -> CategoricalColumn:
-
     """Creates a CategoricalColumn from a pandas.Categorical
 
     If ``codes`` is defined, use it instead of ``categorical.codes``

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -135,7 +135,6 @@ class CategoricalAccessor(ColumnMethods):
 
         Parameters
         ----------
-
         inplace : bool, default False
             Whether or not to add the categories inplace
             or return a copy of this categorical with
@@ -192,7 +191,6 @@ class CategoricalAccessor(ColumnMethods):
 
         Parameters
         ----------
-
         inplace : bool, default False
             Whether or not to set the ordered attribute
             in-place or return a copy of this
@@ -266,10 +264,8 @@ class CategoricalAccessor(ColumnMethods):
 
         Parameters
         ----------
-
         new_categories : category or list-like of category
             The new categories to be included.
-
         inplace : bool, default False
             Whether or not to add the categories inplace
             or return a copy of this categorical with
@@ -353,10 +349,8 @@ class CategoricalAccessor(ColumnMethods):
 
         Parameters
         ----------
-
         removals : category or list-like of category
             The categories which should be removed.
-
         inplace : bool, default False
             Whether or not to remove the categories
             inplace or return a copy of this categorical
@@ -461,20 +455,16 @@ class CategoricalAccessor(ColumnMethods):
 
         Parameters
         ----------
-
         new_categories : list-like
             The categories in new order.
-
         ordered : bool, default None
             Whether or not the categorical is treated as
             a ordered categorical. If not given, do
             not change the ordered information.
-
         rename : bool, default False
             Whether or not the `new_categories` should be
             considered as a rename of the old categories
             or as reordered categories.
-
         inplace : bool, default False
             Whether or not to reorder the categories in-place
             or return a copy of this categorical with
@@ -540,21 +530,16 @@ class CategoricalAccessor(ColumnMethods):
 
         Parameters
         ----------
-
         new_categories : Index-like
             The categories in new order.
-
         ordered : bool, optional
             Whether or not the categorical is treated
             as a ordered categorical. If not given, do
             not change the ordered information.
-
-
         inplace : bool, default False
             Whether or not to reorder the categories
             inplace or return a copy of this categorical
             with reordered categories.
-
 
         Returns
         -------

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -793,6 +793,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         Calculate slice bound that corresponds to given label.
         Returns leftmost (one-past-the-rightmost if ``side=='right'``) position
         of given label.
+
         Parameters
         ----------
         label : Scalar

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -882,7 +882,6 @@ class StringMethods(ColumnMethods):
 
         Examples
         --------
-
         >>> import cudf
         >>> s = cudf.Series(['foo', 'fuz', None])
         >>> s
@@ -4475,7 +4474,6 @@ class StringMethods(ColumnMethods):
 
         Parameters
         ----------
-
         delimiter : str or list of strs, Default is whitespace.
             The characters or strings used to locate the
             split points of each string.

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -1013,7 +1013,7 @@ class StringMethods(ColumnMethods):
             Series or Index from sliced substring from
             original string object.
 
-        See also
+        See Also
         --------
         slice_replace
             Replace a slice with a string.
@@ -1076,7 +1076,7 @@ class StringMethods(ColumnMethods):
             Series or Index of boolean values with the same
             length as the original Series/Index.
 
-        See also
+        See Also
         --------
         isalnum
             Check whether all characters are alphanumeric.
@@ -1138,7 +1138,7 @@ class StringMethods(ColumnMethods):
             Series or Index of boolean values with the same
             length as the original Series/Index.
 
-        See also
+        See Also
         --------
         isdecimal
             Check whether all characters are decimal.
@@ -1205,7 +1205,7 @@ class StringMethods(ColumnMethods):
             Series or Index of boolean values with the same
             length as the original Series/Index.
 
-        See also
+        See Also
         --------
         isalnum
             Check whether all characters are alphanumeric.
@@ -1274,7 +1274,7 @@ class StringMethods(ColumnMethods):
             Series or Index of boolean values with the same
             length as the original Series/Index.
 
-        See also
+        See Also
         --------
         isalnum
             Check whether all characters are alphanumeric.
@@ -1338,7 +1338,7 @@ class StringMethods(ColumnMethods):
             Series or Index of boolean values with the
             same length as the original Series/Index.
 
-        See also
+        See Also
         --------
         isalpha
             Check whether all characters are alphabetic.
@@ -1407,7 +1407,7 @@ class StringMethods(ColumnMethods):
             Series or Index of boolean values with the same length
             as the original Series/Index.
 
-        See also
+        See Also
         --------
         isalnum
             Check whether all characters are alphanumeric.
@@ -1466,7 +1466,7 @@ class StringMethods(ColumnMethods):
             Series or Index of boolean values with the same
             length as the original Series/Index.
 
-        See also
+        See Also
         --------
         isalnum
             Check whether all characters are alphanumeric.
@@ -1529,7 +1529,7 @@ class StringMethods(ColumnMethods):
             Series or Index of boolean values with the same
             length as the original Series/Index.
 
-        See also
+        See Also
         --------
         isalnum
             Check whether all characters are alphanumeric.
@@ -1600,7 +1600,7 @@ class StringMethods(ColumnMethods):
             Series or Index of boolean values with the same
             length as the original Series/Index.
 
-        See also
+        See Also
         --------
         isalnum
             Check whether all characters are alphanumeric.
@@ -1659,7 +1659,7 @@ class StringMethods(ColumnMethods):
             Series or Index of boolean values with the same
             length as the original Series/Index.
 
-        See also
+        See Also
         --------
         isalnum
             Check whether all characters are alphanumeric.
@@ -1739,7 +1739,7 @@ class StringMethods(ColumnMethods):
         Series or Index of object
             A copy of the object with all strings converted to lowercase.
 
-        See also
+        See Also
         --------
         upper
             Converts all characters to uppercase.
@@ -1780,7 +1780,7 @@ class StringMethods(ColumnMethods):
         -------
         Series or Index of object
 
-        See also
+        See Also
         --------
         lower
             Converts all characters to lowercase.
@@ -1859,7 +1859,7 @@ class StringMethods(ColumnMethods):
         -------
         Series or Index of object
 
-        See also
+        See Also
         --------
         lower
             Converts all characters to lowercase.
@@ -1907,7 +1907,7 @@ class StringMethods(ColumnMethods):
         -------
         Series or Index of object
 
-        See also
+        See Also
         --------
         lower
             Converts all characters to lowercase.
@@ -2076,7 +2076,7 @@ class StringMethods(ColumnMethods):
             A new string with the specified section of the string
             replaced with `repl` string.
 
-        See also
+        See Also
         --------
         slice
             Just slicing without replacement.
@@ -2373,7 +2373,7 @@ class StringMethods(ColumnMethods):
         Series, Index, DataFrame or MultiIndex
             Type matches caller unless ``expand=True`` (see Notes).
 
-        See also
+        See Also
         --------
         rsplit
             Splits string around given separator/delimiter, starting from
@@ -2540,7 +2540,7 @@ class StringMethods(ColumnMethods):
         Series, Index, DataFrame or MultiIndex
             Type matches caller unless ``expand=True`` (see Notes).
 
-        See also
+        See Also
         --------
         split
             Split strings around given separator/delimiter.
@@ -2700,7 +2700,7 @@ class StringMethods(ColumnMethods):
         The parameter `expand` is not yet supported and will raise a
         `NotImplementedError` if anything other than the default value is set.
 
-        See also
+        See Also
         --------
         rpartition
             Split the string at the last occurrence of sep.
@@ -2845,7 +2845,7 @@ class StringMethods(ColumnMethods):
             Returns Series or Index with minimum number
             of char in object.
 
-        See also
+        See Also
         --------
         rjust
             Fills the left side of strings with an arbitrary character.
@@ -2928,7 +2928,7 @@ class StringMethods(ColumnMethods):
         Series/Index of str dtype
             Returns Series or Index with prepended ‘0’ characters.
 
-        See also
+        See Also
         --------
         rjust
             Fills the left side of strings with an arbitrary character.
@@ -3181,7 +3181,7 @@ class StringMethods(ColumnMethods):
         Series/Index of str dtype
             Returns Series or Index.
 
-        See also
+        See Also
         --------
         lstrip
             Remove leading characters in Series/Index.
@@ -3240,7 +3240,7 @@ class StringMethods(ColumnMethods):
         -------
             Series or Index of object
 
-        See also
+        See Also
         --------
         strip
             Remove leading and trailing characters in Series/Index.
@@ -3289,7 +3289,7 @@ class StringMethods(ColumnMethods):
         Series/Index of str dtype
             Returns Series or Index.
 
-        See also
+        See Also
         --------
         strip
             Remove leading and trailing characters in Series/Index.
@@ -3601,7 +3601,7 @@ class StringMethods(ColumnMethods):
             Series or Index of boolean values with the same length as
             the original Series/Index.
 
-        See also
+        See Also
         --------
         isalnum
             Check whether all characters are alphanumeric.
@@ -3720,7 +3720,7 @@ class StringMethods(ColumnMethods):
             A Series of booleans indicating whether the given
             pattern matches the start of each string element.
 
-        See also
+        See Also
         --------
         endswith
             Same as startswith, but tests the end of string.
@@ -3839,7 +3839,7 @@ class StringMethods(ColumnMethods):
         -------
         Series or Index of int
 
-        See also
+        See Also
         --------
         find
             Return lowest indexes in each strings.

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -4103,7 +4103,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         na_action: Union[str, None] = None,
         **kwargs,
     ) -> DataFrame:
-
         """
         Apply a function to a Dataframe elementwise.
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1799,7 +1799,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
     def _get_renderable_dataframe(self):
         """
-        takes rows and columns from pandas settings or estimation from size.
+        Takes rows and columns from pandas settings or estimation from size.
         pulls quadrants based off of some known parameters then style for
         multiindex as well producing an efficient representative string
         for printing with the dataframe.

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -525,21 +525,17 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
     ----------
     data : array-like, Iterable, dict, or DataFrame.
         Dict can contain Series, arrays, constants, or list-like objects.
-
     index : Index or array-like
         Index to use for resulting frame. Will default to
         RangeIndex if no indexing information part of input data and
         no index provided.
-
     columns : Index or array-like
         Column labels to use for resulting frame.
         Will default to RangeIndex (0, 1, 2, …, n) if no column
         labels are provided.
-
     dtype : dtype, default None
         Data type to force. Only a single dtype is allowed.
         If None, infer.
-
     nan_as_null : bool, Default True
         If ``None``/``True``, converts ``np.nan`` values to
         ``null`` values.
@@ -547,7 +543,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
     Examples
     --------
-
     Build dataframe with ``__setitem__``:
 
     >>> import cudf
@@ -3866,7 +3861,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
         Parameters
         ----------
-
         expr : str
             A boolean expression. Names in expression refer to columns.
             `index` can be used instead of index name, but this is not
@@ -3882,8 +3876,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
         Returns
         -------
-
-        filtered :  DataFrame
+        filtered : DataFrame
 
         Examples
         --------
@@ -3979,7 +3972,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
         Examples
         --------
-
         Simple function of a single variable which could be NA:
 
         >>> def f(row):
@@ -5174,7 +5166,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
         Parameters
         ----------
-
         q : float or array-like
             0 <= q <= 1, the quantile(s) to compute
         axis : int
@@ -5277,7 +5268,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
         Parameters
         ----------
-
         q : float or array-like
             0 <= q <= 1, the quantile(s) to compute
         interpolation : {`lower`, `higher`, `nearest`}
@@ -5287,7 +5277,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
         Returns
         -------
-
         DataFrame
         """
         if isinstance(q, numbers.Number):
@@ -5317,7 +5306,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
         Parameters
         ----------
-
         values : iterable, Series, DataFrame or dict
             The result will only be true at a location if all
             the labels match. If values is a Series, that’s the index.

--- a/python/cudf/cudf/core/df_protocol.py
+++ b/python/cudf/cudf/core/df_protocol.py
@@ -186,25 +186,25 @@ class _CuDFColumn:
                         Data Interface format.
         Endianness : current only native endianness (``=``) is supported
 
-        Notes:
-
-            - Kind specifiers are aligned with DLPack where possible
-             (hence the jump to 20, leave enough room for future extension)
-            - Masks must be specified as boolean with either bit width 1
-             (for bit masks) or 8 (for byte masks).
-            - Dtype width in bits was preferred over bytes
-            - Endianness isn't too useful, but included now in case
-              in the future we need to support non-native endianness
-            - Went with Apache Arrow format strings over NumPy format strings
-              because they're more complete from a dataframe perspective
-            - Format strings are mostly useful for datetime specification,
-              and for categoricals.
-            - For categoricals, the format string describes the type of the
-              categorical in the data buffer. In case of a separate encoding
-              of the categorical (e.g. an integer to string mapping),
-              this can be derived from ``self.describe_categorical``.
-            - Data types not included: complex, Arrow-style null,
-              binary, decimal, and nested (list, struct, map, union) dtypes.
+        Notes
+        -----
+        - Kind specifiers are aligned with DLPack where possible
+         (hence the jump to 20, leave enough room for future extension)
+        - Masks must be specified as boolean with either bit width 1
+         (for bit masks) or 8 (for byte masks).
+        - Dtype width in bits was preferred over bytes
+        - Endianness isn't too useful, but included now in case
+          in the future we need to support non-native endianness
+        - Went with Apache Arrow format strings over NumPy format strings
+          because they're more complete from a dataframe perspective
+        - Format strings are mostly useful for datetime specification,
+          and for categoricals.
+        - For categoricals, the format string describes the type of the
+          categorical in the data buffer. In case of a separate encoding
+          of the categorical (e.g. an integer to string mapping),
+          this can be derived from ``self.describe_categorical``.
+        - Data types not included: complex, Arrow-style null,
+          binary, decimal, and nested (list, struct, map, union) dtypes.
         """
         dtype = self._col.dtype
 

--- a/python/cudf/cudf/core/df_protocol.py
+++ b/python/cudf/cudf/core/df_protocol.py
@@ -80,7 +80,7 @@ class _CuDFBuffer:
     @property
     def bufsize(self) -> int:
         """
-        DeviceBufferLike size in bytes.
+        The DeviceBufferLike size in bytes.
         """
         return self._buf.size
 
@@ -92,17 +92,12 @@ class _CuDFBuffer:
         return self._buf.ptr
 
     def __dlpack__(self):
-        """
-        DLPack not implemented in NumPy yet, so leave it out here.
-        """
+        # DLPack not implemented in NumPy yet, so leave it out here.
         try:
-            cudarray = as_cuda_array(self._buf).view(self._dtype)
-            res = cp.asarray(cudarray).toDlpack()
-
+            cuda_array = as_cuda_array(self._buf).view(self._dtype)
+            return cp.asarray(cuda_array).toDlpack()
         except ValueError:
             raise TypeError(f"dtype {self._dtype} unsupported by `dlpack`")
-
-        return res
 
     def __dlpack_device__(self) -> Tuple[_Device, int]:
         """

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -724,7 +724,6 @@ class Frame(BinaryOperand, Scannable):
 
         Examples
         --------
-
         Use ``.pipe`` when chaining together functions that expect
         Series, DataFrames or GroupBy objects. Instead of writing
 
@@ -1202,7 +1201,6 @@ class Frame(BinaryOperand, Scannable):
 
         Examples
         --------
-
         Show which entries in a DataFrame are NA.
 
         >>> import cudf
@@ -1282,7 +1280,6 @@ class Frame(BinaryOperand, Scannable):
 
         Examples
         --------
-
         Show which entries in a DataFrame are NA.
 
         >>> import cudf
@@ -1976,7 +1973,6 @@ class Frame(BinaryOperand, Scannable):
 
         Parameters
         ----------
-
         axis: {index (0), columns(1)}
             Axis for the function to be applied on.
         skipna: bool, default True
@@ -2035,7 +2031,6 @@ class Frame(BinaryOperand, Scannable):
 
         Parameters
         ----------
-
         axis: {index (0), columns(1)}
             Axis for the function to be applied on.
         skipna: bool, default True
@@ -2147,7 +2142,6 @@ class Frame(BinaryOperand, Scannable):
 
         Parameters
         ----------
-
         axis: {index (0), columns(1)}
             Axis for the function to be applied on.
         skipna: bool, default True
@@ -2200,11 +2194,10 @@ class Frame(BinaryOperand, Scannable):
         Return unbiased variance of the DataFrame.
 
         Normalized by N-1 by default. This can be changed using the
-        ddof argument
+        ddof argument.
 
         Parameters
         ----------
-
         axis: {index (0), columns(1)}
             Axis for the function to be applied on.
         skipna: bool, default True
@@ -2254,7 +2247,6 @@ class Frame(BinaryOperand, Scannable):
 
         Parameters
         ----------
-
         axis: {index (0), columns(1)}
             Axis for the function to be applied on.
         skipna: bool, default True
@@ -2376,7 +2368,6 @@ class Frame(BinaryOperand, Scannable):
 
         Parameters
         ----------
-
         skipna: bool, default True
             Exclude NA/null values. If the entire row/column is NA and
             skipna is True, then the result will be True, as for an
@@ -2416,7 +2407,6 @@ class Frame(BinaryOperand, Scannable):
 
         Parameters
         ----------
-
         skipna: bool, default True
             Exclude NA/null values. If the entire row/column is NA and
             skipna is True, then the result will be False, as for an
@@ -2482,7 +2472,6 @@ class Frame(BinaryOperand, Scannable):
 
         Parameters
         ----------
-
         skipna : bool, default True
             Exclude NA/null values when computing the result.
 
@@ -2601,7 +2590,6 @@ class Frame(BinaryOperand, Scannable):
 
         Examples
         --------
-
         **Series**
 
         >>> ser = cudf.Series(['alligator', 'bee', 'falcon',
@@ -2666,7 +2654,6 @@ class Frame(BinaryOperand, Scannable):
 
         Examples
         --------
-
         **DataFrame**
 
         >>> import cudf
@@ -2716,7 +2703,6 @@ class Frame(BinaryOperand, Scannable):
 
         Examples
         --------
-
         **Series**
 
         >>> import cudf, numpy as np

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -1171,7 +1171,7 @@ class GroupBy(Serializable, Reducible, Scannable):
 
     def _cov_or_corr(self, func, method_name):
         """
-        internal function that is called by either corr() or cov()
+        Internal function that is called by either corr() or cov()
         for sort groupby correlation and covariance computations,
         respectively.
         """

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -607,7 +607,7 @@ class GroupBy(Serializable, Reducible, Scannable):
         -------
         object : the return type of ``func``.
 
-        See also
+        See Also
         --------
         cudf.Series.pipe
             Apply a function with arguments to a series.
@@ -907,7 +907,7 @@ class GroupBy(Serializable, Reducible, Scannable):
           3  5
           4  5
 
-        See also
+        See Also
         --------
         agg
         """
@@ -930,7 +930,7 @@ class GroupBy(Serializable, Reducible, Scannable):
         Returns a `RollingGroupby` object that enables rolling window
         calculations on the groups.
 
-        See also
+        See Also
         --------
         cudf.core.window.Rolling
         """

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -355,13 +355,11 @@ class IndexedFrame(Frame):
 
         Parameters
         ----------
-
         axis: {{index (0), columns(1)}}
             Axis for the function to be applied on.
         skipna: bool, default True
             Exclude NA/null values. If an entire row/column is NA,
             the result will be NA.
-
 
         Returns
         -------
@@ -2404,16 +2402,12 @@ class IndexedFrame(Frame):
         --------
         cudf.DataFrame.isna
             Indicate null values.
-
         cudf.DataFrame.notna
             Indicate non-null values.
-
         cudf.DataFrame.fillna
             Replace null values.
-
         cudf.Series.dropna
             Drop null values.
-
         cudf.Index.dropna
             Drop null indices.
 

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -552,7 +552,7 @@ class IndexedFrame(Frame):
         inplace : bool, default False
             If True, in place.
 
-        See also
+        See Also
         --------
         Series.fillna
 
@@ -2400,7 +2400,7 @@ class IndexedFrame(Frame):
         -------
         Copy of the DataFrame with rows/columns containing nulls dropped.
 
-        See also
+        See Also
         --------
         cudf.DataFrame.isna
             Indicate null values.

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2837,7 +2837,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         -------
         result : Series containing counts of unique values.
 
-        See also
+        See Also
         --------
         Series.count
             Number of non-NA elements in a Series.

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1341,7 +1341,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
     @property  # type: ignore
     @_cudf_nvtx_annotate
     def dtype(self):
-        """dtype of the Series"""
+        """The dtype of the Series."""
         return self._column.dtype
 
     @classmethod

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2275,7 +2275,6 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
 
         Examples
         --------
-
         Apply a basic function to a series
         >>> sr = cudf.Series([1,2,3])
         >>> def f(x):
@@ -2952,7 +2951,6 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
 
         Parameters
         ----------
-
         q : float or array-like, default 0.5 (50% quantile)
             0 <= q <= 1, the quantile(s) to compute
         interpolation : {’linear’, ‘lower’, ‘higher’, ‘midpoint’, ‘nearest’}
@@ -4372,7 +4370,6 @@ class DatetimeProperties:
 
         Notes
         -----
-
         The following date format identifiers are not yet
         supported: ``%c``, ``%x``,``%X``
 

--- a/python/cudf/cudf/core/udf/utils.py
+++ b/python/cudf/cudf/core/udf/utils.py
@@ -208,7 +208,7 @@ def _compile_or_get(frame, func, args, kernel_getter=None):
 
 
 def _get_kernel(kernel_string, globals_, sig, func):
-    """template kernel compilation helper function"""
+    """Template kernel compilation helper function."""
     f_ = cuda.jit(device=True)(func)
     globals_["f_"] = f_
     exec(kernel_string, globals_)

--- a/python/cudf/cudf/core/window/rolling.py
+++ b/python/cudf/cudf/core/window/rolling.py
@@ -347,7 +347,7 @@ class Rolling(GetAttrGetItemMixin, Reducible):
         kwargs
             unsupported
 
-        See also
+        See Also
         --------
         cudf.Series.applymap : Apply an elementwise function to
             transform the values in the Column.
@@ -470,7 +470,7 @@ class RollingGroupby(Rolling):
     """
     Grouped rolling window calculation.
 
-    See also
+    See Also
     --------
     cudf.core.window.Rolling
     """

--- a/python/cudf/cudf/core/window/rolling.py
+++ b/python/cudf/cudf/core/window/rolling.py
@@ -358,7 +358,6 @@ class Rolling(GetAttrGetItemMixin, Reducible):
 
         Examples
         --------
-
         >>> import cudf
         >>> def count_if_gt_3(window):
         ...     count = 0

--- a/python/cudf/cudf/testing/dataset_generator.py
+++ b/python/cudf/cudf/testing/dataset_generator.py
@@ -25,7 +25,7 @@ class ColumnParameters:
     """Parameters for generating column of data
 
     Attributes
-    ---
+    ----------
     cardinality : int or None
         Size of a random set of values that generated data is sampled from.
         The values in the random set are derived from the given generator.
@@ -65,7 +65,7 @@ class Parameters:
     """Parameters for random dataset generation
 
     Attributes
-    ---
+    ----------
     num_rows : int
         Number of rows to generate
     column_parameters : List[ColumnParams]

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -902,19 +902,21 @@ def list_row_gen(
     """
     Generate a single row for a List<List<>> column based on input parameters.
 
-    Args:
-        gen: A callable which generates an individual leaf element based on an
-            absolute index.
-        first_val : Generate the column as if it had started at 'first_val'
-            instead of 0.
-        list_size : Size of each generated list.
-        lists_per_row : Number of lists to generate per row.
-        include_validity : Whether or not to include nulls as part of the
-            column. If true, it will add a selection of nulls at both the
-            topmost row level and at the leaf level.
+    Parameters
+    ----------
+    gen : A callable which generates an individual leaf element based on an
+        absolute index.
+    first_val : Generate the column as if it had started at 'first_val'
+        instead of 0.
+    list_size : Size of each generated list.
+    lists_per_row : Number of lists to generate per row.
+    include_validity : Whether or not to include nulls as part of the
+        column. If true, it will add a selection of nulls at both the
+        topmost row level and at the leaf level.
 
-    Returns:
-        The generated list column.
+    Returns
+    -------
+    The generated list column.
     """
 
     def L(list_size, first_val):
@@ -937,18 +939,20 @@ def list_gen(gen, num_rows, lists_per_row, list_size, include_validity=False):
     """
     Generate a list column based on input parameters.
 
-    Args:
-        gen: A callable which generates an individual leaf element based on an
-            absolute index.
-        num_rows : Number of rows to generate.
-        lists_per_row : Number of lists to generate per row.
-        list_size : Size of each generated list.
-        include_validity : Whether or not to include nulls as part of the
-            column. If true, it will add a selection of nulls at both the
-            topmost row level and at the leaf level.
+    Parameters
+    ----------
+    gen : A callable which generates an individual leaf element based on an
+        absolute index.
+    num_rows : Number of rows to generate.
+    lists_per_row : Number of lists to generate per row.
+    list_size : Size of each generated list.
+    include_validity : Whether or not to include nulls as part of the
+        column. If true, it will add a selection of nulls at both the
+        topmost row level and at the leaf level.
 
-    Returns:
-        The generated list column.
+    Returns
+    -------
+    The generated list column.
     """
 
     def L(list_size, first_val):
@@ -1076,19 +1080,21 @@ def struct_gen(gen, skip_rows, num_rows, include_validity=False):
     """
     Generate a struct column based on input parameters.
 
-    Args:
-        gen: A array of callables which generate an individual row based on an
-            absolute index.
-        skip_rows : Generate the column as if it had started at 'skip_rows'
-            instead of 0. The intent here is to emulate the skip_rows
-            parameter of the parquet reader.
-        num_fields : Number of fields in the struct.
-        include_validity : Whether or not to include nulls as part of the
-            column. If true, it will add a selection of nulls at both the
-            field level and at the value level.
+    Parameters
+    ----------
+    gen : A array of callables which generate an individual row based on an
+        absolute index.
+    skip_rows : Generate the column as if it had started at 'skip_rows'
+        instead of 0. The intent here is to emulate the skip_rows
+        parameter of the parquet reader.
+    num_fields : Number of fields in the struct.
+    include_validity : Whether or not to include nulls as part of the
+        column. If true, it will add a selection of nulls at both the
+        field level and at the value level.
 
-    Returns:
-        The generated struct column.
+    Returns
+    -------
+    The generated struct column.
     """
 
     def R(first_val, num_fields):

--- a/python/cudf/cudf/utils/cudautils.py
+++ b/python/cudf/cudf/utils/cudautils.py
@@ -218,7 +218,7 @@ def compile_udf(udf, type_signature):
     compiled at runtime and launched.
 
     Parameters
-    --------
+    ----------
     udf:
       a python callable function
 

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1520,6 +1520,7 @@ def stringify_pathlike(pathlike):
 def buffer_write_lines(buf, lines):
     """
     Appends lines to a buffer.
+
     Parameters
     ----------
     buf

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -319,7 +319,7 @@ def search_range(start, stop, x, step=1, side="left"):
     `all(x <= n for x in range_left) and all(x > n for x in range_right)`
 
     Parameters
-    --------
+    ----------
     start : int
         Start value of the series
     stop : int

--- a/python/custreamz/custreamz/kafka.py
+++ b/python/custreamz/custreamz/kafka.py
@@ -8,7 +8,6 @@ import cudf
 # Base class for anything class that needs to interact with Apache Kafka
 class CudfKafkaClient:
     def __init__(self, kafka_configs):
-
         """
         Base object for any client that wants to interact with a Kafka broker.
         This object creates the underlying KafkaDatasource connection which
@@ -28,7 +27,6 @@ class CudfKafkaClient:
         self.kafka_meta_client = KafkaDatasource(kafka_configs)
 
     def list_topics(self, specific_topic=None):
-
         """
         List the topics associated with the underlying Kafka Broker connection.
 
@@ -45,7 +43,6 @@ class CudfKafkaClient:
         )
 
     def unsubscribe(self):
-
         """
         Stop all active consumption and remove consumer subscriptions
         to topic/partition instances
@@ -54,7 +51,6 @@ class CudfKafkaClient:
         self.kafka_meta_client.unsubscribe()
 
     def close(self, timeout=10000):
-
         """
         Close the underlying socket connection to Kafka and
         clean up system resources
@@ -66,7 +62,6 @@ class CudfKafkaClient:
 # Apache Kafka Consumer implementation
 class Consumer(CudfKafkaClient):
     def __init__(self, kafka_configs):
-
         """
         Creates a KafkaConsumer object which allows for all valid Kafka
         consumer type operations such as reading messages, committing
@@ -94,7 +89,6 @@ class Consumer(CudfKafkaClient):
         delimiter="\n",
         message_format="json",
     ):
-
         r"""
         Read messages from the underlying KafkaDatasource connection and create
         a cudf Dataframe
@@ -176,7 +170,6 @@ class Consumer(CudfKafkaClient):
             return cudf.DataFrame()
 
     def committed(self, partitions, timeout=10000):
-
         """
         Retrieves the last successfully committed Kafka offset of the
         underlying KafkaDatasource connection.
@@ -259,7 +252,6 @@ class Consumer(CudfKafkaClient):
         return offsets[b"low"], offsets[b"high"]
 
     def commit(self, offsets=None, asynchronous=True):
-
         """
         Takes a list of ck.TopicPartition objects and commits their
         offset values to the KafkaDatasource connection

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -565,7 +565,8 @@ def align_partitions(args):
     """Align partitions between dask_cudf objects.
 
     Note that if all divisions are unknown, but have equal npartitions, then
-    they will be passed through unchanged."""
+    they will be passed through unchanged.
+    """
     dfs = [df for df in args if isinstance(df, _Frame)]
     if not dfs:
         return args

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,8 @@ per-file-ignores =
 match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks)).*$
 # Allow missing docstrings for docutils
 ignore-decorators = .*(docutils|doc_apply|copy_docstring).*
-select = 
-    D30
+select =
+    D300, D301, D302
 
 [mypy]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,9 @@ match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks)).*$
 # Allow missing docstrings for docutils
 ignore-decorators = .*(docutils|doc_apply|copy_docstring).*
 select =
-    D201, D300, D301, D302
-    # Would like to enable: D200
+    D201, D204, D206, D207, D208, D209, D300, D301, D302
+    # Would like to enable the following rules in the future:
+    # D200, D202, D205
 
 [mypy]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,9 +31,9 @@ match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks)).*$
 # Allow missing docstrings for docutils
 ignore-decorators = .*(docutils|doc_apply|copy_docstring).*
 select =
-    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302
+    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302, D403
     # Would like to enable the following rules in the future:
-    # D200, D202, D205
+    # D200, D202, D205, D400
 
 [mypy]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks)).*$
 # Allow missing docstrings for docutils
 ignore-decorators = .*(docutils|doc_apply|copy_docstring).*
 select =
-    D201, D204, D206, D207, D208, D209, D300, D301, D302
+    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302
     # Would like to enable the following rules in the future:
     # D200, D202, D205
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,8 @@ match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks)).*$
 # Allow missing docstrings for docutils
 ignore-decorators = .*(docutils|doc_apply|copy_docstring).*
 select =
-    D300, D301, D302
+    D201, D300, D301, D302
+    # Would like to enable: D200
 
 [mypy]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks)).*$
 # Allow missing docstrings for docutils
 ignore-decorators = .*(docutils|doc_apply|copy_docstring).*
 select =
-    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302, D403, D405
+    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302, D403, D405, D406, D407
     # Would like to enable the following rules in the future:
     # D200, D202, D205, D400
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks)).*$
 # Allow missing docstrings for docutils
 ignore-decorators = .*(docutils|doc_apply|copy_docstring).*
 select =
-    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302, D403
+    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302, D403, D405
     # Would like to enable the following rules in the future:
     # D200, D202, D205, D400
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks)).*$
 # Allow missing docstrings for docutils
 ignore-decorators = .*(docutils|doc_apply|copy_docstring).*
 select =
-    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302, D403, D405, D406, D407, D408, D409, D410, D411
+    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302, D403, D405, D406, D407, D408, D409, D410, D411, D412, D414, D418
     # Would like to enable the following rules in the future:
     # D200, D202, D205, D400
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks)).*$
 # Allow missing docstrings for docutils
 ignore-decorators = .*(docutils|doc_apply|copy_docstring).*
 select =
-    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302, D403, D405, D406, D407, D408, D409
+    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302, D403, D405, D406, D407, D408, D409, D410, D411
     # Would like to enable the following rules in the future:
     # D200, D202, D205, D400
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ match-dir = ^(?!(ci|cpp|conda|docs|java|notebooks)).*$
 # Allow missing docstrings for docutils
 ignore-decorators = .*(docutils|doc_apply|copy_docstring).*
 select =
-    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302, D403, D405, D406, D407
+    D201, D204, D206, D207, D208, D209, D210, D211, D214, D215, D300, D301, D302, D403, D405, D406, D407, D408, D409
     # Would like to enable the following rules in the future:
     # D200, D202, D205, D400
 


### PR DESCRIPTION
## Description
Recently I have reviewed a handful of PRs with problems in their docstrings that I've been fixing with GitHub review suggestions. I took 40 minutes and enabled a bunch of pydocstyle rules that we agreed on in #10711, to help prevent some of these problems and reduce the amount of review effort required for the future. There are a handful of big ones (`D200, D202, D205, D400`) that will require a more intense effort to implement -- those rules may not be worth the significant refactoring effort. I think this may resolve the part of #10711 that we wanted to tackle in the short term, though I'm happy to hear others' views (@shwina @vyasr).

Error code reference: https://www.pydocstyle.org/en/stable/error_codes.html

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
