### PR TITLE
Remove redundant style check for clang-format.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,9 +40,8 @@ repos:
         rev: v11.1.0
         hooks:
               - id: clang-format
-                files: \.(cu|cuh|h|hpp|cpp|inl)$
-                types_or: [file]
-                args: ['-fallback-style=none', '-style=file', '-i']
+                types_or: [c, c++, cuda]
+                args: ["-fallback-style=none", "-style=file", "-i"]
       - repo: local
         hooks:
               - id: no-deprecationwarning

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -19,35 +19,9 @@ export RAPIDS_CMAKE_FORMAT_FILE=/tmp/rapids_cmake_ci/cmake-formats-rapids-cmake.
 mkdir -p $(dirname ${RAPIDS_CMAKE_FORMAT_FILE})
 wget -O ${RAPIDS_CMAKE_FORMAT_FILE} ${FORMAT_FILE_URL}
 
-
+# Run pre-commit checks
 pre-commit run --hook-stage manual --all-files
 PRE_COMMIT_RETVAL=$?
-
-# Check for copyright headers in the files modified currently
-COPYRIGHT=`python ci/checks/copyright.py --git-modified-only 2>&1`
-CR_RETVAL=$?
-
-# Output results if failure otherwise show pass
-if [ "$CR_RETVAL" != "0" ]; then
-  echo -e "\n\n>>>> FAILED: copyright check; begin output\n\n"
-  echo -e "$COPYRIGHT"
-  echo -e "\n\n>>>> FAILED: copyright check; end output\n\n"
-else
-  echo -e "\n\n>>>> PASSED: copyright check\n\n"
-  echo -e "$COPYRIGHT"
-fi
-
-# Run clang-format and check for a consistent code format
-CLANG_FORMAT=`python cpp/scripts/run-clang-format.py 2>&1`
-CLANG_FORMAT_RETVAL=$?
-
-if [ "$CLANG_FORMAT_RETVAL" != "0" ]; then
-  echo -e "\n\n>>>> FAILED: clang format check; begin output\n\n"
-  echo -e "$CLANG_FORMAT"
-  echo -e "\n\n>>>> FAILED: clang format check; end output\n\n"
-else
-  echo -e "\n\n>>>> PASSED: clang format check\n\n"
-fi
 
 # Run header meta.yml check and get results/return code
 HEADER_META=`ci/checks/headers_test.sh`
@@ -55,7 +29,7 @@ HEADER_META_RETVAL=$?
 echo -e "$HEADER_META"
 
 RETVALS=(
-  $CR_RETVAL $PRE_COMMIT_RETVAL $CLANG_FORMAT_RETVAL $HEADER_META_RETVAL
+  $PRE_COMMIT_RETVAL $HEADER_META_RETVAL
 )
 IFS=$'\n'
 RETVAL=`echo "${RETVALS[*]}" | sort -nr | head -n1`

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -23,13 +23,28 @@ wget -O ${RAPIDS_CMAKE_FORMAT_FILE} ${FORMAT_FILE_URL}
 pre-commit run --hook-stage manual --all-files
 PRE_COMMIT_RETVAL=$?
 
+# Check for copyright headers in the files modified currently
+COPYRIGHT=`python ci/checks/copyright.py --git-modified-only 2>&1`
+COPYRIGHT_RETVAL=$?
+
+# Output results if failure otherwise show pass
+if [ "$COPYRIGHT_RETVAL" != "0" ]; then
+  echo -e "\n\n>>>> FAILED: copyright check; begin output\n\n"
+  echo -e "$COPYRIGHT"
+  echo -e "\n\n>>>> FAILED: copyright check; end output\n\n"
+else
+  echo -e "\n\n>>>> PASSED: copyright check\n\n"
+  echo -e "$COPYRIGHT"
+fi
+
+
 # Run header meta.yml check and get results/return code
 HEADER_META=`ci/checks/headers_test.sh`
 HEADER_META_RETVAL=$?
 echo -e "$HEADER_META"
 
 RETVALS=(
-  $PRE_COMMIT_RETVAL $HEADER_META_RETVAL
+  $PRE_COMMIT_RETVAL $COPYRIGHT_RETVAL $HEADER_META_RETVAL
 )
 IFS=$'\n'
 RETVAL=`echo "${RETVALS[*]}" | sort -nr | head -n1`

--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -15,7 +15,7 @@ AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: true 
+AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
@@ -27,7 +27,7 @@ AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: Yes
-BinPackArguments:  false       
+BinPackArguments:  false
 BinPackParameters: false
 BraceWrapping:
   AfterClass:            false

--- a/cpp/src/column/column_factories.cpp
+++ b/cpp/src/column/column_factories.cpp
@@ -157,7 +157,7 @@ std::unique_ptr<column> make_fixed_width_column(data_type type,
   else if (is_duration   (type)) return make_duration_column   (type, size, state, stream, mr);
   else if (is_fixed_point(type)) return make_fixed_point_column(type, size, state, stream, mr);
   else                           return make_numeric_column    (type, size, state, stream, mr);
-  /// clang-format on
+  // clang-format on
 }
 
 std::unique_ptr<column> make_dictionary_from_scalar(scalar const& s,


### PR DESCRIPTION
## Description
This PR removes a redundant style check for clang-format. Our configuration in `.pre-commit-config.yaml` already runs clang-format so we don't need a separate step for that purpose in `style.sh`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
