### PR TITLE
Make pinning >=.

### DIFF
--- a/python/dask_cudf/setup.py
+++ b/python/dask_cudf/setup.py
@@ -8,8 +8,8 @@ from setuptools import find_packages, setup
 cuda_suffix = os.getenv("RAPIDS_PY_WHEEL_CUDA_SUFFIX", default="")
 
 install_requires = [
-    "dask==2022.9.2",
-    "distributed==2022.9.2",
+    "dask>=2022.9.2",
+    "distributed>=2022.9.2",
     "fsspec>=0.6.0",
     "numpy",
     "pandas>=1.0,<1.6.0dev0",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR relaxes the pinning of dask and distributed for 22.12 so that it can be updated in lockstep with other packages in #12165. The current strict pinning causes problems for all downstream RAPIDS packages that have cudf as a pip dependency.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
