### PR TITLE
[REVIEW] Fix pre-commit copyright check

### DIFF
--- a/ci/checks/copyright.py
+++ b/ci/checks/copyright.py
@@ -82,17 +82,17 @@ def modifiedFiles():
         # returns None if no tracking branch is set.
         upstream_target_branch = repo.heads[target_branch].tracking_branch()
     if upstream_target_branch is None:
-        if target_branch in repo.remote().refs:
-            # Fall back to the remote reference. This code path is used on CI
-            # because the only local branch reference is current-pr-branch, and
-            # thus target_branch is not in repo.heads. This also happens if no
-            # tracking branch is defined for the local target_branch. We use
-            # the remote with the latest commit if multiple remotes are
-            # defined.
-            candidate_branches = [
-                remote.refs[target_branch] for remote in repo.remotes
-                if target_branch in remote.refs
-            ]
+        # Fall back to the remote with the newest target_branch. This code
+        # path is used on CI because the only local branch reference is
+        # current-pr-branch, and thus target_branch is not in repo.heads.
+        # This also happens if no tracking branch is defined for the local
+        # target_branch. We use the remote with the latest commit if
+        # multiple remotes are defined.
+        candidate_branches = [
+            remote.refs[target_branch] for remote in repo.remotes
+            if target_branch in remote.refs
+        ]
+        if len(candidate_branches) > 0:
             upstream_target_branch = sorted(
                 candidate_branches,
                 key=lambda branch: branch.commit.committed_datetime,

--- a/ci/checks/copyright.py
+++ b/ci/checks/copyright.py
@@ -91,6 +91,7 @@ def modifiedFiles():
             # defined.
             candidate_branches = [
                 remote.refs[target_branch] for remote in repo.remotes
+                if target_branch in remote.refs
             ]
             upstream_target_branch = sorted(
                 candidate_branches,


### PR DESCRIPTION
## Description
This PR improves the copyright check script to handle cases where the ancestor `branch-*` does not have an upstream set.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
