### PR TITLE
Use pragma once

### DIFF
--- a/cpp/benchmarks/synchronization/synchronization.hpp
+++ b/cpp/benchmarks/synchronization/synchronization.hpp
@@ -58,8 +58,7 @@
 
  */
 
-#ifndef CUDF_BENCH_SYNCHRONIZATION_H
-#define CUDF_BENCH_SYNCHRONIZATION_H
+#pragma once
 
 // Google Benchmark library
 #include <benchmark/benchmark.h>
@@ -102,5 +101,3 @@ class cuda_event_timer {
   rmm::cuda_stream_view stream;
   benchmark::State* p_state;
 };
-
-#endif

--- a/cpp/src/hash/hash_allocator.cuh
+++ b/cpp/src/hash/hash_allocator.cuh
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef HASH_ALLOCATOR_CUH
-#define HASH_ALLOCATOR_CUH
+#pragma once
 
 #include <new>
 
@@ -61,5 +60,3 @@ bool operator!=(const default_allocator<T>&, const default_allocator<U>&)
 {
   return false;
 }
-
-#endif

--- a/cpp/src/hash/helper_functions.cuh
+++ b/cpp/src/hash/helper_functions.cuh
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef HELPER_FUNCTIONS_CUH
-#define HELPER_FUNCTIONS_CUH
+#pragma once
 
 #include <cudf/types.hpp>
 
@@ -242,5 +241,3 @@ __host__ __device__ bool operator!=(const cycle_iterator_adapter<T>& lhs,
 {
   return !lhs.equal(rhs);
 }
-
-#endif  // HELPER_FUNCTIONS_CUH

--- a/cpp/src/hash/helper_functions.cuh
+++ b/cpp/src/hash/helper_functions.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2017-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/hash/managed.cuh
+++ b/cpp/src/hash/managed.cuh
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef MANAGED_CUH
-#define MANAGED_CUH
+#pragma once
 
 #include <new>
 
@@ -43,5 +42,3 @@ inline bool isPtrManaged(cudaPointerAttributes attr)
   return attr.isManaged;
 #endif
 }
-
-#endif  // MANAGED_CUH

--- a/cpp/src/hash/managed.cuh
+++ b/cpp/src/hash/managed.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION.
+ * Copyright (c) 2017-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/unary/unary_ops.cuh
+++ b/cpp/src/unary/unary_ops.cuh
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef UNARY_OPS_H
-#define UNARY_OPS_H
+#pragma once
 
 #include <cudf/copying.hpp>
 #include <cudf/detail/copy.hpp>
@@ -78,5 +77,3 @@ struct launcher {
 
 }  // namespace unary
 }  // namespace cudf
-
-#endif  // UNARY_OPS_H


### PR DESCRIPTION
## Description
This PR adapts a few files using header guards with `#ifndef… #define` to use `#pragma once` instead. This establishes a more consistent code style for the library.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
