### PR TITLE
Remove deprecated regex functions from libcudf

### DIFF
--- a/cpp/include/cudf/strings/contains.hpp
+++ b/cpp/include/cudf/strings/contains.hpp
@@ -62,36 +62,6 @@ std::unique_ptr<column> contains_re(
 
 /**
  * @brief Returns a boolean column identifying rows which
- * match the given regex pattern.
- *
- * @code{.pseudo}
- * Example:
- * s = ["abc","123","def456"]
- * r = contains_re(s,"\\d+")
- * r is now [false, true, true]
- * @endcode
- *
- * Any null string entries return corresponding null output column entries.
- *
- * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
- *
- * @deprecated Use @link contains_re contains_re(strings_column_view const&,
- * regex_program const&, rmm::mr::device_memory_resource*) @endlink
- *
- * @param strings Strings instance for this operation.
- * @param pattern Regex pattern to match to each string.
- * @param flags Regex flags for interpreting special characters in the pattern.
- * @param mr Device memory resource used to allocate the returned column's device memory.
- * @return New column of boolean results for each string.
- */
-[[deprecated]] std::unique_ptr<column> contains_re(
-  strings_column_view const& strings,
-  std::string_view pattern,
-  regex_flags const flags             = regex_flags::DEFAULT,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
-/**
- * @brief Returns a boolean column identifying rows which
  * matching the given regex_program object but only at the beginning the string.
  *
  * @code{.pseudo}
@@ -114,36 +84,6 @@ std::unique_ptr<column> contains_re(
 std::unique_ptr<column> matches_re(
   strings_column_view const& strings,
   regex_program const& prog,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
-/**
- * @brief Returns a boolean column identifying rows which
- * matching the given regex pattern but only at the beginning the string.
- *
- * @code{.pseudo}
- * Example:
- * s = ["abc","123","def456"]
- * r = matches_re(s,"\\d+")
- * r is now [false, true, false]
- * @endcode
- *
- * Any null string entries return corresponding null output column entries.
- *
- * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
- *
- * @deprecated Use @link matches_re matches_re(strings_column_view const&,
- * regex_program const&, rmm::mr::device_memory_resource*) @endlink
- *
- * @param strings Strings instance for this operation.
- * @param pattern Regex pattern to match to each string.
- * @param flags Regex flags for interpreting special characters in the pattern.
- * @param mr Device memory resource used to allocate the returned column's device memory.
- * @return New column of boolean results for each string.
- */
-[[deprecated]] std::unique_ptr<column> matches_re(
-  strings_column_view const& strings,
-  std::string_view pattern,
-  regex_flags const flags             = regex_flags::DEFAULT,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -170,36 +110,6 @@ std::unique_ptr<column> matches_re(
 std::unique_ptr<column> count_re(
   strings_column_view const& strings,
   regex_program const& prog,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
-/**
- * @brief Returns the number of times the given regex pattern
- * matches in each string.
- *
- * @code{.pseudo}
- * Example:
- * s = ["abc","123","def45"]
- * r = count_re(s,"\\d")
- * r is now [0, 3, 2]
- * @endcode
- *
- * Any null string entries return corresponding null output column entries.
- *
- * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
- *
- * @deprecated Use @link count_re count_re(strings_column_view const&,
- * regex_program const&, rmm::mr::device_memory_resource*) @endlink
- *
- * @param strings Strings instance for this operation.
- * @param pattern Regex pattern to match within each string.
- * @param flags Regex flags for interpreting special characters in the pattern.
- * @param mr Device memory resource used to allocate the returned column's device memory.
- * @return New INT32 column with counts for each string.
- */
-[[deprecated]] std::unique_ptr<column> count_re(
-  strings_column_view const& strings,
-  std::string_view pattern,
-  regex_flags const flags             = regex_flags::DEFAULT,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**

--- a/cpp/include/cudf/strings/extract.hpp
+++ b/cpp/include/cudf/strings/extract.hpp
@@ -64,41 +64,6 @@ std::unique_ptr<table> extract(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Returns a table of strings columns where each column corresponds to the matching
- * group specified in the given regular expression pattern.
- *
- * All the strings for the first group will go in the first output column; the second group
- * go in the second column and so on. Null entries are added to the columns in row `i` if
- * the string at row `i` does not match.
- *
- * Any null string entries return corresponding null output column entries.
- *
- * @code{.pseudo}
- * Example:
- * s = ["a1", "b2", "c3"]
- * r = extract(s, "([ab])(\\d)")
- * r is now [ ["a", "b", null],
- *            ["1", "2", null] ]
- * @endcode
- *
- * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
- *
- * @deprecated Use @link extract extract(strings_column_view const&,
- * regex_program const&, rmm::mr::device_memory_resource*) @endlink
- *
- * @param strings Strings instance for this operation.
- * @param pattern The regular expression pattern with group indicators.
- * @param flags Regex flags for interpreting special characters in the pattern.
- * @param mr Device memory resource used to allocate the returned table's device memory.
- * @return Columns of strings extracted from the input column.
- */
-[[deprecated]] std::unique_ptr<table> extract(
-  strings_column_view const& strings,
-  std::string_view pattern,
-  regex_flags const flags             = regex_flags::DEFAULT,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
-/**
  * @brief Returns a lists column of strings where each string column row corresponds to the
  * matching group specified in the given regex_program object
  *
@@ -130,44 +95,6 @@ std::unique_ptr<table> extract(
 std::unique_ptr<column> extract_all_record(
   strings_column_view const& strings,
   regex_program const& prog,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
-/**
- * @brief Returns a lists column of strings where each string column row corresponds to the
- * matching group specified in the given regular expression pattern.
- *
- * All the matching groups for the first row will go in the first row output column; the second
- * row results will go into the second row output column and so on.
- *
- * A null output row will result if the corresponding input string row does not match or
- * that input row is null.
- *
- * @code{.pseudo}
- * Example:
- * s = ["a1 b4", "b2", "c3 a5", "b", null]
- * r = extract_all_record(s,"([ab])(\\d)")
- * r is now [ ["a", "1", "b", "4"],
- *            ["b", "2"],
- *            ["a", "5"],
- *            null,
- *            null ]
- * @endcode
- *
- * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
- *
- * @deprecated Use @link extract_all_record extract_all_record(strings_column_view const&,
- * regex_program const&, rmm::mr::device_memory_resource*) @endlink
- *
- * @param strings Strings instance for this operation.
- * @param pattern The regular expression pattern with group indicators.
- * @param flags Regex flags for interpreting special characters in the pattern.
- * @param mr Device memory resource used to allocate any returned device memory.
- * @return Lists column containing strings extracted from the input column.
- */
-[[deprecated]] std::unique_ptr<column> extract_all_record(
-  strings_column_view const& strings,
-  std::string_view pattern,
-  regex_flags const flags             = regex_flags::DEFAULT,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of doxygen group

--- a/cpp/include/cudf/strings/findall.hpp
+++ b/cpp/include/cudf/strings/findall.hpp
@@ -65,43 +65,6 @@ std::unique_ptr<column> findall(
   regex_program const& prog,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
-/**
- * @brief Returns a lists column of strings for each matching occurrence of the
- * regex pattern within each string.
- *
- * Each output row includes all the substrings within the corresponding input row
- * that match the given pattern. If no matches are found, the output row is empty.
- *
- * @code{.pseudo}
- * Example:
- * s = ["bunny", "rabbit", "hare", "dog"]
- * r = findall(s, "[ab]")
- * r is now a lists column like:
- *  [ ["b"]
- *    ["a","b","b"]
- *    ["a"]
- *    [] ]
- * @endcode
- *
- * A null output row occurs if the corresponding input row is null.
- *
- * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
- *
- * @deprecated Use @link findall findall(strings_column_view const&,
- * regex_program const&, rmm::mr::device_memory_resource*) @endlink
- *
- * @param input Strings instance for this operation.
- * @param pattern Regex pattern to match within each string.
- * @param flags Regex flags for interpreting special characters in the pattern.
- * @param mr Device memory resource used to allocate the returned column's device memory.
- * @return New lists column of strings.
- */
-[[deprecated]] std::unique_ptr<column> findall(
-  strings_column_view const& input,
-  std::string_view pattern,
-  regex_flags const flags             = regex_flags::DEFAULT,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
 /** @} */  // end of doxygen group
 }  // namespace strings
 }  // namespace cudf

--- a/cpp/include/cudf/strings/replace_re.hpp
+++ b/cpp/include/cudf/strings/replace_re.hpp
@@ -60,35 +60,6 @@ std::unique_ptr<column> replace_re(
   rmm::mr::device_memory_resource* mr        = rmm::mr::get_current_device_resource());
 
 /**
- * @brief For each string, replaces any character sequence matching the given pattern
- * with the provided replacement string.
- *
- * Any null string entries return corresponding null output column entries.
- *
- * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
- *
- * @deprecated Use @link replace_re replace_re(strings_column_view const&, regex_program const&,
- * string_scalar const&, std::optional<size_type>, rmm::mr::device_memory_resource*) @endlink
- *
- * @param strings Strings instance for this operation.
- * @param pattern The regular expression pattern to search within each string.
- * @param replacement The string used to replace the matched sequence in each string.
- *        Default is an empty string.
- * @param max_replace_count The maximum number of times to replace the matched pattern
- *        within each string. Default replaces every substring that is matched.
- * @param flags Regex flags for interpreting special characters in the pattern.
- * @param mr Device memory resource used to allocate the returned column's device memory.
- * @return New strings column.
- */
-[[deprecated]] std::unique_ptr<column> replace_re(
-  strings_column_view const& strings,
-  std::string_view pattern,
-  string_scalar const& replacement           = string_scalar(""),
-  std::optional<size_type> max_replace_count = std::nullopt,
-  regex_flags const flags                    = regex_flags::DEFAULT,
-  rmm::mr::device_memory_resource* mr        = rmm::mr::get_current_device_resource());
-
-/**
  * @brief For each string, replaces any character sequence matching the given patterns
  * with the corresponding string in the `replacements` column.
  *
@@ -131,34 +102,6 @@ std::unique_ptr<column> replace_with_backrefs(
   strings_column_view const& strings,
   regex_program const& prog,
   std::string_view replacement,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
-/**
- * @brief For each string, replaces any character sequence matching the given pattern
- * using the replacement template for back-references.
- *
- * Any null string entries return corresponding null output column entries.
- *
- * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
- *
- * @deprecated Use @link replace_with_backrefs replace_with_backrefs(strings_column_view const&,
- * regex_program const&, string_view, rmm::mr::device_memory_resource*) @endlink
- *
- * @throw cudf::logic_error if capture index values in `replacement` are not in range 0-99, and also
- * if the index exceeds the group count specified in the pattern
- *
- * @param strings Strings instance for this operation.
- * @param pattern The regular expression patterns to search within each string.
- * @param replacement The replacement template for creating the output string.
- * @param flags Regex flags for interpreting special characters in the pattern.
- * @param mr Device memory resource used to allocate the returned column's device memory.
- * @return New strings column.
- */
-[[deprecated]] std::unique_ptr<column> replace_with_backrefs(
-  strings_column_view const& strings,
-  std::string_view pattern,
-  std::string_view replacement,
-  regex_flags const flags             = regex_flags::DEFAULT,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 }  // namespace strings

--- a/cpp/include/cudf/strings/split/split_re.hpp
+++ b/cpp/include/cudf/strings/split/split_re.hpp
@@ -85,57 +85,6 @@ std::unique_ptr<table> split_re(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Splits strings elements into a table of strings columns
- * using a regex pattern to delimit each string.
- *
- * Each element generates a vector of strings that are stored in corresponding
- * rows in the output table -- `table[col,row] = token[col] of strings[row]`
- * where `token` is a substring between delimiters.
- *
- * The number of rows in the output table will be the same as the number of
- * elements in the input column. The resulting number of columns will be the
- * maximum number of tokens found in any input row.
- *
- * The `pattern` is used to identify the delimiters within a string
- * and splitting stops when either `maxsplit` or the end of the string is reached.
- *
- * An empty input string will produce a corresponding empty string in the
- * corresponding row of the first column.
- * A null row will produce corresponding null rows in the output table.
- *
- * @code{.pseudo}
- * s = ["a_bc def_g", "a__bc", "_ab cd", "ab_cd "]
- * s1 = split_re(s, "[_ ]")
- * s1 is a table of strings columns:
- *     [ ["a", "a", "", "ab"],
- *       ["bc", "", "ab", "cd"],
- *       ["def", "bc", "cd", ""],
- *       ["g", null, null, null] ]
- * s2 = split_re(s, "[ _]", 1)
- * s2 is a table of strings columns:
- *     [ ["a", "a", "", "ab"],
- *       ["bc def_g", "_bc", "ab cd", "cd "] ]
- * @endcode
- *
- * @deprecated Use @link split_re split_re(strings_column_view const&,
- * regex_program const&, size_type, rmm::mr::device_memory_resource*) @endlink
- *
- * @throw cudf::logic_error if `pattern` is empty.
- *
- * @param input A column of string elements to be split.
- * @param pattern The regex pattern for delimiting characters within each string.
- * @param maxsplit Maximum number of splits to perform.
- *        Default of -1 indicates all possible splits on each string.
- * @param mr Device memory resource used to allocate the returned result's device memory.
- * @return A table of columns of strings.
- */
-[[deprecated]] std::unique_ptr<table> split_re(
-  strings_column_view const& input,
-  std::string_view pattern,
-  size_type maxsplit                  = -1,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
-/**
  * @brief Splits strings elements into a table of strings columns using a
  * regex_program's pattern to delimit each string starting from the end of the string
  *
@@ -186,59 +135,6 @@ std::unique_ptr<table> split_re(
 std::unique_ptr<table> rsplit_re(
   strings_column_view const& input,
   regex_program const& prog,
-  size_type maxsplit                  = -1,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
-/**
- * @brief Splits strings elements into a table of strings columns
- * using a regex pattern to delimit each string starting from the end of the string.
- *
- * Each element generates a vector of strings that are stored in corresponding
- * rows in the output table -- `table[col,row] = token[col] of string[row]`
- * where `token` is the substring between each delimiter.
- *
- * The number of rows in the output table will be the same as the number of
- * elements in the input column. The resulting number of columns will be the
- * maximum number of tokens found in any input row.
- *
- * Splitting occurs by traversing starting from the end of the input string.
- * The `pattern` is used to identify the delimiters within a string
- * and splitting stops when either `maxsplit` or the beginning of the string
- * is reached.
- *
- * An empty input string will produce a corresponding empty string in the
- * corresponding row of the first column.
- * A null row will produce corresponding null rows in the output table.
- *
- * @code{.pseudo}
- * s = ["a_bc def_g", "a__bc", "_ab cd", "ab_cd "]
- * s1 = rsplit_re(s, "[_ ]")
- * s1 is a table of strings columns:
- *     [ ["a", "a", "", "ab"],
- *       ["bc", "", "ab", "cd"],
- *       ["def", "bc", "cd", ""],
- *       ["g", null, null, null] ]
- * s2 = rsplit_re(s, "[ _]", 1)
- * s2 is a table of strings columns:
- *     [ ["a_bc def", "a_", "_ab", "ab"],
- *       ["g", "bc", "cd", "cd "] ]
- * @endcode
- *
- * @deprecated Use @link rsplit_re rsplit_re(strings_column_view const&,
- * regex_program const&, size_type, rmm::mr::device_memory_resource*) @endlink
- *
- * @throw cudf::logic_error if `pattern` is empty.
- *
- * @param input A column of string elements to be split.
- * @param pattern The regex pattern for delimiting characters within each string.
- * @param maxsplit Maximum number of splits to perform.
- *        Default of -1 indicates all possible splits on each string.
- * @param mr Device memory resource used to allocate the returned result's device memory.
- * @return A table of columns of strings.
- */
-[[deprecated]] std::unique_ptr<table> rsplit_re(
-  strings_column_view const& input,
-  std::string_view pattern,
   size_type maxsplit                  = -1,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
@@ -299,61 +195,6 @@ std::unique_ptr<column> split_record_re(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Splits strings elements into a list column of strings
- * using the given regex pattern to delimit each string.
- *
- * Each element generates an array of strings that are stored in an output
- * lists column -- `list[row] = [token1, token2, ...] found in input[row]`
- * where `token` is a substring between delimiters.
- *
- * The number of elements in the output column will be the same as the number of
- * elements in the input column. Each individual list item will contain the
- * new strings for that row. The resulting number of strings in each row can vary
- * from 0 to `maxsplit + 1`.
- *
- * The `pattern` is used to identify the delimiters within a string
- * and splitting stops when either `maxsplit` or the end of the string is reached.
- *
- * An empty input string will produce a corresponding empty list item output row.
- * A null row will produce a corresponding null output row.
- *
- * @code{.pseudo}
- * s = ["a_bc def_g", "a__bc", "_ab cd", "ab_cd "]
- * s1 = split_record_re(s, "[_ ]")
- * s1 is a lists column of strings:
- *     [ ["a", "bc", "def", "g"],
- *       ["a", "", "bc"],
- *       ["", "ab", "cd"],
- *       ["ab", "cd", ""] ]
- * s2 = split_record_re(s, "[ _]", 1)
- * s2 is a lists column of strings:
- *     [ ["a", "bc def_g"],
- *       ["a", "_bc"],
- *       ["", "ab cd"],
- *       ["ab", "cd "] ]
- * @endcode
- *
- * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
- *
- * @deprecated Use @link split_record_re split_record_re(strings_column_view const&,
- * regex_program const&, size_type, rmm::mr::device_memory_resource*) @endlink
- *
- * @throw cudf::logic_error if `pattern` is empty.
- *
- * @param input A column of string elements to be split.
- * @param pattern The regex pattern for delimiting characters within each string.
- * @param maxsplit Maximum number of splits to perform.
- *        Default of -1 indicates all possible splits on each string.
- * @param mr Device memory resource used to allocate the returned result's device memory.
- * @return Lists column of strings.
- */
-[[deprecated]] std::unique_ptr<column> split_record_re(
-  strings_column_view const& input,
-  std::string_view pattern,
-  size_type maxsplit                  = -1,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
-/**
  * @brief Splits strings elements into a list column of strings using the given
  * regex_program to delimit each string starting from the end of the string
  *
@@ -408,63 +249,6 @@ std::unique_ptr<column> split_record_re(
 std::unique_ptr<column> rsplit_record_re(
   strings_column_view const& input,
   regex_program const& prog,
-  size_type maxsplit                  = -1,
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
-/**
- * @brief Splits strings elements into a list column of strings
- * using the given regex pattern to delimit each string starting from the end of the string.
- *
- * Each element generates a vector of strings that are stored in an output
- * lists column -- `list[row] = [token1, token2, ...] found in input[row]`
- * where `token` is a substring between delimiters.
- *
- * The number of elements in the output column will be the same as the number of
- * elements in the input column. Each individual list item will contain the
- * new strings for that row. The resulting number of strings in each row can vary
- * from 0 to `maxsplit + 1`.
- *
- * Splitting occurs by traversing starting from the end of the input string.
- * The `pattern` is used to identify the separation points within a string
- * and splitting stops when either `maxsplit` or the beginning of the string
- * is reached.
- *
- * An empty input string will produce a corresponding empty list item output row.
- * A null row will produce a corresponding null output row.
- *
- * @code{.pseudo}
- * s = ["a_bc def_g", "a__bc", "_ab cd", "ab_cd "]
- * s1 = rsplit_record_re(s, "[_ ]")
- * s1 is a lists column of strings:
- *     [ ["a", "bc", "def", "g"],
- *       ["a", "", "bc"],
- *       ["", "ab", "cd"],
- *       ["ab", "cd", ""] ]
- * s2 = rsplit_record_re(s, "[ _]", 1)
- * s2 is a lists column of strings:
- *     [ ["a_bc def", "g"],
- *       ["a_", "bc"],
- *       ["_ab", "cd"],
- *       ["ab_cd", ""] ]
- * @endcode
- *
- * See the @ref md_regex "Regex Features" page for details on patterns supported by this API.
- *
- * @deprecated Use @link rsplit_record_re rsplit_record_re(strings_column_view const&,
- * regex_program const&, size_type, rmm::mr::device_memory_resource*) @endlink
- *
- * @throw cudf::logic_error if `pattern` is empty.
- *
- * @param input A column of string elements to be split.
- * @param pattern The regex pattern for delimiting characters within each string.
- * @param maxsplit Maximum number of splits to perform.
- *        Default of -1 indicates all possible splits on each string.
- * @param mr Device memory resource used to allocate the returned result's device memory.
- * @return Lists column of strings.
- */
-[[deprecated]] std::unique_ptr<column> rsplit_record_re(
-  strings_column_view const& input,
-  std::string_view pattern,
   size_type maxsplit                  = -1,
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 

--- a/cpp/src/strings/contains.cu
+++ b/cpp/src/strings/contains.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,16 +125,6 @@ std::unique_ptr<column> count_re(strings_column_view const& input,
 // external APIs
 
 std::unique_ptr<column> contains_re(strings_column_view const& strings,
-                                    std::string_view pattern,
-                                    regex_flags const flags,
-                                    rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern, flags, capture_groups::NON_CAPTURE);
-  return detail::contains_re(strings, *h_prog, cudf::get_default_stream(), mr);
-}
-
-std::unique_ptr<column> contains_re(strings_column_view const& strings,
                                     regex_program const& prog,
                                     rmm::mr::device_memory_resource* mr)
 {
@@ -143,31 +133,11 @@ std::unique_ptr<column> contains_re(strings_column_view const& strings,
 }
 
 std::unique_ptr<column> matches_re(strings_column_view const& strings,
-                                   std::string_view pattern,
-                                   regex_flags const flags,
-                                   rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern, flags, capture_groups::NON_CAPTURE);
-  return detail::matches_re(strings, *h_prog, cudf::get_default_stream(), mr);
-}
-
-std::unique_ptr<column> matches_re(strings_column_view const& strings,
                                    regex_program const& prog,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::matches_re(strings, prog, cudf::get_default_stream(), mr);
-}
-
-std::unique_ptr<column> count_re(strings_column_view const& strings,
-                                 std::string_view pattern,
-                                 regex_flags const flags,
-                                 rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern, flags, capture_groups::NON_CAPTURE);
-  return detail::count_re(strings, *h_prog, cudf::get_default_stream(), mr);
 }
 
 std::unique_ptr<column> count_re(strings_column_view const& strings,

--- a/cpp/src/strings/extract/extract.cu
+++ b/cpp/src/strings/extract/extract.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,16 +129,6 @@ std::unique_ptr<table> extract(strings_column_view const& input,
 }  // namespace detail
 
 // external API
-
-std::unique_ptr<table> extract(strings_column_view const& strings,
-                               std::string_view pattern,
-                               regex_flags const flags,
-                               rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern, flags, capture_groups::EXTRACT);
-  return detail::extract(strings, *h_prog, cudf::get_default_stream(), mr);
-}
 
 std::unique_ptr<table> extract(strings_column_view const& strings,
                                regex_program const& prog,

--- a/cpp/src/strings/extract/extract_all.cu
+++ b/cpp/src/strings/extract/extract_all.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -164,16 +164,6 @@ std::unique_ptr<column> extract_all_record(strings_column_view const& input,
 }  // namespace detail
 
 // external API
-
-std::unique_ptr<column> extract_all_record(strings_column_view const& strings,
-                                           std::string_view pattern,
-                                           regex_flags const flags,
-                                           rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern, flags, capture_groups::EXTRACT);
-  return detail::extract_all_record(strings, *h_prog, cudf::get_default_stream(), mr);
-}
 
 std::unique_ptr<column> extract_all_record(strings_column_view const& strings,
                                            regex_program const& prog,

--- a/cpp/src/strings/replace/backref_re.cu
+++ b/cpp/src/strings/replace/backref_re.cu
@@ -146,18 +146,6 @@ std::unique_ptr<column> replace_with_backrefs(strings_column_view const& input,
 // external API
 
 std::unique_ptr<column> replace_with_backrefs(strings_column_view const& strings,
-                                              std::string_view pattern,
-                                              std::string_view replacement,
-                                              regex_flags const flags,
-                                              rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern, flags, capture_groups::EXTRACT);
-  return detail::replace_with_backrefs(
-    strings, *h_prog, replacement, cudf::get_default_stream(), mr);
-}
-
-std::unique_ptr<column> replace_with_backrefs(strings_column_view const& strings,
                                               regex_program const& prog,
                                               std::string_view replacement,
                                               rmm::mr::device_memory_resource* mr)

--- a/cpp/src/strings/replace/replace_re.cu
+++ b/cpp/src/strings/replace/replace_re.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,19 +133,6 @@ std::unique_ptr<column> replace_re(strings_column_view const& input,
 }  // namespace detail
 
 // external API
-
-std::unique_ptr<column> replace_re(strings_column_view const& strings,
-                                   std::string_view pattern,
-                                   string_scalar const& replacement,
-                                   std::optional<size_type> max_replace_count,
-                                   regex_flags const flags,
-                                   rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern, flags, capture_groups::NON_CAPTURE);
-  return detail::replace_re(
-    strings, *h_prog, replacement, max_replace_count, cudf::get_default_stream(), mr);
-}
 
 std::unique_ptr<column> replace_re(strings_column_view const& strings,
                                    regex_program const& prog,

--- a/cpp/src/strings/search/findall.cu
+++ b/cpp/src/strings/search/findall.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,16 +132,6 @@ std::unique_ptr<column> findall(strings_column_view const& input,
 }  // namespace detail
 
 // external API
-
-std::unique_ptr<column> findall(strings_column_view const& input,
-                                std::string_view pattern,
-                                regex_flags const flags,
-                                rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern, flags, capture_groups::NON_CAPTURE);
-  return detail::findall(input, *h_prog, cudf::get_default_stream(), mr);
-}
 
 std::unique_ptr<column> findall(strings_column_view const& input,
                                 regex_program const& prog,

--- a/cpp/src/strings/split/split_re.cu
+++ b/cpp/src/strings/split/split_re.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -333,32 +333,12 @@ std::unique_ptr<column> rsplit_record_re(strings_column_view const& input,
 // external APIs
 
 std::unique_ptr<table> split_re(strings_column_view const& input,
-                                std::string_view pattern,
-                                size_type maxsplit,
-                                rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern);
-  return detail::split_re(input, *h_prog, maxsplit, cudf::get_default_stream(), mr);
-}
-
-std::unique_ptr<table> split_re(strings_column_view const& input,
                                 regex_program const& prog,
                                 size_type maxsplit,
                                 rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::split_re(input, prog, maxsplit, cudf::get_default_stream(), mr);
-}
-
-std::unique_ptr<column> split_record_re(strings_column_view const& input,
-                                        std::string_view pattern,
-                                        size_type maxsplit,
-                                        rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern);
-  return detail::split_record_re(input, *h_prog, maxsplit, cudf::get_default_stream(), mr);
 }
 
 std::unique_ptr<column> split_record_re(strings_column_view const& input,
@@ -371,32 +351,12 @@ std::unique_ptr<column> split_record_re(strings_column_view const& input,
 }
 
 std::unique_ptr<table> rsplit_re(strings_column_view const& input,
-                                 std::string_view pattern,
-                                 size_type maxsplit,
-                                 rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern);
-  return detail::rsplit_re(input, *h_prog, maxsplit, cudf::get_default_stream(), mr);
-}
-
-std::unique_ptr<table> rsplit_re(strings_column_view const& input,
                                  regex_program const& prog,
                                  size_type maxsplit,
                                  rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::rsplit_re(input, prog, maxsplit, cudf::get_default_stream(), mr);
-}
-
-std::unique_ptr<column> rsplit_record_re(strings_column_view const& input,
-                                         std::string_view pattern,
-                                         size_type maxsplit,
-                                         rmm::mr::device_memory_resource* mr)
-{
-  CUDF_FUNC_RANGE();
-  auto const h_prog = regex_program::create(pattern);
-  return detail::rsplit_record_re(input, *h_prog, maxsplit, cudf::get_default_stream(), mr);
 }
 
 std::unique_ptr<column> rsplit_record_re(strings_column_view const& input,


### PR DESCRIPTION
## Description
Removes the libcudf regex APIs that were deprecated in 23.04. All calls to these functions within the repo had already been removed.
Marking this breaking since APIs are being removed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
