### PR TITLE
[REVIEW] Fix an issue related to `Multindex` when `group_keys=True`

### DIFF
--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -2701,7 +2701,7 @@ def test_groupby_pct_change_empty_columns():
 @pytest.mark.parametrize("by", ["A", ["A", "B"]])
 def test_groupby_group_keys(group_keys, by):
     gdf = cudf.DataFrame(
-        {"A": "a a b".split(), "B": [1, 1, 3], "C": [4, 6, 5]}
+        {"A": "a a a a b b".split(), "B": [1, 1, 2, 2, 3, 3], "C": [4, 6, 5, 9, 8, 7]}
     )
     pdf = gdf.to_pandas()
 

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -2698,14 +2698,15 @@ def test_groupby_pct_change_empty_columns():
         False,
     ],
 )
-def test_groupby_group_keys(group_keys):
+@pytest.mark.parametrize("by", ["A", ["A", "B"]])
+def test_groupby_group_keys(group_keys, by):
     gdf = cudf.DataFrame(
-        {"A": "a a b".split(), "B": [1, 2, 3], "C": [4, 6, 5]}
+        {"A": "a a b".split(), "B": [1, 1, 3], "C": [4, 6, 5]}
     )
     pdf = gdf.to_pandas()
 
-    g_group = gdf.groupby("A", group_keys=group_keys)
-    p_group = pdf.groupby("A", group_keys=group_keys)
+    g_group = gdf.groupby(by, group_keys=group_keys)
+    p_group = pdf.groupby(by, group_keys=group_keys)
 
     actual = g_group[["B", "C"]].apply(lambda x: x / x.sum())
     expected = p_group[["B", "C"]].apply(lambda x: x / x.sum())

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -2701,7 +2701,11 @@ def test_groupby_pct_change_empty_columns():
 @pytest.mark.parametrize("by", ["A", ["A", "B"]])
 def test_groupby_group_keys(group_keys, by):
     gdf = cudf.DataFrame(
-        {"A": "a a a a b b".split(), "B": [1, 1, 2, 2, 3, 3], "C": [4, 6, 5, 9, 8, 7]}
+        {
+            "A": "a a a a b b".split(),
+            "B": [1, 1, 2, 2, 3, 3],
+            "C": [4, 6, 5, 9, 8, 7],
+        }
     )
     pdf = gdf.to_pandas()
 


### PR DESCRIPTION
## Description
When there are multiple groups in a groupby, passing `group_keys=True` raises an error:
```python
In [1]: import cudf

In [2]: gdf = cudf.DataFrame(
   ...: {"A": "a a b".split(), "B": [1, 1, 3], "C": [4, 6, 5]}
   ...: )

In [3]: g_group = gdf.groupby(["A", "B"], group_keys=True)

In [4]: g_group[["B", "C"]].apply(lambda x: x / x.sum())
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In [4], line 1
----> 1 g_group[["B", "C"]].apply(lambda x: x / x.sum())

File /nvme/0/pgali/envs/cudfdev/lib/python3.9/site-packages/cudf/core/groupby/groupby.py:782, in GroupBy.apply(self, function, *args)
    778         result = cudf.concat(chunk_results)
    779         if self._group_keys:
    780             result.index = cudf.MultiIndex._from_data(
    781                 {
--> 782                     group_keys.name: group_keys._column,
    783                     None: grouped_values.index._column,
    784                 }
    785             )
    787 if self._sort:
    788     result = result.sort_index()

AttributeError: 'MultiIndex' object has no attribute '_column'
```

This PR fixes the issue:
```python
In [1]: import cudf

In [2]: gdf = cudf.DataFrame(
   ...: {"A": "a a b".split(), "B": [1, 1, 3], "C": [4, 6, 5]}
   ...: )

In [3]: g_group = gdf.groupby(["A", "B"], group_keys=True)

In [4]: g_group[["B", "C"]].apply(lambda x: x / x.sum())
Out[4]: 
         B    C
A B            
a 1 0  0.5  0.4
    1  0.5  0.6
b 3 2  1.0  1.0
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
