### PR TITLE
Pin wheel dependencies to same RAPIDS release

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -87,3 +87,10 @@ sed_runner "s/CUDF_TAG branch-${CURRENT_SHORT_TAG}/CUDF_TAG branch-${NEXT_SHORT_
 # ucx-py version update
 sed_runner "s/export UCX_PY_VERSION=.*/export UCX_PY_VERSION='${NEXT_UCX_PY_VERSION}'/g" ci/gpu/build.sh
 sed_runner "s/export UCX_PY_VERSION=.*/export UCX_PY_VERSION='${NEXT_UCX_PY_VERSION}'/g" ci/gpu/java.sh
+
+# Need to distutils-normalize the original version
+NEXT_SHORT_TAG_PEP440=$(python -c "from setuptools.extern import packaging; print(packaging.version.Version('${NEXT_SHORT_TAG}'))")
+
+# Wheel builds install intra-RAPIDS dependencies from same release
+sed_runner "s/rmm{cuda_suffix}.*\",/rmm{cuda_suffix}==${NEXT_SHORT_TAG_PEP440}.*\",/g" python/cudf/setup.py
+sed_runner "s/cudf{cuda_suffix}==.*\",/cudf{cuda_suffix}==${NEXT_SHORT_TAG_PEP440}.*\",/g" python/dask_cudf/setup.py

--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "typing_extensions",
     # Allow floating minor versions for Arrow.
     "pyarrow==10",
-    f"rmm{cuda_suffix}",
+    f"rmm{cuda_suffix}==23.2.*",
     f"ptxcompiler{cuda_suffix}",
     f"cubinlinker{cuda_suffix}",
     "cupy-cuda11x",

--- a/python/dask_cudf/setup.py
+++ b/python/dask_cudf/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     "fsspec>=0.6.0",
     "numpy",
     "pandas>=1.0,<1.6.0dev0",
-    f"cudf{cuda_suffix}",
+    f"cudf{cuda_suffix}==23.2.*",
     "cupy-cuda11x",
 ]
 


### PR DESCRIPTION
Now that wheel CI is enabled, the nightly index will contain next release wheels, so we need to ensure those don't get installed while still building this release.