### PR TITLE
Fix is_valid checks in _binaryop

### DIFF
--- a/python/cudf/cudf/core/scalar.py
+++ b/python/cudf/cudf/core/scalar.py
@@ -339,8 +339,8 @@ class Scalar(BinaryOperand, metaclass=CachedScalarInstanceMeta):
         if is_scalar(other):
             other = to_cudf_compatible_scalar(other)
             out_dtype = self._binop_result_dtype_or_error(other, op)
-            valid = self.is_valid and (
-                isinstance(other, np.generic) or other.is_valid
+            valid = self.is_valid() and (
+                isinstance(other, np.generic) or other.is_valid()
             )
             if not valid:
                 return Scalar(None, dtype=out_dtype)


### PR DESCRIPTION
## Description

We need to actually call the method otherwise we will get false positives for validity of the operands.

Fortunately, this seems to have been a benign bug since the host pandas `NAType` handles all of 
the operations appropriately, so the code was "working" before, but the logic was incorrect.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
