### PR TITLE
Remove uncompressed block size estimate from ORC reader

### DIFF
--- a/cpp/src/io/orc/orc.cpp
+++ b/cpp/src/io/orc/orc.cpp
@@ -368,24 +368,12 @@ size_t ProtobufWriter::write(const Metadata& s)
 OrcDecompressor::OrcDecompressor(CompressionKind kind, uint32_t blockSize) : m_blockSize(blockSize)
 {
   switch (kind) {
-    case NONE:
-      _compression   = compression_type::NONE;
-      m_log2MaxRatio = 0;
-      break;
-    case ZLIB:
-      _compression   = compression_type::ZLIB;
-      m_log2MaxRatio = 11;  // < 2048:1
-      break;
-    case SNAPPY:
-      _compression   = compression_type::SNAPPY;
-      m_log2MaxRatio = 5;  // < 32:1
-      break;
+    case NONE: _compression = compression_type::NONE; break;
+    case ZLIB: _compression = compression_type::ZLIB; break;
+    case SNAPPY: _compression = compression_type::SNAPPY; break;
     case LZO: _compression = compression_type::LZO; break;
     case LZ4: _compression = compression_type::LZ4; break;
-    case ZSTD:
-      m_log2MaxRatio = 11;
-      _compression   = compression_type::ZSTD;
-      break;
+    case ZSTD: _compression = compression_type::ZSTD; break;
     default: CUDF_FAIL("Invalid compression type");
   }
 }

--- a/cpp/src/io/orc/orc.hpp
+++ b/cpp/src/io/orc/orc.hpp
@@ -561,17 +561,11 @@ class OrcDecompressor {
    */
   host_span<uint8_t const> decompress_blocks(host_span<uint8_t const> src,
                                              rmm::cuda_stream_view stream);
-  [[nodiscard]] uint32_t GetLog2MaxCompressionRatio() const { return m_log2MaxRatio; }
-  [[nodiscard]] uint32_t GetMaxUncompressedBlockSize(uint32_t block_len) const
-  {
-    return std::min(block_len << m_log2MaxRatio, m_blockSize);
-  }
   [[nodiscard]] compression_type compression() const { return _compression; }
   [[nodiscard]] uint32_t GetBlockSize() const { return m_blockSize; }
 
  protected:
   compression_type _compression;
-  uint32_t m_log2MaxRatio = 24;  // log2 of maximum compression ratio
   uint32_t m_blockSize;
   std::vector<uint8_t> m_buf;
 };

--- a/cpp/src/io/orc/orc_gpu.hpp
+++ b/cpp/src/io/orc/orc_gpu.hpp
@@ -209,16 +209,11 @@ constexpr uint32_t encode_block_size = 512;
  * @param[in] strm_info List of compressed streams
  * @param[in] num_streams Number of compressed streams
  * @param[in] compression_block_size maximum size of compressed blocks (up to 16M)
- * @param[in] log2maxcr log2 of maximum compression ratio (used to infer max uncompressed size from
- * compressed size)
- * @param[in] allow_block_size_estimate If true, estimate uncompressed size for small blocks
  * @param[in] stream CUDA stream used for device memory operations and kernel launches
  */
 void ParseCompressedStripeData(CompressedStreamInfo* strm_info,
                                int32_t num_streams,
                                uint32_t compression_block_size,
-                               uint32_t log2maxcr,
-                               bool allow_block_size_estimate,
                                rmm::cuda_stream_view stream);
 
 /**

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -309,16 +309,8 @@ rmm::device_buffer reader::impl::decompress_stripe_data(
   }
   compinfo.host_to_device(stream);
 
-  // Workaround for ZSTD. It is possible to have compression ratios > 2048:1,
-  // so the heuristic in gpuParseCompressedStripeData() to estimate the size for
-  // small blocks can be too low. Disable the estimation for ZSTD.
-  auto allow_block_size_estimate = (decompressor.compression() != compression_type::ZSTD);
-  gpu::ParseCompressedStripeData(compinfo.device_ptr(),
-                                 compinfo.size(),
-                                 decompressor.GetBlockSize(),
-                                 decompressor.GetLog2MaxCompressionRatio(),
-                                 allow_block_size_estimate,
-                                 stream);
+  gpu::ParseCompressedStripeData(
+    compinfo.device_ptr(), compinfo.size(), decompressor.GetBlockSize(), stream);
   compinfo.device_to_host(stream, true);
 
   // Count the exact number of compressed blocks
@@ -365,12 +357,8 @@ rmm::device_buffer reader::impl::decompress_stripe_data(
       std::max(max_uncomp_block_size, compinfo[i].max_uncompressed_block_size);
   }
   compinfo.host_to_device(stream);
-  gpu::ParseCompressedStripeData(compinfo.device_ptr(),
-                                 compinfo.size(),
-                                 decompressor.GetBlockSize(),
-                                 decompressor.GetLog2MaxCompressionRatio(),
-                                 allow_block_size_estimate,
-                                 stream);
+  gpu::ParseCompressedStripeData(
+    compinfo.device_ptr(), compinfo.size(), decompressor.GetBlockSize(), stream);
 
   // Dispatch batches of blocks to decompress
   if (num_compressed_blocks > 0) {


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/11280

ORC reader estimates the uncompressed block size when the compressed block is much smaller than the maximum uncompressed block size (64KB-256KB). This estimate is based on compression ratio and has shown to be a bit flaky (see https://github.com/rapidsai/cudf/pull/11288).

This PR removes this logic so now reader allocates max block size (typically not larger than 256KB) for each block, regardless of the compressed size. 

In theory this impacts the memory usage when file contains many small blocks. However, there is no observed increase in peak memory usage when reading files with a thousand columns that each contain ~512 bytes of data.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
