### PR TITLE
cudftestutil supports static gtest dependencies

### DIFF
--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -74,7 +74,7 @@ outputs:
     test:
       commands:
         - test -f $PREFIX/lib/libcudf.so
-        - test -f $PREFIX/lib/libcudftestutil.so
+        - test -f $PREFIX/lib/libcudftestutil.a
         - test -f $PREFIX/lib/libcudf_identify_stream_usage_mode_cudf.so
         - test -f $PREFIX/lib/libcudf_identify_stream_usage_mode_testing.so
         - test -f $PREFIX/include/cudf/aggregation.hpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -766,6 +766,8 @@ if(CUDF_BUILD_TESTUTIL)
 
   add_library(cudf::cudftest_default_stream ALIAS cudftest_default_stream)
 
+  # Needs to be static so that we support usage of static builds of gtest which doesn't compile with
+  # fPIC enabled and therefore can't be embedded into shared libraries.
   add_library(
     cudftestutil STATIC
     tests/io/metadata_utilities.cpp

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -741,10 +741,9 @@ add_library(cudf::cudf ALIAS cudf)
 if(CUDF_BUILD_TESTUTIL)
   add_library(
     cudftest_default_stream
-    # This library when compiled as a dynamic library allows us to
-    # LD_PRELOAD injection of symbols. We currently leverage this for
-    # stream-related library validation and may make use of it for other
-    # similar features in the future.
+    # When compiled as a dynamic library allows us to use LD_PRELOAD injection of symbols. We
+    # currently leverage this for stream-related library validation and may make use of it for
+    # other similar features in the future.
     tests/utilities/default_stream.cpp
   )
   set_target_properties(

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -73,7 +73,7 @@ option(CUDA_WARNINGS_AS_ERRORS "Enable -Werror=all-warnings for all CUDA compila
 option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" OFF)
 
 set(DEFAULT_CUDF_BUILD_STREAMS_TEST_UTIL ON)
-if(${CUDA_STATIC_RUNTIME})
+if(CUDA_STATIC_RUNTIME OR NOT BUILD_SHARED_LIBS)
   set(DEFAULT_CUDF_BUILD_STREAMS_TEST_UTIL OFF)
 endif()
 option(
@@ -740,15 +740,38 @@ add_library(cudf::cudf ALIAS cudf)
 
 if(CUDF_BUILD_TESTUTIL)
   add_library(
-    # This library must also be compiled as a dynamic library to support
+    cudftest_default_stream
+    # This library when compiled as a dynamic library allows us to
     # LD_PRELOAD injection of symbols. We currently leverage this for
     # stream-related library validation and may make use of it for other
     # similar features in the future.
-    cudftestutil SHARED
+    tests/utilities/default_stream.cpp
+  )
+  set_target_properties(
+    cudftest_default_stream
+    PROPERTIES BUILD_RPATH "\$ORIGIN"
+               INSTALL_RPATH "\$ORIGIN"
+               # set target compile options
+               CXX_STANDARD 17
+               CXX_STANDARD_REQUIRED ON
+               CUDA_STANDARD 17
+               CUDA_STANDARD_REQUIRED ON
+               POSITION_INDEPENDENT_CODE ON
+               INTERFACE_POSITION_INDEPENDENT_CODE ON
+  )
+  target_link_libraries(
+    cudftest_default_stream
+    PUBLIC cudf
+    PRIVATE $<TARGET_NAME_IF_EXISTS:conda_env>
+  )
+
+  add_library(cudf::cudftest_default_stream ALIAS cudftest_default_stream)
+
+  add_library(
+    cudftestutil STATIC
     tests/io/metadata_utilities.cpp
     tests/utilities/base_fixture.cpp
     tests/utilities/column_utilities.cu
-    tests/utilities/default_stream.cpp
     tests/utilities/table_utilities.cu
     tests/utilities/tdigest_utilities.cu
   )
@@ -773,7 +796,7 @@ if(CUDF_BUILD_TESTUTIL)
 
   target_link_libraries(
     cudftestutil
-    PUBLIC GTest::gmock GTest::gtest Threads::Threads cudf
+    PUBLIC GTest::gmock GTest::gtest Threads::Threads cudf cudftest_default_stream
     PRIVATE $<TARGET_NAME_IF_EXISTS:conda_env>
   )
 
@@ -871,7 +894,7 @@ install(DIRECTORY ${CUDF_SOURCE_DIR}/include/cudf ${CUDF_SOURCE_DIR}/include/cud
 
 if(CUDF_BUILD_TESTUTIL)
   install(
-    TARGETS cudftestutil
+    TARGETS cudftest_default_stream cudftestutil
     DESTINATION ${lib_dir}
     EXPORT cudf-testing-exports
   )


### PR DESCRIPTION
## Description
cudftestutil needs to be statically so that it can support gtest. So to allow this and the preload hooks we have to roll `tests/utilities/default_stream.cpp` into a separate lib.

Will correct downstream issues including: https://github.com/NVIDIA/spark-rapids-jni/issues/1006

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
