### PR TITLE
Fix COPYING_TEST: gtests coded in namespace cudf::test

### DIFF
--- a/cpp/tests/copying/copy_if_else_nested_tests.cpp
+++ b/cpp/tests/copying/copy_if_else_nested_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/copying/copy_if_else_nested_tests.cpp
+++ b/cpp/tests/copying/copy_if_else_nested_tests.cpp
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-#include <cudf/copying.hpp>
-#include <cudf/scalar/scalar_factories.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
+
+#include <cudf/copying.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
 
 using namespace cudf::test::iterators;
 
@@ -38,13 +39,10 @@ TYPED_TEST(TypedCopyIfElseNestedTest, Structs)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using ints    = fixed_width_column_wrapper<T, int32_t>;
-  using strings = strings_column_wrapper;
-  using structs = structs_column_wrapper;
-  using bools   = fixed_width_column_wrapper<bool, int32_t>;
+  using ints    = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using strings = cudf::test::strings_column_wrapper;
+  using structs = cudf::test::structs_column_wrapper;
+  using bools   = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
 
   auto lhs_ints_child     = ints{0, 1, 2, 3, 4, 5, 6};
   auto lhs_strings_child  = strings{"0", "1", "2", "3", "4", "5", "6"};
@@ -56,8 +54,8 @@ TYPED_TEST(TypedCopyIfElseNestedTest, Structs)
 
   auto selector_column = bools{1, 1, 0, 1, 1, 0, 1}.release();
 
-  auto result_column =
-    copy_if_else(lhs_structs_column->view(), rhs_structs_column->view(), selector_column->view());
+  auto result_column = cudf::copy_if_else(
+    lhs_structs_column->view(), rhs_structs_column->view(), selector_column->view());
 
   auto expected_ints    = ints{0, 1, 22, 3, 4, 55, 6};
   auto expected_strings = strings{"0", "1", "22", "3", "4", "55", "6"};
@@ -70,13 +68,10 @@ TYPED_TEST(TypedCopyIfElseNestedTest, StructsWithNulls)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using ints    = fixed_width_column_wrapper<T, int32_t>;
-  using strings = strings_column_wrapper;
-  using structs = structs_column_wrapper;
-  using bools   = fixed_width_column_wrapper<bool, int32_t>;
+  using ints    = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using strings = cudf::test::strings_column_wrapper;
+  using structs = cudf::test::structs_column_wrapper;
+  using bools   = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
 
   auto null_at_0 = null_at(0);
   auto null_at_3 = null_at(3);
@@ -92,11 +87,11 @@ TYPED_TEST(TypedCopyIfElseNestedTest, StructsWithNulls)
 
   auto selector_column = bools{1, 1, 0, 1, 1, 0, 1}.release();
 
-  auto result_column =
-    copy_if_else(lhs_structs_column->view(), rhs_structs_column->view(), selector_column->view());
+  auto result_column = cudf::copy_if_else(
+    lhs_structs_column->view(), rhs_structs_column->view(), selector_column->view());
 
-  auto null_at_0_3 = nulls_at(std::vector<size_type>{0, 3});
-  auto null_at_3_5 = nulls_at(std::vector<size_type>{3, 5});
+  auto null_at_0_3 = nulls_at(std::vector<cudf::size_type>{0, 3});
+  auto null_at_3_5 = nulls_at(std::vector<cudf::size_type>{3, 5});
 
   auto expected_ints    = ints{{-1, 1, 22, 3, 4, 55, 6}, null_at_0_3};
   auto expected_strings = strings{{"0", "1", "22", "", "4", "", "6"}, null_at_3_5};
@@ -109,12 +104,9 @@ TYPED_TEST(TypedCopyIfElseNestedTest, LongerStructsWithNulls)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using ints    = fixed_width_column_wrapper<T, int32_t>;
-  using structs = structs_column_wrapper;
-  using bools   = fixed_width_column_wrapper<bool, int32_t>;
+  using ints    = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using structs = cudf::test::structs_column_wrapper;
+  using bools   = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
 
   auto selector_column = bools{1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0,
                                0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0,
@@ -125,11 +117,11 @@ TYPED_TEST(TypedCopyIfElseNestedTest, LongerStructsWithNulls)
           86, 125, 0,   0,   0,   75,  -49, 125, 60,  116, 118,  64,   20,  -70, -18, 0,   -25,
           22, -46, -89, -9,  27,  -56, -77, 123, 0,   -90, 87,   -113, -37, 22,  -22, -53, 73,
           99, 113, -2,  -24, 113, 75,  6,   82,  -58, 122, -123, -127, 19,  -62, -24},
-         nulls_at(std::vector<size_type>{13, 19, 20, 21, 32, 42})};
+         nulls_at(std::vector<cudf::size_type>{13, 19, 20, 21, 32, 42})};
 
   auto lhs_structs_column = structs{{lhs_child_1}}.release();
-  auto result_column =
-    copy_if_else(lhs_structs_column->view(), lhs_structs_column->view(), selector_column->view());
+  auto result_column      = cudf::copy_if_else(
+    lhs_structs_column->view(), lhs_structs_column->view(), selector_column->view());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(result_column->view(), lhs_structs_column->view());
 }
@@ -138,23 +130,20 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarStructBothInvalid)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using ints    = fixed_width_column_wrapper<T, int32_t>;
-  using strings = strings_column_wrapper;
-  using structs = structs_column_wrapper;
-  using bools   = fixed_width_column_wrapper<bool, int32_t>;
+  using ints    = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using strings = cudf::test::strings_column_wrapper;
+  using structs = cudf::test::structs_column_wrapper;
+  using bools   = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
 
   auto lhs_child_ints    = ints{11};
   auto lhs_child_strings = strings{"11"};
-  auto lhs_children      = std::vector<column_view>{{lhs_child_ints, lhs_child_strings}};
-  auto lhs_scalar        = struct_scalar{lhs_children, false};
+  auto lhs_children      = std::vector<cudf::column_view>{{lhs_child_ints, lhs_child_strings}};
+  auto lhs_scalar        = cudf::struct_scalar{lhs_children, false};
 
   auto rhs_child_ints    = ints{{22}, null_at(0)};
   auto rhs_child_strings = strings{"22"};
-  auto rhs_children      = std::vector<column_view>{{rhs_child_ints, rhs_child_strings}};
-  auto rhs_scalar        = struct_scalar{rhs_children, false};
+  auto rhs_children      = std::vector<cudf::column_view>{{rhs_child_ints, rhs_child_strings}};
+  auto rhs_scalar        = cudf::struct_scalar{rhs_children, false};
 
   auto selector_column = bools{1, 1, 0, 1, 1, 0, 1}.release();
 
@@ -162,7 +151,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarStructBothInvalid)
   auto expected_strings = strings{"-11", "-11", "-22", "-11", "-22", "-11", "-11"};
   auto expected_result  = structs{{expected_ints, expected_strings}, all_nulls()}.release();
 
-  auto result_column = copy_if_else(lhs_scalar, rhs_scalar, selector_column->view());
+  auto result_column = cudf::copy_if_else(lhs_scalar, rhs_scalar, selector_column->view());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result->view(), result_column->view());
 }
@@ -171,32 +160,30 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarStructBothValid)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using ints    = fixed_width_column_wrapper<T, int32_t>;
-  using strings = strings_column_wrapper;
-  using structs = structs_column_wrapper;
-  using bools   = fixed_width_column_wrapper<bool, int32_t>;
+  using ints    = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using strings = cudf::test::strings_column_wrapper;
+  using structs = cudf::test::structs_column_wrapper;
+  using bools   = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
 
   auto lhs_child_ints    = ints{11};
   auto lhs_child_strings = strings{{"11"}, null_at(0)};
-  auto lhs_children      = std::vector<column_view>{{lhs_child_ints, lhs_child_strings}};
+  auto lhs_children      = std::vector<cudf::column_view>{{lhs_child_ints, lhs_child_strings}};
   auto lhs_scalar        = cudf::make_struct_scalar(lhs_children);
 
   auto rhs_child_ints    = ints{{22}, null_at(0)};
   auto rhs_child_strings = strings{"22"};
-  auto rhs_children      = std::vector<column_view>{{rhs_child_ints, rhs_child_strings}};
+  auto rhs_children      = std::vector<cudf::column_view>{{rhs_child_ints, rhs_child_strings}};
   auto rhs_scalar        = cudf::make_struct_scalar(rhs_children);
 
   auto selector_column = bools{1, 1, 0, 1, 1, 0, 1}.release();
 
-  auto expected_ints = ints{{11, 11, -22, 11, 11, -22, 11}, nulls_at(std::vector<size_type>{2, 5})};
+  auto expected_ints =
+    ints{{11, 11, -22, 11, 11, -22, 11}, nulls_at(std::vector<cudf::size_type>{2, 5})};
   auto expected_strings = strings{{"NA", "NA", "22", "NA", "NA", "22", "NA"},
-                                  nulls_at(std::vector<size_type>{0, 1, 3, 4, 6})};
+                                  nulls_at(std::vector<cudf::size_type>{0, 1, 3, 4, 6})};
   auto expected_result  = structs{{expected_ints, expected_strings}}.release();
 
-  auto result_column = copy_if_else(*lhs_scalar, *rhs_scalar, selector_column->view());
+  auto result_column = cudf::copy_if_else(*lhs_scalar, *rhs_scalar, selector_column->view());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result->view(), result_column->view());
 }
@@ -205,17 +192,14 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarStructLeft)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using ints    = fixed_width_column_wrapper<T, int32_t>;
-  using strings = strings_column_wrapper;
-  using structs = structs_column_wrapper;
-  using bools   = fixed_width_column_wrapper<bool, int32_t>;
+  using ints    = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using strings = cudf::test::strings_column_wrapper;
+  using structs = cudf::test::structs_column_wrapper;
+  using bools   = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
 
   auto lhs_child_ints    = ints{11};
   auto lhs_child_strings = strings{{"11"}, null_at(0)};
-  auto lhs_children      = std::vector<column_view>{{lhs_child_ints, lhs_child_strings}};
+  auto lhs_children      = std::vector<cudf::column_view>{{lhs_child_ints, lhs_child_strings}};
   auto lhs_scalar        = cudf::make_struct_scalar(lhs_children);
 
   auto rhs_child_ints    = ints{{22, 22, 22, 22, 22, 22, 22}, null_at(2)};
@@ -228,10 +212,10 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarStructLeft)
 
   auto expected_ints    = ints{{11, 11, -22, 11, 11, 22, 11}, null_at(2)};
   auto expected_strings = strings{{"NA", "NA", "22", "NA", "NA", "22", "NA"},
-                                  nulls_at(std::vector<size_type>{0, 1, 3, 4, 6})};
+                                  nulls_at(std::vector<cudf::size_type>{0, 1, 3, 4, 6})};
   auto expected_result  = structs{{expected_ints, expected_strings}, null_at(5)}.release();
 
-  auto result_column = copy_if_else(*lhs_scalar, rhs_column->view(), selector_column->view());
+  auto result_column = cudf::copy_if_else(*lhs_scalar, rhs_column->view(), selector_column->view());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result->view(), result_column->view());
 }
@@ -240,31 +224,29 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarStructRight)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
+  using ints    = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using strings = cudf::test::strings_column_wrapper;
+  using structs = cudf::test::structs_column_wrapper;
+  using bools   = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
 
-  using ints    = fixed_width_column_wrapper<T, int32_t>;
-  using strings = strings_column_wrapper;
-  using structs = structs_column_wrapper;
-  using bools   = fixed_width_column_wrapper<bool, int32_t>;
-
-  auto lhs_child_ints = ints{{11, 11, 11, 11, 11, 11, 11}, nulls_at(std::vector<size_type>{1, 4})};
+  auto lhs_child_ints =
+    ints{{11, 11, 11, 11, 11, 11, 11}, nulls_at(std::vector<cudf::size_type>{1, 4})};
   auto lhs_child_strings = strings{"11", "11", "11", "11", "11", "11", "11"};
   auto lhs_column        = structs{{lhs_child_ints, lhs_child_strings}, null_at(6)}.release();
 
   auto rhs_child_ints    = ints{{22}, null_at(0)};
-  auto rhs_child_strigns = strings{"22"};
-  auto rhs_children      = std::vector<column_view>{{rhs_child_ints, rhs_child_strigns}};
+  auto rhs_child_strings = strings{"22"};
+  auto rhs_children      = std::vector<cudf::column_view>{{rhs_child_ints, rhs_child_strings}};
   auto rhs_scalar        = cudf::make_struct_scalar(rhs_children);
 
   auto selector_column = bools{1, 1, 0, 1, 1, 0, 1}.release();
 
   auto expected_ints =
-    ints{{11, 11, -22, 11, 11, -22, 11}, nulls_at(std::vector<size_type>{1, 2, 4, 5})};
+    ints{{11, 11, -22, 11, 11, -22, 11}, nulls_at(std::vector<cudf::size_type>{1, 2, 4, 5})};
   auto expected_strings = strings{"11", "11", "22", "11", "11", "22", "11"};
   auto expected_result  = structs{{expected_ints, expected_strings}, null_at(6)}.release();
 
-  auto result_column = copy_if_else(lhs_column->view(), *rhs_scalar, selector_column->view());
+  auto result_column = cudf::copy_if_else(lhs_column->view(), *rhs_scalar, selector_column->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result->view(), result_column->view());
 }
 
@@ -272,10 +254,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, Lists)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using lcw = lists_column_wrapper<T, int32_t>;
+  using lcw = cudf::test::lists_column_wrapper<T, int32_t>;
 
   auto lhs =
     lcw{{0, 0}, {1, 1}, {2, 2}, {3, 3, 3}, {4, 4, 4, 4}, {5, 5, 5, 5, 5}, {6, 6, 6, 6, 6, 6}}
@@ -290,9 +269,10 @@ TYPED_TEST(TypedCopyIfElseNestedTest, Lists)
                  {66, 66, 66, 66, 66, 66}}
                .release();
 
-  auto selector_column = fixed_width_column_wrapper<bool, int32_t>{1, 1, 0, 1, 1, 0, 1}.release();
+  auto selector_column =
+    cudf::test::fixed_width_column_wrapper<bool, int32_t>{1, 1, 0, 1, 1, 0, 1}.release();
 
-  auto result_column = copy_if_else(lhs->view(), rhs->view(), selector_column->view());
+  auto result_column = cudf::copy_if_else(lhs->view(), rhs->view(), selector_column->view());
 
   auto expected_output =
     lcw{{0, 0}, {1, 1}, {22, 22}, {3, 3, 3}, {4, 4, 4, 4}, {55, 55, 55, 55, 55}, {6, 6, 6, 6, 6, 6}}
@@ -305,10 +285,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithNulls)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using lcw = lists_column_wrapper<T, int32_t>;
+  using lcw = cudf::test::lists_column_wrapper<T, int32_t>;
 
   auto null_at_0 = null_at(0);
   auto null_at_4 = null_at(4);
@@ -334,9 +311,10 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithNulls)
                  null_at_5}
                .release();
 
-  auto selector_column = fixed_width_column_wrapper<bool, int32_t>{1, 1, 0, 1, 1, 0, 1}.release();
+  auto selector_column =
+    cudf::test::fixed_width_column_wrapper<bool, int32_t>{1, 1, 0, 1, 1, 0, 1}.release();
 
-  auto result_column = copy_if_else(lhs->view(), rhs->view(), selector_column->view());
+  auto result_column = cudf::copy_if_else(lhs->view(), rhs->view(), selector_column->view());
 
   auto null_at_4_5 = nulls_at(std::vector{4, 5});
 
@@ -352,14 +330,11 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithStructs)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using ints    = fixed_width_column_wrapper<T, int32_t>;
-  using strings = strings_column_wrapper;
-  using structs = structs_column_wrapper;
-  using bools   = fixed_width_column_wrapper<bool, int32_t>;
-  using offsets = fixed_width_column_wrapper<offset_type, int32_t>;
+  using ints    = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using strings = cudf::test::strings_column_wrapper;
+  using structs = cudf::test::structs_column_wrapper;
+  using bools   = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
+  using offsets = cudf::test::fixed_width_column_wrapper<cudf::offset_type, int32_t>;
 
   auto const null_at_0 = null_at(0);
   auto const null_at_3 = null_at(3);
@@ -372,26 +347,28 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithStructs)
   auto lhs_strings = strings{{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}, null_at_4};
   auto lhs_structs = structs{{lhs_ints, lhs_strings}}.release();
   auto lhs_offsets = offsets{0, 2, 4, 6, 10, 10}.release();
-  auto const lhs   = make_lists_column(5,
-                                     std::move(lhs_offsets),
-                                     std::move(lhs_structs),
-                                     1,
-                                     cudf::test::detail::make_null_mask(null_at_4, null_at_4 + 5));
+  auto const lhs =
+    cudf::make_lists_column(5,
+                            std::move(lhs_offsets),
+                            std::move(lhs_structs),
+                            1,
+                            cudf::test::detail::make_null_mask(null_at_4, null_at_4 + 5));
 
   auto rhs_ints = ints{{0, 11, 22, 33, 44, 55, 66, 77, 88, 99}, null_at_6};
   auto rhs_strings =
     strings{{"00", "11", "22", "33", "44", "55", "66", "77", "88", "99"}, null_at_7};
   auto rhs_structs = structs{{rhs_ints, rhs_strings}, null_at_8};
   auto rhs_offsets = offsets{0, 0, 4, 6, 8, 10};
-  auto const rhs   = make_lists_column(5,
-                                     rhs_offsets.release(),
-                                     rhs_structs.release(),
-                                     1,
-                                     cudf::test::detail::make_null_mask(null_at_0, null_at_0 + 5));
+  auto const rhs =
+    cudf::make_lists_column(5,
+                            rhs_offsets.release(),
+                            rhs_structs.release(),
+                            1,
+                            cudf::test::detail::make_null_mask(null_at_0, null_at_0 + 5));
 
   auto selector_column = bools{1, 0, 1, 0, 1}.release();
 
-  auto result_column = copy_if_else(lhs->view(), rhs->view(), selector_column->view());
+  auto result_column = cudf::copy_if_else(lhs->view(), rhs->view(), selector_column->view());
 
   auto const null_at_6_9 = nulls_at(std::vector{6, 9});
   auto expected_ints     = ints{{0, 1, 0, 11, 22, 33, 4, 5, -1, 77}, null_at_8};
@@ -400,11 +377,11 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ListsWithStructs)
   auto expected_structs = structs{{expected_ints, expected_strings}};
   auto expected_offsets = offsets{0, 2, 6, 8, 10, 10};
   auto const expected =
-    make_lists_column(5,
-                      expected_offsets.release(),
-                      expected_structs.release(),
-                      1,
-                      cudf::test::detail::make_null_mask(null_at_4, null_at_4 + 5));
+    cudf::make_lists_column(5,
+                            expected_offsets.release(),
+                            expected_structs.release(),
+                            1,
+                            cudf::test::detail::make_null_mask(null_at_4, null_at_4 + 5));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(result_column->view(), expected->view());
 }
@@ -413,15 +390,12 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarListBothInvalid)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
+  using ints  = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using bools = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
+  using lcw   = cudf::test::lists_column_wrapper<T, int32_t>;
 
-  using ints  = fixed_width_column_wrapper<T, int32_t>;
-  using bools = fixed_width_column_wrapper<bool, int32_t>;
-  using lcw   = lists_column_wrapper<T, int32_t>;
-
-  auto lhs_scalar = list_scalar{ints{33, 33, 33}, false};
-  auto rhs_scalar = list_scalar{ints{22, 22}, false};
+  auto lhs_scalar = cudf::list_scalar{ints{33, 33, 33}, false};
+  auto rhs_scalar = cudf::list_scalar{ints{22, 22}, false};
 
   auto selector_column = bools{1, 1, 0, 1, 1, 0, 1}.release();
 
@@ -437,7 +411,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarListBothInvalid)
                       all_nulls()}
                     .release();
 
-  auto result = copy_if_else(lhs_scalar, rhs_scalar, selector_column->view());
+  auto result = cudf::copy_if_else(lhs_scalar, rhs_scalar, selector_column->view());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected->view(), result->view());
 }
@@ -446,12 +420,9 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarListBothValid)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using ints  = fixed_width_column_wrapper<T, int32_t>;
-  using bools = fixed_width_column_wrapper<bool, int32_t>;
-  using lcw   = lists_column_wrapper<T, int32_t>;
+  using ints  = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using bools = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
+  using lcw   = cudf::test::lists_column_wrapper<T, int32_t>;
 
   auto lhs_scalar = cudf::make_list_scalar(ints{{33, 33, 33}, null_at(1)});
   auto rhs_scalar = cudf::make_list_scalar(ints{{22, 22}, null_at(0)});
@@ -470,7 +441,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarListBothValid)
     }
       .release();
 
-  auto result = copy_if_else(*lhs_scalar, *rhs_scalar, selector_column->view());
+  auto result = cudf::copy_if_else(*lhs_scalar, *rhs_scalar, selector_column->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected->view(), result->view());
 }
 
@@ -478,12 +449,9 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarListLeft)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using ints  = fixed_width_column_wrapper<T, int32_t>;
-  using bools = fixed_width_column_wrapper<bool, int32_t>;
-  using lcw   = lists_column_wrapper<T, int32_t>;
+  using ints  = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using bools = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
+  using lcw   = cudf::test::lists_column_wrapper<T, int32_t>;
 
   auto lhs_scalar = cudf::make_list_scalar(ints{{33, 33, 33}, null_at(1)});
   auto rhs_column = lcw{{{-2, -1},
@@ -508,7 +476,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarListLeft)
                       null_at(2)}
                     .release();
 
-  auto result = copy_if_else(*lhs_scalar, rhs_column->view(), selector_column->view());
+  auto result = cudf::copy_if_else(*lhs_scalar, rhs_column->view(), selector_column->view());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected->view(), result->view());
 }
@@ -517,12 +485,9 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarListRight)
 {
   using T = TypeParam;
 
-  using namespace cudf;
-  using namespace cudf::test;
-
-  using ints  = fixed_width_column_wrapper<T, int32_t>;
-  using bools = fixed_width_column_wrapper<bool, int32_t>;
-  using lcw   = lists_column_wrapper<T, int32_t>;
+  using ints  = cudf::test::fixed_width_column_wrapper<T, int32_t>;
+  using bools = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
+  using lcw   = cudf::test::lists_column_wrapper<T, int32_t>;
 
   auto lhs_column = lcw{{{-2, -1},
                          {-2, -1, 0},
@@ -550,7 +515,7 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarListRight)
                       null_at(2)}
                     .release();
 
-  auto result = copy_if_else(lhs_column->view(), *rhs_scalar, selector_column->view());
+  auto result = cudf::copy_if_else(lhs_column->view(), *rhs_scalar, selector_column->view());
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected->view(), result->view());
 }

--- a/cpp/tests/copying/copy_range_tests.cpp
+++ b/cpp/tests/copying/copy_range_tests.cpp
@@ -492,7 +492,6 @@ TYPED_TEST(FixedPointTypesCopyRange, FixedPointSimple)
 TYPED_TEST(FixedPointTypesCopyRange, FixedPointLarge)
 {
   using namespace numeric;
-  using namespace cudf::test;
   using decimalXX  = TypeParam;
   using RepType    = cudf::device_storage_type_t<decimalXX>;
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;

--- a/cpp/tests/copying/copy_tests.cpp
+++ b/cpp/tests/copying/copy_tests.cpp
@@ -611,7 +611,6 @@ TYPED_TEST(FixedPointTypes, FixedPointSimple)
 TYPED_TEST(FixedPointTypes, FixedPointLarge)
 {
   using namespace numeric;
-  using namespace cudf::test;
   using decimalXX  = TypeParam;
   using RepType    = cudf::device_storage_type_t<decimalXX>;
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;

--- a/cpp/tests/copying/gather_list_tests.cpp
+++ b/cpp/tests/copying/gather_list_tests.cpp
@@ -23,7 +23,6 @@
 
 #include <cudf/column/column_view.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/detail/gather.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table.hpp>
@@ -67,7 +66,6 @@ TYPED_TEST(GatherTestListTyped, Gather)
 TYPED_TEST(GatherTestListTyped, GatherNothing)
 {
   using T = TypeParam;
-  using namespace cudf;
 
   // List<T>
   {
@@ -94,13 +92,15 @@ TYPED_TEST(GatherTestListTyped, GatherNothing)
     // even though it is empty past the first level
     cudf::lists_column_view lcv(result->view().column(0));
     EXPECT_EQ(lcv.size(), 0);
-    EXPECT_EQ(lcv.child().type().id(), type_id::LIST);
+    EXPECT_EQ(lcv.child().type().id(), cudf::type_id::LIST);
     EXPECT_EQ(lcv.child().size(), 0);
-    EXPECT_EQ(lists_column_view(lcv.child()).child().type().id(), type_id::LIST);
-    EXPECT_EQ(lists_column_view(lcv.child()).child().size(), 0);
-    EXPECT_EQ(lists_column_view(lists_column_view(lcv.child()).child()).child().type().id(),
-              type_id::INT32);
-    EXPECT_EQ(lists_column_view(lists_column_view(lcv.child()).child()).child().size(), 0);
+    EXPECT_EQ(cudf::lists_column_view(lcv.child()).child().type().id(), cudf::type_id::LIST);
+    EXPECT_EQ(cudf::lists_column_view(lcv.child()).child().size(), 0);
+    EXPECT_EQ(
+      cudf::lists_column_view(cudf::lists_column_view(lcv.child()).child()).child().type().id(),
+      cudf::type_id::INT32);
+    EXPECT_EQ(cudf::lists_column_view(cudf::lists_column_view(lcv.child()).child()).child().size(),
+              0);
   }
 }
 
@@ -263,11 +263,7 @@ TYPED_TEST(GatherTestListTyped, GatherDetailInvalidIndex)
     cudf::test::fixed_width_column_wrapper<int> gather_map{0, 15, 16, 2};
 
     cudf::table_view source_table({list});
-    auto results = cudf::detail::gather(source_table,
-                                        gather_map,
-                                        cudf::out_of_bounds_policy::NULLIFY,
-                                        cudf::detail::negative_index_policy::NOT_ALLOWED,
-                                        cudf::get_default_stream());
+    auto results = cudf::gather(source_table, gather_map, cudf::out_of_bounds_policy::NULLIFY);
 
     std::vector<int32_t> expected_validity{1, 0, 0, 1};
     LCW<T> expected{{{{2, 3}, {4, 5}},
@@ -283,7 +279,6 @@ TYPED_TEST(GatherTestListTyped, GatherDetailInvalidIndex)
 TEST_F(GatherTestList, GatherIncompleteHierarchies)
 {
   using LCW = cudf::test::lists_column_wrapper<int32_t>;
-  using namespace cudf;
 
   {
     // List<List<List<int>, but rows 1 and 2 are empty at the very top.
@@ -299,13 +294,15 @@ TEST_F(GatherTestList, GatherIncompleteHierarchies)
     // even though it is empty past the first level
     cudf::lists_column_view lcv(result->view().column(0));
     EXPECT_EQ(lcv.size(), 1);
-    EXPECT_EQ(lcv.child().type().id(), type_id::LIST);
+    EXPECT_EQ(lcv.child().type().id(), cudf::type_id::LIST);
     EXPECT_EQ(lcv.child().size(), 0);
-    EXPECT_EQ(lists_column_view(lcv.child()).child().type().id(), type_id::LIST);
-    EXPECT_EQ(lists_column_view(lcv.child()).child().size(), 0);
-    EXPECT_EQ(lists_column_view(lists_column_view(lcv.child()).child()).child().type().id(),
-              type_id::INT32);
-    EXPECT_EQ(lists_column_view(lists_column_view(lcv.child()).child()).child().size(), 0);
+    EXPECT_EQ(cudf::lists_column_view(lcv.child()).child().type().id(), cudf::type_id::LIST);
+    EXPECT_EQ(cudf::lists_column_view(lcv.child()).child().size(), 0);
+    EXPECT_EQ(
+      cudf::lists_column_view(cudf::lists_column_view(lcv.child()).child()).child().type().id(),
+      cudf::type_id::INT32);
+    EXPECT_EQ(cudf::lists_column_view(cudf::lists_column_view(lcv.child()).child()).child().size(),
+              0);
   }
 
   {
@@ -322,13 +319,15 @@ TEST_F(GatherTestList, GatherIncompleteHierarchies)
     // even though it is empty past the first level
     cudf::lists_column_view lcv(result->view().column(0));
     EXPECT_EQ(lcv.size(), 0);
-    EXPECT_EQ(lcv.child().type().id(), type_id::LIST);
+    EXPECT_EQ(lcv.child().type().id(), cudf::type_id::LIST);
     EXPECT_EQ(lcv.child().size(), 0);
-    EXPECT_EQ(lists_column_view(lcv.child()).child().type().id(), type_id::LIST);
-    EXPECT_EQ(lists_column_view(lcv.child()).child().size(), 0);
-    EXPECT_EQ(lists_column_view(lists_column_view(lcv.child()).child()).child().type().id(),
-              type_id::INT32);
-    EXPECT_EQ(lists_column_view(lists_column_view(lcv.child()).child()).child().size(), 0);
+    EXPECT_EQ(cudf::lists_column_view(lcv.child()).child().type().id(), cudf::type_id::LIST);
+    EXPECT_EQ(cudf::lists_column_view(lcv.child()).child().size(), 0);
+    EXPECT_EQ(
+      cudf::lists_column_view(cudf::lists_column_view(lcv.child()).child()).child().type().id(),
+      cudf::type_id::INT32);
+    EXPECT_EQ(cudf::lists_column_view(cudf::lists_column_view(lcv.child()).child()).child().size(),
+              0);
   }
 }
 

--- a/cpp/tests/copying/gather_struct_tests.cpp
+++ b/cpp/tests/copying/gather_struct_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/copying/gather_struct_tests.cpp
+++ b/cpp/tests/copying/gather_struct_tests.cpp
@@ -56,15 +56,14 @@ using lists = cudf::test::lists_column_wrapper<T, int32_t>;
 
 auto constexpr null_index = std::numeric_limits<cudf::offset_type>::max();
 
-namespace cudf::test {
-struct StructGatherTest : public BaseFixture {
+struct StructGatherTest : public cudf::test::BaseFixture {
 };
 
 template <typename T>
-struct TypedStructGatherTest : public BaseFixture {
+struct TypedStructGatherTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(TypedStructGatherTest, FixedWidthTypes);
+TYPED_TEST_SUITE(TypedStructGatherTest, cudf::test::FixedWidthTypes);
 
 namespace {
 template <typename ElementTo, typename SourceElementT = ElementTo>
@@ -121,11 +120,11 @@ auto get_expected_column(std::vector<SourceElementT> const& input_values,
     cudf::detail::make_counting_transform_iterator(0, is_valid));
 }
 
-auto do_gather(column_view const& input, gather_map_t const& gather_map)
+auto do_gather(cudf::column_view const& input, gather_map_t const& gather_map)
 {
-  auto result = gather(table_view{{input}},
-                       offsets(gather_map.begin(), gather_map.end()),
-                       out_of_bounds_policy::NULLIFY);
+  auto result = cudf::gather(cudf::table_view{{input}},
+                             offsets(gather_map.begin(), gather_map.end()),
+                             cudf::out_of_bounds_policy::NULLIFY);
   return std::move(result->release()[0]);
 }
 }  // namespace
@@ -180,20 +179,21 @@ TYPED_TEST(TypedStructGatherTest, TestSimpleStructGather)
 TYPED_TEST(TypedStructGatherTest, TestSlicedStructsColumnGatherNoNulls)
 {
   auto const structs_original = [] {
-    auto child1 = fixed_width_column_wrapper<TypeParam, int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    auto child2 = strings_column_wrapper{
+    auto child1 =
+      cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    auto child2 = cudf::test::strings_column_wrapper{
       "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"};
-    return structs_column_wrapper{{child1, child2}};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   auto const expected = [] {
-    auto child1 = fixed_width_column_wrapper<TypeParam, int32_t>{6, 10, 8};
-    auto child2 = strings_column_wrapper{"Six", "Ten", "Eight"};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>{6, 10, 8};
+    auto child2 = cudf::test::strings_column_wrapper{"Six", "Ten", "Eight"};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   auto const structs    = cudf::slice(structs_original, {4, 10})[0];
-  auto const gather_map = fixed_width_column_wrapper<int32_t>{1, 5, 3};
+  auto const gather_map = cudf::test::fixed_width_column_wrapper<int32_t>{1, 5, 3};
   auto const result     = cudf::gather(cudf::table_view{{structs}}, gather_map)->get_column(0);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.view(), expected);
 }
@@ -204,33 +204,35 @@ TYPED_TEST(TypedStructGatherTest, TestSlicedStructsColumnGatherWithNulls)
   auto constexpr XXX  = int32_t{0};  // null at parent
 
   auto const structs_original = [] {
-    auto child1 = fixed_width_column_wrapper<TypeParam, int32_t>{
+    auto child1 = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>{
       {null, XXX, 3, null, null, 6, XXX, null, null, 10}, nulls_at({0, 3, 4, 7, 8})};
-    auto child2 = strings_column_wrapper{{"One",
-                                          "" /*NULL at both parent and child*/,
-                                          "Three",
-                                          "" /*NULL*/,
-                                          "Five",
-                                          "" /*NULL*/,
-                                          "" /*NULL at parent*/,
-                                          "" /*NULL*/,
-                                          "Nine",
-                                          "" /*NULL*/},
-                                         nulls_at({1, 3, 5, 7, 9})};
-    return structs_column_wrapper{{child1, child2}, nulls_at({1, 6})};
+    auto child2 = cudf::test::strings_column_wrapper{{"One",
+                                                      "" /*NULL at both parent and child*/,
+                                                      "Three",
+                                                      "" /*NULL*/,
+                                                      "Five",
+                                                      "" /*NULL*/,
+                                                      "" /*NULL at parent*/,
+                                                      "" /*NULL*/,
+                                                      "Nine",
+                                                      "" /*NULL*/},
+                                                     nulls_at({1, 3, 5, 7, 9})};
+    return cudf::test::structs_column_wrapper{{child1, child2}, nulls_at({1, 6})};
   }();
 
   auto const expected = [] {
-    auto child1 = fixed_width_column_wrapper<TypeParam, int32_t>{{6, 10, null, XXX}, null_at(2)};
-    auto child2 = strings_column_wrapper{{
+    auto child1 =
+      cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>{{6, 10, null, XXX}, null_at(2)};
+    auto child2 =
+      cudf::test::strings_column_wrapper{{
                                            "" /*NULL*/, "" /*NULL*/, "Nine", "" /*NULL at parent*/
                                          },
                                          nulls_at({0, 1})};
-    return structs_column_wrapper{{child1, child2}, null_at(3)};
+    return cudf::test::structs_column_wrapper{{child1, child2}, null_at(3)};
   }();
 
   auto const structs    = cudf::slice(structs_original, {4, 10})[0];
-  auto const gather_map = fixed_width_column_wrapper<int32_t>{1, 5, 4, 2};
+  auto const gather_map = cudf::test::fixed_width_column_wrapper<int32_t>{1, 5, 4, 2};
   auto const result     = cudf::gather(cudf::table_view{{structs}}, gather_map)->get_column(0);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.view(), expected);
 }
@@ -269,7 +271,8 @@ TYPED_TEST(TypedStructGatherTest, TestNullifyOnNonNullInput)
       get_expected_column<TypeParam, int32_t>(ages, no_nulls(), no_nulls(), gather_map);
     auto is_human_member = get_expected_column<bool>(
       std::vector<bool>(is_human.begin(), is_human.end()), no_nulls(), no_nulls(), gather_map);
-    return structs_column_wrapper{{names_member, ages_member, is_human_member}, null_at(0)};
+    return cudf::test::structs_column_wrapper{{names_member, ages_member, is_human_member},
+                                              null_at(0)};
   }();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(output->view(), expected_output);
@@ -288,7 +291,7 @@ TYPED_TEST(TypedStructGatherTest, TestGatherStructOfLists)
   // Assemble struct column.
   auto const structs_column = [&] {
     auto lists_column = lists_column_exemplar();
-    return structs_column_wrapper{{lists_column}};
+    return cudf::test::structs_column_wrapper{{lists_column}};
   }();
 
   // Gather to new struct column.
@@ -327,7 +330,7 @@ TYPED_TEST(TypedStructGatherTest, TestGatherStructOfListsOfLists)
 
   auto const structs_column = [&] {
     auto lists_column = lists_column_exemplar();
-    return structs_column_wrapper{{lists_column}};
+    return cudf::test::structs_column_wrapper{{lists_column}};
   }();
 
   // Gather to new struct column.
@@ -358,8 +361,8 @@ TYPED_TEST(TypedStructGatherTest, TestGatherStructOfStructs)
 
   auto const struct_of_structs_column = [&] {
     auto numeric_column = numeric_column_exemplar();
-    auto structs_column = structs_column_wrapper{{numeric_column}};
-    return structs_column_wrapper{{structs_column}};
+    auto structs_column = cudf::test::structs_column_wrapper{{numeric_column}};
+    return cudf::test::structs_column_wrapper{{structs_column}};
   }();
 
   // Gather to new struct column.
@@ -437,8 +440,8 @@ TYPED_TEST(TypedStructGatherTest, TestGatherStructOfStructsWithValidity)
     // Every 3rd element is null.
     auto numeric_column = numeric_column_exemplar(nulls_at({0, 3, 6, 9, 12, 15}));
     // 12th element is null.
-    auto structs_column = structs_column_wrapper{{numeric_column}, nulls_at({11})};
-    return structs_column_wrapper{{structs_column}};
+    auto structs_column = cudf::test::structs_column_wrapper{{numeric_column}, nulls_at({11})};
+    return cudf::test::structs_column_wrapper{{structs_column}};
   }();
 
   // Gather to new struct column.
@@ -463,7 +466,7 @@ TYPED_TEST(TypedStructGatherTest, TestEmptyGather)
 {
   auto const struct_column = [&] {
     auto ages = numerics<TypeParam>{{5, 10, 15, 20, 25, 30}, null_at(4)};
-    return structs_column_wrapper{{ages}, null_at(5)};
+    return cudf::test::structs_column_wrapper{{ages}, null_at(5)};
   }();
 
   auto const empty_gather_map = gather_map_t{};
@@ -472,10 +475,8 @@ TYPED_TEST(TypedStructGatherTest, TestEmptyGather)
   // Expect empty struct column gathered.
   auto const expected_empty_column = [&] {
     auto expected_empty_numerics = numerics<TypeParam>{};
-    return structs_column_wrapper{{expected_empty_numerics}};
+    return cudf::test::structs_column_wrapper{{expected_empty_numerics}};
   }();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_empty_column, gathered_structs->view());
 }
-
-}  // namespace cudf::test

--- a/cpp/tests/copying/get_value_tests.cpp
+++ b/cpp/tests/copying/get_value_tests.cpp
@@ -926,6 +926,3 @@ TEST_F(StructGetValueTest, multi_level_nested)
   EXPECT_TRUE(typed_s->is_valid());
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(fields, typed_s->view());
 }
-
-//}  // namespace test
-//}  // namespace cudf

--- a/cpp/tests/copying/get_value_tests.cpp
+++ b/cpp/tests/copying/get_value_tests.cpp
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-#include <cudf/column/column_factories.hpp>
-#include <cudf/concatenate.hpp>
-#include <cudf/copying.hpp>
-#include <cudf/detail/iterator.cuh>
-#include <cudf/dictionary/dictionary_factories.hpp>
-#include <cudf/dictionary/update_keys.hpp>
-#include <cudf/scalar/scalar.hpp>
-#include <cudf/types.hpp>
-#include <cudf/utilities/type_dispatcher.hpp>
-
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
@@ -32,25 +22,31 @@
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/column/column_factories.hpp>
+#include <cudf/concatenate.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/dictionary/dictionary_factories.hpp>
+#include <cudf/dictionary/update_keys.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/types.hpp>
+
 #include <thrust/iterator/counting_iterator.h>
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
-
 template <typename T>
-struct FixedWidthGetValueTest : public BaseFixture {
+struct FixedWidthGetValueTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(FixedWidthGetValueTest, FixedWidthTypesWithoutFixedPoint);
+TYPED_TEST_SUITE(FixedWidthGetValueTest, cudf::test::FixedWidthTypesWithoutFixedPoint);
 
 TYPED_TEST(FixedWidthGetValueTest, BasicGet)
 {
-  fixed_width_column_wrapper<TypeParam, int32_t> col({9, 8, 7, 6});
-  auto s = get_element(col, 0);
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> col({9, 8, 7, 6});
+  auto s = cudf::get_element(col, 0);
 
-  using ScalarType = scalar_type_t<TypeParam>;
+  using ScalarType = cudf::scalar_type_t<TypeParam>;
   auto typed_s     = static_cast<ScalarType const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
@@ -59,10 +55,10 @@ TYPED_TEST(FixedWidthGetValueTest, BasicGet)
 
 TYPED_TEST(FixedWidthGetValueTest, GetFromNullable)
 {
-  fixed_width_column_wrapper<TypeParam, int32_t> col({9, 8, 7, 6}, {0, 1, 0, 1});
-  auto s = get_element(col, 1);
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> col({9, 8, 7, 6}, {0, 1, 0, 1});
+  auto s = cudf::get_element(col, 1);
 
-  using ScalarType = scalar_type_t<TypeParam>;
+  using ScalarType = cudf::scalar_type_t<TypeParam>;
   auto typed_s     = static_cast<ScalarType const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
@@ -71,30 +67,30 @@ TYPED_TEST(FixedWidthGetValueTest, GetFromNullable)
 
 TYPED_TEST(FixedWidthGetValueTest, GetNull)
 {
-  fixed_width_column_wrapper<TypeParam, int32_t> col({9, 8, 7, 6}, {0, 1, 0, 1});
-  auto s = get_element(col, 2);
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> col({9, 8, 7, 6}, {0, 1, 0, 1});
+  auto s = cudf::get_element(col, 2);
 
   EXPECT_FALSE(s->is_valid());
 }
 
 TYPED_TEST(FixedWidthGetValueTest, IndexOutOfBounds)
 {
-  fixed_width_column_wrapper<TypeParam, int32_t> col({9, 8, 7, 6}, {0, 1, 0, 1});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> col({9, 8, 7, 6}, {0, 1, 0, 1});
 
   // Test for out of bounds indexes in both directions.
-  EXPECT_THROW(get_element(col, -1), cudf::logic_error);
-  EXPECT_THROW(get_element(col, 4), cudf::logic_error);
+  EXPECT_THROW(cudf::get_element(col, -1), cudf::logic_error);
+  EXPECT_THROW(cudf::get_element(col, 4), cudf::logic_error);
 }
 
-struct StringGetValueTest : public BaseFixture {
+struct StringGetValueTest : public cudf::test::BaseFixture {
 };
 
 TEST_F(StringGetValueTest, BasicGet)
 {
-  strings_column_wrapper col{"this", "is", "a", "test"};
-  auto s = get_element(col, 3);
+  cudf::test::strings_column_wrapper col{"this", "is", "a", "test"};
+  auto s = cudf::get_element(col, 3);
 
-  auto typed_s = static_cast<string_scalar const*>(s.get());
+  auto typed_s = static_cast<cudf::string_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   EXPECT_EQ("test", typed_s->to_string());
@@ -102,10 +98,10 @@ TEST_F(StringGetValueTest, BasicGet)
 
 TEST_F(StringGetValueTest, GetEmpty)
 {
-  strings_column_wrapper col{"this", "is", "", "test"};
-  auto s = get_element(col, 2);
+  cudf::test::strings_column_wrapper col{"this", "is", "", "test"};
+  auto s = cudf::get_element(col, 2);
 
-  auto typed_s = static_cast<string_scalar const*>(s.get());
+  auto typed_s = static_cast<cudf::string_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   EXPECT_EQ("", typed_s->to_string());
@@ -113,10 +109,10 @@ TEST_F(StringGetValueTest, GetEmpty)
 
 TEST_F(StringGetValueTest, GetFromNullable)
 {
-  strings_column_wrapper col({"this", "is", "a", "test"}, {0, 1, 0, 1});
-  auto s = get_element(col, 1);
+  cudf::test::strings_column_wrapper col({"this", "is", "a", "test"}, {0, 1, 0, 1});
+  auto s = cudf::get_element(col, 1);
 
-  auto typed_s = static_cast<string_scalar const*>(s.get());
+  auto typed_s = static_cast<cudf::string_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   EXPECT_EQ("is", typed_s->to_string());
@@ -124,27 +120,27 @@ TEST_F(StringGetValueTest, GetFromNullable)
 
 TEST_F(StringGetValueTest, GetNull)
 {
-  strings_column_wrapper col({"this", "is", "a", "test"}, {0, 1, 0, 1});
-  auto s = get_element(col, 2);
+  cudf::test::strings_column_wrapper col({"this", "is", "a", "test"}, {0, 1, 0, 1});
+  auto s = cudf::get_element(col, 2);
 
   EXPECT_FALSE(s->is_valid());
 }
 
 template <typename T>
-struct DictionaryGetValueTest : public BaseFixture {
+struct DictionaryGetValueTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(DictionaryGetValueTest, FixedWidthTypesWithoutFixedPoint);
+TYPED_TEST_SUITE(DictionaryGetValueTest, cudf::test::FixedWidthTypesWithoutFixedPoint);
 
 TYPED_TEST(DictionaryGetValueTest, BasicGet)
 {
-  fixed_width_column_wrapper<TypeParam, int32_t> keys({6, 7, 8, 9});
-  fixed_width_column_wrapper<uint32_t> indices{0, 0, 1, 2, 1, 3, 3, 2};
-  auto col = make_dictionary_column(keys, indices);
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> keys({6, 7, 8, 9});
+  cudf::test::fixed_width_column_wrapper<uint32_t> indices{0, 0, 1, 2, 1, 3, 3, 2};
+  auto col = cudf::make_dictionary_column(keys, indices);
 
-  auto s = get_element(*col, 2);
+  auto s = cudf::get_element(*col, 2);
 
-  using ScalarType = scalar_type_t<TypeParam>;
+  using ScalarType = cudf::scalar_type_t<TypeParam>;
   auto typed_s     = static_cast<ScalarType const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
@@ -153,13 +149,14 @@ TYPED_TEST(DictionaryGetValueTest, BasicGet)
 
 TYPED_TEST(DictionaryGetValueTest, GetFromNullable)
 {
-  fixed_width_column_wrapper<TypeParam, int32_t> keys({6, 7, 8, 9});
-  fixed_width_column_wrapper<uint32_t> indices({0, 0, 1, 2, 1, 3, 3, 2}, {0, 1, 0, 1, 1, 1, 0, 0});
-  auto col = make_dictionary_column(keys, indices);
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> keys({6, 7, 8, 9});
+  cudf::test::fixed_width_column_wrapper<uint32_t> indices({0, 0, 1, 2, 1, 3, 3, 2},
+                                                           {0, 1, 0, 1, 1, 1, 0, 0});
+  auto col = cudf::make_dictionary_column(keys, indices);
 
-  auto s = get_element(*col, 3);
+  auto s = cudf::get_element(*col, 3);
 
-  using ScalarType = scalar_type_t<TypeParam>;
+  using ScalarType = cudf::scalar_type_t<TypeParam>;
   auto typed_s     = static_cast<ScalarType const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
@@ -168,11 +165,12 @@ TYPED_TEST(DictionaryGetValueTest, GetFromNullable)
 
 TYPED_TEST(DictionaryGetValueTest, GetNull)
 {
-  fixed_width_column_wrapper<TypeParam, int32_t> keys({6, 7, 8, 9});
-  fixed_width_column_wrapper<uint32_t> indices({0, 0, 1, 2, 1, 3, 3, 2}, {0, 1, 0, 1, 1, 1, 0, 0});
-  auto col = make_dictionary_column(keys, indices);
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> keys({6, 7, 8, 9});
+  cudf::test::fixed_width_column_wrapper<uint32_t> indices({0, 0, 1, 2, 1, 3, 3, 2},
+                                                           {0, 1, 0, 1, 1, 1, 0, 0});
+  auto col = cudf::make_dictionary_column(keys, indices);
 
-  auto s = get_element(*col, 2);
+  auto s = cudf::get_element(*col, 2);
 
   EXPECT_FALSE(s->is_valid());
 }
@@ -185,29 +183,29 @@ TYPED_TEST(DictionaryGetValueTest, GetNull)
  */
 
 template <typename T>
-struct ListGetFixedWidthValueTest : public BaseFixture {
+struct ListGetFixedWidthValueTest : public cudf::test::BaseFixture {
   auto odds_valid()
   {
     return cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
   }
-  auto nth_valid(size_type x)
+  auto nth_valid(cudf::size_type x)
   {
     return cudf::detail::make_counting_transform_iterator(0, [=](auto i) { return x == i; });
   }
 };
 
-TYPED_TEST_SUITE(ListGetFixedWidthValueTest, FixedWidthTypes);
+TYPED_TEST_SUITE(ListGetFixedWidthValueTest, cudf::test::FixedWidthTypes);
 
 TYPED_TEST(ListGetFixedWidthValueTest, NonNestedGetNonNullNonEmpty)
 {
   using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
 
   LCW col{LCW({1, 2, 34}, this->odds_valid()), LCW{}, LCW{1}, LCW{}};
-  fixed_width_column_wrapper<TypeParam> expected_data({1, 2, 34}, this->odds_valid());
-  size_type index = 0;
+  cudf::test::fixed_width_column_wrapper<TypeParam> expected_data({1, 2, 34}, this->odds_valid());
+  cudf::size_type index = 0;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_data, typed_s->view());
@@ -218,11 +216,11 @@ TYPED_TEST(ListGetFixedWidthValueTest, NonNestedGetNonNullEmpty)
   using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
 
   LCW col{LCW{1, 2, 34}, LCW{}, LCW{1}, LCW{}};
-  fixed_width_column_wrapper<TypeParam> expected_data{};
-  size_type index = 1;
+  cudf::test::fixed_width_column_wrapper<TypeParam> expected_data{};
+  cudf::size_type index = 1;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_data, typed_s->view());
@@ -234,10 +232,10 @@ TYPED_TEST(ListGetFixedWidthValueTest, NonNestedGetNull)
   using FCW = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
   LCW col({LCW{1, 2, 34}, LCW{}, LCW{1}, LCW{}}, this->odds_valid());
-  size_type index = 2;
+  cudf::size_type index = 2;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_FALSE(s->is_valid());
   // Test preserve column hierarchy
@@ -258,10 +256,10 @@ TYPED_TEST(ListGetFixedWidthValueTest, NestedGetNonNullNonEmpty)
   // clang-format on
   LCW expected_data{LCW{42}, LCW{10}};
 
-  size_type index = 3;
+  cudf::size_type index = 3;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_data, typed_s->view());
@@ -271,7 +269,7 @@ TYPED_TEST(ListGetFixedWidthValueTest, NestedGetNonNullNonEmptyPreserveNull)
 {
   using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
 
-  std::vector<valid_type> valid{0, 1, 1};
+  std::vector<cudf::valid_type> valid{0, 1, 1};
   // clang-format off
   LCW col{
     LCW{LCW{1, 2}, LCW{34}},
@@ -281,10 +279,10 @@ TYPED_TEST(ListGetFixedWidthValueTest, NestedGetNonNullNonEmptyPreserveNull)
   };
   // clang-format on
   LCW expected_data({LCW{42}, LCW{10}, LCW({1, 3, 2}, this->nth_valid(1))}, valid.begin());
-  size_type index = 3;
+  cudf::size_type index = 3;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_data, typed_s->view());
@@ -303,10 +301,10 @@ TYPED_TEST(ListGetFixedWidthValueTest, NestedGetNonNullEmpty)
   };
   // clang-format on
   LCW expected_data{};
-  size_type index = 1;
+  cudf::size_type index = 1;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_data, typed_s->view());
@@ -316,9 +314,9 @@ TYPED_TEST(ListGetFixedWidthValueTest, NestedGetNull)
 {
   using LCW      = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
   using FCW      = cudf::test::fixed_width_column_wrapper<TypeParam>;
-  using offset_t = cudf::test::fixed_width_column_wrapper<offset_type>;
+  using offset_t = cudf::test::fixed_width_column_wrapper<cudf::offset_type>;
 
-  std::vector<valid_type> valid{1, 0, 1, 0};
+  std::vector<cudf::valid_type> valid{1, 0, 1, 0};
   // clang-format off
   LCW col(
     {
@@ -328,25 +326,25 @@ TYPED_TEST(ListGetFixedWidthValueTest, NestedGetNull)
       LCW{LCW{42}, LCW{10}}
     }, valid.begin());
   // clang-format on
-  size_type index = 1;
+  cudf::size_type index = 1;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   auto expected_data =
-    make_lists_column(0, offset_t{}.release(), FCW{}.release(), 0, rmm::device_buffer{});
+    cudf::make_lists_column(0, offset_t{}.release(), FCW{}.release(), 0, rmm::device_buffer{});
 
   EXPECT_FALSE(s->is_valid());
   // Test preserve column hierarchy
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(typed_s->view(), *expected_data);
 }
 
-struct ListGetStringValueTest : public BaseFixture {
+struct ListGetStringValueTest : public cudf::test::BaseFixture {
   auto odds_valid()
   {
     return cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
   }
-  auto nth_valid(size_type x)
+  auto nth_valid(cudf::size_type x)
   {
     return cudf::detail::make_counting_transform_iterator(0, [=](auto i) { return x == i; });
   }
@@ -354,14 +352,14 @@ struct ListGetStringValueTest : public BaseFixture {
 
 TEST_F(ListGetStringValueTest, NonNestedGetNonNullNonEmpty)
 {
-  using LCW = cudf::test::lists_column_wrapper<string_view>;
+  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
 
   LCW col{LCW({"aaa", "Héllo"}, this->odds_valid()), LCW{}, LCW{""}, LCW{"42"}};
-  strings_column_wrapper expected_data({"aaa", "Héllo"}, this->odds_valid());
-  size_type index = 0;
+  cudf::test::strings_column_wrapper expected_data({"aaa", "Héllo"}, this->odds_valid());
+  cudf::size_type index = 0;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_data, typed_s->view());
@@ -369,14 +367,14 @@ TEST_F(ListGetStringValueTest, NonNestedGetNonNullNonEmpty)
 
 TEST_F(ListGetStringValueTest, NonNestedGetNonNullEmpty)
 {
-  using LCW = cudf::test::lists_column_wrapper<string_view>;
+  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
 
   LCW col{LCW{"aaa", "Héllo"}, LCW{}, LCW{""}, LCW{"42"}};
-  strings_column_wrapper expected_data{};
-  size_type index = 1;
+  cudf::test::strings_column_wrapper expected_data{};
+  cudf::size_type index = 1;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_data, typed_s->view());
@@ -384,15 +382,15 @@ TEST_F(ListGetStringValueTest, NonNestedGetNonNullEmpty)
 
 TEST_F(ListGetStringValueTest, NonNestedGetNull)
 {
-  using LCW      = cudf::test::lists_column_wrapper<string_view>;
-  using StringCW = strings_column_wrapper;
+  using LCW      = cudf::test::lists_column_wrapper<cudf::string_view>;
+  using StringCW = cudf::test::strings_column_wrapper;
 
-  std::vector<valid_type> valid{1, 0, 0, 1};
+  std::vector<cudf::valid_type> valid{1, 0, 0, 1};
   LCW col({LCW{"aaa", "Héllo"}, LCW{}, LCW{""}, LCW{"42"}}, valid.begin());
-  size_type index = 2;
+  cudf::size_type index = 2;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_FALSE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(typed_s->view(), StringCW{});
@@ -400,7 +398,7 @@ TEST_F(ListGetStringValueTest, NonNestedGetNull)
 
 TEST_F(ListGetStringValueTest, NestedGetNonNullNonEmpty)
 {
-  using LCW = cudf::test::lists_column_wrapper<string_view>;
+  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
 
   // clang-format off
   LCW col{
@@ -411,10 +409,10 @@ TEST_F(ListGetStringValueTest, NestedGetNonNullNonEmpty)
   };
   // clang-format on
   LCW expected_data{LCW{""}, LCW({"string", "str2", "xyz"}, this->nth_valid(0))};
-  size_type index = 2;
+  cudf::size_type index = 2;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_data, typed_s->view());
@@ -422,9 +420,9 @@ TEST_F(ListGetStringValueTest, NestedGetNonNullNonEmpty)
 
 TEST_F(ListGetStringValueTest, NestedGetNonNullNonEmptyPreserveNull)
 {
-  using LCW = cudf::test::lists_column_wrapper<string_view>;
+  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
 
-  std::vector<valid_type> valid{0, 1, 1};
+  std::vector<cudf::valid_type> valid{0, 1, 1};
   // clang-format off
   LCW col{
     LCW{LCW{"aaa", "Héllo"}},
@@ -435,10 +433,10 @@ TEST_F(ListGetStringValueTest, NestedGetNonNullNonEmptyPreserveNull)
   // clang-format on
   LCW expected_data({LCW{""}, LCW{"cc"}, LCW({"string", "str2", "xyz"}, this->nth_valid(0))},
                     valid.begin());
-  size_type index = 2;
+  cudf::size_type index = 2;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_data, typed_s->view());
@@ -446,7 +444,7 @@ TEST_F(ListGetStringValueTest, NestedGetNonNullNonEmptyPreserveNull)
 
 TEST_F(ListGetStringValueTest, NestedGetNonNullEmpty)
 {
-  using LCW = cudf::test::lists_column_wrapper<string_view>;
+  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
 
   // clang-format off
   LCW col{
@@ -457,10 +455,10 @@ TEST_F(ListGetStringValueTest, NestedGetNonNullEmpty)
   };
   // clang-format on
   LCW expected_data{};
-  size_type index = 3;
+  cudf::size_type index = 3;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   // Relax to equivalent. `expected_data` leaf string column does not
@@ -470,11 +468,11 @@ TEST_F(ListGetStringValueTest, NestedGetNonNullEmpty)
 
 TEST_F(ListGetStringValueTest, NestedGetNull)
 {
-  using LCW      = cudf::test::lists_column_wrapper<string_view>;
-  using offset_t = cudf::test::fixed_width_column_wrapper<offset_type>;
+  using LCW      = cudf::test::lists_column_wrapper<cudf::string_view>;
+  using offset_t = cudf::test::fixed_width_column_wrapper<cudf::offset_type>;
   using StringCW = cudf::test::strings_column_wrapper;
 
-  std::vector<valid_type> valid{0, 0, 1, 1};
+  std::vector<cudf::valid_type> valid{0, 0, 1, 1};
   // clang-format off
   LCW col(
     {
@@ -484,13 +482,13 @@ TEST_F(ListGetStringValueTest, NestedGetNull)
       LCW{}
     }, valid.begin());
   // clang-format on
-  size_type index = 0;
+  cudf::size_type index = 0;
 
-  auto s       = get_element(col, index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(col, index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   auto expected_data =
-    make_lists_column(0, offset_t{}.release(), StringCW{}.release(), 0, rmm::device_buffer{});
+    cudf::make_lists_column(0, offset_t{}.release(), StringCW{}.release(), 0, rmm::device_buffer{});
 
   EXPECT_FALSE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_data, typed_s->view());
@@ -500,8 +498,8 @@ TEST_F(ListGetStringValueTest, NestedGetNull)
  * @brief Some shared helper functions used by lists of structs test.
  */
 template <typename T>
-struct ListGetStructValueTest : public BaseFixture {
-  using SCW        = structs_column_wrapper;
+struct ListGetStructValueTest : public cudf::test::BaseFixture {
+  using SCW        = cudf::test::structs_column_wrapper;
   using LCWinner_t = cudf::test::lists_column_wrapper<T, int32_t>;
 
   /**
@@ -512,19 +510,20 @@ struct ListGetStructValueTest : public BaseFixture {
    * calls `cudf::set_null_mask` for each row.
    */
   std::unique_ptr<cudf::column> make_test_lists_column(
-    size_type num_lists,
-    fixed_width_column_wrapper<offset_type> offsets,
+    cudf::size_type num_lists,
+    cudf::test::fixed_width_column_wrapper<cudf::offset_type> offsets,
     std::unique_ptr<cudf::column> child,
-    std::initializer_list<valid_type> null_mask)
+    std::initializer_list<cudf::valid_type> null_mask)
   {
-    size_type null_count = num_lists - std::accumulate(null_mask.begin(), null_mask.end(), 0);
-    auto d_null_mask     = cudf::create_null_mask(
+    cudf::size_type null_count = num_lists - std::accumulate(null_mask.begin(), null_mask.end(), 0);
+    auto d_null_mask           = cudf::create_null_mask(
       num_lists, null_count == 0 ? cudf::mask_state::UNALLOCATED : cudf::mask_state::ALL_NULL);
     if (null_count > 0) {
       std::for_each(
         thrust::make_counting_iterator(0), thrust::make_counting_iterator(num_lists), [&](auto i) {
           if (*(null_mask.begin() + i)) {
-            set_null_mask(static_cast<bitmask_type*>(d_null_mask.data()), i, i + 1, true);
+            cudf::set_null_mask(
+              static_cast<cudf::bitmask_type*>(d_null_mask.data()), i, i + 1, true);
           }
         });
     }
@@ -536,9 +535,9 @@ struct ListGetStructValueTest : public BaseFixture {
    * @brief Create a structs column that contains 3 fields: int, string, List<int>
    */
   template <typename MaskIterator>
-  SCW make_test_structs_column(fixed_width_column_wrapper<T> field1,
-                               strings_column_wrapper field2,
-                               lists_column_wrapper<T, int32_t> field3,
+  SCW make_test_structs_column(cudf::test::fixed_width_column_wrapper<T> field1,
+                               cudf::test::strings_column_wrapper field2,
+                               cudf::test::lists_column_wrapper<T, int32_t> field3,
                                MaskIterator mask)
   {
     return SCW{{field1, field2, field3}, mask};
@@ -554,9 +553,10 @@ struct ListGetStructValueTest : public BaseFixture {
    */
   std::unique_ptr<cudf::column> concat(std::initializer_list<SCW> rows)
   {
-    std::vector<column_view> views;
-    std::transform(
-      rows.begin(), rows.end(), std::back_inserter(views), [](auto& r) { return column_view(r); });
+    std::vector<cudf::column_view> views;
+    std::transform(rows.begin(), rows.end(), std::back_inserter(views), [](auto& r) {
+      return cudf::column_view(r);
+    });
     return cudf::concatenate(views);
   }
 
@@ -567,7 +567,7 @@ struct ListGetStructValueTest : public BaseFixture {
   {
     // {int: 1, string: NULL, list: NULL}
     return this->make_test_structs_column({{1}, {1}},
-                                          strings_column_wrapper({"aa"}, {false}),
+                                          cudf::test::strings_column_wrapper({"aa"}, {false}),
                                           LCWinner_t({{}}, all_nulls()),
                                           no_nulls());
   }
@@ -588,7 +588,7 @@ struct ListGetStructValueTest : public BaseFixture {
   {
     // {int: 3, string: "xyz", list: [3, 8, 4]}
     return this->make_test_structs_column({{3}, {1}},
-                                          strings_column_wrapper({"xyz"}, {true}),
+                                          cudf::test::strings_column_wrapper({"xyz"}, {true}),
                                           LCWinner_t({{3, 8, 4}}, no_nulls()),
                                           no_nulls());
   }
@@ -606,20 +606,20 @@ struct ListGetStructValueTest : public BaseFixture {
   }
 };
 
-TYPED_TEST_SUITE(ListGetStructValueTest, FixedWidthTypes);
+TYPED_TEST_SUITE(ListGetStructValueTest, cudf::test::FixedWidthTypes);
 
 TYPED_TEST(ListGetStructValueTest, NonNestedGetNonNullNonEmpty)
 {
   // 2-rows
   // [{1, NULL, NULL}, NULL]
-  // [{3, "xyz", [3, 8, 4]}] <- get_element(1)
+  // [{3, "xyz", [3, 8, 4]}] <- cudf::get_element(1)
 
-  auto list_column   = this->make_test_lists_column(2, {0, 2, 3}, this->leaf_data(), {1, 1});
-  size_type index    = 1;
-  auto expected_data = this->row2();
+  auto list_column      = this->make_test_lists_column(2, {0, 2, 3}, this->leaf_data(), {1, 1});
+  cudf::size_type index = 1;
+  auto expected_data    = this->row2();
 
-  auto s       = get_element(list_column->view(), index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(list_column->view(), index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   // Relax to equivalent. The nested list column in struct allocates `null_mask`.
@@ -629,15 +629,15 @@ TYPED_TEST(ListGetStructValueTest, NonNestedGetNonNullNonEmpty)
 TYPED_TEST(ListGetStructValueTest, NonNestedGetNonNullNonEmpty2)
 {
   // 2-rows
-  // [{1, NULL, NULL}, NULL] <- get_element(0)
+  // [{1, NULL, NULL}, NULL] <- cudf::get_element(0)
   // [{3, "xyz", [3, 8, 4]}]
 
-  auto list_column   = this->make_test_lists_column(2, {0, 2, 3}, this->leaf_data(), {1, 1});
-  size_type index    = 0;
-  auto expected_data = this->concat({this->row0(), this->row1()});
+  auto list_column      = this->make_test_lists_column(2, {0, 2, 3}, this->leaf_data(), {1, 1});
+  cudf::size_type index = 0;
+  auto expected_data    = this->concat({this->row0(), this->row1()});
 
-  auto s       = get_element(list_column->view(), index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(list_column->view(), index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_data, typed_s->view());
@@ -648,16 +648,16 @@ TYPED_TEST(ListGetStructValueTest, NonNestedGetNonNullEmpty)
   // 3-rows
   // [{1, NULL, NULL}, NULL]
   // [{3, "xyz", [3, 8, 4]}]
-  // []                      <- get_element(2)
+  // []                      <- cudf::get_element(2)
 
   auto list_column = this->make_test_lists_column(3, {0, 2, 3, 3}, this->leaf_data(), {1, 1, 1});
-  size_type index  = 2;
+  cudf::size_type index = 2;
   // For well-formed list column, an empty list still holds the complete structure of
   // a 0-length structs column
   auto expected_data = this->zero_length_struct();
 
-  auto s       = get_element(list_column->view(), index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(list_column->view(), index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   // Relax to equivalent. The nested list column in struct allocates `null_mask`.
@@ -667,16 +667,16 @@ TYPED_TEST(ListGetStructValueTest, NonNestedGetNonNullEmpty)
 TYPED_TEST(ListGetStructValueTest, NonNestedGetNull)
 {
   // 2-rows
-  // NULL                    <- get_element(0)
+  // NULL                    <- cudf::get_element(0)
   // [{3, "xyz", [3, 8, 4]}]
 
-  using valid_t = std::vector<valid_type>;
+  using valid_t = std::vector<cudf::valid_type>;
 
-  auto list_column = this->make_test_lists_column(2, {0, 2, 3}, this->leaf_data(), {0, 1});
-  size_type index  = 0;
+  auto list_column      = this->make_test_lists_column(2, {0, 2, 3}, this->leaf_data(), {0, 1});
+  cudf::size_type index = 0;
 
-  auto s       = get_element(list_column->view(), index);
-  auto typed_s = static_cast<list_scalar const*>(s.get());
+  auto s       = cudf::get_element(list_column->view(), index);
+  auto typed_s = static_cast<cudf::list_scalar const*>(s.get());
 
   auto expected_data = this->make_test_structs_column({}, {}, {}, valid_t{}.begin());
 
@@ -687,7 +687,7 @@ TYPED_TEST(ListGetStructValueTest, NonNestedGetNull)
 TYPED_TEST(ListGetStructValueTest, NestedGetNonNullNonEmpty)
 {
   // 2-rows
-  // [[{1, NULL, NULL}, NULL], [{3, "xyz", [3, 8, 4]}]] <- get_element(0)
+  // [[{1, NULL, NULL}, NULL], [{3, "xyz", [3, 8, 4]}]] <- cudf::get_element(0)
   // []
 
   auto list_column   = this->make_test_lists_column(2, {0, 2, 3}, this->leaf_data(), {1, 1});
@@ -696,9 +696,9 @@ TYPED_TEST(ListGetStructValueTest, NestedGetNonNullNonEmpty)
   auto list_column_nested =
     this->make_test_lists_column(2, {0, 2, 2}, std::move(list_column), {1, 1});
 
-  size_type index = 0;
-  auto s          = get_element(list_column_nested->view(), index);
-  auto typed_s    = static_cast<list_scalar const*>(s.get());
+  cudf::size_type index = 0;
+  auto s                = cudf::get_element(list_column_nested->view(), index);
+  auto typed_s          = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_data, typed_s->view());
@@ -707,7 +707,7 @@ TYPED_TEST(ListGetStructValueTest, NestedGetNonNullNonEmpty)
 TYPED_TEST(ListGetStructValueTest, NestedGetNonNullNonEmpty2)
 {
   // 2-rows
-  // [[{1, NULL, NULL}, NULL]] <- get_element(0)
+  // [[{1, NULL, NULL}, NULL]] <- cudf::get_element(0)
   // [[{3, "xyz", [3, 8, 4]}]]
 
   auto list_column = this->make_test_lists_column(2, {0, 2, 3}, this->leaf_data(), {1, 1});
@@ -717,9 +717,9 @@ TYPED_TEST(ListGetStructValueTest, NestedGetNonNullNonEmpty2)
   auto expected_data =
     this->make_test_lists_column(1, {0, 2}, this->concat({this->row0(), this->row1()}), {1});
 
-  size_type index = 0;
-  auto s          = get_element(list_column_nested->view(), index);
-  auto typed_s    = static_cast<list_scalar const*>(s.get());
+  cudf::size_type index = 0;
+  auto s                = cudf::get_element(list_column_nested->view(), index);
+  auto typed_s          = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_data, typed_s->view());
@@ -729,7 +729,7 @@ TYPED_TEST(ListGetStructValueTest, NestedGetNonNullNonEmpty3)
 {
   // 2-rows
   // [[{1, NULL, NULL}, NULL]]
-  // [[{3, "xyz", [3, 8, 4]}]] <- get_element(1)
+  // [[{3, "xyz", [3, 8, 4]}]] <- cudf::get_element(1)
 
   auto list_column = this->make_test_lists_column(2, {0, 2, 3}, this->leaf_data(), {1, 1});
   auto list_column_nested =
@@ -737,9 +737,9 @@ TYPED_TEST(ListGetStructValueTest, NestedGetNonNullNonEmpty3)
 
   auto expected_data = this->make_test_lists_column(1, {0, 1}, this->row2().release(), {1});
 
-  size_type index = 1;
-  auto s          = get_element(list_column_nested->view(), index);
-  auto typed_s    = static_cast<list_scalar const*>(s.get());
+  cudf::size_type index = 1;
+  auto s                = cudf::get_element(list_column_nested->view(), index);
+  auto typed_s          = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   // Relax to equivalent. For `get_element`, the nested list column in struct
@@ -751,7 +751,7 @@ TYPED_TEST(ListGetStructValueTest, NestedGetNonNullEmpty)
 {
   // 3-rows
   // [[{1, NULL, NULL}, NULL]]
-  // []                        <- get_element(1)
+  // []                        <- cudf::get_element(1)
   // [[{3, "xyz", [3, 8, 4]}]]
 
   auto list_column = this->make_test_lists_column(2, {0, 2, 3}, this->leaf_data(), {1, 1});
@@ -761,9 +761,9 @@ TYPED_TEST(ListGetStructValueTest, NestedGetNonNullEmpty)
   auto expected_data =
     this->make_test_lists_column(0, {0}, this->zero_length_struct().release(), {1});
 
-  size_type index = 1;
-  auto s          = get_element(list_column_nested->view(), index);
-  auto typed_s    = static_cast<list_scalar const*>(s.get());
+  cudf::size_type index = 1;
+  auto s                = cudf::get_element(list_column_nested->view(), index);
+  auto typed_s          = static_cast<cudf::list_scalar const*>(s.get());
 
   EXPECT_TRUE(s->is_valid());
   // Relax to equivalent. The sliced version still has the array for fields
@@ -776,58 +776,58 @@ TYPED_TEST(ListGetStructValueTest, NestedGetNull)
   // 3-rows
   // [[{1, NULL, NULL}, NULL]]
   // []
-  // NULL                      <- get_element(2)
+  // NULL                      <- cudf::get_element(2)
 
-  using valid_t  = std::vector<valid_type>;
-  using offset_t = cudf::test::fixed_width_column_wrapper<offset_type>;
+  using valid_t  = std::vector<cudf::valid_type>;
+  using offset_t = cudf::test::fixed_width_column_wrapper<cudf::offset_type>;
 
   auto list_column = this->make_test_lists_column(2, {0, 2, 3}, this->leaf_data(), {1, 1});
   auto list_column_nested =
     this->make_test_lists_column(3, {0, 1, 1, 2}, std::move(list_column), {1, 1, 0});
 
-  size_type index = 2;
-  auto s          = get_element(list_column_nested->view(), index);
-  auto typed_s    = static_cast<list_scalar const*>(s.get());
+  cudf::size_type index = 2;
+  auto s                = cudf::get_element(list_column_nested->view(), index);
+  auto typed_s          = static_cast<cudf::list_scalar const*>(s.get());
 
   auto nested = this->make_test_structs_column({}, {}, {}, valid_t{}.begin());
   auto expected_data =
-    make_lists_column(0, offset_t{}.release(), nested.release(), 0, rmm::device_buffer{});
+    cudf::make_lists_column(0, offset_t{}.release(), nested.release(), 0, rmm::device_buffer{});
 
   EXPECT_FALSE(s->is_valid());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_data, typed_s->view());
 }
 
-struct StructGetValueTest : public BaseFixture {
+struct StructGetValueTest : public cudf::test::BaseFixture {
 };
 template <typename T>
-struct StructGetValueTestTyped : public BaseFixture {
+struct StructGetValueTestTyped : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(StructGetValueTestTyped, FixedWidthTypes);
+TYPED_TEST_SUITE(StructGetValueTestTyped, cudf::test::FixedWidthTypes);
 
 TYPED_TEST(StructGetValueTestTyped, mixed_types_valid)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
 
   // col fields
-  fixed_width_column_wrapper<TypeParam> f1{1, 2, 3};
-  strings_column_wrapper f2{"aa", "bbb", "c"};
-  dictionary_column_wrapper<TypeParam, uint32_t> f3{42, 42, 24};
+  cudf::test::fixed_width_column_wrapper<TypeParam> f1{1, 2, 3};
+  cudf::test::strings_column_wrapper f2{"aa", "bbb", "c"};
+  cudf::test::dictionary_column_wrapper<TypeParam, uint32_t> f3{42, 42, 24};
   LCW f4{LCW{8, 8, 8}, LCW{9, 9}, LCW{10}};
 
-  structs_column_wrapper col{f1, f2, f3, f4};
+  cudf::test::structs_column_wrapper col{f1, f2, f3, f4};
 
-  size_type index = 2;
-  auto s          = get_element(col, index);
-  auto typed_s    = static_cast<struct_scalar const*>(s.get());
+  cudf::size_type index = 2;
+  auto s                = cudf::get_element(col, index);
+  auto typed_s          = static_cast<cudf::struct_scalar const*>(s.get());
 
   // expect fields
-  fixed_width_column_wrapper<TypeParam> ef1{3};
-  strings_column_wrapper ef2{"c"};
-  dictionary_column_wrapper<int32_t, TypeParam> ef3{24};
+  cudf::test::fixed_width_column_wrapper<TypeParam> ef1{3};
+  cudf::test::strings_column_wrapper ef2{"c"};
+  cudf::test::dictionary_column_wrapper<int32_t, TypeParam> ef3{24};
   LCW ef4{LCW{10}};
 
-  table_view expect_data{{ef1, ef2, ef3, ef4}};
+  cudf::table_view expect_data{{ef1, ef2, ef3, ef4}};
 
   EXPECT_TRUE(typed_s->is_valid());
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expect_data, typed_s->view());
@@ -835,34 +835,34 @@ TYPED_TEST(StructGetValueTestTyped, mixed_types_valid)
 
 TYPED_TEST(StructGetValueTestTyped, mixed_types_valid_with_nulls)
 {
-  using LCW             = lists_column_wrapper<TypeParam, int32_t>;
-  using validity_mask_t = std::vector<valid_type>;
+  using LCW             = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using validity_mask_t = std::vector<cudf::valid_type>;
 
   // col fields
-  fixed_width_column_wrapper<TypeParam> f1({1, 2, 3}, {true, false, true});
-  strings_column_wrapper f2({"aa", "bbb", "c"}, {false, false, true});
-  dictionary_column_wrapper<TypeParam, uint32_t> f3({42, 42, 24},
-                                                    validity_mask_t{true, true, true}.begin());
+  cudf::test::fixed_width_column_wrapper<TypeParam> f1({1, 2, 3}, {true, false, true});
+  cudf::test::strings_column_wrapper f2({"aa", "bbb", "c"}, {false, false, true});
+  cudf::test::dictionary_column_wrapper<TypeParam, uint32_t> f3(
+    {42, 42, 24}, validity_mask_t{true, true, true}.begin());
   LCW f4({LCW{8, 8, 8}, LCW{9, 9}, LCW{10}}, validity_mask_t{false, false, false}.begin());
 
-  structs_column_wrapper col{f1, f2, f3, f4};
+  cudf::test::structs_column_wrapper col{f1, f2, f3, f4};
 
-  size_type index = 1;
-  auto s          = get_element(col, index);
-  auto typed_s    = static_cast<struct_scalar const*>(s.get());
+  cudf::size_type index = 1;
+  auto s                = cudf::get_element(col, index);
+  auto typed_s          = static_cast<cudf::struct_scalar const*>(s.get());
 
   // expect fields
-  fixed_width_column_wrapper<TypeParam> ef1({-1}, {false});
-  strings_column_wrapper ef2({""}, {false});
+  cudf::test::fixed_width_column_wrapper<TypeParam> ef1({-1}, {false});
+  cudf::test::strings_column_wrapper ef2({""}, {false});
 
-  dictionary_column_wrapper<TypeParam, uint32_t> x({42}, {true});
-  dictionary_column_view dict_col(x);
-  fixed_width_column_wrapper<TypeParam> new_key{24};
+  cudf::test::dictionary_column_wrapper<TypeParam, uint32_t> x({42}, {true});
+  cudf::dictionary_column_view dict_col(x);
+  cudf::test::fixed_width_column_wrapper<TypeParam> new_key{24};
   auto ef3 = cudf::dictionary::add_keys(dict_col, new_key);
 
   LCW ef4({LCW{10}}, validity_mask_t{false}.begin());
 
-  table_view expect_data{{ef1, ef2, *ef3, ef4}};
+  cudf::table_view expect_data{{ef1, ef2, *ef3, ef4}};
 
   EXPECT_TRUE(typed_s->is_valid());
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expect_data, typed_s->view());
@@ -870,60 +870,62 @@ TYPED_TEST(StructGetValueTestTyped, mixed_types_valid_with_nulls)
 
 TYPED_TEST(StructGetValueTestTyped, mixed_types_invalid)
 {
-  using LCW             = lists_column_wrapper<TypeParam, int32_t>;
-  using validity_mask_t = std::vector<valid_type>;
+  using LCW             = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using validity_mask_t = std::vector<cudf::valid_type>;
 
   // col fields
-  fixed_width_column_wrapper<TypeParam> f1{1, 2, 3};
-  strings_column_wrapper f2{"aa", "bbb", "c"};
-  dictionary_column_wrapper<TypeParam, uint32_t> f3{42, 42, 24};
+  cudf::test::fixed_width_column_wrapper<TypeParam> f1{1, 2, 3};
+  cudf::test::strings_column_wrapper f2{"aa", "bbb", "c"};
+  cudf::test::dictionary_column_wrapper<TypeParam, uint32_t> f3{42, 42, 24};
   LCW f4{LCW{8, 8, 8}, LCW{9, 9}, LCW{10}};
 
-  structs_column_wrapper col({f1, f2, f3, f4}, validity_mask_t{false, true, true}.begin());
+  cudf::test::structs_column_wrapper col({f1, f2, f3, f4},
+                                         validity_mask_t{false, true, true}.begin());
 
-  size_type index = 0;
-  auto s          = get_element(col, index);
-  auto typed_s    = static_cast<struct_scalar const*>(s.get());
+  cudf::size_type index = 0;
+  auto s                = cudf::get_element(col, index);
+  auto typed_s          = static_cast<cudf::struct_scalar const*>(s.get());
 
   EXPECT_FALSE(typed_s->is_valid());
 
   // expect to preserve types along column hierarchy.
-  EXPECT_EQ(typed_s->view().column(0).type().id(), type_to_id<TypeParam>());
-  EXPECT_EQ(typed_s->view().column(1).type().id(), type_id::STRING);
-  EXPECT_EQ(typed_s->view().column(2).type().id(), type_id::DICTIONARY32);
-  EXPECT_EQ(typed_s->view().column(2).child(1).type().id(), type_to_id<TypeParam>());
-  EXPECT_EQ(typed_s->view().column(3).type().id(), type_id::LIST);
-  EXPECT_EQ(typed_s->view().column(3).child(1).type().id(), type_to_id<TypeParam>());
+  EXPECT_EQ(typed_s->view().column(0).type().id(), cudf::type_to_id<TypeParam>());
+  EXPECT_EQ(typed_s->view().column(1).type().id(), cudf::type_id::STRING);
+  EXPECT_EQ(typed_s->view().column(2).type().id(), cudf::type_id::DICTIONARY32);
+  EXPECT_EQ(typed_s->view().column(2).child(1).type().id(), cudf::type_to_id<TypeParam>());
+  EXPECT_EQ(typed_s->view().column(3).type().id(), cudf::type_id::LIST);
+  EXPECT_EQ(typed_s->view().column(3).child(1).type().id(), cudf::type_to_id<TypeParam>());
 }
 
 TEST_F(StructGetValueTest, multi_level_nested)
 {
-  using LCW             = lists_column_wrapper<int32_t, int32_t>;
-  using validity_mask_t = std::vector<valid_type>;
+  using LCW             = cudf::test::lists_column_wrapper<int32_t, int32_t>;
+  using validity_mask_t = std::vector<cudf::valid_type>;
 
   // col fields
   LCW l3({LCW{1, 1, 1}, LCW{2, 2}, LCW{3}}, validity_mask_t{false, true, true}.begin());
-  structs_column_wrapper l2{l3};
-  auto l1 = make_lists_column(1,
-                              fixed_width_column_wrapper<offset_type>{0, 3}.release(),
-                              l2.release(),
-                              0,
-                              create_null_mask(1, mask_state::UNALLOCATED));
-  std::vector<std::unique_ptr<column>> l0_fields;
+  cudf::test::structs_column_wrapper l2{l3};
+  auto l1 = cudf::make_lists_column(
+    1,
+    cudf::test::fixed_width_column_wrapper<cudf::offset_type>{0, 3}.release(),
+    l2.release(),
+    0,
+    cudf::create_null_mask(1, cudf::mask_state::UNALLOCATED));
+  std::vector<std::unique_ptr<cudf::column>> l0_fields;
   l0_fields.emplace_back(std::move(l1));
-  structs_column_wrapper l0(std::move(l0_fields));
+  cudf::test::structs_column_wrapper l0(std::move(l0_fields));
 
-  size_type index = 0;
-  auto s          = get_element(l0, index);
-  auto typed_s    = static_cast<struct_scalar const*>(s.get());
+  cudf::size_type index = 0;
+  auto s                = cudf::get_element(l0, index);
+  auto typed_s          = static_cast<cudf::struct_scalar const*>(s.get());
 
   // Expect fields
-  column_view cv = column_view(l0);
-  table_view fields(std::vector<column_view>(cv.child_begin(), cv.child_end()));
+  cudf::column_view cv = cudf::column_view(l0);
+  cudf::table_view fields(std::vector<cudf::column_view>(cv.child_begin(), cv.child_end()));
 
   EXPECT_TRUE(typed_s->is_valid());
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(fields, typed_s->view());
 }
 
-}  // namespace test
-}  // namespace cudf
+//}  // namespace test
+//}  // namespace cudf

--- a/cpp/tests/copying/scatter_list_scalar_tests.cpp
+++ b/cpp/tests/copying/scatter_list_scalar_tests.cpp
@@ -23,22 +23,19 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 
-namespace cudf {
-namespace test {
-
-using mask_vector = std::vector<valid_type>;
-using size_column = fixed_width_column_wrapper<size_type>;
+using mask_vector = std::vector<cudf::valid_type>;
+using size_column = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
 
 class ScatterListScalarTests : public cudf::test::BaseFixture {
 };
 
-std::unique_ptr<column> single_scalar_scatter(column_view const& target,
-                                              scalar const& slr,
-                                              column_view const& scatter_map)
+std::unique_ptr<cudf::column> single_scalar_scatter(cudf::column_view const& target,
+                                                    cudf::scalar const& slr,
+                                                    cudf::column_view const& scatter_map)
 {
-  std::vector<std::reference_wrapper<const scalar>> slrs{slr};
-  table_view targets{{target}};
-  auto result = scatter(slrs, scatter_map, targets);
+  std::vector<std::reference_wrapper<const cudf::scalar>> slrs{slr};
+  cudf::table_view targets{{target}};
+  auto result = cudf::scatter(slrs, scatter_map, targets);
   return std::move(result->release()[0]);
 }
 
@@ -46,7 +43,7 @@ template <typename T>
 class ScatterListOfFixedWidthScalarTest : public ScatterListScalarTests {
 };
 
-TYPED_TEST_SUITE(ScatterListOfFixedWidthScalarTest, FixedWidthTypesWithoutFixedPoint);
+TYPED_TEST_SUITE(ScatterListOfFixedWidthScalarTest, cudf::test::FixedWidthTypesWithoutFixedPoint);
 
 // Test grid
 // Dim1 : {Fixed width, strings, lists, structs}
@@ -55,10 +52,10 @@ TYPED_TEST_SUITE(ScatterListOfFixedWidthScalarTest, FixedWidthTypesWithoutFixedP
 
 TYPED_TEST(ScatterListOfFixedWidthScalarTest, Basic)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
-  using FCW = fixed_width_column_wrapper<TypeParam>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using FCW = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
-  auto slr = std::make_unique<list_scalar>(FCW({2, 2, 2}, {1, 0, 1}), true);
+  auto slr = std::make_unique<cudf::list_scalar>(FCW({2, 2, 2}, {1, 0, 1}), true);
   LCW col{LCW{1, 1, 1}, LCW{8, 8}, LCW{10, 10, 10, 10}, LCW{5}};
   size_column scatter_map{3, 1, 0};
 
@@ -72,10 +69,10 @@ TYPED_TEST(ScatterListOfFixedWidthScalarTest, Basic)
 
 TYPED_TEST(ScatterListOfFixedWidthScalarTest, EmptyValidScalar)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
-  using FCW = fixed_width_column_wrapper<TypeParam>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using FCW = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
-  auto slr = std::make_unique<list_scalar>(FCW{}, true);
+  auto slr = std::make_unique<cudf::list_scalar>(FCW{}, true);
   LCW col{LCW{1, 1, 1},
           LCW{8, 8},
           LCW({10, 10, 10, 10}, mask_vector{1, 0, 1, 0}.begin()),
@@ -91,10 +88,10 @@ TYPED_TEST(ScatterListOfFixedWidthScalarTest, EmptyValidScalar)
 
 TYPED_TEST(ScatterListOfFixedWidthScalarTest, NullScalar)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
-  using FCW = fixed_width_column_wrapper<TypeParam>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using FCW = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
-  auto slr = std::make_unique<list_scalar>(FCW{}, false);
+  auto slr = std::make_unique<cudf::list_scalar>(FCW{}, false);
   LCW col{LCW({1, 1, 1}, mask_vector{0, 0, 1}.begin()), LCW{8, 8}, LCW{10, 10, 10, 10}, LCW{5}};
   size_column scatter_map{3, 1};
 
@@ -106,10 +103,10 @@ TYPED_TEST(ScatterListOfFixedWidthScalarTest, NullScalar)
 
 TYPED_TEST(ScatterListOfFixedWidthScalarTest, NullableTargetRow)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
-  using FCW = fixed_width_column_wrapper<TypeParam>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using FCW = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
-  auto slr = std::make_unique<list_scalar>(FCW{9, 9}, true);
+  auto slr = std::make_unique<cudf::list_scalar>(FCW{9, 9}, true);
   LCW col({LCW{4, 4}, LCW{}, LCW{8, 8, 8}, LCW{}, LCW{9, 9, 9}},
           mask_vector{1, 0, 1, 0, 1}.begin());
   size_column scatter_map{0, 1};
@@ -125,10 +122,10 @@ class ScatterListOfStringScalarTest : public ScatterListScalarTests {
 
 TEST_F(ScatterListOfStringScalarTest, Basic)
 {
-  using LCW      = lists_column_wrapper<string_view, int32_t>;
-  using StringCW = strings_column_wrapper;
+  using LCW      = cudf::test::lists_column_wrapper<cudf::string_view, int32_t>;
+  using StringCW = cudf::test::strings_column_wrapper;
 
-  auto slr = std::make_unique<list_scalar>(
+  auto slr = std::make_unique<cudf::list_scalar>(
     StringCW({"Hello!", "", "你好！", "صباح الخير!", "", "こんにちは！"},
              {true, false, true, true, false, true}),
     true);
@@ -148,10 +145,10 @@ TEST_F(ScatterListOfStringScalarTest, Basic)
 
 TEST_F(ScatterListOfStringScalarTest, EmptyValidScalar)
 {
-  using LCW      = lists_column_wrapper<string_view, int32_t>;
-  using StringCW = strings_column_wrapper;
+  using LCW      = cudf::test::lists_column_wrapper<cudf::string_view, int32_t>;
+  using StringCW = cudf::test::strings_column_wrapper;
 
-  auto slr = std::make_unique<list_scalar>(StringCW{}, true);
+  auto slr = std::make_unique<cudf::list_scalar>(StringCW{}, true);
 
   LCW col{LCW({"xx", "yy"}, mask_vector{0, 1}.begin()),
           LCW{""},
@@ -168,10 +165,10 @@ TEST_F(ScatterListOfStringScalarTest, EmptyValidScalar)
 
 TEST_F(ScatterListOfStringScalarTest, NullScalar)
 {
-  using LCW      = lists_column_wrapper<string_view, int32_t>;
-  using StringCW = strings_column_wrapper;
+  using LCW      = cudf::test::lists_column_wrapper<cudf::string_view, int32_t>;
+  using StringCW = cudf::test::strings_column_wrapper;
 
-  auto slr = std::make_unique<list_scalar>(StringCW{}, false);
+  auto slr = std::make_unique<cudf::list_scalar>(StringCW{}, false);
   LCW col{LCW{"xx", "yy"},
           LCW({""}, mask_vector{0}.begin()),
           LCW{"a", "bab", "bacab"},
@@ -187,10 +184,10 @@ TEST_F(ScatterListOfStringScalarTest, NullScalar)
 
 TEST_F(ScatterListOfStringScalarTest, NullableTargetRow)
 {
-  using LCW      = lists_column_wrapper<string_view, int32_t>;
-  using StringCW = strings_column_wrapper;
+  using LCW      = cudf::test::lists_column_wrapper<cudf::string_view, int32_t>;
+  using StringCW = cudf::test::strings_column_wrapper;
 
-  auto slr = std::make_unique<list_scalar>(
+  auto slr = std::make_unique<cudf::list_scalar>(
     StringCW({"Hello!", "", "こんにちは！"}, {true, false, true}), true);
   LCW col({LCW{"xx", "yy"}, LCW({""}, mask_vector{0}.begin()), LCW{}, LCW{"888", "777"}},
           mask_vector{1, 1, 0, 1}.begin());
@@ -211,13 +208,13 @@ template <typename T>
 class ScatterListOfListScalarTest : public ScatterListScalarTests {
 };
 
-TYPED_TEST_SUITE(ScatterListOfListScalarTest, FixedWidthTypesWithoutFixedPoint);
+TYPED_TEST_SUITE(ScatterListOfListScalarTest, cudf::test::FixedWidthTypesWithoutFixedPoint);
 
 TYPED_TEST(ScatterListOfListScalarTest, Basic)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
 
-  auto slr = std::make_unique<list_scalar>(
+  auto slr = std::make_unique<cudf::list_scalar>(
     LCW({LCW{1, 2, 3}, LCW{4}, LCW{}, LCW{5, 6}}, mask_vector{1, 1, 0, 1}.begin()), true);
   LCW col({LCW({LCW{88, 88}, LCW{}, LCW{9, 9, 9}}, mask_vector{1, 0, 1}.begin()),
            LCW{LCW{66}, LCW{}, LCW({77, 77, 77, 77}, mask_vector{1, 0, 0, 1}.begin())},
@@ -237,9 +234,9 @@ TYPED_TEST(ScatterListOfListScalarTest, Basic)
 
 TYPED_TEST(ScatterListOfListScalarTest, EmptyValidScalar)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
 
-  auto slr = std::make_unique<list_scalar>(LCW{}, true);
+  auto slr = std::make_unique<cudf::list_scalar>(LCW{}, true);
   LCW col({LCW({LCW{88, 88}, LCW{}, LCW{9, 9, 9}}, mask_vector{1, 0, 1}.begin()),
            LCW{LCW{66}, LCW{}, LCW({77, 77, 77, 77}, mask_vector{1, 0, 0, 1}.begin())},
            LCW{LCW{55, 55}, LCW{}, LCW{10, 10, 10}},
@@ -258,9 +255,9 @@ TYPED_TEST(ScatterListOfListScalarTest, EmptyValidScalar)
 
 TYPED_TEST(ScatterListOfListScalarTest, NullScalar)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
 
-  auto slr = std::make_unique<list_scalar>(LCW{}, false);
+  auto slr = std::make_unique<cudf::list_scalar>(LCW{}, false);
   LCW col({LCW({LCW{88, 88}, LCW{}, LCW{9, 9, 9}}, mask_vector{1, 0, 1}.begin()),
            LCW{LCW{66}, LCW{}, LCW({77, 77, 77, 77}, mask_vector{1, 0, 0, 1}.begin())},
            LCW{LCW{44, 44}}});
@@ -275,9 +272,9 @@ TYPED_TEST(ScatterListOfListScalarTest, NullScalar)
 
 TYPED_TEST(ScatterListOfListScalarTest, NullableTargetRows)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
 
-  auto slr = std::make_unique<list_scalar>(
+  auto slr = std::make_unique<cudf::list_scalar>(
     LCW({LCW{1, 1, 1}, LCW{3, 3}, LCW{}, LCW{4}}, mask_vector{1, 1, 0, 1}.begin()), true);
 
   LCW col({LCW({LCW{88, 88}, LCW{}, LCW{9, 9, 9}}, mask_vector{1, 0, 1}.begin()),
@@ -299,28 +296,29 @@ TYPED_TEST(ScatterListOfListScalarTest, NullableTargetRows)
 template <typename T>
 class ScatterListOfStructScalarTest : public ScatterListScalarTests {
  protected:
-  structs_column_wrapper make_test_structs(fixed_width_column_wrapper<T> field0,
-                                           strings_column_wrapper field1,
-                                           lists_column_wrapper<T, int32_t> field2,
-                                           std::vector<valid_type> mask)
+  cudf::test::structs_column_wrapper make_test_structs(
+    cudf::test::fixed_width_column_wrapper<T> field0,
+    cudf::test::strings_column_wrapper field1,
+    cudf::test::lists_column_wrapper<T, int32_t> field2,
+    std::vector<cudf::valid_type> mask)
   {
-    return structs_column_wrapper({field0, field1, field2}, mask.begin());
+    return cudf::test::structs_column_wrapper({field0, field1, field2}, mask.begin());
   }
 };
 
-TYPED_TEST_SUITE(ScatterListOfStructScalarTest, FixedWidthTypesWithoutFixedPoint);
+TYPED_TEST_SUITE(ScatterListOfStructScalarTest, cudf::test::FixedWidthTypesWithoutFixedPoint);
 
 TYPED_TEST(ScatterListOfStructScalarTest, Basic)
 {
-  using LCW      = lists_column_wrapper<TypeParam, int32_t>;
-  using offset_t = fixed_width_column_wrapper<offset_type>;
+  using LCW      = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using offset_t = cudf::test::fixed_width_column_wrapper<cudf::offset_type>;
 
   auto data =
     this->make_test_structs({{42, 42, 42}, {1, 0, 1}},
                             {{"hello", "你好！", "bonjour!"}, {false, true, true}},
                             LCW({LCW{88}, LCW{}, LCW{99, 99}}, mask_vector{1, 0, 1}.begin()),
                             {1, 1, 0});
-  auto slr = std::make_unique<list_scalar>(data, true);
+  auto slr = std::make_unique<cudf::list_scalar>(data, true);
 
   auto child = this->make_test_structs(
     {{1, 1, 2, 3, 3, 3}, {0, 1, 1, 1, 0, 0}},
@@ -329,7 +327,8 @@ TYPED_TEST(ScatterListOfStructScalarTest, Basic)
         mask_vector{1, 0, 1, 1, 0, 1}.begin()),
     {1, 1, 0, 0, 1, 1});
   offset_t offsets{0, 2, 2, 3, 6};
-  auto col = make_lists_column(4, offsets.release(), child.release(), 0, rmm::device_buffer{});
+  auto col =
+    cudf::make_lists_column(4, offsets.release(), child.release(), 0, rmm::device_buffer{});
 
   size_column scatter_map{1, 3};
 
@@ -342,7 +341,7 @@ TYPED_TEST(ScatterListOfStructScalarTest, Basic)
     {1, 1, 1, 1, 0, 0, 1, 1, 0});
   offset_t ex_offsets{0, 2, 5, 6, 9};
   auto expected =
-    make_lists_column(4, ex_offsets.release(), ex_child.release(), 0, rmm::device_buffer{});
+    cudf::make_lists_column(4, ex_offsets.release(), ex_child.release(), 0, rmm::device_buffer{});
 
   auto result = single_scalar_scatter(*col, *slr, scatter_map);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, *expected);
@@ -350,11 +349,11 @@ TYPED_TEST(ScatterListOfStructScalarTest, Basic)
 
 TYPED_TEST(ScatterListOfStructScalarTest, EmptyValidScalar)
 {
-  using LCW      = lists_column_wrapper<TypeParam, int32_t>;
-  using offset_t = fixed_width_column_wrapper<offset_type>;
+  using LCW      = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using offset_t = cudf::test::fixed_width_column_wrapper<cudf::offset_type>;
 
   auto data = this->make_test_structs({}, {}, LCW{}, {});
-  auto slr  = std::make_unique<list_scalar>(data, true);
+  auto slr  = std::make_unique<cudf::list_scalar>(data, true);
 
   auto child = this->make_test_structs(
     {{1, 1, 2, 3, 3, 3}, {0, 1, 1, 1, 0, 0}},
@@ -363,7 +362,8 @@ TYPED_TEST(ScatterListOfStructScalarTest, EmptyValidScalar)
         mask_vector{1, 0, 1, 1, 0, 1}.begin()),
     {1, 1, 0, 0, 1, 1});
   offset_t offsets{0, 2, 2, 3, 6};
-  auto col = make_lists_column(4, offsets.release(), child.release(), 0, rmm::device_buffer{});
+  auto col =
+    cudf::make_lists_column(4, offsets.release(), child.release(), 0, rmm::device_buffer{});
 
   size_column scatter_map{0, 2};
 
@@ -374,7 +374,7 @@ TYPED_TEST(ScatterListOfStructScalarTest, EmptyValidScalar)
                             {0, 1, 1});
   offset_t ex_offsets{0, 0, 0, 0, 3};
   auto expected =
-    make_lists_column(4, ex_offsets.release(), ex_child.release(), 0, rmm::device_buffer{});
+    cudf::make_lists_column(4, ex_offsets.release(), ex_child.release(), 0, rmm::device_buffer{});
 
   auto result = single_scalar_scatter(*col, *slr, scatter_map);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, *expected);
@@ -382,11 +382,11 @@ TYPED_TEST(ScatterListOfStructScalarTest, EmptyValidScalar)
 
 TYPED_TEST(ScatterListOfStructScalarTest, NullScalar)
 {
-  using LCW      = lists_column_wrapper<TypeParam, int32_t>;
-  using offset_t = fixed_width_column_wrapper<offset_type>;
+  using LCW      = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using offset_t = cudf::test::fixed_width_column_wrapper<cudf::offset_type>;
 
   auto data = this->make_test_structs({}, {}, {}, {});
-  auto slr  = std::make_unique<list_scalar>(data, false);
+  auto slr  = std::make_unique<cudf::list_scalar>(data, false);
 
   auto child = this->make_test_structs(
     {{1, 1, 2, 3, 3, 3}, {0, 1, 1, 1, 0, 0}},
@@ -395,17 +395,18 @@ TYPED_TEST(ScatterListOfStructScalarTest, NullScalar)
         mask_vector{1, 0, 1, 1, 0, 1}.begin()),
     {1, 1, 1, 0, 1, 1});
   offset_t offsets{0, 2, 2, 3, 6};
-  auto col = make_lists_column(4, offsets.release(), child.release(), 0, rmm::device_buffer{});
+  auto col =
+    cudf::make_lists_column(4, offsets.release(), child.release(), 0, rmm::device_buffer{});
 
   size_column scatter_map{3, 1, 0};
 
   auto ex_child = this->make_test_structs({2}, {"yy"}, LCW({10}, mask_vector{1}.begin()), {1});
   offset_t ex_offsets{0, 0, 0, 1, 1};
 
-  auto null_mask = create_null_mask(4, mask_state::ALL_NULL);
-  set_null_mask(static_cast<bitmask_type*>(null_mask.data()), 2, 3, true);
+  auto null_mask = cudf::create_null_mask(4, cudf::mask_state::ALL_NULL);
+  cudf::set_null_mask(static_cast<cudf::bitmask_type*>(null_mask.data()), 2, 3, true);
   auto expected =
-    make_lists_column(4, ex_offsets.release(), ex_child.release(), 3, std::move(null_mask));
+    cudf::make_lists_column(4, ex_offsets.release(), ex_child.release(), 3, std::move(null_mask));
 
   auto result = single_scalar_scatter(*col, *slr, scatter_map);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, *expected);
@@ -413,15 +414,15 @@ TYPED_TEST(ScatterListOfStructScalarTest, NullScalar)
 
 TYPED_TEST(ScatterListOfStructScalarTest, NullableTargetRow)
 {
-  using LCW      = lists_column_wrapper<TypeParam, int32_t>;
-  using offset_t = fixed_width_column_wrapper<offset_type>;
+  using LCW      = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using offset_t = cudf::test::fixed_width_column_wrapper<cudf::offset_type>;
 
   auto data =
     this->make_test_structs({{42, 42, 42}, {1, 0, 1}},
                             {{"hello", "你好！", "bonjour!"}, {false, true, true}},
                             LCW({LCW{88}, LCW{}, LCW{99, 99}}, mask_vector{1, 0, 1}.begin()),
                             {1, 1, 0});
-  auto slr = std::make_unique<list_scalar>(data, true);
+  auto slr = std::make_unique<cudf::list_scalar>(data, true);
 
   auto child = this->make_test_structs(
     {{1, 1, 2, 3, 3, 3}, {0, 1, 1, 1, 0, 0}},
@@ -430,9 +431,10 @@ TYPED_TEST(ScatterListOfStructScalarTest, NullableTargetRow)
         mask_vector{1, 0, 1, 1, 0, 1}.begin()),
     {1, 1, 1, 0, 1, 1});
   offset_t offsets{0, 2, 2, 3, 6};
-  auto null_mask = create_null_mask(4, mask_state::ALL_VALID);
-  set_null_mask(static_cast<bitmask_type*>(null_mask.data()), 1, 3, false);
-  auto col = make_lists_column(4, offsets.release(), child.release(), 2, std::move(null_mask));
+  auto null_mask = cudf::create_null_mask(4, cudf::mask_state::ALL_VALID);
+  cudf::set_null_mask(static_cast<cudf::bitmask_type*>(null_mask.data()), 1, 3, false);
+  auto col =
+    cudf::make_lists_column(4, offsets.release(), child.release(), 2, std::move(null_mask));
 
   size_column scatter_map{3, 2};
 
@@ -445,14 +447,11 @@ TYPED_TEST(ScatterListOfStructScalarTest, NullableTargetRow)
     {1, 1, 1, 1, 0, 1, 1, 0});
   offset_t ex_offsets{0, 2, 2, 5, 8};
 
-  auto ex_null_mask = create_null_mask(4, mask_state::ALL_VALID);
-  set_null_mask(static_cast<bitmask_type*>(ex_null_mask.data()), 1, 2, false);
-  auto expected =
-    make_lists_column(4, ex_offsets.release(), ex_child.release(), 1, std::move(ex_null_mask));
+  auto ex_null_mask = cudf::create_null_mask(4, cudf::mask_state::ALL_VALID);
+  cudf::set_null_mask(static_cast<cudf::bitmask_type*>(ex_null_mask.data()), 1, 2, false);
+  auto expected = cudf::make_lists_column(
+    4, ex_offsets.release(), ex_child.release(), 1, std::move(ex_null_mask));
 
   auto result = single_scalar_scatter(*col, *slr, scatter_map);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*result, *expected);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/copying/scatter_list_tests.cpp
+++ b/cpp/tests/copying/scatter_list_tests.cpp
@@ -18,16 +18,12 @@
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
-#include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/column/column_view.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/detail/copy.hpp>
-#include <cudf/lists/lists_column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
-#include <cudf/utilities/default_stream.hpp>
 
 template <typename T>
 class TypedScatterListsTest : public cudf::test::BaseFixture {
@@ -40,91 +36,90 @@ class ScatterListsTest : public cudf::test::BaseFixture {
 
 TYPED_TEST(TypedScatterListsTest, ListsOfFixedWidth)
 {
-  using namespace cudf::test;
   using T = TypeParam;
 
-  auto src_list_column = lists_column_wrapper<T, int32_t>{{9, 9, 9, 9}, {8, 8, 8}};
+  auto src_list_column = cudf::test::lists_column_wrapper<T, int32_t>{{9, 9, 9, 9}, {8, 8, 8}};
 
-  auto target_list_column =
-    lists_column_wrapper<T, int32_t>{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
+  auto target_list_column = cudf::test::lists_column_wrapper<T, int32_t>{
+    {0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<cudf::size_type>{2, 0};
 
   auto ret = cudf::scatter(
     cudf::table_view({src_list_column}), scatter_map, cudf::table_view({target_list_column}));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     ret->get_column(0),
-    lists_column_wrapper<T, int32_t>{
+    cudf::test::lists_column_wrapper<T, int32_t>{
       {8, 8, 8}, {1, 1}, {9, 9, 9, 9}, {3, 3}, {4, 4}, {5, 5}, {6, 6}});
 }
 
 TYPED_TEST(TypedScatterListsTest, SlicedInputLists)
 {
-  using namespace cudf::test;
   using T = TypeParam;
 
-  auto src_list_column =
-    lists_column_wrapper<T, int32_t>{{0, 0, 0, 0}, {9, 9, 9, 9}, {8, 8, 8}, {7, 7, 7}}.release();
-  auto src_sliced =
-    cudf::detail::slice(src_list_column->view(), {1, 3}, cudf::get_default_stream()).front();
+  auto src_list_column = cudf::test::lists_column_wrapper<T, int32_t>{
+    {0, 0, 0, 0},
+    {9, 9, 9, 9},
+    {8, 8, 8},
+    {7, 7, 7}}.release();
+  auto src_sliced = cudf::slice(src_list_column->view(), {1, 3}).front();
 
   auto target_list_column =
-    lists_column_wrapper<T, int32_t>{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}}
+    cudf::test::lists_column_wrapper<T, int32_t>{
+      {0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}}
       .release();
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<cudf::size_type>{2, 0};
 
   auto ret_1 = cudf::scatter(
     cudf::table_view({src_sliced}), scatter_map, cudf::table_view({target_list_column->view()}));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     ret_1->get_column(0),
-    lists_column_wrapper<T, int32_t>{
+    cudf::test::lists_column_wrapper<T, int32_t>{
       {8, 8, 8}, {1, 1}, {9, 9, 9, 9}, {3, 3}, {4, 4}, {5, 5}, {6, 6}});
 
-  auto target_sliced =
-    cudf::detail::slice(target_list_column->view(), {1, 6}, cudf::get_default_stream());
+  auto target_sliced = cudf::slice(target_list_column->view(), {1, 6});
 
   auto ret_2 =
     cudf::scatter(cudf::table_view({src_sliced}), scatter_map, cudf::table_view({target_sliced}));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
     ret_2->get_column(0),
-    lists_column_wrapper<T, int32_t>{{8, 8, 8}, {2, 2}, {9, 9, 9, 9}, {4, 4}, {5, 5}});
+    cudf::test::lists_column_wrapper<T, int32_t>{{8, 8, 8}, {2, 2}, {9, 9, 9, 9}, {4, 4}, {5, 5}});
 }
 
 TYPED_TEST(TypedScatterListsTest, EmptyListsOfFixedWidth)
 {
-  using namespace cudf::test;
   using T = TypeParam;
 
-  auto src_child = fixed_width_column_wrapper<T, int32_t>{
+  auto src_child = cudf::test::fixed_width_column_wrapper<T, int32_t>{
     {9, 9, 9, 9, 8, 8, 8},
   };
 
   // One null list row, and one row with nulls.
-  auto src_list_column =
-    cudf::make_lists_column(3,
-                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
-                            src_child.release(),
-                            0,
-                            {});
+  auto src_list_column = cudf::make_lists_column(
+    3,
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+    src_child.release(),
+    0,
+    {});
 
-  auto target_list_column =
-    lists_column_wrapper<T, int32_t>{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
+  auto target_list_column = cudf::test::lists_column_wrapper<T, int32_t>{
+    {0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
 
   auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
                            scatter_map,
                            cudf::table_view({target_list_column}));
 
-  auto expected_child_ints =
-    fixed_width_column_wrapper<T, int32_t>{{8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 6, 6}};
+  auto expected_child_ints = cudf::test::fixed_width_column_wrapper<T, int32_t>{
+    {8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 6, 6}};
   auto expected_lists_column = cudf::make_lists_column(
     7,
-    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
     expected_child_ints.release(),
     0,
     {});
@@ -134,34 +129,33 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfFixedWidth)
 
 TYPED_TEST(TypedScatterListsTest, EmptyListsOfNullableFixedWidth)
 {
-  using namespace cudf::test;
   using T = TypeParam;
 
-  auto src_child =
-    fixed_width_column_wrapper<T, int32_t>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
+  auto src_child = cudf::test::fixed_width_column_wrapper<T, int32_t>{{9, 9, 9, 9, 8, 8, 8},
+                                                                      {1, 1, 1, 0, 1, 1, 1}};
 
   // One null list row, and one row with nulls.
-  auto src_list_column =
-    cudf::make_lists_column(3,
-                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
-                            src_child.release(),
-                            0,
-                            {});
+  auto src_list_column = cudf::make_lists_column(
+    3,
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+    src_child.release(),
+    0,
+    {});
 
-  auto target_list_column =
-    lists_column_wrapper<T, int32_t>{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
+  auto target_list_column = cudf::test::lists_column_wrapper<T, int32_t>{
+    {0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
 
   auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
                            scatter_map,
                            cudf::table_view({target_list_column}));
 
-  auto expected_child_ints = fixed_width_column_wrapper<T, int32_t>{
+  auto expected_child_ints = cudf::test::fixed_width_column_wrapper<T, int32_t>{
     {8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 6, 6}, {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}};
   auto expected_lists_column = cudf::make_lists_column(
     7,
-    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
     expected_child_ints.release(),
     0,
     {});
@@ -171,102 +165,97 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfNullableFixedWidth)
 
 TYPED_TEST(TypedScatterListsTest, NullableListsOfNullableFixedWidth)
 {
-  using namespace cudf::test;
   using T = TypeParam;
 
-  auto src_child =
-    fixed_width_column_wrapper<T, int32_t>{{9, 9, 9, 9, 8, 8, 8}, {1, 1, 1, 0, 1, 1, 1}};
+  auto src_child = cudf::test::fixed_width_column_wrapper<T, int32_t>{{9, 9, 9, 9, 8, 8, 8},
+                                                                      {1, 1, 1, 0, 1, 1, 1}};
 
   auto src_list_validity =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2; });
   // One null list row, and one row with nulls.
-  auto src_list_column =
-    cudf::make_lists_column(3,
-                            fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
-                            src_child.release(),
-                            1,
-                            detail::make_null_mask(src_list_validity, src_list_validity + 3));
+  auto src_list_column = cudf::make_lists_column(
+    3,
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 4, 7, 7}.release(),
+    src_child.release(),
+    1,
+    cudf::test::detail::make_null_mask(src_list_validity, src_list_validity + 3));
 
-  auto target_list_column =
-    lists_column_wrapper<T, int32_t>{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
+  auto target_list_column = cudf::test::lists_column_wrapper<T, int32_t>{
+    {0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}};
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<cudf::size_type>{2, 0, 5};
 
   auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
                            scatter_map,
                            cudf::table_view({target_list_column}));
 
-  auto expected_child_ints = fixed_width_column_wrapper<T, int32_t>{
+  auto expected_child_ints = cudf::test::fixed_width_column_wrapper<T, int32_t>{
     {8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 6, 6}, {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}};
 
   auto expected_validity =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 5; });
   auto expected_lists_column = cudf::make_lists_column(
     7,
-    fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 3, 5, 9, 11, 13, 13, 15}.release(),
     expected_child_ints.release(),
     1,
-    detail::make_null_mask(expected_validity, expected_validity + 7));
+    cudf::test::detail::make_null_mask(expected_validity, expected_validity + 7));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists_column->view(), ret->get_column(0));
 }
 
 TEST_F(ScatterListsTest, ListsOfStrings)
 {
-  using namespace cudf::test;
-
-  auto src_list_column = lists_column_wrapper<cudf::string_view>{
+  auto src_list_column = cudf::test::lists_column_wrapper<cudf::string_view>{
     {"all", "the", "leaves", "are", "brown"}, {"california", "dreaming"}};
 
   auto target_list_column =
-    lists_column_wrapper<cudf::string_view>{{"zero"},
-                                            {"one", "one"},
-                                            {"two", "two"},
-                                            {"three", "three", "three"},
-                                            {"four", "four", "four", "four"}};
+    cudf::test::lists_column_wrapper<cudf::string_view>{{"zero"},
+                                                        {"one", "one"},
+                                                        {"two", "two"},
+                                                        {"three", "three", "three"},
+                                                        {"four", "four", "four", "four"}};
 
-  auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 0};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<int32_t>{2, 0};
 
   auto ret = cudf::scatter(
     cudf::table_view({src_list_column}), scatter_map, cudf::table_view({target_list_column}));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-    lists_column_wrapper<cudf::string_view>{{"california", "dreaming"},
-                                            {"one", "one"},
-                                            {"all", "the", "leaves", "are", "brown"},
-                                            {"three", "three", "three"},
-                                            {"four", "four", "four", "four"}},
+    cudf::test::lists_column_wrapper<cudf::string_view>{{"california", "dreaming"},
+                                                        {"one", "one"},
+                                                        {"all", "the", "leaves", "are", "brown"},
+                                                        {"three", "three", "three"},
+                                                        {"four", "four", "four", "four"}},
     ret->get_column(0));
 }
 
 TEST_F(ScatterListsTest, ListsOfNullableStrings)
 {
-  using namespace cudf::test;
-
-  auto src_strings_column = strings_column_wrapper{
+  auto src_strings_column = cudf::test::strings_column_wrapper{
     {"all", "the", "leaves", "are", "brown", "california", "dreaming"}, {1, 1, 1, 0, 1, 0, 1}};
 
-  auto src_list_column =
-    cudf::make_lists_column(2,
-                            fixed_width_column_wrapper<cudf::size_type>{0, 5, 7}.release(),
-                            src_strings_column.release(),
-                            0,
-                            {});
+  auto src_list_column = cudf::make_lists_column(
+    2,
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 5, 7}.release(),
+    src_strings_column.release(),
+    0,
+    {});
 
-  auto target_list_column = lists_column_wrapper<cudf::string_view>{{"zero"},
-                                                                    {"one", "one"},
-                                                                    {"two", "two"},
-                                                                    {"three", "three"},
-                                                                    {"four", "four"},
-                                                                    {"five", "five"}};
+  auto target_list_column = cudf::test::lists_column_wrapper<cudf::string_view>{{"zero"},
+                                                                                {"one", "one"},
+                                                                                {"two", "two"},
+                                                                                {"three", "three"},
+                                                                                {"four", "four"},
+                                                                                {"five", "five"}};
 
-  auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 0};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<int32_t>{2, 0};
 
   auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
                            scatter_map,
                            cudf::table_view({target_list_column}));
 
-  auto expected_strings = strings_column_wrapper{
+  auto expected_strings = cudf::test::strings_column_wrapper{
     {"california",
      "dreaming",
      "one",
@@ -286,7 +275,7 @@ TEST_F(ScatterListsTest, ListsOfNullableStrings)
 
   auto expected_lists = cudf::make_lists_column(
     6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 9, 11, 13, 15}.release(),
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 9, 11, 13, 15}.release(),
     expected_strings.release(),
     0,
     {});
@@ -296,32 +285,30 @@ TEST_F(ScatterListsTest, ListsOfNullableStrings)
 
 TEST_F(ScatterListsTest, EmptyListsOfNullableStrings)
 {
-  using namespace cudf::test;
-
-  auto src_strings_column = strings_column_wrapper{
+  auto src_strings_column = cudf::test::strings_column_wrapper{
     {"all", "the", "leaves", "are", "brown", "california", "dreaming"}, {1, 1, 1, 0, 1, 0, 1}};
 
-  auto src_list_column =
-    cudf::make_lists_column(3,
-                            fixed_width_column_wrapper<cudf::size_type>{0, 5, 5, 7}.release(),
-                            src_strings_column.release(),
-                            0,
-                            {});
+  auto src_list_column = cudf::make_lists_column(
+    3,
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 5, 5, 7}.release(),
+    src_strings_column.release(),
+    0,
+    {});
 
-  auto target_list_column = lists_column_wrapper<cudf::string_view>{{"zero"},
-                                                                    {"one", "one"},
-                                                                    {"two", "two"},
-                                                                    {"three", "three"},
-                                                                    {"four", "four"},
-                                                                    {"five", "five"}};
+  auto target_list_column = cudf::test::lists_column_wrapper<cudf::string_view>{{"zero"},
+                                                                                {"one", "one"},
+                                                                                {"two", "two"},
+                                                                                {"three", "three"},
+                                                                                {"four", "four"},
+                                                                                {"five", "five"}};
 
-  auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 4, 0};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<int32_t>{2, 4, 0};
 
   auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
                            scatter_map,
                            cudf::table_view({target_list_column}));
 
-  auto expected_strings = strings_column_wrapper{
+  auto expected_strings = cudf::test::strings_column_wrapper{
     {"california",
      "dreaming",
      "one",
@@ -339,7 +326,7 @@ TEST_F(ScatterListsTest, EmptyListsOfNullableStrings)
 
   auto expected_lists = cudf::make_lists_column(
     6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 9, 11, 11, 13}.release(),
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 9, 11, 11, 13}.release(),
     expected_strings.release(),
     0,
     {});
@@ -349,34 +336,32 @@ TEST_F(ScatterListsTest, EmptyListsOfNullableStrings)
 
 TEST_F(ScatterListsTest, NullableListsOfNullableStrings)
 {
-  using namespace cudf::test;
-
-  auto src_strings_column = strings_column_wrapper{
+  auto src_strings_column = cudf::test::strings_column_wrapper{
     {"all", "the", "leaves", "are", "brown", "california", "dreaming"}, {1, 1, 1, 0, 1, 0, 1}};
 
   auto src_validity =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; });
-  auto src_list_column =
-    cudf::make_lists_column(3,
-                            fixed_width_column_wrapper<cudf::size_type>{0, 5, 5, 7}.release(),
-                            src_strings_column.release(),
-                            1,
-                            detail::make_null_mask(src_validity, src_validity + 3));
+  auto src_list_column = cudf::make_lists_column(
+    3,
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 5, 5, 7}.release(),
+    src_strings_column.release(),
+    1,
+    cudf::test::detail::make_null_mask(src_validity, src_validity + 3));
 
-  auto target_list_column = lists_column_wrapper<cudf::string_view>{{"zero"},
-                                                                    {"one", "one"},
-                                                                    {"two", "two"},
-                                                                    {"three", "three"},
-                                                                    {"four", "four"},
-                                                                    {"five", "five"}};
+  auto target_list_column = cudf::test::lists_column_wrapper<cudf::string_view>{{"zero"},
+                                                                                {"one", "one"},
+                                                                                {"two", "two"},
+                                                                                {"three", "three"},
+                                                                                {"four", "four"},
+                                                                                {"five", "five"}};
 
-  auto scatter_map = fixed_width_column_wrapper<int32_t>{2, 4, 0};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<int32_t>{2, 4, 0};
 
   auto ret = cudf::scatter(cudf::table_view({src_list_column->view()}),
                            scatter_map,
                            cudf::table_view({target_list_column}));
 
-  auto expected_strings = strings_column_wrapper{
+  auto expected_strings = cudf::test::strings_column_wrapper{
     {"california",
      "dreaming",
      "one",
@@ -396,97 +381,97 @@ TEST_F(ScatterListsTest, NullableListsOfNullableStrings)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 4; });
   auto expected_lists = cudf::make_lists_column(
     6,
-    fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 9, 11, 11, 13}.release(),
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 9, 11, 11, 13}.release(),
     expected_strings.release(),
     1,
-    detail::make_null_mask(expected_validity, expected_validity + 6));
+    cudf::test::detail::make_null_mask(expected_validity, expected_validity + 6));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), ret->get_column(0));
 }
 
 TYPED_TEST(TypedScatterListsTest, ListsOfLists)
 {
-  using namespace cudf::test;
   using T = TypeParam;
 
-  auto src_list_column =
-    lists_column_wrapper<T, int32_t>{{{1, 1, 1, 1}, {2, 2, 2, 2}}, {{3, 3, 3, 3}, {4, 4, 4, 4}}};
+  auto src_list_column = cudf::test::lists_column_wrapper<T, int32_t>{{{1, 1, 1, 1}, {2, 2, 2, 2}},
+                                                                      {{3, 3, 3, 3}, {4, 4, 4, 4}}};
 
-  auto target_list_column = lists_column_wrapper<T, int32_t>{{{9, 9, 9}, {8, 8, 8}, {7, 7, 7}},
-                                                             {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
-                                                             {{3, 3, 3}, {2, 2, 2}, {1, 1, 1}},
-                                                             {{9, 9}, {8, 8}, {7, 7}},
-                                                             {{6, 6}, {5, 5}, {4, 4}},
-                                                             {{3, 3}, {2, 2}, {1, 1}}};
+  auto target_list_column =
+    cudf::test::lists_column_wrapper<T, int32_t>{{{9, 9, 9}, {8, 8, 8}, {7, 7, 7}},
+                                                 {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+                                                 {{3, 3, 3}, {2, 2, 2}, {1, 1, 1}},
+                                                 {{9, 9}, {8, 8}, {7, 7}},
+                                                 {{6, 6}, {5, 5}, {4, 4}},
+                                                 {{3, 3}, {2, 2}, {1, 1}}};
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<cudf::size_type>{2, 0};
 
   auto ret = cudf::scatter(
     cudf::table_view({src_list_column}), scatter_map, cudf::table_view({target_list_column}));
 
-  auto expected = lists_column_wrapper<T, int32_t>{{{3, 3, 3, 3}, {4, 4, 4, 4}},
-                                                   {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
-                                                   {{1, 1, 1, 1}, {2, 2, 2, 2}},
-                                                   {{9, 9}, {8, 8}, {7, 7}},
-                                                   {{6, 6}, {5, 5}, {4, 4}},
-                                                   {{3, 3}, {2, 2}, {1, 1}}};
+  auto expected = cudf::test::lists_column_wrapper<T, int32_t>{{{3, 3, 3, 3}, {4, 4, 4, 4}},
+                                                               {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+                                                               {{1, 1, 1, 1}, {2, 2, 2, 2}},
+                                                               {{9, 9}, {8, 8}, {7, 7}},
+                                                               {{6, 6}, {5, 5}, {4, 4}},
+                                                               {{3, 3}, {2, 2}, {1, 1}}};
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, ret->get_column(0));
 }
 
 TYPED_TEST(TypedScatterListsTest, EmptyListsOfLists)
 {
-  using namespace cudf::test;
   using T = TypeParam;
 
-  auto src_list_column =
-    lists_column_wrapper<T, int32_t>{{{1, 1, 1, 1}, {2, 2, 2, 2}}, {{3, 3, 3, 3}, {}}, {}};
+  auto src_list_column = cudf::test::lists_column_wrapper<T, int32_t>{
+    {{1, 1, 1, 1}, {2, 2, 2, 2}}, {{3, 3, 3, 3}, {}}, {}};
 
-  auto target_list_column = lists_column_wrapper<T, int32_t>{{{9, 9, 9}, {8, 8, 8}, {7, 7, 7}},
-                                                             {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
-                                                             {{3, 3, 3}, {2, 2, 2}, {1, 1, 1}},
-                                                             {{9, 9}, {8, 8}, {7, 7}},
-                                                             {{6, 6}, {5, 5}, {4, 4}},
-                                                             {{3, 3}, {2, 2}, {1, 1}}};
+  auto target_list_column =
+    cudf::test::lists_column_wrapper<T, int32_t>{{{9, 9, 9}, {8, 8, 8}, {7, 7, 7}},
+                                                 {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+                                                 {{3, 3, 3}, {2, 2, 2}, {1, 1, 1}},
+                                                 {{9, 9}, {8, 8}, {7, 7}},
+                                                 {{6, 6}, {5, 5}, {4, 4}},
+                                                 {{3, 3}, {2, 2}, {1, 1}}};
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
 
   auto ret = cudf::scatter(
     cudf::table_view({src_list_column}), scatter_map, cudf::table_view({target_list_column}));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-    lists_column_wrapper<T, int32_t>{{{3, 3, 3, 3}, {}},
-                                     {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
-                                     {{1, 1, 1, 1}, {2, 2, 2, 2}},
-                                     {{9, 9}, {8, 8}, {7, 7}},
-                                     {},
-                                     {{3, 3}, {2, 2}, {1, 1}}},
+    cudf::test::lists_column_wrapper<T, int32_t>{{{3, 3, 3, 3}, {}},
+                                                 {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+                                                 {{1, 1, 1, 1}, {2, 2, 2, 2}},
+                                                 {{9, 9}, {8, 8}, {7, 7}},
+                                                 {},
+                                                 {{3, 3}, {2, 2}, {1, 1}}},
     ret->get_column(0));
 }
 
 TYPED_TEST(TypedScatterListsTest, NullListsOfLists)
 {
-  using namespace cudf::test;
   using T = TypeParam;
 
-  auto src_list_column = lists_column_wrapper<T, int32_t>{
+  auto src_list_column = cudf::test::lists_column_wrapper<T, int32_t>{
     {{{1, 1, 1, 1}, {2, 2, 2, 2}}, {{3, 3, 3, 3}, {}}, {}},
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2; })};
 
-  auto target_list_column = lists_column_wrapper<T, int32_t>{{{9, 9, 9}, {8, 8, 8}, {7, 7, 7}},
-                                                             {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
-                                                             {{3, 3, 3}, {2, 2, 2}, {1, 1, 1}},
-                                                             {{9, 9}, {8, 8}, {7, 7}},
-                                                             {{6, 6}, {5, 5}, {4, 4}},
-                                                             {{3, 3}, {2, 2}, {1, 1}}};
+  auto target_list_column =
+    cudf::test::lists_column_wrapper<T, int32_t>{{{9, 9, 9}, {8, 8, 8}, {7, 7, 7}},
+                                                 {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+                                                 {{3, 3, 3}, {2, 2, 2}, {1, 1, 1}},
+                                                 {{9, 9}, {8, 8}, {7, 7}},
+                                                 {{6, 6}, {5, 5}, {4, 4}},
+                                                 {{3, 3}, {2, 2}, {1, 1}}};
 
-  auto scatter_map = fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
+  auto scatter_map = cudf::test::fixed_width_column_wrapper<cudf::size_type>{2, 0, 4};
 
   auto ret = cudf::scatter(
     cudf::table_view({src_list_column}), scatter_map, cudf::table_view({target_list_column}));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-    lists_column_wrapper<T, int32_t>{
+    cudf::test::lists_column_wrapper<T, int32_t>{
       {{{3, 3, 3, 3}, {}},
        {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
        {{1, 1, 1, 1}, {2, 2, 2, 2}},
@@ -499,10 +484,9 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfLists)
 
 TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
 {
-  using namespace cudf::test;
   using T               = TypeParam;
-  using offsets_column  = fixed_width_column_wrapper<cudf::size_type>;
-  using numerics_column = fixed_width_column_wrapper<T>;
+  using offsets_column  = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
+  using numerics_column = cudf::test::fixed_width_column_wrapper<T>;
 
   // clang-format off
   auto source_numerics = numerics_column{
@@ -510,13 +494,13 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
     8, 8, 8
   };
 
-  auto source_strings = strings_column_wrapper{
+  auto source_strings = cudf::test::strings_column_wrapper{
     "nine", "nine", "nine", "nine",
     "eight", "eight", "eight"
   };
   // clang-format on
 
-  auto source_structs = structs_column_wrapper{{source_numerics, source_strings}};
+  auto source_structs = cudf::test::structs_column_wrapper{{source_numerics, source_strings}};
 
   auto source_lists =
     cudf::make_lists_column(2, offsets_column{0, 4, 7}.release(), source_structs.release(), 0, {});
@@ -531,7 +515,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
     5, 5
   };
 
-  auto target_strings = strings_column_wrapper{
+  auto target_strings = cudf::test::strings_column_wrapper{
     "zero",  "zero",
     "one",   "one",
     "two",   "two",
@@ -541,7 +525,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
   };
   // clang-format on
 
-  auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
+  auto target_structs = cudf::test::structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
     6, offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), target_structs.release(), 0, {});
@@ -560,7 +544,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
     3, 3, 4, 4, 5, 5
   };
 
-  auto expected_strings = strings_column_wrapper{
+  auto expected_strings = cudf::test::strings_column_wrapper{
     "eight", "eight", "eight",
     "one", "one",
     "nine", "nine", "nine", "nine",
@@ -570,7 +554,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
   };
   // clang-format on
 
-  auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
+  auto expected_structs = cudf::test::structs_column_wrapper{{expected_numerics, expected_strings}};
 
   auto expected_lists = cudf::make_lists_column(
     6, offsets_column{0, 3, 5, 9, 11, 13, 15}.release(), expected_structs.release(), 0, {});
@@ -580,10 +564,9 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructs)
 
 TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
 {
-  using namespace cudf::test;
   using T               = TypeParam;
-  using offsets_column  = fixed_width_column_wrapper<cudf::size_type>;
-  using numerics_column = fixed_width_column_wrapper<T>;
+  using offsets_column  = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
+  using numerics_column = cudf::test::fixed_width_column_wrapper<T>;
 
   // clang-format off
   auto source_numerics = numerics_column{
@@ -594,7 +577,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; })
   };
 
-  auto source_strings = strings_column_wrapper{
+  auto source_strings = cudf::test::strings_column_wrapper{
     {
       "nine",  "nine",  "nine", "nine",
       "eight", "eight", "eight"
@@ -603,7 +586,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
   };
   // clang-format on
 
-  auto source_structs = structs_column_wrapper{{source_numerics, source_strings}};
+  auto source_structs = cudf::test::structs_column_wrapper{{source_numerics, source_strings}};
 
   auto source_lists =
     cudf::make_lists_column(2, offsets_column{0, 4, 7}.release(), source_structs.release(), 0, {});
@@ -618,7 +601,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
     5, 5
   };
 
-  auto target_strings = strings_column_wrapper{
+  auto target_strings = cudf::test::strings_column_wrapper{
     "zero", "zero",
     "one",  "one",
     "two",  "two",
@@ -628,7 +611,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
   };
   // clang-format on
 
-  auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
+  auto target_structs = cudf::test::structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
     6, offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), target_structs.release(), 0, {});
@@ -653,7 +636,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 8; })
   };
 
-  auto expected_strings = strings_column_wrapper{
+  auto expected_strings = cudf::test::strings_column_wrapper{
     {
       "eight", "eight", "eight",
       "one",   "one",
@@ -666,7 +649,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
   };
   // clang-format on
 
-  auto expected_structs = structs_column_wrapper{{expected_numerics, expected_strings}};
+  auto expected_structs = cudf::test::structs_column_wrapper{{expected_numerics, expected_strings}};
 
   auto expected_lists = cudf::make_lists_column(
     6, offsets_column{0, 3, 5, 9, 11, 13, 15}.release(), expected_structs.release(), 0, {});
@@ -676,10 +659,9 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
 
 TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
 {
-  using namespace cudf::test;
   using T               = TypeParam;
-  using offsets_column  = fixed_width_column_wrapper<cudf::size_type>;
-  using numerics_column = fixed_width_column_wrapper<T>;
+  using offsets_column  = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
+  using numerics_column = cudf::test::fixed_width_column_wrapper<T>;
 
   // clang-format off
   auto source_numerics = numerics_column{
@@ -690,7 +672,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; })
   };
 
-  auto source_strings = strings_column_wrapper{
+  auto source_strings = cudf::test::strings_column_wrapper{
     {
       "nine",  "nine",  "nine", "nine",
       "eight", "eight", "eight"
@@ -699,7 +681,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
   };
   // clang-format on
 
-  auto source_structs = structs_column_wrapper{
+  auto source_structs = cudf::test::structs_column_wrapper{
     {source_numerics, source_strings},
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
 
@@ -716,7 +698,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
     5, 5
   };
 
-  auto target_strings = strings_column_wrapper{
+  auto target_strings = cudf::test::strings_column_wrapper{
     "zero",  "zero",
     "one",   "one",
     "two",   "two",
@@ -726,7 +708,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
   };
   // clang-format on
 
-  auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
+  auto target_structs = cudf::test::structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
     6, offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), target_structs.release(), 0, {});
@@ -750,7 +732,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i != 6) && (i != 8); })
   };
 
-  auto expected_strings = strings_column_wrapper{
+  auto expected_strings = cudf::test::strings_column_wrapper{
     {
       "eight", "eight", "eight",
       "one",   "one",
@@ -763,7 +745,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
   };
   // clang-format on
 
-  auto expected_structs = structs_column_wrapper{
+  auto expected_structs = cudf::test::structs_column_wrapper{
     {expected_numerics, expected_strings},
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 6; })};
 
@@ -775,10 +757,9 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
 
 TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
 {
-  using namespace cudf::test;
   using T               = TypeParam;
-  using offsets_column  = fixed_width_column_wrapper<cudf::size_type>;
-  using numerics_column = fixed_width_column_wrapper<T>;
+  using offsets_column  = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
+  using numerics_column = cudf::test::fixed_width_column_wrapper<T>;
 
   // clang-format off
   auto source_numerics = numerics_column{
@@ -789,7 +770,7 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; })
   };
 
-  auto source_strings = strings_column_wrapper{
+  auto source_strings = cudf::test::strings_column_wrapper{
     {
       "nine",  "nine",  "nine", "nine",
       "eight", "eight", "eight"
@@ -798,7 +779,7 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
   };
   // clang-format on
 
-  auto source_structs = structs_column_wrapper{
+  auto source_structs = cudf::test::structs_column_wrapper{
     {source_numerics, source_strings},
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
 
@@ -815,7 +796,7 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
     5, 5
   };
 
-  auto target_strings = strings_column_wrapper{
+  auto target_strings = cudf::test::strings_column_wrapper{
     "zero",  "zero",
     "one",   "one",
     "two",   "two",
@@ -825,7 +806,7 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
   };
   // clang-format on
 
-  auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
+  auto target_structs = cudf::test::structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
     6, offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), target_structs.release(), 0, {});
@@ -848,7 +829,7 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i != 6) && (i != 8); })
   };
 
-  auto expected_strings = strings_column_wrapper{
+  auto expected_strings = cudf::test::strings_column_wrapper{
     {
       "eight", "eight", "eight",
       "one",   "one",
@@ -860,7 +841,7 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
   };
   // clang-format on
 
-  auto expected_structs = structs_column_wrapper{
+  auto expected_structs = cudf::test::structs_column_wrapper{
     {expected_numerics, expected_strings},
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 6; })};
 
@@ -872,10 +853,9 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
 
 TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
 {
-  using namespace cudf::test;
   using T               = TypeParam;
-  using offsets_column  = fixed_width_column_wrapper<cudf::size_type>;
-  using numerics_column = fixed_width_column_wrapper<T>;
+  using offsets_column  = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
+  using numerics_column = cudf::test::fixed_width_column_wrapper<T>;
 
   // clang-format off
   auto source_numerics = numerics_column{
@@ -886,7 +866,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; })
   };
 
-  auto source_strings = strings_column_wrapper{
+  auto source_strings = cudf::test::strings_column_wrapper{
     {
       "nine",  "nine",  "nine", "nine",
       "eight", "eight", "eight"
@@ -895,19 +875,20 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
   };
   // clang-format on
 
-  auto source_structs = structs_column_wrapper{
+  auto source_structs = cudf::test::structs_column_wrapper{
     {source_numerics, source_strings},
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
 
   auto source_list_null_mask_begin =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2; });
 
-  auto source_lists = cudf::make_lists_column(
-    3,
-    offsets_column{0, 4, 7, 7}.release(),
-    source_structs.release(),
-    1,
-    detail::make_null_mask(source_list_null_mask_begin, source_list_null_mask_begin + 3));
+  auto source_lists =
+    cudf::make_lists_column(3,
+                            offsets_column{0, 4, 7, 7}.release(),
+                            source_structs.release(),
+                            1,
+                            cudf::test::detail::make_null_mask(source_list_null_mask_begin,
+                                                               source_list_null_mask_begin + 3));
 
   // clang-format off
   auto target_ints    = numerics_column{
@@ -918,7 +899,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
     4, 4,
     5, 5
   };
-  auto target_strings = strings_column_wrapper{
+  auto target_strings = cudf::test::strings_column_wrapper{
     "zero",  "zero",
     "one",   "one",
     "two",   "two",
@@ -928,7 +909,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
   };
   // clang-format on
 
-  auto target_structs = structs_column_wrapper{{target_ints, target_strings}};
+  auto target_structs = cudf::test::structs_column_wrapper{{target_ints, target_strings}};
 
   auto target_lists = cudf::make_lists_column(
     6, offsets_column{0, 2, 4, 6, 8, 10, 12}.release(), target_structs.release(), 0, {});
@@ -951,7 +932,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i != 6) && (i != 8); })
   };
 
-  auto expected_strings = strings_column_wrapper{
+  auto expected_strings = cudf::test::strings_column_wrapper{
     {
       "eight", "eight", "eight",
       "one",   "one",
@@ -963,19 +944,20 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
   };
   // clang-format on
 
-  auto expected_structs = structs_column_wrapper{
+  auto expected_structs = cudf::test::structs_column_wrapper{
     {expected_numerics, expected_strings},
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 6; })};
 
   auto expected_lists_null_mask_begin =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 4; });
 
-  auto expected_lists = cudf::make_lists_column(
-    6,
-    offsets_column{0, 3, 5, 9, 11, 11, 13}.release(),
-    expected_structs.release(),
-    1,
-    detail::make_null_mask(expected_lists_null_mask_begin, expected_lists_null_mask_begin + 6));
+  auto expected_lists =
+    cudf::make_lists_column(6,
+                            offsets_column{0, 3, 5, 9, 11, 11, 13}.release(),
+                            expected_structs.release(),
+                            1,
+                            cudf::test::detail::make_null_mask(expected_lists_null_mask_begin,
+                                                               expected_lists_null_mask_begin + 6));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }

--- a/cpp/tests/copying/scatter_struct_scalar_tests.cpp
+++ b/cpp/tests/copying/scatter_struct_scalar_tests.cpp
@@ -24,10 +24,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 
-namespace cudf {
-namespace test {
-
-constexpr debug_output_level verbosity{debug_output_level::ALL_ERRORS};
+constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::ALL_ERRORS};
 constexpr int32_t null{0};  // Mark for null child elements
 constexpr int32_t XXX{0};   // Mark for null struct elements
 
@@ -37,34 +34,36 @@ template <typename T>
 struct TypedStructScalarScatterTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(TypedStructScalarScatterTest, FixedWidthTypes);
+TYPED_TEST_SUITE(TypedStructScalarScatterTest, cudf::test::FixedWidthTypes);
 
-column scatter_single_scalar(scalar const& slr, column_view scatter_map, column_view target)
+cudf::column scatter_single_scalar(cudf::scalar const& slr,
+                                   cudf::column_view scatter_map,
+                                   cudf::column_view target)
 {
-  auto result = scatter({slr}, scatter_map, table_view{{target}});
+  auto result = cudf::scatter({slr}, scatter_map, cudf::table_view{{target}});
   return result->get_column(0);
 }
 
 TYPED_TEST(TypedStructScalarScatterTest, Basic)
 {
-  using fixed_width_wrapper = fixed_width_column_wrapper<TypeParam>;
+  using fixed_width_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
   // Source scalar
   fixed_width_wrapper slr_f0{777};
-  strings_column_wrapper slr_f1{"hello"};
-  auto slr = make_struct_scalar(table_view{{slr_f0, slr_f1}});
+  cudf::test::strings_column_wrapper slr_f1{"hello"};
+  auto slr = cudf::make_struct_scalar(cudf::table_view{{slr_f0, slr_f1}});
 
   // Scatter map
-  fixed_width_column_wrapper<size_type> scatter_map{2};
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> scatter_map{2};
 
   // Target column
   fixed_width_wrapper field0{11, 11, 22, 22, 33};
-  strings_column_wrapper field1{"aa", "aa", "bb", "bb", "cc"};
+  cudf::test::strings_column_wrapper field1{"aa", "aa", "bb", "bb", "cc"};
   structs_col target{field0, field1};
 
   // Expect column
   fixed_width_wrapper ef0{11, 11, 777, 22, 33};
-  strings_column_wrapper ef1{"aa", "aa", "hello", "bb", "cc"};
+  cudf::test::strings_column_wrapper ef1{"aa", "aa", "hello", "bb", "cc"};
   structs_col expected{ef0, ef1};
 
   auto got = scatter_single_scalar(*slr, scatter_map, target);
@@ -74,18 +73,18 @@ TYPED_TEST(TypedStructScalarScatterTest, Basic)
 
 TYPED_TEST(TypedStructScalarScatterTest, FillNulls)
 {
-  using fixed_width_wrapper = fixed_width_column_wrapper<TypeParam>;
+  using fixed_width_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
   // Source scalar
   fixed_width_wrapper slr_f0{777};
-  auto slr = make_struct_scalar(table_view{{slr_f0}});
+  auto slr = cudf::make_struct_scalar(cudf::table_view{{slr_f0}});
 
   // Scatter map
-  fixed_width_column_wrapper<size_type> scatter_map{3, 4};
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> scatter_map{3, 4};
 
   // Target column
-  fixed_width_wrapper field0({11, 11, 22, null, XXX}, iterators::null_at(3));
-  structs_col target({field0}, iterators::null_at(4));
+  fixed_width_wrapper field0({11, 11, 22, null, XXX}, cudf::test::iterators::null_at(3));
+  structs_col target({field0}, cudf::test::iterators::null_at(4));
 
   // Expect column
   fixed_width_wrapper ef0{11, 11, 22, 777, 777};
@@ -98,19 +97,19 @@ TYPED_TEST(TypedStructScalarScatterTest, FillNulls)
 
 TYPED_TEST(TypedStructScalarScatterTest, ScatterNullElements)
 {
-  using fixed_width_wrapper = fixed_width_column_wrapper<TypeParam>;
+  using fixed_width_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
   // Source scalar
   fixed_width_wrapper slr_f0{777};
-  std::vector<column_view> source_fields{slr_f0};
-  auto slr = std::make_unique<struct_scalar>(source_fields, false);
+  std::vector<cudf::column_view> source_fields{slr_f0};
+  auto slr = std::make_unique<cudf::struct_scalar>(source_fields, false);
 
   // Scatter map
-  fixed_width_column_wrapper<size_type> scatter_map{0, 3, 4};
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> scatter_map{0, 3, 4};
 
   // Target column
-  fixed_width_wrapper field0({11, 11, 22, null, XXX}, iterators::null_at(3));
-  structs_col target({field0}, iterators::null_at(4));
+  fixed_width_wrapper field0({11, 11, 22, null, XXX}, cudf::test::iterators::null_at(3));
+  structs_col target({field0}, cudf::test::iterators::null_at(4));
 
   // Expect column
   fixed_width_wrapper ef0{XXX, 11, 22, XXX, XXX};
@@ -123,22 +122,22 @@ TYPED_TEST(TypedStructScalarScatterTest, ScatterNullElements)
 
 TYPED_TEST(TypedStructScalarScatterTest, ScatterNullFields)
 {
-  using fixed_width_wrapper = fixed_width_column_wrapper<TypeParam>;
+  using fixed_width_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
   // Source scalar
   fixed_width_wrapper slr_f0({null}, {false});
-  auto slr = make_struct_scalar(table_view{{slr_f0}});
+  auto slr = cudf::make_struct_scalar(cudf::table_view{{slr_f0}});
 
   // Scatter map
-  fixed_width_column_wrapper<size_type> scatter_map{0, 2};
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> scatter_map{0, 2};
 
   // Target column
-  fixed_width_wrapper field0({11, 11, 22, null, XXX}, iterators::null_at(3));
-  structs_col target({field0}, iterators::null_at(4));
+  fixed_width_wrapper field0({11, 11, 22, null, XXX}, cudf::test::iterators::null_at(3));
+  structs_col target({field0}, cudf::test::iterators::null_at(4));
 
   // Expect column
   fixed_width_wrapper ef0({null, 11, null, null, XXX}, {false, true, false, false, true});
-  structs_col expected({ef0}, iterators::null_at(4));
+  structs_col expected({ef0}, cudf::test::iterators::null_at(4));
 
   auto got = scatter_single_scalar(*slr, scatter_map, target);
 
@@ -147,21 +146,21 @@ TYPED_TEST(TypedStructScalarScatterTest, ScatterNullFields)
 
 TYPED_TEST(TypedStructScalarScatterTest, NegativeIndices)
 {
-  using fixed_width_wrapper = fixed_width_column_wrapper<TypeParam>;
+  using fixed_width_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
   // Source scalar
   fixed_width_wrapper slr_f0{777};
-  auto slr = make_struct_scalar(table_view{{slr_f0}});
+  auto slr = cudf::make_struct_scalar(cudf::table_view{{slr_f0}});
 
   // Scatter map
-  fixed_width_column_wrapper<size_type> scatter_map{-1, -5};
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> scatter_map{-1, -5};
 
   // Target column
-  fixed_width_wrapper field0({11, 11, 22, null, XXX}, iterators::null_at(3));
-  structs_col target({field0}, iterators::null_at(4));
+  fixed_width_wrapper field0({11, 11, 22, null, XXX}, cudf::test::iterators::null_at(3));
+  structs_col target({field0}, cudf::test::iterators::null_at(4));
 
   // Expect column
-  fixed_width_wrapper ef0({777, 11, 22, null, 777}, iterators::null_at(3));
+  fixed_width_wrapper ef0({777, 11, 22, null, 777}, cudf::test::iterators::null_at(3));
   structs_col expected{ef0};
 
   auto got = scatter_single_scalar(*slr, scatter_map, target);
@@ -171,14 +170,14 @@ TYPED_TEST(TypedStructScalarScatterTest, NegativeIndices)
 
 TYPED_TEST(TypedStructScalarScatterTest, EmptyInputTest)
 {
-  using fixed_width_wrapper = fixed_width_column_wrapper<TypeParam>;
+  using fixed_width_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
   // Source scalar
   fixed_width_wrapper slr_f0{777};
-  auto slr = make_struct_scalar(table_view{{slr_f0}});
+  auto slr = cudf::make_struct_scalar(cudf::table_view{{slr_f0}});
 
   // Scatter map
-  fixed_width_column_wrapper<size_type> scatter_map{};
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> scatter_map{};
 
   // Target column
   fixed_width_wrapper field0{};
@@ -195,18 +194,18 @@ TYPED_TEST(TypedStructScalarScatterTest, EmptyInputTest)
 
 TYPED_TEST(TypedStructScalarScatterTest, EmptyScatterMapTest)
 {
-  using fixed_width_wrapper = fixed_width_column_wrapper<TypeParam>;
+  using fixed_width_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
   // Source scalar
   fixed_width_wrapper slr_f0{777};
-  auto slr = make_struct_scalar(table_view{{slr_f0}});
+  auto slr = cudf::make_struct_scalar(cudf::table_view{{slr_f0}});
 
   // Scatter map
-  fixed_width_column_wrapper<size_type> scatter_map{};
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> scatter_map{};
 
   // Target column
-  fixed_width_wrapper field0({11, 11, 22, null, XXX}, iterators::null_at(3));
-  structs_col target({field0}, iterators::null_at(4));
+  fixed_width_wrapper field0({11, 11, 22, null, XXX}, cudf::test::iterators::null_at(3));
+  structs_col target({field0}, cudf::test::iterators::null_at(4));
 
   auto got = scatter_single_scalar(*slr, scatter_map, target);
 
@@ -215,26 +214,26 @@ TYPED_TEST(TypedStructScalarScatterTest, EmptyScatterMapTest)
 
 TYPED_TEST(TypedStructScalarScatterTest, FixedWidthStringTypes)
 {
-  using fixed_width_wrapper = fixed_width_column_wrapper<TypeParam>;
+  using fixed_width_wrapper = cudf::test::fixed_width_column_wrapper<TypeParam>;
 
   // Source scalar
   fixed_width_wrapper slr_f0{777};
-  strings_column_wrapper slr_f1{"hello"};
-  auto slr = make_struct_scalar(table_view{{slr_f0, slr_f1}});
+  cudf::test::strings_column_wrapper slr_f1{"hello"};
+  auto slr = cudf::make_struct_scalar(cudf::table_view{{slr_f0, slr_f1}});
 
   // Scatter map
-  fixed_width_column_wrapper<size_type> scatter_map{0, 2, 4};
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> scatter_map{0, 2, 4};
 
   // Target column
-  fixed_width_wrapper field0({11, 11, 22, null, XXX}, iterators::null_at(3));
-  strings_column_wrapper field1({"aa", "null", "ccc", "null", "XXX"},
-                                {true, false, true, false, true});
-  structs_col target({field0, field1}, iterators::null_at(4));
+  fixed_width_wrapper field0({11, 11, 22, null, XXX}, cudf::test::iterators::null_at(3));
+  cudf::test::strings_column_wrapper field1({"aa", "null", "ccc", "null", "XXX"},
+                                            {true, false, true, false, true});
+  structs_col target({field0, field1}, cudf::test::iterators::null_at(4));
 
   // Expect column
-  fixed_width_wrapper ef0({777, 11, 777, null, 777}, iterators::null_at(3));
-  strings_column_wrapper ef1({"hello", "null", "hello", "null", "hello"},
-                             {true, false, true, false, true});
+  fixed_width_wrapper ef0({777, 11, 777, null, 777}, cudf::test::iterators::null_at(3));
+  cudf::test::strings_column_wrapper ef1({"hello", "null", "hello", "null", "hello"},
+                                         {true, false, true, false, true});
   structs_col expected{ef0, ef1};
 
   auto got = scatter_single_scalar(*slr, scatter_map, target);
@@ -244,27 +243,26 @@ TYPED_TEST(TypedStructScalarScatterTest, FixedWidthStringTypes)
 
 TYPED_TEST(TypedStructScalarScatterTest, StructOfLists)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
 
   // Source scalar
   LCW slr_f0{777};
-  auto slr = make_struct_scalar(table_view{{slr_f0}});
+  auto slr = cudf::make_struct_scalar(cudf::table_view{{slr_f0}});
 
   // Scatter map
-  fixed_width_column_wrapper<size_type> scatter_map{0, 1, 4};
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> scatter_map{0, 1, 4};
 
   // Target column
-  LCW field0({LCW{XXX}, LCW{22}, LCW{33, 44}, LCW{null}, LCW{55}}, iterators::null_at(3));
-  structs_col target({field0}, iterators::null_at(0));
+  LCW field0({LCW{XXX}, LCW{22}, LCW{33, 44}, LCW{null}, LCW{55}},
+             cudf::test::iterators::null_at(3));
+  structs_col target({field0}, cudf::test::iterators::null_at(0));
 
   // Expect column
-  LCW ef0({LCW{777}, LCW{777}, LCW{33, 44}, LCW{null}, LCW{777}}, iterators::null_at(3));
+  LCW ef0({LCW{777}, LCW{777}, LCW{33, 44}, LCW{null}, LCW{777}},
+          cudf::test::iterators::null_at(3));
   structs_col expected{ef0};
 
   auto got = scatter_single_scalar(*slr, scatter_map, target);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, got, verbosity);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/copying/scatter_tests.cpp
+++ b/cpp/tests/copying/scatter_tests.cpp
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cudf/copying.hpp>
-#include <cudf/detail/iterator.cuh>
-#include <cudf/scalar/scalar_factories.hpp>
-#include <cudf/stream_compaction.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
@@ -24,17 +20,20 @@
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/copying.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/stream_compaction.hpp>
+
 class ScatterUntypedTests : public cudf::test::BaseFixture {
 };
 
 // Throw logic error if scatter map is longer than source
 TEST_F(ScatterUntypedTests, ScatterMapTooLong)
 {
-  using cudf::test::fixed_width_column_wrapper;
-
-  fixed_width_column_wrapper<int32_t> source({1, 2, 3, 4, 5, 6});
-  fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1, 0, 2, 4, 6});
+  cudf::test::fixed_width_column_wrapper<int32_t> source({1, 2, 3, 4, 5, 6});
+  cudf::test::fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1, 0, 2, 4, 6});
 
   auto const source_table = cudf::table_view({source, source});
   auto const target_table = cudf::table_view({target, target});
@@ -45,11 +44,9 @@ TEST_F(ScatterUntypedTests, ScatterMapTooLong)
 // Throw logic error if scatter map has nulls
 TEST_F(ScatterUntypedTests, ScatterMapNulls)
 {
-  using cudf::test::fixed_width_column_wrapper;
-
-  fixed_width_column_wrapper<int32_t> source({1, 2, 3, 4, 5, 6});
-  fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1}, {0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int32_t> source({1, 2, 3, 4, 5, 6});
+  cudf::test::fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1}, {0, 1, 1, 1});
 
   auto const source_table = cudf::table_view({source, source});
   auto const target_table = cudf::table_view({target, target});
@@ -60,15 +57,12 @@ TEST_F(ScatterUntypedTests, ScatterMapNulls)
 // Throw logic error if scatter map has nulls
 TEST_F(ScatterUntypedTests, ScatterScalarMapNulls)
 {
-  using cudf::scalar_type_t;
-  using cudf::test::fixed_width_column_wrapper;
-
-  auto const source = scalar_type_t<int32_t>{100};
+  auto const source = cudf::scalar_type_t<int32_t>{100};
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
   std::vector<std::reference_wrapper<const cudf::scalar>> source_vector{slr_ref};
 
-  fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1}, {0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1}, {0, 1, 1, 1});
 
   auto const target_table = cudf::table_view({target});
 
@@ -78,11 +72,9 @@ TEST_F(ScatterUntypedTests, ScatterScalarMapNulls)
 // Throw logic error if source and target have different number of columns
 TEST_F(ScatterUntypedTests, ScatterColumnNumberMismatch)
 {
-  using cudf::test::fixed_width_column_wrapper;
-
-  fixed_width_column_wrapper<int32_t> source({1, 2, 3, 4, 5, 6});
-  fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<int32_t> source({1, 2, 3, 4, 5, 6});
+  cudf::test::fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
 
   auto const source_table = cudf::table_view({source});
   auto const target_table = cudf::table_view({target, target});
@@ -93,15 +85,12 @@ TEST_F(ScatterUntypedTests, ScatterColumnNumberMismatch)
 // Throw logic error if number of scalars doesn't match number of columns
 TEST_F(ScatterUntypedTests, ScatterScalarColumnNumberMismatch)
 {
-  using cudf::scalar_type_t;
-  using cudf::test::fixed_width_column_wrapper;
-
-  auto const source = scalar_type_t<int32_t>(100);
+  auto const source = cudf::scalar_type_t<int32_t>(100);
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
   std::vector<std::reference_wrapper<const cudf::scalar>> source_vector{slr_ref};
 
-  fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
 
   auto const target_table = cudf::table_view({target, target});
 
@@ -111,11 +100,9 @@ TEST_F(ScatterUntypedTests, ScatterScalarColumnNumberMismatch)
 // Throw logic error if source and target have different data types
 TEST_F(ScatterUntypedTests, ScatterDataTypeMismatch)
 {
-  using cudf::test::fixed_width_column_wrapper;
-
-  fixed_width_column_wrapper<int32_t> source({1, 2, 3, 4, 5, 6});
-  fixed_width_column_wrapper<float> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<int32_t> source({1, 2, 3, 4, 5, 6});
+  cudf::test::fixed_width_column_wrapper<float> target({10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
 
   auto const source_table = cudf::table_view({source});
   auto const target_table = cudf::table_view({target});
@@ -126,15 +113,12 @@ TEST_F(ScatterUntypedTests, ScatterDataTypeMismatch)
 // Throw logic error if source and target have different data types
 TEST_F(ScatterUntypedTests, ScatterScalarDataTypeMismatch)
 {
-  using cudf::scalar_type_t;
-  using cudf::test::fixed_width_column_wrapper;
-
-  auto const source = scalar_type_t<int32_t>(100);
+  auto const source = cudf::scalar_type_t<int32_t>(100);
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
   std::vector<std::reference_wrapper<const cudf::scalar>> source_vector{slr_ref};
 
-  fixed_width_column_wrapper<float> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<float> target({10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
 
   auto const target_table = cudf::table_view({target});
 
@@ -151,12 +135,10 @@ TYPED_TEST_SUITE(ScatterIndexTypeTests, IndexTypes);
 // Validate that each of the index types work
 TYPED_TEST(ScatterIndexTypeTests, ScatterIndexType)
 {
-  using cudf::test::fixed_width_column_wrapper;
-
-  fixed_width_column_wrapper<TypeParam> source({1, 2, 3, 4, 5, 6});
-  fixed_width_column_wrapper<TypeParam> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<TypeParam> scatter_map({-3, 3, 1, -1});
-  fixed_width_column_wrapper<TypeParam> expected({10, 3, 30, 2, 50, 1, 70, 4});
+  cudf::test::fixed_width_column_wrapper<TypeParam> source({1, 2, 3, 4, 5, 6});
+  cudf::test::fixed_width_column_wrapper<TypeParam> target({10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<TypeParam> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<TypeParam> expected({10, 3, 30, 2, 50, 1, 70, 4});
 
   auto const source_table   = cudf::table_view({source, source});
   auto const target_table   = cudf::table_view({target, target});
@@ -170,16 +152,13 @@ TYPED_TEST(ScatterIndexTypeTests, ScatterIndexType)
 // Validate that each of the index types work
 TYPED_TEST(ScatterIndexTypeTests, ScatterScalarIndexType)
 {
-  using cudf::scalar_type_t;
-  using cudf::test::fixed_width_column_wrapper;
-
-  auto const source = scalar_type_t<TypeParam>(100, true);
+  auto const source = cudf::scalar_type_t<TypeParam>(100, true);
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
   std::vector<std::reference_wrapper<const cudf::scalar>> source_vector{slr_ref};
 
-  fixed_width_column_wrapper<TypeParam> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<TypeParam> scatter_map({-3, 3, 1, -1});
-  fixed_width_column_wrapper<TypeParam> expected({10, 100, 30, 100, 50, 100, 70, 100});
+  cudf::test::fixed_width_column_wrapper<TypeParam> target({10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<TypeParam> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<TypeParam> expected({10, 100, 30, 100, 50, 100, 70, 100});
 
   auto const target_table   = cudf::table_view({target});
   auto const expected_table = cudf::table_view({expected});
@@ -202,11 +181,9 @@ TYPED_TEST_SUITE(ScatterInvalidIndexTypeTests, InvalidIndexTypes);
 // Throw logic error if scatter map column has invalid data type
 TYPED_TEST(ScatterInvalidIndexTypeTests, ScatterInvalidIndexType)
 {
-  using cudf::test::fixed_width_column_wrapper;
-
-  fixed_width_column_wrapper<int32_t> source({1, 2, 3, 4, 5, 6});
-  fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<TypeParam, int32_t> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<int32_t> source({1, 2, 3, 4, 5, 6});
+  cudf::test::fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> scatter_map({-3, 3, 1, -1});
 
   auto const source_table = cudf::table_view({source, source});
   auto const target_table = cudf::table_view({target, target});
@@ -217,15 +194,12 @@ TYPED_TEST(ScatterInvalidIndexTypeTests, ScatterInvalidIndexType)
 // Throw logic error if scatter map column has invalid data type
 TYPED_TEST(ScatterInvalidIndexTypeTests, ScatterScalarInvalidIndexType)
 {
-  using cudf::scalar_type_t;
-  using cudf::test::fixed_width_column_wrapper;
-
-  auto const source = scalar_type_t<int32_t>(100, true);
+  auto const source = cudf::scalar_type_t<int32_t>(100, true);
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
   std::vector<std::reference_wrapper<const cudf::scalar>> source_vector{slr_ref};
 
-  fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<TypeParam, int32_t> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> scatter_map({-3, 3, 1, -1});
 
   auto const target_table = cudf::table_view({target});
 
@@ -241,11 +215,10 @@ TYPED_TEST_SUITE(ScatterDataTypeTests, cudf::test::FixedWidthTypes);
 // Empty scatter map returns copy of input
 TYPED_TEST(ScatterDataTypeTests, EmptyScatterMap)
 {
-  using cudf::test::fixed_width_column_wrapper;
-
-  fixed_width_column_wrapper<TypeParam, int32_t> source({1, 2, 3, 4, 5, 6});
-  fixed_width_column_wrapper<TypeParam, int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> source({1, 2, 3, 4, 5, 6});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> target(
+    {10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({});
 
   auto const source_table = cudf::table_view({source, source});
   auto const target_table = cudf::table_view({target, target});
@@ -259,16 +232,14 @@ TYPED_TEST(ScatterDataTypeTests, EmptyScatterMap)
 // Empty scatter map returns copy of input
 TYPED_TEST(ScatterDataTypeTests, EmptyScalarScatterMap)
 {
-  using cudf::scalar_type_t;
-  using cudf::test::fixed_width_column_wrapper;
-
   auto const source =
-    scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<TypeParam>(100), true);
+    cudf::scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<TypeParam>(100), true);
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
   std::vector<std::reference_wrapper<const cudf::scalar>> source_vector{slr_ref};
 
-  fixed_width_column_wrapper<TypeParam, int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> target(
+    {10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({});
 
   auto const target_table = cudf::table_view({target});
 
@@ -280,12 +251,11 @@ TYPED_TEST(ScatterDataTypeTests, EmptyScalarScatterMap)
 
 TYPED_TEST(ScatterDataTypeTests, ScatterNoNulls)
 {
-  using cudf::test::fixed_width_column_wrapper;
-
-  fixed_width_column_wrapper<TypeParam, int32_t> source({1, 2, 3, 4, 5, 6});
-  fixed_width_column_wrapper<TypeParam, int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
-  fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 3, 30, 2, 50, 1, 70, 4});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> source({1, 2, 3, 4, 5, 6});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> target(
+    {10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 3, 30, 2, 50, 1, 70, 4});
 
   auto const source_table   = cudf::table_view({source, source});
   auto const target_table   = cudf::table_view({target, target});
@@ -298,14 +268,12 @@ TYPED_TEST(ScatterDataTypeTests, ScatterNoNulls)
 
 TYPED_TEST(ScatterDataTypeTests, ScatterBothNulls)
 {
-  using cudf::test::fixed_width_column_wrapper;
-
-  fixed_width_column_wrapper<TypeParam, int32_t> source({2, 4, 6, 8}, {1, 1, 0, 0});
-  fixed_width_column_wrapper<TypeParam, int32_t> target({10, 20, 30, 40, 50, 60, 70, 80},
-                                                        {0, 0, 0, 0, 1, 1, 1, 1});
-  fixed_width_column_wrapper<int32_t> scatter_map({1, 3, -3, -1});
-  fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 2, 30, 4, 50, 6, 70, 8},
-                                                          {0, 1, 0, 1, 1, 0, 1, 0});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> source({2, 4, 6, 8}, {1, 1, 0, 0});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> target(
+    {10, 20, 30, 40, 50, 60, 70, 80}, {0, 0, 0, 0, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({1, 3, -3, -1});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 2, 30, 4, 50, 6, 70, 8},
+                                                                      {0, 1, 0, 1, 1, 0, 1, 0});
 
   auto const source_table   = cudf::table_view({source, source});
   auto const target_table   = cudf::table_view({target, target});
@@ -318,13 +286,12 @@ TYPED_TEST(ScatterDataTypeTests, ScatterBothNulls)
 
 TYPED_TEST(ScatterDataTypeTests, ScatterSourceNulls)
 {
-  using cudf::test::fixed_width_column_wrapper;
-
-  fixed_width_column_wrapper<TypeParam, int32_t> source({2, 4, 6, 8}, {1, 1, 0, 0});
-  fixed_width_column_wrapper<TypeParam, int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({1, 3, -3, -1});
-  fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 2, 30, 4, 50, 6, 70, 8},
-                                                          {1, 1, 1, 1, 1, 0, 1, 0});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> source({2, 4, 6, 8}, {1, 1, 0, 0});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> target(
+    {10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({1, 3, -3, -1});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 2, 30, 4, 50, 6, 70, 8},
+                                                                      {1, 1, 1, 1, 1, 0, 1, 0});
 
   auto const source_table   = cudf::table_view({source, source});
   auto const target_table   = cudf::table_view({target, target});
@@ -337,14 +304,12 @@ TYPED_TEST(ScatterDataTypeTests, ScatterSourceNulls)
 
 TYPED_TEST(ScatterDataTypeTests, ScatterTargetNulls)
 {
-  using cudf::test::fixed_width_column_wrapper;
-
-  fixed_width_column_wrapper<TypeParam, int32_t> source({2, 4, 6, 8});
-  fixed_width_column_wrapper<TypeParam, int32_t> target({10, 20, 30, 40, 50, 60, 70, 80},
-                                                        {0, 0, 0, 0, 1, 1, 1, 1});
-  fixed_width_column_wrapper<int32_t> scatter_map({1, 3, -3, -1});
-  fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 2, 30, 4, 50, 6, 70, 8},
-                                                          {0, 1, 0, 1, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> source({2, 4, 6, 8});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> target(
+    {10, 20, 30, 40, 50, 60, 70, 80}, {0, 0, 0, 0, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({1, 3, -3, -1});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 2, 30, 4, 50, 6, 70, 8},
+                                                                      {0, 1, 0, 1, 1, 1, 1, 1});
 
   auto const source_table   = cudf::table_view({source, source});
   auto const target_table   = cudf::table_view({target, target});
@@ -357,17 +322,18 @@ TYPED_TEST(ScatterDataTypeTests, ScatterTargetNulls)
 
 TYPED_TEST(ScatterDataTypeTests, ScatterScalarNoNulls)
 {
-  using cudf::scalar_type_t;
-  using cudf::test::fixed_width_column_wrapper;
   using Type = cudf::device_storage_type_t<TypeParam>;
 
-  auto const source = scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<Type>(100), true);
+  auto const source =
+    cudf::scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<Type>(100), true);
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
   std::vector<std::reference_wrapper<const cudf::scalar>> source_vector{slr_ref};
 
-  fixed_width_column_wrapper<TypeParam, int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
-  fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 100, 30, 100, 50, 100, 70, 100});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> target(
+    {10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> expected(
+    {10, 100, 30, 100, 50, 100, 70, 100});
 
   auto const target_table   = cudf::table_view({target});
   auto const expected_table = cudf::table_view({expected});
@@ -379,19 +345,18 @@ TYPED_TEST(ScatterDataTypeTests, ScatterScalarNoNulls)
 
 TYPED_TEST(ScatterDataTypeTests, ScatterScalarTargetNulls)
 {
-  using cudf::scalar_type_t;
-  using cudf::test::fixed_width_column_wrapper;
   using Type = cudf::device_storage_type_t<TypeParam>;
 
-  auto const source = scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<Type>(100), true);
+  auto const source =
+    cudf::scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<Type>(100), true);
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
   std::vector<std::reference_wrapper<const cudf::scalar>> source_vector{slr_ref};
 
-  fixed_width_column_wrapper<TypeParam, int32_t> target({10, 20, 30, 40, 50, 60, 70, 80},
-                                                        {0, 0, 0, 0, 1, 1, 1, 1});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
-  fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 100, 30, 100, 50, 100, 70, 100},
-                                                          {0, 1, 0, 1, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> target(
+    {10, 20, 30, 40, 50, 60, 70, 80}, {0, 0, 0, 0, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> expected(
+    {10, 100, 30, 100, 50, 100, 70, 100}, {0, 1, 0, 1, 1, 1, 1, 1});
 
   auto const target_table   = cudf::table_view({target});
   auto const expected_table = cudf::table_view({expected});
@@ -403,19 +368,18 @@ TYPED_TEST(ScatterDataTypeTests, ScatterScalarTargetNulls)
 
 TYPED_TEST(ScatterDataTypeTests, ScatterScalarSourceNulls)
 {
-  using cudf::scalar_type_t;
-  using cudf::test::fixed_width_column_wrapper;
   using Type = cudf::device_storage_type_t<TypeParam>;
 
   auto const source =
-    scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<Type>(100), false);
+    cudf::scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<Type>(100), false);
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
   std::vector<std::reference_wrapper<const cudf::scalar>> source_vector{slr_ref};
 
-  fixed_width_column_wrapper<TypeParam, int32_t> target({10, 20, 30, 40, 50, 60, 70, 80});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
-  fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 100, 30, 100, 50, 100, 70, 100},
-                                                          {1, 0, 1, 0, 1, 0, 1, 0});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> target(
+    {10, 20, 30, 40, 50, 60, 70, 80});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> expected(
+    {10, 100, 30, 100, 50, 100, 70, 100}, {1, 0, 1, 0, 1, 0, 1, 0});
 
   auto const target_table   = cudf::table_view({target});
   auto const expected_table = cudf::table_view({expected});
@@ -427,20 +391,18 @@ TYPED_TEST(ScatterDataTypeTests, ScatterScalarSourceNulls)
 
 TYPED_TEST(ScatterDataTypeTests, ScatterScalarBothNulls)
 {
-  using cudf::scalar_type_t;
-  using cudf::test::fixed_width_column_wrapper;
   using Type = cudf::device_storage_type_t<TypeParam>;
 
   auto const source =
-    scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<Type>(100), false);
+    cudf::scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<Type>(100), false);
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
   std::vector<std::reference_wrapper<const cudf::scalar>> source_vector{slr_ref};
 
-  fixed_width_column_wrapper<TypeParam, int32_t> target({10, 20, 30, 40, 50, 60, 70, 80},
-                                                        {0, 0, 0, 0, 1, 1, 1, 1});
-  fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
-  fixed_width_column_wrapper<TypeParam, int32_t> expected({10, 100, 30, 100, 50, 100, 70, 100},
-                                                          {0, 0, 0, 0, 1, 0, 1, 0});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> target(
+    {10, 20, 30, 40, 50, 60, 70, 80}, {0, 0, 0, 0, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-3, 3, 1, -1});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> expected(
+    {10, 100, 30, 100, 50, 100, 70, 100}, {0, 0, 0, 0, 1, 0, 1, 0});
 
   auto const target_table   = cudf::table_view({target});
   auto const expected_table = cudf::table_view({expected});
@@ -452,13 +414,10 @@ TYPED_TEST(ScatterDataTypeTests, ScatterScalarBothNulls)
 
 TYPED_TEST(ScatterDataTypeTests, ScatterSourceNullsLarge)
 {
-  using cudf::detail::make_counting_transform_iterator;
-  using cudf::test::fixed_width_column_wrapper;
-
   constexpr cudf::size_type N{513};
 
-  fixed_width_column_wrapper<TypeParam, int32_t> source({0, 0, 0, 0}, {0, 0, 0, 0});
-  fixed_width_column_wrapper<int32_t> scatter_map({0, 1, 2, 3});
+  cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> source({0, 0, 0, 0}, {0, 0, 0, 0});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({0, 1, 2, 3});
   auto target_data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
   cudf::test::fixed_width_column_wrapper<TypeParam, typename decltype(target_data)::value_type>
     target(target_data, target_data + N);
@@ -466,8 +425,8 @@ TYPED_TEST(ScatterDataTypeTests, ScatterSourceNullsLarge)
   auto expect_data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
   auto expect_valid =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i > 3; });
-  fixed_width_column_wrapper<TypeParam, typename decltype(expect_data)::value_type> expected(
-    expect_data, expect_data + N, expect_valid);
+  cudf::test::fixed_width_column_wrapper<TypeParam, typename decltype(expect_data)::value_type>
+    expected(expect_data, expect_data + N, expect_valid);
 
   auto const source_table   = cudf::table_view({source, source});
   auto const target_table   = cudf::table_view({target, target});
@@ -483,21 +442,18 @@ class ScatterStringsTests : public cudf::test::BaseFixture {
 
 TEST_F(ScatterStringsTests, ScatterNoNulls)
 {
-  using cudf::test::fixed_width_column_wrapper;
-  using cudf::test::strings_column_wrapper;
-
   std::vector<const char*> h_source{"dog", "the", "jumps", "brown", "the"};
-  strings_column_wrapper source(h_source.begin(), h_source.end());
+  cudf::test::strings_column_wrapper source(h_source.begin(), h_source.end());
 
   std::vector<const char*> h_target{
     "a", "quick", "fire", "fox", "browses", "over", "a", "lazy", "web"};
-  strings_column_wrapper target(h_target.begin(), h_target.end());
+  cudf::test::strings_column_wrapper target(h_target.begin(), h_target.end());
 
-  fixed_width_column_wrapper<int32_t> scatter_map({-1, -3, -5, 2, 0});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({-1, -3, -5, 2, 0});
 
   std::vector<const char*> h_expected{
     "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"};
-  strings_column_wrapper expected(h_expected.begin(), h_expected.end());
+  cudf::test::strings_column_wrapper expected(h_expected.begin(), h_expected.end());
 
   auto const source_table   = cudf::table_view({source, source});
   auto const target_table   = cudf::table_view({target, target});
@@ -510,23 +466,19 @@ TEST_F(ScatterStringsTests, ScatterNoNulls)
 
 TEST_F(ScatterStringsTests, ScatterScalarNoNulls)
 {
-  using cudf::string_scalar;
-  using cudf::test::fixed_width_column_wrapper;
-  using cudf::test::strings_column_wrapper;
-
-  auto const source = string_scalar("buffalo");
+  auto const source = cudf::string_scalar("buffalo");
   std::reference_wrapper<const cudf::scalar> slr_ref{source};
   std::vector<std::reference_wrapper<const cudf::scalar>> source_vector{slr_ref};
 
   std::vector<const char*> h_target{
     "Buffalo", "bison", "Buffalo", "bison", "bully", "bully", "Buffalo", "bison"};
-  strings_column_wrapper target(h_target.begin(), h_target.end());
+  cudf::test::strings_column_wrapper target(h_target.begin(), h_target.end());
 
-  fixed_width_column_wrapper<int32_t> scatter_map({1, 3, -4, -3, -1});
+  cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({1, 3, -4, -3, -1});
 
   std::vector<const char*> h_expected{
     "Buffalo", "buffalo", "Buffalo", "buffalo", "buffalo", "buffalo", "Buffalo", "buffalo"};
-  strings_column_wrapper expected(h_expected.begin(), h_expected.end());
+  cudf::test::strings_column_wrapper expected(h_expected.begin(), h_expected.end());
 
   auto const target_table   = cudf::table_view({target});
   auto const expected_table = cudf::table_view({expected});

--- a/cpp/tests/copying/segmented_gather_list_tests.cpp
+++ b/cpp/tests/copying/segmented_gather_list_tests.cpp
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cudf/column/column_view.hpp>
-#include <cudf/copying.hpp>
-#include <cudf/detail/iterator.cuh>
-#include <cudf/detail/null_mask.hpp>
-#include <cudf/lists/detail/gather.cuh>
-#include <cudf/lists/lists_column_view.hpp>
-
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/lists/gather.hpp>
+#include <cudf/lists/lists_column_view.hpp>
 
 template <typename T>
 class SegmentedGatherTest : public cudf::test::BaseFixture {
@@ -40,8 +40,6 @@ TYPED_TEST_SUITE(SegmentedGatherTest, FixedWidthTypesNotBool);
 // empty lists in lists_column_wrapper documentation
 template <typename T>
 using LCW = cudf::test::lists_column_wrapper<T, int32_t>;
-using cudf::lists_column_view;
-using cudf::lists::detail::segmented_gather;
 using namespace cudf::test::iterators;
 auto constexpr NULLIFY = cudf::out_of_bounds_policy::NULLIFY;
 
@@ -56,7 +54,8 @@ TYPED_TEST(SegmentedGatherTest, Gather)
     // Straight-line case.
     auto const gather_map = LCW<int>{{3, 2, 1, 0}, {0}, {0, 1}, {0, 2, 1}};
     auto const expected   = LCW<T>{{4, 3, 2, 1}, {5}, {6, 7}, {8, 10, 9}};
-    auto const results = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                                       cudf::lists_column_view{gather_map});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
   }
 
@@ -64,8 +63,8 @@ TYPED_TEST(SegmentedGatherTest, Gather)
     // Nullify out-of-bounds values.
     auto const gather_map = LCW<int>{{3, 2, 4, 0}, {0}, {0, -3}, {0, 2, 1}};
     auto const expected = LCW<T>{{{4, 3, 2, 1}, null_at(2)}, {5}, {{6, 7}, null_at(1)}, {8, 10, 9}};
-    auto const results =
-      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+    auto const results  = cudf::lists::segmented_gather(
+      cudf::lists_column_view{list}, cudf::lists_column_view{gather_map}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
   }
 }
@@ -73,21 +72,22 @@ TYPED_TEST(SegmentedGatherTest, Gather)
 TYPED_TEST(SegmentedGatherTest, GatherNothing)
 {
   using T = TypeParam;
-  using namespace cudf;
 
   // List<T>
   {
     auto const list       = LCW<T>{{1, 2, 3, 4}, {5}, {6, 7}, {8, 9, 10}};
     auto const gather_map = LCW<int>{LCW<int>{}, LCW<int>{}, LCW<int>{}, LCW<int>{}};
-    auto const results  = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
-    auto const expected = LCW<T>{LCW<T>{}, LCW<T>{}, LCW<T>{}, LCW<T>{}};
+    auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                                       cudf::lists_column_view{gather_map});
+    auto const expected   = LCW<T>{LCW<T>{}, LCW<T>{}, LCW<T>{}, LCW<T>{}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
   }
   // List<List<T>>
   {
     auto const list       = LCW<T>{{{1, 2, 3, 4}, {5}}, {{6, 7}}, {{}, {8, 9, 10}}};
     auto const gather_map = LCW<int>{LCW<int>{}, LCW<int>{}, LCW<int>{}};
-    auto const results = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                                       cudf::lists_column_view{gather_map});
 
     // hack to get column of empty list of list
     auto const expected_dummy = LCW<T>{{{1, 2, 3, 4}, {5}}, LCW<T>{}, LCW<T>{}, LCW<T>{}};
@@ -98,7 +98,8 @@ TYPED_TEST(SegmentedGatherTest, GatherNothing)
   {
     auto const list       = LCW<T>{{{{1, 2, 3, 4}, {5}}}, {{{6, 7}, {8, 9, 10}}}};
     auto const gather_map = LCW<int>{LCW<int>{}, LCW<int>{}};
-    auto const results = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                                       cudf::lists_column_view{gather_map});
     // hack to get column of empty list of list of list
     auto const expected_dummy = LCW<T>{{{{1, 2, 3, 4}}}, LCW<T>{}, LCW<T>{}};
     auto const expected       = cudf::split(expected_dummy, {1})[1];
@@ -108,13 +109,15 @@ TYPED_TEST(SegmentedGatherTest, GatherNothing)
     // even though it is empty past the first level
     cudf::lists_column_view lcv(results->view());
     EXPECT_EQ(lcv.size(), 2);
-    EXPECT_EQ(lcv.child().type().id(), type_id::LIST);
+    EXPECT_EQ(lcv.child().type().id(), cudf::type_id::LIST);
     EXPECT_EQ(lcv.child().size(), 0);
-    EXPECT_EQ(lists_column_view(lcv.child()).child().type().id(), type_id::LIST);
-    EXPECT_EQ(lists_column_view(lcv.child()).child().size(), 0);
-    EXPECT_EQ(lists_column_view(lists_column_view(lcv.child()).child()).child().type().id(),
-              type_to_id<T>());
-    EXPECT_EQ(lists_column_view(lists_column_view(lcv.child()).child()).child().size(), 0);
+    EXPECT_EQ(cudf::lists_column_view(lcv.child()).child().type().id(), cudf::type_id::LIST);
+    EXPECT_EQ(cudf::lists_column_view(lcv.child()).child().size(), 0);
+    EXPECT_EQ(
+      cudf::lists_column_view(cudf::lists_column_view(lcv.child()).child()).child().type().id(),
+      cudf::type_to_id<T>());
+    EXPECT_EQ(cudf::lists_column_view(cudf::lists_column_view(lcv.child()).child()).child().size(),
+              0);
   }
 }
 
@@ -131,7 +134,8 @@ TYPED_TEST(SegmentedGatherTest, GatherNulls)
   {
     // Test gathering on lists that contain nulls.
     auto const gather_map = LCW<int>{{0, 1}, LCW<int>{}, {1}, {2, 1, 0}};
-    auto const results = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                                       cudf::lists_column_view{gather_map});
     auto const expected =
       LCW<T>{{{1, 2}, valids}, LCW<T>{}, {{7}, valids + 1}, {{10, 9, 8}, valids}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
@@ -139,8 +143,8 @@ TYPED_TEST(SegmentedGatherTest, GatherNulls)
   {
     // Test gathering on lists that contain nulls, with out-of-bounds indices.
     auto const gather_map = LCW<int>{{10, -10}, LCW<int>{}, {1}, {2, -10, 0}};
-    auto const results =
-      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+    auto const results    = cudf::lists::segmented_gather(
+      cudf::lists_column_view{list}, cudf::lists_column_view{gather_map}, NULLIFY);
     auto const expected =
       LCW<T>{{{0, 0}, nulls_at({0, 1})}, LCW<T>{}, {{7}, valids + 1}, {{10, 0, 8}, null_at(1)}};
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
@@ -158,7 +162,7 @@ TYPED_TEST(SegmentedGatherTest, GatherNested)
                                    {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
                                    {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {-17, -18}}};
     auto const gather_map = LCW<int>{{0, -2, -2}, {1}, {1, 0, -1, -5}};
-    auto const results    = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list}, cudf::lists_column_view{gather_map});
     auto const expected   = LCW<T>{{{2, 3}, {2, 3}, {2, 3}},
                                    {{9, 10, 11}},
                                    {{17, 18}, {15, 16}, {-17, -18}, {15, 16}}};
@@ -174,7 +178,7 @@ TYPED_TEST(SegmentedGatherTest, GatherNested)
                                    {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {-17, -18}}};
     auto const gather_map = LCW<int>{{0, 2, -2}, {1}, {1, 0, -1, -6}};
     auto const results =
-      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+      cudf::lists::segmented_gather(cudf::lists_column_view{list}, cudf::lists_column_view{gather_map}, NULLIFY);
     auto const expected = LCW<T>{{{{2, 3}, LCW<T>{}, {2, 3}}, null_at(1)},
                                  {{9, 10, 11}},
                                  {{{17, 18}, {15, 16}, {-17, -18}, LCW<T>{}}, null_at(3)}};
@@ -193,7 +197,7 @@ TYPED_TEST(SegmentedGatherTest, GatherNested)
                               {{11, 12, 13, 14, 15}, {16, 17}, {0}}},
                              {{{10, 20}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}};
     auto const gather_map = LCW<int>{{1}, LCW<int>{}, {0}, {1}, {0, -1, 1}};
-    auto const results = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const results = cudf::lists::segmented_gather(cudf::lists_column_view{list}, cudf::lists_column_view{gather_map});
     auto const expected = LCW<T>{{{{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
                                  LCW<T>{},
                                  {{LCW<T>{0}}},
@@ -213,8 +217,8 @@ TYPED_TEST(SegmentedGatherTest, GatherNested)
                               {{11, 12, 13, 14, 15}, {16, 17}, {0}}},
                              {{{10, 20}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}};
     auto const gather_map = LCW<int>{{1}, LCW<int>{}, {0}, {1}, {0, -1, 3, -4}};
-    auto const results =
-      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+    auto const results    = cudf::lists::segmented_gather(
+      cudf::lists_column_view{list}, cudf::lists_column_view{gather_map}, NULLIFY);
     auto const expected =
       LCW<T>{{{{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}},
              LCW<T>{},
@@ -237,7 +241,7 @@ TYPED_TEST(SegmentedGatherTest, GatherOutOfOrder)
                                    {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
                                    {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
     auto const gather_map = LCW<int>{{1, 0}, {1, 2, 0}, {4, 3, 2, 1, 0}};
-    auto const results    = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list}, cudf::lists_column_view{gather_map});
     auto const expected   = LCW<T>{{{4, 5}, {2, 3}},
                                    {{9, 10, 11}, {12, 13, 14}, {6, 7, 8}},
                                    {{17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}};
@@ -252,7 +256,7 @@ TYPED_TEST(SegmentedGatherTest, GatherOutOfOrder)
                                    {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
                                    {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
     auto const gather_map = LCW<int>{{1, 0}, {3, -1, -4}, {5, 4, 3, 2, 1, 0}};
-    auto const results    = segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+    auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list}, cudf::lists_column_view{gather_map}, NULLIFY);
     auto const expected   = LCW<T>{{{4, 5}, {2, 3}},
                                    {{LCW<T>{}, {12, 13, 14}, LCW<T>{}}, nulls_at({0, 2})},
                                    {{LCW<T>{}, {17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}, null_at(0)}};
@@ -272,7 +276,7 @@ TYPED_TEST(SegmentedGatherTest, GatherNegatives)
                                    {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}},
                                    {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
     auto const gather_map = LCW<int>{{-1, 0}, {-2, -1, 0}, {-5, -4, -3, -2, -1, 0}};
-    auto const results    = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list}, cudf::lists_column_view{gather_map});
     auto const expected   = LCW<T>{{{4, 5}, {2, 3}},
                                    {{9, 10, 11}, {12, 13, 14}, {6, 7, 8}},
                                    {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}};
@@ -287,7 +291,7 @@ TYPED_TEST(SegmentedGatherTest, GatherNegatives)
                                    {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}}};
     auto const gather_map = LCW<int>{{-1, 0}, {-2, -1, -4}, {-6, -4, -3, -2, -1, 0}};
     auto const results    =
-      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+      cudf::lists::segmented_gather(cudf::lists_column_view{list}, cudf::lists_column_view{gather_map}, NULLIFY);
     auto const expected   = LCW<T>{{{4, 5}, {2, 3}},
                                    {{{9, 10, 11}, {12, 13, 14}, LCW<T>{}}, null_at(2)},
                                    {{LCW<T>{}, {17, 18}, {17, 18}, {17, 18}, {17, 18}, {15, 16}}, null_at(0)}};
@@ -312,7 +316,8 @@ TYPED_TEST(SegmentedGatherTest, GatherOnNonCompactedNullLists)
   auto const gather_map = LCW<int>{{-1, 2, 1, -4}, {0}, {-2, 1}, {0, 2, 1}, {}, {0}, {1, 2}};
   auto const expected =
     LCW<T>{{{4, 3, 2, 1}, {5}, {6, 7}, {8, 0, 9}, {}, {{X}, all_nulls()}, {4, 5}}, null_at(5)};
-  auto const results = segmented_gather(lists_column_view{*input}, lists_column_view{gather_map});
+  auto const results = cudf::lists::segmented_gather(cudf::lists_column_view{*input},
+                                                     cudf::lists_column_view{gather_map});
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
 }
 
@@ -331,7 +336,7 @@ TYPED_TEST(SegmentedGatherTest, GatherNestedNulls)
                              {{15, 16}, {17, 18}, {17, 18}, {17, 18}, {17, 18}},
                              {{{{25, 26}, valids}, {27, 28}, {{29, 30}, valids}, {31, 32}, {33, 34}}, valids}};
     auto const gather_map = LCW<int>{{0, 1}, {0, 2}, LCW<int>{}, {0, 1, 4}};
-    auto const results  = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const results  = cudf::lists::segmented_gather(cudf::lists_column_view{list}, cudf::lists_column_view{gather_map});
     auto const expected = LCW<T>{{{{2, 3}, valids}, {4, 5}},
                                  {{{6, 7, 8}, {12, 13, 14}}, no_nulls()},
                                  LCW<T>{},
@@ -351,7 +356,7 @@ TYPED_TEST(SegmentedGatherTest, GatherNestedNulls)
                                 {{11, 12, 13, 14, 15}, {16, 17}, {0}}},
                               {{{{{10, 20}, valids}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}, valids}}};
     auto const gather_map = LCW<int>{{1, 2, 4}};
-    auto const results    = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list}, cudf::lists_column_view{gather_map});
     auto const expected   = LCW<T>{{{{{15, 16}, {{27, 28}, valids}, {{37, 38}, valids}, {47, 48}, {57, 58}}},
                                     {{LCW<T>{0}}},
                                     {{{{{10, 20}, valids}}, {LCW<T>{30}}, {{40, 50}, {60, 70, 80}}}, valids}}};
@@ -366,7 +371,8 @@ TYPED_TEST(SegmentedGatherTest, GatherNestedWithEmpties)
 
   auto const list = LCW<T>{{{2, 3}, LCW<T>{}}, {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}, {LCW<T>{}}};
   auto const gather_map = LCW<int>{LCW<int>{0}, LCW<int>{0}, LCW<int>{0}};
-  auto results          = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+  auto results          = cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                               cudf::lists_column_view{gather_map});
   auto const expected =
     LCW<T>{{{2, 3}}, {{6, 7, 8}}, {LCW<T>{}}};  // skip one null, gather one null.
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
@@ -390,9 +396,10 @@ TYPED_TEST(SegmentedGatherTest, GatherSliced)
 
     {
       auto const list       = LCW<int>{{1, 2}, {0, 2}, {0, 1}};
-      auto const gather_map = lists_column_view{list};
-      auto const result     = segmented_gather(lists_column_view{split_a[0]}, gather_map);
-      auto const expected   = LCW<T>{
+      auto const gather_map = cudf::lists_column_view{list};
+      auto const result =
+        cudf::lists::segmented_gather(cudf::lists_column_view{split_a[0]}, gather_map);
+      auto const expected = LCW<T>{
         {{2, 2}, {3, 3}},
         {{4, 4, 4}, {6, 6}},
         {{7, 7, 7}, {8, 8}},
@@ -402,8 +409,9 @@ TYPED_TEST(SegmentedGatherTest, GatherSliced)
 
     {
       auto const list       = LCW<int>{{0, 1}, LCW<int>{}, LCW<int>{}, {0, 1}, LCW<int>{}};
-      auto const gather_map = lists_column_view{list};
-      auto const result     = segmented_gather(lists_column_view{split_a[1]}, gather_map);
+      auto const gather_map = cudf::lists_column_view{list};
+      auto const result =
+        cudf::lists::segmented_gather(cudf::lists_column_view{split_a[1]}, gather_map);
       auto const expected =
         LCW<T>{{{10, 10, 10}, {11, 11}}, LCW<T>{}, LCW<T>{}, {{50, 50, 50, 50}, {6, 13}}, LCW<T>{}};
       CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
@@ -438,8 +446,8 @@ TYPED_TEST(SegmentedGatherTest, GatherSliced)
     // gather from slice 0
     {
       LCW<int> map{{0, 1}};
-      auto result =
-        cudf::lists::detail::segmented_gather(lists_column_view{sliced[0]}, lists_column_view{map});
+      auto result = cudf::lists::segmented_gather(cudf::lists_column_view{sliced[0]},
+                                                  cudf::lists_column_view{map});
       LCW<T> expected{{{{2, 3}, {4, 5}}, {{6, 7, 8}, {9, 10, 11}, {12, 13, 14}}}};
       CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, result->view());
     }
@@ -447,8 +455,8 @@ TYPED_TEST(SegmentedGatherTest, GatherSliced)
     // gather from slice 1
     {
       LCW<int16_t> map{{0}, {1, 2, 0, 1}, {0, 1, 2}};
-      auto result =
-        cudf::lists::detail::segmented_gather(lists_column_view{sliced[1]}, lists_column_view{map});
+      auto result = cudf::lists::segmented_gather(cudf::lists_column_view{sliced[1]},
+                                                  cudf::lists_column_view{map});
       LCW<T> expected{
         {{LCW<T>{0}}},
 
@@ -465,8 +473,8 @@ TYPED_TEST(SegmentedGatherTest, GatherSliced)
     // gather from slice 2
     {
       LCW<int> map{{1, 0, 0, 1, 1, 0}, {1, 0, 0, 1, 1, 2}};
-      auto result =
-        cudf::lists::detail::segmented_gather(lists_column_view{sliced[2]}, lists_column_view{map});
+      auto result = cudf::lists::segmented_gather(cudf::lists_column_view{sliced[2]},
+                                                  cudf::lists_column_view{map});
       std::vector<bool> expected_valids = {false, true, true, false, false, true};
 
       LCW<T> expected{{{{LCW<T>{30}},
@@ -497,7 +505,8 @@ TEST_F(SegmentedGatherTestString, StringGather)
     auto const list       = LCW<T>{{"a", "b", "c", "d"}, {"1", "22", "333", "4"}, {"x", "y", "z"}};
     auto const gather_map = LCW<int8_t>{{0, 1, 3, 2}, {1, 0, 3, 2}, LCW<int8_t>{}};
     auto const expected   = LCW<T>{{"a", "b", "d", "c"}, {"22", "1", "4", "333"}, LCW<T>{}};
-    auto const result = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const result     = cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                                      cudf::lists_column_view{gather_map});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
   }
 
@@ -508,7 +517,8 @@ TEST_F(SegmentedGatherTestString, StringGather)
     auto const expected   = LCW<T>{{{"a", "b", "d", "c"}, cudf::test::iterators::null_at(3)},
                                  {{"22", "1", "4", "333"}, cudf::test::iterators::null_at(1)},
                                  LCW<T>{}};
-    auto result = segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+    auto result           = cudf::lists::segmented_gather(
+      cudf::lists_column_view{list}, cudf::lists_column_view{gather_map}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
   }
 }
@@ -524,18 +534,22 @@ TEST_F(SegmentedGatherTestFloat, GatherMapSliced)
     auto const gather_map = LCW<int>{{3, 2, 1, 0}, {0}, {0, 1}, {0, 2, 1}, {0}, {1}};
     // gather_map.offset: 0, 4, 5, 7, 10, 11, 12
     auto const expected = LCW<T>{{4, 3, 2, 1}, {5}, {6, 7}, {8, 10, 9}, {11}, {14}};
-    auto const results  = segmented_gather(lists_column_view{list}, lists_column_view{gather_map});
+    auto const results  = cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                                       cudf::lists_column_view{gather_map});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
 
     auto const sliced  = cudf::split(list, {1, 4});
     auto const split_m = cudf::split(gather_map, {1, 4});
     auto const split_e = cudf::split(expected, {1, 4});
 
-    auto result0 = segmented_gather(lists_column_view{sliced[0]}, lists_column_view{split_m[0]});
+    auto result0 = cudf::lists::segmented_gather(cudf::lists_column_view{sliced[0]},
+                                                 cudf::lists_column_view{split_m[0]});
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[0], result0->view());
-    auto result1 = segmented_gather(lists_column_view{sliced[1]}, lists_column_view{split_m[1]});
+    auto result1 = cudf::lists::segmented_gather(cudf::lists_column_view{sliced[1]},
+                                                 cudf::lists_column_view{split_m[1]});
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[1], result1->view());
-    auto result2 = segmented_gather(lists_column_view{sliced[2]}, lists_column_view{split_m[2]});
+    auto result2 = cudf::lists::segmented_gather(cudf::lists_column_view{sliced[2]},
+                                                 cudf::lists_column_view{split_m[2]});
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[2], result2->view());
   }
 
@@ -546,22 +560,22 @@ TEST_F(SegmentedGatherTestFloat, GatherMapSliced)
     // gather_map.offset: 0, 4, 5, 7, 10, 11, 12
     auto const expected =
       LCW<T>{{{4, 0, 2, 1}, null_at(1)}, {5}, {6, 7}, {{8, 10, 9}, null_at(2)}, {11}, {14}};
-    auto results =
-      segmented_gather(lists_column_view{list}, lists_column_view{gather_map}, NULLIFY);
+    auto results = cudf::lists::segmented_gather(
+      cudf::lists_column_view{list}, cudf::lists_column_view{gather_map}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
 
     auto const sliced  = cudf::split(list, {1, 4});
     auto const split_m = cudf::split(gather_map, {1, 4});
     auto const split_e = cudf::split(expected, {1, 4});
 
-    auto const result0 =
-      segmented_gather(lists_column_view{sliced[0]}, lists_column_view{split_m[0]}, NULLIFY);
+    auto const result0 = cudf::lists::segmented_gather(
+      cudf::lists_column_view{sliced[0]}, cudf::lists_column_view{split_m[0]}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[0], result0->view());
-    auto const result1 =
-      segmented_gather(lists_column_view{sliced[1]}, lists_column_view{split_m[1]}, NULLIFY);
+    auto const result1 = cudf::lists::segmented_gather(
+      cudf::lists_column_view{sliced[1]}, cudf::lists_column_view{split_m[1]}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[1], result1->view());
-    auto const result2 =
-      segmented_gather(lists_column_view{sliced[2]}, lists_column_view{split_m[2]}, NULLIFY);
+    auto const result2 = cudf::lists::segmented_gather(
+      cudf::lists_column_view{sliced[2]}, cudf::lists_column_view{split_m[2]}, NULLIFY);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(split_e[2], result2->view());
   }
 }
@@ -578,29 +592,29 @@ TEST_F(SegmentedGatherTestFloat, Fails)
 
   // Input must be a list of integer indices. It should fail for integers,
   // strings, or lists containing anything other than integers.
-  EXPECT_THROW(
-    cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{nonlist_map0}),
-    cudf::logic_error);
+  EXPECT_THROW(cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                             cudf::lists_column_view{nonlist_map0}),
+               cudf::logic_error);
 
-  EXPECT_THROW(
-    cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{nonlist_map1}),
-    cudf::logic_error);
+  EXPECT_THROW(cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                             cudf::lists_column_view{nonlist_map1}),
+               cudf::logic_error);
 
-  EXPECT_THROW(
-    cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{nonlist_map2}),
-    cudf::logic_error);
+  EXPECT_THROW(cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                             cudf::lists_column_view{nonlist_map2}),
+               cudf::logic_error);
 
   auto valids =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
   LCW<int8_t> nulls_map{{{3, 2, 1, 0}, {0}, {0}, {0, 1}}, valids};
 
   // Nulls are not supported in the gather map.
-  EXPECT_THROW(
-    cudf::lists::detail::segmented_gather(lists_column_view{list}, lists_column_view{nulls_map}),
-    cudf::logic_error);
+  EXPECT_THROW(cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                             cudf::lists_column_view{nulls_map}),
+               cudf::logic_error);
 
   // Gather map and list column sizes must be the same.
-  EXPECT_THROW(cudf::lists::detail::segmented_gather(lists_column_view{list},
-                                                     lists_column_view{size_mismatch_map}),
+  EXPECT_THROW(cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                             cudf::lists_column_view{size_mismatch_map}),
                cudf::logic_error);
 }

--- a/cpp/tests/copying/shift_tests.cpp
+++ b/cpp/tests/copying/shift_tests.cpp
@@ -30,7 +30,6 @@
 #include <limits>
 #include <memory>
 
-using cudf::test::fixed_width_column_wrapper;
 using TestTypes = cudf::test::Types<int32_t>;
 
 template <typename T, typename ScalarType = cudf::scalar_type_t<T>>
@@ -83,8 +82,8 @@ TYPED_TEST(ShiftTestsTyped, ColumnEmpty)
   std::vector<T> vals{};
   std::vector<bool> mask{};
 
-  auto input    = fixed_width_column_wrapper<T>(vals.begin(), vals.end(), mask.begin());
-  auto expected = fixed_width_column_wrapper<T>(vals.begin(), vals.end(), mask.begin());
+  auto input    = cudf::test::fixed_width_column_wrapper<T>(vals.begin(), vals.end(), mask.begin());
+  auto expected = cudf::test::fixed_width_column_wrapper<T>(vals.begin(), vals.end(), mask.begin());
 
   auto fill   = make_scalar<T>();
   auto actual = cudf::shift(input, 5, *fill);
@@ -96,20 +95,21 @@ TYPED_TEST(ShiftTestsTyped, NonNullColumn)
 {
   using T = TypeParam;
 
-  auto input    = fixed_width_column_wrapper<T>{lowest<T>(),
-                                             cudf::test::make_type_param_scalar<T>(1),
-                                             cudf::test::make_type_param_scalar<T>(2),
-                                             cudf::test::make_type_param_scalar<T>(3),
-                                             cudf::test::make_type_param_scalar<T>(4),
-                                             cudf::test::make_type_param_scalar<T>(5),
-                                             highest<T>()};
-  auto expected = fixed_width_column_wrapper<T>{cudf::test::make_type_param_scalar<T>(7),
-                                                cudf::test::make_type_param_scalar<T>(7),
-                                                lowest<T>(),
-                                                cudf::test::make_type_param_scalar<T>(1),
-                                                cudf::test::make_type_param_scalar<T>(2),
-                                                cudf::test::make_type_param_scalar<T>(3),
-                                                cudf::test::make_type_param_scalar<T>(4)};
+  auto input = cudf::test::fixed_width_column_wrapper<T>{lowest<T>(),
+                                                         cudf::test::make_type_param_scalar<T>(1),
+                                                         cudf::test::make_type_param_scalar<T>(2),
+                                                         cudf::test::make_type_param_scalar<T>(3),
+                                                         cudf::test::make_type_param_scalar<T>(4),
+                                                         cudf::test::make_type_param_scalar<T>(5),
+                                                         highest<T>()};
+  auto expected =
+    cudf::test::fixed_width_column_wrapper<T>{cudf::test::make_type_param_scalar<T>(7),
+                                              cudf::test::make_type_param_scalar<T>(7),
+                                              lowest<T>(),
+                                              cudf::test::make_type_param_scalar<T>(1),
+                                              cudf::test::make_type_param_scalar<T>(2),
+                                              cudf::test::make_type_param_scalar<T>(3),
+                                              cudf::test::make_type_param_scalar<T>(4)};
 
   auto fill   = make_scalar<T>(cudf::test::make_type_param_scalar<T>(7));
   auto actual = cudf::shift(input, 2, *fill);
@@ -121,20 +121,21 @@ TYPED_TEST(ShiftTestsTyped, NegativeShift)
 {
   using T = TypeParam;
 
-  auto input    = fixed_width_column_wrapper<T>{lowest<T>(),
-                                             cudf::test::make_type_param_scalar<T>(1),
-                                             cudf::test::make_type_param_scalar<T>(2),
-                                             cudf::test::make_type_param_scalar<T>(3),
-                                             cudf::test::make_type_param_scalar<T>(4),
-                                             cudf::test::make_type_param_scalar<T>(5),
-                                             highest<T>()};
-  auto expected = fixed_width_column_wrapper<T>{cudf::test::make_type_param_scalar<T>(4),
-                                                cudf::test::make_type_param_scalar<T>(5),
-                                                highest<T>(),
-                                                cudf::test::make_type_param_scalar<T>(7),
-                                                cudf::test::make_type_param_scalar<T>(7),
-                                                cudf::test::make_type_param_scalar<T>(7),
-                                                cudf::test::make_type_param_scalar<T>(7)};
+  auto input = cudf::test::fixed_width_column_wrapper<T>{lowest<T>(),
+                                                         cudf::test::make_type_param_scalar<T>(1),
+                                                         cudf::test::make_type_param_scalar<T>(2),
+                                                         cudf::test::make_type_param_scalar<T>(3),
+                                                         cudf::test::make_type_param_scalar<T>(4),
+                                                         cudf::test::make_type_param_scalar<T>(5),
+                                                         highest<T>()};
+  auto expected =
+    cudf::test::fixed_width_column_wrapper<T>{cudf::test::make_type_param_scalar<T>(4),
+                                              cudf::test::make_type_param_scalar<T>(5),
+                                              highest<T>(),
+                                              cudf::test::make_type_param_scalar<T>(7),
+                                              cudf::test::make_type_param_scalar<T>(7),
+                                              cudf::test::make_type_param_scalar<T>(7),
+                                              cudf::test::make_type_param_scalar<T>(7)};
 
   auto fill   = make_scalar<T>(cudf::test::make_type_param_scalar<T>(7));
   auto actual = cudf::shift(input, -4, *fill);
@@ -146,21 +147,22 @@ TYPED_TEST(ShiftTestsTyped, NullScalar)
 {
   using T = TypeParam;
 
-  auto input    = fixed_width_column_wrapper<T>{lowest<T>(),
-                                             cudf::test::make_type_param_scalar<T>(5),
-                                             cudf::test::make_type_param_scalar<T>(0),
-                                             cudf::test::make_type_param_scalar<T>(3),
-                                             cudf::test::make_type_param_scalar<T>(0),
-                                             cudf::test::make_type_param_scalar<T>(1),
-                                             highest<T>()};
-  auto expected = fixed_width_column_wrapper<T>({cudf::test::make_type_param_scalar<T>(0),
-                                                 cudf::test::make_type_param_scalar<T>(0),
-                                                 lowest<T>(),
-                                                 cudf::test::make_type_param_scalar<T>(5),
-                                                 cudf::test::make_type_param_scalar<T>(0),
-                                                 cudf::test::make_type_param_scalar<T>(3),
-                                                 cudf::test::make_type_param_scalar<T>(0)},
-                                                {0, 0, 1, 1, 1, 1, 1});
+  auto input = cudf::test::fixed_width_column_wrapper<T>{lowest<T>(),
+                                                         cudf::test::make_type_param_scalar<T>(5),
+                                                         cudf::test::make_type_param_scalar<T>(0),
+                                                         cudf::test::make_type_param_scalar<T>(3),
+                                                         cudf::test::make_type_param_scalar<T>(0),
+                                                         cudf::test::make_type_param_scalar<T>(1),
+                                                         highest<T>()};
+  auto expected =
+    cudf::test::fixed_width_column_wrapper<T>({cudf::test::make_type_param_scalar<T>(0),
+                                               cudf::test::make_type_param_scalar<T>(0),
+                                               lowest<T>(),
+                                               cudf::test::make_type_param_scalar<T>(5),
+                                               cudf::test::make_type_param_scalar<T>(0),
+                                               cudf::test::make_type_param_scalar<T>(3),
+                                               cudf::test::make_type_param_scalar<T>(0)},
+                                              {0, 0, 1, 1, 1, 1, 1});
 
   auto fill = make_scalar<T>();
 
@@ -173,8 +175,9 @@ TYPED_TEST(ShiftTestsTyped, NullableColumn)
 {
   using T = TypeParam;
 
-  auto input    = fixed_width_column_wrapper<T, int32_t>({1, 2, 3, 4, 5}, {0, 1, 1, 1, 0});
-  auto expected = fixed_width_column_wrapper<T, int32_t>({7, 7, 1, 2, 3}, {1, 1, 0, 1, 1});
+  auto input = cudf::test::fixed_width_column_wrapper<T, int32_t>({1, 2, 3, 4, 5}, {0, 1, 1, 1, 0});
+  auto expected =
+    cudf::test::fixed_width_column_wrapper<T, int32_t>({7, 7, 1, 2, 3}, {1, 1, 0, 1, 1});
 
   auto fill   = make_scalar<T>(cudf::test::make_type_param_scalar<T>(7));
   auto actual = cudf::shift(input, 2, *fill);
@@ -186,7 +189,7 @@ TYPED_TEST(ShiftTestsTyped, MismatchFillValueDtypes)
 {
   using T = TypeParam;
 
-  auto input = fixed_width_column_wrapper<T>{};
+  auto input = cudf::test::fixed_width_column_wrapper<T>{};
 
   auto fill = cudf::string_scalar("");
 
@@ -239,15 +242,16 @@ TEST_F(ShiftTests, OffsetGreaterThanSize)
   results = cudf::shift(input_str, -6, cudf::string_scalar("", false));
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_str, *results);
 
-  auto const input = fixed_width_column_wrapper<int32_t>({0, 2, 3, 4, 0}, {0, 1, 1, 1, 0});
-  results          = cudf::shift(input, 6, cudf::numeric_scalar<int32_t>(9));
-  auto expected    = fixed_width_column_wrapper<int32_t>({9, 9, 9, 9, 9});
+  auto const input =
+    cudf::test::fixed_width_column_wrapper<int32_t>({0, 2, 3, 4, 0}, {0, 1, 1, 1, 0});
+  results       = cudf::shift(input, 6, cudf::numeric_scalar<int32_t>(9));
+  auto expected = cudf::test::fixed_width_column_wrapper<int32_t>({9, 9, 9, 9, 9});
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *results);
   results = cudf::shift(input, -6, cudf::numeric_scalar<int32_t>(9));
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *results);
 
   results  = cudf::shift(input, 6, cudf::numeric_scalar<int32_t>(0, false));
-  expected = fixed_width_column_wrapper<int32_t>({0, 0, 0, 0, 0}, {0, 0, 0, 0, 0});
+  expected = cudf::test::fixed_width_column_wrapper<int32_t>({0, 0, 0, 0, 0}, {0, 0, 0, 0, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *results);
   results = cudf::shift(input, -6, cudf::numeric_scalar<int32_t>(0, false));
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected, *results);


### PR DESCRIPTION
## Description
Fixes gtests source files in `COPYING_TEST` coded in namespace `cudf::test`
No function or test has changed just the test source code reworked per namespaces.

Reference https://github.com/rapidsai/cudf/issues/11734

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
