### PR TITLE
Automatic include sorting with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -71,7 +71,110 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IncludeBlocks: Preserve
+IncludeBlocks: Regroup
+IncludeCategories:
+  # Local includes first
+  - Regex:           '".*"'
+    Priority:        0
+  # Internal includes from non-cudf source directories
+  - Regex:           '^<benchmarks/'
+    Priority:        1
+  - Regex:           '^<binaryop/'
+    Priority:        2
+  - Regex:           '^<groupby/'
+    Priority:        2
+  - Regex:           '^<hash/'
+    Priority:        3
+  - Regex:           '^<io/'
+    Priority:        3
+  - Regex:           '^<jit_preprocessed_files/'
+    Priority:        4
+  - Regex:           '^<jit/'
+    Priority:        5
+  - Regex:           '^<join/'
+    Priority:        3
+  - Regex:           '^<lists/'
+    Priority:        3
+  - Regex:           '^<quantiles/'
+    Priority:        3
+  - Regex:           '^<reductions/'
+    Priority:        3
+  - Regex:           '^<rolling/'
+    Priority:        3
+  - Regex:           '^<sort/'
+    Priority:        3
+  - Regex:           '^<src/'
+    Priority:        3
+  - Regex:           '^<strings/'
+    Priority:        3
+  - Regex:           '^<tests/'
+    Priority:        6
+  - Regex:           '^<text/'
+    Priority:        6
+  # cudf_test, cudf, nvtext are "proper" packages
+  - Regex:           '^<cudf_test/'
+    Priority:        7
+  - Regex:           '^<cudf/'
+    Priority:        8
+  - Regex:           '^<nvtext/'
+    Priority:        9
+  # Google Benchmark and NVBench
+  - Regex:           '^<benchmark/'
+    Priority:        10
+  - Regex:           '^<nvbench/'
+    Priority:        11
+  # gmock and gtest
+  - Regex:           '^<gmock/'
+    Priority:        12
+  - Regex:           '^<gtest/'
+    Priority:        13
+  # External dependencies (rmm, cub/thrust, cuco, arrow, ...)
+  - Regex:           '^<rmm/'
+    Priority:        12
+  - Regex:           '^<kvikio/'
+    Priority:        12
+  - Regex:           '^<cub/'
+    Priority:        13
+  - Regex:           '^<cuco/'
+    Priority:        14
+  - Regex:           '^<thrust/'
+    Priority:        15
+  - Regex:           '^<arrow/'
+    Priority:        16
+  - Regex:           '^<dlpack/'
+    Priority:        17
+  - Regex:           '^<jitify2.hpp>'
+    Priority:        20
+  - Regex:           '^<librdkafka/'
+    Priority:        18
+  - Regex:           '^<nvcomp'
+    Priority:        18
+  - Regex:           '^((<|")(gtest|gmock|isl|json)/)'
+    Priority:        19
+  - Regex:           '^<zlib.h>'
+    Priority:        20
+  # CUDA Toolkit and related libraries
+  - Regex:           '^<cuda[[:alnum:]_]+.h>'
+    Priority:        21
+  - Regex:           '^<cooperative_groups'
+    Priority:        22
+  - Regex:           '^<(nvtx3/.*|nvToolsExt.h)>'
+    Priority:        23
+  # CUDA math libraries (cuBLAS, cuRAND, ...)
+  - Regex:           '<cu[[:alnum:]_]+.h>'
+    Priority:        25
+    SortPriority:    24
+  # libcu++ and C/C++ STL includes
+  - Regex:           '^<cuda/'
+    Priority:        24
+    SortPriority:    25
+  - Regex:           '<[[:alnum:]._]+>'
+    Priority:        26
+  - Regex:           '<sys/'
+    Priority:        26
+  - Regex:           '<unicode/'
+    Priority:        26
+  # Anything not listed above goes last
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
 IndentPPDirectives: None

--- a/cpp/benchmarks/stream_compaction/apply_boolean_mask.cpp
+++ b/cpp/benchmarks/stream_compaction/apply_boolean_mask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,11 @@
  */
 
 #include <benchmarks/common/generate_input.hpp>
-#include <fixture/benchmark_fixture.hpp>
-#include <synchronization/synchronization.hpp>
+#include <benchmarks/fixture/benchmark_fixture.hpp>
+#include <benchmarks/synchronization/synchronization.hpp>
 
 #include <cudf/stream_compaction.hpp>
+
 
 namespace {
 


### PR DESCRIPTION
## Description
This PR is inspired by [a comment from @wence-](https://github.com/rapidsai/cudf/pull/12705#discussion_r1099912044)

> I guess it would be nice to do this automatically with clang-format, but perhaps [`IncludeBlocks: Regroup`](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#includeblocks) plus [`IncludeCategories`](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#includecategories) leads to too many bad automated decisions.

I looked into these clang-format options and I came up with some settings that I think are pretty good.

I haven't quite finished iterating on the rule set, so I'm opening this draft just to mark my progress. If you're interested in seeing the results or tweak the rules, check out this PR and run `pre-commit run clang-format --all-files`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
