### PR TITLE
[REVIEW] Fix docs build to be `pydata-sphinx-theme=0.13.0` compatible

### DIFF
--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -45,7 +45,7 @@ extensions = [
     "myst_nb",
 ]
 
-nb_execution_timeout = "force"
+nb_execution_mode = "force"
 nb_execution_timeout = 300
 
 copybutton_prompt_text = ">>> "

--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -45,8 +45,8 @@ extensions = [
     "myst_nb",
 ]
 
-jupyter_execute_notebooks = "force"
-execution_timeout = 300
+nb_execution_timeout = "force"
+nb_execution_timeout = 300
 
 copybutton_prompt_text = ">>> "
 autosummary_generate = True
@@ -103,6 +103,8 @@ todo_include_todos = False
 
 html_theme_options = {
     "external_links": [],
+    # https://github.com/pydata/pydata-sphinx-theme/issues/1220
+    "icon_links": [],
     "github_url": "https://github.com/rapidsai/cudf",
     "twitter_url": "https://twitter.com/rapidsai",
     "show_toc_level": 1,


### PR DESCRIPTION
## Description
This PR fixes cudf docs build to be compatible with `pydata-sphinx-theme=0.13.0` by adding an empty `icon_links` entry.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
