### PR TITLE
[skip gpuci] Update `ops-bot.yaml`

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -5,6 +5,5 @@ auto_merger: true
 branch_checker: true
 label_checker: true
 release_drafter: true
-external_contributors: false
 copy_prs: true
-rerun_tests: true
+recently_updated: true


### PR DESCRIPTION
## Description

This PR updates the `ops-bot.yaml` configuration. `external_contributors` and `rerun_tests` aren't valid configuration values at this time.

The [Recently Updated](https://docs.rapids.ai/resources/recently-updated/) check is intended to be used with GitHub Actions.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
