### PR TITLE
Fix benchmarks coded in namespace cudf and using namespace cudf

### DIFF
--- a/cpp/benchmarks/binaryop/compiled_binaryop.cpp
+++ b/cpp/benchmarks/binaryop/compiled_binaryop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,8 +66,14 @@ void BM_compiled_binaryop(benchmark::State& state, cudf::binary_operator binop)
 #define BINARYOP_BENCHMARK_DEFINE(lhs, rhs, bop, tout) \
   BM_BINARYOP_BENCHMARK_DEFINE(build_name(bop, lhs, rhs, tout), lhs, rhs, bop, tout)
 
-using namespace cudf;
-using namespace numeric;
+using cudf::duration_D;
+using cudf::duration_ms;
+using cudf::duration_ns;
+using cudf::duration_s;
+using cudf::timestamp_D;
+using cudf::timestamp_ms;
+using cudf::timestamp_s;
+using numeric::decimal32;
 
 // clang-format off
 BINARYOP_BENCHMARK_DEFINE(float,        int64_t,      ADD,                  int32_t);

--- a/cpp/benchmarks/groupby/group_rank.cpp
+++ b/cpp/benchmarks/groupby/group_rank.cpp
@@ -28,8 +28,7 @@ template <cudf::rank_method method>
 static void nvbench_groupby_rank(nvbench::state& state,
                                  nvbench::type_list<nvbench::enum_type<method>>)
 {
-  using namespace cudf;
-  constexpr auto dtype = type_to_id<int64_t>();
+  constexpr auto dtype = cudf::type_to_id<int64_t>();
 
   bool const is_sorted              = state.get_int64("is_sorted");
   cudf::size_type const column_size = state.get_int64("data_size");
@@ -43,16 +42,17 @@ static void nvbench_groupby_rank(nvbench::state& state,
   // values to be pre-sorted too for groupby rank
   if (is_sorted) source_table = cudf::sort(*source_table);
 
-  table_view keys{{source_table->view().column(0)}};
-  column_view order_by{source_table->view().column(1)};
+  cudf::table_view keys{{source_table->view().column(0)}};
+  cudf::column_view order_by{source_table->view().column(1)};
 
-  auto agg = cudf::make_rank_aggregation<groupby_scan_aggregation>(method);
-  std::vector<groupby::scan_request> requests;
-  requests.emplace_back(groupby::scan_request());
+  auto agg = cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(method);
+  std::vector<cudf::groupby::scan_request> requests;
+  requests.emplace_back(cudf::groupby::scan_request());
   requests[0].values = order_by;
   requests[0].aggregations.push_back(std::move(agg));
 
-  groupby::groupby gb_obj(keys, null_policy::EXCLUDE, is_sorted ? sorted::YES : sorted::NO);
+  cudf::groupby::groupby gb_obj(
+    keys, cudf::null_policy::EXCLUDE, is_sorted ? cudf::sorted::YES : cudf::sorted::NO);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     rmm::cuda_stream_view stream_view{launch.get_stream()};

--- a/cpp/benchmarks/lists/copying/scatter_lists.cu
+++ b/cpp/benchmarks/lists/copying/scatter_lists.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,6 @@
 
 #include <cmath>
 
-namespace cudf {
-
 class ScatterLists : public cudf::benchmark {
 };
 
@@ -43,14 +41,20 @@ void BM_lists_scatter(::benchmark::State& state)
   auto stream = cudf::get_default_stream();
   auto mr     = rmm::mr::get_current_device_resource();
 
-  const size_type base_size{(size_type)state.range(0)};
-  const size_type num_elements_per_row{(size_type)state.range(1)};
-  const auto num_rows = (size_type)ceil(double(base_size) / num_elements_per_row);
+  const cudf::size_type base_size{(cudf::size_type)state.range(0)};
+  const cudf::size_type num_elements_per_row{(cudf::size_type)state.range(1)};
+  const auto num_rows = (cudf::size_type)ceil(double(base_size) / num_elements_per_row);
 
-  auto source_base_col = make_fixed_width_column(
-    data_type{type_to_id<TypeParam>()}, base_size, mask_state::UNALLOCATED, stream, mr);
-  auto target_base_col = make_fixed_width_column(
-    data_type{type_to_id<TypeParam>()}, base_size, mask_state::UNALLOCATED, stream, mr);
+  auto source_base_col = make_fixed_width_column(cudf::data_type{cudf::type_to_id<TypeParam>()},
+                                                 base_size,
+                                                 cudf::mask_state::UNALLOCATED,
+                                                 stream,
+                                                 mr);
+  auto target_base_col = make_fixed_width_column(cudf::data_type{cudf::type_to_id<TypeParam>()},
+                                                 base_size,
+                                                 cudf::mask_state::UNALLOCATED,
+                                                 stream,
+                                                 mr);
   thrust::sequence(rmm::exec_policy(stream),
                    source_base_col->mutable_view().begin<TypeParam>(),
                    source_base_col->mutable_view().end<TypeParam>());
@@ -58,19 +62,27 @@ void BM_lists_scatter(::benchmark::State& state)
                    target_base_col->mutable_view().begin<TypeParam>(),
                    target_base_col->mutable_view().end<TypeParam>());
 
-  auto source_offsets = make_fixed_width_column(
-    data_type{type_to_id<offset_type>()}, num_rows + 1, mask_state::UNALLOCATED, stream, mr);
-  auto target_offsets = make_fixed_width_column(
-    data_type{type_to_id<offset_type>()}, num_rows + 1, mask_state::UNALLOCATED, stream, mr);
+  auto source_offsets =
+    make_fixed_width_column(cudf::data_type{cudf::type_to_id<cudf::offset_type>()},
+                            num_rows + 1,
+                            cudf::mask_state::UNALLOCATED,
+                            stream,
+                            mr);
+  auto target_offsets =
+    make_fixed_width_column(cudf::data_type{cudf::type_to_id<cudf::offset_type>()},
+                            num_rows + 1,
+                            cudf::mask_state::UNALLOCATED,
+                            stream,
+                            mr);
 
   thrust::sequence(rmm::exec_policy(stream),
-                   source_offsets->mutable_view().begin<offset_type>(),
-                   source_offsets->mutable_view().end<offset_type>(),
+                   source_offsets->mutable_view().begin<cudf::offset_type>(),
+                   source_offsets->mutable_view().end<cudf::offset_type>(),
                    0,
                    num_elements_per_row);
   thrust::sequence(rmm::exec_policy(stream),
-                   target_offsets->mutable_view().begin<offset_type>(),
-                   target_offsets->mutable_view().end<offset_type>(),
+                   target_offsets->mutable_view().begin<cudf::offset_type>(),
+                   target_offsets->mutable_view().end<cudf::offset_type>(),
                    0,
                    num_elements_per_row);
 
@@ -78,37 +90,40 @@ void BM_lists_scatter(::benchmark::State& state)
                                   std::move(source_offsets),
                                   std::move(source_base_col),
                                   0,
-                                  cudf::create_null_mask(num_rows, mask_state::UNALLOCATED),
+                                  cudf::create_null_mask(num_rows, cudf::mask_state::UNALLOCATED),
                                   stream,
                                   mr);
   auto target = make_lists_column(num_rows,
                                   std::move(target_offsets),
                                   std::move(target_base_col),
                                   0,
-                                  cudf::create_null_mask(num_rows, mask_state::UNALLOCATED),
+                                  cudf::create_null_mask(num_rows, cudf::mask_state::UNALLOCATED),
                                   stream,
                                   mr);
 
-  auto scatter_map = make_fixed_width_column(
-    data_type{type_to_id<size_type>()}, num_rows, mask_state::UNALLOCATED, stream, mr);
+  auto scatter_map   = make_fixed_width_column(cudf::data_type{cudf::type_to_id<cudf::size_type>()},
+                                             num_rows,
+                                             cudf::mask_state::UNALLOCATED,
+                                             stream,
+                                             mr);
   auto m_scatter_map = scatter_map->mutable_view();
   thrust::sequence(rmm::exec_policy(stream),
-                   m_scatter_map.begin<size_type>(),
-                   m_scatter_map.end<size_type>(),
+                   m_scatter_map.begin<cudf::size_type>(),
+                   m_scatter_map.end<cudf::size_type>(),
                    num_rows - 1,
                    -1);
 
   if (not coalesce) {
     thrust::default_random_engine g;
     thrust::shuffle(rmm::exec_policy(stream),
-                    m_scatter_map.begin<size_type>(),
-                    m_scatter_map.begin<size_type>(),
+                    m_scatter_map.begin<cudf::size_type>(),
+                    m_scatter_map.begin<cudf::size_type>(),
                     g);
   }
 
   for (auto _ : state) {
     cuda_event_timer raii(state, true);  // flush_l2_cache = true, stream = 0
-    scatter(table_view{{*source}}, *scatter_map, table_view{{*target}}, mr);
+    scatter(cudf::table_view{{*source}}, *scatter_map, cudf::table_view{{*target}}, mr);
   }
 
   state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * state.range(0) * 2 *
@@ -127,5 +142,3 @@ void BM_lists_scatter(::benchmark::State& state)
 
 SBM_BENCHMARK_DEFINE(double_type_colesce_o, double, true);
 SBM_BENCHMARK_DEFINE(double_type_colesce_x, double, false);
-
-}  // namespace cudf


### PR DESCRIPTION
## Description
Fixes BINARYOP_BENCH, GROUPBY_NVBENCH benchmarks from using namespace cudf directly.
Fixes SCATTER_LISTS_BENCH benchmarks coded in namespace cudf

Reference https://github.com/rapidsai/cudf/issues/11734
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
