### PR TITLE
[REVIEW] Fix `DataFrame` constructor to broadcast scalar inputs properly

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -920,7 +920,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                         data[key] = value
 
                 if len(lengths - {1}) > 1:
-                    raise ValueError("Length mismatch")
+                    raise ValueError("All arrays must be of the same length")
                 else:
                     num_rows = (
                         1 if lengths == {1} else next(iter(lengths - {1}))

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -907,14 +907,24 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         if index is None:
             num_rows = 0
             if data:
-                col_name = next(iter(data))
-                if is_scalar(data[col_name]):
-                    num_rows = num_rows or 1
+                lengths = set()
+                for key, value in data.items():
+                    if is_scalar(value):
+                        data[key] = value
+                        lengths.add(1)
+                    else:
+                        value = column.as_column(
+                            value, nan_as_null=nan_as_null
+                        )
+                        lengths.add(len(value))
+                        data[key] = value
+
+                if len(lengths - {1}) > 1:
+                    raise ValueError("Length mismatch")
                 else:
-                    data[col_name] = column.as_column(
-                        data[col_name], nan_as_null=nan_as_null
+                    num_rows = (
+                        1 if lengths == {1} else next(iter(lengths - {1}))
                     )
-                    num_rows = len(data[col_name])
             self._index = RangeIndex(0, num_rows)
         else:
             self._index = as_index(index)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -10058,3 +10058,18 @@ def test_dataframe_init_from_scalar_and_lists(data):
     expected = pd.DataFrame(data)
 
     assert_eq(expected, actual)
+
+
+def test_dataframe_init_length_error():
+    assert_exceptions_equal(
+        lfunc=pd.DataFrame,
+        rfunc=cudf.DataFrame,
+        lfunc_args_and_kwargs=(
+            [],
+            {"data": {"a": [1, 2, 3], "b": ["x", "y", "z", "z"], "c": 4}},
+        ),
+        rfunc_args_and_kwargs=(
+            [],
+            {"data": {"a": [1, 2, 3], "b": ["x", "y", "z", "z"], "c": 4}},
+        ),
+    )

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -10043,3 +10043,18 @@ def test_dataframe_from_arrow_slice():
     actual = cudf.DataFrame.from_arrow(table_slice)
 
     assert_eq(expected, actual)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"a": [1, 2, 3], "b": ["x", "y", "z"], "c": 4},
+        {"c": 4, "a": [1, 2, 3], "b": ["x", "y", "z"]},
+        {"a": [1, 2, 3], "c": 4},
+    ],
+)
+def test_dataframe_init_from_scalar_and_lists(data):
+    actual = cudf.DataFrame(data)
+    expected = pd.DataFrame(data)
+
+    assert_eq(expected, actual)


### PR DESCRIPTION
## Description
Fixes: #12646

This PR fixes an issue with `DataFrame` where broadcasting scalar inputs was order dependent.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
