### PR TITLE
Install gdb via conda-forge in the test environment

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -304,6 +304,7 @@ dependencies:
           - python-snappy>=0.6.0
           - s3fs>=2022.3.0
           - scipy
+          - gdb
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
## Description

Since #12545, we use cuda-gdb for scripting (since that is already installed in the nvidia/cuda:-devel docker images) to check that RAPIDS_NO_INITIALIZE ensured that cuInit is not called on import.

Unfortunately, the official cuda-gdb-11-2 package for Debian-based systems does not correctly advertise all its dependencies (we need to manually install libtinfo5 and libncursesw5). Consequently cuda-gdb does not work if the base image rapids builds against is for CUDA 11.2.

To workaround this, just ask conda to install gdb for us, since we don't actually need any cuda-gdb features.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
