### PR TITLE
Implement initial support for avro logical types (#6482)

### DIFF
--- a/cpp/src/io/avro/avro.hpp
+++ b/cpp/src/io/avro/avro.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,8 @@ struct schema_entry {
   int32_t parent_idx   = -1;  // index of parent entry in schema array, negative if no parent
   int32_t num_children = 0;
   type_kind_e kind     = type_not_set;
-  std::string name     = "";
+  logicaltype_kind_e logical_kind = logicaltype_not_set;
+  std::string name                = "";
   std::vector<std::string> symbols;
 };
 

--- a/cpp/src/io/avro/avro_common.hpp
+++ b/cpp/src/io/avro/avro_common.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,74 @@ enum type_kind_e {
   type_record,
   type_union,
   type_array,
+  type_fixed,
+  // Logical types
+  type_decimal,
+  type_uuid,
+  type_date,
+  type_time_millis,
+  type_time_micros,
+  type_timestamp_millis,
+  type_timestamp_micros,
+  type_local_timestamp_millis,
+  type_local_timestamp_micros,
+  type_duration,
 };
+
+enum logicaltype_kind_e {
+  logicaltype_not_set = 0,
+  // N.B. We intentionally mirror the logicaltype enum values with their
+  //      equivalent type enum value, as this allows us to cast the type
+  //      value directly to a logical type without an intermediate
+  //      mapping step, and vice versa, e.g.:
+  //
+  //        auto kind = type_date;
+  //        auto logical_kind = static_cast<logical_kind_e>(type_date);
+  //        // logical_kind == logicaltype_kind_e::logicaltype_date
+  //
+  //      And:
+  //
+  //        auto logical_kind = logicaltype_date;
+  //        auto kind = static_cast<type_kind_e>(logical_kind);
+  //        // kind == type_kind_e::type_date
+  //
+  logicaltype_decimal = type_decimal,
+  logicaltype_uuid,
+  logicaltype_date,
+  logicaltype_time_millis,
+  logicaltype_time_micros,
+  logicaltype_timestamp_millis,
+  logicaltype_timestamp_micros,
+  logicaltype_local_timestamp_millis,
+  logicaltype_local_timestamp_micros,
+  logicaltype_duration,
+};
+
+/**
+ * @brief Determines if the supplied logical type is currently supported.
+ *
+ * @param[in] logical_kind Supplies the logicaltype_kind_e enum value.
+ *
+ * @return true if the logical type is supported, false otherwise.
+ */
+inline bool __host__ __device__ is_supported_logical_type(logicaltype_kind_e logical_kind)
+{
+  switch (logical_kind) {
+    case logicaltype_date: return true;
+
+    case logicaltype_not_set:
+    case logicaltype_decimal:
+    case logicaltype_uuid:
+    case logicaltype_time_millis:
+    case logicaltype_time_micros:
+    case logicaltype_timestamp_millis:
+    case logicaltype_timestamp_micros:
+    case logicaltype_local_timestamp_millis:
+    case logicaltype_local_timestamp_micros:
+    case logicaltype_duration:
+    default: return false;
+  }
+}
 
 using cudf::io::detail::string_index_pair;
 

--- a/cpp/src/io/avro/avro_common.hpp
+++ b/cpp/src/io/avro/avro_common.hpp
@@ -106,21 +106,21 @@ enum logicaltype_kind_e {
  *
  * @return true if the logical type is supported, false otherwise.
  */
-inline bool __host__ __device__ is_supported_logical_type(logicaltype_kind_e logical_kind)
+inline constexpr bool is_supported_logical_type(logicaltype_kind_e logical_kind)
 {
   switch (logical_kind) {
     case logicaltype_date: return true;
 
-    case logicaltype_not_set:
-    case logicaltype_decimal:
-    case logicaltype_uuid:
-    case logicaltype_time_millis:
-    case logicaltype_time_micros:
-    case logicaltype_timestamp_millis:
-    case logicaltype_timestamp_micros:
-    case logicaltype_local_timestamp_millis:
-    case logicaltype_local_timestamp_micros:
-    case logicaltype_duration:
+    case logicaltype_not_set: [[fallthrough]];
+    case logicaltype_decimal: [[fallthrough]];
+    case logicaltype_uuid: [[fallthrough]];
+    case logicaltype_time_millis: [[fallthrough]];
+    case logicaltype_time_micros: [[fallthrough]];
+    case logicaltype_timestamp_millis: [[fallthrough]];
+    case logicaltype_timestamp_micros: [[fallthrough]];
+    case logicaltype_local_timestamp_millis: [[fallthrough]];
+    case logicaltype_local_timestamp_micros: [[fallthrough]];
+    case logicaltype_duration: [[fallthrough]];
     default: return false;
   }
 }

--- a/cpp/src/io/avro/avro_gpu.cu
+++ b/cpp/src/io/avro/avro_gpu.cu
@@ -75,7 +75,6 @@ avro_decode_row(schemadesc_s const* schema,
                 uint8_t const* end,
                 device_span<string_index_pair const> global_dictionary)
 {
-  using namespace cudf::io::avro;
   uint32_t array_start = 0, array_repeat_count = 0;
   int array_children = 0;
   for (uint32_t i = 0; i < schema_len;) {
@@ -223,7 +222,7 @@ avro_decode_row(schemadesc_s const* schema,
         //      way of the zig-zag varint encoding, so we can safely treat them
         //      both as int64_t.  Everything else is 64-bit in both avro and
         //      cudf.
-        CUDF_UNREACHABLE("avro type yet implemented");
+        CUDF_UNREACHABLE("avro time/timestamp types not yet implemented");
         int64_t v = avro_decode_zigzag_varint(cur, end);
         if (dataptr != nullptr && row < max_rows) { static_cast<int64_t*>(dataptr)[row] = v; }
       } break;

--- a/cpp/src/io/avro/avro_gpu.cu
+++ b/cpp/src/io/avro/avro_gpu.cu
@@ -96,7 +96,11 @@ avro_decode_row(schemadesc_s const* schema,
         --skip;
       }
       if (i >= schema_len || skip_after < 0) break;
-      kind = schema[i].kind;
+      kind         = schema[i].kind;
+      logical_kind = schema[i].logical_kind;
+      if (is_supported_logical_type(logical_kind)) {
+        kind = static_cast<type_kind_e>(logical_kind);
+      }
       skip = skip_after;
     }
 
@@ -110,13 +114,15 @@ avro_decode_row(schemadesc_s const* schema,
         break;
 
       case type_int: {
-        int64_t v                           = avro_decode_zigzag_varint(cur, end);
-        static_cast<int32_t*>(dataptr)[row] = static_cast<int32_t>(v);
+        int64_t v = avro_decode_zigzag_varint(cur, end);
+        if (dataptr != nullptr && row < max_rows) {
+          static_cast<int32_t*>(dataptr)[row] = static_cast<int32_t>(v);
+        }
       } break;
 
       case type_long: {
-        int64_t v                           = avro_decode_zigzag_varint(cur, end);
-        static_cast<int64_t*>(dataptr)[row] = v;
+        int64_t v = avro_decode_zigzag_varint(cur, end);
+        if (dataptr != nullptr && row < max_rows) { static_cast<int64_t*>(dataptr)[row] = v; }
       } break;
 
       case type_bytes: [[fallthrough]];

--- a/cpp/src/io/avro/avro_gpu.cu
+++ b/cpp/src/io/avro/avro_gpu.cu
@@ -110,12 +110,12 @@ avro_decode_row(schemadesc_s const* schema,
         }
         break;
 
-      case type_int:
-      case type_long:
-      case type_bytes:
-      case type_fixed:
-      case type_string:
-      case type_uuid:
+      case type_int: [[fallthrough]];
+      case type_long: [[fallthrough]];
+      case type_bytes: [[fallthrough]];
+      case type_fixed: [[fallthrough]];
+      case type_string: [[fallthrough]];
+      case type_uuid: [[fallthrough]];
       case type_enum: {
         int64_t v = avro_decode_zigzag_varint(cur, end);
         if (kind == type_int) {
@@ -125,7 +125,7 @@ avro_decode_row(schemadesc_s const* schema,
         } else if (kind == type_long) {
           if (dataptr != nullptr && row < max_rows) { static_cast<int64_t*>(dataptr)[row] = v; }
         } else if (kind == type_fixed) {
-          // XXX TODO: Not yet implemented.
+          CUDF_UNREACHABLE("avro type 'fixed' type not yet implemented");
         } else {  // string, uuid, or enum
           size_t count    = 0;
           const char* ptr = nullptr;
@@ -205,19 +205,17 @@ avro_decode_row(schemadesc_s const* schema,
         // at different granularities of time. The first stores a number in
         // months, the second stores a number in days, and the third stores a
         // number in milliseconds.
-
-        // XXX TODO: Not yet implemented.
-
+        CUDF_UNREACHABLE("avro type 'duration' not yet implemented");
       } break;
 
       // N.B. These aren't handled yet, see the discussion on
       //      https://github.com/rapidsai/cudf/pull/12788.  The decoding logic
       //      is correct, though, so there's no harm in having them here.
-      case type_timestamp_millis:
-      case type_timestamp_micros:
-      case type_local_timestamp_millis:
-      case type_local_timestamp_micros:
-      case type_time_millis:
+      case type_timestamp_millis: [[fallthrough]];
+      case type_timestamp_micros: [[fallthrough]];
+      case type_local_timestamp_millis: [[fallthrough]];
+      case type_local_timestamp_micros: [[fallthrough]];
+      case type_time_millis: [[fallthrough]];
       case type_time_micros: {
         // N.B. time-millis is stored as a 32-bit int, however, cudf expects an
         //      int64 for DURATION_MILLISECONDS.  From our perspective, the fact
@@ -225,6 +223,7 @@ avro_decode_row(schemadesc_s const* schema,
         //      way of the zig-zag varint encoding, so we can safely treat them
         //      both as int64_t.  Everything else is 64-bit in both avro and
         //      cudf.
+        CUDF_UNREACHABLE("avro type yet implemented");
         int64_t v = avro_decode_zigzag_varint(cur, end);
         if (dataptr != nullptr && row < max_rows) { static_cast<int64_t*>(dataptr)[row] = v; }
       } break;

--- a/cpp/src/io/avro/avro_gpu.cu
+++ b/cpp/src/io/avro/avro_gpu.cu
@@ -223,8 +223,12 @@ avro_decode_row(schemadesc_s const* schema,
         //      both as int64_t.  Everything else is 64-bit in both avro and
         //      cudf.
         CUDF_UNREACHABLE("avro time/timestamp types not yet implemented");
-        int64_t v = avro_decode_zigzag_varint(cur, end);
-        if (dataptr != nullptr && row < max_rows) { static_cast<int64_t*>(dataptr)[row] = v; }
+        //
+        // When we do implement these, the following decoding logic should
+        // be correct:
+        //
+        // int64_t v = avro_decode_zigzag_varint(cur, end);
+        // if (dataptr != nullptr && row < max_rows) { static_cast<int64_t*>(dataptr)[row] = v; }
       } break;
 
       case type_date: {

--- a/cpp/src/io/avro/avro_gpu.hpp
+++ b/cpp/src/io/avro/avro_gpu.hpp
@@ -26,15 +26,12 @@ namespace io {
 namespace avro {
 namespace gpu {
 
-using namespace cudf::io::avro;
-using namespace cudf::io;
-
 /**
  * @brief Struct to describe the avro schema
  */
 struct schemadesc_s {
-  avro::type_kind_e kind;                 // avro type kind
-  avro::logicaltype_kind_e logical_kind;  // avro logicaltype kind
+  cudf::io::avro::type_kind_e kind;                 // avro type kind
+  cudf::io::avro::logicaltype_kind_e logical_kind;  // avro logicaltype kind
   uint32_t count;  // for records/unions: number of following child columns, for nulls: global
                    // null_count, for enums: dictionary ofs
   void* dataptr;   // Ptr to column data, or null if column not selected

--- a/cpp/src/io/avro/avro_gpu.hpp
+++ b/cpp/src/io/avro/avro_gpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,11 +26,15 @@ namespace io {
 namespace avro {
 namespace gpu {
 
+using namespace cudf::io::avro;
+using namespace cudf::io;
+
 /**
  * @brief Struct to describe the avro schema
  */
 struct schemadesc_s {
-  uint32_t kind;   // avro type kind
+  avro::type_kind_e kind;                 // avro type kind
+  avro::logicaltype_kind_e logical_kind;  // avro logicaltype kind
   uint32_t count;  // for records/unions: number of following child columns, for nulls: global
                    // null_count, for enums: dictionary ofs
   void* dataptr;   // Ptr to column data, or null if column not selected

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -73,7 +73,7 @@ type_id to_type_id(avro::schema_entry const* col)
   //      them in the future.
   switch (col->logical_kind) {
     case avro::logicaltype_date: kind = static_cast<avro::type_kind_e>(col->logical_kind); break;
-    case avro::logicaltype_not_set:
+    case avro::logicaltype_not_set: [[fallthrough]];
     default: kind = col->kind; break;
   }
 
@@ -83,7 +83,7 @@ type_id to_type_id(avro::schema_entry const* col)
     case avro::type_long: return type_id::INT64;
     case avro::type_float: return type_id::FLOAT32;
     case avro::type_double: return type_id::FLOAT64;
-    case avro::type_bytes:
+    case avro::type_bytes: [[fallthrough]];
     case avro::type_string: return type_id::STRING;
     case avro::type_date: return type_id::TIMESTAMP_DAYS;
     case avro::type_timestamp_millis: return type_id::TIMESTAMP_MILLISECONDS;
@@ -96,12 +96,12 @@ type_id to_type_id(avro::schema_entry const* col)
     // 23:59:59.9999 (or .999999 for micros).  There's no equivalent cudf
     // type for this; type_id::DURATION_MILLISECONDS/MICROSECONDS are close,
     // but they're not semantically the same.
-    case avro::type_time_millis:
-    case avro::type_time_micros:
+    case avro::type_time_millis: [[fallthrough]];
+    case avro::type_time_micros: [[fallthrough]];
     // There's no cudf equivalent for the avro duration type, which is a fixed
     // 12 byte value which stores three little-endian unsigned 32-bit integers
     // representing months, days, and milliseconds, respectively.
-    case avro::type_duration:
+    case avro::type_duration: [[fallthrough]];
     default: return type_id::EMPTY;
   }
 }

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -66,7 +66,18 @@ namespace {
  */
 type_id to_type_id(avro::schema_entry const* col)
 {
-  switch (col->kind) {
+  avro::type_kind_e kind;
+
+  // N.B. The switch statement seems a bit ridiculous for a single type, but the
+  //      plan is to incrementally add more types to it as support is added for
+  //      them in the future.
+  switch (col->logical_kind) {
+    case avro::logicaltype_date: kind = static_cast<avro::type_kind_e>(col->logical_kind); break;
+    case avro::logicaltype_not_set:
+    default: kind = col->kind; break;
+  }
+
+  switch (kind) {
     case avro::type_boolean: return type_id::BOOL8;
     case avro::type_int: return type_id::INT32;
     case avro::type_long: return type_id::INT64;
@@ -74,7 +85,23 @@ type_id to_type_id(avro::schema_entry const* col)
     case avro::type_double: return type_id::FLOAT64;
     case avro::type_bytes:
     case avro::type_string: return type_id::STRING;
+    case avro::type_date: return type_id::TIMESTAMP_DAYS;
+    case avro::type_timestamp_millis: return type_id::TIMESTAMP_MILLISECONDS;
+    case avro::type_timestamp_micros: return type_id::TIMESTAMP_MICROSECONDS;
+    case avro::type_local_timestamp_millis: return type_id::TIMESTAMP_MILLISECONDS;
+    case avro::type_local_timestamp_micros: return type_id::TIMESTAMP_MICROSECONDS;
     case avro::type_enum: return (!col->symbols.empty()) ? type_id::STRING : type_id::INT32;
+    // The avro time-millis and time-micros types are closest to Arrow's
+    // TIME32 and TIME64.  They're single-day units, i.e. they won't exceed
+    // 23:59:59.9999 (or .999999 for micros).  There's no equivalent cudf
+    // type for this; type_id::DURATION_MILLISECONDS/MICROSECONDS are close,
+    // but they're not semantically the same.
+    case avro::type_time_millis:
+    case avro::type_time_micros:
+    // There's no cudf equivalent for the avro duration type, which is a fixed
+    // 12 byte value which stores three little-endian unsigned 32-bit integers
+    // representing months, days, and milliseconds, respectively.
+    case avro::type_duration:
     default: return type_id::EMPTY;
   }
 }
@@ -141,6 +168,7 @@ class metadata : public file_metadata {
             break;
           }
         }
+
         if (!column_in_array) {
           auto col_type = to_type_id(&schema[columns[i].schema_data_idx]);
           CUDF_EXPECTS(col_type != type_id::EMPTY, "Unsupported data type");
@@ -360,7 +388,9 @@ std::vector<column_buffer> decode_data(metadata& meta,
   int skip_field_cnt         = 0;
 
   for (size_t i = 0; i < meta.schema.size(); i++) {
-    type_kind_e kind = meta.schema[i].kind;
+    type_kind_e kind                = meta.schema[i].kind;
+    logicaltype_kind_e logical_kind = meta.schema[i].logical_kind;
+
     if (skip_field_cnt != 0) {
       // Exclude union and array members from min_row_data_size
       skip_field_cnt += meta.schema[i].num_children - 1;
@@ -382,7 +412,8 @@ std::vector<column_buffer> decode_data(metadata& meta,
       }
     }
     if (kind == type_enum && !meta.schema[i].symbols.size()) { kind = type_int; }
-    schema_desc[i].kind = kind;
+    schema_desc[i].kind         = kind;
+    schema_desc[i].logical_kind = logical_kind;
     schema_desc[i].count =
       (kind == type_enum) ? 0 : static_cast<uint32_t>(meta.schema[i].num_children);
     schema_desc[i].dataptr = nullptr;

--- a/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
+++ b/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
@@ -323,29 +323,26 @@ def test_can_parse_avro_date_logical_type(namespace, nullable, prepend_null):
 
     schema = fastavro.parse_schema(schema_dict)
 
-    if nullable:
-        # Insert some None values in no particular order.  These will get
-        # converted into avro "nulls" by the fastavro writer.
-        dates = [
-            None,
-            datetime.date(1970, 1, 1),
-            datetime.date(1970, 1, 2),
-            datetime.date(1981, 10, 25),
-            None,
-            None,
-            datetime.date(2012, 5, 18),
-            None,
-            datetime.date(2019, 9, 3),
-            None,
-        ]
-    else:
-        dates = [
-            datetime.date(1970, 1, 1),
-            datetime.date(1970, 1, 2),
-            datetime.date(1981, 10, 25),
-            datetime.date(2012, 5, 18),
-            datetime.date(2019, 9, 3),
-        ]
+    # Insert some None values in no particular order.  These will get converted
+    # into avro "nulls" by the fastavro writer (or filtered out if we're not
+    # nullable).  The first and last dates are epoch min/max values, the rest
+    # are arbitrarily chosen.
+    dates = [
+        None,
+        datetime.date(1970, 1, 1),
+        datetime.date(1970, 1, 2),
+        datetime.date(1981, 10, 25),
+        None,
+        None,
+        datetime.date(2012, 5, 18),
+        None,
+        datetime.date(2019, 9, 3),
+        None,
+        datetime.date(9999, 12, 31),
+    ]
+
+    if not nullable:
+        dates = [date for date in dates if date is not None]
 
     days_from_epoch = [get_days_from_epoch(date) for date in dates]
 


### PR DESCRIPTION
## Description

This includes the date type.  Scaffolding has been put in place to handle the other logical types.  This closes #6482.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
