### PR TITLE
Fix compute sanitizer in GitHub Actions CI

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -93,6 +93,11 @@ if [[ "${RAPIDS_BUILD_TYPE}" == "nightly" ]]; then
         fi
         echo "Running gtest $test_name"
         ${COMPUTE_SANITIZER_CMD} ${gt} | tee "${RAPIDS_TESTS_DIR}${test_name}.cs.log"
+        exitcode=$?
+        if (( ${exitcode} != 0 )); then
+            SUITEERROR=${exitcode}
+            echo "FAILED: GTest ${gt}"
+        fi
     done
     unset GTEST_CUDF_RMM_MODE
     # TODO: test-results/*.cs.log are processed in gpuci

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -16,6 +16,7 @@ dependencies:
 - cmake>=3.23.1,!=3.25.0
 - cubinlinker
 - cuda-python>=11.7.1,<12.0
+- cuda-sanitizer-api=11.8.86
 - cudatoolkit=11.8
 - cupy>=9.5.0,<12.0.0a0
 - cxx-compiler

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -13,12 +13,14 @@ files:
       - notebooks
       - py_version
       - run
+      - test_cpp
       - test_python
   test_cpp:
     output: none
     includes:
       - cudatoolkit
       - libidentify_stream_usage_build
+      - test_cpp
   test_python:
     output: none
     includes:
@@ -265,6 +267,15 @@ dependencies:
               arch: aarch64
             packages:
               - cupy-cuda11x -f https://pip.cupy.dev/aarch64 # TODO: Verify that this works.
+  test_cpp:
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "11.8"
+            packages:
+              # Needed for compute-sanitizer --tool memcheck
+              - cuda-sanitizer-api=11.8.86
   test_java:
     common:
       - output_types: conda


### PR DESCRIPTION
## Description
@davidwendt noticed that the [nightly builds](https://github.com/rapidsai/cudf/actions/workflows/test.yaml) were passing unexpectedly on GitHub Actions, after they had been regularly failing on a `compute-sanitizer --tool memcheck` step in gpuCI.

https://github.com/rapidsai/cudf/actions/runs/3880698576/jobs/6618987835#step:6:66543

After some investigation, I found the job was failing -- but for the wrong reason, and silently.

```
RAPIDS logger » [01/10/23 06:24:39]
┌──────────────────────────────────────────┐
|    Memcheck gtests with rmm_mode=cuda    |
└──────────────────────────────────────────┘

Running gtest ARROW_IO_SOURCE_TEST
ci/test_cpp.sh: line 95: compute-sanitizer: command not found
...
```

In this PR, I add the `cuda-sanitizer-api` package to our C++ test dependencies, which should fix the nightly tests (so they fail as expected). I also fixed a script bug that let the tests pass silently despite having failures.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
