### PR TITLE
Use get_current_device_resource for intermediate allocations in COLLECT_LIST window code

### DIFF
--- a/cpp/src/rolling/detail/rolling_collect_list.cuh
+++ b/cpp/src/rolling/detail/rolling_collect_list.cuh
@@ -53,8 +53,7 @@ std::unique_ptr<column> create_collect_offsets(size_type input_size,
 {
   // Materialize offsets column.
   auto static constexpr size_data_type = data_type{type_to_id<size_type>()};
-  auto sizes =
-    make_fixed_width_column(size_data_type, input_size, mask_state::UNALLOCATED, stream, mr);
+  auto sizes = make_fixed_width_column(size_data_type, input_size, mask_state::UNALLOCATED, stream);
   auto mutable_sizes = sizes->mutable_view();
 
   // Consider the following preceding/following values:


### PR DESCRIPTION
## Description
Updated code to use defaulted argument get_current_device_resource() for intermediate allocations in COLLECT_LIST window code
one-line fix.
Fixes https://github.com/rapidsai/cudf/issues/8219

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
