### PR TITLE
Fix regex negated classes to not automatically include new-lines

### DIFF
--- a/cpp/src/strings/regex/regcomp.cpp
+++ b/cpp/src/strings/regex/regcomp.cpp
@@ -298,9 +298,6 @@ class regex_parser {
     if (!is_quoted && chr == '^') {
       type                     = NCCLASS;
       std::tie(is_quoted, chr) = next_char();
-      // negated classes also don't match '\n'
-      literals.push_back('\n');
-      literals.push_back('\n');
     }
 
     // parse class into a set of spans

--- a/cpp/tests/strings/contains_tests.cpp
+++ b/cpp/tests/strings/contains_tests.cpp
@@ -460,6 +460,23 @@ TEST_F(StringsContainsTests, OverlappedClasses)
   }
 }
 
+TEST_F(StringsContainsTests, NegatedClasses)
+{
+  auto input = cudf::test::strings_column_wrapper({"abcdefg", "def\tghí", "", "éeé\néeé", "ABC"});
+  auto sv    = cudf::strings_column_view(input);
+
+  {
+    auto results = cudf::strings::count_re(sv, "[^a-f]");
+    cudf::test::fixed_width_column_wrapper<int32_t> expected({1, 4, 0, 5, 3});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+  {
+    auto results = cudf::strings::count_re(sv, "[^a-eá-é]");
+    cudf::test::fixed_width_column_wrapper<int32_t> expected({2, 5, 0, 1, 3});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+  }
+}
+
 TEST_F(StringsContainsTests, IncompleteClassesRange)
 {
   auto input = cudf::test::strings_column_wrapper({"abc-def", "---", "", "ghijkl", "-wxyz-"});


### PR DESCRIPTION
## Description
Fixes the regex negated class NCCLASS builder to not automatically include the new-line character in the negated range.
This logic is from the original plan9 source but does not appear to be honored by any other known regex implementation.
Marking this as a breaking change since it changes the existing behavior in case someone is depending on the current logic.
Also added a new gtest to include `\n` data when matching with a negated class.

Closes #11643 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
