### PR TITLE
Add docs for use of string data to `DataFrame.apply` and `Series.apply` and update guide to UDFs notebook

### DIFF
--- a/docs/cudf/source/user_guide/guide-to-udfs.ipynb
+++ b/docs/cudf/source/user_guide/guide-to-udfs.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "Like many tabular data processing APIs, cuDF provides a range of composable, DataFrame style operators. While out of the box functions are flexible and useful, it is sometimes necessary to write custom code, or user-defined functions (UDFs), that can be applied to rows, columns, and other groupings of the cells making up the DataFrame.\n",
     "\n",
-    "In conjunction with the broader GPU PyData ecosystem, cuDF provides interfaces to run UDFs on a variety of data structures. Currently, we can only execute UDFs on numeric, boolean, datetime, and timedelta typed data (support for strings is being planned). This guide covers writing and executing UDFs on the following data structures:\n",
+    "In conjunction with the broader GPU PyData ecosystem, cuDF provides interfaces to run UDFs on a variety of data structures. Currently, we can only execute UDFs on numeric, boolean, datetime, and timedelta typed data with partial support for strings in some APIs. This guide covers writing and executing UDFs on the following data structures:\n",
     "\n",
     "- Series\n",
     "- DataFrame\n",
@@ -330,6 +330,91 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cc7c7e67",
+   "metadata": {},
+   "source": [
+    "### String data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0980218",
+   "metadata": {},
+   "source": [
+    "Support for a subset of string functionality is available for `apply` through the `strings_udf` rapids library, which is separately installable. If present, users are able to involve string columns in UDFs and operate under the assumption that those strings behave exactly like python `str` objects, albeit with a subset of supported functions and methods. Currently, the following string operations are provided through `strings_udf`:\n",
+    "- `str.count`\n",
+    "- `str.startswith`\n",
+    "- `str.endswith`\n",
+    "- `str.find`\n",
+    "- `str.rfind`\n",
+    "- `str.isalnum`\n",
+    "- `str.isdecimal`\n",
+    "- `str.isdigit`\n",
+    "- `str.islower`\n",
+    "- `str.isupper`\n",
+    "- `str.isalpha`\n",
+    "- `str.istitle`\n",
+    "- `str.isspace`\n",
+    "- `==`, `!=`, `>=`, `<=`, `>`, `<` (between two strings)\n",
+    "- `len` (e.g. `len(some_string))`\n",
+    "- `__contains__` (e.g, `'abc' in some_string`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d7d1abd7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sr = cudf.Series(['', 'abc', 'some_example'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e8538ba0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def f(st):\n",
+    "    if len(st) > 0:\n",
+    "        if st.startswith('a'):\n",
+    "            return 1\n",
+    "        elif 'example' in st:\n",
+    "            return 2\n",
+    "        else:\n",
+    "            return -1\n",
+    "    else:\n",
+    "        return 42"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "23524fd8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    42\n",
+       "1     1\n",
+       "2     2\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sr.apply(f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "54cafbc0",
    "metadata": {},
    "source": [
@@ -349,7 +434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "732434f6",
    "metadata": {},
    "outputs": [],
@@ -359,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "4f5997e5",
    "metadata": {},
    "outputs": [],
@@ -385,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "ea6008a6",
    "metadata": {},
    "outputs": [],
@@ -405,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "183a82ed",
    "metadata": {},
    "outputs": [
@@ -485,7 +570,7 @@
        "4   979   982  1011   9790.0"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -534,7 +619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "73653918",
    "metadata": {},
    "outputs": [],
@@ -553,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "id": "077feb75",
    "metadata": {},
    "outputs": [
@@ -609,7 +694,7 @@
        "2  3     6"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -632,7 +717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "091e39e1",
    "metadata": {},
    "outputs": [
@@ -645,7 +730,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -664,7 +749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "id": "bd345fab",
    "metadata": {},
    "outputs": [
@@ -677,7 +762,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -704,7 +789,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "id": "b70f4b3b",
    "metadata": {},
    "outputs": [
@@ -756,7 +841,7 @@
        "2     3"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -775,7 +860,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "id": "0313c8df",
    "metadata": {},
    "outputs": [
@@ -788,7 +873,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -807,7 +892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "id": "96a7952a",
    "metadata": {},
    "outputs": [
@@ -863,7 +948,7 @@
        "2  3  1"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -886,7 +971,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "id": "e0815f60",
    "metadata": {},
    "outputs": [
@@ -899,7 +984,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -918,7 +1003,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "id": "495efd14",
    "metadata": {},
    "outputs": [
@@ -974,7 +1059,7 @@
        "2  3  3.14"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -992,7 +1077,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "id": "678b0b5a",
    "metadata": {},
    "outputs": [
@@ -1005,7 +1090,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1037,7 +1122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 29,
    "id": "acf48d56",
    "metadata": {},
    "outputs": [
@@ -1089,7 +1174,7 @@
        "2  5"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1110,7 +1195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 30,
    "id": "78a98172",
    "metadata": {},
    "outputs": [
@@ -1123,7 +1208,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1142,7 +1227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "id": "142c30a9",
    "metadata": {},
    "outputs": [
@@ -1210,7 +1295,7 @@
        "2  3  6     4  8  6"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1231,7 +1316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 32,
    "id": "fee9198a",
    "metadata": {},
    "outputs": [
@@ -1244,13 +1329,141 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "df.apply(f, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71e30d33",
+   "metadata": {},
+   "source": [
+    "### String Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a3694ea",
+   "metadata": {},
+   "source": [
+    "String data may be used inside `DataFrame.apply` UDFs, subject to the same constrains as those for `Series.apply`. See the section on string handling for `Series` UDFs above for details. Below is a simple example extending the row UDF logic from above in the case of a string column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "cccd59f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>str_col</th>\n",
+       "      <th>scale</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>abc</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ABC</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Example</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   str_col  scale\n",
+       "0      abc      1\n",
+       "1      ABC      2\n",
+       "2  Example      3"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "str_df = cudf.DataFrame({\n",
+    "    'str_col': ['abc', 'ABC', 'Example'],\n",
+    "    'scale': [1, 2, 3]\n",
+    "})\n",
+    "str_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "35737fd9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def f(row):\n",
+    "    st = row['str_col']\n",
+    "    scale = row['scale']\n",
+    "    \n",
+    "    if len(st) > 5:\n",
+    "        return len(st) + scale\n",
+    "    else:\n",
+    "        return len(st)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "4ede4d5b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0     3\n",
+       "1     3\n",
+       "2    10\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "str_df.apply(f, axis=1)"
    ]
   },
   {
@@ -1273,7 +1486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 36,
    "id": "90cbcd85",
    "metadata": {},
    "outputs": [],
@@ -1304,7 +1517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 37,
    "id": "e782daff",
    "metadata": {},
    "outputs": [
@@ -1376,7 +1589,7 @@
        "2  3  6     4  8  6  9.0"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1410,7 +1623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 38,
    "id": "befd8333",
    "metadata": {},
    "outputs": [
@@ -1484,7 +1697,7 @@
        "4   979   982  1011"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1511,7 +1724,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 39,
    "id": "d1f3dcaf",
    "metadata": {},
    "outputs": [
@@ -1591,7 +1804,7 @@
        "4   979   982  1011  1961.0"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1626,7 +1839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 40,
    "id": "6bc6aea3",
    "metadata": {},
    "outputs": [
@@ -1642,7 +1855,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1654,7 +1867,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 41,
    "id": "a4c31df1",
    "metadata": {},
    "outputs": [
@@ -1664,7 +1877,7 @@
        "Rolling [window=3,min_periods=3,center=False]"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1684,7 +1897,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 42,
    "id": "eb5a081b",
    "metadata": {},
    "outputs": [],
@@ -1710,7 +1923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 43,
    "id": "ddec3263",
    "metadata": {},
    "outputs": [
@@ -1726,7 +1939,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1745,7 +1958,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 44,
    "id": "8b61094a",
    "metadata": {},
    "outputs": [
@@ -1813,7 +2026,7 @@
        "4  59.0  59.0"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1827,7 +2040,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 45,
    "id": "bb8c3019",
    "metadata": {},
    "outputs": [
@@ -1925,7 +2138,7 @@
        "9        100.0        100.0"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1949,7 +2162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 46,
    "id": "3dc272ab",
    "metadata": {},
    "outputs": [
@@ -2029,7 +2242,7 @@
        "4 -0.970850  False   Sarah  0.342905"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2041,7 +2254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 47,
    "id": "c0578e0a",
    "metadata": {},
    "outputs": [],
@@ -2059,7 +2272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 48,
    "id": "19f0f7fe",
    "metadata": {},
    "outputs": [],
@@ -2088,7 +2301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 49,
    "id": "c43426c3",
    "metadata": {},
    "outputs": [
@@ -2219,7 +2432,7 @@
        "9 -0.725581   True  George  0.405245       0.271319"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2251,7 +2464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 50,
    "id": "aa6a8509",
    "metadata": {},
    "outputs": [
@@ -2261,7 +2474,7 @@
        "array([ 1.,  2.,  3.,  4., 10.])"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2284,7 +2497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 51,
    "id": "0bb8bf93",
    "metadata": {},
    "outputs": [
@@ -2299,7 +2512,7 @@
        "dtype: int32"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2326,7 +2539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 52,
    "id": "ce60b639",
    "metadata": {},
    "outputs": [
@@ -2336,7 +2549,7 @@
        "array([ 5., 10., 15., 20., 50.])"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2360,7 +2573,7 @@
    "id": "fe7eb68b",
    "metadata": {},
    "source": [
-    "- Only numeric nondecimal scalar types are currently supported as of yet, but strings and structured types are in planning. Attempting to use this API with those types will throw a `TypeError`.\n",
+    "- Only numeric nondecimal scalar types are currently supported as of yet, with support for strings in `Series` and `DataFrame` `apply` subject to the caveats outlined above. Attempting to use this API with unsupported types will throw a `TypeError`.\n",
     "- We do not yet fully support all arithmetic operators. Certain ops like bitwise operations are not currently implemented, but planned in future releases. If an operator is needed, a github issue should be raised so that it can be properly prioritized and implemented."
    ]
   },
@@ -2402,7 +2615,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/docs/cudf/source/user_guide/guide-to-udfs.ipynb
+++ b/docs/cudf/source/user_guide/guide-to-udfs.ipynb
@@ -341,7 +341,7 @@
    "id": "c0980218",
    "metadata": {},
    "source": [
-    "Support for a subset of string functionality is available for `apply` through the `strings_udf` rapids library, which is separately installable. If present, users are able to involve string columns in UDFs and operate under the assumption that those strings behave exactly like python `str` objects, albeit with a subset of supported functions and methods. Currently, the following string operations are provided through `strings_udf`:\n",
+    "Support for a subset of string functionality is available for `apply` through the [strings_udf](https://anaconda.org/rapidsai-nightly/strings_udf) package, which is separately installable. Currently, the following string operations are provided through `strings_udf`:\",\n",
     "- `str.count`\n",
     "- `str.startswith`\n",
     "- `str.endswith`\n",
@@ -1351,7 +1351,7 @@
    "id": "1a3694ea",
    "metadata": {},
    "source": [
-    "String data may be used inside `DataFrame.apply` UDFs, subject to the same constrains as those for `Series.apply`. See the section on string handling for `Series` UDFs above for details. Below is a simple example extending the row UDF logic from above in the case of a string column:"
+    "String data may be used inside `DataFrame.apply` UDFs, subject to the same constraints as those for `Series.apply`. See the section on string handling for `Series` UDFs above for details. Below is a simple example extending the row UDF logic from above in the case of a string column:"
    ]
   },
   {
@@ -2573,7 +2573,7 @@
    "id": "fe7eb68b",
    "metadata": {},
    "source": [
-    "- Only numeric nondecimal scalar types are currently supported as of yet, with support for strings in `Series` and `DataFrame` `apply` subject to the caveats outlined above. Attempting to use this API with unsupported types will throw a `TypeError`.\n",
+    "- UDFs are currently only supported for numeric nondecimal scalar types (full support) and strings in `Series.apply` and `DataFrame.apply` (partial support, subject to the caveats outlined above). Attempting to use this API with unsupported types will raise a `TypeError`.\n",
     "- We do not yet fully support all arithmetic operators. Certain ops like bitwise operations are not currently implemented, but planned in future releases. If an operator is needed, a github issue should be raised so that it can be properly prioritized and implemented."
    ]
   },

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -3956,10 +3956,10 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         <https://docs.rapids.ai/api/cudf/stable/user_guide/guide-to-udfs.html>`__.
 
         Support for use of string data within UDFs is provided through the
-        ``strings_udf`` rapids library. Supported operations on strings include
-        the subset of functions and string methods that expect an input string
-        but do not return a string. Refer to caveats in the ``guide-to-udfs``
-        notebook referenced above.
+        [strings_udf](https://anaconda.org/rapidsai-nightly/strings_udf) RAPIDS
+        library. Supported operations on strings include the subset of
+        functions and string methods that expect an input string but do not
+        return a string. Refer to caveats in the UDF guide referenced above.
 
         Parameters
         ----------
@@ -4085,8 +4085,9 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         2     5.0
         dtype: float64
 
-        String data is allowed, so long as its use does not modify or create
-        a new string. The following UDF is allowed:
+        UDFs manipulating string data are allowed, as long as
+        they neither modify strings in place nor create new strings.
+        For example, the following UDF is allowed:
 
         >>> def f(row):
         ...     st = row['str_col']
@@ -4110,18 +4111,19 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         2    4
         dtype: int64
 
-        However the following UDF is not allowed, because it includes an
-        operation that requires the creation of a new string, namely the
-        ``upper`` method. Methods that are not supported in this manner
-        will raise an ``AttributeError``.
+        However, the following UDF is not allowed since it includes an
+            operation that requires the creation of a new string: a call to the
+            ``upper`` method. Methods that are not supported in this manner
+            will raise an ``AttributeError``.
 
         >>> def f(row):
         ...     st = row['str_col'].upper()
         ...     return 'ABC' in st
         >>> df.apply(f, axis=1) # AttributeError
 
-        For a complete list of supported functions and methods that may be used
-        to manipulate string data, see the ``guide-to-udfs`` IPython notebook.
+        For a complete list of supported functions and methods that may be
+        used to manipulate string data, see the the UDF guide,
+        <https://docs.rapids.ai/api/cudf/stable/user_guide/guide-to-udfs.html>
         """
         if axis != 1:
             raise ValueError(

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -3956,8 +3956,8 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         <https://docs.rapids.ai/api/cudf/stable/user_guide/guide-to-udfs.html>`__.
 
         Support for use of string data within UDFs is provided through the
-        `strings_udf <https://anaconda.org/rapidsai-nightly/strings_udf>`__ RAPIDS
-        library. Supported operations on strings include the subset of
+        `strings_udf <https://anaconda.org/rapidsai-nightly/strings_udf>`__
+        RAPIDS library. Supported operations on strings include the subset of
         functions and string methods that expect an input string but do not
         return a string. Refer to caveats in the UDF guide referenced above.
 

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -4105,7 +4105,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         ...     'str_col': ['', 'abc', 'some_example'],
         ...     'scale': [1, 2, 3]
         ... })
-        >>> df.apply(f, axis=1)
+        >>> df.apply(f, axis=1)  # doctest: +SKIP
         0   -1
         1   -1
         2    4
@@ -4119,7 +4119,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         >>> def f(row):
         ...     st = row['str_col'].upper()
         ...     return 'ABC' in st
-        >>> df.apply(f, axis=1) # AttributeError
+        >>> df.apply(f, axis=1)  # doctest: +SKIP
 
         For a complete list of supported functions and methods that may be
         used to manipulate string data, see the the UDF guide,

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -3956,7 +3956,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         <https://docs.rapids.ai/api/cudf/stable/user_guide/guide-to-udfs.html>`__.
 
         Support for use of string data within UDFs is provided through the
-        [strings_udf](https://anaconda.org/rapidsai-nightly/strings_udf) RAPIDS
+        `strings_udf <https://anaconda.org/rapidsai-nightly/strings_udf>`__ RAPIDS
         library. Supported operations on strings include the subset of
         functions and string methods that expect an input string but do not
         return a string. Refer to caveats in the UDF guide referenced above.
@@ -4112,9 +4112,9 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         dtype: int64
 
         However, the following UDF is not allowed since it includes an
-            operation that requires the creation of a new string: a call to the
-            ``upper`` method. Methods that are not supported in this manner
-            will raise an ``AttributeError``.
+        operation that requires the creation of a new string: a call to the
+        ``upper`` method. Methods that are not supported in this manner
+        will raise an ``AttributeError``.
 
         >>> def f(row):
         ...     st = row['str_col'].upper()

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -3955,6 +3955,12 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         For more information, see the `cuDF guide to user defined functions
         <https://docs.rapids.ai/api/cudf/stable/user_guide/guide-to-udfs.html>`__.
 
+        Support for use of string data within UDFs is provided through the
+        ``strings_udf`` rapids library. Supported operations on strings include
+        the subset of functions and string methods that expect an input string
+        but do not return a string. Refer to caveats in the ``guide-to-udfs``
+        notebook referenced above.
+
         Parameters
         ----------
         func : function
@@ -4078,6 +4084,44 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         1     4.8
         2     5.0
         dtype: float64
+
+        String data is allowed, so long as its use does not modify or create
+        a new string. The following UDF is allowed:
+
+        >>> def f(row):
+        ...     st = row['str_col']
+        ...     scale = row['scale']
+        ...     if len(st) == 0:
+        ...             return -1
+        ...     elif st.startswith('a'):
+        ...             return 1 - scale
+        ...     elif 'example' in st:
+        ...             return 1 + scale
+        ...     else:
+        ...             return 42
+        ...
+        >>> df = cudf.DataFrame({
+        ...     'str_col': ['', 'abc', 'some_example'],
+        ...     'scale': [1, 2, 3]
+        ... })
+        >>> df.apply(f, axis=1)
+        0   -1
+        1   -1
+        2    4
+        dtype: int64
+
+        However the following UDF is not allowed, because it includes an
+        operation that requires the creation of a new string, namely the
+        ``upper`` method. Methods that are not supported in this manner
+        will raise an ``AttributeError``.
+
+        >>> def f(row):
+        ...     st = row['str_col'].upper()
+        ...     return 'ABC' in st
+        >>> df.apply(f, axis=1) # AttributeError
+
+        For a complete list of supported functions and methods that may be used
+        to manipulate string data, see the ``guide-to-udfs`` IPython notebook.
         """
         if axis != 1:
             raise ValueError(

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2252,7 +2252,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         <https://docs.rapids.ai/api/cudf/stable/user_guide/guide-to-udfs.html>`__.
 
         Support for use of string data within UDFs is provided through the
-        [strings_udf](https://anaconda.org/rapidsai-nightly/strings_udf) RAPIDS
+        `strings_udf <https://anaconda.org/rapidsai-nightly/strings_udf>`__ RAPIDS
         library. Supported operations on strings include the subset of
         functions and string methods that expect an input string but do not
         return a string. Refer to caveats in the UDF guide referenced above.
@@ -2361,9 +2361,9 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         dtype: int64
 
         However, the following UDF is not allowed since it includes an
-            operation that requires the creation of a new string: a call to the
-            ``upper`` method. Methods that are not supported in this manner
-            will raise an ``AttributeError``.
+        operation that requires the creation of a new string: a call to the
+        ``upper`` method. Methods that are not supported in this manner
+        will raise an ``AttributeError``.
 
         >>> def f(st):
         ...     new = st.upper()

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2354,7 +2354,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         ...             return 3
         ...
         >>> sr = cudf.Series(['', 'abc', 'some_example'])
-        >>> sr.apply(f)
+        >>> sr.apply(f)  # doctest: +SKIP
         0   -1
         1    1
         2    2
@@ -2369,7 +2369,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         ...     new = st.upper()
         ...     return 'ABC' in new
         ...
-        >>> sr.apply(f) # AttributeError
+        >>> sr.apply(f)  # doctest: +SKIP
 
         For a complete list of supported functions and methods that may be
         used to manipulate string data, see the the UDF guide,

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2252,8 +2252,8 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         <https://docs.rapids.ai/api/cudf/stable/user_guide/guide-to-udfs.html>`__.
 
         Support for use of string data within UDFs is provided through the
-        `strings_udf <https://anaconda.org/rapidsai-nightly/strings_udf>`__ RAPIDS
-        library. Supported operations on strings include the subset of
+        `strings_udf <https://anaconda.org/rapidsai-nightly/strings_udf>`__
+        RAPIDS library. Supported operations on strings include the subset of
         functions and string methods that expect an input string but do not
         return a string. Refer to caveats in the UDF guide referenced above.
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2252,10 +2252,10 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         <https://docs.rapids.ai/api/cudf/stable/user_guide/guide-to-udfs.html>`__.
 
         Support for use of string data within UDFs is provided through the
-        ``strings_udf`` rapids library. Supported operations include
-        the subset of functions and string methods that expect an input string
-        but do not return a string. Refer to caveats in the ``guide-to-udfs``
-        notebook referenced above.
+        [strings_udf](https://anaconda.org/rapidsai-nightly/strings_udf) RAPIDS
+        library. Supported operations on strings include the subset of
+        functions and string methods that expect an input string but do not
+        return a string. Refer to caveats in the UDF guide referenced above.
 
         Parameters
         ----------
@@ -2339,8 +2339,9 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         2     4.5
         dtype: float64
 
-        String data is allowed, so long as its use does not modify or create
-        a new string. The following UDF is allowed:
+        UDFs manipulating string data are allowed, as long as
+        they neither modify strings in place nor create new strings.
+        For example, the following UDF is allowed:
 
         >>> def f(st):
         ...     if len(st) == 0:
@@ -2359,18 +2360,20 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         2    2
         dtype: int64
 
-        However the following UDF is not allowed, because it includes an
-        operation that requires the creation of a new string, namely the
-        ``upper`` method. Methods that are not supported in this manner
-        will raise an ``AttributeError``.
+        However, the following UDF is not allowed since it includes an
+            operation that requires the creation of a new string: a call to the
+            ``upper`` method. Methods that are not supported in this manner
+            will raise an ``AttributeError``.
+
         >>> def f(st):
         ...     new = st.upper()
         ...     return 'ABC' in new
         ...
         >>> sr.apply(f) # AttributeError
 
-        For a complete list of supported functions and methods that may be used
-        to manipulate string data, see the ``guide-to-udfs`` IPython notebook.
+        For a complete list of supported functions and methods that may be
+        used to manipulate string data, see the the UDF guide,
+        <https://docs.rapids.ai/api/cudf/stable/user_guide/guide-to-udfs.html>
 
         """
         if convert_dtype is not True:


### PR DESCRIPTION
This PR updates some docstrings around cuDF to show some examples of how to use strings inside UDFs, as well as provide some caveats. It also adds a section with some detail and examples to our guide to udfs ipython notebook.