### PR TITLE
Raise `NotImplementedError` when attempting to construct cuDF objects from timezone-aware datetimes

### DIFF
--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -512,7 +512,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         elif isinstance(data, pd.Index):
             if name is None:
                 name = data.name
-            data = data.values
+            data = as_column(data, nan_as_null=nan_as_null, dtype=dtype)
         elif isinstance(data, BaseIndex):
             if name is None:
                 name = data.name

--- a/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
+++ b/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import datetime
 import io
 import pathlib
 from typing import Optional
 
 import fastavro
+import pandas as pd
 import pytest
 
 import cudf
@@ -427,7 +427,10 @@ def test_alltypes_plain_avro():
     # our corresponding read_avro()-returned data frame.
 
     data = [{column: row[column] for column in columns} for row in records]
-    expected = cudf.DataFrame(data)
+
+    # discard timezone information as we don't support it:
+    expected = pd.DataFrame(data)
+    expected["timestamp_col"].dt.tz_localize(None)
 
     # The fastavro.reader supports the `'logicalType': 'timestamp-micros'` used
     # by the 'timestamp_col' column, which is converted into Python

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2078,3 +2078,18 @@ def test_datetime_constructor(data, dtype):
     actual = cudf.DatetimeIndex(data=cudf.Series(data), dtype=dtype)
 
     assert_eq(expected, actual)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [pd.Timestamp("2001-01-01", tz="America/New_York")],
+        pd.Series(["2001-01-01"], dtype="datetime64[ns, America/New_York]"),
+        pd.Index(["2001-01-01"], dtype="datetime64[ns, America/New_York]"),
+    ],
+)
+def test_construction_from_tz_timestamps(data):
+    with pytest.raises(NotImplementedError):
+        _ = cudf.Series(data)
+    with pytest.raises(NotImplementedError):
+        _ = cudf.Index(data)


### PR DESCRIPTION
Closes #13077 
