### PR TITLE
Remove KAFKA_HOST_TEST from compute-sanitizer check

### DIFF
--- a/ci/test_cpp_memcheck.sh
+++ b/ci/test_cpp_memcheck.sh
@@ -11,7 +11,7 @@ set +e
 rapids-logger "Memcheck gtests with rmm_mode=cuda"
 export GTEST_CUDF_RMM_MODE=cuda
 COMPUTE_SANITIZER_CMD="compute-sanitizer --tool memcheck"
-for gt in "$CONDA_PREFIX"/bin/gtests/{libcudf,libcudf_kafka}/* ; do
+for gt in "$CONDA_PREFIX"/bin/gtests/libcudf/* ; do
     test_name=$(basename ${gt})
     if [[ "$test_name" == "ERROR_TEST" ]] || [[ "$test_name" == "STREAM_IDENTIFICATION_TEST" ]]; then
         continue


### PR DESCRIPTION
## Description
Removes the `KAFKA_HOST_TEST` from the compute-sanitizer memcheck nighly runs. 
The following error occurs when running this host test.
```
Running compute-sanitizer on KAFKA_HOST_TEST
========= COMPUTE-SANITIZER
Running main() from gmock_main.cc
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from KafkaDatasourceTest
[ RUN      ] KafkaDatasourceTest.MissingGroupID
[       OK ] KafkaDatasourceTest.MissingGroupID (0 ms)
[ RUN      ] KafkaDatasourceTest.InvalidConfigValues
[       OK ] KafkaDatasourceTest.InvalidConfigValues (0 ms)
[----------] 2 tests from KafkaDatasourceTest (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.
========= Error: Target application terminated before first instrumented API call
========= Tracking kernels launched by child processes requires the --target-processes all option.
```
Adding the `--target-processes all` option gives the same error.

Disabling the check of this test since it is a host test that checks error conditions and does not appear to make any device calls.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
