### PR TITLE
[REVIEW] Fix operator `NotImplemented` issue with `numpy`

### DIFF
--- a/python/cudf/cudf/core/scalar.py
+++ b/python/cudf/cudf/core/scalar.py
@@ -356,9 +356,10 @@ class Scalar(BinaryOperand, metaclass=CachedScalarInstanceMeta):
             other = other.value
         try:
             func = getattr(operator, op)
-            return func(self.value, other)
         except AttributeError:
             func = getattr(self.value, op)
+        else:
+            return func(self.value, other)
         return func(other)
 
     def _unaop_result_type_or_error(self, op):

--- a/python/cudf/cudf/core/scalar.py
+++ b/python/cudf/cudf/core/scalar.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020-2022, NVIDIA CORPORATION.
 
 import decimal
+import operator
 from collections import OrderedDict
 
 import numpy as np
@@ -353,7 +354,12 @@ class Scalar(BinaryOperand, metaclass=CachedScalarInstanceMeta):
     def _dispatch_scalar_binop(self, other, op):
         if isinstance(other, Scalar):
             other = other.value
-        return getattr(self.value, op)(other)
+        try:
+            func = getattr(operator, op)
+            return func(self.value, other)
+        except AttributeError:
+            func = getattr(self.value, op)
+        return func(other)
 
     def _unaop_result_type_or_error(self, op):
         if op == "__neg__" and self.dtype == "bool":

--- a/python/cudf/cudf/tests/test_scalar.py
+++ b/python/cudf/cudf/tests/test_scalar.py
@@ -443,3 +443,10 @@ def test_default_float_bitwidth_scalar(default_float_bitwidth):
     # Test that float scalars are default to 32 bits under user options.
     slr = cudf.Scalar(128.0)
     assert slr.dtype == np.dtype(f"f{default_float_bitwidth//8}")
+
+
+def test_scalar_numpy_casting():
+    # binop should upcast to wider type
+    s1 = cudf.Scalar(1, dtype=np.int32)
+    s2 = np.int64(2)
+    assert s1 < s2


### PR DESCRIPTION
## Description

Root cause:
```python
In [1]: import numpy as np

In [2]: x = np.uint8(1)

In [3]: y = np.float64(1.0)

In [4]: x.__ge__(y)
Out[4]: NotImplemented

In [8]: x >= y
Out[8]: True
```
This is leading to the following error whenever there is a Scalar binary operation involved:
```python
python/cudf/cudf/tests/test_series.py:449: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../envs/cudfdev/lib/python3.9/contextlib.py:79: in inner
    return func(*args, **kwds)
../envs/cudfdev/lib/python3.9/site-packages/cudf/core/series.py:2988: in describe
    data = _describe_categorical(self, percentiles)
../envs/cudfdev/lib/python3.9/site-packages/cudf/core/series.py:152: in _describe_categorical
    val_counts = obj.value_counts(ascending=False)
../envs/cudfdev/lib/python3.9/contextlib.py:79: in inner
    return func(*args, **kwds)
../envs/cudfdev/lib/python3.9/site-packages/cudf/core/series.py:2862: in value_counts
    res = res.sort_values(ascending=ascending)
../envs/cudfdev/lib/python3.9/contextlib.py:79: in inner
    return func(*args, **kwds)
../envs/cudfdev/lib/python3.9/site-packages/cudf/core/series.py:1910: in sort_values
    return super().sort_values(
../envs/cudfdev/lib/python3.9/site-packages/cudf/core/indexed_frame.py:1916: in sort_values
    out = self._gather(
../envs/cudfdev/lib/python3.9/site-packages/cudf/core/indexed_frame.py:1523: in _gather
    if not libcudf.copying._gather_map_is_valid(
copying.pyx:67: in cudf._lib.copying._gather_map_is_valid
    ???
../envs/cudfdev/lib/python3.9/site-packages/cudf/core/mixins/mixin_factory.py:11: in wrapper
    return method(self, *args1, *args2, **kwargs1, **kwargs2)
../envs/cudfdev/lib/python3.9/site-packages/cudf/core/scalar.py:350: in _binaryop
    return Scalar(result, dtype=out_dtype)
../envs/cudfdev/lib/python3.9/site-packages/cudf/core/scalar.py:56: in __call__
    obj = super().__call__(value, dtype=dtype)
../envs/cudfdev/lib/python3.9/site-packages/cudf/core/scalar.py:128: in __init__
    self._host_value, self._host_dtype = self._preprocess_host_value(
../envs/cudfdev/lib/python3.9/site-packages/cudf/core/scalar.py:222: in _preprocess_host_value
    value = to_cudf_compatible_scalar(value, dtype=dtype)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

val = NotImplemented, dtype = <class 'numpy.bool_'>

    def to_cudf_compatible_scalar(val, dtype=None):
        """
        Converts the value `val` to a numpy/Pandas scalar,
        optionally casting to `dtype`.
    
        If `val` is None, returns None.
        """
    
        if cudf._lib.scalar._is_null_host_scalar(val) or isinstance(
            val, cudf.Scalar
        ):
            return val
    
        if not cudf.api.types._is_scalar_or_zero_d_array(val):
>           raise ValueError(
                f"Cannot convert value of type {type(val).__name__} "
                "to cudf scalar"
            )
E           ValueError: Cannot convert value of type NotImplementedType to cudf scalar

../envs/cudfdev/lib/python3.9/site-packages/cudf/utils/dtypes.py:248: ValueError
```
This PR fixes the issue by first trying to call the `op` with `operator` standard library and then try to `getattr` if the `op` is not found in `operator` module.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).

