### PR TITLE
Correct behaviour of sort in `concat` for singleton concatenations

### DIFF
--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -234,6 +234,12 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
     if not objs:
         raise ValueError("All objects passed were None")
 
+    axis = _AXIS_MAP.get(axis, None)
+    if axis is None:
+        raise ValueError(
+            f'`axis` must be 0 / "index" or 1 / "columns", got: {axis}'
+        )
+
     # Return for single object
     if len(objs) == 1:
         obj = objs[0]
@@ -294,12 +300,6 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
             raise TypeError(f"cannot concatenate object of type {type(o)}")
 
     allowed_typs = {cudf.Series, cudf.DataFrame}
-
-    axis = _AXIS_MAP.get(axis, None)
-    if axis is None:
-        raise ValueError(
-            f'`axis` must be 0 / "index" or 1 / "columns", got: {axis}'
-        )
 
     # when axis is 1 (column) we can concat with Series and Dataframes
     if axis == 1:

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -255,7 +255,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
                 # in the data that are not in `columns`, so we have to rename
                 # after construction.
                 result.columns = pd.RangeIndex(len(obj._data.names))
-            elif axis == 0:
+            else:
                 if isinstance(obj, cudf.Series):
                     result = cudf.Series._from_data(
                         data=obj._data.copy(deep=True),

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -279,9 +279,15 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
                 if isinstance(obj, cudf.Series) and obj.name is None:
                     # If the Series has no name, pandas renames it to 0.
                     data[0] = data.pop(None)
-                result = cudf.DataFrame._from_data(data)
+                result = cudf.DataFrame._from_data(
+                    data, index=obj.index.copy(deep=True)
+                )
 
-        return result.sort_index(axis=axis) if sort else result
+        if isinstance(result, cudf.Series) and axis == 0:
+            # sort has no effect for series concatted along axis 0
+            return result
+        else:
+            return result.sort_index(axis=(1 - axis)) if sort else result
 
     # Retrieve the base types of `objs`. In order to support sub-types
     # and object wrappers, we use `isinstance()` instead of comparing

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -1796,7 +1796,7 @@ def test_concat_categorical_ordering():
 
 
 @pytest.fixture(params=["rangeindex", "index"])
-def concat_index(request):
+def singleton_concat_index(request):
     if request.param == "rangeindex":
         return pd.RangeIndex(0, 4)
     else:
@@ -1804,8 +1804,8 @@ def concat_index(request):
 
 
 @pytest.fixture(params=["dataframe", "series"])
-def concat_obj(request, concat_index):
-    if request == "dataframe":
+def singleton_concat_obj(request, singleton_concat_index):
+    if request.param == "dataframe":
         return pd.DataFrame(
             {
                 "b": [1, 2, 3, 4],
@@ -1813,22 +1813,24 @@ def concat_obj(request, concat_index):
                 "a": [4, 5, 6, 7],
                 "c": [10, 11, 12, 13],
             },
-            index=concat_index,
+            index=singleton_concat_index,
         )
     else:
-        return pd.Series([4, 5, 5, 6], index=concat_index)
+        return pd.Series([4, 5, 5, 6], index=singleton_concat_index)
 
 
 @pytest.mark.parametrize("axis", [0, 1, "columns", "index"])
 @pytest.mark.parametrize("sort", [False, True])
 @pytest.mark.parametrize("ignore_index", [False, True])
-def test_concat_singleton_sorting(axis, sort, ignore_index, concat_obj):
-    gobj = gd.from_pandas(concat_obj)
+def test_concat_singleton_sorting(
+    axis, sort, ignore_index, singleton_concat_obj
+):
+    gobj = gd.from_pandas(singleton_concat_obj)
     gconcat = gd.concat(
         [gobj], axis=axis, sort=sort, ignore_index=ignore_index
     )
     pconcat = pd.concat(
-        [concat_obj], axis=axis, sort=sort, ignore_index=ignore_index
+        [singleton_concat_obj], axis=axis, sort=sort, ignore_index=ignore_index
     )
     assert_eq(pconcat, gconcat)
 

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -1793,3 +1793,41 @@ def test_concat_categorical_ordering():
     got = gd.concat([gdf, gdf, gdf])
 
     assert_eq(expect, got)
+
+
+@pytest.fixture(params=["rangeindex", "index"])
+def concat_index(request):
+    if request.param == "rangeindex":
+        return pd.RangeIndex(0, 4)
+    else:
+        return pd.Index(["a", "h", "g", "f"])
+
+
+@pytest.fixture(params=["dataframe", "series"])
+def concat_obj(request, concat_index):
+    if request == "dataframe":
+        return pd.DataFrame(
+            {
+                "b": [1, 2, 3, 4],
+                "d": [7, 8, 9, 10],
+                "a": [4, 5, 6, 7],
+                "c": [10, 11, 12, 13],
+            },
+            index=concat_index,
+        )
+    else:
+        return pd.Series([4, 5, 5, 6], index=concat_index)
+
+
+@pytest.mark.parametrize("axis", [0, 1, "columns", "index"])
+@pytest.mark.parametrize("sort", [False, True])
+@pytest.mark.parametrize("ignore_index", [False, True])
+def test_concat_singleton_sorting(axis, sort, ignore_index, concat_obj):
+    gobj = gd.from_pandas(concat_obj)
+    gconcat = gd.concat(
+        [gobj], axis=axis, sort=sort, ignore_index=ignore_index
+    )
+    pconcat = pd.concat(
+        [concat_obj], axis=axis, sort=sort, ignore_index=ignore_index
+    )
+    assert_eq(pconcat, gconcat)

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -1831,3 +1831,10 @@ def test_concat_singleton_sorting(axis, sort, ignore_index, concat_obj):
         [concat_obj], axis=axis, sort=sort, ignore_index=ignore_index
     )
     assert_eq(pconcat, gconcat)
+
+
+@pytest.mark.parametrize("axis", [2, "invalid"])
+def test_concat_invalid_axis(axis):
+    s = gd.Series([1, 2, 3])
+    with pytest.raises(ValueError):
+        gd.concat([s], axis=axis)


### PR DESCRIPTION
## Description

The sort argument to `concat` requests a sort of the non-concatenated axis.
Previously this was handled correctly except when passing only a single object
to concatenate.

Closes #12132.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
