### PR TITLE
Include gtest in build environment.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -30,6 +30,7 @@ dependencies:
 - fmt>=9.1.0,<10
 - fsspec>=0.6.0
 - gcc_linux-64=11.*
+- gtest==1.10.0.*
 - hypothesis
 - ipython
 - libarrow==10.0.1.*

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -30,6 +30,7 @@ dependencies:
 - fmt>=9.1.0,<10
 - fsspec>=0.6.0
 - gcc_linux-64=11.*
+- gmock==1.10.0.*
 - gtest==1.10.0.*
 - hypothesis
 - ipython

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     - librdkafka {{ librdkafka_version }}
     - fmt {{ fmt_version }}
     - spdlog {{ spdlog_version }}
+    - gtest==1.10.0.*
 
 outputs:
   - name: libcudf

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -73,6 +73,8 @@ outputs:
         - librmm ={{ minor_version }}
         - libarrow {{ libarrow_version }}
         - dlpack {{ dlpack_version }}
+        - gtest {{ gtest_version }}
+        - gmock {{ gtest_version }}
     test:
       commands:
         - test -f $PREFIX/lib/libcudf.so

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -51,7 +51,8 @@ requirements:
     - librdkafka {{ librdkafka_version }}
     - fmt {{ fmt_version }}
     - spdlog {{ spdlog_version }}
-    - gtest==1.10.0.*
+    - gtest {{ gtest_version }}
+    - gmock {{ gtest_version }}
 
 outputs:
   - name: libcudf
@@ -380,8 +381,6 @@ outputs:
         - {{ pin_subpackage('libcudf', exact=True) }}
         - {{ pin_subpackage('libcudf_kafka', exact=True) }}
         - cudatoolkit {{ cuda_spec }}
-        - gtest {{ gtest_version }}
-        - gmock {{ gtest_version }}
     about:
       home: https://rapids.ai/
       license: Apache-2.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -213,6 +213,7 @@ dependencies:
         packages:
           - fmt>=9.1.0,<10
           - gtest==1.10.0.*
+          - gmock==1.10.0.*
           # Hard pin the patch version used during the build. This must be kept
           # in sync with the version pinned in get_arrow.cmake.
           - libarrow==10.0.1.*

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -212,8 +212,8 @@ dependencies:
       - output_types: conda
         packages:
           - fmt>=9.1.0,<10
-          - gtest==1.10.0.*
-          - gmock==1.10.0.*
+          - &gtest gtest==1.10.0.*
+          - &gmock gmock==1.10.0.*
           # Hard pin the patch version used during the build. This must be kept
           # in sync with the version pinned in get_arrow.cmake.
           - libarrow==10.0.1.*
@@ -407,6 +407,11 @@ dependencies:
           - *cudf
           - cudf_kafka==23.4.*
   test_cpp:
+    common:
+      - output_types: conda
+        packages:
+          - *gtest
+          - *gmock
     specific:
       - output_types: conda
         matrices:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -212,11 +212,12 @@ dependencies:
       - output_types: conda
         packages:
           - fmt>=9.1.0,<10
-          - librdkafka=1.7.0
-          - spdlog>=1.11.0,<1.12
+          - gtest==1.10.0.*
           # Hard pin the patch version used during the build. This must be kept
           # in sync with the version pinned in get_arrow.cmake.
           - libarrow==10.0.1.*
+          - librdkafka=1.7.0
+          - spdlog>=1.11.0,<1.12
   build_wheels:
     common:
       - output_types: pyproject


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Google test is currently being pulled via CPM when our packages are being built instead of using the conda package. This results in gtest (and all its CMake files) being bundled into the cudf package, which interferes with package discovery.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
