### PR TITLE
[REVIEW] Pin `numpy` to `<1.23`

### DIFF
--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -19,7 +19,7 @@ dependencies:
   - scikit-build>=0.13.1
   - python>=3.8,<3.10
   - numba>=0.54
-  - numpy
+  - numpy<1.23
   - pandas>=1.0,<1.5.0dev0
   - pyarrow=8
   - fastavro>=0.22.9

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - pandas >=1.0,<1.5.0dev0
     - cupy >=9.5.0,<11.0.0a0
     - numba >=0.54
-    - numpy
+    - numpy<1.23
     - {{ pin_compatible('pyarrow', max_pin='x.x.x') }}
     - libcudf {{ version }}
     - fastavro >=0.22.0


### PR DESCRIPTION
## Description
Because of the issue discovered here: https://github.com/rapidsai/cudf/pull/11816, we would like to pin the max version of `numpy` to `<1.23` thus averting the same error in `22.08`. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
