### PR TITLE
When building Arrow shared look for a shared OpenSSL

### DIFF
--- a/cpp/cmake/thirdparty/get_arrow.cmake
+++ b/cpp/cmake/thirdparty/get_arrow.cmake
@@ -126,13 +126,13 @@ function(find_and_configure_arrow VERSION BUILD_STATIC ENABLE_S3 ENABLE_ORC ENAB
     # Turn off CPM using `find_package` so we always download and make sure we get proper static
     # library.
     set(CPM_DOWNLOAD_Arrow TRUE)
-    # We don't want to explicitly force a static OpenSSL when `BUILD_STATIC` so we allow the
-    # caller to still request a shared OpenSSL, therefore we don't modify `ARROW_OPENSSL_USE_SHARED`
+    # We don't want to explicitly force a static OpenSSL when `BUILD_STATIC` so we allow the caller
+    # to still request a shared OpenSSL, therefore we don't modify `ARROW_OPENSSL_USE_SHARED`
   else()
     set(ARROW_BUILD_SHARED ON)
     set(ARROW_BUILD_STATIC OFF)
-    # By default ARROW will try to search for a static version of OpenSSL which is a bad idea
-    # given that shared linking is advised for critical components like SSL
+    # By default ARROW will try to search for a static version of OpenSSL which is a bad idea given
+    # that shared linking is advised for critical components like SSL
     set(ARROW_OPENSSL_USE_SHARED ON)
   endif()
 

--- a/cpp/cmake/thirdparty/get_arrow.cmake
+++ b/cpp/cmake/thirdparty/get_arrow.cmake
@@ -126,9 +126,14 @@ function(find_and_configure_arrow VERSION BUILD_STATIC ENABLE_S3 ENABLE_ORC ENAB
     # Turn off CPM using `find_package` so we always download and make sure we get proper static
     # library.
     set(CPM_DOWNLOAD_Arrow TRUE)
+    # We don't want to explicitly force a static OpenSSL when `BUILD_STATIC` so we allow the
+    # caller to still request a shared OpenSSL, therefore we don't modify `ARROW_OPENSSL_USE_SHARED`
   else()
     set(ARROW_BUILD_SHARED ON)
     set(ARROW_BUILD_STATIC OFF)
+    # By default ARROW will try to search for a static version of OpenSSL which is a bad idea
+    # given that shared linking is advised for critical components like SSL
+    set(ARROW_OPENSSL_USE_SHARED ON)
   endif()
 
   set(ARROW_PYTHON_OPTIONS "")

--- a/cpp/cmake/thirdparty/get_arrow.cmake
+++ b/cpp/cmake/thirdparty/get_arrow.cmake
@@ -126,8 +126,10 @@ function(find_and_configure_arrow VERSION BUILD_STATIC ENABLE_S3 ENABLE_ORC ENAB
     # Turn off CPM using `find_package` so we always download and make sure we get proper static
     # library.
     set(CPM_DOWNLOAD_Arrow TRUE)
-    # We don't want to explicitly force a static OpenSSL when `BUILD_STATIC` so we allow the caller
-    # to still request a shared OpenSSL, therefore we don't modify `ARROW_OPENSSL_USE_SHARED`
+    # By default ARROW will try to search for a static version of OpenSSL which is a bad idea given
+    # that shared linking is advised for critical components like SSL. If a static build is
+    # requested, we honor ARROW's default of static linking, but users may consider setting
+    # ARROW_OPENSSL_USE_SHARED even in static builds.
   else()
     set(ARROW_BUILD_SHARED ON)
     set(ARROW_BUILD_STATIC OFF)


### PR DESCRIPTION
## Description
When asked to build arrow from source, state that we want a shared library version of OpenSSL instead of a static. That ensures that we use the OpenSSL provided by conda ( which only provides shared ).

Plus in general building against a static OpenSSL is a bad idea as it makes deploying SSL CVE fixes very hard. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
