### PR TITLE
Ensure that all tests launch kernels on cudf's default stream

### DIFF
--- a/cpp/tests/column/column_test.cu
+++ b/cpp/tests/column/column_test.cu
@@ -31,6 +31,8 @@
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <rmm/exec_policy.hpp>
+
 #include <thrust/execution_policy.h>
 #include <thrust/sequence.h>
 
@@ -46,8 +48,10 @@ struct TypedColumnTest : public cudf::test::BaseFixture {
   {
     auto typed_data = static_cast<char*>(data.data());
     auto typed_mask = static_cast<char*>(mask.data());
-    thrust::sequence(thrust::device, typed_data, typed_data + data.size());
-    thrust::sequence(thrust::device, typed_mask, typed_mask + mask.size());
+    thrust::sequence(
+      rmm::exec_policy(cudf::default_stream_value), typed_data, typed_data + data.size());
+    thrust::sequence(
+      rmm::exec_policy(cudf::default_stream_value), typed_mask, typed_mask + mask.size());
   }
 
   cudf::size_type num_elements() { return _num_elements; }
@@ -349,7 +353,7 @@ TYPED_TEST(TypedColumnTest, DeviceUvectorConstructorNoMask)
 {
   rmm::device_uvector<TypeParam> original{static_cast<std::size_t>(this->num_elements()),
                                           cudf::default_stream_value};
-  thrust::copy(thrust::device,
+  thrust::copy(rmm::exec_policy(cudf::default_stream_value),
                static_cast<TypeParam*>(this->data.data()),
                static_cast<TypeParam*>(this->data.data()) + this->num_elements(),
                original.begin());
@@ -366,7 +370,7 @@ TYPED_TEST(TypedColumnTest, DeviceUvectorConstructorWithMask)
 {
   rmm::device_uvector<TypeParam> original{static_cast<std::size_t>(this->num_elements()),
                                           cudf::default_stream_value};
-  thrust::copy(thrust::device,
+  thrust::copy(rmm::exec_policy(cudf::default_stream_value),
                static_cast<TypeParam*>(this->data.data()),
                static_cast<TypeParam*>(this->data.data()) + this->num_elements(),
                original.begin());

--- a/cpp/tests/column/compound_test.cu
+++ b/cpp/tests/column/compound_test.cu
@@ -66,7 +66,7 @@ struct checker_for_level2 {
 TEST_F(CompoundColumnTest, ChildrenLevel1)
 {
   rmm::device_uvector<int32_t> data(1000, cudf::default_stream_value);
-  thrust::sequence(rmm::exec_policy(), data.begin(), data.end(), 1);
+  thrust::sequence(rmm::exec_policy(cudf::default_stream_value), data.begin(), data.end(), 1);
 
   auto null_mask = cudf::create_null_mask(100, cudf::mask_state::UNALLOCATED);
   rmm::device_buffer data1{data.data() + 100, 100 * sizeof(int32_t), cudf::default_stream_value};
@@ -105,14 +105,14 @@ TEST_F(CompoundColumnTest, ChildrenLevel1)
 
   {
     auto column = cudf::column_device_view::create(parent->view());
-    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(),
+    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(cudf::default_stream_value),
                                thrust::make_counting_iterator<int32_t>(0),
                                thrust::make_counting_iterator<int32_t>(100),
                                checker_for_level1<cudf::column_device_view>{*column}));
   }
   {
     auto column = cudf::mutable_column_device_view::create(parent->mutable_view());
-    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(),
+    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(cudf::default_stream_value),
                                thrust::make_counting_iterator<int32_t>(0),
                                thrust::make_counting_iterator<int32_t>(100),
                                checker_for_level1<cudf::mutable_column_device_view>{*column}));
@@ -122,7 +122,7 @@ TEST_F(CompoundColumnTest, ChildrenLevel1)
 TEST_F(CompoundColumnTest, ChildrenLevel2)
 {
   rmm::device_uvector<int32_t> data(1000, cudf::default_stream_value);
-  thrust::sequence(rmm::exec_policy(), data.begin(), data.end(), 1);
+  thrust::sequence(rmm::exec_policy(cudf::default_stream_value), data.begin(), data.end(), 1);
 
   auto null_mask = cudf::create_null_mask(100, cudf::mask_state::UNALLOCATED);
   rmm::device_buffer data11{data.data() + 100, 100 * sizeof(int32_t), cudf::default_stream_value};
@@ -202,14 +202,14 @@ TEST_F(CompoundColumnTest, ChildrenLevel2)
 
   {
     auto column = cudf::column_device_view::create(parent->view());
-    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(),
+    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(cudf::default_stream_value),
                                thrust::make_counting_iterator<int32_t>(0),
                                thrust::make_counting_iterator<int32_t>(100),
                                checker_for_level2<cudf::column_device_view>{*column}));
   }
   {
     auto column = cudf::mutable_column_device_view::create(parent->mutable_view());
-    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(),
+    EXPECT_TRUE(thrust::any_of(rmm::exec_policy(cudf::default_stream_value),
                                thrust::make_counting_iterator<int32_t>(0),
                                thrust::make_counting_iterator<int32_t>(100),
                                checker_for_level2<cudf::mutable_column_device_view>{*column}));

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -522,11 +522,11 @@ TEST_F(OverflowTest, Presliced)
 
     // try and concatenate 4 string columns of with ~1/2 billion chars in each
     auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
-    thrust::fill(rmm::exec_policy(),
+    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                  offsets->mutable_view().begin<offset_type>(),
                  offsets->mutable_view().end<offset_type>(),
                  string_size);
-    thrust::exclusive_scan(rmm::exec_policy(),
+    thrust::exclusive_scan(rmm::exec_policy(cudf::default_stream_value),
                            offsets->view().begin<offset_type>(),
                            offsets->view().end<offset_type>(),
                            offsets->mutable_view().begin<offset_type>());
@@ -596,11 +596,11 @@ TEST_F(OverflowTest, Presliced)
 
     // try and concatenate 4 struct columns of with ~1/2 billion elements in each
     auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
-    thrust::fill(rmm::exec_policy(),
+    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                  offsets->mutable_view().begin<offset_type>(),
                  offsets->mutable_view().end<offset_type>(),
                  list_size);
-    thrust::exclusive_scan(rmm::exec_policy(),
+    thrust::exclusive_scan(rmm::exec_policy(cudf::default_stream_value),
                            offsets->view().begin<offset_type>(),
                            offsets->view().end<offset_type>(),
                            offsets->mutable_view().begin<offset_type>());
@@ -688,11 +688,11 @@ TEST_F(OverflowTest, BigColumnsSmallSlices)
     constexpr size_type string_size = inner_size / num_rows;
 
     auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
-    thrust::fill(rmm::exec_policy(),
+    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                  offsets->mutable_view().begin<offset_type>(),
                  offsets->mutable_view().end<offset_type>(),
                  string_size);
-    thrust::exclusive_scan(rmm::exec_policy(),
+    thrust::exclusive_scan(rmm::exec_policy(cudf::default_stream_value),
                            offsets->view().begin<offset_type>(),
                            offsets->view().end<offset_type>(),
                            offsets->mutable_view().begin<offset_type>());
@@ -715,11 +715,11 @@ TEST_F(OverflowTest, BigColumnsSmallSlices)
     constexpr size_type list_size = inner_size / num_rows;
 
     auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
-    thrust::fill(rmm::exec_policy(),
+    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                  offsets->mutable_view().begin<offset_type>(),
                  offsets->mutable_view().end<offset_type>(),
                  list_size);
-    thrust::exclusive_scan(rmm::exec_policy(),
+    thrust::exclusive_scan(rmm::exec_policy(cudf::default_stream_value),
                            offsets->view().begin<offset_type>(),
                            offsets->view().end<offset_type>(),
                            offsets->mutable_view().begin<offset_type>());
@@ -742,11 +742,11 @@ TEST_F(OverflowTest, BigColumnsSmallSlices)
     constexpr size_type list_size = inner_size / num_rows;
 
     auto offsets = cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows + 1);
-    thrust::fill(rmm::exec_policy(),
+    thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                  offsets->mutable_view().begin<offset_type>(),
                  offsets->mutable_view().end<offset_type>(),
                  list_size);
-    thrust::exclusive_scan(rmm::exec_policy(),
+    thrust::exclusive_scan(rmm::exec_policy(cudf::default_stream_value),
                            offsets->view().begin<offset_type>(),
                            offsets->view().end<offset_type>(),
                            offsets->mutable_view().begin<offset_type>());

--- a/cpp/tests/copying/detail_gather_tests.cu
+++ b/cpp/tests/copying/detail_gather_tests.cu
@@ -48,7 +48,8 @@ TYPED_TEST(GatherTest, GatherDetailDeviceVectorTest)
 {
   constexpr cudf::size_type source_size{1000};
   rmm::device_uvector<cudf::size_type> gather_map(source_size, cudf::default_stream_value);
-  thrust::sequence(thrust::device, gather_map.begin(), gather_map.end());
+  thrust::sequence(
+    rmm::exec_policy(cudf::default_stream_value), gather_map.begin(), gather_map.end());
 
   auto data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
   cudf::test::fixed_width_column_wrapper<TypeParam> source_column(data, data + source_size);

--- a/cpp/tests/device_atomics/device_atomics_test.cu
+++ b/cpp/tests/device_atomics/device_atomics_test.cu
@@ -147,9 +147,11 @@ struct AtomicsTest : public cudf::test::BaseFixture {
     if (block_size == 0) { block_size = vec_size; }
 
     if (is_cas_test) {
-      gpu_atomicCAS_test<<<grid_size, block_size>>>(dev_result.data(), dev_data.data(), vec_size);
+      gpu_atomicCAS_test<<<grid_size, block_size, 0, cudf::default_stream_value.value()>>>(
+        dev_result.data(), dev_data.data(), vec_size);
     } else {
-      gpu_atomic_test<<<grid_size, block_size>>>(dev_result.data(), dev_data.data(), vec_size);
+      gpu_atomic_test<<<grid_size, block_size, 0, cudf::default_stream_value.value()>>>(
+        dev_result.data(), dev_data.data(), vec_size);
     }
 
     auto host_result = cudf::detail::make_host_vector_sync(dev_result);
@@ -296,7 +298,7 @@ struct AtomicsBitwiseOpTest : public cudf::test::BaseFixture {
 
     if (block_size == 0) { block_size = vec_size; }
 
-    gpu_atomic_bitwiseOp_test<T><<<grid_size, block_size>>>(
+    gpu_atomic_bitwiseOp_test<T><<<grid_size, block_size, 0, cudf::default_stream_value.value()>>>(
       reinterpret_cast<T*>(dev_result.data()), reinterpret_cast<T*>(dev_data.data()), vec_size);
 
     auto host_result = cudf::detail::make_host_vector_sync(dev_result);

--- a/cpp/tests/error/error_handling_test.cu
+++ b/cpp/tests/error/error_handling_test.cu
@@ -17,6 +17,7 @@
 #include <cudf_test/base_fixture.hpp>
 
 #include <cudf/filling.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream.hpp>
@@ -89,7 +90,7 @@ TEST(DeathTest, CudaFatalError)
 {
   testing::FLAGS_gtest_death_test_style = "threadsafe";
   auto call_kernel                      = []() {
-    kernel<<<1, 1>>>();
+    kernel<<<1, 1, 0, cudf::default_stream_value.value()>>>();
     try {
       CUDF_CUDA_TRY(cudaDeviceSynchronize());
     } catch (const cudf::fatal_cuda_error& fe) {

--- a/cpp/tests/fixed_point/fixed_point_tests.cu
+++ b/cpp/tests/fixed_point/fixed_point_tests.cu
@@ -85,8 +85,10 @@ TEST_F(FixedPointTest, DecimalXXThrustOnDevice)
   std::vector<decimal32> vec1(1000, decimal32{1, scale_type{-2}});
   auto d_vec1 = cudf::detail::make_device_uvector_sync(vec1);
 
-  auto const sum = thrust::reduce(
-    rmm::exec_policy(), std::cbegin(d_vec1), std::cend(d_vec1), decimal32{0, scale_type{-2}});
+  auto const sum = thrust::reduce(rmm::exec_policy(cudf::default_stream_value),
+                                  std::cbegin(d_vec1),
+                                  std::cend(d_vec1),
+                                  decimal32{0, scale_type{-2}});
 
   EXPECT_EQ(static_cast<int32_t>(sum), 1000);
 
@@ -99,8 +101,10 @@ TEST_F(FixedPointTest, DecimalXXThrustOnDevice)
   std::vector<int32_t> vec2(1000);
   std::iota(std::begin(vec2), std::end(vec2), 1);
 
-  auto const res1 = thrust::reduce(
-    rmm::exec_policy(), std::cbegin(d_vec1), std::cend(d_vec1), decimal32{0, scale_type{-2}});
+  auto const res1 = thrust::reduce(rmm::exec_policy(cudf::default_stream_value),
+                                   std::cbegin(d_vec1),
+                                   std::cend(d_vec1),
+                                   decimal32{0, scale_type{-2}});
 
   auto const res2 = std::accumulate(std::cbegin(vec2), std::cend(vec2), 0);
 
@@ -108,7 +112,7 @@ TEST_F(FixedPointTest, DecimalXXThrustOnDevice)
 
   rmm::device_uvector<int32_t> d_vec3(1000, cudf::default_stream_value);
 
-  thrust::transform(rmm::exec_policy(),
+  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
                     std::cbegin(d_vec1),
                     std::cend(d_vec1),
                     std::begin(d_vec3),

--- a/cpp/tests/groupby/lists_tests.cu
+++ b/cpp/tests/groupby/lists_tests.cu
@@ -28,6 +28,8 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
+#include <rmm/exec_policy.hpp>
+
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/logical.h>
 
@@ -122,7 +124,8 @@ inline void test_hash_based_sum_agg(column_view const& keys,
 
   // For each row in expected table `t[0, num_rows)`, there must be a match
   // in the resulting table `t[num_rows, 2 * num_rows)`
-  EXPECT_TRUE(thrust::all_of(thrust::make_counting_iterator<cudf::size_type>(0),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(cudf::default_stream_value),
+                             thrust::make_counting_iterator<cudf::size_type>(0),
                              thrust::make_counting_iterator<cudf::size_type>(num_rows),
                              func));
 }

--- a/cpp/tests/hash_map/map_test.cu
+++ b/cpp/tests/hash_map/map_test.cu
@@ -140,16 +140,18 @@ TYPED_TEST(InsertTest, UniqueKeysUniqueValues)
 {
   using map_type  = typename TypeParam::map_type;
   using pair_type = typename TypeParam::pair_type;
-  thrust::tabulate(
-    rmm::exec_policy(), this->pairs.begin(), this->pairs.end(), unique_pair_generator<pair_type>{});
+  thrust::tabulate(rmm::exec_policy(cudf::default_stream_value),
+                   this->pairs.begin(),
+                   this->pairs.end(),
+                   unique_pair_generator<pair_type>{});
   // All pairs should be new inserts
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(cudf::default_stream_value),
                              this->pairs.begin(),
                              this->pairs.end(),
                              insert_pair<map_type, pair_type>{*this->map}));
 
   // All pairs should be present in the map
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(cudf::default_stream_value),
                              this->pairs.begin(),
                              this->pairs.end(),
                              find_pair<map_type, pair_type>{*this->map}));
@@ -159,23 +161,23 @@ TYPED_TEST(InsertTest, IdenticalKeysIdenticalValues)
 {
   using map_type  = typename TypeParam::map_type;
   using pair_type = typename TypeParam::pair_type;
-  thrust::tabulate(rmm::exec_policy(),
+  thrust::tabulate(rmm::exec_policy(cudf::default_stream_value),
                    this->pairs.begin(),
                    this->pairs.end(),
                    identical_pair_generator<pair_type>{});
   // Insert a single pair
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(cudf::default_stream_value),
                              this->pairs.begin(),
                              this->pairs.begin() + 1,
                              insert_pair<map_type, pair_type>{*this->map}));
   // Identical inserts should all return false (no new insert)
-  EXPECT_FALSE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_FALSE(thrust::all_of(rmm::exec_policy(cudf::default_stream_value),
                               this->pairs.begin(),
                               this->pairs.end(),
                               insert_pair<map_type, pair_type>{*this->map}));
 
   // All pairs should be present in the map
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(cudf::default_stream_value),
                              this->pairs.begin(),
                              this->pairs.end(),
                              find_pair<map_type, pair_type>{*this->map}));
@@ -185,30 +187,30 @@ TYPED_TEST(InsertTest, IdenticalKeysUniqueValues)
 {
   using map_type  = typename TypeParam::map_type;
   using pair_type = typename TypeParam::pair_type;
-  thrust::tabulate(rmm::exec_policy(),
+  thrust::tabulate(rmm::exec_policy(cudf::default_stream_value),
                    this->pairs.begin(),
                    this->pairs.end(),
                    identical_key_generator<pair_type>{});
 
   // Insert a single pair
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(cudf::default_stream_value),
                              this->pairs.begin(),
                              this->pairs.begin() + 1,
                              insert_pair<map_type, pair_type>{*this->map}));
 
   // Identical key inserts should all return false (no new insert)
-  EXPECT_FALSE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_FALSE(thrust::all_of(rmm::exec_policy(cudf::default_stream_value),
                               this->pairs.begin() + 1,
                               this->pairs.end(),
                               insert_pair<map_type, pair_type>{*this->map}));
 
   // Only first pair is present in map
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(cudf::default_stream_value),
                              this->pairs.begin(),
                              this->pairs.begin() + 1,
                              find_pair<map_type, pair_type>{*this->map}));
 
-  EXPECT_FALSE(thrust::all_of(rmm::exec_policy(),
+  EXPECT_FALSE(thrust::all_of(rmm::exec_policy(cudf::default_stream_value),
                               this->pairs.begin() + 1,
                               this->pairs.end(),
                               find_pair<map_type, pair_type>{*this->map}));

--- a/cpp/tests/io/json_type_cast_test.cu
+++ b/cpp/tests/io/json_type_cast_test.cu
@@ -70,7 +70,7 @@ TEST_F(JSONTypeCastTest, String)
 
   auto d_column = cudf::column_device_view::create(input);
   rmm::device_uvector<thrust::pair<const char*, cudf::size_type>> svs(d_column->size(), stream);
-  thrust::transform(thrust::device,
+  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
                     d_column->pair_begin<cudf::string_view, false>(),
                     d_column->pair_end<cudf::string_view, false>(),
                     svs.begin(),
@@ -100,7 +100,7 @@ TEST_F(JSONTypeCastTest, Int)
   cudf::test::strings_column_wrapper data({"1", "null", "3", "true", "5", "false"});
   auto d_column = cudf::column_device_view::create(data);
   rmm::device_uvector<thrust::pair<const char*, cudf::size_type>> svs(d_column->size(), stream);
-  thrust::transform(thrust::device,
+  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
                     d_column->pair_begin<cudf::string_view, false>(),
                     d_column->pair_end<cudf::string_view, false>(),
                     svs.begin(),
@@ -137,7 +137,7 @@ TEST_F(JSONTypeCastTest, StringEscapes)
   });
   auto d_column = cudf::column_device_view::create(data);
   rmm::device_uvector<thrust::pair<const char*, cudf::size_type>> svs(d_column->size(), stream);
-  thrust::transform(thrust::device,
+  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
                     d_column->pair_begin<cudf::string_view, false>(),
                     d_column->pair_end<cudf::string_view, false>(),
                     svs.begin(),

--- a/cpp/tests/io/type_inference_test.cu
+++ b/cpp/tests/io/type_inference_test.cu
@@ -39,7 +39,7 @@ struct TypeInference : public cudf::test::BaseFixture {
 
 TEST_F(TypeInference, Basic)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cudf::default_stream_value;
 
   auto options       = parse_options{',', '\n', '\"'};
   options.trie_true  = cudf::detail::create_serialized_trie({"true"}, stream);
@@ -71,7 +71,7 @@ TEST_F(TypeInference, Basic)
 
 TEST_F(TypeInference, Null)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cudf::default_stream_value;
 
   auto options       = parse_options{',', '\n', '\"'};
   options.trie_true  = cudf::detail::create_serialized_trie({"true"}, stream);
@@ -104,7 +104,7 @@ TEST_F(TypeInference, Null)
 
 TEST_F(TypeInference, AllNull)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cudf::default_stream_value;
 
   auto options       = parse_options{',', '\n', '\"'};
   options.trie_true  = cudf::detail::create_serialized_trie({"true"}, stream);
@@ -136,7 +136,7 @@ TEST_F(TypeInference, AllNull)
 
 TEST_F(TypeInference, String)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cudf::default_stream_value;
 
   auto options       = parse_options{',', '\n', '\"'};
   options.trie_true  = cudf::detail::create_serialized_trie({"true"}, stream);
@@ -168,7 +168,7 @@ TEST_F(TypeInference, String)
 
 TEST_F(TypeInference, Bool)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cudf::default_stream_value;
 
   auto options       = parse_options{',', '\n', '\"'};
   options.trie_true  = cudf::detail::create_serialized_trie({"true"}, stream);
@@ -200,7 +200,7 @@ TEST_F(TypeInference, Bool)
 
 TEST_F(TypeInference, Timestamp)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cudf::default_stream_value;
 
   auto options       = parse_options{',', '\n', '\"'};
   options.trie_true  = cudf::detail::create_serialized_trie({"true"}, stream);
@@ -233,7 +233,7 @@ TEST_F(TypeInference, Timestamp)
 
 TEST_F(TypeInference, InvalidInput)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cudf::default_stream_value;
 
   auto options       = parse_options{',', '\n', '\"'};
   options.trie_true  = cudf::detail::create_serialized_trie({"true"}, stream);

--- a/cpp/tests/iterator/optional_iterator_test_numeric.cu
+++ b/cpp/tests/iterator/optional_iterator_test_numeric.cu
@@ -112,12 +112,13 @@ TYPED_TEST(NumericOptionalIteratorTest, mean_var_output)
   // this can be computed with a single reduce and without a temporary output vector
   // but the approach increases the compile time by ~2x
   auto results = rmm::device_uvector<T_output>(d_col->size(), cudf::default_stream_value);
-  thrust::transform(thrust::device,
+  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
                     it_dev_squared,
                     it_dev_squared + d_col->size(),
                     results.begin(),
                     optional_to_meanvar<T_output>{});
-  auto result = thrust::reduce(thrust::device, results.begin(), results.end(), T_output{});
+  auto result = thrust::reduce(
+    rmm::exec_policy(cudf::default_stream_value), results.begin(), results.end(), T_output{});
 
   if (not std::is_floating_point<T>()) {
     EXPECT_EQ(expected_value, result) << "optional iterator reduction sum";

--- a/cpp/tests/iterator/pair_iterator_test_numeric.cu
+++ b/cpp/tests/iterator/pair_iterator_test_numeric.cu
@@ -14,6 +14,8 @@
  */
 #include <tests/iterator/pair_iterator_test.cuh>
 
+#include <rmm/exec_policy.hpp>
+
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/pair.h>
 #include <thrust/reduce.h>
@@ -111,7 +113,8 @@ TYPED_TEST(NumericPairIteratorTest, mean_var_output)
   // GPU test
   auto it_dev         = d_col->pair_begin<T, true>();
   auto it_dev_squared = thrust::make_transform_iterator(it_dev, transformer);
-  auto result         = thrust::reduce(it_dev_squared,
+  auto result         = thrust::reduce(rmm::exec_policy(cudf::default_stream_value),
+                               it_dev_squared,
                                it_dev_squared + d_col->size(),
                                thrust::make_pair(T_output{}, true),
                                sum_if_not_null{});

--- a/cpp/tests/scalar/scalar_device_view_test.cu
+++ b/cpp/tests/scalar/scalar_device_view_test.cu
@@ -59,13 +59,15 @@ TYPED_TEST(TypedScalarDeviceViewTest, Value)
   auto scalar_device_view1 = cudf::get_scalar_device_view(s1);
   rmm::device_scalar<bool> result{cudf::default_stream_value};
 
-  test_set_value<<<1, 1>>>(scalar_device_view, scalar_device_view1);
+  test_set_value<<<1, 1, 0, cudf::default_stream_value.value()>>>(scalar_device_view,
+                                                                  scalar_device_view1);
   CUDF_CHECK_CUDA(0);
 
   EXPECT_EQ(s1.value(), value);
   EXPECT_TRUE(s1.is_valid());
 
-  test_value<<<1, 1>>>(scalar_device_view, scalar_device_view1, result.data());
+  test_value<<<1, 1, 0, cudf::default_stream_value.value()>>>(
+    scalar_device_view, scalar_device_view1, result.data());
   CUDF_CHECK_CUDA(0);
 
   EXPECT_TRUE(result.value(cudf::default_stream_value));
@@ -84,7 +86,7 @@ TYPED_TEST(TypedScalarDeviceViewTest, ConstructNull)
   auto scalar_device_view = cudf::get_scalar_device_view(s);
   rmm::device_scalar<bool> result{cudf::default_stream_value};
 
-  test_null<<<1, 1>>>(scalar_device_view, result.data());
+  test_null<<<1, 1, 0, cudf::default_stream_value.value()>>>(scalar_device_view, result.data());
   CUDF_CHECK_CUDA(0);
 
   EXPECT_FALSE(result.value(cudf::default_stream_value));
@@ -104,7 +106,7 @@ TYPED_TEST(TypedScalarDeviceViewTest, SetNull)
   s.set_valid_async(true);
   EXPECT_TRUE(s.is_valid());
 
-  test_setnull<<<1, 1>>>(scalar_device_view);
+  test_setnull<<<1, 1, 0, cudf::default_stream_value.value()>>>(scalar_device_view);
   CUDF_CHECK_CUDA(0);
 
   EXPECT_FALSE(s.is_valid());
@@ -130,7 +132,8 @@ TEST_F(StringScalarDeviceViewTest, Value)
   rmm::device_scalar<bool> result{cudf::default_stream_value};
   auto value_v = cudf::detail::make_device_uvector_sync(value);
 
-  test_string_value<<<1, 1>>>(scalar_device_view, value_v.data(), value.size(), result.data());
+  test_string_value<<<1, 1, 0, cudf::default_stream_value.value()>>>(
+    scalar_device_view, value_v.data(), value.size(), result.data());
   CUDF_CHECK_CUDA(0);
 
   EXPECT_TRUE(result.value(cudf::default_stream_value));

--- a/cpp/tests/strings/factories_test.cu
+++ b/cpp/tests/strings/factories_test.cu
@@ -30,6 +30,7 @@
 #include <tests/strings/utilities.h>
 
 #include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/execution_policy.h>
 #include <thrust/host_vector.h>
@@ -213,7 +214,7 @@ TEST_F(StringsFactoriesTest, StringPairWithNullsAndEmpty)
 
   auto d_column = cudf::column_device_view::create(data);
   rmm::device_uvector<string_pair> pairs(d_column->size(), cudf::default_stream_value);
-  thrust::transform(thrust::device,
+  thrust::transform(rmm::exec_policy(cudf::default_stream_value),
                     d_column->pair_begin<cudf::string_view, true>(),
                     d_column->pair_end<cudf::string_view, true>(),
                     pairs.data(),

--- a/cpp/tests/transform/row_bit_count_test.cu
+++ b/cpp/tests/transform/row_bit_count_test.cu
@@ -27,7 +27,6 @@
 
 #include <rmm/exec_policy.hpp>
 
-#include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -54,7 +53,7 @@ TYPED_TEST(RowBitCountTyped, SimpleTypes)
   // expect size of the type per row
   auto expected = make_fixed_width_column(data_type{type_id::INT32}, 16);
   cudf::mutable_column_view mcv(*expected);
-  thrust::fill(rmm::exec_policy(),
+  thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                mcv.begin<size_type>(),
                mcv.end<size_type>(),
                sizeof(device_storage_type_t<T>) * CHAR_BIT);
@@ -77,7 +76,7 @@ TYPED_TEST(RowBitCountTyped, SimpleTypesWithNulls)
   // expect size of the type + 1 bit per row
   auto expected = make_fixed_width_column(data_type{type_id::INT32}, 16);
   cudf::mutable_column_view mcv(*expected);
-  thrust::fill(rmm::exec_policy(),
+  thrust::fill(rmm::exec_policy(cudf::default_stream_value),
                mcv.begin<size_type>(),
                mcv.end<size_type>(),
                (sizeof(device_storage_type_t<T>) * CHAR_BIT) + 1);
@@ -612,7 +611,7 @@ TEST_F(RowBitCount, Table)
   auto expected   = cudf::make_fixed_width_column(data_type{type_id::INT32}, t.num_rows());
   cudf::mutable_column_view mcv(*expected);
   thrust::transform(
-    rmm::exec_policy(),
+    rmm::exec_policy(cudf::default_stream_value),
     thrust::make_counting_iterator(0),
     thrust::make_counting_iterator(0) + t.num_rows(),
     mcv.begin<size_type>(),

--- a/cpp/tests/types/type_dispatcher_test.cu
+++ b/cpp/tests/types/type_dispatcher_test.cu
@@ -70,7 +70,8 @@ __global__ void dispatch_test_kernel(cudf::type_id id, bool* d_result)
 TYPED_TEST(TypedDispatcherTest, DeviceDispatch)
 {
   auto result = cudf::detail::make_zeroed_device_uvector_sync<bool>(1);
-  dispatch_test_kernel<<<1, 1>>>(cudf::type_to_id<TypeParam>(), result.data());
+  dispatch_test_kernel<<<1, 1, 0, cudf::default_stream_value.value()>>>(
+    cudf::type_to_id<TypeParam>(), result.data());
   CUDF_CUDA_TRY(cudaDeviceSynchronize());
   EXPECT_EQ(true, result.front_element(cudf::default_stream_value));
 }
@@ -130,7 +131,7 @@ __global__ void double_dispatch_test_kernel(cudf::type_id id1, cudf::type_id id2
 TYPED_TEST(TypedDoubleDispatcherTest, DeviceDoubleDispatch)
 {
   auto result = cudf::detail::make_zeroed_device_uvector_sync<bool>(1);
-  double_dispatch_test_kernel<<<1, 1>>>(
+  double_dispatch_test_kernel<<<1, 1, 0, cudf::default_stream_value.value()>>>(
     cudf::type_to_id<TypeParam>(), cudf::type_to_id<TypeParam>(), result.data());
   CUDF_CUDA_TRY(cudaDeviceSynchronize());
   EXPECT_EQ(true, result.front_element(cudf::default_stream_value));

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -66,7 +66,7 @@ std::unique_ptr<column> generate_all_row_indices(size_type num_rows)
 {
   auto indices =
     cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows, mask_state::UNALLOCATED);
-  thrust::sequence(rmm::exec_policy(),
+  thrust::sequence(rmm::exec_policy(cudf::default_stream_value),
                    indices->mutable_view().begin<size_type>(),
                    indices->mutable_view().end<size_type>(),
                    0);
@@ -132,8 +132,9 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
                ? (offsets[true_index + 1] - offsets[true_index])
                : 0;
     });
-  auto const output_size =
-    thrust::reduce(rmm::exec_policy(), row_size_iter, row_size_iter + row_indices.size());
+  auto const output_size = thrust::reduce(rmm::exec_policy(cudf::default_stream_value),
+                                          row_size_iter,
+                                          row_size_iter + row_indices.size());
   // no output. done.
   auto result =
     cudf::make_fixed_width_column(data_type{type_id::INT32}, output_size, mask_state::UNALLOCATED);
@@ -146,7 +147,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   //
   auto output_row_start = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, row_indices.size(), mask_state::UNALLOCATED);
-  thrust::exclusive_scan(rmm::exec_policy(),
+  thrust::exclusive_scan(rmm::exec_policy(cudf::default_stream_value),
                          row_size_iter,
                          row_size_iter + row_indices.size(),
                          output_row_start->mutable_view().begin<size_type>());
@@ -155,7 +156,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   //
   // result = [1, 1, 1, 1, 1]
   //
-  thrust::generate(rmm::exec_policy(),
+  thrust::generate(rmm::exec_policy(cudf::default_stream_value),
                    result->mutable_view().begin<size_type>(),
                    result->mutable_view().end<size_type>(),
                    [] __device__() { return 1; });
@@ -174,7 +175,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
       auto const true_index = row_indices[index] + offset;
       return offsets[true_index] - first_offset;
     });
-  thrust::scatter_if(rmm::exec_policy(),
+  thrust::scatter_if(rmm::exec_policy(cudf::default_stream_value),
                      output_row_iter,
                      output_row_iter + row_indices.size(),
                      output_row_start->view().begin<size_type>(),
@@ -188,18 +189,18 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   //
   auto keys =
     cudf::make_fixed_width_column(data_type{type_id::INT32}, output_size, mask_state::UNALLOCATED);
-  thrust::generate(rmm::exec_policy(),
+  thrust::generate(rmm::exec_policy(cudf::default_stream_value),
                    keys->mutable_view().begin<size_type>(),
                    keys->mutable_view().end<size_type>(),
                    [] __device__() { return 0; });
-  thrust::scatter_if(rmm::exec_policy(),
+  thrust::scatter_if(rmm::exec_policy(cudf::default_stream_value),
                      row_size_iter,
                      row_size_iter + row_indices.size(),
                      output_row_start->view().begin<size_type>(),
                      row_size_iter,
                      keys->mutable_view().begin<size_type>(),
                      [] __device__(auto row_size) { return row_size != 0; });
-  thrust::inclusive_scan(rmm::exec_policy(),
+  thrust::inclusive_scan(rmm::exec_policy(cudf::default_stream_value),
                          keys->view().begin<size_type>(),
                          keys->view().end<size_type>(),
                          keys->mutable_view().begin<size_type>());
@@ -212,7 +213,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   // output
   //    result = [6, 7, 11, 12, 13]
   //
-  thrust::inclusive_scan_by_key(rmm::exec_policy(),
+  thrust::inclusive_scan_by_key(rmm::exec_policy(cudf::default_stream_value),
                                 keys->view().begin<size_type>(),
                                 keys->view().end<size_type>(),
                                 result->view().begin<size_type>(),
@@ -255,7 +256,9 @@ struct column_property_comparator {
         auto const true_index = row_indices[index] + offset;
         return !validity || cudf::bit_is_set(validity, true_index) ? 0 : 1;
       });
-    return thrust::reduce(rmm::exec_policy(), validity_iter, validity_iter + row_indices.size());
+    return thrust::reduce(rmm::exec_policy(cudf::default_stream_value),
+                          validity_iter,
+                          validity_iter + row_indices.size());
   }
 
   bool compare_common(cudf::column_view const& lhs,
@@ -549,7 +552,7 @@ struct column_comparator_impl {
       lhs.size(), cudf::default_stream_value);  // worst case: everything different
     auto input_iter = thrust::make_counting_iterator(0);
     auto diff_iter  = thrust::copy_if(
-      rmm::exec_policy(),
+      rmm::exec_policy(cudf::default_stream_value),
       input_iter,
       input_iter + lhs_row_indices.size(),
       differences.begin(),
@@ -640,7 +643,7 @@ struct column_comparator_impl<list_view, check_exact_equality> {
     //
     auto input_iter = thrust::make_counting_iterator(0);
     auto diff_iter  = thrust::copy_if(
-      rmm::exec_policy(),
+      rmm::exec_policy(cudf::default_stream_value),
       input_iter,
       input_iter + lhs_row_indices.size(),
       differences.begin(),
@@ -957,7 +960,7 @@ std::string nested_offsets_to_string(NestedColumnView const& c, std::string cons
   // normalize the offset values for the column offset
   size_type const* d_offsets = offsets.head<size_type>() + c.offset();
   thrust::transform(
-    rmm::exec_policy(),
+    rmm::exec_policy(cudf::default_stream_value),
     d_offsets,
     d_offsets + output_size,
     shifted_offsets.begin(),

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -865,7 +865,8 @@ void expect_equal_buffers(void const* lhs, void const* rhs, std::size_t size_byt
   }
   auto typed_lhs = static_cast<char const*>(lhs);
   auto typed_rhs = static_cast<char const*>(rhs);
-  EXPECT_TRUE(thrust::equal(thrust::device, typed_lhs, typed_lhs + size_bytes, typed_rhs));
+  EXPECT_TRUE(thrust::equal(
+    rmm::exec_policy(cudf::default_stream_value), typed_lhs, typed_lhs + size_bytes, typed_rhs));
 }
 
 /**

--- a/cpp/tests/utilities_tests/span_tests.cu
+++ b/cpp/tests/utilities_tests/span_tests.cu
@@ -238,7 +238,7 @@ TEST(SpanTest, CanUseDeviceSpan)
 
   auto d_span = device_span<bool>(d_message.data().get(), d_message.size());
 
-  simple_device_kernel<<<1, 1>>>(d_span);
+  simple_device_kernel<<<1, 1, 0, cudf::default_stream_value.value()>>>(d_span);
 
   cudaDeviceSynchronize();
 
@@ -277,8 +277,8 @@ TEST(MdSpanTest, DeviceReadWrite)
 {
   auto vector = hostdevice_2dvector<int>(11, 23, cudf::default_stream_value);
 
-  readwrite_kernel<<<1, 1>>>(vector);
-  readwrite_kernel<<<1, 1>>>(vector);
+  readwrite_kernel<<<1, 1, 0, cudf::default_stream_value.value()>>>(vector);
+  readwrite_kernel<<<1, 1, 0, cudf::default_stream_value.value()>>>(vector);
   vector.device_to_host(cudf::default_stream_value, true);
   EXPECT_EQ(vector[5][6], 30);
 }

--- a/cpp/tests/wrappers/timestamps_test.cu
+++ b/cpp/tests/wrappers/timestamps_test.cu
@@ -94,8 +94,8 @@ TYPED_TEST(ChronoColumnTest, ChronoDurationsMatchPrimitiveRepresentation)
     fixed_width_column_wrapper<Rep>(chrono_col_data.begin(), chrono_col_data.end());
 
   rmm::device_uvector<int32_t> indices(this->size(), cudf::default_stream_value);
-  thrust::sequence(rmm::exec_policy(), indices.begin(), indices.end());
-  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(),
+  thrust::sequence(rmm::exec_policy(cudf::default_stream_value), indices.begin(), indices.end());
+  EXPECT_TRUE(thrust::all_of(rmm::exec_policy(cudf::default_stream_value),
                              indices.begin(),
                              indices.end(),
                              compare_chrono_elements_to_primitive_representation<T>{
@@ -148,10 +148,10 @@ TYPED_TEST(ChronoColumnTest, ChronosCanBeComparedInDeviceCode)
     generate_timestamps<T>(this->size(), time_point_ms(start_rhs), time_point_ms(stop_rhs));
 
   rmm::device_uvector<int32_t> indices(this->size(), cudf::default_stream_value);
-  thrust::sequence(rmm::exec_policy(), indices.begin(), indices.end());
+  thrust::sequence(rmm::exec_policy(cudf::default_stream_value), indices.begin(), indices.end());
 
   EXPECT_TRUE(thrust::all_of(
-    rmm::exec_policy(),
+    rmm::exec_policy(cudf::default_stream_value),
     indices.begin(),
     indices.end(),
     compare_chrono_elements<TypeParam>{cudf::binary_operator::LESS,
@@ -159,7 +159,7 @@ TYPED_TEST(ChronoColumnTest, ChronosCanBeComparedInDeviceCode)
                                        *cudf::column_device_view::create(chrono_rhs_col)}));
 
   EXPECT_TRUE(thrust::all_of(
-    rmm::exec_policy(),
+    rmm::exec_policy(cudf::default_stream_value),
     indices.begin(),
     indices.end(),
     compare_chrono_elements<TypeParam>{cudf::binary_operator::GREATER,
@@ -167,7 +167,7 @@ TYPED_TEST(ChronoColumnTest, ChronosCanBeComparedInDeviceCode)
                                        *cudf::column_device_view::create(chrono_lhs_col)}));
 
   EXPECT_TRUE(thrust::all_of(
-    rmm::exec_policy(),
+    rmm::exec_policy(cudf::default_stream_value),
     indices.begin(),
     indices.end(),
     compare_chrono_elements<TypeParam>{cudf::binary_operator::LESS_EQUAL,
@@ -175,7 +175,7 @@ TYPED_TEST(ChronoColumnTest, ChronosCanBeComparedInDeviceCode)
                                        *cudf::column_device_view::create(chrono_lhs_col)}));
 
   EXPECT_TRUE(thrust::all_of(
-    rmm::exec_policy(),
+    rmm::exec_policy(cudf::default_stream_value),
     indices.begin(),
     indices.end(),
     compare_chrono_elements<TypeParam>{cudf::binary_operator::GREATER_EQUAL,


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Currently many of our tests are only stream-safe because libcudf runs everything on the default stream. This PR updates tests to ensure that any function that launches a kernel and supports passing streams will act on cudf's default stream even when it is _not_ CUDA's default stream.

There are other aspects required for stream-safety that are not addressed in this PR. For instance, some of our tests make use of `thrust::device_vector`, and its initialization is implicitly always on the default stream. I'll work on that in a separate PR since that also requires some discussion with the team on what expectations a stream-based libcudf API could like like for consumers that make use of thrust (i.e. do we start requiring device syncs for such consumers?). There are also numerous tests that fail when swapping in an alternate default stream, indicating other potential dependencies on streams. I'll work through those remaining issues separately as well to limit the scope of this PR.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
