### PR TITLE
[REVIEW] Fix a pytest to match libcudf error type

### DIFF
--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -479,7 +479,7 @@ def test_contains_null_search_key(data, expect):
 def test_contains_invalid(data, scalar):
     sr = cudf.Series(data)
     with pytest.raises(
-        TypeError,
+        ValueError,
         match="Type/Scale of search key does not "
         "match list column element type.",
     ):
@@ -565,7 +565,7 @@ def test_index(data, search_key, expect):
 def test_index_invalid_type(data, search_key):
     sr = cudf.Series(data)
     with pytest.raises(
-        TypeError,
+        ValueError,
         match="Type/Scale of search key does not "
         "match list column element type.",
     ):


### PR DESCRIPTION
## Description
Recently in https://github.com/rapidsai/cudf/pull/12426, we changed the runtime exceptions to more specific exceptions on user side. This PR fixes a leftover in pytests that matches with libcudf error type.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
