### PR TITLE
Add pivot_table and crosstab to docs.

### DIFF
--- a/docs/cudf/source/api_docs/general_functions.rst
+++ b/docs/cudf/source/api_docs/general_functions.rst
@@ -14,6 +14,8 @@ Data manipulations
    cudf.get_dummies
    cudf.melt
    cudf.pivot
+   cudf.pivot_table
+   cudf.crosstab
    cudf.unstack
 
 Top-level conversions


### PR DESCRIPTION
## Description
This PR resolves #12012 by adding `cudf.pivot_table` and `cudf.crosstab` to the documentation.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
