### PR TITLE
Fix include line for IO Cython modules

### DIFF
--- a/python/cudf/cudf/_lib/io/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/io/CMakeLists.txt
@@ -22,5 +22,5 @@ rapids_cython_create_modules(
 
 set(targets_using_numpy io_datasource io_utils)
 foreach(target IN LISTS targets_using_numpy)
-  target_include_directories(${target} PRIVATE "${Python_NumPy_INCLUDE_DIRS}")
+  target_include_directories(${target} PRIVATE "${NumPy_INCLUDE_DIRS}")
 endforeach()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR ensures that numpy include directories are visible to the cuIO Cython TUs. #12096 changed the way that numpy was being found but did not update this line. The old variable is automatically being created by scikit-build's Python code, so as long as skbuild correctly finds the libraries the old variable still works, but we do not want to rely on that since it is not true in all environments.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
