### PR TITLE
[discussion] KvikIO as the default IO backend

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -153,11 +153,11 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
             ${gt} --gtest_output=xml:"$WORKSPACE/test-results/"
         done
 
-        # Test libcudf (csv, orc, and parquet) with `LIBCUDF_CUFILE_POLICY=KVIKIO`
+        # Test libcudf (csv, orc, and parquet) with `LIBCUDF_CUFILE_POLICY=OFF`
         for test_name in "CSV_TEST" "ORC_TEST" "PARQUET_TEST"; do
             gt="$WORKSPACE/cpp/build/gtests/$test_name"
-            echo "Running GoogleTest $test_name (LIBCUDF_CUFILE_POLICY=KVIKIO)"
-            LIBCUDF_CUFILE_POLICY=KVIKIO ${gt} --gtest_output=xml:"$WORKSPACE/test-results/"
+            echo "Running GoogleTest $test_name (LIBCUDF_CUFILE_POLICY=OFF)"
+            LIBCUDF_CUFILE_POLICY=OFF ${gt} --gtest_output=xml:"$WORKSPACE/test-results/"
         done
     fi
 else
@@ -194,11 +194,11 @@ else
         ${gt} --gtest_output=xml:"$WORKSPACE/test-results/"
     done
 
-    # Test libcudf (csv, orc, and parquet) with `LIBCUDF_CUFILE_POLICY=KVIKIO`
+    # Test libcudf (csv, orc, and parquet) with `LIBCUDF_CUFILE_POLICY=OFF`
     for test_name in "CSV_TEST" "ORC_TEST" "PARQUET_TEST"; do
         gt="$CONDA_PREFIX/bin/gtests/libcudf/$test_name"
-        echo "Running GoogleTest $test_name (LIBCUDF_CUFILE_POLICY=KVIKIO)"
-        LIBCUDF_CUFILE_POLICY=KVIKIO ${gt} --gtest_output=xml:"$WORKSPACE/test-results/"
+        echo "Running GoogleTest $test_name (LIBCUDF_CUFILE_POLICY=OFF)"
+        LIBCUDF_CUFILE_POLICY=OFF ${gt} --gtest_output=xml:"$WORKSPACE/test-results/"
     done
 
     export LIB_BUILD_DIR="$WORKSPACE/ci/artifacts/cudf/cpu/libcudf_work/cpp/build"

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -42,7 +42,7 @@ enum class usage_policy : uint8_t { OFF, GDS, ALWAYS, KVIKIO };
  */
 usage_policy get_env_policy()
 {
-  static auto const env_val = getenv_or<std::string>("LIBCUDF_CUFILE_POLICY", "GDS");
+  static auto const env_val = getenv_or<std::string>("LIBCUDF_CUFILE_POLICY", "KVIKIO");
   if (env_val == "OFF") return usage_policy::OFF;
   if (env_val == "GDS") return usage_policy::GDS;
   if (env_val == "ALWAYS") return usage_policy::ALWAYS;


### PR DESCRIPTION
I would like to discuss the process of unifying all of disk IO in cuDF. I think KvikIO is getting to a good state where it makes sense to make it the default backend. 

#### Performance 
The performance of KvikIO is on par with the existing GDS backend when cuFile is available and significantly faster when cuFile is not available when running the `PARQUET_READER_BENCH` (see https://gist.github.com/madsbk/3f4ab00d9b4ae01e19b0ef4d959d3a3a).

#### Benefits 
 - Sharing IO code and optimizations between RAPIDS projects.  
- If we make KvikIO default in `v22.10`, we can remove all the other IO backends in `v22.12`, which will simplify the code significantly. Currently, we have a lot of duplicate code for both cuFile usages and manually disk-to-host-to-gpu implementations such as [this](https://github.com/rapidsai/cudf/blob/branch-22.10/cpp/src/io/parquet/writer_impl.cu#L1737-L1748). 
- No changes to dependencies, cuDF already depends on KvikIO. Furthermore, KvikIO builds and works on systems without cuFile and only requires `libcuda.so`. 

---

Any thoughts?  

 