### PR TITLE
Replace column/table test utilities with macros

### DIFF
--- a/cpp/include/cudf_test/column_utilities.hpp
+++ b/cpp/include/cudf_test/column_utilities.hpp
@@ -28,8 +28,7 @@
 #include <thrust/host_vector.h>
 #include <thrust/iterator/transform_iterator.h>
 
-namespace cudf {
-namespace test {
+namespace cudf::test {
 
 /**
  * @brief Verbosity level of output from column and table comparison functions.
@@ -41,6 +40,8 @@ enum class debug_output_level {
 };
 
 constexpr size_type default_ulp = 4;
+
+namespace detail {
 
 /**
  * @brief Verifies the property equality of two columns.
@@ -108,13 +109,6 @@ bool expect_columns_equivalent(cudf::column_view const& lhs,
                                size_type fp_ulps            = cudf::test::default_ulp);
 
 /**
- * @brief Verifies the given column is empty
- *
- * @param col The column to check
- */
-void expect_column_empty(cudf::column_view const& col);
-
-/**
  * @brief Verifies the bitwise equality of two device memory buffers.
  *
  * @param lhs The first buffer
@@ -122,6 +116,15 @@ void expect_column_empty(cudf::column_view const& col);
  * @param size_bytes The number of bytes to check for equality
  */
 void expect_equal_buffers(void const* lhs, void const* rhs, std::size_t size_bytes);
+
+}  // namespace detail
+
+/**
+ * @brief Verifies the given column is empty
+ *
+ * @param col The column to check
+ */
+void expect_column_empty(cudf::column_view const& col);
 
 /**
  * @brief Formats a column view as a string
@@ -260,36 +263,35 @@ inline std::pair<thrust::host_vector<std::string>, std::vector<bitmask_type>> to
   return {host_data, bitmask_to_host(c)};
 }
 
-}  // namespace test
-}  // namespace cudf
+}  // namespace cudf::test
 
 // Macros for showing line of failure.
-#define CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(lhs, rhs) \
-  do {                                                     \
-    SCOPED_TRACE(" <--  line of failure\n");               \
-    cudf::test::expect_column_properties_equal(lhs, rhs);  \
+#define CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(lhs, rhs)        \
+  do {                                                            \
+    SCOPED_TRACE(" <--  line of failure\n");                      \
+    cudf::test::detail::expect_column_properties_equal(lhs, rhs); \
   } while (0)
 
-#define CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(lhs, rhs) \
-  do {                                                          \
-    SCOPED_TRACE(" <--  line of failure\n");                    \
-    cudf::test::expect_column_properties_equivalent(lhs, rhs);  \
+#define CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(lhs, rhs)        \
+  do {                                                                 \
+    SCOPED_TRACE(" <--  line of failure\n");                           \
+    cudf::test::detail::expect_column_properties_equivalent(lhs, rhs); \
   } while (0)
 
-#define CUDF_TEST_EXPECT_COLUMNS_EQUAL(lhs, rhs...) \
-  do {                                              \
-    SCOPED_TRACE(" <--  line of failure\n");        \
-    cudf::test::expect_columns_equal(lhs, rhs);     \
+#define CUDF_TEST_EXPECT_COLUMNS_EQUAL(lhs, rhs...)     \
+  do {                                                  \
+    SCOPED_TRACE(" <--  line of failure\n");            \
+    cudf::test::detail::expect_columns_equal(lhs, rhs); \
   } while (0)
 
-#define CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(lhs, rhs...) \
-  do {                                                   \
-    SCOPED_TRACE(" <--  line of failure\n");             \
-    cudf::test::expect_columns_equivalent(lhs, rhs);     \
-  } while (0)
-
-#define CUDF_TEST_EXPECT_EQUAL_BUFFERS(lhs, rhs, size_bytes) \
+#define CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(lhs, rhs...)     \
   do {                                                       \
     SCOPED_TRACE(" <--  line of failure\n");                 \
-    cudf::test::expect_equal_buffers(lhs, rhs, size_bytes);  \
+    cudf::test::detail::expect_columns_equivalent(lhs, rhs); \
+  } while (0)
+
+#define CUDF_TEST_EXPECT_EQUAL_BUFFERS(lhs, rhs, size_bytes)        \
+  do {                                                              \
+    SCOPED_TRACE(" <--  line of failure\n");                        \
+    cudf::test::detail::expect_equal_buffers(lhs, rhs, size_bytes); \
   } while (0)

--- a/cpp/include/cudf_test/table_utilities.hpp
+++ b/cpp/include/cudf_test/table_utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-namespace cudf {
-namespace test {
+namespace cudf::test::detail {
 /**
  * @brief Verifies the property equality of two tables.
  *
@@ -50,24 +49,23 @@ void expect_tables_equal(cudf::table_view lhs, cudf::table_view rhs);
  */
 void expect_tables_equivalent(cudf::table_view lhs, cudf::table_view rhs);
 
-}  // namespace test
-}  // namespace cudf
+}  // namespace cudf::test::detail
 
 // Macros for showing line of failure.
-#define CUDF_TEST_EXPECT_TABLE_PROPERTIES_EQUAL(lhs, rhs) \
-  do {                                                    \
-    SCOPED_TRACE(" <--  line of failure\n");              \
-    cudf::test::expect_table_properties_equal(lhs, rhs);  \
+#define CUDF_TEST_EXPECT_TABLE_PROPERTIES_EQUAL(lhs, rhs)        \
+  do {                                                           \
+    SCOPED_TRACE(" <--  line of failure\n");                     \
+    cudf::test::detail::expect_table_properties_equal(lhs, rhs); \
   } while (0)
 
-#define CUDF_TEST_EXPECT_TABLES_EQUAL(lhs, rhs) \
-  do {                                          \
-    SCOPED_TRACE(" <--  line of failure\n");    \
-    cudf::test::expect_tables_equal(lhs, rhs);  \
+#define CUDF_TEST_EXPECT_TABLES_EQUAL(lhs, rhs)        \
+  do {                                                 \
+    SCOPED_TRACE(" <--  line of failure\n");           \
+    cudf::test::detail::expect_tables_equal(lhs, rhs); \
   } while (0)
 
-#define CUDF_TEST_EXPECT_TABLES_EQUIVALENT(lhs, rhs) \
-  do {                                               \
-    SCOPED_TRACE(" <--  line of failure\n");         \
-    cudf::test::expect_tables_equivalent(lhs, rhs);  \
+#define CUDF_TEST_EXPECT_TABLES_EQUIVALENT(lhs, rhs)        \
+  do {                                                      \
+    SCOPED_TRACE(" <--  line of failure\n");                \
+    cudf::test::detail::expect_tables_equivalent(lhs, rhs); \
   } while (0)

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -60,7 +60,7 @@ TEST_F(TransformTest, ColumnReference)
   auto const& expected = c_0;
   auto result          = cudf::compute_column(table, col_ref_0);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, Literal)
@@ -75,7 +75,7 @@ TEST_F(TransformTest, Literal)
   auto expected = column_wrapper<int32_t>{42, 42, 42, 42};
   auto result   = cudf::compute_column(table, literal);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, NullLiteral)
@@ -92,7 +92,7 @@ TEST_F(TransformTest, NullLiteral)
   auto result   = cudf::compute_column(table, expression);
   auto expected = column_wrapper<int32_t>({-123, -123, -123, -123}, {0, 0, 0, 0});
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, BasicAddition)
@@ -108,7 +108,7 @@ TEST_F(TransformTest, BasicAddition)
   auto expected = column_wrapper<int32_t>{13, 27, 21, 50};
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, BasicAdditionCast)
@@ -125,7 +125,7 @@ TEST_F(TransformTest, BasicAdditionCast)
   auto expected = column_wrapper<int64_t>{13, 27, 21, 50};
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, BasicEquality)
@@ -141,7 +141,7 @@ TEST_F(TransformTest, BasicEquality)
   auto expected = column_wrapper<bool>{true, false, true, false};
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, BasicAdditionLarge)
@@ -157,7 +157,7 @@ TEST_F(TransformTest, BasicAdditionLarge)
   auto expected = column_wrapper<int32_t>(b, b + 2000);
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, LessComparator)
@@ -173,7 +173,7 @@ TEST_F(TransformTest, LessComparator)
   auto expected = column_wrapper<bool>{true, false, true, false};
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, LessComparatorLarge)
@@ -192,7 +192,7 @@ TEST_F(TransformTest, LessComparatorLarge)
   auto expected = column_wrapper<bool>(c, c + 2000);
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, MultiLevelTreeArithmetic)
@@ -218,7 +218,7 @@ TEST_F(TransformTest, MultiLevelTreeArithmetic)
   auto result   = cudf::compute_column(table, expression_tree);
   auto expected = column_wrapper<int32_t>{7, 73, 22, -99};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, MultiLevelTreeArithmeticLarge)
@@ -246,7 +246,7 @@ TEST_F(TransformTest, MultiLevelTreeArithmeticLarge)
   auto d      = cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return calc(i); });
   auto expected = column_wrapper<int32_t>(d, d + 2000);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, ImbalancedTreeArithmetic)
@@ -270,7 +270,7 @@ TEST_F(TransformTest, ImbalancedTreeArithmetic)
   auto expected =
     column_wrapper<double>{0.6, std::numeric_limits<double>::infinity(), -3.201, -2099.18};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, MultiLevelTreeComparator)
@@ -296,7 +296,7 @@ TEST_F(TransformTest, MultiLevelTreeComparator)
   auto result   = cudf::compute_column(table, expression_tree);
   auto expected = column_wrapper<bool>{false, true, false, false};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, MultiTypeOperationFailure)
@@ -332,7 +332,7 @@ TEST_F(TransformTest, LiteralComparison)
   auto result   = cudf::compute_column(table, expression);
   auto expected = column_wrapper<bool>{false, false, false, true};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, UnaryNot)
@@ -347,7 +347,7 @@ TEST_F(TransformTest, UnaryNot)
   auto result   = cudf::compute_column(table, expression);
   auto expected = column_wrapper<bool>{false, true, false, false};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, UnaryTrigonometry)
@@ -360,17 +360,17 @@ TEST_F(TransformTest, UnaryTrigonometry)
   auto expected_sin   = column_wrapper<double>{0.0, std::sqrt(2) / 2, std::sqrt(3.0) / 2.0};
   auto expression_sin = cudf::ast::operation(cudf::ast::ast_operator::SIN, col_ref_0);
   auto result_sin     = cudf::compute_column(table, expression_sin);
-  cudf::test::expect_columns_equivalent(expected_sin, result_sin->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_sin, result_sin->view(), verbosity);
 
   auto expected_cos   = column_wrapper<double>{1.0, std::sqrt(2) / 2, 0.5};
   auto expression_cos = cudf::ast::operation(cudf::ast::ast_operator::COS, col_ref_0);
   auto result_cos     = cudf::compute_column(table, expression_cos);
-  cudf::test::expect_columns_equivalent(expected_cos, result_cos->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_cos, result_cos->view(), verbosity);
 
   auto expected_tan   = column_wrapper<double>{0.0, 1.0, std::sqrt(3.0)};
   auto expression_tan = cudf::ast::operation(cudf::ast::ast_operator::TAN, col_ref_0);
   auto result_tan     = cudf::compute_column(table, expression_tan);
-  cudf::test::expect_columns_equivalent(expected_tan, result_tan->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_tan, result_tan->view(), verbosity);
 }
 
 TEST_F(TransformTest, ArityCheckFailure)
@@ -394,7 +394,7 @@ TEST_F(TransformTest, StringComparison)
   auto expected = column_wrapper<bool>{true, false, true, false};
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, CopyColumn)
@@ -408,7 +408,7 @@ TEST_F(TransformTest, CopyColumn)
   auto result   = cudf::compute_column(table, expression);
   auto expected = column_wrapper<int32_t>{3, 0, 1, 50};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, CopyLiteral)
@@ -424,7 +424,7 @@ TEST_F(TransformTest, CopyLiteral)
   auto result   = cudf::compute_column(table, expression);
   auto expected = column_wrapper<int32_t>{-123, -123, -123, -123};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, TrueDiv)
@@ -441,7 +441,7 @@ TEST_F(TransformTest, TrueDiv)
   auto result   = cudf::compute_column(table, expression);
   auto expected = column_wrapper<double>{1.5, 0.0, 0.5, 25.0};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, FloorDiv)
@@ -458,7 +458,7 @@ TEST_F(TransformTest, FloorDiv)
   auto result   = cudf::compute_column(table, expression);
   auto expected = column_wrapper<double>{1.0, 0.0, 0.0, 25.0};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, Mod)
@@ -475,7 +475,7 @@ TEST_F(TransformTest, Mod)
   auto result   = cudf::compute_column(table, expression);
   auto expected = column_wrapper<double>{1.0, 0.0, -1.0, 0.0};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, PyMod)
@@ -492,7 +492,7 @@ TEST_F(TransformTest, PyMod)
   auto result   = cudf::compute_column(table, expression);
   auto expected = column_wrapper<double>{1.0, 0.0, 1.0, 0.0};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, BasicEqualityNullEqualNoNulls)
@@ -508,7 +508,7 @@ TEST_F(TransformTest, BasicEqualityNullEqualNoNulls)
   auto expected = column_wrapper<bool>{true, false, true, false};
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, BasicEqualityNormalEqualWithNulls)
@@ -524,7 +524,7 @@ TEST_F(TransformTest, BasicEqualityNormalEqualWithNulls)
   auto expected = column_wrapper<bool>{{true, false, true, true}, {1, 1, 0, 0}};
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, BasicEqualityNulls)
@@ -540,7 +540,7 @@ TEST_F(TransformTest, BasicEqualityNulls)
   auto expected = column_wrapper<bool>{{true, false, false, false, true}, {1, 1, 1, 1, 1}};
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, UnaryNotNulls)
@@ -555,7 +555,7 @@ TEST_F(TransformTest, UnaryNotNulls)
   auto result   = cudf::compute_column(table, expression);
   auto expected = column_wrapper<bool>{{false, true, true, false}, {0, 0, 1, 1}};
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, BasicAdditionNulls)
@@ -571,7 +571,7 @@ TEST_F(TransformTest, BasicAdditionNulls)
   auto expected = column_wrapper<int32_t>{{0, 0, 0, 50}, {0, 0, 0, 1}};
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, BasicAdditionLargeNulls)
@@ -597,7 +597,7 @@ TEST_F(TransformTest, BasicAdditionLargeNulls)
   auto expected = column_wrapper<int32_t>(b, b + N, validities.begin());
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, NullLogicalAnd)
@@ -617,7 +617,7 @@ TEST_F(TransformTest, NullLogicalAnd)
                                        {1, 1, 1, 1, 1, 0, 1, 0}};
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 TEST_F(TransformTest, NullLogicalOr)
@@ -637,7 +637,7 @@ TEST_F(TransformTest, NullLogicalOr)
                                        {1, 1, 1, 1, 0, 1, 1, 0}};
   auto result   = cudf::compute_column(table, expression);
 
-  cudf::test::expect_columns_equal(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
 CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/column/bit_cast_test.cpp
+++ b/cpp/tests/column/bit_cast_test.cpp
@@ -67,16 +67,16 @@ void do_bit_cast(cudf::column_view const& column_view, Iterator begin, Iterator 
     // Cast to same to_type
     auto output  = cudf::bit_cast(column_view, column_view.type());
     auto output1 = cudf::bit_cast(mutable_column_view, mutable_column_view.type());
-    cudf::test::expect_columns_equal(output, column_view);
-    cudf::test::expect_columns_equal(output1, mutable_column_view);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(output, column_view);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(output1, mutable_column_view);
   } else if (std::is_same_v<rep_type_t<FromType>, ToType> ||
              std::is_same_v<FromType, rep_type_t<ToType>>) {
     // Cast integer to timestamp or vice versa
     auto output  = cudf::bit_cast(column_view, to_type);
     auto output1 = cudf::bit_cast(mutable_column_view, to_type);
     cudf::test::fixed_width_column_wrapper<ToType, cudf::size_type> expected(begin, end);
-    cudf::test::expect_columns_equal(output, expected);
-    cudf::test::expect_columns_equal(output1, expected);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(output, expected);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(output1, expected);
   } else {
     if (cuda::std::is_trivially_copyable_v<FromType> &&
         cuda::std::is_trivially_copyable_v<ToType>) {
@@ -92,8 +92,8 @@ void do_bit_cast(cudf::column_view const& column_view, Iterator begin, Iterator 
         auto output2         = cudf::bit_cast(output1, from_type);
         auto output2_mutable = cudf::bit_cast(output1_mutable, from_type);
 
-        cudf::test::expect_columns_equal(output2, column_view);
-        cudf::test::expect_columns_equal(output2_mutable, mutable_column_view);
+        CUDF_TEST_EXPECT_COLUMNS_EQUAL(output2, column_view);
+        CUDF_TEST_EXPECT_COLUMNS_EQUAL(output2_mutable, mutable_column_view);
       } else {
         // Not allow to cast if sizes are mismatched
         EXPECT_THROW(cudf::bit_cast(column_view, to_type), cudf::logic_error);

--- a/cpp/tests/column/column_test.cu
+++ b/cpp/tests/column/column_test.cu
@@ -494,7 +494,7 @@ TYPED_TEST(ListsColumnTest, ListsColumnViewConstructor)
 
   auto result = std::make_unique<cudf::column>(list);
 
-  cudf::test::expect_columns_equal(list, result->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(list, result->view());
 }
 
 TYPED_TEST(ListsColumnTest, ListsSlicedColumnViewConstructor)
@@ -505,7 +505,7 @@ TYPED_TEST(ListsColumnTest, ListsSlicedColumnViewConstructor)
   auto sliced = cudf::slice(list, {1, 3}).front();
   auto result = std::make_unique<cudf::column>(sliced);
 
-  cudf::test::expect_columns_equal(expect, result->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, result->view());
 }
 
 TYPED_TEST(ListsColumnTest, ListsSlicedIncludesEmpty)
@@ -516,7 +516,7 @@ TYPED_TEST(ListsColumnTest, ListsSlicedIncludesEmpty)
   auto sliced = cudf::slice(list, {1, 3}).front();
   auto result = std::make_unique<cudf::column>(sliced);
 
-  cudf::test::expect_columns_equal(expect, result->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, result->view());
 }
 
 TYPED_TEST(ListsColumnTest, ListsSlicedNonNestedEmpty)
@@ -531,7 +531,7 @@ TYPED_TEST(ListsColumnTest, ListsSlicedNonNestedEmpty)
   auto sliced = cudf::slice(list, {1, 2}).front();
   auto result = std::make_unique<cudf::column>(sliced);
 
-  cudf::test::expect_columns_equal(expect, result->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, result->view());
 }
 
 TYPED_TEST(ListsColumnTest, ListsSlicedNestedEmpty)
@@ -564,7 +564,7 @@ TYPED_TEST(ListsColumnTest, ListsSlicedNestedEmpty)
   auto sliced = cudf::slice(list, {1, 2}).front();
   auto result = std::make_unique<cudf::column>(sliced);
 
-  cudf::test::expect_columns_equal(*expect, result->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expect, result->view());
 }
 
 TYPED_TEST(ListsColumnTest, ListsSlicedZeroSliceLengthNested)
@@ -580,7 +580,7 @@ TYPED_TEST(ListsColumnTest, ListsSlicedZeroSliceLengthNested)
   auto sliced = cudf::slice(list, {0, 0}).front();
   auto result = std::make_unique<cudf::column>(sliced);
 
-  cudf::test::expect_columns_equal(*expect, result->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expect, result->view());
 }
 
 TYPED_TEST(ListsColumnTest, ListsSlicedZeroSliceLengthNonNested)
@@ -595,7 +595,7 @@ TYPED_TEST(ListsColumnTest, ListsSlicedZeroSliceLengthNonNested)
   auto sliced = cudf::slice(list, {0, 0}).front();
   auto result = std::make_unique<cudf::column>(sliced);
 
-  cudf::test::expect_columns_equal(*expect, result->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expect, result->view());
 }
 
 TYPED_TEST(ListsColumnTest, ListsSlicedColumnViewConstructorWithNulls)
@@ -618,13 +618,13 @@ TYPED_TEST(ListsColumnTest, ListsSlicedColumnViewConstructorWithNulls)
   auto sliced = cudf::slice(list, {1, 5}).front();
   auto result = std::make_unique<cudf::column>(sliced);
 
-  cudf::test::expect_columns_equal(expect, result->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, result->view());
 
   // TODO: null mask equality is being checked separately because
   // expect_columns_equal doesn't do the check for lists columns.
   // This is fixed in https://github.com/rapidsai/cudf/pull/5904,
   // so we should remove this check after that's merged:
-  cudf::test::expect_columns_equal(
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
     cudf::mask_to_bools(result->view().null_mask(), 0, 4)->view(),
     cudf::mask_to_bools(static_cast<cudf::column_view>(expect).null_mask(), 0, 4)->view());
 }

--- a/cpp/tests/copying/concatenate_tests.cu
+++ b/cpp/tests/copying/concatenate_tests.cu
@@ -833,7 +833,7 @@ TEST_F(StructsColumnTest, ConcatenateStructs)
 
   // concatenate
   auto result = cudf::concatenate(std::vector<column_view>({src[0], src[1], src[2], src[3]}));
-  cudf::test::expect_columns_equivalent(*result, *expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, *expected);
 }
 
 TEST_F(StructsColumnTest, ConcatenateEmptyStructs)
@@ -849,7 +849,7 @@ TEST_F(StructsColumnTest, ConcatenateEmptyStructs)
   // concatenate
   auto result = cudf::concatenate(std::vector<column_view>({*first, *second, *third, *fourth}));
   CUDF_EXPECTS(result->size() == expected->size(), "column size changed after concat");
-  cudf::test::expect_columns_equivalent(*result, *expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, *expected);
 }
 
 TEST_F(StructsColumnTest, ConcatenateSplitStructs)
@@ -922,7 +922,7 @@ TEST_F(StructsColumnTest, ConcatenateSplitStructs)
   // concatenate
 
   auto result = cudf::concatenate(std::vector<column_view>({src[0], src[1]}));
-  cudf::test::expect_columns_equivalent(*result, *expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, *expected);
 }
 
 TEST_F(StructsColumnTest, ConcatenateStructsNested)
@@ -994,7 +994,7 @@ TEST_F(StructsColumnTest, ConcatenateStructsNested)
 
   // concatenate
   auto result = cudf::concatenate(std::vector<column_view>({src[0], src[1]}));
-  cudf::test::expect_columns_equivalent(*result, *expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, *expected);
 }
 
 struct ListsColumnTest : public cudf::test::BaseFixture {
@@ -1288,7 +1288,7 @@ TEST_F(ListsColumnTest, SlicedColumns)
                                                     {{-3, -3, -3, -3}, {-4}}};
 
     auto result0 = cudf::concatenate(std::vector<column_view>({split_a[0], split_b[0]}));
-    cudf::test::expect_columns_equivalent(*result0, expected0);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result0, expected0);
 
     cudf::test::lists_column_wrapper<int> expected1{{{1, 1, 1}, {2, 2}, {3, 3}},
                                                     {{4, 4, 4}, {5, 5}, {6, 6}},
@@ -1296,7 +1296,7 @@ TEST_F(ListsColumnTest, SlicedColumns)
                                                     {{-7, -7, -7, -7}, {-8}}};
 
     auto result1 = cudf::concatenate(std::vector<column_view>({split_a[0], split_b[1]}));
-    cudf::test::expect_columns_equivalent(*result1, expected1);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result1, expected1);
 
     cudf::test::lists_column_wrapper<int> expected2{
       {{7, 7, 7}, {8, 8}, {9, 9}},
@@ -1306,7 +1306,7 @@ TEST_F(ListsColumnTest, SlicedColumns)
     };
 
     auto result2 = cudf::concatenate(std::vector<column_view>({split_a[1], split_b[0]}));
-    cudf::test::expect_columns_equivalent(*result2, expected2);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result2, expected2);
 
     cudf::test::lists_column_wrapper<int> expected3{{{7, 7, 7}, {8, 8}, {9, 9}},
                                                     {{10, 10, 10}, {11, 11}, {12, 12}},
@@ -1314,7 +1314,7 @@ TEST_F(ListsColumnTest, SlicedColumns)
                                                     {{-7, -7, -7, -7}, {-8}}};
 
     auto result3 = cudf::concatenate(std::vector<column_view>({split_a[1], split_b[1]}));
-    cudf::test::expect_columns_equivalent(*result3, expected3);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result3, expected3);
   }
 
   {
@@ -1341,7 +1341,7 @@ TEST_F(ListsColumnTest, SlicedColumns)
 
     auto result0 = cudf::concatenate(std::vector<column_view>({split_a[0], split_b[0]}));
 
-    cudf::test::expect_columns_equivalent(*result0, expected0);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result0, expected0);
 
     cudf::test::lists_column_wrapper<int> expected1{
       {{{1, 1, 1}, {2, 2}}, {{3, 3}}, {{10, 9, 16}, {8, 7, 1}, {6, 8, 2}}},
@@ -1351,7 +1351,7 @@ TEST_F(ListsColumnTest, SlicedColumns)
     };
 
     auto result1 = cudf::concatenate(std::vector<column_view>({split_a[0], split_b[1]}));
-    cudf::test::expect_columns_equivalent(*result1, expected1);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result1, expected1);
 
     cudf::test::lists_column_wrapper<int> expected2{
       {LCW{}, LCW{}},
@@ -1360,7 +1360,7 @@ TEST_F(ListsColumnTest, SlicedColumns)
       {LCW{}, {LCW{}}}};
 
     auto result2 = cudf::concatenate(std::vector<column_view>({split_a[1], split_b[0]}));
-    cudf::test::expect_columns_equivalent(*result2, expected2);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result2, expected2);
 
     cudf::test::lists_column_wrapper<int> expected3{
       {LCW{}, LCW{}},
@@ -1370,7 +1370,7 @@ TEST_F(ListsColumnTest, SlicedColumns)
     };
 
     auto result3 = cudf::concatenate(std::vector<column_view>({split_a[1], split_b[1]}));
-    cudf::test::expect_columns_equivalent(*result3, expected3);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result3, expected3);
   }
 }
 
@@ -1402,7 +1402,7 @@ TEST_F(ListsColumnTest, SlicedColumnsWithNulls)
                                                     {{{{-5, -5, -5, -5}, valids}, {-6}}, valids}};
 
     auto result0 = cudf::concatenate(std::vector<column_view>({split_a[0], split_b[0]}));
-    cudf::test::expect_columns_equivalent(*result0, expected0);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result0, expected0);
 
     cudf::test::lists_column_wrapper<int> expected1{{{{1, 1, 1}, valids}, {2, 2}, {{3, 3}, valids}},
                                                     {{{4, 4, 4}, {{5, 5}, valids}, {6, 6}}, valids},
@@ -1410,7 +1410,7 @@ TEST_F(ListsColumnTest, SlicedColumnsWithNulls)
                                                     {{{{-7, -7, -7, -7}, valids}, {-8}}, valids}};
 
     auto result1 = cudf::concatenate(std::vector<column_view>({split_a[0], split_b[1]}));
-    cudf::test::expect_columns_equivalent(*result1, expected1);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result1, expected1);
 
     cudf::test::lists_column_wrapper<int> expected2{
       {{{10, 10, 10}, {11, 11}, {{12, 12}, valids}}, valids},
@@ -1419,14 +1419,14 @@ TEST_F(ListsColumnTest, SlicedColumnsWithNulls)
       {{{{-5, -5, -5, -5}, valids}, {-6}}, valids}};
 
     auto result2 = cudf::concatenate(std::vector<column_view>({split_a[1], split_b[0]}));
-    cudf::test::expect_columns_equivalent(*result2, expected2);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result2, expected2);
 
     cudf::test::lists_column_wrapper<int> expected3{
       {{{10, 10, 10}, {11, 11}, {{12, 12}, valids}}, valids},
       {{{{-7, -7, -7, -7}, valids}, {-8}}, valids}};
 
     auto result3 = cudf::concatenate(std::vector<column_view>({split_a[1], split_b[1]}));
-    cudf::test::expect_columns_equivalent(*result3, expected3);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result3, expected3);
   }
 
   {
@@ -1459,7 +1459,7 @@ TEST_F(ListsColumnTest, SlicedColumnsWithNulls)
     };
 
     auto result0 = cudf::concatenate(std::vector<column_view>({split_a[0], split_b[0]}));
-    cudf::test::expect_columns_equivalent(*result0, expected0);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result0, expected0);
 
     cudf::test::lists_column_wrapper<int> expected1{
       {{{{1, 1, 1}, valids}, {2, 2}},
@@ -1471,7 +1471,7 @@ TEST_F(ListsColumnTest, SlicedColumnsWithNulls)
     };
 
     auto result1 = cudf::concatenate(std::vector<column_view>({split_a[0], split_b[1]}));
-    cudf::test::expect_columns_equivalent(*result1, expected1);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result1, expected1);
 
     cudf::test::lists_column_wrapper<int> expected2{
       {LCW{}, LCW{}, {{{10, 10, 10}, {{11, 11}, valids}, {12, 12}}, valids}, LCW{}},
@@ -1481,7 +1481,7 @@ TEST_F(ListsColumnTest, SlicedColumnsWithNulls)
     };
 
     auto result2 = cudf::concatenate(std::vector<column_view>({split_a[1], split_b[0]}));
-    cudf::test::expect_columns_equivalent(*result2, expected2);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result2, expected2);
 
     cudf::test::lists_column_wrapper<int> expected3{
       {LCW{}, LCW{}, {{{10, 10, 10}, {{11, 11}, valids}, {12, 12}}, valids}, LCW{}},
@@ -1489,7 +1489,7 @@ TEST_F(ListsColumnTest, SlicedColumnsWithNulls)
     };
 
     auto result3 = cudf::concatenate(std::vector<column_view>({split_a[1], split_b[1]}));
-    cudf::test::expect_columns_equivalent(*result3, expected3);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result3, expected3);
   }
 }
 
@@ -1557,7 +1557,7 @@ TEST_F(ListsColumnTest, ListOfStructs)
 
   // concatenate
   auto result = cudf::concatenate(std::vector<column_view>({*src[0], *src[1], *src[2], *src[3]}));
-  cudf::test::expect_columns_equivalent(*result, *expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, *expected);
 }
 
 template <typename T>

--- a/cpp/tests/copying/gather_list_tests.cpp
+++ b/cpp/tests/copying/gather_list_tests.cpp
@@ -355,14 +355,14 @@ TYPED_TEST(GatherTestListTyped, GatherSliced)
       {{4, 4, 4}, {5, 5}, {6, 6}},
       {{7, 7, 7}, {8, 8}, {9, 9}},
     };
-    cudf::test::expect_columns_equal(expected0, result0->get_column(0).view());
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected0, result0->get_column(0).view());
 
     auto result1 = cudf::gather(tbl1, cudf::test::fixed_width_column_wrapper<int>{0, 3});
     LCW<T> expected1{
       {{10, 10, 10}, {11, 11}, {12, 12}},
       {{50, 50, 50, 50}, {6, 13}},
     };
-    cudf::test::expect_columns_equal(expected1, result1->get_column(0).view());
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, result1->get_column(0).view());
   }
 
   auto valids =
@@ -397,7 +397,7 @@ TYPED_TEST(GatherTestListTyped, GatherSliced)
       cudf::test::fixed_width_column_wrapper<int> map{0};
       auto result = cudf::gather(tbl, map);
       LCW<T> expected{{{{2, 3}, {4, 5}}, {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}}};
-      cudf::test::expect_columns_equivalent(expected, result->get_column(0).view());
+      CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->get_column(0).view());
     }
 
     // gather from slice 1
@@ -419,7 +419,7 @@ TYPED_TEST(GatherTestListTyped, GatherSliced)
          {{0, 1, 3}, {5}},
          {{11, 12, 13, 14, 15}, {16, 17}, {0}}},
       };
-      cudf::test::expect_columns_equivalent(expected, result->get_column(0).view());
+      CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->get_column(0).view());
     }
 
     // gather from slice 2
@@ -434,7 +434,7 @@ TYPED_TEST(GatherTestListTyped, GatherSliced)
                       {{{{10, 20, 30}}, {LCW<T>{30}}, {{{20, 30}, valids}, {62, 72, 82}}}, valids},
                       {{{{10, 20, 30}}, {LCW<T>{30}}, {{{20, 30}, valids}, {62, 72, 82}}}, valids},
                       {{{{{10, 20}, valids}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}, valids}};
-      cudf::test::expect_columns_equivalent(expected, result->get_column(0).view());
+      CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->get_column(0).view());
     }
   }
 }

--- a/cpp/tests/copying/pack_tests.cpp
+++ b/cpp/tests/copying/pack_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ struct PackUnpackTest : public BaseFixture {
     // verify pack/unpack works
     auto packed   = pack(t);
     auto unpacked = unpack(packed);
-    cudf::test::expect_tables_equal(t, unpacked);
+    CUDF_TEST_EXPECT_TABLES_EQUAL(t, unpacked);
 
     // verify pack_metadata itself works
     auto metadata = pack_metadata(

--- a/cpp/tests/copying/slice_tests.cpp
+++ b/cpp/tests/copying/slice_tests.cpp
@@ -163,7 +163,7 @@ TEST_F(SliceListTest, Lists)
     EXPECT_EQ(expected.size(), result.size());
 
     for (unsigned long index = 0; index < result.size(); index++) {
-      cudf::test::expect_columns_equivalent(expected[index], result[index]);
+      CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected[index], result[index]);
     }
   }
 
@@ -186,7 +186,7 @@ TEST_F(SliceListTest, Lists)
     EXPECT_EQ(expected.size(), result.size());
 
     for (unsigned long index = 0; index < result.size(); index++) {
-      cudf::test::expect_columns_equivalent(expected[index], result[index]);
+      CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected[index], result[index]);
     }
   }
 }
@@ -228,7 +228,7 @@ TEST_F(SliceListTest, ListsWithNulls)
     EXPECT_EQ(expected.size(), result.size());
 
     for (unsigned long index = 0; index < result.size(); index++) {
-      cudf::test::expect_columns_equivalent(expected[index], result[index]);
+      CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected[index], result[index]);
     }
   }
 
@@ -253,7 +253,7 @@ TEST_F(SliceListTest, ListsWithNulls)
     EXPECT_EQ(expected.size(), result.size());
 
     for (unsigned long index = 0; index < result.size(); index++) {
-      cudf::test::expect_columns_equivalent(expected[index], result[index]);
+      CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected[index], result[index]);
     }
   }
 }

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -2056,6 +2056,6 @@ TEST_F(ContiguousSplitNestedTypesTest, ListOfStruct)
   CUDF_EXPECTS(result.size() == expected.size(), "Split result size mismatch");
 
   for (std::size_t index = 0; index < result.size(); index++) {
-    cudf::test::expect_columns_equivalent(expected[index], result[index].table.column(0));
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected[index], result[index].table.column(0));
   }
 }

--- a/cpp/tests/copying/utility_tests.cpp
+++ b/cpp/tests/copying/utility_tests.cpp
@@ -22,6 +22,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <thrust/iterator/transform_iterator.h>
@@ -168,14 +169,6 @@ std::unique_ptr<cudf::table> create_table(cudf::size_type size, cudf::mask_state
   return std::make_unique<cudf::table>(std::move(columns));
 }
 
-void expect_tables_prop_equal(cudf::table_view const& lhs, cudf::table_view const& rhs)
-{
-  EXPECT_EQ(lhs.num_columns(), rhs.num_columns());
-  for (cudf::size_type index = 0; index < lhs.num_columns(); index++) {
-    CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(lhs.column(index), rhs.column(index));
-  }
-}
-
 struct EmptyLikeTableTest : public cudf::test::BaseFixture {
 };
 
@@ -187,7 +180,7 @@ TEST_F(EmptyLikeTableTest, TableTest)
   auto expected          = create_table(0, cudf::mask_state::ALL_VALID);
   auto got               = cudf::empty_like(input->view());
 
-  expect_tables_prop_equal(got->view(), expected->view());
+  CUDF_TEST_EXPECT_TABLES_EQUAL(got->view(), expected->view());
 }
 
 template <typename T>

--- a/cpp/tests/encode/encode_tests.cpp
+++ b/cpp/tests/encode/encode_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ TYPED_TEST(EncodeNumericTests, TableEncodeWithNulls)
 
   auto const result = cudf::encode(input);
 
-  cudf::test::expect_tables_equivalent(result.first->view(), expect_keys);
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(result.first->view(), expect_keys);
   cudf::test::expect_columns_equal(result.second->view(), expect);
 }
 

--- a/cpp/tests/encode/encode_tests.cpp
+++ b/cpp/tests/encode/encode_tests.cpp
@@ -135,7 +135,7 @@ TYPED_TEST(EncodeNumericTests, TableEncodeWithNulls)
   auto const result = cudf::encode(input);
 
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(result.first->view(), expect_keys);
-  cudf::test::expect_columns_equal(result.second->view(), expect);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.second->view(), expect);
 }
 
 CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/groupby/groupby_test_util.hpp
+++ b/cpp/tests/groupby/groupby_test_util.hpp
@@ -91,7 +91,7 @@ inline void test_single_agg(column_view const& keys,
 
   if (use_sort == force_use_sort_impl::YES) {
     CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({expect_keys}), result.first->view());
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+    cudf::test::detail::expect_columns_equivalent(
       expect_vals, *result.second[0].results[0], debug_output_level::ALL_ERRORS);
   } else {
     auto const sort_order  = sorted_order(result.first->view(), {}, {null_order::AFTER});
@@ -99,7 +99,7 @@ inline void test_single_agg(column_view const& keys,
     auto const sorted_vals = gather(table_view({result.second[0].results[0]->view()}), *sort_order);
 
     CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({expect_keys}), *sorted_keys);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+    cudf::test::detail::expect_columns_equivalent(
       expect_vals, sorted_vals->get_column(0), debug_output_level::ALL_ERRORS);
   }
 }
@@ -127,7 +127,7 @@ inline void test_single_scan(column_view const& keys,
   auto result = gb_obj.scan(requests);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({expect_keys}), result.first->view());
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
+  cudf::test::detail::expect_columns_equivalent(
     expect_vals, *result.second[0].results[0], debug_output_level::ALL_ERRORS);
 }
 

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -1276,7 +1276,7 @@ TEST_F(CsvReaderTest, nullHandling)
     const auto view   = result.tbl->view();
     auto expect =
       cudf::test::strings_column_wrapper({"NULL", "", "null", "n/a", "Null", "NA", "nan"});
-    expect_columns_equal(expect, view.column(0));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, view.column(0));
   }
 
   // Test enabling na_filter
@@ -1292,7 +1292,7 @@ TEST_F(CsvReaderTest, nullHandling)
       cudf::test::strings_column_wrapper({"NULL", "", "null", "n/a", "Null", "NA", "nan"},
                                          {false, false, false, false, true, false, false});
 
-    expect_columns_equal(expect, view.column(0));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, view.column(0));
   }
 
   // Setting na_values with default values
@@ -1309,7 +1309,7 @@ TEST_F(CsvReaderTest, nullHandling)
       cudf::test::strings_column_wrapper({"NULL", "", "null", "n/a", "Null", "NA", "nan"},
                                          {false, false, false, false, false, false, false});
 
-    expect_columns_equal(expect, view.column(0));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, view.column(0));
   }
 
   // Setting na_values without default values
@@ -1327,7 +1327,7 @@ TEST_F(CsvReaderTest, nullHandling)
       cudf::test::strings_column_wrapper({"NULL", "", "null", "n/a", "Null", "NA", "nan"},
                                          {true, true, true, true, false, true, true, true});
 
-    expect_columns_equal(expect, view.column(0));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, view.column(0));
   }
 }
 

--- a/cpp/tests/quantiles/percentile_approx_test.cpp
+++ b/cpp/tests/quantiles/percentile_approx_test.cpp
@@ -103,7 +103,7 @@ struct percentile_approx_dispatch {
     cudf::tdigest::tdigest_column_view tdv(*agg_result);
     auto result = cudf::percentile_approx(tdv, g_percentages);
 
-    cudf::test::expect_columns_equivalent(
+    cudf::test::detail::expect_columns_equivalent(
       *expected, *result, cudf::test::debug_output_level::FIRST_ERROR, ulps);
 
     return result;

--- a/cpp/tests/rolling/lead_lag_test.cpp
+++ b/cpp/tests/rolling/lead_lag_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ TYPED_TEST(TypedLeadLagWindowTest, LeadLagBasics)
                                  min_periods,
                                  *cudf::make_lead_aggregation<cudf::rolling_aggregation>(3));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lead_3_output_col,
     fixed_width_column_wrapper<T>{{3, 4, 5, -1, -1, -1, 30, 40, 50, -1, -1, -1},
                                   {1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0}}
@@ -98,7 +98,7 @@ TYPED_TEST(TypedLeadLagWindowTest, LeadLagBasics)
                                  min_periods,
                                  *cudf::make_lag_aggregation<cudf::rolling_aggregation>(2));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lag_2_output_col,
     fixed_width_column_wrapper<T>{{-1, -1, 0, 1, 2, 3, -1, -1, 0, 10, 20, 30},
                                   {0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1}}
@@ -129,7 +129,7 @@ TYPED_TEST(TypedLeadLagWindowTest, LeadLagWithNulls)
                                  min_periods,
                                  *cudf::make_lead_aggregation<cudf::rolling_aggregation>(3));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lead_3_output_col,
     fixed_width_column_wrapper<T>{{3, 4, 5, -1, -1, -1, 30, 40, 50, -1, -1, -1},
                                   {1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0}}
@@ -144,7 +144,7 @@ TYPED_TEST(TypedLeadLagWindowTest, LeadLagWithNulls)
                                  min_periods,
                                  *cudf::make_lag_aggregation<cudf::rolling_aggregation>(2));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lag_2_output_col,
     fixed_width_column_wrapper<T>{{-1, -1, 0, 1, -1, 3, -1, -1, 0, 10, -1, 30},
                                   {0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1}}
@@ -179,7 +179,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithDefaults)
                                  following,
                                  min_periods,
                                  *cudf::make_lead_aggregation<cudf::rolling_aggregation>(3));
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lead_3_output_col,
     fixed_width_column_wrapper<T>{{3, 4, 5, 99, 99, 99, 30, 40, 50, 99, 99, 99},
                                   {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}
@@ -195,7 +195,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithDefaults)
                                  min_periods,
                                  *cudf::make_lag_aggregation<cudf::rolling_aggregation>(2));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lag_2_output_col,
     fixed_width_column_wrapper<T>{{99, 99, 0, 1, -1, 3, 99, 99, 0, 10, -1, 30},
                                   {1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1}}
@@ -231,7 +231,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithDefaultsContainingNulls)
                                  following,
                                  min_periods,
                                  *cudf::make_lead_aggregation<cudf::rolling_aggregation>(3));
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lead_3_output_col,
     fixed_width_column_wrapper<T>{{3, 4, 5, 99, 99, -1, 30, 40, 50, 99, 99, -1},
                                   {1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0}}
@@ -247,7 +247,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithDefaultsContainingNulls)
                                  min_periods,
                                  *cudf::make_lag_aggregation<cudf::rolling_aggregation>(2));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lag_2_output_col,
     fixed_width_column_wrapper<T>{{-1, 99, 0, 1, -1, 3, 99, 99, 0, 10, -1, 30},
                                   {0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1}}
@@ -282,7 +282,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithOutOfRangeOffsets)
                                  min_periods,
                                  *cudf::make_lead_aggregation<cudf::rolling_aggregation>(30));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lead_30_output_col,
     fixed_width_column_wrapper<T>{{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
                                   {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}
@@ -298,7 +298,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithOutOfRangeOffsets)
                                  min_periods,
                                  *cudf::make_lag_aggregation<cudf::rolling_aggregation>(20));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lag_20_output_col,
     fixed_width_column_wrapper<T>{{99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99},
                                   {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}
@@ -329,7 +329,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithZeroOffsets)
                                  min_periods,
                                  *cudf::make_lead_aggregation<cudf::rolling_aggregation>(0));
 
-  expect_columns_equivalent(*lead_0_output_col, *input_col);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*lead_0_output_col, *input_col);
 
   auto const lag_0_output_col =
     cudf::grouped_rolling_window(grouping_keys,
@@ -339,7 +339,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithZeroOffsets)
                                  min_periods,
                                  *cudf::make_lag_aggregation<cudf::rolling_aggregation>(0));
 
-  expect_columns_equivalent(*lag_0_output_col, *input_col);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*lag_0_output_col, *input_col);
 }
 
 TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithNegativeOffsets)
@@ -370,7 +370,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithNegativeOffsets)
                                  min_periods,
                                  *cudf::make_lag_aggregation<cudf::rolling_aggregation>(-3));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lag_minus_3_output_col,
     fixed_width_column_wrapper<T>{{3, 4, 5, 99, 99, 99, 30, 40, 50, 99, 99, 99},
                                   {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}
@@ -386,7 +386,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithNegativeOffsets)
                                  min_periods,
                                  *cudf::make_lead_aggregation<cudf::rolling_aggregation>(-2));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lead_minus_2_output_col,
     fixed_width_column_wrapper<T>{{99, 99, 0, 1, -1, 3, 99, 99, 0, 10, -1, 30},
                                   {1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1}}
@@ -420,7 +420,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithNoGrouping)
                                  min_periods,
                                  *cudf::make_lead_aggregation<cudf::rolling_aggregation>(3));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lead_3_output_col,
     fixed_width_column_wrapper<T>{{3, 4, 5, 99, 99, 99}, {1, 1, 1, 1, 1, 1}}.release()->view());
 
@@ -433,7 +433,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithNoGrouping)
                                  min_periods,
                                  *cudf::make_lag_aggregation<cudf::rolling_aggregation>(2));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lag_2_output_col,
     fixed_width_column_wrapper<T>{{99, 99, 0, 1, -1, 3}, {1, 1, 1, 1, 0, 1}}.release()->view());
 }
@@ -467,7 +467,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithAllNullInput)
                                  following,
                                  min_periods,
                                  *cudf::make_lead_aggregation<cudf::rolling_aggregation>(3));
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lead_3_output_col,
     fixed_width_column_wrapper<T>{{-1, -1, -1, 99, 99, 99, -1, -1, -1, 99, 99, 99},
                                   {0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1}}
@@ -483,7 +483,7 @@ TYPED_TEST(TypedLeadLagWindowTest, TestLeadLagWithAllNullInput)
                                  min_periods,
                                  *cudf::make_lag_aggregation<cudf::rolling_aggregation>(2));
 
-  expect_columns_equivalent(
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     *lag_2_output_col,
     fixed_width_column_wrapper<T>{{99, 99, -1, -1, -1, -1, 99, 99, -1, -1, -1, -1},
                                   {1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0}}
@@ -599,22 +599,22 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithNullsAllOver)
                                  min_periods,
                                  *cudf::make_lag_aggregation<cudf::rolling_aggregation>(1));
 
-  expect_columns_equivalent(lag_1_output_col->view(),
-                            lcw{{{},
-                                 {0, 0},
-                                 {1, 1},
-                                 {2, 2},
-                                 {3, 3, 3},
-                                 {{4, 4, 4, 4}, null_at_2},
-                                 {},
-                                 {0, 0},
-                                 {10, 10},
-                                 {20, 20},
-                                 {30, 30, 30},
-                                 {40, 40, 40, 40}},
-                                nulls_at({0, 3, 6})}
-                              .release()
-                              ->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(lag_1_output_col->view(),
+                                      lcw{{{},
+                                           {0, 0},
+                                           {1, 1},
+                                           {2, 2},
+                                           {3, 3, 3},
+                                           {{4, 4, 4, 4}, null_at_2},
+                                           {},
+                                           {0, 0},
+                                           {10, 10},
+                                           {20, 20},
+                                           {30, 30, 30},
+                                           {40, 40, 40, 40}},
+                                          nulls_at({0, 3, 6})}
+                                        .release()
+                                        ->view());
 }
 
 TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithDefaults)
@@ -697,22 +697,22 @@ TYPED_TEST(TypedNestedLeadLagWindowTest, NumericListsWithDefaults)
                                  min_periods,
                                  *cudf::make_lag_aggregation<cudf::rolling_aggregation>(1));
 
-  expect_columns_equivalent(lag_1_output_col->view(),
-                            lcw{{{},
-                                 {0, 0},
-                                 {1, 1},
-                                 {2, 2},
-                                 {3, 3, 3},
-                                 {{4, 4, 4, 4}, null_at_2},
-                                 {},
-                                 {0, 0},
-                                 {10, 10},
-                                 {20, 20},
-                                 {30, 30, 30},
-                                 {40, 40, 40, 40}},
-                                nulls_at({0, 3, 6})}
-                              .release()
-                              ->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(lag_1_output_col->view(),
+                                      lcw{{{},
+                                           {0, 0},
+                                           {1, 1},
+                                           {2, 2},
+                                           {3, 3, 3},
+                                           {{4, 4, 4, 4}, null_at_2},
+                                           {},
+                                           {0, 0},
+                                           {10, 10},
+                                           {20, 20},
+                                           {30, 30, 30},
+                                           {40, 40, 40, 40}},
+                                          nulls_at({0, 3, 6})}
+                                        .release()
+                                        ->view());
 }
 
 TYPED_TEST(TypedNestedLeadLagWindowTest, Structs)

--- a/cpp/tests/strings/replace_tests.cpp
+++ b/cpp/tests/strings/replace_tests.cpp
@@ -235,15 +235,15 @@ TEST_F(StringsReplaceTest, ReplaceEndOfString)
 
   auto results =
     cudf::strings::replace(strings_view, cudf::string_scalar("in"), cudf::string_scalar(" "));
-  cudf::test::expect_columns_equal(*results, expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   results = cudf::strings::detail::replace<cudf::strings::detail::replace_algorithm::CHAR_PARALLEL>(
     strings_view, cudf::string_scalar("in"), cudf::string_scalar(" "), -1, stream, mr);
-  cudf::test::expect_columns_equal(*results, expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 
   results = cudf::strings::detail::replace<cudf::strings::detail::replace_algorithm::ROW_PARALLEL>(
     strings_view, cudf::string_scalar("in"), cudf::string_scalar(" "), -1, stream, mr);
-  cudf::test::expect_columns_equal(*results, expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 }
 
 TEST_F(StringsReplaceTest, ReplaceSlice)

--- a/cpp/tests/structs/structs_column_tests.cpp
+++ b/cpp/tests/structs/structs_column_tests.cpp
@@ -105,8 +105,8 @@ TYPED_TEST(TypedStructColumnWrapperTest, TestColumnFactoryConstruction)
   std::for_each(thrust::make_counting_iterator(0),
                 thrust::make_counting_iterator(0) + expected_children.size(),
                 [&](auto idx) {
-                  cudf::test::expect_columns_equivalent(struct_col_view.child(idx),
-                                                        expected_children[idx]->view());
+                  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(struct_col_view.child(idx),
+                                                      expected_children[idx]->view());
                 });
 }
 
@@ -156,14 +156,14 @@ TYPED_TEST(TypedStructColumnWrapperTest, TestColumnWrapperConstruction)
   std::for_each(thrust::make_counting_iterator(0),
                 thrust::make_counting_iterator(0) + expected_children.size(),
                 [&](auto idx) {
-                  cudf::test::expect_columns_equivalent(struct_col_view.child(idx),
-                                                        expected_children[idx]->view());
+                  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(struct_col_view.child(idx),
+                                                      expected_children[idx]->view());
                 });
 
   auto expected_struct_col =
     cudf::test::structs_column_wrapper{std::move(expected_children), {1, 1, 1, 0, 1, 1}}.release();
 
-  cudf::test::expect_columns_equivalent(struct_col_view, expected_struct_col->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(struct_col_view, expected_struct_col->view());
 }
 
 TYPED_TEST(TypedStructColumnWrapperTest, TestStructsContainingLists)
@@ -262,18 +262,18 @@ TYPED_TEST(TypedStructColumnWrapperTest, StructOfStructs)
       cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 0 && i != 4; }))
       .release();
 
-  cudf::test::expect_columns_equivalent(*expected_names_col, struct_2->child(1).child(0));
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_names_col, struct_2->child(1).child(0));
 
   auto expected_ages_col = cudf::test::fixed_width_column_wrapper<int32_t>{
     {48, 27, 25, 31, 351, 351},
     {0, 1, 1, 1, 0, 0}}.release();
-  cudf::test::expect_columns_equivalent(*expected_ages_col, struct_2->child(1).child(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_ages_col, struct_2->child(1).child(1));
 
   auto expected_bool_col = cudf::test::fixed_width_column_wrapper<bool>{
     {true, true, false, false, false, false},
     {0, 1, 0, 1, 1, 0}}.release();
 
-  cudf::test::expect_columns_equivalent(*expected_bool_col, struct_2->child(0));
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_bool_col, struct_2->child(0));
 
   // Verify that recursive struct columns may be compared
   // using expect_columns_equivalent.
@@ -290,7 +290,7 @@ TYPED_TEST(TypedStructColumnWrapperTest, StructOfStructs)
   auto expected_struct_2 =
     cudf::test::structs_column_wrapper(std::move(expected_cols_2), {0, 1, 1, 1, 1, 1}).release();
 
-  cudf::test::expect_columns_equivalent(*expected_struct_2, *struct_2);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_struct_2, *struct_2);
 }
 
 TYPED_TEST(TypedStructColumnWrapperTest, TestNullMaskPropagationForNonNullStruct)
@@ -341,18 +341,18 @@ TYPED_TEST(TypedStructColumnWrapperTest, TestNullMaskPropagationForNonNullStruct
       cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 0; }))
       .release();
 
-  cudf::test::expect_columns_equivalent(*expected_names_col, struct_2->child(1).child(0));
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_names_col, struct_2->child(1).child(0));
 
   auto expected_ages_col = cudf::test::fixed_width_column_wrapper<int32_t>{
     {48, 27, 25, 31, 351, 351},
     {0, 1, 1, 1, 1, 1}}.release();
-  cudf::test::expect_columns_equivalent(*expected_ages_col, struct_2->child(1).child(1));
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_ages_col, struct_2->child(1).child(1));
 
   auto expected_bool_col = cudf::test::fixed_width_column_wrapper<bool>{
     {true, true, false, false, false, false},
     {0, 1, 0, 1, 1, 0}}.release();
 
-  cudf::test::expect_columns_equivalent(*expected_bool_col, struct_2->child(0));
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_bool_col, struct_2->child(0));
 
   // Verify that recursive struct columns may be compared
   // using expect_columns_equivalent.
@@ -369,7 +369,7 @@ TYPED_TEST(TypedStructColumnWrapperTest, TestNullMaskPropagationForNonNullStruct
   auto expected_struct_2 =
     cudf::test::structs_column_wrapper(std::move(expected_cols_2), {0, 1, 1, 1, 1, 1}).release();
 
-  cudf::test::expect_columns_equivalent(*expected_struct_2, *struct_2);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_struct_2, *struct_2);
 }
 
 TEST_F(StructColumnWrapperTest, StructWithNoMembers)
@@ -431,8 +431,8 @@ TYPED_TEST(TypedStructColumnWrapperTest, TestListsOfStructs)
   // List of structs was constructed successfully. No exceptions.
   // Verify that child columns is as it was set.
 
-  cudf::test::expect_columns_equivalent(expected_unchanged_struct_col,
-                                        cudf::lists_column_view(*list_col).child());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_unchanged_struct_col,
+                                      cudf::lists_column_view(*list_col).child());
 }
 
 TYPED_TEST(TypedStructColumnWrapperTest, ListOfStructOfList)
@@ -465,8 +465,8 @@ TYPED_TEST(TypedStructColumnWrapperTest, ListOfStructOfList)
 
   auto expected_level2_struct = structs_column_wrapper{{expected_level0_list}}.release();
 
-  expect_columns_equivalent(cudf::lists_column_view(*list_of_struct_of_list).child(),
-                            *expected_level2_struct);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(cudf::lists_column_view(*list_of_struct_of_list).child(),
+                                      *expected_level2_struct);
 
   auto expected_level3_list = cudf::make_lists_column(
     5,
@@ -475,7 +475,7 @@ TYPED_TEST(TypedStructColumnWrapperTest, ListOfStructOfList)
     cudf::UNKNOWN_NULL_COUNT,
     detail::make_null_mask(list_of_struct_of_list_validity, list_of_struct_of_list_validity + 5));
 
-  expect_columns_equivalent(*list_of_struct_of_list, *expected_level3_list);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*list_of_struct_of_list, *expected_level3_list);
 }
 
 TYPED_TEST(TypedStructColumnWrapperTest, StructOfListOfStruct)
@@ -523,13 +523,13 @@ TYPED_TEST(TypedStructColumnWrapperTest, StructOfListOfStruct)
     detail::make_null_mask(list_validity, list_validity + 5));
 
   // Test that the lists child column is as expected.
-  cudf::test::expect_columns_equivalent(*expected_lists_col, struct_of_list_of_struct->child(0));
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_lists_col, struct_of_list_of_struct->child(0));
 
   // Test that the outer struct column is as expected.
   cols.clear();
   cols.push_back(std::move(expected_lists_col));
-  cudf::test::expect_columns_equivalent(*(structs_column_wrapper{std::move(cols)}.release()),
-                                        *struct_of_list_of_struct);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*(structs_column_wrapper{std::move(cols)}.release()),
+                                      *struct_of_list_of_struct);
 }
 
 TYPED_TEST(TypedStructColumnWrapperTest, EmptyColumnsOfStructs)
@@ -581,8 +581,9 @@ TYPED_TEST(TypedStructColumnWrapperTest, EmptyColumnsOfStructs)
   //     cudf::make_lists_column(
   //       0, std::move(list_offsets), std::move(non_empty_column_of_numbers), 0, {});
   //
-  //   expect_columns_equivalent(*lists_column_wrapper<TypeParam>{}.release(), *empty_list_column);
-  //   auto struct_column = structs_column_wrapper{{empty_list_column}}.release();
+  //   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*lists_column_wrapper<TypeParam>{}.release(),
+  //   *empty_list_column); auto struct_column =
+  //   structs_column_wrapper{{empty_list_column}}.release();
   //   EXPECT_TRUE(struct_column->num_children() == 1);
   //   EXPECT_TRUE(struct_column->size() == 0);
   //   EXPECT_TRUE(struct_column->null_count() == 0);

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -779,6 +779,7 @@ struct column_comparator {
 
 }  // namespace
 
+namespace detail {
 /**
  * @copydoc cudf::test::expect_column_properties_equal
  */
@@ -855,15 +856,6 @@ bool expect_columns_equivalent(cudf::column_view const& lhs,
 }
 
 /**
- * @copydoc cudf::test::expect_column_empty
- */
-void expect_column_empty(cudf::column_view const& col)
-{
-  EXPECT_EQ(0, col.size());
-  EXPECT_EQ(0, col.null_count());
-}
-
-/**
  * @copydoc cudf::test::expect_equal_buffers
  */
 void expect_equal_buffers(void const* lhs, void const* rhs, std::size_t size_bytes)
@@ -876,6 +868,16 @@ void expect_equal_buffers(void const* lhs, void const* rhs, std::size_t size_byt
   auto typed_rhs = static_cast<char const*>(rhs);
   EXPECT_TRUE(thrust::equal(
     rmm::exec_policy(cudf::get_default_stream()), typed_lhs, typed_lhs + size_bytes, typed_rhs));
+}
+}  // namespace detail
+
+/**
+ * @copydoc cudf::test::expect_column_empty
+ */
+void expect_column_empty(cudf::column_view const& col)
+{
+  EXPECT_EQ(0, col.size());
+  EXPECT_EQ(0, col.null_count());
 }
 
 /**

--- a/cpp/tests/utilities/table_utilities.cu
+++ b/cpp/tests/utilities/table_utilities.cu
@@ -19,8 +19,7 @@
 
 #include <gmock/gmock.h>
 
-namespace cudf {
-namespace test {
+namespace cudf::test::detail {
 void expect_table_properties_equal(cudf::table_view lhs, cudf::table_view rhs)
 {
   EXPECT_EQ(lhs.num_rows(), rhs.num_rows());
@@ -46,5 +45,4 @@ void expect_tables_equivalent(cudf::table_view lhs, cudf::table_view rhs)
   }
 }
 
-}  // namespace test
-}  // namespace cudf
+}  // namespace cudf::test::detail

--- a/cpp/tests/utilities/table_utilities.cu
+++ b/cpp/tests/utilities/table_utilities.cu
@@ -30,7 +30,7 @@ void expect_tables_equal(cudf::table_view lhs, cudf::table_view rhs)
 {
   expect_table_properties_equal(lhs, rhs);
   for (auto i = 0; i < lhs.num_columns(); ++i) {
-    cudf::test::expect_columns_equal(lhs.column(i), rhs.column(i));
+    cudf::test::detail::expect_columns_equal(lhs.column(i), rhs.column(i));
   }
 }
 
@@ -41,7 +41,7 @@ void expect_tables_equivalent(cudf::table_view lhs, cudf::table_view rhs)
 {
   auto num_columns = lhs.num_columns();
   for (auto i = 0; i < num_columns; ++i) {
-    cudf::test::expect_columns_equivalent(lhs.column(i), rhs.column(i));
+    cudf::test::detail::expect_columns_equivalent(lhs.column(i), rhs.column(i));
   }
 }
 

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -566,9 +566,7 @@ TEST_F(ColumnUtilitiesStructsTest, Values)
 
   // equivalent, but not equal
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(s_col0, s_col1);
-  EXPECT_EQ(
-    cudf::test::detail::expect_columns_equal(s_col0, s_col1, cudf::test::debug_output_level::QUIET),
-    false);
+  EXPECT_FALSE(cudf::test::detail::expect_columns_equal(s_col0, s_col1, cudf::test::debug_output_level::QUIET));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(s_col0, s_col0);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(s_col1, s_col1);

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -336,7 +336,7 @@ TEST_F(ColumnUtilitiesListsTest, Equivalence)
     cudf::test::lists_column_wrapper<int> b{{{1, 2, 3}, {5, 6}, {8, 9}, {10}, {14, 15}}, all_valid};
 
     // properties
-    CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(a, b);
+    CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(a, b);
     EXPECT_EQ(cudf::test::detail::expect_column_properties_equal(
                 a, b, cudf::test::debug_output_level::QUIET),
               false);

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -336,14 +336,15 @@ TEST_F(ColumnUtilitiesListsTest, Equivalence)
     cudf::test::lists_column_wrapper<int> b{{{1, 2, 3}, {5, 6}, {8, 9}, {10}, {14, 15}}, all_valid};
 
     // properties
-    cudf::test::expect_column_properties_equivalent(a, b);
-    EXPECT_EQ(
-      cudf::test::expect_column_properties_equal(a, b, cudf::test::debug_output_level::QUIET),
-      false);
+    CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(a, b);
+    EXPECT_EQ(cudf::test::detail::expect_column_properties_equal(
+                a, b, cudf::test::debug_output_level::QUIET),
+              false);
 
     // values
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(a, b);
-    EXPECT_EQ(cudf::test::expect_columns_equal(a, b, cudf::test::debug_output_level::QUIET), false);
+    EXPECT_EQ(cudf::test::detail::expect_columns_equal(a, b, cudf::test::debug_output_level::QUIET),
+              false);
   }
 
   // list<list<int>>, nullable vs. non-nullable
@@ -354,13 +355,14 @@ TEST_F(ColumnUtilitiesListsTest, Equivalence)
                                             all_valid};
 
     // properties
-    cudf::test::expect_column_properties_equivalent(a, b);
-    EXPECT_EQ(
-      cudf::test::expect_column_properties_equal(a, b, cudf::test::debug_output_level::QUIET),
-      false);
+    CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(a, b);
+    EXPECT_EQ(cudf::test::detail::expect_column_properties_equal(
+                a, b, cudf::test::debug_output_level::QUIET),
+              false);
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(a, b);
-    EXPECT_EQ(cudf::test::expect_columns_equal(a, b, cudf::test::debug_output_level::QUIET), false);
+    EXPECT_EQ(cudf::test::detail::expect_columns_equal(a, b, cudf::test::debug_output_level::QUIET),
+              false);
   }
 }
 
@@ -369,12 +371,14 @@ TEST_F(ColumnUtilitiesListsTest, DifferingRowCounts)
   cudf::test::fixed_width_column_wrapper<int> a{1, 1, 1, 1};
   cudf::test::fixed_width_column_wrapper<int> b{1, 1, 1, 1, 1};
 
-  EXPECT_FALSE(cudf::test::expect_columns_equal(a, b, cudf::test::debug_output_level::QUIET));
   EXPECT_FALSE(
-    cudf::test::expect_column_properties_equal(a, b, cudf::test::debug_output_level::QUIET));
-  EXPECT_FALSE(cudf::test::expect_columns_equivalent(a, b, cudf::test::debug_output_level::QUIET));
+    cudf::test::detail::expect_columns_equal(a, b, cudf::test::debug_output_level::QUIET));
+  EXPECT_FALSE(cudf::test::detail::expect_column_properties_equal(
+    a, b, cudf::test::debug_output_level::QUIET));
   EXPECT_FALSE(
-    cudf::test::expect_column_properties_equivalent(a, b, cudf::test::debug_output_level::QUIET));
+    cudf::test::detail::expect_columns_equivalent(a, b, cudf::test::debug_output_level::QUIET));
+  EXPECT_FALSE(cudf::test::detail::expect_column_properties_equivalent(
+    a, b, cudf::test::debug_output_level::QUIET));
 }
 
 TEST_F(ColumnUtilitiesListsTest, UnsanitaryLists)
@@ -406,7 +410,8 @@ TEST_F(ColumnUtilitiesListsTest, UnsanitaryLists)
 
   // equivalent, but not equal
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*l0, l1);
-  EXPECT_FALSE(cudf::test::expect_columns_equal(*l0, l1, cudf::test::debug_output_level::QUIET));
+  EXPECT_FALSE(
+    cudf::test::detail::expect_columns_equal(*l0, l1, cudf::test::debug_output_level::QUIET));
 }
 
 TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructure)
@@ -433,15 +438,16 @@ TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructure)
                                 cudf::test::detail::make_null_mask(valids.begin(), valids.end()));
 
     // properties
-    cudf::test::expect_column_properties_equivalent(*c0, *c1);
-    EXPECT_EQ(
-      cudf::test::expect_column_properties_equal(*c0, *c1, cudf::test::debug_output_level::QUIET),
-      false);
+    CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(*c0, *c1);
+    EXPECT_EQ(cudf::test::detail::expect_column_properties_equal(
+                *c0, *c1, cudf::test::debug_output_level::QUIET),
+              false);
 
     // values
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*c0, *c1);
-    EXPECT_EQ(cudf::test::expect_columns_equal(*c0, *c1, cudf::test::debug_output_level::QUIET),
-              false);
+    EXPECT_EQ(
+      cudf::test::detail::expect_columns_equal(*c0, *c1, cudf::test::debug_output_level::QUIET),
+      false);
   }
 
   // list<list<struct<int, float>>>
@@ -490,15 +496,16 @@ TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructure)
       cudf::test::detail::make_null_mask(level1_valids.begin(), level1_valids.end()));
 
     // properties
-    cudf::test::expect_column_properties_equivalent(*c0, *c1);
-    EXPECT_EQ(
-      cudf::test::expect_column_properties_equal(*c0, *c1, cudf::test::debug_output_level::QUIET),
-      false);
+    CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(*c0, *c1);
+    EXPECT_EQ(cudf::test::detail::expect_column_properties_equal(
+                *c0, *c1, cudf::test::debug_output_level::QUIET),
+              false);
 
     // values
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*c0, *c1);
-    EXPECT_EQ(cudf::test::expect_columns_equal(*c0, *c1, cudf::test::debug_output_level::QUIET),
-              false);
+    EXPECT_EQ(
+      cudf::test::detail::expect_columns_equal(*c0, *c1, cudf::test::debug_output_level::QUIET),
+      false);
   }
 }
 
@@ -527,13 +534,13 @@ TEST_F(ColumnUtilitiesStructsTest, Properties)
   cudf::test::structs_column_wrapper s_col1({s1_scol0, s1_scol1, s1_scol2});
 
   // equivalent, but not equal
-  cudf::test::expect_column_properties_equivalent(s_col0, s_col1);
-  EXPECT_EQ(cudf::test::expect_column_properties_equal(
+  CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(s_col0, s_col1);
+  EXPECT_EQ(cudf::test::detail::expect_column_properties_equal(
               s_col0, s_col1, cudf::test::debug_output_level::QUIET),
             false);
 
-  cudf::test::expect_column_properties_equal(s_col0, s_col0);
-  cudf::test::expect_column_properties_equal(s_col1, s_col1);
+  CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(s_col0, s_col0);
+  CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(s_col1, s_col1);
 }
 
 TEST_F(ColumnUtilitiesStructsTest, Values)
@@ -559,8 +566,9 @@ TEST_F(ColumnUtilitiesStructsTest, Values)
 
   // equivalent, but not equal
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(s_col0, s_col1);
-  EXPECT_EQ(cudf::test::expect_columns_equal(s_col0, s_col1, cudf::test::debug_output_level::QUIET),
-            false);
+  EXPECT_EQ(
+    cudf::test::detail::expect_columns_equal(s_col0, s_col1, cudf::test::debug_output_level::QUIET),
+    false);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(s_col0, s_col0);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(s_col1, s_col1);

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -337,14 +337,13 @@ TEST_F(ColumnUtilitiesListsTest, Equivalence)
 
     // properties
     CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(a, b);
-    EXPECT_EQ(cudf::test::detail::expect_column_properties_equal(
-                a, b, cudf::test::debug_output_level::QUIET),
-              false);
+    EXPECT_FALSE(cudf::test::detail::expect_column_properties_equal(
+      a, b, cudf::test::debug_output_level::QUIET));
 
     // values
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(a, b);
-    EXPECT_EQ(cudf::test::detail::expect_columns_equal(a, b, cudf::test::debug_output_level::QUIET),
-              false);
+    EXPECT_FALSE(
+      cudf::test::detail::expect_columns_equal(a, b, cudf::test::debug_output_level::QUIET));
   }
 
   // list<list<int>>, nullable vs. non-nullable
@@ -356,13 +355,12 @@ TEST_F(ColumnUtilitiesListsTest, Equivalence)
 
     // properties
     CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(a, b);
-    EXPECT_EQ(cudf::test::detail::expect_column_properties_equal(
-                a, b, cudf::test::debug_output_level::QUIET),
-              false);
+    EXPECT_FALSE(cudf::test::detail::expect_column_properties_equal(
+      a, b, cudf::test::debug_output_level::QUIET));
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(a, b);
-    EXPECT_EQ(cudf::test::detail::expect_columns_equal(a, b, cudf::test::debug_output_level::QUIET),
-              false);
+    EXPECT_FALSE(
+      cudf::test::detail::expect_columns_equal(a, b, cudf::test::debug_output_level::QUIET));
   }
 }
 
@@ -439,15 +437,13 @@ TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructure)
 
     // properties
     CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(*c0, *c1);
-    EXPECT_EQ(cudf::test::detail::expect_column_properties_equal(
-                *c0, *c1, cudf::test::debug_output_level::QUIET),
-              false);
+    EXPECT_FALSE(cudf::test::detail::expect_column_properties_equal(
+      *c0, *c1, cudf::test::debug_output_level::QUIET));
 
     // values
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*c0, *c1);
-    EXPECT_EQ(
-      cudf::test::detail::expect_columns_equal(*c0, *c1, cudf::test::debug_output_level::QUIET),
-      false);
+    EXPECT_FALSE(
+      cudf::test::detail::expect_columns_equal(*c0, *c1, cudf::test::debug_output_level::QUIET));
   }
 
   // list<list<struct<int, float>>>
@@ -497,15 +493,13 @@ TEST_F(ColumnUtilitiesListsTest, DifferentPhysicalStructure)
 
     // properties
     CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(*c0, *c1);
-    EXPECT_EQ(cudf::test::detail::expect_column_properties_equal(
-                *c0, *c1, cudf::test::debug_output_level::QUIET),
-              false);
+    EXPECT_FALSE(cudf::test::detail::expect_column_properties_equal(
+      *c0, *c1, cudf::test::debug_output_level::QUIET));
 
     // values
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*c0, *c1);
-    EXPECT_EQ(
-      cudf::test::detail::expect_columns_equal(*c0, *c1, cudf::test::debug_output_level::QUIET),
-      false);
+    EXPECT_FALSE(
+      cudf::test::detail::expect_columns_equal(*c0, *c1, cudf::test::debug_output_level::QUIET));
   }
 }
 
@@ -535,9 +529,8 @@ TEST_F(ColumnUtilitiesStructsTest, Properties)
 
   // equivalent, but not equal
   CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUIVALENT(s_col0, s_col1);
-  EXPECT_EQ(cudf::test::detail::expect_column_properties_equal(
-              s_col0, s_col1, cudf::test::debug_output_level::QUIET),
-            false);
+  EXPECT_FALSE(cudf::test::detail::expect_column_properties_equal(
+    s_col0, s_col1, cudf::test::debug_output_level::QUIET));
 
   CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(s_col0, s_col0);
   CUDF_TEST_EXPECT_COLUMN_PROPERTIES_EQUAL(s_col1, s_col1);
@@ -566,7 +559,8 @@ TEST_F(ColumnUtilitiesStructsTest, Values)
 
   // equivalent, but not equal
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(s_col0, s_col1);
-  EXPECT_FALSE(cudf::test::detail::expect_columns_equal(s_col0, s_col1, cudf::test::debug_output_level::QUIET));
+  EXPECT_FALSE(cudf::test::detail::expect_columns_equal(
+    s_col0, s_col1, cudf::test::debug_output_level::QUIET));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(s_col0, s_col0);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(s_col1, s_col1);

--- a/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
+++ b/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
@@ -1391,8 +1391,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListsOfStructs)
   auto expected_struct_column =
     test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
 
-  cudf::test::expect_columns_equal(*expected_struct_column,
-                                   lists_column_view(*lists_column).child());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_struct_column, lists_column_view(*lists_column).child());
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListsOfStructsWithValidity)
@@ -1427,8 +1426,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListsOfStructsWithValidity)
   auto expected_struct_column =
     test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
 
-  cudf::test::expect_columns_equal(*expected_struct_column,
-                                   lists_column_view(*lists_column).child());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_struct_column, lists_column_view(*lists_column).child());
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListsOfListsOfStructs)
@@ -1467,7 +1465,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListsOfListsOfStructs)
   auto expected_struct_column =
     test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
 
-  cudf::test::expect_columns_equal(
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
     *expected_struct_column,
     lists_column_view{lists_column_view{*lists_of_lists_of_structs_column}.child()}.child());
 }
@@ -1515,7 +1513,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListsOfListsOfStructsWithValidity)
   auto expected_struct_column =
     test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
 
-  cudf::test::expect_columns_equal(
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
     *expected_struct_column,
     lists_column_view{lists_column_view{*lists_of_lists_of_structs_column}.child()}.child());
 }
@@ -1580,6 +1578,5 @@ TYPED_TEST(ListColumnWrapperTestTyped, LargeListsOfStructsWithValidity)
       std::vector<bool>(struct_validity_iterator, struct_validity_iterator + num_struct_rows)}
       .release();
 
-  cudf::test::expect_columns_equal(*expected_struct_column,
-                                   lists_column_view(*lists_column).child());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_struct_column, lists_column_view(*lists_column).child());
 }


### PR DESCRIPTION
w.r.t. #11007

This PR moves `cudf::test::expect_column/table*` utilities to the `detail` namespace and replace their use cases with corresponding macros when possible.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
