### PR TITLE
[REVIEW] Fix set index error for Series rolling window operations

### DIFF
--- a/python/cudf/cudf/core/window/rolling.py
+++ b/python/cudf/cudf/core/window/rolling.py
@@ -557,5 +557,6 @@ class RollingGroupby(Rolling):
             )
         )
 
-        result = super()._apply_agg(agg_name).set_index(index)
+        result = super()._apply_agg(agg_name)
+        result.index = index
         return result

--- a/python/cudf/cudf/tests/test_rolling.py
+++ b/python/cudf/cudf/tests/test_rolling.py
@@ -547,3 +547,13 @@ def test_rolling_indexer_support(indexer):
     actual = gdf.rolling(window=indexer, min_periods=2).sum()
 
     assert_eq(expected, actual)
+
+
+def test_rolling_series():
+    df = cudf.DataFrame({"a": range(0, 100), "b": [10, 20, 30, 40, 50] * 20})
+    pdf = df.to_pandas()
+
+    expected = pdf.groupby("b")["a"].rolling(5).mean()
+    actual = df.groupby("b")["a"].rolling(5).mean()
+
+    assert_eq(expected, actual)


### PR DESCRIPTION
## Description
This PR fixes an issue with Series rolling window operations where there is a failure because `Series.set_index` has been dropped in the previous release. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
