### PR TITLE
Remove default parameters for cudf::dictionary::detail functions

### DIFF
--- a/cpp/include/cudf/detail/scatter.cuh
+++ b/cpp/include/cudf/detail/scatter.cuh
@@ -218,7 +218,8 @@ struct column_scatterer_impl<dictionary32> {
     // first combine keys so both dictionaries have the same set
     auto target_matched    = dictionary::detail::add_keys(target, source.keys(), stream, mr);
     auto const target_view = dictionary_column_view(target_matched->view());
-    auto source_matched    = dictionary::detail::set_keys(source, target_view.keys(), stream);
+    auto source_matched    = dictionary::detail::set_keys(
+      source, target_view.keys(), stream, rmm::mr::get_current_device_resource());
     auto const source_view = dictionary_column_view(source_matched->view());
 
     // now build the new indices by doing a scatter on just the matched indices

--- a/cpp/include/cudf/dictionary/detail/concatenate.hpp
+++ b/cpp/include/cudf/dictionary/detail/concatenate.hpp
@@ -37,10 +37,9 @@ namespace detail {
  * @param mr Device memory resource used to allocate the returned column's device memory.
  * @return New column with concatenated results.
  */
-std::unique_ptr<column> concatenate(
-  host_span<column_view const> columns,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> concatenate(host_span<column_view const> columns,
+                                    rmm::cuda_stream_view stream,
+                                    rmm::mr::device_memory_resource* mr);
 
 }  // namespace detail
 }  // namespace dictionary

--- a/cpp/include/cudf/dictionary/detail/encode.hpp
+++ b/cpp/include/cudf/dictionary/detail/encode.hpp
@@ -51,11 +51,10 @@ namespace detail {
  * @param mr Device memory resource used to allocate the returned column's device memory.
  * @return Returns a dictionary column.
  */
-std::unique_ptr<column> encode(
-  column_view const& column,
-  data_type indices_type              = data_type{type_id::UINT32},
-  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> encode(column_view const& column,
+                               data_type indices_type,
+                               rmm::cuda_stream_view stream,
+                               rmm::mr::device_memory_resource* mr);
 
 /**
  * @brief Create a column by gathering the keys from the provided
@@ -72,10 +71,9 @@ std::unique_ptr<column> encode(
  * @param mr Device memory resource used to allocate the returned column's device memory.
  * @return New column with type matching the dictionary_column's keys.
  */
-std::unique_ptr<column> decode(
-  dictionary_column_view const& dictionary_column,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> decode(dictionary_column_view const& dictionary_column,
+                               rmm::cuda_stream_view stream,
+                               rmm::mr::device_memory_resource* mr);
 
 /**
  * @brief Return minimal integer type for the given number of elements.

--- a/cpp/include/cudf/dictionary/detail/replace.hpp
+++ b/cpp/include/cudf/dictionary/detail/replace.hpp
@@ -39,11 +39,10 @@ namespace detail {
  * @param mr Device memory resource used to allocate the returned column's device memory.
  * @return New dictionary column with null rows replaced.
  */
-std::unique_ptr<column> replace_nulls(
-  dictionary_column_view const& input,
-  dictionary_column_view const& replacement,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
+                                      dictionary_column_view const& replacement,
+                                      rmm::cuda_stream_view stream,
+                                      rmm::mr::device_memory_resource* mr);
 
 /**
  * @brief Create a new dictionary column by replacing nulls with a
@@ -57,11 +56,10 @@ std::unique_ptr<column> replace_nulls(
  * @param mr Device memory resource used to allocate the returned column's device memory.
  * @return New dictionary column with null rows replaced.
  */
-std::unique_ptr<column> replace_nulls(
-  dictionary_column_view const& input,
-  scalar const& replacement,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
+                                      scalar const& replacement,
+                                      rmm::cuda_stream_view stream,
+                                      rmm::mr::device_memory_resource* mr);
 
 }  // namespace detail
 }  // namespace dictionary

--- a/cpp/include/cudf/dictionary/detail/search.hpp
+++ b/cpp/include/cudf/dictionary/detail/search.hpp
@@ -31,11 +31,10 @@ namespace detail {
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<scalar> get_index(
-  dictionary_column_view const& dictionary,
-  scalar const& key,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<scalar> get_index(dictionary_column_view const& dictionary,
+                                  scalar const& key,
+                                  rmm::cuda_stream_view stream,
+                                  rmm::mr::device_memory_resource* mr);
 
 /**
  * @brief Get the index for a key if it were added to the given dictionary.
@@ -56,11 +55,10 @@ std::unique_ptr<scalar> get_index(
  * @param mr Device memory resource used to allocate the returned column's device memory.
  * @return Numeric scalar index value of the key within the dictionary
  */
-std::unique_ptr<scalar> get_insert_index(
-  dictionary_column_view const& dictionary,
-  scalar const& key,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<scalar> get_insert_index(dictionary_column_view const& dictionary,
+                                         scalar const& key,
+                                         rmm::cuda_stream_view stream,
+                                         rmm::mr::device_memory_resource* mr);
 
 }  // namespace detail
 }  // namespace dictionary

--- a/cpp/include/cudf/dictionary/detail/update_keys.hpp
+++ b/cpp/include/cudf/dictionary/detail/update_keys.hpp
@@ -32,11 +32,10 @@ namespace detail {
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<column> add_keys(
-  dictionary_column_view const& dictionary_column,
-  column_view const& new_keys,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> add_keys(dictionary_column_view const& dictionary_column,
+                                 column_view const& new_keys,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc cudf::dictionary::remove_keys(dictionary_column_view const&,column_view
@@ -44,11 +43,10 @@ std::unique_ptr<column> add_keys(
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<column> remove_keys(
-  dictionary_column_view const& dictionary_column,
-  column_view const& keys_to_remove,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> remove_keys(dictionary_column_view const& dictionary_column,
+                                    column_view const& keys_to_remove,
+                                    rmm::cuda_stream_view stream,
+                                    rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc cudf::dictionary::remove_unused_keys(dictionary_column_view
@@ -56,10 +54,9 @@ std::unique_ptr<column> remove_keys(
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<column> remove_unused_keys(
-  dictionary_column_view const& dictionary_column,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> remove_unused_keys(dictionary_column_view const& dictionary_column,
+                                           rmm::cuda_stream_view stream,
+                                           rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc cudf::dictionary::set_keys(dictionary_column_view
@@ -67,11 +64,10 @@ std::unique_ptr<column> remove_unused_keys(
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<column> set_keys(
-  dictionary_column_view const& dictionary_column,
-  column_view const& keys,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> set_keys(dictionary_column_view const& dictionary_column,
+                                 column_view const& keys,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc
@@ -82,7 +78,7 @@ std::unique_ptr<column> set_keys(
 std::vector<std::unique_ptr<column>> match_dictionaries(
   cudf::host_span<dictionary_column_view const> input,
   rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+  rmm::mr::device_memory_resource* mr);
 
 /**
  * @brief Create new dictionaries that have keys merged from dictionary columns
@@ -106,7 +102,7 @@ std::vector<std::unique_ptr<column>> match_dictionaries(
 std::pair<std::vector<std::unique_ptr<column>>, std::vector<table_view>> match_dictionaries(
   std::vector<table_view> tables,
   rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+  rmm::mr::device_memory_resource* mr);
 
 }  // namespace detail
 }  // namespace dictionary

--- a/cpp/src/copying/copy_range.cu
+++ b/cpp/src/copying/copy_range.cu
@@ -172,7 +172,8 @@ std::unique_ptr<cudf::column> out_of_place_copy_range_dispatch::operator()<cudf:
   auto target_matched =
     cudf::dictionary::detail::add_keys(dict_target, dict_source.keys(), stream, mr);
   auto const target_view = cudf::dictionary_column_view(target_matched->view());
-  auto source_matched = cudf::dictionary::detail::set_keys(dict_source, target_view.keys(), stream);
+  auto source_matched    = cudf::dictionary::detail::set_keys(
+    dict_source, target_view.keys(), stream, rmm::mr::get_current_device_resource());
   auto const source_view = cudf::dictionary_column_view(source_matched->view());
 
   // build the new indices by calling in_place_copy_range on just the indices

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -184,8 +184,9 @@ struct column_scalar_scatterer_impl<dictionary32, MapIterator> {
                                    stream,
                                    mr);
     auto dict_view    = dictionary_column_view(dict_target->view());
-    auto scalar_index = dictionary::detail::get_index(dict_view, source.get(), stream);
-    auto scalar_iter  = thrust::make_permutation_iterator(
+    auto scalar_index = dictionary::detail::get_index(
+      dict_view, source.get(), stream, rmm::mr::get_current_device_resource());
+    auto scalar_iter = thrust::make_permutation_iterator(
       indexalator_factory::make_input_iterator(*scalar_index), thrust::make_constant_iterator(0));
     auto new_indices = std::make_unique<column>(dict_view.get_indices_annotated(), stream, mr);
     auto target_iter = indexalator_factory::make_output_iterator(new_indices->mutable_view());

--- a/cpp/src/dictionary/add_keys.cu
+++ b/cpp/src/dictionary/add_keys.cu
@@ -44,11 +44,10 @@ namespace detail {
  * d2 is now {[a, b, c, d, e, f], [5, 0, 3, 1, 2, 2, 2, 5, 0]}
  * ```
  */
-std::unique_ptr<column> add_keys(
-  dictionary_column_view const& dictionary_column,
-  column_view const& new_keys,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
+std::unique_ptr<column> add_keys(dictionary_column_view const& dictionary_column,
+                                 column_view const& new_keys,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_EXPECTS(!new_keys.has_nulls(), "Keys must not have nulls");
   auto old_keys = dictionary_column.keys();  // [a,b,c,d,f]

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -56,11 +56,10 @@ namespace {
  * @param mr Device memory resource used to allocate the returned column's device memory.
  */
 template <typename KeysKeeper>
-std::unique_ptr<column> remove_keys_fn(
-  dictionary_column_view const& dictionary_column,
-  KeysKeeper keys_to_keep_fn,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
+std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_column,
+                                       KeysKeeper keys_to_keep_fn,
+                                       rmm::cuda_stream_view stream,
+                                       rmm::mr::device_memory_resource* mr)
 {
   auto const keys_view    = dictionary_column.keys();
   auto const indices_type = dictionary_column.indices().type();
@@ -148,11 +147,10 @@ std::unique_ptr<column> remove_keys_fn(
 
 }  // namespace
 
-std::unique_ptr<column> remove_keys(
-  dictionary_column_view const& dictionary_column,
-  column_view const& keys_to_remove,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
+std::unique_ptr<column> remove_keys(dictionary_column_view const& dictionary_column,
+                                    column_view const& keys_to_remove,
+                                    rmm::cuda_stream_view stream,
+                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_EXPECTS(!keys_to_remove.has_nulls(), "keys_to_remove must not have nulls");
   auto const keys_view = dictionary_column.keys();
@@ -166,10 +164,9 @@ std::unique_ptr<column> remove_keys(
   return remove_keys_fn(dictionary_column, key_matcher, stream, mr);
 }
 
-std::unique_ptr<column> remove_unused_keys(
-  dictionary_column_view const& dictionary_column,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
+std::unique_ptr<column> remove_unused_keys(dictionary_column_view const& dictionary_column,
+                                           rmm::cuda_stream_view stream,
+                                           rmm::mr::device_memory_resource* mr)
 {
   // locate the keys to remove
   auto const keys_size     = dictionary_column.keys_size();

--- a/cpp/src/dictionary/replace.cu
+++ b/cpp/src/dictionary/replace.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/dictionary/replace.cu
+++ b/cpp/src/dictionary/replace.cu
@@ -123,8 +123,9 @@ std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
   // first add the replacement to the keys so only the indices need to be processed
   auto input_matched = dictionary::detail::add_keys(
     input, make_column_from_scalar(replacement, 1, stream)->view(), stream, mr);
-  auto const input_view   = dictionary_column_view(input_matched->view());
-  auto const scalar_index = get_index(input_view, replacement, stream);
+  auto const input_view = dictionary_column_view(input_matched->view());
+  auto const scalar_index =
+    get_index(input_view, replacement, stream, rmm::mr::get_current_device_resource());
 
   // now build the new indices by doing replace-null on the updated indices
   auto const input_indices = input_view.get_indices_annotated();

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -116,11 +116,10 @@ struct dispatch_compute_indices {
 }  // namespace
 
 //
-std::unique_ptr<column> set_keys(
-  dictionary_column_view const& dictionary_column,
-  column_view const& new_keys,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
+std::unique_ptr<column> set_keys(dictionary_column_view const& dictionary_column,
+                                 column_view const& new_keys,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_EXPECTS(!new_keys.has_nulls(), "keys parameter must not have nulls");
   auto keys = dictionary_column.keys();

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -171,7 +171,8 @@ std::unique_ptr<cudf::column> out_of_place_fill_range_dispatch::operator()<cudf:
     cudf::dictionary_column_view(target_matched->view()).get_indices_annotated();
 
   // get the index of the key just added
-  auto index_of_value = cudf::dictionary::detail::get_index(target_matched->view(), value, stream);
+  auto index_of_value = cudf::dictionary::detail::get_index(
+    target_matched->view(), value, stream, rmm::mr::get_current_device_resource());
   // now call fill using just the indices column and the new index
   auto new_indices =
     cudf::type_dispatcher(target_indices.type(),

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -300,14 +300,17 @@ std::unique_ptr<column> dispatch_clamp::operator()<cudf::dictionary32>(
     return result;
   }();
   auto matched_view = dictionary_column_view(matched_column->view());
+  auto default_mr   = rmm::mr::get_current_device_resource();
 
   // get the indexes for lo_replace and for hi_replace
-  auto lo_replace_index = dictionary::detail::get_index(matched_view, lo_replace, stream);
-  auto hi_replace_index = dictionary::detail::get_index(matched_view, hi_replace, stream);
+  auto lo_replace_index =
+    dictionary::detail::get_index(matched_view, lo_replace, stream, default_mr);
+  auto hi_replace_index =
+    dictionary::detail::get_index(matched_view, hi_replace, stream, default_mr);
 
   // get the closest indexes for lo and for hi
-  auto lo_index = dictionary::detail::get_insert_index(matched_view, lo, stream);
-  auto hi_index = dictionary::detail::get_insert_index(matched_view, hi, stream);
+  auto lo_index = dictionary::detail::get_insert_index(matched_view, lo, stream, default_mr);
+  auto hi_index = dictionary::detail::get_insert_index(matched_view, hi, stream, default_mr);
 
   // call clamp with the scalar indexes and the matched indices
   auto matched_indices = matched_view.get_indices_annotated();

--- a/cpp/src/replace/replace.cu
+++ b/cpp/src/replace/replace.cu
@@ -457,9 +457,10 @@ std::unique_ptr<cudf::column> replace_kernel_forwarder::operator()<cudf::diction
     return cudf::dictionary::detail::add_keys(input, new_keys->view(), stream, mr);
   }();
   auto matched_view   = cudf::dictionary_column_view(matched_input->view());
-  auto matched_values = cudf::dictionary::detail::set_keys(values, matched_view.keys(), stream);
-  auto matched_replacements =
-    cudf::dictionary::detail::set_keys(replacements, matched_view.keys(), stream);
+  auto matched_values = cudf::dictionary::detail::set_keys(
+    values, matched_view.keys(), stream, rmm::mr::get_current_device_resource());
+  auto matched_replacements = cudf::dictionary::detail::set_keys(
+    replacements, matched_view.keys(), stream, rmm::mr::get_current_device_resource());
 
   auto indices_type = matched_view.indices().type();
   auto new_indices  = cudf::type_dispatcher<cudf::dispatch_storage_type>(

--- a/cpp/src/search/contains_column.cu
+++ b/cpp/src/search/contains_column.cu
@@ -119,9 +119,11 @@ std::unique_ptr<column> contains_column_dispatch::operator()<dictionary32>(
   dictionary_column_view const haystack(haystack_in);
   dictionary_column_view const needles(needles_in);
   // first combine keys so both dictionaries have the same set
-  auto needles_matched     = dictionary::detail::add_keys(needles, haystack.keys(), stream);
-  auto const needles_view  = dictionary_column_view(needles_matched->view());
-  auto haystack_matched    = dictionary::detail::set_keys(haystack, needles_view.keys(), stream);
+  auto needles_matched = dictionary::detail::add_keys(
+    needles, haystack.keys(), stream, rmm::mr::get_current_device_resource());
+  auto const needles_view = dictionary_column_view(needles_matched->view());
+  auto haystack_matched   = dictionary::detail::set_keys(
+    haystack, needles_view.keys(), stream, rmm::mr::get_current_device_resource());
   auto const haystack_view = dictionary_column_view(haystack_matched->view());
 
   // now just use the indices for the contains

--- a/cpp/src/search/contains_scalar.cu
+++ b/cpp/src/search/contains_scalar.cu
@@ -128,7 +128,8 @@ bool contains_scalar_dispatch::operator()<cudf::dictionary32>(column_view const&
 {
   auto const dict_col = cudf::dictionary_column_view(haystack);
   // first, find the needle in the dictionary's key set
-  auto const index = cudf::dictionary::detail::get_index(dict_col, needle, stream);
+  auto const index = cudf::dictionary::detail::get_index(
+    dict_col, needle, stream, rmm::mr::get_current_device_resource());
   // if found, check the index is actually in the indices column
   return index->is_valid(stream) && cudf::type_dispatcher(dict_col.indices().type(),
                                                           contains_scalar_dispatch{},

--- a/cpp/src/search/search_ordered.cu
+++ b/cpp/src/search/search_ordered.cu
@@ -61,7 +61,8 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
 
   // This utility will ensure all corresponding dictionary columns have matching keys.
   // It will return any new dictionary columns created as well as updated table_views.
-  auto const matched = dictionary::detail::match_dictionaries({haystack, needles}, stream);
+  auto const matched = dictionary::detail::match_dictionaries(
+    {haystack, needles}, stream, rmm::mr::get_current_device_resource());
   auto const& matched_haystack = matched.second.front();
   auto const& matched_needles  = matched.second.back();
 

--- a/cpp/tests/dictionary/search_test.cpp
+++ b/cpp/tests/dictionary/search_test.cpp
@@ -35,8 +35,10 @@ TEST_F(DictionarySearchTest, StringsColumn)
 
   result = cudf::dictionary::get_index(dictionary, cudf::string_scalar("eee"));
   EXPECT_FALSE(result->is_valid());
-  result = cudf::dictionary::detail::get_insert_index(
-    dictionary, cudf::string_scalar("eee"), cudf::get_default_stream());
+  result   = cudf::dictionary::detail::get_insert_index(dictionary,
+                                                      cudf::string_scalar("eee"),
+                                                      cudf::get_default_stream(),
+                                                      rmm::mr::get_current_device_resource());
   n_result = dynamic_cast<cudf::numeric_scalar<uint32_t>*>(result.get());
   EXPECT_EQ(uint32_t{5}, n_result->value());
 }
@@ -52,8 +54,10 @@ TEST_F(DictionarySearchTest, WithNulls)
 
   result = cudf::dictionary::get_index(dictionary, cudf::numeric_scalar<int64_t>(5));
   EXPECT_FALSE(result->is_valid());
-  result = cudf::dictionary::detail::get_insert_index(
-    dictionary, cudf::numeric_scalar<int64_t>(5), cudf::get_default_stream());
+  result   = cudf::dictionary::detail::get_insert_index(dictionary,
+                                                      cudf::numeric_scalar<int64_t>(5),
+                                                      cudf::get_default_stream(),
+                                                      rmm::mr::get_current_device_resource());
   n_result = dynamic_cast<cudf::numeric_scalar<uint32_t>*>(result.get());
   EXPECT_EQ(uint32_t{1}, n_result->value());
 }
@@ -64,7 +68,8 @@ TEST_F(DictionarySearchTest, EmptyColumn)
   cudf::numeric_scalar<int64_t> key(7);
   auto result = cudf::dictionary::get_index(dictionary, key);
   EXPECT_FALSE(result->is_valid());
-  result = cudf::dictionary::detail::get_insert_index(dictionary, key, cudf::get_default_stream());
+  result = cudf::dictionary::detail::get_insert_index(
+    dictionary, key, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
   EXPECT_FALSE(result->is_valid());
 }
 
@@ -74,6 +79,7 @@ TEST_F(DictionarySearchTest, Errors)
   cudf::numeric_scalar<double> key(7);
   EXPECT_THROW(cudf::dictionary::get_index(dictionary, key), cudf::logic_error);
   EXPECT_THROW(
-    cudf::dictionary::detail::get_insert_index(dictionary, key, cudf::get_default_stream()),
+    cudf::dictionary::detail::get_insert_index(
+      dictionary, key, cudf::get_default_stream(), rmm::mr::get_current_device_resource()),
     cudf::logic_error);
 }

--- a/cpp/tests/replace/replace_nulls_tests.cpp
+++ b/cpp/tests/replace/replace_nulls_tests.cpp
@@ -21,7 +21,6 @@
 
 #include <tests/groupby/groupby_test_util.hpp>
 
-#include <cudf/dictionary/detail/replace.hpp>
 #include <cudf/dictionary/encode.hpp>
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/scalar/scalar.hpp>
@@ -680,7 +679,8 @@ TEST_F(ReplaceDictionaryTest, ReplaceNullsError)
   auto dict_input = cudf::dictionary_column_view(input_one->view());
   auto dict_repl  = cudf::dictionary_column_view(replacement->view());
   EXPECT_THROW(
-    cudf::dictionary::detail::replace_nulls(dict_input, dict_repl, cudf::get_default_stream()),
+    // cudf::dictionary::detail::replace_nulls(dict_input, dict_repl, cudf::get_default_stream()),
+    cudf::replace_nulls(input->view(), replacement->view()),
     cudf::logic_error);
 }
 
@@ -688,23 +688,26 @@ TEST_F(ReplaceDictionaryTest, ReplaceNullsEmpty)
 {
   cudf::test::fixed_width_column_wrapper<int64_t> input_empty_w({});
   auto input_empty = cudf::dictionary::encode(input_empty_w);
-  auto dict_input  = cudf::dictionary_column_view(input_empty->view());
-  auto result =
-    cudf::dictionary::detail::replace_nulls(dict_input, dict_input, cudf::get_default_stream());
+  // auto dict_input  = cudf::dictionary_column_view(input_empty->view());
+  // auto result =
+  //  cudf::dictionary::detail::replace_nulls(dict_input, dict_input, cudf::get_default_stream());
+  auto result = cudf::replace_nulls(input_empty->view(), input_empty->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), input_empty->view());
 }
 
 TEST_F(ReplaceDictionaryTest, ReplaceNullsNoNulls)
 {
   cudf::test::fixed_width_column_wrapper<int8_t> input_w({1, 1, 1});
-  auto input      = cudf::dictionary::encode(input_w);
-  auto dict_input = cudf::dictionary_column_view(input->view());
-  auto result =
-    cudf::dictionary::detail::replace_nulls(dict_input, dict_input, cudf::get_default_stream());
+  auto input = cudf::dictionary::encode(input_w);
+  // auto dict_input = cudf::dictionary_column_view(input->view());
+  // auto result =
+  //  cudf::dictionary::detail::replace_nulls(dict_input, dict_input, cudf::get_default_stream());
+  auto result = cudf::replace_nulls(input->view(), input->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), input->view());
 
-  result = cudf::dictionary::detail::replace_nulls(
-    dict_input, cudf::numeric_scalar<int64_t>(0, false), cudf::get_default_stream());
+  // result = cudf::dictionary::detail::replace_nulls(
+  //  dict_input, cudf::numeric_scalar<int64_t>(0, false), cudf::get_default_stream());
+  result = cudf::replace_nulls(input->view(), cudf::numeric_scalar<int8_t>(0, false));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), input->view());
 }
 

--- a/cpp/tests/replace/replace_nulls_tests.cpp
+++ b/cpp/tests/replace/replace_nulls_tests.cpp
@@ -678,35 +678,24 @@ TEST_F(ReplaceDictionaryTest, ReplaceNullsError)
   auto input_one  = cudf::dictionary::encode(input_one_w);
   auto dict_input = cudf::dictionary_column_view(input_one->view());
   auto dict_repl  = cudf::dictionary_column_view(replacement->view());
-  EXPECT_THROW(
-    // cudf::dictionary::detail::replace_nulls(dict_input, dict_repl, cudf::get_default_stream()),
-    cudf::replace_nulls(input->view(), replacement->view()),
-    cudf::logic_error);
+  EXPECT_THROW(cudf::replace_nulls(input->view(), replacement->view()), cudf::logic_error);
 }
 
 TEST_F(ReplaceDictionaryTest, ReplaceNullsEmpty)
 {
   cudf::test::fixed_width_column_wrapper<int64_t> input_empty_w({});
   auto input_empty = cudf::dictionary::encode(input_empty_w);
-  // auto dict_input  = cudf::dictionary_column_view(input_empty->view());
-  // auto result =
-  //  cudf::dictionary::detail::replace_nulls(dict_input, dict_input, cudf::get_default_stream());
-  auto result = cudf::replace_nulls(input_empty->view(), input_empty->view());
+  auto result      = cudf::replace_nulls(input_empty->view(), input_empty->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), input_empty->view());
 }
 
 TEST_F(ReplaceDictionaryTest, ReplaceNullsNoNulls)
 {
   cudf::test::fixed_width_column_wrapper<int8_t> input_w({1, 1, 1});
-  auto input = cudf::dictionary::encode(input_w);
-  // auto dict_input = cudf::dictionary_column_view(input->view());
-  // auto result =
-  //  cudf::dictionary::detail::replace_nulls(dict_input, dict_input, cudf::get_default_stream());
+  auto input  = cudf::dictionary::encode(input_w);
   auto result = cudf::replace_nulls(input->view(), input->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), input->view());
 
-  // result = cudf::dictionary::detail::replace_nulls(
-  //  dict_input, cudf::numeric_scalar<int64_t>(0, false), cudf::get_default_stream());
   result = cudf::replace_nulls(input->view(), cudf::numeric_scalar<int8_t>(0, false));
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), input->view());
 }


### PR DESCRIPTION
## Description
Removes default parameters from the `cudf::dictionary::detail` functions. Most of these were allowing for the default memory-resource which is unnecessary. One non-stream, non-mr parameter was defaulted but the default was never used.

Reference #11967

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
