### PR TITLE
JNI Avoid NPE for reading host binary data

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVectorCore.java
@@ -399,7 +399,9 @@ public class HostColumnVectorCore implements AutoCloseable {
     int size = end - start;
 
     byte[] result = new byte[size];
-    listData.offHeap.data.getBytes(result, 0, start, size);
+    if (size > 0) {
+      listData.offHeap.data.getBytes(result, 0, start, size);
+    }
     return result;
   }
 


### PR DESCRIPTION
## Description
This avoids a potential null pointer exception when trying to read byte data from an empty column

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
