### PR TITLE
Accept const refs instead of const unique_ptr refs in reduce and scan APIs.

### DIFF
--- a/cpp/benchmarks/reduction/anyall.cpp
+++ b/cpp/benchmarks/reduction/anyall.cpp
@@ -41,7 +41,7 @@ void BM_reduction_anyall(benchmark::State& state,
 
   for (auto _ : state) {
     cuda_event_timer timer(state, true);
-    auto result = cudf::reduce(*values, agg, output_dtype);
+    auto result = cudf::reduce(*values, *agg, output_dtype);
   }
 }
 

--- a/cpp/benchmarks/reduction/dictionary.cpp
+++ b/cpp/benchmarks/reduction/dictionary.cpp
@@ -51,7 +51,7 @@ void BM_reduction_dictionary(benchmark::State& state,
 
   for (auto _ : state) {
     cuda_event_timer timer(state, true);
-    auto result = cudf::reduce(*values, agg, output_dtype);
+    auto result = cudf::reduce(*values, *agg, output_dtype);
   }
 }
 

--- a/cpp/benchmarks/reduction/reduce.cpp
+++ b/cpp/benchmarks/reduction/reduce.cpp
@@ -45,7 +45,7 @@ void BM_reduction(benchmark::State& state, std::unique_ptr<cudf::reduce_aggregat
 
   for (auto _ : state) {
     cuda_event_timer timer(state, true);
-    auto result = cudf::reduce(*input_column, agg, output_dtype);
+    auto result = cudf::reduce(*input_column, *agg, output_dtype);
   }
 }
 

--- a/cpp/benchmarks/reduction/scan.cpp
+++ b/cpp/benchmarks/reduction/scan.cpp
@@ -38,7 +38,7 @@ static void BM_reduction_scan(benchmark::State& state, bool include_nulls)
   for (auto _ : state) {
     cuda_event_timer timer(state, true);
     auto result = cudf::scan(
-      *column, cudf::make_min_aggregation<cudf::scan_aggregation>(), cudf::scan_type::INCLUSIVE);
+      *column, *cudf::make_min_aggregation<cudf::scan_aggregation>(), cudf::scan_type::INCLUSIVE);
   }
 }
 

--- a/cpp/include/cudf/detail/scan.hpp
+++ b/cpp/include/cudf/detail/scan.hpp
@@ -38,7 +38,7 @@ namespace detail {
  *                           `agg` is not Min or Max.
  *
  * @param input The input column view for the scan.
- * @param agg Aggregation operator applied by the scan.
+ * @param agg Aggregation operator applied by the scan
  * @param null_handling Exclude null values when computing the result if null_policy::EXCLUDE.
  *                      Include nulls if null_policy::INCLUDE. Any operation with a null results in
  *                      a null.

--- a/cpp/include/cudf/detail/scan.hpp
+++ b/cpp/include/cudf/detail/scan.hpp
@@ -38,7 +38,7 @@ namespace detail {
  *                           `agg` is not Min or Max.
  *
  * @param input The input column view for the scan.
- * @param agg aggregation operator applied by the scan.
+ * @param agg Aggregation operator applied by the scan.
  * @param null_handling Exclude null values when computing the result if null_policy::EXCLUDE.
  *                      Include nulls if null_policy::INCLUDE. Any operation with a null results in
  *                      a null.
@@ -64,7 +64,7 @@ std::unique_ptr<column> scan_exclusive(column_view const& input,
  *                           but the `agg` is not Min or Max.
  *
  * @param input The input column view for the scan.
- * @param agg aggregation operator applied by the scan.
+ * @param agg Aggregation operator applied by the scan
  * @param null_handling Exclude null values when computing the result if null_policy::EXCLUDE.
  *                      Include nulls if null_policy::INCLUDE. Any operation with a null results in
  *                      a null.

--- a/cpp/include/cudf/detail/scan.hpp
+++ b/cpp/include/cudf/detail/scan.hpp
@@ -38,7 +38,7 @@ namespace detail {
  *                           `agg` is not Min or Max.
  *
  * @param input The input column view for the scan.
- * @param agg unique_ptr to aggregation operator applied by the scan.
+ * @param agg aggregation operator applied by the scan.
  * @param null_handling Exclude null values when computing the result if null_policy::EXCLUDE.
  *                      Include nulls if null_policy::INCLUDE. Any operation with a null results in
  *                      a null.
@@ -47,7 +47,7 @@ namespace detail {
  * @returns Column with scan results.
  */
 std::unique_ptr<column> scan_exclusive(column_view const& input,
-                                       std::unique_ptr<scan_aggregation> const& agg,
+                                       scan_aggregation const& agg,
                                        null_policy null_handling,
                                        rmm::cuda_stream_view stream,
                                        rmm::mr::device_memory_resource* mr);
@@ -64,7 +64,7 @@ std::unique_ptr<column> scan_exclusive(column_view const& input,
  *                           but the `agg` is not Min or Max.
  *
  * @param input The input column view for the scan.
- * @param agg unique_ptr to aggregation operator applied by the scan.
+ * @param agg aggregation operator applied by the scan.
  * @param null_handling Exclude null values when computing the result if null_policy::EXCLUDE.
  *                      Include nulls if null_policy::INCLUDE. Any operation with a null results in
  *                      a null.
@@ -73,7 +73,7 @@ std::unique_ptr<column> scan_exclusive(column_view const& input,
  * @returns Column with scan results.
  */
 std::unique_ptr<column> scan_inclusive(column_view const& input,
-                                       std::unique_ptr<scan_aggregation> const& agg,
+                                       scan_aggregation const& agg,
                                        null_policy null_handling,
                                        rmm::cuda_stream_view stream,
                                        rmm::mr::device_memory_resource* mr);

--- a/cpp/include/cudf/reduction.hpp
+++ b/cpp/include/cudf/reduction.hpp
@@ -72,7 +72,7 @@ enum class scan_type : bool { INCLUSIVE, EXCLUSIVE };
  */
 std::unique_ptr<scalar> reduce(
   column_view const& col,
-  std::unique_ptr<reduce_aggregation> const& agg,
+  reduce_aggregation const& agg,
   data_type output_dtype,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
@@ -89,7 +89,7 @@ std::unique_ptr<scalar> reduce(
  */
 std::unique_ptr<scalar> reduce(
   column_view const& col,
-  std::unique_ptr<reduce_aggregation> const& agg,
+  reduce_aggregation const& agg,
   data_type output_dtype,
   std::optional<std::reference_wrapper<scalar const>> init,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
@@ -187,7 +187,7 @@ std::unique_ptr<column> segmented_reduce(
  */
 std::unique_ptr<column> scan(
   const column_view& input,
-  std::unique_ptr<scan_aggregation> const& agg,
+  scan_aggregation const& agg,
   scan_type inclusive,
   null_policy null_handling           = null_policy::EXCLUDE,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -49,7 +49,7 @@ struct reduce_dispatch_functor {
   }
 
   template <aggregation::Kind k>
-  std::unique_ptr<scalar> operator()(std::unique_ptr<reduce_aggregation> const& agg)
+  std::unique_ptr<scalar> operator()(reduce_aggregation const& agg)
   {
     switch (k) {
       case aggregation::SUM: return reduction::sum(col, output_dtype, init, stream, mr);
@@ -62,12 +62,12 @@ struct reduce_dispatch_functor {
         return reduction::sum_of_squares(col, output_dtype, stream, mr);
       case aggregation::MEAN: return reduction::mean(col, output_dtype, stream, mr);
       case aggregation::VARIANCE: {
-        auto var_agg = dynamic_cast<var_aggregation const*>(agg.get());
-        return reduction::variance(col, output_dtype, var_agg->_ddof, stream, mr);
+        auto var_agg = static_cast<var_aggregation const&>(agg);
+        return reduction::variance(col, output_dtype, var_agg._ddof, stream, mr);
       }
       case aggregation::STD: {
-        auto var_agg = dynamic_cast<std_aggregation const*>(agg.get());
-        return reduction::standard_deviation(col, output_dtype, var_agg->_ddof, stream, mr);
+        auto var_agg = static_cast<std_aggregation const&>(agg);
+        return reduction::standard_deviation(col, output_dtype, var_agg._ddof, stream, mr);
       }
       case aggregation::MEDIAN: {
         auto sorted_indices = sorted_order(table_view{{col}}, {}, {null_order::AFTER}, stream);
@@ -78,60 +78,59 @@ struct reduce_dispatch_functor {
         return get_element(*col_ptr, 0, stream, mr);
       }
       case aggregation::QUANTILE: {
-        auto quantile_agg = dynamic_cast<quantile_aggregation const*>(agg.get());
-        CUDF_EXPECTS(quantile_agg->_quantiles.size() == 1,
+        auto quantile_agg = static_cast<quantile_aggregation const&>(agg);
+        CUDF_EXPECTS(quantile_agg._quantiles.size() == 1,
                      "Reduction quantile accepts only one quantile value");
         auto sorted_indices = sorted_order(table_view{{col}}, {}, {null_order::AFTER}, stream);
         auto valid_sorted_indices =
           split(*sorted_indices, {col.size() - col.null_count()}, stream)[0];
 
         auto col_ptr = quantile(col,
-                                quantile_agg->_quantiles,
-                                quantile_agg->_interpolation,
+                                quantile_agg._quantiles,
+                                quantile_agg._interpolation,
                                 valid_sorted_indices,
                                 true,
                                 stream);
         return get_element(*col_ptr, 0, stream, mr);
       }
       case aggregation::NUNIQUE: {
-        auto nunique_agg = dynamic_cast<nunique_aggregation const*>(agg.get());
+        auto nunique_agg = static_cast<nunique_aggregation const&>(agg);
         return make_fixed_width_scalar(
-          detail::distinct_count(
-            col, nunique_agg->_null_handling, nan_policy::NAN_IS_VALID, stream),
+          detail::distinct_count(col, nunique_agg._null_handling, nan_policy::NAN_IS_VALID, stream),
           stream,
           mr);
       }
       case aggregation::NTH_ELEMENT: {
-        auto nth_agg = dynamic_cast<nth_element_aggregation const*>(agg.get());
-        return reduction::nth_element(col, nth_agg->_n, nth_agg->_null_handling, stream, mr);
+        auto nth_agg = static_cast<nth_element_aggregation const&>(agg);
+        return reduction::nth_element(col, nth_agg._n, nth_agg._null_handling, stream, mr);
       }
       case aggregation::COLLECT_LIST: {
-        auto col_agg = dynamic_cast<collect_list_aggregation const*>(agg.get());
-        return reduction::collect_list(col, col_agg->_null_handling, stream, mr);
+        auto col_agg = static_cast<collect_list_aggregation const&>(agg);
+        return reduction::collect_list(col, col_agg._null_handling, stream, mr);
       }
       case aggregation::COLLECT_SET: {
-        auto col_agg = dynamic_cast<collect_set_aggregation const*>(agg.get());
+        auto col_agg = static_cast<collect_set_aggregation const&>(agg);
         return reduction::collect_set(
-          col, col_agg->_null_handling, col_agg->_nulls_equal, col_agg->_nans_equal, stream, mr);
+          col, col_agg._null_handling, col_agg._nulls_equal, col_agg._nans_equal, stream, mr);
       }
       case aggregation::MERGE_LISTS: {
         return reduction::merge_lists(col, stream, mr);
       }
       case aggregation::MERGE_SETS: {
-        auto col_agg = dynamic_cast<merge_sets_aggregation const*>(agg.get());
-        return reduction::merge_sets(col, col_agg->_nulls_equal, col_agg->_nans_equal, stream, mr);
+        auto col_agg = static_cast<merge_sets_aggregation const&>(agg);
+        return reduction::merge_sets(col, col_agg._nulls_equal, col_agg._nans_equal, stream, mr);
       }
       case aggregation::TDIGEST: {
         CUDF_EXPECTS(output_dtype.id() == type_id::STRUCT,
                      "Tdigest aggregations expect output type to be STRUCT");
-        auto td_agg = dynamic_cast<tdigest_aggregation const*>(agg.get());
-        return detail::tdigest::reduce_tdigest(col, td_agg->max_centroids, stream, mr);
+        auto td_agg = static_cast<tdigest_aggregation const&>(agg);
+        return detail::tdigest::reduce_tdigest(col, td_agg.max_centroids, stream, mr);
       }
       case aggregation::MERGE_TDIGEST: {
         CUDF_EXPECTS(output_dtype.id() == type_id::STRUCT,
                      "Tdigest aggregations expect output type to be STRUCT");
-        auto td_agg = dynamic_cast<merge_tdigest_aggregation const*>(agg.get());
-        return detail::tdigest::reduce_merge_tdigest(col, td_agg->max_centroids, stream, mr);
+        auto td_agg = static_cast<merge_tdigest_aggregation const&>(agg);
+        return detail::tdigest::reduce_merge_tdigest(col, td_agg.max_centroids, stream, mr);
       }
       default: CUDF_FAIL("Unsupported reduction operator");
     }
@@ -140,7 +139,7 @@ struct reduce_dispatch_functor {
 
 std::unique_ptr<scalar> reduce(
   column_view const& col,
-  std::unique_ptr<reduce_aggregation> const& agg,
+  reduce_aggregation const& agg,
   data_type output_dtype,
   std::optional<std::reference_wrapper<scalar const>> init,
   rmm::cuda_stream_view stream        = cudf::default_stream_value,
@@ -148,16 +147,16 @@ std::unique_ptr<scalar> reduce(
 {
   CUDF_EXPECTS(!init.has_value() || col.type() == init.value().get().type(),
                "column and initial value must be the same type");
-  if (init.has_value() && !(agg->kind == aggregation::SUM || agg->kind == aggregation::PRODUCT ||
-                            agg->kind == aggregation::MIN || agg->kind == aggregation::MAX ||
-                            agg->kind == aggregation::ANY || agg->kind == aggregation::ALL)) {
+  if (init.has_value() && !(agg.kind == aggregation::SUM || agg.kind == aggregation::PRODUCT ||
+                            agg.kind == aggregation::MIN || agg.kind == aggregation::MAX ||
+                            agg.kind == aggregation::ANY || agg.kind == aggregation::ALL)) {
     CUDF_FAIL(
       "Initial value is only supported for SUM, PRODUCT, MIN, MAX, ANY, and ALL aggregation types");
   }
   // Returns default scalar if input column is non-valid. In terms of nested columns, we need to
   // handcraft the default scalar with input column.
   if (col.size() <= col.null_count()) {
-    if (agg->kind == aggregation::TDIGEST || agg->kind == aggregation::MERGE_TDIGEST) {
+    if (agg.kind == aggregation::TDIGEST || agg.kind == aggregation::MERGE_TDIGEST) {
       return detail::tdigest::make_empty_tdigest_scalar();
     }
     if (col.type().id() == type_id::EMPTY || col.type() != output_dtype) {
@@ -176,12 +175,12 @@ std::unique_ptr<scalar> reduce(
   }
 
   return aggregation_dispatcher(
-    agg->kind, reduce_dispatch_functor{col, output_dtype, init, stream, mr}, agg);
+    agg.kind, reduce_dispatch_functor{col, output_dtype, init, stream, mr}, agg);
 }
 }  // namespace detail
 
 std::unique_ptr<scalar> reduce(column_view const& col,
-                               std::unique_ptr<reduce_aggregation> const& agg,
+                               reduce_aggregation const& agg,
                                data_type output_dtype,
                                rmm::mr::device_memory_resource* mr)
 {
@@ -190,7 +189,7 @@ std::unique_ptr<scalar> reduce(column_view const& col,
 }
 
 std::unique_ptr<scalar> reduce(column_view const& col,
-                               std::unique_ptr<reduce_aggregation> const& agg,
+                               reduce_aggregation const& agg,
                                data_type output_dtype,
                                std::optional<std::reference_wrapper<scalar const>> init,
                                rmm::mr::device_memory_resource* mr)

--- a/cpp/src/reductions/scan/scan.cpp
+++ b/cpp/src/reductions/scan/scan.cpp
@@ -25,16 +25,16 @@ namespace cudf {
 
 namespace detail {
 std::unique_ptr<column> scan(column_view const& input,
-                             std::unique_ptr<scan_aggregation> const& agg,
+                             scan_aggregation const& agg,
                              scan_type inclusive,
                              null_policy null_handling,
                              rmm::cuda_stream_view stream,
                              rmm::mr::device_memory_resource* mr)
 {
-  if (agg->kind == aggregation::RANK) {
+  if (agg.kind == aggregation::RANK) {
     CUDF_EXPECTS(inclusive == scan_type::INCLUSIVE,
                  "Rank aggregation operator requires an inclusive scan");
-    auto const& rank_agg = dynamic_cast<cudf::detail::rank_aggregation const&>(*agg);
+    auto const& rank_agg = static_cast<cudf::detail::rank_aggregation const&>(agg);
     if (rank_agg._method == rank_method::MIN) {
       if (rank_agg._percentage == rank_percentage::NONE) {
         return inclusive_rank_scan(input, stream, mr);
@@ -55,7 +55,7 @@ std::unique_ptr<column> scan(column_view const& input,
 }  // namespace detail
 
 std::unique_ptr<column> scan(column_view const& input,
-                             std::unique_ptr<scan_aggregation> const& agg,
+                             scan_aggregation const& agg,
                              scan_type inclusive,
                              null_policy null_handling,
                              rmm::mr::device_memory_resource* mr)

--- a/cpp/src/reductions/scan/scan.cuh
+++ b/cpp/src/reductions/scan/scan.cuh
@@ -35,12 +35,12 @@ rmm::device_buffer mask_scan(column_view const& input_view,
 
 template <template <typename> typename DispatchFn>
 std::unique_ptr<column> scan_agg_dispatch(const column_view& input,
-                                          std::unique_ptr<scan_aggregation> const& agg,
+                                          scan_aggregation const& agg,
                                           null_policy null_handling,
                                           rmm::cuda_stream_view stream,
                                           rmm::mr::device_memory_resource* mr)
 {
-  switch (agg->kind) {
+  switch (agg.kind) {
     case aggregation::SUM:
       return type_dispatcher<dispatch_storage_type>(
         input.type(), DispatchFn<DeviceSum>(), input, null_handling, stream, mr);

--- a/cpp/src/reductions/scan/scan_exclusive.cu
+++ b/cpp/src/reductions/scan/scan_exclusive.cu
@@ -81,7 +81,7 @@ struct scan_dispatcher {
 }  // namespace
 
 std::unique_ptr<column> scan_exclusive(const column_view& input,
-                                       std::unique_ptr<scan_aggregation> const& agg,
+                                       scan_aggregation const& agg,
                                        null_policy null_handling,
                                        rmm::cuda_stream_view stream,
                                        rmm::mr::device_memory_resource* mr)

--- a/cpp/src/reductions/scan/scan_inclusive.cu
+++ b/cpp/src/reductions/scan/scan_inclusive.cu
@@ -248,7 +248,7 @@ struct scan_dispatcher {
 
 std::unique_ptr<column> scan_inclusive(
   column_view const& input,
-  std::unique_ptr<scan_aggregation> const& agg,
+  scan_aggregation const& agg,
   null_policy null_handling,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())

--- a/cpp/tests/quantiles/percentile_approx_test.cu
+++ b/cpp/tests/quantiles/percentile_approx_test.cu
@@ -184,7 +184,7 @@ void percentile_approx_test(column_view const& _keys,
       // result is a scalar, but we want to extract out the underlying column
       auto scalar_result =
         cudf::reduce(values,
-                     cudf::make_tdigest_aggregation<cudf::reduce_aggregation>(delta),
+                     *cudf::make_tdigest_aggregation<cudf::reduce_aggregation>(delta),
                      data_type{type_id::STRUCT});
       auto tbl = static_cast<cudf::struct_scalar const*>(scalar_result.get())->view();
       std::vector<std::unique_ptr<cudf::column>> cols;

--- a/cpp/tests/reductions/collect_ops_tests.cpp
+++ b/cpp/tests/reductions/collect_ops_tests.cpp
@@ -31,7 +31,7 @@ namespace {
 
 auto collect_set(cudf::column_view const& input, std::unique_ptr<reduce_aggregation> const& agg)
 {
-  auto const result_scalar = cudf::reduce(input, agg, data_type{type_id::LIST});
+  auto const result_scalar = cudf::reduce(input, *agg, data_type{type_id::LIST});
 
   // The results of `collect_set` are unordered thus we need to sort them for comparison.
   auto const result_sorted_table =
@@ -63,20 +63,20 @@ TYPED_TEST(CollectTestFixedWidth, CollectList)
   // null_include without nulls
   fw_wrapper col(values.begin(), values.end());
   auto const ret = cudf::reduce(
-    col, make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
+    col, *make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(col, dynamic_cast<list_scalar*>(ret.get())->view());
 
   // null_include with nulls
   fw_wrapper col_with_null(values.begin(), values.end(), null_mask.begin());
   auto const ret1 = cudf::reduce(
-    col_with_null, make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
+    col_with_null, *make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_with_null, dynamic_cast<list_scalar*>(ret1.get())->view());
 
   // null_exclude with nulls
   fw_wrapper col_null_filtered{{5, 0, -111, 0, 64, 99, -16}};
   auto const ret2 =
     cudf::reduce(col_with_null,
-                 make_collect_list_aggregation<reduce_aggregation>(null_policy::EXCLUDE),
+                 *make_collect_list_aggregation<reduce_aggregation>(null_policy::EXCLUDE),
                  data_type{type_id::LIST});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_null_filtered, dynamic_cast<list_scalar*>(ret2.get())->view());
 }
@@ -128,7 +128,7 @@ TYPED_TEST(CollectTestFixedWidth, MergeLists)
   auto const lists1    = lists_col{{1, 2, 3}, {}, {}, {4}, {5, 6, 7}, {8, 9}, {}};
   auto const expected1 = fw_wrapper{{1, 2, 3, 4, 5, 6, 7, 8, 9}};
   auto const ret1      = cudf::reduce(
-    lists1, make_merge_lists_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
+    lists1, *make_merge_lists_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<list_scalar*>(ret1.get())->view());
 
   // test with nulls
@@ -145,7 +145,7 @@ TYPED_TEST(CollectTestFixedWidth, MergeLists)
   auto const expected2 = fw_wrapper{{1, 2, 3, 0, 4, 0, 5, 0, 0, 0, 6, 7, 8, 9},
                                     {1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1, 1, 1}};
   auto const ret2      = cudf::reduce(
-    lists2, make_merge_lists_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
+    lists2, *make_merge_lists_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<list_scalar*>(ret2.get())->view());
 }
 
@@ -274,14 +274,14 @@ TEST_F(CollectTest, CollectStrings)
 
   // collect_list including nulls
   auto const ret1 = cudf::reduce(
-    s_col, make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
+    s_col, *make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(s_col, dynamic_cast<list_scalar*>(ret1.get())->view());
 
   // collect_list excluding nulls
   auto const expected2 = str_col{"a", "a", "b", "b", "c", "d", "e", "e"};
   auto const ret2 =
     cudf::reduce(s_col,
-                 make_collect_list_aggregation<reduce_aggregation>(null_policy::EXCLUDE),
+                 *make_collect_list_aggregation<reduce_aggregation>(null_policy::EXCLUDE),
                  data_type{type_id::LIST});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<list_scalar*>(ret2.get())->view());
 
@@ -309,7 +309,7 @@ TEST_F(CollectTest, CollectStrings)
   auto const expected5 = str_col{{"a", "a", "b", "b", "null", "c", "null", "d", "null", "e"},
                                  {1, 1, 1, 1, 0, 1, 0, 1, 0, 1}};
   auto const ret5      = cudf::reduce(
-    strings, make_merge_lists_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
+    strings, *make_merge_lists_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected5, dynamic_cast<list_scalar*>(ret5.get())->view());
 
   // merge_sets with null_equal
@@ -332,7 +332,7 @@ TEST_F(CollectTest, CollectEmptys)
   // test collect empty columns
   auto empty = int_col{};
   auto ret   = cudf::reduce(
-    empty, make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
+    empty, *make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(int_col{}, dynamic_cast<list_scalar*>(ret.get())->view());
 
   ret = collect_set(empty, make_collect_set_aggregation<reduce_aggregation>());
@@ -341,7 +341,7 @@ TEST_F(CollectTest, CollectEmptys)
   // test collect all null columns
   auto all_nulls = int_col{{1, 2, 3, 4, 5}, {0, 0, 0, 0, 0}};
   ret            = cudf::reduce(
-    all_nulls, make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
+    all_nulls, *make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(int_col{}, dynamic_cast<list_scalar*>(ret.get())->view());
 
   ret = collect_set(all_nulls, make_collect_set_aggregation<reduce_aggregation>());

--- a/cpp/tests/reductions/list_rank_test.cpp
+++ b/cpp/tests/reductions/list_rank_test.cpp
@@ -27,7 +27,7 @@
 struct ListRankScanTest : public cudf::test::BaseFixture {
   inline void test_ungrouped_rank_scan(cudf::column_view const& input,
                                        cudf::column_view const& expect_vals,
-                                       std::unique_ptr<cudf::scan_aggregation> const& agg,
+                                       cudf::scan_aggregation const& agg,
                                        cudf::null_policy null_handling)
   {
     auto col_out = cudf::scan(input, agg, cudf::scan_type::INCLUSIVE, null_handling);
@@ -46,7 +46,7 @@ TEST_F(ListRankScanTest, BasicList)
   this->test_ungrouped_rank_scan(
     col,
     expected_dense_vals,
-    cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
+    *cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
     cudf::null_policy::INCLUDE);
 }
 
@@ -78,7 +78,7 @@ TEST_F(ListRankScanTest, DeepList)
     this->test_ungrouped_rank_scan(
       col,
       expected_dense_vals,
-      cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
+      *cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
       cudf::null_policy::INCLUDE);
   }
 
@@ -89,7 +89,7 @@ TEST_F(ListRankScanTest, DeepList)
     this->test_ungrouped_rank_scan(
       sliced_col,
       expected_dense_vals,
-      cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
+      *cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
       cudf::null_policy::INCLUDE);
   }
 }
@@ -145,7 +145,7 @@ TEST_F(ListRankScanTest, ListOfStruct)
     this->test_ungrouped_rank_scan(
       list_column,
       expect,
-      cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
+      *cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
       cudf::null_policy::INCLUDE);
   }
 
@@ -157,7 +157,7 @@ TEST_F(ListRankScanTest, ListOfStruct)
     this->test_ungrouped_rank_scan(
       sliced_col,
       expect,
-      cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
+      *cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
       cudf::null_policy::INCLUDE);
   }
 }
@@ -201,7 +201,7 @@ TEST_F(ListRankScanTest, ListOfEmptyStruct)
   this->test_ungrouped_rank_scan(
     *list_column,
     expect,
-    cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
+    *cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
     cudf::null_policy::INCLUDE);
 }
 
@@ -231,6 +231,6 @@ TEST_F(ListRankScanTest, EmptyDeepList)
   this->test_ungrouped_rank_scan(
     *list_column,
     expect,
-    cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
+    *cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE),
     cudf::null_policy::INCLUDE);
 }

--- a/cpp/tests/reductions/rank_tests.cpp
+++ b/cpp/tests/reductions/rank_tests.cpp
@@ -52,7 +52,7 @@ template <typename T>
 struct TypedRankScanTest : BaseScanTest<T> {
   inline void test_ungrouped_rank_scan(cudf::column_view const& input,
                                        cudf::column_view const& expect_vals,
-                                       std::unique_ptr<scan_aggregation> const& agg)
+                                       scan_aggregation const& agg)
   {
     auto col_out = cudf::scan(input, agg, INCLUSIVE_SCAN, INCLUDE_NULLS);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expect_vals, col_out->view());
@@ -90,9 +90,9 @@ TYPED_TEST(TypedRankScanTest, Rank)
                                                    6.0 / 11,
                                                    10.0 / 11,
                                                    11.0 / 11};
-  this->test_ungrouped_rank_scan(*col, expected_dense, dense_rank);
-  this->test_ungrouped_rank_scan(*col, expected_rank, rank);
-  this->test_ungrouped_rank_scan(*col, expected_percent, percent_rank);
+  this->test_ungrouped_rank_scan(*col, expected_dense, *dense_rank);
+  this->test_ungrouped_rank_scan(*col, expected_rank, *rank);
+  this->test_ungrouped_rank_scan(*col, expected_percent, *percent_rank);
 }
 
 TYPED_TEST(TypedRankScanTest, RankWithNulls)
@@ -120,9 +120,9 @@ TYPED_TEST(TypedRankScanTest, RankWithNulls)
                                                    8.0 / 11,
                                                    10.0 / 11,
                                                    11.0 / 11};
-  this->test_ungrouped_rank_scan(*col, expected_dense, dense_rank);
-  this->test_ungrouped_rank_scan(*col, expected_rank, rank);
-  this->test_ungrouped_rank_scan(*col, expected_percent, percent_rank);
+  this->test_ungrouped_rank_scan(*col, expected_dense, *dense_rank);
+  this->test_ungrouped_rank_scan(*col, expected_rank, *rank);
+  this->test_ungrouped_rank_scan(*col, expected_percent, *percent_rank);
 }
 
 namespace {
@@ -172,9 +172,9 @@ TYPED_TEST(TypedRankScanTest, MixedStructs)
                                                    9.0 / 11,
                                                    11.0 / 11};
 
-  this->test_ungrouped_rank_scan(struct_col, expected_dense, dense_rank);
-  this->test_ungrouped_rank_scan(struct_col, expected_rank, rank);
-  this->test_ungrouped_rank_scan(struct_col, expected_percent, percent_rank);
+  this->test_ungrouped_rank_scan(struct_col, expected_dense, *dense_rank);
+  this->test_ungrouped_rank_scan(struct_col, expected_rank, *rank);
+  this->test_ungrouped_rank_scan(struct_col, expected_percent, *percent_rank);
 }
 
 TYPED_TEST(TypedRankScanTest, NestedStructs)
@@ -196,16 +196,16 @@ TYPED_TEST(TypedRankScanTest, NestedStructs)
     return structs_column_wrapper{{col, strings_col, nuther_col}};
   }();
 
-  auto const dense_out      = cudf::scan(nested_col, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
-  auto const dense_expected = cudf::scan(flat_col, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const dense_out      = cudf::scan(nested_col, *dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const dense_expected = cudf::scan(flat_col, *dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_out->view(), dense_expected->view());
 
-  auto const rank_out      = cudf::scan(nested_col, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
-  auto const rank_expected = cudf::scan(flat_col, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const rank_out      = cudf::scan(nested_col, *rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const rank_expected = cudf::scan(flat_col, *rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_out->view(), rank_expected->view());
 
-  auto const percent_out      = cudf::scan(nested_col, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
-  auto const percent_expected = cudf::scan(flat_col, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const percent_out = cudf::scan(nested_col, *percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const percent_expected = cudf::scan(flat_col, *percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(percent_out->view(), percent_expected->view());
 }
 
@@ -220,9 +220,9 @@ TYPED_TEST(TypedRankScanTest, StructsWithNullPushdown)
     auto const expected_null_result = rank_result_col{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
     auto const expected_percent_rank_null_result =
       percent_result_col{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-    auto const dense_out   = cudf::scan(*struct_col, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
-    auto const rank_out    = cudf::scan(*struct_col, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
-    auto const percent_out = cudf::scan(*struct_col, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+    auto const dense_out   = cudf::scan(*struct_col, *dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+    auto const rank_out    = cudf::scan(*struct_col, *rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+    auto const percent_out = cudf::scan(*struct_col, *percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_out->view(), expected_null_result);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_out->view(), expected_null_result);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(percent_out->view(), expected_percent_rank_null_result);
@@ -248,9 +248,9 @@ TYPED_TEST(TypedRankScanTest, StructsWithNullPushdown)
                                                      9.0 / 11,
                                                      9.0 / 11,
                                                      11.0 / 11};
-    auto const dense_out   = cudf::scan(*struct_col, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
-    auto const rank_out    = cudf::scan(*struct_col, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
-    auto const percent_out = cudf::scan(*struct_col, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+    auto const dense_out   = cudf::scan(*struct_col, *dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+    auto const rank_out    = cudf::scan(*struct_col, *rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+    auto const percent_out = cudf::scan(*struct_col, *percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(dense_out->view(), expected_dense);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(rank_out->view(), expected_rank);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(percent_out->view(), expected_percent);
@@ -278,9 +278,9 @@ TEST(RankScanTest, BoolRank)
                                                    3.0 / 11,
                                                    3.0 / 11};
 
-  auto const dense_out   = cudf::scan(vals, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
-  auto const rank_out    = cudf::scan(vals, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
-  auto const percent_out = cudf::scan(vals, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const dense_out   = cudf::scan(vals, *dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const rank_out    = cudf::scan(vals, *rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto const percent_out = cudf::scan(vals, *percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_dense, dense_out->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_rank, rank_out->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_percent, percent_out->view());
@@ -304,9 +304,9 @@ TEST(RankScanTest, BoolRankWithNull)
                                                    8.0 / 11,
                                                    8.0 / 11};
 
-  auto nullable_dense_out   = cudf::scan(vals, dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
-  auto nullable_rank_out    = cudf::scan(vals, rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
-  auto nullable_percent_out = cudf::scan(vals, percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto nullable_dense_out   = cudf::scan(vals, *dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto nullable_rank_out    = cudf::scan(vals, *rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
+  auto nullable_percent_out = cudf::scan(vals, *percent_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_dense, nullable_dense_out->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_rank, nullable_rank_out->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_percent, nullable_percent_out->view());
@@ -316,11 +316,11 @@ TEST(RankScanTest, ExclusiveScan)
 {
   auto const vals = input<uint32_t>{3, 4, 5};
 
-  CUDF_EXPECT_THROW_MESSAGE(cudf::scan(vals, dense_rank, scan_type::EXCLUSIVE, INCLUDE_NULLS),
+  CUDF_EXPECT_THROW_MESSAGE(cudf::scan(vals, *dense_rank, scan_type::EXCLUSIVE, INCLUDE_NULLS),
                             "Rank aggregation operator requires an inclusive scan");
-  CUDF_EXPECT_THROW_MESSAGE(cudf::scan(vals, rank, scan_type::EXCLUSIVE, INCLUDE_NULLS),
+  CUDF_EXPECT_THROW_MESSAGE(cudf::scan(vals, *rank, scan_type::EXCLUSIVE, INCLUDE_NULLS),
                             "Rank aggregation operator requires an inclusive scan");
-  CUDF_EXPECT_THROW_MESSAGE(cudf::scan(vals, percent_rank, scan_type::EXCLUSIVE, INCLUDE_NULLS),
+  CUDF_EXPECT_THROW_MESSAGE(cudf::scan(vals, *percent_rank, scan_type::EXCLUSIVE, INCLUDE_NULLS),
                             "Rank aggregation operator requires an inclusive scan");
 }
 

--- a/cpp/tests/reductions/reduction_tests.cpp
+++ b/cpp/tests/reductions/reduction_tests.cpp
@@ -94,7 +94,7 @@ struct ReductionTest : public cudf::test::BaseFixture {
 
   template <typename T_out>
   std::pair<T_out, bool> reduction_test(cudf::column_view const& underlying_column,
-                                        std::unique_ptr<reduce_aggregation> const& agg,
+                                        reduce_aggregation const& agg,
                                         std::optional<cudf::data_type> _output_dtype = {})
   {
     auto const output_dtype                 = _output_dtype.value_or(underlying_column.type());
@@ -108,7 +108,7 @@ struct ReductionTest : public cudf::test::BaseFixture {
   template <typename T_out>
   std::pair<T_out, bool> reduction_test(cudf::column_view const& underlying_column,
                                         cudf::scalar const& initial_value,
-                                        std::unique_ptr<reduce_aggregation> const& agg,
+                                        reduce_aggregation const& agg,
                                         std::optional<cudf::data_type> _output_dtype = {})
   {
     auto const output_dtype = _output_dtype.value_or(underlying_column.type());
@@ -152,19 +152,19 @@ TYPED_TEST(MinMaxReductionTest, MinMaxTypes)
     v.begin(), v.end(), init_value, [](const T& a, const T& b) { return std::max<T>(a, b); });
 
   EXPECT_EQ(
-    this->template reduction_test<T>(col, cudf::make_min_aggregation<reduce_aggregation>()).first,
+    this->template reduction_test<T>(col, *cudf::make_min_aggregation<reduce_aggregation>()).first,
     expected_min_result);
   EXPECT_EQ(
-    this->template reduction_test<T>(col, cudf::make_max_aggregation<reduce_aggregation>()).first,
+    this->template reduction_test<T>(col, *cudf::make_max_aggregation<reduce_aggregation>()).first,
     expected_max_result);
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col, *init_scalar, cudf::make_min_aggregation<reduce_aggregation>())
+                col, *init_scalar, *cudf::make_min_aggregation<reduce_aggregation>())
               .first,
             expected_min_init_result);
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col, *init_scalar, cudf::make_max_aggregation<reduce_aggregation>())
+                col, *init_scalar, *cudf::make_max_aggregation<reduce_aggregation>())
               .first,
             expected_max_init_result);
 
@@ -194,21 +194,21 @@ TYPED_TEST(MinMaxReductionTest, MinMaxTypes)
     });
 
   EXPECT_EQ(
-    this->template reduction_test<T>(col_nulls, cudf::make_min_aggregation<reduce_aggregation>())
+    this->template reduction_test<T>(col_nulls, *cudf::make_min_aggregation<reduce_aggregation>())
       .first,
     expected_min_null_result);
   EXPECT_EQ(
-    this->template reduction_test<T>(col_nulls, cudf::make_max_aggregation<reduce_aggregation>())
+    this->template reduction_test<T>(col_nulls, *cudf::make_max_aggregation<reduce_aggregation>())
       .first,
     expected_max_null_result);
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col_nulls, *init_scalar, cudf::make_min_aggregation<reduce_aggregation>())
+                col_nulls, *init_scalar, *cudf::make_min_aggregation<reduce_aggregation>())
               .first,
             expected_min_init_null_result);
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col_nulls, *init_scalar, cudf::make_max_aggregation<reduce_aggregation>())
+                col_nulls, *init_scalar, *cudf::make_max_aggregation<reduce_aggregation>())
               .first,
             expected_max_init_null_result);
 
@@ -226,19 +226,19 @@ TYPED_TEST(MinMaxReductionTest, MinMaxTypes)
 
   EXPECT_FALSE(
     this
-      ->template reduction_test<T>(col_all_nulls, cudf::make_min_aggregation<reduce_aggregation>())
+      ->template reduction_test<T>(col_all_nulls, *cudf::make_min_aggregation<reduce_aggregation>())
       .second);
   EXPECT_FALSE(
     this
-      ->template reduction_test<T>(col_all_nulls, cudf::make_max_aggregation<reduce_aggregation>())
+      ->template reduction_test<T>(col_all_nulls, *cudf::make_max_aggregation<reduce_aggregation>())
       .second);
   EXPECT_FALSE(this
                  ->template reduction_test<T>(
-                   col_all_nulls, *init_scalar, cudf::make_min_aggregation<reduce_aggregation>())
+                   col_all_nulls, *init_scalar, *cudf::make_min_aggregation<reduce_aggregation>())
                  .second);
   EXPECT_FALSE(this
                  ->template reduction_test<T>(
-                   col_all_nulls, *init_scalar, cudf::make_max_aggregation<reduce_aggregation>())
+                   col_all_nulls, *init_scalar, *cudf::make_max_aggregation<reduce_aggregation>())
                  .second);
 
   auto all_null_res = cudf::minmax(col_all_nulls);
@@ -271,11 +271,11 @@ TYPED_TEST(SumReductionTest, Sum)
   T expected_value_init = std::accumulate(v.begin(), v.end(), init_value);
 
   EXPECT_EQ(
-    this->template reduction_test<T>(col, cudf::make_sum_aggregation<reduce_aggregation>()).first,
+    this->template reduction_test<T>(col, *cudf::make_sum_aggregation<reduce_aggregation>()).first,
     expected_value);
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col, *init_scalar, cudf::make_sum_aggregation<reduce_aggregation>())
+                col, *init_scalar, *cudf::make_sum_aggregation<reduce_aggregation>())
               .first,
             expected_value_init);
 
@@ -286,12 +286,12 @@ TYPED_TEST(SumReductionTest, Sum)
   init_scalar->set_valid_async(false);
 
   EXPECT_EQ(
-    this->template reduction_test<T>(col_nulls, cudf::make_sum_aggregation<reduce_aggregation>())
+    this->template reduction_test<T>(col_nulls, *cudf::make_sum_aggregation<reduce_aggregation>())
       .first,
     expected_null_value);
   EXPECT_FALSE(this
                  ->template reduction_test<T>(
-                   col_nulls, *init_scalar, cudf::make_sum_aggregation<reduce_aggregation>())
+                   col_nulls, *init_scalar, *cudf::make_sum_aggregation<reduce_aggregation>())
                  .second);
 }
 
@@ -323,12 +323,12 @@ TYPED_TEST(ReductionTest, Product)
   TypeParam expected_value_init = calc_prod_init(v, init_value);
 
   EXPECT_EQ(
-    this->template reduction_test<T>(col, cudf::make_product_aggregation<reduce_aggregation>())
+    this->template reduction_test<T>(col, *cudf::make_product_aggregation<reduce_aggregation>())
       .first,
     expected_value);
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col, *init_scalar, cudf::make_product_aggregation<reduce_aggregation>())
+                col, *init_scalar, *cudf::make_product_aggregation<reduce_aggregation>())
               .first,
             expected_value_init);
 
@@ -340,12 +340,12 @@ TYPED_TEST(ReductionTest, Product)
 
   EXPECT_EQ(
     this
-      ->template reduction_test<T>(col_nulls, cudf::make_product_aggregation<reduce_aggregation>())
+      ->template reduction_test<T>(col_nulls, *cudf::make_product_aggregation<reduce_aggregation>())
       .first,
     expected_null_value);
   EXPECT_FALSE(this
                  ->template reduction_test<T>(
-                   col_nulls, *init_scalar, cudf::make_product_aggregation<reduce_aggregation>())
+                   col_nulls, *init_scalar, *cudf::make_product_aggregation<reduce_aggregation>())
                  .second);
 }
 
@@ -365,11 +365,11 @@ TYPED_TEST(ReductionTest, SumOfSquare)
   cudf::test::fixed_width_column_wrapper<T> col(v.begin(), v.end());
   T expected_value = calc_reduction(v);
 
-  EXPECT_EQ(
-    this
-      ->template reduction_test<T>(col, cudf::make_sum_of_squares_aggregation<reduce_aggregation>())
-      .first,
-    expected_value);
+  EXPECT_EQ(this
+              ->template reduction_test<T>(
+                col, *cudf::make_sum_of_squares_aggregation<reduce_aggregation>())
+              .first,
+            expected_value);
 
   // test with nulls
   cudf::test::fixed_width_column_wrapper<T> col_nulls = construct_null_column(v, host_bools);
@@ -378,7 +378,7 @@ TYPED_TEST(ReductionTest, SumOfSquare)
 
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col_nulls, cudf::make_sum_of_squares_aggregation<reduce_aggregation>())
+                col_nulls, *cudf::make_sum_of_squares_aggregation<reduce_aggregation>())
               .first,
             expected_null_value);
 }
@@ -407,22 +407,22 @@ TYPED_TEST(ReductionAnyAllTest, AnyAllTrueTrue)
 
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                col, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                col, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col, *init_scalar, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                col, *init_scalar, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col, *init_scalar, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                col, *init_scalar, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
 
@@ -432,23 +432,23 @@ TYPED_TEST(ReductionAnyAllTest, AnyAllTrueTrue)
 
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col_nulls, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                col_nulls, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col_nulls, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                col_nulls, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
   EXPECT_FALSE(
     this
       ->template reduction_test<bool>(
-        col_nulls, *init_scalar, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+        col_nulls, *init_scalar, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
       .second);
   EXPECT_FALSE(
     this
       ->template reduction_test<bool>(
-        col_nulls, *init_scalar, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+        col_nulls, *init_scalar, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
       .second);
 }
 
@@ -470,22 +470,22 @@ TYPED_TEST(ReductionAnyAllTest, AnyAllFalseFalse)
 
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                col, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                col, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col, *init_scalar, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                col, *init_scalar, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col, *init_scalar, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                col, *init_scalar, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
 
@@ -495,23 +495,23 @@ TYPED_TEST(ReductionAnyAllTest, AnyAllFalseFalse)
 
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col_nulls, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                col_nulls, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
   EXPECT_EQ(this
               ->template reduction_test<bool>(
-                col_nulls, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                col_nulls, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
               .first,
             expected);
   EXPECT_FALSE(
     this
       ->template reduction_test<bool>(
-        col_nulls, *init_scalar, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+        col_nulls, *init_scalar, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
       .second);
   EXPECT_FALSE(
     this
       ->template reduction_test<bool>(
-        col_nulls, *init_scalar, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+        col_nulls, *init_scalar, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
       .second);
 }
 
@@ -541,7 +541,7 @@ TYPED_TEST(MultiStepReductionTest, Mean)
 
   EXPECT_EQ(this
               ->template reduction_test<double>(col,
-                                                cudf::make_mean_aggregation<reduce_aggregation>(),
+                                                *cudf::make_mean_aggregation<reduce_aggregation>(),
                                                 cudf::data_type(cudf::type_id::FLOAT64))
               .first,
             expected_value);
@@ -556,7 +556,7 @@ TYPED_TEST(MultiStepReductionTest, Mean)
 
   EXPECT_EQ(this
               ->template reduction_test<double>(col_nulls,
-                                                cudf::make_mean_aggregation<reduce_aggregation>(),
+                                                *cudf::make_mean_aggregation<reduce_aggregation>(),
                                                 cudf::data_type(cudf::type_id::FLOAT64))
               .first,
             expected_value_nulls);
@@ -598,11 +598,11 @@ TYPED_TEST(MultiStepReductionTest, DISABLED_var_std)
   auto std_agg    = cudf::make_std_aggregation<reduce_aggregation>(ddof);
 
   EXPECT_EQ(
-    this->template reduction_test<double>(col, var_agg, cudf::data_type(cudf::type_id::FLOAT64))
+    this->template reduction_test<double>(col, *var_agg, cudf::data_type(cudf::type_id::FLOAT64))
       .first,
     var);
   EXPECT_EQ(
-    this->template reduction_test<double>(col, std_agg, cudf::data_type(cudf::type_id::FLOAT64))
+    this->template reduction_test<double>(col, *std_agg, cudf::data_type(cudf::type_id::FLOAT64))
       .first,
     std);
 
@@ -615,16 +615,16 @@ TYPED_TEST(MultiStepReductionTest, DISABLED_var_std)
   double var_nulls = calc_var(replaced_array, valid_count, ddof);
   double std_nulls = std::sqrt(var_nulls);
 
-  EXPECT_EQ(
-    this
-      ->template reduction_test<double>(col_nulls, var_agg, cudf::data_type(cudf::type_id::FLOAT64))
-      .first,
-    var_nulls);
-  EXPECT_EQ(
-    this
-      ->template reduction_test<double>(col_nulls, std_agg, cudf::data_type(cudf::type_id::FLOAT64))
-      .first,
-    std_nulls);
+  EXPECT_EQ(this
+              ->template reduction_test<double>(
+                col_nulls, *var_agg, cudf::data_type(cudf::type_id::FLOAT64))
+              .first,
+            var_nulls);
+  EXPECT_EQ(this
+              ->template reduction_test<double>(
+                col_nulls, *std_agg, cudf::data_type(cudf::type_id::FLOAT64))
+              .first,
+            std_nulls);
 }
 
 // ----------------------------------------------------------------------------
@@ -633,7 +633,7 @@ template <typename T>
 struct ReductionMultiStepErrorCheck : public ReductionTest<T> {
   void reduction_error_check(cudf::test::fixed_width_column_wrapper<T>& col,
                              bool succeeded_condition,
-                             std::unique_ptr<reduce_aggregation> const& agg,
+                             reduce_aggregation const& agg,
                              cudf::data_type output_dtype)
   {
     const cudf::column_view underlying_column = col;
@@ -685,14 +685,14 @@ TYPED_TEST(ReductionMultiStepErrorCheck, DISABLED_ErrorHandling)
     auto var_agg        = cudf::make_variance_aggregation<reduce_aggregation>(ddof);
     auto std_agg        = cudf::make_std_aggregation<reduce_aggregation>(ddof);
     this->reduction_error_check(
-      col, expect_succeed, cudf::make_mean_aggregation<reduce_aggregation>(), dtype);
-    this->reduction_error_check(col, expect_succeed, var_agg, dtype);
-    this->reduction_error_check(col, expect_succeed, std_agg, dtype);
+      col, expect_succeed, *cudf::make_mean_aggregation<reduce_aggregation>(), dtype);
+    this->reduction_error_check(col, expect_succeed, *var_agg, dtype);
+    this->reduction_error_check(col, expect_succeed, *std_agg, dtype);
 
     this->reduction_error_check(
-      col_nulls, expect_succeed, cudf::make_mean_aggregation<reduce_aggregation>(), dtype);
-    this->reduction_error_check(col_nulls, expect_succeed, var_agg, dtype);
-    this->reduction_error_check(col_nulls, expect_succeed, std_agg, dtype);
+      col_nulls, expect_succeed, *cudf::make_mean_aggregation<reduce_aggregation>(), dtype);
+    this->reduction_error_check(col_nulls, expect_succeed, *var_agg, dtype);
+    this->reduction_error_check(col_nulls, expect_succeed, *std_agg, dtype);
     return;
   };
 
@@ -706,7 +706,7 @@ struct ReductionDtypeTest : public cudf::test::BaseFixture {
   void reduction_test(std::vector<int>& int_values,
                       T_out expected_value,
                       bool succeeded_condition,
-                      std::unique_ptr<reduce_aggregation> const& agg,
+                      reduce_aggregation const& agg,
                       cudf::data_type out_dtype,
                       bool expected_overflow = false)
   {
@@ -739,7 +739,7 @@ TEST_F(ReductionDtypeTest, all_null_output)
     cudf::test::fixed_point_column_wrapper<int32_t>{{0, 0, 0}, {0, 0, 0}, numeric::scale_type{-2}}
       .release();
 
-  std::unique_ptr<cudf::scalar> result = cudf::reduce(*col, sum_agg, col->type());
+  std::unique_ptr<cudf::scalar> result = cudf::reduce(*col, *sum_agg, col->type());
   EXPECT_EQ(result->is_valid(), false);
   EXPECT_EQ(result->type().id(), col->type().id());
   EXPECT_EQ(result->type().scale(), col->type().scale());
@@ -757,27 +757,27 @@ TEST_F(ReductionDtypeTest, different_precision)
   this->reduction_test<int8_t, int8_t>(int_values,
                                        static_cast<int8_t>(expected_value),
                                        true,
-                                       sum_agg,
+                                       *sum_agg,
                                        cudf::data_type(cudf::type_id::INT8),
                                        expected_overflow);
 
   this->reduction_test<int8_t, int64_t>(int_values,
                                         static_cast<int64_t>(expected_value),
                                         true,
-                                        sum_agg,
+                                        *sum_agg,
                                         cudf::data_type(cudf::type_id::INT64));
 
   this->reduction_test<int8_t, double>(int_values,
                                        static_cast<double>(expected_value),
                                        true,
-                                       sum_agg,
+                                       *sum_agg,
                                        cudf::data_type(cudf::type_id::FLOAT64));
 
   // down cast (over flow)
   this->reduction_test<double, int8_t>(int_values,
                                        static_cast<int8_t>(expected_value),
                                        true,
-                                       sum_agg,
+                                       *sum_agg,
                                        cudf::data_type(cudf::type_id::INT8),
                                        expected_overflow);
 
@@ -785,7 +785,7 @@ TEST_F(ReductionDtypeTest, different_precision)
   this->reduction_test<double, int16_t>(int_values,
                                         static_cast<int16_t>(expected_value),
                                         true,
-                                        sum_agg,
+                                        *sum_agg,
                                         cudf::data_type(cudf::type_id::INT16));
 
   // not supported case:
@@ -794,21 +794,21 @@ TEST_F(ReductionDtypeTest, different_precision)
     int_values,
     cudf::timestamp_s{cudf::duration_s(expected_value)},
     false,
-    sum_agg,
+    *sum_agg,
     cudf::data_type(cudf::type_id::TIMESTAMP_SECONDS));
 
   this->reduction_test<cudf::timestamp_s, cudf::timestamp_ns>(
     int_values,
     cudf::timestamp_ns{cudf::duration_ns(expected_value)},
     false,
-    sum_agg,
+    *sum_agg,
     cudf::data_type(cudf::type_id::TIMESTAMP_NANOSECONDS));
 
   this->reduction_test<int8_t, cudf::timestamp_us>(
     int_values,
     cudf::timestamp_us{cudf::duration_us(expected_value)},
     false,
-    sum_agg,
+    *sum_agg,
     cudf::data_type(cudf::type_id::TIMESTAMP_MICROSECONDS));
 
   std::vector<bool> v = convert_values<bool>(int_values);
@@ -817,46 +817,49 @@ TEST_F(ReductionDtypeTest, different_precision)
   // it's an integer/float sum of ones and zeros.
   int expected = std::accumulate(v.begin(), v.end(), int{0});
 
-  this->reduction_test<bool, int8_t>(
-    int_values, static_cast<int8_t>(expected), true, sum_agg, cudf::data_type(cudf::type_id::INT8));
+  this->reduction_test<bool, int8_t>(int_values,
+                                     static_cast<int8_t>(expected),
+                                     true,
+                                     *sum_agg,
+                                     cudf::data_type(cudf::type_id::INT8));
   this->reduction_test<bool, int16_t>(int_values,
                                       static_cast<int16_t>(expected),
                                       true,
-                                      sum_agg,
+                                      *sum_agg,
                                       cudf::data_type(cudf::type_id::INT16));
   this->reduction_test<bool, int32_t>(int_values,
                                       static_cast<int32_t>(expected),
                                       true,
-                                      sum_agg,
+                                      *sum_agg,
                                       cudf::data_type(cudf::type_id::INT32));
   this->reduction_test<bool, int64_t>(int_values,
                                       static_cast<int64_t>(expected),
                                       true,
-                                      sum_agg,
+                                      *sum_agg,
                                       cudf::data_type(cudf::type_id::INT64));
   this->reduction_test<bool, float>(int_values,
                                     static_cast<float>(expected),
                                     true,
-                                    sum_agg,
+                                    *sum_agg,
                                     cudf::data_type(cudf::type_id::FLOAT32));
   this->reduction_test<bool, double>(int_values,
                                      static_cast<double>(expected),
                                      true,
-                                     sum_agg,
+                                     *sum_agg,
                                      cudf::data_type(cudf::type_id::FLOAT64));
 
   // make sure boolean arithmetic semantics are obeyed when reducing to a bool
   this->reduction_test<bool, bool>(
-    int_values, true, true, sum_agg, cudf::data_type(cudf::type_id::BOOL8));
+    int_values, true, true, *sum_agg, cudf::data_type(cudf::type_id::BOOL8));
 
   this->reduction_test<int32_t, bool>(
-    int_values, true, true, sum_agg, cudf::data_type(cudf::type_id::BOOL8));
+    int_values, true, true, *sum_agg, cudf::data_type(cudf::type_id::BOOL8));
 
   // cudf::timestamp_s and int64_t are not convertible types.
   this->reduction_test<cudf::timestamp_s, int64_t>(int_values,
                                                    static_cast<int64_t>(expected_value),
                                                    false,
-                                                   sum_agg,
+                                                   *sum_agg,
                                                    cudf::data_type(cudf::type_id::INT64));
 }
 
@@ -868,8 +871,10 @@ TEST_F(ReductionErrorTest, empty_column)
 {
   using T        = int32_t;
   auto statement = [](cudf::column_view const& col) {
-    std::unique_ptr<cudf::scalar> result = cudf::reduce(
-      col, cudf::make_sum_aggregation<reduce_aggregation>(), cudf::data_type(cudf::type_id::INT64));
+    std::unique_ptr<cudf::scalar> result =
+      cudf::reduce(col,
+                   *cudf::make_sum_aggregation<reduce_aggregation>(),
+                   cudf::data_type(cudf::type_id::INT64));
     EXPECT_EQ(result->is_valid(), false);
   };
 
@@ -935,11 +940,11 @@ TEST_P(ReductionParamTest, DISABLED_std_var)
   auto std_agg = cudf::make_std_aggregation<reduce_aggregation>(ddof);
 
   EXPECT_EQ(
-    this->template reduction_test<double>(col, var_agg, cudf::data_type(cudf::type_id::FLOAT64))
+    this->template reduction_test<double>(col, *var_agg, cudf::data_type(cudf::type_id::FLOAT64))
       .first,
     var);
   EXPECT_EQ(
-    this->template reduction_test<double>(col, std_agg, cudf::data_type(cudf::type_id::FLOAT64))
+    this->template reduction_test<double>(col, *std_agg, cudf::data_type(cudf::type_id::FLOAT64))
       .first,
     std);
 
@@ -953,16 +958,16 @@ TEST_P(ReductionParamTest, DISABLED_std_var)
   double var_nulls = calc_var(replaced_array, valid_count);
   double std_nulls = std::sqrt(var_nulls);
 
-  EXPECT_EQ(
-    this
-      ->template reduction_test<double>(col_nulls, var_agg, cudf::data_type(cudf::type_id::FLOAT64))
-      .first,
-    var_nulls);
-  EXPECT_EQ(
-    this
-      ->template reduction_test<double>(col_nulls, std_agg, cudf::data_type(cudf::type_id::FLOAT64))
-      .first,
-    std_nulls);
+  EXPECT_EQ(this
+              ->template reduction_test<double>(
+                col_nulls, *var_agg, cudf::data_type(cudf::type_id::FLOAT64))
+              .first,
+            var_nulls);
+  EXPECT_EQ(this
+              ->template reduction_test<double>(
+                col_nulls, *std_agg, cudf::data_type(cudf::type_id::FLOAT64))
+              .first,
+            std_nulls);
 }
 
 //-------------------------------------------------------------------
@@ -973,7 +978,7 @@ struct StringReductionTest : public cudf::test::BaseFixture,
   void reduction_test(cudf::column_view const& underlying_column,
                       std::string expected_value,
                       bool succeeded_condition,
-                      std::unique_ptr<reduce_aggregation> const& agg,
+                      reduce_aggregation const& agg,
                       cudf::data_type output_dtype = cudf::data_type{})
   {
     if (cudf::data_type{} == output_dtype) output_dtype = underlying_column.type();
@@ -986,7 +991,7 @@ struct StringReductionTest : public cudf::test::BaseFixture,
       if (!result1->is_valid())
         std::cout << "expected=" << expected_value << ",got=" << result1->to_string() << std::endl;
       EXPECT_EQ(expected_value, result1->to_string())
-        << (agg->kind == aggregation::MIN ? "MIN" : "MAX");
+        << (agg.kind == aggregation::MIN ? "MIN" : "MAX");
     };
 
     if (succeeded_condition) {
@@ -1000,7 +1005,7 @@ struct StringReductionTest : public cudf::test::BaseFixture,
                       std::string initial_value,
                       std::string expected_value,
                       bool succeeded_condition,
-                      std::unique_ptr<reduce_aggregation> const& agg,
+                      reduce_aggregation const& agg,
                       cudf::data_type output_dtype = cudf::data_type{})
   {
     if (cudf::data_type{} == output_dtype) output_dtype = underlying_column.type();
@@ -1015,7 +1020,7 @@ struct StringReductionTest : public cudf::test::BaseFixture,
       if (!result1->is_valid())
         std::cout << "expected=" << expected_value << ",got=" << result1->to_string() << std::endl;
       EXPECT_EQ(expected_value, result1->to_string())
-        << (agg->kind == aggregation::MIN ? "MIN" : "MAX");
+        << (agg.kind == aggregation::MIN ? "MIN" : "MAX");
     };
 
     if (succeeded_condition) {
@@ -1072,34 +1077,38 @@ TEST_P(StringReductionTest, MinMax)
 
   // MIN
   this->reduction_test(
-    col, expected_min_result, succeed, cudf::make_min_aggregation<reduce_aggregation>());
-  this->reduction_test(
-    col_nulls, expected_min_null_result, succeed, cudf::make_min_aggregation<reduce_aggregation>());
+    col, expected_min_result, succeed, *cudf::make_min_aggregation<reduce_aggregation>());
+  this->reduction_test(col_nulls,
+                       expected_min_null_result,
+                       succeed,
+                       *cudf::make_min_aggregation<reduce_aggregation>());
   this->reduction_test(col,
                        initial_value,
                        expected_min_init_result,
                        succeed,
-                       cudf::make_min_aggregation<reduce_aggregation>());
+                       *cudf::make_min_aggregation<reduce_aggregation>());
   this->reduction_test(col_nulls,
                        initial_value,
                        expected_min_init_null_result,
                        succeed,
-                       cudf::make_min_aggregation<reduce_aggregation>());
+                       *cudf::make_min_aggregation<reduce_aggregation>());
   // MAX
   this->reduction_test(
-    col, expected_max_result, succeed, cudf::make_max_aggregation<reduce_aggregation>());
-  this->reduction_test(
-    col_nulls, expected_max_null_result, succeed, cudf::make_max_aggregation<reduce_aggregation>());
+    col, expected_max_result, succeed, *cudf::make_max_aggregation<reduce_aggregation>());
+  this->reduction_test(col_nulls,
+                       expected_max_null_result,
+                       succeed,
+                       *cudf::make_max_aggregation<reduce_aggregation>());
   this->reduction_test(col,
                        initial_value,
                        expected_max_init_result,
                        succeed,
-                       cudf::make_max_aggregation<reduce_aggregation>());
+                       *cudf::make_max_aggregation<reduce_aggregation>());
   this->reduction_test(col_nulls,
                        initial_value,
                        expected_max_init_null_result,
                        succeed,
-                       cudf::make_max_aggregation<reduce_aggregation>());
+                       *cudf::make_max_aggregation<reduce_aggregation>());
 
   // MINMAX
   auto result = cudf::minmax(col);
@@ -1176,16 +1185,16 @@ TEST_F(StringReductionTest, AllNull)
 
   // MIN
   auto result =
-    cudf::reduce(col_nulls, cudf::make_min_aggregation<reduce_aggregation>(), output_dtype);
+    cudf::reduce(col_nulls, *cudf::make_min_aggregation<reduce_aggregation>(), output_dtype);
   EXPECT_FALSE(result->is_valid());
   result = cudf::reduce(
-    col_nulls, cudf::make_min_aggregation<reduce_aggregation>(), output_dtype, *initial_value);
+    col_nulls, *cudf::make_min_aggregation<reduce_aggregation>(), output_dtype, *initial_value);
   EXPECT_FALSE(result->is_valid());
   // MAX
-  result = cudf::reduce(col_nulls, cudf::make_max_aggregation<reduce_aggregation>(), output_dtype);
+  result = cudf::reduce(col_nulls, *cudf::make_max_aggregation<reduce_aggregation>(), output_dtype);
   EXPECT_FALSE(result->is_valid());
   result = cudf::reduce(
-    col_nulls, cudf::make_max_aggregation<reduce_aggregation>(), output_dtype, *initial_value);
+    col_nulls, *cudf::make_max_aggregation<reduce_aggregation>(), output_dtype, *initial_value);
   EXPECT_FALSE(result->is_valid());
   // MINMAX
   auto mm_result = cudf::minmax(col_nulls);
@@ -1209,7 +1218,7 @@ TYPED_TEST(ReductionTest, Median)
     return 13.5;
   }();
   EXPECT_EQ(
-    this->template reduction_test<double>(col, cudf::make_median_aggregation<reduce_aggregation>())
+    this->template reduction_test<double>(col, *cudf::make_median_aggregation<reduce_aggregation>())
       .first,
     expected_value);
 
@@ -1220,8 +1229,8 @@ TYPED_TEST(ReductionTest, Median)
     return 14.0;
   }();
   EXPECT_EQ(this
-              ->template reduction_test<double>(col_odd,
-                                                cudf::make_median_aggregation<reduce_aggregation>())
+              ->template reduction_test<double>(
+                col_odd, *cudf::make_median_aggregation<reduce_aggregation>())
               .first,
             expected_value_odd);
 
@@ -1234,8 +1243,8 @@ TYPED_TEST(ReductionTest, Median)
   }();
 
   EXPECT_EQ(this
-              ->template reduction_test<double>(col_nulls,
-                                                cudf::make_median_aggregation<reduce_aggregation>())
+              ->template reduction_test<double>(
+                col_nulls, *cudf::make_median_aggregation<reduce_aggregation>())
               .first,
             expected_null_value);
 
@@ -1246,8 +1255,8 @@ TYPED_TEST(ReductionTest, Median)
     return 13.5;
   }();
   EXPECT_EQ(this
-              ->template reduction_test<double>(col_nulls_odd,
-                                                cudf::make_median_aggregation<reduce_aggregation>())
+              ->template reduction_test<double>(
+                col_nulls_odd, *cudf::make_median_aggregation<reduce_aggregation>())
               .first,
             expected_null_value_odd);
 }
@@ -1266,14 +1275,14 @@ TYPED_TEST(ReductionTest, Quantile)
   double expected_value0 = std::is_same_v<T, bool> || std::is_unsigned_v<T> ? v[4] : v[6];
   EXPECT_EQ(this
               ->template reduction_test<double>(
-                col, cudf::make_quantile_aggregation<reduce_aggregation>({0.0}, interp))
+                col, *cudf::make_quantile_aggregation<reduce_aggregation>({0.0}, interp))
               .first,
             expected_value0);
 
   double expected_value1 = v[3];
   EXPECT_EQ(this
               ->template reduction_test<double>(
-                col, cudf::make_quantile_aggregation<reduce_aggregation>({1.0}, interp))
+                col, *cudf::make_quantile_aggregation<reduce_aggregation>({1.0}, interp))
               .first,
             expected_value1);
 
@@ -1283,12 +1292,12 @@ TYPED_TEST(ReductionTest, Quantile)
 
   EXPECT_EQ(this
               ->template reduction_test<double>(
-                col_nulls, cudf::make_quantile_aggregation<reduce_aggregation>({0}, interp))
+                col_nulls, *cudf::make_quantile_aggregation<reduce_aggregation>({0}, interp))
               .first,
             expected_value0);
   EXPECT_EQ(this
               ->template reduction_test<double>(
-                col_nulls, cudf::make_quantile_aggregation<reduce_aggregation>({1}, interp))
+                col_nulls, *cudf::make_quantile_aggregation<reduce_aggregation>({1}, interp))
               .first,
             expected_null_value1);
 }
@@ -1303,16 +1312,18 @@ TYPED_TEST(ReductionTest, UniqueCount)
   // test without nulls
   cudf::test::fixed_width_column_wrapper<T> col(v.begin(), v.end());
   cudf::size_type expected_value = std::is_same_v<T, bool> ? 2 : 6;
-  EXPECT_EQ(this
-              ->template reduction_test<cudf::size_type>(
-                col, cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE))
-              .first,
-            expected_value);
-  EXPECT_EQ(this
-              ->template reduction_test<cudf::size_type>(
-                col, cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::EXCLUDE))
-              .first,
-            expected_value);
+  EXPECT_EQ(
+    this
+      ->template reduction_test<cudf::size_type>(
+        col, *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE))
+      .first,
+    expected_value);
+  EXPECT_EQ(
+    this
+      ->template reduction_test<cudf::size_type>(
+        col, *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::EXCLUDE))
+      .first,
+    expected_value);
 
   // test with nulls
   cudf::test::fixed_width_column_wrapper<T> col_nulls = construct_null_column(v, host_bools);
@@ -1322,13 +1333,13 @@ TYPED_TEST(ReductionTest, UniqueCount)
   EXPECT_EQ(
     this
       ->template reduction_test<cudf::size_type>(
-        col_nulls, cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE))
+        col_nulls, *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE))
       .first,
     expected_null_value0);
   EXPECT_EQ(
     this
       ->template reduction_test<cudf::size_type>(
-        col_nulls, cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::EXCLUDE))
+        col_nulls, *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::EXCLUDE))
       .first,
     expected_null_value1);
 }
@@ -1357,7 +1368,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionProductZeroScale)
   auto const out_type = static_cast<cudf::column_view>(column).type();
 
   auto const result =
-    cudf::reduce(column, cudf::make_product_aggregation<reduce_aggregation>(), out_type);
+    cudf::reduce(column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type);
   auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
   auto const result_fp     = decimalXX{result_scalar->value()};
 
@@ -1370,7 +1381,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionProductZeroScale)
   auto const init_scalar = cudf::make_fixed_point_scalar<decimalXX>(2, scale_type{0});
 
   auto const init_result = cudf::reduce(
-    column, cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+    column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
   auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(init_result.get());
   auto const init_result_fp     = decimalXX{init_result_scalar->value()};
 
@@ -1392,7 +1403,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionProduct)
     auto const expected = decimalXX{scaled_integer<RepType>{36, scale_type{i * 6}}};
 
     auto const result =
-      cudf::reduce(column, cudf::make_product_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1402,7 +1413,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionProduct)
     auto const init_scalar   = cudf::make_fixed_point_scalar<decimalXX>(2, scale);
 
     auto const init_result = cudf::reduce(
-      column, cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+      column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
     auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(init_result.get());
 
     EXPECT_EQ(init_result_scalar->fixed_point_value(), init_expected);
@@ -1423,7 +1434,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionProductWithNulls)
     auto const expected = decimalXX{scaled_integer<RepType>{6, scale_type{i * 3}}};
 
     auto const result =
-      cudf::reduce(column, cudf::make_product_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1433,7 +1444,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionProductWithNulls)
     auto const init_scalar   = cudf::make_fixed_point_scalar<decimalXX>(2, scale);
 
     auto const init_result = cudf::reduce(
-      column, cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+      column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
     auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(init_result.get());
 
     EXPECT_EQ(init_result_scalar->fixed_point_value(), init_expected);
@@ -1455,7 +1466,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionSum)
     auto const out_type = static_cast<cudf::column_view>(column).type();
 
     auto const result =
-      cudf::reduce(column, cudf::make_sum_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_sum_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1465,7 +1476,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionSum)
     auto const init_scalar   = cudf::make_fixed_point_scalar<decimalXX>(2, scale);
 
     auto const init_result = cudf::reduce(
-      column, cudf::make_sum_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+      column, *cudf::make_sum_aggregation<reduce_aggregation>(), out_type, *init_scalar);
     auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(init_result.get());
 
     EXPECT_EQ(init_result_scalar->fixed_point_value(), init_expected);
@@ -1491,7 +1502,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionSumAlternate)
   auto const out_type = static_cast<cudf::column_view>(column).type();
 
   auto const result =
-    cudf::reduce(column, cudf::make_sum_aggregation<reduce_aggregation>(), out_type);
+    cudf::reduce(column, *cudf::make_sum_aggregation<reduce_aggregation>(), out_type);
   auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
   EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1502,7 +1513,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionSumAlternate)
   auto const init_scalar   = cudf::make_fixed_point_scalar<decimalXX>(2, scale_type{0});
 
   auto const init_result =
-    cudf::reduce(column, cudf::make_sum_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+    cudf::reduce(column, *cudf::make_sum_aggregation<reduce_aggregation>(), out_type, *init_scalar);
   auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(init_result.get());
 
   EXPECT_EQ(init_result_scalar->fixed_point_value(), init_expected);
@@ -1523,7 +1534,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionSumFractional)
     auto const expected = decimalXX{scaled_integer<RepType>{666, scale}};
 
     auto const result =
-      cudf::reduce(column, cudf::make_sum_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_sum_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1533,7 +1544,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionSumFractional)
     auto const init_scalar   = cudf::make_fixed_point_scalar<decimalXX>(2, scale);
 
     auto const init_result = cudf::reduce(
-      column, cudf::make_sum_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+      column, *cudf::make_sum_aggregation<reduce_aggregation>(), out_type, *init_scalar);
     auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(init_result.get());
 
     EXPECT_EQ(init_result_scalar->fixed_point_value(), init_expected);
@@ -1557,7 +1568,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionSumLarge)
     auto const expected       = decimalXX{scaled_integer<RepType>{expected_value, scale}};
 
     auto const result =
-      cudf::reduce(column, cudf::make_sum_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_sum_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1570,7 +1581,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionSumLarge)
     auto const init_scalar   = cudf::make_fixed_point_scalar<decimalXX>(init_value, scale);
 
     auto const init_result = cudf::reduce(
-      column, cudf::make_sum_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+      column, *cudf::make_sum_aggregation<reduce_aggregation>(), out_type, *init_scalar);
     auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(init_result.get());
 
     EXPECT_EQ(init_result_scalar->fixed_point_value(), init_expected);
@@ -1591,7 +1602,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionMin)
     auto const out_type = static_cast<cudf::column_view>(column).type();
 
     auto const result =
-      cudf::reduce(column, cudf::make_min_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_min_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), ONE);
@@ -1601,7 +1612,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionMin)
     auto const init_scalar   = cudf::make_fixed_point_scalar<decimalXX>(0, scale);
 
     auto const init_result = cudf::reduce(
-      column, cudf::make_min_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+      column, *cudf::make_min_aggregation<reduce_aggregation>(), out_type, *init_scalar);
     auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(init_result.get());
 
     EXPECT_EQ(init_result_scalar->fixed_point_value(), init_expected);
@@ -1623,7 +1634,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionMinLarge)
     auto const expected = decimalXX{0, scale};
 
     auto const result =
-      cudf::reduce(column, cudf::make_min_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_min_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1633,7 +1644,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionMinLarge)
     auto const init_scalar   = cudf::make_fixed_point_scalar<decimalXX>(0, scale);
 
     auto const init_result = cudf::reduce(
-      column, cudf::make_min_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+      column, *cudf::make_min_aggregation<reduce_aggregation>(), out_type, *init_scalar);
     auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(init_result.get());
 
     EXPECT_EQ(init_result_scalar->fixed_point_value(), init_expected);
@@ -1654,7 +1665,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionMax)
     auto const out_type = static_cast<cudf::column_view>(column).type();
 
     auto const result =
-      cudf::reduce(column, cudf::make_max_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_max_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), FOUR);
@@ -1664,7 +1675,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionMax)
     auto const init_scalar   = cudf::make_fixed_point_scalar<decimalXX>(5, scale);
 
     auto const init_result = cudf::reduce(
-      column, cudf::make_max_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+      column, *cudf::make_max_aggregation<reduce_aggregation>(), out_type, *init_scalar);
     auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(init_result.get());
 
     EXPECT_EQ(init_result_scalar->fixed_point_value(), init_expected);
@@ -1686,7 +1697,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionMaxLarge)
     auto const expected = decimalXX{scaled_integer<RepType>{42, scale}};
 
     auto const result =
-      cudf::reduce(column, cudf::make_max_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_max_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1696,7 +1707,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionMaxLarge)
     auto const init_scalar   = cudf::make_fixed_point_scalar<decimalXX>(43, scale);
 
     auto const init_result = cudf::reduce(
-      column, cudf::make_max_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+      column, *cudf::make_max_aggregation<reduce_aggregation>(), out_type, *init_scalar);
     auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(init_result.get());
 
     EXPECT_EQ(init_result_scalar->fixed_point_value(), init_expected);
@@ -1716,7 +1727,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionNUnique)
     auto const out_type = static_cast<cudf::column_view>(column).type();
 
     auto const result =
-      cudf::reduce(column, cudf::make_nunique_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_nunique_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<cudf::size_type>*>(result.get());
 
     EXPECT_EQ(result_scalar->value(), 4);
@@ -1737,7 +1748,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionSumOfSquares)
     auto const expected = decimalXX{scaled_integer<RepType>{30, scale_type{i * 2}}};
 
     auto const result =
-      cudf::reduce(column, cudf::make_sum_of_squares_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_sum_of_squares_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1758,7 +1769,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionMedianOddNumberOfElements)
     auto const expected = decimalXX{scaled_integer<RepType>{2, scale}};
 
     auto const result =
-      cudf::reduce(column, cudf::make_median_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_median_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1779,7 +1790,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionMedianEvenNumberOfElements)
     auto const expected = decimalXX{scaled_integer<RepType>{25, scale}};
 
     auto const result =
-      cudf::reduce(column, cudf::make_median_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_median_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1799,11 +1810,11 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionQuantile)
     auto const out_type = static_cast<cudf::column_view>(column).type();
 
     for (auto const i : {0, 1, 2, 3, 4}) {
-      auto const expected = decimalXX{scaled_integer<RepType>{i + 1, scale}};
-      auto const result   = cudf::reduce(
-        column,
-        cudf::make_quantile_aggregation<reduce_aggregation>({i / 4.0}, cudf::interpolation::LINEAR),
-        out_type);
+      auto const expected      = decimalXX{scaled_integer<RepType>{i + 1, scale}};
+      auto const result        = cudf::reduce(column,
+                                       *cudf::make_quantile_aggregation<reduce_aggregation>(
+                                         {i / 4.0}, cudf::interpolation::LINEAR),
+                                       out_type);
       auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
       EXPECT_EQ(result_scalar->fixed_point_value(), expected);
     }
@@ -1827,7 +1838,7 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionNthElement)
       auto const expected = decimalXX{scaled_integer<RepType>{values[i], scale}};
       auto const result   = cudf::reduce(
         column,
-        cudf::make_nth_element_aggregation<reduce_aggregation>(i, cudf::null_policy::INCLUDE),
+        *cudf::make_nth_element_aggregation<reduce_aggregation>(i, cudf::null_policy::INCLUDE),
         out_type);
       auto const result_scalar = static_cast<cudf::scalar_type_t<decimalXX>*>(result.get());
       EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1851,7 +1862,7 @@ TEST_F(Decimal128Only, Decimal128ProductReduction)
 
     auto const out_type = cudf::data_type{cudf::type_id::DECIMAL128, scale};
     auto const result =
-      cudf::reduce(column, cudf::make_product_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimal128>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1861,7 +1872,7 @@ TEST_F(Decimal128Only, Decimal128ProductReduction)
     auto const init_scalar   = cudf::make_fixed_point_scalar<decimal128>(2, scale);
 
     auto const init_result = cudf::reduce(
-      column, cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+      column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
     auto const init_result_scalar =
       static_cast<cudf::scalar_type_t<decimal128>*>(init_result.get());
 
@@ -1882,7 +1893,7 @@ TEST_F(Decimal128Only, Decimal128ProductReduction2)
 
     auto const out_type = cudf::data_type{cudf::type_id::DECIMAL128, scale};
     auto const result =
-      cudf::reduce(column, cudf::make_product_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<decimal128>*>(result.get());
 
     EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1892,7 +1903,7 @@ TEST_F(Decimal128Only, Decimal128ProductReduction2)
     auto const init_scalar   = cudf::make_fixed_point_scalar<decimal128>(3, scale);
 
     auto const init_result = cudf::reduce(
-      column, cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+      column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
     auto const init_result_scalar =
       static_cast<cudf::scalar_type_t<decimal128>*>(init_result.get());
 
@@ -1914,7 +1925,7 @@ TEST_F(Decimal128Only, Decimal128ProductReduction3)
 
   auto const out_type = cudf::data_type{cudf::type_id::DECIMAL128, scale};
   auto const result =
-    cudf::reduce(column, cudf::make_product_aggregation<reduce_aggregation>(), out_type);
+    cudf::reduce(column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type);
   auto const result_scalar = static_cast<cudf::scalar_type_t<decimal128>*>(result.get());
 
   EXPECT_EQ(result_scalar->fixed_point_value(), expected);
@@ -1923,7 +1934,7 @@ TEST_F(Decimal128Only, Decimal128ProductReduction3)
   auto const init_scalar = cudf::make_fixed_point_scalar<decimal128>(5, scale);
 
   auto const init_result = cudf::reduce(
-    column, cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
+    column, *cudf::make_product_aggregation<reduce_aggregation>(), out_type, *init_scalar);
   auto const init_result_scalar = static_cast<cudf::scalar_type_t<decimal128>*>(init_result.get());
 
   EXPECT_EQ(init_result_scalar->fixed_point_value(), expected);
@@ -1955,21 +1966,23 @@ TYPED_TEST(ReductionTest, NthElement)
     auto const index         = mod(n, v.size());
     T expected_value_nonull  = v[index];
     bool const expected_null = host_bools[index];
-    EXPECT_EQ(this
-                ->template reduction_test<T>(col,
-                                             cudf::make_nth_element_aggregation<reduce_aggregation>(
-                                               n, cudf::null_policy::INCLUDE))
-                .first,
-              expected_value_nonull);
-    EXPECT_EQ(this
-                ->template reduction_test<T>(col,
-                                             cudf::make_nth_element_aggregation<reduce_aggregation>(
-                                               n, cudf::null_policy::EXCLUDE))
-                .first,
-              expected_value_nonull);
+    EXPECT_EQ(
+      this
+        ->template reduction_test<T>(
+          col,
+          *cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::INCLUDE))
+        .first,
+      expected_value_nonull);
+    EXPECT_EQ(
+      this
+        ->template reduction_test<T>(
+          col,
+          *cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::EXCLUDE))
+        .first,
+      expected_value_nonull);
     auto res = this->template reduction_test<T>(
       col_nulls,
-      cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::INCLUDE));
+      *cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::INCLUDE));
     EXPECT_EQ(res.first, expected_value_nonull);
     EXPECT_EQ(res.second, expected_null);
   }
@@ -1977,25 +1990,26 @@ TYPED_TEST(ReductionTest, NthElement)
   for (cudf::size_type n :
        {-valid_count, -valid_count / 2, -2, -1, 0, 1, 2, valid_count / 2, valid_count - 1}) {
     T expected_value_null = v_valid[mod(n, v_valid.size())];
-    EXPECT_EQ(this
-                ->template reduction_test<T>(col_nulls,
-                                             cudf::make_nth_element_aggregation<reduce_aggregation>(
-                                               n, cudf::null_policy::EXCLUDE))
-                .first,
-              expected_value_null);
+    EXPECT_EQ(
+      this
+        ->template reduction_test<T>(
+          col_nulls,
+          *cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::EXCLUDE))
+        .first,
+      expected_value_null);
   }
   // error cases
   for (cudf::size_type n : {-input_size - 1, input_size}) {
     EXPECT_ANY_THROW(this->template reduction_test<T>(
-      col, cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::INCLUDE)));
+      col, *cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::INCLUDE)));
     EXPECT_ANY_THROW(this->template reduction_test<T>(
       col_nulls,
-      cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::INCLUDE)));
+      *cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::INCLUDE)));
     EXPECT_ANY_THROW(this->template reduction_test<T>(
-      col, cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::EXCLUDE)));
+      col, *cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::EXCLUDE)));
     EXPECT_ANY_THROW(this->template reduction_test<T>(
       col_nulls,
-      cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::EXCLUDE)));
+      *cudf::make_nth_element_aggregation<reduce_aggregation>(n, cudf::null_policy::EXCLUDE)));
   }
 }
 
@@ -2019,25 +2033,25 @@ TEST_P(DictionaryStringReductionTest, MinMax)
   this->reduction_test(col,
                        *(std::min_element(host_strings.begin(), host_strings.end())),
                        true,
-                       cudf::make_min_aggregation<reduce_aggregation>(),
+                       *cudf::make_min_aggregation<reduce_aggregation>(),
                        output_type);
   // sliced
   this->reduction_test(cudf::slice(col, {1, 7}).front(),
                        *(std::min_element(host_strings.begin() + 1, host_strings.begin() + 7)),
                        true,
-                       cudf::make_min_aggregation<reduce_aggregation>(),
+                       *cudf::make_min_aggregation<reduce_aggregation>(),
                        output_type);
   // MAX
   this->reduction_test(col,
                        *(std::max_element(host_strings.begin(), host_strings.end())),
                        true,
-                       cudf::make_max_aggregation<reduce_aggregation>(),
+                       *cudf::make_max_aggregation<reduce_aggregation>(),
                        output_type);
   // sliced
   this->reduction_test(cudf::slice(col, {1, 7}).front(),
                        *(std::max_element(host_strings.begin() + 1, host_strings.begin() + 7)),
                        true,
-                       cudf::make_max_aggregation<reduce_aggregation>(),
+                       *cudf::make_max_aggregation<reduce_aggregation>(),
                        output_type);
 }
 
@@ -2062,39 +2076,39 @@ TYPED_TEST(DictionaryAnyAllTest, AnyAll)
     cudf::test::dictionary_column_wrapper<T> all_col(v_all.begin(), v_all.end());
     EXPECT_TRUE(this
                   ->template reduction_test<bool>(
-                    all_col, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                    all_col, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
                   .first);
     EXPECT_TRUE(this
                   ->template reduction_test<bool>(
-                    all_col, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                    all_col, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
                   .first);
     cudf::test::dictionary_column_wrapper<T> none_col(v_none.begin(), v_none.end());
     EXPECT_FALSE(this
                    ->template reduction_test<bool>(
-                     none_col, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                     none_col, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
                    .first);
     EXPECT_FALSE(this
                    ->template reduction_test<bool>(
-                     none_col, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                     none_col, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
                    .first);
     cudf::test::dictionary_column_wrapper<T> some_col(v_some.begin(), v_some.end());
     EXPECT_TRUE(this
                   ->template reduction_test<bool>(
-                    some_col, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                    some_col, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
                   .first);
     EXPECT_FALSE(this
                    ->template reduction_test<bool>(
-                     some_col, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                     some_col, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
                    .first);
     // sliced test
     EXPECT_TRUE(this
                   ->template reduction_test<bool>(cudf::slice(some_col, {1, 3}).front(),
-                                                  cudf::make_any_aggregation<reduce_aggregation>(),
+                                                  *cudf::make_any_aggregation<reduce_aggregation>(),
                                                   output_dtype)
                   .first);
     EXPECT_TRUE(this
                   ->template reduction_test<bool>(cudf::slice(some_col, {1, 2}).front(),
-                                                  cudf::make_all_aggregation<reduce_aggregation>(),
+                                                  *cudf::make_all_aggregation<reduce_aggregation>(),
                                                   output_dtype)
                   .first);
   }
@@ -2104,39 +2118,39 @@ TYPED_TEST(DictionaryAnyAllTest, AnyAll)
     cudf::test::dictionary_column_wrapper<T> all_col(v_all.begin(), v_all.end(), valid.begin());
     EXPECT_TRUE(this
                   ->template reduction_test<bool>(
-                    all_col, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                    all_col, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
                   .first);
     EXPECT_TRUE(this
                   ->template reduction_test<bool>(
-                    all_col, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                    all_col, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
                   .first);
     cudf::test::dictionary_column_wrapper<T> none_col(v_none.begin(), v_none.end(), valid.begin());
     EXPECT_FALSE(this
                    ->template reduction_test<bool>(
-                     none_col, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                     none_col, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
                    .first);
     EXPECT_FALSE(this
                    ->template reduction_test<bool>(
-                     none_col, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                     none_col, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
                    .first);
     cudf::test::dictionary_column_wrapper<T> some_col(v_some.begin(), v_some.end(), valid.begin());
     EXPECT_TRUE(this
                   ->template reduction_test<bool>(
-                    some_col, cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
+                    some_col, *cudf::make_any_aggregation<reduce_aggregation>(), output_dtype)
                   .first);
     EXPECT_FALSE(this
                    ->template reduction_test<bool>(
-                     some_col, cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
+                     some_col, *cudf::make_all_aggregation<reduce_aggregation>(), output_dtype)
                    .first);
     // sliced test
     EXPECT_TRUE(this
                   ->template reduction_test<bool>(cudf::slice(some_col, {0, 3}).front(),
-                                                  cudf::make_any_aggregation<reduce_aggregation>(),
+                                                  *cudf::make_any_aggregation<reduce_aggregation>(),
                                                   output_dtype)
                   .first);
     EXPECT_TRUE(this
                   ->template reduction_test<bool>(cudf::slice(some_col, {1, 4}).front(),
-                                                  cudf::make_all_aggregation<reduce_aggregation>(),
+                                                  *cudf::make_all_aggregation<reduce_aggregation>(),
                                                   output_dtype)
                   .first);
   }
@@ -2160,7 +2174,7 @@ TYPED_TEST(DictionaryReductionTest, Sum)
   T expected_value = std::accumulate(v.begin(), v.end(), T{0});
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col, cudf::make_sum_aggregation<reduce_aggregation>(), output_type)
+                col, *cudf::make_sum_aggregation<reduce_aggregation>(), output_type)
               .first,
             expected_value);
 
@@ -2173,7 +2187,7 @@ TYPED_TEST(DictionaryReductionTest, Sum)
   }();
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col_nulls, cudf::make_sum_aggregation<reduce_aggregation>(), output_type)
+                col_nulls, *cudf::make_sum_aggregation<reduce_aggregation>(), output_type)
               .first,
             expected_value);
 }
@@ -2194,7 +2208,7 @@ TYPED_TEST(DictionaryReductionTest, Product)
 
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col, cudf::make_product_aggregation<reduce_aggregation>(), output_type)
+                col, *cudf::make_product_aggregation<reduce_aggregation>(), output_type)
               .first,
             calc_prod(v));
 
@@ -2204,7 +2218,7 @@ TYPED_TEST(DictionaryReductionTest, Product)
 
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col_nulls, cudf::make_product_aggregation<reduce_aggregation>(), output_type)
+                col_nulls, *cudf::make_product_aggregation<reduce_aggregation>(), output_type)
               .first,
             calc_prod(replace_nulls(v, validity, T{1})));
 }
@@ -2225,7 +2239,7 @@ TYPED_TEST(DictionaryReductionTest, SumOfSquare)
 
   EXPECT_EQ(this
               ->template reduction_test<T>(
-                col, cudf::make_sum_of_squares_aggregation<reduce_aggregation>(), output_type)
+                col, *cudf::make_sum_of_squares_aggregation<reduce_aggregation>(), output_type)
               .first,
             calc_reduction(v));
 
@@ -2233,11 +2247,12 @@ TYPED_TEST(DictionaryReductionTest, SumOfSquare)
   std::vector<bool> validity({1, 1, 0, 0, 1, 1, 1, 1});
   cudf::test::dictionary_column_wrapper<T> col_nulls(v.begin(), v.end(), validity.begin());
 
-  EXPECT_EQ(this
-              ->template reduction_test<T>(
-                col_nulls, cudf::make_sum_of_squares_aggregation<reduce_aggregation>(), output_type)
-              .first,
-            calc_reduction(replace_nulls(v, validity, T{0})));
+  EXPECT_EQ(
+    this
+      ->template reduction_test<T>(
+        col_nulls, *cudf::make_sum_of_squares_aggregation<reduce_aggregation>(), output_type)
+      .first,
+    calc_reduction(replace_nulls(v, validity, T{0})));
 }
 
 TYPED_TEST(DictionaryReductionTest, Mean)
@@ -2257,7 +2272,7 @@ TYPED_TEST(DictionaryReductionTest, Mean)
 
   EXPECT_EQ(this
               ->template reduction_test<double>(
-                col, cudf::make_mean_aggregation<reduce_aggregation>(), output_type)
+                col, *cudf::make_mean_aggregation<reduce_aggregation>(), output_type)
               .first,
             calc_mean(v, v.size()));
 
@@ -2269,7 +2284,7 @@ TYPED_TEST(DictionaryReductionTest, Mean)
 
   EXPECT_EQ(this
               ->template reduction_test<double>(
-                col_nulls, cudf::make_mean_aggregation<reduce_aggregation>(), output_type)
+                col_nulls, *cudf::make_mean_aggregation<reduce_aggregation>(), output_type)
               .first,
             calc_mean(replace_nulls(v, validity, T{0}), valid_count));
 }
@@ -2304,8 +2319,8 @@ TYPED_TEST(DictionaryReductionTest, DISABLED_VarStd)
   auto var_agg               = cudf::make_variance_aggregation<reduce_aggregation>(ddof);
   auto std_agg               = cudf::make_std_aggregation<reduce_aggregation>(ddof);
 
-  EXPECT_EQ(this->template reduction_test<double>(col, var_agg, output_type).first, var);
-  EXPECT_EQ(this->template reduction_test<double>(col, std_agg, output_type).first, std);
+  EXPECT_EQ(this->template reduction_test<double>(col, *var_agg, output_type).first, var);
+  EXPECT_EQ(this->template reduction_test<double>(col, *std_agg, output_type).first, std);
 
   // test with nulls
   std::vector<bool> validity({1, 1, 0, 1, 1, 1, 0, 1});
@@ -2316,9 +2331,9 @@ TYPED_TEST(DictionaryReductionTest, DISABLED_VarStd)
   double var_nulls = calc_var(replace_nulls(v, validity, T{0}), valid_count, ddof);
   double std_nulls = std::sqrt(var_nulls);
 
-  EXPECT_EQ(this->template reduction_test<double>(col_nulls, var_agg, output_type).first,
+  EXPECT_EQ(this->template reduction_test<double>(col_nulls, *var_agg, output_type).first,
             var_nulls);
-  EXPECT_EQ(this->template reduction_test<double>(col_nulls, std_agg, output_type).first,
+  EXPECT_EQ(this->template reduction_test<double>(col_nulls, *std_agg, output_type).first,
             std_nulls);
 }
 
@@ -2334,7 +2349,7 @@ TYPED_TEST(DictionaryReductionTest, NthElement)
   cudf::size_type n = 5;
   EXPECT_EQ(this
               ->template reduction_test<T>(col,
-                                           cudf::make_nth_element_aggregation<reduce_aggregation>(
+                                           *cudf::make_nth_element_aggregation<reduce_aggregation>(
                                              n, cudf::null_policy::INCLUDE),
                                            output_type)
               .first,
@@ -2346,7 +2361,7 @@ TYPED_TEST(DictionaryReductionTest, NthElement)
 
   EXPECT_EQ(this
               ->template reduction_test<T>(col_nulls,
-                                           cudf::make_nth_element_aggregation<reduce_aggregation>(
+                                           *cudf::make_nth_element_aggregation<reduce_aggregation>(
                                              n, cudf::null_policy::INCLUDE),
                                            output_type)
               .first,
@@ -2355,7 +2370,7 @@ TYPED_TEST(DictionaryReductionTest, NthElement)
     this
       ->template reduction_test<T>(
         col_nulls,
-        cudf::make_nth_element_aggregation<reduce_aggregation>(2, cudf::null_policy::INCLUDE),
+        *cudf::make_nth_element_aggregation<reduce_aggregation>(2, cudf::null_policy::INCLUDE),
         output_type)
       .second);
 }
@@ -2372,7 +2387,7 @@ TYPED_TEST(DictionaryReductionTest, UniqueCount)
   EXPECT_EQ(this
               ->template reduction_test<int>(
                 col,
-                cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE),
+                *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE),
                 output_type)
               .first,
             6);
@@ -2384,14 +2399,14 @@ TYPED_TEST(DictionaryReductionTest, UniqueCount)
   EXPECT_EQ(this
               ->template reduction_test<int>(
                 col_nulls,
-                cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE),
+                *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE),
                 output_type)
               .first,
             7);
   EXPECT_EQ(this
               ->template reduction_test<int>(
                 col_nulls,
-                cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::EXCLUDE),
+                *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::EXCLUDE),
                 output_type)
               .first,
             6);
@@ -2402,12 +2417,11 @@ TYPED_TEST(DictionaryReductionTest, Median)
   using T = TypeParam;
   std::vector<int> int_values({6, -14, 13, 64, 0, -13, -20, 45});
   std::vector<T> v = convert_values<T>(int_values);
-  cudf::data_type output_type{cudf::type_to_id<double>()};
 
   // test without nulls
   cudf::test::dictionary_column_wrapper<T> col(v.begin(), v.end());
   EXPECT_EQ(
-    this->template reduction_test<double>(col, cudf::make_median_aggregation<reduce_aggregation>())
+    this->template reduction_test<double>(col, *cudf::make_median_aggregation<reduce_aggregation>())
       .first,
     (std::is_signed_v<T>) ? 3.0 : 13.5);
 
@@ -2415,8 +2429,8 @@ TYPED_TEST(DictionaryReductionTest, Median)
   std::vector<bool> validity({1, 1, 1, 0, 1, 1, 1, 1});
   cudf::test::dictionary_column_wrapper<T> col_nulls(v.begin(), v.end(), validity.begin());
   EXPECT_EQ(this
-              ->template reduction_test<double>(col_nulls,
-                                                cudf::make_median_aggregation<reduce_aggregation>())
+              ->template reduction_test<double>(
+                col_nulls, *cudf::make_median_aggregation<reduce_aggregation>())
               .first,
             (std::is_signed_v<T>) ? 0.0 : 13.0);
 }
@@ -2427,19 +2441,18 @@ TYPED_TEST(DictionaryReductionTest, Quantile)
   std::vector<int> int_values({6, -14, 13, 64, 0, -13, -20, 45});
   std::vector<T> v = convert_values<T>(int_values);
   cudf::interpolation interp{cudf::interpolation::LINEAR};
-  cudf::data_type output_type{cudf::type_to_id<double>()};
 
   // test without nulls
   cudf::test::dictionary_column_wrapper<T> col(v.begin(), v.end());
   double expected_value = std::is_same_v<T, bool> || std::is_unsigned_v<T> ? 0.0 : -20.0;
   EXPECT_EQ(this
               ->template reduction_test<double>(
-                col, cudf::make_quantile_aggregation<reduce_aggregation>({0.0}, interp))
+                col, *cudf::make_quantile_aggregation<reduce_aggregation>({0.0}, interp))
               .first,
             expected_value);
   EXPECT_EQ(this
               ->template reduction_test<double>(
-                col, cudf::make_quantile_aggregation<reduce_aggregation>({1.0}, interp))
+                col, *cudf::make_quantile_aggregation<reduce_aggregation>({1.0}, interp))
               .first,
             64.0);
 
@@ -2449,12 +2462,12 @@ TYPED_TEST(DictionaryReductionTest, Quantile)
 
   EXPECT_EQ(this
               ->template reduction_test<double>(
-                col_nulls, cudf::make_quantile_aggregation<reduce_aggregation>({0}, interp))
+                col_nulls, *cudf::make_quantile_aggregation<reduce_aggregation>({0}, interp))
               .first,
             expected_value);
   EXPECT_EQ(this
               ->template reduction_test<double>(
-                col_nulls, cudf::make_quantile_aggregation<reduce_aggregation>({1}, interp))
+                col_nulls, *cudf::make_quantile_aggregation<reduce_aggregation>({1}, interp))
               .first,
             45.0);
 }
@@ -2464,7 +2477,7 @@ struct ListReductionTest : public cudf::test::BaseFixture {
                       cudf::column_view const& expected_value,
                       bool succeeded_condition,
                       bool is_valid,
-                      std::unique_ptr<reduce_aggregation> const& agg)
+                      reduce_aggregation const& agg)
   {
     auto statement = [&]() {
       std::unique_ptr<cudf::scalar> result =
@@ -2498,7 +2511,7 @@ TEST_F(ListReductionTest, ListReductionNthElement)
     ElementCol{0, 5, -3},  // expected_value,
     true,
     true,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(2, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(2, cudf::null_policy::INCLUDE));
 
   // test with null-exclude
   std::vector<bool> validity{1, 0, 0, 1, 1, 0};
@@ -2508,7 +2521,7 @@ TEST_F(ListReductionTest, ListReductionNthElement)
     ElementCol{-2},  // expected_value,
     true,
     true,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(1, cudf::null_policy::EXCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(1, cudf::null_policy::EXCLUDE));
 
   // test with null-include
   this->reduction_test(
@@ -2516,7 +2529,7 @@ TEST_F(ListReductionTest, ListReductionNthElement)
     ElementCol{},  // expected_value,
     true,
     false,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(1, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(1, cudf::null_policy::INCLUDE));
 }
 
 TEST_F(ListReductionTest, NestedListReductionNthElement)
@@ -2533,7 +2546,7 @@ TEST_F(ListReductionTest, NestedListReductionNthElement)
     LCW{{}, {2, 3, 4}},  // expected_value,
     true,
     true,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(0, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(0, cudf::null_policy::INCLUDE));
 
   // test with null-include
   this->reduction_test(
@@ -2541,7 +2554,7 @@ TEST_F(ListReductionTest, NestedListReductionNthElement)
     LCW{},  // expected_value,
     true,
     false,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(2, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(2, cudf::null_policy::INCLUDE));
 
   // test with null-exclude
   this->reduction_test(
@@ -2549,7 +2562,7 @@ TEST_F(ListReductionTest, NestedListReductionNthElement)
     LCW{{11}, {12, 13}},  // expected_value,
     true,
     true,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(2, cudf::null_policy::EXCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(2, cudf::null_policy::EXCLUDE));
 }
 
 TEST_F(ListReductionTest, NonValidListReductionNthElement)
@@ -2564,7 +2577,7 @@ TEST_F(ListReductionTest, NonValidListReductionNthElement)
     ElementCol{},  // expected_value,
     true,
     false,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(0, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(0, cudf::null_policy::INCLUDE));
 
   // test against empty input
   this->reduction_test(
@@ -2572,7 +2585,7 @@ TEST_F(ListReductionTest, NonValidListReductionNthElement)
     ElementCol{},  // expected_value,
     true,
     false,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(0, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(0, cudf::null_policy::INCLUDE));
 }
 
 struct StructReductionTest : public cudf::test::BaseFixture {
@@ -2582,7 +2595,7 @@ struct StructReductionTest : public cudf::test::BaseFixture {
                       cudf::table_view const& expected_value,
                       bool succeeded_condition,
                       bool is_valid,
-                      std::unique_ptr<reduce_aggregation> const& agg)
+                      reduce_aggregation const& agg)
   {
     auto statement = [&]() {
       std::unique_ptr<cudf::scalar> result =
@@ -2622,7 +2635,7 @@ TEST_F(StructReductionTest, StructReductionNthElement)
     cudf::table_view{{result_col0, result_col1, result_col2}},  // expected_value,
     true,
     true,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(2, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(2, cudf::null_policy::INCLUDE));
 
   // test with null-include
   std::vector<bool> validity{1, 1, 1, 0, 1, 0, 0, 1};
@@ -2639,7 +2652,7 @@ TEST_F(StructReductionTest, StructReductionNthElement)
     cudf::table_view{{result_col0, result_col1, result_col2}},  // expected_value,
     true,
     false,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(6, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(6, cudf::null_policy::INCLUDE));
 
   // test with null-exclude
   result_col0 = ICW{{28}, {1}};
@@ -2650,7 +2663,7 @@ TEST_F(StructReductionTest, StructReductionNthElement)
     cudf::table_view{{result_col0, result_col1, result_col2}},  // expected_value,
     true,
     true,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(4, cudf::null_policy::EXCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(4, cudf::null_policy::EXCLUDE));
 }
 
 TEST_F(StructReductionTest, NestedStructReductionNthElement)
@@ -2673,7 +2686,7 @@ TEST_F(StructReductionTest, NestedStructReductionNthElement)
     cudf::table_view{{result_col0, result_col1, result_col2}},  // expected_value,
     true,
     true,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(1, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(1, cudf::null_policy::INCLUDE));
 
   // test with null-include
   result_child0 = ICW{0};
@@ -2685,7 +2698,7 @@ TEST_F(StructReductionTest, NestedStructReductionNthElement)
     cudf::table_view{{result_col0, result_col1, result_col2}},  // expected_value,
     true,
     false,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(3, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(3, cudf::null_policy::INCLUDE));
 
   // test with null-exclude
   result_child0 = ICW{0};
@@ -2697,7 +2710,7 @@ TEST_F(StructReductionTest, NestedStructReductionNthElement)
     cudf::table_view{{result_col0, result_col1, result_col2}},  // expected_value,
     true,
     true,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(3, cudf::null_policy::EXCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(3, cudf::null_policy::EXCLUDE));
 }
 
 TEST_F(StructReductionTest, NonValidStructReductionNthElement)
@@ -2717,7 +2730,7 @@ TEST_F(StructReductionTest, NonValidStructReductionNthElement)
     cudf::table_view{{ret_col0, ret_col1, ret_col2}},  // expected_value,
     true,
     false,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(0, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(0, cudf::null_policy::INCLUDE));
 
   // test against empty input (would fail because we can not create empty struct scalar)
   child0     = ICW{};
@@ -2732,7 +2745,7 @@ TEST_F(StructReductionTest, NonValidStructReductionNthElement)
     cudf::table_view{{ret_col0, ret_col1, ret_col2}},  // expected_value,
     false,
     false,
-    cudf::make_nth_element_aggregation<reduce_aggregation>(0, cudf::null_policy::INCLUDE));
+    *cudf::make_nth_element_aggregation<reduce_aggregation>(0, cudf::null_policy::INCLUDE));
 }
 
 TEST_F(StructReductionTest, StructReductionMinMaxNoNull)
@@ -2754,7 +2767,7 @@ TEST_F(StructReductionTest, StructReductionMinMaxNoNull)
                          cudf::table_view{{expected_child1, expected_child2}},
                          true,
                          true,
-                         cudf::make_min_aggregation<reduce_aggregation>());
+                         *cudf::make_min_aggregation<reduce_aggregation>());
   }
 
   {
@@ -2764,7 +2777,7 @@ TEST_F(StructReductionTest, StructReductionMinMaxNoNull)
                          cudf::table_view{{expected_child1, expected_child2}},
                          true,
                          true,
-                         cudf::make_max_aggregation<reduce_aggregation>());
+                         *cudf::make_max_aggregation<reduce_aggregation>());
   }
 }
 
@@ -2802,7 +2815,7 @@ TEST_F(StructReductionTest, StructReductionMinMaxSlicedInput)
                          cudf::table_view{{expected_child1, expected_child2}},
                          true,
                          true,
-                         cudf::make_min_aggregation<reduce_aggregation>());
+                         *cudf::make_min_aggregation<reduce_aggregation>());
   }
 
   {
@@ -2812,7 +2825,7 @@ TEST_F(StructReductionTest, StructReductionMinMaxSlicedInput)
                          cudf::table_view{{expected_child1, expected_child2}},
                          true,
                          true,
-                         cudf::make_max_aggregation<reduce_aggregation>());
+                         *cudf::make_max_aggregation<reduce_aggregation>());
   }
 }
 
@@ -2851,7 +2864,7 @@ TEST_F(StructReductionTest, StructReductionMinMaxWithNulls)
                          cudf::table_view{{expected_child1, expected_child2}},
                          true,
                          true,
-                         cudf::make_min_aggregation<reduce_aggregation>());
+                         *cudf::make_min_aggregation<reduce_aggregation>());
   }
 
   {
@@ -2861,7 +2874,7 @@ TEST_F(StructReductionTest, StructReductionMinMaxWithNulls)
                          cudf::table_view{{expected_child1, expected_child2}},
                          true,
                          true,
-                         cudf::make_max_aggregation<reduce_aggregation>());
+                         *cudf::make_max_aggregation<reduce_aggregation>());
   }
 }
 

--- a/cpp/tests/reductions/tdigest_tests.cu
+++ b/cpp/tests/reductions/tdigest_tests.cu
@@ -35,7 +35,7 @@ struct reduce_op {
     // result is a scalar, but we want to extract out the underlying column
     auto scalar_result =
       cudf::reduce(values,
-                   cudf::make_tdigest_aggregation<cudf::reduce_aggregation>(delta),
+                   *cudf::make_tdigest_aggregation<cudf::reduce_aggregation>(delta),
                    cudf::data_type{cudf::type_id::STRUCT});
     auto tbl = static_cast<cudf::struct_scalar const*>(scalar_result.get())->view();
     std::vector<std::unique_ptr<cudf::column>> cols;
@@ -53,7 +53,7 @@ struct reduce_merge_op {
     // result is a scalar, but we want to extract out the underlying column
     auto scalar_result =
       cudf::reduce(values,
-                   cudf::make_merge_tdigest_aggregation<cudf::reduce_aggregation>(delta),
+                   *cudf::make_merge_tdigest_aggregation<cudf::reduce_aggregation>(delta),
                    cudf::data_type{cudf::type_id::STRUCT});
     auto tbl = static_cast<cudf::struct_scalar const*>(scalar_result.get())->view();
     std::vector<std::unique_ptr<cudf::column>> cols;
@@ -133,7 +133,7 @@ TEST_F(ReductionTDigestMerge, FewHeavyCentroids)
   // merge
   auto scalar_result =
     cudf::reduce(*values,
-                 cudf::make_merge_tdigest_aggregation<cudf::reduce_aggregation>(1000),
+                 *cudf::make_merge_tdigest_aggregation<cudf::reduce_aggregation>(1000),
                  cudf::data_type{cudf::type_id::STRUCT});
 
   // convert to a table

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -263,10 +263,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_reduce(JNIEnv *env, jclas
     auto agg = reinterpret_cast<cudf::aggregation *>(j_agg);
     cudf::data_type out_dtype = cudf::jni::make_data_type(j_dtype, scale);
     return release_as_jlong(
-        cudf::reduce(*col,
-                     std::unique_ptr<cudf::reduce_aggregation>(
-                         dynamic_cast<cudf::reduce_aggregation *>(agg->clone().release())),
-                     out_dtype));
+        cudf::reduce(*col, *dynamic_cast<cudf::reduce_aggregation *>(agg), out_dtype));
   }
   CATCH_STD(env, 0);
 }
@@ -321,10 +318,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_scan(JNIEnv *env, jclass,
     auto scan_type = is_inclusive ? cudf::scan_type::INCLUSIVE : cudf::scan_type::EXCLUSIVE;
     auto null_policy = include_nulls ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE;
     return release_as_jlong(
-        cudf::scan(*col,
-                   std::unique_ptr<cudf::scan_aggregation>(
-                       dynamic_cast<cudf::scan_aggregation *>(agg->clone().release())),
-                   scan_type, null_policy));
+        cudf::scan(*col, *dynamic_cast<cudf::scan_aggregation *>(agg), scan_type, null_policy));
   }
   CATCH_STD(env, 0);
 }

--- a/python/cudf/cudf/_lib/cpp/reduce.pxd
+++ b/python/cudf/cudf/_lib/cpp/reduce.pxd
@@ -14,7 +14,7 @@ from cudf._lib.scalar cimport DeviceScalar
 cdef extern from "cudf/reduction.hpp" namespace "cudf" nogil:
     cdef unique_ptr[scalar] cpp_reduce "cudf::reduce" (
         column_view col,
-        const unique_ptr[reduce_aggregation] agg,
+        const reduce_aggregation& agg,
         data_type type
     ) except +
 
@@ -24,7 +24,7 @@ cdef extern from "cudf/reduction.hpp" namespace "cudf" nogil:
 
     cdef unique_ptr[column] cpp_scan "cudf::scan" (
         column_view col,
-        const unique_ptr[scan_aggregation] agg,
+        const scan_aggregation& agg,
         scan_type inclusive
     ) except +
 

--- a/python/cudf/cudf/_lib/reduce.pyx
+++ b/python/cudf/cudf/_lib/reduce.pyx
@@ -1,5 +1,7 @@
 # Copyright (c) 2020-2022, NVIDIA CORPORATION.
 
+from cython.operator import dereference
+
 import cudf
 from cudf.api.types import is_decimal_dtype
 
@@ -74,7 +76,7 @@ def reduce(reduction_op, Column incol, dtype=None, **kwargs):
     with nogil:
         c_result = move(cpp_reduce(
             c_incol_view,
-            cython_agg.c_obj,
+            dereference(cython_agg.c_obj),
             c_out_dtype
         ))
 
@@ -112,7 +114,7 @@ def scan(scan_op, Column incol, inclusive, **kwargs):
     with nogil:
         c_result = move(cpp_scan(
             c_incol_view,
-            cython_agg.c_obj,
+            dereference(cython_agg.c_obj),
             c_inclusive
         ))
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
There is almost never a good reason to pass arguments as `unique_ptr<T> const&`. Since those arguments cannot be modified, the only use case is accessing the underlying pointer, at which point the function better communicates its intent by accepting the underlying pointer/reference as an argument instead and is also more flexible as a result.

Resolves #10393

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
