### PR TITLE
Upgrade protobuf to 4.21

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -132,8 +132,8 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
                   "ucx-py=${UCX_PY_VERSION}"
 
     # https://docs.rapids.ai/maintainers/depmgmt/
-    # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
-    # gpuci_mamba_retry install -y "your-pkg=1.0.0"
+    gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
+    gpuci_mamba_retry install -y "protobuf=4.21"
 
     ################################################################################
     # BUILD - Build libcudf, cuDF, libcudf_kafka, dask_cudf, and strings_udf from source

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -132,8 +132,8 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
                   "ucx-py=${UCX_PY_VERSION}"
 
     # https://docs.rapids.ai/maintainers/depmgmt/
-    gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
-    gpuci_mamba_retry install -y "protobuf=4.21"
+    # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
+    # gpuci_mamba_retry install -y "your-pkg=1.0.0"
 
     ################################################################################
     # BUILD - Build libcudf, cuDF, libcudf_kafka, dask_cudf, and strings_udf from source

--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -48,7 +48,7 @@ dependencies:
 - pandoc<=2.0.0
 - pip
 - pre-commit
-- protobuf>=3.20.1,<3.21.0a0
+- protobuf=3.21
 - ptxcompiler
 - pyarrow=9.0.0
 - pydata-sphinx-theme

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - ninja
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
-    - protobuf>=3.20.1,<3.21.0a0
+    - protobuf=3.21
     - python
     - cython >=0.29,<0.30
     - scikit-build>=0.13.1
@@ -57,7 +57,7 @@ requirements:
     - rmm ={{ minor_version }}
     - cudatoolkit ={{ cuda_version }}
   run:
-    - protobuf>=3.20.1,<3.21.0a0
+    - protobuf=3.21
     - python
     - typing_extensions
     - pandas >=1.0,<1.6.0dev0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,7 +66,7 @@ dependencies:
           - c-compiler
           - cxx-compiler
           - librdkafka=1.7.0
-          - protobuf>=3.20.1,<3.21.0a0
+          - protobuf=3.21
     specific:
       - output_types: conda
         matrices:

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     "nvtx>=0.2.1",
     "packaging",
     "pandas>=1.0,<1.6.0dev0",
-    "protobuf>=3.20.1,<3.21.0a0",
+    "protobuf==3.21",
     "typing_extensions",
     "pyarrow==9.0.0",
     f"rmm{cuda_suffix}",


### PR DESCRIPTION
## Description

Upgrades protobuf to 4.21 to align with the conda-forge pinning. https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml#L490-L491

Starting to run into issues solving environments where other desired packages are forced to be downgraded due to the protobuf versioning differing between the packages.

Depends on: https://github.com/rapidsai/integration/pull/577

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
