### PR TITLE
Update required spdlog and fmt version for our conda envs

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -26,6 +26,7 @@ dependencies:
 - dlpack>=0.5,<0.6.0a0
 - doxygen=1.8.20
 - fastavro>=0.22.9
+- fmt>=9.1.0,<10
 - fsspec>=0.6.0
 - gcc_linux-64=9.*
 - hypothesis
@@ -66,6 +67,7 @@ dependencies:
 - s3fs>=2022.3.0
 - scikit-build>=0.13.1
 - scipy
+- spdlog>=1.11.0,<1.12
 - sphinx
 - sphinx-autobuild
 - sphinx-copybutton

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -68,6 +68,8 @@ dependencies:
           - cxx-compiler
           - librdkafka=1.7.0
           - protobuf=4.21
+          - fmt>=9.1.0,<10
+          - spdlog>=1.11.0,<1.12
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
## Description
This ensures that we don't have older versions of these packages installed causing rapids-cmake to download the newer versions.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
