### PR TITLE
[REVIEW] Fix an issue with `to_arrow` when column name type is not a string

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1145,7 +1145,7 @@ class Frame(BinaryOperand, Scannable):
         index: [[1,2,3]]
         """
         return pa.Table.from_pydict(
-            {name: col.to_arrow() for name, col in self._data.items()}
+            {str(name): col.to_arrow() for name, col in self._data.items()}
         )
 
     def _positions_from_column_names(self, column_names):

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -9514,3 +9514,19 @@ def test_dataframe_assign_scalar_to_empty_series():
     expected.a = 0
     actual.a = 0
     assert_eq(expected, actual)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {0: [1, 2, 3], 2: [10, 11, 23]},
+        {("a", "b"): [1, 2, 3], ("2",): [10, 11, 23]},
+    ],
+)
+def test_non_string_column_name_to_arrow(data):
+    df = cudf.DataFrame(data)
+
+    expected = df.to_arrow()
+    actual = pa.Table.from_pandas(df.to_pandas())
+
+    assert expected.equals(actual)


### PR DESCRIPTION
## Description
Fixes: #11589 

This PR fixes an issue with `DataFrame.to_arrow` when the column names are `int`/`tuples` i.e., non-string types.
The fix is trivial and retains the same behavior that of `pa.Table.from_pandas` which converts all non-string column names to `strings`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
