### PR TITLE
Fix `sort_values` when column is all empty strings

### DIFF
--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 from collections.abc import Iterator
 
@@ -218,9 +218,10 @@ def quantile_divisions(df, by, npartitions):
                 divisions[col].iloc[-1] += 1
                 divisions[col] = divisions[col].astype(dtype)
             else:
-                divisions[col].iloc[-1] = chr(
-                    ord(divisions[col].iloc[-1][0]) + 1
-                )
+                if last := divisions[col].iloc[-1]:
+                    divisions[col].iloc[-1] = chr(ord(last[0]) + 1)
+                else:
+                    divisions[col].iloc[-1] = chr(1)  # b/c "" < chr(1)
         divisions = divisions.drop_duplicates().sort_index()
     return divisions
 

--- a/python/dask_cudf/dask_cudf/tests/test_sort.py
+++ b/python/dask_cudf/dask_cudf/tests/test_sort.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 
 import cupy as cp
 import numpy as np
@@ -104,3 +104,13 @@ def test_sort_values_custom_function(by, nparts):
         )
     expect = df.sort_values(by=by)
     dd.assert_eq(got, expect, check_index=False)
+
+
+@pytest.mark.parametrize("by", ["a", "b", ["a", "b"], ["b", "a"]])
+def test_sort_values_empty_string(by):
+    df = cudf.DataFrame({"a": [3, 2, 1, 4], "b": [""] * 4})
+    ddf = dd.from_pandas(df, npartitions=2)
+    got = ddf.sort_values(by)
+    if "a" in by:
+        expect = df.sort_values(by)
+        assert dd.assert_eq(got, expect, check_index=False)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
See test for simple MRE.

This fixes https://github.com/rapidsai/cugraph/issues/3058

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
