### PR TITLE
Add JNI method for strings::replace multi variety

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2915,11 +2915,11 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   /**
-   * Returns a new strings column where target strings with each string are replaced with 
-   * corresponding replacement strings. For each string in the column, the list of targets 
+   * Returns a new strings column where target strings with each string are replaced with
+   * corresponding replacement strings. For each string in the column, the list of targets
    * is searched within that string. If a target string is found, it is replaced by the
    * corresponding entry in the repls column. All occurrences found in each string are replaced.
-   * The repls argument can optionally contain a single string. In this case, all matching 
+   * The repls argument can optionally contain a single string. In this case, all matching
    * target substrings will be replaced by that single string.
    *
    * Example:

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2921,12 +2921,14 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * corresponding entry in the repls column. All occurrences found in each string are replaced.
    * The repls argument can optionally contain a single string. In this case, all matching 
    * target substrings will be replaced by that single string.
+   *
    * Example:
    * cv = ["hello", "goodbye"]
    * targets = ["e","o"]
    * repls = ["EE","OO"]
    * r1 = cv.stringReplace(targets, repls)
    * r1 is now ["hEEllO", "gOOOOdbyEE"]
+   *
    * targets = ["e", "o"]
    * repls = ["_"]
    * r2 = cv.stringReplace(targets, repls)
@@ -4205,11 +4207,11 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
 
   /**
    * Native method to replace target strings by corresponding repl strings.
-   * @param columnView native handle of the cudf::column_view being operated on.
-   * @param targets handle of column containing the strings being searched.
-   * @param repls handle of column containing the strings to replace (can optionally contain a single string)
+   * @param inputCV native handle of the cudf::column_view being operated on.
+   * @param targetsCV handle of column containing the strings being searched.
+   * @param replsCV handle of column containing the strings to replace (can optionally contain a single string)
    */
-  private static native long stringReplaceMulti(long columnView, long targets, long repls) throws CudfException;
+  private static native long stringReplaceMulti(long inputCV, long targetsCV, long replsCV) throws CudfException;
 
   /**
    * Native method for replacing each regular expression pattern match with the specified

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2933,7 +2933,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * repls = ["_"]
    * r2 = cv.stringReplace(targets, repls)
    * r2 is now ["h_ll_", "g__dby_"]
-   * 
+   *
    * @param targets Strings to search for in each string.
    * @param repls Corresponding replacement strings for target strings.
    * @return A new java column vector containing the replaced strings.

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2915,6 +2915,39 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   /**
+   * Returns a new strings column where target strings with each string are replaced with 
+   * corresponding replacement strings. For each string in the column, the list of targets 
+   * is searched within that string. If a target string is found, it is replaced by the
+   * corresponding entry in the repls column. All occurrences found in each string are replaced.
+   * The repls argument can optionally contain a single string. In this case, all matching 
+   * target substrings will be replaced by that single string.
+   * Example:
+   * cv = ["hello", "goodbye"]
+   * targets = ["e","o"]
+   * repls = ["EE","OO"]
+   * r1 = cv.stringReplace(targets, repls)
+   * r1 is now ["hEEllO", "gOOOOdbyEE"]
+   * targets = ["e", "o"]
+   * repls = ["_"]
+   * r2 = cv.stringReplace(targets, repls)
+   * r2 is now ["h_ll_", "g__dby_"]
+   * 
+   * @param targets Strings to search for in each string.
+   * @param repls Corresponding replacement strings for target strings.
+   * @return A new java column vector containing the replaced strings
+   */
+  public final ColumnVector stringReplace(ColumnView targets, ColumnView repls) {
+    assert type.equals(DType.STRING) : "column type must be a String";
+    assert targets != null : "target list may not be null";
+    assert targets.getType().equals(DType.STRING) : "target list must be a string column";
+    assert repls != null : "replacement list may not be null";
+    assert repls.getType().equals(DType.STRING) : "replacement list must be a string column";
+
+    return new ColumnVector(stringReplaceMulti(getNativeView(), targets.getNativeView(),
+        repls.getNativeView()));
+  }
+
+  /**
    * For each string, replaces any character sequence matching the given pattern using the
    * replacement string scalar.
    *
@@ -4169,6 +4202,14 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @param repl handle of scalar containing the string to replace.
    */
   private static native long stringReplace(long columnView, long target, long repl) throws CudfException;
+
+  /**
+   * Native method to replace target strings by corresponding repl strings.
+   * @param columnView native handle of the cudf::column_view being operated on.
+   * @param targets handle of column containing the strings being searched.
+   * @param repls handle of column containing the strings to replace (can optionally contain a single string)
+   */
+  private static native long stringReplaceMulti(long columnView, long targets, long repls) throws CudfException;
 
   /**
    * Native method for replacing each regular expression pattern match with the specified

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2936,7 +2936,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * 
    * @param targets Strings to search for in each string.
    * @param repls Corresponding replacement strings for target strings.
-   * @return A new java column vector containing the replaced strings
+   * @return A new java column vector containing the replaced strings.
    */
   public final ColumnVector stringReplace(ColumnView targets, ColumnView repls) {
     assert type.equals(DType.STRING) : "column type must be a String";
@@ -4209,7 +4209,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Native method to replace target strings by corresponding repl strings.
    * @param inputCV native handle of the cudf::column_view being operated on.
    * @param targetsCV handle of column containing the strings being searched.
-   * @param replsCV handle of column containing the strings to replace (can optionally contain a single string)
+   * @param replsCV handle of column containing the strings to replace (can optionally contain a single string).
    */
   private static native long stringReplaceMulti(long inputCV, long targetsCV, long replsCV) throws CudfException;
 

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1548,7 +1548,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplace(JNIEnv *env
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplaceMulti(JNIEnv *env, jclass,
                                                                           jlong inputs_cv,
-                                                                          jlong targets_cv, jlong repls_cv) {
+                                                                          jlong targets_cv,
+                                                                          jlong repls_cv) {
   JNI_NULL_CHECK(env, inputs_cv, "column is null", 0);
   JNI_NULL_CHECK(env, targets_cv, "targets string column view is null", 0);
   JNI_NULL_CHECK(env, repls_cv, "repls string column view is null", 0);

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1546,6 +1546,25 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplace(JNIEnv *env
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplaceMulti(JNIEnv *env, jclass,
+                                                                          jlong column_view,
+                                                                          jlong targets, jlong repls) {
+  JNI_NULL_CHECK(env, column_view, "column is null", 0);
+  JNI_NULL_CHECK(env, targets, "targets string column view is null", 0);
+  JNI_NULL_CHECK(env, repls, "repls string column view is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::column_view *cv = reinterpret_cast<cudf::column_view *>(column_view);
+    cudf::strings_column_view scv(*cv);
+    cudf::column_view *cvtargets = reinterpret_cast<cudf::column_view *>(targets);
+    cudf::strings_column_view scvtargets(*cvtargets);
+    cudf::column_view *cvrepls = reinterpret_cast<cudf::column_view *>(repls);
+    cudf::strings_column_view scvrepls(*cvrepls);
+    return release_as_jlong(cudf::strings::replace(scv, scvtargets, scvrepls));
+  }
+  CATCH_STD(env, 0);
+}
+
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapLookupForKeys(JNIEnv *env, jclass,
                                                                         jlong map_column_view,
                                                                         jlong lookup_keys) {

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1547,18 +1547,18 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplace(JNIEnv *env
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplaceMulti(JNIEnv *env, jclass,
-                                                                          jlong column_view,
-                                                                          jlong targets, jlong repls) {
-  JNI_NULL_CHECK(env, column_view, "column is null", 0);
-  JNI_NULL_CHECK(env, targets, "targets string column view is null", 0);
-  JNI_NULL_CHECK(env, repls, "repls string column view is null", 0);
+                                                                          jlong inputs_cv,
+                                                                          jlong targets_cv, jlong repls_cv) {
+  JNI_NULL_CHECK(env, inputs_cv, "column is null", 0);
+  JNI_NULL_CHECK(env, targets_cv, "targets string column view is null", 0);
+  JNI_NULL_CHECK(env, repls_cv, "repls string column view is null", 0);
   try {
     cudf::jni::auto_set_device(env);
-    cudf::column_view *cv = reinterpret_cast<cudf::column_view *>(column_view);
+    cudf::column_view *cv = reinterpret_cast<cudf::column_view *>(inputs_cv);
     cudf::strings_column_view scv(*cv);
-    cudf::column_view *cvtargets = reinterpret_cast<cudf::column_view *>(targets);
+    cudf::column_view *cvtargets = reinterpret_cast<cudf::column_view *>(targets_cv);
     cudf::strings_column_view scvtargets(*cvtargets);
-    cudf::column_view *cvrepls = reinterpret_cast<cudf::column_view *>(repls);
+    cudf::column_view *cvrepls = reinterpret_cast<cudf::column_view *>(repls_cv);
     cudf::strings_column_view scvrepls(*cvrepls);
     return release_as_jlong(cudf::strings::replace(scv, scvtargets, scvrepls));
   }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -5147,6 +5147,27 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void teststringReplaceMulti() {
+    try (ColumnVector v = ColumnVector.fromStrings("Héllo", "thésssé", null, "", "ARé", "sssstrings");
+         ColumnVector e_allParameters = ColumnVector.fromStrings("Hello", "theSse", null, "", "ARe", "SStrings");
+         ColumnVector targets = ColumnVector.fromStrings("ss", "é");
+         ColumnVector repls = ColumnVector.fromStrings("S", "e");
+         ColumnVector replace_allParameters = v.stringReplace(targets, repls)) {
+      assertColumnsAreEqual(e_allParameters, replace_allParameters);
+    }
+  }
+
+  @Test
+  void teststringReplaceMultiThrowsException() {
+    assertThrows(AssertionError.class, () -> {
+      try (ColumnVector testStrings = ColumnVector.fromStrings("Héllo", "thésé", null, "", "ARé", "strings");
+           ColumnVector targets = ColumnVector.fromInts(0, 1);
+           ColumnVector repls = null;
+           ColumnVector result = testStrings.stringReplace(targets,repls)){}
+    });
+  }
+
+  @Test
   void testReplaceRegex() {
     try (ColumnVector v = ColumnVector.fromStrings("title and Title with title", "nothing", null, "Title");
          Scalar repl = Scalar.fromString("Repl")) {


### PR DESCRIPTION
## Description
Adds the JNI API for `stringReplace` using column vector arguments for `targets` and `repls` (to make this consistent with the C++ API). Also adds unit tests for the new API.
Part of the work for https://github.com/NVIDIA/spark-rapids/issues/7907.


## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
