### PR TITLE
Fix regex working-memory-size refactor error

### DIFF
--- a/cpp/src/strings/regex/regexec.cpp
+++ b/cpp/src/strings/regex/regexec.cpp
@@ -130,7 +130,7 @@ void reprog_device::destroy() { delete this; }
 
 std::size_t reprog_device::working_memory_size(int32_t num_threads) const
 {
-  return compute_working_memory_size(insts_counts(), num_threads);
+  return compute_working_memory_size(num_threads, insts_counts());
 }
 
 std::pair<std::size_t, int32_t> reprog_device::compute_strided_working_memory(


### PR DESCRIPTION
## Description
Fixes error in `working_memory_size()` member function passing the parameters incorrectly.
This was introduce in #11927 and found in the nightly compute-sanitizer check.
https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cudf/job/branches/job/cudf-gpu-build-branch-22.12/19/CUDA=11.5/testReport/junit/cudamemcheck/STRINGS_TEST/StringsContainsTests_ContainsTest/

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
