### PR TITLE
Support NTH_ELEMENT(0) and NTH_ELEMENT(-1) as hash aggregations

### DIFF
--- a/cpp/src/groupby/hash/groupby_kernels.cuh
+++ b/cpp/src/groupby/hash/groupby_kernels.cuh
@@ -82,9 +82,9 @@ struct compute_single_pass_aggs_fn {
    * @param aggs The set of aggregation operations to perform across the
    * columns of the `input_values` rows
    * @param row_bitmask Bitmask where bit `i` indicates the presence of a null
-   * value in row `i` of input keys. Only used if `skip_rows_with_nulls` is `true`
+   * value in row `i` of input keys. Used only if `skip_rows_with_nulls` is `true`
    * @param skip_rows_with_nulls Indicates if rows in `input_keys` containing
-   * null values should be skipped. It `true`, it is assumed `row_bitmask` is a
+   * null values should be skipped. If `true`, it is assumed `row_bitmask` is a
    * bitmask where bit `i` indicates the presence of a null value in row `i`.
    */
   compute_single_pass_aggs_fn(Map map,

--- a/cpp/tests/groupby/groupby_test_util.hpp
+++ b/cpp/tests/groupby/groupby_test_util.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/groupby/groupby_test_util.hpp
+++ b/cpp/tests/groupby/groupby_test_util.hpp
@@ -81,7 +81,7 @@ inline void test_single_agg(column_view const& keys,
 
   if (use_sort == force_use_sort_impl::YES) {
     // WAR to force groupby to use sort implementation
-    requests[0].aggregations.push_back(make_nth_element_aggregation<groupby_aggregation>(0));
+    requests[0].aggregations.push_back(make_nth_element_aggregation<groupby_aggregation>(1));
   }
 
   groupby::groupby gb_obj(


### PR DESCRIPTION
## Description
This change adds special cases for `NTH_ELEMENT(0)` (i.e. `FIRST()`)
and `NTH_ELEMENT(-1)` (i.e. `LAST()`) groupby aggregations to be
computed as hash aggregations, instead of the regular sort-based
groupby.

This change should allow groupby aggregation requests
to avoid sorting the input projection on the groupby keys, if:
  1. All aggregations in the requests are among the hash-supported
     aggregations (E.g. `MIN`, `MAX`, `SUM`, `COUNT`, etc.).
  2. Any `NTH_ELEMENT` aggregations in the requests are specifically
     for `NTH_ELEMENT(0)` or `NTH_ELEMENT(-1)`.

Avoiding sorting should speed up groupby queries that include
these `NTH_ELEMENT` special cases. This will be of specific relevance
for CUDF-dependent systems like Spark-SQL that have first class support for
`FIRST()` and `LAST()` aggregations.

This change does not address `NTH_ELEMENT` for `N ∉ {0, -1}`.
A solution for the generic case is likely more involved, and
left to a later date.

It appears that the extant tests in [`tests/groupby/nth_element_tests.cpp`](https://github.com/rapidsai/cudf/blob/5ee4b3be3de87f9f16943fb0eea1d81c39269c5f/cpp/tests/groupby/nth_element_tests.cpp)
already cover the special cases of `NTH_ELEMENT(0)` and `NTH_ELEMENT(-1)`, 
with and without null exclusion, and with nested types.

Signed-off-by: MithunR <mythrocks@gmail.com>

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
