### PR TITLE
Always call rapids_cuda_init_architectures before enabling CUDA language

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -329,7 +329,7 @@ fi
 if buildAll || hasArg cudf; then
 
     cd ${REPODIR}/python/cudf
-    python setup.py build_ext --inplace -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUDF_BUILD_DIR} ${EXTRA_CMAKE_ARGS} -- -j${PARALLEL_LEVEL:-1}
+    python setup.py build_ext --inplace -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUDF_BUILD_DIR} -DCMAKE_CUDA_ARCHITECTURES=${CUDF_CMAKE_CUDA_ARCHITECTURES} ${EXTRA_CMAKE_ARGS} -- -j${PARALLEL_LEVEL:-1}
     if [[ ${INSTALL_TARGET} != "" ]]; then
         python setup.py install --single-version-externally-managed --record=record.txt  -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUDF_BUILD_DIR} ${EXTRA_CMAKE_ARGS} -- -j${PARALLEL_LEVEL:-1}
     fi
@@ -338,7 +338,7 @@ fi
 if buildAll || hasArg strings_udf; then
 
     cd ${REPODIR}/python/strings_udf
-    python setup.py build_ext --inplace -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUDF_BUILD_DIR} ${EXTRA_CMAKE_ARGS} -- -j${PARALLEL_LEVEL:-1}
+    python setup.py build_ext --inplace -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUDF_BUILD_DIR} -DCMAKE_CUDA_ARCHITECTURES=${CUDF_CMAKE_CUDA_ARCHITECTURES} ${EXTRA_CMAKE_ARGS} -- -j${PARALLEL_LEVEL:-1}
     if [[ ${INSTALL_TARGET} != "" ]]; then
         python setup.py install --single-version-externally-managed --record=record.txt  -- -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_LIBRARY_PATH=${LIBCUDF_BUILD_DIR} ${EXTRA_CMAKE_ARGS} -- -j${PARALLEL_LEVEL:-1}
     fi

--- a/python/strings_udf/CMakeLists.txt
+++ b/python/strings_udf/CMakeLists.txt
@@ -18,6 +18,9 @@ set(strings_udf_version 22.10.00)
 
 include(../../fetch_rapids.cmake)
 
+include(rapids-cuda)
+rapids_cuda_init_architectures(strings-udf-python)
+
 project(
   strings-udf-python
   VERSION ${strings_udf_version}

--- a/python/strings_udf/cpp/CMakeLists.txt
+++ b/python/strings_udf/cpp/CMakeLists.txt
@@ -19,9 +19,7 @@ include(rapids-cpm)
 include(rapids-cuda)
 include(rapids-find)
 
-rapids_cpm_init()
-
-rapids_cuda_init_architectures(STRINGS_UDF)
+rapids_cuda_init_architectures(strings-udf-cpp)
 
 # Create a project so that we can enable CUDA architectures in this file.
 project(
@@ -29,6 +27,8 @@ project(
   VERSION ${strings_udf_version}
   LANGUAGES CUDA
 )
+
+rapids_cpm_init()
 
 rapids_find_package(
   CUDAToolkit REQUIRED


### PR DESCRIPTION
## Description
Ensures that strings_udf_python and strings_udf_cpp properly initialize the CUDA architectures before enabling the CUDA language.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
