### PR TITLE
Fix bug in all-null list due to join_list_elements special handling

### DIFF
--- a/cpp/src/io/json/write_json.cu
+++ b/cpp/src/io/json/write_json.cu
@@ -438,7 +438,7 @@ struct column_to_strings_fn {
           ->view(),
         narep,
         stream_,
-        mr_);
+        rmm::mr::get_current_device_resource());
       auto const list_child_string =
         column_view(column.type(),
                     column.size(),

--- a/cpp/src/io/json/write_json.cu
+++ b/cpp/src/io/json/write_json.cu
@@ -417,21 +417,28 @@ struct column_to_strings_fn {
     auto child_view            = lists_column_view(column).get_sliced_child(stream_);
     auto constexpr child_index = lists_column_view::child_column_index;
     auto list_string           = [&]() {
-      auto child_string = [&]() {
-        if (child_view.type().id() == type_id::STRUCT) {
-          return (*this).template operator()<cudf::struct_view>(
-            child_view,
-            children_names.size() > child_index ? children_names[child_index].children
-                                                          : std::vector<column_name_info>{});
-        } else if (child_view.type().id() == type_id::LIST) {
-          return (*this).template operator()<cudf::list_view>(
-            child_view,
-            children_names.size() > child_index ? children_names[child_index].children
-                                                          : std::vector<column_name_info>{});
-        } else {
-          return cudf::type_dispatcher(child_view.type(), *this, child_view);
-        }
-      }();
+      // nulls are replaced due to special handling of all-null lists as empty lists
+      // by join_list_elements
+      auto child_string = cudf::strings::detail::replace_nulls(
+        [&]() {
+          if (child_view.type().id() == type_id::STRUCT) {
+            return (*this).template operator()<cudf::struct_view>(
+              child_view,
+              children_names.size() > child_index ? children_names[child_index].children
+                                                            : std::vector<column_name_info>{});
+          } else if (child_view.type().id() == type_id::LIST) {
+            return (*this).template operator()<cudf::list_view>(
+              child_view,
+              children_names.size() > child_index ? children_names[child_index].children
+                                                            : std::vector<column_name_info>{});
+          } else {
+            return cudf::type_dispatcher(child_view.type(), *this, child_view);
+          }
+        }()
+          ->view(),
+        narep,
+        stream_,
+        mr_);
       auto const list_child_string =
         column_view(column.type(),
                     column.size(),


### PR DESCRIPTION
## Description
All-null list is considered as empty list in `join_list_elements`. So, nulls of children are replaced by `narep` before passing to `join_list_elements` API.
Related https://github.com/rapidsai/cudf/issues/12766

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
