### PR TITLE
[REVIEW] Enable metadata transfer for complex types in transpose

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -3802,6 +3802,14 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                 )
                 for codes in result_columns
             ]
+        elif isinstance(
+            source_dtype,
+            (cudf.ListDtype, cudf.StructDtype, cudf.core.dtypes.DecimalDtype),
+        ):
+            result_columns = [
+                result_column._with_type_metadata(source_dtype)
+                for result_column in result_columns
+            ]
 
         # Set the old column names as the new index
         result = self.__class__._from_data(

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2,6 +2,7 @@
 
 import array as arr
 import datetime
+import decimal
 import io
 import operator
 import random
@@ -9992,5 +9993,23 @@ def test_dataframe_duplicated(data, subset, keep):
 
     expected = pdf.duplicated(subset=subset, keep=keep)
     actual = gdf.duplicated(subset=subset, keep=keep)
+
+    assert_eq(expected, actual)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"col": [{"a": 1.1}, {"a": 2.1}, {"a": 10.0}, {"a": 11.2323}, None]},
+        {"a": [[{"b": 567}]] * 10},
+        {"a": [decimal.Decimal(10), decimal.Decimal(20), None]},
+    ],
+)
+def test_dataframe_transpose_complex_types(data):
+    gdf = cudf.DataFrame(data)
+    pdf = gdf.to_pandas()
+
+    expected = pdf.T
+    actual = gdf.T
 
     assert_eq(expected, actual)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -10001,7 +10001,7 @@ def test_dataframe_duplicated(data, subset, keep):
     "data",
     [
         {"col": [{"a": 1.1}, {"a": 2.1}, {"a": 10.0}, {"a": 11.2323}, None]},
-        {"a": [[{"b": 567}]] * 10},
+        {"a": [[{"b": 567}], None] * 10},
         {"a": [decimal.Decimal(10), decimal.Decimal(20), None]},
     ],
 )


### PR DESCRIPTION
## Description
Fixes: #12489 

This PR fixes an issue in `DataFrame.transpose` where metadata of some complex types is not being transferred.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
