### PR TITLE
JNI bindings to write CSV

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
@@ -1,0 +1,122 @@
+/*
+ *
+ *  Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package ai.rapids.cudf;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class CSVWriterOptions {
+  
+  // private final Table table;
+  private String[] columnNames;
+  private Boolean includeHeader = false;
+  private String rowDelimiter = "\n";
+  private byte fieldDelimiter = ',';
+  private String nullValue = "\\N";
+
+  private CSVWriterOptions(Builder builder) {
+    // this.table = builder.table;
+    this.columnNames = builder.columnNames.toArray(new String[builder.columnNames.size()]);
+    this.nullValue = builder.nullValue;
+    this.includeHeader = builder.includeHeader;
+    this.fieldDelimiter = builder.fieldDelimiter;
+    this.rowDelimiter = builder.rowDelimiter;
+  }
+
+  // public Table getTable() {
+  //   return table;
+  // }
+
+  public String[] getColumnNames() {
+    return columnNames;
+  }
+
+  public Boolean getIncludeHeader() {
+    return includeHeader;
+  }
+
+  public String getRowDelimiter() {
+    return rowDelimiter;
+  }
+
+  public byte getFieldDelimiter() {
+    return fieldDelimiter;
+  }
+
+  public String getNullValue() {
+    return nullValue;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    // private Table table;
+    private List<String> columnNames = Collections.emptyList();
+    private Boolean includeHeader = false;
+    private String rowDelimiter = "\n";
+    private byte fieldDelimiter = ',';
+    private String nullValue = "\\N";
+    
+    public CSVWriterOptions build() {
+      return new CSVWriterOptions(this);
+    }
+
+    // public Builder withTable(Table table) {
+    //   this.table = table;
+    //   return this;
+    // }
+
+    public Builder withColumnNames(List<String> columnNames) {
+      this.columnNames = columnNames;
+      return this;
+    }
+
+    public Builder withColumnNames(String... columnNames) {
+      List<String> columnNamesList = new ArrayList<>();
+      for (String columnName : columnNames) {
+        columnNamesList.add(columnName);
+      }
+      return withColumnNames(columnNamesList);
+    }
+
+    public Builder withIncludeHeader(Boolean includeHeader) {
+      this.includeHeader = includeHeader;
+      return this;
+    }
+
+    public Builder withRowDelimiter(String rowDelimiter) {
+      this.rowDelimiter = rowDelimiter;
+      return this;
+    }
+
+    public Builder withFieldDelimiter(byte fieldDelimiter) {
+      this.fieldDelimiter = fieldDelimiter;
+      return this;
+    }
+
+    public Builder withNullValue(String nullValue) {
+      this.nullValue = nullValue;
+      return this;
+    }
+  }
+}

--- a/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 public class CSVWriterOptions {
   
-  // private final Table table;
   private String[] columnNames;
   private Boolean includeHeader = false;
   private String rowDelimiter = "\n";
@@ -32,17 +31,12 @@ public class CSVWriterOptions {
   private String nullValue = "\\N";
 
   private CSVWriterOptions(Builder builder) {
-    // this.table = builder.table;
     this.columnNames = builder.columnNames.toArray(new String[builder.columnNames.size()]);
     this.nullValue = builder.nullValue;
     this.includeHeader = builder.includeHeader;
     this.fieldDelimiter = builder.fieldDelimiter;
     this.rowDelimiter = builder.rowDelimiter;
   }
-
-  // public Table getTable() {
-  //   return table;
-  // }
 
   public String[] getColumnNames() {
     return columnNames;
@@ -70,7 +64,6 @@ public class CSVWriterOptions {
 
   public static class Builder {
 
-    // private Table table;
     private List<String> columnNames = Collections.emptyList();
     private Boolean includeHeader = false;
     private String rowDelimiter = "\n";
@@ -80,11 +73,6 @@ public class CSVWriterOptions {
     public CSVWriterOptions build() {
       return new CSVWriterOptions(this);
     }
-
-    // public Builder withTable(Table table) {
-    //   this.table = table;
-    //   return this;
-    // }
 
     public Builder withColumnNames(List<String> columnNames) {
       this.columnNames = columnNames;

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -874,7 +874,6 @@ public final class Table implements AutoCloseable {
 
   public void writeCSVToFile(CSVWriterOptions options, String outputPath)
   {
-    testBoolNative(options.getIncludeHeader());
     writeCSVToFile(nativeHandle, 
                    options.getColumnNames(), 
                    options.getIncludeHeader(), 
@@ -882,6 +881,26 @@ public final class Table implements AutoCloseable {
                    options.getFieldDelimiter(), 
                    options.getNullValue(), 
                    outputPath);
+  }
+
+  private static native void writeCSVToBuffer(long table,
+                                              String[] columnNames,
+                                              boolean includeHeader,
+                                              String rowDelimiter,
+                                              byte fieldDelimiter,
+                                              String nullValue,
+                                              HostBufferConsumer buffer) throws CudfException;
+
+  public void writeCSVToBuffer(CSVWriterOptions options, HostBufferConsumer bufferConsumer)
+  {
+    testBoolNative(options.getIncludeHeader());
+    writeCSVToBuffer(nativeHandle, 
+                    options.getColumnNames(), 
+                    options.getIncludeHeader(), 
+                    options.getRowDelimiter(), 
+                    options.getFieldDelimiter(), 
+                    options.getNullValue(), 
+                    bufferConsumer);
   }
 
   /**

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -857,6 +857,33 @@ public final class Table implements AutoCloseable {
         opts.getFalseValues()));
   }
 
+  private static native void testBoolNative(boolean boo) throws CudfException;
+
+  public void testBool(boolean boo)
+  {
+    Table.testBoolNative(boo);
+  }
+
+  private static native void writeCSVToFile(long table,
+                                            String[] columnNames,
+                                            boolean includeHeader,
+                                            String rowDelimiter,
+                                            byte fieldDelimiter,
+                                            String nullValue,
+                                            String outputPath) throws CudfException;
+
+  public void writeCSVToFile(CSVWriterOptions options, String outputPath)
+  {
+    testBoolNative(options.getIncludeHeader());
+    writeCSVToFile(nativeHandle, 
+                   options.getColumnNames(), 
+                   options.getIncludeHeader(), 
+                   options.getRowDelimiter(), 
+                   options.getFieldDelimiter(), 
+                   options.getNullValue(), 
+                   outputPath);
+  }
+
   /**
    * Read a JSON file using the default JSONOptions.
    * @param schema the schema of the file.  You may use Schema.INFERRED to infer the schema.

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -857,13 +857,6 @@ public final class Table implements AutoCloseable {
         opts.getFalseValues()));
   }
 
-  private static native void testBoolNative(boolean boo) throws CudfException;
-
-  public void testBool(boolean boo)
-  {
-    Table.testBoolNative(boo);
-  }
-
   private static native void writeCSVToFile(long table,
                                             String[] columnNames,
                                             boolean includeHeader,

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -893,7 +893,6 @@ public final class Table implements AutoCloseable {
 
   public void writeCSVToBuffer(CSVWriterOptions options, HostBufferConsumer bufferConsumer)
   {
-    testBoolNative(options.getIncludeHeader());
     writeCSVToBuffer(nativeHandle, 
                     options.getColumnNames(), 
                     options.getIncludeHeader(), 

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1323,6 +1323,53 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(
   CATCH_STD(env, NULL);
 }
 
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_testBoolNative(JNIEnv *env, jclass, jboolean boo)
+{
+  std::cout << "CALEB: Native: boo == " <<  static_cast<int>(boo) << std::endl; 
+  std::cout << "CALEB: Native: As bool: boo == " << std::boolalpha << static_cast<bool>(boo) << std::endl; 
+}
+
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(JNIEnv *env,
+                                                                jclass,
+                                                                jlong j_table_handle,
+                                                                jobjectArray j_column_names,
+                                                                jboolean include_header,
+                                                                jstring j_row_delimiter,
+                                                                jbyte j_field_delimiter,
+                                                                jstring j_null_value,
+                                                                jstring j_output_path) 
+{
+  JNI_NULL_CHECK(env, j_table_handle, "table handle cannot be null.", );
+  JNI_NULL_CHECK(env, j_column_names, "column name array cannot be null", );
+  JNI_NULL_CHECK(env, j_row_delimiter, "row delimiter cannot be null", );
+  JNI_NULL_CHECK(env, j_field_delimiter, "field delimiter cannot be null", );
+  JNI_NULL_CHECK(env, j_null_value, "null representation string cannot be itself null", );
+  JNI_NULL_CHECK(env, j_output_path, "output path cannot be null", );
+
+  try {
+    cudf::jni::auto_set_device(env);
+
+    auto const native_output_path = cudf::jni::native_jstring{env, j_output_path};
+    auto const output_path = native_output_path.get();
+
+    auto const table = reinterpret_cast<cudf::table_view *>(j_table_handle);
+    auto const n_column_names = cudf::jni::native_jstringArray{env, j_column_names};
+    auto const column_names = n_column_names.as_cpp_vector();
+
+    auto const line_terminator = cudf::jni::native_jstring{env, j_row_delimiter};
+    auto const na_rep = cudf::jni::native_jstring{env, j_null_value};
+    auto options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{output_path}, *table)
+                        .names(column_names)
+                        .include_header(static_cast<bool>(include_header))
+                        .line_terminator(line_terminator.get())
+                        .inter_column_delimiter(j_field_delimiter)
+                        .na_rep(na_rep.get());
+
+    cudf::io::write_csv(options.build());
+  }
+  CATCH_STD(env, );
+}
+
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_readAndInferJSON(
     JNIEnv *env, jclass, jlong buffer, jlong buffer_length, jboolean day_first, jboolean lines) {
 

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1329,12 +1329,6 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(
   CATCH_STD(env, NULL);
 }
 
-JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_testBoolNative(JNIEnv *env, jclass, jboolean boo)
-{
-  std::cout << "CALEB: Native: boo == " <<  static_cast<int>(boo) << std::endl; 
-  std::cout << "CALEB: Native: As bool: boo == " << std::boolalpha << static_cast<bool>(boo) << std::endl; 
-}
-
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(JNIEnv *env,
                                                                 jclass,
                                                                 jlong j_table_handle,
@@ -1396,8 +1390,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToBuffer(JNIEnv *env,
   try {
     cudf::jni::auto_set_device(env);
 
-    // auto data_sink = std::make_unique<cudf::jni::jni_writer_data_sink>(env, j_buffer);
-    auto data_sink = new cudf::jni::jni_writer_data_sink{env, j_buffer};
+    auto data_sink = cudf::jni::jni_writer_data_sink{env, j_buffer}; 
 
     auto const table = reinterpret_cast<cudf::table_view *>(j_table_handle);
     auto const n_column_names = cudf::jni::native_jstringArray{env, j_column_names};
@@ -1405,8 +1398,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToBuffer(JNIEnv *env,
 
     auto const line_terminator = cudf::jni::native_jstring{env, j_row_delimiter};
     auto const na_rep = cudf::jni::native_jstring{env, j_null_value};
-    // auto options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{data_sink.get()}, *table)
-    auto options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{data_sink}, *table)
+    auto options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{&data_sink}, *table)
                         .names(column_names)
                         .include_header(static_cast<bool>(include_header))
                         .line_terminator(line_terminator.get())
@@ -1414,15 +1406,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToBuffer(JNIEnv *env,
                         .na_rep(na_rep.get());
 
     cudf::io::write_csv(options.build());
-
-    std::cout << "CALEB: Examining what was written to the buffer: " 
-              << data_sink->bytes_written() << " bytes." 
-              << std::endl;
-
-    data_sink->flush();
-
-
-
+    data_sink.flush();
   }
   CATCH_STD(env, );
 }

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -160,6 +160,7 @@ public:
   }
 
   void flush() override {
+    std::cout << "CALEB: jni_writer_data_sink::flush()!!\n";
     if (current_buffer_written > 0) {
       JNIEnv *env = cudf::jni::get_jni_env(jvm);
       handle_buffer(env, current_buffer, current_buffer_written);
@@ -179,6 +180,7 @@ public:
 
 private:
   void rotate_buffer(JNIEnv *env) {
+    std::cout << "CALEB: jni_writer_data_sink::rotate_buffer()!!\n";
     if (current_buffer != nullptr) {
       handle_buffer(env, current_buffer, current_buffer_written);
       env->DeleteGlobalRef(current_buffer);

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1370,6 +1370,46 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(JNIEnv *env,
   CATCH_STD(env, );
 }
 
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToBuffer(JNIEnv *env,
+                                                                  jclass,
+                                                                  jlong j_table_handle,
+                                                                  jobjectArray j_column_names,
+                                                                  jboolean include_header,
+                                                                  jstring j_row_delimiter,
+                                                                  jbyte j_field_delimiter,
+                                                                  jstring j_null_value,
+                                                                  jobject j_buffer) 
+{
+  JNI_NULL_CHECK(env, j_table_handle, "table handle cannot be null.", );
+  JNI_NULL_CHECK(env, j_column_names, "column name array cannot be null", );
+  JNI_NULL_CHECK(env, j_row_delimiter, "row delimiter cannot be null", );
+  JNI_NULL_CHECK(env, j_field_delimiter, "field delimiter cannot be null", );
+  JNI_NULL_CHECK(env, j_null_value, "null representation string cannot be itself null", );
+  JNI_NULL_CHECK(env, j_buffer, "output buffer cannot be null", );
+
+  try {
+    cudf::jni::auto_set_device(env);
+
+    auto data_sink = std::make_unique<cudf::jni::jni_writer_data_sink>(env, j_buffer);
+
+    auto const table = reinterpret_cast<cudf::table_view *>(j_table_handle);
+    auto const n_column_names = cudf::jni::native_jstringArray{env, j_column_names};
+    auto const column_names = n_column_names.as_cpp_vector();
+
+    auto const line_terminator = cudf::jni::native_jstring{env, j_row_delimiter};
+    auto const na_rep = cudf::jni::native_jstring{env, j_null_value};
+    auto options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{data_sink.get()}, *table)
+                        .names(column_names)
+                        .include_header(static_cast<bool>(include_header))
+                        .line_terminator(line_terminator.get())
+                        .inter_column_delimiter(j_field_delimiter)
+                        .na_rep(na_rep.get());
+
+    cudf::io::write_csv(options.build());
+  }
+  CATCH_STD(env, );
+}
+
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_readAndInferJSON(
     JNIEnv *env, jclass, jlong buffer, jlong buffer_length, jboolean day_first, jboolean lines) {
 

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -61,6 +61,7 @@ constexpr long MINIMUM_WRITE_BUFFER_SIZE = 10 * 1024 * 1024; // 10 MB
 class jni_writer_data_sink final : public cudf::io::data_sink {
 public:
   explicit jni_writer_data_sink(JNIEnv *env, jobject callback) {
+    std::cout << "CALEB: jni_writer_data_sink::jni_writer_data_sink()!!\n";
     if (env->GetJavaVM(&jvm) < 0) {
       throw std::runtime_error("GetJavaVM failed");
     }
@@ -98,6 +99,7 @@ public:
   }
 
   void host_write(void const *data, size_t size) override {
+    std::cout << "CALEB: jni_writer_data_sink::host_write(" << size << " bytes)!!\n";
     JNIEnv *env = cudf::jni::get_jni_env(jvm);
     long left_to_copy = static_cast<long>(size);
     const char *copy_from = static_cast<const char *>(data);
@@ -123,6 +125,7 @@ public:
   bool supports_device_write() const override { return true; }
 
   void device_write(void const *gpu_data, size_t size, rmm::cuda_stream_view stream) override {
+    std::cout << "CALEB: jni_writer_data_sink::device_write(" << size << " bytes)!!\n";
     JNIEnv *env = cudf::jni::get_jni_env(jvm);
     long left_to_copy = static_cast<long>(size);
     const char *copy_from = static_cast<const char *>(gpu_data);
@@ -189,6 +192,7 @@ private:
   }
 
   void handle_buffer(JNIEnv *env, jobject buffer, jlong len) {
+    std::cout << "CALEB: jni_writer_data_sink::handle_buffer(" << len << " bytes)!!\n";
     env->CallVoidMethod(callback, handle_buffer_method, buffer, len);
     if (env->ExceptionCheck()) {
       throw std::runtime_error("handleBuffer threw an exception");
@@ -1390,7 +1394,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToBuffer(JNIEnv *env,
   try {
     cudf::jni::auto_set_device(env);
 
-    auto data_sink = std::make_unique<cudf::jni::jni_writer_data_sink>(env, j_buffer);
+    // auto data_sink = std::make_unique<cudf::jni::jni_writer_data_sink>(env, j_buffer);
+    auto data_sink = new cudf::jni::jni_writer_data_sink{env, j_buffer};
 
     auto const table = reinterpret_cast<cudf::table_view *>(j_table_handle);
     auto const n_column_names = cudf::jni::native_jstringArray{env, j_column_names};
@@ -1398,7 +1403,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToBuffer(JNIEnv *env,
 
     auto const line_terminator = cudf::jni::native_jstring{env, j_row_delimiter};
     auto const na_rep = cudf::jni::native_jstring{env, j_null_value};
-    auto options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{data_sink.get()}, *table)
+    // auto options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{data_sink.get()}, *table)
+    auto options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{data_sink}, *table)
                         .names(column_names)
                         .include_header(static_cast<bool>(include_header))
                         .line_terminator(line_terminator.get())
@@ -1406,6 +1412,15 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToBuffer(JNIEnv *env,
                         .na_rep(na_rep.get());
 
     cudf::io::write_csv(options.build());
+
+    std::cout << "CALEB: Examining what was written to the buffer: " 
+              << data_sink->bytes_written() << " bytes." 
+              << std::endl;
+
+    data_sink->flush();
+
+
+
   }
   CATCH_STD(env, );
 }

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1,4 +1,5 @@
 /*
+
  * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,7 +62,6 @@ constexpr long MINIMUM_WRITE_BUFFER_SIZE = 10 * 1024 * 1024; // 10 MB
 class jni_writer_data_sink final : public cudf::io::data_sink {
 public:
   explicit jni_writer_data_sink(JNIEnv *env, jobject callback) {
-    std::cout << "CALEB: jni_writer_data_sink::jni_writer_data_sink()!!\n";
     if (env->GetJavaVM(&jvm) < 0) {
       throw std::runtime_error("GetJavaVM failed");
     }
@@ -99,7 +99,6 @@ public:
   }
 
   void host_write(void const *data, size_t size) override {
-    std::cout << "CALEB: jni_writer_data_sink::host_write(" << size << " bytes)!!\n";
     JNIEnv *env = cudf::jni::get_jni_env(jvm);
     long left_to_copy = static_cast<long>(size);
     const char *copy_from = static_cast<const char *>(data);
@@ -125,7 +124,6 @@ public:
   bool supports_device_write() const override { return true; }
 
   void device_write(void const *gpu_data, size_t size, rmm::cuda_stream_view stream) override {
-    std::cout << "CALEB: jni_writer_data_sink::device_write(" << size << " bytes)!!\n";
     JNIEnv *env = cudf::jni::get_jni_env(jvm);
     long left_to_copy = static_cast<long>(size);
     const char *copy_from = static_cast<const char *>(gpu_data);
@@ -160,7 +158,6 @@ public:
   }
 
   void flush() override {
-    std::cout << "CALEB: jni_writer_data_sink::flush()!!\n";
     if (current_buffer_written > 0) {
       JNIEnv *env = cudf::jni::get_jni_env(jvm);
       handle_buffer(env, current_buffer, current_buffer_written);
@@ -180,7 +177,6 @@ public:
 
 private:
   void rotate_buffer(JNIEnv *env) {
-    std::cout << "CALEB: jni_writer_data_sink::rotate_buffer()!!\n";
     if (current_buffer != nullptr) {
       handle_buffer(env, current_buffer, current_buffer_written);
       env->DeleteGlobalRef(current_buffer);
@@ -194,7 +190,6 @@ private:
   }
 
   void handle_buffer(JNIEnv *env, jobject buffer, jlong len) {
-    std::cout << "CALEB: jni_writer_data_sink::handle_buffer(" << len << " bytes)!!\n";
     env->CallVoidMethod(callback, handle_buffer_method, buffer, len);
     if (env->ExceptionCheck()) {
       throw std::runtime_error("handleBuffer threw an exception");

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -639,11 +639,13 @@ public class TableTest extends CudfTestBase {
               .build();
           MyBufferConsumer consumer = new MyBufferConsumer()) {
       inputTable.writeCSVToBuffer(writeOptions, consumer);
+      inputTable.writeCSVToBuffer(writeOptions, consumer);
+      inputTable.writeCSVToBuffer(writeOptions, consumer);
 
       System.out.println("CALEB: TableTest: Buffer offset: " + consumer.offset);
       ByteBuffer buff = consumer.buffer.asByteBuffer(0, Long.valueOf(consumer.offset).intValue());
       System.out.println("CALEB: Buffer: " + buff);
-      
+
       // Read back.
       CSVOptions readOptions = CSVOptions.builder()
                                          .includeColumn("i")
@@ -653,8 +655,10 @@ public class TableTest extends CudfTestBase {
                                          .hasHeader(false)
                                          .withDelim('\u0001')
                                          .build();
-      try (Table readTable = Table.readCSV(schema, readOptions, consumer.buffer, 0, consumer.offset)) {
-        assertTablesAreEqual(inputTable, readTable);
+      try (Table readTable = Table.readCSV(schema, readOptions, consumer.buffer, 0, consumer.offset);
+           Table expected  = Table.concatenate(inputTable, inputTable, inputTable)) {
+        System.out.println("CALEB: Read table size: " + readTable.getRowCount());
+        assertTablesAreEqual(expected, readTable);
       }
     }
   }

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -639,6 +639,10 @@ public class TableTest extends CudfTestBase {
               .build();
           MyBufferConsumer consumer = new MyBufferConsumer()) {
       inputTable.writeCSVToBuffer(writeOptions, consumer);
+
+      System.out.println("CALEB: TableTest: Buffer offset: " + consumer.offset);
+      ByteBuffer buff = consumer.buffer.asByteBuffer(0, Long.valueOf(consumer.offset).intValue());
+      System.out.println("CALEB: Buffer: " + buff);
       
       // Read back.
       CSVOptions readOptions = CSVOptions.builder()
@@ -7585,10 +7589,12 @@ public class TableTest extends CudfTestBase {
 
     public MyBufferConsumer() {
       buffer = HostMemoryBuffer.allocate(10 * 1024 * 1024);
+      System.out.println("MyBufferConsumer::ctor()!! Alloced address: " + buffer.getAddress());
     }
 
     @Override
     public void handleBuffer(HostMemoryBuffer src, long len) {
+      System.out.println("MyBufferConsumer::handleBuffer() called! Writing: " + len + " bytes.");
       try {
         this.buffer.copyFromHostBuffer(offset, src, 0, len);
         offset += len;

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -575,46 +575,15 @@ public class TableTest extends CudfTestBase {
     }
   }
 
-  /* 
-  @Test
-  void testWriteCSVToBuffer() {
-    Schema schema = Schema.builder().column(DType.INT32, "a").build();
-    CSVWriterOptions writeOptions = CSVWriterOptions.builder()
-                                               .withColumnNames(schema.getColumnNames())
-                                               .withIncludeHeader(false)
-                                               .withFieldDelimiter((byte)'|')
-                                               .withRowDelimiter("\n")
-                                               .build();
-    try (Table inputTable 
-          = new Table.TestBuilder()
-              .column(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-              .build();
-         MyBufferConsumer consumer = new MyBufferConsumer()) {
-      inputTable.writeCSVToBuffer(writeOptions, consumer);
-
-      // Read back.
-      CSVOptions readOptions = CSVOptions.builder()
-                                         .includeColumn("a")
-                                         .hasHeader(false)
-                                         .withDelim(',')
-                                         .build();
-
-      try (Table readTable = Table.readCSV(schema, 
-                                           readOptions, 
-                                           consumer.buffer, 0, consumer.offset))
-      {
-        assertTablesAreEqual(inputTable, readTable);
-      }
-    }
-
-  }*/
-
   @Test
   void testWriteCSVToFile() throws IOException {
     File outputFile = File.createTempFile("testWriteCSVToFile", ".csv");
     Schema schema = Schema.builder()
-                          .column(DType.INT32, "a")
-                          .column(DType.FLOAT64, "b").build(); // TODO: Switch to Float32.
+                          .column(DType.INT32, "i")
+                          .column(DType.FLOAT64, "f")
+                          .column(DType.BOOL8, "b")
+                          .column(DType.STRING, "str")
+                          .build(); 
     CSVWriterOptions writeOptions = CSVWriterOptions.builder()
                                                .withColumnNames(schema.getColumnNames())
                                                .withIncludeHeader(false)
@@ -625,14 +594,17 @@ public class TableTest extends CudfTestBase {
           = new Table.TestBuilder()
               .column(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
               .column(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0)
+              .column(false, true, false, true, false, true, false, true, false, true)
+              .column("All", "the", "leaves", "are", "brown", "and", "the", "sky", "is", "grey")
               .build()) {
-      // inputTable.writeCSVToFile(writeOptions, "/tmp/testWriteCSVFile.csv");
       inputTable.writeCSVToFile(writeOptions, outputFile.getAbsolutePath());
       
       // Read back.
       CSVOptions readOptions = CSVOptions.builder()
-                                         .includeColumn("a")
+                                         .includeColumn("i")
+                                         .includeColumn("f")
                                          .includeColumn("b")
+                                         .includeColumn("str")
                                          .hasHeader(false)
                                          .withDelim('\u0001')
                                          .build();
@@ -643,6 +615,47 @@ public class TableTest extends CudfTestBase {
       outputFile.delete();
     }
   }
+
+  @Test
+  void testWriteCSVToBuffer() throws IOException {
+    Schema schema = Schema.builder()
+                          .column(DType.INT32, "i")
+                          .column(DType.FLOAT64, "f")
+                          .column(DType.BOOL8, "b")
+                          .column(DType.STRING, "str")
+                          .build(); 
+    CSVWriterOptions writeOptions = CSVWriterOptions.builder()
+                                               .withColumnNames(schema.getColumnNames())
+                                               .withIncludeHeader(false)
+                                               .withFieldDelimiter((byte)'\u0001')
+                                               .withRowDelimiter("\n")
+                                               .build();
+    try (Table inputTable 
+          = new Table.TestBuilder()
+              .column(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+              .column(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0)
+              .column(false, true, false, true, false, true, false, true, false, true)
+              .column("All", "the", "leaves", "are", "brown", "and", "the", "sky", "is", "grey")
+              .build();
+          MyBufferConsumer consumer = new MyBufferConsumer()) {
+      inputTable.writeCSVToBuffer(writeOptions, consumer);
+      
+      // Read back.
+      CSVOptions readOptions = CSVOptions.builder()
+                                         .includeColumn("i")
+                                         .includeColumn("f")
+                                         .includeColumn("b")
+                                         .includeColumn("str")
+                                         .hasHeader(false)
+                                         .withDelim('\u0001')
+                                         .build();
+      try (Table readTable = Table.readCSV(schema, readOptions, consumer.buffer, 0, consumer.offset)) {
+        assertTablesAreEqual(inputTable, readTable);
+      }
+    }
+  }
+
+
 
   @Test
   void testBool()

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -575,6 +575,88 @@ public class TableTest extends CudfTestBase {
     }
   }
 
+  /* 
+  @Test
+  void testWriteCSVToBuffer() {
+    Schema schema = Schema.builder().column(DType.INT32, "a").build();
+    CSVWriterOptions writeOptions = CSVWriterOptions.builder()
+                                               .withColumnNames(schema.getColumnNames())
+                                               .withIncludeHeader(false)
+                                               .withFieldDelimiter((byte)'|')
+                                               .withRowDelimiter("\n")
+                                               .build();
+    try (Table inputTable 
+          = new Table.TestBuilder()
+              .column(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+              .build();
+         MyBufferConsumer consumer = new MyBufferConsumer()) {
+      inputTable.writeCSVToBuffer(writeOptions, consumer);
+
+      // Read back.
+      CSVOptions readOptions = CSVOptions.builder()
+                                         .includeColumn("a")
+                                         .hasHeader(false)
+                                         .withDelim(',')
+                                         .build();
+
+      try (Table readTable = Table.readCSV(schema, 
+                                           readOptions, 
+                                           consumer.buffer, 0, consumer.offset))
+      {
+        assertTablesAreEqual(inputTable, readTable);
+      }
+    }
+
+  }*/
+
+  @Test
+  void testWriteCSVToFile() throws IOException {
+    File outputFile = File.createTempFile("testWriteCSVToFile", ".csv");
+    Schema schema = Schema.builder()
+                          .column(DType.INT32, "a")
+                          .column(DType.FLOAT64, "b").build(); // TODO: Switch to Float32.
+    CSVWriterOptions writeOptions = CSVWriterOptions.builder()
+                                               .withColumnNames(schema.getColumnNames())
+                                               .withIncludeHeader(false)
+                                               .withFieldDelimiter((byte)'\u0001')
+                                               .withRowDelimiter("\n")
+                                               .build();
+    try (Table inputTable 
+          = new Table.TestBuilder()
+              .column(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+              .column(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0)
+              .build()) {
+      // inputTable.writeCSVToFile(writeOptions, "/tmp/testWriteCSVFile.csv");
+      inputTable.writeCSVToFile(writeOptions, outputFile.getAbsolutePath());
+      
+      // Read back.
+      CSVOptions readOptions = CSVOptions.builder()
+                                         .includeColumn("a")
+                                         .includeColumn("b")
+                                         .hasHeader(false)
+                                         .withDelim('\u0001')
+                                         .build();
+      try (Table readTable = Table.readCSV(schema, readOptions, outputFile)) {
+        assertTablesAreEqual(inputTable, readTable);
+      }
+    } finally {
+      outputFile.delete();
+    }
+  }
+
+  @Test
+  void testBool()
+  {
+    try (Table inputTable 
+          = new Table.TestBuilder()
+              .column(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+              .build()) {
+      inputTable.testBool(false);
+      inputTable.testBool(true);
+    }
+
+  }
+
   @Test
   void testReadParquet() {
     ParquetOptions opts = ParquetOptions.builder()

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -663,21 +663,6 @@ public class TableTest extends CudfTestBase {
     }
   }
 
-
-
-  @Test
-  void testBool()
-  {
-    try (Table inputTable 
-          = new Table.TestBuilder()
-              .column(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-              .build()) {
-      inputTable.testBool(false);
-      inputTable.testBool(true);
-    }
-
-  }
-
   @Test
   void testReadParquet() {
     ParquetOptions opts = ParquetOptions.builder()

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -7580,12 +7580,10 @@ public class TableTest extends CudfTestBase {
 
     public MyBufferConsumer() {
       buffer = HostMemoryBuffer.allocate(10 * 1024 * 1024);
-      System.out.println("MyBufferConsumer::ctor()!! Alloced address: " + buffer.getAddress());
     }
 
     @Override
     public void handleBuffer(HostMemoryBuffer src, long len) {
-      System.out.println("MyBufferConsumer::handleBuffer() called! Writing: " + len + " bytes.");
       try {
         this.buffer.copyFromHostBuffer(offset, src, 0, len);
         offset += len;

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -626,7 +626,7 @@ public class TableTest extends CudfTestBase {
     CSVWriterOptions writeOptions = CSVWriterOptions.builder()
                                                .withColumnNames(schema.getColumnNames())
                                                .withIncludeHeader(false)
-                                               .withFieldDelimiter((byte)'\u0001')
+                                               .withFieldDelimiter((byte)fieldDelim)
                                                .withRowDelimiter("\n")
                                                .withNullValue("\\N")
                                                .build();
@@ -634,7 +634,7 @@ public class TableTest extends CudfTestBase {
           = new Table.TestBuilder()
               .column(0, 1, 2, 3, 4, 5, 6, 7, 8, null)
               .column(0.0, 1.0, 2.0, 3.0, 4.0, null, 6.0, 7.0, 8.0, 9.0)
-              .column(false, true, null, true, false, true, false, true, false, true)
+              .column(false, true, null, true, false, true, null, true, false, true)
               .column("All", "the", "leaves", "are", "brown", "and", "the", "sky", "is", null)
               .build();
           MyBufferConsumer consumer = new MyBufferConsumer()) {
@@ -649,7 +649,7 @@ public class TableTest extends CudfTestBase {
                                          .includeColumn("b")
                                          .includeColumn("str")
                                          .hasHeader(false)
-                                         .withDelim('\u0001')
+                                         .withDelim(fieldDelim)
                                          .withNullValue("\\N")
                                          .build();
       try (Table readTable = Table.readCSV(schema, readOptions, consumer.buffer, 0, consumer.offset);

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -576,7 +576,7 @@ public class TableTest extends CudfTestBase {
   }
 
   @Test
-  void testWriteCSVToFile() throws IOException {
+  void testWriteCSVToFileBasic() throws IOException {
     File outputFile = File.createTempFile("testWriteCSVToFile", ".csv");
     Schema schema = Schema.builder()
                           .column(DType.INT32, "i")
@@ -616,8 +616,7 @@ public class TableTest extends CudfTestBase {
     }
   }
 
-  @Test
-  void testWriteCSVToBuffer() throws IOException {
+  private void testWriteCSVToBufferBasicImpl(char fieldDelim) throws IOException {
     Schema schema = Schema.builder()
                           .column(DType.INT32, "i")
                           .column(DType.FLOAT64, "f")
@@ -642,10 +641,6 @@ public class TableTest extends CudfTestBase {
       inputTable.writeCSVToBuffer(writeOptions, consumer);
       inputTable.writeCSVToBuffer(writeOptions, consumer);
 
-      System.out.println("CALEB: TableTest: Buffer offset: " + consumer.offset);
-      ByteBuffer buff = consumer.buffer.asByteBuffer(0, Long.valueOf(consumer.offset).intValue());
-      System.out.println("CALEB: Buffer: " + buff);
-
       // Read back.
       CSVOptions readOptions = CSVOptions.builder()
                                          .includeColumn("i")
@@ -657,10 +652,15 @@ public class TableTest extends CudfTestBase {
                                          .build();
       try (Table readTable = Table.readCSV(schema, readOptions, consumer.buffer, 0, consumer.offset);
            Table expected  = Table.concatenate(inputTable, inputTable, inputTable)) {
-        System.out.println("CALEB: Read table size: " + readTable.getRowCount());
         assertTablesAreEqual(expected, readTable);
       }
     }
+  }
+
+  @Test
+  void testWriteCSVToBufferBasic() throws IOException {
+    testWriteCSVToBufferBasicImpl(',');
+    testWriteCSVToBufferBasicImpl('\u0001');
   }
 
   @Test

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -576,7 +576,7 @@ public class TableTest extends CudfTestBase {
   }
 
   @Test
-  void testWriteCSVToFileBasic() throws IOException {
+  void testWriteCSVToFile() throws IOException {
     File outputFile = File.createTempFile("testWriteCSVToFile", ".csv");
     Schema schema = Schema.builder()
                           .column(DType.INT32, "i")
@@ -616,7 +616,7 @@ public class TableTest extends CudfTestBase {
     }
   }
 
-  private void testWriteCSVToBufferBasicImpl(char fieldDelim) throws IOException {
+  private void testWriteCSVToBufferImpl(char fieldDelim) throws IOException {
     Schema schema = Schema.builder()
                           .column(DType.INT32, "i")
                           .column(DType.FLOAT64, "f")
@@ -660,9 +660,9 @@ public class TableTest extends CudfTestBase {
   }
 
   @Test
-  void testWriteCSVToBufferBasic() throws IOException {
-    testWriteCSVToBufferBasicImpl(',');
-    testWriteCSVToBufferBasicImpl('\u0001');
+  void testWriteCSVToBuffer() throws IOException {
+    testWriteCSVToBufferImpl(',');
+    testWriteCSVToBufferImpl('\u0001');
   }
 
   @Test

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -628,13 +628,14 @@ public class TableTest extends CudfTestBase {
                                                .withIncludeHeader(false)
                                                .withFieldDelimiter((byte)'\u0001')
                                                .withRowDelimiter("\n")
+                                               .withNullValue("\\N")
                                                .build();
     try (Table inputTable 
           = new Table.TestBuilder()
-              .column(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-              .column(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0)
-              .column(false, true, false, true, false, true, false, true, false, true)
-              .column("All", "the", "leaves", "are", "brown", "and", "the", "sky", "is", "grey")
+              .column(0, 1, 2, 3, 4, 5, 6, 7, 8, null)
+              .column(0.0, 1.0, 2.0, 3.0, 4.0, null, 6.0, 7.0, 8.0, 9.0)
+              .column(false, true, null, true, false, true, false, true, false, true)
+              .column("All", "the", "leaves", "are", "brown", "and", "the", "sky", "is", null)
               .build();
           MyBufferConsumer consumer = new MyBufferConsumer()) {
       inputTable.writeCSVToBuffer(writeOptions, consumer);
@@ -649,6 +650,7 @@ public class TableTest extends CudfTestBase {
                                          .includeColumn("str")
                                          .hasHeader(false)
                                          .withDelim('\u0001')
+                                         .withNullValue("\\N")
                                          .build();
       try (Table readTable = Table.readCSV(schema, readOptions, consumer.buffer, 0, consumer.offset);
            Table expected  = Table.concatenate(inputTable, inputTable, inputTable)) {


### PR DESCRIPTION
## Description
This change adds JNI bindings to write tables out as CSV, to either the filesystem or memory.

The Java `Table` class now has additional methods:
1. `Table.writeCSVToFile()`: Writes the current table out to the specified file on the filesystem.
2. `Table.writeCSVToBuffer()`: Writes the current table out to a `HostBufferConsumer`.

These calls are analogous to `cudf::io::write_csv()`.

### Current limitations:
1. The `cudf::io::csv_writer_options` interface binds the CSV options tightly to the `Table` being written. This makes it a little clumsy to write multiple `Table`s to the same `HostBufferConsumer`, because each could be written with different, contradictory options.
2. `cudf::io::write_csv(file_name)` overwrites the specified file, if it exists. There currently isn't a way to keep a file open, and write multiple tables to it; each write call overwrites the previous file.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
