### PR TITLE
Remove outdated doc references

### DIFF
--- a/docs/cudf/source/api_docs/index_objects.rst
+++ b/docs/cudf/source/api_docs/index_objects.rst
@@ -21,19 +21,14 @@ Properties
 .. autosummary::
    :toctree: api/
 
-   Index.empty
    Index.has_duplicates
    Index.duplicated
    Index.hasnans
    Index.is_monotonic
    Index.is_monotonic_increasing
    Index.is_monotonic_decreasing
-   Index.is_unique
-   Index.name
    Index.names
-   Index.ndim
    Index.nlevels
-   Index.shape
    Index.size
    Index.values
 
@@ -45,21 +40,15 @@ Modifying and computations
    Index.any
    Index.copy
    Index.drop_duplicates
-   Index.equals
-   Index.factorize
    Index.is_boolean
    Index.is_categorical
    Index.is_floating
    Index.is_integer
    Index.is_interval
-   Index.is_mixed
    Index.is_numeric
    Index.is_object
-   Index.min
-   Index.max
    Index.rename
    Index.repeat
-   Index.where
    Index.take
    Index.unique
 
@@ -80,23 +69,11 @@ Missing values
    Index.isna
    Index.notna
 
-Memory usage
-~~~~~~~~~~~~
-.. autosummary::
-   :toctree: api/
-
-   Index.memory_usage
-
 Conversion
 ~~~~~~~~~~
 .. autosummary::
    :toctree: api/
 
-   Index.astype
-   Index.to_arrow
-   Index.to_cupy
-   Index.to_list
-   Index.to_numpy
    Index.to_series
    Index.to_frame
    Index.to_pandas
@@ -109,16 +86,7 @@ Sorting
 .. autosummary::
    :toctree: api/
 
-   Index.argsort
-   Index.searchsorted
    Index.sort_values
-
-Time-specific operations
-~~~~~~~~~~~~~~~~~~~~~~~~
-.. autosummary::
-   :toctree: api/
-
-   Index.shift
 
 Combining / joining / set operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/cudf/source/api_docs/series.rst
+++ b/docs/cudf/source/api_docs/series.rst
@@ -102,7 +102,6 @@ Function application, GroupBy & window
    :toctree: api/
 
    Series.apply
-   Series.applymap
    Series.map
    Series.groupby
    Series.rolling
@@ -359,7 +358,6 @@ the ``Series.cat`` accessor.
        Series.str
        Series.cat
        Series.dt
-       Index.str
 
 
 Serialization / IO / conversion

--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -51,8 +51,8 @@ extensions = [
     "myst_nb",
 ]
 
-jupyter_execute_notebooks = "force"
-execution_timeout = 300
+nb_execution_mode = "force"
+nb_execution_timeout = 300
 
 copybutton_prompt_text = ">>> "
 autosummary_generate = True


### PR DESCRIPTION
## Description
Removes documentation for deprecated references. This issue was discovered while building the docs in #12592.

See https://github.com/rapidsai/cudf/pull/12684