### PR TITLE
avro/reader_impl.cu includes <algorithm> as it uses std::reduce

### DIFF
--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -43,6 +43,7 @@
 
 #include <nvcomp/snappy.h>
 
+#include <algorithm>
 #include <memory>
 #include <numeric>
 #include <string>


### PR DESCRIPTION
## Description
The avro/reader_impl.cu uses functions defined in <algorithm> but doesn't include it directly. We shouldn't rely on other standard library headers bringing in <algorithm> for us.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
