### PR TITLE
[REVIEW] Change default value of `ordered` to `False` in `CategoricalDtype`

### DIFF
--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -123,7 +123,7 @@ class CategoricalAccessor(ColumnMethods):
         return cudf.Series(self._column.codes, index=index)
 
     @property
-    def ordered(self) -> Optional[bool]:
+    def ordered(self) -> bool:
         """
         Whether the categories have an ordered relationship.
         """
@@ -729,7 +729,7 @@ class CategoricalColumn(column.ColumnBase):
         return cast(cudf.core.column.NumericalColumn, self._codes)
 
     @property
-    def ordered(self) -> Optional[bool]:
+    def ordered(self) -> bool:
         return self.dtype.ordered
 
     @ordered.setter

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1475,7 +1475,7 @@ def build_categorical_column(
     size: int = None,
     offset: int = 0,
     null_count: int = None,
-    ordered: bool = None,
+    ordered: bool = False,
 ) -> "cudf.core.column.CategoricalColumn":
     """
     Build a CategoricalColumn

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1491,7 +1491,7 @@ def build_categorical_column(
         Null mask
     size : int, optional
     offset : int, optional
-    ordered : bool
+    ordered : bool, default False
         Indicates whether the categories are ordered
     """
     codes_dtype = min_unsigned_type(len(categories))

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -139,7 +139,7 @@ class CategoricalDtype(_BaseDtype):
     --------
     >>> import cudf
     >>> dtype = cudf.CategoricalDtype(categories=['b', 'a'], ordered=True)
-    >>> cudf.Series(['a', 'b', 'a', 'c'], dtype=t)
+    >>> cudf.Series(['a', 'b', 'a', 'c'], dtype=dtype)
     0       a
     1       b
     2       a

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -3,7 +3,7 @@
 import decimal
 import operator
 import pickle
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -125,9 +125,9 @@ class CategoricalDtype(_BaseDtype):
     stored on the GPU.
     """
 
-    ordered: Optional[bool]
+    ordered: bool
 
-    def __init__(self, categories=None, ordered: bool = None) -> None:
+    def __init__(self, categories=None, ordered: bool = False) -> None:
         self._categories = self._init_categories(categories)
         self.ordered = ordered
 

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -121,8 +121,31 @@ class _BaseDtype(ExtensionDtype, Serializable):
 
 class CategoricalDtype(_BaseDtype):
     """
-    dtype similar to pd.CategoricalDtype with the categories
-    stored on the GPU.
+    Type for categorical data with the categories and orderedness.
+
+    Parameters
+    ----------
+    categories : sequence, optional
+        Must be unique, and must not contain any nulls.
+        The categories are stored in an Index,
+        and if an index is provided the dtype of that index will be used.
+    ordered : bool or None, default False
+        Whether or not this categorical is treated as a ordered categorical.
+        None can be used to maintain the ordered value of existing categoricals
+        when used in operations that combine categoricals, e.g. astype, and
+        will resolve to False if there is no existing ordered to maintain.
+
+    Examples
+    --------
+    >>> import cudf
+    >>> dtype = cudf.CategoricalDtype(categories=['b', 'a'], ordered=True)
+    >>> cudf.Series(['a', 'b', 'a', 'c'], dtype=t)
+    0       a
+    1       b
+    2       a
+    3    <NA>
+    dtype: category
+    Categories (2, object): ['b' < 'a']
     """
 
     ordered: bool

--- a/python/cudf/cudf/tests/test_categorical.py
+++ b/python/cudf/cudf/tests/test_categorical.py
@@ -685,6 +685,10 @@ def test_categorical_dtype(categories, ordered):
     got = cudf.CategoricalDtype(categories=categories, ordered=ordered)
     assert_eq(expected, got)
 
+    expected = pd.CategoricalDtype(categories=categories)
+    got = cudf.CategoricalDtype(categories=categories)
+    assert_eq(expected, got)
+
 
 @pytest.mark.parametrize(
     ("data", "expected"),

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -279,7 +279,7 @@ def concat_cudf(
     (cudf.DataFrame, cudf.Series, cudf.BaseIndex)
 )
 @_dask_cudf_nvtx_annotate
-def categorical_dtype_cudf(categories=None, ordered=None):
+def categorical_dtype_cudf(categories=None, ordered=False):
     return cudf.CategoricalDtype(categories=categories, ordered=ordered)
 
 


### PR DESCRIPTION
## Description
Fixes: #11487 

This PR switches default value of `ordered` parameter in `CategoricalDtype` to `False`. This fixes some issues around concat and building categorical columns.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
