### PR TITLE
Support DECIMAL order-by for RANGE window functions

### DIFF
--- a/cpp/src/rolling/detail/range_window_bounds.hpp
+++ b/cpp/src/rolling/detail/range_window_bounds.hpp
@@ -87,8 +87,6 @@ using range_type = typename range_type_impl<ColumnType>::type;
 template <typename ColumnType>
 using range_rep_type = typename range_type_impl<ColumnType>::rep_type;
 
-namespace {
-
 template <typename T>
 void assert_non_negative([[maybe_unused]] T const& value)
 {
@@ -136,7 +134,6 @@ RepT range_comparable_value_impl(scalar const& range_scalar,
   assert_non_negative(value);
   return value;
 }
-}  // namespace
 
 /**
  * @brief Fetch the value of the range_window_bounds scalar, for comparisons

--- a/cpp/src/rolling/detail/range_window_bounds.hpp
+++ b/cpp/src/rolling/detail/range_window_bounds.hpp
@@ -53,7 +53,7 @@ constexpr bool is_supported_order_by_column_type()
 ///      after scaling the rep value to the same scale as the order by column:
 ///      a. For decimal32, the range-type is `int32_t`.
 ///      b. For decimal64, the range-type is `int64_t`.
-///      a. For decimal128, the range-type is `__int128_t`.
+///      c. For decimal128, the range-type is `__int128_t`.
 template <typename ColumnType, typename = void>
 struct range_type_impl {
   using type     = void;

--- a/cpp/src/rolling/detail/range_window_bounds.hpp
+++ b/cpp/src/rolling/detail/range_window_bounds.hpp
@@ -28,7 +28,7 @@ namespace detail {
 template <typename RangeType>
 constexpr bool is_supported_range_type()
 {
-  return cudf::is_duration<RangeType>() ||
+  return cudf::is_duration<RangeType>() || cudf::is_fixed_point<RangeType>() ||
          (std::is_integral_v<RangeType> && !cudf::is_boolean<RangeType>());
 }
 
@@ -37,7 +37,7 @@ constexpr bool is_supported_range_type()
 template <typename ColumnType>
 constexpr bool is_supported_order_by_column_type()
 {
-  return cudf::is_timestamp<ColumnType>() ||
+  return cudf::is_timestamp<ColumnType>() || cudf::is_fixed_point<ColumnType>() ||
          (std::is_integral_v<ColumnType> && !cudf::is_boolean<ColumnType>());
 }
 
@@ -49,6 +49,10 @@ constexpr bool is_supported_order_by_column_type()
 ///      a. For `TIMESTAMP_DAYS`, the range-type is `DURATION_DAYS`.
 ///         Comparisons are done in `int32_t`.
 ///      b. For all other timestamp types, comparisons are done in `int64_t`.
+///   3. For decimal types, all comparisons are done with the rep type:
+///      a. For decimal32, the range-type is `int32_t`.
+///      b. For decimal64, the range-type is `int64_t`.
+///      a. For decimal128, the range-type is `__int128_t`.
 template <typename ColumnType, typename = void>
 struct range_type_impl {
   using type     = void;
@@ -69,6 +73,13 @@ struct range_type_impl<TimestampType, std::enable_if_t<cudf::is_timestamp<Timest
   using rep_type = typename type::rep;
 };
 
+template <typename FixedPointType>
+struct range_type_impl<FixedPointType,
+                       std::enable_if_t<cudf::is_fixed_point<FixedPointType>(), void>> {
+  using type     = FixedPointType;
+  using rep_type = typename type::rep;
+};
+
 template <typename ColumnType>
 using range_type = typename range_type_impl<ColumnType>::type;
 
@@ -78,19 +89,19 @@ using range_rep_type = typename range_type_impl<ColumnType>::rep_type;
 namespace {
 
 template <typename T>
-void assert_non_negative(T const& value)
+void assert_non_negative([[maybe_unused]] T const& value)
 {
-  (void)value;
   if constexpr (std::numeric_limits<T>::is_signed) {
     CUDF_EXPECTS(value >= T{0}, "Range scalar must be >= 0.");
   }
 }
 
-template <
-  typename RangeT,
-  typename RepT,
-  std::enable_if_t<std::is_integral_v<RangeT> && !cudf::is_boolean<RangeT>(), void>* = nullptr>
-RepT range_comparable_value_impl(scalar const& range_scalar, rmm::cuda_stream_view stream)
+template <typename RangeT,
+          typename RepT,
+          CUDF_ENABLE_IF(std::is_integral_v<RangeT> && !cudf::is_boolean<RangeT>())>
+RepT range_comparable_value_impl(scalar const& range_scalar,
+                                 data_type const&,
+                                 rmm::cuda_stream_view stream)
 {
   auto val = static_cast<numeric_scalar<RangeT> const&>(range_scalar).value(stream);
   assert_non_negative(val);
@@ -100,13 +111,29 @@ RepT range_comparable_value_impl(scalar const& range_scalar, rmm::cuda_stream_vi
 template <typename RangeT,
           typename RepT,
           std::enable_if_t<cudf::is_duration<RangeT>(), void>* = nullptr>
-RepT range_comparable_value_impl(scalar const& range_scalar, rmm::cuda_stream_view stream)
+RepT range_comparable_value_impl(scalar const& range_scalar,
+                                 data_type const&,
+                                 rmm::cuda_stream_view stream)
 {
   auto val = static_cast<duration_scalar<RangeT> const&>(range_scalar).value(stream).count();
   assert_non_negative(val);
   return val;
 }
 
+template <typename RangeT, typename RepT, CUDF_ENABLE_IF(cudf::is_fixed_point<RangeT>())>
+RepT range_comparable_value_impl(scalar const& range_scalar,
+                                 data_type const& order_by_data_type,
+                                 rmm::cuda_stream_view stream)
+{
+  CUDF_EXPECTS(range_scalar.type().scale() >= order_by_data_type.scale(),
+               "Range bounds scalar must match/exceed the scale of the orderby column.");
+  auto const fixed_point_value =
+    static_cast<fixed_point_scalar<RangeT> const&>(range_scalar).fixed_point_value(stream);
+  auto const value =
+    fixed_point_value.rescaled(numeric::scale_type{order_by_data_type.scale()}).value();
+  assert_non_negative(value);
+  return value;
+}
 }  // namespace
 
 /**
@@ -115,22 +142,25 @@ RepT range_comparable_value_impl(scalar const& range_scalar, rmm::cuda_stream_vi
  *
  * @tparam OrderByType The type of the orderby column with which the range value will be compared
  * @param range_bounds The range_window_bounds whose value is to be read
+ * @param order_by_data_type The data type for the order-by column
  * @param stream The CUDA stream for device memory operations
  * @return RepType Value of the range scalar
  */
 template <typename OrderByType>
 range_rep_type<OrderByType> range_comparable_value(
   range_window_bounds const& range_bounds,
-  rmm::cuda_stream_view stream = cudf::default_stream_value)
+  data_type const& order_by_data_type = data_type{type_to_id<OrderByType>()},
+  rmm::cuda_stream_view stream        = cudf::default_stream_value)
 {
   auto const& range_scalar = range_bounds.range_scalar();
   using range_type         = cudf::detail::range_type<OrderByType>;
 
   CUDF_EXPECTS(range_scalar.type().id() == cudf::type_to_id<range_type>(),
-               "Unexpected range type for specified orderby column.");
+               "Range bounds scalar must match the type of the orderby column.");
 
   using rep_type = cudf::detail::range_rep_type<OrderByType>;
-  return range_comparable_value_impl<range_type, rep_type>(range_scalar, stream);
+  return range_comparable_value_impl<range_type, rep_type>(
+    range_scalar, order_by_data_type, stream);
 }
 
 }  // namespace detail

--- a/cpp/src/rolling/detail/range_window_bounds.hpp
+++ b/cpp/src/rolling/detail/range_window_bounds.hpp
@@ -49,7 +49,8 @@ constexpr bool is_supported_order_by_column_type()
 ///      a. For `TIMESTAMP_DAYS`, the range-type is `DURATION_DAYS`.
 ///         Comparisons are done in `int32_t`.
 ///      b. For all other timestamp types, comparisons are done in `int64_t`.
-///   3. For decimal types, all comparisons are done with the rep type:
+///   3. For decimal types, all comparisons are done with the rep type,
+///      after scaling the rep value to the same scale as the order by column:
 ///      a. For decimal32, the range-type is `int32_t`.
 ///      b. For decimal64, the range-type is `int64_t`.
 ///      a. For decimal128, the range-type is `__int128_t`.
@@ -109,9 +110,7 @@ RepT range_comparable_value_impl(scalar const& range_scalar,
   return val;
 }
 
-template <typename RangeT,
-          typename RepT,
-          std::enable_if_t<cudf::is_duration<RangeT>(), void>* = nullptr>
+template <typename RangeT, typename RepT, CUDF_ENABLE_IF(cudf::is_duration<RangeT>())>
 RepT range_comparable_value_impl(scalar const& range_scalar,
                                  bool,
                                  data_type const&,

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -224,47 +224,49 @@ namespace {
 /**
  * @brief Add `delta` to value, and cap at numeric_limits::max(), for signed types.
  */
-template <typename T, std::enable_if_t<std::numeric_limits<T>::is_signed>* = nullptr>
+template <typename T, CUDF_ENABLE_IF(cuda::std::numeric_limits<T>::is_signed)>
 __device__ T add_safe(T const& value, T const& delta)
 {
   // delta >= 0.
-  return (value < 0 || (std::numeric_limits<T>::max() - value) >= delta)
+  return (value < 0 || (cuda::std::numeric_limits<T>::max() - value) >= delta)
            ? (value + delta)
-           : std::numeric_limits<T>::max();
+           : cuda::std::numeric_limits<T>::max();
 }
 
 /**
  * @brief Add `delta` to value, and cap at numeric_limits::max(), for unsigned types.
  */
-template <typename T, std::enable_if_t<!std::numeric_limits<T>::is_signed>* = nullptr>
+template <typename T, CUDF_ENABLE_IF(not cuda::std::numeric_limits<T>::is_signed)>
 __device__ T add_safe(T const& value, T const& delta)
 {
   // delta >= 0.
-  return ((std::numeric_limits<T>::max() - value) >= delta) ? (value + delta)
-                                                            : std::numeric_limits<T>::max();
+  return ((cuda::std::numeric_limits<T>::max() - value) >= delta)
+           ? (value + delta)
+           : cuda::std::numeric_limits<T>::max();
 }
 
 /**
  * @brief Subtract `delta` from value, and cap at numeric_limits::min(), for signed types.
  */
-template <typename T, std::enable_if_t<std::numeric_limits<T>::is_signed>* = nullptr>
+template <typename T, CUDF_ENABLE_IF(cuda::std::numeric_limits<T>::is_signed)>
 __device__ T subtract_safe(T const& value, T const& delta)
 {
   // delta >= 0;
-  return (value >= 0 || (value - std::numeric_limits<T>::min()) >= delta)
+  return (value >= 0 || (value - cuda::std::numeric_limits<T>::min()) >= delta)
            ? (value - delta)
-           : std::numeric_limits<T>::min();
+           : cuda::std::numeric_limits<T>::min();
 }
 
 /**
  * @brief Subtract `delta` from value, and cap at numeric_limits::min(), for unsigned types.
  */
-template <typename T, std::enable_if_t<!std::numeric_limits<T>::is_signed>* = nullptr>
+template <typename T, CUDF_ENABLE_IF(not cuda::std::numeric_limits<T>::is_signed)>
 __device__ T subtract_safe(T const& value, T const& delta)
 {
   // delta >= 0;
-  return ((value - std::numeric_limits<T>::min()) >= delta) ? (value - delta)
-                                                            : std::numeric_limits<T>::min();
+  return ((value - cuda::std::numeric_limits<T>::min()) >= delta)
+           ? (value - delta)
+           : cuda::std::numeric_limits<T>::min();
 }
 
 /// Given a single, ungrouped order-by column, return the indices corresponding
@@ -780,7 +782,7 @@ template <typename OrderByT>
 std::unique_ptr<column> grouped_range_rolling_window_impl(
   column_view const& input,
   column_view const& orderby_column,
-  cudf::order const& timestamp_ordering,
+  cudf::order const& order_of_orderby_column,
   rmm::device_uvector<cudf::size_type> const& group_offsets,
   rmm::device_uvector<cudf::size_type> const& group_labels,
   range_window_bounds const& preceding_window,
@@ -790,10 +792,12 @@ std::unique_ptr<column> grouped_range_rolling_window_impl(
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr)
 {
-  auto preceding_value = detail::range_comparable_value<OrderByT>(preceding_window);
-  auto following_value = detail::range_comparable_value<OrderByT>(following_window);
+  auto preceding_value =
+    detail::range_comparable_value<OrderByT>(preceding_window, orderby_column.type(), stream);
+  auto following_value =
+    detail::range_comparable_value<OrderByT>(following_window, orderby_column.type(), stream);
 
-  if (timestamp_ordering == cudf::order::ASCENDING) {
+  if (order_of_orderby_column == cudf::order::ASCENDING) {
     return group_offsets.is_empty() ? range_window_ASC(input,
                                                        orderby_column,
                                                        preceding_value,
@@ -856,7 +860,7 @@ struct dispatch_grouped_range_rolling_window {
                    std::unique_ptr<column>>
   operator()(column_view const& input,
              column_view const& orderby_column,
-             cudf::order const& timestamp_ordering,
+             cudf::order const& order_of_orderby_column,
              rmm::device_uvector<cudf::size_type> const& group_offsets,
              rmm::device_uvector<cudf::size_type> const& group_labels,
              range_window_bounds const& preceding_window,
@@ -868,7 +872,7 @@ struct dispatch_grouped_range_rolling_window {
   {
     return grouped_range_rolling_window_impl<OrderByColumnType>(input,
                                                                 orderby_column,
-                                                                timestamp_ordering,
+                                                                order_of_orderby_column,
                                                                 group_offsets,
                                                                 group_labels,
                                                                 preceding_window,

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -343,6 +343,7 @@ ConfigureTest(
   ROLLING_TEST
   rolling/collect_ops_test.cpp
   rolling/empty_input_test.cpp
+  rolling/grouped_rolling_range_test.cpp
   rolling/grouped_rolling_test.cpp
   rolling/lead_lag_test.cpp
   rolling/nth_element_test.cpp

--- a/cpp/tests/rolling/grouped_rolling_range_test.cpp
+++ b/cpp/tests/rolling/grouped_rolling_range_test.cpp
@@ -64,7 +64,6 @@ using base = BaseGroupedRollingRangeOrderByDecimalTest;  // Shortcut to base tes
 
 template <typename DecimalT>
 struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrderByDecimalTest {
-
   using Rep = typename DecimalT::rep;
 
   auto make_fixed_point_range_bounds(typename DecimalT::rep value, scale_type scale) const
@@ -140,19 +139,19 @@ struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrder
 
   void run_test_unbounded_preceding_to_unbounded_following(scale_type oby_column_scale)
   {
-    auto const order_by = generate_order_by_column(oby_column_scale);
+    auto const order_by  = generate_order_by_column(oby_column_scale);
     auto const preceding = make_unbounded_decimal_range_bounds();
     auto const following = make_unbounded_decimal_range_bounds();
-    auto results = cudf::grouped_range_rolling_window(
-      cudf::table_view{{grouping_keys->view()}},
-      order_by->view(),
-      cudf::order::ASCENDING,
-      agg_values->view(),
-      preceding,
-      following,
-      1,  // min_periods
-      *cudf::make_sum_aggregation<rolling_aggregation>());
-    
+    auto results =
+      cudf::grouped_range_rolling_window(cudf::table_view{{grouping_keys->view()}},
+                                         order_by->view(),
+                                         cudf::order::ASCENDING,
+                                         agg_values->view(),
+                                         preceding,
+                                         following,
+                                         1,  // min_periods
+                                         *cudf::make_sum_aggregation<rolling_aggregation>());
+
     auto expected_results = bigints{{6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 12, 12, 12, 12}, no_nulls()};
   }
 };

--- a/cpp/tests/rolling/grouped_rolling_range_test.cpp
+++ b/cpp/tests/rolling/grouped_rolling_range_test.cpp
@@ -94,7 +94,7 @@ struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrder
    * value remains identical.
    *
    * Keeping the effective range bounds value identical ensures that
-   * the expected results from grouped_rolling remains the same.
+   * the expected result from grouped_rolling remains the same.
    */
   Rep rescale_range_value(Rep const& value_at_scale_0, scale_type new_scale) const
   {
@@ -257,9 +257,7 @@ struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrder
   }
 };
 
-using DecimalTypes = ::testing::Types<numeric::decimal32, numeric::decimal64, numeric::decimal128>;
-
-TYPED_TEST_SUITE(GroupedRollingRangeOrderByDecimalTypedTest, DecimalTypes);
+TYPED_TEST_SUITE(GroupedRollingRangeOrderByDecimalTypedTest, FixedPointTypes);
 
 TYPED_TEST(GroupedRollingRangeOrderByDecimalTypedTest, BoundedRanges)
 {

--- a/cpp/tests/rolling/grouped_rolling_range_test.cpp
+++ b/cpp/tests/rolling/grouped_rolling_range_test.cpp
@@ -44,10 +44,10 @@ namespace cudf::test::rolling {
 template <typename T>
 using fwcw = cudf::test::fixed_width_column_wrapper<T>;
 template <typename T>
-using decimals   = cudf::test::fixed_point_column_wrapper<T>;
-using ints       = fwcw<int32_t>;
-using bigints    = fwcw<int64_t>;
-using column_ptr = std::unique_ptr<cudf::column>;
+using decimals_column = cudf::test::fixed_point_column_wrapper<T>;
+using ints_column     = fwcw<int32_t>;
+using bigints_column  = fwcw<int64_t>;
+using column_ptr      = std::unique_ptr<cudf::column>;
 using namespace numeric;
 using namespace cudf::test::iterators;
 
@@ -55,8 +55,8 @@ struct BaseGroupedRollingRangeOrderByDecimalTest : public BaseFixture {
   // Stand-in for std::pow(10, n), but for integral return.
   static constexpr std::array<int32_t, 6> pow10{1, 10, 100, 1000, 10000, 100000};
   // Test data.
-  column_ptr const grouping_keys = ints{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2}.release();
-  column_ptr const agg_values    = ints{1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3}.release();
+  column_ptr const grouping_keys = ints_column{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2}.release();
+  column_ptr const agg_values    = ints_column{1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3}.release();
   cudf::size_type const num_rows = grouping_keys->size();
 };
 
@@ -86,7 +86,7 @@ struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrder
       thrust::make_counting_iterator<Rep>(0),
       [&](auto i) -> Rep { return (i * 10000) / base::pow10[scale + 2]; });
 
-    return decimals<Rep>{begin, begin + num_rows, scale_type{scale}}.release();
+    return decimals_column<Rep>{begin, begin + num_rows, scale_type{scale}}.release();
   }
 
   /**
@@ -141,7 +141,7 @@ struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrder
     for (int32_t range_scale = order_by_column_scale; range_scale <= 2; ++range_scale) {
       auto const results = get_grouped_range_rolling_result(*order_by, scale_type{range_scale});
       auto const expected_results =
-        bigints{{2, 3, 4, 4, 4, 3, 4, 6, 8, 6, 6, 9, 12, 9}, no_nulls()};
+        bigints_column{{2, 3, 4, 4, 4, 3, 4, 6, 8, 6, 6, 9, 12, 9}, no_nulls()};
       CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_results);
     }
   }
@@ -171,7 +171,8 @@ struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrder
     for (auto range_scale = int32_t{order_by_column_scale}; range_scale <= 2; ++range_scale) {
       auto const results =
         get_grouped_range_rolling_result(*nulled_order_by, scale_type{range_scale});
-      auto const expected_results = bigints{{2, 2, 2, 3, 4, 3, 4, 4, 4, 4, 6, 6, 6, 6}, no_nulls()};
+      auto const expected_results =
+        bigints_column{{2, 2, 2, 3, 4, 3, 4, 4, 4, 4, 6, 6, 6, 6}, no_nulls()};
       CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_results);
     }
   }
@@ -196,7 +197,8 @@ struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrder
                                          1,  // min_periods
                                          *cudf::make_sum_aggregation<rolling_aggregation>());
 
-    auto expected_results = bigints{{6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 12, 12, 12, 12}, no_nulls()};
+    auto expected_results =
+      bigints_column{{6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 12, 12, 12, 12}, no_nulls()};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_results);
   }
 
@@ -223,7 +225,8 @@ struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrder
                                            1,  // min_periods
                                            *cudf::make_sum_aggregation<rolling_aggregation>());
 
-      auto expected_results = bigints{{1, 2, 3, 4, 5, 6, 2, 4, 6, 8, 3, 6, 9, 12}, no_nulls()};
+      auto expected_results =
+        bigints_column{{1, 2, 3, 4, 5, 6, 2, 4, 6, 8, 3, 6, 9, 12}, no_nulls()};
       CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_results);
     }
   }
@@ -251,7 +254,8 @@ struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrder
                                            1,  // min_periods
                                            *cudf::make_sum_aggregation<rolling_aggregation>());
 
-      auto expected_results = bigints{{6, 5, 4, 3, 2, 1, 8, 6, 4, 2, 12, 9, 6, 3}, no_nulls()};
+      auto expected_results =
+        bigints_column{{6, 5, 4, 3, 2, 1, 8, 6, 4, 2, 12, 9, 6, 3}, no_nulls()};
       CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_results);
     }
   }

--- a/cpp/tests/rolling/grouped_rolling_range_test.cpp
+++ b/cpp/tests/rolling/grouped_rolling_range_test.cpp
@@ -257,8 +257,7 @@ struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrder
   }
 };
 
-using DecimalTypes =
-  ::testing::Types<numeric::decimal32, numeric::decimal64, numeric::decimal128>;
+using DecimalTypes = ::testing::Types<numeric::decimal32, numeric::decimal64, numeric::decimal128>;
 
 TYPED_TEST_SUITE(GroupedRollingRangeOrderByDecimalTypedTest, DecimalTypes);
 

--- a/cpp/tests/rolling/grouped_rolling_range_test.cpp
+++ b/cpp/tests/rolling/grouped_rolling_range_test.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/cudf_gtest.hpp>
+#include <cudf_test/iterator_utilities.hpp>
+#include <cudf_test/type_lists.hpp>
+
+#include <cudf/aggregation.hpp>
+#include <cudf/column/column.hpp>
+#include <cudf/detail/aggregation/aggregation.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/rolling.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/bit.hpp>
+#include <src/rolling/detail/rolling.hpp>
+
+#include <thrust/host_vector.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+
+#include <algorithm>
+#include <vector>
+
+namespace cudf::test::rolling {
+
+template <typename T>
+using fwcw = cudf::test::fixed_width_column_wrapper<T>;
+template <typename T>
+using decimals   = cudf::test::fixed_point_column_wrapper<T>;
+using ints       = fwcw<int32_t>;
+using bigints    = fwcw<int64_t>;
+using column_ptr = std::unique_ptr<cudf::column>;
+using namespace numeric;
+using namespace cudf::test::iterators;
+
+struct BaseGroupedRollingRangeOrderByDecimalTest : public BaseFixture {
+  // Stand-in for std::pow(10, n), but for integral return.
+  static constexpr std::array<int32_t, 6> pow10{1, 10, 100, 1000, 10000, 100000};
+  // Test data.
+  column_ptr const grouping_keys = ints{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2}.release();
+  column_ptr const agg_values    = ints{1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3}.release();
+  cudf::size_type const num_rows = grouping_keys->size();
+};
+
+using base = BaseGroupedRollingRangeOrderByDecimalTest;  // Shortcut to base test class.
+
+template <typename DecimalT>
+struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrderByDecimalTest {
+  auto make_fixed_point_range_bounds(typename DecimalT::rep value, scale_type scale)
+  {
+    return cudf::range_window_bounds::get(*cudf::make_fixed_point_scalar<DecimalT>(value, scale));
+  }
+
+  void run_test_no_null_oby(column_view const& order_by,
+                            range_window_bounds preceding,
+                            range_window_bounds following)
+  {
+    auto const results =
+      cudf::grouped_range_rolling_window(cudf::table_view{{grouping_keys->view()}},
+                                         order_by,
+                                         cudf::order::ASCENDING,
+                                         agg_values->view(),
+                                         preceding,
+                                         following,
+                                         1,  // min_periods
+                                         *cudf::make_sum_aggregation<rolling_aggregation>());
+    auto const expected_results = bigints{{2, 3, 4, 4, 4, 3, 4, 6, 8, 6, 6, 9, 12, 9}, no_nulls()};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_results);
+  }
+
+  void run_test_nulls_in_oby(column_view const& order_by,
+                             range_window_bounds preceding,
+                             range_window_bounds following)
+  {
+    // Nullify the first two rows of each group in the order_by column.
+    auto const nulled_order_by = [&]() {
+      auto col           = cudf::column{order_by};
+      auto new_null_mask = create_null_mask(col.size(), mask_state::ALL_VALID);
+      set_null_mask(
+        static_cast<bitmask_type*>(new_null_mask.data()), 0, 2, false);  // Nulls in first group.
+      set_null_mask(
+        static_cast<bitmask_type*>(new_null_mask.data()), 6, 8, false);  // Nulls in second group.
+      set_null_mask(
+        static_cast<bitmask_type*>(new_null_mask.data()), 10, 12, false);  // Nulls in third group.
+      col.set_null_mask(std::move(new_null_mask));
+      return col;
+    }();
+
+    auto const results =
+      cudf::grouped_range_rolling_window(cudf::table_view{{grouping_keys->view()}},
+                                         nulled_order_by.view(),
+                                         cudf::order::ASCENDING,
+                                         agg_values->view(),
+                                         preceding,
+                                         following,
+                                         1,  // min_periods
+                                         *cudf::make_sum_aggregation<rolling_aggregation>());
+    auto const expected_results = bigints{{2, 2, 2, 3, 4, 3, 4, 4, 4, 4, 6, 6, 6, 6}, no_nulls()};
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected_results);
+  }
+};
+
+using RepresentationTypes =
+  ::testing::Types<numeric::decimal32, numeric::decimal64, numeric::decimal128>;
+
+TYPED_TEST_SUITE(GroupedRollingRangeOrderByDecimalTypedTest, RepresentationTypes);
+
+TYPED_TEST(GroupedRollingRangeOrderByDecimalTypedTest, BasicGrouping)
+{
+  using DecimalT = TypeParam;               // Decimal type for order_by column.
+  using Rep      = typename DecimalT::rep;  // Representation type for order_by column.
+
+  // For different scales, generate order_by column with
+  // the same effective values:           [0, 100,   200,   300,   ... 1100,   1200,   1300]
+  // For scale == -2, the rep values are: [0, 10000, 20000, 30000, ... 110000, 120000, 130000]
+  // For scale ==  2, the rep values are: [0, 1,     2,     3,     ... 11,     12,     13]
+  for (auto oby_column_scale : {-2, -1, 0, 1, 2}) {
+    auto const order_by = [num_rows = this->num_rows, oby_column_scale] {
+      auto const begin = thrust::make_transform_iterator(
+        thrust::make_counting_iterator<Rep>(0),
+        [&](auto i) -> Rep { return (i * 10000) / base::pow10[oby_column_scale + 2]; });
+      return decimals<Rep>{begin, begin + num_rows, scale_type{oby_column_scale}}.release();
+    }();
+
+    // Run tests for range bounds generated for all scales >= oby_column_scale.
+    for (auto range_scale = oby_column_scale; range_scale <= 2; ++range_scale) {
+      // Scale the range bounds value, depending on the scale,
+      // so that the effective range bounds value is the same.
+      // This keeps the expected results the same for all scales.
+      auto rescale_range_value = [&](auto value, auto scale) {
+        // Scale  ->   Rep (for value == 200)
+        //  -2    ->       20000
+        //  -1    ->       2000
+        //   0    ->       200
+        //   1    ->       20
+        //   2    ->       2
+        return (value * 100) / base::pow10[scale + 2];
+      };
+      auto const preceding = this->make_fixed_point_range_bounds(
+        rescale_range_value(Rep{200}, range_scale), scale_type{range_scale});
+      auto const following = this->make_fixed_point_range_bounds(
+        rescale_range_value(Rep{100}, range_scale), scale_type{range_scale});
+
+      this->run_test_no_null_oby(order_by->view(), preceding, following);
+      this->run_test_nulls_in_oby(order_by->view(), preceding, following);
+    }
+  }
+}
+
+}  // namespace cudf::test::rolling

--- a/cpp/tests/rolling/range_window_bounds_test.cpp
+++ b/cpp/tests/rolling/range_window_bounds_test.cpp
@@ -151,7 +151,62 @@ TYPED_TEST(NumericRangeWindowBoundsTest, WrongRangeType)
                cudf::logic_error);
 }
 
-TEST_F(RangeWindowBoundsTest, Decimal) {}
+template <typename T>
+struct DecimalRangeBoundsTest : RangeWindowBoundsTest {
+};
+
+TYPED_TEST_SUITE(DecimalRangeBoundsTest, cudf::test::FixedPointTypes);
+
+TYPED_TEST(DecimalRangeBoundsTest, BoundsConstruction)
+{
+  using namespace numeric;
+  using DecimalT = TypeParam;
+  using Rep      = cudf::detail::range_rep_type<DecimalT>;
+
+  // Interval type must match the decimal type.
+  static_assert(std::is_same_v<cudf::detail::range_type<DecimalT>, DecimalT>);
+
+  auto const range_3 =
+    range_window_bounds::get(fixed_point_scalar<DecimalT>{Rep{3}, scale_type{0}});
+  EXPECT_FALSE(range_3.is_unbounded() &&
+               "range_window_bounds constructed from scalar cannot be unbounded.");
+  EXPECT_EQ(cudf::detail::range_comparable_value<DecimalT>(range_3), Rep{3});
+
+  auto const range_unbounded = range_window_bounds::unbounded(data_type{type_to_id<DecimalT>()});
+  EXPECT_TRUE(range_unbounded.is_unbounded() &&
+              "range_window_bounds::unbounded() must return an unbounded range.");
+}
+
+TYPED_TEST(DecimalRangeBoundsTest, Rescale)
+{
+  using namespace numeric;
+  using DecimalT = TypeParam;
+  using RepT     = typename DecimalT::rep;
+
+  // Powers of 10.
+  auto constexpr pow10 = std::array{1, 10, 100, 1000, 10000, 100000};
+
+  // Check that the rep has expected values at different range scales.
+  auto const order_by_scale     = -2;
+  auto const order_by_data_type = data_type{type_to_id<DecimalT>(), order_by_scale};
+
+  for (auto const range_scale : {-2, -1, 0, 1, 2}) {
+    auto const decimal_range_bounds =
+      range_window_bounds::get(fixed_point_scalar<DecimalT>{RepT{20}, scale_type{range_scale}});
+    auto const rescaled_range_rep =
+      cudf::detail::range_comparable_value<DecimalT>(decimal_range_bounds, order_by_data_type);
+    EXPECT_EQ(rescaled_range_rep, RepT{20} * pow10[range_scale - order_by_scale]);
+  }
+
+  // Order By column scale cannot exceed range scale:
+  {
+    auto const decimal_range_bounds =
+      range_window_bounds::get(fixed_point_scalar<DecimalT>{RepT{200}, scale_type{-3}});
+    EXPECT_THROW(
+      cudf::detail::range_comparable_value<DecimalT>(decimal_range_bounds, order_by_data_type),
+      cudf::logic_error);
+  }
+}
 
 }  // namespace test
 }  // namespace cudf

--- a/cpp/tests/rolling/range_window_bounds_test.cpp
+++ b/cpp/tests/rolling/range_window_bounds_test.cpp
@@ -151,5 +151,7 @@ TYPED_TEST(NumericRangeWindowBoundsTest, WrongRangeType)
                cudf::logic_error);
 }
 
+TEST_F(RangeWindowBoundsTest, Decimal) {}
+
 }  // namespace test
 }  // namespace cudf

--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -754,6 +754,8 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
     case TIMESTAMP_NANOSECONDS:
     case DECIMAL64:
       return getLong() == other.getLong();
+    case DECIMAL128:
+      return getBigDecimal().equals(other.getBigDecimal());
     case STRING:
       return Arrays.equals(getUTF8(), other.getUTF8());
     case LIST:

--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -819,6 +819,9 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
           valueHash = v.hashCode();
         }
         break;
+      case DECIMAL128:
+        valueHash = getBigDecimal().hashCode();
+        break;
       default:
         throw new IllegalStateException("Unknown scalar type: " + type);
       }

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -3915,6 +3915,9 @@ public final class Table implements AutoCloseable {
           case TIMESTAMP_DAYS:
           case TIMESTAMP_NANOSECONDS:
           case TIMESTAMP_MICROSECONDS:
+          case DECIMAL32:
+          case DECIMAL64:
+          case DECIMAL128:
             break;
           default:
             throw new IllegalArgumentException("Expected range-based window orderBy's " +

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -4037,7 +4037,7 @@ public class TableTest extends CudfTestBase {
     }
   }
 
-/**
+  /**
    * Helper to get scalar for following == Decimal(100),
    * with data width depending upon the the order-by
    * column index:

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -4006,8 +4006,6 @@ public class TableTest extends CudfTestBase {
     }
   }
 
-
-
   @Test
   void testWindowingMin() {
     try (Table unsorted = new Table.TestBuilder()
@@ -4964,8 +4962,6 @@ public class TableTest extends CudfTestBase {
     }
   }
 
-  // Test Decimal OBY column with Range queries.
-
   @Test
   void testWindowingWithoutGroupByColumns() {
     try (Table unsorted = new Table.TestBuilder().column( 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6) // OBY Key
@@ -5806,7 +5802,7 @@ public class TableTest extends CudfTestBase {
     {
       case 2: return Scalar.fromDecimal(scale, unscaledValue);
       case 3: return Scalar.fromDecimal(scale, Long.valueOf(unscaledValue));
-      case 4: return Scalar.fromDecimal(scale, new BigInteger("" + unscaledValue));
+      case 4: return Scalar.fromDecimal(scale, big(unscaledValue));
       default: 
         throw new IllegalStateException("Unexpected order by column index: " 
                                         + orderby_col_idx);

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -4006,103 +4006,7 @@ public class TableTest extends CudfTestBase {
     }
   }
 
-  /**
-   * Helper for constructing BigInteger from int
-   * @param x Integer value
-   * @return BigInteger equivalent of x
-   */
-  private static BigInteger big(int x)
-  {
-    return new BigInteger("" + x);
-  }
 
-  /**
-   * Helper to get scalar for preceding == Decimal(200),
-   * with data width depending upon the the order-by
-   * column index:
-   *   orderby_col_idx = 2 -> Decimal32
-   *   orderby_col_idx = 3 -> Decimal64
-   *   orderby_col_idx = 4 -> Decimal128
-   */
-  private static Scalar getPrecedingDecimal200(int orderby_col_idx)
-  {
-    switch(orderby_col_idx)
-    {
-      case 2: return Scalar.fromDecimal(0, 200);
-      case 3: return Scalar.fromDecimal(0, 200l);
-      case 4: return Scalar.fromDecimal(0, new BigInteger("" + 200));
-      default: 
-        throw new IllegalStateException("Unexpected order by column index: " 
-                                        + orderby_col_idx);
-    }
-  }
-
-  /**
-   * Helper to get scalar for following == Decimal(100),
-   * with data width depending upon the the order-by
-   * column index:
-   *   orderby_col_idx = 2 -> Decimal32
-   *   orderby_col_idx = 3 -> Decimal64
-   *   orderby_col_idx = 4 -> Decimal128
-   */
-  private static Scalar getFollowingDecimal100(int orderby_col_idx)
-  {
-    switch(orderby_col_idx)
-    {
-      case 2: return Scalar.fromDecimal(2, 1);
-      case 3: return Scalar.fromDecimal(2, 1l);
-      case 4: return Scalar.fromDecimal(2, new BigInteger("" + 1));
-      default: 
-        throw new IllegalStateException("Unexpected order by column index: " 
-                                        + orderby_col_idx);
-    }
-  }
-
-  @Test
-  void testWindowingWithDecimalOrderBy() {
-    try (Table unsorted = new Table.TestBuilder()
-        .column(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) // GBY Key
-        .column(1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3) // GBY Key
-        .decimal32Column(-1, 4000, 3000, 2000, 1000, 
-                             4000, 3000, 2000, 1000, 
-                             4000, 3000, 2000, 1000) // Decimal OBY Key
-        .decimal64Column(-1, 4000l, 3000l, 2000l, 1000l, 
-                             4000l, 3000l, 2000l, 1000l, 
-                             4000l, 3000l, 2000l, 1000l) // Decimal OBY Key
-        .decimal128Column(-1, RoundingMode.UNNECESSARY,
-                              big(4000), big(3000), big(2000), big(1000),
-                              big(4000), big(3000), big(2000), big(1000),
-                              big(4000), big(3000), big(2000), big(1000))
-        .column(9, 1, 5, 7, 2, 8, 9, 7, 6, 6, 0, 8) // Agg Column
-        .build()) {
-      for (int decimal_oby_col_idx = 2; decimal_oby_col_idx <= 4; ++decimal_oby_col_idx) {
-        try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), 
-                                             OrderByArg.asc(1), 
-                                             OrderByArg.asc(decimal_oby_col_idx));
-            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6);
-            Scalar preceding_200 = Scalar.fromDecimal(0, 200);
-            Scalar following_100 = Scalar.fromDecimal(2, 1)) {
-          ColumnVector sortedAggColumn = sorted.getColumn(5);
-          assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
-
-          try (WindowOptions window = WindowOptions.builder()
-              .minPeriods(1)
-              .window(getPrecedingDecimal200(decimal_oby_col_idx), getFollowingDecimal100(decimal_oby_col_idx))
-              .orderByColumnIndex(decimal_oby_col_idx)
-              .build()) {
-
-            try (Table windowAggResults = sorted.groupBy(0, 1)
-                                                .aggregateWindowsOverRanges(RollingAggregation.count()
-                                                                                              .onColumn(5)
-                                                                                              .overWindow(window));
-                ColumnVector expect = ColumnVector.fromBoxedInts(2, 3, 4, 3, 2, 3, 4, 3, 2, 3, 4, 3)) {
-              assertColumnsAreEqual(expect, windowAggResults.getColumn(0));
-            }
-          }
-        }
-      }
-    }
-  }
 
   @Test
   void testWindowingMin() {
@@ -5871,6 +5775,124 @@ public class TableTest extends CudfTestBase {
                 assertColumnsAreEqual(expect_3, windowAggResults.getColumn(3));
                 assertColumnsAreEqual(expect_4, windowAggResults.getColumn(4));
               }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Helper for constructing BigInteger from int
+   * @param x Integer value
+   * @return BigInteger equivalent of x
+   */
+  private static BigInteger big(int x)
+  {
+    return new BigInteger("" + x);
+  }
+
+  /**
+   * Helper to get scalar for preceding == Decimal(value),
+   * with data width depending upon the the order-by
+   * column index:
+   *   orderby_col_idx = 2 -> Decimal32
+   *   orderby_col_idx = 3 -> Decimal64
+   *   orderby_col_idx = 4 -> Decimal128
+   */
+  private static Scalar getDecimalScalarRangeBounds(int scale, int unscaledValue, int orderby_col_idx)
+  {
+    switch(orderby_col_idx)
+    {
+      case 2: return Scalar.fromDecimal(scale, unscaledValue);
+      case 3: return Scalar.fromDecimal(scale, Long.valueOf(unscaledValue));
+      case 4: return Scalar.fromDecimal(scale, new BigInteger("" + unscaledValue));
+      default: 
+        throw new IllegalStateException("Unexpected order by column index: " 
+                                        + orderby_col_idx);
+    }
+  }
+
+  @Test
+  void testRangeWindowsWithDecimalOrderBy() {
+    try (Table unsorted = new Table.TestBuilder()
+        .column(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) // GBY Key
+        .column(1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3) // GBY Key
+        .decimal32Column(-1, 4000, 3000, 2000, 1000, 
+                             4000, 3000, 2000, 1000, 
+                             4000, 3000, 2000, 1000) // Decimal OBY Key
+        .decimal64Column(-1, 4000l, 3000l, 2000l, 1000l, 
+                             4000l, 3000l, 2000l, 1000l, 
+                             4000l, 3000l, 2000l, 1000l) // Decimal OBY Key
+        .decimal128Column(-1, RoundingMode.UNNECESSARY,
+                              big(4000), big(3000), big(2000), big(1000),
+                              big(4000), big(3000), big(2000), big(1000),
+                              big(4000), big(3000), big(2000), big(1000))
+        .column(9, 1, 5, 7, 2, 8, 9, 7, 6, 6, 0, 8) // Agg Column
+        .build()) {
+
+      // Columns 2,3,4 are decimal order-by columns of type DECIMAL32, DECIMAL64, 
+      // and DECIMAL128 respectively, with similarly ordered values.
+      // In the following loop, each decimal type is tested as the order-by column,
+      // producing the same results with similar range bounds.
+      for (int decimal_oby_col_idx = 2; decimal_oby_col_idx <= 4; ++decimal_oby_col_idx) {
+        try (Table sorted = unsorted.orderBy(OrderByArg.asc(0), 
+                                             OrderByArg.asc(1), 
+                                             OrderByArg.asc(decimal_oby_col_idx));
+            ColumnVector expectSortedAggColumn = ColumnVector.fromBoxedInts(7, 5, 1, 9, 7, 9, 8, 2, 8, 0, 6, 6)) {
+          ColumnVector sortedAggColumn = sorted.getColumn(5);
+          assertColumnsAreEqual(expectSortedAggColumn, sortedAggColumn);
+
+          // Test Window functionality with range window (200 PRECEDING and 100 FOLLOWING)
+          try (Scalar preceding200 = getDecimalScalarRangeBounds(0, 200, decimal_oby_col_idx);
+               Scalar following100 = getDecimalScalarRangeBounds(2, 1, decimal_oby_col_idx);
+               WindowOptions window = WindowOptions.builder()
+                .minPeriods(1)
+                .window(preceding200, following100)
+                .orderByColumnIndex(decimal_oby_col_idx)
+                .build()) {
+
+            try (Table windowAggResults = sorted.groupBy(0, 1)
+                                                .aggregateWindowsOverRanges(RollingAggregation.count()
+                                                                                              .onColumn(5)
+                                                                                              .overWindow(window));
+                ColumnVector expect = ColumnVector.fromBoxedInts(2, 3, 4, 3, 2, 3, 4, 3, 2, 3, 4, 3)) {
+              assertColumnsAreEqual(expect, windowAggResults.getColumn(0));
+            }
+          }
+
+          // Test Window functionality with range window (UNBOUNDED PRECEDING and CURRENT ROW)
+          try (Scalar current_row = getDecimalScalarRangeBounds(0, 0, decimal_oby_col_idx);
+               WindowOptions window = WindowOptions.builder()
+                .minPeriods(1)
+                .unboundedPreceding()
+                .following(current_row)
+                .orderByColumnIndex(decimal_oby_col_idx)
+                .build()) {
+
+            try (Table windowAggResults = sorted.groupBy(0, 1)
+                                                .aggregateWindowsOverRanges(RollingAggregation.count()
+                                                                                              .onColumn(5)
+                                                                                              .overWindow(window));
+                ColumnVector expect = ColumnVector.fromBoxedInts(1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4)) {
+              assertColumnsAreEqual(expect, windowAggResults.getColumn(0));
+            }
+          }
+
+          // Test Window functionality with range window (UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING)
+          try (WindowOptions window = WindowOptions.builder()
+                .minPeriods(1)
+                .unboundedPreceding()
+                .unboundedFollowing()
+                .orderByColumnIndex(decimal_oby_col_idx)
+                .build()) {
+
+            try (Table windowAggResults = sorted.groupBy(0, 1)
+                                                .aggregateWindowsOverRanges(RollingAggregation.count()
+                                                                                              .onColumn(5)
+                                                                                              .overWindow(window));
+                ColumnVector expect = ColumnVector.fromBoxedInts(4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4)) {
+              assertColumnsAreEqual(expect, windowAggResults.getColumn(0));
             }
           }
         }


### PR DESCRIPTION
## Description
CUDF grouped RANGE window functions currently support only
integral types and timestamps as the ORDER BY (OBY) column.

This commit adds support for DECIMAL types (i.e. decimal32,
decimal64, and decimal128) to be used as the ORDER BY
column in RANGE window functions.

This feature allows `spark-rapids` to address https://github.com/NVIDIA/spark-rapids/issues/6400.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
