### PR TITLE
Fix return type of `Index.isna` & `Index.notna`

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1266,7 +1266,7 @@ class Frame(BinaryOperand, Scannable):
         >>> idx
         Float64Index([1.0, 2.0, <NA>, <NA>, 0.32, Inf], dtype='float64')
         >>> idx.isna()
-        GenericIndex([False, False, True, True, False, False], dtype='bool')
+        array([False, False,  True,  True, False, False])
         """
         data_columns = (col.isnull() for col in self._columns)
         return self._from_data_like_self(zip(self._column_names, data_columns))
@@ -1345,7 +1345,7 @@ class Frame(BinaryOperand, Scannable):
         >>> idx
         Float64Index([1.0, 2.0, <NA>, <NA>, 0.32, Inf], dtype='float64')
         >>> idx.notna()
-        GenericIndex([True, True, False, False, True, True], dtype='bool')
+        array([ True,  True, False, False,  True,  True])
         """
         data_columns = (col.notnull() for col in self._columns)
         return self._from_data_like_self(zip(self._column_names, data_columns))

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1196,7 +1196,7 @@ class Frame(BinaryOperand, Scannable):
         return self
 
     @_cudf_nvtx_annotate
-    def isnull(self):
+    def isna(self):
         """
         Identify missing values.
 
@@ -1236,7 +1236,7 @@ class Frame(BinaryOperand, Scannable):
         0     5                        <NA>  Alfred       <NA>
         1     6  1939-05-27 00:00:00.000000  Batman  Batmobile
         2  <NA>  1940-04-25 00:00:00.000000              Joker
-        >>> df.isnull()
+        >>> df.isna()
              age   born   name    toy
         0  False   True  False   True
         1  False  False  False  False
@@ -1252,7 +1252,7 @@ class Frame(BinaryOperand, Scannable):
         3     Inf
         4    -Inf
         dtype: float64
-        >>> ser.isnull()
+        >>> ser.isna()
         0    False
         1    False
         2     True
@@ -1265,17 +1265,17 @@ class Frame(BinaryOperand, Scannable):
         >>> idx = cudf.Index([1, 2, None, np.NaN, 0.32, np.inf])
         >>> idx
         Float64Index([1.0, 2.0, <NA>, <NA>, 0.32, Inf], dtype='float64')
-        >>> idx.isnull()
+        >>> idx.isna()
         GenericIndex([False, False, True, True, False, False], dtype='bool')
         """
         data_columns = (col.isnull() for col in self._columns)
         return self._from_data_like_self(zip(self._column_names, data_columns))
 
-    # Alias for isnull
-    isna = isnull
+    # Alias for isna
+    isnull = isna
 
     @_cudf_nvtx_annotate
-    def notnull(self):
+    def notna(self):
         """
         Identify non-missing values.
 
@@ -1315,7 +1315,7 @@ class Frame(BinaryOperand, Scannable):
         0     5                        <NA>  Alfred       <NA>
         1     6  1939-05-27 00:00:00.000000  Batman  Batmobile
         2  <NA>  1940-04-25 00:00:00.000000              Joker
-        >>> df.notnull()
+        >>> df.notna()
              age   born  name    toy
         0   True  False  True  False
         1   True   True  True   True
@@ -1331,7 +1331,7 @@ class Frame(BinaryOperand, Scannable):
         3     Inf
         4    -Inf
         dtype: float64
-        >>> ser.notnull()
+        >>> ser.notna()
         0     True
         1     True
         2    False
@@ -1344,14 +1344,14 @@ class Frame(BinaryOperand, Scannable):
         >>> idx = cudf.Index([1, 2, None, np.NaN, 0.32, np.inf])
         >>> idx
         Float64Index([1.0, 2.0, <NA>, <NA>, 0.32, Inf], dtype='float64')
-        >>> idx.notnull()
+        >>> idx.notna()
         GenericIndex([True, True, False, False, True, True], dtype='bool')
         """
         data_columns = (col.notnull() for col in self._columns)
         return self._from_data_like_self(zip(self._column_names, data_columns))
 
-    # Alias for notnull
-    notna = notnull
+    # Alias for notna
+    notnull = notna
 
     @_cudf_nvtx_annotate
     def searchsorted(

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -841,6 +841,14 @@ class RangeIndex(BaseIndex, BinaryOperand):
     def isna(self):
         return cupy.zeros(len(self), dtype=bool)
 
+    isnull = isna
+
+    @_cudf_nvtx_annotate
+    def notna(self):
+        return cupy.ones(len(self), dtype=bool)
+
+    notnull = isna
+
     @_cudf_nvtx_annotate
     def _minmax(self, meth: str):
         no_steps = len(self) - 1
@@ -1312,6 +1320,18 @@ class GenericIndex(SingleColumnFrame, BaseIndex):
             end = col.find_last_value(last, closest=True)
             end += 1
         return begin, end
+
+    @_cudf_nvtx_annotate
+    def isna(self):
+        return self._column.isnull().values
+
+    isnull = isna
+
+    @_cudf_nvtx_annotate
+    def notna(self):
+        return self._column.notnull().values
+
+    notnull = notna
 
     @_cudf_nvtx_annotate
     def get_slice_bound(self, label, side, kind=None):

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -406,14 +406,14 @@ def test_index_copy_deep(idx, deep):
 def test_index_isna(idx):
     pidx = pd.Index(idx, name="idx")
     gidx = cudf.core.index.Int64Index(idx, name="idx")
-    assert_eq(gidx.isna().to_numpy(), pidx.isna())
+    assert_eq(gidx.isna(), pidx.isna())
 
 
 @pytest.mark.parametrize("idx", [[1, None, 3, None, 5]])
 def test_index_notna(idx):
     pidx = pd.Index(idx, name="idx")
     gidx = cudf.core.index.Int64Index(idx, name="idx")
-    assert_eq(gidx.notna().to_numpy(), pidx.notna())
+    assert_eq(gidx.notna(), pidx.notna())
 
 
 def test_rangeindex_slice_attr_name():


### PR DESCRIPTION
## Description
This PR fixes: #11159 by returning correct object type for the result of `isna` & `notna` in `Index`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
