### PR TITLE
Safely allocate `udf_string` pointers in `strings_udf`

### DIFF
--- a/python/strings_udf/cpp/src/strings/udf/shim.cu
+++ b/python/strings_udf/cpp/src/strings/udf/shim.cu
@@ -223,7 +223,7 @@ extern "C" __device__ int udf_string_from_string_view(int* nb_retbal,
                                                       void* udf_str)
 {
   auto str_view_ptr = reinterpret_cast<cudf::string_view const*>(str);
-  auto udf_str_ptr  = reinterpret_cast<udf_string*>(udf_str);
+  auto udf_str_ptr  = new (udf_str) udf_string;
   *udf_str_ptr      = udf_string(*str_view_ptr);
 
   return 0;
@@ -236,7 +236,7 @@ extern "C" __device__ int strip(int* nb_retval,
 {
   auto to_strip_ptr  = reinterpret_cast<cudf::string_view const*>(to_strip);
   auto strip_str_ptr = reinterpret_cast<cudf::string_view const*>(strip_str);
-  auto udf_str_ptr   = reinterpret_cast<udf_string*>(udf_str);
+  auto udf_str_ptr   = new (udf_str) udf_string;
 
   *udf_str_ptr = strip(*to_strip_ptr, *strip_str_ptr);
 
@@ -250,7 +250,7 @@ extern "C" __device__ int lstrip(int* nb_retval,
 {
   auto to_strip_ptr  = reinterpret_cast<cudf::string_view const*>(to_strip);
   auto strip_str_ptr = reinterpret_cast<cudf::string_view const*>(strip_str);
-  auto udf_str_ptr   = reinterpret_cast<udf_string*>(udf_str);
+  auto udf_str_ptr   = new (udf_str) udf_string;
 
   *udf_str_ptr = strip(*to_strip_ptr, *strip_str_ptr, cudf::strings::side_type::LEFT);
 
@@ -264,7 +264,7 @@ extern "C" __device__ int rstrip(int* nb_retval,
 {
   auto to_strip_ptr  = reinterpret_cast<cudf::string_view const*>(to_strip);
   auto strip_str_ptr = reinterpret_cast<cudf::string_view const*>(strip_str);
-  auto udf_str_ptr   = reinterpret_cast<udf_string*>(udf_str);
+  auto udf_str_ptr   = new (udf_str) udf_string;
 
   *udf_str_ptr = strip(*to_strip_ptr, *strip_str_ptr, cudf::strings::side_type::RIGHT);
 

--- a/python/strings_udf/strings_udf/lowering.py
+++ b/python/strings_udf/strings_udf/lowering.py
@@ -115,7 +115,9 @@ def cast_string_literal_to_string_view(context, builder, fromty, toty, val):
 @cuda_lowering_registry.lower_cast(string_view, udf_string)
 def cast_string_view_to_udf_string(context, builder, fromty, toty, val):
     sv_ptr = builder.alloca(default_manager[fromty].get_value_type())
-    udf_str_ptr = builder.alloca(default_manager[toty].get_value_type())
+    udf_str_ptr = cgutils.alloca_once(
+        builder, default_manager[toty].get_value_type(), zfill=True
+    )
     builder.store(val, sv_ptr)
     _ = context.compile_internal(
         builder,
@@ -196,8 +198,10 @@ def create_binary_string_func(binary_func, retty):
                 # value of compile_internal is therefore discarded (although
                 # this may change in the future if we need to return error
                 # codes, for instance).
-                udf_str_ptr = builder.alloca(
-                    default_manager[udf_string].get_value_type()
+                udf_str_ptr = cgutils.alloca_once(
+                    builder,
+                    default_manager[udf_string].get_value_type(),
+                    zfill=True,
                 )
 
                 _ = context.compile_internal(

--- a/python/strings_udf/strings_udf/lowering.py
+++ b/python/strings_udf/strings_udf/lowering.py
@@ -115,9 +115,7 @@ def cast_string_literal_to_string_view(context, builder, fromty, toty, val):
 @cuda_lowering_registry.lower_cast(string_view, udf_string)
 def cast_string_view_to_udf_string(context, builder, fromty, toty, val):
     sv_ptr = builder.alloca(default_manager[fromty].get_value_type())
-    udf_str_ptr = cgutils.alloca_once(
-        builder, default_manager[toty].get_value_type(), zfill=True
-    )
+    udf_str_ptr = builder.alloca(default_manager[toty].get_value_type())
     builder.store(val, sv_ptr)
     _ = context.compile_internal(
         builder,
@@ -198,12 +196,9 @@ def create_binary_string_func(binary_func, retty):
                 # value of compile_internal is therefore discarded (although
                 # this may change in the future if we need to return error
                 # codes, for instance).
-                udf_str_ptr = cgutils.alloca_once(
-                    builder,
-                    default_manager[udf_string].get_value_type(),
-                    zfill=True,
+                udf_str_ptr = builder.alloca(
+                    default_manager[udf_string].get_value_type()
                 )
-
                 _ = context.compile_internal(
                     builder,
                     cuda_func,


### PR DESCRIPTION
In `strings_udf`, functions that return strings are built around c++ methods that return a `cudf::strings::udf::udf_string` object. However due to requiring external `C` linkage, our shim functions need to work by accepting a pointer to a preallocated `udf_string` object and setting the result into the memory it points to before returning. 

This piece of memory is allocated based off our `UDFString` extension class datamodel and while it is set up to be the right size, simply allocating it does not actually call the underlying `udf_string` default constructor so the memory isn't necessarily initialized in the same way a proper `udf_string` would initialize it. 

This can lead to some unsafe behavior when we try and assign the result. This PR changes it so that whenever we need to allocate a `udf_string` and pass its pointer to a shim function, we first zfill that memory.