### PR TITLE
Changing `cudf::io::source_info` to use `host_span` of `std::byte`

### DIFF
--- a/cpp/benchmarks/io/cuio_common.cpp
+++ b/cpp/benchmarks/io/cuio_common.cpp
@@ -47,7 +47,9 @@ cudf::io::source_info cuio_source_sink_pair::make_source_info()
 {
   switch (type) {
     case io_type::FILEPATH: return cudf::io::source_info(file_name);
-    case io_type::HOST_BUFFER: return cudf::io::source_info(h_buffer.data(), h_buffer.size());
+    case io_type::HOST_BUFFER:
+      return cudf::io::source_info(cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(h_buffer.data()), h_buffer.size()));
     case io_type::DEVICE_BUFFER: {
       // TODO: make cuio_source_sink_pair stream-friendly and avoid implicit use of the default
       // stream

--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -115,7 +115,7 @@ class datasource {
    * @param[in] buffer Host buffer object
    * @return Constructed datasource object
    */
-  static std::unique_ptr<datasource> create(host_buffer const& buffer);
+  static std::unique_ptr<datasource> create(host_span<std::byte const> buffer);
 
   /**
    * @brief Creates a source from a device memory buffer.

--- a/cpp/include/cudf/io/types.hpp
+++ b/cpp/include/cudf/io/types.hpp
@@ -148,25 +148,6 @@ struct table_with_metadata {
 };
 
 /**
- * @brief Non-owning view of a host memory buffer
- *
- * Used to describe buffer input in `source_info` objects.
- */
-struct host_buffer {
-  // TODO: to be replaced by `host_span`
-  char const* data = nullptr;  //!< Pointer to the buffer
-  size_t size      = 0;        //!< Size of the buffer
-  host_buffer()    = default;
-  /**
-   * @brief Construct a new host buffer object
-   *
-   * @param data Pointer to the buffer
-   * @param size Size of the buffer
-   */
-  host_buffer(const char* data, size_t size) : data(data), size(size) {}
-};
-
-/**
  * @brief Source information for read interfaces
  */
 struct source_info {
@@ -193,7 +174,7 @@ struct source_info {
    *
    * @param host_buffers Input buffers in host memory
    */
-  explicit source_info(std::vector<host_buffer> const& host_buffers)
+  explicit source_info(std::vector<cudf::host_span<std::byte const>> const& host_buffers)
     : _type(io_type::HOST_BUFFER), _host_buffers(host_buffers)
   {
   }
@@ -204,8 +185,8 @@ struct source_info {
    * @param host_data Input buffer in host memory
    * @param size Size of the buffer
    */
-  explicit source_info(const char* host_data, size_t size)
-    : _type(io_type::HOST_BUFFER), _host_buffers({{host_data, size}})
+  explicit source_info(cudf::host_span<std::byte const> host_data)
+    : _type(io_type::HOST_BUFFER), _host_buffers({{host_data}})
   {
   }
 
@@ -289,7 +270,7 @@ struct source_info {
  private:
   io_type _type = io_type::FILEPATH;
   std::vector<std::string> _filepaths;
-  std::vector<host_buffer> _host_buffers;
+  std::vector<cudf::host_span<std::byte const>> _host_buffers;
   std::vector<cudf::device_span<std::byte const>> _device_buffers;
   std::vector<cudf::io::datasource*> _user_sources;
 };

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -328,11 +328,11 @@ std::unique_ptr<datasource> datasource::create(const std::string& filepath,
   return std::make_unique<memory_mapped_source>(filepath.c_str(), offset, size);
 }
 
-std::unique_ptr<datasource> datasource::create(host_buffer const& buffer)
+std::unique_ptr<datasource> datasource::create(cudf::host_span<std::byte const> buffer)
 {
   // Use Arrow IO buffer class for zero-copy reads of host memory
   return std::make_unique<arrow_io_source>(std::make_shared<arrow::io::BufferReader>(
-    reinterpret_cast<const uint8_t*>(buffer.data), buffer.size));
+    reinterpret_cast<const uint8_t*>(buffer.data()), buffer.size()));
 }
 
 std::unique_ptr<datasource> datasource::create(cudf::device_span<std::byte const> buffer)

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -112,7 +112,9 @@ struct CsvFixedPointReaderTest : public CsvReaderTest {
                                         });
 
     cudf::io::csv_reader_options const in_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
         .dtypes({data_type{type_to_id<DecimalType>(), scale}})
         .header(-1);
 
@@ -1072,7 +1074,9 @@ TEST_F(CsvReaderTest, ByteRangeStrings)
 {
   std::string input = "\"a\"\n\"b\"\n\"c\"";
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{input.c_str(), input.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(input.data()), input.size())})
       .names({"A"})
       .dtypes({dtype<cudf::string_view>()})
       .header(-1)
@@ -1209,7 +1213,9 @@ TEST_F(CsvReaderTest, StringInference)
 {
   std::string buffer = "\"-1\"\n";
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
       .header(-1);
   const auto result = cudf::io::read_csv(in_opts);
 
@@ -1221,7 +1227,9 @@ TEST_F(CsvReaderTest, TypeInferenceThousands)
 {
   std::string buffer = "1`400,123,1`234.56\n123`456,123456,12.34";
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
       .header(-1)
       .thousands('`');
   const auto result      = cudf::io::read_csv(in_opts);
@@ -1248,7 +1256,9 @@ TEST_F(CsvReaderTest, TypeInferenceWithDecimal)
   // col#2 => FLOAT64 (column contains digits and decimal point (i.e., ';'))
   std::string buffer = "1`400,1.23,1`234;56\n123`456,123.456,12;34";
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
       .header(-1)
       .thousands('`')
       .decimal(';');
@@ -1273,13 +1283,17 @@ TEST_F(CsvReaderTest, SkipRowsXorSkipFooter)
   std::string buffer = "1,2,3";
 
   cudf::io::csv_reader_options skiprows_options =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
       .header(-1)
       .skiprows(1);
   EXPECT_NO_THROW(cudf::io::read_csv(skiprows_options));
 
   cudf::io::csv_reader_options skipfooter_options =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
       .header(-1)
       .skipfooter(1);
   EXPECT_NO_THROW(cudf::io::read_csv(skipfooter_options));
@@ -1364,111 +1378,126 @@ TEST_F(CsvReaderTest, FailCases)
 {
   std::string buffer = "1,2,3";
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_offset(4)
-        .skiprows(1),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .byte_range_offset(4)
+                   .skiprows(1),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_offset(4)
-        .skipfooter(1),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .byte_range_offset(4)
+                   .skipfooter(1),
+                 cudf::logic_error);
   }
 
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_offset(4)
-        .nrows(1),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .byte_range_offset(4)
+                   .nrows(1),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_size(4)
-        .skiprows(1),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .byte_range_size(4)
+                   .skiprows(1),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_size(4)
-        .skipfooter(1),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .byte_range_size(4)
+                   .skipfooter(1),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_size(4)
-        .nrows(1),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .byte_range_size(4)
+                   .nrows(1),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .skiprows(1)
-        .byte_range_offset(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .skiprows(1)
+                   .byte_range_offset(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .skipfooter(1)
-        .byte_range_offset(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .skipfooter(1)
+                   .byte_range_offset(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .nrows(1)
-        .byte_range_offset(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .nrows(1)
+                   .byte_range_offset(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .skiprows(1)
-        .byte_range_size(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .skiprows(1)
+                   .byte_range_size(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .skipfooter(1)
-        .byte_range_size(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .skipfooter(1)
+                   .byte_range_size(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .nrows(1)
-        .byte_range_size(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .nrows(1)
+                   .byte_range_size(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .nrows(1)
-        .skipfooter(1),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .nrows(1)
+                   .skipfooter(1),
+                 cudf::logic_error);
     ;
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .skipfooter(1)
-        .nrows(1),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .skipfooter(1)
+                   .nrows(1),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .na_filter(false)
-        .na_values({"Null"}),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>(
+                     reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
+                   .na_filter(false)
+                   .na_values({"Null"}),
+                 cudf::logic_error);
   }
 }
 
@@ -2206,7 +2235,9 @@ TEST_F(CsvReaderTest, DtypesMap)
   std::string csv_in{"12,9\n34,8\n56,7"};
 
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(csv_in.data()), csv_in.size())})
       .names({"A", "B"})
       .dtypes({{"B", dtype<int16_t>()}, {"A", dtype<int32_t>()}})
       .header(-1);
@@ -2223,7 +2254,8 @@ TEST_F(CsvReaderTest, DtypesMap)
 TEST_F(CsvReaderTest, DtypesMapPartial)
 {
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{nullptr, 0})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(nullptr, 0)})
       .names({"A", "B"})
       .dtypes({{"A", dtype<int16_t>()}});
   {
@@ -2248,7 +2280,8 @@ TEST_F(CsvReaderTest, DtypesMapPartial)
 TEST_F(CsvReaderTest, DtypesArrayInvalid)
 {
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{nullptr, 0})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(nullptr, 0)})
       .names({"A", "B", "C"})
       .dtypes(std::vector<cudf::data_type>{dtype<int16_t>(), dtype<int8_t>()});
 
@@ -2288,19 +2321,25 @@ TEST_F(CsvReaderTest, UseColsValidation)
   const std::string buffer = "1,2,3";
 
   const cudf::io::csv_reader_options idx_cnt_options =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
       .names({"a", "b"})
       .use_cols_indexes({0});
   EXPECT_THROW(cudf::io::read_csv(idx_cnt_options), cudf::logic_error);
 
   cudf::io::csv_reader_options unique_idx_cnt_options =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
       .names({"a", "b"})
       .use_cols_indexes({0, 0});
   EXPECT_THROW(cudf::io::read_csv(unique_idx_cnt_options), cudf::logic_error);
 
   cudf::io::csv_reader_options bad_name_options =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
       .names({"a", "b", "c"})
       .use_cols_names({"nonexistent_name"});
   EXPECT_THROW(cudf::io::read_csv(bad_name_options), cudf::logic_error);
@@ -2311,7 +2350,9 @@ TEST_F(CsvReaderTest, CropColumns)
   const std::string csv_in{"12,9., 10\n34,8., 20\n56,7., 30"};
 
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(csv_in.data()), csv_in.size())})
       .dtypes(std::vector<data_type>{dtype<int32_t>(), dtype<float>()})
       .names({"a", "b"})
       .header(-1);
@@ -2330,7 +2371,9 @@ TEST_F(CsvReaderTest, CropColumnsUseColsNames)
   std::string csv_in{"12,9., 10\n34,8., 20\n56,7., 30"};
 
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(csv_in.data()), csv_in.size())})
       .dtypes(std::vector<data_type>{dtype<int32_t>(), dtype<float>()})
       .names({"a", "b"})
       .use_cols_names({"b"})
@@ -2348,7 +2391,9 @@ TEST_F(CsvReaderTest, ExtraColumns)
   std::string csv_in{"12,9., 10\n34,8., 20\n56,7., 30"};
   {
     cudf::io::csv_reader_options opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(csv_in.data()), csv_in.size())})
         .names({"a", "b", "c", "d"})
         .header(-1);
     auto result = cudf::io::read_csv(opts);
@@ -2360,7 +2405,9 @@ TEST_F(CsvReaderTest, ExtraColumns)
   }
   {
     cudf::io::csv_reader_options with_dtypes_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(csv_in.data()), csv_in.size())})
         .names({"a", "b", "c", "d"})
         .dtypes({dtype<int32_t>(), dtype<int32_t>(), dtype<int32_t>(), dtype<float>()})
         .header(-1);
@@ -2379,7 +2426,9 @@ TEST_F(CsvReaderTest, ExtraColumnsUseCols)
 
   {
     cudf::io::csv_reader_options in_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(csv_in.data()), csv_in.size())})
         .names({"a", "b", "c", "d"})
         .use_cols_names({"b", "d"})
         .header(-1);
@@ -2392,7 +2441,9 @@ TEST_F(CsvReaderTest, ExtraColumnsUseCols)
   }
   {
     cudf::io::csv_reader_options with_dtypes_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(csv_in.data()), csv_in.size())})
         .names({"a", "b", "c", "d"})
         .use_cols_names({"b", "d"})
         .dtypes({dtype<int32_t>(), dtype<int32_t>(), dtype<int32_t>(), dtype<cudf::string_view>()})
@@ -2412,7 +2463,9 @@ TEST_F(CsvReaderTest, EmptyColumns)
   std::string csv_in{",null\n,null"};
 
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(csv_in.data()), csv_in.size())})
       .names({"a", "b", "c", "d"})
       .header(-1);
   // More elements in `names` than in the file; additional columns are filled with nulls
@@ -2433,7 +2486,9 @@ TEST_F(CsvReaderTest, BlankLineAfterFirstRow)
 
   {
     cudf::io::csv_reader_options no_header_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(csv_in.data()), csv_in.size())})
         .header(-1);
     // No header, getting column names/count from first row
     auto result = cudf::io::read_csv(no_header_opts);
@@ -2443,7 +2498,8 @@ TEST_F(CsvReaderTest, BlankLineAfterFirstRow)
   }
   {
     cudf::io::csv_reader_options header_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()});
+      cudf::io::csv_reader_options::builder(cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(csv_in.data()), csv_in.size())});
     // Getting column names/count from header
     auto result = cudf::io::read_csv(header_opts);
 

--- a/cpp/tests/io/json_chunked_reader.cpp
+++ b/cpp/tests/io/json_chunked_reader.cpp
@@ -97,7 +97,8 @@ TEST_F(JsonReaderTest, ByteRange)
   // Initialize parsing options (reading json lines)
   cudf::io::json_reader_options json_lines_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.c_str(), json_string.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(json_string.data()), json_string.size())})
       .compression(cudf::io::compression_type::NONE)
       .lines(true);
 

--- a/cpp/tests/io/json_test.cpp
+++ b/cpp/tests/io/json_test.cpp
@@ -253,7 +253,9 @@ struct JsonValidFixedPointReaderTest : public JsonFixedPointReaderTest<DecimalTy
                         return acc + (acc.empty() ? "" : "\n") + "{\"col0\":" + rhs + "}";
                       });
     cudf::io::json_reader_options const in_opts =
-      cudf::io::json_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+      cudf::io::json_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
         .dtypes({data_type{type_to_id<DecimalType>(), scale}})
         .lines(true)
         .legacy(use_legacy_parser);
@@ -300,7 +302,9 @@ TEST_P(JsonReaderParamTest, BasicJsonLines)
   std::string data = is_row_orient_test(test_opt) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(data.data()), data.size())})
       .dtypes(std::vector<data_type>{dtype<int32_t>(), dtype<double>()})
       .lines(true)
       .legacy(is_legacy_test(test_opt));
@@ -377,7 +381,9 @@ TEST_P(JsonReaderParamTest, JsonLinesStrings)
   std::string data          = is_row_orient_test(test_opt) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(data.data()), data.size())})
       .dtypes({{"2", dtype<cudf::string_view>()}, {"0", dtype<int32_t>()}, {"1", dtype<double>()}})
       .lines(true)
       .legacy(is_legacy_test(test_opt));
@@ -642,7 +648,9 @@ TEST_P(JsonReaderParamTest, JsonLinesDtypeInference)
   std::string data          = is_row_orient_test(test_opt) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(data.data()), data.size())})
       .lines(true)
       .legacy(is_legacy_test(test_opt));
 
@@ -764,7 +772,9 @@ TEST_P(JsonReaderDualTest, JsonLinesObjectsStrings)
   auto const test_opt    = GetParam();
   auto test_json_objects = [test_opt](std::string const& data) {
     cudf::io::json_reader_options in_options =
-      cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+      cudf::io::json_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(data.data()), data.size())})
         .lines(true)
         .legacy(is_legacy_test(test_opt));
 
@@ -807,7 +817,9 @@ TEST_P(JsonReaderDualTest, JsonLinesObjectsMissingData)
     "{              \"col2\":1.1, \"col3\":\"aaa\"}\n"
     "{\"col1\":200,               \"col3\":\"bbb\"}\n";
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(data.data()), data.size())})
       .lines(true)
       .legacy(is_legacy_test(test_opt));
 
@@ -844,7 +856,9 @@ TEST_P(JsonReaderDualTest, JsonLinesObjectsOutOfOrder)
     "{\"col3\":\"bbb\", \"col1\":200, \"col2\":2.2}\n";
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(data.data()), data.size())})
       .lines(true)
       .legacy(is_legacy_test(test_opt));
 
@@ -989,7 +1003,9 @@ TEST_P(JsonReaderParamTest, StringInference)
   std::string data          = is_row_orient_test(test_opt) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.c_str(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(data.data()), data.size())})
       .lines(true)
       .legacy(is_legacy_test(test_opt));
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
@@ -1244,7 +1260,9 @@ TEST_F(JsonReaderTest, BadDtypeParams)
   std::string buffer = "[1,2,3,4]";
 
   cudf::io::json_reader_options options_vec =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
       .lines(true)
       .dtypes({dtype<int8_t>()})
       .legacy(true);
@@ -1253,7 +1271,9 @@ TEST_F(JsonReaderTest, BadDtypeParams)
   EXPECT_THROW(cudf::io::read_json(options_vec), cudf::logic_error);
 
   cudf::io::json_reader_options options_map =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
       .lines(true)
       .legacy(true)
       .dtypes(std::map<std::string, cudf::data_type>{{"0", dtype<int8_t>()},
@@ -1302,7 +1322,8 @@ TEST_F(JsonReaderTest, JsonExperimentalLines)
   // Initialize parsing options (reading json lines)
   cudf::io::json_reader_options json_lines_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.c_str(), json_string.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(json_string.data()), json_string.size())})
       .lines(true);
 
   // Read test data via nested JSON reader
@@ -1330,7 +1351,8 @@ TEST_F(JsonReaderTest, TokenAllocation)
     // Initialize parsing options (reading json lines)
     cudf::io::json_reader_options json_lines_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.c_str(), json_string.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(json_string.data()), json_string.size())})
         .lines(true);
 
     EXPECT_NO_THROW(cudf::io::read_json(json_lines_options));
@@ -1358,7 +1380,8 @@ TEST_F(JsonReaderTest, ExperimentalLinesNoOmissions)
     // Initialize parsing options (reading json lines)
     cudf::io::json_reader_options json_lines_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.c_str(), json_string.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(json_string.data()), json_string.size())})
         .lines(true);
 
     // Read test data via nested JSON reader
@@ -1391,7 +1414,8 @@ TEST_F(JsonReaderTest, TestColumnOrder)
   // Initialize parsing options (reading json lines)
   cudf::io::json_reader_options json_lines_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.c_str(), json_string.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(json_string.data()), json_string.size())})
       .lines(true);
 
   // Read in data using nested JSON reader
@@ -1449,7 +1473,9 @@ TEST_P(JsonReaderParamTest, JsonDtypeSchema)
   std::map<std::string, cudf::io::schema_element> dtype_schema{
     {"2", {dtype<cudf::string_view>()}}, {"0", {dtype<int32_t>()}}, {"1", {dtype<double>()}}};
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(data.data()), data.size())})
       .dtypes(dtype_schema)
       .lines(true)
       .legacy(is_legacy_test(test_opt));
@@ -1490,7 +1516,8 @@ TEST_F(JsonReaderTest, JsonNestedDtypeSchema)
 
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.data(), json_string.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(json_string.data()), json_string.size())})
       .dtypes(dtype_schema)
       .lines(false);
 
@@ -1647,7 +1674,9 @@ TEST_P(JsonReaderParamTest, JsonDtypeParsing)
   for (size_t col_type = 0; col_type < cols.size(); col_type++) {
     std::map<std::string, cudf::io::schema_element> dtype_schema{{"0", {dtypes[col_type]}}};
     cudf::io::json_reader_options in_options =
-      cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+      cudf::io::json_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(data.data()), data.size())})
         .dtypes(dtype_schema)
         .lines(true)
         .legacy(is_legacy_test(test_opt));
@@ -1687,7 +1716,9 @@ TYPED_TEST(JsonFixedPointReaderTest, EmptyValues)
   auto const buffer = std::string{"{\"col0\":}"};
 
   cudf::io::json_reader_options const in_opts =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size())})
       .dtypes({data_type{type_to_id<TypeParam>(), 0}})
       .lines(true)
       .legacy(true);  // Legacy behavior; not aligned with JSON specs
@@ -1704,8 +1735,9 @@ TYPED_TEST(JsonFixedPointReaderTest, EmptyValues)
 TEST_F(JsonReaderTest, UnsupportedMultipleFileInputs)
 {
   std::string const data = "{\"col\":0}";
-  auto const buffer      = cudf::io::host_buffer{data.data(), data.size()};
-  auto const src         = cudf::io::source_info{{buffer, buffer}};
+  auto const buffer =
+    cudf::host_span<std::byte const>(reinterpret_cast<std::byte const*>(data.data()), data.size());
+  auto const src = cudf::io::source_info{{buffer, buffer}};
 
   cudf::io::json_reader_options const not_lines_opts = cudf::io::json_reader_options::builder(src);
   EXPECT_THROW(cudf::io::read_json(not_lines_opts), cudf::logic_error);
@@ -1735,7 +1767,8 @@ TEST_F(JsonReaderTest, TrailingCommas)
     // Initialize parsing options (reading json lines)
     cudf::io::json_reader_options json_parser_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.c_str(), json_string.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>(
+          reinterpret_cast<std::byte const*>(json_string.data()), json_string.size())})
         .lines(true);
     EXPECT_NO_THROW(cudf::io::read_json(json_parser_options)) << "Failed on test case " << i;
   }
@@ -1747,9 +1780,10 @@ TEST_F(JsonReaderTest, TrailingCommas)
     R"([{"a": 1,}, {"a": null, "b": [null,],}])",
   };
   for (size_t i = 0; i < json_valid.size(); i++) {
-    auto const& json_string                           = json_valid[i];
-    cudf::io::json_reader_options json_parser_options = cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.c_str(), json_string.size()});
+    auto const& json_string = json_valid[i];
+    cudf::io::json_reader_options json_parser_options =
+      cudf::io::json_reader_options::builder(cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(json_string.data()), json_string.size())});
     EXPECT_NO_THROW(cudf::io::read_json(json_parser_options)) << "Failed on test case " << i;
   }
 
@@ -1764,9 +1798,10 @@ TEST_F(JsonReaderTest, TrailingCommas)
     R"([{,,}])",
   };
   for (size_t i = 0; i < json_invalid.size(); i++) {
-    auto const& json_string                           = json_invalid[i];
-    cudf::io::json_reader_options json_parser_options = cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.c_str(), json_string.size()});
+    auto const& json_string = json_invalid[i];
+    cudf::io::json_reader_options json_parser_options =
+      cudf::io::json_reader_options::builder(cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(json_string.data()), json_string.size())});
     EXPECT_THROW(cudf::io::read_json(json_parser_options), cudf::logic_error)
       << "Failed on test case " << i;
   }

--- a/cpp/tests/io/parquet_test.cpp
+++ b/cpp/tests/io/parquet_test.cpp
@@ -1109,7 +1109,8 @@ TEST_F(ParquetWriterTest, BufferSource)
   // host buffer
   {
     cudf::io::parquet_reader_options in_opts = cudf::io::parquet_reader_options::builder(
-      cudf::io::source_info(out_buffer.data(), out_buffer.size()));
+      cudf::io::source_info(cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(out_buffer.data()), out_buffer.size())));
     const auto result = cudf::io::read_parquet(in_opts);
 
     CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
@@ -1411,7 +1412,8 @@ TEST_F(ParquetWriterTest, CustomDataSink)
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 
   cudf::io::parquet_reader_options buf_args = cudf::io::parquet_reader_options::builder(
-    cudf::io::source_info{buf_sink.data(), buf_sink.size()});
+    cudf::io::source_info{cudf::host_span<std::byte const>(
+      reinterpret_cast<std::byte const*>(buf_sink.data()), buf_sink.size())});
   auto buf_tbl = cudf::io::read_parquet(buf_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(buf_tbl.tbl->view(), expected->view());
 }
@@ -2456,8 +2458,9 @@ TEST_F(ParquetWriterStressTest, LargeTableWeakCompression)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>(
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size())});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -2477,8 +2480,9 @@ TEST_F(ParquetWriterStressTest, LargeTableGoodCompression)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>(
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size())});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -2498,8 +2502,9 @@ TEST_F(ParquetWriterStressTest, LargeTableWithValids)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>(
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size())});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -2519,8 +2524,9 @@ TEST_F(ParquetWriterStressTest, DeviceWriteLargeTableWeakCompression)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>(
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size())});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -2540,8 +2546,9 @@ TEST_F(ParquetWriterStressTest, DeviceWriteLargeTableGoodCompression)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>(
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size())});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -2561,8 +2568,9 @@ TEST_F(ParquetWriterStressTest, DeviceWriteLargeTableWithValids)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>(
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size())});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -3265,7 +3273,8 @@ TEST_F(ParquetReaderTest, DecimalRead)
     unsigned int decimals_parquet_len = 2366;
 
     cudf::io::parquet_reader_options read_opts = cudf::io::parquet_reader_options::builder(
-      cudf::io::source_info{reinterpret_cast<const char*>(decimals_parquet), decimals_parquet_len});
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(decimals_parquet), decimals_parquet_len)});
     auto result = cudf::io::read_parquet(read_opts);
 
     auto validity =
@@ -3407,9 +3416,9 @@ TEST_F(ParquetReaderTest, DecimalRead)
 
     unsigned int parquet_len = 1226;
 
-    cudf::io::parquet_reader_options read_opts =
-      cudf::io::parquet_reader_options::builder(cudf::io::source_info{
-        reinterpret_cast<const char*>(fixed_len_bytes_decimal_parquet), parquet_len});
+    cudf::io::parquet_reader_options read_opts = cudf::io::parquet_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(fixed_len_bytes_decimal_parquet), parquet_len)});
     auto result = cudf::io::read_parquet(read_opts);
     EXPECT_EQ(result.tbl->view().num_columns(), 3);
 
@@ -4598,7 +4607,8 @@ TEST_F(ParquetReaderTest, EmptyColumnsParam)
 
   cudf::io::parquet_reader_options read_opts =
     cudf::io::parquet_reader_options::builder(
-      cudf::io::source_info{out_buffer.data(), out_buffer.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>(
+        reinterpret_cast<std::byte const*>(out_buffer.data()), out_buffer.size())})
       .columns({});
   auto const result = cudf::io::read_parquet(read_opts);
 

--- a/cpp/tests/io/text/data_chunk_source_test.cpp
+++ b/cpp/tests/io/text/data_chunk_source_test.cpp
@@ -99,9 +99,9 @@ void test_source(const std::string& content, const cudf::io::text::data_chunk_so
 TEST_F(DataChunkSourceTest, DataSourceHost)
 {
   std::string const content = "host buffer source";
-  auto const datasource =
-    cudf::io::datasource::create(cudf::io::host_buffer{content.data(), content.size()});
-  auto const source = cudf::io::text::make_source(*datasource);
+  auto const datasource     = cudf::io::datasource::create(cudf::host_span<std::byte const>(
+    reinterpret_cast<std::byte const*>(content.data()), content.size()));
+  auto const source         = cudf::io::text::make_source(*datasource);
 
   test_source(content, *source);
 }


### PR DESCRIPTION
## Description

Closes #12576

This change converts `cudf::io::source_info` to take a `host_span` of `std::byte`.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
