### PR TITLE
Disable nvCOMP DEFLATE integration

### DIFF
--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -377,8 +377,7 @@ void batched_compress(compression_type compression,
 bool is_compression_enabled(compression_type compression)
 {
   switch (compression) {
-    case compression_type::DEFLATE:
-      return NVCOMP_HAS_DEFLATE and detail::nvcomp_integration::is_all_enabled();
+    case compression_type::DEFLATE: return false;
     case compression_type::SNAPPY: return detail::nvcomp_integration::is_stable_enabled();
     case compression_type::ZSTD:
       return NVCOMP_HAS_ZSTD_COMP and detail::nvcomp_integration::is_all_enabled();

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -377,7 +377,9 @@ void batched_compress(compression_type compression,
 bool is_compression_enabled(compression_type compression)
 {
   switch (compression) {
-    case compression_type::DEFLATE: return false;
+    case compression_type::DEFLATE:
+      // See https://github.com/rapidsai/cudf/issues/11812
+      return false;
     case compression_type::SNAPPY: return detail::nvcomp_integration::is_stable_enabled();
     case compression_type::ZSTD:
       return NVCOMP_HAS_ZSTD_COMP and detail::nvcomp_integration::is_all_enabled();

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -379,7 +379,7 @@ rmm::device_buffer reader::impl::decompress_stripe_data(
     device_span<device_span<uint8_t>> inflate_out_view{inflate_out.data(), num_compressed_blocks};
     switch (decompressor.compression()) {
       case compression_type::ZLIB:
-        if (nvcomp_integration::is_all_enabled()) {
+        if (false) {
           nvcomp::batched_decompress(nvcomp::compression_type::DEFLATE,
                                      inflate_in_view,
                                      inflate_out_view,

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -379,6 +379,7 @@ rmm::device_buffer reader::impl::decompress_stripe_data(
     device_span<device_span<uint8_t>> inflate_out_view{inflate_out.data(), num_compressed_blocks};
     switch (decompressor.compression()) {
       case compression_type::ZLIB:
+        // See https://github.com/rapidsai/cudf/issues/11812
         if (false) {
           nvcomp::batched_decompress(nvcomp::compression_type::DEFLATE,
                                      inflate_in_view,

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -1746,8 +1746,10 @@ def test_writer_protobuf_large_rowindexentry():
 
 
 @pytest.mark.parametrize("compression", ["ZLIB", "ZSTD"])
-def test_orc_writer_nvcomp(list_struct_buff, compression):
-    expected = cudf.read_orc(list_struct_buff)
+def test_orc_writer_nvcomp(compression):
+    expected = cudf.datasets.randomdata(
+        nrows=12345, dtypes={"a": int, "b": str, "c": float}, seed=1
+    )
 
     buff = BytesIO()
     try:

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -429,7 +429,7 @@ Parameters
 ----------
 fname : str
     File path or object where the ORC dataset will be stored.
-compression : {{ 'snappy', 'ZLIB', 'ZSTD', None }}, default 'snappy'
+compression : {{ 'snappy', 'ZSTD', None }}, default 'snappy'
     Name of the compression to use. Use None for no compression.
 enable_statistics: boolean, default True
     Enable writing column statistics.


### PR DESCRIPTION
## Description
Disable the use of nvCOMP DEFLATE because of issues with nvCOMP 2.4.
Also fix a Python test (did not block CI because the comparison in the test is only done with  `LIBCUDF_NVCOMP_POLICY="ALWAYS"`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
