### PR TITLE
Make JNI QuoteStyle accessible outside ai.rapids.cudf

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/QuoteStyle.java
+++ b/java/src/main/java/ai/rapids/cudf/QuoteStyle.java
@@ -20,7 +20,7 @@ package ai.rapids.cudf;
 /**
  * Quote style for CSV records, closely following cudf::io::quote_style.
  */
-enum QuoteStyle {
+public enum QuoteStyle {
     MINIMAL(0),    // Quote only fields which contain special characters
     ALL(1),        // Quote all fields
     NONNUMERIC(2), // Quote all non-numeric fields


### PR DESCRIPTION
When `QuoteStyle` was added in #12539, it was inadvertently made package- private to `ai.rapids.cudf`. This makes it unusable from `spark-rapids` plugin.

This commit makes the enum publicly accessible.

Signed-off-by: MithunR <mythrocks@gmail.com>

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
