### PR TITLE
Fix GPU_ARCHS setting in Java CMake build and CMAKE_CUDA_ARCHITECTURES in Python package build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -257,7 +257,7 @@ fi
 ################################################################################
 # Configure, build, and install libcudf
 
-if buildAll || hasArg libcudf || hasArg cudfjar; then
+if buildAll || hasArg libcudf || hasArg cudf || hasArg cudfjar; then
     if (( ${BUILD_ALL_GPU_ARCH} == 0 )); then
         CUDF_CMAKE_CUDA_ARCHITECTURES="${CUDF_CMAKE_CUDA_ARCHITECTURES:-NATIVE}"
         if [[ "$CUDF_CMAKE_CUDA_ARCHITECTURES" == "NATIVE" ]]; then

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -166,7 +166,7 @@
         <CUDA_STATIC_RUNTIME>OFF</CUDA_STATIC_RUNTIME>
         <CUDF_USE_PER_THREAD_DEFAULT_STREAM>OFF</CUDF_USE_PER_THREAD_DEFAULT_STREAM>
         <USE_GDS>OFF</USE_GDS>
-        <GPU_ARCHS>ALL</GPU_ARCHS>
+        <GPU_ARCHS>RAPIDS</GPU_ARCHS>
         <CUDF_JNI_LIBCUDF_STATIC>OFF</CUDF_JNI_LIBCUDF_STATIC>
         <native.build.path>${project.build.directory}/cmake-build</native.build.path>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
## Description
Changes the `GPU_ARCHS` setting in `pom.xml` from `ALL` to `RAPIDS` per recent change in rapidsai/rapids-cmake/pull/397

The Python package build requires CUDA as of the addition of string UDFs, which added compilation of ptx code to the Python build. Therefore CMAKE_CUDA_ARCHITECTURES must be set appropriately even when only the Python package is being built. https://github.com/rapidsai/rapids-cmake/pull/397 requires a nonempty string value to be used if the variable is set at all. This PR updates build.sh to include the appropriate default when only the Python build is requested.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
