### PR TITLE
Fix compile warning in nested_json_gpu.cu

### DIFF
--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -967,7 +967,6 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr)
 {
-  constexpr std::size_t single_item_count = 1ULL;
   rmm::device_uvector<PdaTokenT> tokens{json_in.size(), stream, mr};
   rmm::device_uvector<SymbolOffsetT> tokens_indices{json_in.size(), stream, mr};
   rmm::device_scalar<SymbolOffsetT> num_written_tokens{stream, mr};


### PR DESCRIPTION
## Description
Fixes compile warning introduced in #11534 
```
/cudf/cpp/src/io/json/nested_json_gpu.cu(970): warning #177-D: variable "single_item_count" was declared but never referenced
```
Removed unreferenced variable declaration.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
