### PR TITLE
Throw an error when libcudf is built without cuFile and `LIBCUDF_CUFILE_POLICY` is set to `"ALWAYS"`

### DIFF
--- a/cpp/src/io/utilities/file_io_utilities.cpp
+++ b/cpp/src/io/utilities/file_io_utilities.cpp
@@ -269,6 +269,10 @@ std::unique_ptr<cufile_input_impl> make_cufile_input(std::string const& filepath
       if (cufile_integration::is_always_enabled()) throw;
     }
   }
+#else
+  CUDF_EXPECTS(not cufile_integration::is_always_enabled(),
+               "Unable to enforce the use of GDS requested through the LIBCUDF_CUFILE_POLICY "
+               "environment variable; current build was compiled without cuFile headers");
 #endif
   return nullptr;
 }
@@ -283,6 +287,10 @@ std::unique_ptr<cufile_output_impl> make_cufile_output(std::string const& filepa
       if (cufile_integration::is_always_enabled()) throw;
     }
   }
+#else
+  CUDF_EXPECTS(not cufile_integration::is_always_enabled(),
+               "Unable to enforce the use of GDS requested through the LIBCUDF_CUFILE_POLICY "
+               "environment variable; current build was compiled without cuFile headers");
 #endif
   return nullptr;
 }

--- a/cpp/src/io/utilities/file_io_utilities.cpp
+++ b/cpp/src/io/utilities/file_io_utilities.cpp
@@ -257,11 +257,20 @@ std::future<void> cufile_output_impl::write_async(void const* data, size_t offse
   // writes.
   return std::async(std::launch::deferred, waiter, std::move(slice_tasks));
 }
+#else
+cufile_input_impl::cufile_input_impl(std::string const& filepath)
+{
+  CUDF_FAIL("Cannot create cuFile source, current build was compiled without cuFile headers");
+}
+
+cufile_output_impl::cufile_output_impl(std::string const& filepath)
+{
+  CUDF_FAIL("Cannot create cuFile sink, current build was compiled without cuFile headers");
+}
 #endif
 
 std::unique_ptr<cufile_input_impl> make_cufile_input(std::string const& filepath)
 {
-#ifdef CUFILE_FOUND
   if (cufile_integration::is_gds_enabled()) {
     try {
       return std::make_unique<cufile_input_impl>(filepath);
@@ -269,17 +278,11 @@ std::unique_ptr<cufile_input_impl> make_cufile_input(std::string const& filepath
       if (cufile_integration::is_always_enabled()) throw;
     }
   }
-#else
-  CUDF_EXPECTS(not cufile_integration::is_always_enabled(),
-               "Unable to enforce the use of GDS requested through the LIBCUDF_CUFILE_POLICY "
-               "environment variable; current build was compiled without cuFile headers");
-#endif
   return nullptr;
 }
 
 std::unique_ptr<cufile_output_impl> make_cufile_output(std::string const& filepath)
 {
-#ifdef CUFILE_FOUND
   if (cufile_integration::is_gds_enabled()) {
     try {
       return std::make_unique<cufile_output_impl>(filepath);
@@ -287,11 +290,6 @@ std::unique_ptr<cufile_output_impl> make_cufile_output(std::string const& filepa
       if (cufile_integration::is_always_enabled()) throw;
     }
   }
-#else
-  CUDF_EXPECTS(not cufile_integration::is_always_enabled(),
-               "Unable to enforce the use of GDS requested through the LIBCUDF_CUFILE_POLICY "
-               "environment variable; current build was compiled without cuFile headers");
-#endif
   return nullptr;
 }
 

--- a/cpp/src/io/utilities/file_io_utilities.hpp
+++ b/cpp/src/io/utilities/file_io_utilities.hpp
@@ -194,6 +194,7 @@ class cufile_output_impl final : public cufile_output {
 
 class cufile_input_impl final : public cufile_input {
  public:
+  cufile_input_impl(std::string const& filepath);
   std::future<size_t> read_async(size_t offset,
                                  size_t size,
                                  uint8_t* dst,
@@ -205,6 +206,7 @@ class cufile_input_impl final : public cufile_input {
 
 class cufile_output_impl final : public cufile_output {
  public:
+  cufile_output_impl(std::string const& filepath);
   std::future<void> write_async(void const* data, size_t offset, size_t size) override
   {
     CUDF_FAIL("Only used to compile without cufile library, should not be called");


### PR DESCRIPTION
## Description
Currently, creating a cufile `datasource` or `data_sink` silently fails if libcudf was built without the cuFile headers. This is expected behavior when the `LIBCUDF_CUFILE_POLICY` is not set, or is set to and value other than "ALWAYS". However, with "ALWAYS", there should be no fallback from GDS.
This PR adds a check to fail loudly when `LIBCUDF_CUFILE_POLICY=="ALWAYS"` cannot be enforced because of missing dependency (cuFile).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
