### PR TITLE
Fix reduction gtests coded in namespace cudf::test

### DIFF
--- a/cpp/tests/reductions/collect_ops_tests.cpp
+++ b/cpp/tests/reductions/collect_ops_tests.cpp
@@ -23,15 +23,12 @@
 #include <cudf/reduction.hpp>
 #include <cudf/sorting.hpp>
 
-using namespace cudf::test::iterators;
-
-namespace cudf::test {
-
 namespace {
 
-auto collect_set(cudf::column_view const& input, std::unique_ptr<reduce_aggregation> const& agg)
+auto collect_set(cudf::column_view const& input,
+                 std::unique_ptr<cudf::reduce_aggregation> const& agg)
 {
-  auto const result_scalar = cudf::reduce(input, *agg, data_type{type_id::LIST});
+  auto const result_scalar = cudf::reduce(input, *agg, cudf::data_type{cudf::type_id::LIST});
 
   // The results of `collect_set` are unordered thus we need to sort them for comparison.
   auto const result_sorted_table =
@@ -48,8 +45,10 @@ template <typename T>
 struct CollectTestFixedWidth : public cudf::test::BaseFixture {
 };
 
-using CollectFixedWidthTypes =
-  Concat<IntegralTypesNotBool, FloatingPointTypes, ChronoTypes, FixedPointTypes>;
+using CollectFixedWidthTypes = cudf::test::Concat<cudf::test::IntegralTypesNotBool,
+                                                  cudf::test::FloatingPointTypes,
+                                                  cudf::test::ChronoTypes,
+                                                  cudf::test::FixedPointTypes>;
 TYPED_TEST_SUITE(CollectTestFixedWidth, CollectFixedWidthTypes);
 
 // ------------------------------------------------------------------------
@@ -62,23 +61,27 @@ TYPED_TEST(CollectTestFixedWidth, CollectList)
 
   // null_include without nulls
   fw_wrapper col(values.begin(), values.end());
-  auto const ret = cudf::reduce(
-    col, *make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col, dynamic_cast<list_scalar*>(ret.get())->view());
+  auto const ret = cudf::reduce(col,
+                                *cudf::make_collect_list_aggregation<cudf::reduce_aggregation>(),
+                                cudf::data_type{cudf::type_id::LIST});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col, dynamic_cast<cudf::list_scalar*>(ret.get())->view());
 
   // null_include with nulls
   fw_wrapper col_with_null(values.begin(), values.end(), null_mask.begin());
-  auto const ret1 = cudf::reduce(
-    col_with_null, *make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_with_null, dynamic_cast<list_scalar*>(ret1.get())->view());
+  auto const ret1 = cudf::reduce(col_with_null,
+                                 *cudf::make_collect_list_aggregation<cudf::reduce_aggregation>(),
+                                 cudf::data_type{cudf::type_id::LIST});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_with_null,
+                                 dynamic_cast<cudf::list_scalar*>(ret1.get())->view());
 
   // null_exclude with nulls
   fw_wrapper col_null_filtered{{5, 0, -111, 0, 64, 99, -16}};
-  auto const ret2 =
-    cudf::reduce(col_with_null,
-                 *make_collect_list_aggregation<reduce_aggregation>(null_policy::EXCLUDE),
-                 data_type{type_id::LIST});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_null_filtered, dynamic_cast<list_scalar*>(ret2.get())->view());
+  auto const ret2 = cudf::reduce(
+    col_with_null,
+    *cudf::make_collect_list_aggregation<cudf::reduce_aggregation>(cudf::null_policy::EXCLUDE),
+    cudf::data_type{cudf::type_id::LIST});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(col_null_filtered,
+                                 dynamic_cast<cudf::list_scalar*>(ret2.get())->view());
 }
 
 TYPED_TEST(CollectTestFixedWidth, CollectSet)
@@ -91,32 +94,32 @@ TYPED_TEST(CollectTestFixedWidth, CollectSet)
   fw_wrapper col(values.begin(), values.end());
   fw_wrapper col_with_null(values.begin(), values.end(), null_mask.begin());
 
-  auto null_exclude = make_collect_set_aggregation<reduce_aggregation>(
-    null_policy::EXCLUDE, null_equality::UNEQUAL, nan_equality::ALL_EQUAL);
-  auto null_eq = make_collect_set_aggregation<reduce_aggregation>(
-    null_policy::INCLUDE, null_equality::EQUAL, nan_equality::ALL_EQUAL);
-  auto null_unequal = make_collect_set_aggregation<reduce_aggregation>(
-    null_policy::INCLUDE, null_equality::UNEQUAL, nan_equality::ALL_EQUAL);
+  auto null_exclude = cudf::make_collect_set_aggregation<cudf::reduce_aggregation>(
+    cudf::null_policy::EXCLUDE, cudf::null_equality::UNEQUAL, cudf::nan_equality::ALL_EQUAL);
+  auto null_eq = cudf::make_collect_set_aggregation<cudf::reduce_aggregation>(
+    cudf::null_policy::INCLUDE, cudf::null_equality::EQUAL, cudf::nan_equality::ALL_EQUAL);
+  auto null_unequal = cudf::make_collect_set_aggregation<cudf::reduce_aggregation>(
+    cudf::null_policy::INCLUDE, cudf::null_equality::UNEQUAL, cudf::nan_equality::ALL_EQUAL);
 
   // test without nulls
   auto const ret = collect_set(col, null_eq);
   fw_wrapper expected{{0, 5, 64, 99, 120}};
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, dynamic_cast<list_scalar*>(ret.get())->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, dynamic_cast<cudf::list_scalar*>(ret.get())->view());
 
   // null exclude
   auto const ret1 = collect_set(col_with_null, null_exclude);
   fw_wrapper expected1{{0, 5, 64, 99}};
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<list_scalar*>(ret1.get())->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<cudf::list_scalar*>(ret1.get())->view());
 
   // null equal
   auto const ret2 = collect_set(col_with_null, null_eq);
   fw_wrapper expected2{{0, 5, 64, 99, -1}, {1, 1, 1, 1, 0}};
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<list_scalar*>(ret2.get())->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<cudf::list_scalar*>(ret2.get())->view());
 
   // null unequal
   auto const ret3 = collect_set(col_with_null, null_unequal);
   fw_wrapper expected3{{0, 5, 64, 99, -1, -1, -1}, {1, 1, 1, 1, 0, 0, 0}};
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, dynamic_cast<list_scalar*>(ret3.get())->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, dynamic_cast<cudf::list_scalar*>(ret3.get())->view());
 }
 
 TYPED_TEST(CollectTestFixedWidth, MergeLists)
@@ -127,26 +130,28 @@ TYPED_TEST(CollectTestFixedWidth, MergeLists)
   // test without nulls
   auto const lists1    = lists_col{{1, 2, 3}, {}, {}, {4}, {5, 6, 7}, {8, 9}, {}};
   auto const expected1 = fw_wrapper{{1, 2, 3, 4, 5, 6, 7, 8, 9}};
-  auto const ret1      = cudf::reduce(
-    lists1, *make_merge_lists_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<list_scalar*>(ret1.get())->view());
+  auto const ret1      = cudf::reduce(lists1,
+                                 *cudf::make_merge_lists_aggregation<cudf::reduce_aggregation>(),
+                                 cudf::data_type{cudf::type_id::LIST});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<cudf::list_scalar*>(ret1.get())->view());
 
   // test with nulls
   auto const lists2    = lists_col{{
                                   lists_col{1, 2, 3},
                                   lists_col{},
-                                  lists_col{{0, 4, 0, 5}, nulls_at({0, 2})},
-                                  lists_col{{0, 0, 0}, all_nulls()},
+                                  lists_col{{0, 4, 0, 5}, cudf::test::iterators::nulls_at({0, 2})},
+                                  lists_col{{0, 0, 0}, cudf::test::iterators::all_nulls()},
                                   lists_col{6},
                                   lists_col{-1, -1},  // null_list
                                   lists_col{7, 8, 9},
                                 },
-                                null_at(5)};
+                                cudf::test::iterators::null_at(5)};
   auto const expected2 = fw_wrapper{{1, 2, 3, 0, 4, 0, 5, 0, 0, 0, 6, 7, 8, 9},
                                     {1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1, 1, 1}};
-  auto const ret2      = cudf::reduce(
-    lists2, *make_merge_lists_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<list_scalar*>(ret2.get())->view());
+  auto const ret2      = cudf::reduce(lists2,
+                                 *cudf::make_merge_lists_aggregation<cudf::reduce_aggregation>(),
+                                 cudf::data_type{cudf::type_id::LIST});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<cudf::list_scalar*>(ret2.get())->view());
 }
 
 TYPED_TEST(CollectTestFixedWidth, MergeSets)
@@ -157,30 +162,33 @@ TYPED_TEST(CollectTestFixedWidth, MergeSets)
   // test without nulls
   auto const lists1    = lists_col{{1, 2, 3}, {}, {}, {4}, {1, 3, 4}, {0, 3, 10}, {}};
   auto const expected1 = fw_wrapper{{0, 1, 2, 3, 4, 10}};
-  auto const ret1      = collect_set(lists1, make_merge_sets_aggregation<reduce_aggregation>());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<list_scalar*>(ret1.get())->view());
+  auto const ret1 =
+    collect_set(lists1, cudf::make_merge_sets_aggregation<cudf::reduce_aggregation>());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<cudf::list_scalar*>(ret1.get())->view());
 
   // test with null_equal
   auto const lists2    = lists_col{{
                                   lists_col{1, 2, 3},
                                   lists_col{},
-                                  lists_col{{0, 4, 0, 5}, nulls_at({0, 2})},
-                                  lists_col{{0, 0, 0}, all_nulls()},
+                                  lists_col{{0, 4, 0, 5}, cudf::test::iterators::nulls_at({0, 2})},
+                                  lists_col{{0, 0, 0}, cudf::test::iterators::all_nulls()},
                                   lists_col{5},
                                   lists_col{-1, -1},  // null_list
                                   lists_col{1, 3, 5},
                                 },
-                                null_at(5)};
+                                cudf::test::iterators::null_at(5)};
   auto const expected2 = fw_wrapper{{1, 2, 3, 4, 5, 0}, {1, 1, 1, 1, 1, 0}};
-  auto const ret2      = collect_set(lists2, make_merge_sets_aggregation<reduce_aggregation>());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<list_scalar*>(ret2.get())->view());
+  auto const ret2 =
+    collect_set(lists2, cudf::make_merge_sets_aggregation<cudf::reduce_aggregation>());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<cudf::list_scalar*>(ret2.get())->view());
 
   // test with null_unequal
   auto const& lists3   = lists2;
   auto const expected3 = fw_wrapper{{1, 2, 3, 4, 5, 0, 0, 0, 0, 0}, {1, 1, 1, 1, 1, 0, 0, 0, 0, 0}};
-  auto const ret3 =
-    collect_set(lists3, make_merge_sets_aggregation<reduce_aggregation>(null_equality::UNEQUAL));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, dynamic_cast<list_scalar*>(ret3.get())->view());
+  auto const ret3      = collect_set(
+    lists3,
+    cudf::make_merge_sets_aggregation<cudf::reduce_aggregation>(cudf::null_equality::UNEQUAL));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, dynamic_cast<cudf::list_scalar*>(ret3.get())->view());
 }
 
 struct CollectTest : public cudf::test::BaseFixture {
@@ -196,36 +204,36 @@ TEST_F(CollectTest, CollectSetWithNaN)
   // nan unequal with null equal
   fp_wrapper expected1{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, -NAN, NAN, NAN, 0.0f},
                        {1, 1, 1, 1, 1, 1, 1, 0}};
-  auto const ret1 =
-    collect_set(col,
-                make_collect_set_aggregation<reduce_aggregation>(
-                  null_policy::INCLUDE, null_equality::EQUAL, nan_equality::UNEQUAL));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<list_scalar*>(ret1.get())->view());
+  auto const ret1 = collect_set(
+    col,
+    cudf::make_collect_set_aggregation<cudf::reduce_aggregation>(
+      cudf::null_policy::INCLUDE, cudf::null_equality::EQUAL, cudf::nan_equality::UNEQUAL));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<cudf::list_scalar*>(ret1.get())->view());
 
   // nan unequal with null unequal
   fp_wrapper expected2{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, -NAN, NAN, NAN, 0.0f, 0.0f},
                        {1, 1, 1, 1, 1, 1, 1, 0, 0}};
-  auto const ret2 =
-    collect_set(col,
-                make_collect_set_aggregation<reduce_aggregation>(
-                  null_policy::INCLUDE, null_equality::UNEQUAL, nan_equality::UNEQUAL));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<list_scalar*>(ret2.get())->view());
+  auto const ret2 = collect_set(
+    col,
+    cudf::make_collect_set_aggregation<cudf::reduce_aggregation>(
+      cudf::null_policy::INCLUDE, cudf::null_equality::UNEQUAL, cudf::nan_equality::UNEQUAL));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<cudf::list_scalar*>(ret2.get())->view());
 
   // nan equal with null equal
   fp_wrapper expected3{{-2.3e-5f, 1.0f, 2.3e5f, NAN, 0.0f}, {1, 1, 1, 1, 0}};
-  auto const ret3 =
-    collect_set(col,
-                make_collect_set_aggregation<reduce_aggregation>(
-                  null_policy::INCLUDE, null_equality::EQUAL, nan_equality::ALL_EQUAL));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, dynamic_cast<list_scalar*>(ret3.get())->view());
+  auto const ret3 = collect_set(
+    col,
+    cudf::make_collect_set_aggregation<cudf::reduce_aggregation>(
+      cudf::null_policy::INCLUDE, cudf::null_equality::EQUAL, cudf::nan_equality::ALL_EQUAL));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, dynamic_cast<cudf::list_scalar*>(ret3.get())->view());
 
   // nan equal with null unequal
   fp_wrapper expected4{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, 0.0f, 0.0f}, {1, 1, 1, 1, 0, 0}};
-  auto const ret4 =
-    collect_set(col,
-                make_collect_set_aggregation<reduce_aggregation>(
-                  null_policy::INCLUDE, null_equality::UNEQUAL, nan_equality::ALL_EQUAL));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected4, dynamic_cast<list_scalar*>(ret4.get())->view());
+  auto const ret4 = collect_set(
+    col,
+    cudf::make_collect_set_aggregation<cudf::reduce_aggregation>(
+      cudf::null_policy::INCLUDE, cudf::null_equality::UNEQUAL, cudf::nan_equality::ALL_EQUAL));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected4, dynamic_cast<cudf::list_scalar*>(ret4.get())->view());
 }
 
 TEST_F(CollectTest, MergeSetsWithNaN)
@@ -236,39 +244,39 @@ TEST_F(CollectTest, MergeSetsWithNaN)
   auto const col = lists_col{
     lists_col{1.0f, -2.3e-5f, NAN},
     lists_col{},
-    lists_col{{-2.3e-5f, 2.3e5f, NAN, 0.0f}, nulls_at({3})},
-    lists_col{{0.0f, 0.0f}, all_nulls()},
+    lists_col{{-2.3e-5f, 2.3e5f, NAN, 0.0f}, cudf::test::iterators::nulls_at({3})},
+    lists_col{{0.0f, 0.0f}, cudf::test::iterators::all_nulls()},
     lists_col{-NAN},
   };
 
   // nan unequal with null equal
   fp_wrapper expected1{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, NAN, NAN, 0.0f}, {1, 1, 1, 1, 1, 1, 0}};
-  auto const ret1 = collect_set(
-    col,
-    make_merge_sets_aggregation<reduce_aggregation>(null_equality::EQUAL, nan_equality::UNEQUAL));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<list_scalar*>(ret1.get())->view());
+  auto const ret1 = collect_set(col,
+                                cudf::make_merge_sets_aggregation<cudf::reduce_aggregation>(
+                                  cudf::null_equality::EQUAL, cudf::nan_equality::UNEQUAL));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, dynamic_cast<cudf::list_scalar*>(ret1.get())->view());
 
   // nan unequal with null unequal
   fp_wrapper expected2{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, NAN, NAN, 0.0f, 0.0f, 0.0f},
                        {1, 1, 1, 1, 1, 1, 0, 0, 0}};
-  auto const ret2 = collect_set(
-    col,
-    make_merge_sets_aggregation<reduce_aggregation>(null_equality::UNEQUAL, nan_equality::UNEQUAL));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<list_scalar*>(ret2.get())->view());
+  auto const ret2 = collect_set(col,
+                                cudf::make_merge_sets_aggregation<cudf::reduce_aggregation>(
+                                  cudf::null_equality::UNEQUAL, cudf::nan_equality::UNEQUAL));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<cudf::list_scalar*>(ret2.get())->view());
 
   // nan equal with null equal
   fp_wrapper expected3{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, 0.0f}, {1, 1, 1, 1, 0}};
-  auto const ret3 = collect_set(
-    col,
-    make_merge_sets_aggregation<reduce_aggregation>(null_equality::EQUAL, nan_equality::ALL_EQUAL));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, dynamic_cast<list_scalar*>(ret3.get())->view());
+  auto const ret3 = collect_set(col,
+                                cudf::make_merge_sets_aggregation<cudf::reduce_aggregation>(
+                                  cudf::null_equality::EQUAL, cudf::nan_equality::ALL_EQUAL));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, dynamic_cast<cudf::list_scalar*>(ret3.get())->view());
 
   // nan equal with null unequal
   fp_wrapper expected4{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, 0.0f, 0.0f, 0.0f}, {1, 1, 1, 1, 0, 0, 0}};
   auto const ret4 = collect_set(col,
-                                make_merge_sets_aggregation<reduce_aggregation>(
-                                  null_equality::UNEQUAL, nan_equality::ALL_EQUAL));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected4, dynamic_cast<list_scalar*>(ret4.get())->view());
+                                cudf::make_merge_sets_aggregation<cudf::reduce_aggregation>(
+                                  cudf::null_equality::UNEQUAL, cudf::nan_equality::ALL_EQUAL));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected4, dynamic_cast<cudf::list_scalar*>(ret4.get())->view());
 }
 
 TEST_F(CollectTest, CollectStrings)
@@ -280,56 +288,61 @@ TEST_F(CollectTest, CollectStrings)
     str_col{{"a", "a", "b", "b", "b", "c", "c", "d", "e", "e"}, {1, 1, 1, 0, 1, 1, 0, 1, 1, 1}};
 
   // collect_list including nulls
-  auto const ret1 = cudf::reduce(
-    s_col, *make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(s_col, dynamic_cast<list_scalar*>(ret1.get())->view());
+  auto const ret1 = cudf::reduce(s_col,
+                                 *cudf::make_collect_list_aggregation<cudf::reduce_aggregation>(),
+                                 cudf::data_type{cudf::type_id::LIST});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(s_col, dynamic_cast<cudf::list_scalar*>(ret1.get())->view());
 
   // collect_list excluding nulls
   auto const expected2 = str_col{"a", "a", "b", "b", "c", "d", "e", "e"};
-  auto const ret2 =
-    cudf::reduce(s_col,
-                 *make_collect_list_aggregation<reduce_aggregation>(null_policy::EXCLUDE),
-                 data_type{type_id::LIST});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<list_scalar*>(ret2.get())->view());
+  auto const ret2      = cudf::reduce(
+    s_col,
+    *cudf::make_collect_list_aggregation<cudf::reduce_aggregation>(cudf::null_policy::EXCLUDE),
+    cudf::data_type{cudf::type_id::LIST});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected2, dynamic_cast<cudf::list_scalar*>(ret2.get())->view());
 
   // collect_set with null_equal
-  auto const expected3 = str_col{{"a", "b", "c", "d", "e", ""}, null_at(5)};
-  auto const ret3      = collect_set(s_col, make_collect_set_aggregation<reduce_aggregation>());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, dynamic_cast<list_scalar*>(ret3.get())->view());
+  auto const expected3 = str_col{{"a", "b", "c", "d", "e", ""}, cudf::test::iterators::null_at(5)};
+  auto const ret3 =
+    collect_set(s_col, cudf::make_collect_set_aggregation<cudf::reduce_aggregation>());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected3, dynamic_cast<cudf::list_scalar*>(ret3.get())->view());
 
   // collect_set with null_unequal
   auto const expected4 = str_col{{"a", "b", "c", "d", "e", "", ""}, {1, 1, 1, 1, 1, 0, 0}};
-  auto const ret4      = collect_set(
-    s_col,
-    make_collect_set_aggregation<reduce_aggregation>(null_policy::INCLUDE, null_equality::UNEQUAL));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected4, dynamic_cast<list_scalar*>(ret4.get())->view());
+  auto const ret4      = collect_set(s_col,
+                                cudf::make_collect_set_aggregation<cudf::reduce_aggregation>(
+                                  cudf::null_policy::INCLUDE, cudf::null_equality::UNEQUAL));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected4, dynamic_cast<cudf::list_scalar*>(ret4.get())->view());
 
   lists_col strings{{"a"},
                     {},
                     {"a", "b"},
-                    lists_col{{"b", "null", "c"}, null_at(1)},
-                    lists_col{{"null", "d"}, null_at(0)},
-                    lists_col{{"null"}, null_at(0)},
+                    lists_col{{"b", "null", "c"}, cudf::test::iterators::null_at(1)},
+                    lists_col{{"null", "d"}, cudf::test::iterators::null_at(0)},
+                    lists_col{{"null"}, cudf::test::iterators::null_at(0)},
                     {"e"}};
 
   // merge_lists
   auto const expected5 = str_col{{"a", "a", "b", "b", "null", "c", "null", "d", "null", "e"},
                                  {1, 1, 1, 1, 0, 1, 0, 1, 0, 1}};
-  auto const ret5      = cudf::reduce(
-    strings, *make_merge_lists_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected5, dynamic_cast<list_scalar*>(ret5.get())->view());
+  auto const ret5      = cudf::reduce(strings,
+                                 *cudf::make_merge_lists_aggregation<cudf::reduce_aggregation>(),
+                                 cudf::data_type{cudf::type_id::LIST});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected5, dynamic_cast<cudf::list_scalar*>(ret5.get())->view());
 
   // merge_sets with null_equal
   auto const expected6 = str_col{{"a", "b", "c", "d", "e", "null"}, {1, 1, 1, 1, 1, 0}};
-  auto const ret6      = collect_set(strings, make_merge_sets_aggregation<reduce_aggregation>());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected6, dynamic_cast<list_scalar*>(ret6.get())->view());
+  auto const ret6 =
+    collect_set(strings, cudf::make_merge_sets_aggregation<cudf::reduce_aggregation>());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected6, dynamic_cast<cudf::list_scalar*>(ret6.get())->view());
 
   // merge_sets with null_unequal
   auto const expected7 =
     str_col{{"a", "b", "c", "d", "e", "null", "null", "null"}, {1, 1, 1, 1, 1, 0, 0, 0}};
-  auto const ret7 =
-    collect_set(strings, make_merge_sets_aggregation<reduce_aggregation>(null_equality::UNEQUAL));
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected7, dynamic_cast<list_scalar*>(ret7.get())->view());
+  auto const ret7 = collect_set(
+    strings,
+    cudf::make_merge_sets_aggregation<cudf::reduce_aggregation>(cudf::null_equality::UNEQUAL));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected7, dynamic_cast<cudf::list_scalar*>(ret7.get())->view());
 }
 
 TEST_F(CollectTest, CollectEmptys)
@@ -338,21 +351,21 @@ TEST_F(CollectTest, CollectEmptys)
 
   // test collect empty columns
   auto empty = int_col{};
-  auto ret   = cudf::reduce(
-    empty, *make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(int_col{}, dynamic_cast<list_scalar*>(ret.get())->view());
+  auto ret   = cudf::reduce(empty,
+                          *cudf::make_collect_list_aggregation<cudf::reduce_aggregation>(),
+                          cudf::data_type{cudf::type_id::LIST});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(int_col{}, dynamic_cast<cudf::list_scalar*>(ret.get())->view());
 
-  ret = collect_set(empty, make_collect_set_aggregation<reduce_aggregation>());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(int_col{}, dynamic_cast<list_scalar*>(ret.get())->view());
+  ret = collect_set(empty, cudf::make_collect_set_aggregation<cudf::reduce_aggregation>());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(int_col{}, dynamic_cast<cudf::list_scalar*>(ret.get())->view());
 
   // test collect all null columns
   auto all_nulls = int_col{{1, 2, 3, 4, 5}, {0, 0, 0, 0, 0}};
-  ret            = cudf::reduce(
-    all_nulls, *make_collect_list_aggregation<reduce_aggregation>(), data_type{type_id::LIST});
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(int_col{}, dynamic_cast<list_scalar*>(ret.get())->view());
+  ret            = cudf::reduce(all_nulls,
+                     *cudf::make_collect_list_aggregation<cudf::reduce_aggregation>(),
+                     cudf::data_type{cudf::type_id::LIST});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(int_col{}, dynamic_cast<cudf::list_scalar*>(ret.get())->view());
 
-  ret = collect_set(all_nulls, make_collect_set_aggregation<reduce_aggregation>());
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(int_col{}, dynamic_cast<list_scalar*>(ret.get())->view());
+  ret = collect_set(all_nulls, cudf::make_collect_set_aggregation<cudf::reduce_aggregation>());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(int_col{}, dynamic_cast<cudf::list_scalar*>(ret.get())->view());
 }
-
-}  // namespace cudf::test

--- a/cpp/tests/reductions/rank_tests.cpp
+++ b/cpp/tests/reductions/rank_tests.cpp
@@ -27,23 +27,18 @@
 
 #include <thrust/host_vector.h>
 
-using aggregation = cudf::aggregation;
-using cudf::null_policy;
-using cudf::scan_type;
+using rank_result_col    = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
+using percent_result_col = cudf::test::fixed_width_column_wrapper<double>;
 
-namespace cudf::test {
-
-using namespace iterators;
-
-template <typename T>
-using input              = fixed_width_column_wrapper<T>;
-using rank_result_col    = fixed_width_column_wrapper<size_type>;
-using percent_result_col = fixed_width_column_wrapper<double>;
-
-auto const rank         = cudf::make_rank_aggregation<scan_aggregation>(cudf::rank_method::MIN);
-auto const dense_rank   = cudf::make_rank_aggregation<scan_aggregation>(cudf::rank_method::DENSE);
-auto const percent_rank = cudf::make_rank_aggregation<scan_aggregation>(
-  cudf::rank_method::MIN, {}, null_policy::INCLUDE, {}, rank_percentage::ONE_NORMALIZED);
+auto const rank = cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::MIN);
+auto const dense_rank =
+  cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::DENSE);
+auto const percent_rank =
+  cudf::make_rank_aggregation<cudf::scan_aggregation>(cudf::rank_method::MIN,
+                                                      {},
+                                                      cudf::null_policy::INCLUDE,
+                                                      {},
+                                                      cudf::rank_percentage::ONE_NORMALIZED);
 
 auto constexpr INCLUSIVE_SCAN = cudf::scan_type::INCLUSIVE;
 auto constexpr INCLUDE_NULLS  = cudf::null_policy::INCLUDE;
@@ -52,7 +47,7 @@ template <typename T>
 struct TypedRankScanTest : BaseScanTest<T> {
   inline void test_ungrouped_rank_scan(cudf::column_view const& input,
                                        cudf::column_view const& expect_vals,
-                                       scan_aggregation const& agg)
+                                       cudf::scan_aggregation const& agg)
   {
     auto col_out = cudf::scan(input, agg, INCLUSIVE_SCAN, INCLUDE_NULLS);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expect_vals, col_out->view());
@@ -102,7 +97,7 @@ TYPED_TEST(TypedRankScanTest, RankWithNulls)
       return make_vector<TypeParam>({-120, -120, -120, -16, -16, 5, 6, 6, 6, 6, 34, 113});
     return make_vector<TypeParam>({5, 5, 5, 6, 6, 9, 11, 11, 11, 11, 14, 34});
   }();
-  auto const null_iter = nulls_at({3, 6, 7, 11});
+  auto const null_iter = cudf::test::iterators::nulls_at({3, 6, 7, 11});
   auto const b         = thrust::host_vector<bool>(null_iter, null_iter + v.size());
   auto col             = this->make_column(v, b);
 
@@ -130,19 +125,23 @@ template <typename TypeParam>
 auto make_input_column()
 {
   if constexpr (std::is_same_v<TypeParam, cudf::string_view>) {
-    return strings_column_wrapper{{"0", "0", "4", "4", "4", "5", "7", "7", "7", "9", "9", "9"},
-                                  null_at(5)};
+    return cudf::test::strings_column_wrapper{
+      {"0", "0", "4", "4", "4", "5", "7", "7", "7", "9", "9", "9"},
+      cudf::test::iterators::null_at(5)};
   } else {
+    using fw_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;
     return (std::is_signed_v<TypeParam>)
-             ? input<TypeParam>{{-1, -1, -4, -4, -4, 5, 7, 7, 7, 9, 9, 9}, null_at(5)}
-             : input<TypeParam>{{0, 0, 4, 4, 4, 5, 7, 7, 7, 9, 9, 9}, null_at(5)};
+             ? fw_wrapper{{-1, -1, -4, -4, -4, 5, 7, 7, 7, 9, 9, 9},
+                          cudf::test::iterators::null_at(5)}
+             : fw_wrapper{{0, 0, 4, 4, 4, 5, 7, 7, 7, 9, 9, 9}, cudf::test::iterators::null_at(5)};
   }
 }
 
 auto make_strings_column()
 {
-  return strings_column_wrapper{
-    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
+  return cudf::test::strings_column_wrapper{
+    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"},
+    cudf::test::iterators::null_at(8)};
 }
 
 template <typename TypeParam>
@@ -150,7 +149,7 @@ auto make_mixed_structs_column()
 {
   auto col     = make_input_column<TypeParam>();
   auto strings = make_strings_column();
-  return structs_column_wrapper{{col, strings}};
+  return cudf::test::structs_column_wrapper{{col, strings}};
 }
 }  // namespace
 
@@ -183,17 +182,17 @@ TYPED_TEST(TypedRankScanTest, NestedStructs)
     auto struct_col = [&] {
       auto col     = make_input_column<TypeParam>();
       auto strings = make_strings_column();
-      return structs_column_wrapper{{col, strings}};
+      return cudf::test::structs_column_wrapper{{col, strings}};
     }();
     auto col = make_input_column<TypeParam>();
-    return structs_column_wrapper{{struct_col, col}};
+    return cudf::test::structs_column_wrapper{{struct_col, col}};
   }();
 
   auto const flat_col = [&] {
     auto col         = make_input_column<TypeParam>();
     auto strings_col = make_strings_column();
     auto nuther_col  = make_input_column<TypeParam>();
-    return structs_column_wrapper{{col, strings_col, nuther_col}};
+    return cudf::test::structs_column_wrapper{{col, strings_col, nuther_col}};
   }();
 
   auto const dense_out      = cudf::scan(nested_col, *dense_rank, INCLUSIVE_SCAN, INCLUDE_NULLS);
@@ -231,7 +230,7 @@ TYPED_TEST(TypedRankScanTest, StructsWithNullPushdown)
   // Next, verify that if the structs column a null mask that is NOT pushed down to members,
   // the ranks are still correct.
   {
-    auto const null_iter = nulls_at({1, 2});
+    auto const null_iter = cudf::test::iterators::nulls_at({1, 2});
     struct_col->set_null_mask(
       cudf::test::detail::make_null_mask(null_iter, null_iter + struct_col->size()));
     auto const expected_dense   = rank_result_col{1, 2, 2, 3, 4, 5, 6, 6, 7, 8, 8, 9};
@@ -262,7 +261,8 @@ struct RankScanTest : public cudf::test::BaseFixture {
 
 TEST(RankScanTest, BoolRank)
 {
-  auto const vals             = input<bool>{0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  auto const vals =
+    cudf::test::fixed_width_column_wrapper<bool>{0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
   auto const expected_dense   = rank_result_col{1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2};
   auto const expected_rank    = rank_result_col{1, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4};
   auto const expected_percent = percent_result_col{0.0,
@@ -288,7 +288,8 @@ TEST(RankScanTest, BoolRank)
 
 TEST(RankScanTest, BoolRankWithNull)
 {
-  auto const vals = input<bool>{{0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}, nulls_at({8, 9, 10, 11})};
+  auto const vals = cudf::test::fixed_width_column_wrapper<bool>{
+    {0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1}, cudf::test::iterators::nulls_at({8, 9, 10, 11})};
   auto const expected_dense   = rank_result_col{1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3};
   auto const expected_rank    = rank_result_col{1, 1, 1, 4, 4, 4, 4, 4, 9, 9, 9, 9};
   auto const expected_percent = percent_result_col{0.0,
@@ -314,14 +315,13 @@ TEST(RankScanTest, BoolRankWithNull)
 
 TEST(RankScanTest, ExclusiveScan)
 {
-  auto const vals = input<uint32_t>{3, 4, 5};
+  auto const vals = cudf::test::fixed_width_column_wrapper<uint32_t>{3, 4, 5};
 
   // Only inclusive scans are supported, so these should all raise exceptions.
-  EXPECT_THROW(cudf::scan(vals, *dense_rank, scan_type::EXCLUSIVE, INCLUDE_NULLS),
+  EXPECT_THROW(cudf::scan(vals, *dense_rank, cudf::scan_type::EXCLUSIVE, INCLUDE_NULLS),
                cudf::logic_error);
-  EXPECT_THROW(cudf::scan(vals, *rank, scan_type::EXCLUSIVE, INCLUDE_NULLS), cudf::logic_error);
-  EXPECT_THROW(cudf::scan(vals, *percent_rank, scan_type::EXCLUSIVE, INCLUDE_NULLS),
+  EXPECT_THROW(cudf::scan(vals, *rank, cudf::scan_type::EXCLUSIVE, INCLUDE_NULLS),
+               cudf::logic_error);
+  EXPECT_THROW(cudf::scan(vals, *percent_rank, cudf::scan_type::EXCLUSIVE, INCLUDE_NULLS),
                cudf::logic_error);
 }
-
-}  // namespace cudf::test

--- a/cpp/tests/reductions/tdigest_tests.cu
+++ b/cpp/tests/reductions/tdigest_tests.cu
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-#include <cudf/reduction.hpp>
-
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/tdigest_utilities.cuh>
 #include <cudf_test/type_lists.hpp>
 
-namespace cudf {
-namespace test {
+#include <cudf/reduction.hpp>
 
 template <typename T>
 struct ReductionTDigestAllTypes : public cudf::test::BaseFixture {
@@ -68,25 +65,28 @@ struct reduce_merge_op {
 TYPED_TEST(ReductionTDigestAllTypes, Simple)
 {
   using T = TypeParam;
-  tdigest_simple_aggregation<T>(reduce_op{});
+  cudf::test::tdigest_simple_aggregation<T>(reduce_op{});
 }
 
 TYPED_TEST(ReductionTDigestAllTypes, SimpleWithNulls)
 {
   using T = TypeParam;
-  tdigest_simple_with_nulls_aggregation<T>(reduce_op{});
+  cudf::test::tdigest_simple_with_nulls_aggregation<T>(reduce_op{});
 }
 
 TYPED_TEST(ReductionTDigestAllTypes, AllNull)
 {
   using T = TypeParam;
-  tdigest_simple_all_nulls_aggregation<T>(reduce_op{});
+  cudf::test::tdigest_simple_all_nulls_aggregation<T>(reduce_op{});
 }
 
 struct ReductionTDigestMerge : public cudf::test::BaseFixture {
 };
 
-TEST_F(ReductionTDigestMerge, Simple) { tdigest_merge_simple(reduce_op{}, reduce_merge_op{}); }
+TEST_F(ReductionTDigestMerge, Simple)
+{
+  cudf::test::tdigest_merge_simple(reduce_op{}, reduce_merge_op{});
+}
 
 // tests an issue with the cluster generating code with a small number of centroids that have large
 // weights
@@ -96,12 +96,12 @@ TEST_F(ReductionTDigestMerge, FewHeavyCentroids)
   cudf::test::fixed_width_column_wrapper<double> c0c{1.0, 2.0};
   cudf::test::fixed_width_column_wrapper<double> c0w{100.0, 50.0};
   cudf::test::structs_column_wrapper c0s({c0c, c0w});
-  cudf::test::fixed_width_column_wrapper<offset_type> c0_offsets{0, 2};
+  cudf::test::fixed_width_column_wrapper<cudf::offset_type> c0_offsets{0, 2};
   auto c0l = cudf::make_lists_column(
     1, c0_offsets.release(), c0s.release(), cudf::UNKNOWN_NULL_COUNT, rmm::device_buffer{});
   cudf::test::fixed_width_column_wrapper<double> c0min{1.0};
   cudf::test::fixed_width_column_wrapper<double> c0max{2.0};
-  std::vector<std::unique_ptr<column>> c0_children;
+  std::vector<std::unique_ptr<cudf::column>> c0_children;
   c0_children.push_back(std::move(c0l));
   c0_children.push_back(c0min.release());
   c0_children.push_back(c0max.release());
@@ -113,19 +113,19 @@ TEST_F(ReductionTDigestMerge, FewHeavyCentroids)
   cudf::test::fixed_width_column_wrapper<double> c1c{3.0, 4.0};
   cudf::test::fixed_width_column_wrapper<double> c1w{200.0, 50.0};
   cudf::test::structs_column_wrapper c1s({c1c, c1w});
-  cudf::test::fixed_width_column_wrapper<offset_type> c1_offsets{0, 2};
+  cudf::test::fixed_width_column_wrapper<cudf::offset_type> c1_offsets{0, 2};
   auto c1l = cudf::make_lists_column(
     1, c1_offsets.release(), c1s.release(), cudf::UNKNOWN_NULL_COUNT, rmm::device_buffer{});
   cudf::test::fixed_width_column_wrapper<double> c1min{3.0};
   cudf::test::fixed_width_column_wrapper<double> c1max{4.0};
-  std::vector<std::unique_ptr<column>> c1_children;
+  std::vector<std::unique_ptr<cudf::column>> c1_children;
   c1_children.push_back(std::move(c1l));
   c1_children.push_back(c1min.release());
   c1_children.push_back(c1max.release());
   // tdigest struct
   auto c1 = cudf::make_structs_column(1, std::move(c1_children), 0, {});
 
-  std::vector<column_view> views;
+  std::vector<cudf::column_view> views;
   views.push_back(*c0);
   views.push_back(*c1);
   auto values = cudf::concatenate(views);
@@ -149,12 +149,12 @@ TEST_F(ReductionTDigestMerge, FewHeavyCentroids)
   cudf::test::fixed_width_column_wrapper<double> ec{1.0, 2.0, 3.0, 4.0};
   cudf::test::fixed_width_column_wrapper<double> ew{100.0, 50.0, 200.0, 50.0};
   cudf::test::structs_column_wrapper es({ec, ew});
-  cudf::test::fixed_width_column_wrapper<offset_type> e_offsets{0, 4};
+  cudf::test::fixed_width_column_wrapper<cudf::offset_type> e_offsets{0, 4};
   auto el = cudf::make_lists_column(
     1, e_offsets.release(), es.release(), cudf::UNKNOWN_NULL_COUNT, rmm::device_buffer{});
   cudf::test::fixed_width_column_wrapper<double> emin{1.0};
   cudf::test::fixed_width_column_wrapper<double> emax{4.0};
-  std::vector<std::unique_ptr<column>> e_children;
+  std::vector<std::unique_ptr<cudf::column>> e_children;
   e_children.push_back(std::move(el));
   e_children.push_back(emin.release());
   e_children.push_back(emax.release());
@@ -163,6 +163,3 @@ TEST_F(ReductionTDigestMerge, FewHeavyCentroids)
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, *expected);
 }
-
-}  // namespace test
-}  // namespace cudf


### PR DESCRIPTION
## Description
Fixes reduction gtests source files coded in namespace `cudf::test`
No function or test has changed just the source code reworked per namespaces.

Fixing this ahead of any changes for #10432 
Reference https://github.com/rapidsai/cudf/issues/11734

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
