### PR TITLE
Parquet writer column_size() should return a size_t

### DIFF
--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -87,7 +87,7 @@ parquet::Compression to_parquet_compression(compression_type compression)
   }
 }
 
-size_type column_size(column_view const& column, rmm::cuda_stream_view stream)
+size_t column_size(column_view const& column, rmm::cuda_stream_view stream)
 {
   if (column.size() == 0) { return 0; }
 
@@ -99,7 +99,7 @@ size_type column_size(column_view const& column, rmm::cuda_stream_view stream)
            cudf::detail::get_value<size_type>(scol.offsets(), 0, stream);
   } else if (column.type().id() == type_id::STRUCT) {
     auto const scol = structs_column_view(column);
-    size_type ret   = 0;
+    size_t ret      = 0;
     for (int i = 0; i < scol.num_children(); i++) {
       ret += column_size(scol.get_sliced_child(i), stream);
     }

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -87,7 +87,6 @@ parquet::Compression to_parquet_compression(compression_type compression)
   }
 }
 
-
 size_t column_size(column_view const& column, rmm::cuda_stream_view stream)
 {
   if (column.size() == 0) { return 0; }

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -87,6 +87,7 @@ parquet::Compression to_parquet_compression(compression_type compression)
   }
 }
 
+
 size_t column_size(column_view const& column, rmm::cuda_stream_view stream)
 {
   if (column.size() == 0) { return 0; }


### PR DESCRIPTION
## Description
Fixes #12867.

Bug introduced in #12685. A calculation of total bytes in a column was returned in a 32-bit `size_type` rather than 64-bit `size_t` leading to overflow for tables with many millions of rows.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
