### PR TITLE
Fix `test_notebooks.sh`

### DIFF
--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -25,6 +25,7 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
 
 rapids-mamba-retry install \
+  -c "${CPP_CHANNEL}" \
   -c "${PYTHON_CHANNEL}" \
   cudf
 


### PR DESCRIPTION
## Description

This PR fixes the `test_notebooks.sh` script to ensure that it uses the `${CPP_CHANNEL}` to install `libcudf`. This will ensure that the version of `libcudf` that's installed is from the current workflow run as opposed to Anaconda.org.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
