### PR TITLE
Fix a crash when parttioning an empty table

### DIFF
--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -2957,6 +2957,15 @@ public class TableTest extends CudfTestBase {
   }
 
   @Test
+  void testPartitionEmptyTable() {
+    try (Table t = new Table.TestBuilder().timestampDayColumn().build();
+         ColumnVector parts = ColumnVector.fromInts();
+         PartitionedTable pt = t.partition(parts, 3)) {
+      assertArrayEquals(new int[]{0, 0, 0}, pt.getPartitions());
+    }
+  }
+
+  @Test
   void testIdentityHashPartition() {
     final int count = 1024 * 1024;
     try (ColumnVector aIn = ColumnVector.build(DType.INT64, count, Range.appendLongs(count));


### PR DESCRIPTION
Closes #11700 

When the row number is 0, the size of `partition_offsets` will be 0. Then `partition_offsets.end() - 1` will point to an invalid address, leading to a crash when copying the offsets.

This PR checks the `partition_offsets` size before setting values to the `output_offsets`, and will fill the output with 0 when the row number is 0.


- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

Signed-off-by: Liangcai Li <liangcail@nvidia.com>