### PR TITLE
[REVIEW] Add doc section for `list` & `struct` handling

### DIFF
--- a/docs/cudf/source/api_docs/index.rst
+++ b/docs/cudf/source/api_docs/index.rst
@@ -19,4 +19,6 @@ This page provides a list of all publicly accessible modules, methods and classe
     io
     subword_tokenize
     string_handling
+    list_handling
+    struct_handling
     options

--- a/docs/cudf/source/api_docs/list_handling.rst
+++ b/docs/cudf/source/api_docs/list_handling.rst
@@ -1,0 +1,21 @@
+List handling
+~~~~~~~~~~~~~
+
+``Series.list`` can be used to access the values of the series as
+lists and apply list methods to it. These can be accessed like
+``Series.list.<function/property>``.
+
+.. currentmodule:: cudf.core.column.lists.ListMethods
+.. autosummary::
+   :toctree: api/
+
+   astype
+   concat
+   contains
+   index
+   get
+   leaves
+   len
+   sort_values
+   take
+   unique

--- a/docs/cudf/source/api_docs/series.rst
+++ b/docs/cudf/source/api_docs/series.rst
@@ -310,21 +310,6 @@ Timedelta properties
 .. include:: string_handling.rst
 
 
-..
-    The following is needed to ensure the generated pages are created with the
-    correct template (otherwise they would be created in the Series/Index class page)
-
-..
-    .. currentmodule:: cudf
-    .. autosummary::
-       :toctree: api/
-       :template: autosummary/accessor.rst
-
-       Series.str
-       Series.cat
-       Series.dt
-       Index.str
-
 .. _api.series.cat:
 
 Categorical accessor
@@ -349,42 +334,27 @@ the ``Series.cat`` accessor.
 
 
 .. _api.series.list:
-
-List handling
-~~~~~~~~~~~~~
-
-``Series.list`` can be used to access the values of the series as
-lists and apply list methods to it. These can be accessed like
-``Series.list.<function/property>``.
-
-.. currentmodule:: cudf.core.column.lists.ListMethods
-.. autosummary::
-   :toctree: api/
-
-   concat
-   contains
-   get
-   len
-   sort_values
-   take
-   unique
+.. include:: list_handling.rst
 
 
 .. _api.series.struct:
+.. include:: struct_handling.rst
 
-Struct handling
-~~~~~~~~~~~~~~~
 
-``Series.struct`` can be used to access the values of the series as
-Structs and apply struct methods to it. These can be accessed like
-``Series.struct.<function/property>``.
+..
+    The following is needed to ensure the generated pages are created with the
+    correct template (otherwise they would be created in the Series/Index class page)
 
-.. currentmodule:: cudf.core.column.struct.StructMethods
-.. autosummary::
-   :toctree: api/
+..
+    .. currentmodule:: cudf
+    .. autosummary::
+       :toctree: api/
+       :template: autosummary/accessor.rst
 
-   field
-   explode
+       Series.str
+       Series.cat
+       Series.dt
+       Index.str
 
 
 Serialization / IO / conversion

--- a/docs/cudf/source/api_docs/struct_handling.rst
+++ b/docs/cudf/source/api_docs/struct_handling.rst
@@ -1,0 +1,13 @@
+Struct handling
+~~~~~~~~~~~~~~~
+
+``Series.struct`` can be used to access the values of the series as
+Structs and apply struct methods to it. These can be accessed like
+``Series.struct.<function/property>``.
+
+.. currentmodule:: cudf.core.column.struct.StructMethods
+.. autosummary::
+   :toctree: api/
+
+   field
+   explode


### PR DESCRIPTION
## Description
Fixes: #11011

This PR:

- [x] Adds a side-section for `list` & `struct` handling.
- [x] Reduces duplication.
- [x] Exposes more `ListMethods` APIs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] The documentation is up to date with these changes.
