### PR TITLE
Workaround groupby aggregate thrust::copy_if overflow

### DIFF
--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -512,18 +512,29 @@ rmm::device_uvector<size_type> extract_populated_keys(map_type const& map,
 {
   rmm::device_uvector<size_type> populated_keys(num_keys, stream);
 
-  auto get_key    = [] __device__(auto const& element) { return element.first; };  // first = key
-  auto get_key_it = thrust::make_transform_iterator(map.data(), get_key);
-  auto key_used   = [unused = map.get_unused_key()] __device__(auto key) { return key != unused; };
+  auto get_key  = [] __device__(auto const& element) { return element.first; };  // first = key
+  auto key_itr  = thrust::make_transform_iterator(map.data(), get_key);
+  auto key_used = [unused = map.get_unused_key()] __device__(auto key) { return key != unused; };
 
-  auto end_it = thrust::copy_if(rmm::exec_policy(stream),
-                                get_key_it,
-                                get_key_it + map.capacity(),
-                                populated_keys.begin(),
-                                key_used);
+  // thrust::copy_if has a bug where it cannot iterate over int-max values
+  // so if map.capacity() > int-max we'll call thrust::copy_if in chunks instead
+  auto const map_size =
+    std::min(map.capacity(), static_cast<std::size_t>(std::numeric_limits<size_type>::max()));
+  auto key_end      = key_itr + map.capacity();
+  auto pop_keys_itr = populated_keys.begin();
 
-  populated_keys.resize(std::distance(populated_keys.begin(), end_it), stream);
+  std::size_t output_size = 0;
+  while (key_itr < key_end) {
+    auto copy_end = key_itr + map_size < key_end ? key_itr + map_size : key_end;
+    auto end_it =
+      thrust::copy_if(rmm::exec_policy(stream), key_itr, copy_end, pop_keys_itr, key_used);
+    auto copied = std::distance(pop_keys_itr, end_it);
+    pop_keys_itr += copied;
+    output_size += copied;
+    key_itr = copy_end;
+  }
 
+  populated_keys.resize(output_size, stream);
   return populated_keys;
 }
 


### PR DESCRIPTION
## Description
Workaround for limitation in `thrust::copy_if` which fails if the input-iterator spans more than int-max.
The `thrust::copy_if` hardcodes the iterator distance type to be an int
https://github.com/NVIDIA/thrust/blob/dbd144ed543b60c4ff9d456edd19869e82fe8873/thrust/system/cuda/detail/copy_if.h#L699-L708

This calls the `copy_if` in chunks if the iterator can span greater than int-max.

Closes #12058 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
