### PR TITLE
Remove using namespace cudf; from libcudf gtests source

### DIFF
--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -613,13 +613,13 @@ TEST_F(OrcWriterTest, negTimestampsNano)
   // seconds from UNIX epoch is read as that timestamp + 1 second. We mimic that behavior and so
   // this test has to hardcode test values which are < -1 second.
   // Details: https://github.com/rapidsai/cudf/pull/5529#issuecomment-648768925
-  using namespace cudf::test;
-  auto timestamps_ns = fixed_width_column_wrapper<cudf::timestamp_ns, cudf::timestamp_ns::rep>{
-    -131968727238000000,
-    -1530705634500000000,
-    -1674638741932929000,
-  };
-  table_view expected({timestamps_ns});
+  auto timestamps_ns =
+    cudf::test::fixed_width_column_wrapper<cudf::timestamp_ns, cudf::timestamp_ns::rep>{
+      -131968727238000000,
+      -1530705634500000000,
+      -1674638741932929000,
+    };
+  cudf::table_view expected({timestamps_ns});
 
   auto filepath = temp_env->get_temp_filepath("OrcNegTimestamp.orc");
   cudf::io::orc_writer_options out_opts =

--- a/cpp/tests/lists/extract_tests.cpp
+++ b/cpp/tests/lists/extract_tests.cpp
@@ -271,162 +271,160 @@ TYPED_TEST_SUITE(ListsExtractColumnIndicesTypedTest, cudf::test::FixedWidthTypes
 
 TYPED_TEST(ListsExtractColumnIndicesTypedTest, ExtractElement)
 {
-  using namespace cudf;
-  using namespace cudf::lists;
-  using namespace cudf::test;
-  using namespace cudf::test::iterators;
-  using LCW     = lists_column_wrapper<TypeParam, int32_t>;
-  using FWCW    = fixed_width_column_wrapper<TypeParam, int32_t>;
-  using indices = fixed_width_column_wrapper<offset_type>;
+  using LCW     = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using FWCW    = cudf::test::fixed_width_column_wrapper<TypeParam, int32_t>;
+  using indices = cudf::test::fixed_width_column_wrapper<cudf::offset_type>;
 
-  auto input_column =
-    LCW({LCW{3, 2, 1}, LCW{}, LCW{30, 20, 10, 50}, LCW{100, 120}, LCW{0}, LCW{}}, null_at(1));
-  auto input = lists_column_view(input_column);
+  auto input_column = LCW({LCW{3, 2, 1}, LCW{}, LCW{30, 20, 10, 50}, LCW{100, 120}, LCW{0}, LCW{}},
+                          cudf::test::iterators::null_at(1));
+  auto input        = cudf::lists_column_view(input_column);
 
   {
     // Test fetching first element.
-    auto result   = extract_list_element(input, indices{0, 0, 0, 0, 0, 0});
-    auto expected = FWCW({3, 0, 30, 100, 0, 0}, nulls_at({1, 5}));
+    auto result   = cudf::lists::extract_list_element(input, indices{0, 0, 0, 0, 0, 0});
+    auto expected = FWCW({3, 0, 30, 100, 0, 0}, cudf::test::iterators::nulls_at({1, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test fetching last element.
-    auto result   = extract_list_element(input, indices{2, 0, 3, 1, 0, 0});
-    auto expected = FWCW({1, 0, 50, 120, 0, 0}, nulls_at({1, 5}));
+    auto result   = cudf::lists::extract_list_element(input, indices{2, 0, 3, 1, 0, 0});
+    auto expected = FWCW({1, 0, 50, 120, 0, 0}, cudf::test::iterators::nulls_at({1, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test fetching *all* out of bounds.
-    auto result   = extract_list_element(input, indices{9, 9, 9, 9, 9, 9});
-    auto expected = FWCW({0, 0, 0, 0, 0, 0}, all_nulls());
+    auto result   = cudf::lists::extract_list_element(input, indices{9, 9, 9, 9, 9, 9});
+    auto expected = FWCW({0, 0, 0, 0, 0, 0}, cudf::test::iterators::all_nulls());
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test fetching first from the end.
-    auto result   = extract_list_element(input, indices{-1, -1, -1, -1, -1, -1});
-    auto expected = FWCW({1, 0, 50, 120, 0, 0}, nulls_at({1, 5}));
+    auto result   = cudf::lists::extract_list_element(input, indices{-1, -1, -1, -1, -1, -1});
+    auto expected = FWCW({1, 0, 50, 120, 0, 0}, cudf::test::iterators::nulls_at({1, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test fetching last from the end.
-    auto result   = extract_list_element(input, indices{-3, 0, -4, -2, -1, 0});
-    auto expected = FWCW({3, 0, 30, 100, 0, 0}, nulls_at({1, 5}));
+    auto result   = cudf::lists::extract_list_element(input, indices{-3, 0, -4, -2, -1, 0});
+    auto expected = FWCW({3, 0, 30, 100, 0, 0}, cudf::test::iterators::nulls_at({1, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test fetching *all* negative out of bounds.
-    auto result   = extract_list_element(input, indices{-9, -9, -9, -9, -9, -9});
-    auto expected = FWCW({0, 0, 0, 0, 0, 0}, all_nulls());
+    auto result   = cudf::lists::extract_list_element(input, indices{-9, -9, -9, -9, -9, -9});
+    auto expected = FWCW({0, 0, 0, 0, 0, 0}, cudf::test::iterators::all_nulls());
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test mixed indices.
-    auto result   = extract_list_element(input, indices{-2, 0, 3, -1, 0, 0});
-    auto expected = FWCW({2, 0, 50, 120, 0, 0}, nulls_at({1, 5}));
+    auto result   = cudf::lists::extract_list_element(input, indices{-2, 0, 3, -1, 0, 0});
+    auto expected = FWCW({2, 0, 50, 120, 0, 0}, cudf::test::iterators::nulls_at({1, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test possibly null indices.
-    auto result   = extract_list_element(input, indices{{-2, 0, 3, -1, 0, 0}, nulls_at({2, 4})});
-    auto expected = FWCW({2, 0, 50, 120, 0, 0}, nulls_at({1, 2, 4, 5}));
+    auto result = cudf::lists::extract_list_element(
+      input, indices{{-2, 0, 3, -1, 0, 0}, cudf::test::iterators::nulls_at({2, 4})});
+    auto expected = FWCW({2, 0, 50, 120, 0, 0}, cudf::test::iterators::nulls_at({1, 2, 4, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
 }
 
 TYPED_TEST(ListsExtractColumnIndicesTypedTest, FailureCases)
 {
-  using namespace cudf;
-  using namespace cudf::lists;
-  using namespace cudf::test;
-  using namespace cudf::test::iterators;
-  using LCW     = lists_column_wrapper<TypeParam, int32_t>;
-  using indices = fixed_width_column_wrapper<offset_type>;
+  using LCW     = cudf::test::lists_column_wrapper<TypeParam, int32_t>;
+  using indices = cudf::test::fixed_width_column_wrapper<cudf::offset_type>;
 
   {
     // Non-empty input, with mismatched size of indices.
     auto input_column =
-      LCW({LCW{3, 2, 1}, LCW{}, LCW{30, 20, 10, 50}, LCW{100, 120}, LCW{0}, LCW{}}, null_at(1));
-    auto input = lists_column_view(input_column);
+      LCW({LCW{3, 2, 1}, LCW{}, LCW{30, 20, 10, 50}, LCW{100, 120}, LCW{0}, LCW{}},
+          cudf::test::iterators::null_at(1));
+    auto input = cudf::lists_column_view(input_column);
 
-    EXPECT_THROW(extract_list_element(input, indices{0, 1, 2}), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::extract_list_element(input, indices{0, 1, 2}), cudf::logic_error);
   }
   {
     // Non-empty input, with empty indices.
     auto input_column =
-      LCW({LCW{3, 2, 1}, LCW{}, LCW{30, 20, 10, 50}, LCW{100, 120}, LCW{0}, LCW{}}, null_at(1));
-    auto input = lists_column_view(input_column);
+      LCW({LCW{3, 2, 1}, LCW{}, LCW{30, 20, 10, 50}, LCW{100, 120}, LCW{0}, LCW{}},
+          cudf::test::iterators::null_at(1));
+    auto input = cudf::lists_column_view(input_column);
 
-    EXPECT_THROW(extract_list_element(input, indices{}), cudf::logic_error);
+    EXPECT_THROW(cudf::lists::extract_list_element(input, indices{}), cudf::logic_error);
   }
   {
     // Empty input, with mismatched size of indices.
     auto input_column = LCW{};
-    auto input        = lists_column_view(input_column);
-    EXPECT_THROW(extract_list_element(input, indices{0, 1, 2}), cudf::logic_error);
+    auto input        = cudf::lists_column_view(input_column);
+    EXPECT_THROW(cudf::lists::extract_list_element(input, indices{0, 1, 2}), cudf::logic_error);
   }
 }
 
 TEST_F(ListsExtractColumnIndicesTest, ExtractStrings)
 {
-  using namespace cudf;
-  using namespace cudf::lists;
-  using namespace cudf::test;
-  using namespace cudf::test::iterators;
-  using LCW     = lists_column_wrapper<string_view>;
-  using strings = strings_column_wrapper;
-  using indices = fixed_width_column_wrapper<offset_type>;
+  using LCW     = cudf::test::lists_column_wrapper<cudf::string_view>;
+  using strings = cudf::test::strings_column_wrapper;
+  using indices = cudf::test::fixed_width_column_wrapper<cudf::offset_type>;
 
   auto input_column = LCW(
     {LCW{"3", "2", "1"}, LCW{}, LCW{"30", "20", "10", "50"}, LCW{"100", "120"}, LCW{"0"}, LCW{}},
-    null_at(1));
-  auto input = lists_column_view(input_column);
+    cudf::test::iterators::null_at(1));
+  auto input = cudf::lists_column_view(input_column);
 
   {
     // Test fetching first element.
-    auto result   = extract_list_element(input, indices{0, 0, 0, 0, 0, 0});
-    auto expected = strings({"3", "", "30", "100", "0", ""}, nulls_at({1, 5}));
+    auto result = cudf::lists::extract_list_element(input, indices{0, 0, 0, 0, 0, 0});
+    auto expected =
+      strings({"3", "", "30", "100", "0", ""}, cudf::test::iterators::nulls_at({1, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test fetching last element.
-    auto result   = extract_list_element(input, indices{2, 0, 3, 1, 0, 0});
-    auto expected = strings({"1", "", "50", "120", "0", ""}, nulls_at({1, 5}));
+    auto result = cudf::lists::extract_list_element(input, indices{2, 0, 3, 1, 0, 0});
+    auto expected =
+      strings({"1", "", "50", "120", "0", ""}, cudf::test::iterators::nulls_at({1, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test fetching *all* out of bounds.
-    auto result   = extract_list_element(input, indices{9, 9, 9, 9, 9, 9});
-    auto expected = strings({"", "", "", "", "", ""}, all_nulls());
+    auto result   = cudf::lists::extract_list_element(input, indices{9, 9, 9, 9, 9, 9});
+    auto expected = strings({"", "", "", "", "", ""}, cudf::test::iterators::all_nulls());
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test fetching first from the end.
-    auto result   = extract_list_element(input, indices{-1, -1, -1, -1, -1, -1});
-    auto expected = strings({"1", "", "50", "120", "0", ""}, nulls_at({1, 5}));
+    auto result = cudf::lists::extract_list_element(input, indices{-1, -1, -1, -1, -1, -1});
+    auto expected =
+      strings({"1", "", "50", "120", "0", ""}, cudf::test::iterators::nulls_at({1, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test fetching last from the end.
-    auto result   = extract_list_element(input, indices{-3, 0, -4, -2, -1, 0});
-    auto expected = strings({"3", "", "30", "100", "0", ""}, nulls_at({1, 5}));
+    auto result = cudf::lists::extract_list_element(input, indices{-3, 0, -4, -2, -1, 0});
+    auto expected =
+      strings({"3", "", "30", "100", "0", ""}, cudf::test::iterators::nulls_at({1, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test fetching *all* negative out of bounds.
-    auto result   = extract_list_element(input, indices{-9, -9, -9, -9, -9, -9});
-    auto expected = strings({"", "", "", "", "", ""}, all_nulls());
+    auto result   = cudf::lists::extract_list_element(input, indices{-9, -9, -9, -9, -9, -9});
+    auto expected = strings({"", "", "", "", "", ""}, cudf::test::iterators::all_nulls());
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test mixed indices.
-    auto result   = extract_list_element(input, indices{-2, 0, 3, -1, 0, 0});
-    auto expected = strings({"2", "", "50", "120", "0", ""}, nulls_at({1, 5}));
+    auto result = cudf::lists::extract_list_element(input, indices{-2, 0, 3, -1, 0, 0});
+    auto expected =
+      strings({"2", "", "50", "120", "0", ""}, cudf::test::iterators::nulls_at({1, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
   {
     // Test possibly null indices.
-    auto result   = extract_list_element(input, indices{{-2, 0, 3, -1, 0, 0}, nulls_at({2, 4})});
-    auto expected = strings({"2", "", "50", "120", "", ""}, nulls_at({1, 2, 4, 5}));
+    auto result = cudf::lists::extract_list_element(
+      input, indices{{-2, 0, 3, -1, 0, 0}, cudf::test::iterators::nulls_at({2, 4})});
+    auto expected =
+      strings({"2", "", "50", "120", "", ""}, cudf::test::iterators::nulls_at({1, 2, 4, 5}));
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *result);
   }
 }

--- a/cpp/tests/types/traits_test.cpp
+++ b/cpp/tests/types/traits_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,47 +47,34 @@ TYPED_TEST_SUITE(TypedTraitsTest, cudf::test::AllTypes);
 
 TEST_F(TraitsTest, NumericDataTypesAreNumeric)
 {
-  using namespace cudf::test;
-  EXPECT_TRUE(std::all_of(numeric_type_ids.begin(), numeric_type_ids.end(), [](cudf::type_id type) {
-    return cudf::is_numeric(cudf::data_type{type});
-  }));
+  EXPECT_TRUE(
+    std::all_of(cudf::test::numeric_type_ids.begin(),
+                cudf::test::numeric_type_ids.end(),
+                [](cudf::type_id type) { return cudf::is_numeric(cudf::data_type{type}); }));
 }
 
 TEST_F(TraitsTest, TimestampDataTypesAreNotNumeric)
 {
-  using namespace cudf::test;
   EXPECT_TRUE(
-    std::none_of(timestamp_type_ids.begin(), timestamp_type_ids.end(), [](cudf::type_id type) {
-      return cudf::is_numeric(cudf::data_type{type});
-    }));
+    std::none_of(cudf::test::timestamp_type_ids.begin(),
+                 cudf::test::timestamp_type_ids.end(),
+                 [](cudf::type_id type) { return cudf::is_numeric(cudf::data_type{type}); }));
 }
-
-/*
-These types are not yet supported by the type dispatcher
-TEST_F(TraitsTest, NonNumericDataTypesAreNotNumeric) {
-  using namespace cudf::test;
-  EXPECT_TRUE(std::none_of(
-      non_numeric_type_ids.begin(), non_numeric_type_ids.end(),
-      [](cudf::type_id type) { return cudf::is_numeric(cudf::data_type{type}); }));
-}
-*/
 
 TEST_F(TraitsTest, NumericDataTypesAreNotTimestamps)
 {
-  using namespace cudf::test;
   EXPECT_TRUE(
-    std::none_of(numeric_type_ids.begin(), numeric_type_ids.end(), [](cudf::type_id type) {
-      return cudf::is_timestamp(cudf::data_type{type});
-    }));
+    std::none_of(cudf::test::numeric_type_ids.begin(),
+                 cudf::test::numeric_type_ids.end(),
+                 [](cudf::type_id type) { return cudf::is_timestamp(cudf::data_type{type}); }));
 }
 
 TEST_F(TraitsTest, TimestampDataTypesAreTimestamps)
 {
-  using namespace cudf::test;
   EXPECT_TRUE(
-    std::all_of(timestamp_type_ids.begin(), timestamp_type_ids.end(), [](cudf::type_id type) {
-      return cudf::is_timestamp(cudf::data_type{type});
-    }));
+    std::all_of(cudf::test::timestamp_type_ids.begin(),
+                cudf::test::timestamp_type_ids.end(),
+                [](cudf::type_id type) { return cudf::is_timestamp(cudf::data_type{type}); }));
 }
 
 TYPED_TEST(TypedTraitsTest, RelationallyComparable)

--- a/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
+++ b/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
@@ -47,7 +47,6 @@ TYPED_TEST_SUITE(ListColumnWrapperTestTyped, FixedWidthTypesNotBool);
 
 TYPED_TEST(ListColumnWrapperTestTyped, List)
 {
-  using namespace cudf;
   using T = TypeParam;
 
   // List<T>, 1 row
@@ -59,19 +58,19 @@ TYPED_TEST(ListColumnWrapperTestTyped, List)
   //    2, 3
   //
   {
-    test::lists_column_wrapper<T, int32_t> list{2, 3};
+    cudf::test::lists_column_wrapper<T, int32_t> list{2, 3};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto data = lcv.child();
     EXPECT_EQ(data.size(), 2);
-    test::fixed_width_column_wrapper<T, int32_t> e_data({2, 3});
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_data({2, 3});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_data, data);
   }
 
@@ -84,26 +83,25 @@ TYPED_TEST(ListColumnWrapperTestTyped, List)
   //    2, 3
   //
   {
-    test::lists_column_wrapper<T, int32_t> list{{2, 3}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{2, 3}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto data = lcv.child();
     EXPECT_EQ(data.size(), 2);
-    test::fixed_width_column_wrapper<T, int32_t> e_data({2, 3});
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_data({2, 3});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_data, data);
   }
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListWithValidity)
 {
-  using namespace cudf;
   using T = TypeParam;
 
   auto valids =
@@ -118,19 +116,19 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListWithValidity)
   //    2, NULL
   //
   {
-    test::lists_column_wrapper<T, int32_t> list{{{2, 3}, valids}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{{2, 3}, valids}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto data = lcv.child();
     EXPECT_EQ(data.size(), 2);
-    test::fixed_width_column_wrapper<T, int32_t> e_data({2, 3}, valids);
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_data({2, 3}, valids);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_data, data);
   }
 
@@ -142,27 +140,26 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListWithValidity)
   // Children :
   //    2, NULL, 4, NULL, 6, NULL, 8
   {
-    test::lists_column_wrapper<T, int32_t> list{
+    cudf::test::lists_column_wrapper<T, int32_t> list{
       {{2, 3}, valids}, {{4, 5}, valids}, {{6, 7, 8}, valids}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2, 4, 7});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2, 4, 7});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto data = lcv.child();
     EXPECT_EQ(data.size(), 7);
-    test::fixed_width_column_wrapper<T, int32_t> e_data({2, 3, 4, 5, 6, 7, 8}, valids);
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_data({2, 3, 4, 5, 6, 7, 8}, valids);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_data, data);
   }
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListFromIterator)
 {
-  using namespace cudf;
   using T = TypeParam;
 
   // List<T>, 1 row
@@ -175,26 +172,25 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListFromIterator)
   //
   auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
 
-  test::lists_column_wrapper<T, typename decltype(sequence)::value_type> list{sequence,
-                                                                              sequence + 5};
+  cudf::test::lists_column_wrapper<T, typename decltype(sequence)::value_type> list{sequence,
+                                                                                    sequence + 5};
 
-  lists_column_view lcv(list);
+  cudf::lists_column_view lcv(list);
   EXPECT_EQ(lcv.size(), 1);
 
   auto offsets = lcv.offsets();
   EXPECT_EQ(offsets.size(), 2);
-  test::fixed_width_column_wrapper<size_type> e_offsets({0, 5});
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 5});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
   auto data = lcv.child();
   EXPECT_EQ(data.size(), 5);
-  test::fixed_width_column_wrapper<T, int32_t> e_data({0, 1, 2, 3, 4});
+  cudf::test::fixed_width_column_wrapper<T, int32_t> e_data({0, 1, 2, 3, 4});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_data, data);
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListFromIteratorWithValidity)
 {
-  using namespace cudf;
   using T = TypeParam;
 
   auto valids =
@@ -210,26 +206,25 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListFromIteratorWithValidity)
   //
   auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
 
-  test::lists_column_wrapper<T, typename decltype(sequence)::value_type> list{
+  cudf::test::lists_column_wrapper<T, typename decltype(sequence)::value_type> list{
     sequence, sequence + 5, valids};
 
-  lists_column_view lcv(list);
+  cudf::lists_column_view lcv(list);
   EXPECT_EQ(lcv.size(), 1);
 
   auto offsets = lcv.offsets();
   EXPECT_EQ(offsets.size(), 2);
-  test::fixed_width_column_wrapper<size_type> e_offsets({0, 5});
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 5});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
   auto data = lcv.child();
   EXPECT_EQ(data.size(), 5);
-  test::fixed_width_column_wrapper<T, int32_t> e_data({0, 0, 2, 0, 4}, valids);
+  cudf::test::fixed_width_column_wrapper<T, int32_t> e_data({0, 0, 2, 0, 4}, valids);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_data, data);
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListOfLists)
 {
-  using namespace cudf;
   using T = TypeParam;
 
   // List<List<T>>, 1 row
@@ -244,28 +239,28 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListOfLists)
   //    Children :
   //      2, 3, 4, 5
   {
-    test::lists_column_wrapper<T, int32_t> list{{{2, 3}, {4, 5}}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{{2, 3}, {4, 5}}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 2);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 2, 4});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 2, 4});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_data = childv.child();
     EXPECT_EQ(child_data.size(), 4);
-    test::fixed_width_column_wrapper<T, int32_t> e_child_data({2, 3, 4, 5});
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_child_data({2, 3, 4, 5});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_data, child_data);
   }
 
@@ -281,35 +276,36 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListOfLists)
   //    Children :
   //      1, 2, 3, 4, 5, 6, 7, 0, 8, 9, 10
   {
-    test::lists_column_wrapper<T, int32_t> list{{{1, 2}, {3, 4}}, {{5, 6, 7}, {0}, {8}}, {{9, 10}}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{
+      {{1, 2}, {3, 4}}, {{5, 6, 7}, {0}, {8}}, {{9, 10}}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2, 5, 6});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2, 5, 6});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 6);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 7);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 2, 4, 7, 8, 9, 11});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 2, 4, 7, 8, 9, 11});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_data = childv.child();
     EXPECT_EQ(child_data.size(), 11);
-    test::fixed_width_column_wrapper<T, int32_t> e_child_data({1, 2, 3, 4, 5, 6, 7, 0, 8, 9, 10});
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_child_data(
+      {1, 2, 3, 4, 5, 6, 7, 0, 8, 9, 10});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_data, child_data);
   }
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListOfListsWithValidity)
 {
-  using namespace cudf;
   using T = TypeParam;
 
   auto valids =
@@ -328,28 +324,28 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListOfListsWithValidity)
   //      2, NULL, 4, NULL
   {
     // equivalent to { {2, NULL}, {4, NULL} }
-    test::lists_column_wrapper<T, int32_t> list{{{{2, 3}, valids}, {{4, 5}, valids}}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{{{2, 3}, valids}, {{4, 5}, valids}}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 2);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 2, 4});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 2, 4});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_data = childv.child();
     EXPECT_EQ(child_data.size(), 4);
-    test::fixed_width_column_wrapper<T, int32_t> e_child_data({2, 3, 4, 5}, valids);
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_child_data({2, 3, 4, 5}, valids);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_data, child_data);
   }
 
@@ -368,37 +364,36 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListOfListsWithValidity)
   //      1, 2, 5, 6, 7, 8, 9, 10
   {
     // equivalent to  { {{1, 2}, NULL}, {{5, 6, 7}, NULL, {8}}, {{9, 10}} }
-    test::lists_column_wrapper<T, int32_t> list{
+    cudf::test::lists_column_wrapper<T, int32_t> list{
       {{{1, 2}, {3, 4}}, valids}, {{{5, 6, 7}, {0}, {8}}, valids}, {{{9, 10}}, valids}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2, 5, 6});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2, 5, 6});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 6);
     EXPECT_EQ(childv.null_count(), 2);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 7);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 2, 2, 5, 5, 6, 8});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 2, 2, 5, 5, 6, 8});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_data = childv.child();
     EXPECT_EQ(child_data.size(), 8);
-    test::fixed_width_column_wrapper<T, int32_t> e_child_data({1, 2, 5, 6, 7, 8, 9, 10});
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_child_data({1, 2, 5, 6, 7, 8, 9, 10});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_data, child_data);
   }
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListOfListOfListsWithValidity)
 {
-  using namespace cudf;
   using T = TypeParam;
 
   auto valids =
@@ -423,39 +418,40 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListOfListOfListsWithValidity)
   //        1, 2, 3, 4, 10, 20, 30, 40, 50, 60, 70, 0
   {
     // equivalent to  { {{{1, 2}, {3, 4}}, NULL}, {{{10, 20}, {30, 40}}, {{50, 60, 70}, {0}}} }
-    test::lists_column_wrapper<T, int32_t> list{{{{{1, 2}, {3, 4}}, {{5, 6, 7}, {0}}}, valids},
-                                                {{{10, 20}, {30, 40}}, {{50, 60, 70}, {0}}}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{
+      {{{{1, 2}, {3, 4}}, {{5, 6, 7}, {0}}}, valids}, {{{10, 20}, {30, 40}}, {{50, 60, 70}, {0}}}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 2);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2, 4});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2, 4});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 4);
     EXPECT_EQ(childv.null_count(), 1);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 5);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 2, 2, 4, 6});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 2, 2, 4, 6});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_child = childv.child();
-    lists_column_view child_childv(child_child);
+    cudf::lists_column_view child_childv(child_child);
     EXPECT_EQ(child_childv.size(), 6);
 
     auto child_child_offsets = child_childv.offsets();
     EXPECT_EQ(child_child_offsets.size(), 7);
-    test::fixed_width_column_wrapper<size_type> e_child_child_offsets({0, 2, 4, 6, 8, 11, 12});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_child_offsets(
+      {0, 2, 4, 6, 8, 11, 12});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_child_offsets, child_child_offsets);
 
     auto child_child_data = child_childv.child();
     EXPECT_EQ(child_child_data.size(), 12);
-    test::fixed_width_column_wrapper<T, int32_t> e_child_child_data(
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_child_child_data(
       {1, 2, 3, 4, 10, 20, 30, 40, 50, 60, 70, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_child_data, child_child_data);
   }
@@ -463,13 +459,12 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListOfListOfListsWithValidity)
 
 TYPED_TEST(ListColumnWrapperTestTyped, EmptyLists)
 {
-  using namespace cudf;
   using T = TypeParam;
 
   // to disambiguate between {} == 0 and {} == List{0}
   // Also, see note about compiler issues when declaring nested
   // empty lists in lists_column_wrapper documentation
-  using LCW = test::lists_column_wrapper<T, int32_t>;
+  using LCW = cudf::test::lists_column_wrapper<T, int32_t>;
 
   // List<T>, empty
   //
@@ -479,9 +474,9 @@ TYPED_TEST(ListColumnWrapperTestTyped, EmptyLists)
   // Children :
   {
     // equivalent to  {}
-    test::lists_column_wrapper<T> list{};
+    cudf::test::lists_column_wrapper<T> list{};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 0);
   }
 
@@ -493,14 +488,14 @@ TYPED_TEST(ListColumnWrapperTestTyped, EmptyLists)
   // Children :
   {
     // equivalent to  {}
-    test::lists_column_wrapper<T, int32_t> list{LCW{}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{LCW{}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
   }
 
@@ -512,14 +507,14 @@ TYPED_TEST(ListColumnWrapperTestTyped, EmptyLists)
   // Children :
   {
     // equivalent to  {}
-    test::lists_column_wrapper<T, int32_t> list{LCW{}, LCW{}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{LCW{}, LCW{}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 2);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
   }
 
@@ -533,19 +528,19 @@ TYPED_TEST(ListColumnWrapperTestTyped, EmptyLists)
   {
     // equivalent to  {{1, 2}, {}, {3, 4}}
 
-    test::lists_column_wrapper<T, int32_t> list{{1, 2}, LCW{}, {3, 4}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{1, 2}, LCW{}, {3, 4}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2, 2, 4});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2, 2, 4});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child_data = lcv.child();
     EXPECT_EQ(child_data.size(), 4);
-    test::fixed_width_column_wrapper<T, int32_t> e_child_data({1, 2, 3, 4});
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_child_data({1, 2, 3, 4});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_data, child_data);
   }
 
@@ -562,42 +557,42 @@ TYPED_TEST(ListColumnWrapperTestTyped, EmptyLists)
   //     1, 2, 3, 4, 5, 6, 7, 8
   {
     // equivalent to  { {{}}, {{1, 2}, {}, {3, 4}}, {{}, {5, 6, 7, 8}, {}} }
-    test::lists_column_wrapper<T, int32_t> list{
+    cudf::test::lists_column_wrapper<T, int32_t> list{
       {LCW{}}, {{1, 2}, LCW{}, {3, 4}}, {LCW{}, {5, 6, 7, 8}, LCW{}}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 1, 4, 7});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 1, 4, 7});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 7);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 8);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 0, 2, 2, 4, 4, 8, 8});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets(
+      {0, 0, 2, 2, 4, 4, 8, 8});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_data = childv.child();
     EXPECT_EQ(child_data.size(), 8);
-    test::fixed_width_column_wrapper<T, int32_t> e_child_data({1, 2, 3, 4, 5, 6, 7, 8});
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_child_data({1, 2, 3, 4, 5, 6, 7, 8});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_data, child_data);
   }
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, EmptyListsWithValidity)
 {
-  using namespace cudf;
   using T = TypeParam;
 
   // to disambiguate between {} == 0 and {} == List{0}
   // Also, see note about compiler issues when declaring nested
   // empty lists in lists_column_wrapper documentation
-  using LCW = test::lists_column_wrapper<T, int32_t>;
+  using LCW = cudf::test::lists_column_wrapper<T, int32_t>;
 
   auto valids =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
@@ -612,15 +607,15 @@ TYPED_TEST(ListColumnWrapperTestTyped, EmptyListsWithValidity)
   // Children :
   {
     // equivalent to  {{}, NULL}
-    test::lists_column_wrapper<T, int32_t> list{{LCW{}, LCW{}}, valids};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{LCW{}, LCW{}}, valids};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 2);
     EXPECT_EQ(lcv.null_count(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
   }
 
@@ -634,15 +629,15 @@ TYPED_TEST(ListColumnWrapperTestTyped, EmptyListsWithValidity)
   // Children :
   {
     // equivalent to  {{}, NULL, {}}
-    test::lists_column_wrapper<T, int32_t> list{{LCW{}, {1, 2, 3}, LCW{}}, valids};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{LCW{}, {1, 2, 3}, LCW{}}, valids};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
     EXPECT_EQ(lcv.null_count(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 0, 0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 0, 0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
   }
 
@@ -657,15 +652,15 @@ TYPED_TEST(ListColumnWrapperTestTyped, EmptyListsWithValidity)
   //   1, 2, 3
   {
     // equivalent to  {{}, NULL, {1, 2, 3}}
-    test::lists_column_wrapper<T, int32_t> list{{LCW{}, LCW{}, {1, 2, 3}}, valids};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{LCW{}, LCW{}, {1, 2, 3}}, valids};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
     EXPECT_EQ(lcv.null_count(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 0, 0, 3});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 0, 0, 3});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
   }
 
@@ -684,42 +679,41 @@ TYPED_TEST(ListColumnWrapperTestTyped, EmptyListsWithValidity)
   //     5, 6, 7, 8
   {
     // equivalent to  { {{}}, NULL, {{}, {5, 6, 7, 8}, {}} }
-    test::lists_column_wrapper<T, int32_t> list{
+    cudf::test::lists_column_wrapper<T, int32_t> list{
       {{LCW{}}, {{1, 2}, LCW{}, {3, 4}}, {LCW{}, {5, 6, 7, 8}, LCW{}}}, valids};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 1, 1, 4});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 1, 1, 4});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 4);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 5);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 0, 0, 4, 4});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 0, 0, 4, 4});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_data = childv.child();
     EXPECT_EQ(child_data.size(), 4);
-    test::fixed_width_column_wrapper<T, int32_t> e_child_data({5, 6, 7, 8});
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_child_data({5, 6, 7, 8});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_data, child_data);
   }
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, IncompleteHierarchies)
 {
-  using namespace cudf;
   using T = TypeParam;
 
   // to disambiguate between {} == 0 and {} == List{0}
   // Also, see note about compiler issues when declaring nested
   // empty lists in lists_column_wrapper documentation
-  using LCW = test::lists_column_wrapper<T, int32_t>;
+  using LCW = cudf::test::lists_column_wrapper<T, int32_t>;
 
   // List<List<List<T>>>:
   // Length : 3
@@ -734,32 +728,32 @@ TYPED_TEST(ListColumnWrapperTestTyped, IncompleteHierarchies)
   //      Offsets : 0, 0
   //      Children :
   {
-    test::lists_column_wrapper<T, int32_t> list{{{LCW{}}}, {LCW{}}, LCW{}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{{LCW{}}}, {LCW{}}, LCW{}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 1, 2, 2});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 1, 2, 2});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 2);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 1, 1});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 1, 1});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_child = childv.child();
-    lists_column_view child_childv(child_child);
+    cudf::lists_column_view child_childv(child_child);
     EXPECT_EQ(child_childv.size(), 1);
 
     auto child_child_offsets = child_childv.offsets();
     EXPECT_EQ(child_child_offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_child_child_offsets({0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_child_offsets({0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_child_offsets, child_child_offsets);
 
     auto child_child_data = child_childv.child();
@@ -779,32 +773,32 @@ TYPED_TEST(ListColumnWrapperTestTyped, IncompleteHierarchies)
   //       Offsets : 0, 0
   //       Children :
   {
-    test::lists_column_wrapper<T, int32_t> list{LCW{}, {LCW{}}, {{LCW{}}}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{LCW{}, {LCW{}}, {{LCW{}}}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 0, 1, 2});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 0, 1, 2});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 2);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 0, 1});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 0, 1});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_child = childv.child();
-    lists_column_view child_childv(child_child);
+    cudf::lists_column_view child_childv(child_child);
     EXPECT_EQ(child_childv.size(), 1);
 
     auto child_child_offsets = child_childv.offsets();
     EXPECT_EQ(child_child_offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_child_child_offsets({0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_child_offsets({0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_child_offsets, child_child_offsets);
 
     auto child_child_data = child_childv.child();
@@ -826,37 +820,37 @@ TYPED_TEST(ListColumnWrapperTestTyped, IncompleteHierarchies)
   //         1, 2, 3
   {
     // { {}, {{{1,2,3}}}, {{}} }
-    test::lists_column_wrapper<T, int32_t> list{LCW{}, {{{1, 2, 3}}}, {LCW{}}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{LCW{}, {{{1, 2, 3}}}, {LCW{}}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 0, 1, 2});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 0, 1, 2});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 2);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 1, 1});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 1, 1});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_child = childv.child();
-    lists_column_view child_childv(child_child);
+    cudf::lists_column_view child_childv(child_child);
     EXPECT_EQ(child_childv.size(), 1);
 
     auto child_child_offsets = child_childv.offsets();
     EXPECT_EQ(child_child_offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_child_child_offsets({0, 3});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_child_offsets({0, 3});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_child_offsets, child_child_offsets);
 
     auto child_child_data = child_childv.child();
     EXPECT_EQ(child_child_data.size(), 3);
-    test::fixed_width_column_wrapper<T, int32_t> e_child_child_data({1, 2, 3});
+    cudf::test::fixed_width_column_wrapper<T, int32_t> e_child_child_data({1, 2, 3});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_child_data, child_child_data);
   }
 
@@ -877,33 +871,33 @@ TYPED_TEST(ListColumnWrapperTestTyped, IncompleteHierarchies)
   {
     // { {{{}}}, {{}}, null }
     std::vector<bool> valids{true, true, false};
-    test::lists_column_wrapper<T, int32_t> list{{{{LCW{}}}, {LCW{}}, LCW{}}, valids.begin()};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{{{LCW{}}}, {LCW{}}, LCW{}}, valids.begin()};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
     EXPECT_EQ(lcv.null_count(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 1, 2, 2});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 1, 2, 2});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 2);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 1, 1});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 1, 1});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_child = childv.child();
-    lists_column_view child_childv(child_child);
+    cudf::lists_column_view child_childv(child_child);
     EXPECT_EQ(child_childv.size(), 1);
 
     auto child_child_offsets = child_childv.offsets();
     EXPECT_EQ(child_child_offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_child_child_offsets({0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_child_offsets({0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_child_offsets, child_child_offsets);
   }
 
@@ -924,33 +918,33 @@ TYPED_TEST(ListColumnWrapperTestTyped, IncompleteHierarchies)
   {
     // { {{{}}}, null, {} }
     std::vector<bool> valids{true, false, true};
-    test::lists_column_wrapper<T, int32_t> list{{{{LCW{}}}, {LCW{}}, LCW{}}, valids.begin()};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{{{LCW{}}}, {LCW{}}, LCW{}}, valids.begin()};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
     EXPECT_EQ(lcv.null_count(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 1, 1, 1});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 1, 1, 1});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 1);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 1});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 1});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_child = childv.child();
-    lists_column_view child_childv(child_child);
+    cudf::lists_column_view child_childv(child_child);
     EXPECT_EQ(child_childv.size(), 1);
 
     auto child_child_offsets = child_childv.offsets();
     EXPECT_EQ(child_child_offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_child_child_offsets({0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_child_offsets({0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_child_offsets, child_child_offsets);
   }
 
@@ -967,24 +961,24 @@ TYPED_TEST(ListColumnWrapperTestTyped, IncompleteHierarchies)
   {
     // { null, {{}}, {} }
     std::vector<bool> valids{false, true, true};
-    test::lists_column_wrapper<T, int32_t> list{{{{LCW{}}}, {LCW{}}, LCW{}}, valids.begin()};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{{{LCW{}}}, {LCW{}}, LCW{}}, valids.begin()};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
     EXPECT_EQ(lcv.null_count(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 0, 1, 1});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 0, 1, 1});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 1);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
   }
 
@@ -1001,19 +995,19 @@ TYPED_TEST(ListColumnWrapperTestTyped, IncompleteHierarchies)
   {
     // { null, null, null }
     std::vector<bool> valids{false, false, false};
-    test::lists_column_wrapper<T, int32_t> list{{{{LCW{}}}, {LCW{}}, LCW{}}, valids.begin()};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{{{LCW{}}}, {LCW{}}, LCW{}}, valids.begin()};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
     EXPECT_EQ(lcv.null_count(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 0, 0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 0, 0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 0);
   }
 
@@ -1030,19 +1024,19 @@ TYPED_TEST(ListColumnWrapperTestTyped, IncompleteHierarchies)
   {
     // { null, null, null }
     std::vector<bool> valids{false, false, false};
-    test::lists_column_wrapper<T, int32_t> list{{LCW{}, {{LCW{}}}, {LCW{}}}, valids.begin()};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{LCW{}, {{LCW{}}}, {LCW{}}}, valids.begin()};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
     EXPECT_EQ(lcv.null_count(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 0, 0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 0, 0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 0);
   }
 
@@ -1063,28 +1057,28 @@ TYPED_TEST(ListColumnWrapperTestTyped, IncompleteHierarchies)
   {
     // { {null}, {{}}, {} }
     std::vector<bool> valids{false};
-    test::lists_column_wrapper<T, int32_t> list{{{{LCW{}}}, valids.begin()}, {LCW{}}, LCW{}};
+    cudf::test::lists_column_wrapper<T, int32_t> list{{{{LCW{}}}, valids.begin()}, {LCW{}}, LCW{}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 1, 2, 2});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 1, 2, 2});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 2);
     EXPECT_EQ(childv.null_count(), 1);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 0, 0});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 0, 0});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_child = childv.child();
-    lists_column_view child_childv(child_child);
+    cudf::lists_column_view child_childv(child_child);
     EXPECT_EQ(child_childv.size(), 0);
   }
 
@@ -1107,43 +1101,41 @@ TYPED_TEST(ListColumnWrapperTestTyped, IncompleteHierarchies)
     // { {{{1, 2, 3}, {4, 5}}}, {{}, {{}}}, {}, {{}, {}} }
     cudf::test::lists_column_wrapper<T, int32_t> list{
       {{{1, 2, 3}, {4, 5}}}, {LCW{}, {LCW{}}}, LCW{}, {LCW{}, LCW{}}};
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 4);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 5);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 1, 3, 3, 5});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 1, 3, 3, 5});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 5);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 6);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 2, 2, 3, 3, 3});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 2, 2, 3, 3, 3});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_child = childv.child();
-    lists_column_view child_childv(child_child);
+    cudf::lists_column_view child_childv(child_child);
     EXPECT_EQ(child_childv.size(), 3);
 
     auto child_child_offsets = child_childv.offsets();
     EXPECT_EQ(child_child_offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_child_child_offsets({0, 3, 5, 5});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_child_offsets({0, 3, 5, 5});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_child_offsets, child_child_offsets);
 
     auto child_child_data = child_childv.child();
     EXPECT_EQ(child_child_data.size(), 5);
-    test::fixed_width_column_wrapper<size_type> e_child_child_data({1, 2, 3, 4, 5});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_child_data({1, 2, 3, 4, 5});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_child_data, e_child_child_data);
   }
 }
 
 TEST_F(ListColumnWrapperTest, ListOfStrings)
 {
-  using namespace cudf;
-
   // List<string>, 2 rows
   //
   // List<cudf::string_view>:
@@ -1152,27 +1144,26 @@ TEST_F(ListColumnWrapperTest, ListOfStrings)
   // Children :
   //    one, two, three, four, five
   {
-    test::lists_column_wrapper<cudf::string_view> list{{"one", "two"}, {"three", "four", "five"}};
+    cudf::test::lists_column_wrapper<cudf::string_view> list{{"one", "two"},
+                                                             {"three", "four", "five"}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 2);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2, 5});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2, 5});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto data = lcv.child();
     EXPECT_EQ(data.size(), 5);
-    test::strings_column_wrapper e_data({"one", "two", "three", "four", "five"});
+    cudf::test::strings_column_wrapper e_data({"one", "two", "three", "four", "five"});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_data, data);
   }
 }
 
 TEST_F(ListColumnWrapperTest, ListOfListOfStrings)
 {
-  using namespace cudf;
-
   // List<List<string>>, 2 rows
   //
   // List<List<cudf::string_view>>:
@@ -1185,29 +1176,29 @@ TEST_F(ListColumnWrapperTest, ListOfListOfStrings)
   //    Children :
   //      one, two, three, four, five, eight, nine, ten
   {
-    test::lists_column_wrapper<cudf::string_view> list{{{"one", "two"}, {"three", "four", "five"}},
-                                                       {{"eight"}, {"nine", "ten"}}};
+    cudf::test::lists_column_wrapper<cudf::string_view> list{
+      {{"one", "two"}, {"three", "four", "five"}}, {{"eight"}, {"nine", "ten"}}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 2);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 3);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2, 4});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2, 4});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 4);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 5);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 2, 5, 6, 8});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 2, 5, 6, 8});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_data = childv.child();
     EXPECT_EQ(child_data.size(), 8);
-    test::strings_column_wrapper e_child_data(
+    cudf::test::strings_column_wrapper e_child_data(
       {"one", "two", "three", "four", "five", "eight", "nine", "ten"});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_data, child_data);
   }
@@ -1215,8 +1206,6 @@ TEST_F(ListColumnWrapperTest, ListOfListOfStrings)
 
 TEST_F(ListColumnWrapperTest, ListOfBools)
 {
-  using namespace cudf;
-
   // List<bool>, 1 row
   //
   // List<bool>:
@@ -1226,19 +1215,19 @@ TEST_F(ListColumnWrapperTest, ListOfBools)
   //   1, 0
   //
   {
-    test::lists_column_wrapper<bool> list{true, false};
+    cudf::test::lists_column_wrapper<bool> list{true, false};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto data = lcv.child();
     EXPECT_EQ(data.size(), 2);
-    test::fixed_width_column_wrapper<bool> e_data({true, false});
+    cudf::test::fixed_width_column_wrapper<bool> e_data({true, false});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_data, data);
   }
 
@@ -1251,27 +1240,25 @@ TEST_F(ListColumnWrapperTest, ListOfBools)
   //   1, 0, 0
   //
   {
-    test::lists_column_wrapper<bool> list{{true, false, false}};
+    cudf::test::lists_column_wrapper<bool> list{{true, false, false}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 1);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 2);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 3});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 3});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto data = lcv.child();
     EXPECT_EQ(data.size(), 3);
-    test::fixed_width_column_wrapper<bool> e_data({true, false, false});
+    cudf::test::fixed_width_column_wrapper<bool> e_data({true, false, false});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_data, data);
   }
 }
 
 TEST_F(ListColumnWrapperTest, ListOfBoolsWithValidity)
 {
-  using namespace cudf;
-
   auto valids =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
 
@@ -1283,29 +1270,27 @@ TEST_F(ListColumnWrapperTest, ListOfBoolsWithValidity)
   // Children :
   //   1, NULL, 0, NULL, 0, NULL, 0
   {
-    test::lists_column_wrapper<bool> list{
+    cudf::test::lists_column_wrapper<bool> list{
       {{true, true}, valids}, {{false, true}, valids}, {{false, true, false}, valids}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2, 4, 7});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2, 4, 7});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto data = lcv.child();
     EXPECT_EQ(data.size(), 7);
-    test::fixed_width_column_wrapper<bool> e_data({true, true, false, true, false, true, false},
-                                                  valids);
+    cudf::test::fixed_width_column_wrapper<bool> e_data(
+      {true, true, false, true, false, true, false}, valids);
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_data, data);
   }
 }
 
 TEST_F(ListColumnWrapperTest, ListOfListOfBools)
 {
-  using namespace cudf;
-
   // List<List<bool>> 3 rows
   //
   // List<List<bool>>:
@@ -1318,29 +1303,29 @@ TEST_F(ListColumnWrapperTest, ListOfListOfBools)
   //    Children :
   //      0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1
   {
-    test::lists_column_wrapper<bool> list{
+    cudf::test::lists_column_wrapper<bool> list{
       {{false, true}, {true, true}}, {{true, false, true}, {true}, {true}}, {{false, true}}};
 
-    lists_column_view lcv(list);
+    cudf::lists_column_view lcv(list);
     EXPECT_EQ(lcv.size(), 3);
 
     auto offsets = lcv.offsets();
     EXPECT_EQ(offsets.size(), 4);
-    test::fixed_width_column_wrapper<size_type> e_offsets({0, 2, 5, 6});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_offsets({0, 2, 5, 6});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_offsets, offsets);
 
     auto child = lcv.child();
-    lists_column_view childv(child);
+    cudf::lists_column_view childv(child);
     EXPECT_EQ(childv.size(), 6);
 
     auto child_offsets = childv.offsets();
     EXPECT_EQ(child_offsets.size(), 7);
-    test::fixed_width_column_wrapper<size_type> e_child_offsets({0, 2, 4, 7, 8, 9, 11});
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> e_child_offsets({0, 2, 4, 7, 8, 9, 11});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_offsets, child_offsets);
 
     auto child_child_data = childv.child();
     EXPECT_EQ(child_child_data.size(), 11);
-    test::fixed_width_column_wrapper<bool> e_child_child_data(
+    cudf::test::fixed_width_column_wrapper<bool> e_child_child_data(
       {false, true, true, true, true, false, true, true, true, false, true});
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(e_child_child_data, child_child_data);
   }
@@ -1348,14 +1333,12 @@ TEST_F(ListColumnWrapperTest, ListOfListOfBools)
 
 TEST_F(ListColumnWrapperTest, MismatchedHierarchies)
 {
-  using namespace cudf;
-
   using T = int;
 
   // to disambiguate between {} == 0 and {} == List{0}
   // Also, see note about compiler issues when declaring nested
   // empty lists in lists_column_wrapper documentation
-  using LCW = test::lists_column_wrapper<T>;
+  using LCW = cudf::test::lists_column_wrapper<T>;
 
   // trying to build a column out of a List<List<int>> column, and a List<int> column
   // is not valid if the leaf lists are not empty.
@@ -1367,88 +1350,87 @@ TEST_F(ListColumnWrapperTest, MismatchedHierarchies)
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListsOfStructs)
 {
-  using namespace cudf;
-
   using T = TypeParam;
 
   auto num_struct_rows = 8;
-  auto numeric_column  = test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto bool_column     = test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
-  auto struct_column   = test::structs_column_wrapper{{numeric_column, bool_column}}.release();
+  auto numeric_column  = cudf::test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto bool_column     = cudf::test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
+  auto struct_column = cudf::test::structs_column_wrapper{{numeric_column, bool_column}}.release();
   EXPECT_EQ(struct_column->size(), num_struct_rows);
   EXPECT_TRUE(!struct_column->nullable());
 
-  auto lists_column_offsets = test::fixed_width_column_wrapper<size_type>{0, 2, 4, 8}.release();
-  auto num_lists            = lists_column_offsets->size() - 1;
+  auto lists_column_offsets =
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 8}.release();
+  auto num_lists = lists_column_offsets->size() - 1;
   auto lists_column =
     make_lists_column(num_lists, std::move(lists_column_offsets), std::move(struct_column), 0, {});
 
   // Check if child column is unchanged.
 
   auto expected_numeric_column =
-    test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto expected_bool_column = test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
+    cudf::test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto expected_bool_column = cudf::test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
   auto expected_struct_column =
-    test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
+    cudf::test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_struct_column, lists_column_view(*lists_column).child());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_struct_column,
+                                 cudf::lists_column_view(*lists_column).child());
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListsOfStructsWithValidity)
 {
-  using namespace cudf;
-
   using T = TypeParam;
 
   auto num_struct_rows = 8;
-  auto numeric_column  = test::fixed_width_column_wrapper<T, int32_t>{{1, 2, 3, 4, 5, 6, 7, 8},
-                                                                     {1, 1, 1, 1, 0, 0, 0, 0}};
-  auto bool_column     = test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
-  auto struct_column   = test::structs_column_wrapper{{numeric_column, bool_column}}.release();
+  auto numeric_column  = cudf::test::fixed_width_column_wrapper<T, int32_t>{
+    {1, 2, 3, 4, 5, 6, 7, 8}, {1, 1, 1, 1, 0, 0, 0, 0}};
+  auto bool_column   = cudf::test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
+  auto struct_column = cudf::test::structs_column_wrapper{{numeric_column, bool_column}}.release();
   EXPECT_EQ(struct_column->size(), num_struct_rows);
   EXPECT_TRUE(!struct_column->nullable());
 
-  auto lists_column_offsets = test::fixed_width_column_wrapper<size_type>{0, 2, 4, 8}.release();
-  auto list_null_mask       = {1, 1, 0};
-  auto num_lists            = lists_column_offsets->size() - 1;
-  auto lists_column =
-    make_lists_column(num_lists,
-                      std::move(lists_column_offsets),
-                      std::move(struct_column),
-                      UNKNOWN_NULL_COUNT,
-                      test::detail::make_null_mask(list_null_mask.begin(), list_null_mask.end()));
+  auto lists_column_offsets =
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 8}.release();
+  auto list_null_mask = {1, 1, 0};
+  auto num_lists      = lists_column_offsets->size() - 1;
+  auto lists_column   = make_lists_column(
+    num_lists,
+    std::move(lists_column_offsets),
+    std::move(struct_column),
+    1,
+    cudf::test::detail::make_null_mask(list_null_mask.begin(), list_null_mask.end()));
 
   // Check if child column is unchanged.
 
   auto expected_numeric_column =
-    test::fixed_width_column_wrapper<T, int32_t>{{1, 2, 3, 4}, {1, 1, 1, 1}};
-  auto expected_bool_column = test::fixed_width_column_wrapper<bool>{1, 1, 1, 1};
+    cudf::test::fixed_width_column_wrapper<T, int32_t>{{1, 2, 3, 4}, {1, 1, 1, 1}};
+  auto expected_bool_column = cudf::test::fixed_width_column_wrapper<bool>{1, 1, 1, 1};
   auto expected_struct_column =
-    test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
+    cudf::test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_struct_column, lists_column_view(*lists_column).child());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_struct_column,
+                                 cudf::lists_column_view(*lists_column).child());
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListsOfListsOfStructs)
 {
-  using namespace cudf;
-
   using T = TypeParam;
 
   auto num_struct_rows = 8;
-  auto numeric_column  = test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto bool_column     = test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
-  auto struct_column   = test::structs_column_wrapper{{numeric_column, bool_column}}.release();
+  auto numeric_column  = cudf::test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto bool_column     = cudf::test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
+  auto struct_column = cudf::test::structs_column_wrapper{{numeric_column, bool_column}}.release();
   EXPECT_EQ(struct_column->size(), num_struct_rows);
   EXPECT_TRUE(!struct_column->nullable());
 
-  auto lists_column_offsets = test::fixed_width_column_wrapper<size_type>{0, 2, 4, 8}.release();
-  auto num_lists            = lists_column_offsets->size() - 1;
+  auto lists_column_offsets =
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 8}.release();
+  auto num_lists = lists_column_offsets->size() - 1;
   auto lists_column =
     make_lists_column(num_lists, std::move(lists_column_offsets), std::move(struct_column), 0, {});
 
   auto lists_of_lists_column_offsets =
-    test::fixed_width_column_wrapper<size_type>{0, 2, 3}.release();
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 2, 3}.release();
   auto num_lists_of_lists               = lists_of_lists_column_offsets->size() - 1;
   auto lists_of_lists_of_structs_column = make_lists_column(
     num_lists_of_lists, std::move(lists_of_lists_column_offsets), std::move(lists_column), 0, {});
@@ -1456,74 +1438,74 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListsOfListsOfStructs)
   // Check if child column is unchanged.
 
   auto expected_numeric_column =
-    test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 4, 5, 6, 7, 8};
-  auto expected_bool_column = test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
+    cudf::test::fixed_width_column_wrapper<T, int32_t>{1, 2, 3, 4, 5, 6, 7, 8};
+  auto expected_bool_column = cudf::test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
   auto expected_struct_column =
-    test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
+    cudf::test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(
     *expected_struct_column,
-    lists_column_view{lists_column_view{*lists_of_lists_of_structs_column}.child()}.child());
+    cudf::lists_column_view{cudf::lists_column_view{*lists_of_lists_of_structs_column}.child()}
+      .child());
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, ListsOfListsOfStructsWithValidity)
 {
-  using namespace cudf;
-
   using T = TypeParam;
 
   auto num_struct_rows = 8;
-  auto numeric_column  = test::fixed_width_column_wrapper<T, int32_t>{{1, 2, 3, 4, 5, 6, 7, 8},
-                                                                     {1, 1, 1, 1, 0, 0, 0, 0}};
-  auto bool_column     = test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
-  auto struct_column   = test::structs_column_wrapper{{numeric_column, bool_column}}.release();
+  auto numeric_column  = cudf::test::fixed_width_column_wrapper<T, int32_t>{
+    {1, 2, 3, 4, 5, 6, 7, 8}, {1, 1, 1, 1, 0, 0, 0, 0}};
+  auto bool_column   = cudf::test::fixed_width_column_wrapper<bool>{1, 1, 1, 1, 0, 0, 0, 0};
+  auto struct_column = cudf::test::structs_column_wrapper{{numeric_column, bool_column}}.release();
   EXPECT_EQ(struct_column->size(), num_struct_rows);
   EXPECT_TRUE(!struct_column->nullable());
 
-  auto lists_column_offsets = test::fixed_width_column_wrapper<size_type>{0, 2, 4, 8}.release();
-  auto num_lists            = lists_column_offsets->size() - 1;
-  auto list_null_mask       = {1, 1, 0};
-  auto lists_column =
-    make_lists_column(num_lists,
-                      std::move(lists_column_offsets),
-                      std::move(struct_column),
-                      UNKNOWN_NULL_COUNT,
-                      test::detail::make_null_mask(list_null_mask.begin(), list_null_mask.end()));
+  auto lists_column_offsets =
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 2, 4, 8}.release();
+  auto num_lists      = lists_column_offsets->size() - 1;
+  auto list_null_mask = {1, 1, 0};
+  auto lists_column   = make_lists_column(
+    num_lists,
+    std::move(lists_column_offsets),
+    std::move(struct_column),
+    1,
+    cudf::test::detail::make_null_mask(list_null_mask.begin(), list_null_mask.end()));
 
   auto lists_of_lists_column_offsets =
-    test::fixed_width_column_wrapper<size_type>{0, 2, 3}.release();
-  auto num_lists_of_lists               = lists_of_lists_column_offsets->size() - 1;
-  auto list_of_lists_null_mask          = {1, 0};
-  auto lists_of_lists_of_structs_column = make_lists_column(
-    num_lists_of_lists,
-    std::move(lists_of_lists_column_offsets),
-    std::move(lists_column),
-    UNKNOWN_NULL_COUNT,
-    test::detail::make_null_mask(list_of_lists_null_mask.begin(), list_of_lists_null_mask.end()));
+    cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 2, 3}.release();
+  auto num_lists_of_lists      = lists_of_lists_column_offsets->size() - 1;
+  auto list_of_lists_null_mask = {1, 0};
+  auto lists_of_lists_of_structs_column =
+    make_lists_column(num_lists_of_lists,
+                      std::move(lists_of_lists_column_offsets),
+                      std::move(lists_column),
+                      1,
+                      cudf::test::detail::make_null_mask(list_of_lists_null_mask.begin(),
+                                                         list_of_lists_null_mask.end()));
 
   // Check if child column is unchanged.
 
   auto expected_numeric_column =
-    test::fixed_width_column_wrapper<T, int32_t>{{1, 2, 3, 4}, {1, 1, 1, 1}};
-  auto expected_bool_column = test::fixed_width_column_wrapper<bool>{1, 1, 1, 1};
+    cudf::test::fixed_width_column_wrapper<T, int32_t>{{1, 2, 3, 4}, {1, 1, 1, 1}};
+  auto expected_bool_column = cudf::test::fixed_width_column_wrapper<bool>{1, 1, 1, 1};
   auto expected_struct_column =
-    test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
+    cudf::test::structs_column_wrapper{{expected_numeric_column, expected_bool_column}}.release();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(
     *expected_struct_column,
-    lists_column_view{lists_column_view{*lists_of_lists_of_structs_column}.child()}.child());
+    cudf::lists_column_view{cudf::lists_column_view{*lists_of_lists_of_structs_column}.child()}
+      .child());
 }
 
 TYPED_TEST(ListColumnWrapperTestTyped, LargeListsOfStructsWithValidity)
 {
-  using namespace cudf;
-
   using T = TypeParam;
 
   auto num_struct_rows = 10000;
 
   // Creating Struct<Numeric, Bool>.
-  auto numeric_column = test::fixed_width_column_wrapper<T, int32_t>{
+  auto numeric_column = cudf::test::fixed_width_column_wrapper<T, int32_t>{
     thrust::make_counting_iterator(0),
     thrust::make_counting_iterator(num_struct_rows),
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 1; })};
@@ -1531,12 +1513,12 @@ TYPED_TEST(ListColumnWrapperTestTyped, LargeListsOfStructsWithValidity)
   auto bool_iterator =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3 == 0; });
   auto bool_column =
-    test::fixed_width_column_wrapper<bool>(bool_iterator, bool_iterator + num_struct_rows);
+    cudf::test::fixed_width_column_wrapper<bool>(bool_iterator, bool_iterator + num_struct_rows);
 
   auto struct_validity_iterator =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 5 == 0; });
   auto struct_column =
-    test::structs_column_wrapper{
+    cudf::test::structs_column_wrapper{
       {numeric_column, bool_column},
       std::vector<bool>(struct_validity_iterator, struct_validity_iterator + num_struct_rows)}
       .release();
@@ -1548,7 +1530,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, LargeListsOfStructsWithValidity)
   auto num_list_rows = num_struct_rows / 50;
   auto list_offset_iterator =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i * 50; });
-  auto list_offset_column = test::fixed_width_column_wrapper<size_type>(
+  auto list_offset_column = cudf::test::fixed_width_column_wrapper<cudf::size_type>(
                               list_offset_iterator, list_offset_iterator + num_list_rows + 1)
                               .release();
   auto lists_column = make_lists_column(
@@ -1557,19 +1539,20 @@ TYPED_TEST(ListColumnWrapperTestTyped, LargeListsOfStructsWithValidity)
   // List construction succeeded.
   // Verify that the child is unchanged.
 
-  auto expected_numeric_column = test::fixed_width_column_wrapper<T, int32_t>{
+  auto expected_numeric_column = cudf::test::fixed_width_column_wrapper<T, int32_t>{
     thrust::make_counting_iterator(0),
     thrust::make_counting_iterator(num_struct_rows),
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 1; })};
 
   auto expected_bool_column =
-    test::fixed_width_column_wrapper<bool>(bool_iterator, bool_iterator + num_struct_rows);
+    cudf::test::fixed_width_column_wrapper<bool>(bool_iterator, bool_iterator + num_struct_rows);
 
   auto expected_struct_column =
-    test::structs_column_wrapper{
+    cudf::test::structs_column_wrapper{
       {expected_numeric_column, expected_bool_column},
       std::vector<bool>(struct_validity_iterator, struct_validity_iterator + num_struct_rows)}
       .release();
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_struct_column, lists_column_view(*lists_column).child());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_struct_column,
+                                 cudf::lists_column_view(*lists_column).child());
 }

--- a/cpp/tests/wrappers/timestamps_test.cu
+++ b/cpp/tests/wrappers/timestamps_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,19 +79,19 @@ TYPED_TEST(ChronoColumnTest, ChronoDurationsMatchPrimitiveRepresentation)
 {
   using T   = TypeParam;
   using Rep = typename T::rep;
-  using namespace cudf::test;
   using namespace cuda::std::chrono;
 
   auto start      = milliseconds(-2500000000000);  // Sat, 11 Oct 1890 19:33:20 GMT
   auto stop       = milliseconds(2500000000000);   // Mon, 22 Mar 2049 04:26:40 GMT
-  auto chrono_col = generate_timestamps<T>(this->size(), time_point_ms(start), time_point_ms(stop));
+  auto chrono_col = cudf::test::generate_timestamps<T>(
+    this->size(), cudf::test::time_point_ms(start), cudf::test::time_point_ms(stop));
 
   // round-trip through the host to copy `chrono_col` values
   // to a new fixed_width_column_wrapper `primitive_col`
-  auto const [chrono_col_data, chrono_col_mask] = to_host<Rep>(chrono_col);
+  auto const [chrono_col_data, chrono_col_mask] = cudf::test::to_host<Rep>(chrono_col);
 
   auto primitive_col =
-    fixed_width_column_wrapper<Rep>(chrono_col_data.begin(), chrono_col_data.end());
+    cudf::test::fixed_width_column_wrapper<Rep>(chrono_col_data.begin(), chrono_col_data.end());
 
   rmm::device_uvector<int32_t> indices(this->size(), cudf::get_default_stream());
   thrust::sequence(rmm::exec_policy(cudf::get_default_stream()), indices.begin(), indices.end());
@@ -133,7 +133,6 @@ struct compare_chrono_elements {
 TYPED_TEST(ChronoColumnTest, ChronosCanBeComparedInDeviceCode)
 {
   using T = TypeParam;
-  using namespace cudf::test;
   using namespace cuda::std::chrono;
 
   auto start_lhs = milliseconds(-2500000000000);  // Sat, 11 Oct 1890 19:33:20 GMT
@@ -141,11 +140,11 @@ TYPED_TEST(ChronoColumnTest, ChronosCanBeComparedInDeviceCode)
   auto stop_lhs  = milliseconds(2500000000000);   // Mon, 22 Mar 2049 04:26:40 GMT
   auto stop_rhs  = milliseconds(2600000000000);   // Wed, 22 May 2052 14:13:20 GMT
 
-  auto chrono_lhs_col =
-    generate_timestamps<T>(this->size(), time_point_ms(start_lhs), time_point_ms(stop_lhs));
+  auto chrono_lhs_col = cudf::test::generate_timestamps<T>(
+    this->size(), cudf::test::time_point_ms(start_lhs), cudf::test::time_point_ms(stop_lhs));
 
-  auto chrono_rhs_col =
-    generate_timestamps<T>(this->size(), time_point_ms(start_rhs), time_point_ms(stop_rhs));
+  auto chrono_rhs_col = cudf::test::generate_timestamps<T>(
+    this->size(), cudf::test::time_point_ms(start_rhs), cudf::test::time_point_ms(stop_rhs));
 
   rmm::device_uvector<int32_t> indices(this->size(), cudf::get_default_stream());
   thrust::sequence(rmm::exec_policy(cudf::get_default_stream()), indices.begin(), indices.end());


### PR DESCRIPTION
## Description
Removes `using namespace cudf;` from gtests source code to make it easier to read -- find where utilities and function calls are implemented. Also removed a few `using namespace cudf::test;` usages which by extension includes namespace `cudf`.

Found these while working on #13081
Reference https://github.com/rapidsai/cudf/issues/11734

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
