### PR TITLE
RMM fragmentation statistics

### DIFF
--- a/docs/cudf/source/developer_guide/library_design.md
+++ b/docs/cudf/source/developer_guide/library_design.md
@@ -252,7 +252,7 @@ Three levels of information gathering exist:
   0. disabled (no overhead). 
   1. gather statistics of duration and number of bytes spilled (very low overhead). 
   2. gather statistics of each time a spillable buffer is exposed permanently (potential high overhead).
-  3. gather statistics of each time spill-on-demand event (high overhead). This includes tracking of
+  3. gather statistics of each time a spill-on-demand event occurs (high overhead). This includes tracking of
      the lowest utilization of device memory, which can be limited by RMM fragmentation.
 
 Statistics can be enabled in two ways (it is disabled by default):

--- a/docs/cudf/source/developer_guide/library_design.md
+++ b/docs/cudf/source/developer_guide/library_design.md
@@ -252,6 +252,8 @@ Three levels of information gathering exist:
   0. disabled (no overhead). 
   1. gather statistics of duration and number of bytes spilled (very low overhead). 
   2. gather statistics of each time a spillable buffer is exposed permanently (potential high overhead).
+  3. gather statistics of each time spill-on-demand event (high overhead). This includes tracking of
+     the lowest utilization of device memory, which can be limited by RMM fragmentation.
 
 Statistics can be enabled in two ways (it is disabled by default):
   - setting the environment variable `CUDF_SPILL_STATS=<statistics-level>`, or

--- a/python/cudf/cudf/core/buffer/spill_manager.py
+++ b/python/cudf/cudf/core/buffer/spill_manager.py
@@ -154,6 +154,16 @@ class SpillStatistics:
                 stat.spilled_nbytes += spilled_nbytes
 
     def log_spill_on_demand(self, manager: SpillManager, nbytes: int):
+        """Log an spill-on-demand event
+
+        Parameters
+        ----------
+        manager : SpillManager
+            The manager evoking the event
+        nbytes : int
+            Number of bytes requested by the event
+        """
+
         if self.level < 3:
             return
 
@@ -211,6 +221,7 @@ class SpillStatistics:
             else:
                 ret += "\n    lowest utilization: "
                 ret += format_bytes(self.lowest_utilization)
+                ret += " (the closer to the RMM pool size, the better)"
             return ret
 
 

--- a/python/cudf/cudf/core/buffer/spill_manager.py
+++ b/python/cudf/cudf/core/buffer/spill_manager.py
@@ -156,7 +156,7 @@ class SpillStatistics:
                 stat.spilled_nbytes += spilled_nbytes
 
     def log_spill_on_demand(self, manager: SpillManager, nbytes: int):
-        """Log an spill-on-demand event (after it has been handled)
+        """Log a spill-on-demand event (after it has been handled)
 
         Parameters
         ----------
@@ -198,7 +198,7 @@ class SpillStatistics:
                 ret += f"{format_bytes(nbytes)} in {time:.3f}s\n"
 
             # Print expose stats
-            ret += "  Permanent exposed buffers (level >= 2): "
+            ret += "  Permanently exposed buffers (level >= 2): "
             if self.level < 2:
                 return ret + "disabled"
             if len(self.exposes) == 0:

--- a/python/cudf/cudf/core/buffer/spill_manager.py
+++ b/python/cudf/cudf/core/buffer/spill_manager.py
@@ -154,7 +154,7 @@ class SpillStatistics:
                 stat.spilled_nbytes += spilled_nbytes
 
     def log_spill_on_demand(self, manager: SpillManager, nbytes: int):
-        """Log an spill-on-demand event
+        """Log an spill-on-demand event (after it has been handled)
 
         Parameters
         ----------
@@ -307,12 +307,12 @@ class SpillManager:
         In order to avoid deadlock, this function should not lock
         already locked buffers.
         """
-        self.statistics.log_spill_on_demand(manager=self, nbytes=nbytes)
 
         # Let's try to spill device memory
         spilled = self.spill_device_memory(nbytes=nbytes)
 
         if spilled > 0:
+            self.statistics.log_spill_on_demand(manager=self, nbytes=nbytes)
             return True  # Ask RMM to retry the allocation
 
         if retry_once:

--- a/python/cudf/cudf/core/buffer/spill_manager.py
+++ b/python/cudf/cudf/core/buffer/spill_manager.py
@@ -57,6 +57,8 @@ class SpillStatistics:
       1+ - duration and number of bytes spilled (very low overhead).
       2+ - a traceback for each time a spillable buffer is exposed
            permanently (potential high overhead).
+      3+ - lowest utilization of device memory, which can be limited by
+           RMM fragmentation (high overhead).
 
     The statistics are printed when spilling-on-demand fails to find
     any buffer to spill. It is possible to retrieve the statistics

--- a/python/cudf/cudf/core/buffer/spill_manager.py
+++ b/python/cudf/cudf/core/buffer/spill_manager.py
@@ -180,18 +180,18 @@ class SpillStatistics:
             # Print spilling stats
             ret += "  Spilling (level >= 1):"
             if len(self.spill_totals) == 0:
-                ret += " None"
+                ret += " none spilled"
             ret += "\n"
             for (src, dst), (nbytes, time) in self.spill_totals.items():
                 ret += f"    {src} => {dst}: "
                 ret += f"{format_bytes(nbytes)} in {time:.3f}s\n"
 
             # Print expose stats
-            ret += "  Exposed buffers (level >= 2): "
+            ret += "  Permanent exposed buffers (level >= 2): "
             if self.level < 2:
                 return ret + "disabled"
             if len(self.exposes) == 0:
-                ret += "None"
+                ret += "none exposed"
             ret += "\n"
             for s in sorted(self.exposes.values(), key=lambda x: -x.count):
                 ret += textwrap.indent(

--- a/python/cudf/cudf/core/buffer/spill_manager.py
+++ b/python/cudf/cudf/core/buffer/spill_manager.py
@@ -172,7 +172,6 @@ class SpillStatistics:
         unspilled = sum(
             buf.size for buf in manager.buffers() if not buf.is_spilled
         )
-
         if self.lowest_utilization is None:
             self.lowest_utilization = unspilled + nbytes
         else:

--- a/python/cudf/cudf/options.py
+++ b/python/cudf/cudf/options.py
@@ -254,7 +254,8 @@ _register_option(
             0  - disabled (no overhead).
             1+ - duration and number of bytes spilled (very low overhead).
             2+ - a traceback for each time a spillable buffer is exposed
-                permanently (potential high overhead).
+                 permanently (potential high overhead).
+            3+ - lowest utilization of device memory (high overhead).
 
         Valid values are any positive integer.
         Default is 0 (disabled).


### PR DESCRIPTION
Implements statistics of RMM fragmentation in cudf-spilling.

Enable by setting the stats level to 3 e.g.  `CUDF_SPILL_STATS=3`.

### Motivation
Memory fragmentation can be an issue when using an RMM memory pool. This PR tracks the lowest utilization of device memory, which is a measure of how good the device memory is being utilized. The difference between it and the size of the RMM pool is a measure of fragmentation.  

See `test_statistics_rmm_fragmentation` for a demo of  RMM fragmentation.

### Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
