### PR TITLE
[JNI] Adds retryCount to RmmEventHandler.onAllocFailure

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/RmmEventHandler.java
+++ b/java/src/main/java/ai/rapids/cudf/RmmEventHandler.java
@@ -27,20 +27,20 @@ public interface RmmEventHandler {
    */
   default boolean onAllocFailure(long sizeRequested) {
     // this should not be called since it was the previous interface,
-    // and it was abstract before.
-    return false;
+    // and it was abstract before, throwing by default for good measure.
+    throw new UnsupportedOperationException(
+        "Unexpected invocation of deprecated onAllocFailure without retry count.");
   }
 
   /**
    * Invoked on a memory allocation failure.
    * @param sizeRequested number of bytes that failed to allocate
-   * @param isRetry whether this failure happened while retrying an allocation
-   *                that had previously failed
+   * @param retryCount number of times this allocation has been retried after failure
    * @return true if the memory allocation should be retried or false if it should fail
    */
-  default boolean onAllocFailure(long sizeRequested, boolean isRetry) {
+  default boolean onAllocFailure(long sizeRequested, int retryCount) {
     // newer code should override this implementation of `onAllocFailure` to handle
-    // the `isRetry` flag. Otherwise, we call the prior implementation to not
+    // `retryCount`. Otherwise, we call the prior implementation to not
     // break existing code.
     return onAllocFailure(sizeRequested);
   }

--- a/java/src/main/java/ai/rapids/cudf/RmmEventHandler.java
+++ b/java/src/main/java/ai/rapids/cudf/RmmEventHandler.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2020, NVIDIA CORPORATION.
+ *  Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -22,9 +22,28 @@ public interface RmmEventHandler {
   /**
    * Invoked on a memory allocation failure.
    * @param sizeRequested number of bytes that failed to allocate
+   * @deprecated deprecated in favor of onAllocFailure(long, boolean)
    * @return true if the memory allocation should be retried or false if it should fail
    */
-  boolean onAllocFailure(long sizeRequested);
+  default boolean onAllocFailure(long sizeRequested) {
+    // this should not be called since it was the previous interface,
+    // and it was abstract before.
+    return false;
+  }
+
+  /**
+   * Invoked on a memory allocation failure.
+   * @param sizeRequested number of bytes that failed to allocate
+   * @param isRetry whether this failure happened while retrying an allocation
+   *                that had previously failed
+   * @return true if the memory allocation should be retried or false if it should fail
+   */
+  default boolean onAllocFailure(long sizeRequested, boolean isRetry) {
+    // newer code should override this implementation of `onAllocFailure` to handle
+    // the `isRetry` flag. Otherwise, we call the prior implementation to not
+    // break existing code.
+    return onAllocFailure(sizeRequested);
+  }
 
   /**
    * Get the memory thresholds that will trigger {@link #onAllocThreshold(long)}

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -255,7 +255,7 @@ private:
   void *do_allocate(std::size_t num_bytes, rmm::cuda_stream_view stream) override {
     std::size_t total_before;
     void *result;
-    // a positive retry_count signifies that the `on_alloc_fail`
+    // a non-zero retry_count signifies that the `on_alloc_fail`
     // callback is being invoked while re-attempting an allocation
     // that had previously failed.
     int retry_count = 0;

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -150,9 +150,15 @@ public:
     if (cls == nullptr) {
       throw cudf::jni::jni_exception("class not found");
     }
-    on_alloc_fail_method = env->GetMethodID(cls, "onAllocFailure", "(J)Z");
+    on_alloc_fail_method = env->GetMethodID(cls, "onAllocFailure", "(JZ)Z");
     if (on_alloc_fail_method == nullptr) {
-      throw cudf::jni::jni_exception("onAllocFailure method");
+      use_old_alloc_fail_interface = true;
+      on_alloc_fail_method = env->GetMethodID(cls, "onAllocFailure", "(J)Z");
+      if (on_alloc_fail_method == nullptr) {
+        throw cudf::jni::jni_exception("onAllocFailure method");
+      }
+    } else {
+      use_old_alloc_fail_interface = false;
     }
     on_alloc_threshold_method = env->GetMethodID(cls, "onAllocThreshold", "(J)V");
     if (on_alloc_threshold_method == nullptr) {
@@ -190,6 +196,7 @@ private:
   JavaVM *jvm;
   jobject handler_obj;
   jmethodID on_alloc_fail_method;
+  bool use_old_alloc_fail_interface;
   jmethodID on_alloc_threshold_method;
   jmethodID on_dealloc_threshold_method;
 
@@ -209,10 +216,17 @@ private:
     }
   }
 
-  bool on_alloc_fail(std::size_t num_bytes) {
+  bool on_alloc_fail(std::size_t num_bytes, bool is_retry) {
     JNIEnv *env = cudf::jni::get_jni_env(jvm);
-    jboolean result =
-        env->CallBooleanMethod(handler_obj, on_alloc_fail_method, static_cast<jlong>(num_bytes));
+    jboolean result = false;
+    if (!use_old_alloc_fail_interface) {
+      result = env->CallBooleanMethod(handler_obj, on_alloc_fail_method, 
+          static_cast<jlong>(num_bytes), static_cast<jboolean>(is_retry));
+
+    } else {
+      result = env->CallBooleanMethod(handler_obj, on_alloc_fail_method, 
+          static_cast<jlong>(num_bytes));
+    }
     if (env->ExceptionCheck()) {
       throw std::runtime_error("onAllocFailure handler threw an exception");
     }
@@ -240,15 +254,19 @@ private:
   void *do_allocate(std::size_t num_bytes, rmm::cuda_stream_view stream) override {
     std::size_t total_before;
     void *result;
+    bool is_retry = false;
     while (true) {
       try {
         total_before = get_total_bytes_allocated();
         result = resource->allocate(num_bytes, stream);
         break;
       } catch (rmm::out_of_memory const &e) {
-        if (!on_alloc_fail(num_bytes)) {
+        if (!on_alloc_fail(num_bytes, is_retry)) {
           throw;
         }
+        // tells the handling code that this failure was on a 
+        // retry
+        is_retry = true;
       }
     }
     auto total_after = get_total_bytes_allocated();

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -220,12 +220,13 @@ private:
     JNIEnv *env = cudf::jni::get_jni_env(jvm);
     jboolean result = false;
     if (!use_old_alloc_fail_interface) {
-      result = env->CallBooleanMethod(handler_obj, on_alloc_fail_method, 
-          static_cast<jlong>(num_bytes), static_cast<jint>(retry_count));
+      result =
+          env->CallBooleanMethod(handler_obj, on_alloc_fail_method, static_cast<jlong>(num_bytes),
+                                 static_cast<jint>(retry_count));
 
     } else {
-      result = env->CallBooleanMethod(handler_obj, on_alloc_fail_method, 
-          static_cast<jlong>(num_bytes));
+      result =
+          env->CallBooleanMethod(handler_obj, on_alloc_fail_method, static_cast<jlong>(num_bytes));
     }
     if (env->ExceptionCheck()) {
       throw std::runtime_error("onAllocFailure handler threw an exception");

--- a/java/src/test/java/ai/rapids/cudf/RmmTest.java
+++ b/java/src/test/java/ai/rapids/cudf/RmmTest.java
@@ -73,11 +73,15 @@ public class RmmTest {
   public void testEventHandler(int rmmAllocMode) {
     AtomicInteger invokedCount = new AtomicInteger();
     AtomicLong amountRequested = new AtomicLong();
+    AtomicInteger amountRetried = new AtomicInteger();
 
     RmmEventHandler handler = new BaseRmmEventHandler() {
       @Override
-      public boolean onAllocFailure(long sizeRequested) {
+      public boolean onAllocFailure(long sizeRequested, boolean isRetry) {
         int count = invokedCount.incrementAndGet();
+        if (isRetry) {
+          amountRetried.getAndIncrement();
+        }
         amountRequested.set(sizeRequested);
         return count != 3;
       }
@@ -100,6 +104,7 @@ public class RmmTest {
     }
 
     assertEquals(3, invokedCount.get());
+    assertEquals(2, amountRetried.get());
     assertEquals(requested, amountRequested.get());
 
     // verify after a failure we can still allocate something more reasonable


### PR DESCRIPTION
This adds the method `boolean onAllocFailure(long sizeRequested, int retryCount)` to `RmmEventHandler`, to help handling code keep track of the number of times an allocation failure has been retried.

With this code callers can perform extra logic that depends on whether the callback was due to a brand new allocation failure, or one that has failed in the past and is being retried.

This will be used here: https://github.com/NVIDIA/spark-rapids/issues/6768