### PR TITLE
Fix some libcudf calls to cudf::detail::gather

### DIFF
--- a/cpp/src/lists/copying/gather.cu
+++ b/cpp/src/lists/copying/gather.cu
@@ -100,36 +100,17 @@ std::unique_ptr<column> gather_list_leaf(column_view const& column,
   size_type gather_map_size = gd.gather_map_size;
 
   // call the normal gather
-  auto leaf_column = cudf::type_dispatcher<dispatch_storage_type>(
-    column.type(),
-    cudf::detail::column_gatherer{},
-    column,
-    gather_map_begin,
-    gather_map_begin + gather_map_size,
-    // note : we don't need to bother checking for out-of-bounds here since
-    // our inputs at this stage aren't coming from the user.
-    false,
-    stream,
-    mr);
+  // note : we don't need to bother checking for out-of-bounds here since
+  // our inputs at this stage aren't coming from the user.
+  auto gather_table = cudf::detail::gather(cudf::table_view({column}),
+                                           gather_map_begin,
+                                           gather_map_begin + gather_map_size,
+                                           out_of_bounds_policy::DONT_CHECK,
+                                           stream,
+                                           mr);
+  auto leaf_column  = std::move(gather_table->release().front());
 
-  // the column_gatherer doesn't create the null mask because it expects
-  // that will be done in the gather_bitmask() step.  however, gather_bitmask()
-  // only happens at the root level, and by definition this column is a
-  // leaf.  so we have to generate the bitmask ourselves.
-  // TODO : it might make sense to expose a gather() function that takes a column_view and
-  // returns a column that does this work correctly.
-  size_type null_count = column.null_count();
-  if (null_count > 0) {
-    auto list_cdv = column_device_view::create(column, stream);
-    auto validity = cudf::detail::valid_if(
-      gather_map_begin,
-      gather_map_begin + gd.gather_map_size,
-      [cdv = *list_cdv] __device__(int index) { return cdv.is_valid(index) ? true : false; },
-      stream,
-      mr);
-
-    leaf_column->set_null_mask(std::move(validity.first), validity.second);
-  }
+  if (column.null_count() == 0) { leaf_column->set_null_mask(rmm::device_buffer{}, 0); }
 
   return leaf_column;
 }


### PR DESCRIPTION
## Description
Fixes a couple source files that were calling gather by type-dispatching directly to the internal `column_gatherer` functor instead of using the `cudf::detail::gather` function(s). This simplifies the code and improves maintenance. For example, extra code to resolve the null-mask is eliminated since the appropriate `cudf::detail::gather` call does this automatically.
No function has changed, just code cleanup.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
