### PR TITLE
Handle when spillable buffers own each other 

### DIFF
--- a/python/cudf/cudf/core/buffer/spillable_buffer.py
+++ b/python/cudf/cudf/core/buffer/spillable_buffer.py
@@ -27,6 +27,14 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound="SpillableBuffer")
 
 
+def as_spillable_buffer(obj, exposed) -> SpillableBuffer:
+    if hasattr(obj, "__cuda_array_interface__"):
+        return SpillableBuffer._from_device_memory(obj, exposed=exposed)
+    if exposed:
+        raise ValueError("cannot created exposed host memory")
+    return SpillableBuffer._from_host_memory(obj)
+
+
 class SpillLock:
     pass
 

--- a/python/cudf/cudf/core/buffer/spillable_buffer.py
+++ b/python/cudf/cudf/core/buffer/spillable_buffer.py
@@ -72,7 +72,9 @@ def as_spillable_buffer(data, exposed: bool) -> SpillableBuffer:
 
     If `data` is owned by a spillable buffer, a "slice" of the buffer is
     returned. In this case, the spillable buffer must either be "exposed" or
-    spilled locked (called within an acquire_spill_lock context).
+    spilled locked (called within an acquire_spill_lock context). This is to
+    guarantee that the memory of `data` isn't spilled before this function gets
+    to calculate the offset of the new slice.
 
     It is illegal for a spillable buffer to own another spillable buffer.
 

--- a/python/cudf/cudf/core/buffer/spillable_buffer.py
+++ b/python/cudf/cudf/core/buffer/spillable_buffer.py
@@ -7,7 +7,16 @@ import pickle
 import time
 import weakref
 from threading import RLock
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+)
 
 import numpy
 
@@ -16,6 +25,7 @@ import rmm
 from cudf.core.buffer.buffer import (
     Buffer,
     cuda_array_interface_wrapper,
+    get_ptr_and_size,
     host_memory_allocation,
 )
 from cudf.utils.string import format_bytes
@@ -27,12 +37,82 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound="SpillableBuffer")
 
 
-def as_spillable_buffer(obj, exposed) -> SpillableBuffer:
-    if hasattr(obj, "__cuda_array_interface__"):
-        return SpillableBuffer._from_device_memory(obj, exposed=exposed)
-    if exposed:
-        raise ValueError("cannot created exposed host memory")
-    return SpillableBuffer._from_host_memory(obj)
+def get_spillable_owner(data) -> Optional[SpillableBuffer]:
+    """Get the spillable owner of `data`, if any exist
+
+    Search through the stack of data owners in order to find an
+    owner of type `SpillableBuffer` (not subclasses).
+
+    Parameters
+    ----------
+    data : buffer-like or array-like
+        A buffer-like or array-like object that represent C-contiguous memory.
+
+    Return
+    ------
+    SpillableBuffer or None
+        The owner of `data` if spillable or None.
+    """
+
+    if type(data) is SpillableBuffer:
+        return data
+    if hasattr(data, "owner"):
+        return get_spillable_owner(data.owner)
+    return None
+
+
+def as_spillable_buffer(data, exposed: bool) -> SpillableBuffer:
+    """Factory function to wrap `data` in a SpillableBuffer object.
+
+    If `data` isn't a buffer already, a new buffer that points to the memory of
+    `data` is created. If `data` represents host memory, it is copied to a new
+    `rmm.DeviceBuffer` device allocation. Otherwise, the memory of `data` is
+    **not** copied, instead the new buffer keeps a reference to `data` in order
+    to retain its lifetime.
+
+    If `data` is owned by a spillable buffer, a "slice" of the buffer is
+    returned. In this case, the spillable buffer must either be "exposed" or
+    spilled locked (called within an acquire_spill_lock context).
+
+    It is illegal for a spillable buffer to own another spillable buffer.
+
+    Parameters
+    ----------
+    data : buffer-like or array-like
+        A buffer-like or array-like object that represent C-contiguous memory.
+    exposed : bool, optional
+        Mark the buffer as permanently exposed (unspillable).
+
+    Return
+    ------
+    SpillableBuffer
+        A spillabe buffer instance that represents the device memory of `data`.
+    """
+
+    from cudf.core.buffer.utils import get_spill_lock
+
+    if not hasattr(data, "__cuda_array_interface__"):
+        if exposed:
+            raise ValueError("cannot created exposed host memory")
+        return SpillableBuffer._from_host_memory(data)
+
+    spillable_owner = get_spillable_owner(data)
+    if spillable_owner is None:
+        return SpillableBuffer._from_device_memory(data, exposed=exposed)
+
+    if not spillable_owner.exposed and get_spill_lock() is None:
+        raise ValueError(
+            "A owning spillable buffer must "
+            "either be exposed or spilled locked."
+        )
+
+    # At this point, we know that `data` is owned by a spillable buffer,
+    # which is exposed or spilled locked.
+    ptr, size = get_ptr_and_size(data.__cuda_array_interface__)
+    base_ptr = spillable_owner.memory_info()[0]
+    return SpillableBufferSlice(
+        spillable_owner, offset=ptr - base_ptr, size=size
+    )
 
 
 class SpillLock:

--- a/python/cudf/cudf/core/buffer/utils.py
+++ b/python/cudf/cudf/core/buffer/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 from cudf.core.buffer.buffer import Buffer, cuda_array_interface_wrapper
 from cudf.core.buffer.spill_manager import get_global_manager
-from cudf.core.buffer.spillable_buffer import SpillableBuffer, SpillLock
+from cudf.core.buffer.spillable_buffer import SpillLock, as_spillable_buffer
 
 
 def as_buffer(
@@ -72,11 +72,7 @@ def as_buffer(
         )
 
     if get_global_manager() is not None:
-        if hasattr(data, "__cuda_array_interface__"):
-            return SpillableBuffer._from_device_memory(data, exposed=exposed)
-        if exposed:
-            raise ValueError("cannot created exposed host memory")
-        return SpillableBuffer._from_host_memory(data)
+        return as_spillable_buffer(data, exposed=exposed)
 
     if hasattr(data, "__cuda_array_interface__"):
         return Buffer._from_device_memory(data)


### PR DESCRIPTION
#12587 exposed a bug triggered when `as_buffer()` is given a pointer already owned by another spillable buffer. In this PR, we make this illegal and return a `SpillableBufferSlice` instead. 

cc. @galipremsagar 

#### Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
