### PR TITLE
Default to equal NaNs in make_merge_sets_aggregation.

### DIFF
--- a/cpp/include/cudf/aggregation.hpp
+++ b/cpp/include/cudf/aggregation.hpp
@@ -588,8 +588,9 @@ std::unique_ptr<Base> make_merge_lists_aggregation();
  * @return A MERGE_SETS aggregation object
  */
 template <typename Base = aggregation>
-std::unique_ptr<Base> make_merge_sets_aggregation(null_equality nulls_equal = null_equality::EQUAL,
-                                                  nan_equality nans_equal = nan_equality::UNEQUAL);
+std::unique_ptr<Base> make_merge_sets_aggregation(
+  null_equality nulls_equal = null_equality::EQUAL,
+  nan_equality nans_equal   = nan_equality::ALL_EQUAL);
 
 /**
  * @brief Factory to create a MERGE_M2 aggregation

--- a/cpp/tests/reductions/collect_ops_tests.cpp
+++ b/cpp/tests/reductions/collect_ops_tests.cpp
@@ -239,14 +239,17 @@ TEST_F(CollectTest, MergeSetsWithNaN)
 
   // nan unequal with null equal
   fp_wrapper expected1{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, NAN, NAN, 0.0f}, {1, 1, 1, 1, 1, 1, 0}};
-  auto const ret1 = collect_set(col, make_merge_sets_aggregation<reduce_aggregation>());
+  auto const ret1 = collect_set(
+    col,
+    make_merge_sets_aggregation<reduce_aggregation>(null_equality::EQUAL, nan_equality::UNEQUAL));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<list_scalar*>(ret1.get())->view());
 
   // nan unequal with null unequal
   fp_wrapper expected2{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, NAN, NAN, 0.0f, 0.0f, 0.0f},
                        {1, 1, 1, 1, 1, 1, 0, 0, 0}};
-  auto const ret2 =
-    collect_set(col, make_merge_sets_aggregation<reduce_aggregation>(null_equality::UNEQUAL));
+  auto const ret2 = collect_set(
+    col,
+    make_merge_sets_aggregation<reduce_aggregation>(null_equality::UNEQUAL, nan_equality::UNEQUAL));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<list_scalar*>(ret2.get())->view());
 
   // nan equal with null equal


### PR DESCRIPTION
## Description
Partially resolves https://github.com/rapidsai/cudf/issues/11329. This helps to align our default behaviors for null and NaN equality across APIs, specifically for `make_merge_sets_aggregation` in this PR. All functions should default to treating null values as equal to one another and NaN values as equal to one another.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
