### PR TITLE
Fix compile issue in `json_chunked_reader.cpp`

### DIFF
--- a/cpp/tests/io/json_chunked_reader.cpp
+++ b/cpp/tests/io/json_chunked_reader.cpp
@@ -75,7 +75,7 @@ std::vector<cudf::io::table_with_metadata> skeleton_for_parellel_chunk_reader(
 
   std::vector<cudf::io::table_with_metadata> tables;
   // Process each chunk in parallel.
-  for (auto const [chunk_start, chunk_end] : record_ranges) {
+  for (auto const& [chunk_start, chunk_end] : record_ranges) {
     if (chunk_start == -1 or chunk_end == -1) continue;
     reader_opts_chunk.set_byte_range_offset(chunk_start);
     reader_opts_chunk.set_byte_range_size(chunk_end - chunk_start);


### PR DESCRIPTION
This issue was introduced in https://github.com/rapidsai/cudf/pull/12017 merged, which triggers compiler error on some systems:
```
../tests/io/json_chunked_reader.cpp: In function 'std::vector<cudf::io::table_with_metadata> skeleton_for_parellel_chunk_reader(cudf::host_span<std::unique_ptr<cudf::io::datasource> >, const cudf::io::json_reader_options&, int32_t, rmm::cuda_stream_view, rmm::mr::device_memory_resource*)':
../tests/io/json_chunked_reader.cpp:78:19: error: loop variable '<structured bindings>' creates a copy from type 'const std::pair<int, int>' [-Werror=range-loop-construct]
   78 |   for (auto const [chunk_start, chunk_end] : record_ranges) {
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
../tests/io/json_chunked_reader.cpp:78:19: note: use reference type to prevent copying
   78 |   for (auto const [chunk_start, chunk_end] : record_ranges) {
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
      |                   &
```

Fixing it is just by following the compiler recommendation: "use reference type to prevent copying".