### PR TITLE
Fix multi-file remote datasource bug

### DIFF
--- a/python/cudf/cudf/_lib/cpp/io/types.pxd
+++ b/python/cudf/cudf/_lib/cpp/io/types.pxd
@@ -105,6 +105,7 @@ cdef extern from "cudf/io/types.hpp" \
         source_info(const vector[string] &filepaths) except +
         source_info(const vector[host_buffer] &host_buffers) except +
         source_info(datasource *source) except +
+        source_info(const vector[datasource*] &datasources) except +
 
     cdef cppclass sink_info:
         io_type type

--- a/python/cudf/cudf/tests/test_s3.py
+++ b/python/cudf/cudf/tests/test_s3.py
@@ -311,6 +311,38 @@ def test_read_parquet_ext(
     assert_eq(expect, got1)
 
 
+def test_read_parquet_multi_file(s3_base, s3so, pdf):
+    fname_1 = "test_parquet_reader_multi_file_1.parquet"
+    buffer_1 = BytesIO()
+    pdf.to_parquet(path=buffer_1)
+    buffer_1.seek(0)
+
+    fname_2 = "test_parquet_reader_multi_file_2.parquet"
+    buffer_2 = BytesIO()
+    pdf.to_parquet(path=buffer_2)
+    buffer_2.seek(0)
+
+    bucket = "parquet"
+    with s3_context(
+        s3_base=s3_base,
+        bucket=bucket,
+        files={
+            fname_1: buffer_1,
+            fname_2: buffer_2,
+        },
+    ):
+        got = cudf.read_parquet(
+            [
+                f"s3://{bucket}/{fname_1}",
+                f"s3://{bucket}/{fname_2}",
+            ],
+            storage_options=s3so,
+        )
+
+    expect = pd.concat([pdf, pdf])
+    assert_eq(expect, got)
+
+
 @pytest.mark.parametrize("columns", [None, ["Float", "String"]])
 def test_read_parquet_arrow_nativefile(s3_base, s3so, pdf, columns):
     # Write to buffer

--- a/python/cudf/cudf/tests/test_s3.py
+++ b/python/cudf/cudf/tests/test_s3.py
@@ -337,9 +337,9 @@ def test_read_parquet_multi_file(s3_base, s3so, pdf):
                 f"s3://{bucket}/{fname_2}",
             ],
             storage_options=s3so,
-        )
+        ).reset_index(drop=True)
 
-    expect = pd.concat([pdf, pdf])
+    expect = pd.concat([pdf, pdf], ignore_index=True)
     assert_eq(expect, got)
 
 


### PR DESCRIPTION
## Description
The intention of this PR is to address the dataset-truncation bug described in #11324. It seems that cudf does not currently handle multiple pyarrow-based datasources correctly.  This means `cudf.read_parquet` will return incorrect results when reading a list of files from remote storage (e.g. from s3 or gcs).

**The underlying problem**: Instead of passing a vector of `datasource` objects to libcudf, the python/cython API only passes along a `datasource` object for the very **first** file in the user-specified list. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
