### PR TITLE
[REVIEW] Fix a mask data corruption in UDF

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2124,7 +2124,9 @@ class IndexedFrame(Frame):
 
         # Mask and data column preallocated
         ans_col = _return_arr_from_dtype(retty, len(self))
-        ans_mask = cudf.core.column.column_empty(len(self), dtype="bool")
+        ans_mask = cudf.core.column.full(
+            size=len(self), fill_value=True, dtype="bool"
+        )
         output_args = [(ans_col, ans_mask), len(self)]
         input_args = _get_input_args_from_frame(self)
         launch_args = output_args + input_args + list(args)


### PR DESCRIPTION
## Description

This PR fixes a mask data corruption issue encountered while working on https://github.com/rapidsai/cudf/pull/12619.

`column_empty` actually returns un-initialized values, but we would want a fully initialized mask column here. Hence it is very inconsistent to test for a failure here, which is the reason it has been passing in CI and many of the local builds.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
