### PR TITLE
Improved error reporting when reading multiple JSON files

### DIFF
--- a/cpp/src/io/json/experimental/read_json.cpp
+++ b/cpp/src/io/json/experimental/read_json.cpp
@@ -161,6 +161,13 @@ table_with_metadata read_json(host_span<std::unique_ptr<datasource>> sources,
                  "specifying a byte range is supported only for json lines");
   }
 
+  if (sources.size() > 1) {
+    CUDF_EXPECTS(reader_opts.get_compression() == compression_type::NONE,
+                 "Multiple compressed inputs are not supported");
+    CUDF_EXPECTS(reader_opts.is_enabled_lines(),
+                 "Multiple inputs are supported only for JSON Lines format");
+  }
+
   auto const buffer = get_record_range_raw_input(sources, reader_opts, stream);
 
   auto data = host_span<char const>(reinterpret_cast<char const*>(buffer.data()), buffer.size());

--- a/cpp/src/io/json/experimental/read_json.cpp
+++ b/cpp/src/io/json/experimental/read_json.cpp
@@ -158,7 +158,7 @@ table_with_metadata read_json(host_span<std::unique_ptr<datasource>> sources,
   CUDF_FUNC_RANGE();
   if (not should_load_whole_source(reader_opts)) {
     CUDF_EXPECTS(reader_opts.is_enabled_lines(),
-                 "specifying a byte range is supported only for json lines");
+                 "specifying a byte range is supported only for JSON Lines");
   }
 
   if (sources.size() > 1) {

--- a/cpp/src/io/json/reader_impl.cu
+++ b/cpp/src/io/json/reader_impl.cu
@@ -603,7 +603,6 @@ table_with_metadata read_json(std::vector<std::unique_ptr<datasource>>& sources,
   CUDF_EXPECTS(not sources.empty(), "No sources were defined");
   CUDF_EXPECTS(sources.size() == 1 or reader_opts.get_compression() == compression_type::NONE,
                "Multiple compressed inputs are not supported");
-
   CUDF_EXPECTS(reader_opts.is_enabled_lines(), "Only JSON Lines format is currently supported.\n");
 
   auto parse_opts = parse_options{',', '\n', '\"', '.'};

--- a/cpp/src/io/json/reader_impl.cu
+++ b/cpp/src/io/json/reader_impl.cu
@@ -601,6 +601,8 @@ table_with_metadata read_json(std::vector<std::unique_ptr<datasource>>& sources,
   }
 
   CUDF_EXPECTS(not sources.empty(), "No sources were defined");
+  CUDF_EXPECTS(sources.size() == 1 or reader_opts.get_compression() == compression_type::NONE,
+               "Multiple compressed inputs are not supported");
 
   CUDF_EXPECTS(reader_opts.is_enabled_lines(), "Only JSON Lines format is currently supported.\n");
 

--- a/cpp/tests/io/json_test.cpp
+++ b/cpp/tests/io/json_test.cpp
@@ -1648,4 +1648,25 @@ TYPED_TEST(JsonFixedPointReaderTest, EmptyValues)
   EXPECT_EQ(result_view.column(0).null_count(), 1);
 }
 
+TEST_F(JsonReaderTest, UnsupportedMultipleFileInputs)
+{
+  std::string const data = "{\"col\":0}";
+  auto const buffer      = cudf::io::host_buffer{data.data(), data.size()};
+  auto const src         = cudf::io::source_info{{buffer, buffer}};
+
+  cudf::io::json_reader_options const not_lines_opts =
+    cudf::io::json_reader_options::builder(src).experimental(true);
+  EXPECT_THROW(cudf::io::read_json(not_lines_opts), cudf::logic_error);
+
+  cudf::io::json_reader_options const comp_exp_opts =
+    cudf::io::json_reader_options::builder(src).experimental(true).compression(
+      cudf::io::compression_type::GZIP);
+  EXPECT_THROW(cudf::io::read_json(comp_exp_opts), cudf::logic_error);
+
+  cudf::io::json_reader_options const comp_opts =
+    cudf::io::json_reader_options::builder(src).experimental(false).compression(
+      cudf::io::compression_type::GZIP);
+  EXPECT_THROW(cudf::io::read_json(comp_opts), cudf::logic_error);
+}
+
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
## Description
`read_json` implementation cannot read multiple inputs when inputs are compressed or not in JSON lines format.
This PR adds explicit checks to return a clear error messages in unsupported cases.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
