### PR TITLE
Fix some libcudf detail calls not passing the stream variable

### DIFF
--- a/cpp/include/cudf/detail/copy_if_else.cuh
+++ b/cpp/include/cudf/detail/copy_if_else.cuh
@@ -166,7 +166,7 @@ std::unique_ptr<column> copy_if_else(
   std::unique_ptr<column> out = make_fixed_width_column(
     output_type, size, nullable ? mask_state::UNINITIALIZED : mask_state::UNALLOCATED, stream, mr);
 
-  auto out_v = mutable_column_device_view::create(*out);
+  auto out_v = mutable_column_device_view::create(*out, stream);
 
   // if we have validity in the output
   if (nullable) {

--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -42,7 +42,7 @@ bool has_nonempty_null_rows(cudf::column_view const& input, rmm::cuda_stream_vie
   auto const type         = input.type().id();
   auto const offsets      = (type == type_id::STRING) ? (strings_column_view{input}).offsets()
                                                       : (lists_column_view{input}).offsets();
-  auto const d_input      = cudf::column_device_view::create(input);
+  auto const d_input      = cudf::column_device_view::create(input, stream);
   auto const is_dirty_row = [d_input = *d_input, offsets = offsets.begin<size_type>()] __device__(
                               size_type const& row_idx) {
     return d_input.is_null_nocheck(row_idx) && (offsets[row_idx] != offsets[row_idx + 1]);

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -181,7 +181,7 @@ std::unique_ptr<column> group_merge_m2(column_view const& values,
   auto [null_mask, null_count] =
     cudf::detail::valid_if(validities.begin(), validities.end(), thrust::identity{}, stream, mr);
   if (null_count > 0) {
-    result_means->set_null_mask(null_mask, null_count);           // copy null_mask
+    result_means->set_null_mask(null_mask, null_count, stream);   // copy null_mask
     result_M2s->set_null_mask(std::move(null_mask), null_count);  // take over null_mask
   }
 

--- a/cpp/src/unary/null_ops.cu
+++ b/cpp/src/unary/null_ops.cu
@@ -15,12 +15,9 @@
  */
 
 #include <cudf/column/column_device_view.cuh>
-#include <cudf/column/column_factories.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/unary.hpp>
-#include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
-#include <cudf/utilities/type_dispatcher.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 
@@ -30,7 +27,7 @@ std::unique_ptr<column> is_null(cudf::column_view const& input,
                                 rmm::cuda_stream_view stream,
                                 rmm::mr::device_memory_resource* mr)
 {
-  auto input_device_view = column_device_view::create(input);
+  auto input_device_view = column_device_view::create(input, stream);
   auto device_view       = *input_device_view;
   auto predicate = [device_view] __device__(auto index) { return (device_view.is_null(index)); };
   return detail::true_if(thrust::make_counting_iterator(0),
@@ -45,7 +42,7 @@ std::unique_ptr<column> is_valid(cudf::column_view const& input,
                                  rmm::cuda_stream_view stream,
                                  rmm::mr::device_memory_resource* mr)
 {
-  auto input_device_view = column_device_view::create(input);
+  auto input_device_view = column_device_view::create(input, stream);
   auto device_view       = *input_device_view;
   auto predicate = [device_view] __device__(auto index) { return device_view.is_valid(index); };
   return detail::true_if(thrust::make_counting_iterator(0),


### PR DESCRIPTION
## Description
Fixes some calls that were not passing the stream variable to detail functions.
Found these while looking into improvements for #11577 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
