### PR TITLE
Add additional mock env vars for `moto`

### DIFF
--- a/python/cudf/cudf/tests/test_s3.py
+++ b/python/cudf/cudf/tests/test_s3.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 import os
 import socket
@@ -62,6 +62,9 @@ def s3_base(endpoint_ip, endpoint_port):
         os.environ.setdefault("AWS_ACCESS_KEY_ID", "foobar_key")
         os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "foobar_secret")
         os.environ.setdefault("S3FS_LOGGING_LEVEL", "DEBUG")
+        os.environ.setdefault("AWS_SECURITY_TOKEN", "foobar_security_token")
+        os.environ.setdefault("AWS_SESSION_TOKEN", "foobar_session_token")
+        os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
 
         # Launching moto in server mode, i.e., as a separate process
         # with an S3 endpoint on localhost

--- a/python/dask_cudf/dask_cudf/io/tests/test_s3.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_s3.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 import os
 import socket
@@ -58,6 +58,9 @@ def s3_base(endpoint_ip, endpoint_port):
         os.environ.setdefault("AWS_ACCESS_KEY_ID", "foobar_key")
         os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "foobar_secret")
         os.environ.setdefault("S3FS_LOGGING_LEVEL", "DEBUG")
+        os.environ.setdefault("AWS_SECURITY_TOKEN", "foobar_security_token")
+        os.environ.setdefault("AWS_SESSION_TOKEN", "foobar_session_token")
+        os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
 
         # Launching moto in server mode, i.e., as a separate process
         # with an S3 endpoint on localhost


### PR DESCRIPTION
## Description

This PR adds some additional AWS related environment variable mocks to the `cudf` `pytest`s.

These environment variables are documented by `moto` here: https://docs.getmoto.org/en/latest/docs/getting_started.html#recommended-usage.

This is important because of some recent CI changes that we made which now populate the `AWS_SESSION_TOKEN` environment variable, which was not mocked prior to the changes in this PR.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
