### PR TITLE
[REVIEW] Drop `kind` parameter from `Index.get_slice_bound`

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -1354,7 +1354,7 @@ class BaseIndex(Serializable):
             out.name = name
             return out
 
-    def get_slice_bound(self, label, side, kind=None):
+    def get_slice_bound(self, label, side):
         """
         Calculate slice bound that corresponds to given label.
         Returns leftmost (one-past-the-rightmost if ``side=='right'``) position
@@ -1364,7 +1364,6 @@ class BaseIndex(Serializable):
         ----------
         label : object
         side : {'left', 'right'}
-        kind : {'ix', 'loc', 'getitem'}
 
         Returns
         -------

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -883,7 +883,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
             ascending=[False], null_position=None
         )
 
-    def get_slice_bound(self, label: ScalarLike, side: str, kind: str) -> int:
+    def get_slice_bound(self, label: ScalarLike, side: str) -> int:
         """
         Calculate slice bound that corresponds to given label.
         Returns leftmost (one-past-the-rightmost if ``side=='right'``) position
@@ -893,22 +893,14 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         ----------
         label : Scalar
         side : {'left', 'right'}
-        kind : {'ix', 'loc', 'getitem'}
         """
-        if kind not in {"ix", "loc", "getitem", None}:
-            raise ValueError(
-                f"Invalid value for ``kind`` parameter,"
-                f" must be either one of the following: "
-                f"{'ix', 'loc', 'getitem', None}, but found: {kind}"
-            )
+
         if side not in {"left", "right"}:
             raise ValueError(
                 "Invalid value for side kwarg,"
                 " must be either 'left' or 'right': %s" % (side,)
             )
 
-        # TODO: Handle errors/missing keys correctly
-        #       Not currently using `kind` argument.
         if side == "left":
             return self.find_first_value(label, closest=True)
         elif side == "right":

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 from __future__ import annotations
 
@@ -510,7 +510,7 @@ class RangeIndex(BaseIndex, BinaryOperand):
         return self._step < 0 or len(self) <= 1
 
     @_cudf_nvtx_annotate
-    def get_slice_bound(self, label, side, kind=None):
+    def get_slice_bound(self, label, side):
         """
         Calculate slice bound that corresponds to given label.
         Returns leftmost (one-past-the-rightmost if ``side=='right'``) position
@@ -521,20 +521,12 @@ class RangeIndex(BaseIndex, BinaryOperand):
         label : int
             A valid value in the ``RangeIndex``
         side : {'left', 'right'}
-        kind : Unused
-            To keep consistency with other index types.
 
         Returns
         -------
         int
             Index of label.
         """
-        if kind is not None:
-            warnings.warn(
-                "'kind' argument in get_slice_bound is deprecated and will be "
-                "removed in a future version.",
-                FutureWarning,
-            )
         if side not in {"left", "right"}:
             raise ValueError(f"Unrecognized side parameter: {side}")
 
@@ -1413,14 +1405,8 @@ class GenericIndex(SingleColumnFrame, BaseIndex):
     notnull = notna
 
     @_cudf_nvtx_annotate
-    def get_slice_bound(self, label, side, kind=None):
-        if kind is not None:
-            warnings.warn(
-                "'kind' argument in get_slice_bound is deprecated and will be "
-                "removed in a future version.",
-                FutureWarning,
-            )
-        return self._values.get_slice_bound(label, side, kind)
+    def get_slice_bound(self, label, side):
+        return self._values.get_slice_bound(label, side)
 
     def is_numeric(self):
         return False

--- a/python/cudf/cudf/tests/test_monotonic.py
+++ b/python/cudf/cudf/tests/test_monotonic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 
 """
 Tests related to is_unique and is_monotonic attributes
@@ -16,7 +16,7 @@ from cudf.core.index import (
     RangeIndex,
     StringIndex,
 )
-from cudf.testing._utils import assert_eq, expect_warning_if
+from cudf.testing._utils import assert_eq
 
 
 @pytest.mark.parametrize("testrange", [(10, 20, 1), (0, -10, -1), (5, 5, 1)])
@@ -261,15 +261,12 @@ def test_multiindex_tuples(testarr):
     ],
 )
 @pytest.mark.parametrize("side", ["left", "right"])
-@pytest.mark.parametrize("kind", ["loc", "getitem", None])
-def test_get_slice_bound(testlist, side, kind):
+def test_get_slice_bound(testlist, side):
     index = GenericIndex(testlist)
     index_pd = pd.Index(testlist)
     for label in testlist:
-        with pytest.warns(FutureWarning):
-            expect = index_pd.get_slice_bound(label, side, kind)
-        with expect_warning_if(kind is not None, FutureWarning):
-            got = index.get_slice_bound(label, side, kind)
+        expect = index_pd.get_slice_bound(label, side)
+        got = index.get_slice_bound(label, side)
         assert got == expect
 
 
@@ -279,16 +276,13 @@ def test_get_slice_bound(testlist, side, kind):
     [[-1, 0, 5, 10, 11], [-1, 0, 1, 2], [2, 3, 4, 5], [-1, 0, 1], [2, 3, 4]],
 )
 @pytest.mark.parametrize("side", ["left", "right"])
-@pytest.mark.parametrize("kind", ["getitem", "loc"])
-def test_rangeindex_get_slice_bound_basic(bounds, indices, side, kind):
+def test_rangeindex_get_slice_bound_basic(bounds, indices, side):
     start, stop = bounds
     pd_index = pd.RangeIndex(start, stop)
     cudf_index = RangeIndex(start, stop)
     for idx in indices:
-        with pytest.warns(FutureWarning):
-            expect = pd_index.get_slice_bound(idx, side, kind)
-        with expect_warning_if(kind is not None, FutureWarning):
-            got = cudf_index.get_slice_bound(idx, side, kind)
+        expect = pd_index.get_slice_bound(idx, side)
+        got = cudf_index.get_slice_bound(idx, side)
         assert expect == got
 
 
@@ -301,31 +295,25 @@ def test_rangeindex_get_slice_bound_basic(bounds, indices, side, kind):
     [3, 8, 13, 18, 20, 15, 10, 5, -1, 0, 19, 21, 6, 11, 17],
 )
 @pytest.mark.parametrize("side", ["left", "right"])
-@pytest.mark.parametrize("kind", ["getitem", "loc"])
-def test_rangeindex_get_slice_bound_step(bounds, label, side, kind):
+def test_rangeindex_get_slice_bound_step(bounds, label, side):
     start, stop, step = bounds
     pd_index = pd.RangeIndex(start, stop, step)
     cudf_index = RangeIndex(start, stop, step)
 
-    with pytest.warns(FutureWarning):
-        expect = pd_index.get_slice_bound(label, side, kind)
-    with expect_warning_if(kind is not None, FutureWarning):
-        got = cudf_index.get_slice_bound(label, side, kind)
+    expect = pd_index.get_slice_bound(label, side)
+    got = cudf_index.get_slice_bound(label, side)
     assert expect == got
 
 
 @pytest.mark.parametrize("label", [1, 3, 5, 7, 9, 11])
 @pytest.mark.parametrize("side", ["left", "right"])
-@pytest.mark.parametrize("kind", ["loc", "getitem", None])
-def test_get_slice_bound_missing(label, side, kind):
+def test_get_slice_bound_missing(label, side):
     mylist = [2, 4, 6, 8, 10]
     index = GenericIndex(mylist)
     index_pd = pd.Index(mylist)
 
-    with pytest.warns(FutureWarning):
-        expect = index_pd.get_slice_bound(label, side, kind)
-    with expect_warning_if(kind is not None, FutureWarning):
-        got = index.get_slice_bound(label, side, kind)
+    expect = index_pd.get_slice_bound(label, side)
+    got = index.get_slice_bound(label, side)
     assert got == expect
 
 
@@ -338,10 +326,8 @@ def test_get_slice_bound_missing_str(label, side):
     mylist = ["b", "d", "f"]
     index = GenericIndex(mylist)
     index_pd = pd.Index(mylist)
-    with pytest.warns(FutureWarning):
-        got = index.get_slice_bound(label, side, "getitem")
-    with pytest.warns(FutureWarning):
-        expect = index_pd.get_slice_bound(label, side, "getitem")
+    got = index.get_slice_bound(label, side)
+    expect = index_pd.get_slice_bound(label, side)
     assert got == expect
 
 


### PR DESCRIPTION
## Description

This PR drops `kind` parameter from `Index.get_slice_bound` to match pandas-2.0 API.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
