### PR TITLE
Unify native methods which are used in `ColumnVector.getData()`

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -3746,12 +3746,13 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   /////////////////////////////////////////////////////////////////////////////
 
   static DeviceMemoryBufferView getDataBuffer(long viewHandle) {
-    long address = getNativeDataAddress(viewHandle);
-    if (address == 0) {
+    long[] bufferAddressAndLength = getNativeDataBuffer(viewHandle);
+    assert bufferAddressAndLength.length == 2;
+
+    if (bufferAddressAndLength[0] == 0) {
       return null;
     }
-    long length = getNativeDataLength(viewHandle);
-    return new DeviceMemoryBufferView(address, length);
+    return new DeviceMemoryBufferView(bufferAddressAndLength[0], bufferAddressAndLength[1]);
   }
 
   static DeviceMemoryBufferView getValidityBuffer(long viewHandle) {
@@ -4446,8 +4447,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
 
   static native void deleteColumnView(long viewHandle) throws CudfException;
 
-  private static native long getNativeDataAddress(long viewHandle) throws CudfException;
-  private static native long getNativeDataLength(long viewHandle) throws CudfException;
+  private static native long[] getNativeDataBuffer(long viewHandle) throws CudfException;
 
   private static native long getNativeOffsetsAddress(long viewHandle) throws CudfException;
   private static native long getNativeOffsetsLength(long viewHandle) throws CudfException;

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1931,6 +1931,7 @@ Java_ai_rapids_cudf_ColumnView_getNativeDataBuffer(JNIEnv *env, jclass, jlong in
         auto const chars_col = cudf::strings_column_view{*input}.chars();
         buff_address = reinterpret_cast<jlong>(chars_col.data<char>());
         buff_size = static_cast<jlong>(chars_col.size());
+        break;
       }
 
       default: {

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1921,6 +1921,9 @@ Java_ai_rapids_cudf_ColumnView_getNativeDataBuffer(JNIEnv *env, jclass, jlong in
     auto const input = reinterpret_cast<cudf::column_view const *>(input_handle);
     auto const buff_address_and_size = [&]() -> std::vector<jlong> {
       if (input->type().id() == cudf::type_id::STRING) {
+        if (input->size() == 0) {
+          return {0, 0};
+        }
         auto const chars_col = cudf::strings_column_view{*input}.chars();
         return {reinterpret_cast<jlong>(chars_col.data<char>()),
                 static_cast<jlong>(chars_col.size())};


### PR DESCRIPTION
The method `getNativeDataAddress` is unified into `getNativeDataLength` which are always (and are only) called together in `ColumVector.getData()`. 

This PR is related to https://github.com/rapidsai/cudf/issues/9497, which asks for throwing exception if `ColumVector.getData()` is called on an input column of type LIST or STRUCT. This PR initially tried to fulfill it but discovered that the callers may get into trouble with complex handling for different input types. Thus, the issue https://github.com/rapidsai/cudf/issues/9497 can be addressed later, or be closed if it is no longer necessary.