### PR TITLE
Remove unused `managed_allocator`

### DIFF
--- a/cpp/src/hash/hash_allocator.cuh
+++ b/cpp/src/hash/hash_allocator.cuh
@@ -27,42 +27,6 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 
 template <class T>
-struct managed_allocator {
-  using value_type                    = T;
-  rmm::mr::device_memory_resource* mr = new rmm::mr::managed_memory_resource;
-
-  managed_allocator() = default;
-
-  template <class U>
-  constexpr managed_allocator(const managed_allocator<U>&) noexcept
-  {
-  }
-
-  T* allocate(std::size_t n, rmm::cuda_stream_view stream = cudf::get_default_stream()) const
-  {
-    return static_cast<T*>(mr->allocate(n * sizeof(T), stream));
-  }
-
-  void deallocate(T* p,
-                  std::size_t n,
-                  rmm::cuda_stream_view stream = cudf::get_default_stream()) const
-  {
-    mr->deallocate(p, n * sizeof(T), stream);
-  }
-};
-
-template <class T, class U>
-bool operator==(const managed_allocator<T>&, const managed_allocator<U>&)
-{
-  return true;
-}
-template <class T, class U>
-bool operator!=(const managed_allocator<T>&, const managed_allocator<U>&)
-{
-  return false;
-}
-
-template <class T>
 struct default_allocator {
   using value_type                    = T;
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource();


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The `managed_allocator` class is not used anywhere. All uses of cuco maps or the `concurrent_unordered_map` just use the `default_allocator`.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
