### PR TITLE
Re-enable `Recently Updated` Check

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -6,4 +6,4 @@ branch_checker: true
 label_checker: true
 release_drafter: true
 copy_prs: true
-recently_updated: false
+recently_updated: true


### PR DESCRIPTION
## Description

This PR re-enables the `Recently Updated` check.

It was previously disabled because it was frequently getting stuck in the `Pending` state.

After investigating the logs, I determined that the job was getting killed prematurely due to an insufficient `timeout` value for the Lambda function that executes the code. Therefore, the Lambda function was being killed before the batch job was able to finish updating the statuses on all of the open PRs.

I increased the `timeout` value from 30 seconds to 15 minutes in the commit below which should resolve that problem.

- https://github.com/rapidsai/ops-bot/commit/4148bb03e47998d4c5b75cf0e35d676b9f7614b5

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
