### PR TITLE
Optimize `cudf::make_lists_column`

### DIFF
--- a/cpp/src/lists/lists_column_factories.cu
+++ b/cpp/src/lists/lists_column_factories.cu
@@ -121,9 +121,7 @@ std::unique_ptr<column> make_lists_column(size_type num_rows,
 
   // Check not having nulls using `null_count==0` along with nullable because we may have
   // `null_count==UNKNOWN_NULL_COUNT`.
-  if (null_count == 0 || !output->nullable() || child_type_id == type_id::EMPTY) {
-    return std::move(output);
-  }
+  if (null_count == 0 || !output->nullable() || child_type_id == type_id::EMPTY) { return output; }
 
   auto const output_cv = output->view();
 

--- a/cpp/src/lists/lists_column_factories.cu
+++ b/cpp/src/lists/lists_column_factories.cu
@@ -131,7 +131,6 @@ std::unique_ptr<column> make_lists_column(size_type num_rows,
   return detail::has_nonempty_nulls(output_cv, stream)
            ? detail::purge_nonempty_nulls(output_cv, stream, mr)
            : std::move(output);
-  ;
 }
 
 }  // namespace cudf

--- a/cpp/src/lists/lists_column_factories.cu
+++ b/cpp/src/lists/lists_column_factories.cu
@@ -119,11 +119,21 @@ std::unique_ptr<column> make_lists_column(size_type num_rows,
                                          null_count,
                                          std::move(children));
 
+  // Check not having nulls using `null_count==0` along with nullable because we may have
+  // `null_count==UNKNOWN_NULL_COUNT`.
+  if (null_count == 0 || !output->nullable() || child_type_id == type_id::EMPTY) {
+    return std::move(output);
+  }
+
+  auto const output_cv = output->view();
+
   // We need to enforce all null lists to be empty.
-  // Checking `null_count==0` is not enough as it can be `UNKNOWN_NULL_COUNT` for nullable column.
-  return null_count == 0 || !output->nullable() || child_type_id == type_id::EMPTY
-           ? std::move(output)
-           : detail::purge_nonempty_nulls(output->view(), stream, mr);
+  // `has_nonempty_nulls` is less expensive than `purge_nonempty_nulls` and can save some
+  // performance if we don't have any non-empty nulls.
+  return detail::has_nonempty_nulls(output_cv, stream)
+           ? detail::purge_nonempty_nulls(output_cv, stream, mr)
+           : std::move(output);
+  ;
 }
 
 }  // namespace cudf

--- a/cpp/tests/copying/purge_nonempty_nulls_tests.cpp
+++ b/cpp/tests/copying/purge_nonempty_nulls_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/copying/purge_nonempty_nulls_tests.cpp
+++ b/cpp/tests/copying/purge_nonempty_nulls_tests.cpp
@@ -350,7 +350,10 @@ TEST_F(PurgeNonEmptyNullsTest, UnsanitizedListOfUnsanitizedStrings)
                             0,
                             cudf::test::detail::make_null_mask(no_nulls(), no_nulls() + 4));
   EXPECT_TRUE(cudf::may_have_nonempty_nulls(*lists));
-  EXPECT_TRUE(cudf::has_nonempty_nulls(*lists));
+
+  // The child column has non-empty nulls but it has already been sanitized during lists column
+  // construction.
+  EXPECT_FALSE(cudf::has_nonempty_nulls(*lists));
 
   // Set lists nullmask, post construction.
   cudf::detail::set_null_mask(


### PR DESCRIPTION
This makes minor optimization to lists column construction after changes made in https://github.com/rapidsai/cudf/pull/12370. Instead of always calling to `cudf::purge_nonempty_nulls` if the being created column is nullable, `has_nonempty_nulls` is called first to check if there is actually any non-empty nulls to clean up.

Because the logic behind `has_nonempty_nulls` is much simpler than `purge_nonempty_nulls`, especially for deeply nested lists, this can speed up list column creation performance to some extent.

This PR also uncovers a test that should fail in https://github.com/rapidsai/cudf/pull/12370 but it didn't, because non-empty nulls were not checked recursively. On the other hand, `has_nonempty_nulls` used in this PR is called recursively thus this completely fixes the issue that https://github.com/rapidsai/cudf/pull/12370 was trying to fix.