### PR TITLE
Verify libcudacxx 1.9.1 doesn't have any atomic compile failures

### DIFF
--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -16,4 +16,6 @@ if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake)
        ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake
   )
 endif()
+set(rapids-cmake-repo robertmaynard/rapids-cmake)
+set(rapids-cmake-branch fea/update_libcudacxx_ver)
 include(${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake)


### PR DESCRIPTION
## Description
Validate https://github.com/rapidsai/rapids-cmake/pull/343

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
