### PR TITLE
Mixed Join benchmark bug due to wrong conditional column

### DIFF
--- a/cpp/benchmarks/join/join_common.hpp
+++ b/cpp/benchmarks/join/join_common.hpp
@@ -77,7 +77,7 @@ template <typename key_type,
           join_t join_type = join_t::HASH,
           typename state_type,
           typename Join>
-static void BM_join(state_type& state, Join JoinFunc)
+void BM_join(state_type& state, Join JoinFunc)
 {
   auto const build_table_size = [&]() {
     if constexpr (std::is_same_v<state_type, benchmark::State>) {
@@ -172,18 +172,18 @@ static void BM_join(state_type& state, Join JoinFunc)
   }
   if constexpr (std::is_same_v<state_type, nvbench::state> and (join_type != join_t::CONDITIONAL)) {
     if constexpr (join_type == join_t::MIXED) {
-      auto const col_ref_left_1 = cudf::ast::column_reference(1);
-      auto const col_ref_right_1 =
-        cudf::ast::column_reference(1, cudf::ast::table_reference::RIGHT);
-      auto left_zero_eq_right_one =
-        cudf::ast::operation(cudf::ast::ast_operator::EQUAL, col_ref_left_1, col_ref_right_1);
+      auto const col_ref_left_0 = cudf::ast::column_reference(0);
+      auto const col_ref_right_0 =
+        cudf::ast::column_reference(0, cudf::ast::table_reference::RIGHT);
+      auto left_zero_eq_right_zero =
+        cudf::ast::operation(cudf::ast::ast_operator::EQUAL, col_ref_left_0, col_ref_right_0);
       state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
         rmm::cuda_stream_view stream_view{launch.get_stream()};
         auto result = JoinFunc(probe_table.select(columns_to_join),
                                build_table.select(columns_to_join),
                                probe_table.select({1}),
                                build_table.select({1}),
-                               left_zero_eq_right_one,
+                               left_zero_eq_right_zero,
                                cudf::null_equality::UNEQUAL,
                                stream_view);
       });

--- a/cpp/benchmarks/join/mixed_join.cu
+++ b/cpp/benchmarks/join/mixed_join.cu
@@ -176,7 +176,7 @@ NVBENCH_BENCH_TYPES(nvbench_mixed_inner_join,
                     NVBENCH_TYPE_AXES(nvbench::type_list<nvbench::int32_t>,
                                       nvbench::type_list<nvbench::int32_t>,
                                       nvbench::enum_type_list<true>))
-  .set_name("inner_join_32bit_nulls")
+  .set_name("mixed_inner_join_32bit_nulls")
   .set_type_axes_names({"Key Type", "Payload Type", "Nullable"})
   .add_int64_axis("Build Table Size", {100'000, 10'000'000, 80'000'000, 100'000'000})
   .add_int64_axis("Probe Table Size",


### PR DESCRIPTION
## Description
I was picking up column index `1` while constructing the AST for a table with only 1 column.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
