### PR TITLE
Fix type casting in Series.__setitem__

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -854,7 +854,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         raise NotImplementedError()
 
     def astype(self, dtype: Dtype, **kwargs) -> ColumnBase:
-        if dtype == self.dtype:
+        if self.dtype == dtype:
             return self
         if is_categorical_dtype(dtype):
             return self.as_categorical_column(dtype, **kwargs)

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -854,6 +854,8 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         raise NotImplementedError()
 
     def astype(self, dtype: Dtype, **kwargs) -> ColumnBase:
+        if dtype == self.dtype:
+            return self
         if is_categorical_dtype(dtype):
             return self.as_categorical_column(dtype, **kwargs)
 

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -742,8 +742,6 @@ class ListMethods(ColumnMethods):
         >>> s2.dtype
         ListDtype(float64)
         """
-        if self.dtype == dtype:
-            return self
         return self._return_or_inplace(
             self._column._transform_leaves(
                 lambda col, dtype: col.astype(dtype), dtype

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -742,6 +742,8 @@ class ListMethods(ColumnMethods):
         >>> s2.dtype
         ListDtype(float64)
         """
+        if self.dtype == dtype:
+            return self
         return self._return_or_inplace(
             self._column._transform_leaves(
                 lambda col, dtype: col.astype(dtype), dtype

--- a/python/cudf/cudf/core/scalar.py
+++ b/python/cudf/cudf/core/scalar.py
@@ -392,4 +392,6 @@ class Scalar(BinaryOperand, metaclass=CachedScalarInstanceMeta):
         return getattr(self.value, op)()
 
     def astype(self, dtype):
+        if self.dtype == dtype:
+            return self
         return Scalar(self.value, dtype)

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -35,6 +35,7 @@ from cudf.api.types import (
     is_integer_dtype,
     is_list_dtype,
     is_scalar,
+    is_string_dtype,
     is_struct_dtype,
 )
 from cudf.core.abc import Serializable
@@ -214,16 +215,9 @@ class _SeriesIlocIndexer(_FrameIndexer):
             value = column.as_column(value)
 
         if (
-            not isinstance(
-                self._frame._column.dtype,
-                (
-                    # Casting only for string and non-decimal numeric
-                    # columns
-                    cudf.core.dtypes.DecimalDtype,
-                    cudf.CategoricalDtype,
-                    cudf.ListDtype,
-                    cudf.StructDtype,
-                ),
+            (
+                _is_non_decimal_numeric_dtype(self._frame._column.dtype)
+                or is_string_dtype(self._frame._column.dtype)
             )
             and hasattr(value, "dtype")
             and _is_non_decimal_numeric_dtype(value.dtype)

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -222,11 +222,12 @@ class _SeriesIlocIndexer(_FrameIndexer):
             and _is_non_decimal_numeric_dtype(value.dtype)
         ):
             # normalize types if necessary:
-            if not is_integer(key):
-                to_dtype = np.result_type(
-                    value.dtype, self._frame._column.dtype
-                )
-                value = value.astype(to_dtype)
+            # In contrast to Column.__setitem__ (which downcasts the value to
+            # the dtype of the column) here we upcast the series to the
+            # larger data type mimicing pandas
+            to_dtype = np.result_type(value.dtype, self._frame._column.dtype)
+            value = value.astype(to_dtype)
+            if to_dtype != self._frame._column.dtype:
                 self._frame._column._mimic_inplace(
                     self._frame._column.astype(to_dtype), inplace=True
                 )

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -231,7 +231,7 @@ class _SeriesIlocIndexer(_FrameIndexer):
             # normalize types if necessary:
             # In contrast to Column.__setitem__ (which downcasts the value to
             # the dtype of the column) here we upcast the series to the
-            # larger data type mimicing pandas
+            # larger data type mimicking pandas
             to_dtype = np.result_type(value.dtype, self._frame._column.dtype)
             value = value.astype(to_dtype)
             if to_dtype != self._frame._column.dtype:

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -216,7 +216,14 @@ class _SeriesIlocIndexer(_FrameIndexer):
         if (
             not isinstance(
                 self._frame._column.dtype,
-                (cudf.core.dtypes.DecimalDtype, cudf.CategoricalDtype),
+                (
+                    # Casting only for string and non-decimal numeric
+                    # columns
+                    cudf.core.dtypes.DecimalDtype,
+                    cudf.CategoricalDtype,
+                    cudf.ListDtype,
+                    cudf.StructDtype,
+                ),
             )
             and hasattr(value, "dtype")
             and _is_non_decimal_numeric_dtype(value.dtype)

--- a/python/cudf/cudf/tests/test_setitem.py
+++ b/python/cudf/cudf/tests/test_setitem.py
@@ -304,12 +304,38 @@ def test_series_slice_setitem_struct():
 def test_series_setitem_upcasting(dtype, indices):
     sr = pd.Series([0, 0, 0], dtype=dtype)
     cr = cudf.from_pandas(sr)
-    assert_eq(sr.values, cr.values)
+    assert_eq(sr, cr)
     new_value = np.float64(10.5)
     col_ref = cr._column
     sr[indices] = new_value
     cr[indices] = new_value
-    assert_eq(sr.values, cr.values)
+    if PANDAS_GE_150:
+        assert_eq(sr, cr)
+    else:
+        # pandas bug, incorrectly fails to upcasting from float32 to float64
+        assert_eq(sr.values, cr.values)
     if dtype == np.float64:
         # no-op type cast should not modify backing column
         assert col_ref == cr._column
+
+
+# TODO: these two tests could perhaps be changed once specifics of
+# pandas compat wrt upcasting are decided on; this is just baking in
+# status-quo.
+def test_series_setitem_upcasting_string_column():
+    sr = pd.Series([0, 0, 0], dtype=str)
+    cr = cudf.from_pandas(sr)
+    new_value = np.float64(10.5)
+    sr[0] = str(new_value)
+    cr[0] = new_value
+    assert_eq(sr, cr)
+
+
+def test_series_setitem_upcasting_string_value():
+    sr = cudf.Series([0, 0, 0], dtype=int)
+    # This is a distinction with pandas, which let's you instead make an
+    # object column with ["10", 0, 0]
+    sr[0] = "10"
+    assert_eq(pd.Series([10, 0, 0], dtype=int), sr)
+    with pytest.raises(ValueError):
+        sr[0] = "non-integer"

--- a/python/cudf/cudf/tests/test_setitem.py
+++ b/python/cudf/cudf/tests/test_setitem.py
@@ -333,7 +333,7 @@ def test_series_setitem_upcasting_string_column():
 
 def test_series_setitem_upcasting_string_value():
     sr = cudf.Series([0, 0, 0], dtype=int)
-    # This is a distinction with pandas, which let's you instead make an
+    # This is a distinction with pandas, which lets you instead make an
     # object column with ["10", 0, 0]
     sr[0] = "10"
     assert_eq(pd.Series([10, 0, 0], dtype=int), sr)

--- a/python/cudf/cudf/tests/test_setitem.py
+++ b/python/cudf/cudf/tests/test_setitem.py
@@ -305,7 +305,10 @@ def test_series_setitem_upcasting(dtype, indices):
     sr = pd.Series([0, 0, 0], dtype=dtype)
     cr = cudf.from_pandas(sr)
     assert_eq(sr, cr)
-    new_value = np.float64(10.5)
+    # Must be a non-integral floating point value that can't be losslessly
+    # converted to float32, otherwise pandas will try and match the source
+    # column dtype.
+    new_value = np.float64(np.pi)
     col_ref = cr._column
     sr[indices] = new_value
     cr[indices] = new_value

--- a/python/cudf/cudf/tests/test_setitem.py
+++ b/python/cudf/cudf/tests/test_setitem.py
@@ -315,7 +315,7 @@ def test_series_setitem_upcasting(dtype, indices):
     if PANDAS_GE_150:
         assert_eq(sr, cr)
     else:
-        # pandas bug, incorrectly fails to upcasting from float32 to float64
+        # pandas bug, incorrectly fails to upcast from float32 to float64
         assert_eq(sr.values, cr.values)
     if dtype == np.float64:
         # no-op type cast should not modify backing column


### PR DESCRIPTION
## Description

To mimic pandas, we must upcast a column to the numpy result_type of the column itself and the input value dtype. This previously occurred in all relevant cases except when the index provided to __setitem__ was a single integer (originally introduced in #2442). Closes #11901.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
