### PR TITLE
[REVIEW] Add ability to construct `ListColumn` when size is `None`

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1595,6 +1595,14 @@ def build_list_column(
     offset: int, optional
     """
     dtype = ListDtype(element_type=elements.dtype)
+    if size is None:
+        if indices.size == 0:
+            size = 0
+        else:
+            # one less because the last element of offsets is the number of
+            # bytes in the data buffer
+            size = indices.size - 1
+        size = size - offset
 
     result = build_column(
         data=None,

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -46,17 +46,6 @@ class ListColumn(ColumnBase):
         null_count=None,
         children=(),
     ):
-        if size is None:
-            if len(children) == 0:
-                size = 0
-            elif children[0].size == 0:
-                size = 0
-            else:
-                # one less because the last element of offsets is the number of
-                # bytes in the data buffer
-                size = children[0].size - 1
-            size = size - offset
-
         super().__init__(
             None,
             size,

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -46,6 +46,17 @@ class ListColumn(ColumnBase):
         null_count=None,
         children=(),
     ):
+        if size is None:
+            if len(children) == 0:
+                size = 0
+            elif children[0].size == 0:
+                size = 0
+            else:
+                # one less because the last element of offsets is the number of
+                # bytes in the data buffer
+                size = children[0].size - 1
+            size = size - offset
+
         super().__init__(
             None,
             size,


### PR DESCRIPTION
## Description
This PR adds ability to construct a `ListColumn` when `size` is `None`:

```python
In [1]: from cudf.core.column import build_list_column
In [2]: from cudf.core.column import as_column
In [3]: build_list_column(indices = as_column([0, 3]), elements = as_column([0, 2, 4]))
...
TypeError: an integer is required
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
