### PR TITLE
Fix ORC string sum statistics

### DIFF
--- a/cpp/include/cudf/io/orc_metadata.hpp
+++ b/cpp/include/cudf/io/orc_metadata.hpp
@@ -107,7 +107,7 @@ struct double_statistics : minmax_statistics<double>, sum_statistics<double> {
  * order. The `sum` is the total length of elements in the column.
  * Note: According to ORC specs, the sum should be signed, but pyarrow uses unsigned value
  */
-struct string_statistics : minmax_statistics<std::string>, sum_statistics<uint64_t> {
+struct string_statistics : minmax_statistics<std::string>, sum_statistics<int64_t> {
 };
 
 /**

--- a/cpp/src/io/orc/stats_enc.cu
+++ b/cpp/src/io/orc/stats_enc.cu
@@ -281,7 +281,7 @@ __global__ void __launch_bounds__(encode_threads_per_block)
         //  optional sint64 sum = 3; // sum will store the total length of all strings
         // }
         if (s->chunk.has_minmax && s->chunk.has_sum) {
-          uint32_t sz = (pb_put_uint(cur, 3, s->chunk.sum.i_val) - cur) +
+          uint32_t sz = (pb_put_int(cur, 3, s->chunk.sum.i_val) - cur) +
                         (pb_put_uint(cur, 1, s->chunk.min_value.str_val.length) - cur) +
                         (pb_put_uint(cur, 2, s->chunk.max_value.str_val.length) - cur) +
                         s->chunk.min_value.str_val.length + s->chunk.max_value.str_val.length;
@@ -291,7 +291,7 @@ __global__ void __launch_bounds__(encode_threads_per_block)
             cur, 1, s->chunk.min_value.str_val.ptr, s->chunk.min_value.str_val.length);
           cur = pb_put_binary(
             cur, 2, s->chunk.max_value.str_val.ptr, s->chunk.max_value.str_val.length);
-          cur = pb_put_uint(cur, 3, s->chunk.sum.i_val);
+          cur = pb_put_int(cur, 3, s->chunk.sum.i_val);
         }
         break;
       case dtype_bool:

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -1880,3 +1880,13 @@ def test_orc_reader_apache_negative_timestamp(datadir):
     gdf = cudf.read_orc(path)
 
     assert_eq(pdf, gdf)
+
+
+def test_statistics_string_sum():
+    strings = ["a string", "another string!"]
+    buff = BytesIO()
+    df = cudf.DataFrame({"str": strings})
+    df.to_orc(buff)
+
+    file_stats, stripe_stats = cudf.io.orc.read_orc_statistics([buff])
+    assert_eq(file_stats[0]["str"].get("sum"), sum(len(s) for s in strings))


### PR DESCRIPTION
## Description
Issue https://github.com/rapidsai/cudf/issues/9313
The root cause is that the sum value was encoded as an unsigned int. ORC specs show that the value should be encoded as signed.
Because both encode and decode where assuming unsigned encoding, the existing C++ test (OrcStatisticsTest, Basic) was passing even without this fix. Added a Python test that uses a different decode method, so it fails without the fix.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
