### PR TITLE
[WIP] Selectively use dictionary encoding in Parquet writer

### DIFF
--- a/cpp/benchmarks/io/nvbench_helpers.hpp
+++ b/cpp/benchmarks/io/nvbench_helpers.hpp
@@ -72,6 +72,7 @@ NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
   [](auto value) {
     switch (value) {
       case cudf::io::compression_type::SNAPPY: return "SNAPPY";
+      case cudf::io::compression_type::ZSTD: return "ZSTD";
       case cudf::io::compression_type::NONE: return "NONE";
       default: return "Unknown";
     }

--- a/cpp/benchmarks/io/parquet/parquet_writer.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_writer.cpp
@@ -197,8 +197,9 @@ using io_list = nvbench::enum_type_list<cudf::io::io_type::FILEPATH,
                                         cudf::io::io_type::HOST_BUFFER,
                                         cudf::io::io_type::VOID>;
 
-using compression_list =
-  nvbench::enum_type_list<cudf::io::compression_type::SNAPPY, cudf::io::compression_type::NONE>;
+using compression_list = nvbench::enum_type_list<cudf::io::compression_type::SNAPPY,
+                                                 cudf::io::compression_type::ZSTD,
+                                                 cudf::io::compression_type::NONE>;
 
 using stats_list = nvbench::enum_type_list<cudf::io::STATISTICS_NONE,
                                            cudf::io::STATISTICS_ROWGROUP,

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -359,6 +359,12 @@ __global__ void __launch_bounds__(128)
       // override this_max_page_size if the requested size is smaller
       this_max_page_size = min(this_max_page_size, max_page_size_bytes);
 
+      // subtract size of rep and def level vectors
+      this_max_page_size -=
+        util::div_rounding_up_unsafe((values_in_page + frag_g.num_values) *
+                                       (col_g.num_def_level_bits() + col_g.num_rep_level_bits()),
+                                     8);
+
       if (num_rows >= ck_g.num_rows ||
           (values_in_page > 0 && (page_size + fragment_data_size > this_max_page_size)) ||
           rows_in_page >= max_page_size_rows) {

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -270,7 +270,7 @@ struct parquet_column_device_view : stats_column_desc {
   bool output_as_byte_array;   //!< Indicates this list column is being written as a byte array
 };
 
-constexpr int max_page_fragment_size = 5000;  //!< Max number of rows in a page fragment
+constexpr int max_page_fragment_size = 1000;  //!< Max number of rows in a page fragment
 
 struct EncColumnChunk;
 


### PR DESCRIPTION
## Description
The current implementation of Zstd compression in nvcomp is limited to 64k chunk sizes.  In some cases, column chunks will not be compressed because the dictionary page exceeds this size, but the data pages do not.  This PR attempts to fix this by selectively disabling dictionary encoding when the dictionary page is too large.  Dictionary encoding will still be used if the data reduction from encoding exceeds a 4:1 ratio (4:1 is chosen rather arbitrarily and needs refinement).

This is a clumsy first attempt to gather feedback and suggestions for other approaches to try.  

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
