### PR TITLE
Fix NumericPairIteratorTest for float values

### DIFF
--- a/cpp/tests/iterator/pair_iterator_test_numeric.cu
+++ b/cpp/tests/iterator/pair_iterator_test_numeric.cu
@@ -84,7 +84,11 @@ TYPED_TEST(NumericPairIteratorTest, mean_var_output)
 
   cudf::test::UniformRandomGenerator<T> rng;
   cudf::test::UniformRandomGenerator<bool> rbg;
-  std::generate(host_values.begin(), host_values.end(), [&rng]() { return rng.generate(); });
+  if constexpr (std::is_floating_point<T>()) {
+    std::fill(host_values.begin(), host_values.end(), T{2});
+  } else {
+    std::generate(host_values.begin(), host_values.end(), [&rng]() { return rng.generate(); });
+  }
   std::generate(host_bools.begin(), host_bools.end(), [&rbg]() { return rbg.generate(); });
 
   cudf::test::fixed_width_column_wrapper<TypeParam> w_col(
@@ -118,7 +122,7 @@ TYPED_TEST(NumericPairIteratorTest, mean_var_output)
                                it_dev_squared + d_col->size(),
                                thrust::make_pair(T_output{}, true),
                                sum_if_not_null{});
-  if (not std::is_floating_point<T>()) {
+  if constexpr (not std::is_floating_point<T>()) {
     EXPECT_EQ(expected_value, result.first) << "pair iterator reduction sum";
   } else {
     EXPECT_NEAR(expected_value.value, result.first.value, 1e-3) << "pair iterator reduction sum";


### PR DESCRIPTION
## Description
Fixes NumericPairIteratorTest for float values that started occurring randomly.
https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cudf/job/prb/job/cudf-gpu-test/CUDA=11.5,GPU_LABEL=driver-495,LINUX_VER=ubuntu20.04,PYTHON=3.9/12008/testReport/junit/(root)/NumericPairIteratorTest_9/mean_var_output/

The error is an accumulation of 5000 floating-point operations (addition and multiplication) and compares the result with the same operations in a single CPU thread. The error accrued over this many operations exceeded the 0.001 expected limit due to the non-deterministic behavior of floating point operations accumulated in parallel device threads.
The gtest logic was changed to only include non-fractional data values for floating point tests. This eliminates the non-deterministic error accumulation.

Recreated locally using: `gtests/ITERATOR_TEST --gtest_filter=NumericPairIteratorTest/*`
```
[ RUN      ] NumericPairIteratorTest/9.mean_var_output
/cudf/cpp/tests/iterator/pair_iterator_test_numeric.cu:124: Failure
The difference between expected_value.value and result.first.value is 0.0018310546875, which exceeds 1e-3, where
expected_value.value evaluates to 1256.650146484375,
result.first.value evaluates to 1256.6519775390625, and
1e-3 evaluates to 0.001.
pair iterator reduction sum
[  FAILED  ] NumericPairIteratorTest/9.mean_var_output, where TypeParam = float (0 ms)
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
