### PR TITLE
Pin arrow 9 in testing dependencies to prevent conda solve issues

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -104,11 +104,11 @@ function install_dask {
     set -x
     if [[ "${INSTALL_DASK_MAIN}" == 1 ]]; then
         gpuci_logger "gpuci_mamba_retry install -c dask/label/dev 'dask/label/dev::dask' 'dask/label/dev::distributed'"
-        gpuci_mamba_retry install -c dask/label/dev "dask/label/dev::dask" "dask/label/dev::distributed"
+        gpuci_mamba_retry install -c dask/label/dev "dask/label/dev::dask" "dask/label/dev::distributed" "pyarrow=9.0.0"
         conda list
     else
         gpuci_logger "gpuci_mamba_retry install conda-forge::dask=={$DASK_STABLE_VERSION} conda-forge::distributed=={$DASK_STABLE_VERSION} conda-forge::dask-core=={$DASK_STABLE_VERSION} --force-reinstall"
-        gpuci_mamba_retry install conda-forge::dask==$DASK_STABLE_VERSION conda-forge::distributed==$DASK_STABLE_VERSION conda-forge::dask-core==$DASK_STABLE_VERSION --force-reinstall
+        gpuci_mamba_retry install conda-forge::dask==$DASK_STABLE_VERSION conda-forge::distributed==$DASK_STABLE_VERSION conda-forge::dask-core==$DASK_STABLE_VERSION "pyarrow=9.0.0" --force-reinstall
     fi
     # Install the main version of streamz
     gpuci_logger "Install the main version of streamz"
@@ -187,10 +187,6 @@ else
     nvidia-smi
 
     gpuci_logger "Installing libcudf, libcudf_kafka and libcudf-tests"
-    # Arrow 10 is pre-installed in the environment and must first be removed
-    # before installing our Arrow 9 dependent packages since there is no clear
-    # downgrade path from Arrow 10 -> Arrow 9 due to their recent upstream changes.
-    gpuci_mamba_retry remove -y arrow-cpp libarrow pyarrow || true
     gpuci_mamba_retry install -y -c ${CONDA_ARTIFACT_PATH} libcudf libcudf_kafka libcudf-tests
 
     # TODO: Move boa install to gpuci/rapidsai

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -187,6 +187,10 @@ else
     nvidia-smi
 
     gpuci_logger "Installing libcudf, libcudf_kafka and libcudf-tests"
+    # Arrow 10 is pre-installed in the environment and must first be removed
+    # before installing our Arrow 9 dependent packages since there is no clear
+    # downgrade path from Arrow 10 -> Arrow 9 due to their recent upstream changes.
+    gpuci_mamba_retry remove -y arrow-cpp libarrow pyarrow || true
     gpuci_mamba_retry install -y -c ${CONDA_ARTIFACT_PATH} libcudf libcudf_kafka libcudf-tests
 
     # TODO: Move boa install to gpuci/rapidsai

--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -43,6 +43,7 @@ dependencies:
 - numpydoc
 - nvcc_linux-64=11.5
 - nvtx>=0.2.1
+- orc=1.7.*
 - packaging
 - pandas>=1.0,<1.6.0dev0
 - pandoc<=2.0.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -288,8 +288,18 @@ dependencies:
           - pytest-cov
           - pytest-xdist
           - python-snappy>=0.6.0
-          - pytorch<1.12.0
           - s3fs>=2022.3.0
           - scipy
           - tokenizers==0.13.1
           - transformers==4.24.0
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              arch: x86_64
+            packages:
+              # Currently, CUDA builds of pytorch do not exist for aarch64. We require
+              # version <1.12.0 because newer versions use nvidia::cuda-toolkit.
+              - pytorch<1.12.0
+          - matrix:
+            packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -288,18 +288,8 @@ dependencies:
           - pytest-cov
           - pytest-xdist
           - python-snappy>=0.6.0
+          - pytorch<1.12.0
           - s3fs>=2022.3.0
           - scipy
           - tokenizers==0.13.1
           - transformers==4.24.0
-    specific:
-      - output_types: conda
-        matrices:
-          - matrix:
-              arch: x86_64
-            packages:
-              # Currently, CUDA builds of pytorch do not exist for aarch64. We require
-              # version <1.12.0 because newer versions use nvidia::cuda-toolkit.
-              - pytorch<1.12.0
-          - matrix:
-            packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -290,6 +290,11 @@ dependencies:
           - python-snappy>=0.6.0
           - s3fs>=2022.3.0
           - scipy
+          # TODO: This is a temporary orc pinning to ensure we get an older
+          # pyarrow 9 build. There is something wrong with the latest pyarrow 9
+          # build that causes conflicts on ARM. We should remove this pinning
+          # after migrating to Arrow 10, and probably update protobuf as well.
+          - orc=1.7.*
     specific:
       - output_types: conda
         matrices:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -273,6 +273,7 @@ dependencies:
           - hypothesis
           - mimesis>=4.1.0
           - moto>=4.0.8
+          - pyarrow=9.0.0
           - pyorc
           - pytest
           - pytest-benchmark

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,7 +57,7 @@ dependencies:
           - cython>=0.29,<0.30
           - dlpack>=0.5,<0.6.0a0
           - ninja
-          - pyarrow=9.0.0
+          - &pyarrow_ver pyarrow=9.0.0
           - rmm=23.02.*
           - scikit-build>=0.13.1
       - output_types: conda
@@ -273,7 +273,14 @@ dependencies:
           - hypothesis
           - mimesis>=4.1.0
           - moto>=4.0.8
-          - pyarrow=9.0.0
+          # We need to pin arrow 9 in the test environment until we upgrade
+          # cudf to use arrow 10. Without the pin, we end up with
+          # unsatisfiabile constraints because changes in the arrow conda
+          # packages in arrow 10 include the creation of new packages (namely
+          # arrow-cpp was renamed to libarrow) that do not have equivalents in
+          # arrow 9 and whose dependency constraints prevent the downgrade to
+          # arrow 9 when (lib)cudf attempts to install.
+          - *pyarrow_ver
           - pyorc
           - pytest
           - pytest-benchmark

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -290,8 +290,6 @@ dependencies:
           - python-snappy>=0.6.0
           - s3fs>=2022.3.0
           - scipy
-          - tokenizers==0.13.1
-          - transformers==4.24.0
     specific:
       - output_types: conda
         matrices:
@@ -301,5 +299,9 @@ dependencies:
               # Currently, CUDA builds of pytorch do not exist for aarch64. We require
               # version <1.12.0 because newer versions use nvidia::cuda-toolkit.
               - pytorch<1.12.0
+              # We only install these on x86_64 to avoid pulling pytorch as a
+              # dependency of transformers.
+              - tokenizers==0.13.1
+              - transformers==4.24.0
           - matrix:
             packages:

--- a/python/cudf/cudf/tests/test_subword_tokenizer.py
+++ b/python/cudf/cudf/tests/test_subword_tokenizer.py
@@ -1,10 +1,9 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 import os
 
 import cupy
 import numpy as np
 import pytest
-from transformers import BertTokenizer
 
 import cudf
 from cudf.core.subword_tokenizer import SubwordTokenizer
@@ -42,7 +41,9 @@ def test_subword_tokenize(
 
     vocab_dir = os.path.join(datadir, "bert_base_cased_sampled")
 
-    hf_tokenizer = BertTokenizer.from_pretrained(
+    transformers = pytest.importorskip("transformers")
+
+    hf_tokenizer = transformers.BertTokenizer.from_pretrained(
         vocab_dir, do_lower_case=do_lower_case
     )
 

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -37,7 +37,7 @@ extras_require = {
         "python-snappy>=0.6.0",
         "pyorc",
         "msgpack",
-        "transformers<=4.10.3",
+        "transformers==4.24.0",
         "tzdata",
     ]
 }


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This pinning is necessary because other testing dependencies require arrow (currently, transformers has a transitive dependency on it) and don't include a pinning as strict as ours, resulting in a newer arrow package (arrow 10) being installed. When we attempt to install our cudf/libcudf packages in CI, it should be able to downgrade to arrow 9, but the downgrade fails because changes in arrow's package structure in arrow 10 include the creation of a new libarrow package (arrow-cpp was renamed to libarrow) and libarrow has no equivalent in arrow 9. As a result, conda does not see a way to downgrade it, and it also does not see a way to satisfy its dependencies if the rest of the arrow packages are downgraded to arrow 9 (because libarrow is tied to arrow 10 packages), so the conda solve fails.

The current changeset will fix Github Actions CI. We may need additional fixes in our Jenkins CI.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
