### PR TITLE
Call set_null_count on a returning column if null-count is known

### DIFF
--- a/cpp/src/datetime/datetime_ops.cu
+++ b/cpp/src/datetime/datetime_ops.cu
@@ -259,6 +259,8 @@ struct dispatch_round {
                       output->mutable_view().begin<Timestamp>(),
                       RoundingDispatcher{round_kind, component});
 
+    output->set_null_count(column.null_count());
+
     return output;
   }
 

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -159,7 +159,7 @@ std::unique_ptr<cudf::column> out_of_place_fill_range_dispatch::operator()<cudf:
     auto result = std::make_unique<cudf::column>(input, stream, mr);
     auto mview  = result->mutable_view();
     cudf::detail::set_null_mask(mview.null_mask(), begin, end, false, stream);
-    mview.set_null_count(input.null_count() + (end - begin));
+    result->set_null_count(input.null_count() + (end - begin));
     return result;
   }
 

--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -206,6 +206,9 @@ std::unique_ptr<column> group_correlation(column_view const& covariance,
                     [] __device__(auto const covariance, auto const stddev) {
                       return covariance / thrust::get<0>(stddev) / thrust::get<1>(stddev);
                     });
+
+  result->set_null_count(covariance.null_count());
+
   return result;
 }
 

--- a/cpp/src/lists/copying/scatter_helper.cu
+++ b/cpp/src/lists/copying/scatter_helper.cu
@@ -203,6 +203,8 @@ struct list_child_constructor {
         return actual_list_row.template element<T>(intra_index);
       });
 
+    child_column->set_null_count(child_null_mask.second);
+
     return child_column;
   }
 

--- a/cpp/src/lists/set_operations.cu
+++ b/cpp/src/lists/set_operations.cu
@@ -119,6 +119,8 @@ std::unique_ptr<column> have_overlap(lists_column_view const& lhs,
                   list_indices.begin(),
                   result_begin);
 
+  result->set_null_count(null_count);
+
   return result;
 }
 

--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -203,6 +203,7 @@ std::unique_ptr<column> normalize_nans_and_zeros(column_view const& input,
   // from device. unique_ptr which gets automatically cleaned up when we leave.
   auto out_view = out->mutable_view();
   normalize_nans_and_zeros(out_view, stream);
+  out->set_null_count(input.null_count());
 
   return out;
 }

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -228,6 +228,8 @@ std::unique_ptr<column> round_with(column_view const& input,
   thrust::transform(
     rmm::exec_policy(stream), input.begin<T>(), input.end<T>(), out_view.begin<T>(), Functor{n});
 
+  result->set_null_count(input.null_count());
+
   return result;
 }
 
@@ -276,6 +278,8 @@ std::unique_ptr<column> round_with(column_view const& input,
                       out_view.begin<Type>(),
                       FixedPointRoundFunctor{n});
   }
+
+  result->set_null_count(input.null_count());
 
   return result;
 }

--- a/cpp/src/search/contains_column.cu
+++ b/cpp/src/search/contains_column.cu
@@ -86,6 +86,9 @@ struct contains_column_dispatch {
                       out_begin,
                       contains_fn<Element, decltype(haystack_set_dv)>{
                         haystack_set_dv, *needles_cdv_ptr, needles.has_nulls()});
+
+    result->set_null_count(needles.null_count());
+
     return result;
   }
 

--- a/cpp/src/strings/capitalize.cu
+++ b/cpp/src/strings/capitalize.cu
@@ -278,6 +278,7 @@ std::unique_ptr<column> is_title(strings_column_view const& input,
                     thrust::make_counting_iterator<size_type>(input.size()),
                     results->mutable_view().data<bool>(),
                     is_title_fn{get_character_flags_table(), *d_column});
+  results->set_null_count(input.null_count());
   return results;
 }
 

--- a/cpp/src/strings/contains.cu
+++ b/cpp/src/strings/contains.cu
@@ -79,6 +79,8 @@ std::unique_ptr<column> contains_impl(strings_column_view const& input,
   launch_transform_kernel(
     contains_fn{*d_strings, beginning_only}, *d_prog, d_results, input.size(), stream);
 
+  results->set_null_count(input.null_count());
+
   return results;
 }
 

--- a/cpp/src/strings/like.cu
+++ b/cpp/src/strings/like.cu
@@ -132,6 +132,8 @@ std::unique_ptr<column> like(
                     results->mutable_view().data<bool>(),
                     like_fn{*d_strings, d_pattern, d_escape});
 
+  results->set_null_count(input.null_count());
+
   return results;
 }
 

--- a/cpp/src/text/stemmer.cu
+++ b/cpp/src/text/stemmer.cu
@@ -117,6 +117,7 @@ std::unique_ptr<cudf::column> is_letter(cudf::strings_column_view const& strings
                     thrust::make_counting_iterator<cudf::size_type>(strings.size()),
                     results->mutable_view().data<bool>(),
                     is_letter_fn<PositionIterator>{*strings_column, ltype, position_itr});
+  results->set_null_count(strings.null_count());
   return results;
 }
 
@@ -226,6 +227,7 @@ std::unique_ptr<cudf::column> porter_stemmer_measure(cudf::strings_column_view c
                     thrust::make_counting_iterator<cudf::size_type>(strings.size()),
                     results->mutable_view().data<int32_t>(),
                     porter_stemmer_measure_fn{*strings_column});
+  results->set_null_count(strings.null_count());
   return results;
 }
 

--- a/cpp/src/unary/math_ops.cu
+++ b/cpp/src/unary/math_ops.cu
@@ -303,6 +303,8 @@ std::unique_ptr<column> unary_op_with(column_view const& input,
                     out_view.begin<Type>(),
                     FixedPointUnaryOpFunctor{n});
 
+  result->set_null_count(input.null_count());
+
   return result;
 }
 
@@ -327,6 +329,7 @@ std::unique_ptr<cudf::column> transform_fn(InputIterator begin,
 
   auto output_view = output->mutable_view();
   thrust::transform(rmm::exec_policy(stream), begin, end, output_view.begin<OutputType>(), UFN{});
+  output->set_null_count(null_count);
   return output;
 }
 


### PR DESCRIPTION
## Description
Adds calls to `cudf::column.set_null_count()` when the null-count is known.
Found these while looking into improvements for #11577 
There are several ways to make a `cudf::column` object to be returned. Many times the column is created and then filled in by calling the `cudf::column.mutable_view()` function and using the `mutable_view` object. The `cudf::column::mutable_view()` function has a side-effect that invalidates it's internal null-count. This is for efficiency so the null-count is only computed when the value is specifically requested through the `cudf::column::null_count()` method. Computing the null-count inside `null_count()` requires a kernel launch. However, there are several places where the null-count is known before returning the column and setting the value means a later call to `cudf::column::null_count()` does not require it to be computed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
