### PR TITLE
Fix unused variable error/warning in page_data.cu

### DIFF
--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -629,13 +629,11 @@ inline __device__ void gpuOutputString(volatile page_state_s* s,
 /**
  * @brief Output a boolean
  *
- * @param[in,out] s Page state input/output
  * @param[out] sb Page state buffer output
  * @param[in] src_pos Source position
  * @param[in] dst Pointer to row output data
  */
-inline __device__ void gpuOutputBoolean(volatile page_state_s*,
-                                        volatile page_state_buffers_s* sb,
+inline __device__ void gpuOutputBoolean(volatile page_state_buffers_s* sb,
                                         int src_pos,
                                         uint8_t* dst)
 {
@@ -2028,7 +2026,7 @@ __global__ void __launch_bounds__(block_size) gpuDecodePageData(
             gpuOutputString(s, sb, val_src_pos, dst);
           }
         } else if (dtype == BOOLEAN) {
-          gpuOutputBoolean(s, sb, val_src_pos, static_cast<uint8_t*>(dst));
+          gpuOutputBoolean(sb, val_src_pos, static_cast<uint8_t*>(dst));
         } else if (s->col.converted_type == DECIMAL) {
           switch (dtype) {
             case INT32: gpuOutputFast(s, sb, val_src_pos, static_cast<uint32_t*>(dst)); break;

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -339,10 +339,11 @@ __device__ void gpuDecodeStream(
  * additional values.
  */
 template <bool sizes_only>
-__device__ cuda::std::pair<int, int> gpuDecodeDictionaryIndices(volatile page_state_s* s,
-                                                                volatile page_state_buffers_s* sb,
-                                                                int target_pos,
-                                                                int t)
+__device__ cuda::std::pair<int, int> gpuDecodeDictionaryIndices(
+  volatile page_state_s* s,
+  [[maybe_unused]] volatile page_state_buffers_s* sb,
+  int target_pos,
+  int t)
 {
   const uint8_t* end = s->data_end;
   int dict_bits      = s->dict_bits;
@@ -524,7 +525,7 @@ __device__ int gpuDecodeRleBooleans(volatile page_state_s* s,
  */
 template <bool sizes_only>
 __device__ size_type gpuInitStringDescriptors(volatile page_state_s* s,
-                                              volatile page_state_buffers_s* sb,
+                                              [[maybe_unused]] volatile page_state_buffers_s* sb,
                                               int target_pos,
                                               int t)
 {
@@ -633,7 +634,7 @@ inline __device__ void gpuOutputString(volatile page_state_s* s,
  * @param[in] src_pos Source position
  * @param[in] dst Pointer to row output data
  */
-inline __device__ void gpuOutputBoolean(volatile page_state_s* s,
+inline __device__ void gpuOutputBoolean(volatile page_state_s*,
                                         volatile page_state_buffers_s* sb,
                                         int src_pos,
                                         uint8_t* dst)


### PR DESCRIPTION
## Description
Fixes a minor compile error/warnings for unused variables in the `cpp/src/io/parquet/page_data.cu` source file.

```
cudf/cpp/src/io/parquet/page_data.cu -o CMakeFiles/cudf.dir/src/io/parquet/page_data.cu.o
/cudf/cpp/src/io/parquet/page_data.cu(636): error #177-D: parameter "s" was declared but never referenced

/cudf/cpp/src/io/parquet/page_data.cu(343): error #177-D: parameter "sb" was declared but never referenced
          detected during instantiation of "cuda::std::__4::pair<int, int> cudf::io::parquet::gpu::<unnamed>::gpuDecodeDictionaryIndices<sizes_only>(volatile cudf::io::parquet::gpu::<unnamed>::page_state_s *, volatile cudf::io::parquet::gpu::<unnamed>::page_state_buffers_s *, int, int) [with sizes_only=true]" 
(1720): here

/cudf/cpp/src/io/parquet/page_data.cu(527): error #177-D: parameter "sb" was declared but never referenced
          detected during instantiation of "cudf::size_type cudf::io::parquet::gpu::<unnamed>::gpuInitStringDescriptors<sizes_only>(volatile cudf::io::parquet::gpu::<unnamed>::page_state_s *, volatile cudf::io::parquet::gpu::<unnamed>::page_state_buffers_s *, int, int) [with sizes_only=true]" 
(1724): here

3 errors detected in the compilation of "/cudf/cpp/src/io/parquet/page_data.cu".

```

Found these with a Debug build using nvcc 11.5 and gcc 9.5.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
