### PR TITLE
[REVIEW] Ignore protobuf generated files in `mypy` checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ exclude = (?x)(
   | cudf/_lib/
   | cudf/cudf/benchmarks/
   | cudf/cudf/tests/
+  | cudf/cudf/utils/metadata/orc_column_statistics_pb2.py
   | custreamz/custreamz/tests/
   | dask_cudf/dask_cudf/tests/
   # This close paren cannot be in column zero otherwise the config parser barfs


### PR DESCRIPTION
## Description
As part of https://github.com/rapidsai/cudf/pull/11640, there was a missing exclusion for `cudf/cudf/utils/metadata/orc_column_statistics_pb2.py`, that causes the following errors:
```bash
(cudfdev) pgali@dt07:/nvme/0/pgali/cudf$ git commit -m "address reviews"
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /home/nfs/pgali/.cache/pre-commit/patch1662993629-63423.
isort....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:7: error: Library stubs not installed for "google.protobuf.internal" (or incompatible with Python 3.9)
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:7: note: Hint: "python3 -m pip install types-protobuf"
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:7: note: (or run "mypy --install-types" to install all missing stub packages)
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:7: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:8: error: Library stubs not installed for "google.protobuf" (or incompatible with Python 3.9)
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:25: error: Name "_BUCKETSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:26: error: Name "_BUCKETSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:27: error: Name "_INTEGERSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:28: error: Name "_INTEGERSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:29: error: Name "_DOUBLESTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:30: error: Name "_DOUBLESTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:31: error: Name "_STRINGSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:32: error: Name "_STRINGSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:33: error: Name "_BUCKETSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:34: error: Name "_BUCKETSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:35: error: Name "_DECIMALSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:36: error: Name "_DECIMALSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:37: error: Name "_DATESTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:38: error: Name "_DATESTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:39: error: Name "_TIMESTAMPSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:40: error: Name "_TIMESTAMPSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:41: error: Name "_BINARYSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:42: error: Name "_BINARYSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:43: error: Name "_COLUMNSTATISTICS" is not defined
python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py:44: error: Name "_COLUMNSTATISTICS" is not defined
Found 22 errors in 1 file (checked 138 source files)

pydocstyle...............................................................Passed
clang-format.........................................(no files to check)Skipped
no-deprecationwarning....................................................Passed
cmake-format.........................................(no files to check)Skipped
- hook id: cmake-format
cmake-lint...........................................(no files to check)Skipped
- hook id: cmake-lint
copyright-check..........................................................Passed
doxygen-check........................................(no files to check)Skipped
- hook id: doxygen-check
[INFO] Restored changes from /home/nfs/pgali/.cache/pre-commit/patch1662993629-63423.
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
