### PR TITLE
Don't use CMake 3.25.0 as it has a show stopping FindCUDAToolkit bug

### DIFF
--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -13,7 +13,7 @@ dependencies:
 - botocore>=1.24.21
 - c-compiler
 - cachetools
-- cmake>=3.23.1
+- cmake>=3.23.1,!=3.25.0
 - cubinlinker
 - cuda-python>=11.7.1,<12.0
 - cudatoolkit=11.5

--- a/conda/recipes/cudf/conda_build_config.yaml
+++ b/conda/recipes/cudf/conda_build_config.yaml
@@ -8,7 +8,7 @@ sysroot_version:
   - "2.17"
 
 cmake_version:
-  - ">=3.23.1"
+  - ">=3.23.1,!=3.25.0"
 
 cuda_compiler:
   - nvcc

--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -22,7 +22,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.23.1
+    - cmake >=3.23.1,!=3.25.0
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}

--- a/conda/recipes/libcudf/conda_build_config.yaml
+++ b/conda/recipes/libcudf/conda_build_config.yaml
@@ -11,7 +11,7 @@ sysroot_version:
   - "2.17"
 
 cmake_version:
-  - ">=3.23.1"
+  - ">=3.23.1,!=3.25.0"
 
 gtest_version:
   - "=1.10.0"

--- a/conda/recipes/strings_udf/conda_build_config.yaml
+++ b/conda/recipes/strings_udf/conda_build_config.yaml
@@ -8,7 +8,7 @@ sysroot_version:
   - "2.17"
 
 cmake_version:
-  - ">=3.23.1"
+  - ">=3.23.1,!=3.25.0"
 
 cuda_compiler:
   - nvcc

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -40,7 +40,7 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - cmake>=3.23.1
+          - cmake>=3.23.1,!=3.25.0
           - cuda-python>=11.7.1,<12.0
           - cython>=0.29,<0.30
           - dlpack>=0.5,<0.6.0a0

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -7,6 +7,6 @@ requires = [
     "setuptools",
     "cython>=0.29,<0.30",
     "scikit-build>=0.13.1",
-    "cmake>=3.23.1",
+    "cmake>=3.23.1,!=3.25.0",
     "ninja",
 ]


### PR DESCRIPTION
## Description
Don't use CMake 3.25.0 as it has a show stopping FindCUDAToolkit bug

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
