### PR TITLE
Fix compile issue with arrow 10

### DIFF
--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -31,10 +31,15 @@
 #include <arrow/filesystem/s3fs.h>
 #pragma nv_diag_default 611
 
+// We disable warning 2810 to workaround the compile issue (warning treated as error):
+// result.h(263): error #2810-D: ignoring return value type with "nodiscard" attribute
+#pragma nv_diag_suppress 2810
+#include <arrow/result.h>
+#pragma nv_diag_default 2810
+
 #include <arrow/io/file.h>
 #include <arrow/io/interfaces.h>
 #include <arrow/io/memory.h>
-#include <arrow/result.h>
 #include <arrow/status.h>
 
 #include <future>


### PR DESCRIPTION
Arrow has been upgraded to version 10 in https://github.com/rapidsai/cudf/pull/12327. Unfortunately the new Arrow version trigger new warnings that are treated as compile error:
```
_deps/arrow-src/cpp/src/arrow/result.h(263): error #2810-D: ignoring return value type with "nodiscard" attribute
```

This PR fixes that by temporarily disabling such warnings.