### PR TITLE
Fix comparisons for `experimental::lexicographical::two_table_comparator`

### DIFF
--- a/cpp/include/cudf/lists/detail/dremel.hpp
+++ b/cpp/include/cudf/lists/detail/dremel.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,15 @@
 #include <rmm/device_uvector.hpp>
 
 namespace cudf::detail {
+
+/**
+ * @brief Get a flattened representation of the nullability of a nested column
+ *        and its children
+ *
+ * @param h_col column_view
+ * @return nullability
+ */
+std::vector<std::uint8_t> get_nested_nullability(column_view h_col);
 
 /**
  * @brief Device view for `dremel_data`.

--- a/cpp/src/lists/dremel.cu
+++ b/cpp/src/lists/dremel.cu
@@ -171,9 +171,7 @@ dremel_data get_dremel_data(column_view h_col,
   std::vector<uint8_t> start_at_sub_level;
   uint8_t curr_nesting_level_idx = 0;
 
-  if (nullability.empty()) {
-    nullability = get_nested_nullability(h_col);
-  }
+  if (nullability.empty()) { nullability = get_nested_nullability(h_col); }
 
   auto add_def_at_level = [&](column_view col) {
     // Add up all def level contributions in this column all the way till the first list column

--- a/cpp/src/lists/dremel.cu
+++ b/cpp/src/lists/dremel.cu
@@ -173,13 +173,7 @@ dremel_data get_dremel_data(column_view h_col,
 
   if (nullability.empty()) {
     nullability = get_nested_nullability(h_col);
-    // while (is_nested(curr_col.type())) {
-    //   nullability.push_back(curr_col.nullable());
-    //   curr_col = curr_col.type().id() == type_id::LIST ? curr_col.child(1) : curr_col.child(0);
-    // }
-    // nullability.push_back(curr_col.nullable());
   }
-  // curr_col = h_col;
 
   auto add_def_at_level = [&](column_view col) {
     // Add up all def level contributions in this column all the way till the first list column

--- a/cpp/src/table/row_operators.cu
+++ b/cpp/src/table/row_operators.cu
@@ -289,6 +289,7 @@ auto list_lex_preprocess(table_view left, table_view right, rmm::cuda_stream_vie
       auto left_nullability  = detail::get_nested_nullability(left_col);
       auto right_nullability = detail::get_nested_nullability(right_col);
 
+      // ensure that either nested column's nullability is captured for both columns
       std::transform(left_nullability.begin(),
                      left_nullability.end(),
                      right_nullability.begin(),

--- a/cpp/tests/search/search_list_test.cpp
+++ b/cpp/tests/search/search_list_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -346,4 +346,67 @@ TYPED_TEST(TypedListContainsTestColumnNeedles, ListsOfStructs)
   auto const expected = bools_col{0, 1, 1, 0, 0};
   auto const result   = cudf::contains(*haystack, *needles);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result, verbosity);
+}
+
+struct ListLowerBound : public cudf::test::BaseFixture {
+};
+
+TEST_F(ListLowerBound, ListWithNulls)
+{
+  {
+    using lcw = cudf::test::lists_column_wrapper<double>;
+    using cudf::test::iterators::nulls_at;
+    lcw col1{
+      lcw{-3.45967821e+12},  // 0
+      lcw{-3.6912186e-32},   // 1
+      lcw{9.721175},         // 2
+    };
+
+    lcw val1{
+      lcw{{0, 4.22671e+32}, nulls_at({0})},
+    };
+
+    cudf::table_view input{{col1}};
+    cudf::table_view values{{val1}};
+    std::vector<cudf::order> column_order{cudf::order::ASCENDING};
+    std::vector<cudf::null_order> null_order_flags{cudf::null_order::BEFORE};
+
+    auto expect = cudf::test::fixed_width_column_wrapper<cudf::size_type>{0};
+    auto result = cudf::lower_bound(input, values, column_order, null_order_flags);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, *result);
+  }
+
+  {
+    using lcw = cudf::test::lists_column_wrapper<int32_t, int32_t>;
+    using cudf::test::iterators::nulls_at;
+    lcw col1{
+      lcw{{0}, nulls_at({0})},  // 0
+      lcw{-80},                 // 1
+      lcw{-17},                 // 2
+    };
+
+    lcw col2{
+      lcw{27},                  // 0
+      lcw{{0}, nulls_at({0})},  // 1
+      lcw{},                    // 2
+    };
+
+    lcw val1{
+      lcw{87},
+    };
+
+    lcw val2{
+      lcw{},
+    };
+
+    cudf::table_view input{{col1, col2}};
+    cudf::table_view values{{val1, val2}};
+    std::vector<cudf::order> column_order{cudf::order::ASCENDING, cudf::order::DESCENDING};
+    std::vector<cudf::null_order> null_order_flags{cudf::null_order::BEFORE,
+                                                   cudf::null_order::BEFORE};
+
+    auto expect = cudf::test::fixed_width_column_wrapper<cudf::size_type>{3};
+    auto result = cudf::lower_bound(input, values, column_order, null_order_flags);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expect, *result);
+  }
 }


### PR DESCRIPTION
Closes #12389. The reason this bug was occurring is explained at https://github.com/rapidsai/cudf/issues/12389#issuecomment-1419949751. 

This PR fixes the discrepancy in Dremel encoding for nested list-types where both tables may have different `nullabilities` in their nested columns, by enforcing a `logical OR` on the `nullability` between two columns. This ensures that the definition levels in the Dremel encoding for both tables are always formed respecting the nullability at a nesting where either column in the two tables may be `nullable`.

Doing it this way also lets us avoid changing the Dremel encoding itself, which would be a breaking change.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
