### PR TITLE
Disable very large column gtest for contiguous-split

### DIFF
--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -1360,7 +1360,8 @@ TEST_F(ContiguousSplitUntypedTest, ValidityEdgeCase)
   }
 }
 
-TEST_F(ContiguousSplitUntypedTest, CalculationOverflow)
+// This test requires about 25GB of device memory when used with the arena allocator
+TEST_F(ContiguousSplitUntypedTest, DISABLED_VeryLargeColumnTest)
 {
   // tests an edge case where buf.elements * buf.element_size overflows an INT32.
   auto col = cudf::make_fixed_width_column(


### PR DESCRIPTION
## Description
Disables a `ContiguousSplitUntypedTest` that simply creates a very large (over 3GB) column to test the output buffer size does not overflow. The gtests ends requiring 25GB of device memory when used with the arena allocator as mentioned in #11249. Very large columns like this should be not part of the unit test for libcudf.
This PR disables the test so it can be available for testing on specific conditions outside of CI.

Closes #11249 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
