### PR TITLE
lists: Transfer dtypes correctly through list.get

### DIFF
--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -372,7 +372,12 @@ class ListMethods(ColumnMethods):
                 out = out._scatter_by_column(
                     out_of_bounds_mask, cudf.Scalar(default)
                 )
-
+        if out.dtype != self._column.dtype.element_type:
+            # libcudf doesn't maintain struct labels so we must transfer over
+            # manually from the input column if we lost some information
+            # somewhere. Not doing this unilaterally since the cost is
+            # non-zero..
+            out = out._with_type_metadata(self._column.dtype.element_type)
         return self._return_or_inplace(out)
 
     def contains(self, search_key: ScalarLike) -> ParentType:

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 import functools
 import operator
@@ -322,6 +322,24 @@ def test_get(data, index, expect):
     got = sr.list.get(index)
 
     assert_eq(expect, got, check_dtype=not expect.isnull().all())
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [{"k": "v1"}, {"k": "v2"}],
+        [[{"k": "v1", "b": "v2"}], [{"k": "v3", "b": "v4"}]],
+        [
+            [{"k": "v1", "b": [{"c": 10, "d": "v5"}]}],
+            [{"k": "v3", "b": [{"c": 14, "d": "v6"}]}],
+        ],
+    ],
+)
+@pytest.mark.parametrize("index", [0, 1])
+def test_get_nested_struct_dtype_transfer(data, index):
+    sr = cudf.Series([data])
+    expect = cudf.Series(data[index : index + 1])
+    assert_eq(expect, sr.list.get(index))
 
 
 def test_get_nested_lists():


### PR DESCRIPTION
## Description

As usual, for (nested) struct dtypes, libcudf doesn't preserve field names so we must fix things up in post.

Closes #12248.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
