### PR TITLE
Fix read_avro() skip_rows and num_rows.

### DIFF
--- a/cpp/src/io/avro/avro.cpp
+++ b/cpp/src/io/avro/avro.cpp
@@ -115,7 +115,7 @@ bool container::parse(file_metadata* md, size_t max_num_rows, size_t first_row)
   //
   // A row offset is also maintained, and added to each block.  This reflects
   // the absolute offset that needs to be added to any given row in order to
-  // get the row's index within the destination array.  See `row_idx` in
+  // get the row's index within the destination array.  See `dst_row` in
   // `avro_decode_row()` for more information.
   //
   // N.B. "object" and "row" are used interchangeably here; "object" is

--- a/cpp/src/io/avro/avro.cpp
+++ b/cpp/src/io/avro/avro.cpp
@@ -101,7 +101,7 @@ bool container::parse(file_metadata* md, size_t max_num_rows, size_t first_row)
   md->sync_marker[1] = get_raw<uint64_t>();
 
   md->metadata_size  = m_cur - m_base;
-  md->skip_rows      = first_row;
+  md->skip_rows      = 0;
   md->total_num_rows = 0;
   max_block_size     = 0;
   total_object_count = 0;
@@ -115,6 +115,10 @@ bool container::parse(file_metadata* md, size_t max_num_rows, size_t first_row)
   //
   // N.B. "object" and "row" are used interchangeably here; "object" is
   //      avro nomenclature, "row" is ours.
+  //
+  // N.B. If we're skipping rows, we ignore blocks (i.e. don't add them to
+  //      md->block_list) that precede the block containing the first row
+  //      we're interested in.
   while (m_cur + 18 < m_end && total_object_count < max_num_rows) {
     auto const object_count = static_cast<uint32_t>(get_encoded<int64_t>());
     auto const block_size   = static_cast<uint32_t>(get_encoded<int64_t>());

--- a/cpp/src/io/avro/avro.cpp
+++ b/cpp/src/io/avro/avro.cpp
@@ -67,7 +67,7 @@ std::string container::get_encoded()
 bool container::parse(file_metadata* md, size_t max_num_rows, size_t first_row)
 {
   constexpr uint32_t avro_magic = (('O' << 0) | ('b' << 8) | ('j' << 16) | (0x01 << 24));
-  uint32_t sig4, max_block_size;
+  uint32_t sig4, max_block_size, num_rows, row_offset;
   size_t total_object_count;
   uint64_t sync_marker[2];
   bool valid_sync_markers;
@@ -101,7 +101,7 @@ bool container::parse(file_metadata* md, size_t max_num_rows, size_t first_row)
   md->sync_marker[1] = get_raw<uint64_t>();
 
   md->metadata_size  = m_cur - m_base;
-  md->skip_rows      = 0;
+  md->skip_rows      = first_row;
   md->total_num_rows = 0;
   max_block_size     = 0;
   total_object_count = 0;
@@ -113,29 +113,71 @@ bool container::parse(file_metadata* md, size_t max_num_rows, size_t first_row)
   //    3. Handle the case where we've been asked to skip or limit rows.
   //    4. Verify sync markers at the end of each block.
   //
+  // A row offset is also maintained, and added to each block.  This reflects
+  // the absolute offset that needs to be added to any given row in order to
+  // get the row's index within the destination array.  See `row_idx` in
+  // `avro_decode_row()` for more information.
+  //
   // N.B. "object" and "row" are used interchangeably here; "object" is
   //      avro nomenclature, "row" is ours.
   //
   // N.B. If we're skipping rows, we ignore blocks (i.e. don't add them to
   //      md->block_list) that precede the block containing the first row
   //      we're interested in.
+  //
+  // N.B. The 18 below is (presumably) intended to account for the two 64-bit
+  //      object count and block size integers (16 bytes total), and then an
+  //      additional two bytes to represent the smallest possible row size.
   while (m_cur + 18 < m_end && total_object_count < max_num_rows) {
     auto const object_count = static_cast<uint32_t>(get_encoded<int64_t>());
     auto const block_size   = static_cast<uint32_t>(get_encoded<int64_t>());
-    if (block_size <= 0 || object_count <= 0 || m_cur + block_size + 16 > m_end) { break; }
+    auto const next_end     = m_cur + block_size + 16;
+    // Abort on terminal conditions.  We keep these as separate lines instead of
+    // combining them into a single if in order to facilitate setting specific
+    // line breakpoints in the debugger.
+    if (block_size <= 0) { return false; }
+    if (object_count <= 0) { return false; }
+    if (next_end > m_end) { return false; }
+
+    // Update our total row count.  This is only captured for information
+    // purposes.
     md->total_num_rows += object_count;
-    if (object_count > first_row) {
-      auto block_row = static_cast<uint32_t>(total_object_count);
+
+    if (object_count <= first_row) {
+      // We've been asked to skip rows, and we haven't yet reached our desired
+      // number of rows to skip.  Subtract this block's rows (`object_count`)
+      // from the remaining rows to skip (`first_row`).  Do not add this block
+      // to our block list.
+      first_row -= object_count;
+    } else {
+      // Either we weren't asked to skip rows, or we were, but we've already hit
+      // our target number of rows to skip.  Add this block to our block list.
       max_block_size = std::max(max_block_size, block_size);
       total_object_count += object_count;
       if (!md->block_list.size()) {
-        md->skip_rows = first_row;
+        // This is the first block, so add it to our list with the current value
+        // of `first_row`, which will reflect the number of rows to skip *in
+        // this block*.
+        m_start = m_cur;
         total_object_count -= first_row;
+        num_rows   = total_object_count;
+        row_offset = 0;
+        if ((max_num_rows > 0) && (max_num_rows < total_object_count)) { num_rows = max_num_rows; }
+        md->block_list.emplace_back(m_cur - m_base, block_size, row_offset, first_row, num_rows);
         first_row = 0;
+        row_offset += num_rows;
+      } else {
+        // Not our first block; `first_row` should always be zero here.
+        CUDF_EXPECTS(first_row == 0, "Invariant check failed: first_row != 0");
+
+        num_rows = object_count;
+        if ((max_num_rows > 0) && (max_num_rows < total_object_count)) {
+          num_rows -= (total_object_count - max_num_rows);
+        }
+
+        md->block_list.emplace_back(m_cur - m_base, block_size, row_offset, first_row, num_rows);
+        row_offset += num_rows;
       }
-      md->block_list.emplace_back(m_cur - m_base, block_size, block_row, object_count);
-    } else {
-      first_row -= object_count;
     }
     m_cur += block_size;
     // Read the next sync markers and ensure they match the first ones we
@@ -157,6 +199,8 @@ bool container::parse(file_metadata* md, size_t max_num_rows, size_t first_row)
     md->num_rows = max_num_rows;
   }
   md->total_data_size = m_cur - (m_base + md->metadata_size);
+  CUDF_EXPECTS(m_cur > m_start, "Invariant check failed: `m_cur > m_start` is false.");
+  md->selected_data_size = m_cur - m_start;
   // Extract columns
   for (size_t i = 0; i < md->schema.size(); i++) {
     type_kind_e kind                = md->schema[i].kind;

--- a/cpp/src/io/avro/avro.hpp
+++ b/cpp/src/io/avro/avro.hpp
@@ -62,13 +62,14 @@ struct column_desc {
  */
 struct file_metadata {
   std::map<std::string, std::string> user_data;
-  std::string codec       = "";
-  uint64_t sync_marker[2] = {0, 0};
-  size_t metadata_size    = 0;
-  size_t total_data_size  = 0;
-  size_t num_rows         = 0;
-  uint32_t skip_rows      = 0;
-  uint32_t max_block_size = 0;
+  std::string codec        = "";
+  uint64_t sync_marker[2]  = {0, 0};
+  size_t metadata_size     = 0;
+  size_t total_data_size   = 0;
+  size_type num_rows       = 0;
+  size_type skip_rows      = 0;
+  size_type total_num_rows = 0;
+  uint32_t max_block_size  = 0;
   std::vector<schema_entry> schema;
   std::vector<block_desc_s> block_list;
   std::vector<column_desc> columns;

--- a/cpp/src/io/avro/avro.hpp
+++ b/cpp/src/io/avro/avro.hpp
@@ -76,7 +76,10 @@ struct column_desc {
  *
  * `skip_rows` is the number of rows to skip.
  *
- * `block_list` is a list of all blocks in the file.
+ * `block_list` is a list of all blocks that contain the selected rows.  If no
+ * row filtering has been done via `num_rows` or `skip_rows`; it will contain
+ * all blocks.  Otherwise, it will contain only blocks selected by those
+ * constraints.
  */
 struct file_metadata {
   std::map<std::string, std::string> user_data;

--- a/cpp/src/io/avro/avro.hpp
+++ b/cpp/src/io/avro/avro.hpp
@@ -64,6 +64,10 @@ struct column_desc {
  *
  * `total_data_size` is the size of all data minus `metadata_size`.
  *
+ * `selected_data_size` is the size of all data minus `metadata_size`, with any
+ * adjustments made to account for the number of rows or rows to skip per the
+ * user's request.  This is the value used to size device-side buffers.
+ *
  * `num_rows` is the number of rows that will be processed.  If the user has not
  * requested the number of rows to be limited (i.e. via the `num_rows` param to
  * `read_avro()`), this number will represent all rows in the file *after* the
@@ -74,23 +78,37 @@ struct column_desc {
  * blocks.  This may be more than `num_rows` if the user has requested a limit
  * on the number of rows to return, or if `skip_rows` is active.
  *
- * `skip_rows` is the number of rows to skip.
+ * `skip_rows` is the number of rows the user has requested to skip.  Note that
+ * this value may differ from the `block_desc_s.first_row` member, which will
+ * capture the number of rows to skip for a given block.
  *
  * `block_list` is a list of all blocks that contain the selected rows.  If no
  * row filtering has been done via `num_rows` or `skip_rows`; it will contain
  * all blocks.  Otherwise, it will contain only blocks selected by those
  * constraints.
+ *
+ * N.B. It is important to note that the coordination of skipping and limiting
+ *      rows is dictated by the `first_row` and `num_rows` members of each block
+ *      in the block list, *not* the `skip_rows` and `num_rows` members of this
+ *      struct.
+ *
+ *      This is because the first row and number of rows to process for each
+ *      block needs to be handled at the individual block level in order to
+ *      correctly support avro multi-block files.
+ *
+ *      See also the `block_desc_s` struct.
  */
 struct file_metadata {
   std::map<std::string, std::string> user_data;
-  std::string codec        = "";
-  uint64_t sync_marker[2]  = {0, 0};
-  size_t metadata_size     = 0;
-  size_t total_data_size   = 0;
-  size_type num_rows       = 0;
-  size_type skip_rows      = 0;
-  size_type total_num_rows = 0;
-  uint32_t max_block_size  = 0;
+  std::string codec         = "";
+  uint64_t sync_marker[2]   = {0, 0};
+  size_t metadata_size      = 0;
+  size_t total_data_size    = 0;
+  size_t selected_data_size = 0;
+  size_type num_rows        = 0;
+  size_type skip_rows       = 0;
+  size_type total_num_rows  = 0;
+  uint32_t max_block_size   = 0;
   std::vector<schema_entry> schema;
   std::vector<block_desc_s> block_list;
   std::vector<column_desc> columns;
@@ -122,11 +140,12 @@ class schema_parser {
  */
 class container {
  public:
-  container(uint8_t const* base, size_t len) noexcept : m_base{base}, m_cur{base}, m_end{base + len}
+  container(uint8_t const* base, size_t len) noexcept
+    : m_base{base}, m_start{base}, m_cur{base}, m_end{base + len}
   {
   }
 
-  [[nodiscard]] auto bytecount() const { return m_cur - m_base; }
+  [[nodiscard]] auto bytecount() const { return m_cur - m_start; }
 
   template <typename T>
   T get_raw()
@@ -145,7 +164,17 @@ class container {
   bool parse(file_metadata* md, size_t max_num_rows = 0x7fff'ffff, size_t first_row = 0);
 
  protected:
+  // Base address of the file data.  This will always point to the file's metadata.
   const uint8_t* m_base;
+
+  // Start, current, and end pointers for the file.  These pointers refer to the
+  // actual data content of the file, not the metadata.  `m_cur` and `m_start`
+  // will only ever differ if a user has requested `read_avro()` to skip rows;
+  // in this case, `m_start` will be the base address of the block that contains
+  // the first row to be processed.  `m_cur` is updated as the file is parsed,
+  // until either `m_end` is reached, or the number of rows requested by the user
+  // is reached.
+  const uint8_t* m_start;
   const uint8_t* m_cur;
   const uint8_t* m_end;
 };

--- a/cpp/src/io/avro/avro.hpp
+++ b/cpp/src/io/avro/avro.hpp
@@ -59,6 +59,24 @@ struct column_desc {
 
 /**
  * @brief AVRO file metadata struct
+ *
+ * `metadata_size` is the size in bytes of the avro file header.
+ *
+ * `total_data_size` is the size of all data minus `metadata_size`.
+ *
+ * `num_rows` is the number of rows that will be processed.  If the user has not
+ * requested the number of rows to be limited (i.e. via the `num_rows` param to
+ * `read_avro()`), this number will represent all rows in the file *after* the
+ * `skip_rows` parameter has been taken into consideration (assuming a request
+ * has been made to also skip rows).
+ *
+ * `total_num_rows` is the total number of rows present in the file, across all
+ * blocks.  This may be more than `num_rows` if the user has requested a limit
+ * on the number of rows to return, or if `skip_rows` is active.
+ *
+ * `skip_rows` is the number of rows to skip.
+ *
+ * `block_list` is a list of all blocks in the file.
  */
 struct file_metadata {
   std::map<std::string, std::string> user_data;

--- a/cpp/src/io/avro/avro_common.hpp
+++ b/cpp/src/io/avro/avro_common.hpp
@@ -26,17 +26,40 @@ namespace io {
 namespace avro {
 struct block_desc_s {
   block_desc_s() {}
-  explicit constexpr block_desc_s(size_t offset_,
-                                  uint32_t size_,
-                                  uint32_t first_row_,
-                                  uint32_t num_rows_)
-    : offset(offset_), size(size_), first_row(first_row_), num_rows(num_rows_)
+  explicit constexpr block_desc_s(
+    size_t offset_, uint32_t size_, uint32_t row_offset_, uint32_t first_row_, uint32_t num_rows_)
+    : offset(offset_),
+      size(size_),
+      row_offset(row_offset_),
+      first_row(first_row_),
+      num_rows(num_rows_)
   {
   }
 
+  // Offset of this block, in bytes, from the start of the file.
   size_t offset;
+
+  // Size of this block, in bytes.
   uint32_t size;
+
+  // The absolute row offset that needs to be added to each row index in order
+  // to derive the offset of the decoded data in the destination array.  E.g.
+  // `const ptrdiff_t row_idx = ((row - first_row) + row_offset)`.  See
+  // `avro_decode_row()` for details.
+  uint32_t row_offset;
+
+  // The index of the first row to be decoded from this block.  That is, the
+  // number of rows to skip in this block before starting to decode.  If this is
+  // 0, then no rows will be skipped.  If a user has requested `read_avro()` to
+  // skip rows, that will materialize as a non-zero `first_row` value in the
+  // appropriate block containing the first row to be decoded.
   uint32_t first_row;
+
+  // The number of rows to decode from this block.  If a user has requested
+  // `read_avro()` to limit the number of rows to return, this will materialize
+  // as a `num_rows` value less than the total number of rows in the appropriate
+  // block.  Otherwise, `num_rows` will be equal to the total number of rows in
+  // the block, after skipping `first_row` rows (if applicable).
   uint32_t num_rows;
 };
 

--- a/cpp/src/io/avro/avro_common.hpp
+++ b/cpp/src/io/avro/avro_common.hpp
@@ -44,22 +44,34 @@ struct block_desc_s {
 
   // The absolute row offset that needs to be added to each row index in order
   // to derive the offset of the decoded data in the destination array.  E.g.
-  // `const ptrdiff_t row_idx = ((row - first_row) + row_offset)`.  See
+  // `const ptrdiff_t dst_row = ((row - first_row) + row_offset)`.  See
   // `avro_decode_row()` for details.
   uint32_t row_offset;
 
-  // The index of the first row to be decoded from this block.  That is, the
-  // number of rows to skip in this block before starting to decode.  If this is
-  // 0, then no rows will be skipped.  If a user has requested `read_avro()` to
-  // skip rows, that will materialize as a non-zero `first_row` value in the
-  // appropriate block containing the first row to be decoded.
+  // The index of the first row to be *saved* from this block.  That is, the
+  // number of rows to skip in this block before starting to save values.  If
+  // this is 0, then no rows will be skipped (all rows will be saved).  If a
+  // user has requested `read_avro()` to skip rows, that will materialize as a
+  // non-zero `first_row` value in the appropriate block containing the first
+  // row to be saved.
+  //
+  // N.B. We explicitly use the word "saved" here, not "decoded".  Technically,
+  //      all rows are decoded, one column at a time, as the process of decoding
+  //      a column value is what informs us of the value's size in bytes (in its
+  //      encoded form), and thus, where the next column starts.  However, we
+  //      only *save* these decoded values based on the `first_row`.
   uint32_t first_row;
 
-  // The number of rows to decode from this block.  If a user has requested
+  // The number of rows to save from this block.  If a user has requested
   // `read_avro()` to limit the number of rows to return, this will materialize
   // as a `num_rows` value less than the total number of rows in the appropriate
   // block.  Otherwise, `num_rows` will be equal to the total number of rows in
   // the block, after skipping `first_row` rows (if applicable).
+  //
+  // N.B. Unlike `first_rows`, where all rows and columns are decoded prior to
+  //      reaching the point we've been requested to start *saving* values --
+  //      once the `num_rows` limit has been reached, no further decoding takes
+  //      place.
   uint32_t num_rows;
 };
 

--- a/cpp/src/io/avro/avro_gpu.cu
+++ b/cpp/src/io/avro/avro_gpu.cu
@@ -366,8 +366,7 @@ __global__ void __launch_bounds__(num_warps * 32, 2)
 
   while (cur < end) {
     uint32_t nrows;
-    const uint8_t* start                = cur;
-    const uint32_t start_rows_remaining = rows_remaining;
+    const uint8_t* start = cur;
 
     if (cur + min_row_size * rows_remaining == end) {
       // We're dealing with predictable fixed-size rows, which means we can
@@ -404,8 +403,10 @@ __global__ void __launch_bounds__(num_warps * 32, 2)
       // Only lane 0 (i.e. 'threadIdx.x == 0') was active, so we need to
       // broadcast the new value of 'cur' and 'rows_remaining' to all other
       // threads in the warp.
-      cur            = start + shuffle(static_cast<uint32_t>(cur - start));
-      rows_remaining = start_rows_remaining + shuffle(rows_remaining - start_rows_remaining);
+      cur = start + shuffle(static_cast<uint32_t>(cur - start));
+      // rows_remaining is already uint32_t, so we don't need to do the
+      // start + shuffle(this - start) dance like we do above.
+      rows_remaining = shuffle(rows_remaining);
     } else if (nrows > 1) {
       cur = start + (nrows * min_row_size);
     }

--- a/cpp/src/io/avro/avro_gpu.cu
+++ b/cpp/src/io/avro/avro_gpu.cu
@@ -57,11 +57,17 @@ static inline int64_t __device__ avro_decode_zigzag_varint(const uint8_t*& cur, 
  * @param[in] schema Schema description
  * @param[in] schema_g Global schema in device mem
  * @param[in] schema_len Number of schema entries
+ * @param[in] first_row First row to start saving decoded data
  * @param[in] row Current row
- * @param[in] max_rows Total number of rows
+ * @param[in] end_row One past the last row to decode
+ * @param[in] row_offset Absolute row offset of this row in the
+ *                       destination data.
  * @param[in] cur Current input data pointer
  * @param[in] end End of input data
  * @param[in] global_Dictionary Global dictionary entries
+ * @param[out] skipped_row Whether the row was skipped; set to false
+ *                         if the row was decoded (caller should ensure
+ *                         this is initialized to true)
  *
  * @return data pointer at the end of the row (start of next row)
  */
@@ -69,12 +75,41 @@ static uint8_t const* __device__
 avro_decode_row(schemadesc_s const* schema,
                 schemadesc_s* schema_g,
                 uint32_t schema_len,
+                size_t first_row,
                 size_t row,
-                size_t max_rows,
+                size_t end_row,
+                size_t row_offset,
                 uint8_t const* cur,
                 uint8_t const* end,
-                device_span<string_index_pair const> global_dictionary)
+                device_span<string_index_pair const> global_dictionary,
+                bool* skipped_row)
 {
+  // `row_idx` depicts the offset of the decoded row in the destination
+  // `dataptr` array, adjusted for skip rows, if applicable.  For example,
+  // if `row` == 5 and `first_row` == 3, then this is the second row we'll
+  // be storing (5-3).  If `first_row` is greater than `row`, this routine
+  // simply decodes the row and adjusts the returned data pointer, but does
+  // *not* actually store the row in the destination `dataptr` array.  This
+  // is enforced by all writes to the destination memory being guarded in the
+  // following fashion:
+  //    if (dataptr != nullptr && row_idx > 0) {
+  //      static_cast<int32_t*>(dataptr)[row_idx] = static_cast<int32_t>(v);
+  //    }
+  // The actual value is calculated by subtracting the first row from this given
+  // row value, and then adding the absolute row offset.  The row offset is
+  // required to ensure we write to the correct destination location when we're
+  // processing multiple blocks, i.e. this block could only have 10 rows, but
+  // it's the 3rd block (where each block has 10 rows), so we need to write to
+  // the 30th row in the destination array.
+  const ptrdiff_t row_idx =
+    (row >= first_row && row < end_row ? static_cast<ptrdiff_t>((row - first_row) + row_offset)
+                                       : -1);
+  // Critical invariant checks: row_idx should be -1 or greater, and
+  // *skipped_row should always be true at this point (we set it to false only
+  // if we write the decoded value to the destination array).
+  if (row_idx < -1) { CUDF_UNREACHABLE("row_idx should be -1 or greater"); }
+  if (*skipped_row != true) { CUDF_UNREACHABLE("skipped_row should be true"); }
+
   uint32_t array_start = 0, array_repeat_count = 0;
   int array_children = 0;
   for (uint32_t i = 0; i < schema_len;) {
@@ -107,22 +142,27 @@ avro_decode_row(schemadesc_s const* schema,
     void* dataptr = schema[i].dataptr;
     switch (kind) {
       case type_null:
-        if (dataptr != nullptr && row < max_rows) {
-          atomicAnd(static_cast<uint32_t*>(dataptr) + (row >> 5), ~(1 << (row & 0x1f)));
+        if (dataptr != nullptr && row_idx >= 0) {
+          atomicAnd(static_cast<uint32_t*>(dataptr) + (row_idx >> 5), ~(1 << (row_idx & 0x1f)));
           atomicAdd(&schema_g[i].count, 1);
+          *skipped_row = false;
         }
         break;
 
       case type_int: {
         int64_t v = avro_decode_zigzag_varint(cur, end);
-        if (dataptr != nullptr && row < max_rows) {
-          static_cast<int32_t*>(dataptr)[row] = static_cast<int32_t>(v);
+        if (dataptr != nullptr && row_idx >= 0) {
+          static_cast<int32_t*>(dataptr)[row_idx] = static_cast<int32_t>(v);
+          *skipped_row                            = false;
         }
       } break;
 
       case type_long: {
         int64_t v = avro_decode_zigzag_varint(cur, end);
-        if (dataptr != nullptr && row < max_rows) { static_cast<int64_t*>(dataptr)[row] = v; }
+        if (dataptr != nullptr && row_idx >= 0) {
+          static_cast<int64_t*>(dataptr)[row_idx] = v;
+          *skipped_row                            = false;
+        }
       } break;
 
       case type_bytes: [[fallthrough]];
@@ -142,14 +182,15 @@ avro_decode_row(schemadesc_s const* schema,
           count = (size_t)v;
           cur += count;
         }
-        if (dataptr != nullptr && row < max_rows) {
-          static_cast<string_index_pair*>(dataptr)[row].first  = ptr;
-          static_cast<string_index_pair*>(dataptr)[row].second = count;
+        if (dataptr != nullptr && row_idx >= 0) {
+          static_cast<string_index_pair*>(dataptr)[row_idx].first  = ptr;
+          static_cast<string_index_pair*>(dataptr)[row_idx].second = count;
+          *skipped_row                                             = false;
         }
       } break;
 
       case type_float:
-        if (dataptr != nullptr && row < max_rows) {
+        if (dataptr != nullptr && row_idx >= 0) {
           uint32_t v;
           if (cur + 3 < end) {
             v = unaligned_load32(cur);
@@ -157,14 +198,15 @@ avro_decode_row(schemadesc_s const* schema,
           } else {
             v = 0;
           }
-          static_cast<uint32_t*>(dataptr)[row] = v;
+          static_cast<uint32_t*>(dataptr)[row_idx] = v;
+          *skipped_row                             = false;
         } else {
           cur += 4;
         }
         break;
 
       case type_double:
-        if (dataptr != nullptr && row < max_rows) {
+        if (dataptr != nullptr && row_idx >= 0) {
           uint64_t v;
           if (cur + 7 < end) {
             v = unaligned_load64(cur);
@@ -172,16 +214,18 @@ avro_decode_row(schemadesc_s const* schema,
           } else {
             v = 0;
           }
-          static_cast<uint64_t*>(dataptr)[row] = v;
+          static_cast<uint64_t*>(dataptr)[row_idx] = v;
+          *skipped_row                             = false;
         } else {
           cur += 8;
         }
         break;
 
       case type_boolean:
-        if (dataptr != nullptr && row < max_rows) {
-          uint8_t v                           = (cur < end) ? *cur : 0;
-          static_cast<uint8_t*>(dataptr)[row] = (v) ? 1 : 0;
+        if (dataptr != nullptr && row_idx >= 0) {
+          uint8_t v                               = (cur < end) ? *cur : 0;
+          static_cast<uint8_t*>(dataptr)[row_idx] = (v) ? 1 : 0;
+          *skipped_row                            = false;
         }
         cur++;
         break;
@@ -230,13 +274,17 @@ avro_decode_row(schemadesc_s const* schema,
         // be correct:
         //
         // int64_t v = avro_decode_zigzag_varint(cur, end);
-        // if (dataptr != nullptr && row < max_rows) { static_cast<int64_t*>(dataptr)[row] = v; }
+        // if (dataptr != nullptr && row_idx >= 0) {
+        //   static_cast<int64_t*>(dataptr)[row_idx] = v;
+        //   *skipped_row = false;
+        // }
       } break;
 
       case type_date: {
         int64_t v = avro_decode_zigzag_varint(cur, end);
-        if (dataptr != nullptr && row < max_rows) {
-          static_cast<int32_t*>(dataptr)[row] = static_cast<int32_t>(v);
+        if (dataptr != nullptr && row_idx >= 0) {
+          static_cast<int32_t*>(dataptr)[row_idx] = static_cast<int32_t>(v);
+          *skipped_row                            = false;
         }
       } break;
     }
@@ -273,8 +321,6 @@ avro_decode_row(schemadesc_s const* schema,
  * @param[in] avro_data Raw block data
  * @param[in] schema_len Number of entries in schema
  * @param[in] min_row_size Minimum size in bytes of a row
- * @param[in] max_rows Maximum number of rows to load
- * @param[in] first_row Crop all rows below first_row
  */
 // blockDim {32,num_warps,1}
 __global__ void __launch_bounds__(num_warps * 32, 2)
@@ -283,17 +329,16 @@ __global__ void __launch_bounds__(num_warps * 32, 2)
                           device_span<string_index_pair const> global_dictionary,
                           uint8_t const* avro_data,
                           uint32_t schema_len,
-                          uint32_t min_row_size,
-                          size_t max_rows,
-                          size_t first_row)
+                          uint32_t min_row_size)
 {
   __shared__ __align__(8) schemadesc_s g_shared_schema[max_shared_schema_len];
   __shared__ __align__(8) block_desc_s blk_g[num_warps];
 
+  bool skipped_row;
   schemadesc_s* schema;
   block_desc_s* const blk = &blk_g[threadIdx.y];
   uint32_t block_id       = blockIdx.x * num_warps + threadIdx.y;
-  size_t cur_row;
+  size_t cur_row, first_row, end_row;
   uint32_t rows_remaining;
   const uint8_t *cur, *end;
 
@@ -307,42 +352,63 @@ __global__ void __launch_bounds__(num_warps * 32, 2)
   } else {
     schema = schema_g;
   }
+
   if (block_id < blocks.size() and threadIdx.x == 0) { *blk = blocks[block_id]; }
   __syncthreads();
   if (block_id >= blocks.size()) { return; }
-  cur_row        = blk->first_row;
-  rows_remaining = blk->num_rows;
+
   cur            = avro_data + blk->offset;
   end            = cur + blk->size;
-  while (rows_remaining > 0 && cur < end) {
-    uint32_t nrows;
-    const uint8_t* start = cur;
+  first_row      = blk->first_row + blk->row_offset;
+  cur_row        = blk->row_offset;
+  end_row        = first_row + blk->num_rows;
+  rows_remaining = blk->num_rows;
 
-    if (cur_row > first_row + max_rows) break;
+  while (cur < end) {
+    uint32_t nrows;
+    const uint8_t* start                = cur;
+    const uint32_t start_rows_remaining = rows_remaining;
+
     if (cur + min_row_size * rows_remaining == end) {
+      // We're dealing with predictable fixed-size rows, which means we can
+      // process up to 32 rows (warp-width) at a time.  This will be the case
+      // when we're dealing with fixed-size data, e.g. of floats or doubles,
+      // which are always 4 or 8 bytes respectively.
       nrows = min(rows_remaining, 32);
       cur += threadIdx.x * min_row_size;
     } else {
+      // We're dealing with variable-size data, so only one row can be processed
+      // by one thread at a time.
       nrows = 1;
     }
+
     if (threadIdx.x < nrows) {
-      cur = avro_decode_row(schema,
+      skipped_row = true;
+      cur         = avro_decode_row(schema,
                             schema_g,
                             schema_len,
-                            cur_row - first_row + threadIdx.x,
-                            max_rows,
+                            first_row,
+                            cur_row + threadIdx.x,
+                            end_row,
+                            blk->row_offset,
                             cur,
                             end,
-                            global_dictionary);
-    }
-    if (nrows <= 1) {
-      cur = start + shuffle(static_cast<uint32_t>(cur - start));
-    } else {
-      cur = start + nrows * min_row_size;
+                            global_dictionary,
+                            &skipped_row);
+      if (!skipped_row) { rows_remaining -= nrows; }
     }
     __syncwarp();
+
     cur_row += nrows;
-    rows_remaining -= nrows;
+    if (nrows == 1) {
+      // Only lane 0 (i.e. 'threadIdx.x == 0') was active, so we need to
+      // broadcast the new value of 'cur' and 'rows_remaining' to all other
+      // threads in the warp.
+      cur            = start + shuffle(static_cast<uint32_t>(cur - start));
+      rows_remaining = start_rows_remaining + shuffle(rows_remaining - start_rows_remaining);
+    } else if (nrows > 1) {
+      cur = start + (nrows * min_row_size);
+    }
   }
 }
 
@@ -354,8 +420,6 @@ __global__ void __launch_bounds__(num_warps * 32, 2)
  * @param[in] global_dictionary Global dictionary entries
  * @param[in] avro_data Raw block data
  * @param[in] schema_len Number of entries in schema
- * @param[in] max_rows Maximum number of rows to load
- * @param[in] first_row Crop all rows below first_row
  * @param[in] min_row_size Minimum size in bytes of a row
  * @param[in] stream CUDA stream to use, default 0
  */
@@ -364,8 +428,6 @@ void DecodeAvroColumnData(device_span<block_desc_s const> blocks,
                           device_span<string_index_pair const> global_dictionary,
                           uint8_t const* avro_data,
                           uint32_t schema_len,
-                          size_t max_rows,
-                          size_t first_row,
                           uint32_t min_row_size,
                           rmm::cuda_stream_view stream)
 {
@@ -375,7 +437,7 @@ void DecodeAvroColumnData(device_span<block_desc_s const> blocks,
   dim3 const dim_grid((blocks.size() + num_warps - 1) / num_warps, 1);
 
   gpuDecodeAvroColumnData<<<dim_grid, dim_block, 0, stream.value()>>>(
-    blocks, schema, global_dictionary, avro_data, schema_len, min_row_size, max_rows, first_row);
+    blocks, schema, global_dictionary, avro_data, schema_len, min_row_size);
 }
 
 }  // namespace gpu

--- a/cpp/src/io/avro/avro_gpu.cu
+++ b/cpp/src/io/avro/avro_gpu.cu
@@ -59,14 +59,14 @@ static inline int64_t __device__ avro_decode_zigzag_varint(const uint8_t*& cur, 
  * @param[in] schema_len Number of schema entries
  * @param[in] first_row First row to start saving decoded data
  * @param[in] row Current row
- * @param[in] end_row One past the last row to decode
+ * @param[in] end_row One past the last row to save
  * @param[in] row_offset Absolute row offset of this row in the
  *                       destination data.
  * @param[in] cur Current input data pointer
  * @param[in] end End of input data
  * @param[in] global_Dictionary Global dictionary entries
  * @param[out] skipped_row Whether the row was skipped; set to false
- *                         if the row was decoded (caller should ensure
+ *                         if the row was saved (caller should ensure
  *                         this is initialized to true)
  *
  * @return data pointer at the end of the row (start of next row)
@@ -94,6 +94,7 @@ avro_decode_row(schemadesc_s const* schema,
   // following fashion:
   //    if (dataptr != nullptr && dst_row > 0) {
   //      static_cast<int32_t*>(dataptr)[dst_row] = static_cast<int32_t>(v);
+  //      *skipped_row = false;
   //    }
   // The actual value is calculated by subtracting the first row from this given
   // row value, and then adding the absolute row offset.  The row offset is

--- a/cpp/src/io/avro/avro_gpu.hpp
+++ b/cpp/src/io/avro/avro_gpu.hpp
@@ -45,8 +45,6 @@ struct schemadesc_s {
  * @param[in] global_dictionary Global dictionary entries
  * @param[in] avro_data Raw block data
  * @param[in] schema_len Number of entries in schema
- * @param[in] max_rows Maximum number of rows to load
- * @param[in] first_row Crop all rows below first_row
  * @param[in] min_row_size Minimum size in bytes of a row
  * @param[in] stream CUDA stream to use
  */
@@ -55,8 +53,6 @@ void DecodeAvroColumnData(cudf::device_span<block_desc_s const> blocks,
                           cudf::device_span<string_index_pair const> global_dictionary,
                           uint8_t const* avro_data,
                           uint32_t schema_len,
-                          size_t max_rows,
-                          size_t first_row,
                           uint32_t min_row_size,
                           rmm::cuda_stream_view stream);
 

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -454,8 +454,6 @@ std::vector<column_buffer> decode_data(metadata& meta,
                             global_dictionary,
                             static_cast<uint8_t const*>(block_data.data()),
                             static_cast<uint32_t>(schema_desc.size()),
-                            meta.num_rows,
-                            meta.skip_rows,
                             min_row_data_size,
                             stream);
 
@@ -511,15 +509,15 @@ table_with_metadata read_avro(std::unique_ptr<cudf::io::datasource>&& source,
 
     if (meta.num_rows > 0) {
       rmm::device_buffer block_data;
-      if (source->is_device_read_preferred(meta.total_data_size)) {
-        block_data      = rmm::device_buffer{meta.total_data_size, stream};
+      if (source->is_device_read_preferred(meta.selected_data_size)) {
+        block_data      = rmm::device_buffer{meta.selected_data_size, stream};
         auto read_bytes = source->device_read(meta.block_list[0].offset,
-                                              meta.total_data_size,
+                                              meta.selected_data_size,
                                               static_cast<uint8_t*>(block_data.data()),
                                               stream);
         block_data.resize(read_bytes, stream);
       } else {
-        auto const buffer = source->host_read(meta.block_list[0].offset, meta.total_data_size);
+        auto const buffer = source->host_read(meta.block_list[0].offset, meta.selected_data_size);
         block_data        = rmm::device_buffer{buffer->data(), buffer->size(), stream};
       }
 

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -122,7 +122,7 @@ class metadata : public file_metadata {
    * @param[in,out] row_start Starting row of the selection
    * @param[in,out] row_count Total number of rows selected
    */
-  void init_and_select_rows(int& row_start, int& row_count)
+  void init_and_select_rows(size_type& row_start, size_type& row_count)
   {
     auto const buffer = source->host_read(0, source->size());
     avro::container pod(buffer->data(), buffer->size());
@@ -487,7 +487,6 @@ table_with_metadata read_avro(std::unique_ptr<cudf::io::datasource>&& source,
 {
   auto skip_rows = options.get_skip_rows();
   auto num_rows  = options.get_num_rows();
-  num_rows       = (num_rows != 0) ? num_rows : -1;
   std::vector<std::unique_ptr<column>> out_columns;
   table_metadata metadata_out;
 
@@ -510,7 +509,7 @@ table_with_metadata read_avro(std::unique_ptr<cudf::io::datasource>&& source,
       column_types.emplace_back(col_type);
     }
 
-    if (meta.total_data_size > 0) {
+    if (meta.num_rows > 0) {
       rmm::device_buffer block_data;
       if (source->is_device_read_preferred(meta.total_data_size)) {
         block_data      = rmm::device_buffer{meta.total_data_size, stream};

--- a/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
+++ b/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
@@ -453,6 +453,11 @@ def test_alltypes_plain_avro():
     assert_eq(actual, expected)
 
 
+def multiblock_testname_ids(param):
+    (total_rows, num_rows, skip_rows, sync_interval) = param
+    return f"{total_rows=}-{num_rows=}-{skip_rows=}-{sync_interval=}"
+
+
 # The following values are used to test various boundary conditions associated
 # with multiblock avro files.  Each tuple consists of four values: total number
 # of rows to generate, number of rows to limit the result set to, number of
@@ -460,95 +465,87 @@ def test_alltypes_plain_avro():
 # number of rows (i.e. first and second tuple elements) are equal, it means
 # that all rows will be returned.  If the rows per block also equals the first
 # two numbers, it means that a single block will be used.
-total_rows_and_num_rows_and_skip_rows_and_rows_per_block = [
-    (10, 10, 9, 9),
-    (10, 10, 9, 5),
-    (10, 10, 9, 3),
-    (10, 10, 9, 2),
-    (10, 10, 9, 10),
-    (10, 10, 8, 2),
-    (10, 10, 5, 5),
-    (10, 10, 2, 9),
-    (10, 10, 2, 2),
-    (10, 10, 1, 9),
-    (10, 10, 1, 5),
-    (10, 10, 1, 2),
-    (10, 10, 1, 10),
-    (10, 10, 10, 9),
-    (10, 10, 10, 5),
-    (10, 10, 10, 2),
-    (10, 10, 10, 10),
-    (10, 10, 0, 9),
-    (10, 10, 0, 5),
-    (10, 10, 0, 2),
-    (10, 10, 0, 10),
-    (100, 100, 99, 10),
-    (100, 100, 90, 90),
-    (100, 100, 90, 89),
-    (100, 100, 90, 88),
-    (100, 100, 90, 87),
-    (100, 100, 90, 5),
-    (100, 100, 89, 90),
-    (100, 100, 87, 90),
-    (100, 100, 50, 7),
-    (100, 100, 50, 31),
-    (10, 1, 8, 9),
-    (100, 1, 99, 10),
-    (100, 1, 98, 10),
-    (100, 1, 97, 10),
-    (100, 3, 90, 87),
-    (100, 4, 90, 5),
-    (100, 2, 89, 90),
-    (100, 9, 87, 90),
-    (100, 20, 50, 7),
-    (100, 10, 50, 31),
-    (100, 20, 50, 31),
-    (100, 30, 50, 31),
-    (256, 256, 0, 256),
-    (256, 256, 0, 32),
-    (256, 256, 0, 31),
-    (256, 256, 0, 33),
-    (256, 256, 31, 32),
-    (256, 256, 32, 31),
-    (256, 256, 31, 33),
-    (512, 512, 0, 32),
-    (512, 512, 0, 31),
-    (512, 512, 0, 33),
-    (512, 512, 31, 32),
-    (512, 512, 32, 31),
-    (512, 512, 31, 33),
-    (1024, 1024, 0, 1),
-    (1024, 1024, 0, 3),
-    (1024, 1024, 0, 7),
-    (1024, 1024, 0, 8),
-    (1024, 1024, 0, 9),
-    (1024, 1024, 0, 15),
-    (1024, 1024, 0, 16),
-    (1024, 1024, 0, 17),
-    (1024, 1024, 0, 32),
-    (1024, 1024, 0, 31),
-    (1024, 1024, 0, 33),
-    (1024, 1024, 31, 32),
-    (1024, 1024, 32, 31),
-    (1024, 1024, 31, 33),
-    (16384, 16384, 0, 31),
-    (16384, 16384, 0, 32),
-    (16384, 16384, 0, 33),
-    (16384, 16384, 0, 16384),
-]
-
-total_rows_and_num_rows_and_skip_rows_and_rows_per_block_ids = [
-    f"total_rows={total_rows}-"
-    + (f"num_rows={num_rows}-" if num_rows != total_rows else "")
-    + f"skip_rows={skip_rows}-"
-    f"sync_interval={sync_interval}"
-    for (
-        total_rows,
-        num_rows,
-        skip_rows,
-        sync_interval,
-    ) in total_rows_and_num_rows_and_skip_rows_and_rows_per_block
-]
+@pytest.fixture(
+    ids=multiblock_testname_ids,
+    params=[
+        (10, 10, 9, 9),
+        (10, 10, 9, 5),
+        (10, 10, 9, 3),
+        (10, 10, 9, 2),
+        (10, 10, 9, 10),
+        (10, 10, 8, 2),
+        (10, 10, 5, 5),
+        (10, 10, 2, 9),
+        (10, 10, 2, 2),
+        (10, 10, 1, 9),
+        (10, 10, 1, 5),
+        (10, 10, 1, 2),
+        (10, 10, 1, 10),
+        (10, 10, 10, 9),
+        (10, 10, 10, 5),
+        (10, 10, 10, 2),
+        (10, 10, 10, 10),
+        (10, 10, 0, 9),
+        (10, 10, 0, 5),
+        (10, 10, 0, 2),
+        (10, 10, 0, 10),
+        (100, 100, 99, 10),
+        (100, 100, 90, 90),
+        (100, 100, 90, 89),
+        (100, 100, 90, 88),
+        (100, 100, 90, 87),
+        (100, 100, 90, 5),
+        (100, 100, 89, 90),
+        (100, 100, 87, 90),
+        (100, 100, 50, 7),
+        (100, 100, 50, 31),
+        (10, 1, 8, 9),
+        (100, 1, 99, 10),
+        (100, 1, 98, 10),
+        (100, 1, 97, 10),
+        (100, 3, 90, 87),
+        (100, 4, 90, 5),
+        (100, 2, 89, 90),
+        (100, 9, 87, 90),
+        (100, 20, 50, 7),
+        (100, 10, 50, 31),
+        (100, 20, 50, 31),
+        (100, 30, 50, 31),
+        (256, 256, 0, 256),
+        (256, 256, 0, 32),
+        (256, 256, 0, 31),
+        (256, 256, 0, 33),
+        (256, 256, 31, 32),
+        (256, 256, 32, 31),
+        (256, 256, 31, 33),
+        (512, 512, 0, 32),
+        (512, 512, 0, 31),
+        (512, 512, 0, 33),
+        (512, 512, 31, 32),
+        (512, 512, 32, 31),
+        (512, 512, 31, 33),
+        (1024, 1024, 0, 1),
+        (1024, 1024, 0, 3),
+        (1024, 1024, 0, 7),
+        (1024, 1024, 0, 8),
+        (1024, 1024, 0, 9),
+        (1024, 1024, 0, 15),
+        (1024, 1024, 0, 16),
+        (1024, 1024, 0, 17),
+        (1024, 1024, 0, 32),
+        (1024, 1024, 0, 31),
+        (1024, 1024, 0, 33),
+        (1024, 1024, 31, 32),
+        (1024, 1024, 32, 31),
+        (1024, 1024, 31, 33),
+        (16384, 16384, 0, 31),
+        (16384, 16384, 0, 32),
+        (16384, 16384, 0, 33),
+        (16384, 16384, 0, 16384),
+    ],
+)
+def total_rows_and_num_rows_and_skip_rows_and_rows_per_block(request):
+    return request.param
 
 
 # N.B. The float32 and float64 types are chosen specifically to exercise
@@ -563,11 +560,6 @@ total_rows_and_num_rows_and_skip_rows_and_rows_per_block_ids = [
     ids=["use_sync_interval", "ignore_sync_interval"],
 )
 @pytest.mark.parametrize("codec", ["null", "deflate", "snappy"])
-@pytest.mark.parametrize(
-    "total_rows_and_num_rows_and_skip_rows_and_rows_per_block",
-    total_rows_and_num_rows_and_skip_rows_and_rows_per_block,
-    ids=total_rows_and_num_rows_and_skip_rows_and_rows_per_block_ids,
-)
 def test_avro_reader_multiblock(
     dtype,
     codec,

--- a/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
+++ b/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
@@ -28,8 +28,8 @@ from cudf.testing.dataset_generator import rand_dataframe
 def cudf_from_avro_util(
     schema: dict,
     records: list,
-    num_rows: Optional[int] = None,
     skip_rows: Optional[int] = None,
+    num_rows: Optional[int] = None,
 ) -> cudf.DataFrame:
     schema = [] if schema is None else fastavro.parse_schema(schema)
     buffer = io.BytesIO()
@@ -456,15 +456,7 @@ def test_alltypes_plain_avro():
 
 @pytest.mark.parametrize(
     "total_rows_and_num_rows",
-    [
-        (1, 1),
-        (10, 5),
-        (100, 10),
-        (10, 10),
-        (10, 0),
-        (10, 9),
-        (10, 1)
-    ],
+    [(1, 1), (10, 5), (100, 10), (10, 10), (10, 0), (10, 9), (10, 1)],
 )
 def test_avro_reader_num_rows(total_rows_and_num_rows):
     (total_rows, num_rows) = total_rows_and_num_rows

--- a/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
+++ b/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
@@ -576,7 +576,7 @@ def test_avro_reader_multiblock(
     assert total_rows >= num_rows
     assert rows_per_block <= total_rows
 
-    limit_rows = not (num_rows == total_rows)
+    limit_rows = num_rows != total_rows
     if limit_rows:
         assert total_rows >= num_rows + skip_rows
 
@@ -596,10 +596,8 @@ def test_avro_reader_multiblock(
         # bytes per row is 6 + 1 = 7.
         bytes_per_row = len(values[0]) + 1
         assert bytes_per_row == 7, bytes_per_row
-
     else:
         assert dtype in ("float32", "float64")
-        bytes_per_row = 4 if dtype == "float32" else 8
         avro_type = "float" if dtype == "float32" else "double"
 
         # We don't use rand_dataframe() here, because it increases the
@@ -607,6 +605,7 @@ def test_avro_reader_multiblock(
         # to use a very costly approach to generating random data).
         # See also: https://github.com/rapidsai/cudf/issues/13128
         values = np.random.rand(total_rows).astype(dtype)
+        bytes_per_row = values.dtype.itemsize
 
     # The sync_interval is the number of bytes between sync blocks.  We know
     # how many bytes we need per row, so we can calculate the number of bytes

--- a/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
+++ b/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
@@ -227,6 +227,7 @@ def test_avro_compression(rows, codec):
 
     # N.B. rand_dataframe() is brutally slow for some reason.  Switching to
     #      np.random() speeds things up by a factor of 10.
+    #      See also: https://github.com/rapidsai/cudf/issues/13128
     df = rand_dataframe(
         [
             {"dtype": "int32", "null_frequency": 0, "cardinality": 1000},
@@ -612,6 +613,7 @@ def test_avro_reader_multiblock(
         # We don't use rand_dataframe() here, because it increases the
         # execution time of each test by a factor of 10 or more (it appears
         # to use a very costly approach to generating random data).
+        # See also: https://github.com/rapidsai/cudf/issues/13128
         values = np.random.rand(total_rows).astype(dtype)
 
     # The sync_interval is the number of bytes between sync blocks.  We know


### PR DESCRIPTION
## Description

This PR fixes the avro reader (`cudf.read_avro()`) such that it honors the values passed to the `skip_rows` and `num_rows` parameters.  In implementing this new logic, we also revamp the reader's ability to handle multi-block avro files, which we also test extensively with a new `test_avro_reader_multiblock()` test that features some 1300 permutations of various block size combinations.

Closes #6529.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
