### PR TITLE
Allow passing different types of physical element comparator to `cudf::detail::sorted_order`

### DIFF
--- a/cpp/src/sort/sort.cu
+++ b/cpp/src/sort/sort.cu
@@ -15,6 +15,7 @@
  */
 
 #include <cudf/column/column.hpp>
+#include <cudf/detail/gather.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/sorting.hpp>
 #include <cudf/sorting.hpp>

--- a/cpp/src/sort/sort_column_impl.cuh
+++ b/cpp/src/sort/sort_column_impl.cuh
@@ -36,6 +36,7 @@ namespace detail {
  * This API offers fast sorting for primitive types. It cannot handle nested types and will not
  * consider `NaN` as equivalent to other `NaN`.
  *
+ * @tparam stable Whether to use stable sort
  * @param input Column to sort. The column data is not modified.
  * @param column_order Ascending or descending sort order
  * @param null_precedence How null rows are to be ordered

--- a/cpp/src/sort/sort_column_impl.cuh
+++ b/cpp/src/sort/sort_column_impl.cuh
@@ -33,6 +33,9 @@ namespace detail {
 /**
  * @brief Sort indices of a single column.
  *
+ * This API offers fast sorting for primitive types. It cannot handle nested types and will not
+ * consider `NaN` as equivalent to other `NaN`.
+ *
  * @param input Column to sort. The column data is not modified.
  * @param column_order Ascending or descending sort order
  * @param null_precedence How null rows are to be ordered

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -16,68 +16,12 @@
 
 #pragma once
 
+#include <sort/sort_column_impl.cuh>
+
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/gather.hpp>
-#include <cudf/detail/utilities/vector_factories.hpp>
-#include <cudf/table/experimental/row_operators.cuh>
-#include <cudf/table/table_device_view.cuh>
-#include <cudf/utilities/error.hpp>
-#include <cudf/utilities/traits.hpp>
-
-#include <rmm/cuda_stream_view.hpp>
-#include <rmm/device_uvector.hpp>
-#include <rmm/exec_policy.hpp>
-
-#include <thrust/sequence.h>
-#include <thrust/sort.h>
-#include <thrust/swap.h>
 
 namespace cudf {
 namespace detail {
-
-/**
- * @brief Comparator functor needed for single column sort.
- *
- * @tparam Column element type.
- */
-template <typename T>
-struct simple_comparator {
-  __device__ bool operator()(size_type lhs, size_type rhs)
-  {
-    if (has_nulls) {
-      bool lhs_null{d_column.is_null(lhs)};
-      bool rhs_null{d_column.is_null(rhs)};
-      if (lhs_null || rhs_null) {
-        if (!ascending) thrust::swap(lhs_null, rhs_null);
-        return (null_precedence == cudf::null_order::BEFORE ? !rhs_null : !lhs_null);
-      }
-    }
-    return relational_compare(d_column.element<T>(lhs), d_column.element<T>(rhs)) ==
-           (ascending ? weak_ordering::LESS : weak_ordering::GREATER);
-  }
-  column_device_view const d_column;
-  bool has_nulls;
-  bool ascending;
-  null_order null_precedence{};
-};
-
-/**
- * @brief Sort indices of a single column.
- *
- * @param input Column to sort. The column data is not modified.
- * @param column_order Ascending or descending sort order
- * @param null_precedence How null rows are to be ordered
- * @param stable True if sort should be stable
- * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned column's device memory
- * @return Sorted indices for the input column.
- */
-template <bool stable>
-std::unique_ptr<column> sorted_order(column_view const& input,
-                                     order column_order,
-                                     null_order null_precedence,
-                                     rmm::cuda_stream_view stream,
-                                     rmm::mr::device_memory_resource* mr);
 
 /**
  * @copydoc

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -29,7 +29,7 @@ namespace detail {
  *
  * @param stream CUDA stream used for device memory operations and kernel launches
  */
-template <bool stable = false>
+template <bool stable>
 std::unique_ptr<column> sorted_order(table_view input,
                                      std::vector<order> const& column_order,
                                      std::vector<null_order> const& null_precedence,

--- a/cpp/src/sort/stable_sort.cu
+++ b/cpp/src/sort/stable_sort.cu
@@ -17,6 +17,7 @@
 #include "sort_impl.cuh"
 
 #include <cudf/column/column.hpp>
+#include <cudf/detail/gather.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/sorting.hpp>
 #include <cudf/sorting.hpp>


### PR DESCRIPTION
The experimental lexicographic comparator allows specifying different types of physical element comparator so that `NaN` values can be compared by:
 * Following the IEEE-754 standard: comparison involving a `NaN` produces undefined output, or
 * A `NaN` value is always equivalent to other `NaN`s and greater than all other non-`NaN` values.

This PR extends the detail version of `sorted_order` so that we can also pass in a type of physical element comparator. This is necessary if we want to use `detail::sorted_order` in places where different types of physical element comparator can be specified.

An immediate usage of this is to implement a customized version of `cudf::rank` to fully support nested types in lexicographic comparison.