### PR TITLE
Remove console output from some libcudf gtests

### DIFF
--- a/cpp/tests/io/json_test.cpp
+++ b/cpp/tests/io/json_test.cpp
@@ -1326,7 +1326,6 @@ TEST_F(JsonReaderTest, TokenAllocation)
   };
 
   for (auto const& json_string : json_inputs) {
-    std::cout << json_string << "\n";
     // Initialize parsing options (reading json lines)
     cudf::io::json_reader_options json_lines_options =
       cudf::io::json_reader_options::builder(

--- a/cpp/tests/reductions/reduction_tests.cpp
+++ b/cpp/tests/reductions/reduction_tests.cpp
@@ -1004,10 +1004,10 @@ struct StringReductionTest : public cudf::test::BaseFixture,
       using ScalarType                     = cudf::scalar_type_t<cudf::string_view>;
       auto result1                         = static_cast<ScalarType*>(result.get());
       EXPECT_TRUE(result1->is_valid());
-      if (!result1->is_valid())
-        std::cout << "expected=" << expected_value << ",got=" << result1->to_string() << std::endl;
-      EXPECT_EQ(expected_value, result1->to_string())
-        << (agg.kind == aggregation::MIN ? "MIN" : "MAX");
+      if (result1->is_valid()) {
+        EXPECT_EQ(expected_value, result1->to_string())
+          << (agg.kind == aggregation::MIN ? "MIN" : "MAX");
+      }
     };
 
     if (succeeded_condition) {
@@ -1033,10 +1033,10 @@ struct StringReductionTest : public cudf::test::BaseFixture,
       using ScalarType = cudf::scalar_type_t<cudf::string_view>;
       auto result1     = static_cast<ScalarType*>(result.get());
       EXPECT_TRUE(result1->is_valid());
-      if (!result1->is_valid())
-        std::cout << "expected=" << expected_value << ",got=" << result1->to_string() << std::endl;
-      EXPECT_EQ(expected_value, result1->to_string())
-        << (agg.kind == aggregation::MIN ? "MIN" : "MAX");
+      if (result1->is_valid()) {
+        EXPECT_EQ(expected_value, result1->to_string())
+          << (agg.kind == aggregation::MIN ? "MIN" : "MAX");
+      }
     };
 
     if (succeeded_condition) {


### PR DESCRIPTION
## Description
Removes some `std::cout` output from some libcudf gtests. These were found while investigating compute-sanitizer test errors.
Also, the `StringReductionTest` gtest was attempting to print an invalid string.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
