### PR TITLE
Fix doxygen description for regex_program::compute_working_memory_size

### DIFF
--- a/cpp/include/cudf/strings/regex/regex_program.hpp
+++ b/cpp/include/cudf/strings/regex/regex_program.hpp
@@ -105,7 +105,7 @@ struct regex_program {
   int32_t groups_count() const;
 
   /**
-   * @brief Return the pattern used to create this instance
+   * @brief Return the size of the working memory for the regex execution
    *
    * @param num_strings Number of strings for computation
    * @return Size of the working memory in bytes


### PR DESCRIPTION
## Description
Fixes doxygen description for `regex_program::compute_working_memory_size`.
This description is published here: https://docs.rapids.ai/api/libcudf/nightly/structcudf_1_1strings_1_1regex__program.html#adc099e7cac91d0ca18095c6364813c7e
Fixing this ahead of deprecating the `non-regex_program` interfaces.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
