### PR TITLE
[REVIEW] Fix dask nightly mixup issue

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -26,6 +26,10 @@ export GPUCI_CONDA_RETRY_SLEEP=30
 export CMAKE_GENERATOR="Ninja"
 export CONDA_BLD_DIR="$WORKSPACE/.conda-bld"
 
+# Whether to keep `dask/label/dev` channel in the env. If INSTALL_DASK_MAIN=0,
+# `dask/label/dev` channel is removed.
+export INSTALL_DASK_MAIN=0
+
 # Switch to project root; also root of repo checkout
 cd "$WORKSPACE"
 
@@ -48,6 +52,11 @@ conda activate rapids
 # Remove `rapidsai-nightly` & `dask/label/dev` channel if we are building main branch
 if [ "$SOURCE_BRANCH" = "main" ]; then
   conda config --system --remove channels rapidsai-nightly
+  conda config --system --remove channels dask/label/dev
+fi
+
+# Remove `dask/label/dev` channel if INSTALL_DASK_MAIN=0
+if [[ "${INSTALL_DASK_MAIN}" == 0 ]]; then
   conda config --system --remove channels dask/label/dev
 fi
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -81,7 +81,7 @@ conda activate rapids
 # Remove `dask/label/dev` channel if INSTALL_DASK_MAIN=0
 if [[ "${INSTALL_DASK_MAIN}" == 0 ]]; then
   conda config --system --remove channels dask/label/dev
-  gpuci_mamba_retry install conda-forge::dask=={$DASK_STABLE_VERSION} conda-forge::distributed=={$DASK_STABLE_VERSION} conda-forge::dask-core=={$DASK_STABLE_VERSION} --force-reinstall
+  gpuci_mamba_retry install conda-forge::dask==$DASK_STABLE_VERSION conda-forge::distributed==$DASK_STABLE_VERSION conda-forge::dask-core==$DASK_STABLE_VERSION --force-reinstall
 fi
 
 gpuci_logger "Check conda environment"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -81,6 +81,7 @@ conda activate rapids
 # Remove `dask/label/dev` channel if INSTALL_DASK_MAIN=0
 if [[ "${INSTALL_DASK_MAIN}" == 0 ]]; then
   conda config --system --remove channels dask/label/dev
+  gpuci_mamba_retry install conda-forge::dask=={$DASK_STABLE_VERSION} conda-forge::distributed=={$DASK_STABLE_VERSION} conda-forge::dask-core=={$DASK_STABLE_VERSION} --force-reinstall
 fi
 
 gpuci_logger "Check conda environment"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -32,7 +32,7 @@ export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 unset GIT_DESCRIBE_TAG
 
 # Dask & Distributed option to install main(nightly) or `conda-forge` packages.
-export INSTALL_DASK_MAIN=1
+export INSTALL_DASK_MAIN=0
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
 export DASK_STABLE_VERSION="2022.7.1"
@@ -77,6 +77,11 @@ nvidia-smi
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
+
+# Remove `dask/label/dev` channel if INSTALL_DASK_MAIN=0
+if [[ "${INSTALL_DASK_MAIN}" == 0 ]]; then
+  conda config --system --remove channels dask/label/dev
+fi
 
 gpuci_logger "Check conda environment"
 conda info


### PR DESCRIPTION
## Description
This PR remove dask nightly channel during release from all jobs so that we don't have a mixup of `dask-core`(nightly) along with `dask`(stable)
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
