### PR TITLE
[REVIEW] Fix pytests to add coverage for index ufunc support introduced in `pandas-2.0`

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -3330,14 +3330,6 @@ class IndexedFrame(Frame):
         fname = ufunc.__name__
 
         if ret is not None:
-            # pandas bitwise operations return bools if indexes are misaligned.
-            if "bitwise" in fname:
-                reflect = self is not inputs[0]
-                other = inputs[0] if reflect else inputs[1]
-                if isinstance(other, self.__class__) and not self.index.equals(
-                    other.index
-                ):
-                    ret = ret.astype(bool)
             return ret
 
         # Attempt to dispatch all other functions to cupy.

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_GE_150
+from cudf.core._compat import PANDAS_GE_150, PANDAS_GE_200
 from cudf.testing._utils import assert_eq, set_random_null_mask_inplace
 
 _UFUNCS = [
@@ -162,6 +162,16 @@ def test_ufunc_series(request, ufunc, has_nulls, indexed):
         pytest.mark.xfail(
             condition=not hasattr(cp, fname),
             reason=f"cupy has no support for '{fname}'",
+        )
+    )
+
+    request.applymarker(
+        pytest.mark.xfail(
+            condition=PANDAS_GE_200
+            and fname.startswith("bitwise")
+            and indexed
+            and has_nulls,
+            reason="https://github.com/pandas-dev/pandas/issues/52500",
         )
     )
 
@@ -342,8 +352,8 @@ def test_ufunc_dataframe(request, ufunc, has_nulls, indexed):
     request.applymarker(
         pytest.mark.xfail(
             condition=(
-                indexed
-                and fname
+                not PANDAS_GE_200
+                and indexed
                 in {
                     "add",
                     "arctan2",
@@ -379,7 +389,7 @@ def test_ufunc_dataframe(request, ufunc, has_nulls, indexed):
                 }
             ),
             reason=(
-                "pandas does not currently support misaligned "
+                "pandas<2.0 does not currently support misaligned "
                 "indexes in DataFrames"
             ),
         )


### PR DESCRIPTION
## Description
Pandas 2.0 introduced support for ufuncs when the two columns are indexed. This PR updates the pytests accordingly. 
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
