### PR TITLE
Use stream in Java API.

### DIFF
--- a/java/src/main/native/src/row_conversion.cu
+++ b/java/src/main/native/src/row_conversion.cu
@@ -1272,7 +1272,7 @@ static std::unique_ptr<column> fixed_width_convert_to_rows(
       input_data.data(), input_nm.data(), data->mutable_view().data<int8_t>());
 
   return make_lists_column(num_rows, std::move(offsets), std::move(data), 0,
-                           rmm::device_buffer{0, cudf::default_stream_value, mr}, stream, mr);
+                           rmm::device_buffer{0, stream, mr}, stream, mr);
 }
 
 static inline bool are_all_fixed_width(std::vector<data_type> const &schema) {


### PR DESCRIPTION
## Description
This fixes an issue where the Java API is using a default stream instead of the stream passed in. This is a small change separated from #11600 because it only touches one Java file and thus only needs a Java reviewer.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
