### PR TITLE
Fix RangeIndex unary operators.

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -867,15 +867,14 @@ class RangeIndex(BaseIndex, BinaryOperand):
     def max(self):
         return self._minmax("max")
 
+    def __neg__(self):
+        return -self._as_int_index()
 
-# Patch in all binops and unary ops, which bypass __getattr__ on the instance
-# and prevent the above overload from working.
-for unaop in ("__neg__", "__pos__", "__abs__"):
-    setattr(
-        RangeIndex,
-        unaop,
-        lambda self, op=unaop: getattr(self._as_int64(), op)(),
-    )
+    def __pos__(self):
+        return +self._as_int_index()
+
+    def __abs__(self):
+        return abs(self._as_int_index())
 
 
 class GenericIndex(SingleColumnFrame, BaseIndex):


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
These operators rely on a method that was renamed in #11272 and are also out of sync with the rest of the `RangeIndex` design now that the `__getattr__` overload has been removed (#10538).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
