### PR TITLE
Don't rely on GNU find in headers_test.sh

### DIFF
--- a/ci/checks/headers_test.sh
+++ b/ci/checks/headers_test.sh
@@ -10,7 +10,7 @@ DIRNAMES="cudf cudf_test"
 
 # existence tests for lib${LIBNAME}
 for DIRNAME in ${DIRNAMES[@]}; do
-    HEADERS=`cd cpp && find include/${DIRNAME}/ -type f \( -iname "*.h" -o  -iname "*.hpp" \) -printf "        - test -f \\\$PREFIX/%p\n" | sort`
+    HEADERS=`cd cpp && find include/${DIRNAME} -type f \( -iname "*.h" -o  -iname "*.hpp" \) -print | sed 's|^|        - test -f $PREFIX/|' | sort`
     META_TESTS=`grep -E "test -f .*/include/${DIRNAME}/.*\.h(pp)?" conda/recipes/lib${LIBNAME}/meta.yaml | sort`
     HEADER_DIFF=`diff <(echo "$HEADERS") <(echo "$META_TESTS")`
     LIB_RETVAL=$?


### PR DESCRIPTION
## Description

`-printf` is a GNU find extension, so `headers_test.sh` fails on systems where binutils is a BSD toolchain.

To get around this, use sed to obtain the effect of `-printf`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
