### PR TITLE
Fix erroneously skipped ORC ZSTD test

### DIFF
--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -36,13 +36,6 @@
 
 #include <type_traits>
 
-#define NVCOMP_ZSTD_HEADER <nvcomp/zstd.h>
-#if __has_include(NVCOMP_ZSTD_HEADER)
-#define ZSTD_SUPPORTED 1
-#else
-#define ZSTD_SUPPORTED 0
-#endif
-
 template <typename T, typename SourceElementT = T>
 using column_wrapper =
   typename std::conditional<std::is_same_v<T, cudf::string_view>,
@@ -1110,10 +1103,11 @@ TEST_F(OrcReaderTest, SingleInputs)
 
 TEST_F(OrcReaderTest, zstdCompressionRegression)
 {
+  if (cudf::io::nvcomp::is_decompression_disabled(cudf::io::nvcomp::compression_type::ZSTD)) {
+    GTEST_SKIP() << "Newer nvCOMP version is required";
+  }
+
   // Test with zstd compressed orc file with high compression ratio.
-#if !ZSTD_SUPPORTED
-  GTEST_SKIP();
-#endif
   constexpr uint8_t input_buffer[] = {
     0x4f, 0x52, 0x43, 0x5a, 0x00, 0x00, 0x28, 0xb5, 0x2f, 0xfd, 0xa4, 0x34, 0xc7, 0x03, 0x00, 0x74,
     0x00, 0x00, 0x18, 0x41, 0xff, 0xaa, 0x02, 0x00, 0xbb, 0xff, 0x45, 0xc8, 0x01, 0x25, 0x30, 0x04,


### PR DESCRIPTION
## Description
A C++ test that requires nvCOMP ZSTD is skipped when the required nvCOMP header is not present. This check does not seem to work correctly, as the test was skipped (on a local system) with nvCOMP 2.5.
This PR modifies the condition to skip the test to use more robust `is_decompression_disabled`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
