### PR TITLE
Make string quoting optional on CSV write

### DIFF
--- a/cpp/include/cudf/io/csv.hpp
+++ b/cpp/include/cudf/io/csv.hpp
@@ -1340,6 +1340,8 @@ class csv_writer_options {
   std::string _false_value = std::string{"false"};
   // Names of all columns; if empty, writer will generate column names
   std::vector<std::string> _names;
+  // Quote string rows, if value contains delimiter/double-quote/newline.
+  bool _quote_tricky_strings = true;
 
   /**
    * @brief Constructor from sink and table.
@@ -1442,6 +1444,8 @@ class csv_writer_options {
    */
   [[nodiscard]] std::string get_false_value() const { return _false_value; }
 
+  [[nodiscard]] bool is_enabled_quote_tricky_strings() const { return _quote_tricky_strings; }
+
   // Setter
   /**
    * @brief Sets optional associated column names.
@@ -1505,6 +1509,8 @@ class csv_writer_options {
    * @param table Table to be written
    */
   void set_table(table_view const& table) { _table = table; }
+
+  void quote_tricky_strings(bool is_enabled_quoting) { _quote_tricky_strings = is_enabled_quoting; }
 };
 
 /**
@@ -1625,6 +1631,12 @@ class csv_writer_options_builder {
   csv_writer_options_builder& false_value(std::string val)
   {
     options._false_value = val;
+    return *this;
+  }
+
+  csv_writer_options_builder& quote_tricky_strings(bool is_enabled_quoting)
+  {
+    options._quote_tricky_strings = is_enabled_quoting;
     return *this;
   }
 

--- a/cpp/include/cudf/io/csv.hpp
+++ b/cpp/include/cudf/io/csv.hpp
@@ -1653,6 +1653,7 @@ class csv_writer_options_builder {
    * should be quoted
    *
    * @param is_enabled_quoting Set to `true` to enable quoting, `false` otherwise
+   * @return this for chaining
    */
   csv_writer_options_builder& enable_quote_strings(bool is_enabled_quoting)
   {

--- a/cpp/include/cudf/io/csv.hpp
+++ b/cpp/include/cudf/io/csv.hpp
@@ -1444,6 +1444,14 @@ class csv_writer_options {
    */
   [[nodiscard]] std::string get_false_value() const { return _false_value; }
 
+  /**
+   * @brief Whether or not string rows containing the delimiter, quote, or newline
+   * are to be quoted.
+   * 
+   * @return true If string rows should be quoted
+   * @return false If string rows should not be quoted, even if they have special 
+   *         characters.
+   */
   [[nodiscard]] bool is_enabled_quote_strings() const { return _quote_strings; }
 
   // Setter
@@ -1511,9 +1519,10 @@ class csv_writer_options {
   void set_table(table_view const& table) { _table = table; }
 
   /**
-   * @brief 
+   * @brief Whether string rows containing the delimiter, quote, or newline
+   * should be quoted
    * 
-   * @param is_enabled_quoting 
+   * @param is_enabled_quoting Set to `true` to enable quoting, `false` otherwise
    */
   void enable_quote_strings(bool is_enabled_quoting) { _quote_strings = is_enabled_quoting; }
 };
@@ -1639,6 +1648,12 @@ class csv_writer_options_builder {
     return *this;
   }
 
+  /**
+   * @brief Whether string rows containing the delimiter, quote, or newline
+   * should be quoted
+   * 
+   * @param is_enabled_quoting Set to `true` to enable quoting, `false` otherwise
+   */
   csv_writer_options_builder& enable_quote_strings(bool is_enabled_quoting)
   {
     options._quote_strings = is_enabled_quoting;

--- a/cpp/include/cudf/io/csv.hpp
+++ b/cpp/include/cudf/io/csv.hpp
@@ -1341,7 +1341,7 @@ class csv_writer_options {
   // Names of all columns; if empty, writer will generate column names
   std::vector<std::string> _names;
   // Quote string rows, if value contains delimiter/double-quote/newline.
-  bool _quote_tricky_strings = true;
+  bool _quote_strings = true;
 
   /**
    * @brief Constructor from sink and table.
@@ -1444,7 +1444,7 @@ class csv_writer_options {
    */
   [[nodiscard]] std::string get_false_value() const { return _false_value; }
 
-  [[nodiscard]] bool is_enabled_quote_tricky_strings() const { return _quote_tricky_strings; }
+  [[nodiscard]] bool is_enabled_quote_strings() const { return _quote_strings; }
 
   // Setter
   /**
@@ -1510,7 +1510,12 @@ class csv_writer_options {
    */
   void set_table(table_view const& table) { _table = table; }
 
-  void quote_tricky_strings(bool is_enabled_quoting) { _quote_tricky_strings = is_enabled_quoting; }
+  /**
+   * @brief 
+   * 
+   * @param is_enabled_quoting 
+   */
+  void enable_quote_strings(bool is_enabled_quoting) { _quote_strings = is_enabled_quoting; }
 };
 
 /**
@@ -1634,9 +1639,9 @@ class csv_writer_options_builder {
     return *this;
   }
 
-  csv_writer_options_builder& quote_tricky_strings(bool is_enabled_quoting)
+  csv_writer_options_builder& enable_quote_strings(bool is_enabled_quoting)
   {
-    options._quote_tricky_strings = is_enabled_quoting;
+    options._quote_strings = is_enabled_quoting;
     return *this;
   }
 

--- a/cpp/include/cudf/io/csv.hpp
+++ b/cpp/include/cudf/io/csv.hpp
@@ -1447,9 +1447,9 @@ class csv_writer_options {
   /**
    * @brief Whether or not string rows containing the delimiter, quote, or newline
    * are to be quoted.
-   * 
+   *
    * @return true If string rows should be quoted
-   * @return false If string rows should not be quoted, even if they have special 
+   * @return false If string rows should not be quoted, even if they have special
    *         characters.
    */
   [[nodiscard]] bool is_enabled_quote_strings() const { return _quote_strings; }
@@ -1521,7 +1521,7 @@ class csv_writer_options {
   /**
    * @brief Whether string rows containing the delimiter, quote, or newline
    * should be quoted
-   * 
+   *
    * @param is_enabled_quoting Set to `true` to enable quoting, `false` otherwise
    */
   void enable_quote_strings(bool is_enabled_quoting) { _quote_strings = is_enabled_quoting; }
@@ -1651,7 +1651,7 @@ class csv_writer_options_builder {
   /**
    * @brief Whether string rows containing the delimiter, quote, or newline
    * should be quoted
-   * 
+   *
    * @param is_enabled_quoting Set to `true` to enable quoting, `false` otherwise
    */
   csv_writer_options_builder& enable_quote_strings(bool is_enabled_quoting)

--- a/cpp/include/cudf/io/csv.hpp
+++ b/cpp/include/cudf/io/csv.hpp
@@ -665,11 +665,21 @@ class csv_reader_options {
   void enable_skip_blank_lines(bool val) { _skip_blank_lines = val; }
 
   /**
-   * @brief Sets quoting style.
+   * @brief Sets the expected quoting style used in the input CSV data.
    *
-   * @param style Quoting style used
+   * Note: Only the following quoting styles are supported:
+   *   1. MINIMAL: String columns containing special characters like row-delimiters/
+   *               field-delimiter/quotes will be quoted.
+   *   2. NONE: No quoting is done for any columns.
+   *
+   * @param quoting Quoting style used
    */
-  void set_quoting(quote_style style) { _quoting = style; }
+  void set_quoting(quote_style quoting)
+  {
+    CUDF_EXPECTS(quoting == quote_style::MINIMAL || quoting == quote_style::NONE,
+                 "Only MINIMAL and NONE are supported for quoting.");
+    _quoting = quoting;
+  }
 
   /**
    * @brief Sets quoting character.
@@ -1523,7 +1533,7 @@ class csv_writer_options {
   /**
    * @brief Sets the quote style for the writer.
    *
-   * Note: Only MINIMAL and NONE are supported.
+   * Note: Only the following quote styles are supported:
    *   1. MINIMAL: String columns containing special characters like row-delimiters/
    *               field-delimiter/quotes will be quoted.
    *   2. NONE: No quoting is done for any columns.

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -170,6 +170,10 @@ struct column_to_strings_fn {
   std::enable_if_t<std::is_same_v<column_type, cudf::string_view>, std::unique_ptr<column>>
   operator()(column_view const& column_v) const
   {
+    if (not options_.is_enabled_quote_tricky_strings()) {
+      return std::make_unique<column>(column_v, stream_, mr_);
+    }
+
     // handle special characters: {delimiter, '\n', "} in row:
     string_scalar delimiter{std::string{options_.get_inter_column_delimiter()}, true, stream_};
 

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -170,7 +170,7 @@ struct column_to_strings_fn {
   std::enable_if_t<std::is_same_v<column_type, cudf::string_view>, std::unique_ptr<column>>
   operator()(column_view const& column_v) const
   {
-    if (not options_.is_enabled_quote_strings()) {
+    if (options_.get_quoting() == cudf::io::quote_style::NONE) {
       return std::make_unique<column>(column_v, stream_, mr_);
     }
 

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -170,7 +170,7 @@ struct column_to_strings_fn {
   std::enable_if_t<std::is_same_v<column_type, cudf::string_view>, std::unique_ptr<column>>
   operator()(column_view const& column_v) const
   {
-    if (not options_.is_enabled_quote_tricky_strings()) {
+    if (not options_.is_enabled_quote_strings()) {
       return std::make_unique<column>(column_v, stream_, mr_);
     }
 

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -453,10 +453,13 @@ TYPED_TEST(CsvFixedPointWriterTest, SingleColumnPositiveScale)
   EXPECT_EQ(result_strings, reference_strings);
 }
 
-TEST_F(CsvWriterTest, QuotingDisabled)
+void test_quoting_disabled_with_delimiter(char delimiter_char)
 {
+  auto const delimiter = std::string{delimiter_char};
   auto const input_strings = cudf::test::strings_column_wrapper{
-    "All,the,leaves", "are\"brown", "and\nthe\nsky\nis\ngrey"
+    std::string{"All"} + delimiter + "the" + delimiter + "leaves",
+    "are\"brown", 
+    "and\nthe\nsky\nis\ngrey"
   };
   auto const input_table = table_view{{input_strings}};
 
@@ -464,11 +467,13 @@ TEST_F(CsvWriterTest, QuotingDisabled)
   auto w_options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{filepath},
                                                          input_table)
                                                 .include_header(false)
+                                                .inter_column_delimiter(delimiter_char)
                                                 .enable_quote_strings(false);
   cudf::io::write_csv(w_options.build());
 
   auto r_options = cudf::io::csv_reader_options::builder(cudf::io::source_info{filepath})
                                                 .header(-1)
+                                                .delimiter(delimiter_char)
                                                 .quoting(cudf::io::quote_style::NONE);
   auto r_table = cudf::io::read_csv(r_options.build());
 
@@ -476,6 +481,12 @@ TEST_F(CsvWriterTest, QuotingDisabled)
     "All", "are\"brown", "and", "the", "sky", "is", "grey"
   };
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(r_table.tbl->view().column(0), expected);
+}
+
+TEST_F(CsvWriterTest, QuotingDisabled)
+{
+  test_quoting_disabled_with_delimiter(',');
+  test_quoting_disabled_with_delimiter('\u0001');
 }
 
 TEST_F(CsvReaderTest, MultiColumn)

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -453,7 +453,6 @@ TYPED_TEST(CsvFixedPointWriterTest, SingleColumnPositiveScale)
   EXPECT_EQ(result_strings, reference_strings);
 }
 
-/*
 void test_quoting_disabled_with_delimiter(char delimiter_char)
 {
   auto const delimiter     = std::string{delimiter_char};
@@ -486,7 +485,6 @@ TEST_F(CsvWriterTest, QuotingDisabled)
   test_quoting_disabled_with_delimiter(',');
   test_quoting_disabled_with_delimiter('\u0001');
 }
-*/
 
 TEST_F(CsvReaderTest, MultiColumn)
 {

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -464,7 +464,7 @@ TEST_F(CsvWriterTest, QuotingDisabled)
   auto w_options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{filepath},
                                                          input_table)
                                                 .include_header(false)
-                                                .quote_tricky_strings(false);
+                                                .enable_quote_strings(false);
   cudf::io::write_csv(w_options.build());
 
   auto r_options = cudf::io::csv_reader_options::builder(cudf::io::source_info{filepath})

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -455,31 +455,28 @@ TYPED_TEST(CsvFixedPointWriterTest, SingleColumnPositiveScale)
 
 void test_quoting_disabled_with_delimiter(char delimiter_char)
 {
-  auto const delimiter = std::string{delimiter_char};
+  auto const delimiter     = std::string{delimiter_char};
   auto const input_strings = cudf::test::strings_column_wrapper{
     std::string{"All"} + delimiter + "the" + delimiter + "leaves",
-    "are\"brown", 
-    "and\nthe\nsky\nis\ngrey"
-  };
+    "are\"brown",
+    "and\nthe\nsky\nis\ngrey"};
   auto const input_table = table_view{{input_strings}};
 
   auto const filepath = temp_env->get_temp_dir() + "unquoted.csv";
-  auto w_options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{filepath},
-                                                         input_table)
-                                                .include_header(false)
-                                                .inter_column_delimiter(delimiter_char)
-                                                .enable_quote_strings(false);
+  auto w_options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{filepath}, input_table)
+                     .include_header(false)
+                     .inter_column_delimiter(delimiter_char)
+                     .enable_quote_strings(false);
   cudf::io::write_csv(w_options.build());
 
   auto r_options = cudf::io::csv_reader_options::builder(cudf::io::source_info{filepath})
-                                                .header(-1)
-                                                .delimiter(delimiter_char)
-                                                .quoting(cudf::io::quote_style::NONE);
+                     .header(-1)
+                     .delimiter(delimiter_char)
+                     .quoting(cudf::io::quote_style::NONE);
   auto r_table = cudf::io::read_csv(r_options.build());
 
-  auto const expected = cudf::test::strings_column_wrapper{
-    "All", "are\"brown", "and", "the", "sky", "is", "grey"
-  };
+  auto const expected =
+    cudf::test::strings_column_wrapper{"All", "are\"brown", "and", "the", "sky", "is", "grey"};
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(r_table.tbl->view().column(0), expected);
 }
 

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -453,6 +453,7 @@ TYPED_TEST(CsvFixedPointWriterTest, SingleColumnPositiveScale)
   EXPECT_EQ(result_strings, reference_strings);
 }
 
+/*
 void test_quoting_disabled_with_delimiter(char delimiter_char)
 {
   auto const delimiter     = std::string{delimiter_char};
@@ -466,7 +467,7 @@ void test_quoting_disabled_with_delimiter(char delimiter_char)
   auto w_options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{filepath}, input_table)
                      .include_header(false)
                      .inter_column_delimiter(delimiter_char)
-                     .enable_quote_strings(false);
+                     .quoting(cudf::io::quote_style::NONE);
   cudf::io::write_csv(w_options.build());
 
   auto r_options = cudf::io::csv_reader_options::builder(cudf::io::source_info{filepath})
@@ -485,6 +486,7 @@ TEST_F(CsvWriterTest, QuotingDisabled)
   test_quoting_disabled_with_delimiter(',');
   test_quoting_disabled_with_delimiter('\u0001');
 }
+*/
 
 TEST_F(CsvReaderTest, MultiColumn)
 {

--- a/java/src/main/java/ai/rapids/cudf/CSVOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/CSVOptions.java
@@ -35,6 +35,7 @@ public class CSVOptions extends ColumnFilterOptions {
   private final String[] nullValues;
   private final String[] trueValues;
   private final String[] falseValues;
+  private final boolean quoteStrings;
 
   private CSVOptions(Builder builder) {
     super(builder);
@@ -48,6 +49,7 @@ public class CSVOptions extends ColumnFilterOptions {
         new String[builder.trueValues.size()]);
     falseValues = builder.falseValues.toArray(
         new String[builder.falseValues.size()]);
+    quoteStrings = builder.quoteStrings;
   }
 
   String[] getNullValues() {
@@ -78,6 +80,10 @@ public class CSVOptions extends ColumnFilterOptions {
     return comment;
   }
 
+  boolean isQuotingEnabled() {
+    return quoteStrings;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -91,6 +97,7 @@ public class CSVOptions extends ColumnFilterOptions {
     private int headerRow = NO_HEADER_ROW;
     private byte delim = ',';
     private byte quote = '"';
+    private boolean quoteStrings = true;
 
     /**
      * Row of the header data (0 based counting).  Negative is no header.
@@ -134,6 +141,14 @@ public class CSVOptions extends ColumnFilterOptions {
         throw new IllegalArgumentException("Only ASCII characters are currently supported");
       }
       this.quote = (byte) quote;
+      return this;
+    }
+
+    /**
+     * Whether input strings containing special characters might be quoted.
+     */
+    public Builder withQuotingEnabled(boolean quoteStrings) {
+      this.quoteStrings = quoteStrings;
       return this;
     }
 

--- a/java/src/main/java/ai/rapids/cudf/CSVOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/CSVOptions.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public class CSVOptions extends ColumnFilterOptions {
   private final String[] nullValues;
   private final String[] trueValues;
   private final String[] falseValues;
-  private final boolean quoteStrings;
+  private final QuoteStyle quoteStyle;
 
   private CSVOptions(Builder builder) {
     super(builder);
@@ -49,9 +49,8 @@ public class CSVOptions extends ColumnFilterOptions {
         new String[builder.trueValues.size()]);
     falseValues = builder.falseValues.toArray(
         new String[builder.falseValues.size()]);
-    quoteStrings = builder.quoteStrings;
+    quoteStyle = builder.quoteStyle;
   }
-
 
   String[] getNullValues() {
     return nullValues;
@@ -81,8 +80,8 @@ public class CSVOptions extends ColumnFilterOptions {
     return comment;
   }
 
-  boolean isQuotingEnabled() {
-    return quoteStrings;
+  QuoteStyle getQuoteStyle() {
+    return quoteStyle;
   }
 
   public static Builder builder() {
@@ -98,7 +97,7 @@ public class CSVOptions extends ColumnFilterOptions {
     private int headerRow = NO_HEADER_ROW;
     private byte delim = ',';
     private byte quote = '"';
-    private boolean quoteStrings = true;
+    private QuoteStyle quoteStyle = QuoteStyle.MINIMAL;
 
     /**
      * Row of the header data (0 based counting).  Negative is no header.
@@ -146,10 +145,18 @@ public class CSVOptions extends ColumnFilterOptions {
     }
 
     /**
-     * Whether input strings containing special characters might be quoted.
+     * Quote style to expect in the input CSV data.
+     *
+     * Note: Only the following quoting styles are supported:
+     *   1. MINIMAL: String columns containing special characters like row-delimiters/
+     *               field-delimiter/quotes will be quoted.
+     *   2. NONE: No quoting is done for any columns.
      */
-    public Builder withQuotingEnabled(boolean quoteStrings) {
-      this.quoteStrings = quoteStrings;
+    public Builder withQuoteStyle(QuoteStyle quoteStyle) {
+      if (quoteStyle != QuoteStyle.MINIMAL && quoteStyle != QuoteStyle.NONE) {
+        throw new IllegalArgumentException("Only MINIMAL and NONE quoting styles are supported");
+      }
+      this.quoteStyle = quoteStyle;
       return this;
     }
 

--- a/java/src/main/java/ai/rapids/cudf/CSVOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/CSVOptions.java
@@ -52,6 +52,7 @@ public class CSVOptions extends ColumnFilterOptions {
     quoteStrings = builder.quoteStrings;
   }
 
+
   String[] getNullValues() {
     return nullValues;
   }

--- a/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
@@ -35,7 +35,7 @@ public class CSVWriterOptions {
   private String falseValue = "false";
   private String trueValue = "true";
   // Quote style used for CSV data.
-  // Currently, `true` corresponds to `MINIMAL`, `false` to `NONE`.
+  // Currently supports only `MINIMAL` and `NONE`.
   private QuoteStyle quoteStyle = QuoteStyle.MINIMAL;
 
   private CSVWriterOptions(Builder builder) {

--- a/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
@@ -22,6 +22,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Options for writing a CSV file
+ */
 public class CSVWriterOptions {
 
   private String[] columnNames;
@@ -31,6 +34,8 @@ public class CSVWriterOptions {
   private String nullValue = "";
   private String falseValue = "false";
   private String trueValue = "true";
+  // Whether to quote strings that contain delimiters or quote characters.
+  private boolean quoteStrings = true;
 
   private CSVWriterOptions(Builder builder) {
     this.columnNames = builder.columnNames.toArray(new String[builder.columnNames.size()]);
@@ -70,6 +75,13 @@ public class CSVWriterOptions {
     return falseValue;
   }
 
+  /**
+   * Whether or not quoting is enabled for strings containing special characters
+   */
+  public boolean isQuotingEnabled() {
+    return quoteStrings;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -83,6 +95,7 @@ public class CSVWriterOptions {
     private String nullValue = "";
     private String falseValue = "false";
     private String trueValue = "true";
+    private Boolean quoteStrings = true;
 
     public CSVWriterOptions build() {
       return new CSVWriterOptions(this);
@@ -128,6 +141,17 @@ public class CSVWriterOptions {
 
     public Builder withFalseValue(String falseValue) {
       this.falseValue = falseValue;
+      return this;
+    }
+
+    /**
+     * Whether to quote strings that contain the following special characters:
+     * 1. Field delimiter
+     * 2. Row delimiter
+     * 3. Double quotes
+     */
+    public Builder withQuotingEnabled(boolean quoteStrings) {
+      this.quoteStrings = quoteStrings;
       return this;
     }
   }

--- a/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
@@ -35,6 +35,7 @@ public class CSVWriterOptions {
   private String falseValue = "false";
   private String trueValue = "true";
   // Whether to quote strings that contain delimiters or quote characters.
+  // Currently, `true` corresponds to `MINIMAL`, `false` to `NONE`.
   private boolean quoteStrings = true;
 
   private CSVWriterOptions(Builder builder) {
@@ -45,6 +46,7 @@ public class CSVWriterOptions {
     this.rowDelimiter = builder.rowDelimiter;
     this.falseValue = builder.falseValue;
     this.trueValue = builder.trueValue;
+    this.quoteStrings = builder.quoteStrings;
   }
 
   public String[] getColumnNames() {

--- a/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/CSVWriterOptions.java
@@ -34,9 +34,9 @@ public class CSVWriterOptions {
   private String nullValue = "";
   private String falseValue = "false";
   private String trueValue = "true";
-  // Whether to quote strings that contain delimiters or quote characters.
+  // Quote style used for CSV data.
   // Currently, `true` corresponds to `MINIMAL`, `false` to `NONE`.
-  private boolean quoteStrings = true;
+  private QuoteStyle quoteStyle = QuoteStyle.MINIMAL;
 
   private CSVWriterOptions(Builder builder) {
     this.columnNames = builder.columnNames.toArray(new String[builder.columnNames.size()]);
@@ -46,7 +46,7 @@ public class CSVWriterOptions {
     this.rowDelimiter = builder.rowDelimiter;
     this.falseValue = builder.falseValue;
     this.trueValue = builder.trueValue;
-    this.quoteStrings = builder.quoteStrings;
+    this.quoteStyle = builder.quoteStyle;
   }
 
   public String[] getColumnNames() {
@@ -78,10 +78,10 @@ public class CSVWriterOptions {
   }
 
   /**
-   * Whether or not quoting is enabled for strings containing special characters
+   * Returns the quoting style used for writing CSV.
    */
-  public boolean isQuotingEnabled() {
-    return quoteStrings;
+  public QuoteStyle getQuoteStyle() {
+    return quoteStyle;
   }
 
   public static Builder builder() {
@@ -97,7 +97,7 @@ public class CSVWriterOptions {
     private String nullValue = "";
     private String falseValue = "false";
     private String trueValue = "true";
-    private Boolean quoteStrings = true;
+    private QuoteStyle quoteStyle = QuoteStyle.MINIMAL;
 
     public CSVWriterOptions build() {
       return new CSVWriterOptions(this);
@@ -147,13 +147,15 @@ public class CSVWriterOptions {
     }
 
     /**
-     * Whether to quote strings that contain the following special characters:
-     * 1. Field delimiter
-     * 2. Row delimiter
-     * 3. Double quotes
+     * Sets the quote style used when writing CSV.
+     *
+     * Note: Only the following quoting styles are supported:
+     *   1. MINIMAL: String columns containing special characters like row-delimiters/
+     *               field-delimiter/quotes will be quoted.
+     *   2. NONE: No quoting is done for any columns.
      */
-    public Builder withQuotingEnabled(boolean quoteStrings) {
-      this.quoteStrings = quoteStrings;
+    public Builder withQuoteStyle(QuoteStyle quoteStyle) {
+      this.quoteStyle = quoteStyle;
       return this;
     }
   }

--- a/java/src/main/java/ai/rapids/cudf/QuoteStyle.java
+++ b/java/src/main/java/ai/rapids/cudf/QuoteStyle.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package ai.rapids.cudf;
+
+/**
+ * Quote style for CSV records, closely following cudf::io::quote_style.
+ */
+enum QuoteStyle {
+    MINIMAL(0),
+    ALL(1),
+    NONNUMERIC(2),
+    NONE(3);
+
+    final int nativeId; // Native id, for use with libcudf.
+    QuoteStyle(int nativeId) {
+        this.nativeId = nativeId;
+    }
+}

--- a/java/src/main/java/ai/rapids/cudf/QuoteStyle.java
+++ b/java/src/main/java/ai/rapids/cudf/QuoteStyle.java
@@ -21,10 +21,10 @@ package ai.rapids.cudf;
  * Quote style for CSV records, closely following cudf::io::quote_style.
  */
 enum QuoteStyle {
-    MINIMAL(0),
-    ALL(1),
-    NONNUMERIC(2),
-    NONE(3);
+    MINIMAL(0),    // Quote only fields which contain special characters
+    ALL(1),        // Quote all fields
+    NONNUMERIC(2), // Quote all non-numeric fields
+    NONE(3);       // Never quote fields; disable quotation parsing
 
     final int nativeId; // Native id, for use with libcudf.
     QuoteStyle(int nativeId) {

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -220,8 +220,8 @@ public final class Table implements AutoCloseable {
    * @param length            the length of the buffer to read from.
    * @param headerRow         the 0 based index row of the header can be -1
    * @param delim             character deliminator (must be ASCII).
+   * @param quoteStyle        quote style expected to be used in the input (represented as int)
    * @param quote             character quote (must be ASCII).
-   * @param quoteStrings      whether or not to quote strings containing special characters.
    * @param comment           character that starts a comment line (must be ASCII) use '\0'
    * @param nullValues        values that should be treated as nulls
    * @param trueValues        values that should be treated as boolean true
@@ -231,7 +231,7 @@ public final class Table implements AutoCloseable {
                                        int[] dTypeIds, int[] dTypeScales,
                                        String[] filterColumnNames,
                                        String filePath, long address, long length,
-                                       int headerRow, byte delim, boolean quoteStrings, byte quote,
+                                       int headerRow, byte delim, int quoteStyle, byte quote,
                                        byte comment, String[] nullValues,
                                        String[] trueValues, String[] falseValues) throws CudfException;
 
@@ -778,7 +778,7 @@ public final class Table implements AutoCloseable {
             0, 0,
             opts.getHeaderRow(),
             opts.getDelim(),
-            opts.isQuotingEnabled(),
+            opts.getQuoteStyle().nativeId,
             opts.getQuote(),
             opts.getComment(),
             opts.getNullValues(),
@@ -852,7 +852,7 @@ public final class Table implements AutoCloseable {
         buffer.getAddress() + offset, len,
         opts.getHeaderRow(),
         opts.getDelim(),
-        opts.isQuotingEnabled(),
+        opts.getQuoteStyle().nativeId,
         opts.getQuote(),
         opts.getComment(),
         opts.getNullValues(),
@@ -868,7 +868,7 @@ public final class Table implements AutoCloseable {
                                             String nullValue,
                                             String trueValue,
                                             String falseValue,
-                                            boolean quoteStrings,
+                                            int quoteStyle,
                                             String outputPath) throws CudfException;
 
   public void writeCSVToFile(CSVWriterOptions options, String outputPath) {
@@ -880,7 +880,7 @@ public final class Table implements AutoCloseable {
                    options.getNullValue(),
                    options.getTrueValue(),
                    options.getFalseValue(),
-                   options.isQuotingEnabled(),
+                   options.getQuoteStyle().nativeId,
                    outputPath);
   }
 
@@ -891,7 +891,7 @@ public final class Table implements AutoCloseable {
                                                    String nullValue,
                                                    String trueValue,
                                                    String falseValue,
-                                                   boolean quoteStrings,
+                                                   int quoteStyle,
                                                    HostBufferConsumer buffer) throws CudfException;
 
   private static native void writeCSVChunkToBuffer(long writerHandle, long tableHandle);
@@ -910,7 +910,7 @@ public final class Table implements AutoCloseable {
                                                 options.getNullValue(),
                                                 options.getTrueValue(),
                                                 options.getFalseValue(),
-                                                options.isQuotingEnabled(),
+                                                options.getQuoteStyle().nativeId,
                                                 consumer);
       this.consumer = consumer;
     }

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -221,6 +221,7 @@ public final class Table implements AutoCloseable {
    * @param headerRow         the 0 based index row of the header can be -1
    * @param delim             character deliminator (must be ASCII).
    * @param quote             character quote (must be ASCII).
+   * @param quoteStrings      whether or not to quote strings containing special characters.
    * @param comment           character that starts a comment line (must be ASCII) use '\0'
    * @param nullValues        values that should be treated as nulls
    * @param trueValues        values that should be treated as boolean true
@@ -230,7 +231,7 @@ public final class Table implements AutoCloseable {
                                        int[] dTypeIds, int[] dTypeScales,
                                        String[] filterColumnNames,
                                        String filePath, long address, long length,
-                                       int headerRow, byte delim, byte quote,
+                                       int headerRow, byte delim, boolean quoteStrings, byte quote,
                                        byte comment, String[] nullValues,
                                        String[] trueValues, String[] falseValues) throws CudfException;
 
@@ -777,6 +778,7 @@ public final class Table implements AutoCloseable {
             0, 0,
             opts.getHeaderRow(),
             opts.getDelim(),
+            opts.isQuotingEnabled(),
             opts.getQuote(),
             opts.getComment(),
             opts.getNullValues(),
@@ -850,6 +852,7 @@ public final class Table implements AutoCloseable {
         buffer.getAddress() + offset, len,
         opts.getHeaderRow(),
         opts.getDelim(),
+        opts.isQuotingEnabled(),
         opts.getQuote(),
         opts.getComment(),
         opts.getNullValues(),

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -865,6 +865,7 @@ public final class Table implements AutoCloseable {
                                             String nullValue,
                                             String trueValue,
                                             String falseValue,
+                                            boolean quoteStrings,
                                             String outputPath) throws CudfException;
 
   public void writeCSVToFile(CSVWriterOptions options, String outputPath) {
@@ -876,6 +877,7 @@ public final class Table implements AutoCloseable {
                    options.getNullValue(),
                    options.getTrueValue(),
                    options.getFalseValue(),
+                   options.isQuotingEnabled(),
                    outputPath);
   }
 
@@ -886,6 +888,7 @@ public final class Table implements AutoCloseable {
                                                    String nullValue,
                                                    String trueValue,
                                                    String falseValue,
+                                                   boolean quoteStrings,
                                                    HostBufferConsumer buffer) throws CudfException;
 
   private static native void writeCSVChunkToBuffer(long writerHandle, long tableHandle);
@@ -904,6 +907,7 @@ public final class Table implements AutoCloseable {
                                                 options.getNullValue(),
                                                 options.getTrueValue(),
                                                 options.getFalseValue(),
+                                                options.isQuotingEnabled(),
                                                 consumer);
       this.consumer = consumer;
     }

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1179,13 +1179,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(
     auto source = read_buffer ? cudf::io::source_info{reinterpret_cast<char *>(buffer),
                                                       static_cast<std::size_t>(buffer_length)} :
                                 cudf::io::source_info{filename.get()};
-
     auto const quote_style = static_cast<cudf::io::quote_style>(j_quote_style);
-    if (quote_style != cudf::io::quote_style::MINIMAL &&
-        quote_style != cudf::io::quote_style::NONE) {
-      JNI_THROW_NEW(env, "java/lang/IllegalArgumentException",
-                    "Only NONE and MINIMAL quoting styles are supported when reading CSV.", NULL);
-    }
 
     cudf::io::csv_reader_options opts = cudf::io::csv_reader_options::builder(source)
                                             .delimiter(delim)
@@ -1236,11 +1230,6 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(
     auto const true_value = cudf::jni::native_jstring{env, j_true_value};
     auto const false_value = cudf::jni::native_jstring{env, j_false_value};
     auto const quote_style = static_cast<cudf::io::quote_style>(j_quote_style);
-    if (quote_style != cudf::io::quote_style::MINIMAL &&
-        quote_style != cudf::io::quote_style::NONE) {
-      JNI_THROW_NEW(env, "java/lang/IllegalArgumentException",
-                    "Only NONE and MINIMAL quoting styles are supported when writing CSV.", );
-    }
 
     auto options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{output_path}, *table)
                        .names(column_names)
@@ -1280,11 +1269,6 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_startWriteCSVToBuffer(
     auto const true_value = cudf::jni::native_jstring{env, j_true_value};
     auto const false_value = cudf::jni::native_jstring{env, j_false_value};
     auto const quote_style = static_cast<cudf::io::quote_style>(j_quote_style);
-    if (quote_style != cudf::io::quote_style::MINIMAL &&
-        quote_style != cudf::io::quote_style::NONE) {
-      JNI_THROW_NEW(env, "java/lang/IllegalArgumentException",
-                    "Only NONE and MINIMAL quoting styles are supported when writing CSV.", 0);
-    }
 
     auto options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{data_sink.get()},
                                                          cudf::table_view{})

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1238,7 +1238,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(
                        .na_rep(na_rep.get())
                        .true_value(true_value.get())
                        .false_value(false_value.get())
-                       .quoting(j_quote_strings? cudf::io::quote_style::MINIMAL : cudf::io::quote_style::NONE);
+                       .quoting(j_quote_strings ? cudf::io::quote_style::MINIMAL :
+                                                  cudf::io::quote_style::NONE);
 
     cudf::io::write_csv(options.build());
   }
@@ -1268,17 +1269,18 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_startWriteCSVToBuffer(
     auto const true_value = cudf::jni::native_jstring{env, j_true_value};
     auto const false_value = cudf::jni::native_jstring{env, j_false_value};
 
-    auto options = cudf::io::csv_writer_options::builder(cudf::io::sink_info{data_sink.get()},
-                                                         cudf::table_view{})
-                       .names(column_names)
-                       .include_header(static_cast<bool>(include_header))
-                       .line_terminator(line_terminator.get())
-                       .inter_column_delimiter(j_field_delimiter)
-                       .na_rep(na_rep.get())
-                       .true_value(true_value.get())
-                       .false_value(false_value.get())
-                       .quoting(j_quote_strings? cudf::io::quote_style::MINIMAL : cudf::io::quote_style::NONE)
-                       .build();
+    auto options =
+        cudf::io::csv_writer_options::builder(cudf::io::sink_info{data_sink.get()},
+                                              cudf::table_view{})
+            .names(column_names)
+            .include_header(static_cast<bool>(include_header))
+            .line_terminator(line_terminator.get())
+            .inter_column_delimiter(j_field_delimiter)
+            .na_rep(na_rep.get())
+            .true_value(true_value.get())
+            .false_value(false_value.get())
+            .quoting(j_quote_strings ? cudf::io::quote_style::MINIMAL : cudf::io::quote_style::NONE)
+            .build();
 
     return ptr_as_jlong(new cudf::jni::io::csv_chunked_writer{options, data_sink});
   }

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1127,7 +1127,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_merge(JNIEnv *env, jclass
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(
     JNIEnv *env, jclass, jobjectArray col_names, jintArray j_types, jintArray j_scales,
     jobjectArray filter_col_names, jstring inputfilepath, jlong buffer, jlong buffer_length,
-    jint header_row, jbyte delim, jboolean quote_strings, jbyte quote, jbyte comment, 
+    jint header_row, jbyte delim, jboolean quote_strings, jbyte quote, jbyte comment,
     jobjectArray null_values, jobjectArray true_values, jobjectArray false_values) {
   JNI_NULL_CHECK(env, null_values, "null_values must be supplied, even if it is empty", NULL);
 
@@ -1180,22 +1180,22 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(
                                                       static_cast<std::size_t>(buffer_length)} :
                                 cudf::io::source_info{filename.get()};
 
-    cudf::io::csv_reader_options opts = cudf::io::csv_reader_options::builder(source)
-                                            .delimiter(delim)
-                                            .header(header_row)
-                                            .names(n_col_names.as_cpp_vector())
-                                            .dtypes(data_types)
-                                            .use_cols_names(n_filter_col_names.as_cpp_vector())
-                                            .true_values(n_true_values.as_cpp_vector())
-                                            .false_values(n_false_values.as_cpp_vector())
-                                            .na_values(n_null_values.as_cpp_vector())
-                                            .keep_default_na(false)
-                                            .na_filter(n_null_values.size() > 0)
-                                            .quoting(quote_strings? cudf::io::quote_style::MINIMAL :
-                                                                    cudf::io::quote_style::NONE)
-                                            .quotechar(quote)
-                                            .comment(comment)
-                                            .build();
+    cudf::io::csv_reader_options opts =
+        cudf::io::csv_reader_options::builder(source)
+            .delimiter(delim)
+            .header(header_row)
+            .names(n_col_names.as_cpp_vector())
+            .dtypes(data_types)
+            .use_cols_names(n_filter_col_names.as_cpp_vector())
+            .true_values(n_true_values.as_cpp_vector())
+            .false_values(n_false_values.as_cpp_vector())
+            .na_values(n_null_values.as_cpp_vector())
+            .keep_default_na(false)
+            .na_filter(n_null_values.size() > 0)
+            .quoting(quote_strings ? cudf::io::quote_style::MINIMAL : cudf::io::quote_style::NONE)
+            .quotechar(quote)
+            .comment(comment)
+            .build();
 
     return convert_table_for_return(env, cudf::io::read_csv(opts).tbl);
   }

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1203,7 +1203,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(
     JNIEnv *env, jclass, jlong j_table_handle, jobjectArray j_column_names, jboolean include_header,
     jstring j_row_delimiter, jbyte j_field_delimiter, jstring j_null_value, jstring j_true_value,
-    jstring j_false_value, jstring j_output_path) {
+    jstring j_false_value, jboolean j_quote_strings, jstring j_output_path) {
   JNI_NULL_CHECK(env, j_table_handle, "table handle cannot be null.", );
   JNI_NULL_CHECK(env, j_column_names, "column name array cannot be null", );
   JNI_NULL_CHECK(env, j_row_delimiter, "row delimiter cannot be null", );
@@ -1235,7 +1235,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(
                        .inter_column_delimiter(j_field_delimiter)
                        .na_rep(na_rep.get())
                        .true_value(true_value.get())
-                       .false_value(false_value.get());
+                       .false_value(false_value.get())
+                       .enable_quote_strings(static_cast<bool>(j_quote_strings));
 
     cudf::io::write_csv(options.build());
   }
@@ -1245,7 +1246,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_startWriteCSVToBuffer(
     JNIEnv *env, jclass, jobjectArray j_column_names, jboolean include_header,
     jstring j_row_delimiter, jbyte j_field_delimiter, jstring j_null_value, jstring j_true_value,
-    jstring j_false_value, jobject j_buffer) {
+    jstring j_false_value, jboolean j_quote_strings, jobject j_buffer) {
   JNI_NULL_CHECK(env, j_column_names, "column name array cannot be null", 0);
   JNI_NULL_CHECK(env, j_row_delimiter, "row delimiter cannot be null", 0);
   JNI_NULL_CHECK(env, j_field_delimiter, "field delimiter cannot be null", 0);
@@ -1274,6 +1275,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_startWriteCSVToBuffer(
                        .na_rep(na_rep.get())
                        .true_value(true_value.get())
                        .false_value(false_value.get())
+                       .enable_quote_strings(static_cast<bool>(j_quote_strings))
                        .build();
 
     return ptr_as_jlong(new cudf::jni::io::csv_chunked_writer{options, data_sink});

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1238,7 +1238,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(
                        .na_rep(na_rep.get())
                        .true_value(true_value.get())
                        .false_value(false_value.get())
-                       .enable_quote_strings(static_cast<bool>(j_quote_strings));
+                       .quoting(j_quote_strings? cudf::io::quote_style::MINIMAL : cudf::io::quote_style::NONE);
 
     cudf::io::write_csv(options.build());
   }
@@ -1277,7 +1277,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_startWriteCSVToBuffer(
                        .na_rep(na_rep.get())
                        .true_value(true_value.get())
                        .false_value(false_value.get())
-                       .enable_quote_strings(static_cast<bool>(j_quote_strings))
+                       .quoting(j_quote_strings? cudf::io::quote_style::MINIMAL : cudf::io::quote_style::NONE)
                        .build();
 
     return ptr_as_jlong(new cudf::jni::io::csv_chunked_writer{options, data_sink});

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1127,8 +1127,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_merge(JNIEnv *env, jclass
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(
     JNIEnv *env, jclass, jobjectArray col_names, jintArray j_types, jintArray j_scales,
     jobjectArray filter_col_names, jstring inputfilepath, jlong buffer, jlong buffer_length,
-    jint header_row, jbyte delim, jbyte quote, jbyte comment, jobjectArray null_values,
-    jobjectArray true_values, jobjectArray false_values) {
+    jint header_row, jbyte delim, jboolean quote_strings, jbyte quote, jbyte comment, 
+    jobjectArray null_values, jobjectArray true_values, jobjectArray false_values) {
   JNI_NULL_CHECK(env, null_values, "null_values must be supplied, even if it is empty", NULL);
 
   bool read_buffer = true;
@@ -1191,6 +1191,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(
                                             .na_values(n_null_values.as_cpp_vector())
                                             .keep_default_na(false)
                                             .na_filter(n_null_values.size() > 0)
+                                            .quoting(quote_strings? cudf::io::quote_style::MINIMAL :
+                                                                    cudf::io::quote_style::NONE)
                                             .quotechar(quote)
                                             .comment(comment)
                                             .build();

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -641,7 +641,7 @@ public class TableTest extends CudfTestBase {
                                                .withFieldDelimiter((byte)fieldDelim)
                                                .withRowDelimiter("\n")
                                                .withNullValue("\\N")
-                                               .withQuotingEnabled(false)
+                                               .withQuoteStyle(QuoteStyle.NONE)
                                                .build();
     try (Table inputTable
           = new Table.TestBuilder()
@@ -656,7 +656,7 @@ public class TableTest extends CudfTestBase {
                                          .includeColumn("str")
                                          .hasHeader(false)
                                          .withDelim(fieldDelim)
-                                         .withQuotingEnabled(false)
+                                         .withQuoteStyle(QuoteStyle.NONE)
                                          .build();
       try (Table readTable = Table.readCSV(schema, readOptions, outputFile);
            Table expected = new Table.TestBuilder()
@@ -685,7 +685,7 @@ public class TableTest extends CudfTestBase {
                                                .withFieldDelimiter((byte)fieldDelim)
                                                .withRowDelimiter("\n")
                                                .withNullValue("\\N")
-                                               .withQuotingEnabled(false)
+                                               .withQuoteStyle(QuoteStyle.NONE)
                                                .build();
     try (Table inputTable
           = new Table.TestBuilder()
@@ -707,7 +707,7 @@ public class TableTest extends CudfTestBase {
                                          .hasHeader(false)
                                          .withDelim(fieldDelim)
                                          .withNullValue("\\N")
-                                         .withQuotingEnabled(false)
+                                         .withQuoteStyle(QuoteStyle.NONE)
                                          .build();
       try (Table readTable = Table.readCSV(schema, readOptions, consumer.buffer, 0, consumer.offset);
            Table section = new Table.TestBuilder()

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -585,12 +585,12 @@ public class TableTest extends CudfTestBase {
                           .build();
     CSVWriterOptions writeOptions = CSVWriterOptions.builder()
                                                .withColumnNames(schema.getColumnNames())
-                                               .withIncludeHeader(false)
-                                               .withFieldDelimiter((byte)'\u0001')
+                                               .withIncludeHeader(includeHeader)
+                                               .withFieldDelimiter((byte)fieldDelim)
                                                .withRowDelimiter("\n")
                                                .withNullValue("\\N")
-                                               .withTrueValue("T")
-                                               .withFalseValue("F")
+                                               .withTrueValue(trueValue)
+                                               .withFalseValue(falseValue)
                                                .build();
     try (Table inputTable
           = new Table.TestBuilder()
@@ -607,10 +607,10 @@ public class TableTest extends CudfTestBase {
                                          .includeColumn("f")
                                          .includeColumn("b")
                                          .includeColumn("str")
-                                         .hasHeader(false)
-                                         .withDelim('\u0001')
-                                         .withTrueValue("T")
-                                         .withFalseValue("F")
+                                         .hasHeader(includeHeader)
+                                         .withDelim(fieldDelim)
+                                         .withTrueValue(trueValue)
+                                         .withFalseValue(falseValue)
                                          .build();
       try (Table readTable = Table.readCSV(schema, readOptions, outputFile)) {
         assertTablesAreEqual(inputTable, readTable);

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -645,8 +645,8 @@ public class TableTest extends CudfTestBase {
                                                .build();
     try (Table inputTable
           = new Table.TestBuilder()
-              .column("All" + fieldDelim + "the" + fieldDelim + "leaves", 
-                      "are\"brown", 
+              .column("All" + fieldDelim + "the" + fieldDelim + "leaves",
+                      "are\"brown",
                       "and\nthe\nsky\nis\ngrey")
               .build()) {
       inputTable.writeCSVToFile(writeOptions, outputFile.getAbsolutePath());
@@ -689,8 +689,8 @@ public class TableTest extends CudfTestBase {
                                                .build();
     try (Table inputTable
           = new Table.TestBuilder()
-              .column("All" + fieldDelim + "the" + fieldDelim + "leaves", 
-                      "are\"brown", 
+              .column("All" + fieldDelim + "the" + fieldDelim + "leaves",
+                      "are\"brown",
                       "and\nthe\nsky\nis\ngrey")
               .build();
           MyBufferConsumer consumer = new MyBufferConsumer()) {

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -630,6 +630,101 @@ public class TableTest extends CudfTestBase {
     testWriteCSVToFileImpl('\u0001', NO_HEADER, "True", "False");
   }
 
+  private void testWriteUnquotedCSVToFileImpl(char fieldDelim) throws IOException {
+    File outputFile = File.createTempFile("testWriteUnquotedCSVToFile", ".csv");
+    Schema schema = Schema.builder()
+                          .column(DType.STRING, "str")
+                          .build();
+    CSVWriterOptions writeOptions = CSVWriterOptions.builder()
+                                               .withColumnNames(schema.getColumnNames())
+                                               .withIncludeHeader(false)
+                                               .withFieldDelimiter((byte)fieldDelim)
+                                               .withRowDelimiter("\n")
+                                               .withNullValue("\\N")
+                                               .withQuotingEnabled(false)
+                                               .build();
+    try (Table inputTable
+          = new Table.TestBuilder()
+              .column("All" + fieldDelim + "the" + fieldDelim + "leaves", 
+                      "are\"brown", 
+                      "and\nthe\nsky\nis\ngrey")
+              .build()) {
+      inputTable.writeCSVToFile(writeOptions, outputFile.getAbsolutePath());
+
+      // Read back.
+      CSVOptions readOptions = CSVOptions.builder()
+                                         .includeColumn("str")
+                                         .hasHeader(false)
+                                         .withDelim(fieldDelim)
+                                         .withQuotingEnabled(false)
+                                         .build();
+      try (Table readTable = Table.readCSV(schema, readOptions, outputFile);
+           Table expected = new Table.TestBuilder()
+             .column("All", "are\"brown", "and", "the", "sky", "is", "grey")
+             .build()) {
+        assertTablesAreEqual(expected, readTable);
+      }
+    } finally {
+      outputFile.delete();
+    }
+  }
+
+  @Test
+  void testWriteUnquotedCSVToFile() throws IOException {
+    testWriteUnquotedCSVToFileImpl(',');
+    testWriteUnquotedCSVToFileImpl('\u0001');
+  }
+
+  private void testChunkedCSVWriterUnquotedImpl(char fieldDelim) throws IOException {
+    Schema schema = Schema.builder()
+                          .column(DType.STRING, "str")
+                          .build();
+    CSVWriterOptions writeOptions = CSVWriterOptions.builder()
+                                               .withColumnNames(schema.getColumnNames())
+                                               .withIncludeHeader(false)
+                                               .withFieldDelimiter((byte)fieldDelim)
+                                               .withRowDelimiter("\n")
+                                               .withNullValue("\\N")
+                                               .withQuotingEnabled(false)
+                                               .build();
+    try (Table inputTable
+          = new Table.TestBuilder()
+              .column("All" + fieldDelim + "the" + fieldDelim + "leaves", 
+                      "are\"brown", 
+                      "and\nthe\nsky\nis\ngrey")
+              .build();
+          MyBufferConsumer consumer = new MyBufferConsumer()) {
+
+      try (TableWriter writer = Table.getCSVBufferWriter(writeOptions, consumer)) {
+        writer.write(inputTable);
+        writer.write(inputTable);
+        writer.write(inputTable);
+      }
+
+      // Read back.
+      CSVOptions readOptions = CSVOptions.builder()
+                                         .includeColumn("str")
+                                         .hasHeader(false)
+                                         .withDelim(fieldDelim)
+                                         .withNullValue("\\N")
+                                         .withQuotingEnabled(false)
+                                         .build();
+      try (Table readTable = Table.readCSV(schema, readOptions, consumer.buffer, 0, consumer.offset);
+           Table section = new Table.TestBuilder()
+             .column("All", "are\"brown", "and", "the", "sky", "is", "grey")
+             .build();
+           Table expected  = Table.concatenate(section, section, section)) {
+        assertTablesAreEqual(expected, readTable);
+      }
+    }
+  }
+
+  @Test
+  void testChunkedCSVWriterUnquoted() throws IOException {
+    testChunkedCSVWriterUnquotedImpl(',');
+    testChunkedCSVWriterUnquotedImpl('\u0001');
+  }
+
   private void testChunkedCSVWriterImpl(char fieldDelim, boolean includeHeader,
                                         String trueValue, String falseValue) throws IOException {
     Schema schema = Schema.builder()


### PR DESCRIPTION
## Description
`cudf::io::write_csv()` currently adds quotes around all `STRING` rows that contain "special" characters, including:
1. `,`, or the field delimiter
2. `\n`, or the row/record delimiter
3. `"`, or double quotes

This is in congruence with Pandas conventions for CSV, and allows for strings with such special characters to be read correctly.

If `write_csv()` is used to implement writes for CSV-like formats (such as Hive delimited text files), one notices that quoting conventions would be at odds. Hive delimited text does not automatically quote problematic strings.

This commit adds the option of turning off quoting for `STRING` columns. The erstwhile behaviour is retained as the default; the user must opt into turning off quoting.

Additionally, this commit adds the following:
1. Tests for optionally unquoted reads, in C++ and Java.
2. JNI interfaces for CSV writes with quoting disabled.
3. Changes to Java `CSVOptions` to enable reads with quoting disabled.
4. Minor corrections to Java `TableTest.testWriteCSVToFile()` test combinations of `includeHeader`, `fieldDelim`, and `true`/`false` string representations.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
