### PR TITLE
Leverage rapids_cython for more automated RPATH handling

### DIFF
--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -12,14 +12,8 @@
 # the License.
 # =============================================================================
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake)
-  file(
-    DOWNLOAD
-    https://raw.githubusercontent.com/vyasr/rapids-cmake/feature/rapids_cython_lib_rpath/RAPIDS.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake
+  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.12/RAPIDS.cmake
+       ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake
   )
 endif()
-
-set(rapids-cmake-repo vyasr/rapids-cmake)
-set(rapids-cmake-branch feature/rapids_cython_lib_rpath)
-
 include(${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake)

--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -12,8 +12,14 @@
 # the License.
 # =============================================================================
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake)
-  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.12/RAPIDS.cmake
-       ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake
+  file(
+    DOWNLOAD
+    https://raw.githubusercontent.com/vyasr/rapids-cmake/feature/rapids_cython_lib_rpath/RAPIDS.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake
   )
 endif()
+
+set(rapids-cmake-repo vyasr/rapids-cmake)
+set(rapids-cmake-branch feature/rapids_cython_lib_rpath)
+
 include(${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake)

--- a/python/cudf/CMakeLists.txt
+++ b/python/cudf/CMakeLists.txt
@@ -59,7 +59,6 @@ if(NOT cudf_FOUND)
   # library in the _lib directory as a single source of truth and modify the other rpaths
   # appropriately.
   set(cython_lib_dir cudf)
-  rapids_cython_set_lib_dirs(${cython_lib_dir})
   install(TARGETS cudf DESTINATION ${cython_lib_dir})
 endif()
 
@@ -68,5 +67,8 @@ rapids_cython_init()
 add_subdirectory(cudf/_lib)
 
 include(cmake/Modules/ProtobufHelpers.cmake)
-
 codegen_protoc(cudf/utils/metadata/orc_column_statistics.proto)
+
+if(DEFINED cython_lib_dir)
+  rapids_cython_add_rpath_entries(TARGET cudf PATHS "${cython_lib_dir}")
+endif()

--- a/python/cudf/CMakeLists.txt
+++ b/python/cudf/CMakeLists.txt
@@ -56,7 +56,7 @@ if(NOT cudf_FOUND)
   add_subdirectory(../../cpp cudf-cpp)
 
   # Since there are multiple subpackages of cudf._lib that require access to libcudf, we place the
-  # library in the _lib directory as a single source of truth and modify the other rpaths
+  # library in the cudf directory as a single source of truth and modify the other rpaths
   # appropriately.
   set(cython_lib_dir cudf)
   install(TARGETS cudf DESTINATION ${cython_lib_dir})

--- a/python/cudf/CMakeLists.txt
+++ b/python/cudf/CMakeLists.txt
@@ -56,10 +56,11 @@ if(NOT cudf_FOUND)
   add_subdirectory(../../cpp cudf-cpp)
 
   # Since there are multiple subpackages of cudf._lib that require access to libcudf, we place the
-  # library in the _lib/cpp directory as a single source of truth and modify the other rpaths
+  # library in the _lib directory as a single source of truth and modify the other rpaths
   # appropriately.
-  rapids_cython_set_lib_dirs(cudf/_lib/cpp)
-  install(TARGETS cudf DESTINATION cudf/_lib/cpp)
+  set(cython_lib_dir cudf)
+  rapids_cython_set_lib_dirs(${cython_lib_dir})
+  install(TARGETS cudf DESTINATION ${cython_lib_dir})
 endif()
 
 rapids_cython_init()

--- a/python/cudf/CMakeLists.txt
+++ b/python/cudf/CMakeLists.txt
@@ -39,6 +39,8 @@ else()
   set(cudf_FOUND OFF)
 endif()
 
+include(rapids-cython)
+
 if(NOT cudf_FOUND)
   # TODO: This will not be necessary once we upgrade to CMake 3.22, which will pull in the required
   # languages for the C++ project even if this project does not require those languges.
@@ -56,10 +58,10 @@ if(NOT cudf_FOUND)
   # Since there are multiple subpackages of cudf._lib that require access to libcudf, we place the
   # library in the _lib/cpp directory as a single source of truth and modify the other rpaths
   # appropriately.
+  rapids_cython_set_lib_dirs(cudf/_lib/cpp)
   install(TARGETS cudf DESTINATION cudf/_lib/cpp)
 endif()
 
-include(rapids-cython)
 rapids_cython_init()
 
 add_subdirectory(cudf/_lib)

--- a/python/cudf/cudf/_lib/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/CMakeLists.txt
@@ -69,10 +69,6 @@ foreach(target IN LISTS targets_using_numpy)
   target_include_directories(${target} PRIVATE "${Python_NumPy_INCLUDE_DIRS}")
 endforeach()
 
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/cpp")
-endforeach()
-
 add_subdirectory(io)
 add_subdirectory(nvtext)
 add_subdirectory(strings)

--- a/python/cudf/cudf/_lib/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/CMakeLists.txt
@@ -57,7 +57,7 @@ set(linked_libraries cudf::cudf)
 rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
-  LINKED_LIBRARIES "${linked_libraries}"
+  LINKED_LIBRARIES "${linked_libraries}" ASSOCIATED_TARGETS cudf
 )
 
 # TODO: Finding NumPy currently requires finding Development due to a bug in CMake. This bug was

--- a/python/cudf/cudf/_lib/io/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/io/CMakeLists.txt
@@ -24,7 +24,3 @@ set(targets_using_numpy io_datasource io_utils)
 foreach(target IN LISTS targets_using_numpy)
   target_include_directories(${target} PRIVATE "${Python_NumPy_INCLUDE_DIRS}")
 endforeach()
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../cpp")
-endforeach()

--- a/python/cudf/cudf/_lib/io/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/io/CMakeLists.txt
@@ -17,7 +17,7 @@ set(linked_libraries cudf::cudf)
 rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
-  LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX io_
+  LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX io_ ASSOCIATED_TARGETS cudf
 )
 
 set(targets_using_numpy io_datasource io_utils)

--- a/python/cudf/cudf/_lib/nvtext/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/nvtext/CMakeLists.txt
@@ -21,7 +21,3 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX nvtext_
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../cpp")
-endforeach()

--- a/python/cudf/cudf/_lib/nvtext/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/nvtext/CMakeLists.txt
@@ -19,5 +19,5 @@ set(linked_libraries cudf::cudf)
 rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
-  LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX nvtext_
+  LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX nvtext_ ASSOCIATED_TARGETS cudf
 )

--- a/python/cudf/cudf/_lib/strings/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/strings/CMakeLists.txt
@@ -41,9 +41,5 @@ rapids_cython_create_modules(
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX strings_
 )
 
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../cpp")
-endforeach()
-
 add_subdirectory(convert)
 add_subdirectory(split)

--- a/python/cudf/cudf/_lib/strings/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/strings/CMakeLists.txt
@@ -38,7 +38,7 @@ set(linked_libraries cudf::cudf)
 rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
-  LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX strings_
+  LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX strings_ ASSOCIATED_TARGETS cudf
 )
 
 add_subdirectory(convert)

--- a/python/cudf/cudf/_lib/strings/convert/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/strings/convert/CMakeLists.txt
@@ -20,5 +20,5 @@ set(linked_libraries cudf::cudf)
 rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
-  LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX strings_
+  LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX strings_ ASSOCIATED_TARGETS cudf
 )

--- a/python/cudf/cudf/_lib/strings/convert/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/strings/convert/CMakeLists.txt
@@ -22,7 +22,3 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX strings_
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../../cpp")
-endforeach()

--- a/python/cudf/cudf/_lib/strings/split/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/strings/split/CMakeLists.txt
@@ -18,5 +18,5 @@ set(linked_libraries cudf::cudf)
 rapids_cython_create_modules(
   CXX
   SOURCE_FILES "${cython_sources}"
-  LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX strings_
+  LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX strings_ ASSOCIATED_TARGETS cudf
 )

--- a/python/cudf/cudf/_lib/strings/split/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/strings/split/CMakeLists.txt
@@ -20,7 +20,3 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}" MODULE_PREFIX strings_
 )
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../../cpp")
-endforeach()

--- a/python/strings_udf/strings_udf/_lib/CMakeLists.txt
+++ b/python/strings_udf/strings_udf/_lib/CMakeLists.txt
@@ -19,7 +19,3 @@ rapids_cython_create_modules(
   SOURCE_FILES "${cython_sources}"
   LINKED_LIBRARIES "${linked_libraries}"
 )
-
-foreach(cython_module IN LISTS _RAPIDS_CYTHON_CREATED_TARGETS)
-  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/cpp")
-endforeach()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR leverages a new feature of rapids-cmake to avoid needing to manually set the RPATHs for all extension modules individually, instead just pointing to a directory once and then letting rapids-cmake automatically handle the rest. This approach is a lot less error-prone since developers do not need to keep track of the relative paths in each CMakeLists.txt file.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
