### PR TITLE
Set `xfail_strict=true` to fail on xpassed pytests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ exclude = '''
     dist
 )/
 '''
+
+[tool.pytest.ini_options]
+xfail_strict = true


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Adds `xfail_strict = true` to our pytest configuration so that xpassed tests will trigger a failed test run; this should make it immediately obvious when previously xfailed tests are now passing.

Will follow up on this initial commit by removing any unnecessary xfails.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
