### PR TITLE
[JNI] Remove child fom newCudaAsyncMemoryResource

### DIFF
--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -549,8 +549,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releaseArenaMemoryResource(JNIEnv
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newCudaAsyncMemoryResource(JNIEnv *env,
-                                                                           jclass clazz,
-                                                                           jlong init,
+                                                                           jclass clazz, jlong init,
                                                                            jlong release) {
   try {
     cudf::jni::auto_set_device(env);

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -550,9 +550,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releaseArenaMemoryResource(JNIEnv
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newCudaAsyncMemoryResource(JNIEnv *env,
                                                                            jclass clazz,
-                                                                           jlong child, jlong init,
+                                                                           jlong init,
                                                                            jlong release) {
-  JNI_NULL_CHECK(env, child, "child is null", 0);
   try {
     cudf::jni::auto_set_device(env);
     auto ret = new rmm::mr::cuda_async_memory_resource(init, release);


### PR DESCRIPTION
Fixes a bug introduced here https://github.com/rapidsai/cudf/pull/12632 where the C++ version of the jni call `Rmm.newCudaAsyncMemoryResource` was taking an extra argument (`child`), causing the `threshold` to be set to a random value since the calling code defined the native method has taking 2 longs, not 3.

The above can affect performance if the threshold is set to 0 for example. The async pool will reduce its footprint by releasing memory, which means we need to go back and reallocate. This is how I found it.

I am starting the build process for this, so it's going to take me a bit to test.