### PR TITLE
timedelta: Don't go via float intermediates for floordiv

### DIFF
--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 from __future__ import annotations
 
@@ -200,9 +200,6 @@ class TimeDeltaColumn(ColumnBase):
 
         if out_dtype is None:
             return NotImplemented
-
-        if op == "__floordiv__":
-            op = "__truediv__"
 
         lhs, rhs = (other, this) if reflect else (this, other)
 

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -915,20 +915,6 @@ def test_timedelta_index_ops_with_scalars(
             reason="Related to https://github.com/rapidsai/cudf/issues/5938",
         )
     )
-    request.applymarker(
-        pytest.mark.xfail(
-            condition=(
-                op == "floordiv"
-                and (None not in ptdi)
-                and np.nan not in expected
-                and (
-                    expected.astype("float64").astype("int64")
-                    != expected.astype("int64")
-                ).any()
-            ),
-            reason="https://github.com/rapidsai/cudf/issues/12393",
-        )
-    )
     assert_eq(expected, actual)
 
 
@@ -1008,20 +994,6 @@ def test_timedelta_index_ops_with_cudf_scalars(
                 and np.timedelta64(cpu_scalar).item() is not None
             ),
             reason="https://github.com/rapidsai/cudf/issues/5938",
-        )
-    )
-    request.applymarker(
-        pytest.mark.xfail(
-            condition=(
-                op == "floordiv"
-                and (None not in ptdi)
-                and np.nan not in expected
-                and (
-                    expected.astype("float64").astype("int64")
-                    != expected.astype("int64")
-                ).any()
-            ),
-            reason="https://github.com/rapidsai/cudf/issues/12393",
         )
     )
     assert_eq(expected, actual)


### PR DESCRIPTION
## Description
Now that we implement proper floor division in libcudf, don't remap floordiv to truediv when dividing timedeltas (first introduced in 826f6267f1). 

Closes #12393.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
