### PR TITLE
[REVIEW] Fix `strings_udf_version` version in `22.12`

### DIFF
--- a/python/strings_udf/CMakeLists.txt
+++ b/python/strings_udf/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
 
-set(strings_udf_version 22.10.00)
+set(strings_udf_version 22.12.00)
 
 include(../../fetch_rapids.cmake)
 


### PR DESCRIPTION
## Description
This PR fixes a missed version upgrade in cmake file. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
