### PR TITLE
Update RMM allocators

### DIFF
--- a/python/cudf/cudf/__init__.py
+++ b/python/cudf/cudf/__init__.py
@@ -8,6 +8,8 @@ import cupy
 from numba import config as numba_config, cuda
 
 import rmm
+from rmm.allocators.cupy import rmm_cupy_allocator
+from rmm.allocators.numba import RMMNumbaManager
 
 from cudf import api, core, datasets, testing
 from cudf.api.extensions import (
@@ -96,8 +98,8 @@ else:
 
     del patch_numba_linker_if_needed
 
-cuda.set_memory_manager(rmm.RMMNumbaManager)
-cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+cuda.set_memory_manager(RMMNumbaManager)
+cupy.cuda.set_allocator(rmm_cupy_allocator)
 
 try:
     # Numba 0.54: Disable low occupancy warnings


### PR DESCRIPTION
Following https://github.com/rapidsai/rmm/pull/1221, RMM allocators now live under the `rmm.allocators` submodule and using old paths causes warnings to be raised. This change updates to the new submodule and prevents such warnings.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
