### PR TITLE
Only exclude join keys that are indices from key columns

### DIFF
--- a/python/cudf/cudf/core/join/join.py
+++ b/python/cudf/cudf/core/join/join.py
@@ -147,12 +147,14 @@ class Merge:
         self._key_columns_with_same_name = (
             set(_coerce_to_tuple(on))
             if on
-            else set()
-            if (self._using_left_index or self._using_right_index)
             else {
                 lkey.name
                 for lkey, rkey in zip(self._left_keys, self._right_keys)
                 if lkey.name == rkey.name
+                and not (
+                    isinstance(lkey, _IndexIndexer)
+                    or isinstance(rkey, _IndexIndexer)
+                )
             }
         )
 


### PR DESCRIPTION
## Description

Previously, if any of the join keys were indices, we assumed that they
all were, and provided an empty set of key columns with matching names
in the left and right dataframe. This does the wrong thing for mixed
join keys (on a combination of index and normal columns), producing
more output columns than is correct. To avoid this, only skip matching
key names if they name indices.

Closes #11550.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
