### PR TITLE
Fix warnings in test_monotonic.py

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pickle
+import warnings
 from functools import cached_property
 from typing import Any, Set, TypeVar
 
@@ -197,6 +198,12 @@ class BaseIndex(Serializable):
         -------
         bool
         """
+        warnings.warn(
+            "is_monotonic is deprecated and will be removed in a future "
+            "version. Use is_monotonic_increasing instead.",
+            FutureWarning,
+        )
+
         return self.is_monotonic_increasing
 
     @property

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -523,6 +523,12 @@ class RangeIndex(BaseIndex, BinaryOperand):
         int
             Index of label.
         """
+        if kind is not None:
+            warnings.warn(
+                "'kind' argument in get_slice_bound is deprecated and will be "
+                "removed in a future version.  Do not pass it.",
+                FutureWarning,
+            )
         if side not in {"left", "right"}:
             raise ValueError(f"Unrecognized side parameter: {side}")
 
@@ -1377,6 +1383,12 @@ class GenericIndex(SingleColumnFrame, BaseIndex):
 
     @_cudf_nvtx_annotate
     def get_slice_bound(self, label, side, kind=None):
+        if kind is not None:
+            warnings.warn(
+                "'kind' argument in get_slice_bound is deprecated and will be "
+                "removed in a future version.  Do not pass it.",
+                FutureWarning,
+            )
         return self._values.get_slice_bound(label, side, kind)
 
     def is_numeric(self):

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -526,7 +526,7 @@ class RangeIndex(BaseIndex, BinaryOperand):
         if kind is not None:
             warnings.warn(
                 "'kind' argument in get_slice_bound is deprecated and will be "
-                "removed in a future version.  Do not pass it.",
+                "removed in a future version.",
                 FutureWarning,
             )
         if side not in {"left", "right"}:
@@ -1386,7 +1386,7 @@ class GenericIndex(SingleColumnFrame, BaseIndex):
         if kind is not None:
             warnings.warn(
                 "'kind' argument in get_slice_bound is deprecated and will be "
-                "removed in a future version.  Do not pass it.",
+                "removed in a future version.",
                 FutureWarning,
             )
         return self._values.get_slice_bound(label, side, kind)

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Dict, Optional, Tuple, TypeVar, Union
 
 import cupy
@@ -233,6 +234,12 @@ class SingleColumnFrame(Frame, NotIterable):
         -------
         bool
         """
+        warnings.warn(
+            "is_monotonic is deprecated and will be removed in a future "
+            "version. Use is_monotonic_increasing instead.",
+            FutureWarning,
+        )
+
         return self.is_monotonic_increasing
 
     @property  # type: ignore

--- a/python/cudf/cudf/tests/test_monotonic.py
+++ b/python/cudf/cudf/tests/test_monotonic.py
@@ -16,7 +16,7 @@ from cudf.core.index import (
     RangeIndex,
     StringIndex,
 )
-from cudf.testing._utils import assert_eq
+from cudf.testing._utils import assert_eq, expect_warning_if
 
 
 @pytest.mark.parametrize("testrange", [(10, 20, 1), (0, -10, -1), (5, 5, 1)])
@@ -266,9 +266,11 @@ def test_get_slice_bound(testlist, side, kind):
     index = GenericIndex(testlist)
     index_pd = pd.Index(testlist)
     for label in testlist:
-        assert index.get_slice_bound(
-            label, side, kind
-        ) == index_pd.get_slice_bound(label, side, kind)
+        with pytest.warns(FutureWarning):
+            expect = index_pd.get_slice_bound(label, side, kind)
+        with expect_warning_if(kind is not None, FutureWarning):
+            got = index.get_slice_bound(label, side, kind)
+        assert got == expect
 
 
 @pytest.mark.parametrize("bounds", [(0, 10), (0, 1), (3, 4), (0, 0), (3, 3)])
@@ -283,8 +285,10 @@ def test_rangeindex_get_slice_bound_basic(bounds, indices, side, kind):
     pd_index = pd.RangeIndex(start, stop)
     cudf_index = RangeIndex(start, stop)
     for idx in indices:
-        expect = pd_index.get_slice_bound(idx, side, kind)
-        got = cudf_index.get_slice_bound(idx, side, kind)
+        with pytest.warns(FutureWarning):
+            expect = pd_index.get_slice_bound(idx, side, kind)
+        with expect_warning_if(kind is not None, FutureWarning):
+            got = cudf_index.get_slice_bound(idx, side, kind)
         assert expect == got
 
 
@@ -303,8 +307,10 @@ def test_rangeindex_get_slice_bound_step(bounds, label, side, kind):
     pd_index = pd.RangeIndex(start, stop, step)
     cudf_index = RangeIndex(start, stop, step)
 
-    expect = pd_index.get_slice_bound(label, side, kind)
-    got = cudf_index.get_slice_bound(label, side, kind)
+    with pytest.warns(FutureWarning):
+        expect = pd_index.get_slice_bound(label, side, kind)
+    with expect_warning_if(kind is not None, FutureWarning):
+        got = cudf_index.get_slice_bound(label, side, kind)
     assert expect == got
 
 
@@ -315,9 +321,12 @@ def test_get_slice_bound_missing(label, side, kind):
     mylist = [2, 4, 6, 8, 10]
     index = GenericIndex(mylist)
     index_pd = pd.Index(mylist)
-    assert index.get_slice_bound(
-        label, side, kind
-    ) == index_pd.get_slice_bound(label, side, kind)
+
+    with pytest.warns(FutureWarning):
+        expect = index_pd.get_slice_bound(label, side, kind)
+    with expect_warning_if(kind is not None, FutureWarning):
+        got = index.get_slice_bound(label, side, kind)
+    assert got == expect
 
 
 @pytest.mark.xfail
@@ -329,9 +338,11 @@ def test_get_slice_bound_missing_str(label, side):
     mylist = ["b", "d", "f"]
     index = GenericIndex(mylist)
     index_pd = pd.Index(mylist)
-    assert index.get_slice_bound(
-        label, side, "getitem"
-    ) == index_pd.get_slice_bound(label, side, "getitem")
+    with pytest.warns(FutureWarning):
+        got = index.get_slice_bound(label, side, "getitem")
+    with pytest.warns(FutureWarning):
+        expect = index_pd.get_slice_bound(label, side, "getitem")
+    assert got == expect
 
 
 testdata = [

--- a/python/cudf/cudf/tests/test_monotonic.py
+++ b/python/cudf/cudf/tests/test_monotonic.py
@@ -30,7 +30,11 @@ def test_range_index(testrange):
     )
 
     assert index.is_unique == index_pd.is_unique
-    assert index.is_monotonic == index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        expect = index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        got = index.is_monotonic
+    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 
@@ -54,7 +58,11 @@ def test_generic_index(testlist):
     index_pd = pd.Index(testlist)
 
     assert index.is_unique == index_pd.is_unique
-    assert index.is_monotonic == index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        expect = index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        got = index.is_monotonic
+    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 
@@ -74,7 +82,11 @@ def test_string_index(testlist):
     index_pd = pd.Index(testlist)
 
     assert index.is_unique == index_pd.is_unique
-    assert index.is_monotonic == index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        expect = index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        got = index.is_monotonic
+    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 
@@ -90,7 +102,11 @@ def test_categorical_index(testlist):
     index_pd = pd.CategoricalIndex(raw_cat)
 
     assert index.is_unique == index_pd.is_unique
-    assert index.is_monotonic == index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        expect = index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        got = index.is_monotonic
+    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 
@@ -131,7 +147,11 @@ def test_datetime_index(testlist):
     index_pd = pd.DatetimeIndex(testlist)
 
     assert index.is_unique == index_pd.is_unique
-    assert index.is_monotonic == index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        expect = index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        got = index.is_monotonic
+    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 
@@ -154,7 +174,11 @@ def test_series(testlist):
     series_pd = pd.Series(testlist)
 
     assert series.is_unique == series_pd.is_unique
-    assert series.is_monotonic == series_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        expect = series_pd.index.is_monotonic
+    with pytest.warns(FutureWarning):
+        got = series.index.is_monotonic
+    assert got == expect
     assert series.is_monotonic_increasing == series_pd.is_monotonic_increasing
     assert series.is_monotonic_decreasing == series_pd.is_monotonic_decreasing
 
@@ -179,7 +203,11 @@ def test_multiindex():
     gdf = cudf.from_pandas(pdf)
 
     assert pdf.index.is_unique == gdf.index.is_unique
-    assert pdf.index.is_monotonic == gdf.index.is_monotonic
+    with pytest.warns(FutureWarning):
+        expect = pdf.index.is_monotonic
+    with pytest.warns(FutureWarning):
+        got = gdf.index.is_monotonic
+    assert got == expect
     assert (
         pdf.index.is_monotonic_increasing == gdf.index.is_monotonic_increasing
     )
@@ -214,7 +242,11 @@ def test_multiindex_tuples(testarr):
     index_pd = pd.MultiIndex.from_tuples(tuples, names=testarr[1])
 
     assert index.is_unique == index_pd.is_unique
-    assert index.is_monotonic == index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        expect = index_pd.is_monotonic
+    with pytest.warns(FutureWarning):
+        got = index.is_monotonic
+    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
One note with these deprecations. pandas has a special value used for parameters that are defaulted, and as a result explicitly passing None will throw a warning. We don't do this, hence the difference in the warnings contexts I use for our calls vs pandas (`pytest.warns` vs `expect_warning_if`). I didn't feel like this was worth commenting on in every place, but I can if reviewers want.

Contributes to #9999 and #10363.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
