### PR TITLE
Enable automatic column projection in groupby().agg

### DIFF
--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -685,8 +685,13 @@ def groupby_agg(
             "with `sort=False`, or set `shuffle=True`."
         )
 
+    # Determine required columns to enable column projection
+    required_columns = list(
+        set(gb_cols).union(aggs.keys()).intersection(ddf.columns)
+    )
+
     return aca(
-        [ddf],
+        [ddf[required_columns]],
         chunk=chunk,
         chunk_kwargs=chunk_kwargs,
         combine=combine,

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -130,6 +130,10 @@ def test_groupby_agg(func, aggregation, pdf):
 
     assert_cudf_groupby_layers(actual)
 
+    # groupby.agg should add an explicit getitem layer
+    # to improve/enable column projection
+    assert hlg_layer(actual.dask, "getitem")
+
     dd.assert_eq(expect, actual, check_names=False, check_dtype=check_dtype)
 
 


### PR DESCRIPTION
## Description
This PR corresponds to the Dask-cudf version of https://github.com/dask/dask/pull/9442, which was found to improve the performance of many groupby-based workflows. After this PR, 

```python
import dask_cudf

path = "/criteo-dataset/day_0.parquet"
ddf = dask_cudf.read_parquet(path, split_row_groups=10)

# The following takes <2s with this PR, and fails with
# an OOM error on main (using a 32GB GPU):
ddf.groupby("C1").agg({"C2": "mean"}).compute()
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
