### PR TITLE
[REVIEW] Fix missing metadata transfer in concat for `ListColumn`

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1702,6 +1702,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                 (
                     cudf.core.column.DecimalBaseColumn,
                     cudf.core.column.StructColumn,
+                    cudf.core.column.ListColumn,
                 ),
             ):
                 out._data[name] = col._with_type_metadata(

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 from __future__ import annotations
 
@@ -1497,6 +1497,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
             (
                 cudf.core.column.DecimalBaseColumn,
                 cudf.core.column.StructColumn,
+                cudf.core.column.ListColumn,
             ),
         ):
             col = col._with_type_metadata(objs[0].dtype)

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -1766,6 +1766,48 @@ def test_concat_struct_column(s1, s2, expected):
     assert_eq(s, expected, check_index_type=True)
 
 
+@pytest.mark.parametrize(
+    "frame1, frame2, expected",
+    [
+        (
+            gd.Series([[{"b": 0}], [{"b": 1}], [{"b": 3}]]),
+            gd.Series([[{"b": 10}], [{"b": 12}], None]),
+            gd.Series(
+                [
+                    [{"b": 0}],
+                    [{"b": 1}],
+                    [{"b": 3}],
+                    [{"b": 10}],
+                    [{"b": 12}],
+                    None,
+                ],
+                index=[0, 1, 2, 0, 1, 2],
+            ),
+        ),
+        (
+            gd.DataFrame({"a": [[{"b": 0}], [{"b": 1}], [{"b": 3}]]}),
+            gd.DataFrame({"a": [[{"b": 10}], [{"b": 12}], None]}),
+            gd.DataFrame(
+                {
+                    "a": [
+                        [{"b": 0}],
+                        [{"b": 1}],
+                        [{"b": 3}],
+                        [{"b": 10}],
+                        [{"b": 12}],
+                        None,
+                    ]
+                },
+                index=[0, 1, 2, 0, 1, 2],
+            ),
+        ),
+    ],
+)
+def test_concat_list_column(frame1, frame2, expected):
+    actual = gd.concat([frame1, frame2])
+    assert_eq(actual, expected, check_index_type=True)
+
+
 def test_concat_categorical_ordering():
     # https://github.com/rapidsai/cudf/issues/11486
     sr = pd.Series(


### PR DESCRIPTION
## Description
Fixes: #12485 

This PR fixes the issue where transfer of ListColumn's metadata is not happening when `concat` is performed on two `ListColumn`'s.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
