### PR TITLE
More `@acquire_spill_lock()` and `as_buffer(..., exposed=False)`

### DIFF
--- a/python/cudf/cudf/_lib/transform.pyx
+++ b/python/cudf/cudf/_lib/transform.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 from numba.np import numpy_support
 
@@ -72,6 +72,7 @@ def mask_to_bools(object mask_buffer, size_type begin_bit, size_type end_bit):
     return Column.from_unique_ptr(move(result))
 
 
+@acquire_spill_lock()
 def nans_to_nulls(Column input):
     cdef column_view c_input = input.view()
     cdef pair[unique_ptr[device_buffer], size_type] c_output
@@ -84,9 +85,7 @@ def nans_to_nulls(Column input):
     if c_output.second == 0:
         return None
 
-    buffer = DeviceBuffer.c_from_unique_ptr(move(c_buffer))
-    buffer = as_buffer(buffer)
-    return buffer
+    return as_buffer(DeviceBuffer.c_from_unique_ptr(move(c_buffer)))
 
 
 @acquire_spill_lock()

--- a/python/cudf/cudf/_lib/transform.pyx
+++ b/python/cudf/cudf/_lib/transform.pyx
@@ -53,6 +53,7 @@ def bools_to_mask(Column col):
     return buf
 
 
+@acquire_spill_lock()
 def mask_to_bools(object mask_buffer, size_type begin_bit, size_type end_bit):
     """
     Given a mask buffer, returns a boolean column representng bit 0 -> False

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1833,7 +1833,7 @@ def as_column(
         ):
             arbitrary = cupy.ascontiguousarray(arbitrary)
 
-        data = as_buffer(arbitrary, exposed=True)
+        data = as_buffer(arbitrary)
         col = build_column(data, dtype=current_dtype, mask=mask)
 
         if dtype is not None:
@@ -2290,7 +2290,7 @@ def _mask_from_cuda_array_interface_desc(obj) -> Union[Buffer, None]:
         typecode = typestr[1]
         if typecode == "t":
             mask_size = bitmask_allocation_size_bytes(nelem)
-            mask = as_buffer(data=ptr, size=mask_size, owner=obj, exposed=True)
+            mask = as_buffer(data=ptr, size=mask_size, owner=obj)
         elif typecode == "b":
             col = as_column(mask)
             mask = bools_to_mask(col)


### PR DESCRIPTION
Now that https://github.com/rapidsai/cudf/pull/12106 is in, wrapping calls to `libcudf` and setting  `as_buffer(..., exposed=False)` is an ongoing effort.
