### PR TITLE
Reduce page fragment size in Parquet writer

### DIFF
--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -269,7 +269,7 @@ struct parquet_column_device_view : stats_column_desc {
   bool output_as_byte_array;   //!< Indicates this list column is being written as a byte array
 };
 
-constexpr int max_page_fragment_size = 1024;  //!< Max number of rows in a page fragment
+constexpr int max_page_fragment_size = 1000;  //!< Max number of rows in a page fragment
 
 struct EncColumnChunk;
 

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -269,7 +269,7 @@ struct parquet_column_device_view : stats_column_desc {
   bool output_as_byte_array;   //!< Indicates this list column is being written as a byte array
 };
 
-constexpr int max_page_fragment_size = 5000;  //!< Max number of rows in a page fragment
+constexpr int max_page_fragment_size = 1024;  //!< Max number of rows in a page fragment
 
 struct EncColumnChunk;
 


### PR DESCRIPTION
## Description
Parquet writer creates pages from fragments of fixed number of rows. With deep nesting or long strings this way of creating pages can lead to pages that are much larger than the target size.
This PR alleviates the issue by reducing the number of rows in each fragment.

Performance impact:
5% throughput increase on average in the writer benchmark. The benefit is very uneven, with numeric types having almost 10% throughput loss and list type getting up to 110% faster.
15% throughput increase on average in the reader benchmark, with ~10% throughput loss with numeric types and up to 220% gain with lists.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
