### PR TITLE
Default `cudf::io::read_json` to nested JSON parser

### DIFF
--- a/cpp/include/cudf/io/json.hpp
+++ b/cpp/include/cudf/io/json.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/io/json.hpp
+++ b/cpp/include/cudf/io/json.hpp
@@ -99,8 +99,8 @@ class json_reader_options {
   // Whether to parse dates as DD/MM versus MM/DD
   bool _dayfirst = false;
 
-  // Whether to use the experimental reader
-  bool _experimental = false;
+  // Whether to use the legacy reader
+  bool _legacy = false;
 
   // Whether to keep the quote characters of string values
   bool _keep_quotes = false;
@@ -222,16 +222,16 @@ class json_reader_options {
   bool is_enabled_dayfirst() const { return _dayfirst; }
 
   /**
-   * @brief Whether the experimental reader should be used.
+   * @brief Whether the legacy reader should be used.
    *
-   * @returns true if the experimental reader will be used, false otherwise
+   * @returns true if the legacy reader will be used, false otherwise
    */
-  bool is_enabled_experimental() const { return _experimental; }
+  bool is_enabled_legacy() const { return _legacy; }
 
   /**
-   * @brief Whether the experimental reader should keep quotes of string values.
+   * @brief Whether the reader should keep quotes of string values.
    *
-   * @returns true if the experimental reader should keep quotes, false otherwise
+   * @returns true if the reader should keep quotes, false otherwise
    */
   bool is_enabled_keep_quotes() const { return _keep_quotes; }
 
@@ -292,16 +292,16 @@ class json_reader_options {
   void enable_dayfirst(bool val) { _dayfirst = val; }
 
   /**
-   * @brief Set whether to use the experimental reader.
+   * @brief Set whether to use the legacy reader.
    *
-   * @param val Boolean value to enable/disable the experimental reader
+   * @param val Boolean value to enable/disable the legacy reader
    */
-  void enable_experimental(bool val) { _experimental = val; }
+  void enable_legacy(bool val) { _legacy = val; }
 
   /**
-   * @brief Set whether the experimental reader should keep quotes of string values.
+   * @brief Set whether the reader should keep quotes of string values.
    *
-   * @param val Boolean value to indicate whether the experimental reader should keep quotes
+   * @param val Boolean value to indicate whether the reader should keep quotes
    * of string values
    */
   void enable_keep_quotes(bool val) { _keep_quotes = val; }
@@ -425,21 +425,21 @@ class json_reader_options_builder {
   }
 
   /**
-   * @brief Set whether to use the experimental reader.
+   * @brief Set whether to use the legacy reader.
    *
-   * @param val Boolean value to enable/disable experimental parsing
+   * @param val Boolean value to enable/disable legacy parsing
    * @return this for chaining
    */
-  json_reader_options_builder& experimental(bool val)
+  json_reader_options_builder& legacy(bool val)
   {
-    options._experimental = val;
+    options._legacy = val;
     return *this;
   }
 
   /**
-   * @brief Set whether the experimental reader should keep quotes of string values.
+   * @brief Set whether the reader should keep quotes of string values.
    *
-   * @param val Boolean value to indicate whether the experimental reader should keep quotes
+   * @param val Boolean value to indicate whether the reader should keep quotes
    * of string values
    * @return this for chaining
    */

--- a/cpp/src/io/json/reader_impl.cu
+++ b/cpp/src/io/json/reader_impl.cu
@@ -593,7 +593,7 @@ table_with_metadata read_json(std::vector<std::unique_ptr<datasource>>& sources,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  if (reader_opts.is_enabled_experimental()) {
+  if (not reader_opts.is_enabled_legacy()) {
     return experimental::read_json(sources, reader_opts, stream, mr);
   }
 

--- a/cpp/tests/io/arrow_io_source_test.cpp
+++ b/cpp/tests/io/arrow_io_source_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/io/arrow_io_source_test.cpp
+++ b/cpp/tests/io/arrow_io_source_test.cpp
@@ -44,7 +44,7 @@ TEST_F(ArrowIOTest, URIFileSystem)
 {
   const std::string file_name = temp_env->get_temp_dir() + "JsonLinesFileTest.json";
   std::ofstream outfile(file_name, std::ofstream::out);
-  outfile << "[11, 1.1]\n[22, 2.2]";
+  outfile << "{\"a\":11, \"b\":1.1}\n{\"a\":22, \"b\":2.2}";
   outfile.close();
 
   std::string file_uri = "file://" + file_name;

--- a/cpp/tests/io/json_chunked_reader.cpp
+++ b/cpp/tests/io/json_chunked_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,8 +99,7 @@ TEST_F(JsonReaderTest, ByteRange)
     cudf::io::json_reader_options::builder(
       cudf::io::source_info{json_string.c_str(), json_string.size()})
       .compression(cudf::io::compression_type::NONE)
-      .lines(true)
-      .experimental(true);
+      .lines(true);
 
   // Read full test data via existing, nested JSON lines reader
   cudf::io::table_with_metadata current_reader_table = cudf::io::read_json(json_lines_options);

--- a/cpp/tests/io/json_test.cpp
+++ b/cpp/tests/io/json_test.cpp
@@ -164,13 +164,19 @@ struct JsonReaderTest : public cudf::test::BaseFixture {
  * @brief Enum class to be used to specify the test case of parametrized tests
  */
 enum class json_test_t {
-  // Run test with the existing JSON lines reader using row-orient input data
-  json_lines_row_orient,
-  // Run test with the existing JSON lines reader using record-orient input data
-  json_lines_record_orient,
   // Run test with the nested JSON lines reader using record-orient input data
-  json_experimental_record_orient
+  record_orient,
+  // Run test with the legacy JSON lines reader using row-orient input data
+  legacy_lines_row_orient,
+  // Run test with the legacy JSON lines reader using record-orient input data
+  legacy_lines_record_orient
 };
+
+constexpr bool is_legacy_test(json_test_t test_opt)
+{
+  return test_opt == json_test_t::legacy_lines_row_orient or
+         test_opt == json_test_t::legacy_lines_record_orient;
+}
 
 /**
  * @brief Test fixture for parametrized JSON reader tests
@@ -224,7 +230,7 @@ template <typename DecimalType>
 struct JsonValidFixedPointReaderTest : public JsonFixedPointReaderTest<DecimalType> {
   void run_test(std::vector<std::string> const& reference_strings,
                 numeric::scale_type scale,
-                bool use_experimental_parser)
+                bool use_legacy_parser)
   {
     cudf::test::strings_column_wrapper const strings(reference_strings.begin(),
                                                      reference_strings.end());
@@ -242,7 +248,7 @@ struct JsonValidFixedPointReaderTest : public JsonFixedPointReaderTest<DecimalTy
       cudf::io::json_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
         .dtypes({data_type{type_to_id<DecimalType>(), scale}})
         .lines(true)
-        .experimental(use_experimental_parser);
+        .legacy(use_legacy_parser);
 
     auto const result      = cudf::io::read_json(in_opts);
     auto const result_view = result.tbl->view();
@@ -267,31 +273,31 @@ TYPED_TEST_SUITE(JsonValidFixedPointReaderTest, cudf::test::FixedPointTypes);
 // reader
 INSTANTIATE_TEST_CASE_P(JsonReaderParamTest,
                         JsonReaderParamTest,
-                        ::testing::Values(json_test_t::json_lines_row_orient,
-                                          json_test_t::json_lines_record_orient,
-                                          json_test_t::json_experimental_record_orient));
+                        ::testing::Values(json_test_t::record_orient,
+                                          json_test_t::legacy_lines_row_orient,
+                                          json_test_t::legacy_lines_record_orient));
 
 // Parametrize qualifying JSON tests for executing both experimental reader and existing JSON lines
 // reader
 INSTANTIATE_TEST_CASE_P(JsonReaderDualTest,
                         JsonReaderDualTest,
-                        ::testing::Values(json_test_t::json_lines_record_orient,
-                                          json_test_t::json_experimental_record_orient));
+                        ::testing::Values(json_test_t::legacy_lines_record_orient,
+                                          json_test_t::record_orient));
 
 TEST_P(JsonReaderParamTest, BasicJsonLines)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  std::string row_orient       = "[1, 1.1]\n[2, 2.2]\n[3, 3.3]\n";
-  std::string record_orient    = to_records_orient(
+  auto const test_opt       = GetParam();
+  std::string row_orient    = "[1, 1.1]\n[2, 2.2]\n[3, 3.3]\n";
+  std::string record_orient = to_records_orient(
     {{{"0", "1"}, {"1", "1.1"}}, {{"0", "2"}, {"1", "2.2"}}, {{"0", "3"}, {"1", "3.3"}}}, "\n");
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
       .dtypes(std::vector<data_type>{dtype<int32_t>(), dtype<double>()})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
   EXPECT_EQ(result.tbl->num_columns(), 2);
@@ -312,8 +318,7 @@ TEST_P(JsonReaderParamTest, BasicJsonLines)
 
 TEST_P(JsonReaderParamTest, FloatingPoint)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
+  auto const test_opt = GetParam();
   std::string row_orient =
     "[5.6]\n[0.5679e2]\n[1.2e10]\n[0.07e1]\n[3000e-3]\n[12.34e0]\n[3.1e-001]\n[-73."
     "98007199999998]\n";
@@ -326,7 +331,8 @@ TEST_P(JsonReaderParamTest, FloatingPoint)
                                                  {{"0", "3.1e-001"}},
                                                  {{"0", "-73.98007199999998"}}},
                                                 "\n");
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   auto filepath = temp_env->get_temp_dir() + "FloatingPoint.json";
   {
@@ -338,7 +344,7 @@ TEST_P(JsonReaderParamTest, FloatingPoint)
     cudf::io::json_reader_options::builder(cudf::io::source_info{filepath})
       .dtypes({dtype<float>()})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -358,19 +364,19 @@ TEST_P(JsonReaderParamTest, FloatingPoint)
 
 TEST_P(JsonReaderParamTest, JsonLinesStrings)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  std::string row_orient       = "[1, 1.1, \"aa \"]\n[2, 2.2, \"  bbb\"]";
-  std::string record_orient    = to_records_orient({{{"0", "1"}, {"1", "1.1"}, {"2", R"("aa ")"}},
+  auto const test_opt       = GetParam();
+  std::string row_orient    = "[1, 1.1, \"aa \"]\n[2, 2.2, \"  bbb\"]";
+  std::string record_orient = to_records_orient({{{"0", "1"}, {"1", "1.1"}, {"2", R"("aa ")"}},
                                                  {{"0", "2"}, {"1", "2.2"}, {"2", R"("  bbb")"}}},
                                                 "\n");
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
       .dtypes({{"2", dtype<cudf::string_view>()}, {"0", dtype<int32_t>()}, {"1", dtype<double>()}})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -395,9 +401,8 @@ TEST_P(JsonReaderParamTest, JsonLinesStrings)
 
 TEST_P(JsonReaderParamTest, MultiColumn)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  bool const row_orient        = (test_opt == json_test_t::json_lines_row_orient);
+  auto const test_opt   = GetParam();
+  bool const row_orient = (test_opt == json_test_t::legacy_lines_row_orient);
 
   constexpr auto num_rows = 10;
   auto int8_values        = random_values<int8_t>(num_rows);
@@ -443,7 +448,7 @@ TEST_P(JsonReaderParamTest, MultiColumn)
                dtype<float>(),
                dtype<double>()})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
   auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
@@ -471,10 +476,9 @@ TEST_P(JsonReaderParamTest, MultiColumn)
 
 TEST_P(JsonReaderParamTest, Booleans)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  std::string row_orient       = "[true]\n[true]\n[false]\n[false]\n[true]";
-  std::string record_orient    = to_records_orient(
+  auto const test_opt       = GetParam();
+  std::string row_orient    = "[true]\n[true]\n[false]\n[false]\n[true]";
+  std::string record_orient = to_records_orient(
     {
       {{"0", "true"}},
       {{"0", "true"}},
@@ -483,7 +487,8 @@ TEST_P(JsonReaderParamTest, Booleans)
       {{"0", "true"}},
     },
     "\n");
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   auto filepath = temp_env->get_temp_dir() + "Booleans.json";
   {
@@ -495,7 +500,7 @@ TEST_P(JsonReaderParamTest, Booleans)
     cudf::io::json_reader_options::builder(cudf::io::source_info{filepath})
       .dtypes({dtype<bool>()})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
   // Booleans are the same (integer) data type, but valued at 0 or 1
@@ -511,8 +516,7 @@ TEST_P(JsonReaderParamTest, Booleans)
 
 TEST_P(JsonReaderParamTest, Dates)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
+  auto const test_opt = GetParam();
   std::string row_orient =
     "[05/03/2001]\n[31/10/2010]\n[20/10/1994]\n[18/10/1990]\n[1/1/1970]\n"
     "[18/04/1995]\n[14/07/1994]\n[07/06/2006 11:20:30.400]\n"
@@ -528,7 +532,8 @@ TEST_P(JsonReaderParamTest, Dates)
                                                  {{"0", R"("16/09/2005T1:2:30.400PM")"}},
                                                  {{"0", R"("2/2/1970")"}}},
                                                 "\n");
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   auto filepath = temp_env->get_temp_dir() + "Dates.json";
   {
@@ -541,7 +546,7 @@ TEST_P(JsonReaderParamTest, Dates)
       .dtypes({data_type{type_id::TIMESTAMP_MILLISECONDS}})
       .lines(true)
       .dayfirst(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
   const auto view = result.tbl->view();
@@ -566,8 +571,7 @@ TEST_P(JsonReaderParamTest, Dates)
 
 TEST_P(JsonReaderParamTest, Durations)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
+  auto const test_opt = GetParam();
   std::string row_orient =
     "[-2]\n[-1]\n[0]\n"
     "[1 days]\n[0 days 23:01:00]\n[0 days 00:00:00.000000123]\n"
@@ -585,8 +589,9 @@ TEST_P(JsonReaderParamTest, Durations)
                                                  {{"0", R"(-2147483648)"}},
                                                  {{"0", R"(2147483647)"}}},
                                                 "\n");
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
-  auto filepath    = temp_env->get_temp_dir() + "Durations.json";
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
+  auto filepath = temp_env->get_temp_dir() + "Durations.json";
   {
     std::ofstream outfile(filepath, std::ofstream::out);
     outfile << data;
@@ -596,7 +601,7 @@ TEST_P(JsonReaderParamTest, Durations)
     cudf::io::json_reader_options::builder(cudf::io::source_info{filepath})
       .dtypes({data_type{type_id::DURATION_NANOSECONDS}})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
   const auto view = result.tbl->view();
@@ -623,18 +628,18 @@ TEST_P(JsonReaderParamTest, Durations)
 
 TEST_P(JsonReaderParamTest, JsonLinesDtypeInference)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  std::string row_orient       = "[100, 1.1, \"aa \"]\n[200, 2.2, \"  bbb\"]";
-  std::string record_orient    = to_records_orient({{{"0", "100"}, {"1", "1.1"}, {"2", R"("aa ")"}},
+  auto const test_opt       = GetParam();
+  std::string row_orient    = "[100, 1.1, \"aa \"]\n[200, 2.2, \"  bbb\"]";
+  std::string record_orient = to_records_orient({{{"0", "100"}, {"1", "1.1"}, {"2", R"("aa ")"}},
                                                  {{"0", "200"}, {"1", "2.2"}, {"2", R"("  bbb")"}}},
                                                 "\n");
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -659,12 +664,12 @@ TEST_P(JsonReaderParamTest, JsonLinesDtypeInference)
 
 TEST_P(JsonReaderParamTest, JsonLinesFileInput)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  std::string row_orient       = "[11, 1.1]\n[22, 2.2]";
+  auto const test_opt    = GetParam();
+  std::string row_orient = "[11, 1.1]\n[22, 2.2]";
   std::string record_orient =
     to_records_orient({{{"0", "11"}, {"1", "1.1"}}, {{"0", "22"}, {"1", "2.2"}}}, "\n");
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   const std::string fname = temp_env->get_temp_dir() + "JsonLinesFileTest.json";
   std::ofstream outfile(fname, std::ofstream::out);
@@ -674,7 +679,7 @@ TEST_P(JsonReaderParamTest, JsonLinesFileInput)
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{fname})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -703,6 +708,7 @@ TEST_F(JsonReaderTest, JsonLinesByteRange)
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{fname})
       .lines(true)
+      .legacy(true)  // Support in new reader coming in https://github.com/rapidsai/cudf/pull/12498
       .byte_range_offset(11)
       .byte_range_size(20);
 
@@ -722,9 +728,8 @@ TEST_F(JsonReaderTest, JsonLinesByteRange)
 
 TEST_P(JsonReaderDualTest, JsonLinesObjects)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  const std::string fname      = temp_env->get_temp_dir() + "JsonLinesObjectsTest.json";
+  auto const test_opt     = GetParam();
+  const std::string fname = temp_env->get_temp_dir() + "JsonLinesObjectsTest.json";
   std::ofstream outfile(fname, std::ofstream::out);
   outfile << " {\"co\\\"l1\" : 1, \"col2\" : 2.0} \n";
   outfile.close();
@@ -732,7 +737,7 @@ TEST_P(JsonReaderDualTest, JsonLinesObjects)
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{fname})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -752,13 +757,12 @@ TEST_P(JsonReaderDualTest, JsonLinesObjects)
 
 TEST_P(JsonReaderDualTest, JsonLinesObjectsStrings)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  auto test_json_objects       = [test_experimental](std::string const& data) {
+  auto const test_opt    = GetParam();
+  auto test_json_objects = [test_opt](std::string const& data) {
     cudf::io::json_reader_options in_options =
       cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
         .lines(true)
-        .experimental(test_experimental);
+        .legacy(is_legacy_test(test_opt));
 
     cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -793,8 +797,7 @@ TEST_P(JsonReaderDualTest, JsonLinesObjectsStrings)
 
 TEST_P(JsonReaderDualTest, JsonLinesObjectsMissingData)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
+  auto const test_opt = GetParam();
   // Note: columns will be ordered based on which fields appear first
   std::string const data =
     "{              \"col2\":1.1, \"col3\":\"aaa\"}\n"
@@ -802,7 +805,7 @@ TEST_P(JsonReaderDualTest, JsonLinesObjectsMissingData)
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -831,8 +834,7 @@ TEST_P(JsonReaderDualTest, JsonLinesObjectsMissingData)
 
 TEST_P(JsonReaderDualTest, JsonLinesObjectsOutOfOrder)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
+  auto const test_opt = GetParam();
   std::string const data =
     "{\"col1\":100, \"col2\":1.1, \"col3\":\"aaa\"}\n"
     "{\"col3\":\"bbb\", \"col1\":200, \"col2\":2.2}\n";
@@ -840,7 +842,7 @@ TEST_P(JsonReaderDualTest, JsonLinesObjectsOutOfOrder)
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -862,39 +864,34 @@ TEST_P(JsonReaderDualTest, JsonLinesObjectsOutOfOrder)
                                  cudf::test::strings_column_wrapper({"aaa", "bbb"}));
 }
 
-// currently, the json reader is strict about having non-empty input.
 TEST_F(JsonReaderTest, EmptyFile)
 {
-  auto filepath = temp_env->get_temp_dir() + "EmptyFile.csv";
+  auto filepath = temp_env->get_temp_dir() + "EmptyFile.json";
   {
     std::ofstream outfile{filepath, std::ofstream::out};
     outfile << "";
   }
 
+  // New reader only - legacy reader is strict about having non-empty input
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{filepath})
-      .lines(true)
-      .experimental(true);
+    cudf::io::json_reader_options::builder(cudf::io::source_info{filepath}).lines(true);
   auto result = cudf::io::read_json(in_options);
 
   const auto view = result.tbl->view();
   EXPECT_EQ(0, view.num_columns());
 }
 
-// currently, the json reader is strict about having non-empty input.
-// experimental reader supports empty input
 TEST_F(JsonReaderTest, NoDataFile)
 {
-  auto filepath = temp_env->get_temp_dir() + "NoDataFile.csv";
+  auto filepath = temp_env->get_temp_dir() + "NoDataFile.json";
   {
     std::ofstream outfile{filepath, std::ofstream::out};
     outfile << "{}\n";
   }
 
+  // New reader only - legacy reader is strict about having non-empty input
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{filepath})
-      .lines(true)
-      .experimental(true);
+    cudf::io::json_reader_options::builder(cudf::io::source_info{filepath}).lines(true);
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
   const auto view = result.tbl->view();
@@ -916,7 +913,8 @@ TEST_F(JsonReaderTest, ArrowFileSource)
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{&arrow_source})
       .dtypes({dtype<int8_t>()})
-      .lines(true);
+      .lines(true)
+      .legacy(true);  // Support in new reader coming in https://github.com/rapidsai/cudf/pull/12498
   ;
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -931,17 +929,17 @@ TEST_F(JsonReaderTest, ArrowFileSource)
 
 TEST_P(JsonReaderParamTest, InvalidFloatingPoint)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  std::string row_orient       = "[1.2e1+]\n[3.4e2-]\n[5.6e3e]\n[7.8e3A]\n[9.0Be1]\n[1C.2]";
-  std::string record_orient    = to_records_orient({{{"0", "1.2e1+"}},
+  auto const test_opt       = GetParam();
+  std::string row_orient    = "[1.2e1+]\n[3.4e2-]\n[5.6e3e]\n[7.8e3A]\n[9.0Be1]\n[1C.2]";
+  std::string record_orient = to_records_orient({{{"0", "1.2e1+"}},
                                                  {{"0", "3.4e2-"}},
                                                  {{"0", "5.6e3e"}},
                                                  {{"0", "7.8e3A"}},
                                                  {{"0", "9.0Be1"}},
                                                  {{"0", "1C.2"}}},
                                                 "\n");
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   const auto filepath = temp_env->get_temp_dir() + "InvalidFloatingPoint.json";
   {
@@ -953,7 +951,7 @@ TEST_P(JsonReaderParamTest, InvalidFloatingPoint)
     cudf::io::json_reader_options::builder(cudf::io::source_info{filepath})
       .dtypes({dtype<float>()})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
   EXPECT_EQ(result.tbl->num_columns(), 1);
@@ -965,16 +963,16 @@ TEST_P(JsonReaderParamTest, InvalidFloatingPoint)
 
 TEST_P(JsonReaderParamTest, StringInference)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  std::string row_orient       = "[\"-1\"]";
-  std::string record_orient    = to_records_orient({{{"0", R"("-1")"}}}, "\n");
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  auto const test_opt       = GetParam();
+  std::string row_orient    = "[\"-1\"]";
+  std::string record_orient = to_records_orient({{{"0", R"("-1")"}}}, "\n");
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{data.c_str(), data.size()})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
   EXPECT_EQ(result.tbl->num_columns(), 1);
@@ -983,9 +981,8 @@ TEST_P(JsonReaderParamTest, StringInference)
 
 TEST_P(JsonReaderParamTest, ParseInRangeIntegers)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  bool const row_orient        = (test_opt == json_test_t::json_lines_row_orient);
+  auto const test_opt   = GetParam();
+  bool const row_orient = (test_opt == json_test_t::legacy_lines_row_orient);
 
   constexpr auto num_rows                      = 4;
   std::vector<int64_t> small_int               = {0, -10, 20, -30};
@@ -1058,7 +1055,7 @@ TEST_P(JsonReaderParamTest, ParseInRangeIntegers)
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{filepath})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -1079,9 +1076,8 @@ TEST_P(JsonReaderParamTest, ParseInRangeIntegers)
 
 TEST_P(JsonReaderParamTest, ParseOutOfRangeIntegers)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  bool const row_orient        = (test_opt == json_test_t::json_lines_row_orient);
+  auto const test_opt   = GetParam();
+  bool const row_orient = (test_opt == json_test_t::legacy_lines_row_orient);
 
   constexpr auto num_rows                        = 4;
   std::vector<std::string> out_of_range_positive = {"111111111111111111111",
@@ -1163,7 +1159,7 @@ TEST_P(JsonReaderParamTest, ParseOutOfRangeIntegers)
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{filepath})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -1183,13 +1179,13 @@ TEST_P(JsonReaderParamTest, ParseOutOfRangeIntegers)
 
 TEST_P(JsonReaderParamTest, JsonLinesMultipleFileInputs)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
+  auto const test_opt = GetParam();
   std::vector<std::string> row_orient{"[11, 1.1]\n[22, 2.2]\n", "[33, 3.3]\n[44, 4.4]"};
   std::vector<std::string> record_orient{
     to_records_orient({{{"0", "11"}, {"1", "1.1"}}, {{"0", "22"}, {"1", "2.2"}}}, "\n") + "\n",
     to_records_orient({{{"0", "33"}, {"1", "3.3"}}, {{"0", "44"}, {"1", "4.4"}}}, "\n") + "\n"};
-  auto const& data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  auto const& data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   const std::string file1 = temp_env->get_temp_dir() + "JsonLinesFileTest1.json";
   std::ofstream outfile(file1, std::ofstream::out);
@@ -1204,7 +1200,7 @@ TEST_P(JsonReaderParamTest, JsonLinesMultipleFileInputs)
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(cudf::io::source_info{{file1, file2}})
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -1256,7 +1252,7 @@ TEST_F(JsonReaderTest, JsonExperimentalBasic)
   outfile.close();
 
   cudf::io::json_reader_options options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{fname}).experimental(true);
+    cudf::io::json_reader_options::builder(cudf::io::source_info{fname});
   auto result = cudf::io::read_json(options);
 
   EXPECT_EQ(result.tbl->num_columns(), 2);
@@ -1289,16 +1285,16 @@ TEST_F(JsonReaderTest, JsonExperimentalLines)
       cudf::io::source_info{json_string.c_str(), json_string.size()})
       .lines(true);
 
-  // Read test data via existing, non-nested JSON lines reader
-  cudf::io::table_with_metadata current_reader_table = cudf::io::read_json(json_lines_options);
+  // Read test data via nested JSON reader
+  auto const table = cudf::io::read_json(json_lines_options);
 
-  // Read test data via new, nested JSON reader
-  json_lines_options.enable_experimental(true);
-  cudf::io::table_with_metadata new_reader_table = cudf::io::read_json(json_lines_options);
+  // Read test data via legacy, non-nested JSON lines reader
+  json_lines_options.enable_legacy(true);
+  auto const legacy_reader_table = cudf::io::read_json(json_lines_options);
 
   // Verify that the data read via non-nested JSON lines reader matches the data read via nested
   // JSON reader
-  CUDF_TEST_EXPECT_TABLES_EQUAL(current_reader_table.tbl->view(), new_reader_table.tbl->view());
+  CUDF_TEST_EXPECT_TABLES_EQUAL(legacy_reader_table.tbl->view(), table.tbl->view());
 }
 
 TEST_F(JsonReaderTest, TokenAllocation)
@@ -1317,8 +1313,6 @@ TEST_F(JsonReaderTest, TokenAllocation)
         cudf::io::source_info{json_string.c_str(), json_string.size()})
         .lines(true);
 
-    // Read test data via new, nested JSON reader
-    json_lines_options.enable_experimental(true);
     EXPECT_NO_THROW(cudf::io::read_json(json_lines_options));
   }
 }
@@ -1347,16 +1341,16 @@ TEST_F(JsonReaderTest, ExperimentalLinesNoOmissions)
         cudf::io::source_info{json_string.c_str(), json_string.size()})
         .lines(true);
 
-    // Read test data via existing, non-nested JSON lines reader
-    cudf::io::table_with_metadata current_reader_table = cudf::io::read_json(json_lines_options);
+    // Read test data via nested JSON reader
+    auto const table = cudf::io::read_json(json_lines_options);
 
-    // Read test data via new, nested JSON reader
-    json_lines_options.enable_experimental(true);
-    cudf::io::table_with_metadata new_reader_table = cudf::io::read_json(json_lines_options);
+    // Read test data via legacy, non-nested JSON lines reader
+    json_lines_options.enable_legacy(true);
+    auto const legacy_reader_table = cudf::io::read_json(json_lines_options);
 
     // Verify that the data read via non-nested JSON lines reader matches the data read via
     // nested JSON reader
-    CUDF_TEST_EXPECT_TABLES_EQUAL(current_reader_table.tbl->view(), new_reader_table.tbl->view());
+    CUDF_TEST_EXPECT_TABLES_EQUAL(legacy_reader_table.tbl->view(), table.tbl->view());
   }
 }
 
@@ -1378,8 +1372,7 @@ TEST_F(JsonReaderTest, TestColumnOrder)
   cudf::io::json_reader_options json_lines_options =
     cudf::io::json_reader_options::builder(
       cudf::io::source_info{json_string.c_str(), json_string.size()})
-      .lines(true)
-      .experimental(true);
+      .lines(true);
 
   // Read in data using nested JSON reader
   cudf::io::table_with_metadata new_reader_table = cudf::io::read_json(json_lines_options);
@@ -1425,14 +1418,14 @@ TEST_F(JsonReaderTest, TestColumnOrder)
 
 TEST_P(JsonReaderParamTest, JsonDtypeSchema)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
-  std::string row_orient       = "[1, 1.1, \"aa \"]\n[2, 2.2, \"  bbb\"]";
-  std::string record_orient    = to_records_orient({{{"0", "1"}, {"1", "1.1"}, {"2", R"("aa ")"}},
+  auto const test_opt       = GetParam();
+  std::string row_orient    = "[1, 1.1, \"aa \"]\n[2, 2.2, \"  bbb\"]";
+  std::string record_orient = to_records_orient({{{"0", "1"}, {"1", "1.1"}, {"2", R"("aa ")"}},
                                                  {{"0", "2"}, {"1", "2.2"}, {"2", R"("  bbb")"}}},
                                                 "\n");
 
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   std::map<std::string, cudf::io::schema_element> dtype_schema{
     {"2", {dtype<cudf::string_view>()}}, {"0", {dtype<int32_t>()}}, {"1", {dtype<double>()}}};
@@ -1440,7 +1433,7 @@ TEST_P(JsonReaderParamTest, JsonDtypeSchema)
     cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
       .dtypes(dtype_schema)
       .lines(true)
-      .experimental(test_experimental);
+      .legacy(is_legacy_test(test_opt));
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -1480,8 +1473,7 @@ TEST_F(JsonReaderTest, JsonNestedDtypeSchema)
     cudf::io::json_reader_options::builder(
       cudf::io::source_info{json_string.data(), json_string.size()})
       .dtypes(dtype_schema)
-      .lines(false)
-      .experimental(true);
+      .lines(false);
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -1531,8 +1523,7 @@ TEST_F(JsonReaderTest, JsonNestedDtypeSchema)
 
 TEST_P(JsonReaderParamTest, JsonDtypeParsing)
 {
-  auto const test_opt          = GetParam();
-  bool const test_experimental = (test_opt == json_test_t::json_experimental_record_orient);
+  auto const test_opt = GetParam();
   // All corner cases of dtype parsing
   //  0, "0", " 0", 1, "1", " 1", "a", "z", null, true, false,  "null", "true", "false", nan, "nan"
   // Test for dtypes: bool, int, float, str, duration, timestamp
@@ -1557,7 +1548,8 @@ TEST_P(JsonReaderParamTest, JsonDtypeParsing)
                                                  {{"0", "\"nan\""}}},
                                                 "\n");
 
-  std::string data = (test_opt == json_test_t::json_lines_row_orient) ? row_orient : record_orient;
+  std::string data =
+    (test_opt == json_test_t::legacy_lines_row_orient) ? row_orient : record_orient;
 
   auto make_validity = [](std::vector<int> const& validity) {
     return cudf::detail::make_counting_transform_iterator(
@@ -1640,7 +1632,7 @@ TEST_P(JsonReaderParamTest, JsonDtypeParsing)
       cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
         .dtypes(dtype_schema)
         .lines(true)
-        .experimental(test_experimental);
+        .legacy(is_legacy_test(test_opt));
 
     cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -1679,7 +1671,8 @@ TYPED_TEST(JsonFixedPointReaderTest, EmptyValues)
   cudf::io::json_reader_options const in_opts =
     cudf::io::json_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
       .dtypes({data_type{type_to_id<TypeParam>(), 0}})
-      .lines(true);
+      .lines(true)
+      .legacy(true);  // Legacy behavior; not aligned with JSON specs
 
   auto const result      = cudf::io::read_json(in_opts);
   auto const result_view = result.tbl->view();
@@ -1696,18 +1689,15 @@ TEST_F(JsonReaderTest, UnsupportedMultipleFileInputs)
   auto const buffer      = cudf::io::host_buffer{data.data(), data.size()};
   auto const src         = cudf::io::source_info{{buffer, buffer}};
 
-  cudf::io::json_reader_options const not_lines_opts =
-    cudf::io::json_reader_options::builder(src).experimental(true);
+  cudf::io::json_reader_options const not_lines_opts = cudf::io::json_reader_options::builder(src);
   EXPECT_THROW(cudf::io::read_json(not_lines_opts), cudf::logic_error);
 
   cudf::io::json_reader_options const comp_exp_opts =
-    cudf::io::json_reader_options::builder(src).experimental(true).compression(
-      cudf::io::compression_type::GZIP);
+    cudf::io::json_reader_options::builder(src).compression(cudf::io::compression_type::GZIP);
   EXPECT_THROW(cudf::io::read_json(comp_exp_opts), cudf::logic_error);
 
   cudf::io::json_reader_options const comp_opts =
-    cudf::io::json_reader_options::builder(src).experimental(false).compression(
-      cudf::io::compression_type::GZIP);
+    cudf::io::json_reader_options::builder(src).compression(cudf::io::compression_type::GZIP);
   EXPECT_THROW(cudf::io::read_json(comp_opts), cudf::logic_error);
 }
 
@@ -1728,8 +1718,7 @@ TEST_F(JsonReaderTest, TrailingCommas)
     cudf::io::json_reader_options json_parser_options =
       cudf::io::json_reader_options::builder(
         cudf::io::source_info{json_string.c_str(), json_string.size()})
-        .lines(true)
-        .experimental(true);
+        .lines(true);
     EXPECT_NO_THROW(cudf::io::read_json(json_parser_options)) << "Failed on test case " << i;
   }
 
@@ -1740,11 +1729,9 @@ TEST_F(JsonReaderTest, TrailingCommas)
     R"([{"a": 1,}, {"a": null, "b": [null,],}])",
   };
   for (size_t i = 0; i < json_valid.size(); i++) {
-    auto const& json_string = json_valid[i];
-    cudf::io::json_reader_options json_parser_options =
-      cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.c_str(), json_string.size()})
-        .experimental(true);
+    auto const& json_string                           = json_valid[i];
+    cudf::io::json_reader_options json_parser_options = cudf::io::json_reader_options::builder(
+      cudf::io::source_info{json_string.c_str(), json_string.size()});
     EXPECT_NO_THROW(cudf::io::read_json(json_parser_options)) << "Failed on test case " << i;
   }
 
@@ -1759,11 +1746,9 @@ TEST_F(JsonReaderTest, TrailingCommas)
     R"([{,,}])",
   };
   for (size_t i = 0; i < json_invalid.size(); i++) {
-    auto const& json_string = json_invalid[i];
-    cudf::io::json_reader_options json_parser_options =
-      cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.c_str(), json_string.size()})
-        .experimental(true);
+    auto const& json_string                           = json_invalid[i];
+    cudf::io::json_reader_options json_parser_options = cudf::io::json_reader_options::builder(
+      cudf::io::source_info{json_string.c_str(), json_string.size()});
     EXPECT_THROW(cudf::io::read_json(json_parser_options), cudf::logic_error)
       << "Failed on test case " << i;
   }

--- a/cpp/tests/io/json_test.cpp
+++ b/cpp/tests/io/json_test.cpp
@@ -186,8 +186,8 @@ struct JsonReaderParamTest : public cudf::test::BaseFixture,
 };
 
 /**
- * @brief Test fixture for parametrized JSON reader tests, testing record orient-only for existing
- * JSON lines reader and the new experimental reader
+ * @brief Test fixture for parametrized JSON reader tests, testing record orient-only for legacy
+ * JSON lines reader and the nested reader
  */
 struct JsonReaderDualTest : public cudf::test::BaseFixture,
                             public testing::WithParamInterface<json_test_t> {
@@ -269,16 +269,14 @@ struct JsonValidFixedPointReaderTest : public JsonFixedPointReaderTest<DecimalTy
 TYPED_TEST_SUITE(JsonFixedPointReaderTest, cudf::test::FixedPointTypes);
 TYPED_TEST_SUITE(JsonValidFixedPointReaderTest, cudf::test::FixedPointTypes);
 
-// Parametrize qualifying JSON tests for executing both experimental reader and existing JSON lines
-// reader
+// Parametrize qualifying JSON tests for executing both nested reader and legacy JSON lines reader
 INSTANTIATE_TEST_CASE_P(JsonReaderParamTest,
                         JsonReaderParamTest,
                         ::testing::Values(json_test_t::record_orient,
                                           json_test_t::legacy_lines_row_orient,
                                           json_test_t::legacy_lines_record_orient));
 
-// Parametrize qualifying JSON tests for executing both experimental reader and existing JSON lines
-// reader
+// Parametrize qualifying JSON tests for executing both nested reader and legacy JSON lines reader
 INSTANTIATE_TEST_CASE_P(JsonReaderDualTest,
                         JsonReaderDualTest,
                         ::testing::Values(json_test_t::legacy_lines_record_orient,

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1328,7 +1328,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_readAndInferJSON(
 
     cudf::io::json_reader_options_builder opts = cudf::io::json_reader_options::builder(source)
                                                      .dayfirst(static_cast<bool>(day_first))
-                                                     .lines(static_cast<bool>(lines));
+                                                     .lines(static_cast<bool>(lines))
+                                                     .legacy(true);
 
     auto result =
         std::make_unique<cudf::io::table_with_metadata>(cudf::io::read_json(opts.build()));
@@ -1434,7 +1435,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readJSON(
 
     cudf::io::json_reader_options_builder opts = cudf::io::json_reader_options::builder(source)
                                                      .dayfirst(static_cast<bool>(day_first))
-                                                     .lines(static_cast<bool>(lines));
+                                                     .lines(static_cast<bool>(lines))
+                                                     .legacy(true);
 
     if (!n_col_names.is_null() && data_types.size() > 0) {
       if (n_col_names.size() != n_types.size()) {

--- a/python/cudf/cudf/_lib/cpp/io/json.pxd
+++ b/python/cudf/cudf/_lib/cpp/io/json.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 from libc.stdint cimport uint8_t
 from libcpp cimport bool
@@ -77,7 +77,7 @@ cdef extern from "cudf/io/json.hpp" \
         json_reader_options_builder& dayfirst(
             bool val
         ) except +
-        json_reader_options_builder& experimental(
+        json_reader_options_builder& legacy(
             bool val
         ) except +
         json_reader_options_builder& keep_quotes(

--- a/python/cudf/cudf/_lib/json.pyx
+++ b/python/cudf/cudf/_lib/json.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 
 # cython: boundscheck = False
 
@@ -99,7 +99,7 @@ cpdef read_json(object filepaths_or_buffers,
         .lines(c_lines)
         .byte_range_offset(c_range_offset)
         .byte_range_size(c_range_size)
-        .experimental(experimental)
+        .legacy(not experimental)
         .build()
     )
     if is_list_like_dtypes:


### PR DESCRIPTION
## Description
Changes libcudf default JSON reader to the new nested reader. 
The previous default is now called "legacy", so the API is update to match.
C++ tests that used the default reader still do, except for "values" orient tests (will be addressed in https://github.com/rapidsai/cudf/pull/12498) and few cases where tested behavior is not desired in the new reader.
Modified Python and Java call sites to keep the current behavior. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
