### PR TITLE
[REVIEW] Fix `DataFrame.from_arrow` to preserve type metadata

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1089,10 +1089,10 @@ class Frame(BinaryOperand, Scannable):
             dtype = None
             if (
                 len(result[name]) == 0
-                and pandas_dtypes.get(name, "") == "categorical"
+                and pandas_dtypes.get(name) == "categorical"
             ):
                 # When pandas_dtype is a categorical column and the size
-                # of column is 0(i.e., empty) then we will have an
+                # of column is 0 (i.e., empty) then we will have an
                 # int8 column in result._data[name] returned by libcudf,
                 # which needs to be type-casted to 'category' dtype.
                 dtype = "category"
@@ -1104,24 +1104,24 @@ class Frame(BinaryOperand, Scannable):
                 # is specified as 'empty' and np_dtypes as 'object',
                 # hence handling this special case to type-cast the empty
                 # float column to str column.
-                dtype = np_dtypes[name]
+                dtype = "object"
             elif name in data.column_names and isinstance(
                 data[name].type,
                 (pa.StructType, pa.ListType, pa.Decimal128Type),
             ):
-                # Incase of struct column, libcudf is not aware of names of
+                # In case of struct column, libcudf is not aware of names of
                 # struct fields, hence renaming the struct fields is
                 # necessary by extracting the field names from arrow
                 # struct types.
 
-                # Incase of decimal column, libcudf is not aware of the
+                # In case of decimal column, libcudf is not aware of the
                 # decimal precision.
 
-                # Incase of list column, there is a possibility of nested
-                # list columns to have struct & decimal columns inside them.
+                # In case of list column, there is a possibility of nested
+                # list columns to have struct or decimal columns inside them.
 
-                # All these are taken care by calling to _with_type_metadata
-                # API on the column.
+                # All of these cases are handled by calling the _with_type_metadata
+                # method on the column.
                 result[name] = result[name]._with_type_metadata(
                     cudf.utils.dtypes.cudf_dtype_from_pa_type(data[name].type)
                 )

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1097,8 +1097,8 @@ class Frame(BinaryOperand, Scannable):
                 # which needs to be type-casted to 'category' dtype.
                 dtype = "category"
             elif (
-                pandas_dtypes.get(name, "") == "empty"
-                and np_dtypes.get(name, "") == "object"
+                pandas_dtypes.get(name) == "empty"
+                and np_dtypes.get(name) == "object"
             ):
                 # When a string column has all null values, pandas_dtype is
                 # is specified as 'empty' and np_dtypes as 'object',

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1012,8 +1012,8 @@ class Frame(BinaryOperand, Scannable):
             )
 
         column_names = data.column_names
-        pandas_dtypes = None
-        np_dtypes = None
+        pandas_dtypes = {}
+        np_dtypes = {}
         if isinstance(data.schema.pandas_metadata, dict):
             metadata = data.schema.pandas_metadata
             pandas_dtypes = {
@@ -1085,42 +1085,49 @@ class Frame(BinaryOperand, Scannable):
 
         # There are some special cases that need to be handled
         # based on metadata.
-        if pandas_dtypes:
-            for name in result:
-                dtype = None
-                if (
-                    len(result[name]) == 0
-                    and pandas_dtypes[name] == "categorical"
-                ):
-                    # When pandas_dtype is a categorical column and the size
-                    # of column is 0(i.e., empty) then we will have an
-                    # int8 column in result._data[name] returned by libcudf,
-                    # which needs to be type-casted to 'category' dtype.
-                    dtype = "category"
-                elif (
-                    pandas_dtypes[name] == "empty"
-                    and np_dtypes[name] == "object"
-                ):
-                    # When a string column has all null values, pandas_dtype is
-                    # is specified as 'empty' and np_dtypes as 'object',
-                    # hence handling this special case to type-cast the empty
-                    # float column to str column.
-                    dtype = np_dtypes[name]
-                elif pandas_dtypes[
-                    name
-                ] == "object" and cudf.api.types.is_struct_dtype(
-                    np_dtypes[name]
-                ):
-                    # Incase of struct column, libcudf is not aware of names of
-                    # struct fields, hence renaming the struct fields is
-                    # necessary by extracting the field names from arrow
-                    # struct types.
-                    result[name] = result[name]._rename_fields(
-                        [field.name for field in data[name].type]
-                    )
+        for name in result:
+            dtype = None
+            if (
+                len(result[name]) == 0
+                and pandas_dtypes.get(name, "") == "categorical"
+            ):
+                # When pandas_dtype is a categorical column and the size
+                # of column is 0(i.e., empty) then we will have an
+                # int8 column in result._data[name] returned by libcudf,
+                # which needs to be type-casted to 'category' dtype.
+                dtype = "category"
+            elif (
+                pandas_dtypes.get(name, "") == "empty"
+                and np_dtypes.get(name, "") == "object"
+            ):
+                # When a string column has all null values, pandas_dtype is
+                # is specified as 'empty' and np_dtypes as 'object',
+                # hence handling this special case to type-cast the empty
+                # float column to str column.
+                dtype = np_dtypes[name]
+            elif name in data.column_names and isinstance(
+                data[name].type,
+                (pa.StructType, pa.ListType, pa.Decimal128Type),
+            ):
+                # Incase of struct column, libcudf is not aware of names of
+                # struct fields, hence renaming the struct fields is
+                # necessary by extracting the field names from arrow
+                # struct types.
 
-                if dtype is not None:
-                    result[name] = result[name].astype(dtype)
+                # Incase of decimal column, libcudf is not aware of the
+                # decimal precision.
+
+                # Incase of list column, there is a possibility of nested
+                # list columns to have struct & decimal columns inside them.
+
+                # All these are taken care by calling to _with_type_metadata
+                # API on the column.
+                result[name] = result[name]._with_type_metadata(
+                    cudf.utils.dtypes.cudf_dtype_from_pa_type(data[name].type)
+                )
+
+            if dtype is not None:
+                result[name] = result[name].astype(dtype)
 
         return cls._from_data({name: result[name] for name in column_names})
 

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1120,8 +1120,8 @@ class Frame(BinaryOperand, Scannable):
                 # In case of list column, there is a possibility of nested
                 # list columns to have struct or decimal columns inside them.
 
-                # All of these cases are handled by calling the _with_type_metadata
-                # method on the column.
+                # All of these cases are handled by calling the
+                # _with_type_metadata method on the column.
                 result[name] = result[name]._with_type_metadata(
                     cudf.utils.dtypes.cudf_dtype_from_pa_type(data[name].type)
                 )

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -9549,3 +9549,23 @@ def test_non_string_column_name_to_arrow(data):
     actual = pa.Table.from_pandas(df.to_pandas())
 
     assert expected.equals(actual)
+
+
+def test_complex_types_from_arrow():
+
+    expected = pa.Table.from_arrays(
+        [
+            pa.array([1, 2, 3]),
+            pa.array([10, 20, 30]),
+            pa.array([{"a": 9}, {"b": 10}, {"c": 11}]),
+            pa.array([[{"a": 1}], [{"b": 2}], [{"c": 3}]]),
+            pa.array([10, 11, 12]).cast(pa.decimal128(21, 2)),
+            pa.array([{"a": 9}, {"b": 10, "c": {"g": 43}}, {"c": {"a": 10}}]),
+        ],
+        names=["a", "b", "c", "d", "e", "f"],
+    )
+
+    df = cudf.DataFrame.from_arrow(expected)
+    actual = df.to_arrow()
+
+    assert expected.equals(actual)


### PR DESCRIPTION
## Description
Fixes: #11693 
This PR fixes `DataFrame.from_arrow` which does not preserve type metadata for `struct`, `list` & `decimal` types.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
