### PR TITLE
Add a `__dataframe__` method to the protocol dataframe object

### DIFF
--- a/python/cudf/cudf/core/df_protocol.py
+++ b/python/cudf/cudf/core/df_protocol.py
@@ -529,6 +529,16 @@ class _CuDFDataFrame:
         self._nan_as_null = nan_as_null
         self._allow_copy = allow_copy
 
+    def __dataframe__(
+        self, nan_as_null: bool = False, allow_copy: bool = True
+    ) -> "_CuDFDataFrame":
+        """
+        See the docstring of the `cudf.DataFrame.__dataframe__` for details
+        """
+        return _CuDFDataFrame(
+            self._df, nan_as_null=nan_as_null, allow_copy=allow_copy
+        )
+
     @property
     def metadata(self):
         # `index` isn't a regular column, and the protocol doesn't support row

--- a/python/cudf/cudf/tests/test_df_protocol.py
+++ b/python/cudf/cudf/tests/test_df_protocol.py
@@ -124,6 +124,9 @@ def test_from_dataframe():
     df2 = cudf.from_dataframe(df1)
     assert_eq(df1, df2)
 
+    df3 = cudf.from_dataframe(df2)
+    assert_eq(df1, df3)
+
 
 def test_int_dtype():
     data_int = dict(a=[1, 2, 3], b=[9, 10, 11])


### PR DESCRIPTION
This will align the implementation with those in other libraries, xref https://github.com/data-apis/dataframe-api/issues/80.

Cc @shwina 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
