### PR TITLE
[REVIEW] Ignore python docs build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ dask-worker-space/
 # Sphinx docs & build artifacts
 docs/cudf/source/api_docs/generated/*
 docs/cudf/source/api_docs/api/*
+docs/cudf/source/user_guide/example_files/*
+docs/cudf/source/user_guide/example_output/*
+docs/cudf/source/user_guide/cudf.*Dtype.*.rst


### PR DESCRIPTION
## Description
This PR gitignores some of the python docs build artifcats that keep showing up in `git status`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
