### PR TITLE
Fix lists and structs gtests coded in namespace cudf::test

### DIFF
--- a/cpp/tests/lists/contains_tests.cpp
+++ b/cpp/tests/lists/contains_tests.cpp
@@ -26,40 +26,37 @@
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
-namespace cudf {
-namespace test {
-
 namespace {
 template <typename T, std::enable_if_t<cudf::is_numeric<T>(), void>* = nullptr>
 auto create_scalar_search_key(T const& value)
 {
-  auto search_key = make_numeric_scalar(data_type{type_to_id<T>()});
+  auto search_key = cudf::make_numeric_scalar(cudf::data_type{cudf::type_to_id<T>()});
   search_key->set_valid_async(true);
-  static_cast<scalar_type_t<T>*>(search_key.get())->set_value(value);
+  static_cast<cudf::scalar_type_t<T>*>(search_key.get())->set_value(value);
   return search_key;
 }
 
 template <typename T, std::enable_if_t<std::is_same_v<T, std::string>, void>* = nullptr>
 auto create_scalar_search_key(std::string const& value)
 {
-  return make_string_scalar(value);
+  return cudf::make_string_scalar(value);
 }
 
 template <typename T, std::enable_if_t<cudf::is_timestamp<T>(), void>* = nullptr>
 auto create_scalar_search_key(typename T::rep const& value)
 {
-  auto search_key = make_timestamp_scalar(data_type{type_to_id<T>()});
+  auto search_key = cudf::make_timestamp_scalar(cudf::data_type{cudf::type_to_id<T>()});
   search_key->set_valid_async(true);
-  static_cast<scalar_type_t<typename T::rep>*>(search_key.get())->set_value(value);
+  static_cast<cudf::scalar_type_t<typename T::rep>*>(search_key.get())->set_value(value);
   return search_key;
 }
 
 template <typename T, std::enable_if_t<cudf::is_duration<T>(), void>* = nullptr>
 auto create_scalar_search_key(typename T::rep const& value)
 {
-  auto search_key = make_duration_scalar(data_type{type_to_id<T>()});
+  auto search_key = cudf::make_duration_scalar(cudf::data_type{cudf::type_to_id<T>()});
   search_key->set_valid_async(true);
-  static_cast<scalar_type_t<typename T::rep>*>(search_key.get())->set_value(value);
+  static_cast<cudf::scalar_type_t<typename T::rep>*>(search_key.get())->set_value(value);
   return search_key;
 }
 
@@ -72,7 +69,7 @@ auto make_struct_scalar(Args&&... args)
 template <typename T, std::enable_if_t<cudf::is_numeric<T>(), void>* = nullptr>
 auto create_null_search_key()
 {
-  auto search_key = make_numeric_scalar(data_type{type_to_id<T>()});
+  auto search_key = cudf::make_numeric_scalar(cudf::data_type{cudf::type_to_id<T>()});
   search_key->set_valid_async(false);
   return search_key;
 }
@@ -80,7 +77,7 @@ auto create_null_search_key()
 template <typename T, std::enable_if_t<cudf::is_timestamp<T>(), void>* = nullptr>
 auto create_null_search_key()
 {
-  auto search_key = make_timestamp_scalar(data_type{type_to_id<T>()});
+  auto search_key = cudf::make_timestamp_scalar(cudf::data_type{cudf::type_to_id<T>()});
   search_key->set_valid_async(false);
   return search_key;
 }
@@ -88,30 +85,29 @@ auto create_null_search_key()
 template <typename T, std::enable_if_t<cudf::is_duration<T>(), void>* = nullptr>
 auto create_null_search_key()
 {
-  auto search_key = make_duration_scalar(data_type{type_to_id<T>()});
+  auto search_key = cudf::make_duration_scalar(cudf::data_type{cudf::type_to_id<T>()});
   search_key->set_valid_async(false);
   return search_key;
 }
 
 }  // namespace
 
-auto constexpr X          = int32_t{0};     // Placeholder for nulls.
-auto constexpr ABSENT     = size_type{-1};  // Index when key is not found in a list.
-auto constexpr FIND_FIRST = lists::duplicate_find_option::FIND_FIRST;
-auto constexpr FIND_LAST  = lists::duplicate_find_option::FIND_LAST;
+auto constexpr X          = int32_t{0};           // Placeholder for nulls.
+auto constexpr ABSENT     = cudf::size_type{-1};  // Index when key is not found in a list.
+auto constexpr FIND_FIRST = cudf::lists::duplicate_find_option::FIND_FIRST;
+auto constexpr FIND_LAST  = cudf::lists::duplicate_find_option::FIND_LAST;
 
 using bools_col   = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
-using indices_col = cudf::test::fixed_width_column_wrapper<size_type>;
-using structs_col = cudf::test::structs_column_wrapper;
-using strings_col = cudf::test::strings_column_wrapper;
+using indices_col = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
 
-using iterators::all_nulls;
-using iterators::null_at;
-using iterators::nulls_at;
+using cudf::test::iterators::all_nulls;
+using cudf::test::iterators::null_at;
+using cudf::test::iterators::nulls_at;
 
-using ContainsTestTypes = Concat<IntegralTypesNotBool, FloatingPointTypes, ChronoTypes>;
+using ContainsTestTypes = cudf::test::
+  Concat<cudf::test::IntegralTypesNotBool, cudf::test::FloatingPointTypes, cudf::test::ChronoTypes>;
 
-struct ContainsTest : public BaseFixture {
+struct ContainsTest : public cudf::test::BaseFixture {
 };
 
 template <typename T>
@@ -124,40 +120,40 @@ TYPED_TEST(TypedContainsTest, ScalarKeyWithNoNulls)
 {
   using T = TypeParam;
 
-  auto const search_space_col = lists_column_wrapper<T, int32_t>{{0, 1, 2, 1},
-                                                                 {3, 4, 5},
-                                                                 {6, 7, 8},
-                                                                 {9, 0, 1, 3, 1},
-                                                                 {2, 3, 4},
-                                                                 {5, 6, 7},
-                                                                 {8, 9, 0},
-                                                                 {},
-                                                                 {1, 2, 1, 3},
-                                                                 {}};
-  auto const search_space     = lists_column_view{search_space_col};
+  auto const search_space_col = cudf::test::lists_column_wrapper<T, int32_t>{{0, 1, 2, 1},
+                                                                             {3, 4, 5},
+                                                                             {6, 7, 8},
+                                                                             {9, 0, 1, 3, 1},
+                                                                             {2, 3, 4},
+                                                                             {5, 6, 7},
+                                                                             {8, 9, 0},
+                                                                             {},
+                                                                             {1, 2, 1, 3},
+                                                                             {}};
+  auto const search_space     = cudf::lists_column_view{search_space_col};
   auto search_key_one         = create_scalar_search_key<T>(1);
 
   {
     // CONTAINS
-    auto result   = lists::contains(search_space, *search_key_one);
+    auto result   = cudf::lists::contains(search_space, *search_key_one);
     auto expected = bools_col{1, 0, 0, 1, 0, 0, 0, 0, 1, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // CONTAINS NULLS
-    auto result   = lists::contains_nulls(search_space);
+    auto result   = cudf::lists::contains_nulls(search_space);
     auto expected = bools_col{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space, *search_key_one, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space, *search_key_one, FIND_FIRST);
     auto expected = indices_col{1, ABSENT, ABSENT, 2, ABSENT, ABSENT, ABSENT, ABSENT, 0, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space, *search_key_one, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space, *search_key_one, FIND_LAST);
     auto expected = indices_col{3, ABSENT, ABSENT, 4, ABSENT, ABSENT, ABSENT, ABSENT, 2, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -168,42 +164,42 @@ TYPED_TEST(TypedContainsTest, ScalarKeyWithNullLists)
   // Test List columns that have NULL list rows.
   using T = TypeParam;
 
-  auto const search_space_col = lists_column_wrapper<T, int32_t>{{{0, 1, 2, 1},
-                                                                  {3, 4, 5},
-                                                                  {6, 7, 8},
-                                                                  {},
-                                                                  {9, 0, 1, 3, 1},
-                                                                  {2, 3, 4},
-                                                                  {5, 6, 7},
-                                                                  {8, 9, 0},
-                                                                  {},
-                                                                  {1, 2, 2, 3},
-                                                                  {}},
-                                                                 nulls_at({3, 10})};
-  auto const search_space     = lists_column_view{search_space_col};
+  auto const search_space_col = cudf::test::lists_column_wrapper<T, int32_t>{{{0, 1, 2, 1},
+                                                                              {3, 4, 5},
+                                                                              {6, 7, 8},
+                                                                              {},
+                                                                              {9, 0, 1, 3, 1},
+                                                                              {2, 3, 4},
+                                                                              {5, 6, 7},
+                                                                              {8, 9, 0},
+                                                                              {},
+                                                                              {1, 2, 2, 3},
+                                                                              {}},
+                                                                             nulls_at({3, 10})};
+  auto const search_space     = cudf::lists_column_view{search_space_col};
   auto search_key_one         = create_scalar_search_key<T>(1);
   {
     // CONTAINS
-    auto result   = lists::contains(search_space, *search_key_one);
+    auto result   = cudf::lists::contains(search_space, *search_key_one);
     auto expected = bools_col{{1, 0, 0, X, 1, 0, 0, 0, 0, 1, X}, nulls_at({3, 10})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // CONTAINS NULLS
-    auto result   = lists::contains_nulls(search_space);
+    auto result   = cudf::lists::contains_nulls(search_space);
     auto expected = bools_col{{0, 0, 0, X, 0, 0, 0, 0, 0, 0, X}, nulls_at({3, 10})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space, *search_key_one, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space, *search_key_one, FIND_FIRST);
     auto expected = indices_col{{1, ABSENT, ABSENT, X, 2, ABSENT, ABSENT, ABSENT, ABSENT, 0, X},
                                 nulls_at({3, 10})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space, *search_key_one, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space, *search_key_one, FIND_LAST);
     auto expected = indices_col{{3, ABSENT, ABSENT, X, 4, ABSENT, ABSENT, ABSENT, ABSENT, 0, X},
                                 nulls_at({3, 10})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
@@ -216,18 +212,18 @@ TYPED_TEST(TypedContainsTest, SlicedLists)
   using namespace cudf;
   using T = TypeParam;
 
-  auto search_space = lists_column_wrapper<T, int32_t>{{{0, 1, 2, 1},
-                                                        {3, 4, 5},
-                                                        {6, 7, 8},
-                                                        {},
-                                                        {9, 0, 1, 3, 1},
-                                                        {2, 3, 4},
-                                                        {5, 6, 7},
-                                                        {8, 9, 0},
-                                                        {},
-                                                        {1, 2, 1, 3},
-                                                        {}},
-                                                       nulls_at({3, 10})};
+  auto search_space = cudf::test::lists_column_wrapper<T, int32_t>{{{0, 1, 2, 1},
+                                                                    {3, 4, 5},
+                                                                    {6, 7, 8},
+                                                                    {},
+                                                                    {9, 0, 1, 3, 1},
+                                                                    {2, 3, 4},
+                                                                    {5, 6, 7},
+                                                                    {8, 9, 0},
+                                                                    {},
+                                                                    {1, 2, 1, 3},
+                                                                    {}},
+                                                                   nulls_at({3, 10})};
 
   {
     // First Slice.
@@ -235,26 +231,26 @@ TYPED_TEST(TypedContainsTest, SlicedLists)
     auto search_key_one  = create_scalar_search_key<T>(1);
     {
       // CONTAINS
-      auto result          = lists::contains(sliced_column_1, *search_key_one);
+      auto result          = cudf::lists::contains(sliced_column_1, *search_key_one);
       auto expected_result = bools_col{{0, 0, X, 1, 0, 0, 0}, null_at(2)};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result, result->view());
     }
     {
       // CONTAINS NULLS
-      auto result          = lists::contains_nulls(sliced_column_1);
+      auto result          = cudf::lists::contains_nulls(sliced_column_1);
       auto expected_result = bools_col{{0, 0, X, 0, 0, 0, 0}, null_at(2)};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result, result->view());
     }
     {
       // FIND_FIRST
-      auto result = lists::index_of(sliced_column_1, *search_key_one, FIND_FIRST);
+      auto result = cudf::lists::index_of(sliced_column_1, *search_key_one, FIND_FIRST);
       auto expected_result =
         indices_col{{ABSENT, ABSENT, 0, 2, ABSENT, ABSENT, ABSENT}, null_at(2)};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result, result->view());
     }
     {
       // FIND_LAST
-      auto result = lists::index_of(sliced_column_1, *search_key_one, FIND_LAST);
+      auto result = cudf::lists::index_of(sliced_column_1, *search_key_one, FIND_LAST);
       auto expected_result =
         indices_col{{ABSENT, ABSENT, 0, 4, ABSENT, ABSENT, ABSENT}, null_at(2)};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result, result->view());
@@ -267,25 +263,25 @@ TYPED_TEST(TypedContainsTest, SlicedLists)
     auto search_key_one  = create_scalar_search_key<T>(1);
     {
       // CONTAINS
-      auto result          = lists::contains(sliced_column_2, *search_key_one);
+      auto result          = cudf::lists::contains(sliced_column_2, *search_key_one);
       auto expected_result = bools_col{{X, 1, 0, 0, 0, 0, 1}, null_at(0)};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result, result->view());
     }
     {
       // CONTAINS NULLS
-      auto result          = lists::contains_nulls(sliced_column_2);
+      auto result          = cudf::lists::contains_nulls(sliced_column_2);
       auto expected_result = bools_col{{X, 0, 0, 0, 0, 0, 0}, null_at(0)};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result, result->view());
     }
     {
       // FIND_FIRST
-      auto result          = lists::index_of(sliced_column_2, *search_key_one, FIND_FIRST);
+      auto result          = cudf::lists::index_of(sliced_column_2, *search_key_one, FIND_FIRST);
       auto expected_result = indices_col{{0, 2, ABSENT, ABSENT, ABSENT, ABSENT, 0}, null_at(0)};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result, result->view());
     }
     {
       // FIND_LAST
-      auto result          = lists::index_of(sliced_column_2, *search_key_one, FIND_LAST);
+      auto result          = cudf::lists::index_of(sliced_column_2, *search_key_one, FIND_LAST);
       auto expected_result = indices_col{{0, 4, ABSENT, ABSENT, ABSENT, ABSENT, 2}, null_at(0)};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result, result->view());
     }
@@ -297,33 +293,33 @@ TYPED_TEST(TypedContainsTest, ScalarKeyNonNullListsWithNullValues)
   // Test List columns that have no NULL list rows, but NULL elements in some list rows.
   using T = TypeParam;
 
-  auto numerals     = fixed_width_column_wrapper<T>{{X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1},
-                                                nulls_at({0, 3, 6, 9, 10, 13})};
-  auto search_space = make_lists_column(
+  auto numerals = cudf::test::fixed_width_column_wrapper<T>{
+    {X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
+  auto search_space = cudf::make_lists_column(
     8, indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(), numerals.release(), 0, {});
   // Search space: [ [x], [1,2], [x,4,5,x], [], [], [7,8,x], [x], [1,2,x,1] ]
   auto search_key_one = create_scalar_search_key<T>(1);
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), *search_key_one);
+    auto result   = cudf::lists::contains(search_space->view(), *search_key_one);
     auto expected = bools_col{0, 1, 0, 0, 0, 0, 0, 1};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // CONTAINS NULLS
-    auto result   = lists::contains_nulls(search_space->view());
+    auto result   = cudf::lists::contains_nulls(search_space->view());
     auto expected = bools_col{1, 0, 1, 0, 0, 1, 1, 1};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space->view(), *search_key_one, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_one, FIND_FIRST);
     auto expected = indices_col{ABSENT, 0, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space->view(), *search_key_one, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_one, FIND_LAST);
     auto expected = indices_col{ABSENT, 0, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 3};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -333,11 +329,11 @@ TYPED_TEST(TypedContainsTest, ScalarKeysWithNullsInLists)
 {
   using T = TypeParam;
 
-  auto numerals = fixed_width_column_wrapper<T>{{X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1},
-                                                nulls_at({0, 3, 6, 9, 10, 13})};
+  auto numerals = cudf::test::fixed_width_column_wrapper<T>{
+    {X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
   auto input_null_mask_iter = null_at(4);
 
-  auto search_space = make_lists_column(
+  auto search_space = cudf::make_lists_column(
     8,
     indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
     numerals.release(),
@@ -348,25 +344,25 @@ TYPED_TEST(TypedContainsTest, ScalarKeysWithNullsInLists)
   auto search_key_one = create_scalar_search_key<T>(1);
   {
     // CONTAINS.
-    auto result   = lists::contains(search_space->view(), *search_key_one);
+    auto result   = cudf::lists::contains(search_space->view(), *search_key_one);
     auto expected = bools_col{{0, 1, 0, 0, X, 0, 0, 1}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // CONTAINS NULLS.
-    auto result   = lists::contains_nulls(search_space->view());
+    auto result   = cudf::lists::contains_nulls(search_space->view());
     auto expected = bools_col{{1, 0, 1, 0, X, 1, 1, 1}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST.
-    auto result   = lists::index_of(search_space->view(), *search_key_one, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_one, FIND_FIRST);
     auto expected = indices_col{{ABSENT, 0, ABSENT, ABSENT, X, ABSENT, ABSENT, 0}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST.
-    auto result   = lists::index_of(search_space->view(), *search_key_one, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_one, FIND_LAST);
     auto expected = indices_col{{ABSENT, 0, ABSENT, ABSENT, X, ABSENT, ABSENT, 3}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -376,12 +372,12 @@ TEST_F(ContainsTest, BoolScalarWithNullsInLists)
 {
   using T = bool;
 
-  auto numerals = fixed_width_column_wrapper<T>{{X, 1, 1, X, 1, 1, X, 1, 1, X, X, 1, 1, X, 1},
-                                                nulls_at({0, 3, 6, 9, 10, 13})};
+  auto numerals = cudf::test::fixed_width_column_wrapper<T>{
+    {X, 1, 1, X, 1, 1, X, 1, 1, X, X, 1, 1, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
   auto input_null_mask_iter = null_at(4);
-  auto search_space         = make_lists_column(
+  auto search_space         = cudf::make_lists_column(
     8,
-    fixed_width_column_wrapper<size_type>{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
     numerals.release(),
     1,
     cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8));
@@ -390,25 +386,25 @@ TEST_F(ContainsTest, BoolScalarWithNullsInLists)
   auto search_key_one = create_scalar_search_key<T>(1);
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), *search_key_one);
+    auto result   = cudf::lists::contains(search_space->view(), *search_key_one);
     auto expected = bools_col{{0, 1, 1, 0, X, 1, 0, 1}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // CONTAINS NULLS
-    auto result   = lists::contains_nulls(search_space->view());
+    auto result   = cudf::lists::contains_nulls(search_space->view());
     auto expected = bools_col{{1, 0, 1, 0, X, 1, 1, 1}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST.
-    auto result   = lists::index_of(search_space->view(), *search_key_one, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_one, FIND_FIRST);
     auto expected = indices_col{{ABSENT, 0, 1, ABSENT, X, 0, ABSENT, 0}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST.
-    auto result   = lists::index_of(search_space->view(), *search_key_one, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_one, FIND_LAST);
     auto expected = indices_col{{ABSENT, 1, 2, ABSENT, X, 1, ABSENT, 3}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -418,11 +414,11 @@ TEST_F(ContainsTest, StringScalarWithNullsInLists)
 {
   using T = std::string;
 
-  auto strings = strings_column_wrapper{
+  auto strings = cudf::test::strings_column_wrapper{
     {"X", "1", "2", "X", "4", "5", "X", "7", "8", "X", "X", "1", "2", "X", "1"},
     nulls_at({0, 3, 6, 9, 10, 13})};
   auto input_null_mask_iter = null_at(4);
-  auto search_space         = make_lists_column(
+  auto search_space         = cudf::make_lists_column(
     8,
     indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
     strings.release(),
@@ -433,25 +429,25 @@ TEST_F(ContainsTest, StringScalarWithNullsInLists)
   auto search_key_one = create_scalar_search_key<T>("1");
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), *search_key_one);
+    auto result   = cudf::lists::contains(search_space->view(), *search_key_one);
     auto expected = bools_col{{0, 1, 0, 0, X, 0, 0, 1}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // CONTAINS NULLS
-    auto result   = lists::contains_nulls(search_space->view());
+    auto result   = cudf::lists::contains_nulls(search_space->view());
     auto expected = bools_col{{1, 0, 1, 0, X, 1, 1, 1}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST.
-    auto result   = lists::index_of(search_space->view(), *search_key_one, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_one, FIND_FIRST);
     auto expected = indices_col{{ABSENT, 0, ABSENT, ABSENT, X, ABSENT, ABSENT, 0}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST.
-    auto result   = lists::index_of(search_space->view(), *search_key_one, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_one, FIND_LAST);
     auto expected = indices_col{{ABSENT, 0, ABSENT, ABSENT, X, ABSENT, ABSENT, 3}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -461,35 +457,35 @@ TYPED_TEST(TypedContainsTest, ScalarNullSearchKey)
 {
   using T = TypeParam;
 
-  auto search_space = lists_column_wrapper<T, int32_t>{{{0, 1, 2},
-                                                        {3, 4, 5},
-                                                        {6, 7, 8},
-                                                        {},
-                                                        {9, 0, 1},
-                                                        {2, 3, 4},
-                                                        {5, 6, 7},
-                                                        {8, 9, 0},
-                                                        {},
-                                                        {1, 2, 3},
-                                                        {}},
-                                                       nulls_at({3, 10})}
+  auto search_space = cudf::test::lists_column_wrapper<T, int32_t>{{{0, 1, 2},
+                                                                    {3, 4, 5},
+                                                                    {6, 7, 8},
+                                                                    {},
+                                                                    {9, 0, 1},
+                                                                    {2, 3, 4},
+                                                                    {5, 6, 7},
+                                                                    {8, 9, 0},
+                                                                    {},
+                                                                    {1, 2, 3},
+                                                                    {}},
+                                                                   nulls_at({3, 10})}
                         .release();
   auto search_key_null = create_null_search_key<T>();
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), *search_key_null);
+    auto result   = cudf::lists::contains(search_space->view(), *search_key_null);
     auto expected = bools_col{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, all_nulls()};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space->view(), *search_key_null, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_null, FIND_FIRST);
     auto expected = indices_col{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, all_nulls()};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space->view(), *search_key_null, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_null, FIND_LAST);
     auto expected = indices_col{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, all_nulls()};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -499,28 +495,29 @@ TEST_F(ContainsTest, ScalarTypeRelatedExceptions)
 {
   {
     // Nested types unsupported.
-    auto list_of_lists = lists_column_wrapper<int32_t>{
+    auto list_of_lists = cudf::test::lists_column_wrapper<int32_t>{
       {{1, 2, 3}, {4, 5, 6}},
       {{1, 2, 3}, {4, 5, 6}},
       {{1, 2, 3},
        {4, 5, 6}}}.release();
     auto skey = create_scalar_search_key<int32_t>(10);
-    EXPECT_THROW(lists::contains(list_of_lists->view(), *skey), cudf::logic_error);
-    EXPECT_THROW(lists::index_of(list_of_lists->view(), *skey, FIND_FIRST), cudf::logic_error);
-    EXPECT_THROW(lists::index_of(list_of_lists->view(), *skey, FIND_LAST), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::contains(list_of_lists->view(), *skey), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::index_of(list_of_lists->view(), *skey, FIND_FIRST),
+                 cudf::logic_error);
+    EXPECT_THROW(cudf::lists::index_of(list_of_lists->view(), *skey, FIND_LAST), cudf::logic_error);
   }
   {
     // Search key must match list elements in type.
     auto list_of_ints =
-      lists_column_wrapper<int32_t>{
+      cudf::test::lists_column_wrapper<int32_t>{
         {0, 1, 2},
         {3, 4, 5},
       }
         .release();
     auto skey = create_scalar_search_key<std::string>("Hello, World!");
-    EXPECT_THROW(lists::contains(list_of_ints->view(), *skey), cudf::logic_error);
-    EXPECT_THROW(lists::index_of(list_of_ints->view(), *skey, FIND_FIRST), cudf::logic_error);
-    EXPECT_THROW(lists::index_of(list_of_ints->view(), *skey, FIND_LAST), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::contains(list_of_ints->view(), *skey), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::index_of(list_of_ints->view(), *skey, FIND_FIRST), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::index_of(list_of_ints->view(), *skey, FIND_LAST), cudf::logic_error);
   }
 }
 
@@ -537,7 +534,7 @@ TYPED_TEST(TypedVectorContainsTest, VectorKeysWithNoNulls)
 {
   using T = TypeParam;
 
-  auto search_space = lists_column_wrapper<T, int32_t>{
+  auto search_space = cudf::test::lists_column_wrapper<T, int32_t>{
     {0, 1, 2, 1},
     {3, 4, 5},
     {6, 7, 8},
@@ -549,22 +546,23 @@ TYPED_TEST(TypedVectorContainsTest, VectorKeysWithNoNulls)
     {1, 2, 3, 3},
     {}}.release();
 
-  auto search_key = fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 1, 2, 3, 1, 2, 3, 1};
+  auto search_key =
+    cudf::test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 1, 2, 3, 1, 2, 3, 1};
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), search_key);
+    auto result   = cudf::lists::contains(search_space->view(), search_key);
     auto expected = bools_col{1, 0, 0, 1, 1, 0, 0, 0, 1, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space->view(), search_key, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_key, FIND_FIRST);
     auto expected = indices_col{1, ABSENT, ABSENT, 2, 0, ABSENT, ABSENT, ABSENT, 2, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space->view(), search_key, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_key, FIND_LAST);
     auto expected = indices_col{3, ABSENT, ABSENT, 4, 0, ABSENT, ABSENT, ABSENT, 3, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -576,38 +574,39 @@ TYPED_TEST(TypedVectorContainsTest, VectorWithNullLists)
 
   using T = TypeParam;
 
-  auto search_space = lists_column_wrapper<T, int32_t>{{{0, 1, 2, 1},
-                                                        {3, 4, 5},
-                                                        {6, 7, 8},
-                                                        {},
-                                                        {9, 0, 1, 3, 1},
-                                                        {2, 3, 4},
-                                                        {5, 6, 7},
-                                                        {8, 9, 0},
-                                                        {},
-                                                        {1, 2, 3, 3},
-                                                        {}},
-                                                       nulls_at({3, 10})}
+  auto search_space = cudf::test::lists_column_wrapper<T, int32_t>{{{0, 1, 2, 1},
+                                                                    {3, 4, 5},
+                                                                    {6, 7, 8},
+                                                                    {},
+                                                                    {9, 0, 1, 3, 1},
+                                                                    {2, 3, 4},
+                                                                    {5, 6, 7},
+                                                                    {8, 9, 0},
+                                                                    {},
+                                                                    {1, 2, 3, 3},
+                                                                    {}},
+                                                                   nulls_at({3, 10})}
                         .release();
 
-  auto search_keys = fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2};
+  auto search_keys =
+    cudf::test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2};
 
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), search_keys);
+    auto result   = cudf::lists::contains(search_space->view(), search_keys);
     auto expected = bools_col{{1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0}, nulls_at({3, 10})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_FIRST);
     auto expected = indices_col{{1, ABSENT, ABSENT, X, ABSENT, 1, ABSENT, ABSENT, ABSENT, 0, X},
                                 nulls_at({3, 10})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_LAST);
     auto expected = indices_col{{3, ABSENT, ABSENT, X, ABSENT, 1, ABSENT, ABSENT, ABSENT, 0, X},
                                 nulls_at({3, 10})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
@@ -619,28 +618,28 @@ TYPED_TEST(TypedVectorContainsTest, VectorNonNullListsWithNullValues)
   // Test List columns that have no NULL list rows, but NULL elements in some list rows.
   using T = TypeParam;
 
-  auto numerals = fixed_width_column_wrapper<T>{{X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1},
-                                                nulls_at({0, 3, 6, 9, 10, 13})};
+  auto numerals = cudf::test::fixed_width_column_wrapper<T>{
+    {X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
 
-  auto search_space = make_lists_column(
+  auto search_space = cudf::make_lists_column(
     8, indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(), numerals.release(), 0, {});
   // Search space: [ [x], [1,2], [x,4,5,x], [], [], [7,8,x], [x], [1,2,x,1] ]
-  auto search_keys = fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 1, 2, 3, 1, 1};
+  auto search_keys = cudf::test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 1, 2, 3, 1, 1};
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), search_keys);
+    auto result   = cudf::lists::contains(search_space->view(), search_keys);
     auto expected = bools_col{0, 1, 0, 0, 0, 0, 0, 1};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_FIRST);
     auto expected = indices_col{ABSENT, 1, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_LAST);
     auto expected = indices_col{ABSENT, 1, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 3};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -650,12 +649,12 @@ TYPED_TEST(TypedVectorContainsTest, VectorWithNullsInLists)
 {
   using T = TypeParam;
 
-  auto numerals = fixed_width_column_wrapper<T>{{X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1},
-                                                nulls_at({0, 3, 6, 9, 10, 13})};
+  auto numerals = cudf::test::fixed_width_column_wrapper<T>{
+    {X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
 
   auto input_null_mask_iter = null_at(4);
 
-  auto search_space = make_lists_column(
+  auto search_space = cudf::make_lists_column(
     8,
     indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
     numerals.release(),
@@ -663,22 +662,22 @@ TYPED_TEST(TypedVectorContainsTest, VectorWithNullsInLists)
     cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8));
   // Search space: [ [x], [1,2], [x,4,5,x], [], x, [7,8,x], [x], [1,2,x,1] ]
 
-  auto search_keys = fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 1, 2, 3, 1, 1};
+  auto search_keys = cudf::test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 1, 2, 3, 1, 1};
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), search_keys);
+    auto result   = cudf::lists::contains(search_space->view(), search_keys);
     auto expected = bools_col{{0, 1, 0, 0, X, 0, 0, 1}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_FIRST);
     auto expected = indices_col{{ABSENT, 1, ABSENT, ABSENT, X, ABSENT, ABSENT, 0}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_LAST);
     auto expected = indices_col{{ABSENT, 1, ABSENT, ABSENT, X, ABSENT, ABSENT, 3}, null_at(4)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -688,12 +687,12 @@ TYPED_TEST(TypedVectorContainsTest, ListContainsVectorWithNullsInListsAndInSearc
 {
   using T = TypeParam;
 
-  auto numerals = fixed_width_column_wrapper<T>{{X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1},
-                                                nulls_at({0, 3, 6, 9, 10, 13})};
+  auto numerals = cudf::test::fixed_width_column_wrapper<T>{
+    {X, 1, 2, X, 4, 5, X, 7, 8, X, X, 1, 2, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
 
   auto input_null_mask_iter = null_at(4);
 
-  auto search_space = make_lists_column(
+  auto search_space = cudf::make_lists_column(
     8,
     indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
     numerals.release(),
@@ -701,22 +700,23 @@ TYPED_TEST(TypedVectorContainsTest, ListContainsVectorWithNullsInListsAndInSearc
     cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8));
   // Search space: [ [x], [1,2], [x,4,5,x], [], x, [7,8,x], [x], [1,2,x,1] ]
 
-  auto search_keys = fixed_width_column_wrapper<T, int32_t>{{1, 2, 3, X, 2, 3, 1, 1}, null_at(3)};
+  auto search_keys =
+    cudf::test::fixed_width_column_wrapper<T, int32_t>{{1, 2, 3, X, 2, 3, 1, 1}, null_at(3)};
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), search_keys);
+    auto result   = cudf::lists::contains(search_space->view(), search_keys);
     auto expected = bools_col{{0, 1, 0, X, X, 0, 0, 1}, nulls_at({3, 4})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_FIRST);
     auto expected = indices_col{{ABSENT, 1, ABSENT, X, X, ABSENT, ABSENT, 0}, nulls_at({3, 4})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_LAST);
     auto expected = indices_col{{ABSENT, 1, ABSENT, X, X, ABSENT, ABSENT, 3}, nulls_at({3, 4})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -726,36 +726,37 @@ TEST_F(ContainsTest, BoolKeyVectorWithNullsInListsAndInSearchKeys)
 {
   using T = bool;
 
-  auto numerals = fixed_width_column_wrapper<T>{{X, 0, 1, X, 1, 1, X, 1, 1, X, X, 0, 1, X, 1},
-                                                nulls_at({0, 3, 6, 9, 10, 13})};
+  auto numerals = cudf::test::fixed_width_column_wrapper<T>{
+    {X, 0, 1, X, 1, 1, X, 1, 1, X, X, 0, 1, X, 1}, nulls_at({0, 3, 6, 9, 10, 13})};
 
   auto input_null_mask_iter = null_at(4);
 
-  auto search_space = make_lists_column(
+  auto search_space = cudf::make_lists_column(
     8,
     indices_col{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
     numerals.release(),
     1,
     cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8));
 
-  auto search_keys = fixed_width_column_wrapper<T, int32_t>{{0, 1, 0, X, 0, 0, 1, 1}, null_at(3)};
+  auto search_keys =
+    cudf::test::fixed_width_column_wrapper<T, int32_t>{{0, 1, 0, X, 0, 0, 1, 1}, null_at(3)};
   // Search space: [ [x], [0,1], [x,1,1,x], [], x, [1,1,x], [x], [0,1,x,1] ]
   // Search keys : [  0,   1,     0,         x, 0,  0,       1,   1        ]
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), search_keys);
+    auto result   = cudf::lists::contains(search_space->view(), search_keys);
     auto expected = bools_col{{0, 1, 0, X, X, 0, 0, 1}, nulls_at({3, 4})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_FIRST);
     auto expected = indices_col{{ABSENT, 1, ABSENT, X, X, ABSENT, ABSENT, 1}, nulls_at({3, 4})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_LAST);
     auto expected = indices_col{{ABSENT, 1, ABSENT, X, X, ABSENT, ABSENT, 3}, nulls_at({3, 4})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -763,37 +764,38 @@ TEST_F(ContainsTest, BoolKeyVectorWithNullsInListsAndInSearchKeys)
 
 TEST_F(ContainsTest, StringKeyVectorWithNullsInListsAndInSearchKeys)
 {
-  auto strings = strings_column_wrapper{
+  auto strings = cudf::test::strings_column_wrapper{
     {"X", "1", "2", "X", "4", "5", "X", "7", "8", "X", "X", "1", "2", "X", "1"},
     nulls_at({0, 3, 6, 9, 10, 13})};
   auto input_null_mask_iter = null_at(4);
-  auto search_space         = make_lists_column(
+  auto search_space         = cudf::make_lists_column(
     8,
-    fixed_width_column_wrapper<size_type>{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 1, 3, 7, 7, 7, 10, 11, 15}.release(),
     strings.release(),
     1,
     cudf::test::detail::make_null_mask(input_null_mask_iter, input_null_mask_iter + 8));
 
-  auto search_keys = strings_column_wrapper{{"1", "2", "3", "X", "2", "3", "1", "1"}, null_at(3)};
+  auto search_keys =
+    cudf::test::strings_column_wrapper{{"1", "2", "3", "X", "2", "3", "1", "1"}, null_at(3)};
 
   // Search space: [ [x], [1,2], [x,4,5,x], [], x, [7,8,x], [x], [1,2,x,1] ]
   // Search keys:  [  1,   2,     3,         X, 2,  3,       1,   1]
 
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), search_keys);
+    auto result   = cudf::lists::contains(search_space->view(), search_keys);
     auto expected = bools_col{{0, 1, 0, X, X, 0, 0, 1}, nulls_at({3, 4})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_FIRST);
     auto expected = indices_col{{ABSENT, 1, ABSENT, X, X, ABSENT, ABSENT, 0}, nulls_at({3, 4})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space->view(), search_keys, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_keys, FIND_LAST);
     auto expected = indices_col{{ABSENT, 1, ABSENT, X, X, ABSENT, ABSENT, 3}, nulls_at({3, 4})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -803,36 +805,37 @@ TEST_F(ContainsTest, VectorTypeRelatedExceptions)
 {
   {
     // Nested types unsupported.
-    auto list_of_lists = lists_column_wrapper<int32_t>{
+    auto list_of_lists = cudf::test::lists_column_wrapper<int32_t>{
       {{1, 2, 3}, {4, 5, 6}},
       {{1, 2, 3}, {4, 5, 6}},
       {{1, 2, 3},
        {4, 5, 6}}}.release();
-    auto skey = fixed_width_column_wrapper<int32_t>{0, 1, 2};
-    EXPECT_THROW(lists::contains(list_of_lists->view(), skey), cudf::logic_error);
-    EXPECT_THROW(lists::index_of(list_of_lists->view(), skey, FIND_FIRST), cudf::logic_error);
-    EXPECT_THROW(lists::index_of(list_of_lists->view(), skey, FIND_LAST), cudf::logic_error);
+    auto skey = cudf::test::fixed_width_column_wrapper<int32_t>{0, 1, 2};
+    EXPECT_THROW(cudf::lists::contains(list_of_lists->view(), skey), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::index_of(list_of_lists->view(), skey, FIND_FIRST), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::index_of(list_of_lists->view(), skey, FIND_LAST), cudf::logic_error);
   }
   {
     // Search key must match list elements in type.
     auto list_of_ints =
-      lists_column_wrapper<int32_t>{
+      cudf::test::lists_column_wrapper<int32_t>{
         {0, 1, 2},
         {3, 4, 5},
       }
         .release();
-    auto skey = strings_column_wrapper{"Hello", "World"};
-    EXPECT_THROW(lists::contains(list_of_ints->view(), skey), cudf::logic_error);
-    EXPECT_THROW(lists::index_of(list_of_ints->view(), skey, FIND_FIRST), cudf::logic_error);
-    EXPECT_THROW(lists::index_of(list_of_ints->view(), skey, FIND_LAST), cudf::logic_error);
+    auto skey = cudf::test::strings_column_wrapper{"Hello", "World"};
+    EXPECT_THROW(cudf::lists::contains(list_of_ints->view(), skey), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::index_of(list_of_ints->view(), skey, FIND_FIRST), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::index_of(list_of_ints->view(), skey, FIND_LAST), cudf::logic_error);
   }
   {
     // Search key column size must match lists column size.
-    auto list_of_ints = lists_column_wrapper<int32_t>{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}}.release();
-    auto skey         = fixed_width_column_wrapper<int32_t>{0, 1, 2, 3};
-    EXPECT_THROW(lists::contains(list_of_ints->view(), skey), cudf::logic_error);
-    EXPECT_THROW(lists::index_of(list_of_ints->view(), skey, FIND_FIRST), cudf::logic_error);
-    EXPECT_THROW(lists::index_of(list_of_ints->view(), skey, FIND_LAST), cudf::logic_error);
+    auto list_of_ints =
+      cudf::test::lists_column_wrapper<int32_t>{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}}.release();
+    auto skey = cudf::test::fixed_width_column_wrapper<int32_t>{0, 1, 2, 3};
+    EXPECT_THROW(cudf::lists::contains(list_of_ints->view(), skey), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::index_of(list_of_ints->view(), skey, FIND_FIRST), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::index_of(list_of_ints->view(), skey, FIND_LAST), cudf::logic_error);
   }
 }
 
@@ -840,7 +843,7 @@ template <typename T>
 struct TypedContainsNaNsTest : public ContainsTest {
 };
 
-TYPED_TEST_SUITE(TypedContainsNaNsTest, FloatingPointTypes);
+TYPED_TEST_SUITE(TypedContainsNaNsTest, cudf::test::FloatingPointTypes);
 
 namespace {
 template <typename T>
@@ -864,7 +867,7 @@ TYPED_TEST(TypedContainsNaNsTest, ListWithNaNsScalar)
   auto nan_2 = get_nan<T>("2");
   auto nan_3 = get_nan<T>("3");
 
-  auto search_space = lists_column_wrapper<T>{
+  auto search_space = cudf::test::lists_column_wrapper<T>{
     {0.0, 1.0, 2.0},
     {3, 4, 5},
     {6, 7, 8},
@@ -879,20 +882,20 @@ TYPED_TEST(TypedContainsNaNsTest, ListWithNaNsScalar)
   auto search_key_nan = create_scalar_search_key<T>(nan_3);
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), *search_key_nan);
+    auto result   = cudf::lists::contains(search_space->view(), *search_key_nan);
     auto expected = bools_col{0, 0, 0, 0, 1, 0, 1, 0, 0, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result = lists::index_of(search_space->view(), *search_key_nan, FIND_FIRST);
+    auto result = cudf::lists::index_of(search_space->view(), *search_key_nan, FIND_FIRST);
     auto expected =
       indices_col{ABSENT, ABSENT, ABSENT, ABSENT, 0, ABSENT, 1, ABSENT, ABSENT, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result = lists::index_of(search_space->view(), *search_key_nan, FIND_LAST);
+    auto result = cudf::lists::index_of(search_space->view(), *search_key_nan, FIND_LAST);
     auto expected =
       indices_col{ABSENT, ABSENT, ABSENT, ABSENT, 0, ABSENT, 1, ABSENT, ABSENT, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
@@ -916,7 +919,7 @@ TYPED_TEST(TypedContainsNaNsTest, ListWithNaNsContainsVector)
   auto nan_2 = get_nan<T>("2");
   auto nan_3 = get_nan<T>("3");
 
-  auto search_space = lists_column_wrapper<T>{
+  auto search_space = cudf::test::lists_column_wrapper<T>{
     {0.0, 1.0, 2.0},
     {{3, 4, 5}, null_at(2)},  // i.e. {3, 4, ∅}.
     {6, 7, 8},
@@ -933,25 +936,26 @@ TYPED_TEST(TypedContainsNaNsTest, ListWithNaNsContainsVector)
   {
     // With nulls in the search key rows. (At index 2.)
     auto search_keys =
-      fixed_width_column_wrapper<T>{search_key_values.begin(), search_key_values.end(), null_at(2)}
+      cudf::test::fixed_width_column_wrapper<T>{
+        search_key_values.begin(), search_key_values.end(), null_at(2)}
         .release();
 
     {
       // CONTAINS
-      auto result   = lists::contains(search_space->view(), search_keys->view());
+      auto result   = cudf::lists::contains(search_space->view(), search_keys->view());
       auto expected = bools_col{{1, 0, 0, 0, 1, 0, 1, 0, 1, 0}, null_at(2)};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // FIND_FIRST
-      auto result = lists::index_of(search_space->view(), search_keys->view(), FIND_FIRST);
+      auto result = cudf::lists::index_of(search_space->view(), search_keys->view(), FIND_FIRST);
       auto expected =
         indices_col{{1, ABSENT, X, ABSENT, 0, ABSENT, 2, ABSENT, 1, ABSENT}, nulls_at({2})};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // FIND_LAST
-      auto result = lists::index_of(search_space->view(), search_keys->view(), FIND_LAST);
+      auto result = cudf::lists::index_of(search_space->view(), search_keys->view(), FIND_LAST);
       auto expected =
         indices_col{{1, ABSENT, X, ABSENT, 0, ABSENT, 2, ABSENT, 1, ABSENT}, nulls_at({2})};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
@@ -960,22 +964,23 @@ TYPED_TEST(TypedContainsNaNsTest, ListWithNaNsContainsVector)
   {
     // No nulls in the search key rows.
     auto search_keys =
-      fixed_width_column_wrapper<T>(search_key_values.begin(), search_key_values.end()).release();
+      cudf::test::fixed_width_column_wrapper<T>(search_key_values.begin(), search_key_values.end())
+        .release();
     {
       // CONTAINS
-      auto result   = lists::contains(search_space->view(), search_keys->view());
+      auto result   = cudf::lists::contains(search_space->view(), search_keys->view());
       auto expected = bools_col{1, 0, 0, 0, 1, 0, 1, 0, 1, 0};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // FIND_FIRST
-      auto result   = lists::index_of(search_space->view(), search_keys->view(), FIND_FIRST);
+      auto result   = cudf::lists::index_of(search_space->view(), search_keys->view(), FIND_FIRST);
       auto expected = indices_col{1, ABSENT, ABSENT, ABSENT, 0, ABSENT, 2, ABSENT, 1, ABSENT};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // FIND_LAST
-      auto result   = lists::index_of(search_space->view(), search_keys->view(), FIND_LAST);
+      auto result   = cudf::lists::index_of(search_space->view(), search_keys->view(), FIND_LAST);
       auto expected = indices_col{1, ABSENT, ABSENT, ABSENT, 0, ABSENT, 2, ABSENT, 1, ABSENT};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
@@ -986,7 +991,7 @@ template <typename T>
 struct TypedContainsDecimalsTest : public ContainsTest {
 };
 
-TYPED_TEST_SUITE(TypedContainsDecimalsTest, FixedPointTypes);
+TYPED_TEST_SUITE(TypedContainsDecimalsTest, cudf::test::FixedPointTypes);
 
 TYPED_TEST(TypedContainsDecimalsTest, ScalarKey)
 {
@@ -995,29 +1000,30 @@ TYPED_TEST(TypedContainsDecimalsTest, ScalarKey)
   auto const search_space = [] {
     auto const values = std::vector<typename T::rep>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1,
                                                      2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3};
-    auto decimals     = fixed_point_column_wrapper<typename T::rep>{
+    auto decimals     = cudf::test::fixed_point_column_wrapper<typename T::rep>{
       values.begin(), values.end(), numeric::scale_type{0}};
     auto list_offsets = indices_col{0, 3, 6, 9, 12, 15, 18, 21, 21, 24, 24};
-    return make_lists_column(10, list_offsets.release(), decimals.release(), 0, {});
+    return cudf::make_lists_column(10, list_offsets.release(), decimals.release(), 0, {});
   }();
-  auto search_key_one = make_fixed_point_scalar<T>(typename T::rep{1}, numeric::scale_type{0});
+  auto search_key_one =
+    cudf::make_fixed_point_scalar<T>(typename T::rep{1}, numeric::scale_type{0});
 
   // Search space: [[0,1,2], [3,4,5], [6,7,8], [9,0,1], [2,3,4], [5,6,7], [8,9,0], [], [1,2,3], []]
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), *search_key_one);
+    auto result   = cudf::lists::contains(search_space->view(), *search_key_one);
     auto expected = bools_col{1, 0, 0, 1, 0, 0, 0, 0, 1, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space->view(), *search_key_one, FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_one, FIND_FIRST);
     auto expected = indices_col{1, ABSENT, ABSENT, 2, ABSENT, ABSENT, ABSENT, ABSENT, 0, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space->view(), *search_key_one, FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), *search_key_one, FIND_LAST);
     auto expected = indices_col{1, ABSENT, ABSENT, 2, ABSENT, ABSENT, ABSENT, ABSENT, 0, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -1030,13 +1036,13 @@ TYPED_TEST(TypedContainsDecimalsTest, VectorKey)
   auto const search_space = [] {
     auto const values = std::vector<typename T::rep>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1,
                                                      2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3};
-    auto decimals     = fixed_point_column_wrapper<typename T::rep>{
+    auto decimals     = cudf::test::fixed_point_column_wrapper<typename T::rep>{
       values.begin(), values.end(), numeric::scale_type{0}};
     auto list_offsets = indices_col{0, 3, 6, 9, 12, 15, 18, 21, 21, 24, 24};
-    return make_lists_column(10, list_offsets.release(), decimals.release(), 0, {});
+    return cudf::make_lists_column(10, list_offsets.release(), decimals.release(), 0, {});
   }();
 
-  auto search_key = fixed_point_column_wrapper<typename T::rep>{
+  auto search_key = cudf::test::fixed_point_column_wrapper<typename T::rep>{
     {1, 2, 3, 1, 2, 3, 1, 2, 3, 1},
     numeric::scale_type{
       0}}.release();
@@ -1045,19 +1051,19 @@ TYPED_TEST(TypedContainsDecimalsTest, VectorKey)
   // ] Search keys:  [  1,       2,       3,       1,       2,       3,       1,       2,  3, 1 ]
   {
     // CONTAINS
-    auto result   = lists::contains(search_space->view(), search_key->view());
+    auto result   = cudf::lists::contains(search_space->view(), search_key->view());
     auto expected = bools_col{1, 0, 0, 1, 1, 0, 0, 0, 1, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto result   = lists::index_of(search_space->view(), search_key->view(), FIND_FIRST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_key->view(), FIND_FIRST);
     auto expected = indices_col{1, ABSENT, ABSENT, 2, 0, ABSENT, ABSENT, ABSENT, 2, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto result   = lists::index_of(search_space->view(), search_key->view(), FIND_LAST);
+    auto result   = cudf::lists::index_of(search_space->view(), search_key->view(), FIND_LAST);
     auto expected = indices_col{1, ABSENT, ABSENT, 2, 0, ABSENT, ABSENT, ABSENT, 2, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -1075,8 +1081,8 @@ TYPED_TEST(TypedStructContainsTest, EmptyInputTest)
   auto const lists = [] {
     auto offsets = indices_col{};
     auto data    = tdata_col{};
-    auto child   = structs_col{{data}};
-    return make_lists_column(0, offsets.release(), child.release(), 0, {});
+    auto child   = cudf::test::structs_column_wrapper{{data}};
+    return cudf::make_lists_column(0, offsets.release(), child.release(), 0, {});
   }();
 
   auto const scalar_key = [] {
@@ -1085,11 +1091,11 @@ TYPED_TEST(TypedStructContainsTest, EmptyInputTest)
   }();
   auto const column_key = [] {
     auto child = tdata_col{};
-    return structs_col{{child}};
+    return cudf::test::structs_column_wrapper{{child}};
   }();
 
-  auto const result1  = lists::contains(lists->view(), scalar_key);
-  auto const result2  = lists::contains(lists->view(), column_key);
+  auto const result1  = cudf::lists::contains(lists->view(), scalar_key);
+  auto const result2  = cudf::lists::contains(lists->view(), column_key);
   auto const expected = bools_col{};
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result1);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result2);
@@ -1121,8 +1127,8 @@ TYPED_TEST(TypedStructContainsTest, ScalarKeyNoNullLists)
                               1, 0, 1, 1
     };
     // clang-format on
-    auto child = structs_col{{data1, data2}};
-    return make_lists_column(10, offsets.release(), child.release(), 0, {});
+    auto child = cudf::test::structs_column_wrapper{{data1, data2}};
+    return cudf::make_lists_column(10, offsets.release(), child.release(), 0, {});
   }();
 
   auto const key = [] {
@@ -1133,26 +1139,26 @@ TYPED_TEST(TypedStructContainsTest, ScalarKeyNoNullLists)
 
   {
     // CONTAINS
-    auto const result   = lists::contains(lists->view(), key);
+    auto const result   = cudf::lists::contains(lists->view(), key);
     auto const expected = bools_col{1, 0, 0, 0, 0, 0, 0, 0, 1, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // CONTAINS NULLS
-    auto const result   = lists::contains_nulls(lists->view());
+    auto const result   = cudf::lists::contains_nulls(lists->view());
     auto const expected = bools_col{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto const result = lists::index_of(lists->view(), key, FIND_FIRST);
+    auto const result = cudf::lists::index_of(lists->view(), key, FIND_FIRST);
     auto const expected =
       indices_col{1, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 0, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto const result = lists::index_of(lists->view(), key, FIND_LAST);
+    auto const result = cudf::lists::index_of(lists->view(), key, FIND_LAST);
     auto const expected =
       indices_col{1, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 2, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
@@ -1185,13 +1191,14 @@ TYPED_TEST(TypedStructContainsTest, ScalarKeyWithNullLists)
                               1, 0, 1, 1
     };
     // clang-format on
-    auto child               = structs_col{{data1, data2}};
+    auto child               = cudf::test::structs_column_wrapper{{data1, data2}};
     auto const validity_iter = nulls_at({3, 10});
-    return make_lists_column(11,
-                             offsets.release(),
-                             child.release(),
-                             2,
-                             detail::make_null_mask(validity_iter, validity_iter + 11));
+    return cudf::make_lists_column(
+      11,
+      offsets.release(),
+      child.release(),
+      2,
+      cudf::test::detail::make_null_mask(validity_iter, validity_iter + 11));
   }();
 
   auto const key = [] {
@@ -1202,26 +1209,26 @@ TYPED_TEST(TypedStructContainsTest, ScalarKeyWithNullLists)
 
   {
     // CONTAINS
-    auto const result   = lists::contains(lists->view(), key);
+    auto const result   = cudf::lists::contains(lists->view(), key);
     auto const expected = bools_col{{1, 0, 0, X, 0, 0, 0, 0, 0, 1, X}, nulls_at({3, 10})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // CONTAINS NULLS
-    auto const result   = lists::contains_nulls(lists->view());
+    auto const result   = cudf::lists::contains_nulls(lists->view());
     auto const expected = bools_col{{0, 0, 0, X, 0, 0, 0, 0, 0, 0, X}, nulls_at({3, 10})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto const result   = lists::index_of(lists->view(), key, FIND_FIRST);
+    auto const result   = cudf::lists::index_of(lists->view(), key, FIND_FIRST);
     auto const expected = indices_col{
       {1, ABSENT, ABSENT, X, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 0, X}, nulls_at({3, 10})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto const result   = lists::index_of(lists->view(), key, FIND_LAST);
+    auto const result   = cudf::lists::index_of(lists->view(), key, FIND_LAST);
     auto const expected = indices_col{
       {1, ABSENT, ABSENT, X, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 2, X}, nulls_at({3, 10})};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
@@ -1254,8 +1261,8 @@ TYPED_TEST(TypedStructContainsTest, SlicedListsColumnNoNulls)
                               1, 0, 1, 1
     };
     // clang-format on
-    auto child = structs_col{{data1, data2}};
-    return make_lists_column(10, offsets.release(), child.release(), 0, {});
+    auto child = cudf::test::structs_column_wrapper{{data1, data2}};
+    return cudf::make_lists_column(10, offsets.release(), child.release(), 0, {});
   }();
   auto const lists = cudf::slice(lists_original->view(), {3, 10})[0];
 
@@ -1267,25 +1274,25 @@ TYPED_TEST(TypedStructContainsTest, SlicedListsColumnNoNulls)
 
   {
     // CONTAINS
-    auto const result   = lists::contains(lists, key);
+    auto const result   = cudf::lists::contains(lists, key);
     auto const expected = bools_col{0, 0, 0, 0, 0, 1, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // CONTAINS NULLS
-    auto const result   = lists::contains_nulls(lists);
+    auto const result   = cudf::lists::contains_nulls(lists);
     auto const expected = bools_col{0, 0, 0, 0, 0, 0, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto const result   = lists::index_of(lists, key, FIND_FIRST);
+    auto const result   = cudf::lists::index_of(lists, key, FIND_FIRST);
     auto const expected = indices_col{ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 0, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto const result   = lists::index_of(lists, key, FIND_LAST);
+    auto const result   = cudf::lists::index_of(lists, key, FIND_LAST);
     auto const expected = indices_col{ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 2, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -1317,8 +1324,8 @@ TYPED_TEST(TypedStructContainsTest, ScalarKeyNoNullListsWithNullStructs)
                               X, 0, 1, 1
     };
     // clang-format on
-    auto child = structs_col{{data1, data2}, nulls_at({1, 10, 15, 24})};
-    return make_lists_column(10, offsets.release(), child.release(), 0, {});
+    auto child = cudf::test::structs_column_wrapper{{data1, data2}, nulls_at({1, 10, 15, 24})};
+    return cudf::make_lists_column(10, offsets.release(), child.release(), 0, {});
   }();
 
   auto const key = [] {
@@ -1329,26 +1336,26 @@ TYPED_TEST(TypedStructContainsTest, ScalarKeyNoNullListsWithNullStructs)
 
   {
     // CONTAINS
-    auto const result   = lists::contains(lists->view(), key);
+    auto const result   = cudf::lists::contains(lists->view(), key);
     auto const expected = bools_col{1, 0, 0, 0, 0, 0, 0, 0, 1, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // CONTAINS NULLS
-    auto const result   = lists::contains_nulls(lists->view());
+    auto const result   = cudf::lists::contains_nulls(lists->view());
     auto const expected = bools_col{1, 0, 0, 1, 1, 0, 0, 0, 1, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto const result = lists::index_of(lists->view(), key, FIND_FIRST);
+    auto const result = cudf::lists::index_of(lists->view(), key, FIND_FIRST);
     auto const expected =
       indices_col{3, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 2, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto const result = lists::index_of(lists->view(), key, FIND_LAST);
+    auto const result = cudf::lists::index_of(lists->view(), key, FIND_LAST);
     auto const expected =
       indices_col{3, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 2, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
@@ -1381,32 +1388,32 @@ TYPED_TEST(TypedStructContainsTest, ColumnKeyNoNullLists)
                               1, 0, 1, 1
     };
     // clang-format on
-    auto child = structs_col{{data1, data2}};
-    return make_lists_column(10, offsets.release(), child.release(), 0, {});
+    auto child = cudf::test::structs_column_wrapper{{data1, data2}};
+    return cudf::make_lists_column(10, offsets.release(), child.release(), 0, {});
   }();
 
   auto const keys = [] {
     auto child1 = tdata_col{1, 3, 1, 1, 2, 1, 0, 0, 1, 0};
     auto child2 = tdata_col{1, 0, 1, 1, 2, 1, 0, 0, 1, 0};
-    return structs_col{{child1, child2}};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   {
     // CONTAINS
-    auto const result   = lists::contains(lists->view(), keys);
+    auto const result   = cudf::lists::contains(lists->view(), keys);
     auto const expected = bools_col{1, 1, 0, 0, 0, 0, 0, 0, 1, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto const result = lists::index_of(lists->view(), keys, FIND_FIRST);
+    auto const result = cudf::lists::index_of(lists->view(), keys, FIND_FIRST);
     auto const expected =
       indices_col{1, 0, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 0, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto const result = lists::index_of(lists->view(), keys, FIND_LAST);
+    auto const result = cudf::lists::index_of(lists->view(), keys, FIND_LAST);
     auto const expected =
       indices_col{1, 2, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, ABSENT, 2, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
@@ -1439,14 +1446,14 @@ TYPED_TEST(TypedStructContainsTest, ColumnKeyWithSlicedListsNoNulls)
                               1, 0, 1, 1
     };
     // clang-format on
-    auto child = structs_col{{data1, data2}};
-    return make_lists_column(10, offsets.release(), child.release(), 0, {});
+    auto child = cudf::test::structs_column_wrapper{{data1, data2}};
+    return cudf::make_lists_column(10, offsets.release(), child.release(), 0, {});
   }();
 
   auto const keys_original = [] {
     auto child1 = tdata_col{1, 9, 1, 6, 2, 1, 0, 0, 1, 0};
     auto child2 = tdata_col{1, 1, 1, 1, 2, 1, 0, 0, 1, 0};
-    return structs_col{{child1, child2}};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   auto const lists = cudf::slice(lists_original->view(), {3, 7})[0];
@@ -1454,19 +1461,19 @@ TYPED_TEST(TypedStructContainsTest, ColumnKeyWithSlicedListsNoNulls)
 
   {
     // CONTAINS
-    auto const result   = lists::contains(lists, keys);
+    auto const result   = cudf::lists::contains(lists, keys);
     auto const expected = bools_col{1, 0, 1, 0};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto const result   = lists::index_of(lists, keys, FIND_FIRST);
+    auto const result   = cudf::lists::index_of(lists, keys, FIND_FIRST);
     auto const expected = indices_col{0, ABSENT, 1, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto const result   = lists::index_of(lists, keys, FIND_LAST);
+    auto const result   = cudf::lists::index_of(lists, keys, FIND_LAST);
     auto const expected = indices_col{0, ABSENT, 1, ABSENT};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -1498,19 +1505,20 @@ TYPED_TEST(TypedStructContainsTest, ColumnKeyWithSlicedListsHavingNulls)
                               X, 0, 1, 1
     };
     // clang-format on
-    auto child               = structs_col{{data1, data2}, nulls_at({1, 10, 15, 24})};
+    auto child = cudf::test::structs_column_wrapper{{data1, data2}, nulls_at({1, 10, 15, 24})};
     auto const validity_iter = nulls_at({3, 10});
-    return make_lists_column(11,
-                             offsets.release(),
-                             child.release(),
-                             2,
-                             detail::make_null_mask(validity_iter, validity_iter + 11));
+    return cudf::make_lists_column(
+      11,
+      offsets.release(),
+      child.release(),
+      2,
+      cudf::test::detail::make_null_mask(validity_iter, validity_iter + 11));
   }();
 
   auto const keys_original = [] {
     auto child1 = tdata_col{{1, X, 1, 6, X, 1, 0, 0, 1, 0, 1}, null_at(4)};
     auto child2 = tdata_col{{1, X, 1, 1, X, 1, 0, 0, 1, 0, 1}, null_at(4)};
-    return structs_col{{child1, child2}, null_at(1)};
+    return cudf::test::structs_column_wrapper{{child1, child2}, null_at(1)};
   }();
 
   auto const lists = cudf::slice(lists_original->view(), {4, 8})[0];
@@ -1518,19 +1526,19 @@ TYPED_TEST(TypedStructContainsTest, ColumnKeyWithSlicedListsHavingNulls)
 
   {
     // CONTAINS
-    auto const result   = lists::contains(lists, keys);
+    auto const result   = cudf::lists::contains(lists, keys);
     auto const expected = bools_col{{X, 0, 1, 0}, null_at(0)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto const result   = lists::index_of(lists, keys, FIND_FIRST);
+    auto const result   = cudf::lists::index_of(lists, keys, FIND_FIRST);
     auto const expected = indices_col{{X, ABSENT, 1, ABSENT}, null_at(0)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto const result   = lists::index_of(lists, keys, FIND_LAST);
+    auto const result   = cudf::lists::index_of(lists, keys, FIND_LAST);
     auto const expected = indices_col{{X, ABSENT, 2, ABSENT}, null_at(0)};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
@@ -1572,31 +1580,31 @@ TYPED_TEST(TypedListContainsTest, ScalarKeyLists)
 
   auto const key = [] {
     auto const child = tdata_col{0, 1, 2};
-    return list_scalar(child);
+    return cudf::list_scalar(child);
   }();
 
   auto const do_test = [&](auto const& lists, bool has_nulls) {
     {
       // CONTAINS
-      auto const result   = lists::contains(lists_column_view{lists}, key);
+      auto const result   = cudf::lists::contains(cudf::lists_column_view{lists}, key);
       auto const expected = bools_col{1, 0, 0};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // CONTAINS NULLS
-      auto const result   = lists::contains_nulls(lists_column_view{lists});
+      auto const result   = cudf::lists::contains_nulls(cudf::lists_column_view{lists});
       auto const expected = has_nulls ? bools_col{1, 1, 0} : bools_col{0, 0, 0};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // FIND_FIRST
-      auto const result   = lists::index_of(lists_column_view{lists}, key, FIND_FIRST);
+      auto const result   = cudf::lists::index_of(cudf::lists_column_view{lists}, key, FIND_FIRST);
       auto const expected = indices_col{0, ABSENT, ABSENT};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // FIND_LAST
-      auto const result   = lists::index_of(lists_column_view{lists}, key, FIND_LAST);
+      auto const result   = cudf::lists::index_of(cudf::lists_column_view{lists}, key, FIND_LAST);
       auto const expected = indices_col{2, ABSENT, ABSENT};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
@@ -1664,31 +1672,31 @@ TYPED_TEST(TypedListContainsTest, SlicedListsColumn)
 
   auto const key = [] {
     auto const child = tdata_col{0, 1, 2};
-    return list_scalar(child);
+    return cudf::list_scalar(child);
   }();
 
   auto const do_test = [&](auto const& lists, bool has_nulls) {
     {
       // CONTAINS
-      auto const result   = lists::contains(lists_column_view{lists}, key);
+      auto const result   = cudf::lists::contains(cudf::lists_column_view{lists}, key);
       auto const expected = bools_col{1, 0, 0};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // CONTAINS NULLS
-      auto const result   = lists::contains_nulls(lists_column_view{lists});
+      auto const result   = cudf::lists::contains_nulls(cudf::lists_column_view{lists});
       auto const expected = has_nulls ? bools_col{1, 1, 0} : bools_col{0, 0, 0};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // FIND_FIRST
-      auto const result   = lists::index_of(lists_column_view{lists}, key, FIND_FIRST);
+      auto const result   = cudf::lists::index_of(cudf::lists_column_view{lists}, key, FIND_FIRST);
       auto const expected = indices_col{0, ABSENT, ABSENT};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // FIND_LAST
-      auto const result   = lists::index_of(lists_column_view{lists}, key, FIND_LAST);
+      auto const result   = cudf::lists::index_of(cudf::lists_column_view{lists}, key, FIND_LAST);
       auto const expected = indices_col{2, ABSENT, ABSENT};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
@@ -1737,25 +1745,25 @@ TYPED_TEST(TypedListContainsTest, ColumnKeyLists)
   auto const do_test = [&](auto const& lists, bool has_nulls) {
     {
       // CONTAINS
-      auto const result   = lists::contains(lists_column_view{lists}, key);
+      auto const result   = cudf::lists::contains(cudf::lists_column_view{lists}, key);
       auto const expected = has_nulls ? bools_col{1, 1, 1} : bools_col{0, 1, 0};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // CONTAINS NULLS
-      auto const result   = lists::contains_nulls(lists_column_view{lists});
+      auto const result   = cudf::lists::contains_nulls(cudf::lists_column_view{lists});
       auto const expected = has_nulls ? bools_col{1, 1, 0} : bools_col{0, 0, 0};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // FIND_FIRST
-      auto const result   = lists::index_of(lists_column_view{lists}, key, FIND_FIRST);
+      auto const result   = cudf::lists::index_of(cudf::lists_column_view{lists}, key, FIND_FIRST);
       auto const expected = has_nulls ? indices_col{0, 2, 1} : indices_col{ABSENT, 0, ABSENT};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
     {
       // FIND_LAST
-      auto const result   = lists::index_of(lists_column_view{lists}, key, FIND_LAST);
+      auto const result   = cudf::lists::index_of(cudf::lists_column_view{lists}, key, FIND_LAST);
       auto const expected = has_nulls ? indices_col{2, 2, 1} : indices_col{ABSENT, 2, ABSENT};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
     }
@@ -1791,40 +1799,38 @@ TYPED_TEST(TypedListContainsTest, ColumnKeyWithListsOfStructsNoNulls)
 
     };
     // clang-format on
-    auto structs = structs_col{{data1, data2}};
-    auto child   = make_lists_column(8, child_offsets.release(), structs.release(), 0, {});
+    auto structs = cudf::test::structs_column_wrapper{{data1, data2}};
+    auto child   = cudf::make_lists_column(8, child_offsets.release(), structs.release(), 0, {});
 
     auto offsets = indices_col{0, 4, 8};
-    return make_lists_column(2, offsets.release(), std::move(child), 0, {});
+    return cudf::make_lists_column(2, offsets.release(), std::move(child), 0, {});
   }();
 
   auto const key = [] {
     auto data1       = tdata_col{0, 0, 2};
     auto data2       = tdata_col{10, 10, 12};
-    auto const child = structs_col{{data1, data2}};
-    return list_scalar(child);
+    auto const child = cudf::test::structs_column_wrapper{{data1, data2}};
+    return cudf::list_scalar(child);
   }();
 
   {
     // CONTAINS
-    auto const result   = lists::contains(lists_column_view{lists->view()}, key);
+    auto const result   = cudf::lists::contains(cudf::lists_column_view{lists->view()}, key);
     auto const expected = bools_col{1, 1};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_FIRST
-    auto const result   = lists::index_of(lists_column_view{lists->view()}, key, FIND_FIRST);
+    auto const result =
+      cudf::lists::index_of(cudf::lists_column_view{lists->view()}, key, FIND_FIRST);
     auto const expected = indices_col{0, 1};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
   {
     // FIND_LAST
-    auto const result   = lists::index_of(lists_column_view{lists->view()}, key, FIND_LAST);
+    auto const result =
+      cudf::lists::index_of(cudf::lists_column_view{lists->view()}, key, FIND_LAST);
     auto const expected = indices_col{2, 1};
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *result);
   }
 }
-
-}  // namespace test
-
-}  // namespace cudf

--- a/cpp/tests/structs/utilities_tests.cpp
+++ b/cpp/tests/structs/utilities_tests.cpp
@@ -28,90 +28,87 @@
 #include <cudf/detail/structs/utilities.hpp>
 #include <cudf/null_mask.hpp>
 
-namespace cudf::test {
-
-using namespace cudf;
-using namespace iterators;
-using namespace cudf::structs::detail;
-using strings    = strings_column_wrapper;
-using dictionary = dictionary_column_wrapper<std::string>;
-using structs    = structs_column_wrapper;
-using bools      = fixed_width_column_wrapper<bool>;
+template <typename T>
+using nums = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
 template <typename T>
-using nums = fixed_width_column_wrapper<T, int32_t>;
+using lists = cudf::test::lists_column_wrapper<T, int32_t>;
 
-template <typename T>
-using lists = lists_column_wrapper<T, int32_t>;
-
-struct StructUtilitiesTest : BaseFixture {
+struct StructUtilitiesTest : cudf::test::BaseFixture {
 };
 
 template <typename T>
 struct TypedStructUtilitiesTest : StructUtilitiesTest {
 };
 
-TYPED_TEST_SUITE(TypedStructUtilitiesTest, FixedWidthTypes);
+TYPED_TEST_SUITE(TypedStructUtilitiesTest, cudf::test::FixedWidthTypes);
 
 TYPED_TEST(TypedStructUtilitiesTest, ListsAtTopLevel)
 {
   using T     = TypeParam;
-  using lists = lists_column_wrapper<T, int32_t>;
-  using nums  = fixed_width_column_wrapper<T, int32_t>;
+  using lists = cudf::test::lists_column_wrapper<T, int32_t>;
+  using nums  = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
   auto lists_col = lists{{0, 1}, {22, 33}, {44, 55, 66}};
-  auto nums_col  = nums{{0, 1, 2}, null_at(6)};
+  auto nums_col  = nums{{0, 1, 2}, cudf::test::iterators::null_at(6)};
 
   auto table = cudf::table_view{{lists_col, nums_col}};
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(table,
-                                flatten_nested_columns(table, {}, {}, column_nullability::FORCE));
+                                cudf::structs::detail::flatten_nested_columns(
+                                  table, {}, {}, cudf::structs::detail::column_nullability::FORCE));
 }
 
 TYPED_TEST(TypedStructUtilitiesTest, NestedListsUnsupported)
 {
   using T     = TypeParam;
-  using lists = lists_column_wrapper<T, int32_t>;
-  using nums  = fixed_width_column_wrapper<T, int32_t>;
+  using lists = cudf::test::lists_column_wrapper<T, int32_t>;
+  using nums  = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
   auto lists_member = lists{{0, 1}, {22, 33}, {44, 55, 66}};
-  auto nums_member  = nums{{0, 1, 2}, null_at(6)};
-  auto structs_col  = structs{{nums_member, lists_member}};
-  auto nums_col     = nums{{0, 1, 2}, null_at(6)};
+  auto nums_member  = nums{{0, 1, 2}, cudf::test::iterators::null_at(6)};
+  auto structs_col  = cudf::test::structs_column_wrapper{{nums_member, lists_member}};
+  auto nums_col     = nums{{0, 1, 2}, cudf::test::iterators::null_at(6)};
 
-  EXPECT_THROW(flatten_nested_columns(
-                 cudf::table_view{{nums_col, structs_col}}, {}, {}, column_nullability::FORCE),
-               cudf::logic_error);
+  EXPECT_THROW(
+    cudf::structs::detail::flatten_nested_columns(cudf::table_view{{nums_col, structs_col}},
+                                                  {},
+                                                  {},
+                                                  cudf::structs::detail::column_nullability::FORCE),
+    cudf::logic_error);
 }
 
 TYPED_TEST(TypedStructUtilitiesTest, NoStructs)
 {
   using T    = TypeParam;
-  using nums = fixed_width_column_wrapper<T, int32_t>;
+  using nums = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
-  auto nums_col        = nums{{0, 1, 22, 33, 44, 55, 66}, null_at(0)};
-  auto strings_col     = strings{{"", "1", "22", "333", "4444", "55555", "666666"}, null_at(1)};
-  auto nuther_nums_col = nums{{0, 1, 2, 3, 4, 5, 6}, null_at(6)};
+  auto nums_col    = nums{{0, 1, 22, 33, 44, 55, 66}, cudf::test::iterators::null_at(0)};
+  auto strings_col = cudf::test::strings_column_wrapper{
+    {"", "1", "22", "333", "4444", "55555", "666666"}, cudf::test::iterators::null_at(1)};
+  auto nuther_nums_col = nums{{0, 1, 2, 3, 4, 5, 6}, cudf::test::iterators::null_at(6)};
 
   auto table = cudf::table_view{{nums_col, strings_col, nuther_nums_col}};
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(table,
-                                flatten_nested_columns(table, {}, {}, column_nullability::FORCE));
+                                cudf::structs::detail::flatten_nested_columns(
+                                  table, {}, {}, cudf::structs::detail::column_nullability::FORCE));
 }
 
 TYPED_TEST(TypedStructUtilitiesTest, SingleLevelStruct)
 {
   using T    = TypeParam;
-  using nums = fixed_width_column_wrapper<T, int32_t>;
+  using nums = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
-  auto nums_member    = nums{{0, 1, 22, 333, 44, 55, 66}, null_at(0)};
-  auto strings_member = strings{{"", "1", "22", "333", "4444", "55555", "666666"}, null_at(1)};
-  auto structs_col    = structs{{nums_member, strings_member}};
-  auto nums_col       = nums{{0, 1, 2, 3, 4, 5, 6}, null_at(6)};
-  auto table          = cudf::table_view{{nums_col, structs_col}};
+  auto nums_member    = nums{{0, 1, 22, 333, 44, 55, 66}, cudf::test::iterators::null_at(0)};
+  auto strings_member = cudf::test::strings_column_wrapper{
+    {"", "1", "22", "333", "4444", "55555", "666666"}, cudf::test::iterators::null_at(1)};
+  auto structs_col = cudf::test::structs_column_wrapper{{nums_member, strings_member}};
+  auto nums_col    = nums{{0, 1, 2, 3, 4, 5, 6}, cudf::test::iterators::null_at(6)};
+  auto table       = cudf::table_view{{nums_col, structs_col}};
 
   auto expected_nums_col_1  = cudf::column(nums_col);
-  auto expected_structs_col = bools{{1, 1, 1, 1, 1, 1, 1}};
+  auto expected_structs_col = cudf::test::fixed_width_column_wrapper<bool>{{1, 1, 1, 1, 1, 1, 1}};
   auto expected_nums_col_2 =
     cudf::column(static_cast<cudf::structs_column_view>(structs_col).get_sliced_child(0));
   auto expected_strings_col =
@@ -120,22 +117,26 @@ TYPED_TEST(TypedStructUtilitiesTest, SingleLevelStruct)
     {expected_nums_col_1, expected_structs_col, expected_nums_col_2, expected_strings_col}};
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected,
-                                flatten_nested_columns(table, {}, {}, column_nullability::FORCE));
+                                cudf::structs::detail::flatten_nested_columns(
+                                  table, {}, {}, cudf::structs::detail::column_nullability::FORCE));
 }
 
 TYPED_TEST(TypedStructUtilitiesTest, SingleLevelStructWithNulls)
 {
   using T    = TypeParam;
-  using nums = fixed_width_column_wrapper<T, int32_t>;
+  using nums = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
-  auto nums_member    = nums{{0, 1, 22, 333, 44, 55, 66}, null_at(0)};
-  auto strings_member = strings{{"", "1", "22", "333", "4444", "55555", "666666"}, null_at(1)};
-  auto structs_col    = structs{{nums_member, strings_member}, null_at(2)};
-  auto nums_col       = nums{{0, 1, 2, 3, 4, 5, 6}, null_at(6)};
-  auto table          = cudf::table_view{{nums_col, structs_col}};
+  auto nums_member    = nums{{0, 1, 22, 333, 44, 55, 66}, cudf::test::iterators::null_at(0)};
+  auto strings_member = cudf::test::strings_column_wrapper{
+    {"", "1", "22", "333", "4444", "55555", "666666"}, cudf::test::iterators::null_at(1)};
+  auto structs_col = cudf::test::structs_column_wrapper{{nums_member, strings_member},
+                                                        cudf::test::iterators::null_at(2)};
+  auto nums_col    = nums{{0, 1, 2, 3, 4, 5, 6}, cudf::test::iterators::null_at(6)};
+  auto table       = cudf::table_view{{nums_col, structs_col}};
 
   auto expected_nums_col_1  = cudf::column(nums_col);
-  auto expected_structs_col = bools{{1, 1, 0, 1, 1, 1, 1}, null_at(2)};
+  auto expected_structs_col = cudf::test::fixed_width_column_wrapper<bool>{
+    {1, 1, 0, 1, 1, 1, 1}, cudf::test::iterators::null_at(2)};
   auto expected_nums_col_2 =
     cudf::column(static_cast<cudf::structs_column_view>(structs_col).get_sliced_child(0));
   auto expected_strings_col =
@@ -144,30 +145,33 @@ TYPED_TEST(TypedStructUtilitiesTest, SingleLevelStructWithNulls)
     {expected_nums_col_1, expected_structs_col, expected_nums_col_2, expected_strings_col}};
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected,
-                                flatten_nested_columns(table, {}, {}, column_nullability::FORCE));
+                                cudf::structs::detail::flatten_nested_columns(
+                                  table, {}, {}, cudf::structs::detail::column_nullability::FORCE));
 }
 
 TYPED_TEST(TypedStructUtilitiesTest, StructOfStruct)
 {
   using T    = TypeParam;
-  using nums = fixed_width_column_wrapper<T, int32_t>;
+  using nums = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
-  auto nums_col = nums{{0, 1, 2, 3, 4, 5, 6}, null_at(6)};
+  auto nums_col = nums{{0, 1, 2, 3, 4, 5, 6}, cudf::test::iterators::null_at(6)};
 
-  auto struct_0_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, null_at(0)};
-  auto struct_0_strings_member =
-    strings{{"", "1", "22", "333", "4444", "55555", "666666"}, null_at(1)};
-  auto structs_1_structs_member = structs{{struct_0_nums_member, struct_0_strings_member}};
+  auto struct_0_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, cudf::test::iterators::null_at(0)};
+  auto struct_0_strings_member = cudf::test::strings_column_wrapper{
+    {"", "1", "22", "333", "4444", "55555", "666666"}, cudf::test::iterators::null_at(1)};
+  auto structs_1_structs_member =
+    cudf::test::structs_column_wrapper{{struct_0_nums_member, struct_0_strings_member}};
 
-  auto struct_1_nums_member  = nums{{0, 1, 22, 33, 44, 55, 66}, null_at(3)};
-  auto struct_of_structs_col = structs{{struct_1_nums_member, structs_1_structs_member}};
-  auto table                 = cudf::table_view{{nums_col, struct_of_structs_col}};
+  auto struct_1_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, cudf::test::iterators::null_at(3)};
+  auto struct_of_structs_col =
+    cudf::test::structs_column_wrapper{{struct_1_nums_member, structs_1_structs_member}};
+  auto table = cudf::table_view{{nums_col, struct_of_structs_col}};
 
   auto expected_nums_col_1    = cudf::column(nums_col);
-  auto expected_structs_col_1 = bools{{1, 1, 1, 1, 1, 1, 1}};
+  auto expected_structs_col_1 = cudf::test::fixed_width_column_wrapper<bool>{{1, 1, 1, 1, 1, 1, 1}};
   auto expected_nums_col_2 =
     cudf::column(static_cast<cudf::structs_column_view>(struct_of_structs_col).get_sliced_child(0));
-  auto expected_structs_col_2 = bools{{1, 1, 1, 1, 1, 1, 1}};
+  auto expected_structs_col_2 = cudf::test::fixed_width_column_wrapper<bool>{{1, 1, 1, 1, 1, 1, 1}};
   auto expected_nums_col_3    = cudf::column(
     static_cast<cudf::structs_column_view>(struct_of_structs_col).get_sliced_child(1).child(0));
   auto expected_strings_col = cudf::column(
@@ -180,32 +184,35 @@ TYPED_TEST(TypedStructUtilitiesTest, StructOfStruct)
                                     expected_strings_col}};
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected,
-                                flatten_nested_columns(table, {}, {}, column_nullability::FORCE));
+                                cudf::structs::detail::flatten_nested_columns(
+                                  table, {}, {}, cudf::structs::detail::column_nullability::FORCE));
 }
 
 TYPED_TEST(TypedStructUtilitiesTest, StructOfStructWithNullsAtLeafLevel)
 {
   using T    = TypeParam;
-  using nums = fixed_width_column_wrapper<T, int32_t>;
+  using nums = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
-  auto nums_col = nums{{0, 1, 2, 3, 4, 5, 6}, null_at(6)};
+  auto nums_col = nums{{0, 1, 2, 3, 4, 5, 6}, cudf::test::iterators::null_at(6)};
 
-  auto struct_0_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, null_at(0)};
-  auto struct_0_strings_member =
-    strings{{"", "1", "22", "333", "4444", "55555", "666666"}, null_at(1)};
-  auto structs_1_structs_member =
-    structs{{struct_0_nums_member, struct_0_strings_member}, null_at(2)};
+  auto struct_0_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, cudf::test::iterators::null_at(0)};
+  auto struct_0_strings_member = cudf::test::strings_column_wrapper{
+    {"", "1", "22", "333", "4444", "55555", "666666"}, cudf::test::iterators::null_at(1)};
+  auto structs_1_structs_member = cudf::test::structs_column_wrapper{
+    {struct_0_nums_member, struct_0_strings_member}, cudf::test::iterators::null_at(2)};
 
-  auto struct_1_nums_member  = nums{{0, 1, 22, 33, 44, 55, 66}, null_at(3)};
-  auto struct_of_structs_col = structs{{struct_1_nums_member, structs_1_structs_member}};
-  auto table                 = cudf::table_view{{nums_col, struct_of_structs_col}};
+  auto struct_1_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, cudf::test::iterators::null_at(3)};
+  auto struct_of_structs_col =
+    cudf::test::structs_column_wrapper{{struct_1_nums_member, structs_1_structs_member}};
+  auto table = cudf::table_view{{nums_col, struct_of_structs_col}};
 
   auto expected_nums_col_1    = cudf::column(nums_col);
-  auto expected_structs_col_1 = bools{{1, 1, 1, 1, 1, 1, 1}};
+  auto expected_structs_col_1 = cudf::test::fixed_width_column_wrapper<bool>{{1, 1, 1, 1, 1, 1, 1}};
   auto expected_nums_col_2 =
     cudf::column(static_cast<cudf::structs_column_view>(struct_of_structs_col).get_sliced_child(0));
-  auto expected_structs_col_2 = bools{{1, 1, 0, 1, 1, 1, 1}, null_at(2)};
-  auto expected_nums_col_3    = cudf::column(
+  auto expected_structs_col_2 = cudf::test::fixed_width_column_wrapper<bool>{
+    {1, 1, 0, 1, 1, 1, 1}, cudf::test::iterators::null_at(2)};
+  auto expected_nums_col_3 = cudf::column(
     static_cast<cudf::structs_column_view>(struct_of_structs_col).get_sliced_child(1).child(0));
   auto expected_strings_col = cudf::column(
     static_cast<cudf::structs_column_view>(struct_of_structs_col).get_sliced_child(1).child(1));
@@ -217,32 +224,36 @@ TYPED_TEST(TypedStructUtilitiesTest, StructOfStructWithNullsAtLeafLevel)
                                     expected_strings_col}};
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected,
-                                flatten_nested_columns(table, {}, {}, column_nullability::FORCE));
+                                cudf::structs::detail::flatten_nested_columns(
+                                  table, {}, {}, cudf::structs::detail::column_nullability::FORCE));
 }
 
 TYPED_TEST(TypedStructUtilitiesTest, StructOfStructWithNullsAtTopLevel)
 {
   using T    = TypeParam;
-  using nums = fixed_width_column_wrapper<T, int32_t>;
+  using nums = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
-  auto nums_col = nums{{0, 1, 2, 3, 4, 5, 6}, null_at(6)};
+  auto nums_col = nums{{0, 1, 2, 3, 4, 5, 6}, cudf::test::iterators::null_at(6)};
 
-  auto struct_0_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, null_at(0)};
-  auto struct_0_strings_member =
-    strings{{"", "1", "22", "333", "4444", "55555", "666666"}, null_at(1)};
-  auto structs_1_structs_member = structs{{struct_0_nums_member, struct_0_strings_member}};
+  auto struct_0_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, cudf::test::iterators::null_at(0)};
+  auto struct_0_strings_member = cudf::test::strings_column_wrapper{
+    {"", "1", "22", "333", "4444", "55555", "666666"}, cudf::test::iterators::null_at(1)};
+  auto structs_1_structs_member =
+    cudf::test::structs_column_wrapper{{struct_0_nums_member, struct_0_strings_member}};
 
-  auto struct_1_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, null_at(3)};
-  auto struct_of_structs_col =
-    structs{{struct_1_nums_member, structs_1_structs_member}, null_at(4)};
+  auto struct_1_nums_member  = nums{{0, 1, 22, 33, 44, 55, 66}, cudf::test::iterators::null_at(3)};
+  auto struct_of_structs_col = cudf::test::structs_column_wrapper{
+    {struct_1_nums_member, structs_1_structs_member}, cudf::test::iterators::null_at(4)};
   auto table = cudf::table_view{{nums_col, struct_of_structs_col}};
 
   auto expected_nums_col_1    = cudf::column(nums_col);
-  auto expected_structs_col_1 = bools{{1, 1, 1, 1, 0, 1, 1}, null_at(4)};
+  auto expected_structs_col_1 = cudf::test::fixed_width_column_wrapper<bool>{
+    {1, 1, 1, 1, 0, 1, 1}, cudf::test::iterators::null_at(4)};
   auto expected_nums_col_2 =
     cudf::column(static_cast<cudf::structs_column_view>(struct_of_structs_col).get_sliced_child(0));
-  auto expected_structs_col_2 = bools{{1, 1, 1, 1, 0, 1, 1}, null_at(4)};
-  auto expected_nums_col_3    = cudf::column(
+  auto expected_structs_col_2 = cudf::test::fixed_width_column_wrapper<bool>{
+    {1, 1, 1, 1, 0, 1, 1}, cudf::test::iterators::null_at(4)};
+  auto expected_nums_col_3 = cudf::column(
     static_cast<cudf::structs_column_view>(struct_of_structs_col).get_sliced_child(1).child(0));
   auto expected_strings_col = cudf::column(
     static_cast<cudf::structs_column_view>(struct_of_structs_col).get_sliced_child(1).child(1));
@@ -254,33 +265,36 @@ TYPED_TEST(TypedStructUtilitiesTest, StructOfStructWithNullsAtTopLevel)
                                     expected_strings_col}};
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected,
-                                flatten_nested_columns(table, {}, {}, column_nullability::FORCE));
+                                cudf::structs::detail::flatten_nested_columns(
+                                  table, {}, {}, cudf::structs::detail::column_nullability::FORCE));
 }
 
 TYPED_TEST(TypedStructUtilitiesTest, StructOfStructWithNullsAtAllLevels)
 {
   using T    = TypeParam;
-  using nums = fixed_width_column_wrapper<T, int32_t>;
+  using nums = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
-  auto nums_col = nums{{0, 1, 2, 3, 4, 5, 6}, null_at(6)};
+  auto nums_col = nums{{0, 1, 2, 3, 4, 5, 6}, cudf::test::iterators::null_at(6)};
 
-  auto struct_0_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, null_at(0)};
-  auto struct_0_strings_member =
-    strings{{"", "1", "22", "333", "4444", "55555", "666666"}, null_at(1)};
-  auto structs_1_structs_member =
-    structs{{struct_0_nums_member, struct_0_strings_member}, null_at(2)};
+  auto struct_0_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, cudf::test::iterators::null_at(0)};
+  auto struct_0_strings_member = cudf::test::strings_column_wrapper{
+    {"", "1", "22", "333", "4444", "55555", "666666"}, cudf::test::iterators::null_at(1)};
+  auto structs_1_structs_member = cudf::test::structs_column_wrapper{
+    {struct_0_nums_member, struct_0_strings_member}, cudf::test::iterators::null_at(2)};
 
-  auto struct_1_nums_member = nums{{0, 1, 22, 33, 44, 55, 66}, null_at(3)};
-  auto struct_of_structs_col =
-    structs{{struct_1_nums_member, structs_1_structs_member}, null_at(4)};
+  auto struct_1_nums_member  = nums{{0, 1, 22, 33, 44, 55, 66}, cudf::test::iterators::null_at(3)};
+  auto struct_of_structs_col = cudf::test::structs_column_wrapper{
+    {struct_1_nums_member, structs_1_structs_member}, cudf::test::iterators::null_at(4)};
   auto table = cudf::table_view{{nums_col, struct_of_structs_col}};
 
   auto expected_nums_col_1    = cudf::column(nums_col);
-  auto expected_structs_col_1 = bools{{1, 1, 1, 1, 0, 1, 1}, null_at(4)};
+  auto expected_structs_col_1 = cudf::test::fixed_width_column_wrapper<bool>{
+    {1, 1, 1, 1, 0, 1, 1}, cudf::test::iterators::null_at(4)};
   auto expected_nums_col_2 =
     cudf::column(static_cast<cudf::structs_column_view>(struct_of_structs_col).get_sliced_child(0));
-  auto expected_structs_col_2 = bools{{1, 1, 0, 1, 0, 1, 1}, {1, 1, 0, 1, 0, 1, 1}};
-  auto expected_nums_col_3    = cudf::column(
+  auto expected_structs_col_2 =
+    cudf::test::fixed_width_column_wrapper<bool>{{1, 1, 0, 1, 0, 1, 1}, {1, 1, 0, 1, 0, 1, 1}};
+  auto expected_nums_col_3 = cudf::column(
     static_cast<cudf::structs_column_view>(struct_of_structs_col).get_sliced_child(1).child(0));
   auto expected_strings_col = cudf::column(
     static_cast<cudf::structs_column_view>(struct_of_structs_col).get_sliced_child(1).child(1));
@@ -292,25 +306,29 @@ TYPED_TEST(TypedStructUtilitiesTest, StructOfStructWithNullsAtAllLevels)
                                     expected_strings_col}};
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected,
-                                flatten_nested_columns(table, {}, {}, column_nullability::FORCE));
+                                cudf::structs::detail::flatten_nested_columns(
+                                  table, {}, {}, cudf::structs::detail::column_nullability::FORCE));
 }
 
 TYPED_TEST(TypedStructUtilitiesTest, ListsAreUnsupported)
 {
   using T    = TypeParam;
-  using ints = fixed_width_column_wrapper<int32_t>;
-  using lcw  = lists_column_wrapper<T, int32_t>;
+  using ints = cudf::test::fixed_width_column_wrapper<int32_t>;
+  using lcw  = cudf::test::lists_column_wrapper<T, int32_t>;
 
   // clang-format off
   auto lists_member = lcw{  {0,1,2}, {3,4,5}, {6,7,8,9} };
   auto ints_member  = ints{       0,       1,         2 };
   // clang-format on
 
-  auto structs_with_lists_col = structs{lists_member, ints_member};
+  auto structs_with_lists_col = cudf::test::structs_column_wrapper{lists_member, ints_member};
 
-  EXPECT_THROW(flatten_nested_columns(
-                 cudf::table_view{{structs_with_lists_col}}, {}, {}, column_nullability::FORCE),
-               cudf::logic_error);
+  EXPECT_THROW(
+    cudf::structs::detail::flatten_nested_columns(cudf::table_view{{structs_with_lists_col}},
+                                                  {},
+                                                  {},
+                                                  cudf::structs::detail::column_nullability::FORCE),
+    cudf::logic_error);
 }
 
 struct SuperimposeTest : StructUtilitiesTest {
@@ -320,7 +338,7 @@ template <typename T>
 struct TypedSuperimposeTest : StructUtilitiesTest {
 };
 
-TYPED_TEST_SUITE(TypedSuperimposeTest, FixedWidthTypes);
+TYPED_TEST_SUITE(TypedSuperimposeTest, cudf::test::FixedWidthTypes);
 
 void test_non_struct_columns(cudf::column_view const& input)
 {
@@ -336,18 +354,21 @@ TYPED_TEST(TypedSuperimposeTest, NoStructInput)
 {
   using T = TypeParam;
 
-  test_non_struct_columns(fixed_width_column_wrapper<T>{{6, 5, 4, 3, 2, 1, 0}, null_at(3)});
-  test_non_struct_columns(
-    lists_column_wrapper<T, int32_t>{{{6, 5}, {4, 3}, {2, 1}, {0}}, null_at(3)});
-  test_non_struct_columns(strings{{"All", "The", "Leaves", "Are", "Brown"}, null_at(3)});
-  test_non_struct_columns(dictionary{{"All", "The", "Leaves", "Are", "Brown"}, null_at(3)});
+  test_non_struct_columns(cudf::test::fixed_width_column_wrapper<T>{
+    {6, 5, 4, 3, 2, 1, 0}, cudf::test::iterators::null_at(3)});
+  test_non_struct_columns(cudf::test::lists_column_wrapper<T, int32_t>{
+    {{6, 5}, {4, 3}, {2, 1}, {0}}, cudf::test::iterators::null_at(3)});
+  test_non_struct_columns(cudf::test::strings_column_wrapper{
+    {"All", "The", "Leaves", "Are", "Brown"}, cudf::test::iterators::null_at(3)});
+  test_non_struct_columns(cudf::test::dictionary_column_wrapper<std::string>{
+    {"All", "The", "Leaves", "Are", "Brown"}, cudf::test::iterators::null_at(3)});
 }
 
 /**
  * @brief Helper to construct a numeric member of a struct column.
  */
 template <typename T, typename NullIter>
-nums<T> make_nums_member(NullIter null_iter = no_nulls())
+nums<T> make_nums_member(NullIter null_iter = cudf::test::iterators::no_nulls())
 {
   return nums<T>{{10, 11, 12, 13, 14, 15, 16}, null_iter};
 }
@@ -356,7 +377,7 @@ nums<T> make_nums_member(NullIter null_iter = no_nulls())
  * @brief Helper to construct a lists member of a struct column.
  */
 template <typename T, typename NullIter>
-lists<T> make_lists_member(NullIter null_iter = no_nulls())
+lists<T> make_lists_member(NullIter null_iter = cudf::test::iterators::no_nulls())
 {
   return lists<T>{{{20, 20}, {21, 21}, {22, 22}, {23, 23}, {24, 24}, {25, 25}, {26, 26}},
                   null_iter};
@@ -366,9 +387,11 @@ TYPED_TEST(TypedSuperimposeTest, BasicStruct)
 {
   using T = TypeParam;
 
-  auto nums_member   = make_nums_member<T>(nulls_at({3, 6}));
-  auto lists_member  = make_lists_member<T>(nulls_at({4, 5}));
-  auto structs_input = structs{{nums_member, lists_member}, no_nulls()}.release();
+  auto nums_member   = make_nums_member<T>(cudf::test::iterators::nulls_at({3, 6}));
+  auto lists_member  = make_lists_member<T>(cudf::test::iterators::nulls_at({4, 5}));
+  auto structs_input = cudf::test::structs_column_wrapper{{nums_member, lists_member},
+                                                          cudf::test::iterators::no_nulls()}
+                         .release();
 
   // Reset STRUCTs' null-mask. Mark first STRUCT row as null.
   auto structs_view = structs_input->mutable_view();
@@ -376,17 +399,19 @@ TYPED_TEST(TypedSuperimposeTest, BasicStruct)
 
   // At this point, the STRUCT nulls aren't pushed down to members,
   // even though the parent null-mask was modified.
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(structs_view.child(0), make_nums_member<T>(nulls_at({3, 6})));
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(structs_view.child(1),
-                                      make_lists_member<T>(nulls_at({4, 5})));
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(structs_view.child(0),
+                                      make_nums_member<T>(cudf::test::iterators::nulls_at({3, 6})));
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+    structs_view.child(1), make_lists_member<T>(cudf::test::iterators::nulls_at({4, 5})));
 
   auto [output, backing_buffers] = cudf::structs::detail::superimpose_parent_nulls(structs_view);
 
   // After superimpose_parent_nulls(), the struct nulls (i.e. at index-0) should have been pushed
   // down to the children. All members should have nulls at row-index 0.
-  auto expected_nums_member    = make_nums_member<T>(nulls_at({0, 3, 6}));
-  auto expected_lists_member   = make_lists_member<T>(nulls_at({0, 4, 5}));
-  auto expected_structs_output = structs{{expected_nums_member, expected_lists_member}, null_at(0)};
+  auto expected_nums_member    = make_nums_member<T>(cudf::test::iterators::nulls_at({0, 3, 6}));
+  auto expected_lists_member   = make_lists_member<T>(cudf::test::iterators::nulls_at({0, 4, 5}));
+  auto expected_structs_output = cudf::test::structs_column_wrapper{
+    {expected_nums_member, expected_lists_member}, cudf::test::iterators::null_at(0)};
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(output, expected_structs_output);
 }
@@ -398,18 +423,21 @@ TYPED_TEST(TypedSuperimposeTest, NonNullableParentStruct)
 
   using T = TypeParam;
 
-  auto nums_member   = make_nums_member<T>(nulls_at({3, 6}));
-  auto lists_member  = make_lists_member<T>(nulls_at({4, 5}));
-  auto structs_input = structs{{nums_member, lists_member}, no_nulls()}.release();
+  auto nums_member   = make_nums_member<T>(cudf::test::iterators::nulls_at({3, 6}));
+  auto lists_member  = make_lists_member<T>(cudf::test::iterators::nulls_at({4, 5}));
+  auto structs_input = cudf::test::structs_column_wrapper{{nums_member, lists_member},
+                                                          cudf::test::iterators::no_nulls()}
+                         .release();
 
   auto [output, backing_buffers] =
     cudf::structs::detail::superimpose_parent_nulls(structs_input->view());
 
   // After superimpose_parent_nulls(), none of the child structs should have changed,
   // because the parent had no nulls to begin with.
-  auto expected_nums_member    = make_nums_member<T>(nulls_at({3, 6}));
-  auto expected_lists_member   = make_lists_member<T>(nulls_at({4, 5}));
-  auto expected_structs_output = structs{{expected_nums_member, expected_lists_member}, no_nulls()};
+  auto expected_nums_member    = make_nums_member<T>(cudf::test::iterators::nulls_at({3, 6}));
+  auto expected_lists_member   = make_lists_member<T>(cudf::test::iterators::nulls_at({4, 5}));
+  auto expected_structs_output = cudf::test::structs_column_wrapper{
+    {expected_nums_member, expected_lists_member}, cudf::test::iterators::no_nulls()};
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(output, expected_structs_output);
 }
@@ -422,26 +450,30 @@ TYPED_TEST(TypedSuperimposeTest, NestedStruct_ChildNullable_ParentNonNullable)
 
   using T = TypeParam;
 
-  auto nums_member          = make_nums_member<T>(nulls_at({3, 6}));
-  auto lists_member         = make_lists_member<T>(nulls_at({4, 5}));
+  auto nums_member          = make_nums_member<T>(cudf::test::iterators::nulls_at({3, 6}));
+  auto lists_member         = make_lists_member<T>(cudf::test::iterators::nulls_at({4, 5}));
   auto outer_struct_members = std::vector<std::unique_ptr<cudf::column>>{};
-  outer_struct_members.push_back(structs{{nums_member, lists_member}, no_nulls()}.release());
+  outer_struct_members.push_back(cudf::test::structs_column_wrapper{
+    {nums_member, lists_member}, cudf::test::iterators::no_nulls()}
+                                   .release());
 
   // Reset STRUCTs' null-mask. Mark first STRUCT row as null.
   auto structs_view = outer_struct_members.back()->mutable_view();
   cudf::detail::set_null_mask(structs_view.null_mask(), 0, 1, false);
 
-  auto structs_of_structs = structs{std::move(outer_struct_members)}.release();
+  auto structs_of_structs =
+    cudf::test::structs_column_wrapper{std::move(outer_struct_members)}.release();
 
   auto [output, backing_buffers] =
     cudf::structs::detail::superimpose_parent_nulls(structs_of_structs->view());
 
   // After superimpose_parent_nulls(), outer-struct column should not have pushed nulls to child
   // structs. But the child struct column must push its nulls to its own children.
-  auto expected_nums_member  = make_nums_member<T>(nulls_at({0, 3, 6}));
-  auto expected_lists_member = make_lists_member<T>(nulls_at({0, 4, 5}));
-  auto expected_structs      = structs{{expected_nums_member, expected_lists_member}, null_at(0)};
-  auto expected_structs_of_structs = structs{{expected_structs}};
+  auto expected_nums_member  = make_nums_member<T>(cudf::test::iterators::nulls_at({0, 3, 6}));
+  auto expected_lists_member = make_lists_member<T>(cudf::test::iterators::nulls_at({0, 4, 5}));
+  auto expected_structs      = cudf::test::structs_column_wrapper{
+    {expected_nums_member, expected_lists_member}, cudf::test::iterators::null_at(0)};
+  auto expected_structs_of_structs = cudf::test::structs_column_wrapper{{expected_structs}};
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(output, expected_structs_of_structs);
 }
@@ -454,18 +486,21 @@ TYPED_TEST(TypedSuperimposeTest, NestedStruct_ChildNullable_ParentNullable)
 
   using T = TypeParam;
 
-  auto nums_member          = make_nums_member<T>(nulls_at({3, 6}));
-  auto lists_member         = make_lists_member<T>(nulls_at({4, 5}));
+  auto nums_member          = make_nums_member<T>(cudf::test::iterators::nulls_at({3, 6}));
+  auto lists_member         = make_lists_member<T>(cudf::test::iterators::nulls_at({4, 5}));
   auto outer_struct_members = std::vector<std::unique_ptr<cudf::column>>{};
-  outer_struct_members.push_back(structs{{nums_member, lists_member}, no_nulls()}.release());
+  outer_struct_members.push_back(cudf::test::structs_column_wrapper{
+    {nums_member, lists_member}, cudf::test::iterators::no_nulls()}
+                                   .release());
 
   // Reset STRUCTs' null-mask. Mark first STRUCT row as null.
   auto structs_view = outer_struct_members.back()->mutable_view();
   auto num_rows     = structs_view.size();
   cudf::detail::set_null_mask(structs_view.null_mask(), 0, 1, false);
 
-  auto structs_of_structs =
-    structs{std::move(outer_struct_members), std::vector<bool>(num_rows, true)}.release();
+  auto structs_of_structs = cudf::test::structs_column_wrapper{std::move(outer_struct_members),
+                                                               std::vector<bool>(num_rows, true)}
+                              .release();
 
   // Modify STRUCT-of-STRUCT's null-mask. Mark second STRUCT row as null.
   auto structs_of_structs_view = structs_of_structs->mutable_view();
@@ -476,10 +511,12 @@ TYPED_TEST(TypedSuperimposeTest, NestedStruct_ChildNullable_ParentNullable)
 
   // After superimpose_parent_nulls(), outer-struct column should not have pushed nulls to child
   // structs. But the child struct column must push its nulls to its own children.
-  auto expected_nums_member  = make_nums_member<T>(nulls_at({0, 1, 3, 6}));
-  auto expected_lists_member = make_lists_member<T>(nulls_at({0, 1, 4, 5}));
-  auto expected_structs = structs{{expected_nums_member, expected_lists_member}, nulls_at({0, 1})};
-  auto expected_structs_of_structs = structs{{expected_structs}, null_at(1)};
+  auto expected_nums_member  = make_nums_member<T>(cudf::test::iterators::nulls_at({0, 1, 3, 6}));
+  auto expected_lists_member = make_lists_member<T>(cudf::test::iterators::nulls_at({0, 1, 4, 5}));
+  auto expected_structs      = cudf::test::structs_column_wrapper{
+    {expected_nums_member, expected_lists_member}, cudf::test::iterators::nulls_at({0, 1})};
+  auto expected_structs_of_structs =
+    cudf::test::structs_column_wrapper{{expected_structs}, cudf::test::iterators::null_at(1)};
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(output, expected_structs_of_structs);
 }
@@ -489,7 +526,7 @@ cudf::column_view slice_off_first_and_last_rows(cudf::column_view const& col)
   return cudf::slice(col, {1, col.size() - 1})[0];
 }
 
-void mark_row_as_null(cudf::mutable_column_view const& col, size_type row_index)
+void mark_row_as_null(cudf::mutable_column_view const& col, cudf::size_type row_index)
 {
   cudf::detail::set_null_mask(col.null_mask(), row_index, row_index + 1, false);
 }
@@ -502,9 +539,11 @@ TYPED_TEST(TypedSuperimposeTest, Struct_Sliced)
 
   using T = TypeParam;
 
-  auto nums_member    = make_nums_member<T>(nulls_at({3, 6}));
-  auto lists_member   = make_lists_member<T>(nulls_at({4, 5}));
-  auto structs_column = structs{{nums_member, lists_member}, no_nulls()}.release();
+  auto nums_member    = make_nums_member<T>(cudf::test::iterators::nulls_at({3, 6}));
+  auto lists_member   = make_lists_member<T>(cudf::test::iterators::nulls_at({4, 5}));
+  auto structs_column = cudf::test::structs_column_wrapper{{nums_member, lists_member},
+                                                           cudf::test::iterators::no_nulls()}
+                          .release();
 
   // Reset STRUCTs' null-mask. Mark second STRUCT row as null.
   mark_row_as_null(structs_column->mutable_view(), 1);
@@ -531,10 +570,11 @@ TYPED_TEST(TypedSuperimposeTest, Struct_Sliced)
 
   // Construct expected columns using structs_column_wrapper, which should push the parent nulls
   // down automatically. Then, slice() off the ends.
-  auto expected_nums             = make_nums_member<T>(nulls_at({1, 3, 6}));
-  auto expected_lists            = make_lists_member<T>(nulls_at({1, 4, 5}));
-  auto expected_unsliced_structs = structs{{expected_nums, expected_lists}, nulls_at({1})};
-  auto expected_structs          = slice_off_first_and_last_rows(expected_unsliced_structs);
+  auto expected_nums             = make_nums_member<T>(cudf::test::iterators::nulls_at({1, 3, 6}));
+  auto expected_lists            = make_lists_member<T>(cudf::test::iterators::nulls_at({1, 4, 5}));
+  auto expected_unsliced_structs = cudf::test::structs_column_wrapper{
+    {expected_nums, expected_lists}, cudf::test::iterators::nulls_at({1})};
+  auto expected_structs = slice_off_first_and_last_rows(expected_unsliced_structs);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(output, expected_structs);
 }
@@ -547,10 +587,13 @@ TYPED_TEST(TypedSuperimposeTest, NestedStruct_Sliced)
 
   using T = TypeParam;
 
-  auto nums_member           = make_nums_member<T>(nulls_at({3, 6}));
-  auto lists_member          = make_lists_member<T>(nulls_at({4, 5}));
-  auto structs_column        = structs{{nums_member, lists_member}, null_at(1)};
-  auto struct_structs_column = structs{{structs_column}, no_nulls()}.release();
+  auto nums_member    = make_nums_member<T>(cudf::test::iterators::nulls_at({3, 6}));
+  auto lists_member   = make_lists_member<T>(cudf::test::iterators::nulls_at({4, 5}));
+  auto structs_column = cudf::test::structs_column_wrapper{{nums_member, lists_member},
+                                                           cudf::test::iterators::null_at(1)};
+  auto struct_structs_column =
+    cudf::test::structs_column_wrapper{{structs_column}, cudf::test::iterators::no_nulls()}
+      .release();
 
   // Reset STRUCT<STRUCT>'s null-mask. Mark third row as null.
   mark_row_as_null(struct_structs_column->mutable_view(), 2);
@@ -580,13 +623,13 @@ TYPED_TEST(TypedSuperimposeTest, NestedStruct_Sliced)
 
   // Construct expected columns using structs_column_wrapper, which should push the parent nulls
   // down automatically. Then, slice() off the ends.
-  auto expected_nums           = make_nums_member<T>(nulls_at({3, 6}));
-  auto expected_lists          = make_lists_member<T>(nulls_at({4, 5}));
-  auto expected_structs        = structs{{expected_nums, expected_lists}, nulls_at({1})};
-  auto expected_struct_structs = structs{{expected_structs}, null_at(2)};
+  auto expected_nums    = make_nums_member<T>(cudf::test::iterators::nulls_at({3, 6}));
+  auto expected_lists   = make_lists_member<T>(cudf::test::iterators::nulls_at({4, 5}));
+  auto expected_structs = cudf::test::structs_column_wrapper{{expected_nums, expected_lists},
+                                                             cudf::test::iterators::nulls_at({1})};
+  auto expected_struct_structs =
+    cudf::test::structs_column_wrapper{{expected_structs}, cudf::test::iterators::null_at(2)};
   auto expected_sliced_structs = slice_off_first_and_last_rows(expected_struct_structs);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(output, expected_sliced_structs);
 }
-
-}  // namespace cudf::test


### PR DESCRIPTION
## Description
Fixes structs and lists gtests source files coded in namespace `cudf::test`
These are the only 2 problem files for this in `cpp/tests/structs` and `cpp/tests/lists` and so will make those two directories complete. 
No function or test has changed just the source code reworked per namespaces.

Reference #11734

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
