### PR TITLE
Remove default parameters from cudf::detail::sort function declarations

### DIFF
--- a/cpp/include/cudf/detail/quantiles.hpp
+++ b/cpp/include/cudf/detail/quantiles.hpp
@@ -29,29 +29,27 @@ namespace detail {
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<column> quantile(
-  column_view const& input,
-  std::vector<double> const& q,
-  interpolation interp                = interpolation::LINEAR,
-  column_view const& ordered_indices  = {},
-  bool exact                          = true,
-  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> quantile(column_view const& input,
+                                 std::vector<double> const& q,
+                                 interpolation interp,
+                                 column_view const& ordered_indices,
+                                 bool exact,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc cudf::quantiles()
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<table> quantiles(
-  table_view const& input,
-  std::vector<double> const& q,
-  interpolation interp                           = interpolation::NEAREST,
-  cudf::sorted is_input_sorted                   = sorted::NO,
-  std::vector<order> const& column_order         = {},
-  std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
-  rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
+std::unique_ptr<table> quantiles(table_view const& input,
+                                 std::vector<double> const& q,
+                                 interpolation interp,
+                                 cudf::sorted is_input_sorted,
+                                 std::vector<order> const& column_order,
+                                 std::vector<null_order> const& null_precedence,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc cudf::percentile_approx(tdigest_column_view const&, column_view const&,
@@ -59,11 +57,10 @@ std::unique_ptr<table> quantiles(
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<column> percentile_approx(
-  tdigest::tdigest_column_view const& input,
-  column_view const& percentiles,
-  rmm::cuda_stream_view stream,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> percentile_approx(tdigest::tdigest_column_view const& input,
+                                          column_view const& percentiles,
+                                          rmm::cuda_stream_view stream,
+                                          rmm::mr::device_memory_resource* mr);
 
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/include/cudf/detail/sorting.hpp
+++ b/cpp/include/cudf/detail/sorting.hpp
@@ -32,50 +32,46 @@ namespace detail {
  *
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<column> sorted_order(
-  table_view const& input,
-  std::vector<order> const& column_order         = {},
-  std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
-  rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> sorted_order(table_view const& input,
+                                     std::vector<order> const& column_order,
+                                     std::vector<null_order> const& null_precedence,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc cudf::stable_sorted_order
  *
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<column> stable_sorted_order(
-  table_view const& input,
-  std::vector<order> const& column_order         = {},
-  std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
-  rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
+std::unique_ptr<column> stable_sorted_order(table_view const& input,
+                                            std::vector<order> const& column_order,
+                                            std::vector<null_order> const& null_precedence,
+                                            rmm::cuda_stream_view stream,
+                                            rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc cudf::sort_by_key
  *
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<table> sort_by_key(
-  table_view const& values,
-  table_view const& keys,
-  std::vector<order> const& column_order         = {},
-  std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
-  rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
+std::unique_ptr<table> sort_by_key(table_view const& values,
+                                   table_view const& keys,
+                                   std::vector<order> const& column_order,
+                                   std::vector<null_order> const& null_precedence,
+                                   rmm::cuda_stream_view stream,
+                                   rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc cudf::stable_sort_by_key
  *
  * @param[in] stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<table> stable_sort_by_key(
-  table_view const& values,
-  table_view const& keys,
-  std::vector<order> const& column_order         = {},
-  std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
-  rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
+std::unique_ptr<table> stable_sort_by_key(table_view const& values,
+                                          table_view const& keys,
+                                          std::vector<order> const& column_order,
+                                          std::vector<null_order> const& null_precedence,
+                                          rmm::cuda_stream_view stream,
+                                          rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc cudf::segmented_sorted_order
@@ -133,12 +129,11 @@ std::unique_ptr<table> stable_segmented_sort_by_key(table_view const& values,
  *
  * @param stream CUDA stream used for device memory operations and kernel launches.
  */
-std::unique_ptr<table> sort(
-  table_view const& values,
-  std::vector<order> const& column_order         = {},
-  std::vector<null_order> const& null_precedence = {},
-  rmm::cuda_stream_view stream                   = cudf::get_default_stream(),
-  rmm::mr::device_memory_resource* mr            = rmm::mr::get_current_device_resource());
+std::unique_ptr<table> sort(table_view const& values,
+                            std::vector<order> const& column_order,
+                            std::vector<null_order> const& null_precedence,
+                            rmm::cuda_stream_view stream,
+                            rmm::mr::device_memory_resource* mr);
 
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/src/quantiles/quantiles.cu
+++ b/cpp/src/quantiles/quantiles.cu
@@ -79,16 +79,12 @@ std::unique_ptr<table> quantiles(table_view const& input,
   CUDF_EXPECTS(input.num_rows() > 0, "multi-column quantiles require at least one input row.");
 
   if (is_input_sorted == sorted::YES) {
-    return detail::quantiles(input,
-                             thrust::make_counting_iterator<size_type>(0),
-                             q,
-                             interp,
-                             cudf::get_default_stream(),
-                             mr);
-  } else {
-    auto sorted_idx = detail::sorted_order(input, column_order, null_precedence);
     return detail::quantiles(
-      input, sorted_idx->view().data<size_type>(), q, interp, cudf::get_default_stream(), mr);
+      input, thrust::make_counting_iterator<size_type>(0), q, interp, stream, mr);
+  } else {
+    auto sorted_idx = detail::sorted_order(
+      input, column_order, null_precedence, stream, rmm::mr::get_current_device_resource());
+    return detail::quantiles(input, sorted_idx->view().data<size_type>(), q, interp, stream, mr);
   }
 }
 

--- a/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
+++ b/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
@@ -1196,7 +1196,8 @@ std::unique_ptr<scalar> reduce_tdigest(column_view const& col,
   // since this isn't coming out of a groupby, we need to sort the inputs in ascending
   // order with nulls at the end.
   table_view t({col});
-  auto sorted = cudf::detail::sort(t, {order::ASCENDING}, {null_order::AFTER}, stream);
+  auto sorted = cudf::detail::sort(
+    t, {order::ASCENDING}, {null_order::AFTER}, stream, rmm::mr::get_current_device_resource());
 
   auto const delta = max_centroids;
   return cudf::type_dispatcher(

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -70,7 +70,11 @@ struct reduce_dispatch_functor {
         return reduction::standard_deviation(col, output_dtype, var_agg._ddof, stream, mr);
       }
       case aggregation::MEDIAN: {
-        auto sorted_indices = sorted_order(table_view{{col}}, {}, {null_order::AFTER}, stream);
+        auto sorted_indices = sorted_order(table_view{{col}},
+                                           {},
+                                           {null_order::AFTER},
+                                           stream,
+                                           rmm::mr::get_current_device_resource());
         auto valid_sorted_indices =
           split(*sorted_indices, {col.size() - col.null_count()}, stream)[0];
         auto col_ptr =
@@ -81,7 +85,11 @@ struct reduce_dispatch_functor {
         auto quantile_agg = static_cast<quantile_aggregation const&>(agg);
         CUDF_EXPECTS(quantile_agg._quantiles.size() == 1,
                      "Reduction quantile accepts only one quantile value");
-        auto sorted_indices = sorted_order(table_view{{col}}, {}, {null_order::AFTER}, stream);
+        auto sorted_indices = sorted_order(table_view{{col}},
+                                           {},
+                                           {null_order::AFTER},
+                                           stream,
+                                           rmm::mr::get_current_device_resource());
         auto valid_sorted_indices =
           split(*sorted_indices, {col.size() - col.null_count()}, stream)[0];
 

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -70,26 +70,22 @@ struct reduce_dispatch_functor {
         return reduction::standard_deviation(col, output_dtype, var_agg._ddof, stream, mr);
       }
       case aggregation::MEDIAN: {
-        auto sorted_indices = sorted_order(table_view{{col}},
-                                           {},
-                                           {null_order::AFTER},
-                                           stream,
-                                           rmm::mr::get_current_device_resource());
+        auto current_mr = rmm::mr::get_current_device_resource();
+        auto sorted_indices =
+          sorted_order(table_view{{col}}, {}, {null_order::AFTER}, stream, current_mr);
         auto valid_sorted_indices =
           split(*sorted_indices, {col.size() - col.null_count()}, stream)[0];
-        auto col_ptr =
-          quantile(col, {0.5}, interpolation::LINEAR, valid_sorted_indices, true, stream);
+        auto col_ptr = quantile(
+          col, {0.5}, interpolation::LINEAR, valid_sorted_indices, true, stream, current_mr);
         return get_element(*col_ptr, 0, stream, mr);
       }
       case aggregation::QUANTILE: {
         auto quantile_agg = static_cast<quantile_aggregation const&>(agg);
         CUDF_EXPECTS(quantile_agg._quantiles.size() == 1,
                      "Reduction quantile accepts only one quantile value");
-        auto sorted_indices = sorted_order(table_view{{col}},
-                                           {},
-                                           {null_order::AFTER},
-                                           stream,
-                                           rmm::mr::get_current_device_resource());
+        auto current_mr = rmm::mr::get_current_device_resource();
+        auto sorted_indices =
+          sorted_order(table_view{{col}}, {}, {null_order::AFTER}, stream, current_mr);
         auto valid_sorted_indices =
           split(*sorted_indices, {col.size() - col.null_count()}, stream)[0];
 
@@ -98,7 +94,8 @@ struct reduce_dispatch_functor {
                                 quantile_agg._interpolation,
                                 valid_sorted_indices,
                                 true,
-                                stream);
+                                stream,
+                                current_mr);
         return get_element(*col_ptr, 0, stream, mr);
       }
       case aggregation::NUNIQUE: {


### PR DESCRIPTION
## Description
Removes the default parameter declarations from `cudf::detail::sort`, `cudf::detail::sorted_order`, `cudf::detail::sort_by_key`,  `cudf::detail::stable_sorted_order`, and `cudf::detail::stable_sort_by_key` as well as `cudf::detail::quantile`, `cudf::detail::quantiles` and `cudf::detail::percentile_approx`
Reference comment: https://github.com/rapidsai/cudf/pull/12237#issuecomment-1329538871
Also fixes incorrect stream parameter passed within a `quantiles.cu` detail function.
No function has been added, modified, or changed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
