### PR TITLE
Add in negative size checks for columns

### DIFF
--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -133,6 +133,7 @@ class column {
       _null_count{null_count},
       _children{std::move(children)}
   {
+    CUDF_EXPECTS(size >= 0, "Column size cannot be negative.");
   }
 
   /**

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -118,6 +118,7 @@ class column {
    * `UNKNOWN_NULL_COUNT` to indicate that the null count should be computed on
    * the first invocation of `null_count()`.
    * @param children Optional, vector of child columns
+   * @throws cudf::logic_error if `size < 0`
    */
   template <typename B1, typename B2 = rmm::device_buffer>
   column(data_type dtype,

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -109,6 +109,8 @@ class column {
    * @note This constructor is primarily intended for use in column factory
    * functions.
    *
+   * @throws cudf::logic_error if `size < 0`
+   *
    * @param[in] dtype The element type
    * @param[in] size The number of elements in the column
    * @param[in] data The column's data
@@ -118,7 +120,6 @@ class column {
    * `UNKNOWN_NULL_COUNT` to indicate that the null count should be computed on
    * the first invocation of `null_count()`.
    * @param children Optional, vector of child columns
-   * @throws cudf::logic_error if `size < 0`
    */
   template <typename B1, typename B2 = rmm::device_buffer>
   column(data_type dtype,

--- a/cpp/include/cudf/column/column_factories.hpp
+++ b/cpp/include/cudf/column/column_factories.hpp
@@ -70,6 +70,7 @@ std::unique_ptr<column> make_empty_column(type_id id);
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  * @param[in] mr Device memory resource used to allocate the returned column's device memory
  * @return Constructed numeric column
+ * @throws cudf::logic_error if `size < 0`
  */
 std::unique_ptr<column> make_numeric_column(
   data_type type,
@@ -127,6 +128,7 @@ std::unique_ptr<column> make_numeric_column(
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  * @param[in] mr Device memory resource used to allocate the returned column's device memory.
  * @return Constructed fixed-point type column
+ * @throws cudf::logic_error if `size < 0`
  */
 std::unique_ptr<column> make_fixed_point_column(
   data_type type,
@@ -184,6 +186,7 @@ std::unique_ptr<column> make_fixed_point_column(
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  * @param[in] mr Device memory resource used to allocate the returned column's device memory
  * @return Constructed timestamp type column
+ * @throws cudf::logic_error if `size < 0`
  */
 std::unique_ptr<column> make_timestamp_column(
   data_type type,
@@ -242,6 +245,7 @@ std::unique_ptr<column> make_timestamp_column(
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  * @param[in] mr Device memory resource used to allocate the returned column's device memory
  * @return Constructed duration type column
+ * @throws cudf::logic_error if `size < 0`
  */
 std::unique_ptr<column> make_duration_column(
   data_type type,
@@ -300,6 +304,7 @@ std::unique_ptr<column> make_duration_column(
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  * @param[in] mr Device memory resource used to allocate the returned column's device memory
  * @return Constructed fixed-width type column
+ * @throws cudf::logic_error if `size < 0`
  */
 std::unique_ptr<column> make_fixed_width_column(
   data_type type,
@@ -366,7 +371,7 @@ std::unique_ptr<column> make_fixed_width_column(
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  * @param[in] mr Device memory resource used for allocation of the column's `null_mask` and children
  * columns' device memory.
-  * @return Constructed strings column
+ * @return Constructed strings column
  */
 std::unique_ptr<column> make_strings_column(
   cudf::device_span<thrust::pair<const char*, size_type> const> strings,

--- a/cpp/include/cudf/column/column_factories.hpp
+++ b/cpp/include/cudf/column/column_factories.hpp
@@ -62,6 +62,7 @@ std::unique_ptr<column> make_empty_column(type_id id);
  *
  * @throws std::bad_alloc if device memory allocation fails
  * @throws cudf::logic_error if `type` is not a numeric type
+ * @throws cudf::logic_error if `size < 0`
  *
  * @param[in] type The desired numeric element type
  * @param[in] size The number of elements in the column
@@ -70,7 +71,6 @@ std::unique_ptr<column> make_empty_column(type_id id);
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  * @param[in] mr Device memory resource used to allocate the returned column's device memory
  * @return Constructed numeric column
- * @throws cudf::logic_error if `size < 0`
  */
 std::unique_ptr<column> make_numeric_column(
   data_type type,
@@ -120,6 +120,7 @@ std::unique_ptr<column> make_numeric_column(
  * @note The column's null count is determined by the requested null mask `state`.
  *
  * @throws cudf::logic_error if `type` is not a `fixed_point` type.
+ * @throws cudf::logic_error if `size < 0`
  *
  * @param[in] type The desired `fixed_point` element type.
  * @param[in] size The number of elements in the column.
@@ -128,7 +129,6 @@ std::unique_ptr<column> make_numeric_column(
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  * @param[in] mr Device memory resource used to allocate the returned column's device memory.
  * @return Constructed fixed-point type column
- * @throws cudf::logic_error if `size < 0`
  */
 std::unique_ptr<column> make_fixed_point_column(
   data_type type,
@@ -178,6 +178,7 @@ std::unique_ptr<column> make_fixed_point_column(
  *
  * @throws std::bad_alloc if device memory allocation fails
  * @throws cudf::logic_error if `type` is not a timestamp type
+ * @throws cudf::logic_error if `size < 0`
  *
  * @param[in] type The desired timestamp element type
  * @param[in] size The number of elements in the column
@@ -186,7 +187,6 @@ std::unique_ptr<column> make_fixed_point_column(
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  * @param[in] mr Device memory resource used to allocate the returned column's device memory
  * @return Constructed timestamp type column
- * @throws cudf::logic_error if `size < 0`
  */
 std::unique_ptr<column> make_timestamp_column(
   data_type type,
@@ -237,6 +237,7 @@ std::unique_ptr<column> make_timestamp_column(
  *
  * @throws std::bad_alloc if device memory allocation fails
  * @throws cudf::logic_error if `type` is not a duration type
+ * @throws cudf::logic_error if `size < 0`
  *
  * @param[in] type The desired duration element type
  * @param[in] size The number of elements in the column
@@ -245,7 +246,6 @@ std::unique_ptr<column> make_timestamp_column(
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  * @param[in] mr Device memory resource used to allocate the returned column's device memory
  * @return Constructed duration type column
- * @throws cudf::logic_error if `size < 0`
  */
 std::unique_ptr<column> make_duration_column(
   data_type type,
@@ -296,6 +296,7 @@ std::unique_ptr<column> make_duration_column(
  *
  * @throws std::bad_alloc if device memory allocation fails
  * @throws cudf::logic_error if `type` is not a fixed width type
+ * @throws cudf::logic_error if `size < 0`
  *
  * @param[in] type The desired fixed width type
  * @param[in] size The number of elements in the column
@@ -304,7 +305,6 @@ std::unique_ptr<column> make_duration_column(
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  * @param[in] mr Device memory resource used to allocate the returned column's device memory
  * @return Constructed fixed-width type column
- * @throws cudf::logic_error if `size < 0`
  */
 std::unique_ptr<column> make_fixed_width_column(
   data_type type,

--- a/cpp/src/column/column_factories.cpp
+++ b/cpp/src/column/column_factories.cpp
@@ -79,6 +79,7 @@ std::unique_ptr<column> make_numeric_column(data_type type,
 {
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(is_numeric(type), "Invalid, non-numeric type.");
+  CUDF_EXPECTS(size >= 0, "Column size cannot be negative.");
 
   return std::make_unique<column>(type,
                                   size,
@@ -97,6 +98,7 @@ std::unique_ptr<column> make_fixed_point_column(data_type type,
 {
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(is_fixed_point(type), "Invalid, non-fixed_point type.");
+  CUDF_EXPECTS(size >= 0, "Column size cannot be negative.");
 
   return std::make_unique<column>(type,
                                   size,
@@ -115,6 +117,7 @@ std::unique_ptr<column> make_timestamp_column(data_type type,
 {
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(is_timestamp(type), "Invalid, non-timestamp type.");
+  CUDF_EXPECTS(size >= 0, "Column size cannot be negative.");
 
   return std::make_unique<column>(type,
                                   size,
@@ -133,6 +136,7 @@ std::unique_ptr<column> make_duration_column(data_type type,
 {
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(is_duration(type), "Invalid, non-duration type.");
+  CUDF_EXPECTS(size >= 0, "Column size cannot be negative.");
 
   return std::make_unique<column>(type,
                                   size,
@@ -166,6 +170,7 @@ std::unique_ptr<column> make_dictionary_from_scalar(scalar const& s,
                                                     rmm::mr::device_memory_resource* mr)
 {
   if (size == 0) return make_empty_column(type_id::DICTIONARY32);
+  CUDF_EXPECTS(size >= 0, "Column size cannot be negative.");
   CUDF_EXPECTS(s.is_valid(stream), "cannot create a dictionary with a null key");
   return make_dictionary_column(
     make_column_from_scalar(s, 1, stream, mr),


### PR DESCRIPTION
## Description
This fixes #12116
This just adds in a few checks for negative sizes to avoid any issues with rounding errors and also helps us detect errors sooner. It will not fix small negative allocations for device buffers directly.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
