### PR TITLE
Fix cudf::segmented_reduce gtest for ANY aggregation

### DIFF
--- a/cpp/tests/reductions/segmented_reduction_tests.cpp
+++ b/cpp/tests/reductions/segmented_reduction_tests.cpp
@@ -31,11 +31,9 @@
 #define XXX 0  // null placeholder
 
 template <typename T>
-struct SegmentedReductionTest : public cudf::test::BaseFixture {
-};
+struct SegmentedReductionTest : public cudf::test::BaseFixture {};
 
-struct SegmentedReductionTestUntyped : public cudf::test::BaseFixture {
-};
+struct SegmentedReductionTestUntyped : public cudf::test::BaseFixture {};
 
 TYPED_TEST_CASE(SegmentedReductionTest, cudf::test::NumericTypes);
 
@@ -251,36 +249,25 @@ TYPED_TEST(SegmentedReductionTest, AnyExcludeNulls)
     {false, false, true, true, bool{XXX}, false, true, bool{XXX}, bool{XXX}},
     {true, true, true, true, false, true, true, false, false}};
 
-  auto res =
-    cudf::segmented_reduce(input,
-                           d_offsets,
-                           *cudf::make_any_aggregation<cudf::segmented_reduce_aggregation>(),
-                           cudf::data_type{cudf::type_id::BOOL8},
-                           cudf::null_policy::EXCLUDE);
+  auto const agg         = cudf::make_any_aggregation<cudf::segmented_reduce_aggregation>();
+  auto const output_type = cudf::data_type{cudf::type_id::BOOL8};
+  auto const policy      = cudf::null_policy::EXCLUDE;
+
+  auto res = cudf::segmented_reduce(input, d_offsets, *agg, output_type, policy);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*res, expect);
 
   // Test with initial value
-  auto const init_scalar = cudf::make_fixed_width_scalar<TypeParam>(1);
+  auto const init_scalar = cudf::make_fixed_width_scalar<TypeParam>(0);
   auto const init_expect = cudf::test::fixed_width_column_wrapper<bool>{
-    {true, true, true, true, true, true, true, true, true},
+    {false, false, true, true, false, false, true, false, false},
     {true, true, true, true, true, true, true, true, true}};
 
-  res = cudf::segmented_reduce(input,
-                               d_offsets,
-                               *cudf::make_any_aggregation<cudf::segmented_reduce_aggregation>(),
-                               cudf::data_type{cudf::type_id::BOOL8},
-                               cudf::null_policy::EXCLUDE,
-                               *init_scalar);
+  res = cudf::segmented_reduce(input, d_offsets, *agg, output_type, policy, *init_scalar);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*res, init_expect);
 
   // Test with null initial value
   init_scalar->set_valid_async(false);
-  res = cudf::segmented_reduce(input,
-                               d_offsets,
-                               *cudf::make_any_aggregation<cudf::segmented_reduce_aggregation>(),
-                               cudf::data_type{cudf::type_id::BOOL8},
-                               cudf::null_policy::EXCLUDE,
-                               *init_scalar);
+  res = cudf::segmented_reduce(input, d_offsets, *agg, output_type, policy, *init_scalar);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*res, expect);
 }
 
@@ -1089,8 +1076,7 @@ TEST_F(SegmentedReductionTestUntyped, EmptyInputWithOffsets)
 }
 
 template <typename T>
-struct SegmentedReductionFixedPointTest : public cudf::test::BaseFixture {
-};
+struct SegmentedReductionFixedPointTest : public cudf::test::BaseFixture {};
 
 TYPED_TEST_SUITE(SegmentedReductionFixedPointTest, cudf::test::FixedPointTypes);
 

--- a/cpp/tests/reductions/segmented_reduction_tests.cpp
+++ b/cpp/tests/reductions/segmented_reduction_tests.cpp
@@ -31,9 +31,11 @@
 #define XXX 0  // null placeholder
 
 template <typename T>
-struct SegmentedReductionTest : public cudf::test::BaseFixture {};
+struct SegmentedReductionTest : public cudf::test::BaseFixture {
+};
 
-struct SegmentedReductionTestUntyped : public cudf::test::BaseFixture {};
+struct SegmentedReductionTestUntyped : public cudf::test::BaseFixture {
+};
 
 TYPED_TEST_CASE(SegmentedReductionTest, cudf::test::NumericTypes);
 
@@ -1076,7 +1078,8 @@ TEST_F(SegmentedReductionTestUntyped, EmptyInputWithOffsets)
 }
 
 template <typename T>
-struct SegmentedReductionFixedPointTest : public cudf::test::BaseFixture {};
+struct SegmentedReductionFixedPointTest : public cudf::test::BaseFixture {
+};
 
 TYPED_TEST_SUITE(SegmentedReductionFixedPointTest, cudf::test::FixedPointTypes);
 


### PR DESCRIPTION
## Description
Minor fix to the `SegmentedReductionTest/AnyExcludeNulls` gtest to use `0/false` as the initial value to better test and demonstrate the usage. Found this when looking for an example to answer issue #10455 
Also reworked the code in this test to use variables to help minimize copy errors and shorten the code size.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
