### PR TITLE
JNI build image default as cuda11.8

### DIFF
--- a/java/ci/Dockerfile.centos7
+++ b/java/ci/Dockerfile.centos7
@@ -17,13 +17,11 @@
 ###
 # Build the image for cudf development environment.
 #
-# Arguments: CUDA_VERSION=11.5.0
+# Arguments: CUDA_VERSION=11.8.0
 #
 ###
-ARG CUDA_VERSION=11.5.0
-# use rapids gpuci/cuda images until nvidia/cuda cuda 11.5+ images are available in docker hub
-# FROM nvidia/cuda:$CUDA_VERSION-devel-centos7
-FROM gpuci/cuda:$CUDA_VERSION-devel-centos7
+ARG CUDA_VERSION=11.8.0
+FROM nvidia/cuda:$CUDA_VERSION-devel-centos7
 
 ### Install basic requirements
 ARG DEVTOOLSET_VERSION=9

--- a/java/ci/Dockerfile.centos7
+++ b/java/ci/Dockerfile.centos7
@@ -17,7 +17,7 @@
 ###
 # Build the image for cudf development environment.
 #
-# Arguments: CUDA_VERSION=11.8.0
+# Arguments: CUDA_VERSION=11.X.Y
 #
 ###
 ARG CUDA_VERSION=11.8.0

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -11,14 +11,14 @@
 
 In the root path of cuDF repo, run below command to build the docker image.
 ```bash
-docker build -f java/ci/Dockerfile.centos7 --build-arg CUDA_VERSION=11.5.0 -t cudf-build:11.5.0-devel-centos7 .
+docker build -f java/ci/Dockerfile.centos7 --build-arg CUDA_VERSION=11.8.0 -t cudf-build:11.8.0-devel-centos7 .
 ```
 
 The following CUDA versions are supported w/ CUDA Enhanced Compatibility:
 * CUDA 11.0+
 
 Change the --build-arg CUDA_VERSION to what you need.
-You can replace the tag "cudf-build:11.5.0-devel-centos7" with another name you like.
+You can replace the tag "cudf-build:11.8.0-devel-centos7" with another name you like.
 
 ## Start the docker then build
 
@@ -26,7 +26,7 @@ You can replace the tag "cudf-build:11.5.0-devel-centos7" with another name you 
 
 Run below command to start a docker container with GPU.
 ```bash
-nvidia-docker run -it cudf-build:11.5.0-devel-centos7 bash
+nvidia-docker run -it cudf-build:11.8.0-devel-centos7 bash
 ```
 
 ### Download the cuDF source code


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

## Description
Update default build image to cuda 11.8

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
