### PR TITLE
Fix reductions any/all return value for empty input

### DIFF
--- a/cpp/include/cudf/reduction.hpp
+++ b/cpp/include/cudf/reduction.hpp
@@ -46,7 +46,7 @@ enum class scan_type : bool { INCLUSIVE, EXCLUSIVE };
  * Any null values are skipped for the operation.
  *
  * If the column is empty or contains all null entries `col.size()==col.null_count()`,
- * the output scalar value will be `true` for reduction type `any` and false
+ * the output scalar value will be `false` for reduction type `any` and `true`
  * for reduction type `all`. For all other reductions, the output scalar
  * returns with `is_valid()==false`.
  *

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -179,7 +179,7 @@ std::unique_ptr<scalar> reduce(
     if (agg.kind == aggregation::ANY || agg.kind == aggregation::ALL) {
       // empty input should return true for ANY and return false for ALL
       dynamic_cast<numeric_scalar<bool>*>(result.get())
-        ->set_value(agg.kind == aggregation::ANY, stream);
+        ->set_value(agg.kind == aggregation::ALL, stream);
     }
     return result;
   }

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -177,7 +177,7 @@ std::unique_ptr<scalar> reduce(
 
     auto result = make_default_constructed_scalar(output_dtype, stream, mr);
     if (agg.kind == aggregation::ANY || agg.kind == aggregation::ALL) {
-      // empty input should return true for ANY and return false for ALL
+      // empty input should return false for ANY and return true for ALL
       dynamic_cast<numeric_scalar<bool>*>(result.get())
         ->set_value(agg.kind == aggregation::ALL, stream);
     }

--- a/cpp/tests/reductions/reduction_tests.cpp
+++ b/cpp/tests/reductions/reduction_tests.cpp
@@ -902,17 +902,17 @@ TEST_F(ReductionEmptyTest, empty_column)
 
   auto result = cudf::reduce(col0, *any_agg, bool_type);
   EXPECT_EQ(result->is_valid(), true);
-  EXPECT_EQ(dynamic_cast<cudf::numeric_scalar<bool>*>(result.get())->value(), true);
+  EXPECT_EQ(dynamic_cast<cudf::numeric_scalar<bool>*>(result.get())->value(), false);
   result = cudf::reduce(col_nulls, *any_agg, bool_type);
   EXPECT_EQ(result->is_valid(), true);
-  EXPECT_EQ(dynamic_cast<cudf::numeric_scalar<bool>*>(result.get())->value(), true);
+  EXPECT_EQ(dynamic_cast<cudf::numeric_scalar<bool>*>(result.get())->value(), false);
 
   result = cudf::reduce(col0, *all_agg, bool_type);
   EXPECT_EQ(result->is_valid(), true);
-  EXPECT_EQ(dynamic_cast<cudf::numeric_scalar<bool>*>(result.get())->value(), false);
+  EXPECT_EQ(dynamic_cast<cudf::numeric_scalar<bool>*>(result.get())->value(), true);
   result = cudf::reduce(col_nulls, *all_agg, bool_type);
   EXPECT_EQ(result->is_valid(), true);
-  EXPECT_EQ(dynamic_cast<cudf::numeric_scalar<bool>*>(result.get())->value(), false);
+  EXPECT_EQ(dynamic_cast<cudf::numeric_scalar<bool>*>(result.get())->value(), true);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Fixes error introduced in #12279 to return the correct boolean value for reductions on empty input for `any(false)` and `all(true)`.
Also fixes incorrectly coded gtest to verify the correct result.
Closes #12373 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
