### PR TITLE
Fix io/text gtests coded in namespace cudf::test

### DIFF
--- a/cpp/tests/io/text/data_chunk_source_test.cpp
+++ b/cpp/tests/io/text/data_chunk_source_test.cpp
@@ -25,12 +25,10 @@
 #include <fstream>
 #include <random>
 
-using namespace cudf::test;
+auto const temp_env = static_cast<cudf::test::TempDirTestEnvironment*>(
+  ::testing::AddGlobalTestEnvironment(new cudf::test::TempDirTestEnvironment));
 
-auto const temp_env = static_cast<TempDirTestEnvironment*>(
-  ::testing::AddGlobalTestEnvironment(new TempDirTestEnvironment));
-
-struct DataChunkSourceTest : public BaseFixture {
+struct DataChunkSourceTest : public cudf::test::BaseFixture {
 };
 
 std::string chunk_to_host(const cudf::io::text::device_data_chunk& chunk)

--- a/cpp/tests/io/text/multibyte_split_test.cpp
+++ b/cpp/tests/io/text/multibyte_split_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,13 +30,11 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-using namespace cudf;
-using namespace test;
-
+using cudf::test::strings_column_wrapper;
 // 😀 | F0 9F 98 80 | 11110000 10011111 10011000 10000000
 // 😎 | F0 9F 98 8E | 11110000 10011111 10011000 10001110
 
-struct MultibyteSplitTest : public BaseFixture {
+struct MultibyteSplitTest : public cudf::test::BaseFixture {
 };
 
 TEST_F(MultibyteSplitTest, Simple)
@@ -265,7 +263,7 @@ TEST_F(MultibyteSplitTest, HandpickedInput)
   auto source = cudf::io::text::make_source(host_input);
   auto out    = cudf::io::text::multibyte_split(*source, delimiters);
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, debug_output_level::ALL_ERRORS);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
 TEST_F(MultibyteSplitTest, LargeInputMultipleRange)
@@ -290,7 +288,8 @@ TEST_F(MultibyteSplitTest, LargeInputMultipleRange)
 
   auto expected = cudf::io::text::multibyte_split(*source, delimiter);
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected->view(), *out, debug_output_level::ALL_ERRORS);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+    expected->view(), *out, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
 TEST_F(MultibyteSplitTest, LargeInputSparseMultipleRange)
@@ -317,7 +316,8 @@ TEST_F(MultibyteSplitTest, LargeInputSparseMultipleRange)
 
   auto expected = cudf::io::text::multibyte_split(*source, delimiter);
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected->view(), *out, debug_output_level::ALL_ERRORS);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+    expected->view(), *out, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
 TEST_F(MultibyteSplitTest, LargeInputMultipleRangeSingleByte)
@@ -342,7 +342,8 @@ TEST_F(MultibyteSplitTest, LargeInputMultipleRangeSingleByte)
 
   auto expected = cudf::io::text::multibyte_split(*source, delimiter);
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected->view(), *out, debug_output_level::ALL_ERRORS);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+    expected->view(), *out, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
 TEST_F(MultibyteSplitTest, LargeInputSparseMultipleRangeSingleByte)
@@ -368,7 +369,8 @@ TEST_F(MultibyteSplitTest, LargeInputSparseMultipleRangeSingleByte)
 
   auto expected = cudf::io::text::multibyte_split(*source, delimiter);
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected->view(), *out, debug_output_level::ALL_ERRORS);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+    expected->view(), *out, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
 TEST_F(MultibyteSplitTest, SmallInputAllPossibleRanges)
@@ -398,7 +400,8 @@ TEST_F(MultibyteSplitTest, SmallInputAllPossibleRanges)
 
       auto expected = multibyte_split(*source, delimiter);
 
-      CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected->view(), *out, debug_output_level::ALL_ERRORS);
+      CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+        expected->view(), *out, cudf::test::debug_output_level::ALL_ERRORS);
     }
   }
 }
@@ -430,7 +433,8 @@ TEST_F(MultibyteSplitTest, SmallInputAllPossibleRangesSingleByte)
 
       auto expected = multibyte_split(*source, delimiter);
 
-      CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected->view(), *out, debug_output_level::ALL_ERRORS);
+      CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+        expected->view(), *out, cudf::test::debug_output_level::ALL_ERRORS);
     }
   }
 }
@@ -447,7 +451,7 @@ TEST_F(MultibyteSplitTest, SingletonRangeAtEnd)
 
   auto out = multibyte_split(*source, delimiter, byte_range_info{5, 1});
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, debug_output_level::ALL_ERRORS);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
 TEST_F(MultibyteSplitTest, EmptyInput)
@@ -460,7 +464,7 @@ TEST_F(MultibyteSplitTest, EmptyInput)
 
   auto out = multibyte_split(*source, delimiter);
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, debug_output_level::ALL_ERRORS);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
 TEST_F(MultibyteSplitTest, EmptyInputSingleByte)
@@ -473,7 +477,7 @@ TEST_F(MultibyteSplitTest, EmptyInputSingleByte)
 
   auto out = multibyte_split(*source, delimiter);
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, debug_output_level::ALL_ERRORS);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
 TEST_F(MultibyteSplitTest, EmptyRange)
@@ -486,7 +490,7 @@ TEST_F(MultibyteSplitTest, EmptyRange)
 
   auto out = multibyte_split(*source, delimiter, byte_range_info{4, 0});
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, debug_output_level::ALL_ERRORS);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
 TEST_F(MultibyteSplitTest, EmptyRangeSingleByte)
@@ -499,7 +503,7 @@ TEST_F(MultibyteSplitTest, EmptyRangeSingleByte)
 
   auto out = multibyte_split(*source, delimiter, byte_range_info{3, 0});
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, debug_output_level::ALL_ERRORS);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *out, cudf::test::debug_output_level::ALL_ERRORS);
 }
 
 TEST_F(MultibyteSplitTest, EmptySplitDeviceSpan)


### PR DESCRIPTION
## Description
Fixes DATA_CHUNK_SOURCE_TEST gtests source files coded in namespace cudf::test
Fixes MULTIBYTE_SPLIT_TEST gtests source files coded in namespace cudf::test

Reference https://github.com/rapidsai/cudf/issues/11734
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
