### PR TITLE
`one_hot_encode` to use experimental row comparators

### DIFF
--- a/cpp/src/transform/one_hot_encode.cu
+++ b/cpp/src/transform/one_hot_encode.cu
@@ -77,7 +77,7 @@ std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const&
     make_counting_transform_iterator(1, [width = input.size()](auto i) { return i * width; });
   std::vector<size_type> split_indices(split_iter, split_iter + categories.size() - 1);
 
-  auto const encodings_view = table_view{split(all_encodings->view(), split_indices, stream)};
+  auto encodings_view = table_view{split(all_encodings->view(), split_indices, stream)};
 
   return std::pair(std::move(all_encodings), std::move(encodings_view));
 }

--- a/cpp/src/transform/one_hot_encode.cu
+++ b/cpp/src/transform/one_hot_encode.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include <cudf/detail/copy.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
-#include <cudf/table/row_operators.cuh>
+#include <cudf/table/experimental/row_operators.cuh>
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
@@ -36,72 +36,6 @@
 namespace cudf {
 namespace detail {
 
-namespace {
-
-template <typename InputType>
-struct one_hot_encode_functor {
-  one_hot_encode_functor(column_device_view input, column_device_view category, bool nulls)
-    : _equality_comparator{nullate::DYNAMIC{nulls}, input, category, null_equality::EQUAL},
-      _input_size{input.size()}
-  {
-  }
-
-  bool __device__ operator()(size_type i)
-  {
-    size_type const element_index  = i % _input_size;
-    size_type const category_index = i / _input_size;
-    return _equality_comparator.template operator()<InputType>(element_index, category_index);
-  }
-
- private:
-  element_equality_comparator<nullate::DYNAMIC> const _equality_comparator;
-  size_type const _input_size;
-};
-
-}  // anonymous namespace
-
-struct one_hot_encode_launcher {
-  template <typename InputType, CUDF_ENABLE_IF(is_equality_comparable<InputType, InputType>())>
-  std::pair<std::unique_ptr<column>, table_view> operator()(column_view const& input_column,
-                                                            column_view const& categories,
-                                                            rmm::cuda_stream_view stream,
-                                                            rmm::mr::device_memory_resource* mr)
-  {
-    auto const total_size = input_column.size() * categories.size();
-    auto all_encodings    = make_numeric_column(
-      data_type{type_id::BOOL8}, total_size, mask_state::UNALLOCATED, stream, mr);
-
-    auto d_input_column    = column_device_view::create(input_column, stream);
-    auto d_category_column = column_device_view::create(categories, stream);
-    one_hot_encode_functor<InputType> one_hot_encoding_compute_f(
-      *d_input_column, *d_category_column, input_column.nullable() || categories.nullable());
-
-    thrust::transform(rmm::exec_policy(stream),
-                      thrust::make_counting_iterator(0),
-                      thrust::make_counting_iterator(total_size),
-                      all_encodings->mutable_view().begin<bool>(),
-                      one_hot_encoding_compute_f);
-
-    auto split_iter = make_counting_transform_iterator(
-      1, [width = input_column.size()](auto i) { return i * width; });
-    std::vector<size_type> split_indices(split_iter, split_iter + categories.size() - 1);
-
-    // TODO: use detail interface, gh9226
-    auto views = cudf::split(all_encodings->view(), split_indices);
-    table_view encodings_view{views};
-
-    return std::pair(std::move(all_encodings), encodings_view);
-  }
-
-  template <typename InputType,
-            typename... Args,
-            CUDF_ENABLE_IF(not is_equality_comparable<InputType, InputType>())>
-  std::pair<std::unique_ptr<column>, table_view> operator()(Args&&...)
-  {
-    CUDF_FAIL("Cannot encode column type without well-defined equality operator.");
-  }
-};
-
 std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const& input,
                                                               column_view const& categories,
                                                               rmm::cuda_stream_view stream,
@@ -117,7 +51,35 @@ std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const&
     return std::pair(std::move(empty_data), table_view{views});
   }
 
-  return type_dispatcher(input.type(), one_hot_encode_launcher{}, input, categories, stream, mr);
+  auto const total_size = input.size() * categories.size();
+  auto all_encodings =
+    make_numeric_column(data_type{type_id::BOOL8}, total_size, mask_state::UNALLOCATED, stream, mr);
+
+  auto t_lhs      = table_view{{input}};
+  auto t_rhs      = table_view{{categories}};
+  auto comparator = cudf::experimental::row::equality::two_table_comparator{t_lhs, t_rhs, stream};
+  auto device_comparator =
+    comparator.equal_to(nullate::DYNAMIC{has_nested_nulls(t_lhs) || has_nested_nulls(t_rhs)});
+
+  thrust::transform(rmm::exec_policy(stream),
+                    thrust::make_counting_iterator(0),
+                    thrust::make_counting_iterator(total_size),
+                    all_encodings->mutable_view().begin<bool>(),
+                    [input_size = input.size(), device_comparator] __device__(size_type i) {
+                      auto element_index  = cudf::experimental::row::lhs_index_type{i % input_size};
+                      auto category_index = cudf::experimental::row::rhs_index_type{i / input_size};
+                      return device_comparator(element_index, category_index);
+                    });
+
+  auto split_iter =
+    make_counting_transform_iterator(1, [width = input.size()](auto i) { return i * width; });
+  std::vector<size_type> split_indices(split_iter, split_iter + categories.size() - 1);
+
+  // TODO: use detail interface, gh9226
+  auto views = cudf::split(all_encodings->view(), split_indices);
+  table_view encodings_view{views};
+
+  return std::pair(std::move(all_encodings), encodings_view);
 }
 
 }  // namespace detail

--- a/cpp/src/transform/one_hot_encode.cu
+++ b/cpp/src/transform/one_hot_encode.cu
@@ -79,7 +79,7 @@ std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const&
 
   auto const encodings_view = table_view{split(all_encodings->view(), split_indices, stream)};
 
-  return std::pair(std::move(all_encodings), encodings_view);
+  return std::pair(std::move(all_encodings), std::move(encodings_view));
 }
 
 }  // namespace detail

--- a/cpp/src/transform/one_hot_encode.cu
+++ b/cpp/src/transform/one_hot_encode.cu
@@ -79,7 +79,7 @@ std::pair<std::unique_ptr<column>, table_view> one_hot_encode(column_view const&
 
   auto encodings_view = table_view{split(all_encodings->view(), split_indices, stream)};
 
-  return std::pair(std::move(all_encodings), std::move(encodings_view));
+  return std::pair(std::move(all_encodings), encodings_view);
 }
 
 }  // namespace detail

--- a/cpp/tests/transform/one_hot_encode_tests.cpp
+++ b/cpp/tests/transform/one_hot_encode_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -23,6 +24,13 @@
 #include <cudf/transform.hpp>
 
 #include <limits>
+
+using lists_col   = cudf::test::lists_column_wrapper<int32_t>;
+using structs_col = cudf::test::structs_column_wrapper;
+using bool_col    = cudf::test::fixed_width_column_wrapper<bool>;
+
+using cudf::test::iterators::null_at;
+using cudf::test::iterators::nulls_at;
 
 template <typename T>
 struct OneHotEncodingTestTyped : public cudf::test::BaseFixture {
@@ -193,4 +201,74 @@ TEST_F(OneHotEncodingTest, MismatchTypes)
   auto category = cudf::test::fixed_width_column_wrapper<int64_t>{1};
 
   EXPECT_THROW(cudf::one_hot_encode(input, category), cudf::logic_error);
+}
+
+TEST_F(OneHotEncodingTest, List)
+{
+  auto input =
+    lists_col{{{}, {1}, {2, 2}, {2, 2}, {}, {2} /*NULL*/, {2}, {5} /*NULL*/}, nulls_at({5, 7})};
+  auto categories = lists_col{{{}, {1}, {2, 2}, {2}, {-1}}, null_at(4)};
+
+  auto col0 = bool_col{1, 0, 0, 0, 1, 0, 0, 0};
+  auto col1 = bool_col{0, 1, 0, 0, 0, 0, 0, 0};
+  auto col2 = bool_col{0, 0, 1, 1, 0, 0, 0, 0};
+  auto col3 = bool_col{0, 0, 0, 0, 0, 0, 1, 0};
+  auto col4 = bool_col{0, 0, 0, 0, 0, 1, 0, 1};
+
+  auto expected = cudf::table_view{{col0, col1, col2, col3, col4}};
+
+  [[maybe_unused]] auto [res_ptr, got] = cudf::one_hot_encode(input, categories);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected, got);
+}
+
+TEST_F(OneHotEncodingTest, StructsOfStructs)
+{
+  //  +-----------------+
+  //  |  s1{s2{a,b}, c} |
+  //  +-----------------+
+  // 0 |  Null          |
+  // 1 |  { {1, 2}, 4}  |
+  // 2 |  { Null,   4}  |
+  // 3 |  Null          |
+  // 4 |  { {2, 1}, 5}  |
+  // 5 |  { Null,   4}  |
+  // 6 |  { {2, 1}, 5}  |
+
+  auto input = [&] {
+    auto a  = cudf::test::fixed_width_column_wrapper<int32_t>{-1, 1, -1, -1, 2, -1, 2};
+    auto b  = cudf::test::fixed_width_column_wrapper<int32_t>{-1, 2, -1, -1, 1, -1, 1};
+    auto s2 = structs_col{{a, b}, nulls_at({2, 5})};
+
+    auto c = cudf::test::fixed_width_column_wrapper<int32_t>{-1, 4, 4, -1, 5, 4, 5};
+    std::vector<std::unique_ptr<cudf::column>> s1_children;
+    s1_children.emplace_back(s2.release());
+    s1_children.emplace_back(c.release());
+    auto const null_it = nulls_at({0, 3});
+    return structs_col(std::move(s1_children), std::vector<bool>{null_it, null_it + 7});
+  }();
+
+  auto categories = [&] {
+    auto a  = cudf::test::fixed_width_column_wrapper<int32_t>{-1, 1, -1, 2};
+    auto b  = cudf::test::fixed_width_column_wrapper<int32_t>{-1, 2, -1, 1};
+    auto s2 = structs_col{{a, b}, null_at(2)};
+
+    auto c = cudf::test::fixed_width_column_wrapper<int32_t>{-1, 4, 4, 5};
+    std::vector<std::unique_ptr<cudf::column>> s1_children;
+    s1_children.emplace_back(s2.release());
+    s1_children.emplace_back(c.release());
+    auto const null_it = null_at(0);
+    return structs_col(std::move(s1_children), std::vector<bool>{null_it, null_it + 4});
+  }();
+
+  auto col0 = bool_col{1, 0, 0, 1, 0, 0, 0};
+  auto col1 = bool_col{0, 1, 0, 0, 0, 0, 0};
+  auto col2 = bool_col{0, 0, 1, 0, 0, 1, 0};
+  auto col3 = bool_col{0, 0, 0, 0, 1, 0, 1};
+
+  auto expected = cudf::table_view{{col0, col1, col2, col3}};
+
+  [[maybe_unused]] auto [res_ptr, got] = cudf::one_hot_encode(input, categories);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected, got);
 }

--- a/cpp/tests/transform/one_hot_encode_tests.cpp
+++ b/cpp/tests/transform/one_hot_encode_tests.cpp
@@ -205,19 +205,19 @@ TEST_F(OneHotEncodingTest, MismatchTypes)
 
 TEST_F(OneHotEncodingTest, List)
 {
-  auto input =
+  auto const input =
     lists_col{{{}, {1}, {2, 2}, {2, 2}, {}, {2} /*NULL*/, {2}, {5} /*NULL*/}, nulls_at({5, 7})};
-  auto categories = lists_col{{{}, {1}, {2, 2}, {2}, {-1}}, null_at(4)};
+  auto const categories = lists_col{{{}, {1}, {2, 2}, {2}, {-1}}, null_at(4)};
 
-  auto col0 = bool_col{1, 0, 0, 0, 1, 0, 0, 0};
-  auto col1 = bool_col{0, 1, 0, 0, 0, 0, 0, 0};
-  auto col2 = bool_col{0, 0, 1, 1, 0, 0, 0, 0};
-  auto col3 = bool_col{0, 0, 0, 0, 0, 0, 1, 0};
-  auto col4 = bool_col{0, 0, 0, 0, 0, 1, 0, 1};
+  auto const col0 = bool_col{1, 0, 0, 0, 1, 0, 0, 0};
+  auto const col1 = bool_col{0, 1, 0, 0, 0, 0, 0, 0};
+  auto const col2 = bool_col{0, 0, 1, 1, 0, 0, 0, 0};
+  auto const col3 = bool_col{0, 0, 0, 0, 0, 0, 1, 0};
+  auto const col4 = bool_col{0, 0, 0, 0, 0, 1, 0, 1};
 
-  auto expected = cudf::table_view{{col0, col1, col2, col3, col4}};
+  auto const expected = cudf::table_view{{col0, col1, col2, col3, col4}};
 
-  [[maybe_unused]] auto [res_ptr, got] = cudf::one_hot_encode(input, categories);
+  [[maybe_unused]] auto const [res_ptr, got] = cudf::one_hot_encode(input, categories);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected, got);
 }
@@ -235,7 +235,7 @@ TEST_F(OneHotEncodingTest, StructsOfStructs)
   // 5 |  { Null,   4}  |
   // 6 |  { {2, 1}, 5}  |
 
-  auto input = [&] {
+  auto const input = [&] {
     auto a  = cudf::test::fixed_width_column_wrapper<int32_t>{-1, 1, -1, -1, 2, -1, 2};
     auto b  = cudf::test::fixed_width_column_wrapper<int32_t>{-1, 2, -1, -1, 1, -1, 1};
     auto s2 = structs_col{{a, b}, nulls_at({2, 5})};
@@ -248,7 +248,7 @@ TEST_F(OneHotEncodingTest, StructsOfStructs)
     return structs_col(std::move(s1_children), std::vector<bool>{null_it, null_it + 7});
   }();
 
-  auto categories = [&] {
+  auto const categories = [&] {
     auto a  = cudf::test::fixed_width_column_wrapper<int32_t>{-1, 1, -1, 2};
     auto b  = cudf::test::fixed_width_column_wrapper<int32_t>{-1, 2, -1, 1};
     auto s2 = structs_col{{a, b}, null_at(2)};
@@ -261,14 +261,14 @@ TEST_F(OneHotEncodingTest, StructsOfStructs)
     return structs_col(std::move(s1_children), std::vector<bool>{null_it, null_it + 4});
   }();
 
-  auto col0 = bool_col{1, 0, 0, 1, 0, 0, 0};
-  auto col1 = bool_col{0, 1, 0, 0, 0, 0, 0};
-  auto col2 = bool_col{0, 0, 1, 0, 0, 1, 0};
-  auto col3 = bool_col{0, 0, 0, 0, 1, 0, 1};
+  auto const col0 = bool_col{1, 0, 0, 1, 0, 0, 0};
+  auto const col1 = bool_col{0, 1, 0, 0, 0, 0, 0};
+  auto const col2 = bool_col{0, 0, 1, 0, 0, 1, 0};
+  auto const col3 = bool_col{0, 0, 0, 0, 1, 0, 1};
 
-  auto expected = cudf::table_view{{col0, col1, col2, col3}};
+  auto const expected = cudf::table_view{{col0, col1, col2, col3}};
 
-  [[maybe_unused]] auto [res_ptr, got] = cudf::one_hot_encode(input, categories);
+  [[maybe_unused]] auto const [res_ptr, got] = cudf::one_hot_encode(input, categories);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected, got);
 }


### PR DESCRIPTION
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
