### PR TITLE
[Java] Add JNI for `substring` without 'end' parameter.

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -3985,7 +3985,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   private static native long substring(long columnView, int start, int end) throws CudfException;
 
   /**
-   * Native method to calculate substring from a given string column. 0 indexing.
+   * Native method to extract substrings from a given strings column.
    * @param columnView native handle of the cudf::column_view being operated on.
    * @param start      first character index to begin the substrings (inclusive).
    */

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2632,12 +2632,13 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
 
   /**
    * Returns a new strings column that contains substrings of the strings in the provided column.
-   * Overloading subString to support if end index is not provided. Appending -1 to indicate to
-   * read until end of string.
+   * The character positions to retrieve in each string are `[start, <the string end>)`..
+   *
    * @param start first character index to begin the substring(inclusive).
    */
   public final ColumnVector substring(int start) {
-    return substring(start, -1);
+    assert type.equals(DType.STRING) : "column type must be a String";
+    return new ColumnVector(substringS(getNativeView(), start));
   }
 
   /**
@@ -3982,6 +3983,13 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @param end        last character index to stop the substring(exclusive).
    */
   private static native long substring(long columnView, int start, int end) throws CudfException;
+
+  /**
+   * Native method to calculate substring from a given string column. 0 indexing.
+   * @param columnView native handle of the cudf::column_view being operated on.
+   * @param start      first character index to begin the substring(inclusive).
+   */
+  private static native long substringS(long columnView, int start) throws CudfException;
 
   /**
    * Native method to calculate substring from a given string column.

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -3987,7 +3987,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   /**
    * Native method to calculate substring from a given string column. 0 indexing.
    * @param columnView native handle of the cudf::column_view being operated on.
-   * @param start      first character index to begin the substring(inclusive).
+   * @param start      first character index to begin the substrings (inclusive).
    */
   private static native long substringS(long columnView, int start) throws CudfException;
 

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1398,7 +1398,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_binaryOpVS(JNIEnv *env, j
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substringS(JNIEnv *env, jclass,
-                                                                 jlong column_view, jint start) {
+                                                                  jlong column_view, jint start) {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   try {
     cudf::jni::auto_set_device(env);

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1398,12 +1398,12 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_binaryOpVS(JNIEnv *env, j
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substringS(JNIEnv *env, jclass,
-                                                                  jlong column_view, jint start) {
-  JNI_NULL_CHECK(env, column_view, "column is null", 0);
+                                                                  jlong cv_handle, jint start) {
+  JNI_NULL_CHECK(env, cv_handle, "column is null", 0);
   try {
     cudf::jni::auto_set_device(env);
-    cudf::column_view *cv = reinterpret_cast<cudf::column_view *>(column_view);
-    cudf::strings_column_view scv(*cv);
+    auto const cv = reinterpret_cast<cudf::column_view const *>(cv_handle);
+    auto const scv = cudf::strings_column_view{*cv};
     return release_as_jlong(cudf::strings::slice_strings(scv, start));
   }
   CATCH_STD(env, 0);

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1397,6 +1397,18 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_binaryOpVS(JNIEnv *env, j
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substringS(JNIEnv *env, jclass,
+                                                                 jlong column_view, jint start) {
+  JNI_NULL_CHECK(env, column_view, "column is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::column_view *cv = reinterpret_cast<cudf::column_view *>(column_view);
+    cudf::strings_column_view scv(*cv);
+    return release_as_jlong(cudf::strings::slice_strings(scv, start));
+  }
+  CATCH_STD(env, 0);
+}
+
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substring(JNIEnv *env, jclass,
                                                                  jlong column_view, jint start,
                                                                  jint end) {
@@ -1405,8 +1417,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substring(JNIEnv *env, jc
     cudf::jni::auto_set_device(env);
     cudf::column_view *cv = reinterpret_cast<cudf::column_view *>(column_view);
     cudf::strings_column_view scv(*cv);
-    return release_as_jlong((end == -1 ? cudf::strings::slice_strings(scv, start) :
-                                         cudf::strings::slice_strings(scv, start, end)));
+    return release_as_jlong(cudf::strings::slice_strings(scv, start, end));
   }
   CATCH_STD(env, 0);
 }


### PR DESCRIPTION
cudf `substring(column, int, int)` has its own behavior when `end` is -1 (a valid position pointing to the last char), which is different from that in JNI. So JNI should not override it.

Besides, JNI's behavior does not match its doc when `end` is "-1". According to the doc, the last char should not be included in the result substring. But currently it does. 

Signed-off-by: Liangcai Li <liangcail@nvidia.com>

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
