### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/ci/checks/headers_test.sh
+++ b/ci/checks/headers_test.sh
@@ -10,7 +10,7 @@ DIRNAMES="cudf cudf_test"
 
 # existence tests for lib${LIBNAME}
 for DIRNAME in ${DIRNAMES[@]}; do
-    HEADERS=`cd cpp && find include/${DIRNAME}/ -type f \( -iname "*.h" -o  -iname "*.hpp" \) -printf "        - test -f \\\$PREFIX/%p\n" | sort`
+    HEADERS=`cd cpp && find include/${DIRNAME} -type f \( -iname "*.h" -o  -iname "*.hpp" \) -print | sed 's|^|        - test -f $PREFIX/|' | sort`
     META_TESTS=`grep -E "test -f .*/include/${DIRNAME}/.*\.h(pp)?" conda/recipes/lib${LIBNAME}/meta.yaml | sort`
     HEADER_DIFF=`diff <(echo "$HEADERS") <(echo "$META_TESTS")`
     LIB_RETVAL=$?


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.