### PR TITLE
Transfer correct dtype to exploded column

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -101,7 +101,9 @@ class BaseIndex(Serializable):
     def __contains__(self, item):
         return item in self._values
 
-    def _copy_type_metadata(self: BaseIndexT, other: BaseIndexT) -> BaseIndexT:
+    def _copy_type_metadata(
+        self: BaseIndexT, other: BaseIndexT, *, override_dtypes=None
+    ) -> BaseIndexT:
         raise NotImplementedError
 
     def get_level_values(self, level):

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -39,7 +39,7 @@ from pandas.io.formats.printing import pprint_thing
 import cudf
 import cudf.core.common
 from cudf import _lib as libcudf
-from cudf._typing import ColumnLike, NotImplementedType
+from cudf._typing import ColumnLike, Dtype, NotImplementedType
 from cudf.api.types import (
     _is_scalar_or_zero_d_array,
     is_bool_dtype,
@@ -6536,9 +6536,14 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         columns: List[ColumnBase],
         column_names: abc.Iterable[str],
         index_names: Optional[List[str]] = None,
+        *,
+        override_dtypes: Optional[abc.Iterable[Optional[Dtype]]] = None,
     ) -> DataFrame:
         result = super()._from_columns_like_self(
-            columns, column_names, index_names
+            columns,
+            column_names,
+            index_names,
+            override_dtypes=override_dtypes,
         )
         result._set_column_names_like(self)
         return result

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1179,16 +1179,13 @@ class Frame(BinaryOperand, Scannable):
 
         See `ColumnBase._with_type_metadata` for more information.
         """
-        for (name, col), dtype in zip(
-            self._data.items(),
-            (
-                dtype or col.dtype
-                for (dtype, col) in zip(
-                    override_dtypes or itertools.repeat(None),
-                    other._data.values(),
-                )
-            ),
-        ):
+        if override_dtypes is None:
+            override_dtypes = itertools.repeat(None)
+        dtypes = (
+            dtype if dtype is not None else col.dtype
+            for (dtype, col) in zip(override_dtypes, other._data.values())
+        )
+        for (name, col), dtype in zip(self._data.items(), dtypes):
             self._data.set_by_label(
                 name, col._with_type_metadata(dtype), validate=False
             )

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import itertools
 import operator
 import pickle
 import warnings
@@ -131,6 +132,8 @@ class Frame(BinaryOperand, Scannable):
         self,
         columns: List[ColumnBase],
         column_names: Optional[abc.Iterable[str]] = None,
+        *,
+        override_dtypes: Optional[abc.Iterable[Optional[Dtype]]] = None,
     ):
         """Construct a Frame from a list of columns with metadata from self.
 
@@ -139,7 +142,7 @@ class Frame(BinaryOperand, Scannable):
         if column_names is None:
             column_names = self._column_names
         frame = self.__class__._from_columns(columns, column_names)
-        return frame._copy_type_metadata(self)
+        return frame._copy_type_metadata(self, override_dtypes=override_dtypes)
 
     def _mimic_inplace(
         self: T, result: T, inplace: bool = False
@@ -1160,17 +1163,34 @@ class Frame(BinaryOperand, Scannable):
             if name in set(column_names)
         ]
 
-    def _copy_type_metadata(self: T, other: T) -> T:
+    def _copy_type_metadata(
+        self: T,
+        other: T,
+        *,
+        override_dtypes: Optional[abc.Iterable[Optional[Dtype]]] = None,
+    ) -> T:
         """
         Copy type metadata from each column of `other` to the corresponding
         column of `self`.
+
+        If override_dtypes is provided, any non-None entry
+        will be used in preference to the relevant column of other to
+        provide the new dtype.
+
         See `ColumnBase._with_type_metadata` for more information.
         """
-        for name, col, other_col in zip(
-            self._data.keys(), self._data.values(), other._data.values()
+        for (name, col), dtype in zip(
+            self._data.items(),
+            (
+                dtype or col.dtype
+                for (dtype, col) in zip(
+                    override_dtypes or itertools.repeat(None),
+                    other._data.values(),
+                )
+            ),
         ):
             self._data.set_by_label(
-                name, col._with_type_metadata(other_col.dtype), validate=False
+                name, col._with_type_metadata(dtype), validate=False
             )
 
         return self

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -184,7 +184,9 @@ class RangeIndex(BaseIndex, BinaryOperand):
         # whereas _stop is an upper bound.
         self._end = self._start + self._step * (len(self._range) - 1)
 
-    def _copy_type_metadata(self: RangeIndex, other: RangeIndex) -> RangeIndex:
+    def _copy_type_metadata(
+        self: RangeIndex, other: RangeIndex, *, override_dtypes=None
+    ) -> RangeIndex:
         # There is no metadata to be copied for RangeIndex since it does not
         # have an underlying column.
         return self
@@ -978,9 +980,11 @@ class GenericIndex(SingleColumnFrame, BaseIndex):
     # Override just to make mypy happy.
     @_cudf_nvtx_annotate
     def _copy_type_metadata(
-        self: GenericIndex, other: GenericIndex
+        self: GenericIndex, other: GenericIndex, *, override_dtypes=None
     ) -> GenericIndex:
-        return super()._copy_type_metadata(other)
+        return super()._copy_type_metadata(
+            other, override_dtypes=override_dtypes
+        )
 
     @property  # type: ignore
     @_cudf_nvtx_annotate

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -3520,7 +3520,7 @@ class IndexedFrame(Frame):
             self._index_names if not ignore_index else None,
             override_dtypes=(
                 exploded_dtype if i == column_index else None
-                for i, _ in enumerate(self._columns)
+                for i in range(len(self._columns))
             ),
         )
 

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -45,6 +45,7 @@ from cudf.api.types import (
 from cudf.core._base_index import BaseIndex
 from cudf.core.column import ColumnBase, as_column, full
 from cudf.core.column_accessor import ColumnAccessor
+from cudf.core.dtypes import ListDtype
 from cudf.core.frame import Frame
 from cudf.core.groupby.groupby import GroupBy
 from cudf.core.index import Index, RangeIndex, _index_from_columns
@@ -3487,7 +3488,15 @@ class IndexedFrame(Frame):
             ],
             explode_column_num,
         )
-
+        # dtype of exploded column is the element dtype of the list
+        # column that was exploded, this needs to be copied over so
+        # that nested struct dtypes maintain the key names.
+        element_type = cast(
+            ListDtype, self._data[explode_column].dtype
+        ).element_type
+        exploded[explode_column_num] = exploded[
+            explode_column_num
+        ]._with_type_metadata(element_type)
         return self._from_columns_like_self(
             exploded,
             self._column_names,

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1854,7 +1854,9 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
         return midx
 
     @_cudf_nvtx_annotate
-    def _copy_type_metadata(self: MultiIndex, other: MultiIndex) -> MultiIndex:
+    def _copy_type_metadata(
+        self: MultiIndex, other: MultiIndex, *, override_dtypes=None
+    ) -> MultiIndex:
         res = super()._copy_type_metadata(other)
         res._names = other._names
         return res

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -2,13 +2,11 @@
 
 import functools
 import operator
-from string import printable
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from hypothesis import given, settings, strategies as st
 
 import cudf
 from cudf import NA
@@ -109,24 +107,48 @@ def test_listdtype_hash():
     assert hash(a) != hash(c)
 
 
-@settings(deadline=None)
-@given(
-    st.builds(
-        lambda x: [x],
-        st.recursive(
-            st.integers(min_value=-100, max_value=100),
-            lambda c: st.lists(c, min_size=1, max_size=1)
-            | st.dictionaries(
-                st.text(printable, min_size=1, max_size=20),
-                c,
-                min_size=1,
-                max_size=10,
-            ),
-        ),
-    )
-)
-def test_list_dtype_explode(x):
-    sr = cudf.Series([x])
+@pytest.fixture(params=["int", "float", "datetime", "timedelta"])
+def leaf_value(request):
+    if request.param == "int":
+        return np.int32(1)
+    elif request.param == "float":
+        return np.float64(1)
+    elif request.param == "datetime":
+        return pd.to_datetime("1900-01-01")
+    elif request.param == "timedelta":
+        return pd.to_timedelta("10d")
+    else:
+        raise ValueError("Unhandled data type")
+
+
+@pytest.fixture(params=["list", "struct"])
+def list_or_struct(request, leaf_value):
+    if request.param == "list":
+        return [[leaf_value], [leaf_value]]
+    elif request.param == "struct":
+        return {"a": leaf_value, "b": [leaf_value], "c": {"d": [leaf_value]}}
+    else:
+        raise ValueError("Unhandled data type")
+
+
+@pytest.fixture(params=["list", "struct"])
+def nested_list(request, list_or_struct, leaf_value):
+    if request.param == "list":
+        return [list_or_struct, list_or_struct]
+    elif request.param == "struct":
+        return [
+            {
+                "a": list_or_struct,
+                "b": leaf_value,
+                "c": {"d": list_or_struct, "e": leaf_value},
+            }
+        ]
+    else:
+        raise ValueError("Unhandled data type")
+
+
+def test_list_dtype_explode(nested_list):
+    sr = cudf.Series([nested_list])
     assert sr.dtype.element_type == sr.explode().dtype
 
 


### PR DESCRIPTION
## Description
Since libcudf doesn't keep track of StructDtype key names, round-tripping through outer_explode loses information. We know the correct dtype, since it is the element_type of the exploded list column, so attach that type metadata before handing back the return value.

Exploding a list series should be equivalent to unwrapping one level of list from the dtype, so that

    x = cudf.Series([[{'a': 'b'}]])
    x.explode().dtype == x.dtype.element_type

Previously this was not the case, since we would lose the names resulting in

    x.explode().dtype == StructDtype({'0': dtype('O')})

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
