### PR TITLE
Force black exclusions for pre-commit.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 line-length = 79
 target-version = ["py38"]
 include = '\.py?$'
-exclude = '''
+force-exclude = '''
 /(
     thirdparty |
     \.eggs |


### PR DESCRIPTION
## Description
This PR fixes an issue where `black` would not respect the exclusions in `pyproject.toml` when run via `pre-commit`. When executing the hook, `pre-commit` explicitly lists all changed files and provides them as positional arguments to `black`. When `black` receives explicit filenames, it does not respect the `exclude` settings but _does_ respect the `force-exclude` settings added in `black 20.8b1`. See issue: https://github.com/psf/black/issues/438 and PR: https://github.com/psf/black/pull/1032.

cc: @csadorf for cuML
 
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
