### PR TITLE
Update test docs to not use detail comparison utilities 

### DIFF
--- a/cpp/doxygen/developer_guide/TESTING.md
+++ b/cpp/doxygen/developer_guide/TESTING.md
@@ -451,7 +451,7 @@ Verifies the bitwise equality of two device memory buffers.
 
 #### Caveats
 
-Column comparison functions in `cudf::test::detail` namespace should NOT be used directly.
+Column comparison functions in the `cudf::test::detail` namespace should **NOT** be used directly.
 
 ### Printing and accessing column data
 

--- a/cpp/doxygen/developer_guide/TESTING.md
+++ b/cpp/doxygen/developer_guide/TESTING.md
@@ -449,6 +449,10 @@ column data. Null elements are treated as equivalent.
 
 Verifies the bitwise equality of two device memory buffers.
 
+#### Caveats
+
+Column comparison functions in `cudf::test::detail` namespace should NOT be used directly.
+
 ### Printing and accessing column data
 
 `include/cudf_test/column_utilities.hpp` defines various functions and overloads for printing

--- a/cpp/include/cudf_test/column_utilities.hpp
+++ b/cpp/include/cudf_test/column_utilities.hpp
@@ -46,6 +46,8 @@ namespace detail {
 /**
  * @brief Verifies the property equality of two columns.
  *
+ * This function should not be used directly.
+ *
  * @param lhs The first column
  * @param rhs The second column
  * @param verbosity Level of debug output verbosity
@@ -63,6 +65,8 @@ bool expect_column_properties_equal(cudf::column_view const& lhs,
  * i.e. the two columns are considered equivalent even if one has a null mask
  * and the other doesn't.
  *
+ * This function should not be used directly.
+ *
  * @param lhs The first column
  * @param rhs The second column
  * @param verbosity Level of debug output verbosity
@@ -78,6 +82,8 @@ bool expect_column_properties_equivalent(
  * @brief Verifies the element-wise equality of two columns.
  *
  * Treats null elements as equivalent.
+ *
+ * This function should not be used directly.
  *
  * @param lhs The first column
  * @param rhs The second column
@@ -95,6 +101,8 @@ bool expect_columns_equal(cudf::column_view const& lhs,
  * Uses machine epsilon to compare floating point types.
  * Treats null elements as equivalent.
  *
+ * This function should not be used directly.
+ *
  * @param lhs The first column
  * @param rhs The second column
  * @param verbosity Level of debug output verbosity
@@ -110,6 +118,8 @@ bool expect_columns_equivalent(cudf::column_view const& lhs,
 
 /**
  * @brief Verifies the bitwise equality of two device memory buffers.
+ *
+ * This function should not be used directly.
  *
  * @param lhs The first buffer
  * @param rhs The second buffer

--- a/cpp/include/cudf_test/table_utilities.hpp
+++ b/cpp/include/cudf_test/table_utilities.hpp
@@ -23,6 +23,8 @@ namespace cudf::test::detail {
 /**
  * @brief Verifies the property equality of two tables.
  *
+ * This function should not be used directly.
+ *
  * @param lhs The first table
  * @param rhs The second table
  */
@@ -32,6 +34,8 @@ void expect_table_properties_equal(cudf::table_view lhs, cudf::table_view rhs);
  * @brief Verifies the equality of two tables.
  *
  * Treats null elements as equivalent.
+ *
+ * This function should not be used directly.
  *
  * @param lhs The first table
  * @param rhs The second table
@@ -43,6 +47,8 @@ void expect_tables_equal(cudf::table_view lhs, cudf::table_view rhs);
  *
  * Treats null elements as equivalent.  Columns that have nullability but no nulls,
  * and columns that are not nullable are considered equivalent.
+ *
+ * This function should not be used directly.
  *
  * @param lhs The first table
  * @param rhs The second table


### PR DESCRIPTION
This PR adds a not for detail column/table comparison utilities since corresponding macros should be used instead.

_Originally suggested by @karthikeyann in https://github.com/rapidsai/cudf/pull/12242#issuecomment-1330266438_

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
