### PR TITLE
Refactors of public/detail APIs, CUDF_FUNC_RANGE, stream handling.

### DIFF
--- a/cpp/include/cudf/concatenate.hpp
+++ b/cpp/include/cudf/concatenate.hpp
@@ -38,7 +38,7 @@ namespace cudf {
  *
  * Returns empty `device_buffer` if the column is not nullable
  *
- * @param views host_span of column views whose bitmask will to be concatenated
+ * @param views host_span of column views whose bitmasks will be concatenated
  * @param mr Device memory resource used for allocating the new device_buffer
  * @return rmm::device_buffer A `device_buffer` containing the bitmasks of all
  * the column views in the views vector

--- a/cpp/include/cudf/detail/concatenate.cuh
+++ b/cpp/include/cudf/detail/concatenate.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,15 @@
 namespace cudf {
 //! Inner interfaces and implementations
 namespace detail {
+
 /**
- * @copydoc cudf::concatenate_masks(std::vector<column_view>
- * const&,rmm::mr::device_memory_resource*)
+ * @brief Concatenates the null mask bits of all the column device views in the
+ * `views` array to the destination bitmask.
  *
+ * @param d_views Column device views whose null masks will be concatenated
+ * @param d_offsets Prefix sum of sizes of elements of `d_views`
+ * @param dest_mask The output buffer to copy null masks into
+ * @param output_size The total number of null masks bits that are being copied
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 void concatenate_masks(device_span<column_device_view const> d_views,
@@ -42,13 +47,26 @@ void concatenate_masks(device_span<column_device_view const> d_views,
                        rmm::cuda_stream_view stream);
 
 /**
- * @copydoc cudf::concatenate_masks(std::vector<column_view> const&,bitmask_type*)
+ * @brief Concatenates `views[i]`'s bitmask from the bits
+ * `[views[i].offset(), views[i].offset() + views[i].size())` for all elements
+ * views[i] in views into a destination bitmask pointer.
  *
+ * @param views Column views whose bitmasks will be concatenated
+ * @param dest_mask The output buffer to copy null masks into
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
 void concatenate_masks(host_span<column_view const> views,
                        bitmask_type* dest_mask,
                        rmm::cuda_stream_view stream);
+
+/**
+ * @copydoc cudf::concatenate_masks(host_span<column_view const>, rmm::mr::device_memory_resource*)
+ *
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ */
+rmm::device_buffer concatenate_masks(host_span<column_view const> views,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::mr::device_memory_resource* mr);
 
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/src/binaryop/binaryop.cpp
+++ b/cpp/src/binaryop/binaryop.cpp
@@ -323,7 +323,7 @@ std::unique_ptr<column> binary_operation(scalar const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   return binops::compiled::binary_operation<scalar, column_view>(
-    lhs, rhs, op, output_type, cudf::default_stream_value, mr);
+    lhs, rhs, op, output_type, stream, mr);
 }
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          scalar const& rhs,
@@ -333,7 +333,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   return binops::compiled::binary_operation<column_view, scalar>(
-    lhs, rhs, op, output_type, cudf::default_stream_value, mr);
+    lhs, rhs, op, output_type, stream, mr);
 }
 std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          column_view const& rhs,
@@ -343,7 +343,7 @@ std::unique_ptr<column> binary_operation(column_view const& lhs,
                                          rmm::mr::device_memory_resource* mr)
 {
   return binops::compiled::binary_operation<column_view, column_view>(
-    lhs, rhs, op, output_type, cudf::default_stream_value, mr);
+    lhs, rhs, op, output_type, stream, mr);
 }
 
 std::unique_ptr<column> binary_operation(column_view const& lhs,

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -1269,7 +1269,7 @@ std::vector<packed_table> contiguous_split(cudf::table_view const& input,
                                            rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::contiguous_split(input, splits, cudf::default_stream_value, mr);
+  return detail::contiguous_split(input, splits, cudf::default_stream_value, mr);
 }
 
 };  // namespace cudf

--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -19,6 +19,7 @@
 #include <cudf/detail/copy.hpp>
 #include <cudf/detail/indexalator.cuh>
 #include <cudf/detail/is_element_valid.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/lists/detail/copying.hpp>
@@ -208,6 +209,7 @@ std::unique_ptr<scalar> get_element(column_view const& input,
                                     size_type index,
                                     rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::get_element(input, index, cudf::default_stream_value, mr);
 }
 

--- a/cpp/src/copying/sample.cu
+++ b/cpp/src/copying/sample.cu
@@ -93,7 +93,6 @@ std::unique_ptr<table> sample(table_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-
   return detail::sample(input, n, replacement, seed, cudf::default_stream_value, mr);
 }
 }  // namespace cudf

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -157,7 +157,6 @@ std::unique_ptr<column> shift(column_view const& input,
                               rmm::cuda_stream_view stream,
                               rmm::mr::device_memory_resource* mr)
 {
-  CUDF_FUNC_RANGE();
   CUDF_EXPECTS(input.type() == fill_value.type(),
                "shift requires each fill value type to match the corresponding column type.");
 
@@ -174,6 +173,7 @@ std::unique_ptr<column> shift(column_view const& input,
                               scalar const& fill_value,
                               rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::shift(input, offset, fill_value, cudf::default_stream_value, mr);
 }
 

--- a/cpp/src/filling/calendrical_month_sequence.cu
+++ b/cpp/src/filling/calendrical_month_sequence.cu
@@ -41,6 +41,7 @@ std::unique_ptr<cudf::column> calendrical_month_sequence(size_type size,
                                                          size_type months,
                                                          rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::calendrical_month_sequence(size, init, months, cudf::default_stream_value, mr);
 }
 

--- a/cpp/src/filling/calendrical_month_sequence.cu
+++ b/cpp/src/filling/calendrical_month_sequence.cu
@@ -16,6 +16,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/detail/calendrical_month_sequence.cuh>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -152,6 +152,7 @@ std::unique_ptr<column> sequence(size_type size,
                                  scalar const& step,
                                  rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::sequence(size, init, step, cudf::default_stream_value, mr);
 }
 
@@ -159,6 +160,7 @@ std::unique_ptr<column> sequence(size_type size,
                                  scalar const& init,
                                  rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::sequence(size, init, cudf::default_stream_value, mr);
 }
 

--- a/cpp/src/filling/sequence.cu
+++ b/cpp/src/filling/sequence.cu
@@ -17,6 +17,7 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/filling.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>

--- a/cpp/src/interop/dlpack.cpp
+++ b/cpp/src/interop/dlpack.cpp
@@ -15,6 +15,7 @@
  */
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/interop.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/lists/list_view.hpp>
 #include <cudf/structs/struct_view.hpp>
 #include <cudf/utilities/default_stream.hpp>

--- a/cpp/src/interop/dlpack.cpp
+++ b/cpp/src/interop/dlpack.cpp
@@ -293,11 +293,13 @@ DLManagedTensor* to_dlpack(table_view const& input,
 std::unique_ptr<table> from_dlpack(DLManagedTensor const* managed_tensor,
                                    rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::from_dlpack(managed_tensor, cudf::default_stream_value, mr);
 }
 
 DLManagedTensor* to_dlpack(table_view const& input, rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::to_dlpack(input, cudf::default_stream_value, mr);
 }
 

--- a/cpp/src/interop/to_arrow.cu
+++ b/cpp/src/interop/to_arrow.cu
@@ -414,7 +414,6 @@ std::shared_ptr<arrow::Table> to_arrow(table_view input,
                                        arrow::MemoryPool* ar_mr)
 {
   CUDF_FUNC_RANGE();
-
   return detail::to_arrow(input, metadata, cudf::default_stream_value, ar_mr);
 }
 

--- a/cpp/src/labeling/label_bins.cu
+++ b/cpp/src/labeling/label_bins.cu
@@ -238,6 +238,7 @@ std::unique_ptr<column> label_bins(column_view const& input,
                                    inclusive right_inclusive,
                                    rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::label_bins(input,
                             left_edges,
                             left_inclusive,

--- a/cpp/src/lists/copying/segmented_gather.cu
+++ b/cpp/src/lists/copying/segmented_gather.cu
@@ -118,6 +118,7 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& source_column,
                                          out_of_bounds_policy bounds_policy,
                                          rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::segmented_gather(
     source_column, gather_map_list, bounds_policy, cudf::default_stream_value, mr);
 }

--- a/cpp/src/lists/extract.cu
+++ b/cpp/src/lists/extract.cu
@@ -17,6 +17,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/detail/iterator.cuh>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/sequence.hpp>
 #include <cudf/lists/detail/extract.hpp>
 #include <cudf/lists/detail/gather.cuh>

--- a/cpp/src/lists/extract.cu
+++ b/cpp/src/lists/extract.cu
@@ -169,7 +169,8 @@ std::unique_ptr<column> extract_list_element(lists_column_view const& lists_colu
                                              size_type index,
                                              rmm::mr::device_memory_resource* mr)
 {
-  return detail::extract_list_element_impl(lists_column, index, cudf::default_stream_value, mr);
+  CUDF_FUNC_RANGE();
+  return detail::extract_list_element(lists_column, index, cudf::default_stream_value, mr);
 }
 
 /**
@@ -181,9 +182,10 @@ std::unique_ptr<column> extract_list_element(lists_column_view const& lists_colu
                                              column_view const& indices,
                                              rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   CUDF_EXPECTS(indices.size() == lists_column.size(),
                "Index column must have as many elements as lists column.");
-  return detail::extract_list_element_impl(lists_column, indices, cudf::default_stream_value, mr);
+  return detail::extract_list_element(lists_column, indices, cudf::default_stream_value, mr);
 }
 
 }  // namespace lists

--- a/cpp/src/lists/stream_compaction/apply_boolean_mask.cu
+++ b/cpp/src/lists/stream_compaction/apply_boolean_mask.cu
@@ -102,6 +102,7 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
                                            lists_column_view const& boolean_mask,
                                            rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::apply_boolean_mask(input, boolean_mask, cudf::default_stream_value, mr);
 }
 

--- a/cpp/src/lists/stream_compaction/apply_boolean_mask.cu
+++ b/cpp/src/lists/stream_compaction/apply_boolean_mask.cu
@@ -19,6 +19,7 @@
 #include <cudf/detail/fill.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/reduction_functions.hpp>
 #include <cudf/detail/replace.hpp>
 #include <cudf/detail/stream_compaction.hpp>

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -267,7 +267,7 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> round_robi
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::round_robin_partition(
+  return detail::round_robin_partition(
     input, num_partitions, start_partition, cudf::default_stream_value, mr);
 }
 

--- a/cpp/src/quantiles/quantiles.cu
+++ b/cpp/src/quantiles/quantiles.cu
@@ -61,17 +61,15 @@ std::unique_ptr<table> quantiles(table_view const& input,
                         mr);
 }
 
-}  // namespace detail
-
 std::unique_ptr<table> quantiles(table_view const& input,
                                  std::vector<double> const& q,
                                  interpolation interp,
                                  cudf::sorted is_input_sorted,
                                  std::vector<order> const& column_order,
                                  std::vector<null_order> const& null_precedence,
+                                 rmm::cuda_stream_view stream,
                                  rmm::mr::device_memory_resource* mr)
 {
-  CUDF_FUNC_RANGE();
   if (q.empty()) { return empty_like(input); }
 
   CUDF_EXPECTS(interp == interpolation::HIGHER || interp == interpolation::LOWER ||
@@ -92,6 +90,27 @@ std::unique_ptr<table> quantiles(table_view const& input,
     return detail::quantiles(
       input, sorted_idx->view().data<size_type>(), q, interp, cudf::default_stream_value, mr);
   }
+}
+
+}  // namespace detail
+
+std::unique_ptr<table> quantiles(table_view const& input,
+                                 std::vector<double> const& q,
+                                 interpolation interp,
+                                 cudf::sorted is_input_sorted,
+                                 std::vector<order> const& column_order,
+                                 std::vector<null_order> const& null_precedence,
+                                 rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::quantiles(input,
+                           q,
+                           interp,
+                           is_input_sorted,
+                           column_order,
+                           null_precedence,
+                           cudf::default_stream_value,
+                           mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -338,7 +338,7 @@ std::unique_ptr<scalar> make_empty_tdigest_scalar(rmm::cuda_stream_view stream,
     std::move(*std::make_unique<table>(std::move(contents.children))), true, stream, mr);
 }
 
-}  // namespace tdigest.
+}  // namespace tdigest
 
 std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
                                           column_view const& percentiles,
@@ -406,7 +406,8 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
                                           column_view const& percentiles,
                                           rmm::mr::device_memory_resource* mr)
 {
-  return percentile_approx(input, percentiles, cudf::default_stream_value, mr);
+  CUDF_FUNC_RANGE();
+  return detail::percentile_approx(input, percentiles, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/reductions/minmax.cu
+++ b/cpp/src/reductions/minmax.cu
@@ -276,6 +276,7 @@ std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
 std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> minmax(
   const column_view& col, rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::minmax(col, cudf::default_stream_value, mr);
 }
 

--- a/cpp/src/reductions/scan/scan.cpp
+++ b/cpp/src/reductions/scan/scan.cpp
@@ -23,6 +23,37 @@
 
 namespace cudf {
 
+namespace detail {
+std::unique_ptr<column> scan(column_view const& input,
+                             std::unique_ptr<scan_aggregation> const& agg,
+                             scan_type inclusive,
+                             null_policy null_handling,
+                             rmm::cuda_stream_view stream,
+                             rmm::mr::device_memory_resource* mr)
+{
+  if (agg->kind == aggregation::RANK) {
+    CUDF_EXPECTS(inclusive == scan_type::INCLUSIVE,
+                 "Rank aggregation operator requires an inclusive scan");
+    auto const& rank_agg = dynamic_cast<cudf::detail::rank_aggregation const&>(*agg);
+    if (rank_agg._method == rank_method::MIN) {
+      if (rank_agg._percentage == rank_percentage::NONE) {
+        return inclusive_rank_scan(input, stream, mr);
+      } else if (rank_agg._percentage == rank_percentage::ONE_NORMALIZED) {
+        return inclusive_one_normalized_percent_rank_scan(input, stream, mr);
+      }
+    } else if (rank_agg._method == rank_method::DENSE) {
+      return inclusive_dense_rank_scan(input, stream, mr);
+    }
+    CUDF_FAIL("Unsupported rank aggregation method for inclusive scan");
+  }
+
+  return inclusive == scan_type::EXCLUSIVE
+           ? detail::scan_exclusive(input, agg, null_handling, stream, mr)
+           : detail::scan_inclusive(input, agg, null_handling, stream, mr);
+}
+
+}  // namespace detail
+
 std::unique_ptr<column> scan(column_view const& input,
                              std::unique_ptr<scan_aggregation> const& agg,
                              scan_type inclusive,
@@ -30,26 +61,7 @@ std::unique_ptr<column> scan(column_view const& input,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-
-  if (agg->kind == aggregation::RANK) {
-    CUDF_EXPECTS(inclusive == scan_type::INCLUSIVE,
-                 "Rank aggregation operator requires an inclusive scan");
-    auto const& rank_agg = dynamic_cast<cudf::detail::rank_aggregation const&>(*agg);
-    if (rank_agg._method == rank_method::MIN) {
-      if (rank_agg._percentage == rank_percentage::NONE) {
-        return inclusive_rank_scan(input, cudf::default_stream_value, mr);
-      } else if (rank_agg._percentage == rank_percentage::ONE_NORMALIZED) {
-        return inclusive_one_normalized_percent_rank_scan(input, cudf::default_stream_value, mr);
-      }
-    } else if (rank_agg._method == rank_method::DENSE) {
-      return inclusive_dense_rank_scan(input, cudf::default_stream_value, mr);
-    }
-    CUDF_FAIL("Unsupported rank aggregation method for inclusive scan");
-  }
-
-  return inclusive == scan_type::EXCLUSIVE
-           ? detail::scan_exclusive(input, agg, null_handling, cudf::default_stream_value, mr)
-           : detail::scan_inclusive(input, agg, null_handling, cudf::default_stream_value, mr);
+  return detail::scan(input, agg, inclusive, null_handling, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -453,7 +453,7 @@ std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::replace_nulls(input, replacement, cudf::default_stream_value, mr);
+  return detail::replace_nulls(input, replacement, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
@@ -461,7 +461,7 @@ std::unique_ptr<cudf::column> replace_nulls(cudf::column_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::replace_nulls(input, replacement, cudf::default_stream_value, mr);
+  return detail::replace_nulls(input, replacement, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<cudf::column> replace_nulls(column_view const& input,
@@ -469,7 +469,7 @@ std::unique_ptr<cudf::column> replace_nulls(column_view const& input,
                                             rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::replace_nulls(input, replace_policy, cudf::default_stream_value, mr);
+  return detail::replace_nulls(input, replace_policy, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/replace/replace.cu
+++ b/cpp/src/replace/replace.cu
@@ -530,7 +530,7 @@ std::unique_ptr<cudf::column> find_and_replace_all(cudf::column_view const& inpu
                                                    cudf::column_view const& replacement_values,
                                                    rmm::mr::device_memory_resource* mr)
 {
-  return cudf::detail::find_and_replace_all(
+  return detail::find_and_replace_all(
     input_col, values_to_replace, replacement_values, cudf::default_stream_value, mr);
 }
 }  // namespace cudf

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -1034,6 +1034,7 @@ std::unique_ptr<column> grouped_time_range_rolling_window(table_view const& grou
                                                           rolling_aggregation const& aggr,
                                                           rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   auto preceding = to_range_bounds(preceding_window_in_days, timestamp_column.type());
   auto following = to_range_bounds(following_window_in_days, timestamp_column.type());
 
@@ -1045,6 +1046,7 @@ std::unique_ptr<column> grouped_time_range_rolling_window(table_view const& grou
                                               following,
                                               min_periods,
                                               aggr,
+                                              cudf::default_stream_value,
                                               mr);
 }
 
@@ -1070,6 +1072,7 @@ std::unique_ptr<column> grouped_time_range_rolling_window(table_view const& grou
                                                           rolling_aggregation const& aggr,
                                                           rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   range_window_bounds preceding =
     to_range_bounds(preceding_window_in_days, timestamp_column.type());
   range_window_bounds following =
@@ -1109,6 +1112,7 @@ std::unique_ptr<column> grouped_range_rolling_window(table_view const& group_key
                                                      rolling_aggregation const& aggr,
                                                      rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::grouped_range_rolling_window(group_keys,
                                               timestamp_column,
                                               timestamp_order,

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -1037,15 +1037,15 @@ std::unique_ptr<column> grouped_time_range_rolling_window(table_view const& grou
   auto preceding = to_range_bounds(preceding_window_in_days, timestamp_column.type());
   auto following = to_range_bounds(following_window_in_days, timestamp_column.type());
 
-  return grouped_range_rolling_window(group_keys,
-                                      timestamp_column,
-                                      timestamp_order,
-                                      input,
-                                      preceding,
-                                      following,
-                                      min_periods,
-                                      aggr,
-                                      mr);
+  return detail::grouped_range_rolling_window(group_keys,
+                                              timestamp_column,
+                                              timestamp_order,
+                                              input,
+                                              preceding,
+                                              following,
+                                              min_periods,
+                                              aggr,
+                                              mr);
 }
 
 /**
@@ -1075,16 +1075,16 @@ std::unique_ptr<column> grouped_time_range_rolling_window(table_view const& grou
   range_window_bounds following =
     to_range_bounds(following_window_in_days, timestamp_column.type());
 
-  return grouped_range_rolling_window(group_keys,
-                                      timestamp_column,
-                                      timestamp_order,
-                                      input,
-                                      preceding,
-                                      following,
-                                      min_periods,
-                                      aggr,
-                                      cudf::default_stream_value,
-                                      mr);
+  return detail::grouped_range_rolling_window(group_keys,
+                                              timestamp_column,
+                                              timestamp_order,
+                                              input,
+                                              preceding,
+                                              following,
+                                              min_periods,
+                                              aggr,
+                                              cudf::default_stream_value,
+                                              mr);
 }
 
 /**

--- a/cpp/src/rolling/rolling.cu
+++ b/cpp/src/rolling/rolling.cu
@@ -17,6 +17,7 @@
 #include "detail/rolling.cuh"
 
 #include <cudf/detail/aggregation/aggregation.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
@@ -33,6 +34,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        rolling_aggregation const& agg,
                                        rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::rolling_window(input,
                                 default_outputs,
                                 preceding_window,
@@ -51,10 +53,17 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        rolling_aggregation const& agg,
                                        rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   auto defaults =
     cudf::is_dictionary(input.type()) ? dictionary_column_view(input).indices() : input;
-  return rolling_window(
-    input, empty_like(defaults)->view(), preceding_window, following_window, min_periods, agg, mr);
+  return detail::rolling_window(input,
+                                empty_like(defaults)->view(),
+                                preceding_window,
+                                following_window,
+                                min_periods,
+                                agg,
+                                cudf::default_stream_value,
+                                mr);
 }
 
 // Applies a variable-size rolling window function to the values in a column.
@@ -65,6 +74,7 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        rolling_aggregation const& agg,
                                        rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::rolling_window(
     input, preceding_window, following_window, min_periods, agg, cudf::default_stream_value, mr);
 }

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -344,7 +344,7 @@ std::unique_ptr<column> round(column_view const& input,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::round(input, decimal_places, method, cudf::default_stream_value, mr);
+  return detail::round(input, decimal_places, method, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/sort/rank.cu
+++ b/cpp/src/sort/rank.cu
@@ -18,6 +18,7 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/sorting.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/table/row_operators.cuh>
@@ -344,6 +345,7 @@ std::unique_ptr<column> rank(column_view const& input,
                              bool percentage,
                              rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::rank(input,
                       method,
                       column_order,

--- a/cpp/src/sort/stable_sort.cu
+++ b/cpp/src/sort/stable_sort.cu
@@ -63,6 +63,7 @@ std::unique_ptr<column> stable_sorted_order(table_view const& input,
                                             std::vector<null_order> const& null_precedence,
                                             rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::stable_sorted_order(
     input, column_order, null_precedence, cudf::default_stream_value, mr);
 }

--- a/cpp/src/stream_compaction/drop_nans.cu
+++ b/cpp/src/stream_compaction/drop_nans.cu
@@ -119,17 +119,17 @@ std::unique_ptr<table> drop_nans(table_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nans(input, keys, keep_threshold, cudf::default_stream_value, mr);
+  return detail::drop_nans(input, keys, keep_threshold, cudf::default_stream_value, mr);
 }
 /*
- * Filters a table to remove nan null elements.
+ * Filters a table to remove nan elements.
  */
 std::unique_ptr<table> drop_nans(table_view const& input,
                                  std::vector<size_type> const& keys,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nans(input, keys, keys.size(), cudf::default_stream_value, mr);
+  return detail::drop_nans(input, keys, keys.size(), cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/stream_compaction/drop_nulls.cu
+++ b/cpp/src/stream_compaction/drop_nulls.cu
@@ -92,7 +92,7 @@ std::unique_ptr<table> drop_nulls(table_view const& input,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nulls(input, keys, keep_threshold, cudf::default_stream_value, mr);
+  return detail::drop_nulls(input, keys, keep_threshold, cudf::default_stream_value, mr);
 }
 /*
  * Filters a table to remove null elements.
@@ -102,7 +102,7 @@ std::unique_ptr<table> drop_nulls(table_view const& input,
                                   rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return cudf::detail::drop_nulls(input, keys, keys.size(), cudf::default_stream_value, mr);
+  return detail::drop_nulls(input, keys, keys.size(), cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/strings/substring.cu
+++ b/cpp/src/strings/substring.cu
@@ -362,6 +362,31 @@ std::unique_ptr<column> slice_strings(strings_column_view const& strings,
     d_column, strings.null_count(), starts_iter, stops_iter, stream, mr);
 }
 
+std::unique_ptr<column> slice_strings(strings_column_view const& strings,
+                                      strings_column_view const& delimiters,
+                                      size_type count,
+                                      rmm::cuda_stream_view stream,
+                                      rmm::mr::device_memory_resource* mr)
+{
+  CUDF_EXPECTS(strings.size() == delimiters.size(),
+               "Strings and delimiters column sizes do not match");
+  auto delimiters_dev_view_ptr = cudf::column_device_view::create(delimiters.parent(), stream);
+  auto delimiters_dev_view     = *delimiters_dev_view_ptr;
+  return (delimiters_dev_view.nullable())
+           ? detail::slice_strings(
+               strings,
+               cudf::detail::make_pair_iterator<string_view, true>(delimiters_dev_view),
+               count,
+               stream,
+               mr)
+           : detail::slice_strings(
+               strings,
+               cudf::detail::make_pair_iterator<string_view, false>(delimiters_dev_view),
+               count,
+               stream,
+               mr);
+}
+
 }  // namespace detail
 
 // external API
@@ -394,26 +419,8 @@ std::unique_ptr<column> slice_strings(strings_column_view const& strings,
                                       size_type count,
                                       rmm::mr::device_memory_resource* mr)
 {
-  CUDF_EXPECTS(strings.size() == delimiters.size(),
-               "Strings and delimiters column sizes do not match");
-
   CUDF_FUNC_RANGE();
-  auto delimiters_dev_view_ptr =
-    cudf::column_device_view::create(delimiters.parent(), cudf::default_stream_value);
-  auto delimiters_dev_view = *delimiters_dev_view_ptr;
-  return (delimiters_dev_view.nullable())
-           ? detail::slice_strings(
-               strings,
-               cudf::detail::make_pair_iterator<string_view, true>(delimiters_dev_view),
-               count,
-               cudf::default_stream_value,
-               mr)
-           : detail::slice_strings(
-               strings,
-               cudf::detail::make_pair_iterator<string_view, false>(delimiters_dev_view),
-               count,
-               cudf::default_stream_value,
-               mr);
+  return detail::slice_strings(strings, delimiters, count, cudf::default_stream_value, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/transform/encode.cu
+++ b/cpp/src/transform/encode.cu
@@ -19,6 +19,7 @@
 #include <cudf/copying.hpp>
 #include <cudf/detail/gather.hpp>
 #include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/search.hpp>
 #include <cudf/detail/sorting.hpp>
 #include <cudf/detail/stream_compaction.hpp>
@@ -71,6 +72,7 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<column>> encode(
 std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::column>> encode(
   cudf::table_view const& input, rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::encode(input, cudf::default_stream_value, mr);
 }
 

--- a/cpp/src/transform/mask_to_bools.cu
+++ b/cpp/src/transform/mask_to_bools.cu
@@ -63,6 +63,7 @@ std::unique_ptr<column> mask_to_bools(bitmask_type const* bitmask,
                                       size_type end_bit,
                                       rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::mask_to_bools(bitmask, begin_bit, end_bit, cudf::default_stream_value, mr);
 }
 }  // namespace cudf

--- a/cpp/src/transform/row_bit_count.cu
+++ b/cpp/src/transform/row_bit_count.cu
@@ -17,6 +17,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/lists/lists_column_view.hpp>
@@ -535,6 +536,7 @@ std::unique_ptr<column> row_bit_count(table_view const& t,
  */
 std::unique_ptr<column> row_bit_count(table_view const& t, rmm::mr::device_memory_resource* mr)
 {
+  CUDF_FUNC_RANGE();
   return detail::row_bit_count(t, cudf::default_stream_value, mr);
 }
 

--- a/cpp/src/unary/null_ops.cu
+++ b/cpp/src/unary/null_ops.cu
@@ -25,9 +25,11 @@
 #include <thrust/iterator/counting_iterator.h>
 
 namespace cudf {
-std::unique_ptr<column> is_null(cudf::column_view const& input, rmm::mr::device_memory_resource* mr)
+namespace detail {
+std::unique_ptr<column> is_null(cudf::column_view const& input,
+                                rmm::cuda_stream_view stream,
+                                rmm::mr::device_memory_resource* mr)
 {
-  CUDF_FUNC_RANGE();
   auto input_device_view = column_device_view::create(input);
   auto device_view       = *input_device_view;
   auto predicate = [device_view] __device__(auto index) { return (device_view.is_null(index)); };
@@ -35,14 +37,14 @@ std::unique_ptr<column> is_null(cudf::column_view const& input, rmm::mr::device_
                          thrust::make_counting_iterator(input.size()),
                          input.size(),
                          predicate,
-                         cudf::default_stream_value,
+                         stream,
                          mr);
 }
 
 std::unique_ptr<column> is_valid(cudf::column_view const& input,
+                                 rmm::cuda_stream_view stream,
                                  rmm::mr::device_memory_resource* mr)
 {
-  CUDF_FUNC_RANGE();
   auto input_device_view = column_device_view::create(input);
   auto device_view       = *input_device_view;
   auto predicate = [device_view] __device__(auto index) { return device_view.is_valid(index); };
@@ -50,8 +52,23 @@ std::unique_ptr<column> is_valid(cudf::column_view const& input,
                          thrust::make_counting_iterator(input.size()),
                          input.size(),
                          predicate,
-                         cudf::default_stream_value,
+                         stream,
                          mr);
+}
+
+}  // namespace detail
+
+std::unique_ptr<column> is_null(cudf::column_view const& input, rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::is_null(input, stream, mr);
+}
+
+std::unique_ptr<column> is_valid(cudf::column_view const& input,
+                                 rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::is_valid(input, stream, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/unary/null_ops.cu
+++ b/cpp/src/unary/null_ops.cu
@@ -61,14 +61,14 @@ std::unique_ptr<column> is_valid(cudf::column_view const& input,
 std::unique_ptr<column> is_null(cudf::column_view const& input, rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_null(input, stream, mr);
+  return detail::is_null(input, cudf::default_stream_value, mr);
 }
 
 std::unique_ptr<column> is_valid(cudf::column_view const& input,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::is_valid(input, stream, mr);
+  return detail::is_valid(input, cudf::default_stream_value, mr);
 }
 
 }  // namespace cudf

--- a/java/src/main/native/src/row_conversion.cu
+++ b/java/src/main/native/src/row_conversion.cu
@@ -1272,7 +1272,7 @@ static std::unique_ptr<column> fixed_width_convert_to_rows(
       input_data.data(), input_nm.data(), data->mutable_view().data<int8_t>());
 
   return make_lists_column(num_rows, std::move(offsets), std::move(data), 0,
-                           rmm::device_buffer{0, cudf::default_stream_value, mr}, stream, mr);
+                           rmm::device_buffer{0, stream, mr}, stream, mr);
 }
 
 static inline bool are_all_fixed_width(std::vector<data_type> const &schema) {

--- a/java/src/main/native/src/row_conversion.cu
+++ b/java/src/main/native/src/row_conversion.cu
@@ -1272,7 +1272,7 @@ static std::unique_ptr<column> fixed_width_convert_to_rows(
       input_data.data(), input_nm.data(), data->mutable_view().data<int8_t>());
 
   return make_lists_column(num_rows, std::move(offsets), std::move(data), 0,
-                           rmm::device_buffer{0, stream, mr}, stream, mr);
+                           rmm::device_buffer{0, cudf::default_stream_value, mr}, stream, mr);
 }
 
 static inline bool are_all_fixed_width(std::vector<data_type> const &schema) {


### PR DESCRIPTION
## Description
This PR is derived from changes I made in #11577 while attempting to consolidate stream handling in public APIs. During that refactoring, I noticed three repeated problems across libcudf APIs that I have addressed in this PR. These refactors will make future work on streams much more straightforward as well as increase consistency and quality in the library.

1. Some APIs were putting too much implementation in a public method. I split these so that the public/detail balance is consistent with the rest of libcudf.
2. A number of public APIs were missing `CUDF_FUNC_RANGE`, making it difficult to recognize those functions in profiles (cc: @GregoryKimball).
3. Stream handling was not consistent, with some functions not using the `stream` they were passed and using `cudf::default_stream_value` instead.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
