### PR TITLE
Fix get_thrust.cmake format at patch command

### DIFF
--- a/cpp/cmake/thirdparty/get_thrust.cmake
+++ b/cpp/cmake/thirdparty/get_thrust.cmake
@@ -41,8 +41,8 @@ function(find_and_configure_thrust VERSION)
     CPM_ARGS
     GIT_REPOSITORY https://github.com/NVIDIA/thrust.git
     GIT_TAG ${VERSION}
-    GIT_SHALLOW TRUE ${cpm_thrust_disconnect_update} PATCH_COMMAND patch --reject-file=- -p1 -N <
-                ${CUDF_SOURCE_DIR}/cmake/thrust.patch || true
+    GIT_SHALLOW TRUE ${cpm_thrust_disconnect_update}
+    PATCH_COMMAND patch --reject-file=- -p1 -N < ${CUDF_SOURCE_DIR}/cmake/thrust.patch || true
     OPTIONS "THRUST_INSTALL TRUE"
   )
 


### PR DESCRIPTION
## Description
Places the `PATCH_COMMAND` on it's own line separate from the `GIT_SHALLOW` command line.
Recently got a style-check error on `get_thrust.cmake`
https://gpuci.gpuopenanalytics.com/blue/organizations/jenkins/rapidsai%2Fgpuci%2Fcudf%2Fprb%2Fcudf-style/detail/cudf-style/28876/pipeline
The style-check tool was used to fix this.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
