### PR TITLE
Set default architectures when only building Python

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -257,7 +257,7 @@ fi
 ################################################################################
 # Configure, build, and install libcudf
 
-if buildAll || hasArg libcudf || hasArg cudfjar; then
+if buildAll || hasArg libcudf || hasArg cudf || hasArg cudfjar; then
     if (( ${BUILD_ALL_GPU_ARCH} == 0 )); then
         CUDF_CMAKE_CUDA_ARCHITECTURES="${CUDF_CMAKE_CUDA_ARCHITECTURES:-NATIVE}"
         if [[ "$CUDF_CMAKE_CUDA_ARCHITECTURES" == "NATIVE" ]]; then


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The Python package build requires CUDA as of the addition of string UDFs, which added compilation of ptx code to the Python build. Therefore `CMAKE_CUDA_ARCHITECTURES` must be set appropriately even when only the Python package is being built. https://github.com/rapidsai/rapids-cmake/pull/397 requires a nonempty string value to be used if the variable is set at all. This PR updates build.sh to include the appropriate default when only the Python build is requested.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
