### PR TITLE
Verify libcudacxx 1.8 works with cudf

### DIFF
--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -11,12 +11,12 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
-  include(FetchContent)
-  FetchContent_Declare(
-    rapids-cmake
-    GIT_REPOSITORY https://github.com/robertmaynard/rapids-cmake.git
-    GIT_TAG fea/move_to_libcudacxx_1.8
-  )
+include(FetchContent)
+FetchContent_Declare(
+  rapids-cmake
+  GIT_REPOSITORY https://github.com/robertmaynard/rapids-cmake.git
+  GIT_TAG fea/move_to_libcudacxx_1.8
+)
 
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake

--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -11,6 +11,13 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
+  include(FetchContent)
+  FetchContent_Declare(
+    rapids-cmake
+    GIT_REPOSITORY https://github.com/robertmaynard/rapids-cmake.git
+    GIT_TAG fea/move_to_libcudacxx_1.8
+  )
+
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake


### PR DESCRIPTION
## Description
Verify that https://github.com/rapidsai/rapids-cmake/pull/253 works as expected.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
