### PR TITLE
Fix tests/identify_stream_usage.cpp

### DIFF
--- a/cpp/tests/utilities/identify_stream_usage.cpp
+++ b/cpp/tests/utilities/identify_stream_usage.cpp
@@ -21,6 +21,7 @@
 
 #include <cstdlib>
 #include <cxxabi.h>
+#include <cstring>
 #include <dlfcn.h>
 #include <execinfo.h>
 #include <iostream>

--- a/cpp/tests/utilities/identify_stream_usage.cpp
+++ b/cpp/tests/utilities/identify_stream_usage.cpp
@@ -20,8 +20,8 @@
 #include <cuda_runtime.h>
 
 #include <cstdlib>
-#include <cxxabi.h>
 #include <cstring>
+#include <cxxabi.h>
 #include <dlfcn.h>
 #include <execinfo.h>
 #include <iostream>


### PR DESCRIPTION
## Description
The identify_stream_usage test uses `strcmp` but not does not include `<cstring>`. This PR fixes that.

The missing include was surfaced by #13064, showing that the test relied on headers in `spdlog` to include `cstring`.

