### PR TITLE
Fix incorrect null counts for sliced columns in JCudfSerialization

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
+++ b/java/src/main/java/ai/rapids/cudf/JCudfSerialization.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -51,12 +51,6 @@ import java.util.Optional;
  * ColumnVectors are closed.  It is assumed that this will not be a problem because for processing
  * efficiency after the data is transferred it will likely be combined with other similar batches
  * from other processes into a single larger buffer.
- * <p>
- * There is a known bug in this where the null count of a range of values is lost, and replaced with
- * a 0 if it is known that there can be no nulls in the data, or a 1 if there is the possibility of
- * a null being in the data.  This is not likely to cause issues if the data is processed using cudf
- * as the null count is only used as a flag to check if a validity buffer is needed or not.
- * Processing outside of cudf should be careful.
  */
 public class JCudfSerialization {
   /**
@@ -240,7 +234,15 @@ public class JCudfSerialization {
     SerializedColumnHeader(ColumnBufferProvider column, long rowOffset, long numRows) {
       this.dtype = column.getType();
       this.rowCount = numRows;
-      this.nullCount = Math.min(column.getNullCount(), numRows);
+      long columnNullCount = column.getNullCount();
+      // For a subset of the original column we do not know the null count unless
+      // the original column is either all nulls or no nulls.
+      if (column.getRowCount() == numRows
+          || columnNullCount == 0 || columnNullCount == column.getRowCount()) {
+        this.nullCount = Math.min(columnNullCount, numRows);
+      } else {
+        this.nullCount = ColumnView.UNKNOWN_NULL_COUNT;
+      }
       ColumnBufferProvider[] childProviders = column.getChildProviders();
       if (childProviders != null) {
         children = new SerializedColumnHeader[childProviders.length];
@@ -756,7 +758,7 @@ public class JCudfSerialization {
   private static long getSlicedSerializedDataSizeInBytes(ColumnBufferProvider column, long rowOffset, long numRows) {
     long totalDataSize = 0;
     DType type = column.getType();
-    if (column.getNullCount() > 0) {
+    if (needsValidityBuffer(column.getNullCount())) {
       totalDataSize += padFor64byteAlignment(BitVectorHelper.getValidityLengthInBytes(numRows));
     }
 
@@ -845,7 +847,7 @@ public class JCudfSerialization {
     long data = 0;
     long dataLen = 0;
     long rowCount = column.getRowCount();
-    if (column.getNullCount() > 0) {
+    if (needsValidityBuffer(column.getNullCount())) {
       long validityLen = padFor64byteAlignment(BitVectorHelper.getValidityLengthInBytes(rowCount));
       validity = bufferOffset;
       bufferOffset += validityLen;
@@ -1076,14 +1078,21 @@ public class JCudfSerialization {
     long nullCount = 0;
     for (ColumnBufferProvider provider : providers) {
       rowCount += provider.getRowCount();
-      nullCount += provider.getNullCount();
+      if (nullCount != ColumnView.UNKNOWN_NULL_COUNT) {
+        long providerNullCount = provider.getNullCount();
+        if (providerNullCount == ColumnView.UNKNOWN_NULL_COUNT) {
+          nullCount = ColumnView.UNKNOWN_NULL_COUNT;
+        } else {
+          nullCount += providerNullCount;
+        }
+      }
     }
 
     if (rowCount > Integer.MAX_VALUE) {
       throw new IllegalArgumentException("Cannot build a batch larger than " + Integer.MAX_VALUE + " rows");
     }
 
-    if (nullCount > 0) {
+    if (needsValidityBuffer(nullCount)) {
       totalSize += padFor64byteAlignment(BitVectorHelper.getValidityLengthInBytes(rowCount));
     }
 
@@ -1154,6 +1163,10 @@ public class JCudfSerialization {
   /////////////////////////////////////////////
   // VALIDITY
   /////////////////////////////////////////////
+
+  private static boolean needsValidityBuffer(long nullCount) {
+    return nullCount > 0 || nullCount == ColumnView.UNKNOWN_NULL_COUNT;
+  }
 
   private static int copyPartialValidity(byte[] dest,
                                          int destBitOffset,
@@ -1309,7 +1322,7 @@ public class JCudfSerialization {
       int validityBitOffset = 0;
       while(rowsLeftInBatch > 0) {
         int rowsStoredJustNow;
-        if (provider.getNullCount() > 0) {
+        if (needsValidityBuffer(provider.getNullCount())) {
           rowsStoredJustNow = copyPartialValidity(arrayBuffer, rowsStoredInArray, provider, validityBitOffset, rowsLeftInBatch);
         } else {
           rowsStoredJustNow = fillValidity(arrayBuffer, rowsStoredInArray, rowsLeftInBatch);
@@ -1463,7 +1476,7 @@ public class JCudfSerialization {
 
   private static void writeConcat(DataWriter out, SerializedColumnHeader header,
                                   ColumnBufferProvider[] providers) throws IOException {
-    if (header.getNullCount() > 0) {
+    if (needsValidityBuffer(header.getNullCount())) {
       concatValidity(out, header.getRowCount(), providers);
     }
 
@@ -1497,7 +1510,7 @@ public class JCudfSerialization {
                                   ColumnBufferProvider column,
                                   long rowOffset,
                                   long numRows) throws IOException {
-    if (column.getNullCount() > 0) {
+    if (needsValidityBuffer(column.getNullCount())) {
       try (NvtxRange range = new NvtxRange("Write Validity", NvtxColor.DARK_GREEN)) {
         copySlicedValidity(out, column, rowOffset, numRows);
       }
@@ -1550,8 +1563,6 @@ public class JCudfSerialization {
     for (int i = 0; i < columns.length; i++) {
       long rows = columns[i].getRowCount();
       assert rowOffset + numRows <= rows;
-      long nullCount = columns[i].getNullCount();
-      assert nullCount == (int) nullCount : "can only support an int for indexes";
       assert rows == (int) rows : "can only support an int for indexes";
     }
 
@@ -1685,7 +1696,7 @@ public class JCudfSerialization {
       if (!dtype.isNestedType()) {
         dataBuffer = buffer.slice(offsetsInfo.data, offsetsInfo.dataLen);
       }
-      if (nullCount > 0) {
+      if (needsValidityBuffer(nullCount)) {
         long validitySize = BitVectorHelper.getValidityLengthInBytes(rowCount);
         validityBuffer = buffer.slice(offsetsInfo.validity, validitySize);
       }
@@ -1697,12 +1708,12 @@ public class JCudfSerialization {
       HostColumnVectorCore result;
       // Only creates HostColumnVector for root columns, since child columns are managed by their parents.
       if (isRootColumn) {
-        result = new HostColumnVector(dtype, column.getRowCount(),
-            Optional.of(column.getNullCount()), dataBuffer, validityBuffer, offsetsBuffer,
+        result = new HostColumnVector(dtype, rowCount,
+            Optional.of(nullCount), dataBuffer, validityBuffer, offsetsBuffer,
             childColumns);
       } else {
-        result = new HostColumnVectorCore(dtype, column.getRowCount(),
-            Optional.of(column.getNullCount()), dataBuffer, validityBuffer, offsetsBuffer,
+        result = new HostColumnVectorCore(dtype, rowCount,
+            Optional.of(nullCount), dataBuffer, validityBuffer, offsetsBuffer,
             childColumns);
       }
       childColumns = null;
@@ -1732,7 +1743,8 @@ public class JCudfSerialization {
       DType dtype = column.getType();
       long bufferAddress = combinedBuffer.getAddress();
       long dataAddress = dtype.isNestedType() ? 0 : bufferAddress + offsetsInfo.data;
-      long validityAddress = column.getNullCount() > 0 ? bufferAddress + offsetsInfo.validity : 0;
+      long validityAddress = needsValidityBuffer(column.getNullCount())
+          ? bufferAddress + offsetsInfo.validity : 0;
       long offsetsAddress = dtype.hasOffsets() ? bufferAddress + offsetsInfo.offsets : 0;
       return ColumnView.makeCudfColumnView(
           dtype.typeId.getNativeId(), dtype.getScale(),

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -3533,7 +3533,7 @@ public class TableTest extends CudfTestBase {
           try (Table found = JCudfSerialization.readAndConcat(
               headers.toArray(new JCudfSerialization.SerializedTableHeader[headers.size()]),
               buffers.toArray(new HostMemoryBuffer[buffers.size()]))) {
-            assertPartialTablesAreEqual(t, 0, t.getRowCount(), found, false, false);
+            assertPartialTablesAreEqual(t, 0, t.getRowCount(), found, true, false);
           }
         } finally {
           for (HostMemoryBuffer buff: buffers) {
@@ -3629,7 +3629,7 @@ public class TableTest extends CudfTestBase {
         try (Table result = JCudfSerialization.readAndConcat(
             new JCudfSerialization.SerializedTableHeader[] {header, header},
             new HostMemoryBuffer[] {buff, buff})) {
-          assertPartialTablesAreEqual(expected, 0, expected.getRowCount(), result, false, false);
+          assertPartialTablesAreEqual(expected, 0, expected.getRowCount(), result, true, false);
         }
       }
     }
@@ -3670,7 +3670,7 @@ public class TableTest extends CudfTestBase {
               buffers.toArray(new HostMemoryBuffer[buffers.size()]), bout2);
           ByteArrayInputStream bin2 = new ByteArrayInputStream(bout2.toByteArray());
           try (JCudfSerialization.TableAndRowCountPair found = JCudfSerialization.readTableFrom(bin2)) {
-            assertPartialTablesAreEqual(t, 0, t.getRowCount(), found.getTable(), false, false);
+            assertPartialTablesAreEqual(t, 0, t.getRowCount(), found.getTable(), true, false);
             assertEquals(found.getTable(), found.getContiguousTable().getTable());
             assertNotNull(found.getContiguousTable().getBuffer());
           }


### PR DESCRIPTION
## Description
This fixes a long-standing problem in JCudfSerialization where sliced columns do not have the correct null counts when serialized and then deserialized.  Previously the null count of the original column was used as a "good enough"  proxy, and this was fine as long as it was only interpreted as a boolean "do I need to worry about nulls" signal.  However it can lead to bad behavior for applications that use the null count directly, such as for statistics in a file footer.

This resolves the issue by explicitly treating sliced column null counts as unknown when it cannot be determined what the true null count is without scanning the sliced validity buffer.  By using the unknown null count sentinel value in the serialized data stream, the deserialized column will compute the null count on demand, producing the correct value.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
