### PR TITLE
Expect cupy to now support bool arrays for dlpack.

### DIFF
--- a/python/cudf/cudf/tests/test_df_protocol.py
+++ b/python/cudf/cudf/tests/test_df_protocol.py
@@ -39,15 +39,12 @@ def assert_buffer_equal(buffer_and_dtype: Tuple[_CuDFBuffer, Any], cudfcol):
         cudfcol.apply_boolean_mask(non_null_idxs),
     )
 
-    if dtype[0] != _DtypeKind.BOOL:
-        array_from_dlpack = cp.from_dlpack(buf.__dlpack__()).get()
-        col_array = cp.asarray(cudfcol.data_array_view(mode="read")).get()
-        assert_eq(
-            array_from_dlpack[non_null_idxs.to_numpy()].flatten(),
-            col_array[non_null_idxs.to_numpy()].flatten(),
-        )
-    else:
-        pytest.raises(TypeError, buf.__dlpack__)
+    array_from_dlpack = cp.from_dlpack(buf.__dlpack__()).get()
+    col_array = cp.asarray(cudfcol.data_array_view(mode="read")).get()
+    assert_eq(
+        array_from_dlpack[non_null_idxs.to_numpy()].flatten(),
+        col_array[non_null_idxs.to_numpy()].flatten(),
+    )
 
 
 def assert_column_equal(col: _CuDFColumn, cudfcol):


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The most recent versions of cupy now support bool arrays in dlpack (see [the release notes](https://github.com/cupy/cupy/releases/tag/v11.6.0) and [the PR adding the feature](https://github.com/cupy/cupy/pull/7376)). Our DataFrame protocol tests were expecting a failure.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
