### PR TITLE
Define needs for pr-builder workflow.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,6 +11,15 @@ concurrency:
 
 jobs:
   pr-builder:
+    needs:
+      - checks
+      - conda-cpp-build
+      - conda-cpp-tests
+      - conda-python-build
+      - conda-python-cudf-tests
+      - conda-python-other-tests
+      - conda-java-tests
+      - conda-notebook-tests
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@main
   checks:


### PR DESCRIPTION
## Description
We are seeing a rate limit on the `pr-builder` workflow. Rather than using `upsidr/merge-gatekeeper` to poll for workflow completion, we just define the `needs:` for the `pr-builder` workflow to ensure all dependencies are met. @ajschmidt8 is opening a companion PR to modify the [upstream workflow](https://github.com/rapidsai/shared-action-workflows/blob/main/.github/workflows/pr-builder.yaml) to simply `exit 0` if all requirements are met.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
