### PR TITLE
Adding ifdefs around nvcc-specific pragmas

### DIFF
--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -329,9 +329,13 @@ class column_view : public detail::column_view_base {
   // they then end up being called by a simple __host__ function
   // (eg std::vector destructor) you get a compile error because you're trying to
   // call a __host__ __device__ function from a __host__ function.
+#ifdef __CUDACC__
 #pragma nv_exec_check_disable
+#endif
   ~column_view() = default;
+#ifdef __CUDACC__
 #pragma nv_exec_check_disable
+#endif
   column_view(column_view const&) = default;  ///< Copy constructor
   column_view(column_view&&)      = default;  ///< Move constructor
   /**

--- a/cpp/include/cudf/detail/interop.hpp
+++ b/cpp/include/cudf/detail/interop.hpp
@@ -19,11 +19,15 @@
 // We disable warning 611 because the `arrow::TableBatchReader` only partially
 // override the `ReadNext` method of `arrow::RecordBatchReader::ReadNext`
 // triggering warning 611-D from nvcc.
+#ifdef __CUDACC__
 #pragma nv_diag_suppress 611
 #pragma nv_diag_suppress 2810
+#endif
 #include <arrow/api.h>
+#ifdef __CUDACC__
 #pragma nv_diag_default 611
 #pragma nv_diag_default 2810
+#endif
 
 #include <cudf/interop.hpp>
 #include <cudf/utilities/default_stream.hpp>

--- a/cpp/include/cudf/interop.hpp
+++ b/cpp/include/cudf/interop.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,15 @@
 // We disable warning 611 because the `arrow::TableBatchReader` only partially
 // override the `ReadNext` method of `arrow::RecordBatchReader::ReadNext`
 // triggering warning 611-D from nvcc.
+#ifdef __CUDACC__
 #pragma nv_diag_suppress 611
 #pragma nv_diag_suppress 2810
+#endif
 #include <arrow/api.h>
+#ifdef __CUDACC__
 #pragma nv_diag_default 611
 #pragma nv_diag_default 2810
+#endif
 
 #include <cudf/column/column.hpp>
 #include <cudf/detail/transform.hpp>

--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -27,16 +27,24 @@
 // We disable warning 611 because some Arrow subclasses of
 // `arrow::fs::FileSystem` only partially override the `Equals` method,
 // triggering warning 611-D from nvcc.
+#ifdef __CUDACC__
 #pragma nv_diag_suppress 611
+#endif
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/filesystem/s3fs.h>
+#ifdef __CUDACC__
 #pragma nv_diag_default 611
+#endif
 
 // We disable warning 2810 to workaround the compile issue (warning treated as error):
 // result.h(263): error #2810-D: ignoring return value type with "nodiscard" attribute
+#ifdef __CUDACC__
 #pragma nv_diag_suppress 2810
+#endif
 #include <arrow/result.h>
+#ifdef __CUDACC__
 #pragma nv_diag_default 2810
+#endif
 
 #include <arrow/io/file.h>
 #include <arrow/io/interfaces.h>

--- a/cpp/include/cudf/utilities/type_dispatcher.hpp
+++ b/cpp/include/cudf/utilities/type_dispatcher.hpp
@@ -433,7 +433,9 @@ using scalar_device_type_t = typename type_to_scalar_type_impl<T>::ScalarDeviceT
  */
 // This pragma disables a compiler warning that complains about the valid usage
 // of calling a __host__ functor from this function which is __host__ __device__
+#ifdef __CUDACC__
 #pragma nv_exec_check_disable
+#endif
 template <template <cudf::type_id> typename IdTypeMap = id_to_type_impl,
           typename Functor,
           typename... Ts>
@@ -540,7 +542,9 @@ CUDF_HOST_DEVICE __forceinline__ constexpr decltype(auto) type_dispatcher(cudf::
 namespace detail {
 template <typename T1>
 struct double_type_dispatcher_second_type {
+#ifdef __CUDACC__
 #pragma nv_exec_check_disable
+#endif
   template <typename T2, typename F, typename... Ts>
   CUDF_HOST_DEVICE __forceinline__ decltype(auto) operator()(F&& f, Ts&&... args) const
   {
@@ -550,7 +554,9 @@ struct double_type_dispatcher_second_type {
 
 template <template <cudf::type_id> typename IdTypeMap>
 struct double_type_dispatcher_first_type {
+#ifdef __CUDACC__
 #pragma nv_exec_check_disable
+#endif
   template <typename T1, typename F, typename... Ts>
   CUDF_HOST_DEVICE __forceinline__ decltype(auto) operator()(cudf::data_type type2,
                                                              F&& f,
@@ -580,7 +586,9 @@ struct double_type_dispatcher_first_type {
  *
  * @return The result of invoking `f.template operator<T1, T2>(args)`
  */
+#ifdef __CUDACC__
 #pragma nv_exec_check_disable
+#endif
 template <template <cudf::type_id> typename IdTypeMap = id_to_type_impl, typename F, typename... Ts>
 CUDF_HOST_DEVICE __forceinline__ constexpr decltype(auto) double_type_dispatcher(
   cudf::data_type type1, cudf::data_type type2, F&& f, Ts&&... args)

--- a/cpp/src/quantiles/quantiles_util.hpp
+++ b/cpp/src/quantiles/quantiles_util.hpp
@@ -104,7 +104,9 @@ struct quantile_index {
   }
 };
 
+#ifdef __CUDACC__
 #pragma nv_exec_check_disable
+#endif
 /* @brief computes a quantile value.
  *
  * Computes a value for a quantile by interpolating between two values on either


### PR DESCRIPTION
## Description
This change wraps the NVCC-specific `#pragma` macros inside an `ifdef` to prevent compilation warnings as described in issue #13106

closes #13106 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
