### PR TITLE
Pin mimesis version in setup.py.

### DIFF
--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -63,7 +63,7 @@ dependencies:
   - myst-nb
   - scipy
   - dask-cuda=22.12.*
-  - mimesis>=4.1
+  - mimesis>=4.1.0
   - packaging
   - protobuf>=3.20.1,<3.21.0a0
   - nvtx>=0.2.1

--- a/conda/environments/cudf_dev_cuda11.5.yml
+++ b/conda/environments/cudf_dev_cuda11.5.yml
@@ -63,7 +63,7 @@ dependencies:
   - myst-nb
   - scipy
   - dask-cuda=22.12.*
-  - mimesis<4.1
+  - mimesis>=4.1
   - packaging
   - protobuf>=3.20.1,<3.21.0a0
   - nvtx>=0.2.1

--- a/python/cudf/cudf/testing/dataset_generator.py
+++ b/python/cudf/cudf/testing/dataset_generator.py
@@ -502,7 +502,7 @@ def rand_dataframe(
                         cardinality=cardinality,
                         null_frequency=null_frequency,
                         generator=lambda cardinality=cardinality: [
-                            mimesis.random.random.schoice(
+                            mimesis.random.random.generate_string(
                                 string.printable,
                                 np.random.randint(
                                     low=0,
@@ -684,7 +684,7 @@ def get_values_for_nested_data(dtype, lists_max_length=None, size=None):
         values = float_generator(dtype=dtype, size=cardinality)()
     elif dtype.kind in ("U", "O"):
         values = [
-            mimesis.random.random.schoice(
+            mimesis.random.random.generate_string(
                 string.printable,
                 100,
             )

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -31,7 +31,7 @@ extras_require = {
         "pytest-benchmark",
         "pytest-xdist",
         "hypothesis",
-        "mimesis",
+        "mimesis<4.1",
         "fastavro>=0.22.9",
         "python-snappy>=0.6.0",
         "pyorc",

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -31,7 +31,7 @@ extras_require = {
         "pytest-benchmark",
         "pytest-xdist",
         "hypothesis",
-        "mimesis>=4.1",
+        "mimesis>=4.1.0",
         "fastavro>=0.22.9",
         "python-snappy>=0.6.0",
         "pyorc",

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -31,7 +31,7 @@ extras_require = {
         "pytest-benchmark",
         "pytest-xdist",
         "hypothesis",
-        "mimesis<4.1",
+        "mimesis>=4.1",
         "fastavro>=0.22.9",
         "python-snappy>=0.6.0",
         "pyorc",


### PR DESCRIPTION
## Description
The dependency pinning for `mimesis` in cudf's `setup.py` didn't match the conda environment. It was missing a pinning to `<4.1` from #8745. However, based on the conversation in #8551, this pinning of `<4.1` was only chosen because 4.1.0 wasn't yet available on conda-forge. Since the current version of mimesis is now 6.1.1, this PR updates the mimesis pinning to `>=4.1` and uses `generate_string` instead of `schoice`. I tested this locally with mimesis 6.1.1 and mimesis 4.1.0 and both passed tests.

Merge this PR concurrently with https://github.com/rapidsai/integration/pull/547.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
