### PR TITLE
Fixes bug in temporary decompression space estimation before calling nvcomp

### DIFF
--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -147,15 +147,14 @@ size_t batched_decompress_temp_size(compression_type compression,
                                     size_t max_uncomp_chunk_size,
                                     size_t max_total_uncomp_size)
 {
-  size_t temp_size = 0;
-  auto nvcomp_status =
-    batched_decompress_get_temp_size_ex(
-      compression, num_chunks, max_uncomp_chunk_size, &temp_size, max_total_uncomp_size);
+  size_t temp_size   = 0;
+  auto nvcomp_status = batched_decompress_get_temp_size_ex(
+    compression, num_chunks, max_uncomp_chunk_size, &temp_size, max_total_uncomp_size);
 
-  if (nvcomp_status
-      .value_or(nvcompStatus_t::nvcompErrorInternal) != nvcompStatus_t::nvcompSuccess) {
-    nvcomp_status = batched_decompress_get_temp_size(
-      compression, num_chunks, max_uncomp_chunk_size, &temp_size);
+  if (nvcomp_status.value_or(nvcompStatus_t::nvcompErrorInternal) !=
+      nvcompStatus_t::nvcompSuccess) {
+    nvcomp_status =
+      batched_decompress_get_temp_size(compression, num_chunks, max_uncomp_chunk_size, &temp_size);
   }
 
   CUDF_EXPECTS(nvcomp_status == nvcompStatus_t::nvcompSuccess,

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -148,11 +148,15 @@ size_t batched_decompress_temp_size(compression_type compression,
                                     size_t max_total_uncomp_size)
 {
   size_t temp_size = 0;
-  auto const nvcomp_status =
+  auto nvcomp_status =
     batched_decompress_get_temp_size_ex(
-      compression, num_chunks, max_uncomp_chunk_size, &temp_size, max_total_uncomp_size)
-      .value_or(batched_decompress_get_temp_size(
-        compression, num_chunks, max_uncomp_chunk_size, &temp_size));
+      compression, num_chunks, max_uncomp_chunk_size, &temp_size, max_total_uncomp_size);
+
+  if (nvcomp_status
+      .value_or(nvcompStatus_t::nvcompErrorInternal) != nvcompStatus_t::nvcompSuccess) {
+    nvcomp_status = batched_decompress_get_temp_size(
+      compression, num_chunks, max_uncomp_chunk_size, &temp_size);
+  }
 
   CUDF_EXPECTS(nvcomp_status == nvcompStatus_t::nvcompSuccess,
                "Unable to get scratch size for decompression");


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/11878

This PR fixes an issue we noticed while trying to read a zstd parquet file where the cuDF code was causing a very large allocation to happen (something much higher than GPU memory like 50 or 60 GB).

We bisected the issue to this PR: https://github.com/rapidsai/cudf/pull/11652. 

The fix has been verified with the original file and Spark.

Thanks to @nvdbaranec, @jbrennan333, @mythrocks  and @vuule for help looking into this!