### PR TITLE
Tune multibyte_split kernel

### DIFF
--- a/cpp/include/cudf/io/text/detail/multistate.hpp
+++ b/cpp/include/cudf/io/text/detail/multistate.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/io/text/detail/multistate.hpp
+++ b/cpp/include/cudf/io/text/detail/multistate.hpp
@@ -27,42 +27,6 @@ namespace detail {
  * @brief Represents up to 7 segments
  */
 struct multistate {
- private:
-  /**
-   * @brief represents a (head, tail] segment, stored as a single 8 bit value
-   */
-  struct multistate_segment {
-   public:
-    /**
-     * @brief Creates a segment which represents (0, 0]
-     */
-
-    constexpr multistate_segment() = default;
-    /**
-     * @brief Creates a segment which represents (head, tail]
-     *
-     * @param head the (head, ____] value. Undefined behavior for values >= 16
-     * @param tail the (____, tail] value. Undefined behavior for values >= 16
-     */
-
-    constexpr multistate_segment(uint8_t head, uint8_t tail) : _data((head & 0b1111) | (tail << 4))
-    {
-    }
-
-    /**
-     * @brief Get's the (head, ____] value from the segment.
-     */
-    [[nodiscard]] constexpr uint8_t get_head() const { return _data & 0b1111; }
-
-    /**
-     * @brief Get's the (____, tail] value from the segment.
-     */
-    [[nodiscard]] constexpr uint8_t get_tail() const { return _data >> 4; }
-
-   private:
-    uint8_t _data{0};
-  };
-
  public:
   /**
    * @brief The maximum state (head or tail) this multistate can represent
@@ -81,7 +45,9 @@ struct multistate {
    */
   constexpr void enqueue(uint8_t head, uint8_t tail)
   {
-    _segments[_size++] = multistate_segment(head, tail);
+    _heads |= (head & 0xFu) << (_size * 4);
+    _tails |= (tail & 0xFu) << (_size * 4);
+    _size++;
   }
 
   /**
@@ -106,16 +72,23 @@ struct multistate {
   /**
    * @brief get's the Nth (head, ____] value state this multistate represents
    */
-  [[nodiscard]] constexpr uint8_t get_head(uint8_t idx) const { return _segments[idx].get_head(); }
+  [[nodiscard]] constexpr uint8_t get_head(uint8_t idx) const
+  {
+    return (_heads >> (idx * 4)) & 0xFu;
+  }
 
   /**
    * @brief get's the Nth (____, tail] value state this multistate represents
    */
-  [[nodiscard]] constexpr uint8_t get_tail(uint8_t idx) const { return _segments[idx].get_tail(); }
+  [[nodiscard]] constexpr uint8_t get_tail(uint8_t idx) const
+  {
+    return (_tails >> (idx * 4)) & 0xFu;
+  }
 
  private:
   uint8_t _size = 0;
-  multistate_segment _segments[max_segment_count];
+  uint32_t _heads{};
+  uint32_t _tails{};
 };
 
 /**

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -202,7 +202,7 @@ __global__ void multibyte_split_seed_kernel(
   }
 }
 
-__global__ void multibyte_split_kernel(
+__global__ __launch_bounds__(THREADS_PER_TILE) void multibyte_split_kernel(
   cudf::size_type base_tile_idx,
   int64_t base_input_offset,
   int64_t base_offset_offset,

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -214,7 +214,7 @@ __global__ void multibyte_split_kernel(
   cudf::split_device_span<int64_t> output_offsets)
 {
   using InputLoad =
-    cub::BlockLoad<char, THREADS_PER_TILE, ITEMS_PER_THREAD, cub::BLOCK_LOAD_VECTORIZE>;
+    cub::BlockLoad<char, THREADS_PER_TILE, ITEMS_PER_THREAD, cub::BLOCK_LOAD_WARP_TRANSPOSE>;
   using OffsetScan         = cub::BlockScan<cutoff_offset, THREADS_PER_TILE>;
   using OffsetScanCallback = cudf::io::text::detail::scan_tile_state_callback<cutoff_offset>;
 

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -243,7 +243,7 @@ __global__ __launch_bounds__(THREADS_PER_TILE) void multibyte_split_kernel(
   // STEP 3: Flag matches
 
   cutoff_offset thread_offset;
-  uint32_t thread_match_mask[ITEMS_PER_THREAD / 32]{};
+  uint32_t thread_match_mask[(ITEMS_PER_THREAD + 31) / 32]{};
 
   for (int32_t i = 0; i < ITEMS_PER_THREAD; i++) {
     thread_multistate        = trie.transition(thread_chars[i], thread_multistate);

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -97,7 +97,7 @@ using cudf::io::text::detail::multistate;
 int32_t constexpr ITEMS_PER_THREAD = 64;
 int32_t constexpr THREADS_PER_TILE = 128;
 int32_t constexpr ITEMS_PER_TILE   = ITEMS_PER_THREAD * THREADS_PER_TILE;
-int32_t constexpr TILES_PER_CHUNK  = 1024;
+int32_t constexpr TILES_PER_CHUNK  = 16384;
 int32_t constexpr ITEMS_PER_CHUNK  = ITEMS_PER_TILE * TILES_PER_CHUNK;
 
 struct PatternScan {

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -97,7 +97,7 @@ using cudf::io::text::detail::multistate;
 int32_t constexpr ITEMS_PER_THREAD = 64;
 int32_t constexpr THREADS_PER_TILE = 128;
 int32_t constexpr ITEMS_PER_TILE   = ITEMS_PER_THREAD * THREADS_PER_TILE;
-int32_t constexpr TILES_PER_CHUNK  = 16384;
+int32_t constexpr TILES_PER_CHUNK  = 4096;
 int32_t constexpr ITEMS_PER_CHUNK  = ITEMS_PER_TILE * TILES_PER_CHUNK;
 
 struct PatternScan {
@@ -532,8 +532,8 @@ std::unique_ptr<cudf::column> multibyte_split(cudf::io::text::data_chunk_source 
   auto chunk_offset         = std::max<int64_t>(0, byte_range.offset() - delimiter.size());
   auto const byte_range_end = byte_range.offset() + byte_range.size();
   reader->skip_bytes(chunk_offset);
-  // amortize output chunk allocations over 16 worst-case outputs. This limits the overallocation
-  constexpr auto max_growth = 16;
+  // amortize output chunk allocations over 8 worst-case outputs. This limits the overallocation
+  constexpr auto max_growth = 8;
   output_builder<int64_t> offset_storage(ITEMS_PER_CHUNK, max_growth, stream);
   output_builder<char> char_storage(ITEMS_PER_CHUNK, max_growth, stream);
 

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -94,7 +94,7 @@ namespace {
 
 using cudf::io::text::detail::multistate;
 
-int32_t constexpr ITEMS_PER_THREAD = 32;
+int32_t constexpr ITEMS_PER_THREAD = 64;
 int32_t constexpr THREADS_PER_TILE = 128;
 int32_t constexpr ITEMS_PER_TILE   = ITEMS_PER_THREAD * THREADS_PER_TILE;
 int32_t constexpr TILES_PER_CHUNK  = 1024;

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -27,7 +27,7 @@
 #include <cudf/io/text/data_chunk_source.hpp>
 #include <cudf/io/text/detail/multistate.hpp>
 #include <cudf/io/text/detail/tile_state.hpp>
-#include <cudf/io/text/detail/trie.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/span.hpp>
 
@@ -100,6 +100,33 @@ int32_t constexpr ITEMS_PER_TILE   = ITEMS_PER_THREAD * THREADS_PER_TILE;
 int32_t constexpr TILES_PER_CHUNK  = 4096;
 int32_t constexpr ITEMS_PER_CHUNK  = ITEMS_PER_TILE * TILES_PER_CHUNK;
 
+constexpr multistate transition_init(char c, cudf::device_span<char const> delim)
+{
+  auto result = multistate();
+
+  result.enqueue(0, 0);
+
+  for (std::size_t i = 0; i < delim.size(); i++) {
+    if (delim[i] == c) { result.enqueue(i, i + 1); }
+  }
+
+  return result;
+}
+
+constexpr multistate transition(char c, multistate state, cudf::device_span<char const> delim)
+{
+  auto result = multistate();
+
+  result.enqueue(0, 0);
+
+  for (uint8_t i = 0; i < state.size(); i++) {
+    auto const tail = state.get_tail(i);
+    if (tail < delim.size() && delim[tail] == c) { result.enqueue(state.get_head(i), tail + 1); }
+  }
+
+  return result;
+}
+
 struct PatternScan {
   using BlockScan         = cub::BlockScan<multistate, THREADS_PER_TILE>;
   using BlockScanCallback = cudf::io::text::detail::scan_tile_state_callback<multistate>;
@@ -116,14 +143,14 @@ struct PatternScan {
 
   __device__ inline void Scan(cudf::size_type tile_idx,
                               cudf::io::text::detail::scan_tile_state_view<multistate> tile_state,
-                              cudf::io::text::detail::trie_device_view trie,
+                              cudf::device_span<char const> delim,
                               char (&thread_data)[ITEMS_PER_THREAD],
                               multistate& thread_multistate)
   {
-    thread_multistate = trie.transition_init(thread_data[0]);
+    thread_multistate = transition_init(thread_data[0], delim);
 
     for (uint32_t i = 1; i < ITEMS_PER_THREAD; i++) {
-      thread_multistate = trie.transition(thread_data[i], thread_multistate);
+      thread_multistate = transition(thread_data[i], thread_multistate, delim);
     }
 
     auto prefix_callback = BlockScanCallback(tile_state, tile_idx);
@@ -202,7 +229,7 @@ __global__ __launch_bounds__(THREADS_PER_TILE) void multibyte_split_kernel(
   int64_t base_offset_offset,
   cudf::io::text::detail::scan_tile_state_view<multistate> tile_multistates,
   cudf::io::text::detail::scan_tile_state_view<cutoff_offset> tile_output_offsets,
-  cudf::io::text::detail::trie_device_view trie,
+  cudf::device_span<char const> delim,
   cudf::device_span<char const> chunk_input_chars,
   int64_t byte_range_end,
   cudf::split_device_span<int64_t> output_offsets)
@@ -238,7 +265,7 @@ __global__ __launch_bounds__(THREADS_PER_TILE) void multibyte_split_kernel(
 
   __syncthreads();  // required before temp_memory re-use
   PatternScan(temp_storage.pattern_scan)
-    .Scan(tile_idx, tile_multistates, trie, thread_chars, thread_multistate);
+    .Scan(tile_idx, tile_multistates, delim, thread_chars, thread_multistate);
 
   // STEP 3: Flag matches
 
@@ -246,9 +273,9 @@ __global__ __launch_bounds__(THREADS_PER_TILE) void multibyte_split_kernel(
   uint32_t thread_match_mask[(ITEMS_PER_THREAD + 31) / 32]{};
 
   for (int32_t i = 0; i < ITEMS_PER_THREAD; i++) {
-    thread_multistate        = trie.transition(thread_chars[i], thread_multistate);
+    thread_multistate        = transition(thread_chars[i], thread_multistate, delim);
     auto const thread_state  = thread_multistate.max_tail();
-    auto const is_match      = i < thread_input_size and trie.is_match(thread_state);
+    auto const is_match      = i < thread_input_size and thread_state == delim.size();
     auto const match_end     = base_input_offset + thread_input_offset + i + 1;
     auto const is_past_range = match_end >= byte_range_end;
     thread_match_mask[i / 32] |= uint32_t{is_match} << (i % 32);
@@ -488,12 +515,25 @@ std::unique_ptr<cudf::column> multibyte_split(cudf::io::text::data_chunk_source 
 
   if (byte_range.empty()) { return make_empty_column(type_id::STRING); }
 
-  auto const trie = cudf::io::text::detail::trie::create({delimiter}, stream);
+  auto device_delim = cudf::string_scalar(delimiter, true, stream, mr);
 
-  CUDF_EXPECTS(trie.max_duplicate_tokens() < multistate::max_segment_count,
+  auto sorted_delim = delimiter;
+  std::sort(sorted_delim.begin(), sorted_delim.end());
+  auto [_last_char, _last_char_count, max_duplicate_tokens] = std::accumulate(
+    sorted_delim.begin(), sorted_delim.end(), std::make_tuple('\0', 0, 0), [](auto acc, char c) {
+      if (std::get<0>(acc) != c) {
+        std::get<0>(acc) = c;
+        std::get<1>(acc) = 0;
+      }
+      std::get<1>(acc)++;
+      std::get<2>(acc) = std::max(std::get<1>(acc), std::get<2>(acc));
+      return acc;
+    });
+
+  CUDF_EXPECTS(max_duplicate_tokens < multistate::max_segment_count,
                "delimiter contains too many duplicate tokens to produce a deterministic result.");
 
-  CUDF_EXPECTS(trie.size() < multistate::max_segment_value,
+  CUDF_EXPECTS(delimiter.size() < multistate::max_segment_value,
                "delimiter contains too many total tokens to produce a deterministic result.");
 
   auto concurrency = 2;
@@ -584,7 +624,7 @@ std::unique_ptr<cudf::column> multibyte_split(cudf::io::text::data_chunk_source 
       offset_storage.size(),
       tile_multistates,
       tile_offsets,
-      trie.view(),
+      {device_delim.data(), static_cast<std::size_t>(device_delim.size())},
       *chunk,
       byte_range_end,
       offset_output);


### PR DESCRIPTION
## Description
This improves the `multibyte_split` kernel by
* Reducing register pressure: Instead of storing `ITEMS_PER_THREAD` individual states, store only the initial `multistate` for the thread and recompute the individual states on-the-fly
* Eliminating local memory usage: Manipulate the `multistate` via shifts instead of array random access
* Eliminating trie overhead: Since we have only a single delimiter, the trie is a path. We can do the traversal implicitly
* Memoizing which chars were a match: We don't need to recompute this information, but can store it in a bitmask
* Changing the block load algorithm: `BLOCK_LOAD_VECTORIZE` was slightly less efficient than `BLOCK_LOAD_WARP_TRANSPOSE`
* Reducing the allocation overhead by limiting the `output_builder` max allocation size
* Tuning the parameters: `ITEMS_PER_THREAD = 64` works better, and we can improve performance further by operating on larger chunks

Overall, this gives a roughly 2x speedup in my benchmarks.

Based on #11500

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
