### PR TITLE
Remove "experimental" warning for struct columns in ORC reader and writer

### DIFF
--- a/cpp/include/cudf/io/orc.hpp
+++ b/cpp/include/cudf/io/orc.hpp
@@ -378,9 +378,6 @@ class orc_reader_options_builder {
  *  auto result  = cudf::io::read_orc(options);
  * @endcode
  *
- * Note: Support for reading files with struct columns is currently experimental, the output may not
- * be as reliable as reading for other datatypes.
- *
  * @param options Settings for controlling reading behavior
  * @param mr Device memory resource used to allocate device memory of the table in the returned
  * table_with_metadata.
@@ -782,9 +779,6 @@ class orc_writer_options_builder {
  *  auto options     = cudf::io::orc_writer_options::builder(destination, table->view());
  *  cudf::io::write_orc(options);
  * @endcode
- *
- * Note: Support for writing tables with struct columns is currently experimental, the output may
- * not be as reliable as writing for other datatypes.
  *
  * @param options Settings for controlling reading behavior
  * @param mr Device memory resource to use for device memory allocation

--- a/python/cudf/cudf/io/orc.py
+++ b/python/cudf/cudf/io/orc.py
@@ -418,11 +418,6 @@ def to_orc(
     """{docstring}"""
 
     for col in df._data.columns:
-        if isinstance(col, cudf.core.column.StructColumn):
-            warnings.warn(
-                "Support for writing tables with struct columns is "
-                "currently experimental."
-            )
         if isinstance(col, cudf.core.column.CategoricalColumn):
             raise NotImplementedError(
                 "Writing to ORC format is not yet supported with "

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -1555,7 +1555,6 @@ def test_names_in_struct_dtype_nesting(datadir):
     assert edf.dtypes.equals(got.dtypes)
 
 
-@pytest.mark.filterwarnings("ignore:.*struct.*experimental")
 def test_writer_lists_structs(list_struct_buff):
     df_in = cudf.read_orc(list_struct_buff)
 
@@ -1567,7 +1566,6 @@ def test_writer_lists_structs(list_struct_buff):
     assert pyarrow_tbl.equals(df_in.to_arrow())
 
 
-@pytest.mark.filterwarnings("ignore:.*struct.*experimental")
 @pytest.mark.parametrize(
     "data",
     [
@@ -1668,7 +1666,6 @@ def test_empty_statistics():
         assert stats[0]["i"].get("sum") == 1
 
 
-@pytest.mark.filterwarnings("ignore:.*struct.*experimental")
 @pytest.mark.parametrize(
     "equivalent_columns",
     [

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -299,12 +299,6 @@ Total number of rows
 Number of stripes
 List of column names
 
-Notes
------
-Support for reading files with struct columns is currently experimental,
-the output may not be as reliable as reading for other datatypes.
-{remote_data_sources}
-
 Examples
 --------
 >>> import cudf
@@ -446,11 +440,6 @@ cols_as_map_type : list of column names or None, default None
     A list of column names which should be written as map type in the ORC file.
     Note that this option only affects columns of ListDtype. Names of other
     column types will be ignored.
-
-Notes
------
-Support for writing tables with struct columns is currently experimental,
-the output may not be as reliable as writing for other datatypes.
 
 See Also
 --------


### PR DESCRIPTION
## Description
Closes https://github.com/rapidsai/cudf/issues/11484


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
