### PR TITLE
Re-enable `sccache` for Jenkins builds

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -29,9 +29,6 @@ export SCCACHE_BUCKET=rapids-sccache
 export SCCACHE_REGION=us-west-2
 export SCCACHE_IDLE_TIMEOUT=32768
 
-# Make Jenkins use unique SCCACHE_S3_KEY_PREFIX compared to GH Actions
-sed -i '/SCCACHE_S3_KEY_PREFIX/ s| #|-jenkins #|g' conda/recipes/**/meta.yaml
-
 # Use Ninja to build, setup Conda Build Dir
 export CMAKE_GENERATOR="Ninja"
 export CONDA_BLD_DIR="$WORKSPACE/.conda-bld"

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -26,6 +26,9 @@ export GPUCI_CONDA_RETRY_SLEEP=30
 # until we migrate fully to GitHub Actions
 export RAPIDS_CUDA_VERSION="${CUDA}"
 
+# Make Jenkins use unique SCCACHE_S3_KEY_PREFIX compared to GH Actions
+sed -i '/SCCACHE_S3_KEY_PREFIX/ s| #|-jenkins #|g' conda/recipes/**/meta.yaml
+
 # Use Ninja to build, setup Conda Build Dir
 export CMAKE_GENERATOR="Ninja"
 export CONDA_BLD_DIR="$WORKSPACE/.conda-bld"

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -25,6 +25,9 @@ export GPUCI_CONDA_RETRY_SLEEP=30
 # Workaround to keep Jenkins builds working
 # until we migrate fully to GitHub Actions
 export RAPIDS_CUDA_VERSION="${CUDA}"
+export SCCACHE_BUCKET=rapids-sccache
+export SCCACHE_REGION=us-west-2
+export SCCACHE_IDLE_TIMEOUT=32768
 
 # Make Jenkins use unique SCCACHE_S3_KEY_PREFIX compared to GH Actions
 sed -i '/SCCACHE_S3_KEY_PREFIX/ s| #|-jenkins #|g' conda/recipes/**/meta.yaml

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -33,9 +33,6 @@ export SCCACHE_BUCKET=rapids-sccache
 export SCCACHE_REGION=us-west-2
 export SCCACHE_IDLE_TIMEOUT=32768
 
-# Make Jenkins use unique SCCACHE_S3_KEY_PREFIX compared to GH Actions
-sed -i '/SCCACHE_S3_KEY_PREFIX/ s| #|-jenkins #|g' conda/recipes/**/meta.yaml
-
 # Parse git describe
 export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -30,6 +30,9 @@ export CONDA_ARTIFACT_PATH="$WORKSPACE/ci/artifacts/cudf/cpu/.conda-bld/"
 # until we migrate fully to GitHub Actions
 export RAPIDS_CUDA_VERSION="${CUDA}"
 
+# Make Jenkins use unique SCCACHE_S3_KEY_PREFIX compared to GH Actions
+sed -i '/SCCACHE_S3_KEY_PREFIX/ s| #|-jenkins #|g' conda/recipes/**/meta.yaml
+
 # Parse git describe
 export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -29,6 +29,9 @@ export CONDA_ARTIFACT_PATH="$WORKSPACE/ci/artifacts/cudf/cpu/.conda-bld/"
 # Workaround to keep Jenkins builds working
 # until we migrate fully to GitHub Actions
 export RAPIDS_CUDA_VERSION="${CUDA}"
+export SCCACHE_BUCKET=rapids-sccache
+export SCCACHE_REGION=us-west-2
+export SCCACHE_IDLE_TIMEOUT=32768
 
 # Make Jenkins use unique SCCACHE_S3_KEY_PREFIX compared to GH Actions
 sed -i '/SCCACHE_S3_KEY_PREFIX/ s| #|-jenkins #|g' conda/recipes/**/meta.yaml


### PR DESCRIPTION
## Description
This PR re-adds some environment variables to the Jenkins scripts that are missing from the Jenkins CI images in order to re-enable `sccache`. These were accidentally removed in #12002.

All of these Jenkins scripts will be removed once Jenkins is disabled.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
