### PR TITLE
Don't upload `libcudf-example` to Anaconda.org

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,7 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
+      skip_upload_pkgs: libcudf-example
   wheel-build-cudf:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@cuda-118


### PR DESCRIPTION
When initially created, the GitHub Actions scripts that upload conda packages would upload all packages that were built indiscriminately.

As a result, the `libcudf-example` package has been uploading to Anaconda.org. It was not previously uploaded to Anaconda.org prior to migrating to GitHub Actions.

While this isn't a huge deal, I recently added some functionality ([here](https://github.com/rapidsai/shared-action-workflows/pull/33)) that allows us to specify package names that shouldn't be uploaded to Anaconda.org in our workflows.

This PR adds the `libcudf-example` package to the list of packages that should not be uploaded to Anaconda.org
