### PR TITLE
Fix groupby gtests coded in namespace cudf::test

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ ConfigureTest(
   groupby/count_scan_tests.cpp
   groupby/count_tests.cpp
   groupby/covariance_tests.cpp
+  groupby/groupby_test_util.cpp
   groupby/groups_tests.cpp
   groupby/keys_tests.cpp
   groupby/lists_tests.cpp

--- a/cpp/tests/groupby/argmax_tests.cpp
+++ b/cpp/tests/groupby/argmax_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,6 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
-using namespace cudf::test::iterators;
-
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_argmax_test : public cudf::test::BaseFixture {
 };
@@ -37,84 +33,85 @@ TYPED_TEST_SUITE(groupby_argmax_test, cudf::test::FixedWidthTypes);
 TYPED_TEST(groupby_argmax_test, basic)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::ARGMAX>;
 
   if (std::is_same_v<V, bool>) return;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R> expect_vals{0, 1, 2};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{0, 1, 2};
 
-  auto agg = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmax_test, zero_valid_keys)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::ARGMAX>;
 
   if (std::is_same_v<V, bool>) return;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals({3, 4, 5});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, cudf::test::iterators::all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5});
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmax_test, zero_valid_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::ARGMAX>;
 
   if (std::is_same_v<V, bool>) return;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, cudf::test::iterators::all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, cudf::test::iterators::all_nulls());
 
-  auto agg = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmax_test, null_keys_and_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::ARGMAX>;
 
   if (std::is_same_v<V, bool>) return;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 4},
-                                     {0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 4},
+                                                 {0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0});
 
   //  {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4},
+                                                        cudf::test::iterators::no_nulls());
   //  {6, 3,     5, 4, 0,   2, 1,    -}
-  fixed_width_column_wrapper<R> expect_vals({3, 4, 7, 0}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3, 4, 7, 0}, {1, 1, 1, 0});
 
-  auto agg = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
@@ -123,37 +120,36 @@ struct groupby_argmax_string_test : public cudf::test::BaseFixture {
 
 TEST_F(groupby_argmax_string_test, basic)
 {
-  using V = string_view;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using R = cudf::detail::target_type_t<cudf::string_view, cudf::aggregation::ARGMAX>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  strings_column_wrapper vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::strings_column_wrapper vals{
+    "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R> expect_vals({0, 4, 2});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0, 4, 2});
 
-  auto agg = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TEST_F(groupby_argmax_string_test, zero_valid_values)
 {
-  using V = string_view;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using R = cudf::detail::target_type_t<cudf::string_view, cudf::aggregation::ARGMAX>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::strings_column_wrapper vals({"año", "bit", "₹1"}, cudf::test::iterators::all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, cudf::test::iterators::all_nulls());
 
-  auto agg = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
@@ -163,22 +159,25 @@ struct groupby_dictionary_argmax_test : public cudf::test::BaseFixture {
 TEST_F(groupby_dictionary_argmax_test, basic)
 {
   using V = std::string;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMAX>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::ARGMAX>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
-  dictionary_column_wrapper<V>  vals{ "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
-  fixed_width_column_wrapper<K> expect_keys({ 1, 2, 3 });
-  fixed_width_column_wrapper<R> expect_vals({ 0, 4, 2 });
+  cudf::test::fixed_width_column_wrapper<K> keys{     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
+  cudf::test::dictionary_column_wrapper<V>  vals{ "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({ 1, 2, 3 });
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({ 0, 4, 2 });
   // clang-format on
 
-  test_single_agg(
-    keys, vals, expect_keys, expect_vals, cudf::make_argmax_aggregation<groupby_aggregation>());
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
-                  cudf::make_argmax_aggregation<groupby_aggregation>(),
+                  cudf::make_argmax_aggregation<cudf::groupby_aggregation>());
+  test_single_agg(keys,
+                  vals,
+                  expect_keys,
+                  expect_vals,
+                  cudf::make_argmax_aggregation<cudf::groupby_aggregation>(),
                   force_use_sort_impl::YES);
 }
 
@@ -187,74 +186,75 @@ struct groupby_argmax_struct_test : public cudf::test::BaseFixture {
 
 TEST_F(groupby_argmax_struct_test, basic)
 {
-  auto const keys = fixed_width_column_wrapper<int32_t>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
   auto const vals = [] {
-    auto child1 =
-      strings_column_wrapper{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{
+      "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto const expect_keys    = fixed_width_column_wrapper<int32_t>{1, 2, 3};
-  auto const expect_indices = fixed_width_column_wrapper<int32_t>{0, 4, 2};
+  auto const expect_keys    = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3};
+  auto const expect_indices = cudf::test::fixed_width_column_wrapper<int32_t>{0, 4, 2};
 
-  auto agg = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_indices, std::move(agg));
 }
 
 TEST_F(groupby_argmax_struct_test, slice_input)
 {
   constexpr int32_t dont_care{1};
-  auto const keys_original = fixed_width_column_wrapper<int32_t>{
+  auto const keys_original = cudf::test::fixed_width_column_wrapper<int32_t>{
     dont_care, dont_care, 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, dont_care};
   auto const vals_original = [] {
-    auto child1 = strings_column_wrapper{"dont_care",
-                                         "dont_care",
-                                         "año",
-                                         "bit",
-                                         "₹1",
-                                         "aaa",
-                                         "zit",
-                                         "bat",
-                                         "aab",
-                                         "$1",
-                                         "€1",
-                                         "wut",
-                                         "dont_care"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{
+    auto child1 = cudf::test::strings_column_wrapper{"dont_care",
+                                                     "dont_care",
+                                                     "año",
+                                                     "bit",
+                                                     "₹1",
+                                                     "aaa",
+                                                     "zit",
+                                                     "bat",
+                                                     "aab",
+                                                     "$1",
+                                                     "€1",
+                                                     "wut",
+                                                     "dont_care"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{
       dont_care, dont_care, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, dont_care};
-    return structs_column_wrapper{{child1, child2}};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   auto const keys           = cudf::slice(keys_original, {2, 12})[0];
   auto const vals           = cudf::slice(vals_original, {2, 12})[0];
-  auto const expect_keys    = fixed_width_column_wrapper<int32_t>{1, 2, 3};
-  auto const expect_indices = fixed_width_column_wrapper<int32_t>{0, 4, 2};
+  auto const expect_keys    = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3};
+  auto const expect_indices = cudf::test::fixed_width_column_wrapper<int32_t>{0, 4, 2};
 
-  auto agg = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_indices, std::move(agg));
 }
 
 TEST_F(groupby_argmax_struct_test, null_keys_and_values)
 {
   constexpr int32_t null{0};
-  auto const keys =
-    fixed_width_column_wrapper<int32_t>{{1, 2, 3, 1, 2, 2, 1, null, 3, 2, 4}, null_at(7)};
+  auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{
+    {1, 2, 3, 1, 2, 2, 1, null, 3, 2, 4}, cudf::test::iterators::null_at(7)};
   auto const vals = [] {
-    auto child1 = strings_column_wrapper{
+    auto child1 = cudf::test::strings_column_wrapper{
       "año", "bit", "₹1", "aaa", "zit", "" /*NULL*/, "" /*NULL*/, "$1", "€1", "wut", "" /*NULL*/};
-    auto child2 = fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
-    return structs_column_wrapper{{child1, child2}, nulls_at({5, 6, 10})};
+    auto child2 =
+      cudf::test::fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
+    return cudf::test::structs_column_wrapper{{child1, child2},
+                                              cudf::test::iterators::nulls_at({5, 6, 10})};
   }();
 
-  auto const expect_keys    = fixed_width_column_wrapper<int32_t>{{1, 2, 3, 4}, no_nulls()};
-  auto const expect_indices = fixed_width_column_wrapper<int32_t>{{0, 4, 2, null}, null_at(3)};
+  auto const expect_keys = cudf::test::fixed_width_column_wrapper<int32_t>{
+    {1, 2, 3, 4}, cudf::test::iterators::no_nulls()};
+  auto const expect_indices = cudf::test::fixed_width_column_wrapper<int32_t>{
+    {0, 4, 2, null}, cudf::test::iterators::null_at(3)};
 
-  auto agg = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_indices, std::move(agg));
 }
-
-}  // namespace test
-}  // namespace cudf
 
 CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/groupby/argmin_tests.cpp
+++ b/cpp/tests/groupby/argmin_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_argmin_test : public cudf::test::BaseFixture {
 };
@@ -37,85 +35,85 @@ TYPED_TEST_SUITE(groupby_argmin_test, cudf::test::FixedWidthTypes);
 TYPED_TEST(groupby_argmin_test, basic)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::ARGMIN>;
 
   if (std::is_same_v<V, bool>) return;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R> expect_vals{6, 9, 8};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{6, 9, 8};
 
-  auto agg = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmin_test, zero_valid_keys)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::ARGMIN>;
 
   if (std::is_same_v<V, bool>) return;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals({3, 4, 5});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5});
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmin_test, zero_valid_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::ARGMIN>;
 
   if (std::is_same_v<V, bool>) return;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
-  auto agg = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_argmin_test, null_keys_and_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::ARGMIN>;
 
   if (std::is_same_v<V, bool>) return;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 4},
-                                     {1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 4},
+                                                 {1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 9, 6,     8, 5, 0,   7, 1,    -}
-  fixed_width_column_wrapper<R> expect_vals({3, 9, 8, 0}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3, 9, 8, 0}, {1, 1, 1, 0});
 
-  auto agg = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
   // TODO: explore making this a gtest parameter
-  auto agg2 = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
@@ -124,37 +122,36 @@ struct groupby_argmin_string_test : public cudf::test::BaseFixture {
 
 TEST_F(groupby_argmin_string_test, basic)
 {
-  using V = string_view;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using R = cudf::detail::target_type_t<cudf::string_view, cudf::aggregation::ARGMIN>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  strings_column_wrapper vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::strings_column_wrapper vals{
+    "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R> expect_vals({3, 5, 7});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3, 5, 7});
 
-  auto agg = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TEST_F(groupby_argmin_string_test, zero_valid_values)
 {
-  using V = string_view;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using R = cudf::detail::target_type_t<cudf::string_view, cudf::aggregation::ARGMIN>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
-  auto agg = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
@@ -164,22 +161,25 @@ struct groupby_dictionary_argmin_test : public cudf::test::BaseFixture {
 TEST_F(groupby_dictionary_argmin_test, basic)
 {
   using V = std::string;
-  using R = cudf::detail::target_type_t<V, aggregation::ARGMIN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::ARGMIN>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{    1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
-  dictionary_column_wrapper<V>  vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
-  fixed_width_column_wrapper<K> expect_keys({ 1, 2, 3 });
-  fixed_width_column_wrapper<R> expect_vals({ 3, 5, 7 });
+  cudf::test::fixed_width_column_wrapper<K> keys{    1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
+  cudf::test::dictionary_column_wrapper<V>  vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({ 1, 2, 3 });
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({ 3, 5, 7 });
   // clang-format on
 
-  test_single_agg(
-    keys, vals, expect_keys, expect_vals, cudf::make_argmin_aggregation<groupby_aggregation>());
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
-                  cudf::make_argmin_aggregation<groupby_aggregation>(),
+                  cudf::make_argmin_aggregation<cudf::groupby_aggregation>());
+  test_single_agg(keys,
+                  vals,
+                  expect_keys,
+                  expect_vals,
+                  cudf::make_argmin_aggregation<cudf::groupby_aggregation>(),
                   force_use_sort_impl::YES);
 }
 
@@ -188,72 +188,72 @@ struct groupby_argmin_struct_test : public cudf::test::BaseFixture {
 
 TEST_F(groupby_argmin_struct_test, basic)
 {
-  auto const keys = fixed_width_column_wrapper<int32_t>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
   auto const vals = [] {
-    auto child1 =
-      strings_column_wrapper{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{
+      "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto const expect_keys    = fixed_width_column_wrapper<int32_t>{1, 2, 3};
-  auto const expect_indices = fixed_width_column_wrapper<int32_t>{3, 5, 7};
+  auto const expect_keys    = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3};
+  auto const expect_indices = cudf::test::fixed_width_column_wrapper<int32_t>{3, 5, 7};
 
-  auto agg = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_indices, std::move(agg));
 }
 
 TEST_F(groupby_argmin_struct_test, slice_input)
 {
   constexpr int32_t dont_care{1};
-  auto const keys_original = fixed_width_column_wrapper<int32_t>{
+  auto const keys_original = cudf::test::fixed_width_column_wrapper<int32_t>{
     dont_care, dont_care, 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, dont_care};
   auto const vals_original = [] {
-    auto child1 = strings_column_wrapper{"dont_care",
-                                         "dont_care",
-                                         "año",
-                                         "bit",
-                                         "₹1",
-                                         "aaa",
-                                         "zit",
-                                         "bat",
-                                         "aab",
-                                         "$1",
-                                         "€1",
-                                         "wut",
-                                         "dont_care"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{
+    auto child1 = cudf::test::strings_column_wrapper{"dont_care",
+                                                     "dont_care",
+                                                     "año",
+                                                     "bit",
+                                                     "₹1",
+                                                     "aaa",
+                                                     "zit",
+                                                     "bat",
+                                                     "aab",
+                                                     "$1",
+                                                     "€1",
+                                                     "wut",
+                                                     "dont_care"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{
       dont_care, dont_care, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, dont_care};
-    return structs_column_wrapper{{child1, child2}};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   auto const keys           = cudf::slice(keys_original, {2, 12})[0];
   auto const vals           = cudf::slice(vals_original, {2, 12})[0];
-  auto const expect_keys    = fixed_width_column_wrapper<int32_t>{1, 2, 3};
-  auto const expect_indices = fixed_width_column_wrapper<int32_t>{3, 5, 7};
+  auto const expect_keys    = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3};
+  auto const expect_indices = cudf::test::fixed_width_column_wrapper<int32_t>{3, 5, 7};
 
-  auto agg = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_indices, std::move(agg));
 }
 
 TEST_F(groupby_argmin_struct_test, null_keys_and_values)
 {
   constexpr int32_t null{0};
-  auto const keys =
-    fixed_width_column_wrapper<int32_t>{{1, 2, 3, 1, 2, 2, 1, null, 3, 2, 4}, null_at(7)};
+  auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{
+    {1, 2, 3, 1, 2, 2, 1, null, 3, 2, 4}, null_at(7)};
   auto const vals = [] {
-    auto child1 = strings_column_wrapper{
+    auto child1 = cudf::test::strings_column_wrapper{
       "año", "bit", "₹1", "aaa", "zit", "" /*NULL*/, "" /*NULL*/, "$1", "€1", "wut", "" /*NULL*/};
-    auto child2 = fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
-    return structs_column_wrapper{{child1, child2}, nulls_at({5, 6, 10})};
+    auto child2 =
+      cudf::test::fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
+    return cudf::test::structs_column_wrapper{{child1, child2}, nulls_at({5, 6, 10})};
   }();
 
-  auto const expect_keys    = fixed_width_column_wrapper<int32_t>{{1, 2, 3, 4}, no_nulls()};
-  auto const expect_indices = fixed_width_column_wrapper<int32_t>{{3, 1, 8, null}, null_at(3)};
+  auto const expect_keys =
+    cudf::test::fixed_width_column_wrapper<int32_t>{{1, 2, 3, 4}, no_nulls()};
+  auto const expect_indices =
+    cudf::test::fixed_width_column_wrapper<int32_t>{{3, 1, 8, null}, null_at(3)};
 
-  auto agg = cudf::make_argmin_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmin_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_indices, std::move(agg));
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/collect_list_tests.cpp
+++ b/cpp/tests/groupby/collect_list_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,6 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
-namespace cudf {
-namespace test {
-
 template <typename V>
 struct groupby_collect_list_test : public cudf::test::BaseFixture {
 };
@@ -39,13 +36,13 @@ TYPED_TEST(groupby_collect_list_test, CollectWithoutNulls)
   using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K, int32_t> keys{1, 1, 1, 2, 2, 2};
-  fixed_width_column_wrapper<V, int32_t> values{1, 2, 3, 4, 5, 6};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> keys{1, 1, 1, 2, 2, 2};
+  cudf::test::fixed_width_column_wrapper<V, int32_t> values{1, 2, 3, 4, 5, 6};
 
-  fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2};
-  lists_column_wrapper<V, int32_t> expect_vals{{1, 2, 3}, {4, 5, 6}};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2};
+  cudf::test::lists_column_wrapper<V, int32_t> expect_vals{{1, 2, 3}, {4, 5, 6}};
 
-  auto agg = cudf::make_collect_list_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_collect_list_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, values, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -54,17 +51,17 @@ TYPED_TEST(groupby_collect_list_test, CollectWithNulls)
   using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K, int32_t> keys{1, 1, 2, 2, 3, 3};
-  fixed_width_column_wrapper<V, int32_t> values{{1, 2, 3, 4, 5, 6},
-                                                {true, false, true, false, true, false}};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> keys{1, 1, 2, 2, 3, 3};
+  cudf::test::fixed_width_column_wrapper<V, int32_t> values{
+    {1, 2, 3, 4, 5, 6}, {true, false, true, false, true, false}};
 
-  fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2, 3};
 
   std::vector<int32_t> validity({true, false});
-  lists_column_wrapper<V, int32_t> expect_vals{
+  cudf::test::lists_column_wrapper<V, int32_t> expect_vals{
     {{1, 2}, validity.begin()}, {{3, 4}, validity.begin()}, {{5, 6}, validity.begin()}};
 
-  auto agg = cudf::make_collect_list_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_collect_list_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, values, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -73,16 +70,17 @@ TYPED_TEST(groupby_collect_list_test, CollectWithNullExclusion)
   using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K, int32_t> keys{1, 1, 1, 2, 2, 3, 3, 4, 4};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> keys{1, 1, 1, 2, 2, 3, 3, 4, 4};
 
-  fixed_width_column_wrapper<V, int32_t> values{
+  cudf::test::fixed_width_column_wrapper<V, int32_t> values{
     {1, 2, 3, 4, 5, 6, 7, 8, 9}, {false, true, false, true, false, false, false, true, true}};
 
-  fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2, 3, 4};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2, 3, 4};
 
-  lists_column_wrapper<V, int32_t> expect_vals{{2}, {4}, {}, {8, 9}};
+  cudf::test::lists_column_wrapper<V, int32_t> expect_vals{{2}, {4}, {}, {8, 9}};
 
-  auto agg = cudf::make_collect_list_aggregation<groupby_aggregation>(null_policy::EXCLUDE);
+  auto agg =
+    cudf::make_collect_list_aggregation<cudf::groupby_aggregation>(cudf::null_policy::EXCLUDE);
   test_single_agg(keys, values, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -91,13 +89,14 @@ TYPED_TEST(groupby_collect_list_test, CollectOnEmptyInput)
   using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K, int32_t> keys{};
-  fixed_width_column_wrapper<V, int32_t> values{};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> keys{};
+  cudf::test::fixed_width_column_wrapper<V, int32_t> values{};
 
-  fixed_width_column_wrapper<K, int32_t> expect_keys{};
-  lists_column_wrapper<V, int32_t> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> expect_keys{};
+  cudf::test::lists_column_wrapper<V, int32_t> expect_vals{};
 
-  auto agg = cudf::make_collect_list_aggregation<groupby_aggregation>(null_policy::EXCLUDE);
+  auto agg =
+    cudf::make_collect_list_aggregation<cudf::groupby_aggregation>(cudf::null_policy::EXCLUDE);
   test_single_agg(keys, values, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -108,15 +107,16 @@ TYPED_TEST(groupby_collect_list_test, CollectLists)
 
   using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
 
-  fixed_width_column_wrapper<K, int32_t> keys{1, 1, 2, 2, 3, 3};
-  lists_column_wrapper<V, int32_t> values{{1, 2}, {3, 4}, {5, 6, 7}, LCW{}, {9, 10}, {11}};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> keys{1, 1, 2, 2, 3, 3};
+  cudf::test::lists_column_wrapper<V, int32_t> values{
+    {1, 2}, {3, 4}, {5, 6, 7}, LCW{}, {9, 10}, {11}};
 
-  fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2, 3};
 
-  lists_column_wrapper<V, int32_t> expect_vals{
+  cudf::test::lists_column_wrapper<V, int32_t> expect_vals{
     {{1, 2}, {3, 4}}, {{5, 6, 7}, LCW{}}, {{9, 10}, {11}}};
 
-  auto agg = cudf::make_collect_list_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_collect_list_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, values, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -127,15 +127,16 @@ TYPED_TEST(groupby_collect_list_test, CollectListsWithNullExclusion)
 
   using LCW = cudf::test::lists_column_wrapper<V, int32_t>;
 
-  fixed_width_column_wrapper<K, int32_t> keys{1, 1, 2, 2, 3, 3, 4, 4};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> keys{1, 1, 2, 2, 3, 3, 4, 4};
   const bool validity_mask[] = {true, false, false, true, true, true, false, false};
   LCW values{{{1, 2}, {3, 4}, {5, 6, 7}, LCW{}, {9, 10}, {11}, {20, 30, 40}, LCW{}}, validity_mask};
 
-  fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2, 3, 4};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2, 3, 4};
 
   LCW expect_vals{{{1, 2}}, {LCW{}}, {{9, 10}, {11}}, {}};
 
-  auto agg = cudf::make_collect_list_aggregation<groupby_aggregation>(null_policy::EXCLUDE);
+  auto agg =
+    cudf::make_collect_list_aggregation<cudf::groupby_aggregation>(cudf::null_policy::EXCLUDE);
   test_single_agg(keys, values, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -146,19 +147,20 @@ TYPED_TEST(groupby_collect_list_test, CollectOnEmptyInputLists)
 
   using LCW = cudf::test::lists_column_wrapper<V, int32_t>;
 
-  auto offsets = data_type{type_to_id<offset_type>()};
+  auto offsets = cudf::data_type{cudf::type_to_id<cudf::offset_type>()};
 
-  fixed_width_column_wrapper<K, int32_t> keys{};
-  auto values = cudf::make_lists_column(0, make_empty_column(offsets), LCW{}.release(), 0, {});
+  cudf::test::fixed_width_column_wrapper<K, int32_t> keys{};
+  auto values =
+    cudf::make_lists_column(0, cudf::make_empty_column(offsets), LCW{}.release(), 0, {});
 
-  fixed_width_column_wrapper<K, int32_t> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> expect_keys{};
 
   auto expect_child =
-    cudf::make_lists_column(0, make_empty_column(offsets), LCW{}.release(), 0, {});
+    cudf::make_lists_column(0, cudf::make_empty_column(offsets), LCW{}.release(), 0, {});
   auto expect_values =
-    cudf::make_lists_column(0, make_empty_column(offsets), std::move(expect_child), 0, {});
+    cudf::make_lists_column(0, cudf::make_empty_column(offsets), std::move(expect_child), 0, {});
 
-  auto agg = cudf::make_collect_list_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_collect_list_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, values->view(), expect_keys, expect_values->view(), std::move(agg));
 }
 
@@ -169,24 +171,36 @@ TYPED_TEST(groupby_collect_list_test, CollectOnEmptyInputListsOfStructs)
 
   using LCW = cudf::test::lists_column_wrapper<V, int32_t>;
 
-  fixed_width_column_wrapper<K, int32_t> keys{};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> keys{};
   auto struct_child  = LCW{};
-  auto struct_column = structs_column_wrapper{{struct_child}};
+  auto struct_column = cudf::test::structs_column_wrapper{{struct_child}};
 
-  auto values = cudf::make_lists_column(
-    0, make_empty_column(type_to_id<offset_type>()), struct_column.release(), 0, {});
+  auto values =
+    cudf::make_lists_column(0,
+                            cudf::make_empty_column(cudf::type_to_id<cudf::offset_type>()),
+                            struct_column.release(),
+                            0,
+                            {});
 
-  fixed_width_column_wrapper<K, int32_t> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> expect_keys{};
 
   auto expect_struct_child  = LCW{};
-  auto expect_struct_column = structs_column_wrapper{{expect_struct_child}};
+  auto expect_struct_column = cudf::test::structs_column_wrapper{{expect_struct_child}};
 
-  auto expect_child = cudf::make_lists_column(
-    0, make_empty_column(type_to_id<offset_type>()), expect_struct_column.release(), 0, {});
-  auto expect_values = cudf::make_lists_column(
-    0, make_empty_column(type_to_id<offset_type>()), std::move(expect_child), 0, {});
+  auto expect_child =
+    cudf::make_lists_column(0,
+                            cudf::make_empty_column(cudf::type_to_id<cudf::offset_type>()),
+                            expect_struct_column.release(),
+                            0,
+                            {});
+  auto expect_values =
+    cudf::make_lists_column(0,
+                            cudf::make_empty_column(cudf::type_to_id<cudf::offset_type>()),
+                            std::move(expect_child),
+                            0,
+                            {});
 
-  auto agg = cudf::make_collect_list_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_collect_list_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, values->view(), expect_keys, expect_values->view(), std::move(agg));
 }
 
@@ -195,13 +209,13 @@ TYPED_TEST(groupby_collect_list_test, dictionary)
   using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K, int32_t> keys{1, 1, 1, 2, 2, 2};
-  dictionary_column_wrapper<V, int32_t> vals{1, 2, 3, 4, 5, 6};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> keys{1, 1, 1, 2, 2, 2};
+  cudf::test::dictionary_column_wrapper<V, int32_t> vals{1, 2, 3, 4, 5, 6};
 
-  fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2};
-  lists_column_wrapper<V, int32_t> expect_vals_w{{1, 2, 3}, {4, 5, 6}};
+  cudf::test::fixed_width_column_wrapper<K, int32_t> expect_keys{1, 2};
+  cudf::test::lists_column_wrapper<V, int32_t> expect_vals_w{{1, 2, 3}, {4, 5, 6}};
 
-  fixed_width_column_wrapper<int32_t> offsets({0, 3, 6});
+  cudf::test::fixed_width_column_wrapper<int32_t> offsets({0, 3, 6});
   auto expect_vals = cudf::make_lists_column(cudf::column_view(offsets).size() - 1,
                                              std::make_unique<cudf::column>(offsets),
                                              std::make_unique<cudf::column>(vals),
@@ -212,8 +226,5 @@ TYPED_TEST(groupby_collect_list_test, dictionary)
                   vals,
                   expect_keys,
                   expect_vals->view(),
-                  cudf::make_collect_list_aggregation<groupby_aggregation>());
+                  cudf::make_collect_list_aggregation<cudf::groupby_aggregation>());
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/collect_set_tests.cpp
+++ b/cpp/tests/groupby/collect_set_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,6 @@
 #include <cudf/sorting.hpp>
 #include <cudf/table/table_view.hpp>
 
-namespace cudf {
-namespace test {
-
 namespace {
 
 constexpr cudf::test::debug_output_level verbosity{cudf::test::debug_output_level::FIRST_ERROR};
@@ -39,7 +36,7 @@ using validity_col  = std::initializer_list<bool>;
 
 auto groupby_collect_set(cudf::column_view const& keys,
                          cudf::column_view const& values,
-                         std::unique_ptr<groupby_aggregation>&& agg)
+                         std::unique_ptr<cudf::groupby_aggregation>&& agg)
 {
   std::vector<cudf::groupby::aggregation_request> requests;
   requests.emplace_back(cudf::groupby::aggregation_request());
@@ -78,13 +75,14 @@ struct CollectSetTest : public cudf::test::BaseFixture {
 
   static auto collect_set_null_unequal()
   {
-    return cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(null_policy::INCLUDE,
-                                                                         null_equality::UNEQUAL);
+    return cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
+      cudf::null_policy::INCLUDE, cudf::null_equality::UNEQUAL);
   }
 
   static auto collect_set_null_exclude()
   {
-    return cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(null_policy::EXCLUDE);
+    return cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
+      cudf::null_policy::EXCLUDE);
   }
 };
 
@@ -245,38 +243,38 @@ TEST_F(CollectSetTest, FloatsWithNaN)
 
   // null equal with nan unequal
   {
-    vals_expected = {{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, -NAN, NAN, NAN, 0.0f},
+    vals_expected                    = {{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, -NAN, NAN, NAN, 0.0f},
                       validity_col{true, true, true, true, true, true, true, false}}};
-    auto const [out_keys, out_lists] =
-      groupby_collect_set(keys,
-                          vals,
-                          cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
-                            null_policy::INCLUDE, null_equality::EQUAL, nan_equality::UNEQUAL));
+    auto const [out_keys, out_lists] = groupby_collect_set(
+      keys,
+      vals,
+      cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
+        cudf::null_policy::INCLUDE, cudf::null_equality::EQUAL, cudf::nan_equality::UNEQUAL));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(keys_expected, *out_keys, verbosity);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(vals_expected, *out_lists, verbosity);
   }
 
   // null unequal with nan unequal
   {
-    vals_expected = {{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, -NAN, NAN, NAN, 0.0f, 0.0f},
+    vals_expected                    = {{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, -NAN, NAN, NAN, 0.0f, 0.0f},
                       validity_col{true, true, true, true, true, true, true, false, false}}};
-    auto const [out_keys, out_lists] =
-      groupby_collect_set(keys,
-                          vals,
-                          cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
-                            null_policy::INCLUDE, null_equality::UNEQUAL, nan_equality::UNEQUAL));
+    auto const [out_keys, out_lists] = groupby_collect_set(
+      keys,
+      vals,
+      cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
+        cudf::null_policy::INCLUDE, cudf::null_equality::UNEQUAL, cudf::nan_equality::UNEQUAL));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(keys_expected, *out_keys, verbosity);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(vals_expected, *out_lists, verbosity);
   }
 
   // null exclude with nan unequal
   {
-    vals_expected = {{-2.3e-5f, 1.0f, 2.3e5f, -NAN, -NAN, NAN, NAN}};
-    auto const [out_keys, out_lists] =
-      groupby_collect_set(keys,
-                          vals,
-                          cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
-                            null_policy::EXCLUDE, null_equality::EQUAL, nan_equality::UNEQUAL));
+    vals_expected                    = {{-2.3e-5f, 1.0f, 2.3e5f, -NAN, -NAN, NAN, NAN}};
+    auto const [out_keys, out_lists] = groupby_collect_set(
+      keys,
+      vals,
+      cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
+        cudf::null_policy::EXCLUDE, cudf::null_equality::EQUAL, cudf::nan_equality::UNEQUAL));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(keys_expected, *out_keys, verbosity);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(vals_expected, *out_lists, verbosity);
   }
@@ -285,24 +283,24 @@ TEST_F(CollectSetTest, FloatsWithNaN)
   {
     vals_expected = {
       {{-2.3e-5f, 1.0f, 2.3e5f, NAN, 0.0f}, validity_col{true, true, true, true, false}}};
-    auto const [out_keys, out_lists] =
-      groupby_collect_set(keys,
-                          vals,
-                          cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
-                            null_policy::INCLUDE, null_equality::EQUAL, nan_equality::ALL_EQUAL));
+    auto const [out_keys, out_lists] = groupby_collect_set(
+      keys,
+      vals,
+      cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
+        cudf::null_policy::INCLUDE, cudf::null_equality::EQUAL, cudf::nan_equality::ALL_EQUAL));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(keys_expected, *out_keys, verbosity);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(vals_expected, *out_lists, verbosity);
   }
 
   // null unequal with nan equal
   {
-    vals_expected = {{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, 0.0f, 0.0f},
+    vals_expected                    = {{{-2.3e-5f, 1.0f, 2.3e5f, -NAN, 0.0f, 0.0f},
                       validity_col{true, true, true, true, false, false}}};
-    auto const [out_keys, out_lists] =
-      groupby_collect_set(keys,
-                          vals,
-                          cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
-                            null_policy::INCLUDE, null_equality::UNEQUAL, nan_equality::ALL_EQUAL));
+    auto const [out_keys, out_lists] = groupby_collect_set(
+      keys,
+      vals,
+      cudf::make_collect_set_aggregation<cudf::groupby_aggregation>(
+        cudf::null_policy::INCLUDE, cudf::null_equality::UNEQUAL, cudf::nan_equality::ALL_EQUAL));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(keys_expected, *out_keys, verbosity);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(vals_expected, *out_lists, verbosity);
   }
@@ -400,6 +398,3 @@ TYPED_TEST(CollectSetTypedTest, CollectWithNulls)
     }
   }
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/correlation_tests.cpp
+++ b/cpp/tests/groupby/correlation_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#include <cudf/detail/aggregation/aggregation.hpp>
-#include <cudf/utilities/traits.hpp>
+#include <tests/groupby/groupby_test_util.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
@@ -23,23 +22,20 @@
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
-#include <tests/groupby/groupby_test_util.hpp>
+#include <cudf/detail/aggregation/aggregation.hpp>
+#include <cudf/utilities/traits.hpp>
 
 #include <limits>
 #include <vector>
 
 using namespace cudf::test::iterators;
-namespace cudf {
-namespace test {
-
-constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
-using structs      = structs_column_wrapper;
 
 template <typename V>
 struct groupby_correlation_test : public cudf::test::BaseFixture {
 };
 
-using supported_types = RemoveIf<ContainedIn<Types<bool>>, cudf::test::NumericTypes>;
+using supported_types =
+  cudf::test::RemoveIf<cudf::test::ContainedIn<cudf::test::Types<bool>>, cudf::test::NumericTypes>;
 
 TYPED_TEST_SUITE(groupby_correlation_test, supported_types);
 using K = int32_t;
@@ -47,115 +43,121 @@ using K = int32_t;
 TYPED_TEST(groupby_correlation_test, basic)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::CORRELATION>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::CORRELATION>;
 
-  auto keys     = fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
-  auto member_0 = fixed_width_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
-  auto member_1 = fixed_width_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
-  auto vals     = structs{{member_0, member_1}};
+  constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R, double> expect_vals{{1.0, 0.6, nan}};
+  auto keys     = cudf::test::fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
+  auto member_0 = cudf::test::fixed_width_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
+  auto member_1 = cudf::test::fixed_width_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
+  auto vals     = cudf::test::structs_column_wrapper{{member_0, member_1}};
+
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals{{1.0, 0.6, nan}};
 
   auto agg =
-    cudf::make_correlation_aggregation<groupby_aggregation>(cudf::correlation_type::PEARSON);
+    cudf::make_correlation_aggregation<cudf::groupby_aggregation>(cudf::correlation_type::PEARSON);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_correlation_test, empty_cols)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::CORRELATION>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::CORRELATION>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> member_0{}, member_1{};
-  auto vals = structs{{member_0, member_1}};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> member_0{}, member_1{};
+  auto vals = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   auto agg =
-    cudf::make_correlation_aggregation<groupby_aggregation>(cudf::correlation_type::PEARSON);
+    cudf::make_correlation_aggregation<cudf::groupby_aggregation>(cudf::correlation_type::PEARSON);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_correlation_test, zero_valid_keys)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::CORRELATION>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::CORRELATION>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> member_0{3, 4, 5}, member_1{6, 7, 8};
-  auto vals = structs{{member_0, member_1}};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> member_0{3, 4, 5}, member_1{6, 7, 8};
+  auto vals = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   auto agg =
-    cudf::make_correlation_aggregation<groupby_aggregation>(cudf::correlation_type::PEARSON);
+    cudf::make_correlation_aggregation<cudf::groupby_aggregation>(cudf::correlation_type::PEARSON);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_correlation_test, zero_valid_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::CORRELATION>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::CORRELATION>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> member_0({3, 4, 5}, all_nulls());
-  fixed_width_column_wrapper<V> member_1({3, 4, 5}, all_nulls());
-  auto vals = structs{{member_0, member_1}};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> member_0({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> member_1({3, 4, 5}, all_nulls());
+  auto vals = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg =
-    cudf::make_correlation_aggregation<groupby_aggregation>(cudf::correlation_type::PEARSON);
+    cudf::make_correlation_aggregation<cudf::groupby_aggregation>(cudf::correlation_type::PEARSON);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_correlation_test, null_keys_and_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::CORRELATION>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::CORRELATION>;
+
+  constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
                                      {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
+  cudf::test::fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
                                      {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
-  fixed_width_column_wrapper<V> val1({1, 1, 1, 2, 0, 3, 3,-1, 0, 2, 2});
+  cudf::test::fixed_width_column_wrapper<V> val1({1, 1, 1, 2, 0, 3, 3,-1, 0, 2, 2});
   // clang-format on
-  auto vals = structs{{val0, val1}};
+  auto vals = cudf::test::structs_column_wrapper{{val0, val1}};
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
-  fixed_width_column_wrapper<R> expect_vals({1.0, 0.6, nan, 0.}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({1.0, 0.6, nan, 0.}, {1, 1, 1, 0});
 
   auto agg =
-    cudf::make_correlation_aggregation<groupby_aggregation>(cudf::correlation_type::PEARSON);
+    cudf::make_correlation_aggregation<cudf::groupby_aggregation>(cudf::correlation_type::PEARSON);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_correlation_test, null_values_same)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::CORRELATION>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::CORRELATION>;
+
+  constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
                                      {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
+  cudf::test::fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
                                      {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
-  fixed_width_column_wrapper<V> val1({1, 1, 1, 2, 0, 3, 3,-1, 0, 2, 2},
+  cudf::test::fixed_width_column_wrapper<V> val1({1, 1, 1, 2, 0, 3, 3,-1, 0, 2, 2},
                                      {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
   // clang-format on
-  auto vals = structs{{val0, val1}};
+  auto vals = cudf::test::structs_column_wrapper{{val0, val1}};
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
-  fixed_width_column_wrapper<R> expect_vals({1.0, 0.6, nan, 0.}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({1.0, 0.6, nan, 0.}, {1, 1, 1, 0});
 
   auto agg =
-    cudf::make_correlation_aggregation<groupby_aggregation>(cudf::correlation_type::PEARSON);
+    cudf::make_correlation_aggregation<cudf::groupby_aggregation>(cudf::correlation_type::PEARSON);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
@@ -166,51 +168,55 @@ TYPED_TEST(groupby_correlation_test, null_values_same)
 TYPED_TEST(groupby_correlation_test, null_values_different)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::CORRELATION>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::CORRELATION>;
+
+  constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
                                      {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
+  cudf::test::fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
                                      {0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1});
-  fixed_width_column_wrapper<V> val1({1, 2, 1, 2,-1, 6, 3,-1, 0, 1, 2},
+  cudf::test::fixed_width_column_wrapper<V> val1({1, 2, 1, 2,-1, 6, 3,-1, 0, 1, 2},
                                      {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
   // clang-format on
-  auto vals = structs{{val0, val1}};
+  auto vals = cudf::test::structs_column_wrapper{{val0, val1}};
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
-  fixed_width_column_wrapper<R> expect_vals({1.0, 0., nan, 0.}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({1.0, 0., nan, 0.}, {1, 1, 1, 0});
 
   auto agg =
-    cudf::make_correlation_aggregation<groupby_aggregation>(cudf::correlation_type::PEARSON);
+    cudf::make_correlation_aggregation<cudf::groupby_aggregation>(cudf::correlation_type::PEARSON);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_correlation_test, min_periods)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::CORRELATION>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::CORRELATION>;
 
-  auto keys     = fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
-  auto member_0 = fixed_width_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
-  auto member_1 = fixed_width_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
-  auto vals     = structs{{member_0, member_1}};
+  constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  auto keys     = cudf::test::fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
+  auto member_0 = cudf::test::fixed_width_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
+  auto member_1 = cudf::test::fixed_width_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
+  auto vals     = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  fixed_width_column_wrapper<R, double> expect_vals1{{1.0, 0.6, nan}};
-  auto agg1 =
-    cudf::make_correlation_aggregation<groupby_aggregation>(cudf::correlation_type::PEARSON, 3);
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals1{{1.0, 0.6, nan}};
+  auto agg1 = cudf::make_correlation_aggregation<cudf::groupby_aggregation>(
+    cudf::correlation_type::PEARSON, 3);
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg1), force_use_sort_impl::YES);
 
-  fixed_width_column_wrapper<R, double> expect_vals2{{1.0, 0.6, nan}, {0, 1, 0}};
-  auto agg2 =
-    cudf::make_correlation_aggregation<groupby_aggregation>(cudf::correlation_type::PEARSON, 4);
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals2{{1.0, 0.6, nan}, {0, 1, 0}};
+  auto agg2 = cudf::make_correlation_aggregation<cudf::groupby_aggregation>(
+    cudf::correlation_type::PEARSON, 4);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2), force_use_sort_impl::YES);
 
-  fixed_width_column_wrapper<R, double> expect_vals3{{1.0, 0.6, nan}, {0, 0, 0}};
-  auto agg3 =
-    cudf::make_correlation_aggregation<groupby_aggregation>(cudf::correlation_type::PEARSON, 5);
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals3{{1.0, 0.6, nan}, {0, 0, 0}};
+  auto agg3 = cudf::make_correlation_aggregation<cudf::groupby_aggregation>(
+    cudf::correlation_type::PEARSON, 5);
   test_single_agg(keys, vals, expect_keys, expect_vals3, std::move(agg3), force_use_sort_impl::YES);
 }
 
@@ -220,20 +226,19 @@ struct groupby_dictionary_correlation_test : public cudf::test::BaseFixture {
 TEST_F(groupby_dictionary_correlation_test, basic)
 {
   using V = int16_t;
-  using R = cudf::detail::target_type_t<V, aggregation::CORRELATION>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::CORRELATION>;
 
-  auto keys     = fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
-  auto member_0 = dictionary_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
-  auto member_1 = dictionary_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
-  auto vals     = structs{{member_0, member_1}};
+  constexpr auto nan = std::numeric_limits<double>::quiet_NaN();
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R, double> expect_vals{{1.0, 0.6, nan}};
+  auto keys     = cudf::test::fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
+  auto member_0 = cudf::test::dictionary_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
+  auto member_1 = cudf::test::dictionary_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
+  auto vals     = cudf::test::structs_column_wrapper{{member_0, member_1}};
+
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals{{1.0, 0.6, nan}};
 
   auto agg =
-    cudf::make_correlation_aggregation<groupby_aggregation>(cudf::correlation_type::PEARSON);
+    cudf::make_correlation_aggregation<cudf::groupby_aggregation>(cudf::correlation_type::PEARSON);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/correlation_tests.cpp
+++ b/cpp/tests/groupby/correlation_tests.cpp
@@ -23,7 +23,6 @@
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
-#include <cudf/utilities/traits.hpp>
 
 #include <limits>
 #include <vector>

--- a/cpp/tests/groupby/count_scan_tests.cpp
+++ b/cpp/tests/groupby/count_scan_tests.cpp
@@ -23,8 +23,7 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
-using K           = int32_t;
-using key_wrapper = cudf::test::fixed_width_column_wrapper<K>;
+using key_wrapper = cudf::test::fixed_width_column_wrapper<int32_t>;
 
 template <typename T>
 struct groupby_count_scan_test : public cudf::test::BaseFixture {
@@ -189,6 +188,7 @@ struct groupby_dictionary_count_scan_test : public cudf::test::BaseFixture {
 
 TEST_F(groupby_dictionary_count_scan_test, basic)
 {
+  using K              = int32_t;
   using V              = std::string;
   using R              = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_ALL>;
   using result_wrapper = cudf::test::fixed_width_column_wrapper<R, int32_t>;

--- a/cpp/tests/groupby/count_scan_tests.cpp
+++ b/cpp/tests/groupby/count_scan_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,19 +23,15 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
-using namespace cudf::test::iterators;
-
-namespace cudf {
-namespace test {
 using K           = int32_t;
-using key_wrapper = fixed_width_column_wrapper<K>;
+using key_wrapper = cudf::test::fixed_width_column_wrapper<K>;
 
 template <typename T>
 struct groupby_count_scan_test : public cudf::test::BaseFixture {
   using V              = T;
-  using R              = cudf::detail::target_type_t<V, aggregation::COUNT_ALL>;
-  using value_wrapper  = fixed_width_column_wrapper<V, int32_t>;
-  using result_wrapper = fixed_width_column_wrapper<R, int32_t>;
+  using R              = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_ALL>;
+  using value_wrapper  = cudf::test::fixed_width_column_wrapper<V, int32_t>;
+  using result_wrapper = cudf::test::fixed_width_column_wrapper<R, int32_t>;
 };
 
 TYPED_TEST_SUITE(groupby_count_scan_test, cudf::test::AllTypes);
@@ -53,12 +49,13 @@ TYPED_TEST(groupby_count_scan_test, basic)
   result_wrapper expect_vals{0, 1, 2, 0, 1, 2, 3, 0, 1, 2};
   // clang-format on
 
-  // Count groupby aggregation is only supported with null_policy::EXCLUDE
-  auto agg1 = cudf::make_count_aggregation<groupby_scan_aggregation>();
+  // Count groupby aggregation is only supported with cudf::null_policy::EXCLUDE
+  auto agg1 = cudf::make_count_aggregation<cudf::groupby_scan_aggregation>();
   EXPECT_THROW(test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg1)),
                cudf::logic_error);
 
-  auto agg2 = cudf::make_count_aggregation<groupby_scan_aggregation>(null_policy::INCLUDE);
+  auto agg2 =
+    cudf::make_count_aggregation<cudf::groupby_scan_aggregation>(cudf::null_policy::INCLUDE);
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
@@ -67,18 +64,16 @@ TYPED_TEST(groupby_count_scan_test, empty_cols)
   using value_wrapper  = typename TestFixture::value_wrapper;
   using result_wrapper = typename TestFixture::result_wrapper;
 
-  // clang-format off
   key_wrapper keys;
   value_wrapper vals;
-
   key_wrapper expect_keys;
   result_wrapper expect_vals;
-  // clang-format on
 
-  auto agg1 = cudf::make_count_aggregation<groupby_scan_aggregation>();
+  auto agg1 = cudf::make_count_aggregation<cudf::groupby_scan_aggregation>();
   EXPECT_NO_THROW(test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg1)));
 
-  auto agg2 = cudf::make_count_aggregation<groupby_scan_aggregation>(null_policy::INCLUDE);
+  auto agg2 =
+    cudf::make_count_aggregation<cudf::groupby_scan_aggregation>(cudf::null_policy::INCLUDE);
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
@@ -87,15 +82,13 @@ TYPED_TEST(groupby_count_scan_test, zero_valid_keys)
   using value_wrapper  = typename TestFixture::value_wrapper;
   using result_wrapper = typename TestFixture::result_wrapper;
 
-  // clang-format off
-  key_wrapper keys( {1, 2, 3}, all_nulls());
+  key_wrapper keys({1, 2, 3}, cudf::test::iterators::all_nulls());
   value_wrapper vals{3, 4, 5};
-
   key_wrapper expect_keys{};
   result_wrapper expect_vals{};
-  // clang-format on
 
-  auto agg2 = cudf::make_count_aggregation<groupby_scan_aggregation>(null_policy::INCLUDE);
+  auto agg2 =
+    cudf::make_count_aggregation<cudf::groupby_scan_aggregation>(cudf::null_policy::INCLUDE);
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
@@ -104,15 +97,13 @@ TYPED_TEST(groupby_count_scan_test, zero_valid_values)
   using value_wrapper  = typename TestFixture::value_wrapper;
   using result_wrapper = typename TestFixture::result_wrapper;
 
-  // clang-format off
-  key_wrapper keys   {1, 1, 1};
-  value_wrapper vals({3, 4, 5}, all_nulls());
-
+  key_wrapper keys{1, 1, 1};
+  value_wrapper vals({3, 4, 5}, cudf::test::iterators::all_nulls());
   key_wrapper expect_keys{1, 1, 1};
   result_wrapper expect_vals{0, 1, 2};
-  // clang-format on
 
-  auto agg2 = cudf::make_count_aggregation<groupby_scan_aggregation>(null_policy::INCLUDE);
+  auto agg2 =
+    cudf::make_count_aggregation<cudf::groupby_scan_aggregation>(cudf::null_policy::INCLUDE);
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
@@ -126,12 +117,13 @@ TYPED_TEST(groupby_count_scan_test, null_keys_and_values)
   value_wrapper vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                        {1, 1, 1, 2, 2, 2, 2, 3, _, 3, 4}
-  key_wrapper expect_keys(  {1, 1, 1, 2, 2, 2, 2, 3,    3, 4}, no_nulls());
+  key_wrapper expect_keys(  {1, 1, 1, 2, 2, 2, 2, 3,    3, 4}, cudf::test::iterators::no_nulls());
   //                        {0, 3, 6, 1, 4, _, 9, 2, 7, 8, -}
   result_wrapper expect_vals{0, 1, 2, 0, 1,    2, 3, 0, 1, 0};
   // clang-format on
 
-  auto agg2 = cudf::make_count_aggregation<groupby_scan_aggregation>(null_policy::INCLUDE);
+  auto agg2 =
+    cudf::make_count_aggregation<cudf::groupby_scan_aggregation>(cudf::null_policy::INCLUDE);
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
@@ -141,56 +133,54 @@ struct groupby_count_scan_string_test : public cudf::test::BaseFixture {
 TEST_F(groupby_count_scan_string_test, basic)
 {
   using V              = cudf::string_view;
-  using R              = cudf::detail::target_type_t<V, aggregation::COUNT_ALL>;
-  using result_wrapper = fixed_width_column_wrapper<R, int32_t>;
+  using R              = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_ALL>;
+  using result_wrapper = cudf::test::fixed_width_column_wrapper<R, int32_t>;
 
   // clang-format off
-  key_wrapper keys           {  1,   3,   3,   5,   5,   0};
-  strings_column_wrapper vals{"1", "1", "1", "1", "1", "1"};
-
+  key_wrapper keys                      {  1,   3,   3,   5,   5,   0};
+  cudf::test::strings_column_wrapper vals{"1", "1", "1", "1", "1", "1"};
   key_wrapper expect_keys   {0, 1, 3, 3, 5, 5};
   result_wrapper expect_vals{0, 0, 0, 1, 0, 1};
   // clang-format on
 
-  auto agg2 = cudf::make_count_aggregation<groupby_scan_aggregation>(null_policy::INCLUDE);
+  auto agg2 =
+    cudf::make_count_aggregation<cudf::groupby_scan_aggregation>(cudf::null_policy::INCLUDE);
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
 template <typename T>
-struct FixedPointTestAllReps : public cudf::test::BaseFixture {
+struct GroupByCountScanFixedPointTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(FixedPointTestAllReps, cudf::test::FixedPointTypes);
+TYPED_TEST_SUITE(GroupByCountScanFixedPointTest, cudf::test::FixedPointTypes);
 
-TYPED_TEST(FixedPointTestAllReps, GroupByCountScan)
+TYPED_TEST(GroupByCountScanFixedPointTest, GroupByCountScan)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;
   using RepType    = cudf::device_storage_type_t<decimalXX>;
-  using fp_wrapper = fixed_point_column_wrapper<RepType>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
 
   using V              = decimalXX;
-  using R              = cudf::detail::target_type_t<V, aggregation::COUNT_ALL>;
-  using result_wrapper = fixed_width_column_wrapper<R, int32_t>;
+  using R              = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_ALL>;
+  using result_wrapper = cudf::test::fixed_width_column_wrapper<R, int32_t>;
 
-  auto const scale = scale_type{-1};
-  // clang-format off
-  auto const keys = key_wrapper{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  auto const vals = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
-
+  auto const scale       = scale_type{-1};
+  auto const keys        = key_wrapper{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  auto const vals        = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
   auto const expect_keys = key_wrapper{1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
   auto const expect_vals = result_wrapper{0, 1, 2, 0, 1, 2, 3, 0, 1, 2};
-  // clang-format on
 
-  // Count groupby aggregation is only supported with null_policy::EXCLUDE
+  // Count groupby aggregation is only supported with cudf::null_policy::EXCLUDE
   EXPECT_THROW(test_single_scan(keys,
                                 vals,
                                 expect_keys,
                                 expect_vals,
-                                cudf::make_count_aggregation<groupby_scan_aggregation>()),
+                                cudf::make_count_aggregation<cudf::groupby_scan_aggregation>()),
                cudf::logic_error);
 
-  auto agg2 = cudf::make_count_aggregation<groupby_scan_aggregation>(null_policy::INCLUDE);
+  auto agg2 =
+    cudf::make_count_aggregation<cudf::groupby_scan_aggregation>(cudf::null_policy::INCLUDE);
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
@@ -200,26 +190,22 @@ struct groupby_dictionary_count_scan_test : public cudf::test::BaseFixture {
 TEST_F(groupby_dictionary_count_scan_test, basic)
 {
   using V              = std::string;
-  using R              = cudf::detail::target_type_t<V, aggregation::COUNT_ALL>;
-  using result_wrapper = fixed_width_column_wrapper<R, int32_t>;
+  using R              = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_ALL>;
+  using result_wrapper = cudf::test::fixed_width_column_wrapper<R, int32_t>;
 
-  // clang-format off
-  strings_column_wrapper keys{"1", "3", "3", "5", "5", "0"};
-  dictionary_column_wrapper<K> vals{1, 1, 1, 1, 1, 1};
-  strings_column_wrapper expect_keys{"0", "1", "3", "3", "5", "5"};
+  cudf::test::strings_column_wrapper keys{"1", "3", "3", "5", "5", "0"};
+  cudf::test::dictionary_column_wrapper<K> vals{1, 1, 1, 1, 1, 1};
+  cudf::test::strings_column_wrapper expect_keys{"0", "1", "3", "3", "5", "5"};
   result_wrapper expect_vals{0, 0, 0, 1, 0, 1};
-  // clang-format on
 
-  // Count groupby aggregation is only supported with null_policy::EXCLUDE
-  auto agg1 = cudf::make_count_aggregation<groupby_scan_aggregation>();
+  // Count groupby aggregation is only supported with cudf::null_policy::EXCLUDE
+  auto agg1 = cudf::make_count_aggregation<cudf::groupby_scan_aggregation>();
   EXPECT_THROW(test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg1)),
                cudf::logic_error);
-  test_single_scan(keys,
-                   vals,
-                   expect_keys,
-                   expect_vals,
-                   cudf::make_count_aggregation<groupby_scan_aggregation>(null_policy::INCLUDE));
+  test_single_scan(
+    keys,
+    vals,
+    expect_keys,
+    expect_vals,
+    cudf::make_count_aggregation<cudf::groupby_scan_aggregation>(cudf::null_policy::INCLUDE));
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/count_tests.cpp
+++ b/cpp/tests/groupby/count_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,6 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
-using namespace cudf::test::iterators;
-
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_count_test : public cudf::test::BaseFixture {
 };
@@ -37,110 +33,110 @@ TYPED_TEST_SUITE(groupby_count_test, cudf::test::AllTypes);
 TYPED_TEST(groupby_count_test, basic)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_VALID>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R> expect_vals{3, 4, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{3, 4, 3};
 
-  auto agg = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg1 = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg1 = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 
-  auto agg2 = cudf::make_count_aggregation<groupby_aggregation>(null_policy::INCLUDE);
+  auto agg2 = cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
 TYPED_TEST(groupby_count_test, empty_cols)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_VALID>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals;
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals;
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals;
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals;
 
-  auto agg = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg1 = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg1 = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_count_test, zero_valid_keys)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_VALID>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals{3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, cudf::test::iterators::all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg1 = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg1 = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 
-  auto agg2 = cudf::make_count_aggregation<groupby_aggregation>(null_policy::INCLUDE);
+  auto agg2 = cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
 TYPED_TEST(groupby_count_test, zero_valid_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_VALID>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, cudf::test::iterators::all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals{0};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{0};
 
-  auto agg = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg1 = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg1 = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 
-  fixed_width_column_wrapper<R> expect_vals2{3};
-  auto agg2 = cudf::make_count_aggregation<groupby_aggregation>(null_policy::INCLUDE);
+  cudf::test::fixed_width_column_wrapper<R> expect_vals2{3};
+  auto agg2 = cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
 }
 
 TYPED_TEST(groupby_count_test, null_keys_and_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_VALID>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   // clang-format off
-  //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_nulls());
-  //                                        {3, 6,     1, 4, 9,   2, 8,    -}
-  fixed_width_column_wrapper<R> expect_vals({2,        3,         2,       0});
+  //                                                    {1, 1,  2, 2, 2,  3, 3,  4}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1,     2,        3,     4}, cudf::test::iterators::no_nulls());
+  //                                                    {3, 6,  1, 4, 9,  2, 8,  -}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({2,     3,        2,     0});
   // clang-format on
 
-  auto agg = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg1 = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg1 = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 
-  fixed_width_column_wrapper<R> expect_vals2{3, 4, 2, 1};
-  auto agg2 = cudf::make_count_aggregation<groupby_aggregation>(null_policy::INCLUDE);
+  cudf::test::fixed_width_column_wrapper<R> expect_vals2{3, 4, 2, 1};
+  auto agg2 = cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
 }
 
@@ -150,31 +146,31 @@ struct groupby_count_string_test : public cudf::test::BaseFixture {
 TEST_F(groupby_count_string_test, basic)
 {
   using V = cudf::string_view;
-  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_VALID>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{1,    3,  3,   5,   5,   0};
-  strings_column_wrapper        vals{"1", "1", "1", "1", "1", "1"};
+  cudf::test::fixed_width_column_wrapper<K> keys{1,    3,  3,   5,   5,   0};
+  cudf::test::strings_column_wrapper        vals{"1", "1", "1", "1", "1", "1"};
   // clang-format on
 
-  fixed_width_column_wrapper<K> expect_keys{0, 1, 3, 5};
-  fixed_width_column_wrapper<R> expect_vals{1, 1, 2, 2};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{0, 1, 3, 5};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{1, 1, 2, 2};
 
-  auto agg = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg1 = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg1 = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 }
 // clang-format on
 
 template <typename T>
-struct FixedPointTestAllReps : public cudf::test::BaseFixture {
+struct GroupByCountFixedPointTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(FixedPointTestAllReps, cudf::test::FixedPointTypes);
+TYPED_TEST_SUITE(GroupByCountFixedPointTest, cudf::test::FixedPointTypes);
 
-TYPED_TEST(FixedPointTestAllReps, GroupByCount)
+TYPED_TEST(GroupByCountFixedPointTest, GroupByCount)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;
@@ -182,22 +178,22 @@ TYPED_TEST(FixedPointTestAllReps, GroupByCount)
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
 
   using V = decimalXX;
-  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_VALID>;
 
   auto const scale = scale_type{-1};
-  auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  auto const keys  = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
   auto const vals  = fp_wrapper{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
 
-  auto const expect_keys = fixed_width_column_wrapper<K>{1, 2, 3};
-  auto const expect_vals = fixed_width_column_wrapper<R>{3, 4, 3};
+  auto const expect_keys = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3};
+  auto const expect_vals = cudf::test::fixed_width_column_wrapper<R>{3, 4, 3};
 
-  auto agg = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg1 = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg1 = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg1), force_use_sort_impl::YES);
 
-  auto agg2 = cudf::make_count_aggregation<groupby_aggregation>(null_policy::INCLUDE);
+  auto agg2 = cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2));
 }
 
@@ -207,24 +203,24 @@ struct groupby_dictionary_count_test : public cudf::test::BaseFixture {
 TEST_F(groupby_dictionary_count_test, basic)
 {
   using V = std::string;
-  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_VALID>;
 
   // clang-format off
-  strings_column_wrapper        keys{"1", "3", "3", "5", "5", "0"};
-  dictionary_column_wrapper<K>  vals{1, 1, 1, 1, 1, 1};
-  strings_column_wrapper        expect_keys{"0", "1", "3", "5"};
-  fixed_width_column_wrapper<R> expect_vals{1, 1, 2, 2};
+  cudf::test::strings_column_wrapper        keys{"1", "3", "3", "5", "5", "0"};
+  cudf::test::dictionary_column_wrapper<K>  vals{1, 1, 1, 1, 1, 1};
+  cudf::test::strings_column_wrapper        expect_keys{"0", "1", "3", "5"};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{1, 1, 2, 2};
   // clang-format on
 
-  test_single_agg(
-    keys, vals, expect_keys, expect_vals, cudf::make_count_aggregation<groupby_aggregation>());
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
-                  cudf::make_count_aggregation<groupby_aggregation>(),
+                  cudf::make_count_aggregation<cudf::groupby_aggregation>());
+  test_single_agg(keys,
+                  vals,
+                  expect_keys,
+                  expect_vals,
+                  cudf::make_count_aggregation<cudf::groupby_aggregation>(),
                   force_use_sort_impl::YES);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/covariance_tests.cpp
+++ b/cpp/tests/groupby/covariance_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#include <cudf/detail/aggregation/aggregation.hpp>
-#include <cudf/utilities/traits.hpp>
+#include <tests/groupby/groupby_test_util.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
@@ -23,22 +22,20 @@
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
-#include <tests/groupby/groupby_test_util.hpp>
+#include <cudf/detail/aggregation/aggregation.hpp>
+#include <cudf/utilities/traits.hpp>
 
 #include <limits>
 #include <vector>
 
 using namespace cudf::test::iterators;
-namespace cudf {
-namespace test {
-
-using structs = structs_column_wrapper;
 
 template <typename V>
 struct groupby_covariance_test : public cudf::test::BaseFixture {
 };
 
-using supported_types = RemoveIf<ContainedIn<Types<bool>>, cudf::test::NumericTypes>;
+using supported_types =
+  cudf::test::RemoveIf<cudf::test::ContainedIn<cudf::test::Types<bool>>, cudf::test::NumericTypes>;
 
 TYPED_TEST_SUITE(groupby_covariance_test, supported_types);
 using K = int32_t;
@@ -47,14 +44,15 @@ TYPED_TEST(groupby_covariance_test, invalid_types)
 {
   using V = TypeParam;
 
-  auto keys     = fixed_width_column_wrapper<K>{{1, 2, 2, 1}};
-  auto member_0 = fixed_width_column_wrapper<V>{{1, 1, 1, 2}};
-  // Covariance aggregations require all types are convertible to double, but
+  auto keys     = cudf::test::fixed_width_column_wrapper<K>{{1, 2, 2, 1}};
+  auto member_0 = cudf::test::fixed_width_column_wrapper<V>{{1, 1, 1, 2}};
+  // Covariance cudf::aggregations require all types are convertible to double, but
   // duration_D cannot be converted to double.
-  auto member_1 = fixed_width_column_wrapper<cudf::duration_D, cudf::duration_D::rep>{{0, 0, 1, 1}};
-  auto vals     = structs{{member_0, member_1}};
+  auto member_1 =
+    cudf::test::fixed_width_column_wrapper<cudf::duration_D, cudf::duration_D::rep>{{0, 0, 1, 1}};
+  auto vals = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_covariance_aggregation<cudf::groupby_aggregation>();
   EXPECT_THROW(test_single_agg(keys, vals, keys, vals, std::move(agg), force_use_sort_impl::YES),
                cudf::logic_error);
 }
@@ -62,179 +60,179 @@ TYPED_TEST(groupby_covariance_test, invalid_types)
 TYPED_TEST(groupby_covariance_test, basic)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COVARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COVARIANCE>;
 
-  auto keys     = fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
-  auto member_0 = fixed_width_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
-  auto member_1 = fixed_width_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
-  auto vals     = structs{{member_0, member_1}};
+  auto keys     = cudf::test::fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
+  auto member_0 = cudf::test::fixed_width_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
+  auto member_1 = cudf::test::fixed_width_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
+  auto vals     = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R, double> expect_vals{{1.0, 1.0, 0.0}};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals{{1.0, 1.0, 0.0}};
 
-  auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_covariance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_covariance_test, empty_cols)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COVARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COVARIANCE>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> member_0{}, member_1{};
-  auto vals = structs{{member_0, member_1}};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> member_0{}, member_1{};
+  auto vals = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_covariance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_covariance_test, zero_valid_keys)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COVARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COVARIANCE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> member_0{3, 4, 5}, member_1{6, 7, 8};
-  auto vals = structs{{member_0, member_1}};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> member_0{3, 4, 5}, member_1{6, 7, 8};
+  auto vals = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_covariance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_covariance_test, zero_valid_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COVARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COVARIANCE>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> member_0({3, 4, 5}, all_nulls());
-  fixed_width_column_wrapper<V> member_1({3, 4, 5}, all_nulls());
-  auto vals = structs{{member_0, member_1}};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> member_0({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> member_1({3, 4, 5}, all_nulls());
+  auto vals = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
-  auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_covariance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_covariance_test, null_keys_and_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COVARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COVARIANCE>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
                                      {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
+  cudf::test::fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
                                      {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
-  fixed_width_column_wrapper<V> val1({1, 1, 1, 2, 0, 3, 3,-1, 0, 2, 2});
+  cudf::test::fixed_width_column_wrapper<V> val1({1, 1, 1, 2, 0, 3, 3,-1, 0, 2, 2});
   // clang-format on
-  auto vals = structs{{val0, val1}};
+  auto vals = cudf::test::structs_column_wrapper{{val0, val1}};
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
-  fixed_width_column_wrapper<R> expect_vals({0.5, 1.0, 0.0, -0.}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0.5, 1.0, 0.0, -0.}, {1, 1, 1, 0});
 
-  auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_covariance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_covariance_test, null_values_same)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COVARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COVARIANCE>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
                                      {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
+  cudf::test::fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
                                      {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
-  fixed_width_column_wrapper<V> val1({1, 1, 1, 2, 0, 3, 3,-1, 0, 2, 2},
+  cudf::test::fixed_width_column_wrapper<V> val1({1, 1, 1, 2, 0, 3, 3,-1, 0, 2, 2},
                                      {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
   // clang-format on
-  auto vals = structs{{val0, val1}};
+  auto vals = cudf::test::structs_column_wrapper{{val0, val1}};
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
-  fixed_width_column_wrapper<R> expect_vals({0.5, 1.0, 0.0, -0.}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0.5, 1.0, 0.0, -0.}, {1, 1, 1, 0});
 
-  auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_covariance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_covariance_test, null_values_different)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COVARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COVARIANCE>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
                                      {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
+  cudf::test::fixed_width_column_wrapper<V> val0({9, 1, 1, 2, 2, 3, 3,-1, 1, 4, 4},
                                      {0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1});
-  fixed_width_column_wrapper<V> val1({1, 2, 1, 2,-1, 3, 3,-1, 0, 4, 2},
+  cudf::test::fixed_width_column_wrapper<V> val1({1, 2, 1, 2,-1, 3, 3,-1, 0, 4, 2},
                                      {0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0});
   // clang-format on
-  auto vals = structs{{val0, val1}};
+  auto vals = cudf::test::structs_column_wrapper{{val0, val1}};
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
-  fixed_width_column_wrapper<R> expect_vals(
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<R> expect_vals(
     {std::numeric_limits<double>::quiet_NaN(), 1.5, 0.0, -0.}, {0, 1, 1, 0});
 
-  auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_covariance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_covariance_test, min_periods)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COVARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COVARIANCE>;
 
-  auto keys     = fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
-  auto member_0 = fixed_width_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
-  auto member_1 = fixed_width_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
-  auto vals     = structs{{member_0, member_1}};
+  auto keys     = cudf::test::fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
+  auto member_0 = cudf::test::fixed_width_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
+  auto member_1 = cudf::test::fixed_width_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
+  auto vals     = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
-  fixed_width_column_wrapper<R, double> expect_vals1{{1.0, 1.0, 0.0}};
-  auto agg1 = cudf::make_covariance_aggregation<groupby_aggregation>(3);
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals1{{1.0, 1.0, 0.0}};
+  auto agg1 = cudf::make_covariance_aggregation<cudf::groupby_aggregation>(3);
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg1), force_use_sort_impl::YES);
 
-  fixed_width_column_wrapper<R, double> expect_vals2{{1.0, 1.0, 0.0}, {0, 1, 0}};
-  auto agg2 = cudf::make_covariance_aggregation<groupby_aggregation>(4);
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals2{{1.0, 1.0, 0.0}, {0, 1, 0}};
+  auto agg2 = cudf::make_covariance_aggregation<cudf::groupby_aggregation>(4);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2), force_use_sort_impl::YES);
 
-  fixed_width_column_wrapper<R, double> expect_vals3{{1.0, 1.0, 0.0}, {0, 0, 0}};
-  auto agg3 = cudf::make_covariance_aggregation<groupby_aggregation>(5);
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals3{{1.0, 1.0, 0.0}, {0, 0, 0}};
+  auto agg3 = cudf::make_covariance_aggregation<cudf::groupby_aggregation>(5);
   test_single_agg(keys, vals, expect_keys, expect_vals3, std::move(agg3), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_covariance_test, ddof)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::COVARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COVARIANCE>;
 
-  auto keys     = fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
-  auto member_0 = fixed_width_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
-  auto member_1 = fixed_width_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
-  auto vals     = structs{{member_0, member_1}};
+  auto keys     = cudf::test::fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
+  auto member_0 = cudf::test::fixed_width_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
+  auto member_1 = cudf::test::fixed_width_column_wrapper<V>{{1, 1, 1, 2, 0, 3, 3, 1, 1, 2}};
+  auto vals     = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
-  fixed_width_column_wrapper<R, double> expect_vals1{{2.0, 1.5, 0.0}};
-  auto agg1 = cudf::make_covariance_aggregation<groupby_aggregation>(1, 2);
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals1{{2.0, 1.5, 0.0}};
+  auto agg1 = cudf::make_covariance_aggregation<cudf::groupby_aggregation>(1, 2);
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg1), force_use_sort_impl::YES);
 
   auto const inf = std::numeric_limits<double>::infinity();
-  fixed_width_column_wrapper<R, double> expect_vals2{{inf, 3.0, 0.0}, {0, 1, 0}};
-  auto agg2 = cudf::make_covariance_aggregation<groupby_aggregation>(1, 3);
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals2{{inf, 3.0, 0.0}, {0, 1, 0}};
+  auto agg2 = cudf::make_covariance_aggregation<cudf::groupby_aggregation>(1, 3);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2), force_use_sort_impl::YES);
 }
 
@@ -244,19 +242,16 @@ struct groupby_dictionary_covariance_test : public cudf::test::BaseFixture {
 TEST_F(groupby_dictionary_covariance_test, basic)
 {
   using V = int16_t;
-  using R = cudf::detail::target_type_t<V, aggregation::COVARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COVARIANCE>;
 
-  auto keys     = fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
-  auto member_0 = dictionary_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
-  auto member_1 = dictionary_column_wrapper<V>{{1, 1, 1, 2, 3, -3, 3, 1, 1, 2}};
-  auto vals     = structs{{member_0, member_1}};
+  auto keys     = cudf::test::fixed_width_column_wrapper<K>{{1, 2, 3, 1, 2, 2, 1, 3, 3, 2}};
+  auto member_0 = cudf::test::dictionary_column_wrapper<V>{{1, 1, 1, 2, 2, 3, 3, 1, 1, 4}};
+  auto member_1 = cudf::test::dictionary_column_wrapper<V>{{1, 1, 1, 2, 3, -3, 3, 1, 1, 2}};
+  auto vals     = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R, double> expect_vals{{1.0, -0.5, 0.0}};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals{{1.0, -0.5, 0.0}};
 
-  auto agg = cudf::make_covariance_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_covariance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), force_use_sort_impl::YES);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/groupby_test_util.cpp
+++ b/cpp/tests/groupby/groupby_test_util.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "groupby_test_util.hpp"
+
+#include <cudf_test/column_utilities.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/table_utilities.hpp>
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/groupby.hpp>
+#include <cudf/sorting.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+#include <cudf/unary.hpp>
+
+#include <random>
+
+void test_single_agg(cudf::column_view const& keys,
+                     cudf::column_view const& values,
+                     cudf::column_view const& expect_keys,
+                     cudf::column_view const& expect_vals,
+                     std::unique_ptr<cudf::groupby_aggregation>&& agg,
+                     force_use_sort_impl use_sort,
+                     cudf::null_policy include_null_keys,
+                     cudf::sorted keys_are_sorted,
+                     std::vector<cudf::order> const& column_order,
+                     std::vector<cudf::null_order> const& null_precedence,
+                     cudf::sorted reference_keys_are_sorted)
+{
+  auto const [sorted_expect_keys, sorted_expect_vals] = [&]() {
+    if (reference_keys_are_sorted == cudf::sorted::NO) {
+      auto const sort_expect_order =
+        cudf::sorted_order(cudf::table_view{{expect_keys}}, column_order, null_precedence);
+      auto sorted_expect_keys = cudf::gather(cudf::table_view{{expect_keys}}, *sort_expect_order);
+      auto sorted_expect_vals = cudf::gather(cudf::table_view{{expect_vals}}, *sort_expect_order);
+      return std::make_pair(std::move(sorted_expect_keys), std::move(sorted_expect_vals));
+    } else {
+      auto sorted_expect_keys = std::make_unique<cudf::table>(cudf::table_view{{expect_keys}});
+      auto sorted_expect_vals = std::make_unique<cudf::table>(cudf::table_view{{expect_vals}});
+      return std::make_pair(std::move(sorted_expect_keys), std::move(sorted_expect_vals));
+    }
+  }();
+
+  std::vector<cudf::groupby::aggregation_request> requests;
+  requests.emplace_back(cudf::groupby::aggregation_request());
+  requests[0].values = values;
+
+  requests[0].aggregations.push_back(std::move(agg));
+
+  if (use_sort == force_use_sort_impl::YES) {
+    // WAR to force cudf::groupby to use sort implementation
+    requests[0].aggregations.push_back(
+      cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0));
+  }
+
+  // since the default behavior of cudf::groupby(...) for an empty null_precedence vector is
+  // null_order::AFTER whereas for cudf::sorted_order(...) it's null_order::BEFORE
+  auto const precedence = null_precedence.empty()
+                            ? std::vector<cudf::null_order>(1, cudf::null_order::BEFORE)
+                            : null_precedence;
+
+  cudf::groupby::groupby gb_obj(
+    cudf::table_view({keys}), include_null_keys, keys_are_sorted, column_order, precedence);
+
+  auto result = gb_obj.aggregate(requests);
+
+  if (use_sort == force_use_sort_impl::YES && keys_are_sorted == cudf::sorted::NO) {
+    CUDF_TEST_EXPECT_TABLES_EQUAL(*sorted_expect_keys, result.first->view());
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted_expect_vals->get_column(0),
+                                        *result.second[0].results[0]);
+
+  } else {
+    auto const sort_order  = cudf::sorted_order(result.first->view(), column_order, precedence);
+    auto const sorted_keys = cudf::gather(result.first->view(), *sort_order);
+    auto const sorted_vals =
+      cudf::gather(cudf::table_view({result.second[0].results[0]->view()}), *sort_order);
+
+    CUDF_TEST_EXPECT_TABLES_EQUAL(*sorted_expect_keys, *sorted_keys);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted_expect_vals->get_column(0),
+                                        sorted_vals->get_column(0));
+  }
+}
+
+void test_sum_agg(cudf::column_view const& keys,
+                  cudf::column_view const& values,
+                  cudf::column_view const& expected_keys,
+                  cudf::column_view const& expected_values)
+{
+  auto const do_test = [&](auto const use_sort_option) {
+    test_single_agg(keys,
+                    values,
+                    expected_keys,
+                    expected_values,
+                    cudf::make_sum_aggregation<cudf::groupby_aggregation>(),
+                    use_sort_option,
+                    cudf::null_policy::INCLUDE);
+  };
+  do_test(force_use_sort_impl::YES);
+  do_test(force_use_sort_impl::NO);
+}
+
+void test_single_scan(cudf::column_view const& keys,
+                      cudf::column_view const& values,
+                      cudf::column_view const& expect_keys,
+                      cudf::column_view const& expect_vals,
+                      std::unique_ptr<cudf::groupby_scan_aggregation>&& agg,
+                      cudf::null_policy include_null_keys,
+                      cudf::sorted keys_are_sorted,
+                      std::vector<cudf::order> const& column_order,
+                      std::vector<cudf::null_order> const& null_precedence)
+{
+  std::vector<cudf::groupby::scan_request> requests;
+  requests.emplace_back(cudf::groupby::scan_request());
+  requests[0].values = values;
+
+  requests[0].aggregations.push_back(std::move(agg));
+
+  cudf::groupby::groupby gb_obj(
+    cudf::table_view({keys}), include_null_keys, keys_are_sorted, column_order, null_precedence);
+
+  // cudf::groupby scan uses sort implementation
+  auto result = gb_obj.scan(requests);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(cudf::table_view({expect_keys}), result.first->view());
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expect_vals, *result.second[0].results[0]);
+}

--- a/cpp/tests/groupby/groupby_test_util.hpp
+++ b/cpp/tests/groupby/groupby_test_util.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,161 +16,36 @@
 
 #pragma once
 
-#include <cudf_test/column_utilities.hpp>
-#include <cudf_test/column_wrapper.hpp>
-#include <cudf_test/table_utilities.hpp>
-
 #include <cudf/column/column_view.hpp>
-#include <cudf/copying.hpp>
-#include <cudf/detail/iterator.cuh>
 #include <cudf/groupby.hpp>
 #include <cudf/sorting.hpp>
-#include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
-#include <cudf/unary.hpp>
 
-#include <random>
-
-namespace cudf {
-namespace test {
 enum class force_use_sort_impl : bool { NO, YES };
 
-inline void test_groups(column_view const& keys,
-                        column_view const& expect_grouped_keys,
-                        std::vector<size_type> const& expect_group_offsets,
-                        column_view const& values                = {},
-                        column_view const& expect_grouped_values = {})
-{
-  groupby::groupby gb(table_view({keys}));
-  groupby::groupby::groups gb_groups;
+void test_single_agg(cudf::column_view const& keys,
+                     cudf::column_view const& values,
+                     cudf::column_view const& expect_keys,
+                     cudf::column_view const& expect_vals,
+                     std::unique_ptr<cudf::groupby_aggregation>&& agg,
+                     force_use_sort_impl use_sort                 = force_use_sort_impl::NO,
+                     cudf::null_policy include_null_keys          = cudf::null_policy::EXCLUDE,
+                     cudf::sorted keys_are_sorted                 = cudf::sorted::NO,
+                     std::vector<cudf::order> const& column_order = {},
+                     std::vector<cudf::null_order> const& null_precedence = {},
+                     cudf::sorted reference_keys_are_sorted               = cudf::sorted::NO);
 
-  if (values.size()) {
-    gb_groups = gb.get_groups(table_view({values}));
-  } else {
-    gb_groups = gb.get_groups();
-  }
-  CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({expect_grouped_keys}), gb_groups.keys->view());
+void test_sum_agg(cudf::column_view const& keys,
+                  cudf::column_view const& values,
+                  cudf::column_view const& expected_keys,
+                  cudf::column_view const& expected_values);
 
-  auto got_offsets = gb_groups.offsets;
-  EXPECT_EQ(expect_group_offsets.size(), got_offsets.size());
-  for (auto i = 0u; i != expect_group_offsets.size(); ++i) {
-    EXPECT_EQ(expect_group_offsets[i], got_offsets[i]);
-  }
-
-  if (values.size()) {
-    CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({expect_grouped_values}), gb_groups.values->view());
-  }
-}
-
-inline void test_single_agg(column_view const& keys,
-                            column_view const& values,
-                            column_view const& expect_keys,
-                            column_view const& expect_vals,
-                            std::unique_ptr<groupby_aggregation>&& agg,
-                            force_use_sort_impl use_sort           = force_use_sort_impl::NO,
-                            null_policy include_null_keys          = null_policy::EXCLUDE,
-                            sorted keys_are_sorted                 = sorted::NO,
-                            std::vector<order> const& column_order = {},
-                            std::vector<null_order> const& null_precedence = {},
-                            sorted reference_keys_are_sorted               = sorted::NO)
-{
-  auto const [sorted_expect_keys, sorted_expect_vals] = [&]() {
-    if (reference_keys_are_sorted == sorted::NO) {
-      auto const sort_expect_order =
-        sorted_order(table_view{{expect_keys}}, column_order, null_precedence);
-      auto sorted_expect_keys = gather(table_view{{expect_keys}}, *sort_expect_order);
-      auto sorted_expect_vals = gather(table_view{{expect_vals}}, *sort_expect_order);
-      return std::make_pair(std::move(sorted_expect_keys), std::move(sorted_expect_vals));
-    } else {
-      auto sorted_expect_keys = std::make_unique<table>(table_view{{expect_keys}});
-      auto sorted_expect_vals = std::make_unique<table>(table_view{{expect_vals}});
-      return std::make_pair(std::move(sorted_expect_keys), std::move(sorted_expect_vals));
-    }
-  }();
-
-  std::vector<groupby::aggregation_request> requests;
-  requests.emplace_back(groupby::aggregation_request());
-  requests[0].values = values;
-
-  requests[0].aggregations.push_back(std::move(agg));
-
-  if (use_sort == force_use_sort_impl::YES) {
-    // WAR to force groupby to use sort implementation
-    requests[0].aggregations.push_back(make_nth_element_aggregation<groupby_aggregation>(0));
-  }
-
-  // since the default behavior of groupby(...) for an empty null_precedence vector is
-  // null_order::AFTER whereas for sorted_order(...) it's null_order::BEFORE
-  auto const precedence =
-    null_precedence.empty() ? std::vector<null_order>(1, null_order::BEFORE) : null_precedence;
-
-  groupby::groupby gb_obj(
-    table_view({keys}), include_null_keys, keys_are_sorted, column_order, precedence);
-
-  auto result = gb_obj.aggregate(requests);
-
-  if (use_sort == force_use_sort_impl::YES && keys_are_sorted == sorted::NO) {
-    CUDF_TEST_EXPECT_TABLES_EQUAL(*sorted_expect_keys, result.first->view());
-    cudf::test::detail::expect_columns_equivalent(sorted_expect_vals->get_column(0),
-                                                  *result.second[0].results[0],
-                                                  debug_output_level::ALL_ERRORS);
-
-  } else {
-    auto const sort_order  = sorted_order(result.first->view(), column_order, precedence);
-    auto const sorted_keys = gather(result.first->view(), *sort_order);
-    auto const sorted_vals = gather(table_view({result.second[0].results[0]->view()}), *sort_order);
-
-    CUDF_TEST_EXPECT_TABLES_EQUAL(*sorted_expect_keys, *sorted_keys);
-    cudf::test::detail::expect_columns_equivalent(sorted_expect_vals->get_column(0),
-                                                  sorted_vals->get_column(0),
-                                                  debug_output_level::ALL_ERRORS);
-  }
-}
-
-inline void test_sum_agg(column_view const& keys,
-                         column_view const& values,
-                         column_view const& expected_keys,
-                         column_view const& expected_values)
-{
-  auto const do_test = [&](auto const use_sort_option) {
-    test_single_agg(keys,
-                    values,
-                    expected_keys,
-                    expected_values,
-                    cudf::make_sum_aggregation<groupby_aggregation>(),
-                    use_sort_option,
-                    null_policy::INCLUDE);
-  };
-  do_test(force_use_sort_impl::YES);
-  do_test(force_use_sort_impl::NO);
-}
-
-inline void test_single_scan(column_view const& keys,
-                             column_view const& values,
-                             column_view const& expect_keys,
-                             column_view const& expect_vals,
-                             std::unique_ptr<groupby_scan_aggregation>&& agg,
-                             null_policy include_null_keys                  = null_policy::EXCLUDE,
-                             sorted keys_are_sorted                         = sorted::NO,
-                             std::vector<order> const& column_order         = {},
-                             std::vector<null_order> const& null_precedence = {})
-{
-  std::vector<groupby::scan_request> requests;
-  requests.emplace_back(groupby::scan_request());
-  requests[0].values = values;
-
-  requests[0].aggregations.push_back(std::move(agg));
-
-  groupby::groupby gb_obj(
-    table_view({keys}), include_null_keys, keys_are_sorted, column_order, null_precedence);
-
-  // groupby scan uses sort implementation
-  auto result = gb_obj.scan(requests);
-
-  CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({expect_keys}), result.first->view());
-  cudf::test::detail::expect_columns_equivalent(
-    expect_vals, *result.second[0].results[0], debug_output_level::ALL_ERRORS);
-}
-
-}  // namespace test
-}  // namespace cudf
+void test_single_scan(cudf::column_view const& keys,
+                      cudf::column_view const& values,
+                      cudf::column_view const& expect_keys,
+                      cudf::column_view const& expect_vals,
+                      std::unique_ptr<cudf::groupby_scan_aggregation>&& agg,
+                      cudf::null_policy include_null_keys          = cudf::null_policy::EXCLUDE,
+                      cudf::sorted keys_are_sorted                 = cudf::sorted::NO,
+                      std::vector<cudf::order> const& column_order = {},
+                      std::vector<cudf::null_order> const& null_precedence = {});

--- a/cpp/tests/groupby/groups_tests.cpp
+++ b/cpp/tests/groupby/groups_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,35 +14,62 @@
  * limitations under the License.
  */
 
-#include <tests/groupby/groupby_test_util.hpp>
+// #include <tests/groupby/groupby_test_util.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/iterator_utilities.hpp>
+#include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/groupby.hpp>
+#include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-using namespace cudf::test::iterators;
+inline void test_groups(cudf::column_view const& keys,
+                        cudf::column_view const& expect_grouped_keys,
+                        std::vector<cudf::size_type> const& expect_group_offsets,
+                        cudf::column_view const& values                = {},
+                        cudf::column_view const& expect_grouped_values = {})
+{
+  cudf::groupby::groupby gb(cudf::table_view({keys}));
+  cudf::groupby::groupby::groups gb_groups;
 
-namespace cudf {
-namespace test {
-struct groupby_group_keys_test : public BaseFixture {
+  if (values.size()) {
+    gb_groups = gb.get_groups(cudf::table_view({values}));
+  } else {
+    gb_groups = gb.get_groups();
+  }
+  CUDF_TEST_EXPECT_TABLES_EQUAL(cudf::table_view({expect_grouped_keys}), gb_groups.keys->view());
+
+  auto got_offsets = gb_groups.offsets;
+  EXPECT_EQ(expect_group_offsets.size(), got_offsets.size());
+  for (auto i = 0u; i != expect_group_offsets.size(); ++i) {
+    EXPECT_EQ(expect_group_offsets[i], got_offsets[i]);
+  }
+
+  if (values.size()) {
+    CUDF_TEST_EXPECT_TABLES_EQUAL(cudf::table_view({expect_grouped_values}),
+                                  gb_groups.values->view());
+  }
+}
+
+struct groupby_group_keys_test : public cudf::test::BaseFixture {
 };
 
 template <typename V>
 struct groupby_group_keys_and_values_test : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(groupby_group_keys_and_values_test, NumericTypes);
+TYPED_TEST_SUITE(groupby_group_keys_and_values_test, cudf::test::NumericTypes);
 
 TEST_F(groupby_group_keys_test, basic)
 {
   using K = int32_t;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 2, 1, 2, 3};
-  fixed_width_column_wrapper<K> expect_grouped_keys{1, 1, 1, 2, 2, 3};
-  std::vector<size_type> expect_group_offsets = {0, 3, 5, 6};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 2, 1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_grouped_keys{1, 1, 1, 2, 2, 3};
+  std::vector<cudf::size_type> expect_group_offsets = {0, 3, 5, 6};
   test_groups(keys, expect_grouped_keys, expect_group_offsets);
 }
 
@@ -50,9 +77,9 @@ TEST_F(groupby_group_keys_test, empty_keys)
 {
   using K = int32_t;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<K> expect_grouped_keys{};
-  std::vector<size_type> expect_group_offsets = {0};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<K> expect_grouped_keys{};
+  std::vector<cudf::size_type> expect_group_offsets = {0};
   test_groups(keys, expect_grouped_keys, expect_group_offsets);
 }
 
@@ -60,9 +87,10 @@ TEST_F(groupby_group_keys_test, all_null_keys)
 {
   using K = int32_t;
 
-  fixed_width_column_wrapper<K> keys({1, 1, 2, 3, 1, 2}, all_nulls());
-  fixed_width_column_wrapper<K> expect_grouped_keys{};
-  std::vector<size_type> expect_group_offsets = {0};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 1, 2, 3, 1, 2},
+                                                 cudf::test::iterators::all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_grouped_keys{};
+  std::vector<cudf::size_type> expect_group_offsets = {0};
   test_groups(keys, expect_grouped_keys, expect_group_offsets);
 }
 
@@ -71,11 +99,11 @@ TYPED_TEST(groupby_group_keys_and_values_test, basic_with_values)
   using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> keys({5, 4, 3, 2, 1, 0});
-  fixed_width_column_wrapper<K> expect_grouped_keys{0, 1, 2, 3, 4, 5};
-  fixed_width_column_wrapper<V> values({0, 0, 1, 1, 2, 2});
-  fixed_width_column_wrapper<V> expect_grouped_values{2, 2, 1, 1, 0, 0};
-  std::vector<size_type> expect_group_offsets = {0, 1, 2, 3, 4, 5, 6};
+  cudf::test::fixed_width_column_wrapper<K> keys({5, 4, 3, 2, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> expect_grouped_keys{0, 1, 2, 3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<V> values({0, 0, 1, 1, 2, 2});
+  cudf::test::fixed_width_column_wrapper<V> expect_grouped_values{2, 2, 1, 1, 0, 0};
+  std::vector<cudf::size_type> expect_group_offsets = {0, 1, 2, 3, 4, 5, 6};
   test_groups(keys, expect_grouped_keys, expect_group_offsets, values, expect_grouped_values);
 }
 
@@ -84,13 +112,11 @@ TYPED_TEST(groupby_group_keys_and_values_test, some_nulls)
   using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> keys({1, 1, 3, 2, 1, 2}, {1, 0, 1, 0, 0, 1});
-  fixed_width_column_wrapper<K> expect_grouped_keys({1, 2, 3}, no_nulls());
-  fixed_width_column_wrapper<V> values({1, 2, 3, 4, 5, 6});
-  fixed_width_column_wrapper<V> expect_grouped_values({1, 6, 3});
-  std::vector<size_type> expect_group_offsets = {0, 1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 1, 3, 2, 1, 2}, {1, 0, 1, 0, 0, 1});
+  cudf::test::fixed_width_column_wrapper<K> expect_grouped_keys({1, 2, 3},
+                                                                cudf::test::iterators::no_nulls());
+  cudf::test::fixed_width_column_wrapper<V> values({1, 2, 3, 4, 5, 6});
+  cudf::test::fixed_width_column_wrapper<V> expect_grouped_values({1, 6, 3});
+  std::vector<cudf::size_type> expect_group_offsets = {0, 1, 2, 3};
   test_groups(keys, expect_grouped_keys, expect_group_offsets, values, expect_grouped_values);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/groups_tests.cpp
+++ b/cpp/tests/groupby/groups_tests.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// #include <tests/groupby/groupby_test_util.hpp>
-
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/iterator_utilities.hpp>
@@ -26,11 +24,11 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
-inline void test_groups(cudf::column_view const& keys,
-                        cudf::column_view const& expect_grouped_keys,
-                        std::vector<cudf::size_type> const& expect_group_offsets,
-                        cudf::column_view const& values                = {},
-                        cudf::column_view const& expect_grouped_values = {})
+void test_groups(cudf::column_view const& keys,
+                 cudf::column_view const& expect_grouped_keys,
+                 std::vector<cudf::size_type> const& expect_group_offsets,
+                 cudf::column_view const& values                = {},
+                 cudf::column_view const& expect_grouped_values = {})
 {
   cudf::groupby::groupby gb(cudf::table_view({keys}));
   cudf::groupby::groupby::groups gb_groups;

--- a/cpp/tests/groupby/keys_tests.cpp
+++ b/cpp/tests/groupby/keys_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,11 @@
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/aggregation.hpp>
 #include <cudf/detail/aggregation/aggregation.hpp>
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_keys_test : public cudf::test::BaseFixture {
 };
@@ -40,17 +39,17 @@ TYPED_TEST(groupby_keys_test, basic)
 {
   using K = TypeParam;
   using V = int32_t;
-  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_VALID>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  fixed_width_column_wrapper<K> expect_keys { 1, 2, 3 };
-  fixed_width_column_wrapper<R> expect_vals { 3, 4, 3 };
+  cudf::test::fixed_width_column_wrapper<K> expect_keys { 1, 2, 3 };
+  cudf::test::fixed_width_column_wrapper<R> expect_vals { 3, 4, 3 };
   // clang-format on
 
-  auto agg = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -58,17 +57,17 @@ TYPED_TEST(groupby_keys_test, zero_valid_keys)
 {
   using K = TypeParam;
   using V = int32_t;
-  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_VALID>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, all_nulls() );
-  fixed_width_column_wrapper<V> vals        { 3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<K> keys      ( { 1, 2, 3}, all_nulls() );
+  cudf::test::fixed_width_column_wrapper<V> vals        { 3, 4, 5};
 
-  fixed_width_column_wrapper<K> expect_keys { };
-  fixed_width_column_wrapper<R> expect_vals { };
+  cudf::test::fixed_width_column_wrapper<K> expect_keys { };
+  cudf::test::fixed_width_column_wrapper<R> expect_vals { };
   // clang-format on
 
-  auto agg = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -76,20 +75,20 @@ TYPED_TEST(groupby_keys_test, some_null_keys)
 {
   using K = TypeParam;
   using V = int32_t;
-  using R = cudf::detail::target_type_t<V, aggregation::COUNT_VALID>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::COUNT_VALID>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                            { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
+  cudf::test::fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                        { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
-                                        //  { 1, 1, 1,  2, 2, 2, 2,  3, 3,  4}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3,     4}, no_nulls() );
-                                        //  { 0, 3, 6,  1, 4, 5, 9,  2, 8,  -}
-  fixed_width_column_wrapper<R> expect_vals { 3,        4,           2,     1};
+                                                    //  { 1, 1, 1,  2, 2, 2, 2,  3, 3,  4}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3,     4}, no_nulls() );
+                                                    //  { 0, 3, 6,  1, 4, 5, 9,  2, 8,  -}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals { 3,        4,           2,     1};
   // clang-format on
 
-  auto agg = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -97,133 +96,133 @@ TYPED_TEST(groupby_keys_test, include_null_keys)
 {
   using K = TypeParam;
   using V = int32_t;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                            { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
+  cudf::test::fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                        { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
-                                        //  { 1, 1, 1,  2, 2, 2, 2,  3, 3,  4,  -}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3,     4,  3},
-                                            { 1,        1,           1,     1,  0});
-                                        //  { 0, 3, 6,  1, 4, 5, 9,  2, 8,  -,  -}
-  fixed_width_column_wrapper<R> expect_vals { 9,        19,          10,    4,  7};
+                                                    //  { 1, 1, 1,  2, 2, 2, 2,  3, 3,  4,  -}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3,     4,  3},
+                                                        { 1,        1,           1,     1,  0});
+                                                    //  { 0, 3, 6,  1, 4, 5, 9,  2, 8,  -,  -}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals { 9,        19,          10,    4,  7};
   // clang-format on
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
                   std::move(agg),
                   force_use_sort_impl::NO,
-                  null_policy::INCLUDE);
+                  cudf::null_policy::INCLUDE);
 }
 
 TYPED_TEST(groupby_keys_test, pre_sorted_keys)
 {
   using K = TypeParam;
   using V = int32_t;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys        { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4};
-  fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
+  cudf::test::fixed_width_column_wrapper<K> keys        { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4};
+  cudf::test::fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
-  fixed_width_column_wrapper<K> expect_keys { 1,       2,          3,       4};
-  fixed_width_column_wrapper<R> expect_vals { 3,       18,         24,      4};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys { 1,       2,          3,       4};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals { 3,       18,         24,      4};
   // clang-format on
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
                   std::move(agg),
                   force_use_sort_impl::YES,
-                  null_policy::EXCLUDE,
-                  sorted::YES);
+                  cudf::null_policy::EXCLUDE,
+                  cudf::sorted::YES);
 }
 
 TYPED_TEST(groupby_keys_test, pre_sorted_keys_descending)
 {
   using K = TypeParam;
   using V = int32_t;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys        { 4, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1};
-  fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
+  cudf::test::fixed_width_column_wrapper<K> keys        { 4, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
-  fixed_width_column_wrapper<K> expect_keys { 4, 3,       2,          1      };
-  fixed_width_column_wrapper<R> expect_vals { 0, 6,       22,        21      };
+  cudf::test::fixed_width_column_wrapper<K> expect_keys { 4, 3,       2,          1      };
+  cudf::test::fixed_width_column_wrapper<R> expect_vals { 0, 6,       22,        21      };
   // clang-format on
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
                   std::move(agg),
                   force_use_sort_impl::YES,
-                  null_policy::EXCLUDE,
-                  sorted::YES,
-                  {order::DESCENDING});
+                  cudf::null_policy::EXCLUDE,
+                  cudf::sorted::YES,
+                  {cudf::order::DESCENDING});
 }
 
 TYPED_TEST(groupby_keys_test, pre_sorted_keys_nullable)
 {
   using K = TypeParam;
   using V = int32_t;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys(       { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4},
-                                            { 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
+  cudf::test::fixed_width_column_wrapper<K> keys(       { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4},
+                                                        { 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
-  fixed_width_column_wrapper<K> expect_keys({ 1,       2,          3,       4}, no_nulls() );
-  fixed_width_column_wrapper<R> expect_vals { 3,       15,         17,      4};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({ 1,       2,          3,       4}, no_nulls() );
+  cudf::test::fixed_width_column_wrapper<R> expect_vals { 3,       15,         17,      4};
   // clang-format on
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
                   std::move(agg),
                   force_use_sort_impl::YES,
-                  null_policy::EXCLUDE,
-                  sorted::YES);
+                  cudf::null_policy::EXCLUDE,
+                  cudf::sorted::YES);
 }
 
 TYPED_TEST(groupby_keys_test, pre_sorted_keys_nulls_before_include_nulls)
 {
   using K = TypeParam;
   using V = int32_t;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys(       { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4},
-                                            { 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
+  cudf::test::fixed_width_column_wrapper<K> keys(       { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4},
+                                                        { 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4};
 
-                                        //  { 1, 1, 1,  -, -,  2, 2,  -,  3, 3,  4}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,     2,     3,  3,     4},
-                                            { 1,        0,     1,     0,  1,     1});
-  fixed_width_column_wrapper<R> expect_vals { 3,        7,     11,    7,  17,    4};
+                                                    //  { 1, 1, 1,  -, -,  2, 2,  -,  3, 3,  4}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({ 1,        2,     2,     3,  3,     4},
+                                                        { 1,        0,     1,     0,  1,     1});
+  cudf::test::fixed_width_column_wrapper<R> expect_vals { 3,        7,     11,    7,  17,    4};
   // clang-format on
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
                   std::move(agg),
                   force_use_sort_impl::YES,
-                  null_policy::INCLUDE,
-                  sorted::YES);
+                  cudf::null_policy::INCLUDE,
+                  cudf::sorted::YES);
 }
 
 TYPED_TEST(groupby_keys_test, mismatch_num_rows)
@@ -231,13 +230,13 @@ TYPED_TEST(groupby_keys_test, mismatch_num_rows)
   using K = TypeParam;
   using V = int32_t;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4};
 
   // Verify that scan throws an error when given data of mismatched sizes.
-  auto agg = cudf::make_count_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_count_aggregation<cudf::groupby_aggregation>();
   EXPECT_THROW(test_single_agg(keys, vals, keys, vals, std::move(agg)), cudf::logic_error);
-  auto agg2 = cudf::make_count_aggregation<groupby_scan_aggregation>();
+  auto agg2 = cudf::make_count_aggregation<cudf::groupby_scan_aggregation>();
   EXPECT_THROW(test_single_scan(keys, vals, keys, vals, std::move(agg2)), cudf::logic_error);
 }
 
@@ -248,7 +247,7 @@ TYPED_TEST(groupby_keys_test, structs)
 {
   using V = TypeParam;
 
-  using R       = cudf::detail::target_type_t<int, aggregation::ARGMAX>;
+  using R       = cudf::detail::target_type_t<int, cudf::aggregation::ARGMAX>;
   using STRINGS = cudf::test::strings_column_wrapper;
   using STRUCTS = cudf::test::structs_column_wrapper;
 
@@ -292,7 +291,7 @@ TYPED_TEST(groupby_keys_test, structs)
   auto expect_keys = STRUCTS{{expected_s2, expected_col_c}, no_nulls()};
   auto expect_vals = FWCW<R>{6, 1, 8, 7};
 
-  auto agg = cudf::make_argmax_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_argmax_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -301,7 +300,7 @@ using LCW = cudf::test::lists_column_wrapper<T, int32_t>;
 
 TYPED_TEST(groupby_keys_test, lists)
 {
-  using R = cudf::detail::target_type_t<int32_t, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<int32_t, cudf::aggregation::SUM>;
 
   // clang-format off
   auto keys   = LCW<TypeParam> { {1,1}, {2,2}, {3,3}, {1,1}, {2,2} };
@@ -311,7 +310,7 @@ TYPED_TEST(groupby_keys_test, lists)
   auto expected_values = FWCW<R>        {    3,     5,     2  };
   // clang-format on
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, values, expected_keys, expected_values, std::move(agg));
 }
 
@@ -321,17 +320,17 @@ struct groupby_string_keys_test : public cudf::test::BaseFixture {
 TEST_F(groupby_string_keys_test, basic)
 {
   using V = int32_t;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
-  strings_column_wrapper        keys        { "aaa", "año", "₹1", "aaa", "año", "año", "aaa", "₹1", "₹1", "año"};
-  fixed_width_column_wrapper<V> vals        {     0,     1,    2,     3,     4,     5,     6,    7,    8,     9};
+  cudf::test::strings_column_wrapper        keys        { "aaa", "año", "₹1", "aaa", "año", "año", "aaa", "₹1", "₹1", "año"};
+  cudf::test::fixed_width_column_wrapper<V> vals        {     0,     1,    2,     3,     4,     5,     6,    7,    8,     9};
 
-  strings_column_wrapper        expect_keys({ "aaa", "año", "₹1" });
-  fixed_width_column_wrapper<R> expect_vals {     9,    19,   17 };
+  cudf::test::strings_column_wrapper        expect_keys({ "aaa", "año", "₹1" });
+  cudf::test::fixed_width_column_wrapper<R> expect_vals {     9,    19,   17 };
   // clang-format on
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 // clang-format on
@@ -343,85 +342,83 @@ TEST_F(groupby_dictionary_keys_test, basic)
 {
   using K = std::string;
   using V = int32_t;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
-  dictionary_column_wrapper<K> keys { "aaa", "año", "₹1", "aaa", "año", "año", "aaa", "₹1", "₹1", "año"};
-  fixed_width_column_wrapper<V> vals{     0,     1,    2,     3,     4,     5,     6,    7,    8,     9};
-  dictionary_column_wrapper<K>expect_keys  ({ "aaa", "año", "₹1" });
-  fixed_width_column_wrapper<R> expect_vals({     9,    19,   17 });
+  cudf::test::dictionary_column_wrapper<K> keys { "aaa", "año", "₹1", "aaa", "año", "año", "aaa", "₹1", "₹1", "año"};
+  cudf::test::fixed_width_column_wrapper<V> vals{     0,     1,    2,     3,     4,     5,     6,    7,    8,     9};
+  cudf::test::dictionary_column_wrapper<K>expect_keys  ({ "aaa", "año", "₹1" });
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({     9,    19,   17 });
   // clang-format on
 
   test_single_agg(
-    keys, vals, expect_keys, expect_vals, cudf::make_sum_aggregation<groupby_aggregation>());
+    keys, vals, expect_keys, expect_vals, cudf::make_sum_aggregation<cudf::groupby_aggregation>());
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
-                  cudf::make_sum_aggregation<groupby_aggregation>(),
+                  cudf::make_sum_aggregation<cudf::groupby_aggregation>(),
                   force_use_sort_impl::YES);
 }
 
 struct groupby_cache_test : public cudf::test::BaseFixture {
 };
 
-// To check if the cache doesn't insert multiple times to cache for same aggregation on a column in
-// same request.
-// If this test fails, then insert happened and key stored in cache map becomes dangling reference.
-// Any comparison with same aggregation as key will fail.
+// To check if the cache doesn't insert multiple times to cache for same cudf::aggregation on a
+// column in same request. If this test fails, then insert happened and key stored in cache map
+// becomes dangling reference. Any comparison with same cudf::aggregation as key will fail.
 TEST_F(groupby_cache_test, duplicate_agggregations)
 {
   using K = int32_t;
   using V = int32_t;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-  groupby::groupby gb_obj(table_view({keys}));
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::groupby::groupby gb_obj(cudf::table_view({keys}));
 
-  std::vector<groupby::aggregation_request> requests;
-  requests.emplace_back(groupby::aggregation_request());
+  std::vector<cudf::groupby::aggregation_request> requests;
+  requests.emplace_back(cudf::groupby::aggregation_request());
   requests[0].values = vals;
-  requests[0].aggregations.push_back(cudf::make_sum_aggregation<groupby_aggregation>());
-  requests[0].aggregations.push_back(cudf::make_sum_aggregation<groupby_aggregation>());
+  requests[0].aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+  requests[0].aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
 
   // hash groupby
   EXPECT_NO_THROW(gb_obj.aggregate(requests));
 
   // sort groupby
   // WAR to force groupby to use sort implementation
-  requests[0].aggregations.push_back(make_nth_element_aggregation<groupby_aggregation>(0));
+  requests[0].aggregations.push_back(
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0));
   EXPECT_NO_THROW(gb_obj.aggregate(requests));
 }
 
-// To check if the cache doesn't insert multiple times to cache for same aggregation on same column
-// but in different requests.
-// If this test fails, then insert happened and key stored in cache map becomes dangling reference.
-// Any comparison with same aggregation as key will fail.
+// To check if the cache doesn't insert multiple times to cache for same cudf::aggregation on same
+// column but in different requests. If this test fails, then insert happened and key stored in
+// cache map becomes dangling reference. Any comparison with same cudf::aggregation as key will
+// fail.
 TEST_F(groupby_cache_test, duplicate_columns)
 {
   using K = int32_t;
   using V = int32_t;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-  groupby::groupby gb_obj(table_view({keys}));
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::groupby::groupby gb_obj(cudf::table_view({keys}));
 
-  std::vector<groupby::aggregation_request> requests;
-  requests.emplace_back(groupby::aggregation_request());
+  std::vector<cudf::groupby::aggregation_request> requests;
+  requests.emplace_back(cudf::groupby::aggregation_request());
   requests[0].values = vals;
-  requests[0].aggregations.push_back(cudf::make_sum_aggregation<groupby_aggregation>());
-  requests.emplace_back(groupby::aggregation_request());
+  requests[0].aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+  requests.emplace_back(cudf::groupby::aggregation_request());
   requests[1].values = vals;
-  requests[1].aggregations.push_back(cudf::make_sum_aggregation<groupby_aggregation>());
+  requests[1].aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
 
   // hash groupby
   EXPECT_NO_THROW(gb_obj.aggregate(requests));
 
   // sort groupby
   // WAR to force groupby to use sort implementation
-  requests[0].aggregations.push_back(make_nth_element_aggregation<groupby_aggregation>(0));
+  requests[0].aggregations.push_back(
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0));
   EXPECT_NO_THROW(gb_obj.aggregate(requests));
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/keys_tests.cpp
+++ b/cpp/tests/groupby/keys_tests.cpp
@@ -364,9 +364,10 @@ TEST_F(groupby_dictionary_keys_test, basic)
 struct groupby_cache_test : public cudf::test::BaseFixture {
 };
 
-// To check if the cache doesn't insert multiple times to cache for same cudf::aggregation on a
-// column in same request. If this test fails, then insert happened and key stored in cache map
-// becomes dangling reference. Any comparison with same cudf::aggregation as key will fail.
+// To check if the cache doesn't insert multiple times to cache for the same aggregation on a
+// column in the same request. If this test fails, then insert happened and the key stored in the
+// cache map becomes a dangling reference. Any comparison with the same aggregation as the key will
+// fail.
 TEST_F(groupby_cache_test, duplicate_agggregations)
 {
   using K = int32_t;
@@ -392,10 +393,10 @@ TEST_F(groupby_cache_test, duplicate_agggregations)
   EXPECT_NO_THROW(gb_obj.aggregate(requests));
 }
 
-// To check if the cache doesn't insert multiple times to cache for same cudf::aggregation on same
-// column but in different requests. If this test fails, then insert happened and key stored in
-// cache map becomes dangling reference. Any comparison with same cudf::aggregation as key will
-// fail.
+// To check if the cache doesn't insert multiple times to cache for the same aggregation on the same
+// column but in different requests. If this test fails, then insert happened and the key stored in
+// the cache map becomes a dangling reference. Any comparison with the same aggregation as the key
+// will fail.
 TEST_F(groupby_cache_test, duplicate_columns)
 {
   using K = int32_t;

--- a/cpp/tests/groupby/lists_tests.cpp
+++ b/cpp/tests/groupby/lists_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,14 @@
  * limitations under the License.
  */
 
-#include "groupby_test_util.hpp"
+#include <tests/groupby/groupby_test_util.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
-#include <cudf/concatenate.hpp>
 #include <cudf/detail/aggregation/aggregation.hpp>
-#include <cudf/table/table_view.hpp>
-#include <cudf/types.hpp>
-#include <cudf/utilities/default_stream.hpp>
-
-#include <rmm/exec_policy.hpp>
-
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/logical.h>
-
-#include <vector>
-
-namespace cudf {
-namespace test {
 
 template <typename V>
 struct groupby_lists_test : public cudf::test::BaseFixture {
@@ -45,9 +31,8 @@ TYPED_TEST_SUITE(groupby_lists_test, cudf::test::FixedWidthTypes);
 
 using namespace cudf::test::iterators;
 
-using R = cudf::detail::target_type_t<int32_t, aggregation::SUM>;  // Type of aggregation result.
-using strings = strings_column_wrapper;
-using structs = structs_column_wrapper;
+// Type of aggregation result.
+using agg_result_t = cudf::detail::target_type_t<int32_t, cudf::aggregation::SUM>;
 
 template <typename T>
 using fwcw = cudf::test::fixed_width_column_wrapper<T>;
@@ -72,8 +57,8 @@ TYPED_TEST(groupby_lists_test, basic)
   auto keys   = lcw<TypeParam> { {1,1}, {2,2}, {3,3}, {1,1}, {2,2} };
   auto values = fwcw<int32_t>  {    0,     1,     2,     3,     4  };
 
-  auto expected_keys   = lcw<TypeParam> { {1,1}, {2,2}, {3,3} };
-  auto expected_values = fwcw<R>        {    3,     5,     2  };
+  auto expected_keys   = lcw<TypeParam>    { {1,1}, {2,2}, {3,3} };
+  auto expected_values = fwcw<agg_result_t>{    3,     5,     2  };
   // clang-format on
 
   test_sum_agg(keys, values, expected_keys, expected_values);
@@ -85,8 +70,8 @@ TYPED_TEST(groupby_lists_test, all_null_input)
   auto keys   = lcw<TypeParam> { {{1,1}, {2,2}, {3,3}, {1,1}, {2,2}}, all_nulls()};
   auto values = fwcw<int32_t>  {     0,     1,     2,     3,     4 };
 
-  auto expected_keys   = lcw<TypeParam> { {{null,null}}, all_nulls()};
-  auto expected_values = fwcw<R>        {          10 };
+  auto expected_keys   = lcw<TypeParam>    { {{null,null}}, all_nulls()};
+  auto expected_values = fwcw<agg_result_t>{          10 };
   // clang-format on
 
   test_sum_agg(keys, values, expected_keys, expected_values);
@@ -98,8 +83,8 @@ TYPED_TEST(groupby_lists_test, lists_with_nulls)
   auto keys   = lcw<TypeParam> { {{1,1}, {2,2}, {3,3}, {1,1}, {2,2}}, nulls_at({1,2,4})};
   auto values = fwcw<int32_t>  {     0,     1,     2,     3,     4 };
 
-  auto expected_keys   = lcw<TypeParam> { {{null,null}, {1,1}}, null_at(0)};
-  auto expected_values = fwcw<R>        {           7,     3 };
+  auto expected_keys   = lcw<TypeParam>    { {{null,null}, {1,1}}, null_at(0)};
+  auto expected_values = fwcw<agg_result_t>{           7,     3 };
   // clang-format on
 
   test_sum_agg(keys, values, expected_keys, expected_values);
@@ -117,9 +102,7 @@ TYPED_TEST(groupby_lists_test, lists_with_null_elements)
 
   auto expected_keys = lcw<TypeParam>{
     {{}, lcw<TypeParam>{{{1, 2, 3}, {}, {4, 5}, {}, {6, 0}}, nulls_at({1, 3})}}, null_at(0)};
-  auto expected_values = fwcw<R>{9, 3};
+  auto expected_values = fwcw<agg_result_t>{9, 3};
 
   test_sum_agg(keys, values, expected_keys, expected_values);
 }
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/max_scan_tests.cpp
+++ b/cpp/tests/groupby/max_scan_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,12 +163,12 @@ TEST_F(groupby_max_scan_string_test, basic)
 }
 
 template <typename T>
-struct FixedPointTestAllReps : public cudf::test::BaseFixture {
+struct GroupByMaxScanFixedPointTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(FixedPointTestAllReps, cudf::test::FixedPointTypes);
+TYPED_TEST_SUITE(GroupByMaxScanFixedPointTest, cudf::test::FixedPointTypes);
 
-TYPED_TEST(FixedPointTestAllReps, GroupBySortMaxScanDecimalAsValue)
+TYPED_TEST(GroupByMaxScanFixedPointTest, GroupBySortMaxScanDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;

--- a/cpp/tests/groupby/max_scan_tests.cpp
+++ b/cpp/tests/groupby/max_scan_tests.cpp
@@ -26,17 +26,14 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
-using K           = int32_t;
-using key_wrapper = fixed_width_column_wrapper<K>;
+using key_wrapper = cudf::test::fixed_width_column_wrapper<int32_t>;
 
 template <typename T>
 struct groupby_max_scan_test : public cudf::test::BaseFixture {
   using V              = T;
-  using R              = cudf::detail::target_type_t<V, aggregation::MAX>;
-  using value_wrapper  = fixed_width_column_wrapper<V, int32_t>;
-  using result_wrapper = fixed_width_column_wrapper<R, int32_t>;
+  using R              = cudf::detail::target_type_t<V, cudf::aggregation::MAX>;
+  using value_wrapper  = cudf::test::fixed_width_column_wrapper<V, int32_t>;
+  using result_wrapper = cudf::test::fixed_width_column_wrapper<R, int32_t>;
 };
 
 TYPED_TEST_SUITE(groupby_max_scan_test, cudf::test::FixedWidthTypesWithoutFixedPoint);
@@ -55,7 +52,7 @@ TYPED_TEST(groupby_max_scan_test, basic)
   result_wrapper expect_vals({5, 8, 8, 6, 9, 9, 9, 7, 7, 7});
   // clang-format on
 
-  auto agg = cudf::make_max_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -72,9 +69,14 @@ TYPED_TEST(groupby_max_scan_test, pre_sorted)
   result_wrapper expect_vals({5, 8, 8, 6, 9, 9, 9, 7, 7, 7});
   // clang-format on
 
-  auto agg = cudf::make_max_aggregation<groupby_scan_aggregation>();
-  test_single_scan(
-    keys, vals, expect_keys, expect_vals, std::move(agg), null_policy::EXCLUDE, sorted::YES);
+  auto agg = cudf::make_max_aggregation<cudf::groupby_scan_aggregation>();
+  test_single_scan(keys,
+                   vals,
+                   expect_keys,
+                   expect_vals,
+                   std::move(agg),
+                   cudf::null_policy::EXCLUDE,
+                   cudf::sorted::YES);
 }
 
 TYPED_TEST(groupby_max_scan_test, empty_cols)
@@ -84,11 +86,10 @@ TYPED_TEST(groupby_max_scan_test, empty_cols)
 
   key_wrapper keys{};
   value_wrapper vals{};
-
   key_wrapper expect_keys{};
   result_wrapper expect_vals{};
 
-  auto agg = cudf::make_max_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -97,15 +98,12 @@ TYPED_TEST(groupby_max_scan_test, zero_valid_keys)
   using value_wrapper  = typename TestFixture::value_wrapper;
   using result_wrapper = typename TestFixture::result_wrapper;
 
-  // clang-format off
-  key_wrapper keys(  {1, 2, 3}, all_nulls());
+  key_wrapper keys({1, 2, 3}, all_nulls());
   value_wrapper vals({3, 4, 5});
-
   key_wrapper expect_keys{};
   result_wrapper expect_vals{};
-  // clang-format on
 
-  auto agg = cudf::make_max_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -114,15 +112,12 @@ TYPED_TEST(groupby_max_scan_test, zero_valid_values)
   using value_wrapper  = typename TestFixture::value_wrapper;
   using result_wrapper = typename TestFixture::result_wrapper;
 
-  // clang-format off
-  key_wrapper keys   {1, 1, 1};
+  key_wrapper keys{1, 1, 1};
   value_wrapper vals({3, 4, 5}, all_nulls());
-
-  key_wrapper expect_keys    {1, 1, 1};
+  key_wrapper expect_keys{1, 1, 1};
   result_wrapper expect_vals({-1, -1, -1}, all_nulls());
-  // clang-format on
 
-  auto agg = cudf::make_max_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -142,7 +137,7 @@ TYPED_TEST(groupby_max_scan_test, null_keys_and_values)
                              { 0, 1, 1, 1, 1,  0, 1, 1,    1, 0});
   // clang-format on
 
-  auto agg = cudf::make_max_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -152,13 +147,14 @@ struct groupby_max_scan_string_test : public cudf::test::BaseFixture {
 TEST_F(groupby_max_scan_string_test, basic)
 {
   key_wrapper keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  strings_column_wrapper vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
+  cudf::test::strings_column_wrapper vals{
+    "año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
 
   key_wrapper expect_keys{1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
-  strings_column_wrapper expect_vals(
+  cudf::test::strings_column_wrapper expect_vals(
     {"año", "año", "año", "bit", "zit", "zit", "zit", "₹1", "₹1", "₹1"});
 
-  auto agg = cudf::make_max_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -173,7 +169,7 @@ TYPED_TEST(GroupByMaxScanFixedPointTest, GroupBySortMaxScanDecimalAsValue)
   using namespace numeric;
   using decimalXX  = TypeParam;
   using RepType    = cudf::device_storage_type_t<decimalXX>;
-  using fp_wrapper = fixed_point_column_wrapper<RepType>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
 
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
@@ -181,12 +177,12 @@ TYPED_TEST(GroupByMaxScanFixedPointTest, GroupBySortMaxScanDecimalAsValue)
     auto const keys = key_wrapper{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
     auto const vals = fp_wrapper{{5, 6, 7, 8, 9, 0, 1, 2, 3, 4}, scale};
 
-    //                                                        {5, 8, 1, 6, 9, 0, 4, 7, 2, 3}
+    //                                      {5, 8, 1, 6, 9, 0, 4, 7, 2, 3}
     auto const expect_keys     = key_wrapper{1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
     auto const expect_vals_max = fp_wrapper{{5, 8, 8, 6, 9, 9, 9, 7, 7, 7}, scale};
     // clang-format on
 
-    auto agg = cudf::make_max_aggregation<groupby_scan_aggregation>();
+    auto agg = cudf::make_max_aggregation<cudf::groupby_scan_aggregation>();
     test_single_scan(keys, vals, expect_keys, expect_vals_max, std::move(agg));
   }
 }
@@ -198,21 +194,21 @@ TEST_F(groupby_max_scan_struct_test, basic)
 {
   auto const keys = key_wrapper{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
   auto const vals = [] {
-    auto child1 =
-      strings_column_wrapper{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{
+      "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   auto const expect_keys = key_wrapper{1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
   auto const expect_vals = [] {
-    auto child1 =
-      strings_column_wrapper{"año", "año", "año", "bit", "zit", "zit", "zit", "₹1", "₹1", "₹1"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 1, 1, 2, 5, 5, 5, 3, 3, 3};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{
+      "año", "año", "año", "bit", "zit", "zit", "zit", "₹1", "₹1", "₹1"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 1, 1, 2, 5, 5, 5, 3, 3, 3};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto agg = cudf::make_max_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -222,34 +218,34 @@ TEST_F(groupby_max_scan_struct_test, slice_input)
   auto const keys_original =
     key_wrapper{dont_care, dont_care, 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, dont_care};
   auto const vals_original = [] {
-    auto child1 = strings_column_wrapper{"dont_care",
-                                         "dont_care",
-                                         "año",
-                                         "bit",
-                                         "₹1",
-                                         "aaa",
-                                         "zit",
-                                         "bat",
-                                         "aab",
-                                         "$1",
-                                         "€1",
-                                         "wut",
-                                         "dont_care"};
+    auto child1 = cudf::test::strings_column_wrapper{"dont_care",
+                                                     "dont_care",
+                                                     "año",
+                                                     "bit",
+                                                     "₹1",
+                                                     "aaa",
+                                                     "zit",
+                                                     "bat",
+                                                     "aab",
+                                                     "$1",
+                                                     "€1",
+                                                     "wut",
+                                                     "dont_care"};
     auto child2 = key_wrapper{dont_care, dont_care, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, dont_care};
-    return structs_column_wrapper{{child1, child2}};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   auto const keys        = cudf::slice(keys_original, {2, 12})[0];
   auto const vals        = cudf::slice(vals_original, {2, 12})[0];
   auto const expect_keys = key_wrapper{1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
   auto const expect_vals = [] {
-    auto child1 =
-      strings_column_wrapper{"año", "año", "año", "bit", "zit", "zit", "zit", "₹1", "₹1", "₹1"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 1, 1, 2, 5, 5, 5, 3, 3, 3};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{
+      "año", "año", "año", "bit", "zit", "zit", "zit", "₹1", "₹1", "₹1"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 1, 1, 2, 5, 5, 5, 3, 3, 3};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto agg = cudf::make_max_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -258,23 +254,22 @@ TEST_F(groupby_max_scan_struct_test, null_keys_and_values)
   constexpr int32_t null{0};
   auto const keys = key_wrapper{{1, 2, 3, 1, 2, 2, 1, null, 3, 2, 4}, null_at(7)};
   auto const vals = [] {
-    auto child1 = strings_column_wrapper{
+    auto child1 = cudf::test::strings_column_wrapper{
       "año", "bit", "₹1", "aaa", "zit", "" /*NULL*/, "" /*NULL*/, "$1", "€1", "wut", "" /*NULL*/};
-    auto child2 = fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
-    return structs_column_wrapper{{child1, child2}, nulls_at({5, 6, 10})};
+    auto child2 =
+      cudf::test::fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
+    return cudf::test::structs_column_wrapper{{child1, child2}, nulls_at({5, 6, 10})};
   }();
 
   auto const expect_keys = key_wrapper{{1, 1, 1, 2, 2, 2, 2, 3, 3, 4}, no_nulls()};
   auto const expect_vals = [] {
-    auto child1 = strings_column_wrapper{
+    auto child1 = cudf::test::strings_column_wrapper{
       "año", "año", "" /*NULL*/, "bit", "zit", "" /*NULL*/, "zit", "₹1", "₹1", "" /*NULL*/};
-    auto child2 = fixed_width_column_wrapper<int32_t>{9, 9, null, 8, 5, null, 5, 7, 7, null};
-    return structs_column_wrapper{{child1, child2}, nulls_at({2, 5, 9})};
+    auto child2 =
+      cudf::test::fixed_width_column_wrapper<int32_t>{9, 9, null, 8, 5, null, 5, 7, 7, null};
+    return cudf::test::structs_column_wrapper{{child1, child2}, nulls_at({2, 5, 9})};
   }();
 
-  auto agg = cudf::make_max_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/max_tests.cpp
+++ b/cpp/tests/groupby/max_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,6 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_max_test : public cudf::test::BaseFixture {
 };
@@ -40,13 +38,13 @@ TYPED_TEST_SUITE(groupby_max_test, cudf::test::FixedWidthTypesWithoutFixedPoint)
 TYPED_TEST(groupby_max_test, basic)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MAX>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MAX>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R> expect_vals({6, 9, 8});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({6, 9, 8});
 
   auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -58,13 +56,13 @@ TYPED_TEST(groupby_max_test, basic)
 TYPED_TEST(groupby_max_test, empty_cols)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MAX>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MAX>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -76,13 +74,13 @@ TYPED_TEST(groupby_max_test, empty_cols)
 TYPED_TEST(groupby_max_test, zero_valid_keys)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MAX>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MAX>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals({3, 4, 5});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5});
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -94,13 +92,13 @@ TYPED_TEST(groupby_max_test, zero_valid_keys)
 TYPED_TEST(groupby_max_test, zero_valid_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MAX>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MAX>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -112,17 +110,17 @@ TYPED_TEST(groupby_max_test, zero_valid_values)
 TYPED_TEST(groupby_max_test, null_keys_and_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MAX>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MAX>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                     {1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                                 {1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 0, 3,     1, 4, 5,   2, 8,    -}
-  fixed_width_column_wrapper<R> expect_vals({3, 5, 8, 0}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3, 5, 8, 0}, {1, 1, 1, 0});
 
   auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -136,11 +134,12 @@ struct groupby_max_string_test : public cudf::test::BaseFixture {
 
 TEST_F(groupby_max_string_test, basic)
 {
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  strings_column_wrapper vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::strings_column_wrapper vals{
+    "año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  strings_column_wrapper expect_vals({"año", "zit", "₹1"});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::strings_column_wrapper expect_vals({"año", "zit", "₹1"});
 
   auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -151,11 +150,11 @@ TEST_F(groupby_max_string_test, basic)
 
 TEST_F(groupby_max_string_test, zero_valid_values)
 {
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  strings_column_wrapper expect_vals({""}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::strings_column_wrapper expect_vals({""}, all_nulls());
 
   auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -186,7 +185,7 @@ TEST_F(groupby_max_string_test, max_sorted_strings)
     {"06", "10", "14", "18", "22", "26", "30", "34", "38", "42", ""},
     {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
 
-  // fixed_width_column_wrapper<size_type> expect_argmax(
+  // cudf::test::fixed_width_column_wrapper<size_type> expect_argmax(
   // {6, 10, 14, 18, 22, 26, 30, 34, 38, 42, -1},
   // {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
   auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
@@ -196,8 +195,8 @@ TEST_F(groupby_max_string_test, max_sorted_strings)
                   expect_vals,
                   std::move(agg),
                   force_use_sort_impl::NO,
-                  null_policy::INCLUDE,
-                  sorted::YES);
+                  cudf::null_policy::INCLUDE,
+                  cudf::sorted::YES);
 }
 
 struct groupby_dictionary_max_test : public cudf::test::BaseFixture {
@@ -208,10 +207,10 @@ TEST_F(groupby_dictionary_max_test, basic)
   using V = std::string;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
-  dictionary_column_wrapper<V>  vals{ "año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
-  fixed_width_column_wrapper<K> expect_keys   {     1,     2,    3 };
-  dictionary_column_wrapper<V>  expect_vals_w({ "año", "zit", "₹1" });
+  cudf::test::fixed_width_column_wrapper<K> keys{     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
+  cudf::test::dictionary_column_wrapper<V>  vals{ "año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys   {     1,     2,    3 };
+  cudf::test::dictionary_column_wrapper<V>  expect_vals_w({ "año", "zit", "₹1" });
   // clang-format on
 
   auto expect_vals = cudf::dictionary::set_keys(expect_vals_w, vals.keys());
@@ -234,10 +233,10 @@ TEST_F(groupby_dictionary_max_test, fixed_width)
   using V = int64_t;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
-  dictionary_column_wrapper<V>  vals{ 0xABC, 0xBBB, 0xF1, 0xAAA, 0xFFF, 0xBAA, 0xAAA, 0x01, 0xF1, 0xEEE};
-  fixed_width_column_wrapper<K> expect_keys    {     1,     2,    3 };
-  fixed_width_column_wrapper<V>  expect_vals_w({ 0xABC, 0xFFF, 0xF1 });
+  cudf::test::fixed_width_column_wrapper<K> keys{     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
+  cudf::test::dictionary_column_wrapper<V>  vals{ 0xABC, 0xBBB, 0xF1, 0xAAA, 0xFFF, 0xBAA, 0xAAA, 0x01, 0xF1, 0xEEE};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys    {     1,     2,    3 };
+  cudf::test::fixed_width_column_wrapper<V>  expect_vals_w({ 0xABC, 0xFFF, 0xF1 });
   // clang-format on
 
   test_single_agg(keys,
@@ -254,12 +253,12 @@ TEST_F(groupby_dictionary_max_test, fixed_width)
 }
 
 template <typename T>
-struct FixedPointTestAllReps : public cudf::test::BaseFixture {
+struct GroupByMaxFixedPointTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(FixedPointTestAllReps, cudf::test::FixedPointTypes);
+TYPED_TEST_SUITE(GroupByMaxFixedPointTest, cudf::test::FixedPointTypes);
 
-TYPED_TEST(FixedPointTestAllReps, GroupBySortMaxDecimalAsValue)
+TYPED_TEST(GroupByMaxFixedPointTest, GroupBySortMaxDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;
@@ -270,11 +269,11 @@ TYPED_TEST(FixedPointTestAllReps, GroupBySortMaxDecimalAsValue)
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
     // clang-format off
-    auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const keys  = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+    auto const vals  = fp_wrapper{                              {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
     // clang-format on
 
-    auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
+    auto const expect_keys     = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_max = fp_wrapper{{6, 9, 8}, scale};
 
     auto agg3 = cudf::make_max_aggregation<cudf::groupby_aggregation>();
@@ -283,7 +282,7 @@ TYPED_TEST(FixedPointTestAllReps, GroupBySortMaxDecimalAsValue)
   }
 }
 
-TYPED_TEST(FixedPointTestAllReps, GroupByHashMaxDecimalAsValue)
+TYPED_TEST(GroupByMaxFixedPointTest, GroupByHashMaxDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;
@@ -294,11 +293,11 @@ TYPED_TEST(FixedPointTestAllReps, GroupByHashMaxDecimalAsValue)
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
     // clang-format off
-    auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const keys  = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+    auto const vals  = fp_wrapper{                              {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
     // clang-format on
 
-    auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
+    auto const expect_keys     = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_max = fp_wrapper{{6, 9, 8}, scale};
 
     auto agg7 = cudf::make_max_aggregation<cudf::groupby_aggregation>();
@@ -311,82 +310,84 @@ struct groupby_max_struct_test : public cudf::test::BaseFixture {
 
 TEST_F(groupby_max_struct_test, basic)
 {
-  auto const keys = fixed_width_column_wrapper<int32_t>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
   auto const vals = [] {
-    auto child1 =
-      strings_column_wrapper{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{
+      "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto const expect_keys = fixed_width_column_wrapper<int32_t>{1, 2, 3};
+  auto const expect_keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3};
   auto const expect_vals = [] {
-    auto child1 = strings_column_wrapper{"año", "zit", "₹1"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 5, 3};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{"año", "zit", "₹1"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 5, 3};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto agg = cudf::make_max_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TEST_F(groupby_max_struct_test, slice_input)
 {
   constexpr int32_t dont_care{1};
-  auto const keys_original = fixed_width_column_wrapper<int32_t>{
+  auto const keys_original = cudf::test::fixed_width_column_wrapper<int32_t>{
     dont_care, dont_care, 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, dont_care};
   auto const vals_original = [] {
-    auto child1 = strings_column_wrapper{"dont_care",
-                                         "dont_care",
-                                         "año",
-                                         "bit",
-                                         "₹1",
-                                         "aaa",
-                                         "zit",
-                                         "bat",
-                                         "aab",
-                                         "$1",
-                                         "€1",
-                                         "wut",
-                                         "dont_care"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{
+    auto child1 = cudf::test::strings_column_wrapper{"dont_care",
+                                                     "dont_care",
+                                                     "año",
+                                                     "bit",
+                                                     "₹1",
+                                                     "aaa",
+                                                     "zit",
+                                                     "bat",
+                                                     "aab",
+                                                     "$1",
+                                                     "€1",
+                                                     "wut",
+                                                     "dont_care"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{
       dont_care, dont_care, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, dont_care};
-    return structs_column_wrapper{{child1, child2}};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   auto const keys        = cudf::slice(keys_original, {2, 12})[0];
   auto const vals        = cudf::slice(vals_original, {2, 12})[0];
-  auto const expect_keys = fixed_width_column_wrapper<int32_t>{1, 2, 3};
+  auto const expect_keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3};
   auto const expect_vals = [] {
-    auto child1 = strings_column_wrapper{"año", "zit", "₹1"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 5, 3};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{"año", "zit", "₹1"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 5, 3};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto agg = cudf::make_max_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TEST_F(groupby_max_struct_test, null_keys_and_values)
 {
   constexpr int32_t null{0};
-  auto const keys =
-    fixed_width_column_wrapper<int32_t>{{1, 2, 3, 1, 2, 2, 1, null, 3, 2, 4}, null_at(7)};
+  auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{
+    {1, 2, 3, 1, 2, 2, 1, null, 3, 2, 4}, null_at(7)};
   auto const vals = [] {
-    auto child1 = strings_column_wrapper{
+    auto child1 = cudf::test::strings_column_wrapper{
       "año", "bit", "₹1", "aaa", "zit", "" /*NULL*/, "" /*NULL*/, "$1", "€1", "wut", "" /*NULL*/};
-    auto child2 = fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
-    return structs_column_wrapper{{child1, child2}, nulls_at({5, 6, 10})};
+    auto child2 =
+      cudf::test::fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
+    return cudf::test::structs_column_wrapper{{child1, child2}, nulls_at({5, 6, 10})};
   }();
 
-  auto const expect_keys = fixed_width_column_wrapper<int32_t>{{1, 2, 3, 4}, no_nulls()};
+  auto const expect_keys =
+    cudf::test::fixed_width_column_wrapper<int32_t>{{1, 2, 3, 4}, no_nulls()};
   auto const expect_vals = [] {
-    auto child1 = strings_column_wrapper{"año", "zit", "₹1", "" /*NULL*/};
-    auto child2 = fixed_width_column_wrapper<int32_t>{9, 5, 7, null};
-    return structs_column_wrapper{{child1, child2}, null_at(3)};
+    auto child1 = cudf::test::strings_column_wrapper{"año", "zit", "₹1", "" /*NULL*/};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{9, 5, 7, null};
+    return cudf::test::structs_column_wrapper{{child1, child2}, null_at(3)};
   }();
 
-  auto agg = cudf::make_max_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -394,40 +395,40 @@ TEST_F(groupby_max_struct_test, values_with_null_child)
 {
   constexpr int32_t null{0};
   {
-    auto const keys = fixed_width_column_wrapper<int32_t>{1, 1};
+    auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 1};
     auto const vals = [] {
-      auto child1 = fixed_width_column_wrapper<int32_t>{1, 1};
-      auto child2 = fixed_width_column_wrapper<int32_t>{{-1, null}, null_at(1)};
-      return structs_column_wrapper{child1, child2};
+      auto child1 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 1};
+      auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{{-1, null}, null_at(1)};
+      return cudf::test::structs_column_wrapper{child1, child2};
     }();
 
-    auto const expect_keys = fixed_width_column_wrapper<int32_t>{1};
+    auto const expect_keys = cudf::test::fixed_width_column_wrapper<int32_t>{1};
     auto const expect_vals = [] {
-      auto child1 = fixed_width_column_wrapper<int32_t>{1};
-      auto child2 = fixed_width_column_wrapper<int32_t>{-1};
-      return structs_column_wrapper{child1, child2};
+      auto child1 = cudf::test::fixed_width_column_wrapper<int32_t>{1};
+      auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{-1};
+      return cudf::test::structs_column_wrapper{child1, child2};
     }();
 
-    auto agg = cudf::make_max_aggregation<groupby_aggregation>();
+    auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
     test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
   }
 
   {
-    auto const keys = fixed_width_column_wrapper<int32_t>{1, 1};
+    auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 1};
     auto const vals = [] {
-      auto child1 = fixed_width_column_wrapper<int32_t>{{-1, null}, null_at(1)};
-      auto child2 = fixed_width_column_wrapper<int32_t>{{null, null}, nulls_at({0, 1})};
-      return structs_column_wrapper{child1, child2};
+      auto child1 = cudf::test::fixed_width_column_wrapper<int32_t>{{-1, null}, null_at(1)};
+      auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{{null, null}, nulls_at({0, 1})};
+      return cudf::test::structs_column_wrapper{child1, child2};
     }();
 
-    auto const expect_keys = fixed_width_column_wrapper<int32_t>{1};
+    auto const expect_keys = cudf::test::fixed_width_column_wrapper<int32_t>{1};
     auto const expect_vals = [] {
-      auto child1 = fixed_width_column_wrapper<int32_t>{-1};
-      auto child2 = fixed_width_column_wrapper<int32_t>{{null}, null_at(0)};
-      return structs_column_wrapper{child1, child2};
+      auto child1 = cudf::test::fixed_width_column_wrapper<int32_t>{-1};
+      auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{{null}, null_at(0)};
+      return cudf::test::structs_column_wrapper{child1, child2};
     }();
 
-    auto agg = cudf::make_max_aggregation<groupby_aggregation>();
+    auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
     test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
   }
 }
@@ -441,8 +442,8 @@ TYPED_TEST_SUITE(groupby_max_floating_point_test, cudf::test::FloatingPointTypes
 TYPED_TEST(groupby_max_floating_point_test, values_with_infinity)
 {
   using T          = TypeParam;
-  using int32s_col = fixed_width_column_wrapper<int32_t>;
-  using floats_col = fixed_width_column_wrapper<T, int32_t>;
+  using int32s_col = cudf::test::fixed_width_column_wrapper<int32_t>;
+  using floats_col = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
   auto constexpr inf = std::numeric_limits<T>::infinity();
 
@@ -453,7 +454,7 @@ TYPED_TEST(groupby_max_floating_point_test, values_with_infinity)
   auto const expected_vals = floats_col{inf, static_cast<T>(2)};
 
   // Related issue: https://github.com/rapidsai/cudf/issues/11352
-  // The issue only occurs in sort-based aggregation.
+  // The issue only occurs in sort-based cudf::aggregation.
   auto agg = cudf::make_max_aggregation<cudf::groupby_aggregation>();
   test_single_agg(
     keys, vals, expected_keys, expected_vals, std::move(agg), force_use_sort_impl::YES);
@@ -462,27 +463,24 @@ TYPED_TEST(groupby_max_floating_point_test, values_with_infinity)
 TYPED_TEST(groupby_max_floating_point_test, values_with_nan)
 {
   using T          = TypeParam;
-  using int32s_col = fixed_width_column_wrapper<int32_t>;
-  using floats_col = fixed_width_column_wrapper<T, int32_t>;
+  using int32s_col = cudf::test::fixed_width_column_wrapper<int32_t>;
+  using floats_col = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
   auto constexpr nan = std::numeric_limits<T>::quiet_NaN();
 
   auto const keys = int32s_col{1, 1};
   auto const vals = floats_col{nan, nan};
 
-  std::vector<groupby::aggregation_request> requests;
-  requests.emplace_back(groupby::aggregation_request());
+  std::vector<cudf::groupby::aggregation_request> requests;
+  requests.emplace_back(cudf::groupby::aggregation_request());
   requests[0].values = vals;
   requests[0].aggregations.emplace_back(cudf::make_max_aggregation<cudf::groupby_aggregation>());
 
   // Without properly handling NaN, this will hang forever in hash-based aggregate (which is the
   // default back-end for min/max in groupby context).
   // This test is just to verify that the aggregate operation does not hang.
-  auto gb_obj       = groupby::groupby(table_view({keys}));
+  auto gb_obj       = cudf::groupby::groupby(cudf::table_view({keys}));
   auto const result = gb_obj.aggregate(requests);
 
   EXPECT_EQ(result.first->num_rows(), 1);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/mean_tests.cpp
+++ b/cpp/tests/groupby/mean_tests.cpp
@@ -23,11 +23,8 @@
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
-#include <cudf/utilities/traits.hpp>
 
 #include <initializer_list>
-#include <iterator>
-#include <type_traits>
 #include <vector>
 
 using namespace cudf::test::iterators;

--- a/cpp/tests/groupby/mean_tests.cpp
+++ b/cpp/tests/groupby/mean_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#include <cudf/detail/aggregation/aggregation.hpp>
-#include <cudf/utilities/traits.hpp>
+#include <tests/groupby/groupby_test_util.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
@@ -23,7 +22,8 @@
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
-#include <tests/groupby/groupby_test_util.hpp>
+#include <cudf/detail/aggregation/aggregation.hpp>
+#include <cudf/utilities/traits.hpp>
 
 #include <initializer_list>
 #include <iterator>
@@ -32,8 +32,6 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_mean_test : public cudf::test::BaseFixture {
 };
@@ -54,88 +52,89 @@ using K = int32_t;
 TYPED_TEST(groupby_mean_test, basic)
 {
   using V  = TypeParam;
-  using R  = cudf::detail::target_type_t<V, aggregation::MEAN>;
+  using R  = cudf::detail::target_type_t<V, cudf::aggregation::MEAN>;
   using RT = typename std::conditional<cudf::is_duration<R>(), int, double>::type;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   // clang-format off
-  fixed_width_column_wrapper<K> expect_keys{1,       2,          3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1,       2,          3};
   //                                       {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
   std::vector<RT> expect_v = convert<RT>(  {3.,      19. / 4,    17. / 3});
-  fixed_width_column_wrapper<R, RT> expect_vals(expect_v.cbegin(), expect_v.cend());
+  cudf::test::fixed_width_column_wrapper<R, RT> expect_vals(expect_v.cbegin(), expect_v.cend());
   // clang-format on
 
-  auto agg = cudf::make_mean_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_mean_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_mean_test, empty_cols)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MEAN>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_mean_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_mean_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_mean_test, zero_valid_keys)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MEAN>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals{3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_mean_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_mean_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_mean_test, zero_valid_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MEAN>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
-  auto agg = cudf::make_mean_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_mean_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_mean_test, null_keys_and_values)
 {
   using V  = TypeParam;
-  using R  = cudf::detail::target_type_t<V, aggregation::MEAN>;
+  using R  = cudf::detail::target_type_t<V, cudf::aggregation::MEAN>;
   using RT = typename std::conditional<cudf::is_duration<R>(), int, double>::type;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   // clang-format off
-  //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_nulls());
-  //                                        {3, 6,     1, 4, 9,   2, 8,    -}
-  std::vector<RT> expect_v = convert<RT>(   {4.5,      14. / 3,   5.,      0.});
-  fixed_width_column_wrapper<R, RT> expect_vals(expect_v.cbegin(), expect_v.cend(), {1, 1, 1, 0});
+  //                                                    {1, 1,     2, 2, 2,   3, 3,    4}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_nulls());
+  //                                                    {3, 6,     1, 4, 9,   2, 8,    -}
+  std::vector<RT> expect_v = convert<RT>(               {4.5,      14. / 3,   5.,      0.});
   // clang-format on
+  cudf::test::fixed_width_column_wrapper<R, RT> expect_vals(
+    expect_v.cbegin(), expect_v.cend(), {1, 1, 1, 0});
 
-  auto agg = cudf::make_mean_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_mean_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 // clang-format on
@@ -146,18 +145,18 @@ struct groupby_dictionary_mean_test : public cudf::test::BaseFixture {
 TEST_F(groupby_dictionary_mean_test, basic)
 {
   using V = int16_t;
-  using R = cudf::detail::target_type_t<V, aggregation::MEAN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MEAN>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  fixed_width_column_wrapper<K> expect_keys(        {1,      2,       3});
-  fixed_width_column_wrapper<R, double> expect_vals({9. / 3, 19. / 4, 17. / 3});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys(        {1,      2,       3});
+  cudf::test::fixed_width_column_wrapper<R, double> expect_vals({9. / 3, 19. / 4, 17. / 3});
   // clang-format on
 
   test_single_agg(
-    keys, vals, expect_keys, expect_vals, cudf::make_mean_aggregation<groupby_aggregation>());
+    keys, vals, expect_keys, expect_vals, cudf::make_mean_aggregation<cudf::groupby_aggregation>());
 }
 
 template <typename T>
@@ -176,11 +175,11 @@ TYPED_TEST(FixedPointTestBothReps, GroupBySortMeanDecimalAsValue)
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
     // clang-format off
-    auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const keys  = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+    auto const vals  = fp_wrapper{                              {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
     // clang-format on
 
-    auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
+    auto const expect_keys     = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_min = fp_wrapper{{3, 4, 5}, scale};
 
     auto agg = cudf::make_mean_aggregation<cudf::groupby_aggregation>();
@@ -200,17 +199,14 @@ TYPED_TEST(FixedPointTestBothReps, GroupByHashMeanDecimalAsValue)
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
     // clang-format off
-    auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const keys  = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+    auto const vals  = fp_wrapper{                              {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
     // clang-format on
 
-    auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
+    auto const expect_keys     = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_min = fp_wrapper{{3, 4, 5}, scale};
 
     auto agg = cudf::make_mean_aggregation<cudf::groupby_aggregation>();
     test_single_agg(keys, vals, expect_keys, expect_vals_min, std::move(agg));
   }
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/median_tests.cpp
+++ b/cpp/tests/groupby/median_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,118 +25,121 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_median_test : public cudf::test::BaseFixture {
 };
 
-using K               = int32_t;
 using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
 
 TYPED_TEST_SUITE(groupby_median_test, supported_types);
 
 TYPED_TEST(groupby_median_test, basic)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MEDIAN>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   // clang-format off
-  //                                       {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys{1,       2,          3};
-  //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,     4.5,        7.}, no_nulls());
+  //                                                   {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1,       2,          3};
+  //                                                    {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3.,     4.5,        7.}, no_nulls());
   // clang-format on
 
-  auto agg = cudf::make_median_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_median_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_median_test, empty_cols)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MEDIAN>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_median_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_median_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_median_test, zero_valid_keys)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MEDIAN>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals{3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_median_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_median_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_median_test, zero_valid_values)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MEDIAN>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
-  auto agg = cudf::make_median_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_median_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_median_test, null_keys_and_values)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MEDIAN>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
-  fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
 
-  auto agg = cudf::make_median_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_median_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_median_test, dictionary)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MEDIAN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MEDIAN>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::dictionary_column_wrapper<V>  vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  //                                        {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({1,       2,          3      });
-  //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       4.5,       7.     }, no_nulls());
+  //                                                    {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1,       2,          3      });
+  //                                                    {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3.,       4.5,       7.     }, no_nulls());
   // clang-format on
 
-  test_single_agg(
-    keys, vals, expect_keys, expect_vals, cudf::make_median_aggregation<groupby_aggregation>());
+  test_single_agg(keys,
+                  vals,
+                  expect_keys,
+                  expect_vals,
+                  cudf::make_median_aggregation<cudf::groupby_aggregation>());
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/min_scan_tests.cpp
+++ b/cpp/tests/groupby/min_scan_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,19 +23,14 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
-using namespace cudf::test::iterators;
-
-namespace cudf {
-namespace test {
-using K           = int32_t;
-using key_wrapper = fixed_width_column_wrapper<K>;
+using key_wrapper = cudf::test::fixed_width_column_wrapper<int32_t>;
 
 template <typename T>
 struct groupby_min_scan_test : public cudf::test::BaseFixture {
   using V              = T;
-  using R              = cudf::detail::target_type_t<V, aggregation::MIN>;
-  using value_wrapper  = fixed_width_column_wrapper<V, int32_t>;
-  using result_wrapper = fixed_width_column_wrapper<R, int32_t>;
+  using R              = cudf::detail::target_type_t<V, cudf::aggregation::MIN>;
+  using value_wrapper  = cudf::test::fixed_width_column_wrapper<V, int32_t>;
+  using result_wrapper = cudf::test::fixed_width_column_wrapper<R, int32_t>;
 };
 
 TYPED_TEST_SUITE(groupby_min_scan_test, cudf::test::FixedWidthTypesWithoutFixedPoint);
@@ -53,7 +48,7 @@ TYPED_TEST(groupby_min_scan_test, basic)
   result_wrapper expect_vals({5, 5, 1, 6, 6, 0, 0, 7, 2, 2});
   // clang-format on
 
-  auto agg = cudf::make_min_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -70,9 +65,14 @@ TYPED_TEST(groupby_min_scan_test, pre_sorted)
   result_wrapper expect_vals({5, 5, 1, 6, 6, 0, 0, 7, 2, 2});
   // clang-format on
 
-  auto agg = cudf::make_min_aggregation<groupby_scan_aggregation>();
-  test_single_scan(
-    keys, vals, expect_keys, expect_vals, std::move(agg), null_policy::EXCLUDE, sorted::YES);
+  auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
+  test_single_scan(keys,
+                   vals,
+                   expect_keys,
+                   expect_vals,
+                   std::move(agg),
+                   cudf::null_policy::EXCLUDE,
+                   cudf::sorted::YES);
 }
 
 TYPED_TEST(groupby_min_scan_test, empty_cols)
@@ -82,11 +82,10 @@ TYPED_TEST(groupby_min_scan_test, empty_cols)
 
   key_wrapper keys{};
   value_wrapper vals{};
-
   key_wrapper expect_keys{};
   result_wrapper expect_vals{};
 
-  auto agg = cudf::make_min_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -95,15 +94,12 @@ TYPED_TEST(groupby_min_scan_test, zero_valid_keys)
   using value_wrapper  = typename TestFixture::value_wrapper;
   using result_wrapper = typename TestFixture::result_wrapper;
 
-  // clang-format off
-  key_wrapper keys({1, 2, 3}, all_nulls());
+  key_wrapper keys({1, 2, 3}, cudf::test::iterators::all_nulls());
   value_wrapper vals({3, 4, 5});
-
   key_wrapper expect_keys{};
   result_wrapper expect_vals{};
-  // clang-format on
 
-  auto agg = cudf::make_min_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -112,15 +108,12 @@ TYPED_TEST(groupby_min_scan_test, zero_valid_values)
   using value_wrapper  = typename TestFixture::value_wrapper;
   using result_wrapper = typename TestFixture::result_wrapper;
 
-  // clang-format off
-  key_wrapper keys   {1, 1, 1};
-  value_wrapper vals({3, 4, 5}, all_nulls());
+  key_wrapper keys{1, 1, 1};
+  value_wrapper vals({3, 4, 5}, cudf::test::iterators::all_nulls());
+  key_wrapper expect_keys{1, 1, 1};
+  result_wrapper expect_vals({-1, -1, -1}, cudf::test::iterators::all_nulls());
 
-  key_wrapper expect_keys    {1, 1, 1};
-  result_wrapper expect_vals({-1, -1, -1}, all_nulls());
-  // clang-format on
-
-  auto agg = cudf::make_min_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -134,13 +127,13 @@ TYPED_TEST(groupby_min_scan_test, null_keys_and_values)
   value_wrapper vals({5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
                          //  { 1, 1, 1, 2, 2,  2, 2, 3, _, 3, 4}
-  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2, 2, 3,    3, 4}, no_nulls());
+  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2, 2, 3,    3, 4}, cudf::test::iterators::no_nulls());
                          //  { _, 8, 1, 6, 9,  _, 4, 7, 2, 3, _}
   result_wrapper expect_vals({-1, 8, 1, 6, 6, -1, 4, 7,    3, -1},
                              { 0, 1, 1, 1, 1,  0, 1, 1,    1, 0});
   // clang-format on
 
-  auto agg = cudf::make_min_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -150,28 +143,29 @@ struct groupby_min_scan_string_test : public cudf::test::BaseFixture {
 TEST_F(groupby_min_scan_string_test, basic)
 {
   key_wrapper keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  strings_column_wrapper vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
+  cudf::test::strings_column_wrapper vals{
+    "año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
 
   key_wrapper expect_keys{1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
-  strings_column_wrapper expect_vals(
+  cudf::test::strings_column_wrapper expect_vals(
     {"año", "aaa", "aaa", "bit", "bit", "bat", "bat", "₹1", "$1", "$1"});
 
-  auto agg = cudf::make_min_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 template <typename T>
-struct FixedPointTestAllReps : public cudf::test::BaseFixture {
+struct GroupByMinScanFixedPointTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(FixedPointTestAllReps, cudf::test::FixedPointTypes);
+TYPED_TEST_SUITE(GroupByMinScanFixedPointTest, cudf::test::FixedPointTypes);
 
-TYPED_TEST(FixedPointTestAllReps, GroupBySortMinScanDecimalAsValue)
+TYPED_TEST(GroupByMinScanFixedPointTest, GroupBySortMinScanDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;
   using RepType    = cudf::device_storage_type_t<decimalXX>;
-  using fp_wrapper = fixed_point_column_wrapper<RepType>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
 
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
@@ -185,7 +179,7 @@ TYPED_TEST(FixedPointTestAllReps, GroupBySortMinScanDecimalAsValue)
     auto const expect_vals_min = fp_wrapper{{5, 5, 1, 6, 6, 0, 0, 7, 2, 2}, scale};
     // clang-format on
 
-    auto agg = cudf::make_min_aggregation<groupby_scan_aggregation>();
+    auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
     test_single_scan(keys, vals, expect_keys, expect_vals_min, std::move(agg));
   }
 }
@@ -197,21 +191,21 @@ TEST_F(groupby_min_scan_struct_test, basic)
 {
   auto const keys = key_wrapper{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
   auto const vals = [] {
-    auto child1 =
-      strings_column_wrapper{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{
+      "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   auto const expect_keys = key_wrapper{1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
   auto const expect_vals = [] {
-    auto child1 =
-      strings_column_wrapper{"año", "aaa", "aaa", "bit", "bit", "bat", "bat", "₹1", "$1", "$1"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 4, 4, 2, 2, 6, 6, 3, 8, 8};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{
+      "año", "aaa", "aaa", "bit", "bit", "bat", "bat", "₹1", "$1", "$1"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 4, 4, 2, 2, 6, 6, 3, 8, 8};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto agg = cudf::make_min_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -221,59 +215,62 @@ TEST_F(groupby_min_scan_struct_test, slice_input)
   auto const keys_original =
     key_wrapper{dont_care, dont_care, 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, dont_care};
   auto const vals_original = [] {
-    auto child1 = strings_column_wrapper{"dont_care",
-                                         "dont_care",
-                                         "año",
-                                         "bit",
-                                         "₹1",
-                                         "aaa",
-                                         "zit",
-                                         "bat",
-                                         "aab",
-                                         "$1",
-                                         "€1",
-                                         "wut",
-                                         "dont_care"};
+    auto child1 = cudf::test::strings_column_wrapper{"dont_care",
+                                                     "dont_care",
+                                                     "año",
+                                                     "bit",
+                                                     "₹1",
+                                                     "aaa",
+                                                     "zit",
+                                                     "bat",
+                                                     "aab",
+                                                     "$1",
+                                                     "€1",
+                                                     "wut",
+                                                     "dont_care"};
     auto child2 = key_wrapper{dont_care, dont_care, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, dont_care};
-    return structs_column_wrapper{{child1, child2}};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   auto const keys        = cudf::slice(keys_original, {2, 12})[0];
   auto const vals        = cudf::slice(vals_original, {2, 12})[0];
   auto const expect_keys = key_wrapper{1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
   auto const expect_vals = [] {
-    auto child1 =
-      strings_column_wrapper{"año", "aaa", "aaa", "bit", "bit", "bat", "bat", "₹1", "$1", "$1"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 4, 4, 2, 2, 6, 6, 3, 8, 8};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{
+      "año", "aaa", "aaa", "bit", "bit", "bat", "bat", "₹1", "$1", "$1"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 4, 4, 2, 2, 6, 6, 3, 8, 8};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto agg = cudf::make_min_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TEST_F(groupby_min_scan_struct_test, null_keys_and_values)
 {
   constexpr int32_t null{0};
-  auto const keys = key_wrapper{{1, 2, 3, 1, 2, 2, 1, null, 3, 2, 4}, null_at(7)};
+  auto const keys =
+    key_wrapper{{1, 2, 3, 1, 2, 2, 1, null, 3, 2, 4}, cudf::test::iterators::null_at(7)};
   auto const vals = [] {
-    auto child1 = strings_column_wrapper{
+    auto child1 = cudf::test::strings_column_wrapper{
       "año", "bit", "₹1", "aaa", "zit", "" /*NULL*/, "" /*NULL*/, "$1", "€1", "wut", "" /*NULL*/};
-    auto child2 = fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
-    return structs_column_wrapper{{child1, child2}, nulls_at({5, 6, 10})};
+    auto child2 =
+      cudf::test::fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
+    return cudf::test::structs_column_wrapper{{child1, child2},
+                                              cudf::test::iterators::nulls_at({5, 6, 10})};
   }();
 
-  auto const expect_keys = key_wrapper{{1, 1, 1, 2, 2, 2, 2, 3, 3, 4}, no_nulls()};
+  auto const expect_keys =
+    key_wrapper{{1, 1, 1, 2, 2, 2, 2, 3, 3, 4}, cudf::test::iterators::no_nulls()};
   auto const expect_vals = [] {
-    auto child1 = strings_column_wrapper{
+    auto child1 = cudf::test::strings_column_wrapper{
       "año", "aaa", "" /*NULL*/, "bit", "bit", "" /*NULL*/, "bit", "₹1", "€1", "" /*NULL*/};
-    auto child2 = fixed_width_column_wrapper<int32_t>{9, 6, null, 8, 8, null, 8, 7, 1, null};
-    return structs_column_wrapper{{child1, child2}, nulls_at({2, 5, 9})};
+    auto child2 =
+      cudf::test::fixed_width_column_wrapper<int32_t>{9, 6, null, 8, 8, null, 8, 7, 1, null};
+    return cudf::test::structs_column_wrapper{{child1, child2},
+                                              cudf::test::iterators::nulls_at({2, 5, 9})};
   }();
 
-  auto agg = cudf::make_min_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/min_tests.cpp
+++ b/cpp/tests/groupby/min_tests.cpp
@@ -185,9 +185,6 @@ TEST_F(groupby_min_string_test, min_sorted_strings)
     {"06", "10", "14", "18", "22", "26", "30", "34", "38", "42", ""},
     {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
 
-  // cudf::test::fixed_width_column_wrapper<size_type> expect_argmin(
-  // {6, 10, 14, 18, 22, 26, 30, 34, 38, 42, -1},
-  // {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
   auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys,
                   vals,

--- a/cpp/tests/groupby/min_tests.cpp
+++ b/cpp/tests/groupby/min_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,6 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_min_test : public cudf::test::BaseFixture {
 };
@@ -40,13 +38,13 @@ TYPED_TEST_SUITE(groupby_min_test, cudf::test::FixedWidthTypesWithoutFixedPoint)
 TYPED_TEST(groupby_min_test, basic)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MIN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MIN>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R> expect_vals({0, 1, 2});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0, 1, 2});
 
   auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -58,13 +56,13 @@ TYPED_TEST(groupby_min_test, basic)
 TYPED_TEST(groupby_min_test, empty_cols)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MIN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MIN>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -76,13 +74,13 @@ TYPED_TEST(groupby_min_test, empty_cols)
 TYPED_TEST(groupby_min_test, zero_valid_keys)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MIN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MIN>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals({3, 4, 5});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5});
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -94,13 +92,13 @@ TYPED_TEST(groupby_min_test, zero_valid_keys)
 TYPED_TEST(groupby_min_test, zero_valid_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MIN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MIN>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -112,17 +110,17 @@ TYPED_TEST(groupby_min_test, zero_valid_values)
 TYPED_TEST(groupby_min_test, null_keys_and_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::MIN>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::MIN>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
-  fixed_width_column_wrapper<R> expect_vals({3, 1, 2, 0}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3, 1, 2, 0}, {1, 1, 1, 0});
 
   auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -136,11 +134,12 @@ struct groupby_min_string_test : public cudf::test::BaseFixture {
 
 TEST_F(groupby_min_string_test, basic)
 {
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  strings_column_wrapper vals{"año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::strings_column_wrapper vals{
+    "año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  strings_column_wrapper expect_vals({"aaa", "bat", "$1"});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::strings_column_wrapper expect_vals({"aaa", "bat", "$1"});
 
   auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -151,11 +150,11 @@ TEST_F(groupby_min_string_test, basic)
 
 TEST_F(groupby_min_string_test, zero_valid_values)
 {
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  strings_column_wrapper expect_vals({""}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::strings_column_wrapper expect_vals({""}, all_nulls());
 
   auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
@@ -186,7 +185,7 @@ TEST_F(groupby_min_string_test, min_sorted_strings)
     {"06", "10", "14", "18", "22", "26", "30", "34", "38", "42", ""},
     {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
 
-  // fixed_width_column_wrapper<size_type> expect_argmin(
+  // cudf::test::fixed_width_column_wrapper<size_type> expect_argmin(
   // {6, 10, 14, 18, 22, 26, 30, 34, 38, 42, -1},
   // {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0});
   auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
@@ -196,8 +195,8 @@ TEST_F(groupby_min_string_test, min_sorted_strings)
                   expect_vals,
                   std::move(agg),
                   force_use_sort_impl::NO,
-                  null_policy::INCLUDE,
-                  sorted::YES);
+                  cudf::null_policy::INCLUDE,
+                  cudf::sorted::YES);
 }
 
 struct groupby_dictionary_min_test : public cudf::test::BaseFixture {
@@ -208,10 +207,10 @@ TEST_F(groupby_dictionary_min_test, basic)
   using V = std::string;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
-  dictionary_column_wrapper<V>  vals{ "año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
-  fixed_width_column_wrapper<K> expect_keys   {     1,     2,    3 };
-  dictionary_column_wrapper<V>  expect_vals_w({ "aaa", "bat", "$1" });
+  cudf::test::fixed_width_column_wrapper<K> keys{     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
+  cudf::test::dictionary_column_wrapper<V>  vals{ "año", "bit", "₹1", "aaa", "zit", "bat", "aaa", "$1", "₹1", "wut"};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys   {     1,     2,    3 };
+  cudf::test::dictionary_column_wrapper<V>  expect_vals_w({ "aaa", "bat", "$1" });
   // clang-format on
 
   auto expect_vals = cudf::dictionary::set_keys(expect_vals_w, vals.keys());
@@ -234,10 +233,10 @@ TEST_F(groupby_dictionary_min_test, fixed_width)
   using V = int64_t;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
-  dictionary_column_wrapper<V>  vals{ 0xABC, 0xBBB, 0xF1, 0xAAA, 0xFFF, 0xBAA, 0xAAA, 0x01, 0xF1, 0xEEE};
-  fixed_width_column_wrapper<K> expect_keys    {     1,     2,    3 };
-  fixed_width_column_wrapper<V>  expect_vals_w({ 0xAAA, 0xBAA, 0x01 });
+  cudf::test::fixed_width_column_wrapper<K> keys{     1,     2,    3,     1,     2,     2,     1,    3,    3,    2 };
+  cudf::test::dictionary_column_wrapper<V>  vals{ 0xABC, 0xBBB, 0xF1, 0xAAA, 0xFFF, 0xBAA, 0xAAA, 0x01, 0xF1, 0xEEE};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys    {     1,     2,    3 };
+  cudf::test::fixed_width_column_wrapper<V>  expect_vals_w({ 0xAAA, 0xBAA, 0x01 });
   // clang-format on
 
   test_single_agg(keys,
@@ -254,12 +253,12 @@ TEST_F(groupby_dictionary_min_test, fixed_width)
 }
 
 template <typename T>
-struct FixedPointTestAllReps : public cudf::test::BaseFixture {
+struct GroupByMinFixedPointTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(FixedPointTestAllReps, cudf::test::FixedPointTypes);
+TYPED_TEST_SUITE(GroupByMinFixedPointTest, cudf::test::FixedPointTypes);
 
-TYPED_TEST(FixedPointTestAllReps, GroupBySortMinDecimalAsValue)
+TYPED_TEST(GroupByMinFixedPointTest, GroupBySortMinDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;
@@ -269,11 +268,11 @@ TYPED_TEST(FixedPointTestAllReps, GroupBySortMinDecimalAsValue)
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
     // clang-format off
-    auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const keys  = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+    auto const vals  = fp_wrapper{                              {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
     // clang-format on
 
-    auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
+    auto const expect_keys     = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_min = fp_wrapper{{0, 1, 2}, scale};
 
     auto agg2 = cudf::make_min_aggregation<cudf::groupby_aggregation>();
@@ -282,7 +281,7 @@ TYPED_TEST(FixedPointTestAllReps, GroupBySortMinDecimalAsValue)
   }
 }
 
-TYPED_TEST(FixedPointTestAllReps, GroupByHashMinDecimalAsValue)
+TYPED_TEST(GroupByMinFixedPointTest, GroupByHashMinDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;
@@ -293,11 +292,11 @@ TYPED_TEST(FixedPointTestAllReps, GroupByHashMinDecimalAsValue)
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
     // clang-format off
-    auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const keys  = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+    auto const vals  = fp_wrapper{                              {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
     // clang-format on
 
-    auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
+    auto const expect_keys     = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_min = fp_wrapper{{0, 1, 2}, scale};
 
     auto agg6 = cudf::make_min_aggregation<cudf::groupby_aggregation>();
@@ -310,82 +309,84 @@ struct groupby_min_struct_test : public cudf::test::BaseFixture {
 
 TEST_F(groupby_min_struct_test, basic)
 {
-  auto const keys = fixed_width_column_wrapper<int32_t>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
   auto const vals = [] {
-    auto child1 =
-      strings_column_wrapper{"año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{
+      "año", "bit", "₹1", "aaa", "zit", "bat", "aab", "$1", "€1", "wut"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto const expect_keys = fixed_width_column_wrapper<int32_t>{1, 2, 3};
+  auto const expect_keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3};
   auto const expect_vals = [] {
-    auto child1 = strings_column_wrapper{"aaa", "bat", "$1"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{4, 6, 8};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{"aaa", "bat", "$1"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{4, 6, 8};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto agg = cudf::make_min_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TEST_F(groupby_min_struct_test, slice_input)
 {
   constexpr int32_t dont_care{1};
-  auto const keys_original = fixed_width_column_wrapper<int32_t>{
+  auto const keys_original = cudf::test::fixed_width_column_wrapper<int32_t>{
     dont_care, dont_care, 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, dont_care};
   auto const vals_original = [] {
-    auto child1 = strings_column_wrapper{"dont_care",
-                                         "dont_care",
-                                         "año",
-                                         "bit",
-                                         "₹1",
-                                         "aaa",
-                                         "zit",
-                                         "bat",
-                                         "aab",
-                                         "$1",
-                                         "€1",
-                                         "wut",
-                                         "dont_care"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{
+    auto child1 = cudf::test::strings_column_wrapper{"dont_care",
+                                                     "dont_care",
+                                                     "año",
+                                                     "bit",
+                                                     "₹1",
+                                                     "aaa",
+                                                     "zit",
+                                                     "bat",
+                                                     "aab",
+                                                     "$1",
+                                                     "€1",
+                                                     "wut",
+                                                     "dont_care"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{
       dont_care, dont_care, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, dont_care};
-    return structs_column_wrapper{{child1, child2}};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
   auto const keys        = cudf::slice(keys_original, {2, 12})[0];
   auto const vals        = cudf::slice(vals_original, {2, 12})[0];
-  auto const expect_keys = fixed_width_column_wrapper<int32_t>{1, 2, 3};
+  auto const expect_keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 2, 3};
   auto const expect_vals = [] {
-    auto child1 = strings_column_wrapper{"aaa", "bat", "$1"};
-    auto child2 = fixed_width_column_wrapper<int32_t>{4, 6, 8};
-    return structs_column_wrapper{{child1, child2}};
+    auto child1 = cudf::test::strings_column_wrapper{"aaa", "bat", "$1"};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{4, 6, 8};
+    return cudf::test::structs_column_wrapper{{child1, child2}};
   }();
 
-  auto agg = cudf::make_min_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TEST_F(groupby_min_struct_test, null_keys_and_values)
 {
   constexpr int32_t null{0};
-  auto const keys =
-    fixed_width_column_wrapper<int32_t>{{1, 2, 3, 1, 2, 2, 1, null, 3, 2, 4}, null_at(7)};
+  auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{
+    {1, 2, 3, 1, 2, 2, 1, null, 3, 2, 4}, null_at(7)};
   auto const vals = [] {
-    auto child1 = strings_column_wrapper{
+    auto child1 = cudf::test::strings_column_wrapper{
       "año", "bit", "₹1", "aaa", "zit", "" /*NULL*/, "" /*NULL*/, "$1", "€1", "wut", "" /*NULL*/};
-    auto child2 = fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
-    return structs_column_wrapper{{child1, child2}, nulls_at({5, 6, 10})};
+    auto child2 =
+      cudf::test::fixed_width_column_wrapper<int32_t>{9, 8, 7, 6, 5, null, null, 2, 1, 0, null};
+    return cudf::test::structs_column_wrapper{{child1, child2}, nulls_at({5, 6, 10})};
   }();
 
-  auto const expect_keys = fixed_width_column_wrapper<int32_t>{{1, 2, 3, 4}, no_nulls()};
+  auto const expect_keys =
+    cudf::test::fixed_width_column_wrapper<int32_t>{{1, 2, 3, 4}, no_nulls()};
   auto const expect_vals = [] {
-    auto child1 = strings_column_wrapper{"aaa", "bit", "€1", "" /*NULL*/};
-    auto child2 = fixed_width_column_wrapper<int32_t>{6, 8, 1, null};
-    return structs_column_wrapper{{child1, child2}, null_at(3)};
+    auto child1 = cudf::test::strings_column_wrapper{"aaa", "bit", "€1", "" /*NULL*/};
+    auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{6, 8, 1, null};
+    return cudf::test::structs_column_wrapper{{child1, child2}, null_at(3)};
   }();
 
-  auto agg = cudf::make_min_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -393,40 +394,40 @@ TEST_F(groupby_min_struct_test, values_with_null_child)
 {
   constexpr int32_t null{0};
   {
-    auto const keys = fixed_width_column_wrapper<int32_t>{1, 1};
+    auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 1};
     auto const vals = [] {
-      auto child1 = fixed_width_column_wrapper<int32_t>{1, 1};
-      auto child2 = fixed_width_column_wrapper<int32_t>{{-1, null}, null_at(1)};
-      return structs_column_wrapper{child1, child2};
+      auto child1 = cudf::test::fixed_width_column_wrapper<int32_t>{1, 1};
+      auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{{-1, null}, null_at(1)};
+      return cudf::test::structs_column_wrapper{child1, child2};
     }();
 
-    auto const expect_keys = fixed_width_column_wrapper<int32_t>{1};
+    auto const expect_keys = cudf::test::fixed_width_column_wrapper<int32_t>{1};
     auto const expect_vals = [] {
-      auto child1 = fixed_width_column_wrapper<int32_t>{1};
-      auto child2 = fixed_width_column_wrapper<int32_t>{{null}, null_at(0)};
-      return structs_column_wrapper{child1, child2};
+      auto child1 = cudf::test::fixed_width_column_wrapper<int32_t>{1};
+      auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{{null}, null_at(0)};
+      return cudf::test::structs_column_wrapper{child1, child2};
     }();
 
-    auto agg = cudf::make_min_aggregation<groupby_aggregation>();
+    auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
     test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
   }
 
   {
-    auto const keys = fixed_width_column_wrapper<int32_t>{1, 1};
+    auto const keys = cudf::test::fixed_width_column_wrapper<int32_t>{1, 1};
     auto const vals = [] {
-      auto child1 = fixed_width_column_wrapper<int32_t>{{-1, null}, null_at(1)};
-      auto child2 = fixed_width_column_wrapper<int32_t>{{null, null}, nulls_at({0, 1})};
-      return structs_column_wrapper{child1, child2};
+      auto child1 = cudf::test::fixed_width_column_wrapper<int32_t>{{-1, null}, null_at(1)};
+      auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{{null, null}, nulls_at({0, 1})};
+      return cudf::test::structs_column_wrapper{child1, child2};
     }();
 
-    auto const expect_keys = fixed_width_column_wrapper<int32_t>{1};
+    auto const expect_keys = cudf::test::fixed_width_column_wrapper<int32_t>{1};
     auto const expect_vals = [] {
-      auto child1 = fixed_width_column_wrapper<int32_t>{{null}, null_at(0)};
-      auto child2 = fixed_width_column_wrapper<int32_t>{{null}, null_at(0)};
-      return structs_column_wrapper{child1, child2};
+      auto child1 = cudf::test::fixed_width_column_wrapper<int32_t>{{null}, null_at(0)};
+      auto child2 = cudf::test::fixed_width_column_wrapper<int32_t>{{null}, null_at(0)};
+      return cudf::test::structs_column_wrapper{child1, child2};
     }();
 
-    auto agg = cudf::make_min_aggregation<groupby_aggregation>();
+    auto agg = cudf::make_min_aggregation<cudf::groupby_aggregation>();
     test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
   }
 }
@@ -440,8 +441,8 @@ TYPED_TEST_SUITE(groupby_min_floating_point_test, cudf::test::FloatingPointTypes
 TYPED_TEST(groupby_min_floating_point_test, values_with_infinity)
 {
   using T          = TypeParam;
-  using int32s_col = fixed_width_column_wrapper<int32_t>;
-  using floats_col = fixed_width_column_wrapper<T, int32_t>;
+  using int32s_col = cudf::test::fixed_width_column_wrapper<int32_t>;
+  using floats_col = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
   auto constexpr inf = std::numeric_limits<T>::infinity();
 
@@ -461,27 +462,24 @@ TYPED_TEST(groupby_min_floating_point_test, values_with_infinity)
 TYPED_TEST(groupby_min_floating_point_test, values_with_nan)
 {
   using T          = TypeParam;
-  using int32s_col = fixed_width_column_wrapper<int32_t>;
-  using floats_col = fixed_width_column_wrapper<T, int32_t>;
+  using int32s_col = cudf::test::fixed_width_column_wrapper<int32_t>;
+  using floats_col = cudf::test::fixed_width_column_wrapper<T, int32_t>;
 
   auto constexpr nan = std::numeric_limits<T>::quiet_NaN();
 
   auto const keys = int32s_col{1, 1};
   auto const vals = floats_col{nan, nan};
 
-  std::vector<groupby::aggregation_request> requests;
-  requests.emplace_back(groupby::aggregation_request());
+  std::vector<cudf::groupby::aggregation_request> requests;
+  requests.emplace_back(cudf::groupby::aggregation_request());
   requests[0].values = vals;
   requests[0].aggregations.emplace_back(cudf::make_min_aggregation<cudf::groupby_aggregation>());
 
   // Without properly handling NaN, this will hang forever in hash-based aggregate (which is the
   // default back-end for min/max in groupby context).
   // This test is just to verify that the aggregate operation does not hang.
-  auto gb_obj       = groupby::groupby(table_view({keys}));
+  auto gb_obj       = cudf::groupby::groupby(cudf::table_view({keys}));
   auto const result = gb_obj.aggregate(requests);
 
   EXPECT_EQ(result.first->num_rows(), 1);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/nth_element_tests.cpp
+++ b/cpp/tests/groupby/nth_element_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,6 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
-
 template <typename V>
 struct groupby_nth_element_test : public cudf::test::BaseFixture {
 };
@@ -40,26 +37,26 @@ TYPED_TEST(groupby_nth_element_test, basic)
 {
   using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
-  //keys                            {1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
-  //vals                            {0, 3, 6, 1, 4, 5, 9, 2, 7, 8};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  //keys                                                  {1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
+  //vals                                                  {0, 3, 6, 1, 4, 5, 9, 2, 7, 8};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
   //groupby.first()
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(0);
-  fixed_width_column_wrapper<R, int32_t> expect_vals0({0, 1, 2});
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0);
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals0({0, 1, 2});
   test_single_agg(keys, vals, expect_keys, expect_vals0, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(1);
-  fixed_width_column_wrapper<R, int32_t> expect_vals1({3, 4, 7});
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(1);
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals1({3, 4, 7});
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(2);
-  fixed_width_column_wrapper<R, int32_t> expect_vals2({6, 5, 8});
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2);
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals2({6, 5, 8});
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg));
 }
 
@@ -67,15 +64,15 @@ TYPED_TEST(groupby_nth_element_test, empty_cols)
 {
   using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(0);
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -83,15 +80,15 @@ TYPED_TEST(groupby_nth_element_test, basic_out_of_bounds)
 {
   using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 3, 2, 2, 9});
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 3, 2, 2, 9});
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(3);
-  fixed_width_column_wrapper<R, int32_t> expect_vals({0, 9, 0}, {0, 1, 0});
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(3);
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals({0, 9, 0}, {0, 1, 0});
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -99,26 +96,26 @@ TYPED_TEST(groupby_nth_element_test, negative)
 {
   using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
   //keys                            {1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
   //vals                            {0, 3, 6, 1, 4, 5, 9, 2, 7, 8};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
   //groupby.last()
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-1);
-  fixed_width_column_wrapper<R, int32_t> expect_vals0({6, 9, 8});
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-1);
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals0({6, 9, 8});
   test_single_agg(keys, vals, expect_keys, expect_vals0, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-2);
-  fixed_width_column_wrapper<R, int32_t> expect_vals1({3, 5, 7});
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-2);
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals1({3, 5, 7});
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-3);
-  fixed_width_column_wrapper<R, int32_t> expect_vals2({0, 4, 2});
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-3);
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals2({0, 4, 2});
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg));
 }
 
@@ -126,15 +123,15 @@ TYPED_TEST(groupby_nth_element_test, negative_out_of_bounds)
 {
   using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 3, 2, 2, 9});
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 3, 2, 2, 9});
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-4);
-  fixed_width_column_wrapper<R, int32_t> expect_vals({0, 1, 0}, {0, 1, 0});
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-4);
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals({0, 1, 0}, {0, 1, 0});
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -142,15 +139,15 @@ TYPED_TEST(groupby_nth_element_test, zero_valid_keys)
 {
   using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5});
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(0);
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -158,15 +155,15 @@ TYPED_TEST(groupby_nth_element_test, zero_valid_values)
 {
   using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({3, 4, 5}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R, int32_t> expect_vals({3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals({3}, all_nulls());
 
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(0);
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -174,19 +171,19 @@ TYPED_TEST(groupby_nth_element_test, null_keys_and_values)
 {
   using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
                                      {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
                                               {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //keys                                    {1, 1, 1   2,2,2,2    3, 3,    4}
   //vals                                    {-,3,6,    1,4,-,9,  2,8,      -}
-  fixed_width_column_wrapper<R, int32_t> expect_vals({-1, 1, 2, -1}, {0, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals({-1, 1, 2, -1}, {0, 1, 1, 0});
 
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(0);
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -194,19 +191,19 @@ TYPED_TEST(groupby_nth_element_test, null_keys_and_values_out_of_bounds)
 {
   using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
                                      {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
                                               {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
   //                                        {1, 1, 1    2, 2, 2,    3, 3,   4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //                                        {-,3,6,     1,4,-,9,    2,8,    -}
   //                                         value,     null,       out,    out
-  fixed_width_column_wrapper<R, int32_t> expect_vals({6, -1, -1, -1}, {1, 0, 0, 0});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals({6, -1, -1, -1}, {1, 0, 0, 0});
 
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(2);
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -214,41 +211,41 @@ TYPED_TEST(groupby_nth_element_test, exclude_nulls)
 {
   using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
                                      {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
-  fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
                                               {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //keys                                    {1, 1, 1    2, 2, 2, 2      3, 3, 3    4}
   //vals                                    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,   4,-}
   //                                      0  null,      value,          value,     null
   //                                      1  value,     value,          value,     null
   //                                      2  value,     null,           value,     out
   //null_policy::INCLUDE
-  fixed_width_column_wrapper<R, int32_t> expect_nuls0({-1, 1, 2, 4}, {0, 1, 1, 1});
-  fixed_width_column_wrapper<R, int32_t> expect_nuls1({3, 4, 2, -1}, {1, 1, 1, 0});
-  fixed_width_column_wrapper<R, int32_t> expect_nuls2({6, -1, 8, -1}, {1, 0, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls0({-1, 1, 2, 4}, {0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls1({3, 4, 2, -1}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls2({6, -1, 8, -1}, {1, 0, 1, 0});
 
   //null_policy::EXCLUDE
-  fixed_width_column_wrapper<R, int32_t> expect_vals0({3, 1, 2, 4});
-  fixed_width_column_wrapper<R, int32_t> expect_vals1({6, 4, 2, -1}, {1, 1, 1, 0});
-  fixed_width_column_wrapper<R, int32_t> expect_vals2({-1, 9, 8, -1}, {0, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals0({3, 1, 2, 4});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals1({6, 4, 2, -1}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals2({-1, 9, 8, -1}, {0, 1, 1, 0});
 
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(0, cudf::null_policy::INCLUDE);
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls0, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(1, cudf::null_policy::INCLUDE);
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(1, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls1, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(2, cudf::null_policy::INCLUDE);
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls2, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(0, cudf::null_policy::EXCLUDE);
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals0, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(1, cudf::null_policy::EXCLUDE);
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(1, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(2, cudf::null_policy::EXCLUDE);
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg));
 }
 
@@ -256,14 +253,14 @@ TYPED_TEST(groupby_nth_element_test, exclude_nulls_negative_index)
 {
   using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NTH_ELEMENT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NTH_ELEMENT>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
                                      {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
-  fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
                                               {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
 
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //keys                                    {1, 1, 1    2, 2, 2,        3, 3,       4}
   //vals                                    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,    4,-}
   //                                      0  null,      value,          value,      value
@@ -273,27 +270,27 @@ TYPED_TEST(groupby_nth_element_test, exclude_nulls_negative_index)
   //                                      4  out,       null,           out,        out
 
   //null_policy::INCLUDE
-  fixed_width_column_wrapper<R, int32_t> expect_nuls0({6, -1, 8, -1}, {1, 0, 1, 0});
-  fixed_width_column_wrapper<R, int32_t> expect_nuls1({3, 9, 2, 4});
-  fixed_width_column_wrapper<R, int32_t> expect_nuls2({-1, -1, 2, -1}, {0, 0, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls0({6, -1, 8, -1}, {1, 0, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls1({3, 9, 2, 4});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls2({-1, -1, 2, -1}, {0, 0, 1, 0});
 
   //null_policy::EXCLUDE
-  fixed_width_column_wrapper<R, int32_t> expect_vals0({6, 9, 8, 4});
-  fixed_width_column_wrapper<R, int32_t> expect_vals1({3, 4, 2, -1}, {1, 1, 1, 0});
-  fixed_width_column_wrapper<R, int32_t> expect_vals2({-1, 1, 2, -1}, {0, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals0({6, 9, 8, 4});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals1({3, 4, 2, -1}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals2({-1, 1, 2, -1}, {0, 1, 1, 0});
 
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-1, cudf::null_policy::INCLUDE);
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-1, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls0, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-2, cudf::null_policy::INCLUDE);
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-2, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls1, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-3, cudf::null_policy::INCLUDE);
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-3, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls2, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-1, cudf::null_policy::EXCLUDE);
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-1, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals0, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-2, cudf::null_policy::EXCLUDE);
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-2, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-3, cudf::null_policy::EXCLUDE);
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-3, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg));
 }
 
@@ -304,47 +301,45 @@ TEST_F(groupby_nth_element_string_test, basic_string)
 {
   using K = int32_t;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  strings_column_wrapper vals{"ABCD", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
-  //keys                     {1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
-  //vals                     {A, 3, 6, 1, 4, 5, 9, 2, 7, 8};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::strings_column_wrapper vals{"ABCD", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
   //groupby.first()
-  auto agg = cudf::make_nth_element_aggregation<groupby_aggregation>(0);
-  strings_column_wrapper expect_vals0{"ABCD", "1", "2"};
+  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0);
+  cudf::test::strings_column_wrapper expect_vals0{"ABCD", "1", "2"};
   test_single_agg(keys, vals, expect_keys, expect_vals0, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(1);
-  strings_column_wrapper expect_vals1{"3", "4", "7"};
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(1);
+  cudf::test::strings_column_wrapper expect_vals1{"3", "4", "7"};
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(2);
-  strings_column_wrapper expect_vals2{"6", "5", "8"};
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2);
+  cudf::test::strings_column_wrapper expect_vals2{"6", "5", "8"};
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg));
 
   //+ve out of bounds
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(3);
-  strings_column_wrapper expect_vals3{{"", "9", ""}, {0, 1, 0}};
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(3);
+  cudf::test::strings_column_wrapper expect_vals3{{"", "9", ""}, {0, 1, 0}};
   test_single_agg(keys, vals, expect_keys, expect_vals3, std::move(agg));
 
   //groupby.last()
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-1);
-  strings_column_wrapper expect_vals4{"6", "9", "8"};
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-1);
+  cudf::test::strings_column_wrapper expect_vals4{"6", "9", "8"};
   test_single_agg(keys, vals, expect_keys, expect_vals4, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-2);
-  strings_column_wrapper expect_vals5{"3", "5", "7"};
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-2);
+  cudf::test::strings_column_wrapper expect_vals5{"3", "5", "7"};
   test_single_agg(keys, vals, expect_keys, expect_vals5, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-3);
-  strings_column_wrapper expect_vals6{"ABCD", "4", "2"};
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-3);
+  cudf::test::strings_column_wrapper expect_vals6{"ABCD", "4", "2"};
   test_single_agg(keys, vals, expect_keys, expect_vals6, std::move(agg));
 
   //-ve out of bounds
-  agg = cudf::make_nth_element_aggregation<groupby_aggregation>(-4);
-  strings_column_wrapper expect_vals7{{"", "1", ""}, {0, 1, 0}};
+  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-4);
+  cudf::test::strings_column_wrapper expect_vals7{{"", "1", ""}, {0, 1, 0}};
   test_single_agg(keys, vals, expect_keys, expect_vals7, std::move(agg));
 }
 // clang-format on
@@ -354,10 +349,10 @@ TEST_F(groupby_nth_element_string_test, dictionary)
   using K = int32_t;
   using V = std::string;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V> vals{"AB", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  dictionary_column_wrapper<V> expect_vals_w{"6", "5", "8"};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::dictionary_column_wrapper<V> vals{"AB", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::dictionary_column_wrapper<V> expect_vals_w{"6", "5", "8"};
 
   auto expect_vals = cudf::dictionary::set_keys(expect_vals_w, vals.keys());
 
@@ -365,14 +360,14 @@ TEST_F(groupby_nth_element_string_test, dictionary)
                   vals,
                   expect_keys,
                   expect_vals->view(),
-                  cudf::make_nth_element_aggregation<groupby_aggregation>(2));
+                  cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2));
 }
 
 template <typename T>
-struct groupby_nth_element_lists_test : BaseFixture {
+struct groupby_nth_element_lists_test : cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(groupby_nth_element_lists_test, FixedWidthTypesWithoutFixedPoint);
+TYPED_TEST_SUITE(groupby_nth_element_lists_test, cudf::test::FixedWidthTypesWithoutFixedPoint);
 
 TYPED_TEST(groupby_nth_element_lists_test, Basics)
 {
@@ -381,17 +376,17 @@ TYPED_TEST(groupby_nth_element_lists_test, Basics)
 
   using lists = cudf::test::lists_column_wrapper<V, int32_t>;
 
-  auto keys   = fixed_width_column_wrapper<K, int32_t>{1, 1, 2, 2, 3, 3};
+  auto keys   = cudf::test::fixed_width_column_wrapper<K, int32_t>{1, 1, 2, 2, 3, 3};
   auto values = lists{{1, 2}, {3, 4}, {5, 6, 7}, lists{}, {9, 10}, {11}};
 
-  auto expected_keys   = fixed_width_column_wrapper<K, int32_t>{1, 2, 3};
+  auto expected_keys   = cudf::test::fixed_width_column_wrapper<K, int32_t>{1, 2, 3};
   auto expected_values = lists{{1, 2}, {5, 6, 7}, {9, 10}};
 
   test_single_agg(keys,
                   values,
                   expected_keys,
                   expected_values,
-                  cudf::make_nth_element_aggregation<groupby_aggregation>(0));
+                  cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0));
 }
 
 TYPED_TEST(groupby_nth_element_lists_test, EmptyInput)
@@ -401,20 +396,20 @@ TYPED_TEST(groupby_nth_element_lists_test, EmptyInput)
 
   using lists = cudf::test::lists_column_wrapper<V, int32_t>;
 
-  auto keys   = fixed_width_column_wrapper<K, int32_t>{};
+  auto keys   = cudf::test::fixed_width_column_wrapper<K, int32_t>{};
   auto values = lists{};
 
-  auto expected_keys   = fixed_width_column_wrapper<K, int32_t>{};
+  auto expected_keys   = cudf::test::fixed_width_column_wrapper<K, int32_t>{};
   auto expected_values = lists{};
 
   test_single_agg(keys,
                   values,
                   expected_keys,
                   expected_values,
-                  cudf::make_nth_element_aggregation<groupby_aggregation>(2));
+                  cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2));
 }
 
-struct groupby_nth_element_structs_test : BaseFixture {
+struct groupby_nth_element_structs_test : cudf::test::BaseFixture {
 };
 
 TEST_F(groupby_nth_element_structs_test, Basics)
@@ -439,18 +434,19 @@ TEST_F(groupby_nth_element_structs_test, Basics)
                   values,
                   expected_keys,
                   expected_values,
-                  cudf::make_nth_element_aggregation<groupby_aggregation>(1));
+                  cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(1));
 
   expected_keys   = ints{0, 1, 2, 3};
   expected_ch0    = ints{0, 4, 6, 9};
   expected_ch1    = doubles{0.1, 4.51, 6.3231, 9.999};
   expected_ch2    = strings{"", "d", "f", "JJJ"};
   expected_values = structs{{expected_ch0, expected_ch1, expected_ch2}, {1, 1, 1, 1}};
-  test_single_agg(keys,
-                  values,
-                  expected_keys,
-                  expected_values,
-                  cudf::make_nth_element_aggregation<groupby_aggregation>(0, null_policy::EXCLUDE));
+  test_single_agg(
+    keys,
+    values,
+    expected_keys,
+    expected_values,
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0, cudf::null_policy::EXCLUDE));
 }
 
 TEST_F(groupby_nth_element_structs_test, NestedStructs)
@@ -479,7 +475,7 @@ TEST_F(groupby_nth_element_structs_test, NestedStructs)
                   values,
                   expected_keys,
                   expected_values,
-                  cudf::make_nth_element_aggregation<groupby_aggregation>(1));
+                  cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(1));
 
   expected_keys       = ints{0, 1, 2, 3};
   expected_ch0        = ints{0, 4, 6, 9};
@@ -488,11 +484,12 @@ TEST_F(groupby_nth_element_structs_test, NestedStructs)
   expected_ch1        = structs{expected_ch0_of_ch1, expected_ch1_of_ch1};
   expected_ch2        = lists{{0}, {5, 6}, {}, {}};
   expected_values     = structs{{expected_ch0, expected_ch1, expected_ch2}, {1, 1, 1, 1}};
-  test_single_agg(keys,
-                  values,
-                  expected_keys,
-                  expected_values,
-                  cudf::make_nth_element_aggregation<groupby_aggregation>(0, null_policy::EXCLUDE));
+  test_single_agg(
+    keys,
+    values,
+    expected_keys,
+    expected_values,
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0, cudf::null_policy::EXCLUDE));
 }
 
 TEST_F(groupby_nth_element_structs_test, EmptyInput)
@@ -517,7 +514,5 @@ TEST_F(groupby_nth_element_structs_test, EmptyInput)
                   values,
                   expected_keys,
                   expected_values,
-                  cudf::make_nth_element_aggregation<groupby_aggregation>(0));
+                  cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0));
 }
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/nunique_tests.cpp
+++ b/cpp/tests/groupby/nunique_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,33 +23,29 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
-using namespace cudf::test::iterators;
-
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_nunique_test : public cudf::test::BaseFixture {
 };
 
-using K = int32_t;
 TYPED_TEST_SUITE(groupby_nunique_test, cudf::test::AllTypes);
 
 TYPED_TEST(groupby_nunique_test, basic)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NUNIQUE>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   // clang-format off
-  //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<K> expect_keys{1,        2,          3};
-  fixed_width_column_wrapper<R> expect_vals{3,        4,          3};
-  fixed_width_column_wrapper<R> expect_bool_vals{2,   1,          1};
+  //                                                   {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1,        2,          3};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{3,        4,          3};
+  cudf::test::fixed_width_column_wrapper<R> expect_bool_vals{2,   1,          1};
   // clang-format on
 
-  auto agg = cudf::make_nunique_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_nunique_aggregation<cudf::groupby_aggregation>();
   if (std::is_same<V, bool>())
     test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
   else
@@ -58,32 +54,34 @@ TYPED_TEST(groupby_nunique_test, basic)
 
 TYPED_TEST(groupby_nunique_test, empty_cols)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NUNIQUE>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_nunique_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_nunique_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_nunique_test, basic_duplicates)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NUNIQUE>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 3, 2, 2, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 3, 2, 2, 9};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R> expect_vals{2, 4, 1};
-  fixed_width_column_wrapper<R> expect_bool_vals{2, 1, 1};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{2, 4, 1};
+  cudf::test::fixed_width_column_wrapper<R> expect_bool_vals{2, 1, 1};
 
-  auto agg = cudf::make_nunique_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_nunique_aggregation<cudf::groupby_aggregation>();
   if (std::is_same<V, bool>())
     test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
   else
@@ -92,51 +90,55 @@ TYPED_TEST(groupby_nunique_test, basic_duplicates)
 
 TYPED_TEST(groupby_nunique_test, zero_valid_keys)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NUNIQUE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals({3, 4, 5});
+  cudf::test::fixed_width_column_wrapper<K> keys({0, 0, 0}, cudf::test::iterators::all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5});
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_nunique_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_nunique_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_nunique_test, zero_valid_values)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NUNIQUE>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 0, 0}, cudf::test::iterators::all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals{0};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{0};
 
-  auto agg = cudf::make_nunique_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_nunique_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_nunique_test, null_keys_and_values)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NUNIQUE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4},
+                                                        cudf::test::iterators::no_nulls());
   // all unique values only                 {3, 6,     1, 4, 9,   2, 8,    -}
-  fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
-  fixed_width_column_wrapper<R> expect_bool_vals{1, 1, 1, 0};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
+  cudf::test::fixed_width_column_wrapper<R> expect_bool_vals{1, 1, 1, 0};
 
-  auto agg = cudf::make_nunique_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_nunique_aggregation<cudf::groupby_aggregation>();
   if (std::is_same<V, bool>())
     test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
   else
@@ -145,22 +147,24 @@ TYPED_TEST(groupby_nunique_test, null_keys_and_values)
 
 TYPED_TEST(groupby_nunique_test, null_keys_and_values_with_duplicates)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NUNIQUE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
-                                     {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
-                                     {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
+                                                 {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
+                                                 {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   //  { 1, 1,     2, 2, 2,    3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4},
+                                                        cudf::test::iterators::no_nulls());
   //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
   //  unique,     with null,  dup,     dup null
-  fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
-  fixed_width_column_wrapper<R> expect_bool_vals{1, 1, 1, 0};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{2, 3, 2, 0};
+  cudf::test::fixed_width_column_wrapper<R> expect_bool_vals{1, 1, 1, 0};
 
-  auto agg = cudf::make_nunique_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_nunique_aggregation<cudf::groupby_aggregation>();
   if (std::is_same<V, bool>())
     test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
   else
@@ -169,22 +173,24 @@ TYPED_TEST(groupby_nunique_test, null_keys_and_values_with_duplicates)
 
 TYPED_TEST(groupby_nunique_test, include_nulls)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NUNIQUE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
-                                     {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
-                                     {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
+                                                 {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
+                                                 {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   //  { 1, 1,     2, 2, 2,    3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4},
+                                                        cudf::test::iterators::no_nulls());
   //  { 3, 6,-    1, 4, 9,-   2*, 8,   -*}
   //  unique,     with null,  dup,     dup null
-  fixed_width_column_wrapper<R> expect_vals{3, 4, 2, 1};
-  fixed_width_column_wrapper<R> expect_bool_vals{2, 2, 1, 1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{3, 4, 2, 1};
+  cudf::test::fixed_width_column_wrapper<R> expect_bool_vals{2, 2, 1, 1};
 
-  auto agg = cudf::make_nunique_aggregation<groupby_aggregation>(null_policy::INCLUDE);
+  auto agg = cudf::make_nunique_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
   if (std::is_same<V, bool>())
     test_single_agg(keys, vals, expect_keys, expect_bool_vals, std::move(agg));
   else
@@ -193,32 +199,31 @@ TYPED_TEST(groupby_nunique_test, include_nulls)
 
 TYPED_TEST(groupby_nunique_test, dictionary)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::NUNIQUE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::NUNIQUE>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 0, 3, 2, 4, 4, 2},
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 0, 3, 2, 4, 4, 2},
                                      {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
-  dictionary_column_wrapper<V>  vals({0, 1, 2, 2, 3, 4, 0, 6, 7, 8, 9, 0, 0, 0},
+  cudf::test::dictionary_column_wrapper<V>  vals({0, 1, 2, 2, 3, 4, 0, 6, 7, 8, 9, 0, 0, 0},
                                      {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0});
 
   // { 1, 1,   2, 2, 2,   3, 3,   4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, cudf::test::iterators::no_nulls());
   // { 3, 6,-  1, 4, 9,-  2*, 8,  -*}
   //  unique,  with null, dup,    dup null
-  fixed_width_column_wrapper<R> expect_fixed_vals({3, 4, 2, 1});
-  fixed_width_column_wrapper<R> expect_bool_vals{2, 2, 1, 1};
+  cudf::test::fixed_width_column_wrapper<R> expect_fixed_vals({3, 4, 2, 1});
+  cudf::test::fixed_width_column_wrapper<R> expect_bool_vals{2, 2, 1, 1};
   // clang-format on
 
   cudf::column_view expect_vals = (std::is_same<V, bool>()) ? cudf::column_view{expect_bool_vals}
                                                             : cudf::column_view{expect_fixed_vals};
 
-  test_single_agg(keys,
-                  vals,
-                  expect_keys,
-                  expect_vals,
-                  cudf::make_nunique_aggregation<groupby_aggregation>(null_policy::INCLUDE));
+  test_single_agg(
+    keys,
+    vals,
+    expect_keys,
+    expect_vals,
+    cudf::make_nunique_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE));
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/product_tests.cpp
+++ b/cpp/tests/groupby/product_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,30 +25,28 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_product_test : public cudf::test::BaseFixture {
 };
 
-using K               = int32_t;
 using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
 
 TYPED_TEST_SUITE(groupby_product_test, supported_types);
 
 TYPED_TEST(groupby_product_test, basic)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::PRODUCT>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys        { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                        //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys { 1,        2,           3      };
-                                        //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({   0.,       180.,      112. }, no_nulls());
+                                                    //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys { 1,        2,           3      };
+                                                    //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({   0.,       180.,      112. }, no_nulls());
   // clang-format on
 
   test_single_agg(keys,
@@ -60,14 +58,15 @@ TYPED_TEST(groupby_product_test, basic)
 
 TYPED_TEST(groupby_product_test, empty_cols)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::PRODUCT>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   test_single_agg(keys,
                   vals,
@@ -78,14 +77,15 @@ TYPED_TEST(groupby_product_test, empty_cols)
 
 TYPED_TEST(groupby_product_test, zero_valid_keys)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::PRODUCT>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals{3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<K> keys({0, 0, 0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   test_single_agg(keys,
                   vals,
@@ -96,14 +96,15 @@ TYPED_TEST(groupby_product_test, zero_valid_keys)
 
 TYPED_TEST(groupby_product_test, zero_valid_values)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::PRODUCT>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 0, 0}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   test_single_agg(keys,
                   vals,
@@ -114,19 +115,20 @@ TYPED_TEST(groupby_product_test, zero_valid_values)
 
 TYPED_TEST(groupby_product_test, null_keys_and_values)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::PRODUCT>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+  cudf::test::fixed_width_column_wrapper<K> keys(       { 1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
                                             { 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals(       { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
+  cudf::test::fixed_width_column_wrapper<V> vals(       { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
                                             { 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
                                         //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({ 1,        2,         3,       4}, no_nulls());
                                         //  { _, 3, 6,  1, 4, 9,   2, 8,    _}
-  fixed_width_column_wrapper<R> expect_vals({ 18.,      36.,       16.,     3.},
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({ 18.,      36.,       16.,     3.},
                                             { 1,        1,         1,       0});
   // clang-format on
 
@@ -139,17 +141,18 @@ TYPED_TEST(groupby_product_test, null_keys_and_values)
 
 TYPED_TEST(groupby_product_test, dictionary)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::PRODUCT>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::dictionary_column_wrapper<V>  vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-                                        //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
-                                        //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        112. }, no_nulls());
+                                                    //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
+                                                    //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        112. }, no_nulls());
   // clang-format on
 
   test_single_agg(keys,
@@ -161,18 +164,19 @@ TYPED_TEST(groupby_product_test, dictionary)
 
 TYPED_TEST(groupby_product_test, dictionary_with_nulls)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::PRODUCT>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::PRODUCT>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+  cudf::test::fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::dictionary_column_wrapper<V>  vals{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
                                      {1, 0, 0, 1, 1, 1, 1, 1, 1, 1}};
 
-                                        //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
-                                        //  { 0, 3, 6,  @, 4, 5, 9,  @, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        56. }, no_nulls());
+                                                    //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({ 1,        2,           3      });
+                                                    //  { 0, 3, 6,  @, 4, 5, 9,  @, 7, 8}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({  0.,     180.,        56. }, no_nulls());
   // clang-format on
 
   test_single_agg(keys,
@@ -181,6 +185,3 @@ TYPED_TEST(groupby_product_test, dictionary_with_nulls)
                   expect_vals,
                   cudf::make_product_aggregation<cudf::groupby_aggregation>());
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/quantile_tests.cpp
+++ b/cpp/tests/groupby/quantile_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_quantile_test : public cudf::test::BaseFixture {
 };
@@ -39,151 +37,156 @@ TYPED_TEST_SUITE(groupby_quantile_test, supported_types);
 TYPED_TEST(groupby_quantile_test, basic)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::QUANTILE>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   // clang-format on
   //                                       {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //                                       {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3., 4.5, 7.}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3., 4.5, 7.}, no_nulls());
   // clang-format on
 
-  auto agg = cudf::make_quantile_aggregation<groupby_aggregation>({0.5}, interpolation::LINEAR);
+  auto agg =
+    cudf::make_quantile_aggregation<cudf::groupby_aggregation>({0.5}, cudf::interpolation::LINEAR);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_quantile_test, empty_cols)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::QUANTILE>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_quantile_aggregation<groupby_aggregation>({0.5}, interpolation::LINEAR);
+  auto agg =
+    cudf::make_quantile_aggregation<cudf::groupby_aggregation>({0.5}, cudf::interpolation::LINEAR);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_quantile_test, zero_valid_keys)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::QUANTILE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals{3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_quantile_aggregation<groupby_aggregation>({0.5}, interpolation::LINEAR);
+  auto agg =
+    cudf::make_quantile_aggregation<cudf::groupby_aggregation>({0.5}, cudf::interpolation::LINEAR);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_quantile_test, zero_valid_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::QUANTILE>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
-  auto agg = cudf::make_quantile_aggregation<groupby_aggregation>({0.5}, interpolation::LINEAR);
+  auto agg =
+    cudf::make_quantile_aggregation<cudf::groupby_aggregation>({0.5}, cudf::interpolation::LINEAR);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_quantile_test, null_keys_and_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::QUANTILE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
-  fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({4.5, 4., 5., 0.}, {1, 1, 1, 0});
 
-  auto agg = cudf::make_quantile_aggregation<groupby_aggregation>({0.5}, interpolation::LINEAR);
+  auto agg =
+    cudf::make_quantile_aggregation<cudf::groupby_aggregation>({0.5}, cudf::interpolation::LINEAR);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_quantile_test, multiple_quantile)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::QUANTILE>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   // clang-format off
   //                                       {1, 1, 1,   2, 2, 2, 2, 3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //                                        {0, 3, 6,  1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({1.5, 4.5, 3.25, 6.,   4.5, 7.5}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({1.5, 4.5, 3.25, 6.,   4.5, 7.5}, no_nulls());
   // clang-format on
 
-  auto agg =
-    cudf::make_quantile_aggregation<groupby_aggregation>({0.25, 0.75}, interpolation::LINEAR);
+  auto agg = cudf::make_quantile_aggregation<cudf::groupby_aggregation>(
+    {0.25, 0.75}, cudf::interpolation::LINEAR);
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
                   std::move(agg),
                   force_use_sort_impl::YES,
-                  null_policy::EXCLUDE,
-                  sorted::NO,
+                  cudf::null_policy::EXCLUDE,
+                  cudf::sorted::NO,
                   {},
                   {},
-                  sorted::YES);
+                  cudf::sorted::YES);
 }
 
 TYPED_TEST(groupby_quantile_test, interpolation_types)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::QUANTILE>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 9};
 
   // clang-format off
-  //                                         {1, 1, 1,  2, 2, 2, 2,  3, 3}
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  //                                                   {1, 1, 1,  2, 2, 2, 2,  3, 3}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
-  //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals1({2.4,      4.2,         4.}, no_nulls());
-  auto agg1 = cudf::make_quantile_aggregation<groupby_aggregation>({0.4}, interpolation::LINEAR);
+  //                                                     {0, 3, 6,  1, 4, 5, 9,  2, 7}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals1({2.4,      4.2,         4.}, no_nulls());
+  auto agg1 = cudf::make_quantile_aggregation<cudf::groupby_aggregation>({0.4}, cudf::interpolation::LINEAR);
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg1));
 
-  //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals2({3,        4,           2}, no_nulls());
-  auto agg2 = cudf::make_quantile_aggregation<groupby_aggregation>({0.4}, interpolation::NEAREST);
+  //                                                     {0, 3, 6,  1, 4, 5, 9,  2, 7}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals2({3,        4,           2}, no_nulls());
+  auto agg2 = cudf::make_quantile_aggregation<cudf::groupby_aggregation>({0.4}, cudf::interpolation::NEAREST);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg2));
 
-  //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals3({0,        4,          2}, no_nulls());
-  auto agg3 = cudf::make_quantile_aggregation<groupby_aggregation>({0.4}, interpolation::LOWER);
+  //                                                     {0, 3, 6,  1, 4, 5, 9,  2, 7}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals3({0,        4,          2}, no_nulls());
+  auto agg3 = cudf::make_quantile_aggregation<cudf::groupby_aggregation>({0.4}, cudf::interpolation::LOWER);
   test_single_agg(keys, vals, expect_keys, expect_vals3, std::move(agg3));
 
-  //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals4({3,        5,           7}, no_nulls());
-  auto agg4 = cudf::make_quantile_aggregation<groupby_aggregation>({0.4}, interpolation::HIGHER);
+  //                                                     {0, 3, 6,  1, 4, 5, 9,  2, 7}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals4({3,        5,           7}, no_nulls());
+  auto agg4 = cudf::make_quantile_aggregation<cudf::groupby_aggregation>({0.4}, cudf::interpolation::HIGHER);
   test_single_agg(keys, vals, expect_keys, expect_vals4, std::move(agg4));
 
-  //                                         {0, 3, 6,  1, 4, 5, 9,  2, 7}
-  fixed_width_column_wrapper<R> expect_vals5({1.5,      4.5,         4.5}, no_nulls());
-  auto agg5 = cudf::make_quantile_aggregation<groupby_aggregation>({0.4}, interpolation::MIDPOINT);
+  //                                                     {0, 3, 6,  1, 4, 5, 9,  2, 7}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals5({1.5,      4.5,         4.5}, no_nulls());
+  auto agg5 = cudf::make_quantile_aggregation<cudf::groupby_aggregation>({0.4}, cudf::interpolation::MIDPOINT);
   test_single_agg(keys, vals, expect_keys, expect_vals5, std::move(agg5));
   // clang-format on
 }
@@ -191,16 +194,16 @@ TYPED_TEST(groupby_quantile_test, interpolation_types)
 TYPED_TEST(groupby_quantile_test, dictionary)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::QUANTILE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::QUANTILE>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::dictionary_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  //                                        {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3});
-  //                                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,      4.5,        7.}, no_nulls());
+  //                                                    {1, 1, 1, 2, 2, 2, 2, 3, 3, 3}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3});
+  //                                                    {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3.,      4.5,        7.}, no_nulls());
   // clang-format on
 
   test_single_agg(
@@ -208,8 +211,5 @@ TYPED_TEST(groupby_quantile_test, dictionary)
     vals,
     expect_keys,
     expect_vals,
-    cudf::make_quantile_aggregation<groupby_aggregation>({0.5}, interpolation::LINEAR));
+    cudf::make_quantile_aggregation<cudf::groupby_aggregation>({0.5}, cudf::interpolation::LINEAR));
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/rank_scan_tests.cpp
+++ b/cpp/tests/groupby/rank_scan_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/iterator_utilities.hpp>
+#include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/aggregation/aggregation.hpp>
@@ -37,11 +38,11 @@ using null_iter_t        = decltype(nulls_at({}));
 auto constexpr X     = int32_t{0};  // Placeholder for NULL rows.
 auto const all_valid = nulls_at({});
 
-inline void test_rank_scans(column_view const& keys,
-                            column_view const& order,
-                            column_view const& expected_dense,
-                            column_view const& expected_rank,
-                            column_view const& expected_percent_rank)
+void test_rank_scans(column_view const& keys,
+                     column_view const& order,
+                     column_view const& expected_dense,
+                     column_view const& expected_rank,
+                     column_view const& expected_percent_rank)
 {
   test_single_scan(
     keys,

--- a/cpp/tests/groupby/rank_scan_tests.cpp
+++ b/cpp/tests/groupby/rank_scan_tests.cpp
@@ -24,65 +24,67 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
-namespace cudf {
-namespace test {
-
-using namespace iterators;
+using namespace cudf::test::iterators;
 
 template <typename T>
-using input              = fixed_width_column_wrapper<T>;
-using rank_result_col    = fixed_width_column_wrapper<size_type>;
-using percent_result_col = fixed_width_column_wrapper<double>;
+using input              = cudf::test::fixed_width_column_wrapper<T>;
+using rank_result_col    = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
+using percent_result_col = cudf::test::fixed_width_column_wrapper<double>;
 using null_iter_t        = decltype(nulls_at({}));
 
 auto constexpr X     = int32_t{0};  // Placeholder for NULL rows.
 auto const all_valid = nulls_at({});
 
-void test_rank_scans(column_view const& keys,
-                     column_view const& order,
-                     column_view const& expected_dense,
-                     column_view const& expected_rank,
-                     column_view const& expected_percent_rank)
+void test_rank_scans(cudf::column_view const& keys,
+                     cudf::column_view const& order,
+                     cudf::column_view const& expected_dense,
+                     cudf::column_view const& expected_rank,
+                     cudf::column_view const& expected_percent_rank)
 {
-  test_single_scan(
-    keys,
-    order,
-    keys,
-    expected_dense,
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::DENSE, {}, null_policy::INCLUDE),
-    null_policy::INCLUDE,
-    sorted::YES);
-  test_single_scan(
-    keys,
-    order,
-    keys,
-    expected_rank,
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::MIN, {}, null_policy::INCLUDE),
-    null_policy::INCLUDE,
-    sorted::YES);
-  test_single_scan(
-    keys,
-    order,
-    keys,
-    expected_percent_rank,
-    make_rank_aggregation<groupby_scan_aggregation>(
-      rank_method::MIN, {}, null_policy::INCLUDE, {}, rank_percentage::ONE_NORMALIZED),
-    null_policy::INCLUDE,
-    sorted::YES);
+  test_single_scan(keys,
+                   order,
+                   keys,
+                   expected_dense,
+                   cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+                     cudf::rank_method::DENSE, {}, cudf::null_policy::INCLUDE),
+                   cudf::null_policy::INCLUDE,
+                   cudf::sorted::YES);
+  test_single_scan(keys,
+                   order,
+                   keys,
+                   expected_rank,
+                   cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+                     cudf::rank_method::MIN, {}, cudf::null_policy::INCLUDE),
+                   cudf::null_policy::INCLUDE,
+                   cudf::sorted::YES);
+  test_single_scan(keys,
+                   order,
+                   keys,
+                   expected_percent_rank,
+                   cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+                     cudf::rank_method::MIN,
+                     {},
+                     cudf::null_policy::INCLUDE,
+                     {},
+                     cudf::rank_percentage::ONE_NORMALIZED),
+                   cudf::null_policy::INCLUDE,
+                   cudf::sorted::YES);
 }
 
-struct groupby_rank_scan_test : public BaseFixture {
+struct groupby_rank_scan_test : public cudf::test::BaseFixture {
 };
 
-struct groupby_rank_scan_test_failures : public BaseFixture {
+struct groupby_rank_scan_test_failures : public cudf::test::BaseFixture {
 };
 
 template <typename T>
-struct typed_groupby_rank_scan_test : public BaseFixture {
+struct typed_groupby_rank_scan_test : public cudf::test::BaseFixture {
 };
 
-using testing_type_set =
-  Concat<IntegralTypesNotBool, FloatingPointTypes, FixedPointTypes, ChronoTypes>;
+using testing_type_set = cudf::test::Concat<cudf::test::IntegralTypesNotBool,
+                                            cudf::test::FloatingPointTypes,
+                                            cudf::test::FixedPointTypes,
+                                            cudf::test::ChronoTypes>;
 
 TYPED_TEST_SUITE(typed_groupby_rank_scan_test, testing_type_set);
 
@@ -92,7 +94,7 @@ TYPED_TEST(typed_groupby_rank_scan_test, empty_cols)
 
   auto const keys            = input<T>{};
   auto const order_by        = input<T>{};
-  auto const order_by_struct = structs_column_wrapper{};
+  auto const order_by_struct = cudf::test::structs_column_wrapper{};
 
   auto const expected_dense   = rank_result_col{};
   auto const expected_rank    = rank_result_col{};
@@ -111,7 +113,7 @@ TYPED_TEST(typed_groupby_rank_scan_test, zero_valid_keys)
   auto const order_by_struct = [] {
     auto member_1 = input<T>{{3, 3, 1}};
     auto member_2 = input<T>{{3, 3, 1}};
-    return structs_column_wrapper{member_1, member_2};
+    return cudf::test::structs_column_wrapper{member_1, member_2};
   }();
 
   auto const dense_rank_results  = rank_result_col{1, 1, 2};
@@ -132,7 +134,7 @@ TYPED_TEST(typed_groupby_rank_scan_test, zero_valid_orders)
   auto const make_struct_order_by = [&](null_iter_t const& null_iter = no_nulls()) {
     auto member1 = make_order_by();
     auto member2 = make_order_by();
-    return structs_column_wrapper{{member1, member2}, null_iter};
+    return cudf::test::structs_column_wrapper{{member1, member2}, null_iter};
   };
   auto const order_by                  = make_order_by();
   auto const order_by_struct           = make_struct_order_by();
@@ -157,7 +159,7 @@ TYPED_TEST(typed_groupby_rank_scan_test, basic)
   auto const order_by_struct = [&] {
     auto order2 = make_order_by();
     auto order3 = make_order_by();
-    return structs_column_wrapper{order2, order3};
+    return cudf::test::structs_column_wrapper{order2, order3};
   }();
 
   auto const expected_dense   = rank_result_col{1, 1, 1, 2, 2, 2, 3, 1, 2, 2, 3, 3};
@@ -181,7 +183,7 @@ TYPED_TEST(typed_groupby_rank_scan_test, null_orders)
   auto const make_struct_order_by = [&](null_iter_t const& null_iter = all_valid) {
     auto member1 = make_order_by();
     auto member2 = make_order_by();
-    return structs_column_wrapper{{member1, member2}, null_iter};
+    return cudf::test::structs_column_wrapper{{member1, member2}, null_iter};
   };
   auto const order_by                   = make_order_by();
   auto const order_by_struct            = make_struct_order_by();
@@ -210,7 +212,7 @@ TYPED_TEST(typed_groupby_rank_scan_test, null_orders_and_keys)
   auto const make_struct_order_by = [&](null_iter_t const& null_iter = all_valid) {
     auto member1 = make_order_by();
     auto member2 = make_order_by();
-    return structs_column_wrapper{{member1, member2}, null_iter};
+    return cudf::test::structs_column_wrapper{{member1, member2}, null_iter};
   };
   auto const order_by                   = make_order_by();
   auto const order_by_struct            = make_struct_order_by();
@@ -231,12 +233,12 @@ TYPED_TEST(typed_groupby_rank_scan_test, mixedStructs)
 {
   auto const struct_col = [] {
     auto nums    = input<TypeParam>{{0, 0, 7, 7, 7, X, 4, 4, 4, 9, 9, 9}, null_at(5)};
-    auto strings = strings_column_wrapper{
+    auto strings = cudf::test::strings_column_wrapper{
       {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "XX", "9", "9", "10d"}, null_at(8)};
-    return structs_column_wrapper{{nums, strings}, null_at(11)}.release();
+    return cudf::test::structs_column_wrapper{{nums, strings}, null_at(11)}.release();
   }();
 
-  auto const keys = strings_column_wrapper{
+  auto const keys = cudf::test::strings_column_wrapper{
     {"0", "0", "0", "0", "0", "0", "1", "1", "1", "X", "X", "X"}, nulls_at({9, 10, 11})};
 
   auto const expected_dense   = rank_result_col{1, 1, 2, 2, 3, 4, 1, 1, 2, 1, 1, 2};
@@ -244,20 +246,25 @@ TYPED_TEST(typed_groupby_rank_scan_test, mixedStructs)
   auto const expected_percent = percent_result_col{
     0.0, 0.0, 2.0 / 5, 2.0 / 5, 4.0 / 5, 5.0 / 5, 0.0, 0.0, 2.0 / 2, 0.0, 0.0, 2.0 / 2};
 
-  std::vector<groupby::scan_request> requests;
-  requests.emplace_back(groupby::scan_request());
+  std::vector<cudf::groupby::scan_request> requests;
+  requests.emplace_back(cudf::groupby::scan_request());
   requests[0].values = *struct_col;
-  requests[0].aggregations.push_back(
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::DENSE, {}, null_policy::INCLUDE));
-  requests[0].aggregations.push_back(
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::MIN, {}, null_policy::INCLUDE));
-  requests[0].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>(
-    rank_method::MIN, {}, null_policy::INCLUDE, {}, rank_percentage::ONE_NORMALIZED));
+  requests[0].aggregations.push_back(cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+    cudf::rank_method::DENSE, {}, cudf::null_policy::INCLUDE));
+  requests[0].aggregations.push_back(cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+    cudf::rank_method::MIN, {}, cudf::null_policy::INCLUDE));
+  requests[0].aggregations.push_back(cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+    cudf::rank_method::MIN,
+    {},
+    cudf::null_policy::INCLUDE,
+    {},
+    cudf::rank_percentage::ONE_NORMALIZED));
 
-  groupby::groupby gb_obj(table_view({keys}), null_policy::INCLUDE, sorted::YES);
+  cudf::groupby::groupby gb_obj(
+    cudf::table_view({keys}), cudf::null_policy::INCLUDE, cudf::sorted::YES);
   auto [result_keys, agg_results] = gb_obj.scan(requests);
 
-  CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({keys}), result_keys->view());
+  CUDF_TEST_EXPECT_TABLES_EQUAL(cudf::table_view({keys}), result_keys->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[0], expected_dense);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[1], expected_rank);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[2], expected_percent);
@@ -270,48 +277,57 @@ TYPED_TEST(typed_groupby_rank_scan_test, nestedStructs)
   auto nested_structs = [] {
     auto structs_member = [] {
       auto nums_member    = input<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-      auto strings_member = strings_column_wrapper{
+      auto strings_member = cudf::test::strings_column_wrapper{
         {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
-      return structs_column_wrapper{nums_member, strings_member};
+      return cudf::test::structs_column_wrapper{nums_member, strings_member};
     }();
     auto nums_member = input<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-    return structs_column_wrapper{structs_member, nums_member}.release();
+    return cudf::test::structs_column_wrapper{structs_member, nums_member}.release();
   }();
 
   auto flat_struct = [] {
     auto nums_member    = input<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-    auto strings_member = strings_column_wrapper{
+    auto strings_member = cudf::test::strings_column_wrapper{
       {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
     auto nuther_nums =
-      fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-    return structs_column_wrapper{nums_member, strings_member, nuther_nums}.release();
+      cudf::test::fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
+    return cudf::test::structs_column_wrapper{nums_member, strings_member, nuther_nums}.release();
   }();
 
-  auto const keys = strings_column_wrapper{
+  auto const keys = cudf::test::strings_column_wrapper{
     {"0", "0", "0", "0", "0", "0", "1", "1", "1", "1", "0", "1"}, nulls_at({9, 10, 11})};
 
-  std::vector<groupby::scan_request> requests;
-  requests.emplace_back(groupby::scan_request());
-  requests.emplace_back(groupby::scan_request());
+  std::vector<cudf::groupby::scan_request> requests;
+  requests.emplace_back(cudf::groupby::scan_request());
+  requests.emplace_back(cudf::groupby::scan_request());
   requests[0].values = *nested_structs;
   requests[0].aggregations.push_back(
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::DENSE));
+    cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(cudf::rank_method::DENSE));
   requests[0].aggregations.push_back(
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::MIN));
-  requests[0].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>(
-    rank_method::MIN, {}, null_policy::INCLUDE, {}, rank_percentage::ONE_NORMALIZED));
+    cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(cudf::rank_method::MIN));
+  requests[0].aggregations.push_back(cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+    cudf::rank_method::MIN,
+    {},
+    cudf::null_policy::INCLUDE,
+    {},
+    cudf::rank_percentage::ONE_NORMALIZED));
   requests[1].values = *flat_struct;
   requests[1].aggregations.push_back(
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::DENSE));
+    cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(cudf::rank_method::DENSE));
   requests[1].aggregations.push_back(
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::MIN));
-  requests[1].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>(
-    rank_method::MIN, {}, null_policy::INCLUDE, {}, rank_percentage::ONE_NORMALIZED));
+    cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(cudf::rank_method::MIN));
+  requests[1].aggregations.push_back(cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+    cudf::rank_method::MIN,
+    {},
+    cudf::null_policy::INCLUDE,
+    {},
+    cudf::rank_percentage::ONE_NORMALIZED));
 
-  groupby::groupby gb_obj(table_view({keys}), null_policy::INCLUDE, sorted::YES);
+  cudf::groupby::groupby gb_obj(
+    cudf::table_view({keys}), cudf::null_policy::INCLUDE, cudf::sorted::YES);
   auto [result_keys, agg_results] = gb_obj.scan(requests);
 
-  CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({keys}), result_keys->view());
+  CUDF_TEST_EXPECT_TABLES_EQUAL(cudf::table_view({keys}), result_keys->view());
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[0], *agg_results[1].results[0]);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[1], *agg_results[1].results[1]);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*agg_results[0].results[2], *agg_results[1].results[2]);
@@ -325,10 +341,10 @@ TYPED_TEST(typed_groupby_rank_scan_test, structsWithNullPushdown)
 
   auto get_struct_column = [] {
     auto nums_member =
-      fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
-    auto strings_member = strings_column_wrapper{
+      cudf::test::fixed_width_column_wrapper<T>{{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9}, null_at(5)};
+    auto strings_member = cudf::test::strings_column_wrapper{
       {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"}, null_at(8)};
-    auto struct_column = structs_column_wrapper{nums_member, strings_member}.release();
+    auto struct_column = cudf::test::structs_column_wrapper{nums_member, strings_member}.release();
     // Reset null-mask, a posteriori. Nulls will not be pushed down to children.
     auto const null_iter = nulls_at({1, 2, 11});
     struct_column->set_null_mask(
@@ -340,32 +356,41 @@ TYPED_TEST(typed_groupby_rank_scan_test, structsWithNullPushdown)
 
   auto const definitely_null_structs = [&] {
     auto struct_column = get_struct_column();
-    struct_column->set_null_mask(create_null_mask(num_rows, mask_state::ALL_NULL));
+    struct_column->set_null_mask(cudf::create_null_mask(num_rows, cudf::mask_state::ALL_NULL));
     return struct_column;
   }();
 
-  strings_column_wrapper keys = {{"0", "0", "0", "0", "0", "0", "1", "1", "1", "X", "X", "X"},
-                                 nulls_at({9, 10, 11})};
+  cudf::test::strings_column_wrapper keys = {
+    {"0", "0", "0", "0", "0", "0", "1", "1", "1", "X", "X", "X"}, nulls_at({9, 10, 11})};
 
-  std::vector<groupby::scan_request> requests;
-  requests.emplace_back(groupby::scan_request());
-  requests.emplace_back(groupby::scan_request());
+  std::vector<cudf::groupby::scan_request> requests;
+  requests.emplace_back(cudf::groupby::scan_request());
+  requests.emplace_back(cudf::groupby::scan_request());
   requests[0].values = *possibly_null_structs;
-  requests[0].aggregations.push_back(
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::DENSE, {}, null_policy::INCLUDE));
-  requests[0].aggregations.push_back(
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::MIN, {}, null_policy::INCLUDE));
-  requests[0].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>(
-    rank_method::MIN, {}, null_policy::INCLUDE, {}, rank_percentage::ONE_NORMALIZED));
+  requests[0].aggregations.push_back(cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+    cudf::rank_method::DENSE, {}, cudf::null_policy::INCLUDE));
+  requests[0].aggregations.push_back(cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+    cudf::rank_method::MIN, {}, cudf::null_policy::INCLUDE));
+  requests[0].aggregations.push_back(cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+    cudf::rank_method::MIN,
+    {},
+    cudf::null_policy::INCLUDE,
+    {},
+    cudf::rank_percentage::ONE_NORMALIZED));
   requests[1].values = *definitely_null_structs;
-  requests[1].aggregations.push_back(
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::DENSE, {}, null_policy::INCLUDE));
-  requests[1].aggregations.push_back(
-    make_rank_aggregation<groupby_scan_aggregation>(rank_method::MIN, {}, null_policy::INCLUDE));
-  requests[1].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>(
-    rank_method::MIN, {}, null_policy::INCLUDE, {}, rank_percentage::ONE_NORMALIZED));
+  requests[1].aggregations.push_back(cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+    cudf::rank_method::DENSE, {}, cudf::null_policy::INCLUDE));
+  requests[1].aggregations.push_back(cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+    cudf::rank_method::MIN, {}, cudf::null_policy::INCLUDE));
+  requests[1].aggregations.push_back(cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+    cudf::rank_method::MIN,
+    {},
+    cudf::null_policy::INCLUDE,
+    {},
+    cudf::rank_percentage::ONE_NORMALIZED));
 
-  groupby::groupby gb_obj(table_view({keys}), null_policy::INCLUDE, sorted::YES);
+  cudf::groupby::groupby gb_obj(
+    cudf::table_view({keys}), cudf::null_policy::INCLUDE, cudf::sorted::YES);
   auto [result_keys, agg_results] = gb_obj.scan(requests);
 
   auto expected_dense   = rank_result_col{1, 2, 2, 3, 4, 5, 1, 1, 2, 1, 1, 2};
@@ -386,7 +411,7 @@ TYPED_TEST(typed_groupby_rank_scan_test, structsWithNullPushdown)
 
 /* List support dependent on https://github.com/rapidsai/cudf/issues/8683
 template <typename T>
-struct list_groupby_rank_scan_test : public BaseFixture {
+struct list_groupby_rank_scan_test : public cudf::test::BaseFixture {
 };
 
 using list_test_type_set = Concat<IntegralTypesNotBool,
@@ -412,24 +437,24 @@ TYPED_TEST(list_groupby_rank_scan_test, lists)
     {9, 9},
     {9, 9},
     {9, 10}}.release();
-  fixed_width_column_wrapper<T> element1{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9};
-  fixed_width_column_wrapper<T> element2{0, 0, 2, 2, 3, 5, 6, 6, 6, 9, 9, 10};
-  auto struct_col = structs_column_wrapper{element1, element2}.release();
+  cudf::test::fixed_width_column_wrapper<T> element1{0, 0, 7, 7, 7, 5, 4, 4, 4, 9, 9, 9};
+  cudf::test::fixed_width_column_wrapper<T> element2{0, 0, 2, 2, 3, 5, 6, 6, 6, 9, 9, 10};
+  auto struct_col =  cudf::test::structs_column_wrapper{element1, element2}.release();
 
-  fixed_width_column_wrapper<T> keys = {{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1},
+  cudf::test::fixed_width_column_wrapper<T> keys = {{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1},
                                         {1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0}};
 
-  std::vector<groupby::scan_request> requests;
+  std::vector<cudf::groupby::scan_request> requests;
   requests.emplace_back(groupby::aggregation_request());
   requests.emplace_back(groupby::aggregation_request());
   requests[0].values = list_col;
-  requests[0].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>(rank_method::DENSE));
-  requests[0].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>(rank_method::MIN));
+  requests[0].aggregations.push_back(make_rank_aggregation<cudf::groupby_scan_aggregation>(rank_method::DENSE));
+  requests[0].aggregations.push_back(make_rank_aggregation<cudf::groupby_scan_aggregation>(rank_method::MIN));
   requests[1].values = struct_col;
-  requests[1].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>(rank_method::DENSE));
-  requests[1].aggregations.push_back(make_rank_aggregation<groupby_scan_aggregation>(rank_method::MIN));
+  requests[1].aggregations.push_back(make_rank_aggregation<cudf::groupby_scan_aggregation>(rank_method::DENSE));
+  requests[1].aggregations.push_back(make_rank_aggregation<cudf::groupby_scan_aggregation>(rank_method::MIN));
 
-  groupby::groupby gb_obj(table_view({keys}), null_policy::INCLUDE, sorted::YES);
+  cudf::groupby::groupby gb_obj(table_view({keys}), null_policy::INCLUDE, cudf::sorted::YES);
   auto result = gb_obj.scan(requests);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(table_view({keys}), result.first->view());
@@ -442,7 +467,7 @@ TYPED_TEST(list_groupby_rank_scan_test, lists)
 
 TEST(groupby_rank_scan_test, bools)
 {
-  using bools       = fixed_width_column_wrapper<bool>;
+  using bools       = cudf::test::fixed_width_column_wrapper<bool>;
   using null_iter_t = decltype(nulls_at({}));
 
   auto const keys          = bools{{0, 0, 0, 0, 0, 0, 1, 1, 1, X, X, X}, nulls_at({9, 10, 11})};
@@ -451,7 +476,7 @@ TEST(groupby_rank_scan_test, bools)
   auto const make_structs  = [&](null_iter_t const& null_iter = all_valid) {
     auto member_1 = make_order_by();
     auto member_2 = make_order_by();
-    return structs_column_wrapper{{member_1, member_2}, null_iter};
+    return cudf::test::structs_column_wrapper{{member_1, member_2}, null_iter};
   };
 
   auto const order_by                    = make_order_by();
@@ -471,7 +496,7 @@ TEST(groupby_rank_scan_test, bools)
 
 TEST(groupby_rank_scan_test, strings)
 {
-  using strings     = strings_column_wrapper;
+  using strings     = cudf::test::strings_column_wrapper;
   using null_iter_t = decltype(nulls_at({}));
 
   auto const keys =
@@ -484,7 +509,7 @@ TEST(groupby_rank_scan_test, strings)
   auto const make_structs = [&](null_iter_t const& null_iter = all_valid) {
     auto member_1 = make_order_by();
     auto member_2 = make_order_by();
-    return structs_column_wrapper{{member_1, member_2}, null_iter};
+    return cudf::test::structs_column_wrapper{{member_1, member_2}, null_iter};
   };
 
   auto const order_by                    = make_order_by();
@@ -514,56 +539,59 @@ TEST_F(groupby_rank_scan_test_failures, DISABLED_test_exception_triggers)
                                 col,
                                 keys,
                                 col,
-                                make_rank_aggregation<groupby_scan_aggregation>(rank_method::DENSE),
-                                null_policy::INCLUDE,
-                                sorted::NO),
+                                cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+                                  cudf::rank_method::DENSE),
+                                cudf::null_policy::INCLUDE,
+                                cudf::sorted::NO),
                cudf::logic_error);
 
   EXPECT_THROW(test_single_scan(keys,
                                 col,
                                 keys,
                                 col,
-                                make_rank_aggregation<groupby_scan_aggregation>(rank_method::MIN),
-                                null_policy::INCLUDE,
-                                sorted::NO),
+                                cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+                                  cudf::rank_method::MIN),
+                                cudf::null_policy::INCLUDE,
+                                cudf::sorted::NO),
                cudf::logic_error);
 
   EXPECT_THROW(test_single_scan(keys,
                                 col,
                                 keys,
                                 col,
-                                make_rank_aggregation<groupby_scan_aggregation>(rank_method::DENSE),
-                                null_policy::EXCLUDE,
-                                sorted::YES),
+                                cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+                                  cudf::rank_method::DENSE),
+                                cudf::null_policy::EXCLUDE,
+                                cudf::sorted::YES),
                cudf::logic_error);
 
   EXPECT_THROW(test_single_scan(keys,
                                 col,
                                 keys,
                                 col,
-                                make_rank_aggregation<groupby_scan_aggregation>(rank_method::MIN),
-                                null_policy::EXCLUDE,
-                                sorted::YES),
+                                cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+                                  cudf::rank_method::MIN),
+                                cudf::null_policy::EXCLUDE,
+                                cudf::sorted::YES),
                cudf::logic_error);
 
   EXPECT_THROW(test_single_scan(keys,
                                 col,
                                 keys,
                                 col,
-                                make_rank_aggregation<groupby_scan_aggregation>(rank_method::DENSE),
-                                null_policy::EXCLUDE,
-                                sorted::NO),
+                                cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+                                  cudf::rank_method::DENSE),
+                                cudf::null_policy::EXCLUDE,
+                                cudf::sorted::NO),
                cudf::logic_error);
 
   EXPECT_THROW(test_single_scan(keys,
                                 col,
                                 keys,
                                 col,
-                                make_rank_aggregation<groupby_scan_aggregation>(rank_method::MIN),
-                                null_policy::EXCLUDE,
-                                sorted::NO),
+                                cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+                                  cudf::rank_method::MIN),
+                                cudf::null_policy::EXCLUDE,
+                                cudf::sorted::NO),
                cudf::logic_error);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/replace_nulls_tests.cpp
+++ b/cpp/tests/groupby/replace_nulls_tests.cpp
@@ -1,6 +1,5 @@
-
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,203 +14,209 @@
  * limitations under the License.
  */
 
-#include <tests/groupby/groupby_test_util.hpp>
-
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/groupby.hpp>
+#include <cudf/replace.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
-
 using K = int32_t;
 
 template <typename T>
-struct GroupbyReplaceNullsFixedWidthTest : public BaseFixture {
+struct GroupbyReplaceNullsFixedWidthTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(GroupbyReplaceNullsFixedWidthTest, FixedWidthTypes);
+TYPED_TEST_SUITE(GroupbyReplaceNullsFixedWidthTest, cudf::test::FixedWidthTypes);
 
 template <typename K, typename V>
-void TestReplaceNullsGroupbySingle(
-  K const& key, V const& input, K const& expected_key, V const& expected_val, replace_policy policy)
+void TestReplaceNullsGroupbySingle(K const& key,
+                                   V const& input,
+                                   K const& expected_key,
+                                   V const& expected_val,
+                                   cudf::replace_policy policy)
 {
-  groupby::groupby gb_obj(table_view({key}));
-  std::vector<replace_policy> policies{policy};
-  auto p = gb_obj.replace_nulls(table_view({input}), policies);
+  cudf::groupby::groupby gb_obj(cudf::table_view({key}));
+  std::vector<cudf::replace_policy> policies{policy};
+  auto p = gb_obj.replace_nulls(cudf::table_view({input}), policies);
 
-  CUDF_TEST_EXPECT_TABLES_EQUAL(*p.first, table_view({expected_key}));
-  CUDF_TEST_EXPECT_TABLES_EQUAL(*p.second, table_view({expected_val}));
+  CUDF_TEST_EXPECT_TABLES_EQUAL(*p.first, cudf::table_view({expected_key}));
+  CUDF_TEST_EXPECT_TABLES_EQUAL(*p.second, cudf::table_view({expected_val}));
 }
 
 TYPED_TEST(GroupbyReplaceNullsFixedWidthTest, PrecedingFill)
 {
   // Group 0 value: {42, 24, null}  --> {42, 24, 24}
   // Group 1 value: {7, null, null} --> {7, 7, 7}
-  fixed_width_column_wrapper<K> key{0, 1, 0, 1, 0, 1};
-  fixed_width_column_wrapper<TypeParam> val({42, 7, 24, 10, 1, 1000}, {1, 1, 1, 0, 0, 0});
+  cudf::test::fixed_width_column_wrapper<K> key{0, 1, 0, 1, 0, 1};
+  cudf::test::fixed_width_column_wrapper<TypeParam> val({42, 7, 24, 10, 1, 1000},
+                                                        {1, 1, 1, 0, 0, 0});
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> expect_val({42, 24, 24, 7, 7, 7}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<TypeParam> expect_val({42, 24, 24, 7, 7, 7}, no_nulls());
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::PRECEDING);
 }
 
 TYPED_TEST(GroupbyReplaceNullsFixedWidthTest, FollowingFill)
 {
   // Group 0 value: {2, null, 32}               --> {2, 32, 32}
   // Group 1 value: {8, null, null, 128, 256}   --> {8, 128, 128, 128, 256}
-  fixed_width_column_wrapper<K> key{0, 0, 1, 1, 0, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> val({2, 4, 8, 16, 32, 64, 128, 256},
-                                            {1, 0, 1, 0, 1, 0, 1, 1});
+  cudf::test::fixed_width_column_wrapper<K> key{0, 0, 1, 1, 0, 1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<TypeParam> val({2, 4, 8, 16, 32, 64, 128, 256},
+                                                        {1, 0, 1, 0, 1, 0, 1, 1});
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> expect_val({2, 32, 32, 8, 128, 128, 128, 256}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<TypeParam> expect_val({2, 32, 32, 8, 128, 128, 128, 256},
+                                                               no_nulls());
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::FOLLOWING);
 }
 
 TYPED_TEST(GroupbyReplaceNullsFixedWidthTest, PrecedingFillLeadingNulls)
 {
   // Group 0 value: {null, 24, null}    --> {null, 24, 24}
   // Group 1 value: {null, null, null}  --> {null, null, null}
-  fixed_width_column_wrapper<K> key{0, 1, 0, 1, 0, 1};
-  fixed_width_column_wrapper<TypeParam> val({42, 7, 24, 10, 1, 1000}, {0, 0, 1, 0, 0, 0});
+  cudf::test::fixed_width_column_wrapper<K> key{0, 1, 0, 1, 0, 1};
+  cudf::test::fixed_width_column_wrapper<TypeParam> val({42, 7, 24, 10, 1, 1000},
+                                                        {0, 0, 1, 0, 0, 0});
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> expect_val({-1, 24, 24, -1, -1, -1}, {0, 1, 1, 0, 0, 0});
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<TypeParam> expect_val({-1, 24, 24, -1, -1, -1},
+                                                               {0, 1, 1, 0, 0, 0});
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::PRECEDING);
 }
 
 TYPED_TEST(GroupbyReplaceNullsFixedWidthTest, FollowingFillTrailingNulls)
 {
   // Group 0 value: {2, null, null}                 --> {2, null, null}
   // Group 1 value: {null, null, 64, null, null}    --> {64, 64, 64, null, null}
-  fixed_width_column_wrapper<K> key{0, 0, 1, 1, 0, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> val({2, 4, 8, 16, 32, 64, 128, 256},
-                                            {1, 0, 0, 0, 0, 1, 0, 0});
+  cudf::test::fixed_width_column_wrapper<K> key{0, 0, 1, 1, 0, 1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<TypeParam> val({2, 4, 8, 16, 32, 64, 128, 256},
+                                                        {1, 0, 0, 0, 0, 1, 0, 0});
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1, 1};
-  fixed_width_column_wrapper<TypeParam> expect_val({2, -1, -1, 64, 64, 64, -1, -1},
-                                                   {1, 0, 0, 1, 1, 1, 0, 0});
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<TypeParam> expect_val({2, -1, -1, 64, 64, 64, -1, -1},
+                                                               {1, 0, 0, 1, 1, 1, 0, 0});
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::FOLLOWING);
 }
 
-struct GroupbyReplaceNullsStringsTest : public BaseFixture {
+struct GroupbyReplaceNullsStringsTest : public cudf::test::BaseFixture {
 };
 
 TEST_F(GroupbyReplaceNullsStringsTest, PrecedingFill)
 {
   // Group 0 value: {"y" "42"}  --> {"y", "42"}
   // Group 1 value: {"xx" @ "zzz" @ "one"} --> {"xx" "xx" "zzz" "zzz" "one"}
-  fixed_width_column_wrapper<K> key{1, 1, 0, 1, 0, 1, 1};
-  strings_column_wrapper val({"xx", "", "y", "zzz", "42", "", "one"},
-                             {true, false, true, true, true, false, true});
+  cudf::test::fixed_width_column_wrapper<K> key{1, 1, 0, 1, 0, 1, 1};
+  cudf::test::strings_column_wrapper val({"xx", "", "y", "zzz", "42", "", "one"},
+                                         {true, false, true, true, true, false, true});
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
-  strings_column_wrapper expect_val({"y", "42", "xx", "xx", "zzz", "zzz", "one"}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
+  cudf::test::strings_column_wrapper expect_val({"y", "42", "xx", "xx", "zzz", "zzz", "one"},
+                                                no_nulls());
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::PRECEDING);
 }
 
 TEST_F(GroupbyReplaceNullsStringsTest, FollowingFill)
 {
   // Group 0 value: {@ "42"}  --> {"42", "42"}
   // Group 1 value: {"xx" @ "zzz" @ "one"} --> {"xx" "zzz" "zzz" "one" "one"}
-  fixed_width_column_wrapper<K> key{1, 1, 0, 1, 0, 1, 1};
-  strings_column_wrapper val({"xx", "", "", "zzz", "42", "", "one"},
-                             {true, false, false, true, true, false, true});
+  cudf::test::fixed_width_column_wrapper<K> key{1, 1, 0, 1, 0, 1, 1};
+  cudf::test::strings_column_wrapper val({"xx", "", "", "zzz", "42", "", "one"},
+                                         {true, false, false, true, true, false, true});
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
-  strings_column_wrapper expect_val({"42", "42", "xx", "zzz", "zzz", "one", "one"}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
+  cudf::test::strings_column_wrapper expect_val({"42", "42", "xx", "zzz", "zzz", "one", "one"},
+                                                no_nulls());
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::FOLLOWING);
 }
 
 TEST_F(GroupbyReplaceNullsStringsTest, PrecedingFillPrecedingNull)
 {
   // Group 0 value: {"y" "42"}  --> {"y", "42"}
   // Group 1 value: {@ @ "zzz" "zzz" "zzz"} --> {@ @ "zzz" "zzz" "zzz"}
-  fixed_width_column_wrapper<K> key{1, 1, 0, 1, 0, 1, 1};
-  strings_column_wrapper val({"", "", "y", "zzz", "42", "", ""},
-                             {false, false, true, true, true, false, false});
+  cudf::test::fixed_width_column_wrapper<K> key{1, 1, 0, 1, 0, 1, 1};
+  cudf::test::strings_column_wrapper val({"", "", "y", "zzz", "42", "", ""},
+                                         {false, false, true, true, true, false, false});
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
-  strings_column_wrapper expect_val({"y", "42", "", "", "zzz", "zzz", "zzz"},
-                                    {true, true, false, false, true, true, true});
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
+  cudf::test::strings_column_wrapper expect_val({"y", "42", "", "", "zzz", "zzz", "zzz"},
+                                                {true, true, false, false, true, true, true});
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::PRECEDING);
 }
 
 TEST_F(GroupbyReplaceNullsStringsTest, FollowingFillTrailingNull)
 {
   // Group 0 value: {@ "y"}  --> {"y", "y"}
   // Group 1 value: {"xx" @ "zzz" @ @} --> {"xx" "zzz" "zzz" @ @}
-  fixed_width_column_wrapper<K> key{1, 1, 0, 1, 0, 1, 1};
-  strings_column_wrapper val({"xx", "", "", "zzz", "y", "", ""},
-                             {true, false, false, true, true, false, false});
+  cudf::test::fixed_width_column_wrapper<K> key{1, 1, 0, 1, 0, 1, 1};
+  cudf::test::strings_column_wrapper val({"xx", "", "", "zzz", "y", "", ""},
+                                         {true, false, false, true, true, false, false});
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
-  strings_column_wrapper expect_val({"y", "y", "xx", "zzz", "zzz", "", ""},
-                                    {true, true, true, true, true, false, false});
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 1, 1, 1, 1, 1};
+  cudf::test::strings_column_wrapper expect_val({"y", "y", "xx", "zzz", "zzz", "", ""},
+                                                {true, true, true, true, true, false, false});
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::FOLLOWING);
 }
 
 template <typename T>
-struct GroupbyReplaceNullsListsTest : public BaseFixture {
+struct GroupbyReplaceNullsListsTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(GroupbyReplaceNullsListsTest, FixedWidthTypes);
+TYPED_TEST_SUITE(GroupbyReplaceNullsListsTest, cudf::test::FixedWidthTypes);
 
 TYPED_TEST(GroupbyReplaceNullsListsTest, PrecedingFillNonNested)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
   // Group 0 value: {{1 2 3} @ {4 5} @} --> {{1 2 3} {1 2 3} {4 5} {4 5}}, w/o leading nulls
   // Group 1 value: {@ {} @} --> {@ {} {}}, w/ leading nulls
-  fixed_width_column_wrapper<K> key{0, 1, 0, 0, 1, 1, 0};
+  cudf::test::fixed_width_column_wrapper<K> key{0, 1, 0, 0, 1, 1, 0};
 
-  std::vector<valid_type> mask{1, 0, 0, 1, 1, 0, 0};
+  std::vector<cudf::valid_type> mask{1, 0, 0, 1, 1, 0, 0};
   LCW val({{1, 2, 3}, {}, {}, {4, 5}, {}, {}, {}}, mask.begin());
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 0, 0, 1, 1, 1};
-  std::vector<valid_type> expected_mask{1, 1, 1, 1, 0, 1, 1};
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 0, 0, 1, 1, 1};
+  std::vector<cudf::valid_type> expected_mask{1, 1, 1, 1, 0, 1, 1};
   LCW expect_val({{1, 2, 3}, {1, 2, 3}, {4, 5}, {4, 5}, {-1}, {}, {}}, expected_mask.begin());
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::PRECEDING);
 }
 
 TYPED_TEST(GroupbyReplaceNullsListsTest, FollowingFillNonNested)
 {
-  using LCW = lists_column_wrapper<TypeParam, int32_t>;
+  using LCW = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
   // Group 0 value: {@ {5 6} @ {-1}} --> {{5 6} {5 6} {-1} {-1}}, w/o trailing nulls
   // Group 1 value: {@ {} @} --> {{} {} @}}, w/ trailing nulls
-  fixed_width_column_wrapper<K> key{0, 1, 0, 0, 1, 1, 0};
+  cudf::test::fixed_width_column_wrapper<K> key{0, 1, 0, 0, 1, 1, 0};
 
-  std::vector<valid_type> mask{0, 0, 1, 0, 1, 0, 1};
+  std::vector<cudf::valid_type> mask{0, 0, 1, 0, 1, 0, 1};
   LCW val({{}, {}, {5, 6}, {}, {}, {}, {-1}}, mask.begin());
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 0, 0, 1, 1, 1};
-  std::vector<valid_type> expected_mask{1, 1, 1, 1, 1, 1, 0};
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 0, 0, 1, 1, 1};
+  std::vector<cudf::valid_type> expected_mask{1, 1, 1, 1, 1, 1, 0};
   LCW expect_val({{5, 6}, {5, 6}, {-1}, {-1}, {}, {}, {}}, expected_mask.begin());
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::FOLLOWING);
 }
 
 TYPED_TEST(GroupbyReplaceNullsListsTest, PrecedingFillNested)
 {
-  using LCW    = lists_column_wrapper<TypeParam, int32_t>;
-  using Mask_t = std::vector<valid_type>;
+  using LCW    = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using Mask_t = std::vector<cudf::valid_type>;
   // Group 0 value: {{{1 @ 3} @}
   //                 @
   //                 {{@} {}}}} -->
@@ -227,7 +232,7 @@ TYPED_TEST(GroupbyReplaceNullsListsTest, PrecedingFillNested)
   //                 {@ {102 @}}
   //                 {{@ 202} {}}}}, w/ leading nulls
   // Only top level nulls are replaced.
-  fixed_width_column_wrapper<K> key{1, 0, 1, 1, 0, 0, 1};
+  cudf::test::fixed_width_column_wrapper<K> key{1, 0, 1, 1, 0, 0, 1};
 
   // clang-format off
   LCW val({{},
@@ -240,7 +245,7 @@ TYPED_TEST(GroupbyReplaceNullsListsTest, PrecedingFillNested)
            Mask_t{0, 1, 1, 0, 0, 1, 1}.begin());
   // clang-format on
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1};
 
   // clang-format off
   LCW expect_val({LCW({LCW({1, -1, 3}, Mask_t{1, 0, 1}.begin()), {}}, Mask_t{1, 0}.begin()),
@@ -253,13 +258,13 @@ TYPED_TEST(GroupbyReplaceNullsListsTest, PrecedingFillNested)
            Mask_t{1, 1, 1, 0, 1 ,1 ,1}.begin());
   // clang-format on
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::PRECEDING);
 }
 
 TYPED_TEST(GroupbyReplaceNullsListsTest, FollowingFillNested)
 {
-  using LCW    = lists_column_wrapper<TypeParam, int32_t>;
-  using Mask_t = std::vector<valid_type>;
+  using LCW    = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using Mask_t = std::vector<cudf::valid_type>;
   // Group 0 value: {{{1 @ 3} @}
   //                 @
   //                 {{@} {}}}} -->
@@ -275,7 +280,7 @@ TYPED_TEST(GroupbyReplaceNullsListsTest, FollowingFillNested)
   //                 {{@ 202} {}}}
   //                 @}, w/ trailing nulls
   // Only top level nulls are replaced.
-  fixed_width_column_wrapper<K> key{1, 0, 1, 1, 0, 0, 1};
+  cudf::test::fixed_width_column_wrapper<K> key{1, 0, 1, 1, 0, 0, 1};
 
   // clang-format off
   LCW val({LCW({LCW{}, LCW({102, -1}, Mask_t{1, 0}.begin())}, Mask_t{0, 1}.begin()),
@@ -288,7 +293,7 @@ TYPED_TEST(GroupbyReplaceNullsListsTest, FollowingFillNested)
            Mask_t{1, 1, 0, 1, 0, 1, 0}.begin());
   // clang-format on
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1};
 
   // clang-format off
   LCW expect_val({LCW({LCW({1, -1, 3}, Mask_t{1, 0, 1}.begin()), {}}, Mask_t{1, 0}.begin()),
@@ -301,16 +306,16 @@ TYPED_TEST(GroupbyReplaceNullsListsTest, FollowingFillNested)
            Mask_t{1, 1, 1, 1, 1, 1, 0}.begin());
   // clang-format on
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::FOLLOWING);
 }
 
-struct GroupbyReplaceNullsStructsTest : public BaseFixture {
-  using SCW = structs_column_wrapper;
+struct GroupbyReplaceNullsStructsTest : public cudf::test::BaseFixture {
+  using SCW = cudf::test::structs_column_wrapper;
 
-  SCW data(fixed_width_column_wrapper<int32_t> field0,
-           strings_column_wrapper field1,
-           lists_column_wrapper<int32_t> field2,
-           std::initializer_list<valid_type> mask)
+  SCW data(cudf::test::fixed_width_column_wrapper<int32_t> field0,
+           cudf::test::strings_column_wrapper field1,
+           cudf::test::lists_column_wrapper<int32_t> field2,
+           std::initializer_list<cudf::valid_type> mask)
   {
     return SCW({field0, field1, field2}, mask.begin());
   }
@@ -318,9 +323,9 @@ struct GroupbyReplaceNullsStructsTest : public BaseFixture {
 
 TEST_F(GroupbyReplaceNullsStructsTest, PrecedingFill)
 {
-  using LCW    = lists_column_wrapper<int32_t>;
-  using Mask_t = std::vector<valid_type>;
-  fixed_width_column_wrapper<K> key{1, 0, 0, 1, 0, 1, 1};
+  using LCW    = cudf::test::lists_column_wrapper<int32_t>;
+  using Mask_t = std::vector<cudf::valid_type>;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 0, 0, 1, 0, 1, 1};
 
   // Only null rows are replaced.
 
@@ -330,7 +335,7 @@ TEST_F(GroupbyReplaceNullsStructsTest, PrecedingFill)
                LCW({{1, 2, 3}, {-1}, {}, {}, {42}, {}, {}}, Mask_t{1, 1, 0, 0, 1, 0, 0}.begin()),
                {1, 1, 0, 0, 1, 1, 0});
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1};
 
   SCW expect_val = this->data(
     {{-1, -1, -1, 1, 1, -1, -1}, {0, 0, 0, 1, 1, 0, 0}},
@@ -338,14 +343,14 @@ TEST_F(GroupbyReplaceNullsStructsTest, PrecedingFill)
     LCW({LCW{-1}, {-1}, {42}, {1, 2, 3}, {1, 2, 3}, {}, {}}, Mask_t{1, 1, 1, 1, 1, 0, 0}.begin()),
     {1, 1, 1, 1, 1, 1, 1});
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::PRECEDING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::PRECEDING);
 }
 
 TEST_F(GroupbyReplaceNullsStructsTest, FollowingFill)
 {
-  using LCW    = lists_column_wrapper<int32_t>;
-  using Mask_t = std::vector<valid_type>;
-  fixed_width_column_wrapper<K> key{1, 0, 0, 1, 0, 1, 1};
+  using LCW    = cudf::test::lists_column_wrapper<int32_t>;
+  using Mask_t = std::vector<cudf::valid_type>;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 0, 0, 1, 0, 1, 1};
 
   // Only null rows are replaced.
 
@@ -355,7 +360,7 @@ TEST_F(GroupbyReplaceNullsStructsTest, FollowingFill)
                LCW({{1, 2, 3}, {-1}, {}, {}, {42}, {}, {}}, Mask_t{1, 1, 0, 0, 1, 0, 0}.begin()),
                {1, 1, 0, 0, 1, 1, 0});
 
-  fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<K> expect_key{0, 0, 0, 1, 1, 1, 1};
 
   SCW expect_val = this->data(
     {{-1, -1, -1, 1, -1, -1, -1}, {0, 0, 0, 1, 0, 0, 0}},
@@ -363,8 +368,5 @@ TEST_F(GroupbyReplaceNullsStructsTest, FollowingFill)
     LCW({LCW{-1}, {42}, {42}, {1, 2, 3}, {}, {}, {}}, Mask_t{1, 1, 1, 1, 0, 0, 0}.begin()),
     {1, 1, 1, 1, 1, 1, 0});
 
-  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, replace_policy::FOLLOWING);
+  TestReplaceNullsGroupbySingle(key, val, expect_key, expect_val, cudf::replace_policy::FOLLOWING);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/shift_tests.cpp
+++ b/cpp/tests/groupby/shift_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,456 +24,510 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 
-namespace cudf {
-namespace test {
-
-using K = int32_t;
 template <typename T>
-struct groupby_shift_fixed_width_test : public BaseFixture {
+struct groupby_shift_fixed_width_test : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(groupby_shift_fixed_width_test, FixedWidthTypes);
+TYPED_TEST_SUITE(groupby_shift_fixed_width_test, cudf::test::FixedWidthTypes);
 
-template <typename V>
-void test_groupby_shift_fixed_width_single(fixed_width_column_wrapper<K> const& key,
-                                           fixed_width_column_wrapper<V> const& value,
-                                           size_type offset,
-                                           scalar const& fill_value,
-                                           fixed_width_column_wrapper<V> const& expected)
+template <typename K, typename V>
+void test_groupby_shift_fixed_width_single(
+  cudf::test::fixed_width_column_wrapper<K> const& key,
+  cudf::test::fixed_width_column_wrapper<V> const& value,
+  cudf::size_type offset,
+  cudf::scalar const& fill_value,
+  cudf::test::fixed_width_column_wrapper<V> const& expected)
 {
-  groupby::groupby gb_obj(table_view({key}));
-  std::vector<size_type> offsets{offset};
-  auto got = gb_obj.shift(table_view{{value}}, offsets, {fill_value});
+  cudf::groupby::groupby gb_obj(cudf::table_view({key}));
+  std::vector<cudf::size_type> offsets{offset};
+  auto got = gb_obj.shift(cudf::table_view{{value}}, offsets, {fill_value});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL((*got.second).view().column(0), expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, ForwardShiftWithoutNull_NullScalar)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9};
-  fixed_width_column_wrapper<V> expected({-1, -1, 3, 5, -1, -1, 4}, {0, 0, 1, 1, 0, 0, 1});
-  size_type offset = 2;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<V> expected({-1, -1, 3, 5, -1, -1, 4},
+                                                     {0, 0, 1, 1, 0, 0, 1});
+  cudf::size_type offset = 2;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, *slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, *slr, expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, ForwardShiftWithNull_NullScalar)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  fixed_width_column_wrapper<V> val({3, 4, 5, 6, 7, 8, 9}, {0, 0, 0, 1, 1, 1, 1});
-  fixed_width_column_wrapper<V> expected({-1, -1, -1, -1, -1, -1, -1}, {0, 0, 0, 0, 0, 0, 0});
-  size_type offset = 2;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> val({3, 4, 5, 6, 7, 8, 9}, {0, 0, 0, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> expected({-1, -1, -1, -1, -1, -1, -1},
+                                                     {0, 0, 0, 0, 0, 0, 0});
+  cudf::size_type offset = 2;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, *slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, *slr, expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, ForwardShiftWithoutNull_ValidScalar)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
-  fixed_width_column_wrapper<V> val({3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5});
-  fixed_width_column_wrapper<V> expected({42, 42, 42, 3, 5, 8, 9, 42, 42, 42, 4, 6, 7});
-  size_type offset = 3;
-  auto slr         = cudf::scalar_type_t<TypeParam>(make_type_param_scalar<TypeParam>(42), true);
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
+  cudf::test::fixed_width_column_wrapper<V> val({3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5});
+  cudf::test::fixed_width_column_wrapper<V> expected({42, 42, 42, 3, 5, 8, 9, 42, 42, 42, 4, 6, 7});
+  cudf::size_type offset = 3;
+  auto slr =
+    cudf::scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<TypeParam>(42), true);
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, slr, expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, ForwardShiftWithNull_ValidScalar)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
-  fixed_width_column_wrapper<V> val({3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5},
-                                    {1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1});
-  fixed_width_column_wrapper<V> expected({42, 42, 42, 3, 5, -1, -1, 42, 42, 42, -1, -1, 7},
-                                         {1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1});
-  size_type offset = 3;
-  auto slr         = cudf::scalar_type_t<TypeParam>(make_type_param_scalar<TypeParam>(42), true);
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
+  cudf::test::fixed_width_column_wrapper<V> val({3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5},
+                                                {1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1});
+  cudf::test::fixed_width_column_wrapper<V> expected(
+    {42, 42, 42, 3, 5, -1, -1, 42, 42, 42, -1, -1, 7}, {1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1});
+  cudf::size_type offset = 3;
+  auto slr =
+    cudf::scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<TypeParam>(42), true);
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, slr, expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, BackwardShiftWithoutNull_NullScalar)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9};
-  fixed_width_column_wrapper<V> expected({5, 8, 9, -1, 6, 7, -1}, {1, 1, 1, 0, 1, 1, 0});
-  size_type offset = -1;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<V> expected({5, 8, 9, -1, 6, 7, -1},
+                                                     {1, 1, 1, 0, 1, 1, 0});
+  cudf::size_type offset = -1;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, *slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, *slr, expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, BackwardShiftWithNull_NullScalar)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  fixed_width_column_wrapper<V> val({3, 4, 5, 6, 7, 8, 9}, {0, 0, 0, 1, 1, 1, 1});
-  fixed_width_column_wrapper<V> expected({-1, 8, 9, -1, 6, 7, -1}, {0, 1, 1, 0, 1, 1, 0});
-  size_type offset = -1;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> val({3, 4, 5, 6, 7, 8, 9}, {0, 0, 0, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> expected({-1, 8, 9, -1, 6, 7, -1},
+                                                     {0, 1, 1, 0, 1, 1, 0});
+  cudf::size_type offset = -1;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, *slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, *slr, expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, BackwardShiftWithoutNull_ValidScalar)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
-  fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5};
-  fixed_width_column_wrapper<V> expected({3, 5, 42, 42, 42, 42, 42, 4, 42, 42, 42, 42, 42});
-  size_type offset = -5;
-  auto slr         = cudf::scalar_type_t<TypeParam>(make_type_param_scalar<TypeParam>(42), true);
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
+  cudf::test::fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<V> expected(
+    {3, 5, 42, 42, 42, 42, 42, 4, 42, 42, 42, 42, 42});
+  cudf::size_type offset = -5;
+  auto slr =
+    cudf::scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<TypeParam>(42), true);
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, slr, expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, BackwardShiftWithNull_ValidScalar)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
-  fixed_width_column_wrapper<V> val({3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5},
-                                    {1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1});
-  fixed_width_column_wrapper<V> expected({5, -1, -1, -1, 3, 5, 42, -1, 7, 0, 2, -1, 42},
-                                         {1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1});
-  size_type offset = -1;
-  auto slr         = cudf::scalar_type_t<TypeParam>(make_type_param_scalar<TypeParam>(42), true);
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
+  cudf::test::fixed_width_column_wrapper<V> val({3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5},
+                                                {1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1});
+  cudf::test::fixed_width_column_wrapper<V> expected({5, -1, -1, -1, 3, 5, 42, -1, 7, 0, 2, -1, 42},
+                                                     {1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1});
+  cudf::size_type offset = -1;
+  auto slr =
+    cudf::scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<TypeParam>(42), true);
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, slr, expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, ZeroShiftNullScalar)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9};
-  fixed_width_column_wrapper<V> expected({3, 5, 8, 9, 4, 6, 7});
-  size_type offset = 0;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<V> expected({3, 5, 8, 9, 4, 6, 7});
+  cudf::size_type offset = 0;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, *slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, *slr, expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, ZeroShiftValidScalar)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
-  fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5};
-  fixed_width_column_wrapper<V> expected({3, 5, 8, 9, 1, 3, 5, 4, 6, 7, 0, 2, 4});
-  size_type offset = 0;
-  auto slr         = cudf::scalar_type_t<TypeParam>(make_type_param_scalar<TypeParam>(42), true);
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
+  cudf::test::fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<V> expected({3, 5, 8, 9, 1, 3, 5, 4, 6, 7, 0, 2, 4});
+  cudf::size_type offset = 0;
+  auto slr =
+    cudf::scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<TypeParam>(42), true);
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, slr, expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, VeryLargeForwardOffset)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
-  fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5};
-  fixed_width_column_wrapper<V> expected({-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
-                                         {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
-  size_type offset = 1024;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
+  cudf::test::fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<V> expected(
+    {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+  cudf::size_type offset = 1024;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, *slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, *slr, expected);
 }
 
 TYPED_TEST(groupby_shift_fixed_width_test, VeryLargeBackwardOffset)
 {
+  using K = int32_t;
   using V = TypeParam;
 
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
-  fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5};
-  fixed_width_column_wrapper<V> expected({-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
-                                         {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
-  size_type offset = -1024;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 1};
+  cudf::test::fixed_width_column_wrapper<V> val{3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<V> expected(
+    {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+  cudf::size_type offset = -1024;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
-  test_groupby_shift_fixed_width_single<V>(key, val, offset, *slr, expected);
+  test_groupby_shift_fixed_width_single<K, V>(key, val, offset, *slr, expected);
 }
 
-struct groupby_shift_string_test : public BaseFixture {
+struct groupby_shift_string_test : public cudf::test::BaseFixture {
 };
 
-void test_groupby_shift_string_single(fixed_width_column_wrapper<K> const& key,
-                                      strings_column_wrapper const& value,
-                                      size_type offset,
-                                      scalar const& fill_value,
-                                      strings_column_wrapper const& expected)
+template <typename K>
+void test_groupby_shift_string_single(cudf::test::fixed_width_column_wrapper<K> const& key,
+                                      cudf::test::strings_column_wrapper const& value,
+                                      cudf::size_type offset,
+                                      cudf::scalar const& fill_value,
+                                      cudf::test::strings_column_wrapper const& expected)
 {
-  groupby::groupby gb_obj(table_view({key}));
-  std::vector<size_type> offsets{offset};
-  auto got = gb_obj.shift(table_view{{value}}, offsets, {fill_value});
+  cudf::groupby::groupby gb_obj(cudf::table_view({key}));
+  std::vector<cudf::size_type> offsets{offset};
+  auto got = gb_obj.shift(cudf::table_view{{value}}, offsets, {fill_value});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL((*got.second).view().column(0), expected);
 }
 
 TEST_F(groupby_shift_string_test, ForwardShiftWithoutNull_NullScalar)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
-  strings_column_wrapper expected({"", "a", "cc", "f", "", "bb", "d"}, {0, 1, 1, 1, 0, 1, 1});
-  size_type offset = 1;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
+  cudf::test::strings_column_wrapper expected({"", "a", "cc", "f", "", "bb", "d"},
+                                              {0, 1, 1, 1, 0, 1, 1});
+  cudf::size_type offset = 1;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 TEST_F(groupby_shift_string_test, ForwardShiftWithNull_NullScalar)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val({"a", "bb", "cc", "d", "eee", "f", "gg"}, {1, 0, 1, 1, 0, 0, 0});
-  strings_column_wrapper expected({"", "", "a", "cc", "", "", ""}, {0, 0, 1, 1, 0, 0, 0});
-  size_type offset = 2;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val({"a", "bb", "cc", "d", "eee", "f", "gg"},
+                                         {1, 0, 1, 1, 0, 0, 0});
+  cudf::test::strings_column_wrapper expected({"", "", "a", "cc", "", "", ""},
+                                              {0, 0, 1, 1, 0, 0, 0});
+  cudf::size_type offset = 2;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 TEST_F(groupby_shift_string_test, ForwardShiftWithoutNull_ValidScalar)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
-  strings_column_wrapper expected({"42", "42", "a", "cc", "42", "42", "bb"});
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
+  cudf::test::strings_column_wrapper expected({"42", "42", "a", "cc", "42", "42", "bb"});
 
-  size_type offset = 2;
-  auto slr         = cudf::make_string_scalar("42");
+  cudf::size_type offset = 2;
+  auto slr               = cudf::make_string_scalar("42");
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 TEST_F(groupby_shift_string_test, ForwardShiftWithNull_ValidScalar)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val({"a", "bb", "cc", "d", "eee", "f", "gg"}, {1, 1, 0, 0, 1, 0, 1});
-  strings_column_wrapper expected({"42", "a", "", "", "42", "bb", ""}, {1, 1, 0, 0, 1, 1, 0});
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val({"a", "bb", "cc", "d", "eee", "f", "gg"},
+                                         {1, 1, 0, 0, 1, 0, 1});
+  cudf::test::strings_column_wrapper expected({"42", "a", "", "", "42", "bb", ""},
+                                              {1, 1, 0, 0, 1, 1, 0});
 
-  size_type offset = 1;
-  auto slr         = cudf::make_string_scalar("42");
+  cudf::size_type offset = 1;
+  auto slr               = cudf::make_string_scalar("42");
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 TEST_F(groupby_shift_string_test, BackwardShiftWithoutNull_NullScalar)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
-  strings_column_wrapper expected({"gg", "", "", "", "", "", ""}, {1, 0, 0, 0, 0, 0, 0});
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
+  cudf::test::strings_column_wrapper expected({"gg", "", "", "", "", "", ""},
+                                              {1, 0, 0, 0, 0, 0, 0});
 
-  size_type offset = -3;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  cudf::size_type offset = -3;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 TEST_F(groupby_shift_string_test, BackwardShiftWithNull_NullScalar)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val({"a", "bb", "cc", "d", "eee", "f", "gg"}, {1, 0, 1, 1, 0, 0, 0});
-  strings_column_wrapper expected({"cc", "", "", "", "d", "", ""}, {1, 0, 0, 0, 1, 0, 0});
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val({"a", "bb", "cc", "d", "eee", "f", "gg"},
+                                         {1, 0, 1, 1, 0, 0, 0});
+  cudf::test::strings_column_wrapper expected({"cc", "", "", "", "d", "", ""},
+                                              {1, 0, 0, 0, 1, 0, 0});
 
-  size_type offset = -1;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  cudf::size_type offset = -1;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 TEST_F(groupby_shift_string_test, BackwardShiftWithoutNull_ValidScalar)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
-  strings_column_wrapper expected({"42", "42", "42", "42", "42", "42", "42"});
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
+  cudf::test::strings_column_wrapper expected({"42", "42", "42", "42", "42", "42", "42"});
 
-  size_type offset = -4;
-  auto slr         = cudf::make_string_scalar("42");
+  cudf::size_type offset = -4;
+  auto slr               = cudf::make_string_scalar("42");
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 TEST_F(groupby_shift_string_test, BackwardShiftWithNull_ValidScalar)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val({"a", "bb", "cc", "d", "eee", "f", "gg"}, {1, 1, 0, 0, 1, 0, 1});
-  strings_column_wrapper expected({"", "gg", "42", "42", "eee", "42", "42"}, {0, 1, 1, 1, 1, 1, 1});
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val({"a", "bb", "cc", "d", "eee", "f", "gg"},
+                                         {1, 1, 0, 0, 1, 0, 1});
+  cudf::test::strings_column_wrapper expected({"", "gg", "42", "42", "eee", "42", "42"},
+                                              {0, 1, 1, 1, 1, 1, 1});
 
-  size_type offset = -2;
-  auto slr         = cudf::make_string_scalar("42");
+  cudf::size_type offset = -2;
+  auto slr               = cudf::make_string_scalar("42");
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 TEST_F(groupby_shift_string_test, ZeroShiftNullScalar)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
-  strings_column_wrapper expected({"a", "cc", "f", "gg", "bb", "d", "eee"});
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
+  cudf::test::strings_column_wrapper expected({"a", "cc", "f", "gg", "bb", "d", "eee"});
 
-  size_type offset = 0;
-  auto slr         = cudf::make_default_constructed_scalar(column_view(val).type());
+  cudf::size_type offset = 0;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 TEST_F(groupby_shift_string_test, ZeroShiftValidScalar)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
-  strings_column_wrapper expected({"a", "cc", "f", "gg", "bb", "d", "eee"});
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
+  cudf::test::strings_column_wrapper expected({"a", "cc", "f", "gg", "bb", "d", "eee"});
 
-  size_type offset = 0;
-  auto slr         = cudf::make_string_scalar("42");
+  cudf::size_type offset = 0;
+  auto slr               = cudf::make_string_scalar("42");
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 TEST_F(groupby_shift_string_test, VeryLargeForwardOffset)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
-  strings_column_wrapper expected({"42", "42", "42", "42", "42", "42", "42"});
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
+  cudf::test::strings_column_wrapper expected({"42", "42", "42", "42", "42", "42", "42"});
 
-  size_type offset = 1024;
-  auto slr         = cudf::make_string_scalar("42");
+  cudf::size_type offset = 1024;
+  auto slr               = cudf::make_string_scalar("42");
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 TEST_F(groupby_shift_string_test, VeryLargeBackwardOffset)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
-  strings_column_wrapper expected({"42", "42", "42", "42", "42", "42", "42"});
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper val{"a", "bb", "cc", "d", "eee", "f", "gg"};
+  cudf::test::strings_column_wrapper expected({"42", "42", "42", "42", "42", "42", "42"});
 
-  size_type offset = -1024;
-  auto slr         = cudf::make_string_scalar("42");
+  cudf::size_type offset = -1024;
+  auto slr               = cudf::make_string_scalar("42");
 
   test_groupby_shift_string_single(key, val, offset, *slr, expected);
 }
 
 template <typename T>
-struct groupby_shift_mixed_test : public BaseFixture {
+struct groupby_shift_mixed_test : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(groupby_shift_mixed_test, FixedWidthTypes);
+TYPED_TEST_SUITE(groupby_shift_mixed_test, cudf::test::FixedWidthTypes);
 
-void test_groupby_shift_multi(fixed_width_column_wrapper<K> const& key,
-                              table_view const& value,
-                              std::vector<size_type> offsets,
-                              std::vector<std::reference_wrapper<const scalar>> fill_values,
-                              table_view const& expected)
+template <typename K>
+void test_groupby_shift_multi(cudf::test::fixed_width_column_wrapper<K> const& key,
+                              cudf::table_view const& value,
+                              std::vector<cudf::size_type> offsets,
+                              std::vector<std::reference_wrapper<const cudf::scalar>> fill_values,
+                              cudf::table_view const& expected)
 {
-  groupby::groupby gb_obj(table_view({key}));
+  cudf::groupby::groupby gb_obj(cudf::table_view({key}));
   auto got = gb_obj.shift(value, offsets, fill_values);
   CUDF_TEST_EXPECT_TABLES_EQUAL((*got.second).view(), expected);
 }
 
 TYPED_TEST(groupby_shift_mixed_test, NoFill)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper v1{"a", "bb", "cc", "d", "eee", "f", "gg"};
-  fixed_width_column_wrapper<TypeParam> v2{1, 2, 3, 4, 5, 6, 7};
-  table_view value{{v1, v2}};
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper v1{"a", "bb", "cc", "d", "eee", "f", "gg"};
+  cudf::test::fixed_width_column_wrapper<TypeParam> v2{1, 2, 3, 4, 5, 6, 7};
+  cudf::table_view value{{v1, v2}};
 
-  strings_column_wrapper e1({"", "", "a", "cc", "", "", "bb"}, {0, 0, 1, 1, 0, 0, 1});
-  fixed_width_column_wrapper<TypeParam> e2({-1, 1, 3, 6, -1, 2, 4}, {0, 1, 1, 1, 0, 1, 1});
-  table_view expected{{e1, e2}};
+  cudf::test::strings_column_wrapper e1({"", "", "a", "cc", "", "", "bb"}, {0, 0, 1, 1, 0, 0, 1});
+  cudf::test::fixed_width_column_wrapper<TypeParam> e2({-1, 1, 3, 6, -1, 2, 4},
+                                                       {0, 1, 1, 1, 0, 1, 1});
+  cudf::table_view expected{{e1, e2}};
 
-  std::vector<size_type> offset{2, 1};
-  auto slr1 = cudf::make_default_constructed_scalar(column_view(v1).type());
-  auto slr2 = cudf::make_default_constructed_scalar(column_view(v2).type());
-  std::vector<std::reference_wrapper<const scalar>> fill_values{*slr1, *slr2};
+  std::vector<cudf::size_type> offset{2, 1};
+  auto slr1 = cudf::make_default_constructed_scalar(cudf::column_view(v1).type());
+  auto slr2 = cudf::make_default_constructed_scalar(cudf::column_view(v2).type());
+  std::vector<std::reference_wrapper<const cudf::scalar>> fill_values{*slr1, *slr2};
 
   test_groupby_shift_multi(key, value, offset, fill_values, expected);
 }
 
 TYPED_TEST(groupby_shift_mixed_test, Fill)
 {
-  fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
-  strings_column_wrapper v1{"a", "bb", "cc", "d", "eee", "f", "gg"};
-  fixed_width_column_wrapper<TypeParam> v2{1, 2, 3, 4, 5, 6, 7};
-  table_view value{{v1, v2}};
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::strings_column_wrapper v1{"a", "bb", "cc", "d", "eee", "f", "gg"};
+  cudf::test::fixed_width_column_wrapper<TypeParam> v2{1, 2, 3, 4, 5, 6, 7};
+  cudf::table_view value{{v1, v2}};
 
-  strings_column_wrapper e1({"cc", "f", "gg", "42", "d", "eee", "42"});
-  fixed_width_column_wrapper<TypeParam> e2({6, 7, 42, 42, 5, 42, 42});
-  table_view expected{{e1, e2}};
+  cudf::test::strings_column_wrapper e1({"cc", "f", "gg", "42", "d", "eee", "42"});
+  cudf::test::fixed_width_column_wrapper<TypeParam> e2({6, 7, 42, 42, 5, 42, 42});
+  cudf::table_view expected{{e1, e2}};
 
-  std::vector<size_type> offset{-1, -2};
+  std::vector<cudf::size_type> offset{-1, -2};
 
   auto slr1 = cudf::make_string_scalar("42");
-  auto slr2 = cudf::scalar_type_t<TypeParam>(make_type_param_scalar<TypeParam>(42), true);
-  std::vector<std::reference_wrapper<const scalar>> fill_values{*slr1, slr2};
+  auto slr2 =
+    cudf::scalar_type_t<TypeParam>(cudf::test::make_type_param_scalar<TypeParam>(42), true);
+  std::vector<std::reference_wrapper<const cudf::scalar>> fill_values{*slr1, slr2};
 
   test_groupby_shift_multi(key, value, offset, fill_values, expected);
 }
 
-struct groupby_shift_fixed_point_type_test : public BaseFixture {
+struct groupby_shift_fixed_point_type_test : public cudf::test::BaseFixture {
 };
 
 TEST_F(groupby_shift_fixed_point_type_test, Matching)
 {
-  fixed_width_column_wrapper<K> key{2, 3, 4, 4, 3, 2, 2, 4};
-  fixed_point_column_wrapper<int32_t> v1{{10, 10, 40, 40, 20, 20, 30, 40}, numeric::scale_type{-1}};
-  fixed_point_column_wrapper<int64_t> v2{{5, 5, 8, 8, 6, 7, 9, 7}, numeric::scale_type{3}};
-  table_view value{{v1, v2}};
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{2, 3, 4, 4, 3, 2, 2, 4};
+  cudf::test::fixed_point_column_wrapper<int32_t> v1{{10, 10, 40, 40, 20, 20, 30, 40},
+                                                     numeric::scale_type{-1}};
+  cudf::test::fixed_point_column_wrapper<int64_t> v2{{5, 5, 8, 8, 6, 7, 9, 7},
+                                                     numeric::scale_type{3}};
+  cudf::table_view value{{v1, v2}};
 
-  std::vector<size_type> offset{-3, 1};
-  auto slr1 = make_fixed_point_scalar<numeric::decimal32>(-42, numeric::scale_type{-1});
-  auto slr2 = make_fixed_point_scalar<numeric::decimal64>(42, numeric::scale_type{3});
-  std::vector<std::reference_wrapper<const scalar>> fill_values{*slr1, *slr2};
+  std::vector<cudf::size_type> offset{-3, 1};
+  auto slr1 = cudf::make_fixed_point_scalar<numeric::decimal32>(-42, numeric::scale_type{-1});
+  auto slr2 = cudf::make_fixed_point_scalar<numeric::decimal64>(42, numeric::scale_type{3});
+  std::vector<std::reference_wrapper<const cudf::scalar>> fill_values{*slr1, *slr2};
 
-  fixed_point_column_wrapper<int32_t> e1{{-42, -42, -42, -42, -42, -42, -42, -42},
-                                         numeric::scale_type{-1}};
-  fixed_point_column_wrapper<int64_t> e2{{42, 5, 7, 42, 5, 42, 8, 8}, numeric::scale_type{3}};
-  table_view expected{{e1, e2}};
+  cudf::test::fixed_point_column_wrapper<int32_t> e1{{-42, -42, -42, -42, -42, -42, -42, -42},
+                                                     numeric::scale_type{-1}};
+  cudf::test::fixed_point_column_wrapper<int64_t> e2{{42, 5, 7, 42, 5, 42, 8, 8},
+                                                     numeric::scale_type{3}};
+  cudf::table_view expected{{e1, e2}};
 
   test_groupby_shift_multi(key, value, offset, fill_values, expected);
 }
 
 TEST_F(groupby_shift_fixed_point_type_test, MismatchScaleType)
 {
-  fixed_width_column_wrapper<K> key{2, 3, 4, 4, 3, 2, 2, 4};
-  fixed_point_column_wrapper<int32_t> v1{{10, 10, 40, 40, 20, 20, 30, 40}, numeric::scale_type{-1}};
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{2, 3, 4, 4, 3, 2, 2, 4};
+  cudf::test::fixed_point_column_wrapper<int32_t> v1{{10, 10, 40, 40, 20, 20, 30, 40},
+                                                     numeric::scale_type{-1}};
 
-  std::vector<size_type> offset{-3};
-  auto slr1 = make_fixed_point_scalar<numeric::decimal32>(-42, numeric::scale_type{-4});
+  std::vector<cudf::size_type> offset{-3};
+  auto slr1 = cudf::make_fixed_point_scalar<numeric::decimal32>(-42, numeric::scale_type{-4});
 
-  fixed_point_column_wrapper<int32_t> stub{{-42, -42, -42, -42, -42, -42, -42, -42},
-                                           numeric::scale_type{-1}};
+  cudf::test::fixed_point_column_wrapper<int32_t> stub{{-42, -42, -42, -42, -42, -42, -42, -42},
+                                                       numeric::scale_type{-1}};
 
-  EXPECT_THROW(test_groupby_shift_multi(key, table_view{{v1}}, offset, {*slr1}, table_view{{stub}}),
-               logic_error);
+  EXPECT_THROW(test_groupby_shift_multi(
+                 key, cudf::table_view{{v1}}, offset, {*slr1}, cudf::table_view{{stub}}),
+               cudf::logic_error);
 }
 
 TEST_F(groupby_shift_fixed_point_type_test, MismatchRepType)
 {
-  fixed_width_column_wrapper<K> key{2, 3, 4, 4, 3, 2, 2, 4};
-  fixed_point_column_wrapper<int64_t> v1{{10, 10, 40, 40, 20, 20, 30, 40}, numeric::scale_type{-1}};
+  using K = int32_t;
+  cudf::test::fixed_width_column_wrapper<K> key{2, 3, 4, 4, 3, 2, 2, 4};
+  cudf::test::fixed_point_column_wrapper<int64_t> v1{{10, 10, 40, 40, 20, 20, 30, 40},
+                                                     numeric::scale_type{-1}};
 
-  std::vector<size_type> offset{-3};
-  auto slr1 = make_fixed_point_scalar<numeric::decimal32>(-42, numeric::scale_type{-1});
+  std::vector<cudf::size_type> offset{-3};
+  auto slr1 = cudf::make_fixed_point_scalar<numeric::decimal32>(-42, numeric::scale_type{-1});
 
-  fixed_point_column_wrapper<int32_t> stub{{-42, -42, -42, -42, -42, -42, -42, -42},
-                                           numeric::scale_type{-1}};
+  cudf::test::fixed_point_column_wrapper<int32_t> stub{{-42, -42, -42, -42, -42, -42, -42, -42},
+                                                       numeric::scale_type{-1}};
 
-  EXPECT_THROW(test_groupby_shift_multi(key, table_view{{v1}}, offset, {*slr1}, table_view{{stub}}),
-               logic_error);
+  EXPECT_THROW(test_groupby_shift_multi(
+                 key, cudf::table_view{{v1}}, offset, {*slr1}, cudf::table_view{{stub}}),
+               cudf::logic_error);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/std_tests.cpp
+++ b/cpp/tests/groupby/std_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#ifdef NDEBUG  // currently groupby std tests are not supported. See groupstd.cu
-
 #include <tests/groupby/groupby_test_util.hpp>
 
 #include <cudf_test/base_fixture.hpp>
@@ -27,140 +25,168 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_std_test : public cudf::test::BaseFixture {
 };
 
-using K               = int32_t;
 using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
 
 TYPED_TEST_SUITE(groupby_std_test, supported_types);
 
+#ifdef NDEBUG  // currently groupby std tests are not supported in debug
 TYPED_TEST(groupby_std_test, basic)
+#else
+TYPED_TEST(groupby_std_test, DISABLED_basic)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::STD>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   // clang-format off
-  //                                        {1, 1, 1,  2, 2, 2, 2,    3, 3, 3}
-  fixed_width_column_wrapper<K>  expect_keys{1,        2,             3};
-  //                                        {0, 3, 6,  1, 4, 5, 9,    2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, no_nulls());
+  //                                                    {1, 1, 1,  2, 2, 2, 2,    3, 3, 3}
+  cudf::test::fixed_width_column_wrapper<K>  expect_keys{1,        2,             3};
+              //                                        {0, 3, 6,  1, 4, 5, 9,    2, 7, 8}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, no_nulls());
   // clang-format on
 
   auto agg = cudf::make_std_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG  // currently groupby std tests are not supported in debug
 TYPED_TEST(groupby_std_test, empty_cols)
+#else
+TYPED_TEST(groupby_std_test, DISABLED_empty_cols)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::STD>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   auto agg = cudf::make_std_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG  // currently groupby std tests are not supported in debug
 TYPED_TEST(groupby_std_test, zero_valid_keys)
+#else
+TYPED_TEST(groupby_std_test, DISABLED_zero_valid_keys)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::STD>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals{3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   auto agg = cudf::make_std_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG  // currently groupby std tests are not supported in debug
 TYPED_TEST(groupby_std_test, zero_valid_values)
+#else
+TYPED_TEST(groupby_std_test, DISABLED_zero_valid_values)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::STD>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_std_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG  // currently groupby std tests are not supported in debug
 TYPED_TEST(groupby_std_test, null_keys_and_values)
+#else
+TYPED_TEST(groupby_std_test, DISABLED_null_keys_and_values)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::STD>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
   //                                        { 1, 1,     2, 2, 2,   3, 3,       4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //                                        { 3, 6,     1, 4, 9,   2, 8,       3}
-  fixed_width_column_wrapper<R> expect_vals({3 / sqrt(2), 7 / sqrt(3), 3 * sqrt(2), 0.},
-                                            {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3 / sqrt(2), 7 / sqrt(3), 3 * sqrt(2), 0.},
+                                                        {1, 1, 1, 0});
 
   auto agg = cudf::make_std_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG  // currently groupby std tests are not supported in debug
 TYPED_TEST(groupby_std_test, ddof_non_default)
+#else
+TYPED_TEST(groupby_std_test, DISABLED_ddof_non_default)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::STD>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
   //                                        { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //                                        { 3, 6,     1, 4, 9,   2, 8,    3}
-  fixed_width_column_wrapper<R> expect_vals({0., 7 * sqrt(2. / 3), 0., 0.}, {0, 1, 0, 0});
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0., 7 * sqrt(2. / 3), 0., 0.},
+                                                        {0, 1, 0, 0});
 
   auto agg = cudf::make_std_aggregation<cudf::groupby_aggregation>(2);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG  // currently groupby std tests are not supported in debug
 TYPED_TEST(groupby_std_test, dictionary)
+#else
+TYPED_TEST(groupby_std_test, DISABLED_dictionary)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::STD>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::STD>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   //                                        {1, 1, 1,  2, 2, 2, 2,    3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,             3});
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1,        2,             3});
   //                                        {0, 3, 6,  1, 4, 5, 9,    2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({3.,       sqrt(131./12), sqrt(31./3)}, no_nulls());
   // clang-format on
 
   test_single_agg(
     keys, vals, expect_keys, expect_vals, cudf::make_std_aggregation<cudf::groupby_aggregation>());
 }
-
-}  // namespace test
-}  // namespace cudf
-
-#endif  // NDEBUG

--- a/cpp/tests/groupby/structs_tests.cpp
+++ b/cpp/tests/groupby/structs_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,27 +25,17 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
-
 template <typename V>
 struct groupby_structs_test : public cudf::test::BaseFixture {
 };
 
 TYPED_TEST_SUITE(groupby_structs_test, cudf::test::FixedWidthTypes);
 
-using V       = int32_t;  // Type of Aggregation Column.
-using M0      = int32_t;  // Type of STRUCT's first (i.e. 0th) member.
-using R       = cudf::detail::target_type_t<V, aggregation::SUM>;  // Type of aggregation result.
-using offsets = std::vector<cudf::offset_type>;
-using strings = strings_column_wrapper;
-using structs = structs_column_wrapper;
+template <typename T>
+using fwcw = cudf::test::fixed_width_column_wrapper<T>;
 
 template <typename T>
-using fwcw = fixed_width_column_wrapper<T>;
-
-template <typename T>
-using lcw = lists_column_wrapper<T>;
+using lcw = cudf::test::lists_column_wrapper<T>;
 
 namespace {
 static constexpr auto null = -1;  // Signifies null value.
@@ -57,22 +47,23 @@ static constexpr auto null = -1;  // Signifies null value.
 // Set this to true to enable printing, for debugging.
 auto constexpr print_enabled = false;
 
-void print_agg_results(column_view const& keys, column_view const& vals)
+void print_agg_results(cudf::column_view const& keys, cudf::column_view const& vals)
 {
   if constexpr (print_enabled) {
-    auto requests = std::vector<groupby::aggregation_request>{};
-    requests.push_back(groupby::aggregation_request{});
+    auto requests = std::vector<cudf::groupby::aggregation_request>{};
+    requests.push_back(cudf::groupby::aggregation_request{});
     requests.back().values = vals;
-    requests.back().aggregations.push_back(cudf::make_sum_aggregation<groupby_aggregation>());
+    requests.back().aggregations.push_back(cudf::make_sum_aggregation<cudf::groupby_aggregation>());
     requests.back().aggregations.push_back(
-      cudf::make_nth_element_aggregation<groupby_aggregation>(0));
+      cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0));
 
-    auto gby    = groupby::groupby{table_view({keys}), null_policy::INCLUDE, sorted::NO, {}, {}};
+    auto gby = cudf::groupby::groupby{
+      cudf::table_view({keys}), cudf::null_policy::INCLUDE, cudf::sorted::NO, {}, {}};
     auto result = gby.aggregate(requests);
     std::cout << "Results: Keys: " << std::endl;
-    print(result.first->get_column(0).view());
+    cudf::test::print(result.first->get_column(0).view());
     std::cout << "Results: Values: " << std::endl;
-    print(result.second.front().results[0]->view());
+    cudf::test::print(result.second.front().results[0]->view());
   }
 }
 
@@ -80,20 +71,23 @@ void print_agg_results(column_view const& keys, column_view const& vals)
 
 TYPED_TEST(groupby_structs_test, basic)
 {
+  using V  = int32_t;    // Type of Aggregation Column.
+  using M0 = int32_t;    // Type of STRUCT's first (i.e. 0th) member.
   using M1 = TypeParam;  // Type of STRUCT's second (i.e. 1th) member.
+  using R  = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
   auto values   = fwcw<V> {  0,    1,    2,    3,    4,    5,    6,    7,    8,    9};
   auto member_0 = fwcw<M0>{  1,    2,    3,    1,    2,    2,    1,    3,    3,    2};
   auto member_1 = fwcw<M1>{ 11,   22,   33,   11,   22,   22,   11,   33,   33,   22};
-  auto member_2 = strings {"11", "22", "33", "11", "22", "22", "11", "33", "33", "22"};
-  auto keys     = structs{member_0, member_1, member_2};
+  auto member_2 = cudf::test::strings_column_wrapper {"11", "22", "33", "11", "22", "22", "11", "33", "33", "22"};
+  auto keys     = cudf::test::structs_column_wrapper{member_0, member_1, member_2};
 
   auto expected_values   = fwcw<R> {  9,   19,   17 };
   auto expected_member_0 = fwcw<M0>{  1,    2,    3 };
   auto expected_member_1 = fwcw<M1>{ 11,   22,   33 };
-  auto expected_member_2 = strings {"11", "22", "33"};
-  auto expected_keys     = structs{expected_member_0, expected_member_1, expected_member_2};
+  auto expected_member_2 = cudf::test::strings_column_wrapper {"11", "22", "33"};
+  auto expected_keys     = cudf::test::structs_column_wrapper{expected_member_0, expected_member_1, expected_member_2};
   // clang-format on
 
   test_sum_agg(keys, values, expected_keys, expected_values);
@@ -101,14 +95,17 @@ TYPED_TEST(groupby_structs_test, basic)
 
 TYPED_TEST(groupby_structs_test, structs_with_nulls_in_members)
 {
+  using V  = int32_t;    // Type of Aggregation Column.
+  using M0 = int32_t;    // Type of STRUCT's first (i.e. 0th) member.
   using M1 = TypeParam;  // Type of STRUCT's second (i.e. 1th) member.
+  using R  = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
   auto values   = fwcw<V> {  0,       1,    2,    3,    4,    5,    6,      7,    8,    9 };
   auto member_0 = fwcw<M0>{{ 1,    null,    3,    1,    2,    2,    1,      3,    3,    2 }, null_at(1)};
   auto member_1 = fwcw<M1>{{ 11,     22,   33,   11,   22,   22,   11,   null,   33,   22 }, null_at(7)};
-  auto member_2 = strings { "11",   "22", "33", "11", "22", "22", "11",   "33", "33", "22"};
-  auto keys     = structs{{member_0, member_1, member_2}};
+  auto member_2 = cudf::test::strings_column_wrapper { "11",   "22", "33", "11", "22", "22", "11",   "33", "33", "22"};
+  auto keys     = cudf::test::structs_column_wrapper{{member_0, member_1, member_2}};
   // clang-format on
 
   print_agg_results(keys, values);
@@ -117,8 +114,8 @@ TYPED_TEST(groupby_structs_test, structs_with_nulls_in_members)
   auto expected_values   = fwcw<R> {    9,   18,    10,     7,     1  };
   auto expected_member_0 = fwcw<M0>{ {  1,    2,     3,     3,  null  }, null_at(4)};
   auto expected_member_1 = fwcw<M1>{ { 11,   22,    33,  null,    22  }, null_at(3)};
-  auto expected_member_2 = strings {  "11", "22",  "33",  "33",  "22" };
-  auto expected_keys     = structs{expected_member_0, expected_member_1, expected_member_2};
+  auto expected_member_2 = cudf::test::strings_column_wrapper {  "11", "22",  "33",  "33",  "22" };
+  auto expected_keys     = cudf::test::structs_column_wrapper{expected_member_0, expected_member_1, expected_member_2};
   // clang-format on
 
   test_sum_agg(keys, values, expected_keys, expected_values);
@@ -126,20 +123,23 @@ TYPED_TEST(groupby_structs_test, structs_with_nulls_in_members)
 
 TYPED_TEST(groupby_structs_test, structs_with_null_rows)
 {
+  using V  = int32_t;    // Type of Aggregation Column.
+  using M0 = int32_t;    // Type of STRUCT's first (i.e. 0th) member.
   using M1 = TypeParam;  // Type of STRUCT's second (i.e. 1th) member.
+  using R  = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
   auto values   = fwcw<V> {  0,    1,    2,    3,    4,    5,    6,    7,    8,    9};
   auto member_0 = fwcw<M0>{  1,    2,    3,    1,    2,    2,    1,    3,    3,    2};
   auto member_1 = fwcw<M1>{ 11,   22,   33,   11,   22,   22,   11,   33,   33,   22};
-  auto member_2 = strings {"11", "22", "33", "11", "22", "22", "11", "33", "33", "22"};
-  auto keys     = structs{{member_0, member_1, member_2}, nulls_at({0, 3})};
+  auto member_2 = cudf::test::strings_column_wrapper {"11", "22", "33", "11", "22", "22", "11", "33", "33", "22"};
+  auto keys     = cudf::test::structs_column_wrapper{{member_0, member_1, member_2}, nulls_at({0, 3})};
 
   auto expected_values   = fwcw<R> {    6,   19,   17,      3  };
   auto expected_member_0 = fwcw<M0>{ {  1,    2,    3,   null  }, null_at(3)};
   auto expected_member_1 = fwcw<M1>{ { 11,   22,   33,   null  }, null_at(3)};
-  auto expected_member_2 = strings { {"11", "22", "33", "null" }, null_at(3)};
-  auto expected_keys     = structs{{expected_member_0, expected_member_1, expected_member_2}, null_at(3)};
+  auto expected_member_2 = cudf::test::strings_column_wrapper { {"11", "22", "33", "null" }, null_at(3)};
+  auto expected_keys     = cudf::test::structs_column_wrapper{{expected_member_0, expected_member_1, expected_member_2}, null_at(3)};
   // clang-format on
 
   print_agg_results(keys, values);
@@ -149,14 +149,17 @@ TYPED_TEST(groupby_structs_test, structs_with_null_rows)
 
 TYPED_TEST(groupby_structs_test, structs_with_nulls_in_rows_and_members)
 {
+  using V  = int32_t;    // Type of Aggregation Column.
+  using M0 = int32_t;    // Type of STRUCT's first (i.e. 0th) member.
   using M1 = TypeParam;  // Type of STRUCT's second (i.e. 1th) member.
+  using R  = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
   auto values   = fwcw<V> {  0,    1,    2,    3,    4,    5,    6,    7,    8,    9  };
   auto member_0 = fwcw<M0>{{ 1,    2,    3,    1,    2,    2,    1,    3,    3,    2  }, null_at(1)};
   auto member_1 = fwcw<M1>{{ 11,   22,   33,   11,   22,   22,   11,   33,   33,   22 }, null_at(7)};
-  auto member_2 = strings { "11", "22", "33", "11", "22", "22", "11", "33", "33", "22"};
-  auto keys     = structs{{member_0, member_1, member_2}, null_at(4)};
+  auto member_2 = cudf::test::strings_column_wrapper { "11", "22", "33", "11", "22", "22", "11", "33", "33", "22"};
+  auto keys     = cudf::test::structs_column_wrapper{{member_0, member_1, member_2}, null_at(4)};
   // clang-format on
 
   print_agg_results(keys, values);
@@ -165,8 +168,8 @@ TYPED_TEST(groupby_structs_test, structs_with_nulls_in_rows_and_members)
   auto expected_values   = fwcw<R> {    9,   14,    10,     7,     1,      4  };
   auto expected_member_0 = fwcw<M0>{{   1,    2,     3,     3,  null,   null  }, nulls_at({4,5})};
   auto expected_member_1 = fwcw<M1>{{  11,   22,    33,  null,    22,   null  }, nulls_at({3,5})};
-  auto expected_member_2 = strings {{ "11", "22",  "33",  "33",  "22", "null" }, null_at(5)};
-  auto expected_keys     = structs{{expected_member_0, expected_member_1, expected_member_2}, null_at(5)};
+  auto expected_member_2 = cudf::test::strings_column_wrapper {{ "11", "22",  "33",  "33",  "22", "null" }, null_at(5)};
+  auto expected_keys     = cudf::test::structs_column_wrapper{{expected_member_0, expected_member_1, expected_member_2}, null_at(5)};
   // clang-format on
 
   print_agg_results(keys, values);
@@ -178,14 +181,17 @@ TYPED_TEST(groupby_structs_test, null_members_differ_from_null_structs)
   // This test specifically confirms that a non-null STRUCT row `{null, null, null}` is grouped
   // differently from a null STRUCT row (whose members are incidentally null).
 
+  using V  = int32_t;    // Type of Aggregation Column.
+  using M0 = int32_t;    // Type of STRUCT's first (i.e. 0th) member.
   using M1 = TypeParam;  // Type of STRUCT's second (i.e. 1th) member.
+  using R  = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
   auto values   = fwcw<V> {    0,      1,    2,    3,    4,    5,    6,    7,    8,    9 };
   auto member_0 = fwcw<M0>{{   1,   null,    3,    1,    2,    2,    1,    3,    3,    2 }, null_at(1)};
   auto member_1 = fwcw<M1>{{  11,   null,   33,   11,   22,   22,   11,   33,   33,   22 }, null_at(1)};
-  auto member_2 = strings {{ "11", "null", "33", "11", "22", "22", "11", "33", "33", "22"}, null_at(1)};
-  auto keys     = structs{{member_0, member_1, member_2}, null_at(4)};
+  auto member_2 = cudf::test::strings_column_wrapper {{ "11", "null", "33", "11", "22", "22", "11", "33", "33", "22"}, null_at(1)};
+  auto keys     = cudf::test::structs_column_wrapper{{member_0, member_1, member_2}, null_at(4)};
   // clang-format on
 
   print_agg_results(keys, values);
@@ -197,8 +203,8 @@ TYPED_TEST(groupby_structs_test, null_members_differ_from_null_structs)
   auto expected_values   = fwcw<R> {    9,   14,    17,      1,      4  };
   auto expected_member_0 = fwcw<M0>{ {  1,    2,     3,   null,   null  }, nulls_at({3,4})};
   auto expected_member_1 = fwcw<M1>{ { 11,   22,    33,   null,   null  }, nulls_at({3,4})};
-  auto expected_member_2 = strings { {"11", "22",  "33", "null", "null" }, nulls_at({3,4})};
-  auto expected_keys     = structs{{expected_member_0, expected_member_1, expected_member_2}, null_at(4)};
+  auto expected_member_2 = cudf::test::strings_column_wrapper { {"11", "22",  "33", "null", "null" }, nulls_at({3,4})};
+  auto expected_keys     = cudf::test::structs_column_wrapper{{expected_member_0, expected_member_1, expected_member_2}, null_at(4)};
   // clang-format on
 
   test_sum_agg(keys, values, expected_keys, expected_values);
@@ -206,19 +212,24 @@ TYPED_TEST(groupby_structs_test, null_members_differ_from_null_structs)
 
 TYPED_TEST(groupby_structs_test, structs_of_structs)
 {
+  using V  = int32_t;    // Type of Aggregation Column.
+  using M0 = int32_t;    // Type of STRUCT's first (i.e. 0th) member.
   using M1 = TypeParam;  // Type of STRUCT's second (i.e. 1th) member.
+  using R  = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
   auto values            = fwcw<V> {    0,      1,    2,    3,    4,    5,    6,    7,    8,    9 };
   auto struct_0_member_0 = fwcw<M0>{{   1,   null,    3,    1,    2,    2,    1,    3,    3,    2 }, null_at(1)};
   auto struct_0_member_1 = fwcw<M1>{{  11,   null,   33,   11,   22,   22,   11,   33,   33,   22 }, null_at(1)};
-  auto struct_0_member_2 = strings {{ "11", "null", "33", "11", "22", "22", "11", "33", "33", "22"}, null_at(1)};
+  auto struct_0_member_2 = cudf::test::strings_column_wrapper {{ "11", "null", "33", "11", "22", "22", "11", "33", "33", "22"}, null_at(1)};
   // clang-format on
 
-  auto struct_0 = structs{{struct_0_member_0, struct_0_member_1, struct_0_member_2}, null_at(4)};
+  auto struct_0 = cudf::test::structs_column_wrapper{
+    {struct_0_member_0, struct_0_member_1, struct_0_member_2}, null_at(4)};
   auto struct_1_member_1 = fwcw<M1>{8, 9, 6, 8, 0, 7, 8, 6, 6, 7};
 
-  auto keys = structs{{struct_0, struct_1_member_1}};  // Struct of structs.
+  auto keys = cudf::test::structs_column_wrapper{
+    {struct_0, struct_1_member_1}};  // Struct of cudf::test::structs_column_wrapper.
 
   print_agg_results(keys, values);
 
@@ -226,10 +237,10 @@ TYPED_TEST(groupby_structs_test, structs_of_structs)
   auto expected_values            = fwcw<R> {    9,   14,    17,      1,      4  };
   auto expected_member_0          = fwcw<M0>{ {  1,    2,     3,   null,   null  }, nulls_at({3,4})};
   auto expected_member_1          = fwcw<M1>{ { 11,   22,    33,   null,   null  }, nulls_at({3,4})};
-  auto expected_member_2          = strings { {"11", "22",  "33", "null", "null" }, nulls_at({3,4})};
-  auto expected_structs           = structs{{expected_member_0, expected_member_1, expected_member_2}, null_at(4)};
+  auto expected_member_2          = cudf::test::strings_column_wrapper { {"11", "22",  "33", "null", "null" }, nulls_at({3,4})};
+  auto expected_structs           = cudf::test::structs_column_wrapper{{expected_member_0, expected_member_1, expected_member_2}, null_at(4)};
   auto expected_struct_1_member_1 = fwcw<M1>{    8,    7,     6,      9,      0  };
-  auto expected_keys              = structs{{expected_structs, expected_struct_1_member_1}};
+  auto expected_keys              = cudf::test::structs_column_wrapper{{expected_structs, expected_struct_1_member_1}};
   // clang-format on
 
   test_sum_agg(keys, values, expected_keys, expected_values);
@@ -237,20 +248,23 @@ TYPED_TEST(groupby_structs_test, structs_of_structs)
 
 TYPED_TEST(groupby_structs_test, empty_input)
 {
+  using V  = int32_t;    // Type of Aggregation Column.
+  using M0 = int32_t;    // Type of STRUCT's first (i.e. 0th) member.
   using M1 = TypeParam;  // Type of STRUCT's second (i.e. 1th) member.
+  using R  = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
   auto values   = fwcw<V> {};
   auto member_0 = fwcw<M0>{};
   auto member_1 = fwcw<M1>{};
-  auto member_2 = strings {};
-  auto keys     = structs{member_0, member_1, member_2};
+  auto member_2 = cudf::test::strings_column_wrapper {};
+  auto keys     = cudf::test::structs_column_wrapper{member_0, member_1, member_2};
 
   auto expected_values   = fwcw<R> {};
   auto expected_member_0 = fwcw<M0>{};
   auto expected_member_1 = fwcw<M1>{};
-  auto expected_member_2 = strings {};
-  auto expected_keys     = structs{expected_member_0, expected_member_1, expected_member_2};
+  auto expected_member_2 = cudf::test::strings_column_wrapper {};
+  auto expected_keys     = cudf::test::structs_column_wrapper{expected_member_0, expected_member_1, expected_member_2};
   // clang-format on
 
   test_sum_agg(keys, values, expected_keys, expected_values);
@@ -258,20 +272,23 @@ TYPED_TEST(groupby_structs_test, empty_input)
 
 TYPED_TEST(groupby_structs_test, all_null_input)
 {
+  using V  = int32_t;    // Type of Aggregation Column.
+  using M0 = int32_t;    // Type of STRUCT's first (i.e. 0th) member.
   using M1 = TypeParam;  // Type of STRUCT's second (i.e. 1th) member.
+  using R  = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
   // clang-format off
   auto values   = fwcw<V> {  0,    1,    2,    3,    4,    5,    6,    7,    8,    9};
   auto member_0 = fwcw<M0>{  1,    2,    3,    1,    2,    2,    1,    3,    3,    2};
   auto member_1 = fwcw<M1>{ 11,   22,   33,   11,   22,   22,   11,   33,   33,   22};
-  auto member_2 = strings {"11", "22", "33", "11", "22", "22", "11", "33", "33", "22"};
-  auto keys     = structs{{member_0, member_1, member_2}, all_nulls()};
+  auto member_2 = cudf::test::strings_column_wrapper {"11", "22", "33", "11", "22", "22", "11", "33", "33", "22"};
+  auto keys     = cudf::test::structs_column_wrapper{{member_0, member_1, member_2}, all_nulls()};
 
   auto expected_values   = fwcw<R> {    45 };
   auto expected_member_0 = fwcw<M0>{ null };
   auto expected_member_1 = fwcw<M1>{ null };
-  auto expected_member_2 = strings {"null"};
-  auto expected_keys     = structs{{expected_member_0, expected_member_1, expected_member_2}, all_nulls()};
+  auto expected_member_2 = cudf::test::strings_column_wrapper {"null"};
+  auto expected_keys     = cudf::test::structs_column_wrapper{{expected_member_0, expected_member_1, expected_member_2}, all_nulls()};
   // clang-format on
 
   test_sum_agg(keys, values, expected_keys, expected_values);
@@ -279,6 +296,8 @@ TYPED_TEST(groupby_structs_test, all_null_input)
 
 TYPED_TEST(groupby_structs_test, lists_are_unsupported)
 {
+  using V  = int32_t;    // Type of Aggregation Column.
+  using M0 = int32_t;    // Type of STRUCT's first (i.e. 0th) member.
   using M1 = TypeParam;  // Type of STRUCT's second (i.e. 1th) member.
 
   // clang-format off
@@ -286,10 +305,7 @@ TYPED_TEST(groupby_structs_test, lists_are_unsupported)
   auto member_0 = lcw<M0> { {1,1},  {2,2},  {3,3},   {1,1},   {2,2} };
   auto member_1 = fwcw<M1>{     1,      2,      3,      1,       2  };
   // clang-format on
-  auto keys = structs{{member_0, member_1}};
+  auto keys = cudf::test::structs_column_wrapper{{member_0, member_1}};
 
   EXPECT_THROW(test_sum_agg(keys, values, keys, values), cudf::logic_error);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/sum_of_squares_tests.cpp
+++ b/cpp/tests/groupby/sum_of_squares_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,119 +25,119 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_sum_of_squares_test : public cudf::test::BaseFixture {
 };
 
 using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
-using K               = int32_t;
 
 TYPED_TEST_SUITE(groupby_sum_of_squares_test, supported_types);
 
 TYPED_TEST(groupby_sum_of_squares_test, basic)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM_OF_SQUARES>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   //  { 1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
   //  { 0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({45., 123., 117.}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({45., 123., 117.}, no_nulls());
 
-  auto agg = cudf::make_sum_of_squares_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_of_squares_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_sum_of_squares_test, empty_cols)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM_OF_SQUARES>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_sum_of_squares_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_of_squares_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_sum_of_squares_test, zero_valid_keys)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM_OF_SQUARES>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals{3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_sum_of_squares_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_of_squares_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_sum_of_squares_test, zero_valid_values)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM_OF_SQUARES>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
-  auto agg = cudf::make_sum_of_squares_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_of_squares_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_sum_of_squares_test, null_keys_and_values)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM_OF_SQUARES>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
   //  { 3, 6,     1, 4, 9,   2, 8,    3}
-  fixed_width_column_wrapper<R> expect_vals({45., 98., 68., 9.}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({45., 98., 68., 9.}, {1, 1, 1, 0});
 
-  auto agg = cudf::make_sum_of_squares_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_of_squares_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 TYPED_TEST(groupby_sum_of_squares_test, dictionary)
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM_OF_SQUARES>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM_OF_SQUARES>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  //                                        {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
-  //                                        {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({45.,       123.,       117.   }, no_nulls());
+  //                                                    {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
+  //                                                    {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({45.,       123.,       117.   }, no_nulls());
   // clang-format on
 
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
-                  cudf::make_sum_of_squares_aggregation<groupby_aggregation>());
+                  cudf::make_sum_of_squares_aggregation<cudf::groupby_aggregation>());
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/sum_scan_tests.cpp
+++ b/cpp/tests/groupby/sum_scan_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,19 +23,14 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 
-using namespace cudf::test::iterators;
-
-namespace cudf {
-namespace test {
-using K           = int32_t;
-using key_wrapper = fixed_width_column_wrapper<K>;
+using key_wrapper = cudf::test::fixed_width_column_wrapper<int32_t>;
 
 template <typename T>
 struct groupby_sum_scan_test : public cudf::test::BaseFixture {
   using V              = T;
-  using R              = cudf::detail::target_type_t<V, aggregation::SUM>;
-  using value_wrapper  = fixed_width_column_wrapper<V, int32_t>;
-  using result_wrapper = fixed_width_column_wrapper<R, int32_t>;
+  using R              = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
+  using value_wrapper  = cudf::test::fixed_width_column_wrapper<V, int32_t>;
+  using result_wrapper = cudf::test::fixed_width_column_wrapper<R, int32_t>;
 };
 
 using supported_types =
@@ -57,7 +52,7 @@ TYPED_TEST(groupby_sum_scan_test, basic)
   //                        {0, 3, 6, 1, 4, 5, 9, 2, 7, 8}
   result_wrapper expect_vals{0, 3, 9, 1, 5, 10, 19, 2, 9, 17};
   // clang-format on
-  auto agg = cudf::make_sum_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -74,9 +69,14 @@ TYPED_TEST(groupby_sum_scan_test, pre_sorted)
   result_wrapper expect_vals{0, 3, 9, 1, 5, 10, 19, 2, 9, 17};
   // clang-format on
 
-  auto agg = cudf::make_sum_aggregation<groupby_scan_aggregation>();
-  test_single_scan(
-    keys, vals, expect_keys, expect_vals, std::move(agg), null_policy::EXCLUDE, sorted::YES);
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_scan_aggregation>();
+  test_single_scan(keys,
+                   vals,
+                   expect_keys,
+                   expect_vals,
+                   std::move(agg),
+                   cudf::null_policy::EXCLUDE,
+                   cudf::sorted::YES);
 }
 
 TYPED_TEST(groupby_sum_scan_test, empty_cols)
@@ -92,7 +92,7 @@ TYPED_TEST(groupby_sum_scan_test, empty_cols)
   result_wrapper expect_vals{};
   // clang-format on
 
-  auto agg = cudf::make_sum_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -101,15 +101,12 @@ TYPED_TEST(groupby_sum_scan_test, zero_valid_keys)
   using value_wrapper  = typename TestFixture::value_wrapper;
   using result_wrapper = typename TestFixture::result_wrapper;
 
-  // clang-format off
-  key_wrapper keys({1, 2, 3}, all_nulls());
+  key_wrapper keys({1, 2, 3}, cudf::test::iterators::all_nulls());
   value_wrapper vals{3, 4, 5};
-
   key_wrapper expect_keys{};
   result_wrapper expect_vals{};
-  // clang-format on
 
-  auto agg = cudf::make_sum_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -118,15 +115,12 @@ TYPED_TEST(groupby_sum_scan_test, zero_valid_values)
   using value_wrapper  = typename TestFixture::value_wrapper;
   using result_wrapper = typename TestFixture::result_wrapper;
 
-  // clang-format off
-  key_wrapper keys   {1, 1, 1};
-  value_wrapper vals({3, 4, 5}, all_nulls());
+  key_wrapper keys{1, 1, 1};
+  value_wrapper vals({3, 4, 5}, cudf::test::iterators::all_nulls());
+  key_wrapper expect_keys{1, 1, 1};
+  result_wrapper expect_vals({3, 4, 5}, cudf::test::iterators::all_nulls());
 
-  key_wrapper expect_keys    {1, 1, 1};
-  result_wrapper expect_vals({3, 4, 5}, all_nulls());
-  // clang-format on
-
-  auto agg = cudf::make_sum_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
@@ -140,28 +134,28 @@ TYPED_TEST(groupby_sum_scan_test, null_keys_and_values)
   value_wrapper vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4}, {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //                         { 1, 1, 1, 2, 2,  2,  2, 3, *, 3, 4};
-  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2,  2, 3,    3, 4}, no_nulls());
+  key_wrapper expect_keys(   { 1, 1, 1, 2, 2,  2,  2, 3,    3, 4}, cudf::test::iterators::no_nulls());
                           // { -, 3, 6, 1, 4,  -,  9, 2, _, 8, -}
   result_wrapper expect_vals({-1, 3, 9, 1, 5, -1, 14, 2,   10, -1},
                              { 0, 1, 1, 1, 1,  0,  1, 1,    1, 0});
   // clang-format on
 
-  auto agg = cudf::make_sum_aggregation<groupby_scan_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_scan_aggregation>();
   test_single_scan(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
 template <typename T>
-struct FixedPointTestAllReps : public cudf::test::BaseFixture {
+struct GroupBySumScanFixedPointTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(FixedPointTestAllReps, cudf::test::FixedPointTypes);
+TYPED_TEST_SUITE(GroupBySumScanFixedPointTest, cudf::test::FixedPointTypes);
 
-TYPED_TEST(FixedPointTestAllReps, GroupBySortSumScanDecimalAsValue)
+TYPED_TEST(GroupBySumScanFixedPointTest, GroupBySortSumScanDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;
   using RepType    = cudf::device_storage_type_t<decimalXX>;
-  using fp_wrapper = fixed_point_column_wrapper<RepType>;
+  using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
 
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
@@ -173,10 +167,7 @@ TYPED_TEST(FixedPointTestAllReps, GroupBySortSumScanDecimalAsValue)
     auto const expect_vals_sum = fp_wrapper{{0, 3, 9, 1, 5, 10, 19, 2, 9, 17}, scale};
     // clang-format on
 
-    auto agg2 = cudf::make_sum_aggregation<groupby_scan_aggregation>();
+    auto agg2 = cudf::make_sum_aggregation<cudf::groupby_scan_aggregation>();
     test_single_scan(keys, vals, expect_keys, expect_vals_sum, std::move(agg2));
   }
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/sum_tests.cpp
+++ b/cpp/tests/groupby/sum_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_sum_test : public cudf::test::BaseFixture {
 };
@@ -41,118 +39,115 @@ TYPED_TEST_SUITE(groupby_sum_test, supported_types);
 TYPED_TEST(groupby_sum_test, basic)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
-  fixed_width_column_wrapper<R> expect_vals{9, 19, 17};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{9, 19, 17};
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_sum_test, empty_cols)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_sum_test, zero_valid_keys)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals{3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, cudf::test::iterators::all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_sum_test, zero_valid_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, cudf::test::iterators::all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, cudf::test::iterators::all_nulls());
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
 
 TYPED_TEST(groupby_sum_test, null_keys_and_values)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   //  { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4},
+                                                        cudf::test::iterators::no_nulls());
   //  { 3, 6,     1, 4, 9,   2, 8,    -}
-  fixed_width_column_wrapper<R> expect_vals({9, 14, 10, 0}, {1, 1, 1, 0});
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({9, 14, 10, 0}, {1, 1, 1, 0});
 
-  auto agg = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 
-  auto agg2 = cudf::make_sum_aggregation<groupby_aggregation>();
+  auto agg2 = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg2), force_use_sort_impl::YES);
 }
-// clang-format on
 
 TYPED_TEST(groupby_sum_test, dictionary)
 {
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::SUM>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::SUM>;
 
-  // clang-format off
-  fixed_width_column_wrapper<K> keys{ 1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-
-  fixed_width_column_wrapper<K> expect_keys{ 1, 2,  3 };
-  fixed_width_column_wrapper<R> expect_vals{ 9, 19, 17};
-  // clang-format on
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::dictionary_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{9, 19, 17};
 
   test_single_agg(
-    keys, vals, expect_keys, expect_vals, cudf::make_sum_aggregation<groupby_aggregation>());
+    keys, vals, expect_keys, expect_vals, cudf::make_sum_aggregation<cudf::groupby_aggregation>());
   test_single_agg(keys,
                   vals,
                   expect_keys,
                   expect_vals,
-                  cudf::make_sum_aggregation<groupby_aggregation>(),
+                  cudf::make_sum_aggregation<cudf::groupby_aggregation>(),
                   force_use_sort_impl::YES);
 }
 
@@ -160,8 +155,8 @@ struct overflow_test : public cudf::test::BaseFixture {
 };
 TEST_F(overflow_test, overflow_integer)
 {
-  using int32_col = fixed_width_column_wrapper<int32_t>;
-  using int64_col = fixed_width_column_wrapper<int64_t>;
+  using int32_col = cudf::test::fixed_width_column_wrapper<int32_t>;
+  using int64_col = cudf::test::fixed_width_column_wrapper<int64_t>;
 
   auto const keys        = int32_col{0, 0};
   auto const vals        = int32_col{-2147483648, -2147483648};
@@ -169,7 +164,7 @@ TEST_F(overflow_test, overflow_integer)
   auto const expect_vals = int64_col{-4294967296L};
 
   auto test_sum = [&](auto const use_sort) {
-    auto agg = make_sum_aggregation<groupby_aggregation>();
+    auto agg = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
     test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg), use_sort);
   };
 
@@ -178,12 +173,12 @@ TEST_F(overflow_test, overflow_integer)
 }
 
 template <typename T>
-struct FixedPointTestAllReps : public cudf::test::BaseFixture {
+struct GroupBySumFixedPointTest : public cudf::test::BaseFixture {
 };
 
-TYPED_TEST_SUITE(FixedPointTestAllReps, cudf::test::FixedPointTypes);
+TYPED_TEST_SUITE(GroupBySumFixedPointTest, cudf::test::FixedPointTypes);
 
-TYPED_TEST(FixedPointTestAllReps, GroupBySortSumDecimalAsValue)
+TYPED_TEST(GroupBySumFixedPointTest, GroupBySortSumDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;
@@ -194,25 +189,25 @@ TYPED_TEST(FixedPointTestAllReps, GroupBySortSumDecimalAsValue)
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
     // clang-format off
-    auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const keys  = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+    auto const vals  = fp_wrapper{                              {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
     // clang-format on
 
-    auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
+    auto const expect_keys     = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_sum = fp_wrapper{{9, 19, 17}, scale};
 
-    auto agg1 = cudf::make_sum_aggregation<groupby_aggregation>();
+    auto agg1 = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
     test_single_agg(
       keys, vals, expect_keys, expect_vals_sum, std::move(agg1), force_use_sort_impl::YES);
 
-    auto agg4 = cudf::make_product_aggregation<groupby_aggregation>();
+    auto agg4 = cudf::make_product_aggregation<cudf::groupby_aggregation>();
     EXPECT_THROW(
       test_single_agg(keys, vals, expect_keys, {}, std::move(agg4), force_use_sort_impl::YES),
       cudf::logic_error);
   }
 }
 
-TYPED_TEST(FixedPointTestAllReps, GroupByHashSumDecimalAsValue)
+TYPED_TEST(GroupBySumFixedPointTest, GroupByHashSumDecimalAsValue)
 {
   using namespace numeric;
   using decimalXX  = TypeParam;
@@ -223,20 +218,17 @@ TYPED_TEST(FixedPointTestAllReps, GroupByHashSumDecimalAsValue)
   for (auto const i : {2, 1, 0, -1, -2}) {
     auto const scale = scale_type{i};
     // clang-format off
-    auto const keys  = fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-    auto const vals  = fp_wrapper{                  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
+    auto const keys  = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+    auto const vals  = fp_wrapper{                              {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, scale};
     // clang-format on
 
-    auto const expect_keys     = fixed_width_column_wrapper<K>{1, 2, 3};
+    auto const expect_keys     = cudf::test::fixed_width_column_wrapper<K>{1, 2, 3};
     auto const expect_vals_sum = fp_wrapper{{9, 19, 17}, scale};
 
-    auto agg5 = cudf::make_sum_aggregation<groupby_aggregation>();
+    auto agg5 = cudf::make_sum_aggregation<cudf::groupby_aggregation>();
     test_single_agg(keys, vals, expect_keys, expect_vals_sum, std::move(agg5));
 
-    auto agg8 = cudf::make_product_aggregation<groupby_aggregation>();
+    auto agg8 = cudf::make_product_aggregation<cudf::groupby_aggregation>();
     EXPECT_THROW(test_single_agg(keys, vals, expect_keys, {}, std::move(agg8)), cudf::logic_error);
   }
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/tdigest_tests.cu
+++ b/cpp/tests/groupby/tdigest_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,26 +14,20 @@
  * limitations under the License.
  */
 
-#include <cudf/detail/aggregation/aggregation.hpp>
-#include <cudf/detail/tdigest/tdigest.hpp>
-#include <cudf/lists/lists_column_view.hpp>
-#include <cudf/tdigest/tdigest_column_view.hpp>
-#include <cudf/utilities/default_stream.hpp>
-
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/tdigest_utilities.cuh>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/detail/aggregation/aggregation.hpp>
+#include <cudf/detail/tdigest/tdigest.hpp>
+#include <cudf/tdigest/tdigest_column_view.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
 #include <thrust/copy.h>
 #include <thrust/fill.h>
 #include <thrust/iterator/counting_iterator.h>
-
-namespace cudf {
-namespace test {
-
-using namespace cudf;
 
 /**
  * @brief Functor to generate a tdigest by key.
@@ -43,7 +37,9 @@ struct tdigest_gen_grouped {
   template <
     typename T,
     typename std::enable_if_t<cudf::is_numeric<T>() || cudf::is_fixed_point<T>()>* = nullptr>
-  std::unique_ptr<column> operator()(column_view const& keys, column_view const& values, int delta)
+  std::unique_ptr<cudf::column> operator()(cudf::column_view const& keys,
+                                           cudf::column_view const& values,
+                                           int delta)
   {
     cudf::table_view t({keys});
     cudf::groupby::groupby gb(t);
@@ -58,7 +54,9 @@ struct tdigest_gen_grouped {
   template <
     typename T,
     typename std::enable_if_t<!cudf::is_numeric<T>() && !cudf::is_fixed_point<T>()>* = nullptr>
-  std::unique_ptr<column> operator()(column_view const& keys, column_view const& values, int delta)
+  std::unique_ptr<cudf::column> operator()(cudf::column_view const& keys,
+                                           cudf::column_view const& values,
+                                           int delta)
   {
     CUDF_FAIL("Invalid tdigest test type");
   }
@@ -69,11 +67,11 @@ struct tdigest_gen_grouped {
  *
  */
 struct tdigest_groupby_simple_op {
-  std::unique_ptr<column> operator()(column_view const& values, int delta) const
+  std::unique_ptr<cudf::column> operator()(cudf::column_view const& values, int delta) const
   {
     // make a simple set of matching keys.
     auto keys = cudf::make_fixed_width_column(
-      data_type{type_id::INT32}, values.size(), mask_state::UNALLOCATED);
+      cudf::data_type{cudf::type_id::INT32}, values.size(), cudf::mask_state::UNALLOCATED);
     thrust::fill(rmm::exec_policy(cudf::get_default_stream()),
                  keys->mutable_view().template begin<int>(),
                  keys->mutable_view().template end<int>(),
@@ -95,11 +93,12 @@ struct tdigest_groupby_simple_op {
  *
  */
 struct tdigest_groupby_simple_merge_op {
-  std::unique_ptr<column> operator()(column_view const& merge_values, int merge_delta) const
+  std::unique_ptr<cudf::column> operator()(cudf::column_view const& merge_values,
+                                           int merge_delta) const
   {
     // make a simple set of matching keys.
     auto merge_keys = cudf::make_fixed_width_column(
-      data_type{type_id::INT32}, merge_values.size(), mask_state::UNALLOCATED);
+      cudf::data_type{cudf::type_id::INT32}, merge_values.size(), cudf::mask_state::UNALLOCATED);
     thrust::fill(rmm::exec_policy(cudf::get_default_stream()),
                  merge_keys->mutable_view().template begin<int>(),
                  merge_keys->mutable_view().template end<int>(),
@@ -125,24 +124,25 @@ TYPED_TEST_SUITE(TDigestAllTypes, cudf::test::NumericTypes);
 TYPED_TEST(TDigestAllTypes, Simple)
 {
   using T = TypeParam;
-  tdigest_simple_aggregation<T>(tdigest_groupby_simple_op{});
+  cudf::test::tdigest_simple_aggregation<T>(tdigest_groupby_simple_op{});
 }
 
 TYPED_TEST(TDigestAllTypes, SimpleWithNulls)
 {
   using T = TypeParam;
-  tdigest_simple_with_nulls_aggregation<T>(tdigest_groupby_simple_op{});
+  cudf::test::tdigest_simple_with_nulls_aggregation<T>(tdigest_groupby_simple_op{});
 }
 
 TYPED_TEST(TDigestAllTypes, AllNull)
 {
   using T = TypeParam;
-  tdigest_simple_all_nulls_aggregation<T>(tdigest_groupby_simple_op{});
+  cudf::test::tdigest_simple_all_nulls_aggregation<T>(tdigest_groupby_simple_op{});
 }
 
 TYPED_TEST(TDigestAllTypes, LargeGroups)
 {
-  auto _values    = generate_standardized_percentile_distribution(data_type{type_id::FLOAT64});
+  auto _values = cudf::test::generate_standardized_percentile_distribution(
+    cudf::data_type{cudf::type_id::FLOAT64});
   int const delta = 1000;
 
   // generate a random set of keys
@@ -150,7 +150,7 @@ TYPED_TEST(TDigestAllTypes, LargeGroups)
   h_keys.reserve(_values->size());
   auto iter = thrust::make_counting_iterator(0);
   std::transform(iter, iter + _values->size(), std::back_inserter(h_keys), [](int i) {
-    return static_cast<int>(round(rand_range(0, 8)));
+    return static_cast<int>(round(cudf::test::rand_range(0, 8)));
   });
   cudf::test::fixed_width_column_wrapper<int> _keys(h_keys.begin(), h_keys.end());
 
@@ -161,8 +161,8 @@ TYPED_TEST(TDigestAllTypes, LargeGroups)
   auto groups = setup_gb.get_groups(v);
 
   // slice it all up so we have keys/columns for everything.
-  std::vector<column_view> keys;
-  std::vector<column_view> values;
+  std::vector<cudf::column_view> keys;
+  std::vector<cudf::column_view> values;
   for (size_t idx = 0; idx < groups.offsets.size() - 1; idx++) {
     auto k =
       cudf::slice(groups.keys->get_column(0), {groups.offsets[idx], groups.offsets[idx + 1]});
@@ -174,7 +174,7 @@ TYPED_TEST(TDigestAllTypes, LargeGroups)
   }
 
   // generate a separate tdigest for each group
-  std::vector<std::unique_ptr<column>> parts;
+  std::vector<std::unique_ptr<cudf::column>> parts;
   std::transform(
     iter, iter + values.size(), std::back_inserter(parts), [&keys, &values, delta](int i) {
       cudf::table_view t({keys[i]});
@@ -186,11 +186,11 @@ TYPED_TEST(TDigestAllTypes, LargeGroups)
       auto result = gb.aggregate(requests);
       return std::move(result.second[0].results[0]);
     });
-  std::vector<column_view> part_views;
+  std::vector<cudf::column_view> part_views;
   std::transform(parts.begin(),
                  parts.end(),
                  std::back_inserter(part_views),
-                 [](std::unique_ptr<column> const& col) { return col->view(); });
+                 [](std::unique_ptr<cudf::column> const& col) { return col->view(); });
   auto merged_parts = cudf::concatenate(part_views);
 
   // generate a tdigest on the whole input set
@@ -224,30 +224,31 @@ TEST_F(TDigestTest, EmptyMixed)
   requests.push_back({values, std::move(aggregations)});
   auto result = gb.aggregate(requests);
 
-  using FCW     = cudf::test::fixed_width_column_wrapper<double>;
-  auto expected = make_expected_tdigest_column({{FCW{}, FCW{}, 0, 0},
-                                                {FCW{123456.78}, FCW{1.0}, 123456.78, 123456.78},
-                                                {FCW{25.0}, FCW{1.0}, 25.0, 25.0},
-                                                {FCW{}, FCW{}, 0, 0},
-                                                {FCW{50.0, 60.0}, FCW{1.0, 1.0}, 50.0, 60.0},
-                                                {FCW{}, FCW{}, 0, 0}});
+  using FCW = cudf::test::fixed_width_column_wrapper<double>;
+  auto expected =
+    cudf::test::make_expected_tdigest_column({{FCW{}, FCW{}, 0, 0},
+                                              {FCW{123456.78}, FCW{1.0}, 123456.78, 123456.78},
+                                              {FCW{25.0}, FCW{1.0}, 25.0, 25.0},
+                                              {FCW{}, FCW{}, 0, 0},
+                                              {FCW{50.0, 60.0}, FCW{1.0, 1.0}, 50.0, 60.0},
+                                              {FCW{}, FCW{}, 0, 0}});
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result.second[0].results[0], *expected);
 }
 
 TEST_F(TDigestTest, LargeInputDouble)
 {
-  tdigest_simple_large_input_double_aggregation(tdigest_groupby_simple_op{});
+  cudf::test::tdigest_simple_large_input_double_aggregation(tdigest_groupby_simple_op{});
 }
 
 TEST_F(TDigestTest, LargeInputInt)
 {
-  tdigest_simple_large_input_int_aggregation(tdigest_groupby_simple_op{});
+  cudf::test::tdigest_simple_large_input_int_aggregation(tdigest_groupby_simple_op{});
 }
 
 TEST_F(TDigestTest, LargeInputDecimal)
 {
-  tdigest_simple_large_input_decimal_aggregation(tdigest_groupby_simple_op{});
+  cudf::test::tdigest_simple_large_input_decimal_aggregation(tdigest_groupby_simple_op{});
 }
 
 struct TDigestMergeTest : public cudf::test::BaseFixture {
@@ -257,19 +258,20 @@ struct TDigestMergeTest : public cudf::test::BaseFixture {
 // the same regardless of input.
 TEST_F(TDigestMergeTest, Simple)
 {
-  tdigest_merge_simple(tdigest_groupby_simple_op{}, tdigest_groupby_simple_merge_op{});
+  cudf::test::tdigest_merge_simple(tdigest_groupby_simple_op{}, tdigest_groupby_simple_merge_op{});
 }
 
 struct key_groups {
-  __device__ size_type operator()(size_type i) { return i < 250000 ? 0 : 1; }
+  __device__ cudf::size_type operator()(cudf::size_type i) { return i < 250000 ? 0 : 1; }
 };
 TEST_F(TDigestMergeTest, Grouped)
 {
-  auto values = generate_standardized_percentile_distribution(data_type{type_id::FLOAT64});
+  auto values = cudf::test::generate_standardized_percentile_distribution(
+    cudf::data_type{cudf::type_id::FLOAT64});
   CUDF_EXPECTS(values->size() == 750000, "Unexpected distribution size");
   // all in the same group
   auto keys = cudf::make_fixed_width_column(
-    data_type{type_id::INT32}, values->size(), mask_state::UNALLOCATED);
+    cudf::data_type{cudf::type_id::INT32}, values->size(), cudf::mask_state::UNALLOCATED);
   // 3 groups. 0-250000 in group 0.  250000-500000 in group 1 and 500000-750000 in group 1
   auto key_iter = cudf::detail::make_counting_transform_iterator(0, key_groups{});
   thrust::copy(rmm::exec_policy(cudf::get_default_stream()),
@@ -284,7 +286,7 @@ TEST_F(TDigestMergeTest, Grouped)
   int const delta = 1000;
 
   // generate separate digests
-  std::vector<std::unique_ptr<column>> parts;
+  std::vector<std::unique_ptr<cudf::column>> parts;
   auto iter = thrust::make_counting_iterator(0);
   std::transform(
     iter,
@@ -300,11 +302,11 @@ TEST_F(TDigestMergeTest, Grouped)
       auto result = gb.aggregate(requests);
       return std::move(result.second[0].results[0]);
     });
-  std::vector<column_view> part_views;
+  std::vector<cudf::column_view> part_views;
   std::transform(parts.begin(),
                  parts.end(),
                  std::back_inserter(part_views),
-                 [](std::unique_ptr<column> const& col) { return col->view(); });
+                 [](std::unique_ptr<cudf::column> const& col) { return col->view(); });
 
   // merge delta = 1000
   {
@@ -326,38 +328,38 @@ TEST_F(TDigestMergeTest, Grouped)
     cudf::tdigest::tdigest_column_view tdv(*result.second[0].results[0]);
 
     // verify centroids
-    std::vector<expected_value> expected{// group 0
-                                         {0, 0.00013945158577498588, 2},
-                                         {10, 0.04804393446447509375, 50},
-                                         {66, 2.10089484962640948851, 316},
-                                         {139, 8.92977366346101852912, 601},
-                                         {243, 23.89152910016953867967, 784},
-                                         {366, 41.62636569363655780762, 586},
-                                         {432, 47.73085102980330418632, 326},
-                                         {460, 49.20637897385523018556, 196},
-                                         {501, 49.99998311512171511595, 1},
-                                         // group 1
-                                         {502 + 0, 50.00022508669655252334, 2},
-                                         {502 + 15, 50.05415694538910287292, 74},
-                                         {502 + 70, 51.21421484112906341579, 334},
-                                         {502 + 150, 55.19367617848146778670, 635},
-                                         {502 + 260, 63.24605285552920008740, 783},
-                                         {502 + 380, 76.99522005804017510400, 1289},
-                                         {502 + 440, 84.22673817294192133431, 758},
-                                         {502 + 490, 88.11787981529532487457, 784},
-                                         {502 + 555, 93.02766411136053648079, 704},
-                                         {502 + 618, 96.91486035315536184953, 516},
-                                         {502 + 710, 99.87755861436669135855, 110},
-                                         {502 + 733, 99.99970905482754801596, 1}};
-    tdigest_sample_compare(tdv, expected);
+    std::vector<cudf::test::expected_value> expected{// group 0
+                                                     {0, 0.00013945158577498588, 2},
+                                                     {10, 0.04804393446447509375, 50},
+                                                     {66, 2.10089484962640948851, 316},
+                                                     {139, 8.92977366346101852912, 601},
+                                                     {243, 23.89152910016953867967, 784},
+                                                     {366, 41.62636569363655780762, 586},
+                                                     {432, 47.73085102980330418632, 326},
+                                                     {460, 49.20637897385523018556, 196},
+                                                     {501, 49.99998311512171511595, 1},
+                                                     // group 1
+                                                     {502 + 0, 50.00022508669655252334, 2},
+                                                     {502 + 15, 50.05415694538910287292, 74},
+                                                     {502 + 70, 51.21421484112906341579, 334},
+                                                     {502 + 150, 55.19367617848146778670, 635},
+                                                     {502 + 260, 63.24605285552920008740, 783},
+                                                     {502 + 380, 76.99522005804017510400, 1289},
+                                                     {502 + 440, 84.22673817294192133431, 758},
+                                                     {502 + 490, 88.11787981529532487457, 784},
+                                                     {502 + 555, 93.02766411136053648079, 704},
+                                                     {502 + 618, 96.91486035315536184953, 516},
+                                                     {502 + 710, 99.87755861436669135855, 110},
+                                                     {502 + 733, 99.99970905482754801596, 1}};
+    cudf::test::tdigest_sample_compare(tdv, expected);
 
     // verify min/max
     auto split_results = cudf::split(*result.second[0].results[0], {1});
     auto iter          = thrust::make_counting_iterator(0);
-    std::for_each(iter, iter + split_results.size(), [&](size_type i) {
-      auto copied = std::make_unique<column>(split_results[i]);
-      tdigest_minmax_compare<double>(cudf::tdigest::tdigest_column_view(*copied),
-                                     grouped_split_values[i]);
+    std::for_each(iter, iter + split_results.size(), [&](cudf::size_type i) {
+      auto copied = std::make_unique<cudf::column>(split_results[i]);
+      cudf::test::tdigest_minmax_compare<double>(cudf::tdigest::tdigest_column_view(*copied),
+                                                 grouped_split_values[i]);
     });
   }
 
@@ -381,30 +383,30 @@ TEST_F(TDigestMergeTest, Grouped)
     cudf::tdigest::tdigest_column_view tdv(*result.second[0].results[0]);
 
     // verify centroids
-    std::vector<expected_value> expected{// group 0
-                                         {0, 0.02182479870203561656, 231},
-                                         {3, 0.60625795002234528219, 1688},
-                                         {13, 8.40462931740497687372, 5867},
-                                         {27, 28.79997783486397722186, 7757},
-                                         {35, 40.22391421196020644402, 6224},
-                                         {45, 48.96506331299028857984, 2225},
-                                         {50, 49.99979491345574444949, 4},
-                                         // group 1
-                                         {51 + 0, 50.02171921312970681583, 460},
-                                         {51 + 5, 51.45308398121498072442, 5074},
-                                         {51 + 11, 55.96880716301625113829, 10011},
-                                         {51 + 22, 70.18029861315150697010, 15351},
-                                         {51 + 38, 92.65943436519887654867, 10718},
-                                         {51 + 47, 99.27745505225347244505, 3639}};
-    tdigest_sample_compare(tdv, expected);
+    std::vector<cudf::test::expected_value> expected{// group 0
+                                                     {0, 0.02182479870203561656, 231},
+                                                     {3, 0.60625795002234528219, 1688},
+                                                     {13, 8.40462931740497687372, 5867},
+                                                     {27, 28.79997783486397722186, 7757},
+                                                     {35, 40.22391421196020644402, 6224},
+                                                     {45, 48.96506331299028857984, 2225},
+                                                     {50, 49.99979491345574444949, 4},
+                                                     // group 1
+                                                     {51 + 0, 50.02171921312970681583, 460},
+                                                     {51 + 5, 51.45308398121498072442, 5074},
+                                                     {51 + 11, 55.96880716301625113829, 10011},
+                                                     {51 + 22, 70.18029861315150697010, 15351},
+                                                     {51 + 38, 92.65943436519887654867, 10718},
+                                                     {51 + 47, 99.27745505225347244505, 3639}};
+    cudf::test::tdigest_sample_compare(tdv, expected);
 
     // verify min/max
     auto split_results = cudf::split(*result.second[0].results[0], {1});
     auto iter          = thrust::make_counting_iterator(0);
-    std::for_each(iter, iter + split_results.size(), [&](size_type i) {
-      auto copied = std::make_unique<column>(split_results[i]);
-      tdigest_minmax_compare<double>(cudf::tdigest::tdigest_column_view(*copied),
-                                     grouped_split_values[i]);
+    std::for_each(iter, iter + split_results.size(), [&](cudf::size_type i) {
+      auto copied = std::make_unique<cudf::column>(split_results[i]);
+      cudf::test::tdigest_minmax_compare<double>(cudf::tdigest::tdigest_column_view(*copied),
+                                                 grouped_split_values[i]);
     });
   }
 
@@ -428,34 +430,37 @@ TEST_F(TDigestMergeTest, Grouped)
     cudf::tdigest::tdigest_column_view tdv(*result.second[0].results[0]);
 
     // verify centroids
-    std::vector<expected_value> expected{// group 0
-                                         {0, 2.34644806683495144028, 23623},
-                                         {1, 10.95523693698660672169, 62290},
-                                         {2, 24.90731657803452847588, 77208},
-                                         {3, 38.88062495289155862110, 62658},
-                                         {4, 47.56288303840698006297, 24217},
-                                         {5, 49.99979491345574444949, 4},
-                                         // group 1
-                                         {6 + 0, 52.40174463129091719793, 47410},
-                                         {6 + 1, 60.97025126481504031517, 124564},
-                                         {6 + 2, 74.91722742839780835311, 154387},
-                                         {6 + 3, 88.87559489177009197647, 124810},
-                                         {6 + 4, 97.55823307073454486726, 48817},
-                                         {6 + 5, 99.99901807905750672489, 12}};
-    tdigest_sample_compare(tdv, expected);
+    std::vector<cudf::test::expected_value> expected{// group 0
+                                                     {0, 2.34644806683495144028, 23623},
+                                                     {1, 10.95523693698660672169, 62290},
+                                                     {2, 24.90731657803452847588, 77208},
+                                                     {3, 38.88062495289155862110, 62658},
+                                                     {4, 47.56288303840698006297, 24217},
+                                                     {5, 49.99979491345574444949, 4},
+                                                     // group 1
+                                                     {6 + 0, 52.40174463129091719793, 47410},
+                                                     {6 + 1, 60.97025126481504031517, 124564},
+                                                     {6 + 2, 74.91722742839780835311, 154387},
+                                                     {6 + 3, 88.87559489177009197647, 124810},
+                                                     {6 + 4, 97.55823307073454486726, 48817},
+                                                     {6 + 5, 99.99901807905750672489, 12}};
+    cudf::test::tdigest_sample_compare(tdv, expected);
 
     // verify min/max
     auto split_results = cudf::split(*result.second[0].results[0], {1});
     auto iter          = thrust::make_counting_iterator(0);
-    std::for_each(iter, iter + split_results.size(), [&](size_type i) {
-      auto copied = std::make_unique<column>(split_results[i]);
-      tdigest_minmax_compare<double>(cudf::tdigest::tdigest_column_view(*copied),
-                                     grouped_split_values[i]);
+    std::for_each(iter, iter + split_results.size(), [&](cudf::size_type i) {
+      auto copied = std::make_unique<cudf::column>(split_results[i]);
+      cudf::test::tdigest_minmax_compare<double>(cudf::tdigest::tdigest_column_view(*copied),
+                                                 grouped_split_values[i]);
     });
   }
 }
 
-TEST_F(TDigestMergeTest, Empty) { tdigest_merge_empty(tdigest_groupby_simple_merge_op{}); }
+TEST_F(TDigestMergeTest, Empty)
+{
+  cudf::test::tdigest_merge_empty(tdigest_groupby_simple_merge_op{});
+}
 
 TEST_F(TDigestMergeTest, EmptyGroups)
 {
@@ -468,13 +473,13 @@ TEST_F(TDigestMergeTest, EmptyGroups)
 
   auto a = cudf::tdigest::detail::make_empty_tdigest_column(cudf::get_default_stream());
   auto b = cudf::type_dispatcher(
-    static_cast<column_view>(values_b).type(), tdigest_gen_grouped{}, keys, values_b, delta);
+    static_cast<cudf::column_view>(values_b).type(), tdigest_gen_grouped{}, keys, values_b, delta);
   auto c = cudf::tdigest::detail::make_empty_tdigest_column(cudf::get_default_stream());
   auto d = cudf::type_dispatcher(
-    static_cast<column_view>(values_d).type(), tdigest_gen_grouped{}, keys, values_d, delta);
+    static_cast<cudf::column_view>(values_d).type(), tdigest_gen_grouped{}, keys, values_d, delta);
   auto e = cudf::tdigest::detail::make_empty_tdigest_column(cudf::get_default_stream());
 
-  std::vector<column_view> cols;
+  std::vector<cudf::column_view> cols;
   cols.push_back(*a);
   cols.push_back(*b);
   cols.push_back(*c);
@@ -496,11 +501,8 @@ TEST_F(TDigestMergeTest, EmptyGroups)
   cudf::test::fixed_width_column_wrapper<double> expected_means{
     2, 55, 67, 99, 100, 126, 200, 300, 400, 500, 600};
   cudf::test::fixed_width_column_wrapper<double> expected_weights{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-  auto expected = make_expected_tdigest_column(
+  auto expected = cudf::test::make_expected_tdigest_column(
     {{expected_means, expected_weights, 2, 600}, {FCW{}, FCW{}, 0, 0}, {FCW{}, FCW{}, 0, 0}});
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *result.second[0].results[0]);
 }
-
-}  // namespace test
-}  // namespace cudf

--- a/cpp/tests/groupby/var_tests.cpp
+++ b/cpp/tests/groupby/var_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#ifdef NDEBUG  // currently groupby variance tests are not supported. See groupstd.cu
-
 #include <tests/groupby/groupby_test_util.hpp>
 
 #include <cudf_test/base_fixture.hpp>
@@ -27,137 +25,169 @@
 
 using namespace cudf::test::iterators;
 
-namespace cudf {
-namespace test {
 template <typename V>
 struct groupby_var_test : public cudf::test::BaseFixture {
 };
-using K = int32_t;
 
 using supported_types = cudf::test::Types<int8_t, int16_t, int32_t, int64_t, float, double>;
 
 TYPED_TEST_SUITE(groupby_var_test, supported_types);
 
+#ifdef NDEBUG
 TYPED_TEST(groupby_var_test, basic)
+#else
+TYPED_TEST(groupby_var_test, DISABLED_basic)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::VARIANCE>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::fixed_width_column_wrapper<V> vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  //                                       {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys{1,        2,           3};
-  //                                       {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({9.,      131. / 12,   31. / 3}, no_nulls());
+  //                                                   {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1,        2,           3};
+  //                                                   {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({9.,      131. / 12,   31. / 3}, no_nulls());
   // clang-format on
 
   auto agg = cudf::make_variance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG
 TYPED_TEST(groupby_var_test, empty_cols)
+#else
+TYPED_TEST(groupby_var_test, DISABLED_empty_cols)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::VARIANCE>;
 
-  fixed_width_column_wrapper<K> keys{};
-  fixed_width_column_wrapper<V> vals{};
+  cudf::test::fixed_width_column_wrapper<K> keys{};
+  cudf::test::fixed_width_column_wrapper<V> vals{};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   auto agg = cudf::make_variance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG
 TYPED_TEST(groupby_var_test, zero_valid_keys)
+#else
+TYPED_TEST(groupby_var_test, DISABLED_zero_valid_keys)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::VARIANCE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
-  fixed_width_column_wrapper<V> vals{3, 4, 5};
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<V> vals{3, 4, 5};
 
-  fixed_width_column_wrapper<K> expect_keys{};
-  fixed_width_column_wrapper<R> expect_vals{};
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals{};
 
   auto agg = cudf::make_variance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG
 TYPED_TEST(groupby_var_test, zero_valid_values)
+#else
+TYPED_TEST(groupby_var_test, DISABLED_zero_valid_values)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::VARIANCE>;
 
-  fixed_width_column_wrapper<K> keys{1, 1, 1};
-  fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
+  cudf::test::fixed_width_column_wrapper<V> vals({3, 4, 5}, all_nulls());
 
-  fixed_width_column_wrapper<K> expect_keys{1};
-  fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
+  cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());
 
   auto agg = cudf::make_variance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG
 TYPED_TEST(groupby_var_test, null_keys_and_values)
+#else
+TYPED_TEST(groupby_var_test, DISABLED_null_keys_and_values)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::VARIANCE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
   // clang-format off
-  //                                        {1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_nulls());
-  //                                        {3, 6,     1, 4, 9,   2, 8,    3}
-  fixed_width_column_wrapper<R> expect_vals({4.5,      49. / 3,   18.,     0.}, {1, 1, 1, 0});
+  //                                                    {1, 1,     2, 2, 2,   3, 3,    4}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1,        2,         3,       4}, no_nulls());
+  //                                                    {3, 6,     1, 4, 9,   2, 8,    3}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({4.5,      49. / 3,   18.,     0.}, {1, 1, 1, 0});
   // clang-format on
 
   auto agg = cudf::make_variance_aggregation<cudf::groupby_aggregation>();
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG
 TYPED_TEST(groupby_var_test, ddof_non_default)
+#else
+TYPED_TEST(groupby_var_test, DISABLED_ddof_non_default)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::VARIANCE>;
 
-  fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
-  fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
-                                     {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+                                                 {1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1});
+  cudf::test::fixed_width_column_wrapper<V> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3},
+                                                 {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1});
 
   // clang-format off
-  //                                        { 1, 1,     2, 2, 2,   3, 3,    4}
-  fixed_width_column_wrapper<K> expect_keys({1,         2,         3,       4}, no_nulls());
-  //                                        { 3, 6,     1, 4, 9,   2, 8,    3}
-  fixed_width_column_wrapper<R> expect_vals({0.,        98. / 3,   0.,      0.},
-                                            {0,         1,         0,       0});
+  //                                                    { 1, 1,     2, 2, 2,   3, 3,    4}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1,         2,         3,       4}, no_nulls());
+  //                                                    { 3, 6,     1, 4, 9,   2, 8,    3}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({0.,        98. / 3,   0.,      0.},
+                                                        {0,         1,         0,       0});
   // clang-format on
 
   auto agg = cudf::make_variance_aggregation<cudf::groupby_aggregation>(2);
   test_single_agg(keys, vals, expect_keys, expect_vals, std::move(agg));
 }
 
+#ifdef NDEBUG
 TYPED_TEST(groupby_var_test, dictionary)
+#else
+TYPED_TEST(groupby_var_test, DISABLED_dictionary)
+#endif
 {
+  using K = int32_t;
   using V = TypeParam;
-  using R = cudf::detail::target_type_t<V, aggregation::VARIANCE>;
+  using R = cudf::detail::target_type_t<V, cudf::aggregation::VARIANCE>;
 
   // clang-format off
-  fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
-  dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  cudf::test::dictionary_column_wrapper<V>  vals{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-  //                                        {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
-  fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
-  //                                        {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
-  fixed_width_column_wrapper<R> expect_vals({9.,      131./12,      31./3  }, no_nulls());
+  //                                                    {1, 1, 1,  2, 2, 2, 2,  3, 3, 3}
+  cudf::test::fixed_width_column_wrapper<K> expect_keys({1,        2,           3      });
+  //                                                    {0, 3, 6,  1, 4, 5, 9,  2, 7, 8}
+  cudf::test::fixed_width_column_wrapper<R> expect_vals({9.,      131./12,      31./3  }, no_nulls());
   // clang-format on
 
   test_single_agg(keys,
@@ -166,8 +196,3 @@ TYPED_TEST(groupby_var_test, dictionary)
                   expect_vals,
                   cudf::make_variance_aggregation<cudf::groupby_aggregation>());
 }
-
-}  // namespace test
-}  // namespace cudf
-
-#endif  // NDEBUG

--- a/cpp/tests/replace/replace_nulls_tests.cpp
+++ b/cpp/tests/replace/replace_nulls_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Copyright 2018 BlazingDB, Inc.
  *     Copyright 2018 Alexander Ocsa <cristhian@blazingdb.com>
@@ -17,22 +17,20 @@
  * limitations under the License.
  */
 
-#include <cudf/replace.hpp>
-
-#include <tests/groupby/groupby_test_util.hpp>
-
-#include <cudf/dictionary/encode.hpp>
-#include <cudf/fixed_point/fixed_point.hpp>
-#include <cudf/scalar/scalar.hpp>
-#include <cudf/scalar/scalar_factories.hpp>
-#include <cudf/utilities/default_stream.hpp>
-#include <cudf/utilities/error.hpp>
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
 #include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
+
+#include <cudf/dictionary/encode.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
+#include <cudf/replace.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/error.hpp>
 
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>


### PR DESCRIPTION
## Description
Fixes `GROUPBY_TEST` gtests source files coded in namespace `cudf::test`
Additional creates a `groupby_test_util.cpp` for utilities rather than inlining the utilities into all 33 source files.
The groupby tests for aggregations `std` and `var` are also not compiled for Debug builds. 
This changes those to compile but be runtime disabled to make them more noticeable in a Debug test run.

Reference https://github.com/rapidsai/cudf/issues/11734

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
