### PR TITLE
Fix local offset handling in bgzip reader

### DIFF
--- a/cpp/src/io/text/bgzip_data_chunk_source.cu
+++ b/cpp/src/io/text/bgzip_data_chunk_source.cu
@@ -271,8 +271,8 @@ class bgzip_data_chunk_reader : public data_chunk_reader {
     // seek to the beginning of the provided local offset
     auto const local_pos = virtual_begin & 0xFFFFu;
     if (local_pos > 0) {
-      CUDF_EXPECTS(_curr_blocks.h_compressed_offsets.size() > 1 &&
-                     local_pos < _curr_blocks.h_compressed_offsets[1],
+      CUDF_EXPECTS(_curr_blocks.h_decompressed_offsets.size() > 1 &&
+                     local_pos < _curr_blocks.h_decompressed_offsets[1],
                    "local part of virtual offset is out of bounds");
       _curr_blocks.consume_bytes(local_pos);
     }

--- a/cpp/tests/io/text/data_chunk_source_test.cpp
+++ b/cpp/tests/io/text/data_chunk_source_test.cpp
@@ -198,6 +198,7 @@ TEST_F(DataChunkSourceTest, BgzipSource)
 {
   auto const filename = temp_env->get_temp_filepath("bgzip_source");
   std::string input{"bananarama"};
+  input.reserve(input.size() << 25);
   for (int i = 0; i < 24; i++) {
     input = input + input;
   }
@@ -216,13 +217,11 @@ TEST_F(DataChunkSourceTest, BgzipSourceVirtualOffsets)
 {
   auto const filename = temp_env->get_temp_filepath("bgzip_source_offsets");
   std::string input{"bananarama"};
+  input.reserve(input.size() << 25);
   for (int i = 0; i < 24; i++) {
     input = input + input;
   }
-  std::string padding_garbage{"garbage"};
-  for (int i = 0; i < 10; i++) {
-    padding_garbage = padding_garbage + padding_garbage;
-  }
+  std::string const padding_garbage(10000, 'g');
   std::string const data_garbage{"GARBAGE"};
   std::string const begininput{"begin of bananarama"};
   std::string const endinput{"end of bananarama"};
@@ -306,13 +305,11 @@ TEST_F(DataChunkSourceTest, BgzipCompressedSourceVirtualOffsets)
 {
   auto const filename = temp_env->get_temp_filepath("bgzip_source_compressed_offsets");
   std::string input{"bananarama"};
+  input.reserve(input.size() << 25);
   for (int i = 0; i < 24; i++) {
     input = input + input;
   }
-  std::string padding_garbage{"garbage"};
-  for (int i = 0; i < 10; i++) {
-    padding_garbage = padding_garbage + padding_garbage;
-  }
+  std::string const padding_garbage(10000, 'g');
   std::string const data_garbage{"GARBAGE"};
   std::string const begininput{"begin of bananarama"};
   std::string const endinput{"end of bananarama"};


### PR DESCRIPTION
## Description
We accidentally checked the local offset against the compressed, not the uncompressed size. The new test failed prior to fixing the behavior.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
