### PR TITLE
New GHA to add issues/prs to project board

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,0 +1,20 @@
+name: Add new issue/PR to project
+
+on:
+  issues:
+    types:
+      - opened
+      
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue or PR to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/rapidsai/projects/51
+          github-token: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
This PR adds a small GitHub action to automatically add new issues and PRs to the cudf GitHub project. It does not impact existing issues/PRs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes. (N/A, no documentation required)
