### PR TITLE
[REVIEW] Drop `inplace` parameter in categorical methods

### DIFF
--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections import abc
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Tuple, cast
@@ -130,28 +129,14 @@ class CategoricalAccessor(ColumnMethods):
         """
         return self._column.ordered
 
-    def as_ordered(self, inplace: bool = False) -> Optional[SeriesOrIndex]:
+    def as_ordered(self) -> Optional[SeriesOrIndex]:
         """
         Set the Categorical to be ordered.
-
-        Parameters
-        ----------
-        inplace : bool, default False
-            Whether or not to add the categories inplace
-            or return a copy of this categorical with
-            added categories.
-
-            .. deprecated:: 23.02
-
-               The `inplace` parameter is is deprecated and
-               will be removed in a future version of cudf.
-               Setting categories as ordered will always
-               return a new Categorical object.
 
         Returns
         -------
         Categorical
-            Ordered Categorical or None if inplace.
+            Ordered Categorical.
 
         Examples
         --------
@@ -177,46 +162,12 @@ class CategoricalAccessor(ColumnMethods):
         6    10
         dtype: category
         Categories (3, int64): [1 < 2 < 10]
-        >>> s.cat.as_ordered(inplace=True)
-        >>> s
-        0    10
-        1     1
-        2     1
-        3     2
-        4    10
-        5     2
-        6    10
-        dtype: category
-        Categories (3, int64): [1 < 2 < 10]
         """
-        if inplace:
-            warnings.warn(
-                "The inplace parameter is deprecated and will be removed in a "
-                "future release. set_ordered will always return a new Series "
-                "in the future.",
-                FutureWarning,
-            )
-        return self._return_or_inplace(
-            self._column.as_ordered(), inplace=inplace
-        )
+        return self._return_or_inplace(self._column.as_ordered())
 
-    def as_unordered(self, inplace: bool = False) -> Optional[SeriesOrIndex]:
+    def as_unordered(self) -> Optional[SeriesOrIndex]:
         """
         Set the Categorical to be unordered.
-
-        Parameters
-        ----------
-        inplace : bool, default False
-            Whether or not to set the ordered attribute
-            in-place or return a copy of this
-            categorical with ordered set to False.
-
-            .. deprecated:: 23.02
-
-               The `inplace` parameter is is deprecated and
-               will be removed in a future version of cudf.
-               Setting categories as unordered will always
-               return a new Categorical object.
 
         Returns
         -------
@@ -258,32 +209,11 @@ class CategoricalAccessor(ColumnMethods):
         6    10
         dtype: category
         Categories (3, int64): [1, 2, 10]
-        >>> s.cat.as_unordered(inplace=True)
-        >>> s
-        0    10
-        1     1
-        2     1
-        3     2
-        4    10
-        5     2
-        6    10
-        dtype: category
-        Categories (3, int64): [1, 2, 10]
         """
-        if inplace:
-            warnings.warn(
-                "The inplace parameter is deprecated and will be removed in a "
-                "future release. set_ordered will always return a new Series "
-                "in the future.",
-                FutureWarning,
-            )
-        return self._return_or_inplace(
-            self._column.as_unordered(), inplace=inplace
-        )
 
-    def add_categories(
-        self, new_categories: Any, inplace: bool = False
-    ) -> Optional[SeriesOrIndex]:
+        return self._return_or_inplace(self._column.as_unordered())
+
+    def add_categories(self, new_categories: Any) -> Optional[SeriesOrIndex]:
         """
         Add new categories.
 
@@ -295,23 +225,11 @@ class CategoricalAccessor(ColumnMethods):
         ----------
         new_categories : category or list-like of category
             The new categories to be included.
-        inplace : bool, default False
-            Whether or not to add the categories inplace
-            or return a copy of this categorical with
-            added categories.
-
-            .. deprecated:: 23.04
-
-               The `inplace` parameter is is deprecated and
-               will be removed in a future version of cudf.
-               Adding categories will always return a
-               new Categorical object.
 
         Returns
         -------
         cat
-            Categorical with new categories added or
-            None if inplace.
+            Categorical with new categories added.
 
         Examples
         --------
@@ -332,21 +250,8 @@ class CategoricalAccessor(ColumnMethods):
         1    2
         dtype: category
         Categories (2, int64): [1, 2]
-        >>> s.cat.add_categories([0, 3, 4], inplace=True)
-        >>> s
-        0    1
-        1    2
-        dtype: category
-        Categories (5, int64): [1, 2, 0, 3, 4]
         """
-        if inplace:
-            warnings.warn(
-                "The `inplace` parameter in cudf.Series.cat.add_categories "
-                "is deprecated and will be removed in a future version of "
-                "cudf. Adding categories will always return a new "
-                "Categorical object.",
-                FutureWarning,
-            )
+
         old_categories = self._column.categories
         new_categories = column.as_column(
             new_categories,
@@ -376,12 +281,11 @@ class CategoricalAccessor(ColumnMethods):
         if not out_col._categories_equal(new_categories):
             out_col = out_col._set_categories(new_categories)
 
-        return self._return_or_inplace(out_col, inplace=inplace)
+        return self._return_or_inplace(out_col)
 
     def remove_categories(
         self,
         removals: Any,
-        inplace: bool = False,
     ) -> Optional[SeriesOrIndex]:
         """
         Remove the specified categories.
@@ -394,23 +298,11 @@ class CategoricalAccessor(ColumnMethods):
         ----------
         removals : category or list-like of category
             The categories which should be removed.
-        inplace : bool, default False
-            Whether or not to remove the categories
-            inplace or return a copy of this categorical
-            with removed categories.
-
-            .. deprecated:: 23.04
-
-               The `inplace` parameter is is deprecated and
-               will be removed in a future version of cudf.
-               Removing categories will always return a
-               new Categorical object.
 
         Returns
         -------
         cat
-            Categorical with removed categories or None
-            if inplace.
+            Categorical with removed categories
 
         Examples
         --------
@@ -446,27 +338,7 @@ class CategoricalAccessor(ColumnMethods):
         6    10
         dtype: category
         Categories (3, int64): [1, 2, 10]
-        >>> s.cat.remove_categories([10], inplace=True)
-        >>> s
-        0    <NA>
-        1       1
-        2       1
-        3       2
-        4    <NA>
-        5       2
-        6    <NA>
-        dtype: category
-        Categories (2, int64): [1, 2]
         """
-        if inplace:
-            warnings.warn(
-                "The `inplace` parameter in "
-                "cudf.Series.cat.remove_categories is deprecated and "
-                "will be removed in a future version of cudf. "
-                "Removing categories will always return a new "
-                "Categorical object.",
-                FutureWarning,
-            )
 
         cats = self.categories.to_series()
         removals = cudf.Series(removals, dtype=cats.dtype)
@@ -483,14 +355,13 @@ class CategoricalAccessor(ColumnMethods):
         if not out_col._categories_equal(new_categories):
             out_col = out_col._set_categories(new_categories)
 
-        return self._return_or_inplace(out_col, inplace=inplace)
+        return self._return_or_inplace(out_col)
 
     def set_categories(
         self,
         new_categories: Any,
         ordered: bool = False,
         rename: bool = False,
-        inplace: bool = False,
     ) -> Optional[SeriesOrIndex]:
         """
         Set the categories to the specified new_categories.
@@ -525,23 +396,11 @@ class CategoricalAccessor(ColumnMethods):
             Whether or not the `new_categories` should be
             considered as a rename of the old categories
             or as reordered categories.
-        inplace : bool, default False
-            Whether or not to reorder the categories in-place
-            or return a copy of this categorical with
-            reordered categories.
-
-            .. deprecated:: 23.04
-
-               The `inplace` parameter is is deprecated and
-               will be removed in a future version of cudf.
-               Setting categories will always return a
-               new Categorical object.
 
         Returns
         -------
         cat
             Categorical with reordered categories
-            or None if inplace.
 
         Examples
         --------
@@ -565,37 +424,18 @@ class CategoricalAccessor(ColumnMethods):
         5      10
         dtype: category
         Categories (2, int64): [1, 10]
-        >>> s.cat.set_categories([1, 10], inplace=True)
-        >>> s
-        0       1
-        1       1
-        2    <NA>
-        3      10
-        4    <NA>
-        5      10
-        dtype: category
-        Categories (2, int64): [1, 10]
         """
-        if inplace:
-            warnings.warn(
-                "The `inplace` parameter in cudf.Series.cat.set_categories is "
-                "deprecated and will be removed in a future version of cudf. "
-                "Setting categories will always return a new Categorical "
-                "object.",
-                FutureWarning,
-            )
+
         return self._return_or_inplace(
             self._column.set_categories(
                 new_categories=new_categories, ordered=ordered, rename=rename
-            ),
-            inplace=inplace,
+            )
         )
 
     def reorder_categories(
         self,
         new_categories: Any,
         ordered: bool = False,
-        inplace: bool = False,
     ) -> Optional[SeriesOrIndex]:
         """
         Reorder categories as specified in new_categories.
@@ -611,23 +451,11 @@ class CategoricalAccessor(ColumnMethods):
             Whether or not the categorical is treated
             as a ordered categorical. If not given, do
             not change the ordered information.
-        inplace : bool, default False
-            Whether or not to reorder the categories
-            inplace or return a copy of this categorical
-            with reordered categories.
-
-            .. deprecated:: 23.04
-
-               The `inplace` parameter is is deprecated and
-               will be removed in a future version of cudf.
-               Reordering categories will always return a
-               new Categorical object.
 
         Returns
         -------
         cat
-            Categorical with reordered categories or
-            None if inplace.
+            Categorical with reordered categories
 
         Raises
         ------
@@ -664,18 +492,9 @@ class CategoricalAccessor(ColumnMethods):
         ValueError: items in new_categories are not the same as in
         old categories
         """
-        if inplace:
-            warnings.warn(
-                "The `inplace` parameter in "
-                "cudf.Series.cat.reorder_categories is deprecated "
-                "and will be removed in a future version of cudf. "
-                "Reordering categories will always return a new "
-                "Categorical object.",
-                FutureWarning,
-            )
+
         return self._return_or_inplace(
             self._column.reorder_categories(new_categories, ordered=ordered),
-            inplace=inplace,
         )
 
 


### PR DESCRIPTION
## Description
This PR drops `inplace` parameters in categorical methods, these are also removed as part of pandas-2.0

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
