### PR TITLE
Fix exception in segmented-reduce benchmark

### DIFF
--- a/cpp/benchmarks/reduction/segment_reduce.cu
+++ b/cpp/benchmarks/reduction/segment_reduce.cu
@@ -32,99 +32,95 @@
 #include <memory>
 #include <type_traits>
 
-namespace cudf {
-
-bool constexpr is_boolean_output_agg(segmented_reduce_aggregation::Kind kind)
+bool constexpr is_boolean_output_agg(cudf::segmented_reduce_aggregation::Kind kind)
 {
-  return kind == segmented_reduce_aggregation::ALL || kind == segmented_reduce_aggregation::ANY;
+  return kind == cudf::segmented_reduce_aggregation::ALL ||
+         kind == cudf::segmented_reduce_aggregation::ANY;
 }
 
-template <segmented_reduce_aggregation::Kind kind>
-std::unique_ptr<segmented_reduce_aggregation> make_simple_aggregation()
+template <cudf::segmented_reduce_aggregation::Kind kind>
+std::unique_ptr<cudf::segmented_reduce_aggregation> make_simple_aggregation()
 {
   switch (kind) {
-    case segmented_reduce_aggregation::SUM:
-      return make_sum_aggregation<segmented_reduce_aggregation>();
-    case segmented_reduce_aggregation::PRODUCT:
-      return make_product_aggregation<segmented_reduce_aggregation>();
-    case segmented_reduce_aggregation::MIN:
-      return make_min_aggregation<segmented_reduce_aggregation>();
-    case segmented_reduce_aggregation::MAX:
-      return make_max_aggregation<segmented_reduce_aggregation>();
-    case segmented_reduce_aggregation::ALL:
-      return make_all_aggregation<segmented_reduce_aggregation>();
-    case segmented_reduce_aggregation::ANY:
-      return make_any_aggregation<segmented_reduce_aggregation>();
+    case cudf::segmented_reduce_aggregation::SUM:
+      return cudf::make_sum_aggregation<cudf::segmented_reduce_aggregation>();
+    case cudf::segmented_reduce_aggregation::PRODUCT:
+      return cudf::make_product_aggregation<cudf::segmented_reduce_aggregation>();
+    case cudf::segmented_reduce_aggregation::MIN:
+      return cudf::make_min_aggregation<cudf::segmented_reduce_aggregation>();
+    case cudf::segmented_reduce_aggregation::MAX:
+      return cudf::make_max_aggregation<cudf::segmented_reduce_aggregation>();
+    case cudf::segmented_reduce_aggregation::ALL:
+      return cudf::make_all_aggregation<cudf::segmented_reduce_aggregation>();
+    case cudf::segmented_reduce_aggregation::ANY:
+      return cudf::make_any_aggregation<cudf::segmented_reduce_aggregation>();
     default: CUDF_FAIL("Unsupported simple segmented aggregation");
   }
 }
 
-template <typename InputType>
-std::pair<std::unique_ptr<column>, thrust::device_vector<size_type>> make_test_data(
+template <typename DataType>
+std::pair<std::unique_ptr<cudf::column>, thrust::device_vector<cudf::size_type>> make_test_data(
   nvbench::state& state)
 {
-  auto const column_size{size_type(state.get_int64("column_size"))};
-  auto const num_segments{size_type(state.get_int64("num_segments"))};
+  auto const column_size{cudf::size_type(state.get_int64("column_size"))};
+  auto const num_segments{cudf::size_type(state.get_int64("num_segments"))};
 
   auto segment_length = column_size / num_segments;
 
-  auto const dtype     = cudf::type_to_id<InputType>();
+  auto const dtype     = cudf::type_to_id<DataType>();
   data_profile profile = data_profile_builder().cardinality(0).no_validity().distribution(
     dtype, distribution_id::UNIFORM, 0, 100);
   auto input = create_random_column(dtype, row_count{column_size}, profile);
 
-  auto offset_it =
-    detail::make_counting_transform_iterator(0, [column_size, segment_length] __device__(auto i) {
+  auto offset_it = cudf::detail::make_counting_transform_iterator(
+    0, [column_size, segment_length] __device__(auto i) {
       return column_size < i * segment_length ? column_size : i * segment_length;
     });
 
-  thrust::device_vector<size_type> d_offsets(offset_it, offset_it + num_segments + 1);
+  thrust::device_vector<cudf::size_type> d_offsets(offset_it, offset_it + num_segments + 1);
 
   return std::pair(std::move(input), d_offsets);
 }
 
-template <typename InputType, typename OutputType, aggregation::Kind kind>
-std::enable_if_t<!is_boolean_output_agg(kind) || std::is_same_v<OutputType, bool>, void>
-BM_Simple_Segmented_Reduction(nvbench::state& state,
-                              nvbench::type_list<InputType, OutputType, nvbench::enum_type<kind>>)
+template <typename DataType, cudf::aggregation::Kind kind>
+void BM_Simple_Segmented_Reduction(nvbench::state& state,
+                                   nvbench::type_list<DataType, nvbench::enum_type<kind>>)
 {
   // TODO: to be replaced by nvbench fixture once it's ready
   cudf::rmm_pool_raii rmm_pool;
 
-  auto const column_size{size_type(state.get_int64("column_size"))};
-  auto [input, offsets] = make_test_data<InputType>(state);
+  auto const column_size{cudf::size_type(state.get_int64("column_size"))};
+  auto [input, offsets] = make_test_data<DataType>(state);
   auto agg              = make_simple_aggregation<kind>();
 
+  auto output_type = is_boolean_output_agg(kind) ? cudf::data_type{cudf::type_id::BOOL8}
+                                                 : cudf::data_type{cudf::type_to_id<DataType>()};
+
   state.add_element_count(column_size);
-  state.add_global_memory_reads<InputType>(column_size);
-  state.add_global_memory_writes<OutputType>(column_size);
+  state.add_global_memory_reads<DataType>(column_size);
+  if (!is_boolean_output_agg(kind))
+    state.add_global_memory_writes<nvbench::int8_t>(1);  // single BOOL8
+  else
+    state.add_global_memory_writes<DataType>(column_size);
+
+  auto const input_view  = input->view();
+  auto const offset_span = cudf::device_span<cudf::size_type>{offsets};
 
   state.exec(
-    nvbench::exec_tag::sync,
-    [input_view = input->view(), offset_span = device_span<size_type>{offsets}, &agg](
-      nvbench::launch& launch) {
-      segmented_reduce(
-        input_view, offset_span, *agg, data_type{type_to_id<OutputType>()}, null_policy::INCLUDE);
+    nvbench::exec_tag::sync, [input_view, output_type, offset_span, &agg](nvbench::launch& launch) {
+      segmented_reduce(input_view, offset_span, *agg, output_type, cudf::null_policy::INCLUDE);
     });
-}
-
-template <typename InputType, typename OutputType, aggregation::Kind kind>
-std::enable_if_t<is_boolean_output_agg(kind) && !std::is_same_v<OutputType, bool>, void>
-BM_Simple_Segmented_Reduction(nvbench::state& state,
-                              nvbench::type_list<InputType, OutputType, nvbench::enum_type<kind>>)
-{
-  state.skip("Invalid combination of dtype and aggregation type.");
 }
 
 using Types = nvbench::type_list<bool, int32_t, float, double>;
 // Skip benchmarking MAX/ANY since they are covered by MIN/ALL respectively.
-using AggKinds = nvbench::
-  enum_type_list<aggregation::SUM, aggregation::PRODUCT, aggregation::MIN, aggregation::ALL>;
+using AggKinds = nvbench::enum_type_list<cudf::aggregation::SUM,
+                                         cudf::aggregation::PRODUCT,
+                                         cudf::aggregation::MIN,
+                                         cudf::aggregation::ALL>;
 
-NVBENCH_BENCH_TYPES(BM_Simple_Segmented_Reduction, NVBENCH_TYPE_AXES(Types, Types, AggKinds))
+NVBENCH_BENCH_TYPES(BM_Simple_Segmented_Reduction, NVBENCH_TYPE_AXES(Types, AggKinds))
   .set_name("segmented_reduction_simple")
-  .set_type_axes_names({"InputType", "OutputType", "AggregationKinds"})
+  .set_type_axes_names({"DataType", "AggregationKinds"})
   .add_int64_axis("column_size", {100'000, 1'000'000, 10'000'000, 100'000'000})
   .add_int64_axis("num_segments", {1'000, 10'000, 100'000});
-
-}  // namespace cudf

--- a/cpp/benchmarks/reduction/segment_reduce.cu
+++ b/cpp/benchmarks/reduction/segment_reduce.cu
@@ -100,10 +100,11 @@ void BM_Simple_Segmented_Reduction(nvbench::state& state,
 
   state.add_element_count(column_size);
   state.add_global_memory_reads<DataType>(column_size);
-  if (!is_boolean_output_agg(kind))
+  if (is_boolean_output_agg(kind)) {
     state.add_global_memory_writes<nvbench::int8_t>(num_segments);  // BOOL8
-  else
+  } else {
     state.add_global_memory_writes<DataType>(num_segments);
+  }
 
   auto const input_view  = input->view();
   auto const offset_span = cudf::device_span<cudf::size_type>{offsets};

--- a/cpp/benchmarks/reduction/segment_reduce.cu
+++ b/cpp/benchmarks/reduction/segment_reduce.cu
@@ -99,7 +99,7 @@ void BM_Simple_Segmented_Reduction(nvbench::state& state,
   state.add_element_count(column_size);
   state.add_global_memory_reads<DataType>(column_size);
   if (!is_boolean_output_agg(kind))
-    state.add_global_memory_writes<nvbench::int8_t>(1);  // single BOOL8
+    state.add_global_memory_writes<nvbench::int8_t>(column_size);  // BOOL8
   else
     state.add_global_memory_writes<DataType>(column_size);
 

--- a/cpp/benchmarks/reduction/segment_reduce.cu
+++ b/cpp/benchmarks/reduction/segment_reduce.cu
@@ -90,6 +90,8 @@ void BM_Simple_Segmented_Reduction(nvbench::state& state,
   cudf::rmm_pool_raii rmm_pool;
 
   auto const column_size{cudf::size_type(state.get_int64("column_size"))};
+  auto const num_segments{cudf::size_type(state.get_int64("num_segments"))};
+
   auto [input, offsets] = make_test_data<DataType>(state);
   auto agg              = make_simple_aggregation<kind>();
 
@@ -99,9 +101,9 @@ void BM_Simple_Segmented_Reduction(nvbench::state& state,
   state.add_element_count(column_size);
   state.add_global_memory_reads<DataType>(column_size);
   if (!is_boolean_output_agg(kind))
-    state.add_global_memory_writes<nvbench::int8_t>(column_size);  // BOOL8
+    state.add_global_memory_writes<nvbench::int8_t>(num_segments);  // BOOL8
   else
-    state.add_global_memory_writes<DataType>(column_size);
+    state.add_global_memory_writes<DataType>(num_segments);
 
   auto const input_view  = input->view();
   auto const offset_span = cudf::device_span<cudf::size_type>{offsets};

--- a/cpp/benchmarks/reduction/segment_reduce.cu
+++ b/cpp/benchmarks/reduction/segment_reduce.cu
@@ -109,6 +109,7 @@ void BM_Simple_Segmented_Reduction(nvbench::state& state,
   auto const input_view  = input->view();
   auto const offset_span = cudf::device_span<cudf::size_type>{offsets};
 
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::default_stream_value.value()));
   state.exec(
     nvbench::exec_tag::sync, [input_view, output_type, offset_span, &agg](nvbench::launch& launch) {
       segmented_reduce(input_view, offset_span, *agg, output_type, cudf::null_policy::INCLUDE);


### PR DESCRIPTION
## Description
Fixes exception thrown in `REDUCTION_NVBENCH`. 

```
Run:  [121/768] segmented_reduction_simple [Device=0 InputType=bool OutputType=F32 AggregationKinds=2 column_size=100000 num_segments=1000]
Fail: Unexpected error: cuDF failure at: /cudf/cpp/src/reductions/segmented_min.cu:33: segmented_min() operation requires matching output type
```
(There are 144 of these)

The code is refactored to reduce the generated benchmark code in order to match input and output types and to force the output type to `BOOL8` for aggregation kind `ALL`. This also removes code generated that is only _skipped_:

```
Run:  [277/768] segmented_reduction_simple [Device=0 InputType=I32 OutputType=I32 AggregationKinds=7 column_size=100000 num_segments=1000]
Skip: Invalid combination of dtype and aggregation type.

```
(There are also 144 of these)

So 37.5% (288/768) of the benchmark runs were either invalid or throw an exception

The code change reduces the benchmarks to 192 valid ones.

Matching type input/output types should provide sufficient coverage since internally the numeric reductions `SUM` and `PRODUCT` are performed on `int64` or `double` and then the results are cast to the output-type. So the `int32` and `float` types will always cover this cast step. Extra measurements for casting to `double` to `int32` for example should not be necessary.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
