### PR TITLE
Add build dependencies to Java tests.

### DIFF
--- a/ci/test_java.sh
+++ b/ci/test_java.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -12,6 +12,8 @@ rapids-dependency-file-generator \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch)" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n test
+
+export CMAKE_GENERATOR=Ninja
 
 # Temporarily allow unbound variables for conda activation.
 set +u

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -28,6 +28,7 @@ files:
   test_java:
     output: none
     includes:
+      - build
       - cudatoolkit
       - test_java
   test_notebooks:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -28,7 +28,6 @@ files:
   test_java:
     output: none
     includes:
-      - build
       - cudatoolkit
       - test_java
   test_notebooks:
@@ -272,6 +271,7 @@ dependencies:
         packages:
           - *cmake_ver
           - maven
+          - ninja
           - openjdk=8.*
     specific:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -28,6 +28,7 @@ files:
   test_java:
     output: none
     includes:
+      - build
       - cudatoolkit
       - test_java
   test_notebooks:
@@ -271,7 +272,6 @@ dependencies:
         packages:
           - *cmake_ver
           - maven
-          - ninja
           - openjdk=8.*
     specific:
       - output_types: conda


### PR DESCRIPTION
## Description
The `latest` CI container was recently updated from CUDA 11.5 to CUDA 11.8. Due to some changes in the image, there are no compilers or `make`. To address this, I added the `build` dependency list to the `test_java` file in `dependencies.yaml`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
