### PR TITLE
Stop using pandas._testing

### DIFF
--- a/python/cudf/cudf/testing/_utils.py
+++ b/python/cudf/cudf/testing/_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 import itertools
+import string
 import warnings
 from collections import abc
 from contextlib import contextmanager
@@ -294,9 +295,13 @@ def gen_rand(dtype, size, **kwargs):
     elif dtype.kind in ("O", "U"):
         low = kwargs.get("low", 10)
         high = kwargs.get("high", 11)
-        return pd._testing.rands_array(
-            np.random.randint(low=low, high=high, size=1)[0], size
+        nchars = np.random.randint(low=low, high=high, size=1)[0]
+        char_options = np.array(list(string.ascii_letters + string.digits))
+        all_chars = "".join(np.random.choice(char_options, nchars * size))
+        return np.array(
+            [all_chars[nchars * i : nchars * (i + 1)] for i in range(size)]
         )
+
     raise NotImplementedError(f"dtype.kind={dtype.kind}")
 
 

--- a/python/cudf/cudf/tests/test_feather.py
+++ b/python/cudf/cudf/tests/test_feather.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 import os
 from string import ascii_letters
@@ -15,16 +15,14 @@ from cudf.testing._utils import NUMERIC_TYPES, assert_eq
 @pytest.fixture(params=[0, 1, 10, 100])
 def pdf(request):
     types = NUMERIC_TYPES + ["bool"]
-    renamer = {
-        "C_l0_g" + str(idx): "col_" + val for (idx, val) in enumerate(types)
-    }
     typer = {"col_" + val: val for val in types}
     ncols = len(types)
     nrows = request.param
 
     # Create a pandas dataframe with random data of mixed types
-    test_pdf = pd._testing.makeCustomDataframe(
-        nrows=nrows, ncols=ncols, data_gen_f=lambda r, c: r, r_idx_type="i"
+    test_pdf = pd.DataFrame(
+        [list(range(ncols * i, ncols * (i + 1))) for i in range(nrows)],
+        columns=pd.Index([f"col_{typ}" for typ in types], name="foo"),
     )
     # Delete the name of the column index, and rename the row index
     test_pdf.columns.name = None
@@ -32,7 +30,7 @@ def pdf(request):
 
     # Cast all the column dtypes to objects, rename them, and then cast to
     # appropriate types
-    test_pdf = test_pdf.astype("object").rename(renamer, axis=1).astype(typer)
+    test_pdf = test_pdf.astype("object").astype(typer)
 
     # Create non-numeric categorical data otherwise may get typecasted
     data = [ascii_letters[np.random.randint(0, 52)] for i in range(nrows)]

--- a/python/cudf/cudf/tests/test_hdf.py
+++ b/python/cudf/cudf/tests/test_hdf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 import os
 from string import ascii_letters
@@ -22,16 +22,14 @@ except ImportError:
 @pytest.fixture(params=[0, 1, 10, 100])
 def pdf(request):
     types = NUMERIC_TYPES + DATETIME_TYPES + ["bool"]
-    renamer = {
-        "C_l0_g" + str(idx): "col_" + val for (idx, val) in enumerate(types)
-    }
     typer = {"col_" + val: val for val in types}
     ncols = len(types)
     nrows = request.param
 
     # Create a pandas dataframe with random data of mixed types
-    test_pdf = pd._testing.makeCustomDataframe(
-        nrows=nrows, ncols=ncols, data_gen_f=lambda r, c: r, r_idx_type="i"
+    test_pdf = pd.DataFrame(
+        [list(range(ncols * i, ncols * (i + 1))) for i in range(nrows)],
+        columns=pd.Index([f"col_{typ}" for typ in types], name="foo"),
     )
     # Delete the name of the column index, and rename the row index
     test_pdf.columns.name = None
@@ -41,7 +39,6 @@ def pdf(request):
     # appropriate types
     test_pdf = (
         test_pdf.astype("object")
-        .rename(renamer, axis=1)
         .astype(typer)
         .rename({"col_datetime64[ms]": "col_datetime64"}, axis=1)
     )

--- a/python/cudf/cudf/tests/test_json.py
+++ b/python/cudf/cudf/tests/test_json.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 import copy
 import gzip
@@ -27,16 +27,14 @@ def make_numeric_dataframe(nrows, dtype):
 @pytest.fixture(params=[0, 1, 10, 100])
 def pdf(request):
     types = NUMERIC_TYPES + DATETIME_TYPES + ["bool"]
-    renamer = {
-        "C_l0_g" + str(idx): "col_" + val for (idx, val) in enumerate(types)
-    }
     typer = {"col_" + val: val for val in types}
     ncols = len(types)
     nrows = request.param
 
     # Create a pandas dataframe with random data of mixed types
-    test_pdf = pd._testing.makeCustomDataframe(
-        nrows=nrows, ncols=ncols, data_gen_f=lambda r, c: r, r_idx_type="i"
+    test_pdf = pd.DataFrame(
+        [list(range(ncols * i, ncols * (i + 1))) for i in range(nrows)],
+        columns=pd.Index([f"col_{typ}" for typ in types], name="foo"),
     )
     # Delete the name of the column index, and rename the row index
     test_pdf.columns.name = None
@@ -44,7 +42,7 @@ def pdf(request):
 
     # Cast all the column dtypes to objects, rename them, and then cast to
     # appropriate types
-    test_pdf = test_pdf.astype("object").rename(renamer, axis=1).astype(typer)
+    test_pdf = test_pdf.astype("object").astype(typer)
 
     return test_pdf
 

--- a/python/cudf/cudf/tests/test_serialize.py
+++ b/python/cudf/cudf/tests/test_serialize.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 import pickle
 
@@ -8,7 +8,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_GE_150
 from cudf.testing import _utils as utils
 from cudf.testing._utils import assert_eq
 
@@ -16,6 +15,8 @@ from cudf.testing._utils import assert_eq
 @pytest.mark.parametrize(
     "df",
     [
+        lambda: cudf.Index([1, 2, 3]),
+        lambda: cudf.Index([1.0, 2.0, 3.0]),
         lambda: cudf.Series([1, 2, 3]),
         lambda: cudf.Series([1, 2, 3], index=[4, 5, 6]),
         lambda: cudf.Series([1, None, 3]),
@@ -53,48 +54,66 @@ from cudf.testing._utils import assert_eq
             {"x": ["a", "bb", "ccc"], "y": [1.0, None, 3.0]},
             index=[1, None, 3],
         ),
-        pd._testing.makeBoolIndex,
-        pd._testing.makeCategoricalIndex,
-        lambda: pd._testing.makeCustomDataframe(3, 4),
-        lambda: pd._testing.makeCustomIndex(2, 5),
-        pd._testing.makeDataFrame,
-        pd._testing.makeDateIndex,
-        pd._testing.makeFloatIndex,
-        pd._testing.makeFloatSeries,
-        pd._testing.makeIntIndex,
-        pd._testing.makeIntervalIndex,
-        pd._testing.makeMissingDataframe,
-        pd._testing.makeMixedDataFrame,
-        pd._testing.makeMultiIndex,
-        lambda: pd._testing.makeNumericIndex(dtype=np.float64),
-        pd._testing.makeObjectSeries,
-        pytest.param(
-            pd._testing.makePeriodFrame,
-            marks=pytest.mark.xfail(
-                reason="Periods not supported in cudf", raises=RuntimeError
+        lambda: pd.Index([True, False] * 5),
+        lambda: pd.CategoricalIndex(["a", "b", "a", "b"], ["a", "b", "c"]),
+        lambda: (
+            cudf.DataFrame(
+                {
+                    "a": [1, 2, 3],
+                    "b": ["c", "e", "g"],
+                    "d": [True, False, True],
+                },
+                index=cudf.MultiIndex.from_tuples(
+                    [("i1", "i2"), ("i3", "i4"), ("i5", "i6")],
+                    names=["foo", "bar"],
+                ),
+            )
+        ),
+        lambda: cudf.Index(
+            cudf.date_range(start="2011-01-01", end="2012-01-01", periods=13)
+        ),
+        lambda: cudf.Index([1.2, 3.4, 5.6]),
+        lambda: cudf.Series([1.2, 3.4, 5.6]),
+        lambda: pd.IntervalIndex.from_breaks(range(10)),
+        lambda: cudf.MultiIndex.from_tuples(
+            [("i1", "i2"), ("i3", "i4"), ("i5", "i6")], names=["foo", "bar"]
+        ),
+        lambda: cudf.RangeIndex(10),
+        lambda: cudf.DataFrame(
+            {"a": list(range(13)), "b": [float(x) for x in range(13)]},
+            index=cudf.Index(
+                cudf.date_range(
+                    start="2011-01-01", end="2012-01-01", periods=13
+                )
             ),
         ),
-        pytest.param(
-            pd._testing.makePeriodIndex,
-            marks=pytest.mark.xfail(
-                reason="Periods not supported in cudf", raises=RuntimeError
+        lambda: cudf.Series(
+            list(range(13)),
+            index=cudf.Index(
+                cudf.date_range(
+                    start="2011-01-01", end="2012-01-01", periods=13
+                )
             ),
         ),
-        pytest.param(
-            pd._testing.makePeriodSeries,
-            marks=pytest.mark.xfail(
-                reason="Periods not supported in cudf", raises=RuntimeError
-            ),
+        lambda: cudf.TimedeltaIndex(
+            [1132223, 2023232, 342234324, 4234324],
+            dtype="timedelta64[ns]",
+            name="foo",
         ),
-        pd._testing.makeRangeIndex,
-        pd._testing.makeStringSeries,
-        pd._testing.makeTimeDataFrame,
-        pd._testing.makeTimeSeries,
-        pd._testing.makeTimedeltaIndex,
-        pd._testing.makeUIntIndex,
-        pd._testing.makeUnicodeIndex
-        if not PANDAS_GE_150
-        else pd._testing.makeStringIndex,
+        lambda: cudf.Index(
+            [
+                "y7ssMP1PWJ",
+                "rZDLbzIQsX",
+                "NrPwYMsxNw",
+                "4zja1Vw9Rq",
+                "Y9TNDhjXgR",
+                "Ryjt7up2hT",
+                "dxYKtRGHkb",
+                "nMCWj5yhMu",
+                "Rt7S362FNX",
+                "OGbssOJLUI",
+            ]
+        ),
     ],
 )
 @pytest.mark.parametrize("to_host", [True, False])

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 
 import random
 
@@ -351,11 +351,28 @@ def test_setitem_scalar_datetime():
 @pytest.mark.parametrize(
     "func",
     [
-        lambda: pd._testing.makeDataFrame().reset_index(),
-        pd._testing.makeDataFrame,
-        pd._testing.makeMixedDataFrame,
-        pd._testing.makeObjectSeries,
-        pd._testing.makeTimeSeries,
+        lambda: pd.DataFrame(
+            {"A": np.random.rand(10), "B": np.random.rand(10)},
+            index=list("abcdefghij"),
+        ),
+        lambda: pd.DataFrame(
+            {
+                "A": np.random.rand(10),
+                "B": list("a" * 10),
+                "C": pd.Series(
+                    [str(20090101 + i) for i in range(10)],
+                    dtype="datetime64[ns]",
+                ),
+            },
+            index=list("abcdefghij"),
+        ),
+        lambda: pd.Series(list("abcdefghijklmnop")),
+        lambda: pd.Series(
+            np.random.rand(10),
+            index=pd.Index(
+                [str(20090101 + i) for i in range(10)], dtype="datetime64[ns]"
+            ),
+        ),
     ],
 )
 def test_repr(func):


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The pandas testing module was deprecated ages ago and should no longer be used. In general we can simply manually construct the necessary objects to get the same effect.

Resolves #6435

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
