### PR TITLE
[FIX] Fix incorrect `nullCount` in `get_json_object`

### DIFF
--- a/cpp/src/strings/json/json_path.cu
+++ b/cpp/src/strings/json/json_path.cu
@@ -909,7 +909,6 @@ __launch_bounds__(block_size) __global__
   size_type tid    = threadIdx.x + (blockDim.x * blockIdx.x);
   size_type stride = blockDim.x * gridDim.x;
 
-  if (out_valid_count.has_value()) { *(out_valid_count.value()) = 0; }
   size_type warp_valid_count{0};
 
   auto active_threads = __ballot_sync(0xffff'ffffu, tid < col.size());

--- a/cpp/src/strings/json/json_path.cu
+++ b/cpp/src/strings/json/json_path.cu
@@ -951,12 +951,8 @@ __launch_bounds__(block_size) __global__
   if (out_valid_count) {
     size_type block_valid_count =
       cudf::detail::single_lane_block_sum_reduce<block_size, 0>(warp_valid_count);
-    if (threadIdx.x == 0) {
-      if (out_valid_count.has_value()) { *(out_valid_count.value()) = 0; }
-      atomicAdd(out_valid_count.value(), block_valid_count);
-    }
+    if (threadIdx.x == 0) { atomicAdd(out_valid_count.value(), block_valid_count); }
   }
-
 }
 
 /**

--- a/cpp/src/strings/json/json_path.cu
+++ b/cpp/src/strings/json/json_path.cu
@@ -951,8 +951,12 @@ __launch_bounds__(block_size) __global__
   if (out_valid_count) {
     size_type block_valid_count =
       cudf::detail::single_lane_block_sum_reduce<block_size, 0>(warp_valid_count);
-    if (threadIdx.x == 0) { atomicAdd(out_valid_count.value(), block_valid_count); }
+    if (threadIdx.x == 0) {
+      if (out_valid_count.has_value()) { *(out_valid_count.value()) = 0; }
+      atomicAdd(out_valid_count.value(), block_valid_count);
+    }
   }
+
 }
 
 /**


### PR DESCRIPTION
Fixes an issue where `get_json_object` returns an incorrect null count on large inputs.

The source of the bug is that each thread was resetting `out_valid_count` to zero, then only the threads that execute in the final block contribute to the value of `out_valid_count`.

cc: @thomcom 
