### PR TITLE
Implement `lists::reverse`

### DIFF
--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -178,6 +178,7 @@ outputs:
         - test -f $PREFIX/include/cudf/lists/detail/dremel.hpp
         - test -f $PREFIX/include/cudf/lists/detail/extract.hpp
         - test -f $PREFIX/include/cudf/lists/detail/interleave_columns.hpp
+        - test -f $PREFIX/include/cudf/lists/detail/reverse.hpp
         - test -f $PREFIX/include/cudf/lists/detail/scatter_helper.cuh
         - test -f $PREFIX/include/cudf/lists/detail/set_operations.hpp
         - test -f $PREFIX/include/cudf/lists/detail/sorting.hpp

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -189,6 +189,7 @@ outputs:
         - test -f $PREFIX/include/cudf/lists/list_view.hpp
         - test -f $PREFIX/include/cudf/lists/lists_column_factories.hpp
         - test -f $PREFIX/include/cudf/lists/lists_column_view.hpp
+        - test -f $PREFIX/include/cudf/lists/reverse.hpp
         - test -f $PREFIX/include/cudf/lists/set_operations.hpp
         - test -f $PREFIX/include/cudf/lists/sorting.hpp
         - test -f $PREFIX/include/cudf/lists/stream_compaction.hpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -411,6 +411,7 @@ add_library(
   src/lists/interleave_columns.cu
   src/lists/lists_column_factories.cu
   src/lists/lists_column_view.cu
+  src/lists/reverse.cu
   src/lists/segmented_sort.cu
   src/lists/sequences.cu
   src/lists/set_operations.cu

--- a/cpp/include/cudf/lists/detail/reverse.hpp
+++ b/cpp/include/cudf/lists/detail/reverse.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/lists/reverse.hpp>
+
+namespace cudf::lists::detail {
+
+/**
+ * @copydoc cudf::lists::reverse
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ */
+std::unique_ptr<column> reverse(
+  lists_column_view const& input,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+}  // namespace cudf::lists::detail

--- a/cpp/include/cudf/lists/reverse.hpp
+++ b/cpp/include/cudf/lists/reverse.hpp
@@ -20,6 +20,8 @@
 
 #include <rmm/mr/device/per_device_resource.hpp>
 
+#include <memory>
+
 namespace cudf::lists {
 /**
  * @addtogroup lists_modify

--- a/cpp/include/cudf/lists/reverse.hpp
+++ b/cpp/include/cudf/lists/reverse.hpp
@@ -28,9 +28,9 @@ namespace cudf::lists {
  */
 
 /**
- * @brief Reverses the elements within each list.
+ * @brief Reverse the element order within each list of the input column.
  *
- * Any null input row returns corresponding null row in the output column.
+ * Any null input row will result in a corresponding null row in the output column.
  *
  * @code{.pseudo}
  * Example:

--- a/cpp/include/cudf/lists/reverse.hpp
+++ b/cpp/include/cudf/lists/reverse.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+
+#include <rmm/mr/device/per_device_resource.hpp>
+
+namespace cudf::lists {
+/**
+ * @addtogroup lists_modify
+ * @{
+ * @file
+ */
+
+/**
+ * @brief Reverses the elements within each list.
+ *
+ * Any null input row returns corresponding null row in the output column.
+ *
+ * @code{.pseudo}
+ * Example:
+ * s = [ [1, 2, 3], [], null, [4, 5, null] ]
+ * r = reverse(s)
+ * r is now [ [3, 2, 1], [], null, [null, 5, 4] ]
+ * @endcode
+ *
+ * @param input Lists column for this operation
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return New lists column with reversed lists
+ */
+std::unique_ptr<column> reverse(
+  lists_column_view const& input,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+/** @} */  // end of doxygen group
+
+}  // namespace cudf::lists

--- a/cpp/src/lists/reverse.cu
+++ b/cpp/src/lists/reverse.cu
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "utilities.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/gather.hpp>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/lists/reverse.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
+
+namespace cudf::lists {
+namespace detail {
+
+std::unique_ptr<column> reverse(lists_column_view const& input,
+                                rmm::cuda_stream_view stream,
+                                rmm::mr::device_memory_resource* mr)
+{
+  if (input.is_empty()) { return empty_like(input.parent()); }
+
+  auto const child = input.get_sliced_child(stream);
+
+  // The labels are also zero-based list indices.
+  auto const labels = generate_labels(input, child.size(), stream);
+
+  // Build a gather map to copy the output list elements.
+  auto gather_map = rmm::device_uvector<size_type>(child.size(), stream);
+  thrust::for_each_n(rmm::exec_policy(stream),
+                     thrust::counting_iterator<size_type>(0),
+                     child.size(),
+                     [d_offsets           = input.offsets_begin(),
+                      list_indices        = labels->view().begin<size_type>(),
+                      new_element_indices = gather_map.begin()] __device__(auto const idx) {
+                       // The first offset value, used for zero-normalizing offsets.
+                       auto const first_offset  = *d_offsets;
+                       auto const list_idx      = list_indices[idx];
+                       auto const begin_offset  = d_offsets[list_idx] - first_offset;
+                       auto const end_offset    = d_offsets[list_idx + 1] - first_offset;
+                       new_element_indices[idx] = begin_offset + (end_offset - idx - 1);
+                     });
+
+  auto reversed_child_table =
+    cudf::detail::gather(table_view{{child}},
+                         device_span<size_type const>{gather_map.data(), gather_map.size()},
+                         out_of_bounds_policy::DONT_CHECK,
+                         cudf::detail::negative_index_policy::NOT_ALLOWED,
+                         stream,
+                         mr);
+  auto out_child   = std::move(reversed_child_table->release().front());
+  auto out_offsets = get_normalized_offsets(input, stream, mr);
+
+  return cudf::make_lists_column(input.size(),
+                                 std::move(out_offsets),
+                                 std::move(out_child),
+                                 input.null_count(),
+                                 cudf::detail::copy_bitmask(input.parent(), stream, mr),
+                                 stream,
+                                 mr);
+}
+
+}  // namespace detail
+
+std::unique_ptr<column> reverse(lists_column_view const& input, rmm::mr::device_memory_resource* mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::reverse(input, cudf::get_default_stream(), mr);
+}
+
+}  // namespace cudf::lists

--- a/cpp/src/lists/utilities.cu
+++ b/cpp/src/lists/utilities.cu
@@ -58,7 +58,7 @@ std::unique_ptr<column> get_normalized_offsets(lists_column_view const& input,
                                                rmm::cuda_stream_view stream,
                                                rmm::mr::device_memory_resource* mr)
 {
-  if (input.is_empty()) { return std::make_unique<column>(input.offsets()); }
+  if (input.is_empty()) { return std::make_unique<column>(input.offsets(), stream, mr); }
 
   auto out_offsets = make_numeric_column(data_type(type_to_id<offset_type>()),
                                          input.size() + 1,

--- a/cpp/src/lists/utilities.cu
+++ b/cpp/src/lists/utilities.cu
@@ -58,7 +58,7 @@ std::unique_ptr<column> get_normalized_offsets(lists_column_view const& input,
                                                rmm::cuda_stream_view stream,
                                                rmm::mr::device_memory_resource* mr)
 {
-  if (input.is_empty()) { return empty_like(input.offsets()); }
+  if (input.is_empty()) { return std::make_unique<column>(input.offsets()); }
 
   auto out_offsets = make_numeric_column(data_type(type_to_id<offset_type>()),
                                          input.size() + 1,

--- a/cpp/src/lists/utilities.cu
+++ b/cpp/src/lists/utilities.cu
@@ -58,7 +58,7 @@ std::unique_ptr<column> get_normalized_offsets(lists_column_view const& input,
                                                rmm::cuda_stream_view stream,
                                                rmm::mr::device_memory_resource* mr)
 {
-  if (input.is_empty()) { return std::make_unique<column>(input.offsets(), stream, mr); }
+  if (input.is_empty()) { return empty_like(input.offsets()); }
 
   auto out_offsets = make_numeric_column(data_type(type_to_id<offset_type>()),
                                          input.size() + 1,

--- a/cpp/src/lists/utilities.hpp
+++ b/cpp/src/lists/utilities.hpp
@@ -53,4 +53,17 @@ std::unique_ptr<column> reconstruct_offsets(column_view const& labels,
                                             rmm::cuda_stream_view stream,
                                             rmm::mr::device_memory_resource* mr);
 
+/**
+ * @brief Generate 0-based list offsets from the offsets of the input lists column.
+ *
+ * @param input The input lists column
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned object
+ * @return The output offsets column with values start from 0
+ */
+std::unique_ptr<column> get_normalized_offsets(
+  lists_column_view const& input,
+  rmm::cuda_stream_view stream,
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
 }  // namespace cudf::lists::detail

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -491,6 +491,7 @@ ConfigureTest(
   lists/count_elements_tests.cpp
   lists/explode_tests.cpp
   lists/extract_tests.cpp
+  lists/reverse_tests.cpp
   lists/sequences_tests.cpp
   lists/set_operations/difference_distinct_tests.cpp
   lists/set_operations/have_overlap_tests.cpp

--- a/cpp/tests/lists/reverse_tests.cpp
+++ b/cpp/tests/lists/reverse_tests.cpp
@@ -17,23 +17,139 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
+#include <cudf_test/type_lists.hpp>
 
 #include <cudf/column/column.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/lists/reverse.hpp>
 
-#include <vector>
+using namespace cudf::test::iterators;
+
+auto constexpr null{0};
 
 using ints_lists = cudf::test::lists_column_wrapper<int32_t>;
 
 struct ListsReverseTest : public cudf::test::BaseFixture {
 };
 
-TEST_F(ListsReverseTest, SimpleReverse)
-{
-  auto const input    = ints_lists{{}, {1, 2, 3}, {}, {4, 5}};
-  auto const expected = ints_lists{{}, {3, 2, 1}, {}, {5, 4}};
-  auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
+template <typename T>
+struct ListsReverseTypedTest : public cudf::test::BaseFixture {
+};
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
+using TestTypes =
+  cudf::test::Concat<cudf::test::IntegralTypesNotBool, cudf::test::FloatingPointTypes>;
+
+TYPED_TEST_SUITE(ListsReverseTypedTest, TestTypes);
+
+TEST_F(ListsReverseTest, EmptyInput)
+{
+  // Empty input.
+  {
+    auto const input   = ints_lists{};
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(input, *results);
+  }
+
+  // Empty lists.
+  {
+    auto const input   = ints_lists{ints_lists{}, ints_lists{}, ints_lists{}};
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(input, *results);
+  }
+
+  // Empty nested lists.
+  {
+    auto const input   = ints_lists{ints_lists{ints_lists{}}, ints_lists{}, ints_lists{}};
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(input, *results);
+  }
+}
+
+TYPED_TEST(ListsReverseTypedTest, InputNoNulls)
+{
+  using lists_col           = cudf::test::lists_column_wrapper<TypeParam>;
+  auto const input_original = lists_col{{}, {1, 2, 3}, {}, {4, 5}, {6, 7, 8}, {9}};
+
+  {
+    auto const expected = lists_col{{}, {3, 2, 1}, {}, {5, 4}, {8, 7, 6}, {9}};
+    auto const results  = cudf::lists::reverse(cudf::lists_column_view(input_original));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
+  }
+
+  {
+    auto const input    = cudf::slice(input_original, {1, 4})[0];
+    auto const expected = lists_col{{3, 2, 1}, {}, {5, 4}};
+    auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
+  }
+
+  {
+    auto const input    = cudf::slice(input_original, {2, 3})[0];
+    auto const expected = lists_col{lists_col{}};
+    auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
+  }
+
+  {
+    auto const input    = cudf::slice(input_original, {2, 4})[0];
+    auto const expected = lists_col{{}, {5, 4}};
+    auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
+  }
+}
+
+TYPED_TEST(ListsReverseTypedTest, InputWithNulls)
+{
+  using lists_col           = cudf::test::lists_column_wrapper<TypeParam>;
+  auto const input_original = lists_col{{lists_col{},
+                                         lists_col{1, 2, 3},
+                                         lists_col{} /*null*/,
+                                         lists_col{{4, 5, null}, null_at(2)},
+                                         lists_col{6, 7, 8},
+                                         lists_col{9}},
+                                        null_at(2)};
+
+  {
+    auto const expected = lists_col{{lists_col{},
+                                     lists_col{3, 2, 1},
+                                     lists_col{} /*null*/,
+                                     lists_col{{null, 5, 4}, null_at(0)},
+                                     lists_col{8, 7, 6},
+                                     lists_col{9}},
+                                    null_at(2)};
+    auto const results  = cudf::lists::reverse(cudf::lists_column_view(input_original));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
+  }
+
+  {
+    auto const input    = cudf::slice(input_original, {1, 4})[0];
+    auto const expected = lists_col{
+      {lists_col{3, 2, 1}, lists_col{} /*null*/, lists_col{{null, 5, 4}, null_at(0)}}, null_at(1)};
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
+  }
+
+  {
+    auto const input    = cudf::slice(input_original, {2, 3})[0];
+    auto const expected = lists_col{{lists_col{} /*null*/}, null_at(0)};
+    auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
+  }
+
+  {
+    auto const input = cudf::slice(input_original, {2, 4})[0];
+    auto const expected =
+      lists_col{{lists_col{} /*null*/, lists_col{{null, 5, 4}, null_at(0)}}, null_at(0)};
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
+  }
+
+  {
+    auto const input    = cudf::slice(input_original, {4, 6})[0];
+    auto const expected = lists_col{{8, 7, 6}, {9}};
+    auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
+    // The result doesn't have nulls, but it is nullable.
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *results);
+  }
 }

--- a/cpp/tests/lists/reverse_tests.cpp
+++ b/cpp/tests/lists/reverse_tests.cpp
@@ -21,14 +21,17 @@
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/lists/reverse.hpp>
+#include <cudf/null_mask.hpp>
 
 using namespace cudf::test::iterators;
 
 auto constexpr null{0};
 
 using ints_lists = cudf::test::lists_column_wrapper<int32_t>;
+using ints_col   = cudf::test::fixed_width_column_wrapper<int32_t>;
 
 struct ListsReverseTest : public cudf::test::BaseFixture {
 };
@@ -151,5 +154,150 @@ TYPED_TEST(ListsReverseTypedTest, InputWithNulls)
     auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
     // The result doesn't have nulls, but it is nullable.
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *results);
+  }
+}
+
+TYPED_TEST(ListsReverseTypedTest, InputListsOfListsNoNulls)
+{
+  using lists_col           = cudf::test::lists_column_wrapper<TypeParam>;
+  auto const input_original = [] {
+    auto child =
+      lists_col{{1, 2, 3}, {4, 5, 6}, {7}, {4, 5}, {}, {4, 5, 6}, {}, {6, 7, 8}, {}, {9}}.release();
+    auto offsets = ints_col{0, 0, 3, 3, 6, 9, 10, 10, 10}.release();
+    return cudf::make_lists_column(8, std::move(offsets), std::move(child), 0, {});
+  }();
+
+  {
+    auto const expected = [] {
+      auto child =
+        lists_col{{7}, {4, 5, 6}, {1, 2, 3}, {4, 5, 6}, {}, {4, 5}, {}, {6, 7, 8}, {}, {9}}
+          .release();
+      auto offsets = ints_col{0, 0, 3, 3, 6, 9, 10, 10, 10}.release();
+      return cudf::make_lists_column(8, std::move(offsets), std::move(child), 0, {});
+    }();
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(*input_original));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results);
+  }
+
+  {
+    auto const input    = cudf::slice(*input_original, {1, 4})[0];
+    auto const expected = [] {
+      auto child   = lists_col{{7}, {4, 5, 6}, {1, 2, 3}, {4, 5, 6}, {}, {4, 5}}.release();
+      auto offsets = ints_col{0, 3, 3, 6}.release();
+      return cudf::make_lists_column(3, std::move(offsets), std::move(child), 0, {});
+    }();
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results);
+  }
+
+  {
+    auto const input   = cudf::slice(*input_original, {2, 3})[0];  // empty column
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(input, *results);
+  }
+
+  {
+    auto const input    = cudf::slice(*input_original, {2, 4})[0];
+    auto const expected = [] {
+      auto child   = lists_col{{4, 5, 6}, {}, {4, 5}}.release();
+      auto offsets = ints_col{0, 0, 3}.release();
+      return cudf::make_lists_column(2, std::move(offsets), std::move(child), 0, {});
+    }();
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results);
+  }
+}
+
+TYPED_TEST(ListsReverseTypedTest, InputListsOfListsWithNulls)
+{
+  using lists_col           = cudf::test::lists_column_wrapper<TypeParam>;
+  auto const input_original = [] {
+    auto child = lists_col{{{1, 2, 3},
+                            {4, 5, 6},
+                            {7},
+                            {4, 5},
+                            {} /*null*/,
+                            {4, 5, 6},
+                            {},
+                            {6, 7, 8},
+                            {} /*null*/,
+                            {9}},
+                           nulls_at({4, 8})}
+                   .release();
+    auto offsets   = ints_col{0, 0, 3, 3, 6, 9, 10, 10, 10}.release();
+    auto null_mask = cudf::create_null_mask(8, cudf::mask_state::ALL_VALID);
+    cudf::set_null_mask(static_cast<cudf::bitmask_type*>(null_mask.data()), 2, 3, false);
+
+    return cudf::make_lists_column(
+      8, std::move(offsets), std::move(child), 1, std::move(null_mask));
+  }();
+
+  {
+    auto const expected = [] {
+      auto child = lists_col{{{7},
+                              {4, 5, 6},
+                              {1, 2, 3},
+                              {4, 5, 6},
+                              {} /*null*/,
+                              {4, 5},
+                              {} /*null*/,
+                              {6, 7, 8},
+                              {},
+                              {9}},
+                             nulls_at({4, 6})}
+                     .release();
+      auto offsets   = ints_col{0, 0, 3, 3, 6, 9, 10, 10, 10}.release();
+      auto null_mask = cudf::create_null_mask(8, cudf::mask_state::ALL_VALID);
+      cudf::set_null_mask(static_cast<cudf::bitmask_type*>(null_mask.data()), 2, 3, false);
+
+      return cudf::make_lists_column(
+        8, std::move(offsets), std::move(child), 1, std::move(null_mask));
+    }();
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(*input_original));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results);
+  }
+
+  {
+    auto const input    = cudf::slice(*input_original, {0, 1})[0];
+    auto const expected = [] {
+      auto child   = lists_col{{7}, {4, 5, 6}, {1, 2, 3}}.release();
+      auto offsets = ints_col{0, 3}.release();
+      return cudf::make_lists_column(1, std::move(offsets), std::move(child), 0, {});
+    }();
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(input, *results);
+  }
+
+  {
+    auto const input    = cudf::slice(*input_original, {1, 4})[0];
+    auto const expected = [] {
+      auto child =
+        lists_col{{{7}, {4, 5, 6}, {1, 2, 3}, {4, 5, 6}, {} /*null*/, {4, 5}}, null_at(4)}
+          .release();
+      auto offsets   = ints_col{0, 3, 3, 6}.release();
+      auto null_mask = cudf::create_null_mask(3, cudf::mask_state::ALL_VALID);
+      cudf::set_null_mask(static_cast<cudf::bitmask_type*>(null_mask.data()), 1, 2, false);
+
+      return cudf::make_lists_column(
+        3, std::move(offsets), std::move(child), 1, std::move(null_mask));
+    }();
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results);
+  }
+
+  {
+    auto const input    = cudf::slice(*input_original, {2, 4})[0];
+    auto const expected = [] {
+      auto child     = lists_col{{{4, 5, 6}, {} /*null*/, {4, 5}}, null_at(1)}.release();
+      auto offsets   = ints_col{0, 0, 3}.release();
+      auto null_mask = cudf::create_null_mask(2, cudf::mask_state::ALL_VALID);
+      cudf::set_null_mask(static_cast<cudf::bitmask_type*>(null_mask.data()), 0, 1, false);
+
+      return cudf::make_lists_column(
+        2, std::move(offsets), std::move(child), 1, std::move(null_mask));
+    }();
+    auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
+    // The result doesn't have nulls, but it is nullable.
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results);
   }
 }

--- a/cpp/tests/lists/reverse_tests.cpp
+++ b/cpp/tests/lists/reverse_tests.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
+#include <cudf_test/column_wrapper.hpp>
+
+#include <cudf/column/column.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/lists/reverse.hpp>
+
+#include <vector>
+
+using ints_lists = cudf::test::lists_column_wrapper<int32_t>;
+
+struct ListsReverseTest : public cudf::test::BaseFixture {
+};
+
+TEST_F(ListsReverseTest, SimpleReverse)
+{
+  auto const input    = ints_lists{{}, {1, 2, 3}, {}, {4, 5}};
+  auto const expected = ints_lists{{}, {3, 2, 1}, {}, {5, 4}};
+  auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
+}

--- a/cpp/tests/lists/reverse_tests.cpp
+++ b/cpp/tests/lists/reverse_tests.cpp
@@ -50,7 +50,7 @@ TYPED_TEST_SUITE(ListsReverseTypedTest, TestTypes);
 
 TEST_F(ListsReverseTest, EmptyInput)
 {
-  // Empty input.
+  // Empty column.
   {
     auto const input   = ints_lists{};
     auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
@@ -72,7 +72,7 @@ TEST_F(ListsReverseTest, EmptyInput)
   }
 }
 
-TYPED_TEST(ListsReverseTypedTest, InputNoNulls)
+TYPED_TEST(ListsReverseTypedTest, SimpleInputNoNulls)
 {
   using lists_col           = cudf::test::lists_column_wrapper<TypeParam>;
   auto const input_original = lists_col{{}, {1, 2, 3}, {}, {4, 5}, {6, 7, 8}, {9}};
@@ -84,28 +84,28 @@ TYPED_TEST(ListsReverseTypedTest, InputNoNulls)
   }
 
   {
-    auto const input    = cudf::slice(input_original, {1, 4})[0];
     auto const expected = lists_col{{3, 2, 1}, {}, {5, 4}};
+    auto const input    = cudf::slice(input_original, {1, 4})[0];
     auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
   }
 
   {
-    auto const input    = cudf::slice(input_original, {2, 3})[0];
     auto const expected = lists_col{lists_col{}};
+    auto const input    = cudf::slice(input_original, {2, 3})[0];
     auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
   }
 
   {
-    auto const input    = cudf::slice(input_original, {2, 4})[0];
     auto const expected = lists_col{{}, {5, 4}};
+    auto const input    = cudf::slice(input_original, {2, 4})[0];
     auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
   }
 }
 
-TYPED_TEST(ListsReverseTypedTest, InputWithNulls)
+TYPED_TEST(ListsReverseTypedTest, SimpleInputWithNulls)
 {
   using lists_col           = cudf::test::lists_column_wrapper<TypeParam>;
   auto const input_original = lists_col{{lists_col{},
@@ -129,24 +129,24 @@ TYPED_TEST(ListsReverseTypedTest, InputWithNulls)
   }
 
   {
-    auto const input    = cudf::slice(input_original, {1, 4})[0];
     auto const expected = lists_col{
       {lists_col{3, 2, 1}, lists_col{} /*null*/, lists_col{{null, 5, 4}, null_at(0)}}, null_at(1)};
+    auto const input   = cudf::slice(input_original, {1, 4})[0];
     auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
   }
 
   {
-    auto const input    = cudf::slice(input_original, {2, 3})[0];
     auto const expected = lists_col{{lists_col{} /*null*/}, null_at(0)};
+    auto const input    = cudf::slice(input_original, {2, 3})[0];
     auto const results  = cudf::lists::reverse(cudf::lists_column_view(input));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
   }
 
   {
-    auto const input = cudf::slice(input_original, {2, 4})[0];
     auto const expected =
       lists_col{{lists_col{} /*null*/, lists_col{{null, 5, 4}, null_at(0)}}, null_at(0)};
+    auto const input   = cudf::slice(input_original, {2, 4})[0];
     auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results);
   }
@@ -183,29 +183,29 @@ TYPED_TEST(ListsReverseTypedTest, InputListsOfListsNoNulls)
   }
 
   {
-    auto const input    = cudf::slice(*input_original, {1, 4})[0];
     auto const expected = [] {
       auto child   = lists_col{{7}, {4, 5, 6}, {1, 2, 3}, {4, 5, 6}, {}, {4, 5}}.release();
       auto offsets = ints_col{0, 3, 3, 6}.release();
       return cudf::make_lists_column(3, std::move(offsets), std::move(child), 0, {});
     }();
+    auto const input   = cudf::slice(*input_original, {1, 4})[0];
     auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results);
   }
 
   {
-    auto const input   = cudf::slice(*input_original, {2, 3})[0];  // empty column
+    auto const input   = cudf::slice(*input_original, {2, 3})[0];
     auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(input, *results);
   }
 
   {
-    auto const input    = cudf::slice(*input_original, {2, 4})[0];
     auto const expected = [] {
       auto child   = lists_col{{4, 5, 6}, {}, {4, 5}}.release();
       auto offsets = ints_col{0, 0, 3}.release();
       return cudf::make_lists_column(2, std::move(offsets), std::move(child), 0, {});
     }();
+    auto const input   = cudf::slice(*input_original, {2, 4})[0];
     auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results);
   }
@@ -261,18 +261,17 @@ TYPED_TEST(ListsReverseTypedTest, InputListsOfListsWithNulls)
   }
 
   {
-    auto const input    = cudf::slice(*input_original, {0, 1})[0];
     auto const expected = [] {
       auto child   = lists_col{{7}, {4, 5, 6}, {1, 2, 3}}.release();
       auto offsets = ints_col{0, 3}.release();
       return cudf::make_lists_column(1, std::move(offsets), std::move(child), 0, {});
     }();
+    auto const input   = cudf::slice(*input_original, {0, 1})[0];
     auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(input, *results);
   }
 
   {
-    auto const input    = cudf::slice(*input_original, {1, 4})[0];
     auto const expected = [] {
       auto child =
         lists_col{{{7}, {4, 5, 6}, {1, 2, 3}, {4, 5, 6}, {} /*null*/, {4, 5}}, null_at(4)}
@@ -284,12 +283,12 @@ TYPED_TEST(ListsReverseTypedTest, InputListsOfListsWithNulls)
       return cudf::make_lists_column(
         3, std::move(offsets), std::move(child), 1, std::move(null_mask));
     }();
+    auto const input   = cudf::slice(*input_original, {1, 4})[0];
     auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results);
   }
 
   {
-    auto const input    = cudf::slice(*input_original, {2, 4})[0];
     auto const expected = [] {
       auto child     = lists_col{{{4, 5, 6}, {} /*null*/, {4, 5}}, null_at(1)}.release();
       auto offsets   = ints_col{0, 0, 3}.release();
@@ -299,6 +298,7 @@ TYPED_TEST(ListsReverseTypedTest, InputListsOfListsWithNulls)
       return cudf::make_lists_column(
         2, std::move(offsets), std::move(child), 1, std::move(null_mask));
     }();
+    auto const input   = cudf::slice(*input_original, {2, 4})[0];
     auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
     // The result doesn't have nulls, but it is nullable.
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results);
@@ -412,7 +412,6 @@ TYPED_TEST(ListsReverseTypedTest, InputListsOfStructsWithNulls)
   }
 
   {
-    auto const input    = cudf::slice(*input_original, {1, 4})[0];
     auto const expected = [] {
       auto child = [] {
         auto grandchild1 = data_col{{
@@ -461,6 +460,7 @@ TYPED_TEST(ListsReverseTypedTest, InputListsOfStructsWithNulls)
       auto offsets = ints_col{0, 8, 16, 16}.release();
       return cudf::make_lists_column(3, std::move(offsets), std::move(child), 0, {});
     }();
+    auto const input   = cudf::slice(*input_original, {1, 4})[0];
     auto const results = cudf::lists::reverse(cudf::lists_column_view(input));
     // The result doesn't have nulls, but it is nullable.
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected, *results);

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -33,6 +33,7 @@
 #include <cudf/lists/extract.hpp>
 #include <cudf/lists/gather.hpp>
 #include <cudf/lists/lists_column_view.hpp>
+#include <cudf/lists/reverse.hpp>
 #include <cudf/lists/set_operations.hpp>
 #include <cudf/lists/sorting.hpp>
 #include <cudf/lists/stream_compaction.hpp>
@@ -668,8 +669,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_reverseStringsOrLists(JNI
       case cudf::type_id::STRING:
         return release_as_jlong(cudf::strings::reverse(cudf::strings_column_view{*input}));
       case cudf::type_id::LIST:
-        JNI_THROW_NEW(env, "java/lang/IllegalArgumentException",
-                      "List type is not yet supported in reverse()", 0);
+        return release_as_jlong(cudf::lists::reverse(cudf::lists_column_view{*input}));
       default:
         JNI_THROW_NEW(env, "java/lang/IllegalArgumentException",
                       "A column of type string or list is required for reverse()", 0);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -4964,9 +4964,26 @@ public class ColumnVectorTest extends CudfTestBase {
   @Test
   void testReverseString() {
     try (ColumnVector input = ColumnVector.fromStrings("abcdef", "12345", "", "", "aébé",
-            "A é Z", "X", "é");
+           "A é Z", "X", "é");
          ColumnVector expected = ColumnVector.fromStrings("fedcba", "54321", "", "", "ébéa",
-            "Z é A", "X", "é");
+           "Z é A", "X", "é");
+         ColumnVector result = input.reverseStringsOrLists()) {
+      assertColumnsAreEqual(expected, result);
+    }
+  }
+
+  @Test
+  void testReverseList() {
+    List<Integer> list0 = Arrays.asList(1, 2, 3);
+    List<Integer> list1 = Arrays.asList(4, 5, null);
+    List<Integer> emptyList = Collections.emptyList();
+    List<Integer> reversedList0 = Arrays.asList(3, 2, 1);
+    List<Integer> reversedList1 = Arrays.asList(null, 5, 4);
+
+    try (ColumnVector input = makeListsColumn(DType.INT32,
+           emptyList, list0, emptyList, null, list1);
+         ColumnVector expected = makeListsColumn(DType.INT32,
+           emptyList, reversedList0, emptyList, null, reversedList1);
          ColumnVector result = input.reverseStringsOrLists()) {
       assertColumnsAreEqual(expected, result);
     }


### PR DESCRIPTION
This implements `lists::reverse` that output a lists column in which each list is generated by reversing the order of the elements in the corresponding input list.

Example:
```
 s = [ [1, 2, 3], [], null, [4, 5, null] ]
 r = reverse(s)
 r is now [ [3, 2, 1], [], null, [null, 5, 4] ]
```

This is to support https://github.com/NVIDIA/spark-rapids/issues/4375 and https://github.com/NVIDIA/spark-rapids/issues/6885.