### PR TITLE
Fix writing of Parquet files with many fragments

### DIFF
--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include "parquet_gpu.hpp"
 
 #include <io/utilities/block_utils.cuh>

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -122,13 +122,13 @@ __global__ void __launch_bounds__(block_size)
   frag_init_state_s* const s = &state_g;
   uint32_t t                 = threadIdx.x;
 #if FRAGSWAP
-  int frag_y                 = blockIdx.x;
-  auto const physical_type   = col_desc[blockIdx.y].physical_type;
+  int frag_y               = blockIdx.x;
+  auto const physical_type = col_desc[blockIdx.y].physical_type;
 
   if (t == 0) s->col = col_desc[blockIdx.y];
 #else
-  int frag_y                 = blockIdx.y;
-  auto const physical_type   = col_desc[blockIdx.x].physical_type;
+  int frag_y               = blockIdx.y;
+  auto const physical_type = col_desc[blockIdx.x].physical_type;
 
   if (t == 0) s->col = col_desc[blockIdx.x];
 #endif
@@ -218,13 +218,13 @@ __global__ void __launch_bounds__(128)
   // TODO: why not 1 block per warp?
   __shared__ __align__(8) statistics_group group_g[4];
 
-  uint32_t lane_id              = threadIdx.x & 0x1f;
+  uint32_t lane_id = threadIdx.x & 0x1f;
 #if FRAGSWAP
-  uint32_t frag_id              = blockIdx.x * 4 + (threadIdx.x >> 5);
-  uint32_t column_id            = blockIdx.y;
+  uint32_t frag_id   = blockIdx.x * 4 + (threadIdx.x >> 5);
+  uint32_t column_id = blockIdx.y;
 #else
-  uint32_t frag_id              = blockIdx.y * 4 + (threadIdx.x >> 5);
-  uint32_t column_id            = blockIdx.x;
+  uint32_t frag_id   = blockIdx.y * 4 + (threadIdx.x >> 5);
+  uint32_t column_id = blockIdx.x;
 #endif
   auto num_fragments_per_column = fragments.size().second;
   statistics_group* const g     = &group_g[threadIdx.x >> 5];
@@ -2044,7 +2044,7 @@ void InitPageFragments(device_2dspan<PageFragment> frag,
 #else
   dim3 dim_grid(num_columns, num_fragments_per_column);  // 1 threadblock per fragment
 #endif
-  //printf("call init frag dim(%d,%d)\n", dim_grid.x, dim_grid.y);
+  // printf("call init frag dim(%d,%d)\n", dim_grid.x, dim_grid.y);
   gpuInitPageFragments<512><<<dim_grid, 512, 0, stream.value()>>>(
     frag, col_desc, partitions, part_frag_offset, fragment_size);
 }
@@ -2060,9 +2060,9 @@ void InitFragmentStatistics(device_2dspan<statistics_group> groups,
 #if FRAGSWAP
   dim3 dim_grid(grid_y, num_columns);  // 1 warp per fragment
 #else
-  dim3 dim_grid(num_columns, grid_y);  // 1 warp per fragment
+  dim3 dim_grid(num_columns, grid_y);                    // 1 warp per fragment
 #endif
-  //printf("call init frag stats dim(%d,%d)\n", dim_grid.x, dim_grid.y);
+  // printf("call init frag stats dim(%d,%d)\n", dim_grid.x, dim_grid.y);
   gpuInitFragmentStats<<<dim_grid, 128, 0, stream.value()>>>(groups, fragments, col_desc);
 }
 

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -1280,7 +1280,6 @@ __global__ void __launch_bounds__(128) gpuDecideCompression(device_span<EncColum
       auto& curr_page         = ck_g.pages[page];
       uint32_t page_data_size = curr_page.max_data_size;
       uncompressed_data_size += page_data_size;
-      //printf("%03d pg=%03d usz=%d\n", blockIdx.x, page, page_data_size);
       if (auto comp_res = curr_page.comp_res; comp_res != nullptr) {
         has_compression = true;
         compressed_data_size += comp_res->bytes_written;
@@ -1296,10 +1295,8 @@ __global__ void __launch_bounds__(128) gpuDecideCompression(device_span<EncColum
     if (has_compression) {
       uint32_t compression_error = atomicAdd(&error_count, 0);
       is_compressed = (!compression_error && compressed_data_size < uncompressed_data_size);
-      //printf("%03d ic=%d ce=%d csz=%d usz=%d\n", blockIdx.x, is_compressed, compression_error, compressed_data_size, uncompressed_data_size);
     } else {
       is_compressed = false;
-      //printf("%d no comp\n", blockIdx.x);
     }
     chunks[blockIdx.x].is_compressed = is_compressed;
     chunks[blockIdx.x].bfr_size      = uncompressed_data_size;

--- a/cpp/tests/io/parquet_test.cpp
+++ b/cpp/tests/io/parquet_test.cpp
@@ -1056,7 +1056,7 @@ TEST_F(ParquetWriterTest, ManyFragments)
   auto filepath = temp_env->get_temp_filepath("ManyFragments.parquet");
   cudf::io::parquet_writer_options args =
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, *expected)
-      .max_page_size_bytes(8*1024);
+      .max_page_size_bytes(8 * 1024);
   cudf::io::write_parquet(args);
 
   cudf::io::parquet_reader_options read_opts =

--- a/cpp/tests/io/parquet_test.cpp
+++ b/cpp/tests/io/parquet_test.cpp
@@ -1048,6 +1048,24 @@ TEST_F(ParquetWriterTest, HostBuffer)
   cudf::test::expect_metadata_equal(expected_metadata, result.metadata);
 }
 
+TEST_F(ParquetWriterTest, ManyFragments)
+{
+  srand(31337);
+  auto expected = create_random_fixed_table<int>(10, 6'000'000, false);
+
+  auto filepath = temp_env->get_temp_filepath("ManyFragments.parquet");
+  cudf::io::parquet_writer_options args =
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, *expected)
+      .max_page_size_bytes(8*1024);
+  cudf::io::write_parquet(args);
+
+  cudf::io::parquet_reader_options read_opts =
+    cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath});
+  auto result = cudf::io::read_parquet(read_opts);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(*result.tbl, *expected);
+}
+
 TEST_F(ParquetWriterTest, NonNullable)
 {
   srand(31337);

--- a/cpp/tests/io/parquet_test.cpp
+++ b/cpp/tests/io/parquet_test.cpp
@@ -1051,17 +1051,17 @@ TEST_F(ParquetWriterTest, HostBuffer)
 TEST_F(ParquetWriterTest, ManyFragments)
 {
   srand(31337);
-  auto expected = create_random_fixed_table<int>(10, 6'000'000, false);
+  auto const expected = create_random_fixed_table<int>(10, 6'000'000, false);
 
-  auto filepath = temp_env->get_temp_filepath("ManyFragments.parquet");
-  cudf::io::parquet_writer_options args =
+  auto const filepath = temp_env->get_temp_filepath("ManyFragments.parquet");
+  cudf::io::parquet_writer_options const args =
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, *expected)
       .max_page_size_bytes(8 * 1024);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options read_opts =
+  cudf::io::parquet_reader_options const read_opts =
     cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath});
-  auto result = cudf::io::read_parquet(read_opts);
+  auto const result = cudf::io::read_parquet(read_opts);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(*result.tbl, *expected);
 }


### PR DESCRIPTION
## Description
This PR fixes an error that can occur when very small page sizes are used when writing Parquet files. #11551 changed from fixed 5000 row page fragments to a scaled value based on the requested max page size. For small page sizes, the number of fragments to process can exceed 64k. The number of fragments is used as the `y` dimension when calling `gpuInitPageFragments`, and when it exceeds 64k the kernel fails to launch, ultimately leading to an invalid memory access. 
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
