### PR TITLE
Tell cudf_kafka to use header-only fmt

### DIFF
--- a/python/cudf_kafka/setup.py
+++ b/python/cudf_kafka/setup.py
@@ -79,9 +79,9 @@ extensions = [
                 CUDF_KAFKA_ROOT,
             ]
         ),
-        libraries=["cudf", "cudf_kafka", "fmt"],
+        libraries=["cudf", "cudf_kafka"],
         language="c++",
-        extra_compile_args=["-std=c++17"],
+        extra_compile_args=["-std=c++17", "-DFMT_HEADER_ONLY=1"],
     )
 ]
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The changes to spdlog/fmt packaging in rmm caused an undefined symbol issue in cudf_kafka. To unblock CI in https://github.com/rapidsai/cudf/pull/12783, I simply added fmt to the list of required libraries for the Python package (see https://github.com/rapidsai/cudf/pull/12783/commits/caf7adfb9a89e585bd4d3239c79643328449a242 and [the explanation](https://github.com/rapidsai/cudf/pull/12783#issuecomment-1431997720)). The underlying issue turns out to be that by default usage of fmt results in the dependent assuming that the headers are compiled in not header-only mode. When using CMake to manage the build, fmt relies on use of the appropriate target `fmt::fmt-header-only` to configure the build such that anything using fmt knows to use it in header-only mode, which sets the `FMT_HEADER_ONLY` preprocessor macro under the hood. Since the Python cudf_kafka package is not built using CMake, however, this information was not propagated to its build from its dependencies (libcudf/libcudf_kafka). As a result, it was compiled expecting an external definition of some fmt symbols rather than inlining them. This PR removes the undesirable library dependency on fmt introduced in https://github.com/rapidsai/cudf/pull/12783 in favor of properly telling fmt to expect inlined symbols.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
