### PR TITLE
Resolve dask_cudf failures caused by upstream groupby changes

### DIFF
--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -57,10 +57,10 @@ def _check_groupby_supported(func):
 
 class CudfDataFrameGroupBy(DataFrameGroupBy):
     @_dask_cudf_nvtx_annotate
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, sort=None, **kwargs):
         self.sep = kwargs.pop("sep", "___")
         self.as_index = kwargs.pop("as_index", True)
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, sort=sort, **kwargs)
 
     @_dask_cudf_nvtx_annotate
     def __getitem__(self, key):
@@ -280,10 +280,10 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
 
 class CudfSeriesGroupBy(SeriesGroupBy):
     @_dask_cudf_nvtx_annotate
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, sort=None, **kwargs):
         self.sep = kwargs.pop("sep", "___")
         self.as_index = kwargs.pop("as_index", True)
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, sort=sort, **kwargs)
 
     @_dask_cudf_nvtx_annotate
     @_check_groupby_supported

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -577,8 +577,12 @@ def test_groupby_categorical_key():
     got = gddf.groupby("name", sort=True).agg(
         {"x": ["mean", "max"], "y": ["mean", "count"]}
     )
-    expect = ddf.groupby("name", sort=True).agg(
-        {"x": ["mean", "max"], "y": ["mean", "count"]}
+    # Use `compute` to avoid upstream issue for now
+    # (See: https://github.com/dask/dask/issues/9515)
+    expect = (
+        ddf.compute()
+        .groupby("name", sort=True)
+        .agg({"x": ["mean", "max"], "y": ["mean", "count"]})
     )
     dd.assert_eq(expect, got)
 


### PR DESCRIPTION
## Description
The `sort=True` default change in https://github.com/dask/dask/pull/9486 was not meant to propagate to the DataFrameGroupby and SeriesGroupby classes just yet. This PR adds the necessary `sort=None` defaults needed to avoid CI failures.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

cc @galipremsagar 