### PR TITLE
Add algorithm include in data_sink.hpp

### DIFF
--- a/cpp/include/cudf/io/data_sink.hpp
+++ b/cpp/include/cudf/io/data_sink.hpp
@@ -21,6 +21,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <algorithm>
 #include <future>
 #include <memory>
 #include <string>


### PR DESCRIPTION
## Description
`data_sink.hpp` uses `std::transform` but not does not include <algorithm>. This PR fixes that.

The missing include was surfaced by https://github.com/rapidsai/cudf/pull/13064.