### PR TITLE
Allow setting the seed argument for hash partition

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -4265,8 +4265,7 @@ public final class Table implements AutoCloseable {
      *             besides IDENTITY and MURMUR3.
      * @param numberOfPartitions number of partitions to use
      * @param seed the seed value for hashing
-     * @return Table that exposes a limited functionality of the
-     * {@link Table} class
+     * @return Table that exposes a limited functionality of the {@link Table} class
      */
     public PartitionedTable hashPartition(HashType type, int numberOfPartitions, int seed) {
       int[] partitionOffsets = new int[numberOfPartitions];

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -4265,7 +4265,7 @@ public final class Table implements AutoCloseable {
      *             besides IDENTITY and MURMUR3.
      * @param numberOfPartitions - number of partitions to use
      * @param seed - the seed of hash algorithm
-     * @return {@link PartitionedTable} - Table that exposes a limited functionality of the
+     * @return Table that exposes a limited functionality of the
      * {@link Table} class
      */
     public PartitionedTable hashPartition(HashType type, int numberOfPartitions, int seed) {

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -4263,8 +4263,8 @@ public final class Table implements AutoCloseable {
      * @param type the type of hash to use. Depending on the type of hash different restrictions
      *             on the hash column(s) may exist. Not all hash functions are guaranteed to work
      *             besides IDENTITY and MURMUR3.
-     * @param numberOfPartitions - number of partitions to use
-     * @param seed - the seed of hash algorithm
+     * @param numberOfPartitions number of partitions to use
+     * @param seed the seed value for hashing
      * @return Table that exposes a limited functionality of the
      * {@link Table} class
      */

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -194,6 +194,7 @@ public final class Table implements AutoCloseable {
                                              int[] columnsToHash,
                                              int hashTypeId,
                                              int numberOfPartitions,
+                                             int seed,
                                              int[] outputOffsets) throws CudfException;
 
   private static native long[] roundRobinPartition(long inputTable,
@@ -4253,12 +4254,28 @@ public final class Table implements AutoCloseable {
      * {@link Table} class
      */
     public PartitionedTable hashPartition(HashType type, int numberOfPartitions) {
+      final int DEFAULT_HASH_SEED = 0;
+      return hashPartition(type, numberOfPartitions, DEFAULT_HASH_SEED);
+    }
+
+    /**
+     * Hash partition a table into the specified number of partitions.
+     * @param type the type of hash to use. Depending on the type of hash different restrictions
+     *             on the hash column(s) may exist. Not all hash functions are guaranteed to work
+     *             besides IDENTITY and MURMUR3.
+     * @param numberOfPartitions - number of partitions to use
+     * @param seed - the seed of hash algorithm
+     * @return {@link PartitionedTable} - Table that exposes a limited functionality of the
+     * {@link Table} class
+     */
+    public PartitionedTable hashPartition(HashType type, int numberOfPartitions, int seed) {
       int[] partitionOffsets = new int[numberOfPartitions];
       return new PartitionedTable(new Table(Table.hashPartition(
           operation.table.nativeHandle,
           operation.indices,
           type.nativeId,
           partitionOffsets.length,
+          seed,
           partitionOffsets)), partitionOffsets);
     }
   }

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -2661,8 +2661,6 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_hashPartition(
   JNI_NULL_CHECK(env, columns_to_hash, "columns_to_hash is null", NULL);
   JNI_NULL_CHECK(env, output_offsets, "output_offsets is null", NULL);
   JNI_ARG_CHECK(env, number_of_partitions > 0, "number_of_partitions is zero", NULL);
-  // For simplicity of converting a signed int to a unsigned int
-  JNI_ARG_CHECK(env, seed >= 0, "seed is negative", NULL);
 
   try {
     cudf::jni::auto_set_device(env);

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -2675,9 +2675,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_hashPartition(
     std::vector<cudf::size_type> columns_to_hash_vec(n_columns_to_hash.begin(),
                                                      n_columns_to_hash.end());
 
-    auto [partitioned_table, partition_offsets] =
-        cudf::hash_partition(*n_input_table, columns_to_hash_vec, number_of_partitions, hash_func,
-                             hash_seed);
+    auto [partitioned_table, partition_offsets] = cudf::hash_partition(
+        *n_input_table, columns_to_hash_vec, number_of_partitions, hash_func, hash_seed);
 
     cudf::jni::native_jintArray n_output_offsets(env, output_offsets);
     std::copy(partition_offsets.begin(), partition_offsets.end(), n_output_offsets.begin());


### PR DESCRIPTION
Signed-off-by: Liangcai Li <firestarmanllc@gmail.com>

## Description
This PR is exposing the `seed` parameter for the JNI hash partition APIs to support customizing the hash algorithm seed.

The existing tests should cover this change.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
