### PR TITLE
Loosen runtime arrow pinning

### DIFF
--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 
 [build-system]
 
@@ -10,6 +10,7 @@ requires = [
     "cmake>=3.23.1,!=3.25.0",
     "ninja",
     "numpy",
+    # Hard pin the patch version used during the build.
     "pyarrow==10.0.1",
     "protoc-wheel",
     "versioneer",

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -19,7 +19,8 @@ install_requires = [
     "pandas>=1.0,<1.6.0dev0",
     "protobuf==4.21",
     "typing_extensions",
-    "pyarrow==10.0.1",
+    # Allow floating minor versions for Arrow.
+    "pyarrow==10",
     f"rmm{cuda_suffix}",
     f"ptxcompiler{cuda_suffix}",
     f"cubinlinker{cuda_suffix}",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The Arrow version used in the build (i.e. in pyproject.toml for wheel builds) must match the exact patch version for libcudf's CMake. However, users should be able to install SemVer-compatible pyarrow packages into an environment with a pre-built cuDF and still have everything work as expected.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
