### PR TITLE
Update libcudf documentation build command in DOCUMENTATION.md

### DIFF
--- a/cpp/doxygen/developer_guide/DOCUMENTATION.md
+++ b/cpp/doxygen/developer_guide/DOCUMENTATION.md
@@ -437,7 +437,7 @@ We recommend installing Doxygen using conda (`conda install doxygen`) or a Linux
 Alternatively you can [build and install doxygen from source](https://www.doxygen.nl/manual/install.html).
 
 To build the libcudf HTML documentation simply run the `doxygen` command from the `cpp/doxygen` directory containing the `Doxyfile`.
-The libcudf documentation can also be built using `make docs_cudf` from the cmake build directory (e.g. `cpp/build`).
+The libcudf documentation can also be built using `cmake --build . --target docs_cudf` from the cmake build directory (e.g. `cpp/build`).
 Doxygen reads and processes all appropriate source files under the `cpp/include/` directory.
 The output is generated in the `cpp/doxygen/html/` directory.
 You can load the local `index.html` file generated there into any web browser to view the result.


### PR DESCRIPTION
## Description

Updates the instruction to build the libcudf documentation files in DOCUMENTATION.md.
The `cmake --build . --target docs_cudf` will invoke the appropriate make tool as setup when cmake was configured for building libcudf.

Closes #11719 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
