### PR TITLE
Rename `cudf::structs::detail::superimpose_parent_nulls` APIs

### DIFF
--- a/cpp/include/cudf/detail/structs/utilities.hpp
+++ b/cpp/include/cudf/detail/structs/utilities.hpp
@@ -24,9 +24,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
-namespace cudf {
-namespace structs {
-namespace detail {
+namespace cudf::structs::detail {
 
 enum class column_nullability {
   MATCH_INCOMING,  ///< generate a null column if the incoming column has nulls
@@ -152,49 +150,49 @@ flattened_table flatten_nested_columns(
   column_nullability nullability = column_nullability::MATCH_INCOMING);
 
 /**
- * @brief Push down nulls from a parent mask into a child column, using bitwise AND.
+ * @brief Push down nulls from a given null mask into the input column, using bitwise AND.
  *
- * This function will recurse through all struct descendants. It is expected that
- * the size of `parent_null_mask` in bits is the same as `child.size()`
+ * This function will recurse through all struct descendants. It is expected that the size of
+ * the given null mask in bits is the same as size of the input column.
  *
- * @param parent_null_mask The mask to be applied to descendants
- * @param parent_null_count Null count in the null mask
- * @param column Column to apply the null mask to.
- * @param stream CUDA stream used for device memory operations and kernel launches.
- * @param mr     Device memory resource used to allocate new device memory.
+ * @param null_mask Null mask to be applied to the input column
+ * @param null_count Null count in the given null mask
+ * @param input Column to apply the null mask to
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate new device memory
  */
-void superimpose_parent_nulls(bitmask_type const* parent_null_mask,
-                              size_type parent_null_count,
-                              column& child,
-                              rmm::cuda_stream_view stream,
-                              rmm::mr::device_memory_resource* mr);
+void superimpose_nulls(bitmask_type const* null_mask,
+                       size_type null_count,
+                       column& input,
+                       rmm::cuda_stream_view stream,
+                       rmm::mr::device_memory_resource* mr);
 
 /**
- * @brief Push down nulls from a parent mask into a child column, using bitwise AND.
+ * @brief Push down nulls from the given input column into its children columns, using bitwise AND.
  *
- * This function constructs a new column_view instance equivalent to the argument column_view,
- * with possibly new child column_views, all with possibly new null mask values reflecting
+ * This function constructs a new column_view instance equivalent to the input column_view,
+ * with possibly new child column_view, all with possibly new null mask reflecting
  * null rows from the parent column:
  * 1. If the specified column is not STRUCT, the column is returned unmodified, with no new
  *    supporting device_buffer instances.
  * 2. If the column is STRUCT, the null masks of the parent and child are bitwise-ANDed, and a
  *    modified column_view is returned. This applies recursively.
  *
- * @param parent The parent (possibly STRUCT) column whose nulls need to be pushed to its members.
- * @param stream CUDA stream used for device memory operations and kernel launches.
- * @param mr     Device memory resource used to allocate new device memory.
+ * @param input The input (possibly STRUCT) column whose nulls need to be pushed to its children
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate new device memory
  * @return A pair of:
  *         1. column_view with nulls pushed down to child columns, as appropriate.
  *         2. Supporting device_buffer instances, for any newly constructed null masks.
  */
-std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> superimpose_parent_nulls(
-  column_view const& parent,
+std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> push_down_nulls(
+  column_view const& input,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Push down nulls from a parent mask into child columns, using bitwise AND,
- * for all columns in the specified table.
+ * @brief Push down nulls from columns of the input table into their children columns, using bitwise
+ * AND.
  *
  * This function constructs a table_view containing a new column_view instance equivalent to
  * every column_view in the specified table. Each column_view might contain possibly new
@@ -205,16 +203,16 @@ std::tuple<cudf::column_view, std::vector<rmm::device_buffer>> superimpose_paren
  * 2. If the column is STRUCT, the null masks of the parent and child are bitwise-ANDed, and a
  *    modified column_view is returned. This applies recursively.
  *
- * @param table The table_view of (possibly STRUCT) columns whose nulls need to be pushed to its
- * members.
- * @param stream CUDA stream used for device memory operations and kernel launches.
- * @param mr     Device memory resource used to allocate new device memory.
+ * @param input The table_view of (possibly STRUCT) columns whose nulls need to be pushed to its
+ *        members
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate new device memory
  * @return A pair of:
  *         1. table_view of columns with nulls pushed down to child columns, as appropriate.
  *         2. Supporting device_buffer instances, for any newly constructed null masks.
  */
-std::tuple<cudf::table_view, std::vector<rmm::device_buffer>> superimpose_parent_nulls(
-  table_view const& table,
+std::tuple<cudf::table_view, std::vector<rmm::device_buffer>> push_down_nulls(
+  table_view const& input,
   rmm::cuda_stream_view stream,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
@@ -231,6 +229,5 @@ std::tuple<cudf::table_view, std::vector<rmm::device_buffer>> superimpose_parent
  * struct.
  */
 bool contains_null_structs(column_view const& col);
-}  // namespace detail
-}  // namespace structs
-}  // namespace cudf
+
+}  // namespace cudf::structs::detail

--- a/cpp/src/groupby/sort/group_scan_util.cuh
+++ b/cpp/src/groupby/sort/group_scan_util.cuh
@@ -226,7 +226,7 @@ struct group_scan_functor<K,
     // column to them.
     if (values.has_nulls()) {
       for (std::unique_ptr<column>& child : scanned_children) {
-        structs::detail::superimpose_parent_nulls(
+        structs::detail::superimpose_nulls(
           values.null_mask(), values.null_count(), *child, stream, mr);
       }
     }

--- a/cpp/src/reductions/scan/scan_inclusive.cu
+++ b/cpp/src/reductions/scan/scan_inclusive.cu
@@ -265,7 +265,7 @@ std::unique_ptr<column> scan_inclusive(
   // into the children columns.
   if (input.type().id() == type_id::STRUCT && output->has_nulls()) {
     for (size_type idx = 0; idx < output->num_children(); ++idx) {
-      structs::detail::superimpose_parent_nulls(
+      structs::detail::superimpose_nulls(
         output->view().null_mask(), output->null_count(), output->child(idx), stream, mr);
     }
   }

--- a/cpp/src/scalar/scalar.cpp
+++ b/cpp/src/scalar/scalar.cpp
@@ -584,7 +584,7 @@ void struct_scalar::superimpose_nulls(rmm::cuda_stream_view stream,
   auto validity = cudf::detail::create_null_mask(1, mask_state::ALL_NULL, stream);
   auto iter     = thrust::make_counting_iterator(0);
   std::for_each(iter, iter + _data.num_columns(), [&](size_type i) {
-    cudf::structs::detail::superimpose_parent_nulls(
+    cudf::structs::detail::superimpose_nulls(
       static_cast<bitmask_type const*>(validity.data()), 1, _data.get_column(i), stream, mr);
   });
 }

--- a/cpp/src/structs/structs_column_factories.cu
+++ b/cpp/src/structs/structs_column_factories.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/structs/structs_column_factories.cu
+++ b/cpp/src/structs/structs_column_factories.cu
@@ -44,7 +44,7 @@ std::unique_ptr<cudf::column> make_structs_column(
 
   if (!null_mask.is_empty()) {
     for (auto& child : child_columns) {
-      cudf::structs::detail::superimpose_parent_nulls(
+      cudf::structs::detail::superimpose_nulls(
         static_cast<bitmask_type const*>(null_mask.data()), null_count, *child, stream, mr);
     }
   }

--- a/cpp/src/table/row_operators.cu
+++ b/cpp/src/table/row_operators.cu
@@ -398,7 +398,7 @@ std::shared_ptr<preprocessed_table> preprocessed_table::create(table_view const&
 {
   check_eq_compatibility(t);
 
-  auto [null_pushed_table, null_masks] = structs::detail::superimpose_parent_nulls(t, stream);
+  auto [null_pushed_table, null_masks] = structs::detail::push_down_nulls(t, stream);
   auto struct_offset_removed_table     = remove_struct_child_offsets(null_pushed_table);
   auto [verticalized_lhs, _, __, ___]  = decompose_structs(struct_offset_removed_table);
 

--- a/cpp/tests/io/parquet_chunked_reader_test.cpp
+++ b/cpp/tests/io/parquet_chunked_reader_test.cpp
@@ -83,11 +83,11 @@ auto write_file(std::vector<std::unique_ptr<cudf::column>>& input_columns,
         auto const null_count = col->null_count();
 
         for (cudf::size_type idx = 0; idx < col->num_children(); ++idx) {
-          cudf::structs::detail::superimpose_parent_nulls(null_mask,
-                                                          null_count,
-                                                          col->child(idx),
-                                                          cudf::get_default_stream(),
-                                                          rmm::mr::get_current_device_resource());
+          cudf::structs::detail::superimpose_nulls(null_mask,
+                                                   null_count,
+                                                   col->child(idx),
+                                                   cudf::get_default_stream(),
+                                                   rmm::mr::get_current_device_resource());
         }
       }
 

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -1898,7 +1898,7 @@ TEST_F(JoinTest, Repro_StructsWithoutNullsPushedDown)
   // Note: Join result might not have nulls pushed down, since it's an output of gather().
   // Must superimpose parent nulls before comparisons.
   auto [superimposed_results, _] =
-    cudf::structs::detail::superimpose_parent_nulls(*result, cudf::get_default_stream());
+    cudf::structs::detail::push_down_nulls(*result, cudf::get_default_stream());
 
   auto const expected = [] {
     auto fact_ints    = ints{0};


### PR DESCRIPTION
There are several overloads of these functions which work differently. They are classified into 2 groups:
 * `superimpose_parent_nulls(null_mask, null_count, column)`: Performs superimposing nulls from somewhere else into the input column,
 * `superimpose_parent_nulls(column_view/table_view)`: Perform superimposing nulls of the input column(s) into their children columns-the input root column(s) are not affected.

That is confusing. They should have different names to reflect their purposes. This PR renames these groups into more meaningful names: `superimpose_nulls` and `push_down_nulls`. No implementation has been changed.

This also supports https://github.com/rapidsai/cudf/issues/12027.