### PR TITLE
[REVIEW] Adapt `value_counts` behavior to match `pandas-2.x`

### DIFF
--- a/python/cudf/cudf/api/types.py
+++ b/python/cudf/cudf/api/types.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 
 """Define common type operations."""
 
@@ -244,7 +244,6 @@ is_datetime64_any_dtype = pd_types.is_datetime64_any_dtype
 is_datetime64_dtype = pd_types.is_datetime64_dtype
 is_datetime64_ns_dtype = pd_types.is_datetime64_ns_dtype
 is_datetime64tz_dtype = pd_types.is_datetime64tz_dtype
-is_extension_type = pd_types.is_extension_type
 is_extension_array_dtype = pd_types.is_extension_array_dtype
 is_float_dtype = _wrap_pandas_is_dtype_api(pd_types.is_float_dtype)
 is_int64_dtype = pd_types.is_int64_dtype
@@ -263,7 +262,7 @@ is_file_like = pd_types.is_file_like
 is_named_tuple = pd_types.is_named_tuple
 is_iterator = pd_types.is_iterator
 is_bool = pd_types.is_bool
-is_categorical = pd_types.is_categorical
+is_categorical = pd_types.is_categorical_dtype
 is_complex = pd_types.is_complex
 is_float = pd_types.is_float
 is_hashable = pd_types.is_hashable

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -7211,12 +7211,18 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         >>> df = cudf.DataFrame({'num_legs': [2, 4, 4, 6],
         ...                    'num_wings': [2, 0, 0, 0]},
         ...                    index=['falcon', 'dog', 'cat', 'ant'])
+        >>> df
+                num_legs  num_wings
+        falcon         2          2
+        dog            4          0
+        cat            4          0
+        ant            6          0
         >>> df.value_counts()
         num_legs  num_wings
         4         0            2
         2         2            1
         6         0            1
-        dtype: int64
+        Name: count, dtype: int64
         """
         if subset:
             diff = set(subset) - set(self._data)
@@ -7238,6 +7244,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         # Pandas always returns MultiIndex even if only one column.
         if not isinstance(result.index, MultiIndex):
             result.index = MultiIndex._from_data(result._index._data)
+        result.name = "proportion" if normalize else "count"
         return result
 
 


### PR DESCRIPTION
## Description
This PR updates `value_counts` behavior to match `pandas-2.x`, the result name will be `count` (or `proportion` if `normalize=True` is passed), and the index will be named after the original object name. This PR also fixes two dtype APIs that are breaking changes on pandas side.

Here are the pytests that were run locally to test these changes :
```python
(cudfdev) pgali@dt07:/nvme/0/pgali/cudf$ pytest python/cudf/cudf/tests/test_dataframe.py::test_value_counts
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.10.9, pytest-7.2.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /nvme/0/pgali/cudf/python/cudf/cudf/tests, configfile: pytest.ini
plugins: anyio-3.6.2, benchmark-4.0.0, xdist-3.2.0, cov-4.0.0, hypothesis-6.68.2, cases-3.6.13
collected 64 items                                                                                                                                                                 

python/cudf/cudf/tests/test_dataframe.py ................................................................                                                                    [100%]

================================================================================ 64 passed in 2.31s ================================================================================
(cudfdev) pgali@dt07:/nvme/0/pgali/cudf$ pytest python/cudf/cudf/tests/test_series.py::test_series_value_counts
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.10.9, pytest-7.2.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /nvme/0/pgali/cudf/python/cudf/cudf/tests, configfile: pytest.ini
plugins: anyio-3.6.2, benchmark-4.0.0, xdist-3.2.0, cov-4.0.0, hypothesis-6.68.2, cases-3.6.13
collected 4 items                                                                                                                                                                  

python/cudf/cudf/tests/test_series.py ....                                                                                                                                   [100%]

================================================================================ 4 passed in 1.25s =================================================================================
(cudfdev) pgali@dt07:/nvme/0/pgali/cudf$ pytest python/cudf/cudf/tests/test_series.py::test_series_datetime_value_counts
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.10.9, pytest-7.2.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /nvme/0/pgali/cudf/python/cudf/cudf/tests, configfile: pytest.ini
plugins: anyio-3.6.2, benchmark-4.0.0, xdist-3.2.0, cov-4.0.0, hypothesis-6.68.2, cases-3.6.13
collected 24 items                                                                                                                                                                 

python/cudf/cudf/tests/test_series.py ........................                                                                                                               [100%]

================================================================================ 24 passed in 1.32s ================================================================================
(cudfdev) pgali@dt07:/nvme/0/pgali/cudf$ pytest python/cudf/cudf/tests/test_series.py::test_categorical_value_counts
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.10.9, pytest-7.2.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /nvme/0/pgali/cudf/python/cudf/cudf/tests, configfile: pytest.ini
plugins: anyio-3.6.2, benchmark-4.0.0, xdist-3.2.0, cov-4.0.0, hypothesis-6.68.2, cases-3.6.13
collected 12 items                                                                                                                                                                 

python/cudf/cudf/tests/test_series.py ............                                                                                                                           [100%]

================================================================================ 12 passed in 1.28s ================================================================================
(cudfdev) pgali@dt07:/nvme/0/pgali/cudf$ pytest python/cudf/cudf/tests/test_series.py::test_series_value_counts_bins
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.10.9, pytest-7.2.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /nvme/0/pgali/cudf/python/cudf/cudf/tests, configfile: pytest.ini
plugins: anyio-3.6.2, benchmark-4.0.0, xdist-3.2.0, cov-4.0.0, hypothesis-6.68.2, cases-3.6.13
collected 3 items                                                                                                                                                                  

python/cudf/cudf/tests/test_series.py ...                                                                                                                                    [100%]

================================================================================ 3 passed in 1.22s =================================================================================
(cudfdev) pgali@dt07:/nvme/0/pgali/cudf$ pytest python/cudf/cudf/tests/test_series.py::test_series_value_counts_bins_dropna
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.10.9, pytest-7.2.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /nvme/0/pgali/cudf/python/cudf/cudf/tests, configfile: pytest.ini
plugins: anyio-3.6.2, benchmark-4.0.0, xdist-3.2.0, cov-4.0.0, hypothesis-6.68.2, cases-3.6.13
collected 6 items                                                                                                                                                                  

python/cudf/cudf/tests/test_series.py ......                                                                                                                                 [100%]

================================================================================ 6 passed in 1.25s =================================================================================
(cudfdev) pgali@dt07:/nvme/0/pgali/cudf$ pytest python/cudf/cudf/tests/test_series.py::test_series_value_counts_optional_arguments
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.10.9, pytest-7.2.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /nvme/0/pgali/cudf/python/cudf/cudf/tests, configfile: pytest.ini
plugins: anyio-3.6.2, benchmark-4.0.0, xdist-3.2.0, cov-4.0.0, hypothesis-6.68.2, cases-3.6.13
collected 8 items                                                                                                                                                                  

python/cudf/cudf/tests/test_series.py ........                                                                                                                               [100%]

================================================================================ 8 passed in 1.20s =================================================================================
(cudfdev) pgali@dt07:/nvme/0/pgali/cudf$ conda list | grep "pandas"
pandas                    2.0.0rc0                 pypi_0    pypi
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
