### PR TITLE
[REVIEW] Drop `is_monotonic` from `Series` and `Index`

### DIFF
--- a/docs/cudf/source/api_docs/index_objects.rst
+++ b/docs/cudf/source/api_docs/index_objects.rst
@@ -25,7 +25,6 @@ Properties
    Index.has_duplicates
    Index.duplicated
    Index.hasnans
-   Index.is_monotonic
    Index.is_monotonic_increasing
    Index.is_monotonic_decreasing
    Index.is_unique

--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pickle
-import warnings
 from functools import cached_property
 from typing import Any, Set, TypeVar
 
@@ -188,24 +187,6 @@ class BaseIndex(Serializable):
         of the actual types correctly.
         """
         raise NotImplementedError
-
-    @property
-    def is_monotonic(self):
-        """Return boolean if values in the object are monotonic_increasing.
-
-        This property is an alias for :attr:`is_monotonic_increasing`.
-
-        Returns
-        -------
-        bool
-        """
-        warnings.warn(
-            "is_monotonic is deprecated and will be removed in a future "
-            "version. Use is_monotonic_increasing instead.",
-            FutureWarning,
-        )
-
-        return self.is_monotonic_increasing
 
     @property
     def is_monotonic_increasing(self):

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+
 """Base class for Frame types that only have a single column."""
 
 from __future__ import annotations
 
-import warnings
 from typing import Any, Dict, Optional, Tuple, TypeVar, Union
 
 import cupy
@@ -222,25 +222,6 @@ class SingleColumnFrame(Frame, NotIterable):
         bool
         """
         return self._column.is_unique
-
-    @property  # type: ignore
-    @_cudf_nvtx_annotate
-    def is_monotonic(self):
-        """Return boolean if values in the object are monotonically increasing.
-
-        This property is an alias for :attr:`is_monotonic_increasing`.
-
-        Returns
-        -------
-        bool
-        """
-        warnings.warn(
-            "is_monotonic is deprecated and will be removed in a future "
-            "version. Use is_monotonic_increasing instead.",
-            FutureWarning,
-        )
-
-        return self.is_monotonic_increasing
 
     @property  # type: ignore
     @_cudf_nvtx_annotate

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2518,8 +2518,6 @@ def test_unary_operators(func, pdf, gdf):
 def test_is_monotonic(gdf):
     pdf = pd.DataFrame({"x": [1, 2, 3]}, index=[3, 1, 2])
     gdf = cudf.DataFrame.from_pandas(pdf)
-    with pytest.warns(FutureWarning):
-        assert not gdf.index.is_monotonic
     assert not gdf.index.is_monotonic_increasing
     assert not gdf.index.is_monotonic_decreasing
 

--- a/python/cudf/cudf/tests/test_monotonic.py
+++ b/python/cudf/cudf/tests/test_monotonic.py
@@ -1,7 +1,8 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 
 """
-Tests related to is_unique and is_monotonic attributes
+Tests related to is_unique, is_monotonic_increasing &
+is_monotonic_decreasing attributes
 """
 import numpy as np
 import pandas as pd
@@ -30,11 +31,6 @@ def test_range_index(testrange):
     )
 
     assert index.is_unique == index_pd.is_unique
-    with pytest.warns(FutureWarning):
-        expect = index_pd.is_monotonic
-    with pytest.warns(FutureWarning):
-        got = index.is_monotonic
-    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 
@@ -58,11 +54,6 @@ def test_generic_index(testlist):
     index_pd = pd.Index(testlist)
 
     assert index.is_unique == index_pd.is_unique
-    with pytest.warns(FutureWarning):
-        expect = index_pd.is_monotonic
-    with pytest.warns(FutureWarning):
-        got = index.is_monotonic
-    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 
@@ -82,11 +73,6 @@ def test_string_index(testlist):
     index_pd = pd.Index(testlist)
 
     assert index.is_unique == index_pd.is_unique
-    with pytest.warns(FutureWarning):
-        expect = index_pd.is_monotonic
-    with pytest.warns(FutureWarning):
-        got = index.is_monotonic
-    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 
@@ -102,11 +88,6 @@ def test_categorical_index(testlist):
     index_pd = pd.CategoricalIndex(raw_cat)
 
     assert index.is_unique == index_pd.is_unique
-    with pytest.warns(FutureWarning):
-        expect = index_pd.is_monotonic
-    with pytest.warns(FutureWarning):
-        got = index.is_monotonic
-    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 
@@ -147,11 +128,6 @@ def test_datetime_index(testlist):
     index_pd = pd.DatetimeIndex(testlist)
 
     assert index.is_unique == index_pd.is_unique
-    with pytest.warns(FutureWarning):
-        expect = index_pd.is_monotonic
-    with pytest.warns(FutureWarning):
-        got = index.is_monotonic
-    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 
@@ -174,11 +150,6 @@ def test_series(testlist):
     series_pd = pd.Series(testlist)
 
     assert series.is_unique == series_pd.is_unique
-    with pytest.warns(FutureWarning):
-        expect = series_pd.index.is_monotonic
-    with pytest.warns(FutureWarning):
-        got = series.index.is_monotonic
-    assert got == expect
     assert series.is_monotonic_increasing == series_pd.is_monotonic_increasing
     assert series.is_monotonic_decreasing == series_pd.is_monotonic_decreasing
 
@@ -203,11 +174,6 @@ def test_multiindex():
     gdf = cudf.from_pandas(pdf)
 
     assert pdf.index.is_unique == gdf.index.is_unique
-    with pytest.warns(FutureWarning):
-        expect = pdf.index.is_monotonic
-    with pytest.warns(FutureWarning):
-        got = gdf.index.is_monotonic
-    assert got == expect
     assert (
         pdf.index.is_monotonic_increasing == gdf.index.is_monotonic_increasing
     )
@@ -242,11 +208,6 @@ def test_multiindex_tuples(testarr):
     index_pd = pd.MultiIndex.from_tuples(tuples, names=testarr[1])
 
     assert index.is_unique == index_pd.is_unique
-    with pytest.warns(FutureWarning):
-        expect = index_pd.is_monotonic
-    with pytest.warns(FutureWarning):
-        got = index.is_monotonic
-    assert got == expect
     assert index.is_monotonic_increasing == index_pd.is_monotonic_increasing
     assert index.is_monotonic_decreasing == index_pd.is_monotonic_decreasing
 


### PR DESCRIPTION
## Description
This PR drops support for `Series.is_monotonic` & `Index.is_monotonic`. Instead, the alternative will be `.is_monotonic_increasing`.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
