### PR TITLE
Floor division uses integer division for integral arguments

### DIFF
--- a/cpp/include/cudf/binaryop.hpp
+++ b/cpp/include/cudf/binaryop.hpp
@@ -42,7 +42,8 @@ enum class binary_operator : int32_t {
   DIV,          ///< operator / using common type of lhs and rhs
   TRUE_DIV,     ///< operator / after promoting type to floating point
   FLOOR_DIV,    ///< operator //
-                ///< standard integer division if both arguments are integral
+                ///< integer division rounding towards negative
+                ///< infinity if both arguments are integral;
                 ///< floor division for floating types (using C++ type
                 ///< promotion for mixed integral/floating arguments)
                 ///< If different promotion semantics are required, it

--- a/cpp/include/cudf/binaryop.hpp
+++ b/cpp/include/cudf/binaryop.hpp
@@ -41,8 +41,13 @@ enum class binary_operator : int32_t {
   MUL,          ///< operator *
   DIV,          ///< operator / using common type of lhs and rhs
   TRUE_DIV,     ///< operator / after promoting type to floating point
-  FLOOR_DIV,    ///< operator / after promoting to 64 bit floating point and then
-                ///< flooring the result
+  FLOOR_DIV,    ///< operator //
+                ///< standard integer division if both arguments are integral
+                ///< floor division for floating types (using C++ type
+                ///< promotion for mixed integral/floating arguments)
+                ///< If different promotion semantics are required, it
+                ///< is the responsibility of the caller to promote
+                ///< manually before calling in to this function.
   MOD,          ///< operator %
   PMOD,         ///< positive modulo operator
                 ///< If remainder is negative, this returns (remainder + divisor) % divisor

--- a/cpp/src/binaryop/compiled/operation.cuh
+++ b/cpp/src/binaryop/compiled/operation.cuh
@@ -99,7 +99,13 @@ struct FloorDiv {
                       is_duration<TypeLhs>())>* = nullptr>
   __device__ inline auto operator()(TypeLhs x, TypeRhs y) -> decltype(x / y)
   {
-    return x / y;
+    if ((x ^ y) >= 0) {
+      return x / y;
+    } else {
+      const auto quotient  = x / y;
+      const auto remainder = x % y;
+      return quotient - !!remainder;
+    }
   }
 
   template <

--- a/cpp/src/binaryop/compiled/operation.cuh
+++ b/cpp/src/binaryop/compiled/operation.cuh
@@ -98,7 +98,7 @@ struct FloorDiv {
   __device__ inline auto operator()(TypeLhs x, TypeRhs y) -> decltype(x / y)
   {
     auto const quotient          = x / y;
-    auto const nonzero_remainder = !!(x % y);
+    auto const nonzero_remainder = (x % y) != 0;
     auto const mixed_sign        = (x ^ y) < 0;
     return quotient - mixed_sign * nonzero_remainder;
   }

--- a/cpp/src/binaryop/compiled/operation.cuh
+++ b/cpp/src/binaryop/compiled/operation.cuh
@@ -91,12 +91,10 @@ struct TrueDiv {
 };
 
 struct FloorDiv {
-  template <
-    typename TypeLhs,
-    typename TypeRhs,
-    std::enable_if_t<(std::is_integral_v<std::common_type_t<TypeLhs, TypeRhs>> or
-                      (cudf::is_fixed_point<TypeLhs>() and std::is_same_v<TypeLhs, TypeRhs>) or
-                      is_duration<TypeLhs>())>* = nullptr>
+  template <typename TypeLhs,
+            typename TypeRhs,
+            std::enable_if_t<(std::is_integral_v<std::common_type_t<TypeLhs, TypeRhs>> and
+                              std::is_signed_v<std::common_type_t<TypeLhs, TypeRhs>>)>* = nullptr>
   __device__ inline auto operator()(TypeLhs x, TypeRhs y) -> decltype(x / y)
   {
     if ((x ^ y) >= 0) {
@@ -106,6 +104,15 @@ struct FloorDiv {
       const auto remainder = x % y;
       return quotient - !!remainder;
     }
+  }
+
+  template <typename TypeLhs,
+            typename TypeRhs,
+            std::enable_if_t<(std::is_integral_v<std::common_type_t<TypeLhs, TypeRhs>> and
+                              !std::is_signed_v<std::common_type_t<TypeLhs, TypeRhs>>)>* = nullptr>
+  __device__ inline auto operator()(TypeLhs x, TypeRhs y) -> decltype(x / y)
+  {
+    return x / y;
   }
 
   template <

--- a/cpp/src/binaryop/compiled/operation.cuh
+++ b/cpp/src/binaryop/compiled/operation.cuh
@@ -100,8 +100,8 @@ struct FloorDiv {
     if ((x ^ y) >= 0) {
       return x / y;
     } else {
-      const auto quotient  = x / y;
-      const auto remainder = x % y;
+      auto const quotient  = x / y;
+      auto const remainder = x % y;
       return quotient - !!remainder;
     }
   }

--- a/cpp/src/binaryop/compiled/operation.cuh
+++ b/cpp/src/binaryop/compiled/operation.cuh
@@ -97,13 +97,10 @@ struct FloorDiv {
                               std::is_signed_v<std::common_type_t<TypeLhs, TypeRhs>>)>* = nullptr>
   __device__ inline auto operator()(TypeLhs x, TypeRhs y) -> decltype(x / y)
   {
-    if ((x ^ y) >= 0) {
-      return x / y;
-    } else {
-      auto const quotient  = x / y;
-      auto const remainder = x % y;
-      return quotient - !!remainder;
-    }
+    auto const quotient          = x / y;
+    auto const nonzero_remainder = !!(x % y);
+    auto const mixed_sign        = (x ^ y) < 0;
+    return quotient - mixed_sign * nonzero_remainder;
   }
 
   template <typename TypeLhs,

--- a/cpp/src/binaryop/compiled/operation.cuh
+++ b/cpp/src/binaryop/compiled/operation.cuh
@@ -91,11 +91,33 @@ struct TrueDiv {
 };
 
 struct FloorDiv {
-  template <typename T1, typename T2>
-  __device__ inline auto operator()(T1 const& lhs, T2 const& rhs)
-    -> decltype(floor(static_cast<double>(lhs) / static_cast<double>(rhs)))
+  template <
+    typename TypeLhs,
+    typename TypeRhs,
+    std::enable_if_t<(std::is_integral_v<std::common_type_t<TypeLhs, TypeRhs>> or
+                      (cudf::is_fixed_point<TypeLhs>() and std::is_same_v<TypeLhs, TypeRhs>) or
+                      is_duration<TypeLhs>())>* = nullptr>
+  __device__ inline auto operator()(TypeLhs x, TypeRhs y) -> decltype(x / y)
   {
-    return floor(static_cast<double>(lhs) / static_cast<double>(rhs));
+    return x / y;
+  }
+
+  template <
+    typename TypeLhs,
+    typename TypeRhs,
+    std::enable_if_t<(std::is_same_v<std::common_type_t<TypeLhs, TypeRhs>, float>)>* = nullptr>
+  __device__ inline auto operator()(TypeLhs x, TypeRhs y) -> float
+  {
+    return floorf(x / y);
+  }
+
+  template <
+    typename TypeLhs,
+    typename TypeRhs,
+    std::enable_if_t<(std::is_same_v<std::common_type_t<TypeLhs, TypeRhs>, double>)>* = nullptr>
+  __device__ inline auto operator()(TypeLhs x, TypeRhs y) -> double
+  {
+    return floor(x / y);
   }
 };
 

--- a/cpp/tests/binaryop/binop-compiled-test.cpp
+++ b/cpp/tests/binaryop/binop-compiled-test.cpp
@@ -27,6 +27,7 @@
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/utilities/error.hpp>
+#include <limits>
 #include <tests/binaryop/assert-binops.h>
 #include <tests/binaryop/binop-fixture.hpp>
 
@@ -418,6 +419,50 @@ TYPED_TEST(BinaryOperationCompiledTest_IntPow, IntPow_SpecialCases)
 
   auto result = cudf::binary_operation(
     lhs, rhs, cudf::binary_operator::INT_POW, data_type(type_to_id<TypeOut>()));
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TEST(BinaryOperationCompiledTestFloorDivInt64, FloorDivInt64Positive)
+{
+  // This tests special values for which integer floor division is
+  // incorrect if round-tripped through casting to double precision.
+  // Double precision floating point does not have enough resolution
+  // to represent these integers distinctly, so if we were to cast to
+  // double, we would get three identical results (all wrong!).
+  auto lhs = fixed_width_column_wrapper<int64_t>({std::numeric_limits<int64_t>::max(),
+                                                  std::numeric_limits<int64_t>::max() - 10,
+                                                  std::numeric_limits<int64_t>::max() - 100});
+  auto rhs = fixed_width_column_wrapper<int64_t>({10, 10, 10});
+  auto expected =
+    fixed_width_column_wrapper<int64_t>({std::numeric_limits<int64_t>::max() / 10,
+                                         (std::numeric_limits<int64_t>::max() - 10) / 10,
+                                         (std::numeric_limits<int64_t>::max() - 100) / 10});
+
+  auto result = cudf::binary_operation(
+    lhs, rhs, cudf::binary_operator::FLOOR_DIV, data_type(type_to_id<int64_t>()));
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
+}
+
+TEST(BinaryOperationCompiledTestFloorDivInt64, FloorDivInt64RoundNegativeInf)
+{
+  // Floor division should round towards negative infinity. Which is
+  // distinct from default integral division in C++ which rounds
+  // towards zero (truncation)
+  auto lhs = fixed_width_column_wrapper<int64_t>({std::numeric_limits<int64_t>::min(),
+                                                  std::numeric_limits<int64_t>::min() + 10,
+                                                  std::numeric_limits<int64_t>::min() + 100});
+  auto rhs = fixed_width_column_wrapper<int64_t>({10, 10, 10});
+  // int64_t::min() is not divisible by 10, so there is a non-zero
+  // remainder which should be rounded down.
+  auto expected =
+    fixed_width_column_wrapper<int64_t>({std::numeric_limits<int64_t>::min() / 10 - 1,
+                                         (std::numeric_limits<int64_t>::min() + 10) / 10 - 1,
+                                         (std::numeric_limits<int64_t>::min() + 100) / 10 - 1});
+
+  auto result = cudf::binary_operation(
+    lhs, rhs, cudf::binary_operator::FLOOR_DIV, data_type(type_to_id<int64_t>()));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }

--- a/cpp/tests/binaryop/binop-compiled-test.cpp
+++ b/cpp/tests/binaryop/binop-compiled-test.cpp
@@ -27,12 +27,12 @@
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/utilities/error.hpp>
-#include <limits>
 #include <tests/binaryop/assert-binops.h>
 #include <tests/binaryop/binop-fixture.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 
+#include <limits>
 #include <type_traits>
 
 namespace cudf::test::binop {

--- a/cpp/tests/binaryop/util/operation.h
+++ b/cpp/tests/binaryop/util/operation.h
@@ -143,9 +143,48 @@ struct TrueDiv {
 
 template <typename TypeOut, typename TypeLhs, typename TypeRhs>
 struct FloorDiv {
+  template <typename OutT                                                         = TypeOut,
+            typename LhsT                                                         = TypeLhs,
+            typename RhsT                                                         = TypeRhs,
+            std::enable_if_t<(std::is_integral_v<std::common_type_t<LhsT, RhsT>> and
+                              std::is_signed_v<std::common_type_t<LhsT, RhsT>>)>* = nullptr>
   TypeOut operator()(TypeLhs lhs, TypeRhs rhs)
   {
-    return static_cast<TypeOut>(floor(static_cast<double>(lhs) / static_cast<double>(rhs)));
+    if ((lhs ^ rhs) >= 0) {
+      return lhs / rhs;
+    } else {
+      const auto quotient  = lhs / rhs;
+      const auto remainder = lhs % rhs;
+      return quotient - !!remainder;
+    }
+  }
+
+  template <typename OutT                                                          = TypeOut,
+            typename LhsT                                                          = TypeLhs,
+            typename RhsT                                                          = TypeRhs,
+            std::enable_if_t<(std::is_integral_v<std::common_type_t<LhsT, RhsT>> and
+                              !std::is_signed_v<std::common_type_t<LhsT, RhsT>>)>* = nullptr>
+  TypeOut operator()(TypeLhs lhs, TypeRhs rhs)
+  {
+    return lhs / rhs;
+  }
+
+  template <typename OutT                                                              = TypeOut,
+            typename LhsT                                                              = TypeLhs,
+            typename RhsT                                                              = TypeRhs,
+            std::enable_if_t<(std::is_same_v<std::common_type_t<LhsT, RhsT>, float>)>* = nullptr>
+  TypeOut operator()(TypeLhs lhs, TypeRhs rhs)
+  {
+    return static_cast<TypeOut>(floorf(lhs / rhs));
+  }
+
+  template <typename OutT                                                               = TypeOut,
+            typename LhsT                                                               = TypeLhs,
+            typename RhsT                                                               = TypeRhs,
+            std::enable_if_t<(std::is_same_v<std::common_type_t<LhsT, RhsT>, double>)>* = nullptr>
+  TypeOut operator()(TypeLhs lhs, TypeRhs rhs)
+  {
+    return static_cast<TypeOut>(floor(lhs / rhs));
   }
 };
 

--- a/cpp/tests/binaryop/util/operation.h
+++ b/cpp/tests/binaryop/util/operation.h
@@ -153,8 +153,8 @@ struct FloorDiv {
     if ((lhs ^ rhs) >= 0) {
       return lhs / rhs;
     } else {
-      const auto quotient  = lhs / rhs;
-      const auto remainder = lhs % rhs;
+      auto const quotient  = lhs / rhs;
+      auto const remainder = lhs % rhs;
       return quotient - !!remainder;
     }
   }
@@ -175,7 +175,7 @@ struct FloorDiv {
             std::enable_if_t<(std::is_same_v<std::common_type_t<LhsT, RhsT>, float>)>* = nullptr>
   TypeOut operator()(TypeLhs lhs, TypeRhs rhs)
   {
-    return static_cast<TypeOut>(floorf(lhs / rhs));
+    return static_cast<TypeOut>(std::floor(lhs / rhs));
   }
 
   template <typename OutT                                                               = TypeOut,
@@ -184,7 +184,7 @@ struct FloorDiv {
             std::enable_if_t<(std::is_same_v<std::common_type_t<LhsT, RhsT>, double>)>* = nullptr>
   TypeOut operator()(TypeLhs lhs, TypeRhs rhs)
   {
-    return static_cast<TypeOut>(floor(lhs / rhs));
+    return static_cast<TypeOut>(std::floor(lhs / rhs));
   }
 };
 

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -881,12 +881,27 @@ def test_logical_operator_func_dataframe(func, nulls, other):
     utils.assert_eq(expect, got)
 
 
-@pytest.mark.parametrize("func", _operators_arithmetic + _operators_comparison)
+@pytest.mark.parametrize(
+    "func",
+    [op for op in _operators_arithmetic if op not in {"rmod", "rfloordiv"}]
+    + _operators_comparison
+    + [
+        pytest.param(
+            "rmod",
+            marks=pytest.mark.xfail(
+                reason="https://github.com/rapidsai/cudf/issues/12162"
+            ),
+        ),
+        pytest.param(
+            "rfloordiv",
+            marks=pytest.mark.xfail(
+                reason="https://github.com/rapidsai/cudf/issues/12162"
+            ),
+        ),
+    ],
+)
 @pytest.mark.parametrize("rhs", [0, 1, 2, 128])
 def test_binop_bool_uint(func, rhs):
-    # TODO: remove this once issue #2172 is resolved
-    if func == "rmod" or func == "rfloordiv":
-        return
     psr = pd.Series([True, False, False])
     gsr = cudf.from_pandas(psr)
     utils.assert_eq(


### PR DESCRIPTION
## Description

Previously (since c8b897ccd) floor division for all pairs of arguments
was implemented by promoting both arguments to double, dividing, and
then taking the floor.

This produces results when both operands are integral that sometimes
don't match the behaviour of normal floor division in any of the
target languages that cuDF supports. Specifically for int64 operands,
any time an operand is larger than $2^{53}$, the conversion to double is
not injective and so information is lost.

To address this, implement SFINAE overloads for the FloorDiv device
functor that use standard C++ type promotion semantics for division
with mixed type operands. In the case of integral types with same
sign, this is then just standard division; if the signs are mixed, we
round towards negative infinity; if either type is floating, we
perform floating point division and then take the floor.

These operations are now explicitly not implemented for Decimal and
duration dtypes (rather than implicitly not implemented in the wrapper
layers).

If the calling library's requirements for type promotion differ from
those of C++, it is the now the responsibility of the caller to
promote the operands to floor division before calling into libcudf.

Closes #12120.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
