### PR TITLE
Fix memcheck script to execute only _TEST files found in bin/gtests/libcudf

### DIFF
--- a/ci/test_cpp_memcheck.sh
+++ b/ci/test_cpp_memcheck.sh
@@ -11,7 +11,7 @@ set +e
 rapids-logger "Memcheck gtests with rmm_mode=cuda"
 export GTEST_CUDF_RMM_MODE=cuda
 COMPUTE_SANITIZER_CMD="compute-sanitizer --tool memcheck"
-for gt in "$CONDA_PREFIX"/bin/gtests/libcudf/* ; do
+for gt in "$CONDA_PREFIX"/bin/gtests/libcudf/*_TEST ; do
     test_name=$(basename ${gt})
     if [[ "$test_name" == "ERROR_TEST" ]] || [[ "$test_name" == "STREAM_IDENTIFICATION_TEST" ]]; then
         continue


### PR DESCRIPTION
The nightly runs of `compute-sanitizer` started failing due to the test script trying to execute some new extra files found in the `$CONDA_PREFIX"/bin/gtests/libcudf/` directory. This change ensures only files ending in `_TEST` are executed by `compute-sanitizer`.

For reference errors are here: https://github.com/rapidsai/cudf/actions/runs/4508267264/jobs/7936800047
Example:
```
Running compute-sanitizer on CTestTestfile.cmake
========= COMPUTE-SANITIZER
========= Error: Target application terminated before first instrumented API call
```

Follow on issue/PR could explore adding a special make option to execute `compute-sanitizer` only on test files.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
