### PR TITLE
Fix get_json_object to return empty column on empty input

### DIFF
--- a/cpp/src/strings/json/json_path.cu
+++ b/cpp/src/strings/json/json_path.cu
@@ -970,6 +970,8 @@ std::unique_ptr<cudf::column> get_json_object(cudf::strings_column_view const& c
   CUDF_EXPECTS(std::get<1>(preprocess) <= max_command_stack_depth,
                "Encountered JSONPath string that is too complex");
 
+  if (col.is_empty()) return make_empty_column(type_id::STRING);
+
   // allocate output offsets buffer.
   auto offsets = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, col.size() + 1, mask_state::UNALLOCATED, stream, mr);

--- a/cpp/tests/strings/json_tests.cpp
+++ b/cpp/tests/strings/json_tests.cpp
@@ -482,7 +482,7 @@ TEST_F(JsonPathTests, GetJsonObjectEmptyQuery)
 
 TEST_F(JsonPathTests, GetJsonObjectEmptyInputsAndOutputs)
 {
-  // empty input -> null
+  // empty string input -> null
   {
     cudf::test::strings_column_wrapper input{""};
     std::string json_path("$");
@@ -505,6 +505,14 @@ TEST_F(JsonPathTests, GetJsonObjectEmptyInputsAndOutputs)
 
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, expected);
   }
+}
+
+TEST_F(JsonPathTests, GetJsonObjectEmptyInput)
+{
+  cudf::test::strings_column_wrapper input{};
+  std::string json_path("$");
+  auto result = cudf::strings::get_json_object(cudf::strings_column_view(input), json_path);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, input);
 }
 
 // badly formed JSONpath strings


### PR DESCRIPTION
## Description
Fixes `cudf::strings::get_json_object` to return an empty column if the input column is empty.

Closes #12383 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
