### PR TITLE
Bump pinned rapids wheel deps to 23.4

### DIFF
--- a/python/cudf/setup.py
+++ b/python/cudf/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "typing_extensions",
     # Allow floating minor versions for Arrow.
     "pyarrow==10",
-    f"rmm{cuda_suffix}==23.2.*",
+    f"rmm{cuda_suffix}==23.4.*",
     f"ptxcompiler{cuda_suffix}",
     f"cubinlinker{cuda_suffix}",
     "cupy-cuda11x",

--- a/python/dask_cudf/setup.py
+++ b/python/dask_cudf/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     "fsspec>=0.6.0",
     "numpy",
     "pandas>=1.0,<1.6.0dev0",
-    f"cudf{cuda_suffix}==23.2.*",
+    f"cudf{cuda_suffix}==23.4.*",
     "cupy-cuda11x",
 ]
 


### PR DESCRIPTION
We introduced a change to pin RAPIDS wheel dependencies to the same release version. However, branch 23.04 was created before that last PR was merged, so as of now cudf's 23.4 wheels are installing 23.2 RAPIDS dependencies. This PR updates those pins to the current release.