### PR TITLE
Use hashing for sort groupby for large key columns

### DIFF
--- a/cpp/include/cudf/detail/groupby/sort_helper.hpp
+++ b/cpp/include/cudf/detail/groupby/sort_helper.hpp
@@ -180,6 +180,7 @@ struct sort_groupby_helper {
    * @return vector of group labels for each row in the sorted key column
    */
   index_vector const& group_labels(rmm::cuda_stream_view stream);
+  void hash_sorter(rmm::cuda_stream_view stream);
 
  private:
   /**
@@ -213,6 +214,7 @@ struct sort_groupby_helper {
   column_view keys_bitmask_column(rmm::cuda_stream_view stream);
 
  private:
+  bool is_using_hashing;             ///< Whether to use hashing for key grouping
   column_ptr _key_sorted_order;      ///< Indices to produce _keys in sorted order
   column_ptr _unsorted_keys_labels;  ///< Group labels for unsorted _keys
   column_ptr _keys_bitmask_column;   ///< Column representing rows with one or more nulls values

--- a/cpp/tests/groupby/groupby_test_util.cpp
+++ b/cpp/tests/groupby/groupby_test_util.cpp
@@ -78,8 +78,11 @@ void test_single_agg(cudf::column_view const& keys,
     cudf::table_view({keys}), include_null_keys, keys_are_sorted, column_order, precedence);
 
   auto result = gb_obj.aggregate(requests, cudf::test::get_default_stream());
+  cudf::test::print(result.second[0].results[0]->view());
+  cudf::test::print(sorted_expect_vals->get_column(0));
 
-  if (use_sort == force_use_sort_impl::YES && keys_are_sorted == cudf::sorted::NO) {
+  if (use_sort == force_use_sort_impl::YES && keys_are_sorted == cudf::sorted::NO &&
+      std::getenv("USE_HASHING") == nullptr) {
     CUDF_TEST_EXPECT_TABLES_EQUAL(*sorted_expect_keys, result.first->view());
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted_expect_vals->get_column(0),
                                         *result.second[0].results[0]);
@@ -91,6 +94,8 @@ void test_single_agg(cudf::column_view const& keys,
       cudf::gather(cudf::table_view({result.second[0].results[0]->view()}), *sort_order);
 
     CUDF_TEST_EXPECT_TABLES_EQUAL(*sorted_expect_keys, *sorted_keys);
+    cudf::test::print(*sort_order);
+    cudf::test::print(sorted_vals->get_column(0));
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted_expect_vals->get_column(0),
                                         sorted_vals->get_column(0));
   }

--- a/cpp/tests/groupby/merge_m2_tests.cpp
+++ b/cpp/tests/groupby/merge_m2_tests.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "cudf/sorting.hpp"
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/iterator_utilities.hpp>
@@ -193,9 +194,14 @@ TYPED_TEST(GroupbyMergeM2TypedTest, SimpleInput)
     auto const [final_keys, final_vals] =
       merge_M2(vcol_views{*out3_keys, *out4_keys}, vcol_views{*out3_vals, *out4_vals});
 
-    auto const out_M2s = final_vals->child(2);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, *final_keys, verbosity);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, out_M2s, verbosity);
+    auto const out_M2s    = final_vals->child(2);
+    auto const sort_order = cudf::sorted_order(cudf::table_view{{final_keys->view()}});
+    auto const sorted_out =
+      cudf::gather(cudf::table_view{{final_keys->view(), out_M2s}}, *sort_order);
+    auto const [sorted_keys, sorted_vals] =
+      std::pair{sorted_out->get_column(0), sorted_out->get_column(1)};
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, sorted_keys, verbosity);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, sorted_vals, verbosity);
   }
 
   // One step merging:
@@ -203,9 +209,14 @@ TYPED_TEST(GroupbyMergeM2TypedTest, SimpleInput)
     auto const [final_keys, final_vals] = merge_M2(vcol_views{*out1_keys, *out2_keys, *out3_keys},
                                                    vcol_views{*out1_vals, *out2_vals, *out3_vals});
 
-    auto const out_M2s = final_vals->child(2);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, *final_keys, verbosity);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, out_M2s, verbosity);
+    auto const out_M2s    = final_vals->child(2);
+    auto const sort_order = cudf::sorted_order(cudf::table_view{{final_keys->view()}});
+    auto const sorted_out =
+      cudf::gather(cudf::table_view{{final_keys->view(), out_M2s}}, *sort_order);
+    auto const [sorted_keys, sorted_vals] =
+      std::pair{sorted_out->get_column(0), sorted_out->get_column(1)};
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, sorted_keys, verbosity);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, sorted_vals, verbosity);
   }
 }
 
@@ -252,9 +263,14 @@ TYPED_TEST(GroupbyMergeM2TypedTest, SimpleInputHavingNegativeValues)
     auto const [final_keys, final_vals] =
       merge_M2(vcol_views{*out3_keys, *out4_keys}, vcol_views{*out3_vals, *out4_vals});
 
-    auto const out_M2s = final_vals->child(2);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, *final_keys, verbosity);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, out_M2s, verbosity);
+    auto const out_M2s    = final_vals->child(2);
+    auto const sort_order = cudf::sorted_order(cudf::table_view{{final_keys->view()}});
+    auto const sorted_out =
+      cudf::gather(cudf::table_view{{final_keys->view(), out_M2s}}, *sort_order);
+    auto const [sorted_keys, sorted_vals] =
+      std::pair{sorted_out->get_column(0), sorted_out->get_column(1)};
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, sorted_keys, verbosity);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, sorted_vals, verbosity);
   }
 
   // One step merging:
@@ -262,9 +278,14 @@ TYPED_TEST(GroupbyMergeM2TypedTest, SimpleInputHavingNegativeValues)
     auto const [final_keys, final_vals] = merge_M2(vcol_views{*out1_keys, *out2_keys, *out3_keys},
                                                    vcol_views{*out1_vals, *out2_vals, *out3_vals});
 
-    auto const out_M2s = final_vals->child(2);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, *final_keys, verbosity);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, out_M2s, verbosity);
+    auto const out_M2s    = final_vals->child(2);
+    auto const sort_order = cudf::sorted_order(cudf::table_view{{final_keys->view()}});
+    auto const sorted_out =
+      cudf::gather(cudf::table_view{{final_keys->view(), out_M2s}}, *sort_order);
+    auto const [sorted_keys, sorted_vals] =
+      std::pair{sorted_out->get_column(0), sorted_out->get_column(1)};
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, sorted_keys, verbosity);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, sorted_vals, verbosity);
   }
 }
 
@@ -312,9 +333,14 @@ TYPED_TEST(GroupbyMergeM2TypedTest, InputHasNulls)
     auto const [final_keys, final_vals] =
       merge_M2(vcol_views{*out3_keys, *out4_keys}, vcol_views{*out3_vals, *out4_vals});
 
-    auto const out_M2s = final_vals->child(2);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, *final_keys, verbosity);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, out_M2s, verbosity);
+    auto const out_M2s    = final_vals->child(2);
+    auto const sort_order = cudf::sorted_order(cudf::table_view{{final_keys->view()}});
+    auto const sorted_out =
+      cudf::gather(cudf::table_view{{final_keys->view(), out_M2s}}, *sort_order);
+    auto const [sorted_keys, sorted_vals] =
+      std::pair{sorted_out->get_column(0), sorted_out->get_column(1)};
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, sorted_keys, verbosity);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, sorted_vals, verbosity);
   }
 
   // One step merging:
@@ -322,9 +348,14 @@ TYPED_TEST(GroupbyMergeM2TypedTest, InputHasNulls)
     auto const [final_keys, final_vals] = merge_M2(vcol_views{*out1_keys, *out2_keys, *out3_keys},
                                                    vcol_views{*out1_vals, *out2_vals, *out3_vals});
 
-    auto const out_M2s = final_vals->child(2);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, *final_keys, verbosity);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, out_M2s, verbosity);
+    auto const out_M2s    = final_vals->child(2);
+    auto const sort_order = cudf::sorted_order(cudf::table_view{{final_keys->view()}});
+    auto const sorted_out =
+      cudf::gather(cudf::table_view{{final_keys->view(), out_M2s}}, *sort_order);
+    auto const [sorted_keys, sorted_vals] =
+      std::pair{sorted_out->get_column(0), sorted_out->get_column(1)};
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, sorted_keys, verbosity);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, sorted_vals, verbosity);
   }
 }
 
@@ -377,9 +408,14 @@ TYPED_TEST(GroupbyMergeM2TypedTest, InputHaveNullsAndNaNs)
     auto const [final_keys, final_vals] =
       merge_M2(vcol_views{*out5_keys, *out6_keys}, vcol_views{*out5_vals, *out6_vals});
 
-    auto const out_M2s = final_vals->child(2);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, *final_keys, verbosity);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, out_M2s, verbosity);
+    auto const out_M2s    = final_vals->child(2);
+    auto const sort_order = cudf::sorted_order(cudf::table_view{{final_keys->view()}});
+    auto const sorted_out =
+      cudf::gather(cudf::table_view{{final_keys->view(), out_M2s}}, *sort_order);
+    auto const [sorted_keys, sorted_vals] =
+      std::pair{sorted_out->get_column(0), sorted_out->get_column(1)};
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, sorted_keys, verbosity);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, sorted_vals, verbosity);
   }
 
   // One step merging:
@@ -388,9 +424,14 @@ TYPED_TEST(GroupbyMergeM2TypedTest, InputHaveNullsAndNaNs)
       merge_M2(vcol_views{*out1_keys, *out2_keys, *out3_keys, *out4_keys},
                vcol_views{*out1_vals, *out2_vals, *out3_vals, *out4_vals});
 
-    auto const out_M2s = final_vals->child(2);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, *final_keys, verbosity);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, out_M2s, verbosity);
+    auto const out_M2s    = final_vals->child(2);
+    auto const sort_order = cudf::sorted_order(cudf::table_view{{final_keys->view()}});
+    auto const sorted_out =
+      cudf::gather(cudf::table_view{{final_keys->view(), out_M2s}}, *sort_order);
+    auto const [sorted_keys, sorted_vals] =
+      std::pair{sorted_out->get_column(0), sorted_out->get_column(1)};
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, sorted_keys, verbosity);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, sorted_vals, verbosity);
   }
 }
 
@@ -459,9 +500,14 @@ TYPED_TEST(GroupbyMergeM2TypedTest, SlicedColumnsInput)
     auto const [final_keys, final_vals] =
       merge_M2(vcol_views{*out5_keys, *out6_keys}, vcol_views{*out5_vals, *out6_vals});
 
-    auto const out_M2s = final_vals->child(2);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, *final_keys, verbosity);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, out_M2s, verbosity);
+    auto const out_M2s    = final_vals->child(2);
+    auto const sort_order = cudf::sorted_order(cudf::table_view{{final_keys->view()}});
+    auto const sorted_out =
+      cudf::gather(cudf::table_view{{final_keys->view(), out_M2s}}, *sort_order);
+    auto const [sorted_keys, sorted_vals] =
+      std::pair{sorted_out->get_column(0), sorted_out->get_column(1)};
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, sorted_keys, verbosity);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, sorted_vals, verbosity);
   }
 
   // One step merging:
@@ -470,8 +516,13 @@ TYPED_TEST(GroupbyMergeM2TypedTest, SlicedColumnsInput)
       merge_M2(vcol_views{*out1_keys, *out2_keys, *out3_keys, *out4_keys},
                vcol_views{*out1_vals, *out2_vals, *out3_vals, *out4_vals});
 
-    auto const out_M2s = final_vals->child(2);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, *final_keys, verbosity);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, out_M2s, verbosity);
+    auto const out_M2s    = final_vals->child(2);
+    auto const sort_order = cudf::sorted_order(cudf::table_view{{final_keys->view()}});
+    auto const sorted_out =
+      cudf::gather(cudf::table_view{{final_keys->view(), out_M2s}}, *sort_order);
+    auto const [sorted_keys, sorted_vals] =
+      std::pair{sorted_out->get_column(0), sorted_out->get_column(1)};
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_keys, sorted_keys, verbosity);
+    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_M2s, sorted_vals, verbosity);
   }
 }


### PR DESCRIPTION
## Description
This PR is an experimental optimization for sort groupby to use hashing to group keys and use the key labels for further sorting purposes in sort-groupby. Since we will be using stable_sorted_order, the keys will retain relative ordering, which will also help with aggregations like nth element. Ordering between different keys does not matter because we don't guarentee any ordering of keys in groupby operation.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
