### PR TITLE
Add Python bindings for string literal support in AST

### DIFF
--- a/cpp/include/cudf/ast/detail/expression_evaluator.cuh
+++ b/cpp/include/cudf/ast/detail/expression_evaluator.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/utilities/assert.cuh>
-#include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>

--- a/cpp/include/cudf/ast/detail/expression_parser.hpp
+++ b/cpp/include/cudf/ast/detail/expression_parser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ using IntermediateDataType = possibly_null_value_t<std::int64_t, has_nulls>;
  */
 struct expression_device_view {
   device_span<detail::device_data_reference const> data_references;
-  device_span<cudf::detail::fixed_width_scalar_device_view_base const> literals;
+  device_span<generic_scalar_device_view const> literals;
   device_span<ast_operator const> operators;
   device_span<cudf::size_type const> operator_source_indices;
   cudf::size_type num_intermediates;
@@ -281,11 +281,10 @@ class expression_parser {
       reinterpret_cast<detail::device_data_reference const*>(device_data_buffer_ptr +
                                                              buffer_offsets[0]),
       _data_references.size());
-    device_expression_data.literals =
-      device_span<cudf::detail::fixed_width_scalar_device_view_base const>(
-        reinterpret_cast<cudf::detail::fixed_width_scalar_device_view_base const*>(
-          device_data_buffer_ptr + buffer_offsets[1]),
-        _literals.size());
+    device_expression_data.literals = device_span<generic_scalar_device_view const>(
+      reinterpret_cast<generic_scalar_device_view const*>(device_data_buffer_ptr +
+                                                          buffer_offsets[1]),
+      _literals.size());
     device_expression_data.operators = device_span<ast_operator const>(
       reinterpret_cast<ast_operator const*>(device_data_buffer_ptr + buffer_offsets[2]),
       _operators.size());
@@ -335,7 +334,7 @@ class expression_parser {
   std::vector<detail::device_data_reference> _data_references;
   std::vector<ast_operator> _operators;
   std::vector<cudf::size_type> _operator_source_indices;
-  std::vector<cudf::detail::fixed_width_scalar_device_view_base> _literals;
+  std::vector<generic_scalar_device_view> _literals;
 };
 
 }  // namespace detail

--- a/cpp/include/cudf/ast/expressions.hpp
+++ b/cpp/include/cudf/ast/expressions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -188,6 +188,16 @@ class literal : public expression {
   template <typename T>
   literal(cudf::duration_scalar<T>& value)
     : scalar(value), value(cudf::get_scalar_device_view(value))
+  {
+  }
+
+  /**
+   * @brief Construct a new literal object.
+   *
+   * @param value A string scalar value
+   */
+  literal(cudf::string_scalar& value)
+    : scalar(value), value(cudf::get_scalar_experimental_device_view(value))
   {
   }
 

--- a/cpp/include/cudf/ast/expressions.hpp
+++ b/cpp/include/cudf/ast/expressions.hpp
@@ -155,16 +155,14 @@ enum class table_reference {
  */
 class generic_scalar_device_view : public cudf::detail::scalar_device_view_base {
  public:
-  // TODO: check if returning reference or value matters for performance, and register count.
   /**
-   * @brief Returns const reference to stored value.
+   * @brief Returns the stored value.
    *
    * @tparam T The desired type
-   * @returns Const reference to stored value
+   * @returns The stored value
    */
   template <typename T>
-  __device__ std::conditional_t<std::is_same_v<T, cudf::string_view>, T const, T const&> value()
-    const noexcept
+  __device__ T const value() const noexcept
   {
     if constexpr (std::is_same_v<T, cudf::string_view>) {
       return string_view(static_cast<char const*>(_data), _size);
@@ -218,9 +216,6 @@ class generic_scalar_device_view : public cudf::detail::scalar_device_view_base 
   /**
    * @brief Construct a new fixed width scalar device view object
    *
-   * This constructor should not be used directly. get_scalar_device_view
-   * should be used to get the view of an existing scalar
-   *
    * @param type The data type of the value
    * @param data The pointer to the data in device memory
    * @param is_valid The pointer to the bool in device memory that indicates the
@@ -232,9 +227,6 @@ class generic_scalar_device_view : public cudf::detail::scalar_device_view_base 
   }
 
   /** @brief Construct a new string scalar device view object
-   *
-   * This constructor should not be used directly. get_scalar_device_view
-   * should be used to get the view of an existing scalar
    *
    * @param type The data type of the value
    * @param data The pointer to the data in device memory

--- a/cpp/include/cudf/scalar/scalar_device_view.cuh
+++ b/cpp/include/cudf/scalar/scalar_device_view.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/string_view.hpp>
 #include <cudf/types.hpp>
+#include <type_traits>
 
 /**
  * @file scalar_device_view.cuh
@@ -98,8 +99,12 @@ class fixed_width_scalar_device_view_base : public detail::scalar_device_view_ba
    * @returns Const reference to stored value
    */
   template <typename T>
-  __device__ T const& value() const noexcept
+  __device__ std::conditional_t<std::is_same_v<T, cudf::string_view>, T const, T const&> value()
+    const noexcept
   {
+    if constexpr (std::is_same_v<T, cudf::string_view>) {
+      return string_view(static_cast<char const*>(_data), _size);
+    }
     return *data<T>();
   }
 
@@ -140,7 +145,8 @@ class fixed_width_scalar_device_view_base : public detail::scalar_device_view_ba
   }
 
  protected:
-  void* _data{};  ///< Pointer to device memory containing the value
+  void* _data{};    ///< Pointer to device memory containing the value
+  size_type _size;  ///< Size of the string in bytes
 
   /**
    * @brief Construct a new fixed width scalar device view object
@@ -155,6 +161,14 @@ class fixed_width_scalar_device_view_base : public detail::scalar_device_view_ba
    */
   fixed_width_scalar_device_view_base(data_type type, void* data, bool* is_valid)
     : detail::scalar_device_view_base(type, is_valid), _data(data)
+  {
+  }
+
+  /** @copydoc fixed_width_scalar_device_view_base(data_type,void*,bool*)
+   * @param size The size of the string in bytes
+   */
+  fixed_width_scalar_device_view_base(data_type type, void* data, bool* is_valid, size_type size)
+    : detail::scalar_device_view_base(type, is_valid), _data(data), _size(size)
   {
   }
 };
@@ -342,6 +356,21 @@ class string_scalar_device_view : public detail::scalar_device_view_base {
 };
 
 /**
+ * @brief A type of scalar_device_view that stores a string value in fixed width device view
+ */
+class string_scalar_experimental_device_view : public detail::fixed_width_scalar_device_view_base {
+ public:
+  /// @copydoc string_scalar_device_view::string_scalar_device_view
+  string_scalar_experimental_device_view(data_type type,
+                                         const char* data,
+                                         bool* is_valid,
+                                         size_type size)
+    : detail::fixed_width_scalar_device_view_base(type, const_cast<char*>(data), is_valid, size)
+  {
+  }
+};
+
+/**
  * @brief A type of scalar_device_view that stores a pointer to a timestamp value
  */
 template <typename T>
@@ -402,6 +431,17 @@ auto get_scalar_device_view(numeric_scalar<T>& s)
 inline auto get_scalar_device_view(string_scalar& s)
 {
   return string_scalar_device_view(s.type(), s.data(), s.validity_data(), s.size());
+}
+
+/**
+ * @brief Get the experimental fixed width device view of a string_scalar
+ *
+ * @param s The string_scalar to get the device view of
+ * @return A device view of a string_scalar
+ */
+inline auto get_scalar_experimental_device_view(string_scalar& s)
+{
+  return string_scalar_experimental_device_view(s.type(), s.data(), s.validity_data(), s.size());
 }
 
 /**

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -18,7 +18,6 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/detail/iterator.cuh>
-#include <cudf/detail/stream_compaction.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/scalar/scalar_factories.hpp>
@@ -26,8 +25,6 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/transform.hpp>
 #include <cudf/types.hpp>
-#include <cudf/utilities/traits.hpp>
-#include <cudf/utilities/type_dispatcher.hpp>
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
@@ -675,78 +672,6 @@ TEST_F(TransformTest, NullLogicalOr)
   auto result   = cudf::compute_column(table, expression);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
-}
-
-struct literal_converter {
-  template <typename T>
-  static constexpr bool is_supported()
-  {
-    return std::is_same_v<T, cudf::string_view> ||
-           (cudf::is_fixed_width<T>() && !cudf::is_fixed_point<T>());
-  }
-
-  template <typename T, std::enable_if_t<is_supported<T>()>* = nullptr>
-  cudf::ast::literal operator()(cudf::scalar& _value)
-  {
-    using scalar_type       = cudf::scalar_type_t<T>;
-    auto& low_literal_value = static_cast<scalar_type&>(_value);
-    return cudf::ast::literal(low_literal_value);
-  }
-
-  template <typename T, std::enable_if_t<!is_supported<T>()>* = nullptr>
-  cudf::ast::literal operator()(cudf::scalar& _value)
-  {
-    CUDF_FAIL("Unsupported type for literal");
-  }
-};
-
-std::unique_ptr<cudf::table> filter_table_by_range(cudf::table_view const& input,
-                                                   cudf::column_view const& sort_col,
-                                                   cudf::scalar& low,
-                                                   cudf::scalar& high,
-                                                   rmm::mr::device_memory_resource* mr)
-{
-  // return low.compare(elem) <= 0 && high.compare(elem) > 0;
-  auto col_ref_0   = cudf::ast::column_reference(0);
-  auto low_literal = cudf::type_dispatcher(low.type(), literal_converter{}, low);
-  auto expr_1 = cudf::ast::operation(cudf::ast::ast_operator::LESS_EQUAL, col_ref_0, low_literal);
-  auto high_literal = cudf::type_dispatcher(high.type(), literal_converter{}, high);
-  auto expr_2 = cudf::ast::operation(cudf::ast::ast_operator::GREATER, col_ref_0, high_literal);
-  auto expr_3 = cudf::ast::operation(cudf::ast::ast_operator::LOGICAL_AND, expr_1, expr_2);
-  auto result = cudf::compute_column(input, expr_3);
-  return cudf::detail::apply_boolean_mask(input, result->view(), rmm::cuda_stream_default, mr);
-}
-
-TEST_F(TransformTest, RangeFilterString)
-{
-  auto c_0   = cudf::test::strings_column_wrapper({"1", "12", "123", "2"});
-  auto table = cudf::table_view{{c_0}};
-  auto mr    = rmm::mr::get_current_device_resource();
-
-  auto lower  = cudf::string_scalar("2", true, rmm::cuda_stream_default, mr);
-  auto higher = cudf::string_scalar("12", true, rmm::cuda_stream_default, mr);
-  // elem > "12" && elem <= "2"  -> "123", "2"
-  auto c_1      = cudf::test::strings_column_wrapper({"123", "2"});
-  auto expected = cudf::table_view{{c_1}};
-  auto result   = filter_table_by_range(table, c_0, lower, higher, mr);
-
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected.column(0), result->view().column(0), verbosity);
-}
-
-TEST_F(TransformTest, RangeFilterNumeric)
-{
-  auto c_0   = column_wrapper<int32_t>{{1, 12, 5, 2}};
-  auto table = cudf::table_view{{c_0}};
-  auto mr    = rmm::mr::get_current_device_resource();
-
-  auto higher = cudf::numeric_scalar<int32_t>(2, true, rmm::cuda_stream_default, mr);
-  auto lower  = cudf::numeric_scalar<int32_t>(12, true, rmm::cuda_stream_default, mr);
-  // elem > 2 && elem <= 12  -> 12, 5
-  auto c_1      = column_wrapper<int32_t>{{12, 5}};
-  auto expected = cudf::table_view{{c_1}};
-  auto result   = filter_table_by_range(table, c_0, lower, higher, mr);
-
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected.column(0), result->view().column(0), verbosity);
 }
 
 CUDF_TEST_PROGRAM_MAIN()

--- a/python/cudf/cudf/_lib/expressions.pxd
+++ b/python/cudf/cudf/_lib/expressions.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 
 from libc.stdint cimport int32_t, int64_t
 from libcpp.memory cimport unique_ptr
@@ -9,16 +9,18 @@ from cudf._lib.cpp.expressions cimport (
     literal,
     operation,
 )
-from cudf._lib.cpp.scalar.scalar cimport numeric_scalar
+from cudf._lib.cpp.scalar.scalar cimport numeric_scalar, string_scalar
 
 ctypedef enum scalar_type_t:
     INT
     DOUBLE
+    STRING
 
 
-ctypedef union int_or_double_scalar_ptr:
+ctypedef union int_or_double_or_string_scalar_ptr:
     unique_ptr[numeric_scalar[int64_t]] int_ptr
     unique_ptr[numeric_scalar[double]] double_ptr
+    unique_ptr[string_scalar] string_ptr
 
 
 cdef class Expression:
@@ -27,7 +29,7 @@ cdef class Expression:
 
 cdef class Literal(Expression):
     cdef scalar_type_t c_scalar_type
-    cdef int_or_double_scalar_ptr c_scalar
+    cdef int_or_double_or_string_scalar_ptr c_scalar
 
 
 cdef class ColumnReference(Expression):

--- a/python/cudf/cudf/core/_internals/expressions.py
+++ b/python/cudf/cudf/core/_internals/expressions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 
 import ast
 import functools
@@ -115,7 +115,7 @@ class libcudfASTVisitor(ast.NodeVisitor):
         self.stack.append(ColumnReference(col_id))
 
     def visit_Constant(self, node):
-        if not isinstance(node, ast.Num):
+        if not isinstance(node, ast.Num) and not isinstance(node, ast.Str):
             raise ValueError(
                 f"Unsupported literal {repr(node.value)} of type "
                 "{type(node.value).__name__}"

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -9806,6 +9806,9 @@ def df_eval():
             float,
         ),
         ("a_b_are_equal = (a == b)", int),
+        ("a > b", str),
+        ("a < '1'", str),
+        ('a == "1"', str),
     ],
 )
 def test_dataframe_eval(df_eval, expr, dtype):


### PR DESCRIPTION
## Description
Depends on https://github.com/rapidsai/cudf/pull/13061
Add Python bindings for string scalar support in AST
Add unit test for string comparison - column vs column, column vs literal.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
