### PR TITLE
[REVIEW] Link unsupported iteration API docstrings

### DIFF
--- a/docs/cudf/source/user_guide/pandas-comparison.md
+++ b/docs/cudf/source/user_guide/pandas-comparison.md
@@ -65,6 +65,8 @@ Categories (2, int64): [1, 2]
 
 See the docs on [missing data](missing-data) for details.
 
+(pandas-comparison/iteration)=
+
 ## Iteration
 
 Iterating over a cuDF `Series`, `DataFrame` or `Index` is not

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -6568,8 +6568,10 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
     def itertuples(self, index=True, name="Pandas"):
         """
-        Iteration is unsupported, See
-        :ref:`iteration <pandas-comparison/iteration>`
+        Iteration is unsupported.
+        
+        See :ref:`iteration <pandas-comparison/iteration>` for more
+        information.
         """
         raise TypeError(
             "cuDF does not support iteration of DataFrame "

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 from __future__ import annotations
 
@@ -6567,6 +6567,10 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         return self._data.to_pandas_index()
 
     def itertuples(self, index=True, name="Pandas"):
+        """
+        Iteration is unsupported, See
+        :ref:`iteration <pandas-comparison/iteration>`
+        """
         raise TypeError(
             "cuDF does not support iteration of DataFrame "
             "via itertuples. Consider using "
@@ -6575,6 +6579,10 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         )
 
     def iterrows(self):
+        """
+        Iteration is unsupported, See
+        :ref:`iteration <pandas-comparison/iteration>`
+        """
         raise TypeError(
             "cuDF does not support iteration of DataFrame "
             "via iterrows. Consider using "

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -6569,7 +6569,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
     def itertuples(self, index=True, name="Pandas"):
         """
         Iteration is unsupported.
-        
+
         See :ref:`iteration <pandas-comparison/iteration>` for more
         information.
         """
@@ -6582,8 +6582,10 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
     def iterrows(self):
         """
-        Iteration is unsupported, See
-        :ref:`iteration <pandas-comparison/iteration>`
+        Iteration is unsupported.
+
+        See :ref:`iteration <pandas-comparison/iteration>` for more
+        information.
         """
         raise TypeError(
             "cuDF does not support iteration of DataFrame "

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -280,8 +280,10 @@ class GetAttrGetItemMixin:
 class NotIterable:
     def __iter__(self):
         """
-        Iteration is unsupported, See
-        :ref:`iteration <pandas-comparison/iteration>`
+        Iteration is unsupported.
+
+        See :ref:`iteration <pandas-comparison/iteration>` for more
+        information.
         """
         raise TypeError(
             f"{self.__class__.__name__} object is not iterable. "

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 import functools
 import hashlib
@@ -279,6 +279,10 @@ class GetAttrGetItemMixin:
 
 class NotIterable:
     def __iter__(self):
+        """
+        Iteration is unsupported, See
+        :ref:`iteration <pandas-comparison/iteration>`
+        """
         raise TypeError(
             f"{self.__class__.__name__} object is not iterable. "
             f"Consider using `.to_arrow()`, `.to_pandas()` or `.values_host` "


### PR DESCRIPTION
## Description
Resolves: #12472 

This PR links the unsupported iteration APIs to an existing docs section that explains why iteration isn't supported on GPU and has alternative workarounds suggested there already.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
