### PR TITLE
[REVIEW] Pin `dask` and `distributed` for release

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -134,5 +134,5 @@ jobs:
       build_type: pull-request
       package-name: dask_cudf
       # Install the cudf we just built, and also test against latest dask/distributed/dask-cuda.
-      test-before: "RAPIDS_PY_WHEEL_NAME=cudf_cu11 rapids-download-wheels-from-s3 ./local-cudf-dep && python -m pip install --no-deps ./local-cudf-dep/cudf*.whl && pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
+      test-before: "RAPIDS_PY_WHEEL_NAME=cudf_cu11 rapids-download-wheels-from-s3 ./local-cudf-dep && python -m pip install --no-deps ./local-cudf-dep/cudf*.whl && pip install git+https://github.com/dask/dask.git@2023.3.2 git+https://github.com/dask/distributed.git@2023.3.2.1 git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
       test-unittest: "python -m pytest -v -n 8 ./python/dask_cudf/dask_cudf/tests"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,5 +98,5 @@ jobs:
       sha: ${{ inputs.sha }}
       package-name: dask_cudf
       # Test against latest dask/distributed/dask-cuda.
-      test-before: "pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
+      test-before: "pip install git+https://github.com/dask/dask.git@2023.3.2 git+https://github.com/dask/distributed.git@2023.3.2.1 git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
       test-unittest: "python -m pytest -v -n 8 ./python/dask_cudf/dask_cudf/tests"

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -22,8 +22,8 @@ dependencies:
 - cxx-compiler
 - cython>=0.29,<0.30
 - dask-cuda==23.4.*
-- dask>=2023.1.1
-- distributed>=2023.1.1
+- dask==2023.3.2
+- distributed==2023.3.2.1
 - dlpack>=0.5,<0.6.0a0
 - doxygen=1.8.20
 - fastavro>=0.22.9

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -23,6 +23,7 @@ dependencies:
 - cython>=0.29,<0.30
 - dask-cuda==23.4.*
 - dask==2023.3.2
+- dask-core==2023.3.2
 - distributed==2023.3.2.1
 - dlpack>=0.5,<0.6.0a0
 - doxygen=1.8.20

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -21,9 +21,9 @@ dependencies:
 - cupy>=9.5.0,<12.0.0a0
 - cxx-compiler
 - cython>=0.29,<0.30
+- dask-core==2023.3.2
 - dask-cuda==23.4.*
 - dask==2023.3.2
-- dask-core==2023.3.2
 - distributed==2023.3.2.1
 - dlpack>=0.5,<0.6.0a0
 - doxygen=1.8.20

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - streamz
     - cudf ={{ version }}
     - dask ==2023.3.2
+    - dask-core ==2023.3.2
     - distributed ==2023.3.2.1
     - python-confluent-kafka >=1.7.0,<1.8.0a0
     - cudf_kafka ={{ version }}

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -41,8 +41,8 @@ requirements:
     - python
     - streamz
     - cudf ={{ version }}
-    - dask >=2023.1.1
-    - distributed >=2023.1.1
+    - dask ==2023.3.2
+    - distributed ==2023.3.2.1
     - python-confluent-kafka >=1.7.0,<1.8.0a0
     - cudf_kafka ={{ version }}
 

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -37,14 +37,14 @@ requirements:
   host:
     - python
     - cudf ={{ version }}
-    - dask >=2023.1.1
-    - distributed >=2023.1.1
+    - dask ==2023.3.2
+    - distributed ==2023.3.2.1
     - cudatoolkit ={{ cuda_version }}
   run:
     - python
     - cudf ={{ version }}
-    - dask >=2023.1.1
-    - distributed >=2023.1.1
+    - dask ==2023.3.2
+    - distributed ==2023.3.2.1
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
 
 test:

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -38,12 +38,14 @@ requirements:
     - python
     - cudf ={{ version }}
     - dask ==2023.3.2
+    - dask-core ==2023.3.2
     - distributed ==2023.3.2.1
     - cudatoolkit ={{ cuda_version }}
   run:
     - python
     - cudf ={{ version }}
     - dask ==2023.3.2
+    - dask-core ==2023.3.2
     - distributed ==2023.3.2.1
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
 

--- a/conda/recipes/dask-cudf/run_test.sh
+++ b/conda/recipes/dask-cudf/run_test.sh
@@ -18,18 +18,18 @@ if [ "${ARCH}" = "aarch64" ]; then
 fi
 
 # Dask & Distributed option to install main(nightly) or `conda-forge` packages.
-export INSTALL_DASK_MAIN=1
+export INSTALL_DASK_MAIN=0
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2023.1.1"
+export DASK_STABLE_VERSION="2023.3.2"
 
 # Install the conda-forge or nightly version of dask and distributed
 if [[ "${INSTALL_DASK_MAIN}" == 1 ]]; then
     rapids-logger "rapids-mamba-retry install -c dask/label/dev 'dask/label/dev::dask' 'dask/label/dev::distributed'"
     rapids-mamba-retry install -c dask/label/dev "dask/label/dev::dask" "dask/label/dev::distributed"
 else
-    rapids-logger "rapids-mamba-retry install conda-forge::dask=={$DASK_STABLE_VERSION} conda-forge::distributed=={$DASK_STABLE_VERSION} conda-forge::dask-core=={$DASK_STABLE_VERSION} --force-reinstall"
-    rapids-mamba-retry install conda-forge::dask=={$DASK_STABLE_VERSION} conda-forge::distributed=={$DASK_STABLE_VERSION} conda-forge::dask-core=={$DASK_STABLE_VERSION} --force-reinstall
+    rapids-logger "rapids-mamba-retry install conda-forge::dask=={$DASK_STABLE_VERSION} conda-forge::distributed==2023.3.2.1 conda-forge::dask-core==2023.3.2.1 --force-reinstall"
+    rapids-mamba-retry install conda-forge::dask=={$DASK_STABLE_VERSION} conda-forge::distributed=="2023.3.2.1" conda-forge::dask-core=="2023.3.2.1" --force-reinstall
 fi
 
 logger "python -c 'import dask_cudf'"

--- a/conda/recipes/dask-cudf/run_test.sh
+++ b/conda/recipes/dask-cudf/run_test.sh
@@ -28,8 +28,8 @@ if [[ "${INSTALL_DASK_MAIN}" == 1 ]]; then
     rapids-logger "rapids-mamba-retry install -c dask/label/dev 'dask/label/dev::dask' 'dask/label/dev::distributed'"
     rapids-mamba-retry install -c dask/label/dev "dask/label/dev::dask" "dask/label/dev::distributed"
 else
-    rapids-logger "rapids-mamba-retry install conda-forge::dask=={$DASK_STABLE_VERSION} conda-forge::distributed==2023.3.2.1 conda-forge::dask-core==2023.3.2.1 --force-reinstall"
-    rapids-mamba-retry install conda-forge::dask=={$DASK_STABLE_VERSION} conda-forge::distributed=="2023.3.2.1" conda-forge::dask-core=="2023.3.2.1" --force-reinstall
+    rapids-logger "rapids-mamba-retry install conda-forge::dask=={$DASK_STABLE_VERSION} conda-forge::distributed==2023.3.2.1 conda-forge::dask-core==2023.3.2 --force-reinstall"
+    rapids-mamba-retry install conda-forge::dask=={$DASK_STABLE_VERSION} conda-forge::distributed=="2023.3.2.1" conda-forge::dask-core=="2023.3.2" --force-reinstall
 fi
 
 logger "python -c 'import dask_cudf'"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -383,6 +383,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - dask==2023.3.2
+          - dask-core==2023.3.2
           - distributed==2023.3.2.1
       - output_types: pyproject
         packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -382,8 +382,8 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - dask>=2023.1.1
-          - distributed>=2023.1.1
+          - dask==2023.3.2
+          - distributed==2023.3.2.1
       - output_types: pyproject
         packages:
           - &cudf cudf==23.4.*

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -383,8 +383,10 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - dask==2023.3.2
-          - dask-core==2023.3.2
           - distributed==2023.3.2.1
+      - output_types: conda
+        packages:
+          - dask-core==2023.3.2
       - output_types: pyproject
         packages:
           - &cudf cudf==23.4.*

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -386,7 +386,7 @@ dependencies:
           - distributed==2023.3.2.1
       - output_types: conda
         packages:
-          - dask-core==2023.3.2
+          - dask-core==2023.3.2  # dask-core in conda is the actual package & dask is the meta package
       - output_types: pyproject
         packages:
           - &cudf cudf==23.4.*

--- a/python/dask_cudf/dask_cudf/io/parquet.py
+++ b/python/dask_cudf/dask_cudf/io/parquet.py
@@ -158,7 +158,7 @@ class CudfEngine(ArrowDatasetEngine):
                 # Build the column from `codes` directly
                 # (since the category is often a larger dtype)
                 codes = as_column(
-                    partitions[i].keys.index(index2),
+                    partitions[i].keys.get_loc(index2),
                     length=len(df),
                 )
                 df[name] = build_categorical_column(

--- a/python/dask_cudf/dask_cudf/io/parquet.py
+++ b/python/dask_cudf/dask_cudf/io/parquet.py
@@ -158,7 +158,7 @@ class CudfEngine(ArrowDatasetEngine):
                 # Build the column from `codes` directly
                 # (since the category is often a larger dtype)
                 codes = as_column(
-                    partitions[i].keys.get_loc(index2),
+                    partitions[i].keys.index(index2),
                     length=len(df),
                 )
                 df[name] = build_categorical_column(

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "cudf==23.4.*",
     "cupy-cuda11x>=9.5.0,<12.0.0a0",
     "dask==2023.3.2",
+    "dask-core==2023.3.2",
     "distributed==2023.3.2.1",
     "fsspec>=0.6.0",
     "numpy>=1.21",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -20,7 +20,6 @@ requires-python = ">=3.8"
 dependencies = [
     "cudf==23.4.*",
     "cupy-cuda11x>=9.5.0,<12.0.0a0",
-    "dask-core==2023.3.2",
     "dask==2023.3.2",
     "distributed==2023.3.2.1",
     "fsspec>=0.6.0",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -20,8 +20,8 @@ requires-python = ">=3.8"
 dependencies = [
     "cudf==23.4.*",
     "cupy-cuda11x>=9.5.0,<12.0.0a0",
-    "dask>=2023.1.1",
-    "distributed>=2023.1.1",
+    "dask==2023.3.2",
+    "distributed==2023.3.2.1",
     "fsspec>=0.6.0",
     "numpy>=1.21",
     "pandas>=1.3,<1.6.0dev0",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -20,8 +20,8 @@ requires-python = ">=3.8"
 dependencies = [
     "cudf==23.4.*",
     "cupy-cuda11x>=9.5.0,<12.0.0a0",
-    "dask==2023.3.2",
     "dask-core==2023.3.2",
+    "dask==2023.3.2",
     "distributed==2023.3.2.1",
     "fsspec>=0.6.0",
     "numpy>=1.21",


### PR DESCRIPTION
## Description
This PR pins `dask` and `distributed` to `2023.3.2` and `2023.3.2.1` respectively for 23.04 release.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
