### PR TITLE
Wrapping concat and file writes in `@acquire_spill_lock()`

### DIFF
--- a/python/cudf/cudf/_lib/concat.pyx
+++ b/python/cudf/cudf/_lib/concat.pyx
@@ -19,7 +19,7 @@ from cudf._lib.utils cimport (
     table_view_from_table,
 )
 
-from cudf.core.buffer import as_buffer
+from cudf.core.buffer import acquire_spill_lock, as_buffer
 
 from rmm._lib.device_buffer cimport DeviceBuffer, device_buffer
 
@@ -36,7 +36,8 @@ cpdef concat_masks(object columns):
     )
 
 
-cpdef concat_columns(object columns):
+@acquire_spill_lock()
+def concat_columns(object columns):
     cdef unique_ptr[column] c_result
     cdef vector[column_view] c_views = make_column_views(columns)
     with nogil:
@@ -44,7 +45,8 @@ cpdef concat_columns(object columns):
     return Column.from_unique_ptr(move(c_result))
 
 
-cpdef concat_tables(object tables, bool ignore_index=False):
+@acquire_spill_lock()
+def concat_tables(object tables, bool ignore_index=False):
     cdef unique_ptr[table] c_result
     cdef vector[table_view] c_views
     c_views.reserve(len(tables))

--- a/python/cudf/cudf/_lib/csv.pyx
+++ b/python/cudf/cudf/_lib/csv.pyx
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 
 import cudf
+from cudf.core.buffer import acquire_spill_lock
 
 from cudf._lib.cpp.types cimport size_type
 
@@ -443,7 +444,8 @@ def read_csv(
     return df
 
 
-cpdef write_csv(
+@acquire_spill_lock()
+def write_csv(
     table,
     object path_or_buf=None,
     object sep=",",

--- a/python/cudf/cudf/_lib/orc.pyx
+++ b/python/cudf/cudf/_lib/orc.pyx
@@ -1,6 +1,7 @@
 # Copyright (c) 2020-2022, NVIDIA CORPORATION.
 
 import cudf
+from cudf.core.buffer import acquire_spill_lock
 
 from libcpp cimport bool, int
 from libcpp.map cimport map
@@ -231,15 +232,18 @@ cdef cudf_io_types.statistics_freq _get_orc_stat_freq(object statistics):
         raise ValueError(f"Unsupported `statistics_freq` type {statistics}")
 
 
-cpdef write_orc(table,
-                object path_or_buf,
-                object compression="snappy",
-                object statistics="ROWGROUP",
-                object stripe_size_bytes=None,
-                object stripe_size_rows=None,
-                object row_index_stride=None,
-                object cols_as_map_type=None,
-                object index=None):
+@acquire_spill_lock()
+def write_orc(
+    table,
+    object path_or_buf,
+    object compression="snappy",
+    object statistics="ROWGROUP",
+    object stripe_size_bytes=None,
+    object stripe_size_rows=None,
+    object row_index_stride=None,
+    object cols_as_map_type=None,
+    object index=None
+):
     """
     Cython function to call into libcudf API, see `cudf::io::write_orc`.
 

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -7,6 +7,7 @@ import io
 import pyarrow as pa
 
 import cudf
+from cudf.core.buffer import acquire_spill_lock
 
 try:
     import ujson as json
@@ -306,19 +307,21 @@ cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
 
     return df
 
-cpdef write_parquet(
-        table,
-        object filepaths_or_buffers,
-        object index=None,
-        object compression="snappy",
-        object statistics="ROWGROUP",
-        object metadata_file_path=None,
-        object int96_timestamps=False,
-        object row_group_size_bytes=_ROW_GROUP_SIZE_BYTES_DEFAULT,
-        object row_group_size_rows=None,
-        object max_page_size_bytes=None,
-        object max_page_size_rows=None,
-        object partitions_info=None):
+@acquire_spill_lock()
+def write_parquet(
+    table,
+    object filepaths_or_buffers,
+    object index=None,
+    object compression="snappy",
+    object statistics="ROWGROUP",
+    object metadata_file_path=None,
+    object int96_timestamps=False,
+    object row_group_size_bytes=_ROW_GROUP_SIZE_BYTES_DEFAULT,
+    object row_group_size_rows=None,
+    object max_page_size_bytes=None,
+    object max_page_size_rows=None,
+    object partitions_info=None
+):
     """
     Cython function to call into libcudf API, see `write_parquet`.
 


### PR DESCRIPTION
Now that https://github.com/rapidsai/cudf/pull/12106 is in, wrapping the calls to `libcudf` is an ongoing effort.
