### PR TITLE
Update docstring for cudf.read_text

### DIFF
--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1142,7 +1142,7 @@ filepath_or_buffer : str, path object, or file-like object
     function or `StringIO`).
 delimiter : string, default None
     The delimiter that should be used for splitting text chunks into 
-    separate cudf column rows. Currently only a single delimiter is supported.
+    separate cudf column rows. The delimiter may be one or more characters.
 byte_range : list or tuple, default None
     Byte range within the input file to be read. The first number is the
     offset in bytes, the second number is the range size in bytes.

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1140,13 +1140,18 @@ filepath_or_buffer : str, path object, or file-like object
     `py._path.local.LocalPath`), URL (including http, ftp, and S3 locations),
     or any object with a `read()` method (such as builtin `open()` file handler
     function or `StringIO`).
-delimiter : string, default None, The delimiter that should be used
-    for splitting text chunks into separate cudf column rows. Currently
-    only a single delimiter is supported.
+delimiter : string, default None
+    The delimiter that should be used for splitting text chunks into 
+    separate cudf column rows. Currently only a single delimiter is supported.
+byte_range : list or tuple, default None
+    Byte range within the input file to be read. The first number is the
+    offset in bytes, the second number is the range size in bytes. Reads the row
+    that starts before or at the end of the range, even if it ends after
+    the end of the range.
 
 Returns
 -------
-result : GPU ``Series``
+result : Series
 
 """
 doc_read_text = docfmt_partial(docstring=_docstring_text_datasource)

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1141,7 +1141,7 @@ filepath_or_buffer : str, path object, or file-like object
     or any object with a `read()` method (such as builtin `open()` file handler
     function or `StringIO`).
 delimiter : string, default None
-    The delimiter that should be used for splitting text chunks into 
+    The delimiter that should be used for splitting text chunks into
     separate cudf column rows. The delimiter may be one or more characters.
 byte_range : list or tuple, default None
     Byte range within the input file to be read. The first number is the

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1145,9 +1145,10 @@ delimiter : string, default None
     separate cudf column rows. Currently only a single delimiter is supported.
 byte_range : list or tuple, default None
     Byte range within the input file to be read. The first number is the
-    offset in bytes, the second number is the range size in bytes. Reads the row
-    that starts before or at the end of the range, even if it ends after
-    the end of the range.
+    offset in bytes, the second number is the range size in bytes.
+    The output contains all rows that start inside the byte range
+    (i.e. at or after the offset, and before the end at `offset + size`),
+    which may include rows that continue past the end.
 
 Returns
 -------


### PR DESCRIPTION
## Description
The docstring for `cudf.read_text` did not include the `byte_range` argument

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
