### PR TITLE
Temporarily pin CI image to cuda11.5.1-ubuntu20.04-py3.9.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,7 +66,7 @@ jobs:
       build_type: pull-request
       node_type: "gpu-v100-495-1"
       arch: "amd64"
-      container_image: "rapidsai/ci:latest"
+      container_image: "rapidsai/ci:cuda11.5.1-ubuntu20.04-py3.9"
       run_script: "ci/test_java.sh"
   conda-notebook-tests:
     needs: conda-python-build
@@ -76,5 +76,5 @@ jobs:
       build_type: pull-request
       node_type: "gpu-v100-495-1"
       arch: "amd64"
-      container_image: "rapidsai/ci:latest"
+      container_image: "rapidsai/ci:cuda11.5.1-ubuntu20.04-py3.9"
       run_script: "ci/test_notebooks.sh"


### PR DESCRIPTION
## Description
This temporarily pins our CI images for Java/notebooks tests to `rapidsai/ci:cuda11.5.1-ubuntu20.04-py3.9` because the `latest` tag is pointing to CUDA 11.8 images that have no matching GitHub Actions runners yet.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
