### PR TITLE
Add BGZIP `data_chunk_reader`

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -353,6 +353,7 @@ add_library(
   src/io/statistics/parquet_column_statistics.cu
   src/io/text/byte_range_info.cpp
   src/io/text/data_chunk_source_factories.cpp
+  src/io/text/bgzip_data_chunk_source.cu
   src/io/text/multibyte_split.cu
   src/io/utilities/column_buffer.cpp
   src/io/utilities/config_utils.cpp

--- a/cpp/include/cudf/io/text/data_chunk_source_factories.hpp
+++ b/cpp/include/cudf/io/text/data_chunk_source_factories.hpp
@@ -40,7 +40,7 @@ std::unique_ptr<data_chunk_source> make_source(host_span<const char> data);
  * @return the data chunk source for the provided filename. It reads data from the file and copies
  *         it to the device.
  */
-std::unique_ptr<data_chunk_source> make_source_from_file(std::string const& filename);
+std::unique_ptr<data_chunk_source> make_source_from_file(std::string_view filename);
 
 /**
  * @brief Creates a data source capable of producing device-buffered views of a BGZIP compressed
@@ -49,7 +49,7 @@ std::unique_ptr<data_chunk_source> make_source_from_file(std::string const& file
  * @return the data chunk source for the provided filename. It reads data from the file and copies
  *         it to the device, where it will be decompressed.
  */
-std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string const& filename);
+std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string_view filename);
 
 /**
  * @brief Creates a data source capable of producing device-buffered views of a BGZIP compressed
@@ -63,7 +63,7 @@ std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string const
  *         it to the device, where it will be decompressed. The chunk source only returns data
  *         between the virtual offsets `virtual_begin` and `virtual_end`.
  */
-std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string const& filename,
+std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string_view filename,
                                                                uint64_t virtual_begin,
                                                                uint64_t virtual_end);
 

--- a/cpp/include/cudf/io/text/data_chunk_source_factories.hpp
+++ b/cpp/include/cudf/io/text/data_chunk_source_factories.hpp
@@ -36,6 +36,20 @@ std::unique_ptr<data_chunk_source> make_source(host_span<const char> data);
 std::unique_ptr<data_chunk_source> make_source_from_file(std::string const& filename);
 
 /**
+ * @brief Creates a data source capable of producing device-buffered views of a BGZIP compressed
+ * file
+ */
+std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string const& filename);
+
+/**
+ * @brief Creates a data source capable of producing device-buffered views of a BGZIP compressed
+ *        file with virtual record offsets.
+ */
+std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string const& filename,
+                                                               uint64_t virtual_begin,
+                                                               uint64_t virtual_end);
+
+/**
  * @brief Creates a data source capable of producing views of the given device string scalar
  */
 std::unique_ptr<data_chunk_source> make_source(cudf::string_scalar& data);

--- a/cpp/include/cudf/io/text/data_chunk_source_factories.hpp
+++ b/cpp/include/cudf/io/text/data_chunk_source_factories.hpp
@@ -36,7 +36,7 @@ std::unique_ptr<data_chunk_source> make_source(host_span<const char> data);
 
 /**
  * @brief Creates a data source capable of producing device-buffered views of the file
- * @param data the filename of the file to be exposed as a data chunk source.
+ * @param filename the filename of the file to be exposed as a data chunk source.
  * @return the data chunk source for the provided filename. It reads data from the file and copies
  *         it to the device.
  */
@@ -45,7 +45,7 @@ std::unique_ptr<data_chunk_source> make_source_from_file(std::string_view filena
 /**
  * @brief Creates a data source capable of producing device-buffered views of a BGZIP compressed
  *        file.
- * @param data the filename of the BGZIP-compressed file to be exposed as a data chunk source.
+ * @param filename the filename of the BGZIP-compressed file to be exposed as a data chunk source.
  * @return the data chunk source for the provided filename. It reads data from the file and copies
  *         it to the device, where it will be decompressed.
  */
@@ -54,7 +54,7 @@ std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string_view 
 /**
  * @brief Creates a data source capable of producing device-buffered views of a BGZIP compressed
  *        file with virtual record offsets.
- * @param data the filename of the BGZIP-compressed file to be exposed as a data chunk source.
+ * @param filename the filename of the BGZIP-compressed file to be exposed as a data chunk source.
  * @param virtual_begin the virtual (Tabix) offset of the first byte to be read. Its upper 48 bits
  *                      describe the offset into the compressed file, its lower 16 bits describe the
  *                      block-local offset.

--- a/cpp/include/cudf/io/text/data_chunk_source_factories.hpp
+++ b/cpp/include/cudf/io/text/data_chunk_source_factories.hpp
@@ -27,23 +27,41 @@ namespace cudf::io::text {
 
 /**
  * @brief Creates a data source capable of producing device-buffered views of the given string.
+ * @param data the host data to be exposed as a data chunk source. Its lifetime must be at least as
+ *             long as the lifetime of the returned data_chunk_source.
+ * @return the data chunk source for the provided host data. It copies data from the host to the
+ *         device.
  */
 std::unique_ptr<data_chunk_source> make_source(host_span<const char> data);
 
 /**
  * @brief Creates a data source capable of producing device-buffered views of the file
+ * @param data the filename of the file to be exposed as a data chunk source.
+ * @return the data chunk source for the provided filename. It reads data from the file and copies
+ *         it to the device.
  */
 std::unique_ptr<data_chunk_source> make_source_from_file(std::string const& filename);
 
 /**
  * @brief Creates a data source capable of producing device-buffered views of a BGZIP compressed
- * file
+ *        file.
+ * @param data the filename of the BGZIP-compressed file to be exposed as a data chunk source.
+ * @return the data chunk source for the provided filename. It reads data from the file and copies
+ *         it to the device, where it will be decompressed.
  */
 std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string const& filename);
 
 /**
  * @brief Creates a data source capable of producing device-buffered views of a BGZIP compressed
  *        file with virtual record offsets.
+ * @param data the filename of the BGZIP-compressed file to be exposed as a data chunk source.
+ * @param virtual_begin the virtual (Tabix) offset of the first byte to be read. Its upper 48 bits
+ *                      describe the offset into the compressed file, its lower 16 bits describe the
+ *                      block-local offset.
+ * @param virtual_end the virtual (Tabix) offset one past the last byte to be read.
+ * @return the data chunk source for the provided filename. It reads data from the file and copies
+ *         it to the device, where it will be decompressed. The chunk source only returns data
+ *         between the virtual offsets `virtual_begin` and `virtual_end`.
  */
 std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string const& filename,
                                                                uint64_t virtual_begin,
@@ -51,6 +69,9 @@ std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string const
 
 /**
  * @brief Creates a data source capable of producing views of the given device string scalar
+ * @param data the device data to be exposed as a data chunk source. Its lifetime must be at least
+ *             as long as the lifetime of the returned data_chunk_source.
+ * @return the data chunk source for the provided host data. It does not create any copies.
  */
 std::unique_ptr<data_chunk_source> make_source(cudf::string_scalar& data);
 

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -85,7 +85,7 @@ std::optional<nvcompStatus_t> batched_decompress_get_temp_size_ex(compression_ty
     default: return std::nullopt;
   }
 #endif
-  CUDF_FAIL("GetTempSizeEx is not supported in the current nvCOMP version");
+  return std::nullopt;
 }
 
 // Dispatcher for nvcompBatched<format>DecompressGetTempSize

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -139,14 +139,12 @@ size_t batched_decompress_temp_size(compression_type compression,
                                     size_t max_uncomp_chunk_size,
                                     size_t max_total_uncomp_size)
 {
-  size_t temp_size         = 0;
-  auto const nvcomp_status = [&]() {
-    auto maybe_result = batched_decompress_get_temp_size_ex(
-      compression, num_chunks, max_uncomp_chunk_size, &temp_size, max_total_uncomp_size);
-    if (maybe_result.has_value()) { return *maybe_result; }
-    return batched_decompress_get_temp_size(
-      compression, num_chunks, max_uncomp_chunk_size, &temp_size);
-  }();
+  size_t temp_size = 0;
+  auto const nvcomp_status =
+    batched_decompress_get_temp_size_ex(
+      compression, num_chunks, max_uncomp_chunk_size, &temp_size, max_total_uncomp_size)
+      .value_or(batched_decompress_get_temp_size(
+        compression, num_chunks, max_uncomp_chunk_size, &temp_size));
 
   CUDF_EXPECTS(nvcomp_status == nvcompStatus_t::nvcompSuccess,
                "Unable to get scratch size for decompression");

--- a/cpp/src/io/text/bgzip_data_chunk_source.cu
+++ b/cpp/src/io/text/bgzip_data_chunk_source.cu
@@ -96,11 +96,11 @@ class bgzip_data_chunk_reader : public data_chunk_reader {
   {
     std::array<char, 12> buffer{};
     _stream->read(buffer.data(), sizeof(buffer));
-    uint8_t constexpr magic_expected_2 = 139;
-    std::array<char, 4> expected_header{{31, 0, 8, 4}};
-    std::memcpy(&expected_header[1], &magic_expected_2, sizeof(char));
-    CUDF_EXPECTS(std::equal(expected_header.begin(), expected_header.end(), buffer.begin()),
-                 "malformed BGZIP header");
+    std::array<uint8_t, 4> expected_header{{31, 139, 8, 4}};
+    CUDF_EXPECTS(
+      std::equal(
+        expected_header.begin(), expected_header.end(), reinterpret_cast<uint8_t*>(buffer.data())),
+      "malformed BGZIP header");
     // we ignore the remaining bytes of the fixed header, since they don't matter to us
     auto extra_length = read_int<uint16_t>(&buffer[10]);
     uint16_t extra_offset{};

--- a/cpp/src/io/text/bgzip_data_chunk_source.cu
+++ b/cpp/src/io/text/bgzip_data_chunk_source.cu
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "io/comp/nvcomp_adapter.hpp"
+#include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/io/text/data_chunk_source_factories.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/host_vector.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/system/cuda/experimental/pinned_allocator.h>
+#include <thrust/transform.h>
+
+#include <fstream>
+#include <limits>
+
+namespace cudf::io::text {
+
+namespace {
+
+class device_uvector_data_chunk : public device_data_chunk {
+ public:
+  device_uvector_data_chunk(rmm::device_uvector<char>&& data) : _data(std::move(data)) {}
+
+  [[nodiscard]] char const* data() const override { return _data.data(); }
+  [[nodiscard]] std::size_t size() const override { return _data.size(); }
+  operator device_span<char const>() const override { return _data; }
+
+ private:
+  rmm::device_uvector<char> _data;
+};
+
+struct bgzip_nvcomp_transform_functor {
+  uint8_t const* compressed_ptr;
+  uint8_t* decompressed_ptr;
+
+  __device__ thrust::tuple<device_span<const uint8_t>, device_span<uint8_t>> operator()(
+    thrust::tuple<std::size_t, std::size_t, std::size_t, std::size_t> t)
+  {
+    auto const compressed_begin   = thrust::get<0>(t);
+    auto const compressed_end     = thrust::get<1>(t);
+    auto const decompressed_begin = thrust::get<2>(t);
+    auto const decompressed_end   = thrust::get<3>(t);
+    return thrust::make_tuple(device_span<const uint8_t>{compressed_ptr + compressed_begin,
+                                                         compressed_end - compressed_begin},
+                              device_span<uint8_t>{decompressed_ptr + decompressed_begin,
+                                                   decompressed_end - decompressed_begin});
+  }
+};
+
+class bgzip_data_chunk_reader : public data_chunk_reader {
+ private:
+  /*
+
+
+     Parsing code
+
+
+  */
+
+  template <typename IntType>
+  static bool is_little_endian()
+  {
+    IntType i = 0x0100;
+    std::array<char, sizeof(i)> bytes;
+    std::memcpy(&bytes[0], &i, sizeof(i));
+    return bytes[0] == 0;
+  }
+
+  template <typename IntType>
+  static IntType read_int(char* data)
+  {
+    IntType result{};
+    if (not is_little_endian<IntType>()) { std::reverse(data, data + sizeof(result)); }
+    std::memcpy(&result, &data[0], sizeof(result));
+    return result;
+  }
+
+  struct bgzip_header {
+    int block_size;
+    int extra_length;
+    [[nodiscard]] int data_size() const { return block_size - extra_length - 20; }
+  };
+
+  bgzip_header read_header()
+  {
+    std::array<char, 12> buffer{};
+    CUDF_EXPECTS(_stream->read(buffer.data(), sizeof(buffer)), "read failed");
+    CUDF_EXPECTS(buffer[0] == 31 && buffer[1] == 139 && buffer[2] == 8 && buffer[3] == 4,
+                 "malformed BGZIP header");
+    auto extra_length = read_int<uint16_t>(&buffer[10]);
+    uint16_t extra_offset{};
+    // read all the extra subfields
+    while (extra_offset < extra_length) {
+      auto const remaining_size = extra_length - extra_offset;
+      CUDF_EXPECTS(remaining_size >= 4, "invalid extra field length");
+      CUDF_EXPECTS(_stream->read(buffer.data(), 4), "read failed");
+      extra_offset += 4;
+      auto subfield_size = read_int<uint16_t>(&buffer[2]);
+      if (buffer[0] == 66 && buffer[1] == 67) {
+        CUDF_EXPECTS(subfield_size == sizeof(uint16_t), "malformed BGZIP extra subfield");
+        CUDF_EXPECTS(_stream->read(buffer.data(), sizeof(uint16_t)), "read failed");
+        CUDF_EXPECTS(_stream->seekg(remaining_size, std::ios_base::cur), "seek failed");
+        auto block_size = read_int<uint16_t>(&buffer[0]);
+        return {block_size + 1, extra_length};
+      } else {
+        CUDF_EXPECTS(_stream->seekg(subfield_size, std::ios_base::cur), "seek failed");
+        extra_offset += subfield_size;
+      }
+    }
+    CUDF_EXPECTS(false, "missing BGZIP size extra subfield");
+  }
+
+  struct bgzip_footer {
+    uint32_t decompressed_size;
+  };
+
+  bgzip_footer read_footer()
+  {
+    std::array<char, 8> buffer{};
+    CUDF_EXPECTS(_stream->read(buffer.data(), sizeof(buffer)), "read failed");
+    return {read_int<uint32_t>(&buffer[4])};
+  }
+
+  /*
+
+
+    High-level control flow
+
+
+  */
+
+  template <typename T>
+  using pinned_host_vector =
+    thrust::host_vector<T, thrust::system::cuda::experimental::pinned_allocator<T>>;
+
+  template <typename T>
+  static void copy_to_device(const pinned_host_vector<T>& host,
+                             rmm::device_uvector<T>& device,
+                             rmm::cuda_stream_view stream)
+  {
+    device.resize(host.size(), stream);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+      device.data(), host.data(), host.size() * sizeof(T), cudaMemcpyHostToDevice, stream.value()));
+  }
+
+  struct compressed_blocks {
+    static constexpr std::size_t default_buffer_alloc =
+      1 << 24;  // 16MB buffer allocation, resized on demand
+    static constexpr std::size_t default_offset_alloc =
+      1 << 16;  // 64k offset allocation, resized on demand
+
+    cudaEvent_t event;
+    pinned_host_vector<char> h_compressed_blocks;
+    pinned_host_vector<std::size_t> h_compressed_offsets;
+    pinned_host_vector<std::size_t> h_decompressed_offsets;
+    rmm::device_uvector<char> d_compressed_blocks;
+    rmm::device_uvector<char> d_decompressed_blocks;
+    rmm::device_uvector<std::size_t> d_compressed_offsets;
+    rmm::device_uvector<std::size_t> d_decompressed_offsets;
+    rmm::device_uvector<device_span<const uint8_t>> d_compressed_spans;
+    rmm::device_uvector<device_span<uint8_t>> d_decompressed_spans;
+    rmm::device_uvector<decompress_status> d_decompressed_status;
+    std::size_t compressed_size_with_headers{};
+    std::size_t max_decompressed_size{};
+    // this is usually equal to decompressed_size()
+    // unless we are in the last chunk, where it's limited by _local_end
+    std::size_t available_decompressed_size{};
+    std::size_t read_pos{};
+    bool decompressed{};
+
+    compressed_blocks()
+      : d_compressed_blocks(0, cudf::default_stream_value),
+        d_decompressed_blocks(0, cudf::default_stream_value),
+        d_compressed_offsets(0, cudf::default_stream_value),
+        d_decompressed_offsets(0, cudf::default_stream_value),
+        d_compressed_spans(0, cudf::default_stream_value),
+        d_decompressed_spans(0, cudf::default_stream_value),
+        d_decompressed_status(0, cudf::default_stream_value)
+    {
+      CUDF_CUDA_TRY(cudaEventCreate(&event));
+      h_compressed_blocks.reserve(default_buffer_alloc);
+      h_compressed_offsets.reserve(default_offset_alloc);
+      h_compressed_offsets.push_back(0);
+      h_decompressed_offsets.reserve(default_offset_alloc);
+      h_decompressed_offsets.push_back(0);
+    }
+
+    void decompress(rmm::cuda_stream_view stream)
+    {
+      if (decompressed) { return; }
+      copy_to_device(h_compressed_blocks, d_compressed_blocks, stream);
+      copy_to_device(h_compressed_offsets, d_compressed_offsets, stream);
+      copy_to_device(h_decompressed_offsets, d_decompressed_offsets, stream);
+      d_decompressed_blocks.resize(decompressed_size(), stream);
+      d_compressed_spans.resize(num_blocks(), stream);
+      d_decompressed_spans.resize(num_blocks(), stream);
+      d_decompressed_status.resize(num_blocks(), stream);
+
+      auto offset_it = thrust::make_zip_iterator(d_compressed_offsets.begin(),
+                                                 d_compressed_offsets.begin() + 1,
+                                                 d_decompressed_offsets.begin(),
+                                                 d_decompressed_offsets.begin() + 1);
+      auto span_it =
+        thrust::make_zip_iterator(d_compressed_spans.begin(), d_decompressed_spans.begin());
+      thrust::transform(
+        rmm::exec_policy_nosync(stream),
+        offset_it,
+        offset_it + num_blocks(),
+        span_it,
+        bgzip_nvcomp_transform_functor{reinterpret_cast<uint8_t*>(d_compressed_blocks.data()),
+                                       reinterpret_cast<uint8_t*>(d_decompressed_blocks.begin())});
+      cudf::io::nvcomp::batched_decompress(cudf::io::nvcomp::compression_type::DEFLATE,
+                                           d_compressed_spans,
+                                           d_decompressed_spans,
+                                           d_decompressed_status,
+                                           max_decompressed_size,
+                                           decompressed_size(),
+                                           stream);
+      decompressed = true;
+    }
+
+    void reset()
+    {
+      h_compressed_blocks.resize(0);
+      h_compressed_offsets.resize(1);
+      h_decompressed_offsets.resize(1);
+      // shrinking doesn't allocate/free, so we don't need to worry about streams
+      auto stream = cudf::default_stream_value;
+      d_compressed_blocks.resize(0, stream);
+      d_decompressed_blocks.resize(0, stream);
+      d_compressed_offsets.resize(0, stream);
+      d_decompressed_offsets.resize(0, stream);
+      d_compressed_spans.resize(0, stream);
+      d_decompressed_spans.resize(0, stream);
+      d_decompressed_status.resize(0, stream);
+      compressed_size_with_headers = 0;
+      max_decompressed_size        = 0;
+      available_decompressed_size  = 0;
+      read_pos                     = 0;
+      decompressed                 = false;
+    }
+
+    [[nodiscard]] std::size_t num_blocks() const { return h_compressed_offsets.size() - 1; }
+
+    [[nodiscard]] std::size_t compressed_size() const { return h_compressed_offsets.back(); }
+
+    [[nodiscard]] std::size_t decompressed_size() const { return h_decompressed_offsets.back(); }
+
+    [[nodiscard]] std::size_t remaining_size() const
+    {
+      return available_decompressed_size - read_pos;
+    }
+
+    void read_block(bgzip_header header, std::istream& stream)
+    {
+      h_compressed_blocks.resize(h_compressed_blocks.size() + header.data_size());
+      CUDF_EXPECTS(stream.read(h_compressed_blocks.data() + compressed_size(), header.data_size()),
+                   "read failed");
+    }
+
+    void add_block_offsets(bgzip_header header, bgzip_footer footer)
+    {
+      max_decompressed_size =
+        std::max<std::size_t>(footer.decompressed_size, max_decompressed_size);
+      h_compressed_offsets.push_back(compressed_size() + header.data_size());
+      h_decompressed_offsets.push_back(decompressed_size() + footer.decompressed_size);
+    }
+
+    void consume_bytes(std::size_t size)
+    {
+      CUDF_EXPECTS(size <= remaining_size(), "out of bounds");
+      read_pos += size;
+    }
+  };
+
+  void read_next_compressed_chunk(std::size_t requested_size)
+  {
+    std::swap(_curr_block, _prev_block);
+    _curr_block.reset();
+    // read chunks until we have enough decompressed data
+    while (_curr_block.decompressed_size() < requested_size) {
+      _stream->peek();
+      if (_stream->eof()) { break; }
+      auto header = read_header();
+      _curr_block.read_block(header, *_stream);
+      auto footer = read_footer();
+      _curr_block.add_block_offsets(header, footer);
+      // for the last GZIP block, we restrict ourselves to the bytes up to _local_end
+      // but only for the reader, not for decompression!
+      if (_compressed_pos == _compressed_end) {
+        _curr_block.available_decompressed_size += _local_end;
+        _compressed_pos += header.block_size;
+        break;
+      } else {
+        _curr_block.available_decompressed_size += footer.decompressed_size;
+        _compressed_pos += header.block_size;
+      }
+    }
+  }
+
+  constexpr static std::size_t chunk_load_size = 1 << 24;  // load 16 MB of data by default
+
+ public:
+  bgzip_data_chunk_reader(std::unique_ptr<std::istream> input_stream,
+                          uint64_t virtual_begin,
+                          uint64_t virtual_end)
+    : _stream(std::move(input_stream)),
+      _local_end{virtual_end & 0xFFFFu},
+      _compressed_pos{virtual_begin >> 16},
+      _compressed_end{virtual_end >> 16}
+  {
+    // seek to the beginning of the provided compressed offset
+    _stream->seekg(_compressed_pos, std::ios_base::cur);
+    // read the first blocks
+    read_next_compressed_chunk(chunk_load_size);
+    // seek to the beginning of the provided local offset
+    auto const local_pos = virtual_begin & 0xFFFFu;
+    _curr_block.consume_bytes(local_pos);
+  }
+
+  void skip_bytes(std::size_t read_size) override
+  {
+    while (read_size > _curr_block.remaining_size()) {
+      read_size -= _curr_block.remaining_size();
+      _curr_block.consume_bytes(_curr_block.remaining_size());
+      read_next_compressed_chunk(chunk_load_size);
+    }
+    _curr_block.consume_bytes(read_size);
+  }
+
+  std::unique_ptr<device_data_chunk> get_next_chunk(std::size_t read_size,
+                                                    rmm::cuda_stream_view cuda_stream) override
+  {
+    CUDF_FUNC_RANGE();
+    if (read_size <= _curr_block.remaining_size()) {
+      _curr_block.decompress(cuda_stream);
+      rmm::device_uvector<char> data(read_size, cuda_stream);
+      CUDF_CUDA_TRY(cudaMemcpyAsync(data.data(),
+                                    _curr_block.d_decompressed_blocks.data() + _curr_block.read_pos,
+                                    read_size,
+                                    cudaMemcpyDeviceToDevice,
+                                    cuda_stream.value()));
+      _curr_block.consume_bytes(read_size);
+      return std::make_unique<device_uvector_data_chunk>(std::move(data));
+    }
+    read_next_compressed_chunk(read_size /* - _curr_block.remaining_size()*/);
+    _prev_block.decompress(cuda_stream);
+    _curr_block.decompress(cuda_stream);
+    read_size = std::min(read_size, _prev_block.remaining_size() + _curr_block.remaining_size());
+    rmm::device_uvector<char> data(read_size, cuda_stream);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(data.data(),
+                                  _prev_block.d_decompressed_blocks.data() + _prev_block.read_pos,
+                                  _prev_block.remaining_size(),
+                                  cudaMemcpyDeviceToDevice,
+                                  cuda_stream.value()));
+    CUDF_CUDA_TRY(cudaMemcpyAsync(data.data() + _prev_block.remaining_size(),
+                                  _curr_block.d_decompressed_blocks.data() + _curr_block.read_pos,
+                                  read_size - _prev_block.remaining_size(),
+                                  cudaMemcpyDeviceToDevice,
+                                  cuda_stream.value()));
+    _prev_block.consume_bytes(_prev_block.remaining_size());
+    _curr_block.consume_bytes(read_size - _prev_block.remaining_size());
+    return std::make_unique<device_uvector_data_chunk>(std::move(data));
+  }
+
+ private:
+  std::unique_ptr<std::istream> _stream;
+  compressed_blocks _prev_block;
+  compressed_blocks _curr_block;
+  std::size_t _local_end;
+  std::size_t _compressed_pos;
+  std::size_t _compressed_end;
+};
+
+class bgzip_data_chunk_source : public data_chunk_source {
+ public:
+  bgzip_data_chunk_source(std::string filename, uint64_t virtual_begin, uint64_t virtual_end)
+    : _filename{std::move(filename)}, _virtual_begin{virtual_begin}, _virtual_end{virtual_end}
+  {
+  }
+  [[nodiscard]] std::unique_ptr<data_chunk_reader> create_reader() const override
+  {
+    return std::make_unique<bgzip_data_chunk_reader>(
+      std::make_unique<std::ifstream>(_filename, std::ifstream::in), _virtual_begin, _virtual_end);
+  }
+
+ private:
+  std::string _filename;
+  uint64_t _virtual_begin;
+  uint64_t _virtual_end;
+};
+
+}  // namespace
+
+std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string const& filename,
+                                                               uint64_t virtual_begin,
+                                                               uint64_t virtual_end)
+{
+  return std::make_unique<bgzip_data_chunk_source>(filename, virtual_begin, virtual_end);
+}
+
+std::unique_ptr<data_chunk_source> make_source_from_bgzip_file(std::string const& filename)
+{
+  return std::make_unique<bgzip_data_chunk_source>(
+    filename, 0, std::numeric_limits<uint64_t>::max());
+}
+
+}  // namespace cudf::io::text

--- a/cpp/src/io/text/bgzip_data_chunk_source.cu
+++ b/cpp/src/io/text/bgzip_data_chunk_source.cu
@@ -352,7 +352,7 @@ class bgzip_data_chunk_reader : public data_chunk_reader {
       _curr_block.consume_bytes(_curr_block.remaining_size());
       read_next_compressed_chunk(chunk_load_size);
       _stream->peek();
-      if (_stream->eof()) { break; }
+      if (_stream->eof() || _compressed_pos > _compressed_end) { break; }
     }
     read_size = std::min(read_size, _curr_block.remaining_size());
     _curr_block.consume_bytes(read_size);

--- a/cpp/src/io/text/bgzip_data_chunk_source.cu
+++ b/cpp/src/io/text/bgzip_data_chunk_source.cu
@@ -83,13 +83,13 @@ class bgzip_data_chunk_reader : public data_chunk_reader {
   {
     std::array<char, 12> buffer{};
     _data_stream->read(buffer.data(), sizeof(buffer));
-    std::array<uint8_t, 4> expected_header{{31, 139, 8, 4}};
+    std::array<uint8_t, 4> const expected_header{{31, 139, 8, 4}};
     CUDF_EXPECTS(
       std::equal(
         expected_header.begin(), expected_header.end(), reinterpret_cast<uint8_t*>(buffer.data())),
       "malformed BGZIP header");
     // we ignore the remaining bytes of the fixed header, since they don't matter to us
-    auto extra_length = read_int<uint16_t>(&buffer[10]);
+    auto const extra_length = read_int<uint16_t>(&buffer[10]);
     uint16_t extra_offset{};
     // read all the extra subfields
     while (extra_offset < extra_length) {
@@ -99,13 +99,13 @@ class bgzip_data_chunk_reader : public data_chunk_reader {
       // 66/67 identifies a BGZIP block size field, we skip all other fields
       _data_stream->read(buffer.data(), 4);
       extra_offset += 4;
-      auto subfield_size = read_int<uint16_t>(&buffer[2]);
+      auto const subfield_size = read_int<uint16_t>(&buffer[2]);
       if (buffer[0] == 66 && buffer[1] == 67) {
         // the block size subfield contains a single uint16 value, which is block_size - 1
         CUDF_EXPECTS(subfield_size == sizeof(uint16_t), "malformed BGZIP extra subfield");
         _data_stream->read(buffer.data(), sizeof(uint16_t));
         _data_stream->seekg(remaining_size - 6, std::ios_base::cur);
-        auto block_size_minus_one = read_int<uint16_t>(&buffer[0]);
+        auto const block_size_minus_one = read_int<uint16_t>(&buffer[0]);
         return {block_size_minus_one + 1, extra_length};
       } else {
         _data_stream->seekg(subfield_size, std::ios_base::cur);

--- a/cpp/src/io/text/bgzip_data_chunk_source.cu
+++ b/cpp/src/io/text/bgzip_data_chunk_source.cu
@@ -106,10 +106,9 @@ class bgzip_data_chunk_reader : public data_chunk_reader {
     std::array<char, 12> buffer{};
     CUDF_EXPECTS(_stream->read(buffer.data(), sizeof(buffer)), "read failed");
     uint8_t constexpr magic_expected_2 = 139;
-    std::array<char, 4> expected_header{{31, -1, 8, 4}};
+    std::array<char, 4> expected_header{{31, 0, 8, 4}};
     std::memcpy(&expected_header[1], &magic_expected_2, sizeof(char));
-    CUDF_EXPECTS(buffer[0] == expected_header[0] && buffer[1] == expected_header[1] &&
-                   buffer[2] == expected_header[2] && buffer[3] == expected_header[3],
+    CUDF_EXPECTS(std::equal(expected_header.begin(), expected_header.end(), buffer.begin()),
                  "malformed BGZIP header");
     auto extra_length = read_int<uint16_t>(&buffer[10]);
     uint16_t extra_offset{};

--- a/cpp/src/io/text/bgzip_data_chunk_source.cu
+++ b/cpp/src/io/text/bgzip_data_chunk_source.cu
@@ -78,19 +78,10 @@ class bgzip_data_chunk_reader : public data_chunk_reader {
   */
 
   template <typename IntType>
-  static bool is_little_endian()
-  {
-    IntType i = 0x0100;
-    std::array<char, sizeof(i)> bytes;
-    std::memcpy(&bytes[0], &i, sizeof(i));
-    return bytes[0] == 0;
-  }
-
-  template <typename IntType>
   static IntType read_int(char* data)
   {
     IntType result{};
-    if (not is_little_endian<IntType>()) { std::reverse(data, data + sizeof(result)); }
+    // we assume little-endian
     std::memcpy(&result, &data[0], sizeof(result));
     return result;
   }

--- a/cpp/src/io/text/bgzip_data_chunk_source.cu
+++ b/cpp/src/io/text/bgzip_data_chunk_source.cu
@@ -342,7 +342,12 @@ class bgzip_data_chunk_reader : public data_chunk_reader {
     read_next_compressed_chunk(chunk_load_size);
     // seek to the beginning of the provided local offset
     auto const local_pos = virtual_begin & 0xFFFFu;
-    _curr_block.consume_bytes(local_pos);
+    if (local_pos > 0) {
+      CUDF_EXPECTS(_curr_block.h_compressed_offsets.size() > 1 &&
+                     local_pos < _curr_block.h_compressed_offsets[1],
+                   "local part of virtual offset is out of bounds");
+      _curr_block.consume_bytes(local_pos);
+    }
   }
 
   void skip_bytes(std::size_t read_size) override

--- a/cpp/src/io/text/data_chunk_source_factories.cpp
+++ b/cpp/src/io/text/data_chunk_source_factories.cpp
@@ -207,7 +207,7 @@ class device_span_data_chunk_reader : public data_chunk_reader {
  */
 class file_data_chunk_source : public data_chunk_source {
  public:
-  file_data_chunk_source(std::string filename) : _filename(std::move(filename)) {}
+  file_data_chunk_source(std::string_view filename) : _filename(filename) {}
   [[nodiscard]] std::unique_ptr<data_chunk_reader> create_reader() const override
   {
     return std::make_unique<istream_data_chunk_reader>(
@@ -255,7 +255,7 @@ std::unique_ptr<data_chunk_source> make_source(host_span<const char> data)
   return std::make_unique<host_span_data_chunk_source>(data);
 }
 
-std::unique_ptr<data_chunk_source> make_source_from_file(std::string const& filename)
+std::unique_ptr<data_chunk_source> make_source_from_file(std::string_view filename)
 {
   return std::make_unique<file_data_chunk_source>(filename);
 }

--- a/cpp/src/io/text/data_chunk_source_factories.cpp
+++ b/cpp/src/io/text/data_chunk_source_factories.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "io/text/device_data_chunks.hpp"
+
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/io/text/data_chunk_source_factories.hpp>
 
@@ -27,30 +29,6 @@
 namespace cudf::io::text {
 
 namespace {
-
-class device_span_data_chunk : public device_data_chunk {
- public:
-  device_span_data_chunk(device_span<char const> data) : _data(data) {}
-
-  [[nodiscard]] char const* data() const override { return _data.data(); }
-  [[nodiscard]] std::size_t size() const override { return _data.size(); }
-  operator device_span<char const>() const override { return _data; }
-
- private:
-  device_span<char const> _data;
-};
-
-class device_uvector_data_chunk : public device_data_chunk {
- public:
-  device_uvector_data_chunk(rmm::device_uvector<char>&& data) : _data(std::move(data)) {}
-
-  [[nodiscard]] char const* data() const override { return _data.data(); }
-  [[nodiscard]] std::size_t size() const override { return _data.size(); }
-  operator device_span<char const>() const override { return _data; }
-
- private:
-  rmm::device_uvector<char> _data;
-};
 
 /**
  * @brief A reader which produces owning chunks of device memory which contain a copy of the data

--- a/cpp/src/io/text/device_data_chunks.hpp
+++ b/cpp/src/io/text/device_data_chunks.hpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/io/text/data_chunk_source.hpp>
+
+namespace cudf::io::text {
+
+class device_span_data_chunk : public device_data_chunk {
+ public:
+  device_span_data_chunk(device_span<char const> data) : _data(data) {}
+
+  [[nodiscard]] char const* data() const override { return _data.data(); }
+  [[nodiscard]] std::size_t size() const override { return _data.size(); }
+  operator device_span<char const>() const override { return _data; }
+
+ private:
+  device_span<char const> _data;
+};
+
+class device_uvector_data_chunk : public device_data_chunk {
+ public:
+  device_uvector_data_chunk(rmm::device_uvector<char>&& data) : _data(std::move(data)) {}
+
+  [[nodiscard]] char const* data() const override { return _data.data(); }
+  [[nodiscard]] std::size_t size() const override { return _data.size(); }
+  operator device_span<char const>() const override { return _data; }
+
+ private:
+  rmm::device_uvector<char> _data;
+};
+
+}  // namespace cudf::io::text

--- a/cpp/tests/io/text/data_chunk_source_test.cpp
+++ b/cpp/tests/io/text/data_chunk_source_test.cpp
@@ -128,14 +128,9 @@ TEST_F(DataChunkSourceTest, Host)
 template <typename T>
 void write_int(std::ostream& stream, T val)
 {
-  // endianness check
-  auto const i = static_cast<T>(0x0100);
   std::array<char, sizeof(T)> bytes;
-  std::memcpy(&bytes[0], &i, sizeof(T));
-  auto const little_endian = bytes[0] == 0;
-  // write
+  // we assume little-endian
   std::memcpy(&bytes[0], &val, sizeof(T));
-  if (not little_endian) { std::reverse(bytes.begin(), bytes.end()); }
   stream.write(bytes.data(), bytes.size());
 }
 

--- a/cpp/tests/io/text/data_chunk_source_test.cpp
+++ b/cpp/tests/io/text/data_chunk_source_test.cpp
@@ -57,6 +57,16 @@ void test_source(const std::string& content, const cudf::io::text::data_chunk_so
     ASSERT_EQ(chunk_to_host(*chunk), content.substr(4));
   }
   {
+    // reading multiple chunks, starting with a small one
+    auto reader = source.create_reader();
+    auto chunk1 = reader->get_next_chunk(5, rmm::cuda_stream_default);
+    auto chunk2 = reader->get_next_chunk(content.size() - 5, rmm::cuda_stream_default);
+    ASSERT_EQ(chunk1->size(), 5);
+    ASSERT_EQ(chunk2->size(), content.size() - 5);
+    ASSERT_EQ(chunk_to_host(*chunk1), content.substr(0, 5));
+    ASSERT_EQ(chunk_to_host(*chunk2), content.substr(5));
+  }
+  {
     // reading multiple chunks
     auto reader = source.create_reader();
     auto chunk1 = reader->get_next_chunk(content.size() / 2, rmm::cuda_stream_default);

--- a/cpp/tests/io/text/data_chunk_source_test.cpp
+++ b/cpp/tests/io/text/data_chunk_source_test.cpp
@@ -43,8 +43,8 @@ void test_source(const std::string& content, const cudf::io::text::data_chunk_so
 {
   {
     // full contents
-    auto reader = source.create_reader();
-    auto chunk  = reader->get_next_chunk(content.size(), rmm::cuda_stream_default);
+    auto reader      = source.create_reader();
+    auto const chunk = reader->get_next_chunk(content.size(), rmm::cuda_stream_default);
     ASSERT_EQ(chunk->size(), content.size());
     ASSERT_EQ(chunk_to_host(*chunk), content);
   }
@@ -52,15 +52,15 @@ void test_source(const std::string& content, const cudf::io::text::data_chunk_so
     // skipping contents
     auto reader = source.create_reader();
     reader->skip_bytes(4);
-    auto chunk = reader->get_next_chunk(content.size(), rmm::cuda_stream_default);
+    auto const chunk = reader->get_next_chunk(content.size(), rmm::cuda_stream_default);
     ASSERT_EQ(chunk->size(), content.size() - 4);
     ASSERT_EQ(chunk_to_host(*chunk), content.substr(4));
   }
   {
     // reading multiple chunks, starting with a small one
-    auto reader = source.create_reader();
-    auto chunk1 = reader->get_next_chunk(5, rmm::cuda_stream_default);
-    auto chunk2 = reader->get_next_chunk(content.size() - 5, rmm::cuda_stream_default);
+    auto reader       = source.create_reader();
+    auto const chunk1 = reader->get_next_chunk(5, rmm::cuda_stream_default);
+    auto const chunk2 = reader->get_next_chunk(content.size() - 5, rmm::cuda_stream_default);
     ASSERT_EQ(chunk1->size(), 5);
     ASSERT_EQ(chunk2->size(), content.size() - 5);
     ASSERT_EQ(chunk_to_host(*chunk1), content.substr(0, 5));
@@ -68,9 +68,9 @@ void test_source(const std::string& content, const cudf::io::text::data_chunk_so
   }
   {
     // reading multiple chunks
-    auto reader = source.create_reader();
-    auto chunk1 = reader->get_next_chunk(content.size() / 2, rmm::cuda_stream_default);
-    auto chunk2 =
+    auto reader       = source.create_reader();
+    auto const chunk1 = reader->get_next_chunk(content.size() / 2, rmm::cuda_stream_default);
+    auto const chunk2 =
       reader->get_next_chunk(content.size() - content.size() / 2, rmm::cuda_stream_default);
     ASSERT_EQ(chunk1->size(), content.size() / 2);
     ASSERT_EQ(chunk2->size(), content.size() - content.size() / 2);
@@ -79,8 +79,8 @@ void test_source(const std::string& content, const cudf::io::text::data_chunk_so
   }
   {
     // reading too many bytes
-    auto reader = source.create_reader();
-    auto chunk  = reader->get_next_chunk(content.size() + 10, rmm::cuda_stream_default);
+    auto reader      = source.create_reader();
+    auto const chunk = reader->get_next_chunk(content.size() + 10, rmm::cuda_stream_default);
     ASSERT_EQ(chunk->size(), content.size());
     ASSERT_EQ(chunk_to_host(*chunk), content);
     auto next_chunk = reader->get_next_chunk(1, rmm::cuda_stream_default);
@@ -90,37 +90,37 @@ void test_source(const std::string& content, const cudf::io::text::data_chunk_so
     // skipping past the end
     auto reader = source.create_reader();
     reader->skip_bytes(content.size() + 10);
-    auto next_chunk = reader->get_next_chunk(1, rmm::cuda_stream_default);
+    auto const next_chunk = reader->get_next_chunk(1, rmm::cuda_stream_default);
     ASSERT_EQ(next_chunk->size(), 0);
   }
 }
 
 TEST_F(DataChunkSourceTest, Device)
 {
-  std::string content = "device buffer source";
+  std::string const content = "device buffer source";
   cudf::string_scalar scalar(content);
-  auto source = cudf::io::text::make_source(scalar);
+  auto const source = cudf::io::text::make_source(scalar);
 
   test_source(content, *source);
 }
 
 TEST_F(DataChunkSourceTest, File)
 {
-  std::string content = "file source";
-  auto filename       = temp_env->get_temp_filepath("file_source");
+  std::string const content = "file source";
+  auto const filename       = temp_env->get_temp_filepath("file_source");
   {
     std::ofstream file{filename};
     file << content;
   }
-  auto source = cudf::io::text::make_source_from_file(filename);
+  auto const source = cudf::io::text::make_source_from_file(filename);
 
   test_source(content, *source);
 }
 
 TEST_F(DataChunkSourceTest, Host)
 {
-  std::string content = "host buffer source";
-  auto source         = cudf::io::text::make_source(content);
+  std::string const content = "host buffer source";
+  auto const source         = cudf::io::text::make_source(content);
 
   test_source(content, *source);
 }
@@ -151,33 +151,33 @@ void write_bgzip_block(std::ostream& stream,
     4,    // xfl: irrelevant
     3     // OS: irrelevant
   }};
-  std::array<char, 4> extra_blocklen_field{{66, 67, 2, 0}};
-  std::array<char, 11> extra_garbage_field1{{13,  // magic number
-                                             37,  // magic number
-                                             7,   // field length
-                                             0,   // field length
-                                             1,
-                                             2,
-                                             3,
-                                             4,
-                                             5,
-                                             6,
-                                             7}};
-  std::array<char, 23> extra_garbage_field2{{12,  // magic number
-                                             34,  // magic number
-                                             2,   // field length
-                                             0,   // field length
-                                             1,  2,
-                                             56,  // magic number
-                                             78,  // magic number
-                                             1,   // field length
-                                             0,   // field length
-                                             3,   //
-                                             90,  // magic number
-                                             12,  // magic number
-                                             8,   // field length
-                                             0,   // field length
-                                             1,  2, 3, 4, 5, 6, 7, 8}};
+  std::array<char, 4> const extra_blocklen_field{{66, 67, 2, 0}};
+  std::array<char, 11> const extra_garbage_field1{{13,  // magic number
+                                                   37,  // magic number
+                                                   7,   // field length
+                                                   0,   // field length
+                                                   1,
+                                                   2,
+                                                   3,
+                                                   4,
+                                                   5,
+                                                   6,
+                                                   7}};
+  std::array<char, 23> const extra_garbage_field2{{12,  // magic number
+                                                   34,  // magic number
+                                                   2,   // field length
+                                                   0,   // field length
+                                                   1,  2,
+                                                   56,  // magic number
+                                                   78,  // magic number
+                                                   1,   // field length
+                                                   0,   // field length
+                                                   3,   //
+                                                   90,  // magic number
+                                                   12,  // magic number
+                                                   8,   // field length
+                                                   0,   // field length
+                                                   1,  2, 3, 4, 5, 6, 7, 8}};
   stream.write(reinterpret_cast<const char*>(header.data()), header.size());
   uint16_t extra_size = extra_blocklen_field.size() + 2;
   if (add_extra_garbage_before) { extra_size += extra_garbage_field1.size(); }
@@ -187,8 +187,8 @@ void write_bgzip_block(std::ostream& stream,
     stream.write(extra_garbage_field1.data(), extra_garbage_field1.size());
   }
   stream.write(extra_blocklen_field.data(), extra_blocklen_field.size());
-  auto compressed_size          = data.size() + 5;
-  uint16_t block_size_minus_one = compressed_size + 19 + extra_size;
+  auto const compressed_size          = data.size() + 5;
+  uint16_t const block_size_minus_one = compressed_size + 19 + extra_size;
   write_int(stream, block_size_minus_one);
   if (add_extra_garbage_after) {
     stream.write(extra_garbage_field2.data(), extra_garbage_field2.size());
@@ -225,7 +225,7 @@ void write_bgzip(std::ostream& stream,
 
 TEST_F(DataChunkSourceTest, BgzipSource)
 {
-  auto filename = temp_env->get_temp_filepath("bgzip_source");
+  auto const filename = temp_env->get_temp_filepath("bgzip_source");
   std::string input{"bananarama"};
   for (int i = 0; i < 24; i++) {
     input = input + input;
@@ -236,14 +236,14 @@ TEST_F(DataChunkSourceTest, BgzipSource)
     write_bgzip(stream, input, rng);
   }
 
-  auto source = cudf::io::text::make_source_from_bgzip_file(filename);
+  auto const source = cudf::io::text::make_source_from_bgzip_file(filename);
 
   test_source(input, *source);
 }
 
 TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsets)
 {
-  auto filename = temp_env->get_temp_filepath("bgzip_source");
+  auto const filename = temp_env->get_temp_filepath("bgzip_source");
   std::string input{"bananarama"};
   for (int i = 0; i < 24; i++) {
     input = input + input;
@@ -252,13 +252,13 @@ TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsets)
   for (int i = 0; i < 10; i++) {
     padding_garbage = padding_garbage + padding_garbage;
   }
-  std::string data_garbage{"GARBAGE"};
-  std::string begininput{"begin of bananarama"};
-  std::string endinput{"end of bananarama"};
+  std::string const data_garbage{"GARBAGE"};
+  std::string const begininput{"begin of bananarama"};
+  std::string const endinput{"end of bananarama"};
   std::size_t begin_compressed_offset{};
   std::size_t end_compressed_offset{};
-  std::size_t begin_local_offset{data_garbage.size()};
-  std::size_t end_local_offset{endinput.size()};
+  std::size_t const begin_local_offset{data_garbage.size()};
+  std::size_t const end_local_offset{endinput.size()};
   {
     std::ofstream stream{filename};
     stream.write(padding_garbage.data(), padding_garbage.size());
@@ -273,7 +273,7 @@ TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsets)
   }
   input = begininput + input + endinput;
 
-  auto source =
+  auto const source =
     cudf::io::text::make_source_from_bgzip_file(filename,
                                                 begin_compressed_offset << 16 | begin_local_offset,
                                                 end_compressed_offset << 16 | end_local_offset);
@@ -283,21 +283,21 @@ TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsets)
 
 TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsetsSingleGZipBlock)
 {
-  auto filename = temp_env->get_temp_filepath("bgzip_source");
-  std::string input{"collection unit brings"};
-  std::string head_garbage{"garbage"};
-  std::string tail_garbage{"GARBAGE"};
+  auto const filename = temp_env->get_temp_filepath("bgzip_source");
+  std::string const input{"collection unit brings"};
+  std::string const head_garbage{"garbage"};
+  std::string const tail_garbage{"GARBAGE"};
   std::size_t begin_compressed_offset{};
   std::size_t end_compressed_offset{};
-  std::size_t begin_local_offset{head_garbage.size()};
-  std::size_t end_local_offset{head_garbage.size() + input.size()};
+  std::size_t const begin_local_offset{head_garbage.size()};
+  std::size_t const end_local_offset{head_garbage.size() + input.size()};
   {
     std::ofstream stream{filename};
     write_bgzip_block(stream, head_garbage + input + tail_garbage, false, false);
     write_bgzip_block(stream, {}, false, false);
   }
 
-  auto source =
+  auto const source =
     cudf::io::text::make_source_from_bgzip_file(filename,
                                                 begin_compressed_offset << 16 | begin_local_offset,
                                                 end_compressed_offset << 16 | end_local_offset);
@@ -307,14 +307,14 @@ TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsetsSingleGZipBlock)
 
 TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsetsSingleChunk)
 {
-  auto filename = temp_env->get_temp_filepath("bgzip_source");
-  std::string input{"collection unit brings"};
-  std::string head_garbage{"garbage"};
-  std::string tail_garbage{"GARBAGE"};
+  auto const filename = temp_env->get_temp_filepath("bgzip_source");
+  std::string const input{"collection unit brings"};
+  std::string const head_garbage{"garbage"};
+  std::string const tail_garbage{"GARBAGE"};
   std::size_t begin_compressed_offset{};
   std::size_t end_compressed_offset{};
-  std::size_t begin_local_offset{head_garbage.size()};
-  std::size_t end_local_offset{input.size() - 10};
+  std::size_t const begin_local_offset{head_garbage.size()};
+  std::size_t const end_local_offset{input.size() - 10};
   {
     std::ofstream stream{filename};
     write_bgzip_block(stream, head_garbage + input.substr(0, 10), false, false);
@@ -323,7 +323,7 @@ TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsetsSingleChunk)
     write_bgzip_block(stream, {}, false, false);
   }
 
-  auto source =
+  auto const source =
     cudf::io::text::make_source_from_bgzip_file(filename,
                                                 begin_compressed_offset << 16 | begin_local_offset,
                                                 end_compressed_offset << 16 | end_local_offset);

--- a/cpp/tests/io/text/data_chunk_source_test.cpp
+++ b/cpp/tests/io/text/data_chunk_source_test.cpp
@@ -219,7 +219,7 @@ TEST_F(DataChunkSourceTest, BgzipSource)
 {
   auto filename = temp_env->get_temp_filepath("bgzip_source");
   std::string input{"bananarama"};
-  for (int i = 0; i < 26; i++) {
+  for (int i = 0; i < 24; i++) {
     input = input + input;
   }
   {
@@ -237,7 +237,7 @@ TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsets)
 {
   auto filename = temp_env->get_temp_filepath("bgzip_source");
   std::string input{"bananarama"};
-  for (int i = 0; i < 26; i++) {
+  for (int i = 0; i < 24; i++) {
     input = input + input;
   }
   std::string garbage{"garbage"};

--- a/cpp/tests/io/text/data_chunk_source_test.cpp
+++ b/cpp/tests/io/text/data_chunk_source_test.cpp
@@ -243,28 +243,28 @@ TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsets)
   for (int i = 0; i < 24; i++) {
     input = input + input;
   }
-  std::string garbage{"garbage"};
+  std::string padding_garbage{"garbage"};
   for (int i = 0; i < 10; i++) {
-    garbage = garbage + garbage;
+    padding_garbage = padding_garbage + padding_garbage;
   }
-  std::string garbage2{"GARBAGE"};
+  std::string data_garbage{"GARBAGE"};
   std::string begininput{"begin of bananarama"};
   std::string endinput{"end of bananarama"};
   std::size_t begin_compressed_offset{};
   std::size_t end_compressed_offset{};
-  std::size_t begin_local_offset{garbage2.size()};
+  std::size_t begin_local_offset{data_garbage.size()};
   std::size_t end_local_offset{endinput.size()};
   {
     std::ofstream stream{filename};
-    stream.write(garbage.data(), garbage.size());
+    stream.write(padding_garbage.data(), padding_garbage.size());
     std::default_random_engine rng{};
     begin_compressed_offset = stream.tellp();
-    write_bgzip_block(stream, garbage2 + begininput, false, false);
+    write_bgzip_block(stream, data_garbage + begininput, false, false);
     write_bgzip(stream, input, rng, false);
     end_compressed_offset = stream.tellp();
-    write_bgzip_block(stream, endinput + garbage2 + garbage2, false, false);
+    write_bgzip_block(stream, endinput + data_garbage + data_garbage, false, false);
     write_bgzip_block(stream, {}, false, false);
-    stream.write(garbage.data(), garbage.size());
+    stream.write(padding_garbage.data(), padding_garbage.size());
   }
   input = begininput + input + endinput;
 
@@ -280,15 +280,15 @@ TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsetsSingleGZipBlock)
 {
   auto filename = temp_env->get_temp_filepath("bgzip_source");
   std::string input{"collection unit brings"};
-  std::string garbage{"garbage"};
-  std::string garbage2{"GARBAGE"};
+  std::string head_garbage{"garbage"};
+  std::string tail_garbage{"GARBAGE"};
   std::size_t begin_compressed_offset{};
   std::size_t end_compressed_offset{};
-  std::size_t begin_local_offset{garbage.size()};
-  std::size_t end_local_offset{garbage.size() + input.size()};
+  std::size_t begin_local_offset{head_garbage.size()};
+  std::size_t end_local_offset{head_garbage.size() + input.size()};
   {
     std::ofstream stream{filename};
-    write_bgzip_block(stream, garbage + input + garbage2, false, false);
+    write_bgzip_block(stream, head_garbage + input + tail_garbage, false, false);
     write_bgzip_block(stream, {}, false, false);
   }
 
@@ -304,17 +304,17 @@ TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsetsSingleChunk)
 {
   auto filename = temp_env->get_temp_filepath("bgzip_source");
   std::string input{"collection unit brings"};
-  std::string garbage{"garbage"};
-  std::string garbage2{"GARBAGE"};
+  std::string head_garbage{"garbage"};
+  std::string tail_garbage{"GARBAGE"};
   std::size_t begin_compressed_offset{};
   std::size_t end_compressed_offset{};
-  std::size_t begin_local_offset{garbage.size()};
+  std::size_t begin_local_offset{head_garbage.size()};
   std::size_t end_local_offset{input.size() - 10};
   {
     std::ofstream stream{filename};
-    write_bgzip_block(stream, garbage + input.substr(0, 10), false, false);
+    write_bgzip_block(stream, head_garbage + input.substr(0, 10), false, false);
     end_compressed_offset = stream.tellp();
-    write_bgzip_block(stream, input.substr(10) + garbage2, false, false);
+    write_bgzip_block(stream, input.substr(10) + tail_garbage, false, false);
     write_bgzip_block(stream, {}, false, false);
   }
 


### PR DESCRIPTION
## Description
This adds a BGZIP `data_chunk_reader` usable with `multibyte_split`. The BGZIP format is a modified GZIP format that consists of multiple blocks of at most 65536 bytes compressed data describing at most 65536 bytes of uncompressed data. The data can be accessed with record offsets provided by Tabix index files, which contain so-called virtual offsets (unsigned 64 bit) of the following form
```
63                    16       0
+----------------------+-------+
|      block offset    | local |
+----------------------+-------+
```
The lower 16 bits describe the offset inside the uncompressed data belonging to a single compressed block, the upper 48 bits describe the offset of the compressed block inside the BGZIP file. The interface allows two modes: Reading a full compressed file, and reading between the locations described by two Tabix virtual offsets.

For a description of the BGZIP format, check section 4 in the [SAM specification](https://github.com/samtools/hts-specs/blob/master/SAMv1.pdf).

Closes #10466 

## TODO
- [x] Use events to avoid clobbering data that is still in use
- [x] stricter handling of local_begin (currently it may overflow into subsequent blocks)
- [x] add tests where  local_begin and local_end are in the same chunk or even block
- [x] ~~add cudf deflate fallback if nvComp doesn't support it~~ this should not be necessary, since we only test with compatible nvcomp versions

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
