### PR TITLE
Update cudf_assert docs with correct NDEBUG behavior

### DIFF
--- a/cpp/include/cudf/detail/utilities/assert.cuh
+++ b/cpp/include/cudf/detail/utilities/assert.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/detail/utilities/assert.cuh
+++ b/cpp/include/cudf/detail/utilities/assert.cuh
@@ -22,7 +22,7 @@
  * @brief `assert`-like macro for device code
  *
  * This is effectively the same as the standard `assert` macro, except it
- * reiles on the `__PRETTY_FUNCTION__` macro which is specific to GCC and Clang
+ * relies on the `__PRETTY_FUNCTION__` macro which is specific to GCC and Clang
  * to produce better assert messages.
  */
 #if !defined(NDEBUG) && defined(__CUDA_ARCH__) && (defined(__clang__) || defined(__GNUC__))

--- a/cpp/include/cudf/detail/utilities/assert.cuh
+++ b/cpp/include/cudf/detail/utilities/assert.cuh
@@ -19,13 +19,11 @@
 #include <cuda_runtime.h>
 
 /**
- * @brief `assert`-like macro for device code that persists in Release builds.
+ * @brief `assert`-like macro for device code
  *
- * This is effectively the same as the standard `assert` macro, except it will
- * not be compiled out in Release builds, i.e., this macro will be present
- * regardless of the state of `NDEBUG`.
- *
- * Relies on the `__PRETTY_FUNCTION__` macro which is specific to GCC and Clang.
+ * This is effectively the same as the standard `assert` macro, except it
+ * reiles on the `__PRETTY_FUNCTION__` macro which is specific to GCC and Clang
+ * to produce better assert messages.
  */
 #if !defined(NDEBUG) && defined(__CUDA_ARCH__) && (defined(__clang__) || defined(__GNUC__))
 #define __ASSERT_STR_HELPER(x) #x


### PR DESCRIPTION
## Description
Since 21.06 `cuff_assert` has been a no-op in release mode. This brings the docs inline with the implementation.

Fixes #12459

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
