### PR TITLE
Update to mypy 0.971

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         rev: 'v0.971'
         hooks:
               - id: mypy
-                additional_dependencies: [types-cachetools==5.2.1]
+                additional_dependencies: [types-cachetools]
                 args: ["--config-file=setup.cfg",
                        "python/cudf/cudf",
                        "python/custreamz/custreamz",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,10 +26,10 @@ repos:
                 files: python/.*\.(py|pyx|pxd)$
                 types: [file]
       - repo: https://github.com/pre-commit/mirrors-mypy
-        rev: 'v0.782'
+        rev: 'v0.971'
         hooks:
               - id: mypy
-                args: ["--config-file=setup.cfg", "python/cudf/cudf", "python/dask_cudf/dask_cudf", "python/custreamz/custreamz", "python/cudf_kafka/cudf_kafka"]
+                args: ["--config-file=setup.cfg", "--explicit-package-bases", "--namespace-packages", "python/cudf/cudf", "python/dask_cudf/dask_cudf", "python/custreamz/custreamz", "python/cudf_kafka/cudf_kafka"]
                 pass_filenames: false
       - repo: https://github.com/PyCQA/pydocstyle
         rev: 6.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,17 @@ repos:
         hooks:
               - id: mypy
                 additional_dependencies: [types-cachetools==5.2.1]
-                args: ["--config-file=setup.cfg", "--explicit-package-bases", "--namespace-packages", "python/cudf/cudf", "python/dask_cudf/dask_cudf", "python/custreamz/custreamz", "python/cudf_kafka/cudf_kafka"]
+                args: ["--config-file=setup.cfg",
+                       "--exclude", "python/cudf/benchmarks",
+                       "--exclude", "python/cudf/cudf/tests",
+                       "--exclude", "python/dask_cudf/dask_cudf/tests",
+                       "--exclude", "python/custreamz/custreamz/tests",
+                       "--exclude", "python/cudf_kafka/cudf_kafka/tests",
+                       "--exclude", "python/cudf/cudf/_lib",
+                       "python/cudf/cudf",
+                       "python/dask_cudf/dask_cudf",
+                       "python/custreamz/custreamz",
+                       "python/cudf_kafka/cudf_kafka"]
                 pass_filenames: false
       - repo: https://github.com/PyCQA/pydocstyle
         rev: 6.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
         rev: 'v0.971'
         hooks:
               - id: mypy
+                additional_dependencies: [types-cachetools==5.2.1]
                 args: ["--config-file=setup.cfg", "--explicit-package-bases", "--namespace-packages", "python/cudf/cudf", "python/dask_cudf/dask_cudf", "python/custreamz/custreamz", "python/cudf_kafka/cudf_kafka"]
                 pass_filenames: false
       - repo: https://github.com/PyCQA/pydocstyle

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,16 +31,10 @@ repos:
               - id: mypy
                 additional_dependencies: [types-cachetools==5.2.1]
                 args: ["--config-file=setup.cfg",
-                       "--exclude", "python/cudf/benchmarks",
-                       "--exclude", "python/cudf/cudf/tests",
-                       "--exclude", "python/dask_cudf/dask_cudf/tests",
-                       "--exclude", "python/custreamz/custreamz/tests",
-                       "--exclude", "python/cudf_kafka/cudf_kafka/tests",
-                       "--exclude", "python/cudf/cudf/_lib",
                        "python/cudf/cudf",
-                       "python/dask_cudf/dask_cudf",
                        "python/custreamz/custreamz",
-                       "python/cudf_kafka/cudf_kafka"]
+                       "python/cudf_kafka/cudf_kafka",
+                       "python/dask_cudf/dask_cudf"]
                 pass_filenames: false
       - repo: https://github.com/PyCQA/pydocstyle
         rev: 6.1.1

--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -43,7 +43,8 @@ dependencies:
   - flake8=3.8.3
   - black=22.3.0
   - isort=5.10.1
-  - mypy=0.782
+  - mypy=0.971
+  - types-cachetools==5.2.1
   - doxygen=1.8.20
   - pydocstyle=6.1.1
   - typing_extensions

--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -44,7 +44,7 @@ dependencies:
   - black=22.3.0
   - isort=5.10.1
   - mypy=0.971
-  - types-cachetools==5.2.1
+  - types-cachetools
   - doxygen=1.8.20
   - pydocstyle=6.1.1
   - typing_extensions

--- a/python/cudf/cudf/_typing.py
+++ b/python/cudf/cudf/_typing.py
@@ -10,7 +10,7 @@ from pandas.api.extensions import ExtensionDtype
 if TYPE_CHECKING:
     import cudf
 
-# Backwards compat: mypy > 0.780 rejects Type[NotImplemented], but
+# Backwards compat: mypy >= 0.790 rejects Type[NotImplemented], but
 # NotImplementedType is only introduced in 3.10
 if sys.version_info >= (3, 10):
     from types import NotImplementedType

--- a/python/cudf/cudf/_typing.py
+++ b/python/cudf/cudf/_typing.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021-2022, NVIDIA CORPORATION.
 
+import sys
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, TypeVar, Union
 
 import numpy as np
@@ -8,6 +9,13 @@ from pandas.api.extensions import ExtensionDtype
 
 if TYPE_CHECKING:
     import cudf
+
+# Backwards compat: mypy > 0.780 rejects Type[NotImplemented], but
+# NotImplementedType is only introduced in 3.10
+if sys.version_info >= (3, 10):
+    from types import NotImplementedType
+else:
+    NotImplementedType = Any
 
 # Many of these are from
 # https://github.com/pandas-dev/pandas/blob/master/pandas/_typing.py

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -3650,7 +3650,12 @@ class StringMethods(ColumnMethods):
         4    False
         dtype: bool
         """
-        return self._return_or_inplace((self._column == "").fillna(False))
+        return self._return_or_inplace(
+            # mypy can't deduce that the return value of
+            # StringColumn.__eq__ is ColumnBase because the binops are
+            # dynamically added by a mixin class
+            (self._column == "").fillna(False)  # type: ignore
+        )
 
     def isspace(self) -> SeriesOrIndex:
         r"""

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -34,6 +34,7 @@ from cudf.api.types import (
 )
 from cudf.core.buffer import DeviceBufferLike
 from cudf.core.column import column, datetime
+from cudf.core.column.column import ColumnBase
 from cudf.core.column.methods import ColumnMethods
 from cudf.utils.docutils import copy_docstring
 from cudf.utils.dtypes import can_convert_to_column
@@ -3654,7 +3655,7 @@ class StringMethods(ColumnMethods):
             # mypy can't deduce that the return value of
             # StringColumn.__eq__ is ColumnBase because the binops are
             # dynamically added by a mixin class
-            (self._column == "").fillna(False)  # type: ignore
+            cast(ColumnBase, self._column == "").fillna(False)
         )
 
     def isspace(self) -> SeriesOrIndex:

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -103,10 +103,12 @@ from cudf.utils.utils import (
     _external_only_api,
 )
 
-if sys.version_info < (3, 10):
-    NotImplementedType = Any
-else:
+if sys.version_info >= (3, 10):
+    # Introduced in Python 3.10
     from types import NotImplementedType
+else:
+    NotImplementedType = Any
+
 
 T = TypeVar("T", bound="DataFrame")
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -12,6 +12,7 @@ import sys
 import textwrap
 import warnings
 from collections import abc, defaultdict
+from types import NotImplementedType
 from typing import (
     Any,
     Callable,
@@ -21,7 +22,6 @@ from typing import (
     Optional,
     Set,
     Tuple,
-    Type,
     TypeVar,
     Union,
 )
@@ -1934,7 +1934,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
     ) -> Tuple[
         Union[
             Dict[Optional[str], Tuple[ColumnBase, Any, bool, Any]],
-            Type[NotImplemented],
+            NotImplementedType,
         ],
         Optional[BaseIndex],
     ]:

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -39,7 +39,7 @@ from pandas.io.formats.printing import pprint_thing
 import cudf
 import cudf.core.common
 from cudf import _lib as libcudf
-from cudf._typing import ColumnLike
+from cudf._typing import ColumnLike, NotImplementedType
 from cudf.api.types import (
     _is_scalar_or_zero_d_array,
     is_bool_dtype,
@@ -102,13 +102,6 @@ from cudf.utils.utils import (
     _cudf_nvtx_annotate,
     _external_only_api,
 )
-
-if sys.version_info >= (3, 10):
-    # Introduced in Python 3.10
-    from types import NotImplementedType
-else:
-    NotImplementedType = Any
-
 
 T = TypeVar("T", bound="DataFrame")
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -12,7 +12,6 @@ import sys
 import textwrap
 import warnings
 from collections import abc, defaultdict
-from types import NotImplementedType
 from typing import (
     Any,
     Callable,
@@ -103,6 +102,11 @@ from cudf.utils.utils import (
     _cudf_nvtx_annotate,
     _external_only_api,
 )
+
+if sys.version_info < (3, 10):
+    NotImplementedType = Any
+else:
+    from types import NotImplementedType
 
 T = TypeVar("T", bound="DataFrame")
 

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -231,7 +231,7 @@ class RangeIndex(BaseIndex, BinaryOperand):
     def _num_rows(self):
         return len(self)
 
-    @cached_property
+    @cached_property  # type: ignore
     @_cudf_nvtx_annotate
     def _values(self):
         if len(self) > 0:

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -9,6 +9,7 @@ import textwrap
 import warnings
 from collections import Counter, abc
 from functools import cached_property
+from types import NotImplementedType
 from typing import (
     Any,
     Callable,
@@ -2991,7 +2992,7 @@ class IndexedFrame(Frame):
     ) -> Tuple[
         Union[
             Dict[Optional[str], Tuple[ColumnBase, Any, bool, Any]],
-            Type[NotImplemented],
+            NotImplementedType,
         ],
         Optional[cudf.BaseIndex],
     ]:

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 
 import numbers
 import operator
+import sys
 import textwrap
 import warnings
 from collections import Counter, abc
 from functools import cached_property
-from types import NotImplementedType
 from typing import (
     Any,
     Callable,
@@ -55,6 +55,13 @@ from cudf.core.resample import _Resampler
 from cudf.core.udf.utils import _compile_or_get, _supported_cols_from_frame
 from cudf.utils import docutils
 from cudf.utils.utils import _cudf_nvtx_annotate
+
+if sys.version_info >= (3, 10):
+    # Introduced in Python 3.10
+    from types import NotImplementedType
+else:
+    NotImplementedType = Any
+
 
 doc_reset_index_template = """
         Reset the index of the {klass}, or a level of it.

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import numbers
 import operator
-import sys
 import textwrap
 import warnings
 from collections import Counter, abc
@@ -31,7 +30,7 @@ import pandas as pd
 
 import cudf
 import cudf._lib as libcudf
-from cudf._typing import ColumnLike, DataFrameOrSeries
+from cudf._typing import ColumnLike, DataFrameOrSeries, NotImplementedType
 from cudf.api.types import (
     _is_non_decimal_numeric_dtype,
     is_bool_dtype,
@@ -55,13 +54,6 @@ from cudf.core.resample import _Resampler
 from cudf.core.udf.utils import _compile_or_get, _supported_cols_from_frame
 from cudf.utils import docutils
 from cudf.utils.utils import _cudf_nvtx_annotate
-
-if sys.version_info >= (3, 10):
-    # Introduced in Python 3.10
-    from types import NotImplementedType
-else:
-    NotImplementedType = Any
-
 
 doc_reset_index_template = """
         Reset the index of the {klass}, or a level of it.

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1458,7 +1458,7 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
         )
         return cls.from_frame(df, names=multiindex.names)
 
-    @cached_property
+    @cached_property  # type: ignore
     @_cudf_nvtx_annotate
     def is_unique(self):
         return len(self) == len(self.unique())

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import functools
 import inspect
 import pickle
-import sys
 import textwrap
 from collections import abc
 from shutil import get_terminal_size
@@ -20,7 +19,12 @@ from pandas.core.dtypes.common import is_float
 import cudf
 from cudf import _lib as libcudf
 from cudf._lib.scalar import _is_null_host_scalar
-from cudf._typing import ColumnLike, DataFrameOrSeries, ScalarLike
+from cudf._typing import (
+    ColumnLike,
+    DataFrameOrSeries,
+    NotImplementedType,
+    ScalarLike,
+)
 from cudf.api.types import (
     _is_non_decimal_numeric_dtype,
     _is_scalar_or_zero_d_array,
@@ -74,12 +78,6 @@ from cudf.utils.dtypes import (
     to_cudf_compatible_scalar,
 )
 from cudf.utils.utils import _cudf_nvtx_annotate
-
-if sys.version_info >= (3, 10):
-    # Introduced in Python 3.10
-    from types import NotImplementedType
-else:
-    NotImplementedType = Any
 
 
 def _format_percentile_names(percentiles):

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import functools
 import inspect
 import pickle
+import sys
 import textwrap
 from collections import abc
 from shutil import get_terminal_size
-from types import NotImplementedType
 from typing import Any, Dict, MutableMapping, Optional, Set, Tuple, Union
 
 import cupy
@@ -74,6 +74,12 @@ from cudf.utils.dtypes import (
     to_cudf_compatible_scalar,
 )
 from cudf.utils.utils import _cudf_nvtx_annotate
+
+if sys.version_info >= (3, 10):
+    # Introduced in Python 3.10
+    from types import NotImplementedType
+else:
+    NotImplementedType = Any
 
 
 def _format_percentile_names(percentiles):

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -8,7 +8,8 @@ import pickle
 import textwrap
 from collections import abc
 from shutil import get_terminal_size
-from typing import Any, Dict, MutableMapping, Optional, Set, Tuple, Type, Union
+from types import NotImplementedType
+from typing import Any, Dict, MutableMapping, Optional, Set, Tuple, Union
 
 import cupy
 import numpy as np
@@ -1289,7 +1290,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
     ) -> Tuple[
         Union[
             Dict[Optional[str], Tuple[ColumnBase, Any, bool, Any]],
-            Type[NotImplemented],
+            NotImplementedType,
         ],
         Optional[BaseIndex],
     ]:

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -22,10 +22,11 @@ from cudf.core.column import ColumnBase, as_column
 from cudf.core.frame import Frame
 from cudf.utils.utils import NotIterable, _cudf_nvtx_annotate
 
-if sys.version_info < (3, 10):
-    NotImplementedType = Any
-else:
+if sys.version_info >= (3, 10):
+    # Introduced in Python 3.10
     from types import NotImplementedType
+else:
+    NotImplementedType = Any
 
 
 T = TypeVar("T", bound="Frame")

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Dict, Optional, Tuple, Type, TypeVar, Union
+from types import NotImplementedType
+from typing import Any, Dict, Optional, Tuple, TypeVar, Union
 
 import cupy
 import numpy as np
@@ -302,7 +303,7 @@ class SingleColumnFrame(Frame, NotIterable):
         **kwargs,
     ) -> Union[
         Dict[Optional[str], Tuple[ColumnBase, Any, bool, Any]],
-        Type[NotImplemented],
+        NotImplementedType,
     ]:
         """Generate the dictionary of operands used for a binary operation.
 

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import sys
 import warnings
 from typing import Any, Dict, Optional, Tuple, TypeVar, Union
 
@@ -12,7 +11,7 @@ import numpy as np
 import pandas as pd
 
 import cudf
-from cudf._typing import Dtype, ScalarLike
+from cudf._typing import Dtype, NotImplementedType, ScalarLike
 from cudf.api.types import (
     _is_scalar_or_zero_d_array,
     is_bool_dtype,
@@ -21,13 +20,6 @@ from cudf.api.types import (
 from cudf.core.column import ColumnBase, as_column
 from cudf.core.frame import Frame
 from cudf.utils.utils import NotIterable, _cudf_nvtx_annotate
-
-if sys.version_info >= (3, 10):
-    # Introduced in Python 3.10
-    from types import NotImplementedType
-else:
-    NotImplementedType = Any
-
 
 T = TypeVar("T", bound="Frame")
 

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
+import sys
 import warnings
-from types import NotImplementedType
 from typing import Any, Dict, Optional, Tuple, TypeVar, Union
 
 import cupy
@@ -21,6 +21,12 @@ from cudf.api.types import (
 from cudf.core.column import ColumnBase, as_column
 from cudf.core.frame import Frame
 from cudf.utils.utils import NotIterable, _cudf_nvtx_annotate
+
+if sys.version_info < (3, 10):
+    NotImplementedType = Any
+else:
+    from types import NotImplementedType
+
 
 T = TypeVar("T", bound="Frame")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,18 +37,15 @@ select =
 
 [mypy]
 ignore_missing_imports = True
-
-[mypy-cudf._version]
-ignore_errors = True
-
-[mypy-cudf.utils.metadata.orc_column_statistics_pb2]
-ignore_errors = True
-
-[mypy-dask_cudf._version]
-ignore_errors = True
-
-[mypy-custreamz._version]
-ignore_errors = True
-
-[mypy-cudf_kafka._version]
-ignore_errors = True
+# If we don't specify this, then mypy will check excluded files if
+# they are imported by an checked file.
+follow_imports = skip
+exclude = (?x)(
+  (cudf|custreamz|cudf_kafka|dask_cudf)/_version\.py
+  | cudf/_lib/
+  | cudf/cudf/benchmarks/
+  | cudf/cudf/tests/
+  | custreamz/custreamz/tests/
+  | dask_cudf/dask_cudf/tests/
+  # This close paren cannot be in column zero otherwise the config parser barfs
+ )

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ select =
 [mypy]
 ignore_missing_imports = True
 # If we don't specify this, then mypy will check excluded files if
-# they are imported by an checked file.
+# they are imported by a checked file.
 follow_imports = skip
 exclude = (?x)(
   (cudf|custreamz|cudf_kafka|dask_cudf)/_version\.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,35 +37,18 @@ select =
 
 [mypy]
 ignore_missing_imports = True
-# We set --explicit-package-bases --namespace-packages in pre-commit
-# which means that mypy thinks the packages are called python.foo.foo
-# hence the leading wildcard
-[mypy-*.cudf._lib.*]
+
+[mypy-cudf._version]
 ignore_errors = True
 
-[mypy-*.cudf._version]
+[mypy-cudf.utils.metadata.orc_column_statistics_pb2]
 ignore_errors = True
 
-[mypy-*.cudf.utils.metadata.orc_column_statistics_pb2]
+[mypy-dask_cudf._version]
 ignore_errors = True
 
-[mypy-*.cudf.tests.*]
+[mypy-custreamz._version]
 ignore_errors = True
 
-[mypy-*.dask_cudf._version]
-ignore_errors = True
-
-[mypy-*.dask_cudf.tests.*]
-ignore_errors = True
-
-[mypy-*.custreamz._version]
-ignore_errors = True
-
-[mypy-*.custreamz.tests.*]
-ignore_errors = True
-
-[mypy-*.cudf_kafka._version]
-ignore_errors = True
-
-[mypy-*.cudf_kafka.tests.*]
+[mypy-cudf_kafka._version]
 ignore_errors = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,33 +37,35 @@ select =
 
 [mypy]
 ignore_missing_imports = True
-
-[mypy-cudf._lib.*]
+# We set --explicit-package-bases --namespace-packages in pre-commit
+# which means that mypy thinks the packages are called python.foo.foo
+# hence the leading wildcard
+[mypy-*.cudf._lib.*]
 ignore_errors = True
 
-[mypy-cudf._version]
+[mypy-*.cudf._version]
 ignore_errors = True
 
-[mypy-cudf.utils.metadata.orc_column_statistics_pb2]
+[mypy-*.cudf.utils.metadata.orc_column_statistics_pb2]
 ignore_errors = True
 
-[mypy-cudf.tests.*]
+[mypy-*.cudf.tests.*]
 ignore_errors = True
 
-[mypy-dask_cudf._version]
+[mypy-*.dask_cudf._version]
 ignore_errors = True
 
-[mypy-dask_cudf.tests.*]
+[mypy-*.dask_cudf.tests.*]
 ignore_errors = True
 
-[mypy-custreamz._version]
+[mypy-*.custreamz._version]
 ignore_errors = True
 
-[mypy-custreamz.tests.*]
+[mypy-*.custreamz.tests.*]
 ignore_errors = True
 
-[mypy-cudf_kafka._version]
+[mypy-*.cudf_kafka._version]
 ignore_errors = True
 
-[mypy-cudf_kafka.tests.*]
+[mypy-*.cudf_kafka.tests.*]
 ignore_errors = True


### PR DESCRIPTION
## Description

Update to current mypy, primarily since on Apple silicon, the previous pinned version of mypy is no longer installable (`typed-ast` does not build from source). This necessitates some minor updates to the type annotation rules, since the newer mypy version is a bit pickier.

While we're here, exclude directories we were previously just ignoring errors in.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
