### PR TITLE
Fix doxygen text for cudf::dictionary::encode

### DIFF
--- a/cpp/include/cudf/dictionary/encode.hpp
+++ b/cpp/include/cudf/dictionary/encode.hpp
@@ -31,7 +31,7 @@ namespace dictionary {
  */
 
 /**
- * @brief Construct a dictionary column by dictionary encoding an existing column.
+ * @brief Construct a dictionary column by dictionary encoding an existing column
  *
  * The output column is a DICTIONARY type with a keys column of non-null, unique values
  * that are in a strict, total order. Meaning, `keys[i]` is _ordered before
@@ -40,21 +40,21 @@ namespace dictionary {
  * The output column has a child indices column that is of integer type and with
  * the same size as the input column.
  *
- * The null_mask and null count are copied from the input column to the output column.
+ * The null mask and null count are copied from the input column to the output column.
  *
- * @throw cudf::logic_error if indices type is not an unsigned integer type.
- * @throw cudf::logic_error if the column to encode is already a DICTIONARY type.
+ * @throw cudf::logic_error if indices type is not an unsigned integer type
+ * @throw cudf::logic_error if the column to encode is already a DICTIONARY type
  *
  * @code{.pseudo}
- * c = [429,111,213,111,213,429,213]
- * d = make_dictionary_column(c)
- * d now has keys [111,213,429] and indices [2,0,1,0,1,2,1]
+ * c = [429, 111, 213, 111, 213, 429, 213]
+ * d = encode(c)
+ * d now has keys [111, 213, 429] and indices [2, 0, 1, 0, 1, 2, 1]
  * @endcode
  *
- * @param column The column to dictionary encode.
- * @param indices_type The integer type to use for the indices.
- * @param mr Device memory resource used to allocate the returned column's device memory.
- * @return Returns a dictionary column.
+ * @param column The column to dictionary encode
+ * @param indices_type The integer type to use for the indices
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return Returns a dictionary column
  */
 std::unique_ptr<column> encode(
   column_view const& column,
@@ -66,14 +66,14 @@ std::unique_ptr<column> encode(
  * dictionary_column into a new column using the indices from that column.
  *
  * @code{.pseudo}
- * d1 = {["a","c","d"],[2,0,1,0]}
+ * d1 = {["a", "c", "d"], [2, 0, 1, 0]}
  * s = decode(d1)
- * s is now ["d","a","c","a"]
+ * s is now ["d", "a", "c", "a"]
  * @endcode
  *
- * @param dictionary_column Existing dictionary column.
- * @param mr Device memory resource used to allocate the returned column's device memory.
- * @return New column with type matching the dictionary_column's keys.
+ * @param dictionary_column Existing dictionary column
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return New column with type matching the dictionary_column's keys
  */
 std::unique_ptr<column> decode(
   dictionary_column_view const& dictionary_column,


### PR DESCRIPTION
## Description
Fixes the example code in the doxygen comment for `cudf::dictionary::encode` to use the correct API name.
No function has change -- just code comments that generate public doxygen content.
https://docs.rapids.ai/api/libcudf/stable/group__dictionary__encode.html#ga06997026d694784d613f4590563a8b33

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
