### PR TITLE
Remove DataFrame.quantiles from docs.

### DIFF
--- a/docs/cudf/source/api_docs/dataframe.rst
+++ b/docs/cudf/source/api_docs/dataframe.rst
@@ -146,7 +146,6 @@ Computations / descriptive stats
    DataFrame.prod
    DataFrame.product
    DataFrame.quantile
-   DataFrame.quantiles
    DataFrame.rank
    DataFrame.round
    DataFrame.skew


### PR DESCRIPTION
## Description
Removes documentation for `DataFrame.quantiles`, which was deprecated and then removed in #12281. This issue was discovered while building the docs in #12592.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
