### PR TITLE
Fix `__setitem__` on string columns when the scalar value ends in a null byte

### DIFF
--- a/python/cudf/cudf/tests/test_setitem.py
+++ b/python/cudf/cudf/tests/test_setitem.py
@@ -355,7 +355,6 @@ def test_scatter_by_slice_with_start_and_step():
     assert_eq(target, ctarget)
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/cudf/issues/12990")
 @pytest.mark.parametrize("n", [1, 3])
 def test_setitem_str_trailing_null(n):
     trailing_nulls = "\x00" * n

--- a/python/cudf/cudf/tests/test_setitem.py
+++ b/python/cudf/cudf/tests/test_setitem.py
@@ -353,3 +353,19 @@ def test_scatter_by_slice_with_start_and_step():
     target[1::2] = source
     ctarget[1::2] = csource
     assert_eq(target, ctarget)
+
+
+@pytest.mark.xfail(reason="https://github.com/rapidsai/cudf/issues/12990")
+@pytest.mark.parametrize("n", [1, 3])
+def test_setitem_str_trailing_null(n):
+    trailing_nulls = "\x00" * n
+    s = cudf.Series(["a", "b", "c" + trailing_nulls])
+    assert s[2] == "c" + trailing_nulls
+    s[0] = "a" + trailing_nulls
+    assert s[0] == "a" + trailing_nulls
+    s[1] = trailing_nulls
+    assert s[1] == trailing_nulls
+    s[0] = ""
+    assert s[0] == ""
+    s[0] = "\x00"
+    assert s[0] == "\x00"

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -259,6 +259,14 @@ def to_cudf_compatible_scalar(val, dtype=None):
         (dtype is None) and isinstance(val, str)
     ) or cudf.api.types.is_string_dtype(dtype):
         dtype = "str"
+        if val.endswith("\x00"):
+            # Numpy string dtypes are fixed width and use NULL to
+            # indicate the end of the string, so they cannot
+            # distinguish between "abc\x00" and "abc".
+            # https://github.com/numpy/numpy/issues/20118
+            # In this case, don't try going through numpy and just use
+            # the string value directly (cudf.DeviceScalar will DTRT)
+            return val
 
     if isinstance(val, datetime.datetime):
         val = np.datetime64(val)

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -259,7 +259,8 @@ def to_cudf_compatible_scalar(val, dtype=None):
         (dtype is None) and isinstance(val, str)
     ) or cudf.api.types.is_string_dtype(dtype):
         dtype = "str"
-        if val.endswith("\x00"):
+
+        if isinstance(val, str) and val.endswith("\x00"):
             # Numpy string dtypes are fixed width and use NULL to
             # indicate the end of the string, so they cannot
             # distinguish between "abc\x00" and "abc".


### PR DESCRIPTION
## Description
Since numpy strings are fixed width and use a null byte as an
indicator of the end of the string, there is no way to distinguish
between numpy.str_("abc\x00").item() and numpy.str_("abc").item().
This has consequences for scalar preprocessing we do when constructing
a cudf.Scalar, since that usually goes through
numpy.astype(...).item(). So, when preprocessing as scalar, if we
notice it is a string with trailing null bytes, keep it as is.

Closes #12990.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
