### PR TITLE
CSV, JSON reader to infer integer column with nulls as int64 instead of float64

### DIFF
--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -536,8 +536,6 @@ void infer_column_types(parse_options const& parse_opts,
   for (auto col_idx = 0u; col_idx < column_flags.size(); ++col_idx) {
     if (not(column_flags[col_idx] & column_parse::inferred)) { continue; }
     auto const& stats = column_stats[inf_col_idx++];
-    unsigned long long int_count_total =
-      stats.big_int_count + stats.negative_small_int_count + stats.positive_small_int_count;
     if (stats.null_count == num_records or stats.total_count() == 0) {
       // Entire column is NULL; allocate the smallest amount of memory
       column_types[col_idx] = data_type(cudf::type_id::INT8);
@@ -549,11 +547,7 @@ void infer_column_types(parse_options const& parse_opts,
                                 : timestamp_type;
     } else if (stats.bool_count > 0L) {
       column_types[col_idx] = data_type(cudf::type_id::BOOL8);
-    } else if (stats.float_count > 0L ||
-               (stats.float_count == 0L && int_count_total > 0L && stats.null_count > 0L)) {
-      // The second condition has been added to conform to
-      // pandas which states that a column of integers with
-      // a single NULL record need to be treated as floats.
+    } else if (stats.float_count > 0L) {
       column_types[col_idx] = data_type(cudf::type_id::FLOAT64);
     } else if (stats.big_int_count == 0) {
       column_types[col_idx] = data_type(cudf::type_id::INT64);

--- a/cpp/src/io/json/reader_impl.cu
+++ b/cpp/src/io/json/reader_impl.cu
@@ -467,7 +467,7 @@ std::vector<data_type> get_data_types(json_reader_options const& reader_opts,
         return type_id::STRING;
       } else if (cinfo.datetime_count > 0) {
         return type_id::TIMESTAMP_MILLISECONDS;
-      } else if (cinfo.float_count > 0 || (int_count_total > 0 && cinfo.null_count > 0)) {
+      } else if (cinfo.float_count > 0) {
         return type_id::FLOAT64;
       } else if (cinfo.big_int_count == 0 && int_count_total != 0) {
         return type_id::INT64;

--- a/cpp/src/io/utilities/type_inference.cuh
+++ b/cpp/src/io/utilities/type_inference.cuh
@@ -299,7 +299,7 @@ cudf::data_type infer_data_type(OptionsView const& options,
       return type_id::STRING;
     } else if (cinfo.datetime_count > 0) {
       CUDF_FAIL("Date time is inferred as string.\n");
-    } else if (cinfo.float_count > 0 || (int_count_total > 0 && cinfo.null_count > 0)) {
+    } else if (cinfo.float_count > 0) {
       return type_id::FLOAT64;
     } else if (cinfo.big_int_count == 0 && int_count_total != 0) {
       return type_id::INT64;

--- a/cpp/tests/io/json_test.cpp
+++ b/cpp/tests/io/json_test.cpp
@@ -811,7 +811,7 @@ TEST_P(JsonReaderDualTest, JsonLinesObjectsMissingData)
 
   EXPECT_EQ(result.tbl->get_column(0).type().id(), cudf::type_id::FLOAT64);
   EXPECT_EQ(result.tbl->get_column(1).type().id(), cudf::type_id::STRING);
-  EXPECT_EQ(result.tbl->get_column(2).type().id(), cudf::type_id::FLOAT64);
+  EXPECT_EQ(result.tbl->get_column(2).type().id(), cudf::type_id::INT64);
 
   EXPECT_EQ(result.metadata.schema_info[0].name, "col2");
   EXPECT_EQ(result.metadata.schema_info[1].name, "col3");
@@ -822,8 +822,7 @@ TEST_P(JsonReaderDualTest, JsonLinesObjectsMissingData)
   auto col2_validity =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i == 0; });
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(2),
-                                 float64_wrapper{{0., 200.}, col1_validity});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(2), int64_wrapper{{0, 200}, col1_validity});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(0),
                                  float64_wrapper{{1.1, 0.}, col2_validity});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(1),

--- a/cpp/tests/io/type_inference_test.cu
+++ b/cpp/tests/io/type_inference_test.cu
@@ -101,8 +101,7 @@ TEST_F(TypeInference, Null)
                     string_offset.size(),
                     stream);
 
-  EXPECT_EQ(res_type,
-            cudf::data_type{cudf::type_id::FLOAT64});  // FLOAT64 to align with pandas's behavior
+  EXPECT_EQ(res_type, cudf::data_type{cudf::type_id::INT64});
 }
 
 TEST_F(TypeInference, AllNull)

--- a/python/cudf/cudf/tests/test_json.py
+++ b/python/cudf/cudf/tests/test_json.py
@@ -964,12 +964,7 @@ class TestNestedJsonReaderCommon:
                 )
             )
         df = cudf.concat(chunks, ignore_index=True)
-        if tag == "missing" and chunk_size == 10:
-            with pytest.raises(AssertionError):
-                # nested JSON reader inferences integer with nulls as float64
-                assert expected.to_arrow().equals(df.to_arrow())
-        else:
-            assert expected.to_arrow().equals(df.to_arrow())
+        assert expected.to_arrow().equals(df.to_arrow())
 
     def test_order_nested_json_reader(self, tag, data):
         expected = pd.read_json(StringIO(data), lines=True)
@@ -980,6 +975,10 @@ class TestNestedJsonReaderCommon:
             with pytest.raises(AssertionError):
                 # pandas parses integer values in float representation
                 # as integer
+                assert pa.Table.from_pandas(expected).equals(target.to_arrow())
+        elif tag == "missing":
+            with pytest.raises(AssertionError):
+                # pandas inferences integer with nulls as float64
                 assert pa.Table.from_pandas(expected).equals(target.to_arrow())
         else:
             assert pa.Table.from_pandas(expected).equals(target.to_arrow())


### PR DESCRIPTION
## Description
When there are nulls in an integer column, libcudf csv, json readers infer it as float column (similar to pandas).
Pandas uses `float nan` because default types do no have null representation. But cuDF has null representation on all types.
Integer column with nulls in CSV or JSON will be infered as nullable integer column, instead of current behaviour of inferring as float64 column.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
