### PR TITLE
[DO NOT MERGE] Experiment with auto-inferring

### DIFF
--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -458,7 +458,7 @@ def _naive_var(ddf, meta, skipna, ddof, split_every, out):
     x = 1.0 * num.sum(skipna=skipna, split_every=split_every)
     x2 = 1.0 * (num**2).sum(skipna=skipna, split_every=split_every)
     n = num.count(split_every=split_every)
-    name = ddf._token_prefix + "var"
+    name = "cuda-" + ddf._token_prefix + "var"
     result = map_partitions(
         var_aggregate, x2, x, n, token=name, meta=meta, ddof=ddof
     )
@@ -500,7 +500,7 @@ def _parallel_var(ddf, meta, skipna, split_every, out):
     nparts = ddf.npartitions
     if not split_every:
         split_every = nparts
-    name = "var-" + tokenize(skipna, split_every, out)
+    name = "cuda-var-" + tokenize(skipna, split_every, out)
     local_name = "local-" + name
     num = ddf._get_numeric_data()
     dsk = {
@@ -723,7 +723,9 @@ def from_cudf(data, npartitions=None, chunksize=None, sort=True, name=None):
             "dask_cudf does not support MultiIndex Dataframes."
         )
 
-    name = name or ("from_cudf-" + tokenize(data, npartitions or chunksize))
+    name = "cuda-" + name or (
+        "cuda-from_cudf-" + tokenize(data, npartitions or chunksize)
+    )
     return dd.from_pandas(
         data,
         npartitions=npartitions,

--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -548,9 +548,9 @@ def groupby_agg(
     # Begin graph construction
     dsk = {}
     token = tokenize(ddf, gb_cols, aggs)
-    partition_agg_name = "groupby_partition_agg-" + token
-    tree_reduce_name = "groupby_tree_reduce-" + token
-    gb_agg_name = "groupby_agg-" + token
+    partition_agg_name = "cuda-" + "groupby_partition_agg-" + token
+    tree_reduce_name = "cuda-" + "groupby_tree_reduce-" + token
+    gb_agg_name = "cuda-" + "groupby_agg-" + token
     for p in range(ddf.npartitions):
         # Perform groupby aggregation on each partition.
         # Split each result into `split_out` chunks (by hashing `gb_cols`)


### PR DESCRIPTION
Related to https://github.com/dask/distributed/issues/4656

In this experiment I did the following:
- change all dask-cudf keynames to be `cuda-` (this PR and https://github.com/quasiben/dask/tree/fea/auto-infer)
- modify the scheduler to redirect any keys with with name `cuda-` (https://github.com/quasiben/distributed/tree/fea/auto-infer) to a [resource defined worker](https://distributed.dask.org/en/stable/resources.html#specifying-resources) with the name `Dask-Agent-GPU: 1`

Here's a small demo of all 3 branches working together:

```python
from distributed.utils_test import gen_cluster
import pandas as pd
import numpy as np
import dask.dataframe as dd
import cudf


@gen_cluster(
    client=True, nthreads=[("127.0.0.1", 2, {"resources": {"Dask-Agent-GPU":
        1.0}}), ("127.0.0.1", 1, {"resources": {"Dask-Agent-CPU": 1.0}})]
)
async def test_restrictions(c, s, a, b):
    workers = await c.run(lambda dask_worker: dask_worker.available_resources)
    gpu_workers = set([k for k, v in workers.items() if 'GPU' in list(v.keys())[0]])
    cpu_workers = set(workers) - gpu_workers

    df = pd.DataFrame({'A': np.arange(30), 'B': np.arange(30), 'C':
        np.random.randint(0,5,size=30)})
    ddf = dd.from_pandas(df, npartitions=3)
    ddf = await ddf.persist()

    # move to gpu should move keys/data to GPU worker
    ddf = ddf.map_partitions(cudf.from_pandas)
    ddf = await ddf.persist()
    gpu_has_what = await c.has_what()

    #assert cuda- is on the GPU worker
    assert any('cuda-' in d for d in gpu_has_what[list(gpu_workers)[0]])

    #assert no cuda- is on the CPU worker
    assert any('cuda-' not in d for d in gpu_has_what[list(cpu_workers)[0]])

    ddf = await ddf.groupby(["C"]).agg({"A": "sum", "B": "mean"}).persist()
    groupby_has_what = await c.has_what()
```