### PR TITLE
[REVIEW] Handle `ptx` file paths 

### DIFF
--- a/python/strings_udf/strings_udf/__init__.py
+++ b/python/strings_udf/strings_udf/__init__.py
@@ -69,13 +69,13 @@ if cp.returncode == 0:
         native_sms = []
         for f in files:
             file_name = os.path.basename(f)
-            sm_number = (
+            sm_number = int(
                 file_name.rstrip(".ptx").lstrip("shim_").rstrip("-real")
             )
             if file_name.endswith("-real.ptx"):
-                native_sms.append((sm_number, file_name))
+                native_sms.append((sm_number, f))
             else:
-                virtual_sms.append((sm_number, file_name))
+                virtual_sms.append((sm_number, f))
 
         result = None
         if virtual_sms:


### PR DESCRIPTION
## Description
`strings_udf` is currently throwing an error on import when source compiled with only one gpu arch:
```python
----> 1 import cudf

File /nvme/0/pgali/envs/cudfdev/lib/python3.9/site-packages/cudf/__init__.py:20
     14 from cudf.api.extensions import (
     15     register_dataframe_accessor,
     16     register_index_accessor,
     17     register_series_accessor,
     18 )
     19 from cudf.api.types import dtype
---> 20 from cudf.core.algorithms import factorize
     21 from cudf.core.cut import cut
     22 from cudf.core.dataframe import DataFrame, from_dataframe, from_pandas, merge

.
.
.
File /nvme/0/pgali/envs/cudfdev/lib/python3.9/site-packages/cudf/core/indexed_frame.py:60
     58 from cudf.core.multiindex import MultiIndex
     59 from cudf.core.resample import _Resampler
---> 60 from cudf.core.udf.utils import (
     61     _compile_or_get,
     62     _get_input_args_from_frame,
     63     _post_process_output_col,
     64     _return_arr_from_dtype,
     65 )
     66 from cudf.utils import docutils
     67 from cudf.utils.utils import _cudf_nvtx_annotate

File /nvme/0/pgali/envs/cudfdev/lib/python3.9/site-packages/cudf/core/udf/__init__.py:27
     25 _STRING_UDFS_ENABLED = False
     26 try:
---> 27     import strings_udf
     29     if strings_udf.ENABLED:
     30         from . import strings_typing  # isort: skip

File /nvme/0/pgali/envs/cudfdev/lib/python3.9/site-packages/strings_udf/__init__.py:66
     62 import pdb;pdb.set_trace()
     63 sms = [
     64     os.path.basename(f).rstrip(".ptx").lstrip("shim_") for f in files
     65 ]
---> 66 selected_sm = max(sm for sm in sms if sm < cc)
     67 ptxpath = os.path.join(
     68     os.path.dirname(__file__), f"shim_{selected_sm}.ptx"
     69 )
     71 if driver_version >= compiler_from_ptx_file(ptxpath):

ValueError: max() arg is an empty sequence
```


This PR fixes the above issue and also handles `shim_sm-real.ptx` and `shim_sm.ptx` files appropriately.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
