### PR TITLE
Ensure dlpack include is provided to cudf interop lib

### DIFF
--- a/cpp/cmake/thirdparty/get_dlpack.cmake
+++ b/cpp/cmake/thirdparty/get_dlpack.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/cpp/cmake/thirdparty/get_dlpack.cmake
+++ b/cpp/cmake/thirdparty/get_dlpack.cmake
@@ -18,7 +18,9 @@ function(find_and_configure_dlpack VERSION)
   include(${rapids-cmake-dir}/find/generate_module.cmake)
   rapids_find_generate_module(DLPACK HEADER_NAMES dlpack.h)
 
+  include(${rapids-cmake-dir}/cpm/init.cmake)
   include(${rapids-cmake-dir}/cpm/find.cmake)
+  rapids_cpm_init()
   rapids_cpm_find(
     dlpack ${VERSION}
     GIT_REPOSITORY https://github.com/dmlc/dlpack.git

--- a/cpp/cmake/thirdparty/get_dlpack.cmake
+++ b/cpp/cmake/thirdparty/get_dlpack.cmake
@@ -18,9 +18,6 @@ function(find_and_configure_dlpack VERSION)
   include(${rapids-cmake-dir}/find/generate_module.cmake)
   rapids_find_generate_module(DLPACK HEADER_NAMES dlpack.h)
 
-  include(${rapids-cmake-dir}/cpm/init.cmake)
-  include(${rapids-cmake-dir}/cpm/find.cmake)
-  rapids_cpm_init()
   rapids_cpm_find(
     dlpack ${VERSION}
     GIT_REPOSITORY https://github.com/dmlc/dlpack.git

--- a/cpp/cmake/thirdparty/get_dlpack.cmake
+++ b/cpp/cmake/thirdparty/get_dlpack.cmake
@@ -18,6 +18,7 @@ function(find_and_configure_dlpack VERSION)
   include(${rapids-cmake-dir}/find/generate_module.cmake)
   rapids_find_generate_module(DLPACK HEADER_NAMES dlpack.h)
 
+  include(${rapids-cmake-dir}/cpm/find.cmake)
   rapids_cpm_find(
     dlpack ${VERSION}
     GIT_REPOSITORY https://github.com/dmlc/dlpack.git

--- a/cpp/cmake/thirdparty/get_dlpack.cmake
+++ b/cpp/cmake/thirdparty/get_dlpack.cmake
@@ -15,6 +15,7 @@
 # This function finds dlpack and sets any additional necessary environment variables.
 function(find_and_configure_dlpack VERSION)
 
+  include(${rapids-cmake-dir}/find/generate_module.cmake)
   rapids_find_generate_module(DLPACK HEADER_NAMES dlpack.h)
 
   rapids_cpm_find(

--- a/python/cudf/CMakeLists.txt
+++ b/python/cudf/CMakeLists.txt
@@ -54,6 +54,8 @@ if(FIND_CUDF_CPP)
 
   # an installed version of libcudf doesn't provide the dlpack headers so we need to download dlpack
   # for the interop.pyx
+  include(rapids-cpm)
+  rapids_cpm_init()
   include(../../cpp/cmake/thirdparty/get_dlpack.cmake)
 else()
   set(cudf_FOUND OFF)

--- a/python/cudf/CMakeLists.txt
+++ b/python/cudf/CMakeLists.txt
@@ -51,6 +51,10 @@ if(FIND_CUDF_CPP)
   endif()
 
   find_package(cudf ${cudf_version} REQUIRED)
+
+  # an installed version of libcudf doesn't provide the dlpack
+  # headers so we need to download dlpack for the interop.pyx
+  include(../../cpp/cmake/thirdparty/get_dlpack.cmake)
 else()
   set(cudf_FOUND OFF)
 endif()

--- a/python/cudf/CMakeLists.txt
+++ b/python/cudf/CMakeLists.txt
@@ -52,8 +52,8 @@ if(FIND_CUDF_CPP)
 
   find_package(cudf ${cudf_version} REQUIRED)
 
-  # an installed version of libcudf doesn't provide the dlpack
-  # headers so we need to download dlpack for the interop.pyx
+  # an installed version of libcudf doesn't provide the dlpack headers so we need to download dlpack
+  # for the interop.pyx
   include(../../cpp/cmake/thirdparty/get_dlpack.cmake)
 else()
   set(cudf_FOUND OFF)

--- a/python/cudf/cudf/_lib/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/CMakeLists.txt
@@ -69,6 +69,11 @@ foreach(target IN LISTS targets_using_numpy)
   target_include_directories(${target} PRIVATE "${Python_NumPy_INCLUDE_DIRS}")
 endforeach()
 
+set(targets_using_dlpack interop)
+foreach(target IN LISTS targets_using_dlpack)
+  target_include_directories(${target} PRIVATE "${DLPACK_INCLUDE_DIR}")
+endforeach()
+
 add_subdirectory(io)
 add_subdirectory(nvtext)
 add_subdirectory(strings)


### PR DESCRIPTION
## Description
As brought up in #12081 it is possible to have python build failures due to no include paths to dlpack being provided. This fixes the issue by ensure that the DLPACK_INCLUDE_DIR is propagated down to the interop target.

We don't run into this issue with conda, since the dlpack headers are inside the conda include dir which is already being provided to the compiler.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
