### PR TITLE
Fixing BUG, `get_next_chunk()` should use the blocking function `device_read()`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -288,6 +288,7 @@ if buildAll || hasArg libcudf; then
           -DDISABLE_DEPRECATION_WARNINGS=${BUILD_DISABLE_DEPRECATION_WARNINGS} \
           -DCUDF_USE_PER_THREAD_DEFAULT_STREAM=${BUILD_PER_THREAD_DEFAULT_STREAM} \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+          -DCPM_KvikIO_SOURCE=/home/nfs/mkristensen/repos/kvikio \
           ${EXTRA_CMAKE_ARGS}
 
     cd ${LIB_BUILD_DIR}

--- a/build.sh
+++ b/build.sh
@@ -288,7 +288,6 @@ if buildAll || hasArg libcudf; then
           -DDISABLE_DEPRECATION_WARNINGS=${BUILD_DISABLE_DEPRECATION_WARNINGS} \
           -DCUDF_USE_PER_THREAD_DEFAULT_STREAM=${BUILD_PER_THREAD_DEFAULT_STREAM} \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-          -DCPM_KvikIO_SOURCE=/home/nfs/mkristensen/repos/kvikio \
           ${EXTRA_CMAKE_ARGS}
 
     cd ${LIB_BUILD_DIR}

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 ##############################################
 # cuDF GPU build and test script for CI      #
 ##############################################

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -232,7 +232,7 @@ else
     done
 
     # Test libcudf (csv, orc, and parquet) with `LIBCUDF_CUFILE_POLICY=KVIKIO`
-    for test_name in "CSV_TEST" "ORC_TEST" "PARQUET_TEST"; do
+    for test_name in "CSV_TEST" "ORC_TEST" "PARQUET_TEST" "DATA_CHUNK_SOURCE_TEST"; do
         gt="$CONDA_PREFIX/bin/gtests/libcudf/$test_name"
         echo "Running GoogleTest $test_name (LIBCUDF_CUFILE_POLICY=KVIKIO)"
         LIBCUDF_CUFILE_POLICY=KVIKIO ${gt} --gtest_output=xml:"$WORKSPACE/test-results/"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -169,7 +169,7 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
         done
 
         # Test libcudf (csv, orc, and parquet) with `LIBCUDF_CUFILE_POLICY=KVIKIO`
-        for test_name in "CSV_TEST" "ORC_TEST" "PARQUET_TEST"; do
+        for test_name in "CSV_TEST" "ORC_TEST" "PARQUET_TEST" "DATA_CHUNK_SOURCE_TEST"; do
             gt="$WORKSPACE/cpp/build/gtests/$test_name"
             echo "Running GoogleTest $test_name (LIBCUDF_CUFILE_POLICY=KVIKIO)"
             LIBCUDF_CUFILE_POLICY=KVIKIO ${gt} --gtest_output=xml:"$WORKSPACE/test-results/"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -71,7 +71,7 @@ done
 
 rapids-logger "Run gtests with kvikio"
 # Test libcudf (csv, orc, and parquet) with `LIBCUDF_CUFILE_POLICY=KVIKIO`
-for test_name in "CSV_TEST" "ORC_TEST" "PARQUET_TEST"; do
+for test_name in "CSV_TEST" "ORC_TEST" "PARQUET_TEST" "DATA_CHUNK_SOURCE_TEST"; do
     gt="$CONDA_PREFIX/bin/gtests/libcudf/${test_name}"
     echo "Running gtest $test_name (LIBCUDF_CUFILE_POLICY=KVIKIO)"
     LIBCUDF_CUFILE_POLICY=KVIKIO ${gt} --gtest_output=xml:${RAPIDS_TESTS_DIR}

--- a/cpp/src/io/text/data_chunk_source_factories.cpp
+++ b/cpp/src/io/text/data_chunk_source_factories.cpp
@@ -74,8 +74,7 @@ class datasource_chunk_reader : public data_chunk_reader {
     auto chunk = rmm::device_uvector<char>(read_size, stream);
 
     if (_source->supports_device_read() && _source->is_device_read_preferred(read_size)) {
-      _source->device_read(
-        _offset, read_size, reinterpret_cast<uint8_t*>(chunk.data()), stream);
+      _source->device_read(_offset, read_size, reinterpret_cast<uint8_t*>(chunk.data()), stream);
     } else {
       auto& h_ticket = _tickets[_next_ticket_idx];
 

--- a/cpp/src/io/text/data_chunk_source_factories.cpp
+++ b/cpp/src/io/text/data_chunk_source_factories.cpp
@@ -74,7 +74,7 @@ class datasource_chunk_reader : public data_chunk_reader {
     auto chunk = rmm::device_uvector<char>(read_size, stream);
 
     if (_source->supports_device_read() && _source->is_device_read_preferred(read_size)) {
-      _source->device_read_async(
+      _source->device_read(
         _offset, read_size, reinterpret_cast<uint8_t*>(chunk.data()), stream);
     } else {
       auto& h_ticket = _tickets[_next_ticket_idx];


### PR DESCRIPTION
`datasource_chunk_reader.get_next_chunk()` called `device_read_async()` without waiting on the returned Future.

Should fix the CI fail in https://github.com/rapidsai/cudf/pull/12574

cc. @vuule 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
