### PR TITLE
Allow falling back to `shim_60.ptx` by default in `strings_udf`

### DIFF
--- a/python/strings_udf/cpp/CMakeLists.txt
+++ b/python/strings_udf/cpp/CMakeLists.txt
@@ -92,6 +92,10 @@ endfunction()
 # Create the shim library for each architecture.
 set(SHIM_CUDA_FLAGS --expt-relaxed-constexpr -rdc=true)
 
+# always build a default PTX file in case RAPIDS_NO_INITIALIZE is set and the device cc can't be
+# safely queried through a context
+list(INSERT CMAKE_CUDA_ARCHITECTURES 0 "60")
+
 list(TRANSFORM CMAKE_CUDA_ARCHITECTURES REPLACE "-real" "")
 list(TRANSFORM CMAKE_CUDA_ARCHITECTURES REPLACE "-virtual" "")
 list(SORT CMAKE_CUDA_ARCHITECTURES)

--- a/python/strings_udf/strings_udf/__init__.py
+++ b/python/strings_udf/strings_udf/__init__.py
@@ -43,7 +43,8 @@ def maybe_patch_numba_linker(driver_version):
 
 def _get_ptx_file():
     if "RAPIDS_NO_INITIALIZE" in os.environ:
-        cc = int(os.environ.get("STRINGS_UDF_CC", "52"))
+        # shim_60.ptx is always built
+        cc = int(os.environ.get("STRINGS_UDF_CC", "60"))
     else:
         dev = cuda.get_current_device()
 


### PR DESCRIPTION
In the context of distributed, `strings_udf` needs to import and set itself up without creating a CUDA context, as this can interfere with up the way the network is being set up. In this situation it can't use it's normal mechanism (which requires a context) to query the compute capability of the device, and it falls back on an environment variable `STRINGS_UDF_CC` that it needs to be passed from dask instead. A user can set this and their code will work no problem, but we also need some default configuration that just works when someone builds their code. Without knowing their setup beforehand this can be problematic, as such I originally added the default value of `cc=52` when the environment variable isn't set. This was however not exactly correct for a few reasons:

- It should be 60 I think since pascal is the oldest arch supported by rapids
- we don't always build shim_60.ptx especially in local mode.

This PR fixes this problem.