### PR TITLE
Forward-merge branch-23.04 to branch-23.06

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -36,6 +36,8 @@ dependencies:
 - hypothesis
 - ipython
 - libarrow==10.0.1.*
+- libcurand-dev=10.3.0.86
+- libcurand=10.3.0.86
 - librdkafka=1.7.0
 - librmm==23.4.*
 - mimesis>=4.1.0

--- a/conda/recipes/libcudf/conda_build_config.yaml
+++ b/conda/recipes/libcudf/conda_build_config.yaml
@@ -25,6 +25,12 @@ dlpack_version:
 librdkafka_version:
   - ">=1.7.0,<1.8.0a0"
 
+libcurand_host_version:
+  - "=10.3.0.86"
+
+libcurand_run_version:
+  - ">=10.2.5.43,<10.3.1"
+
 fmt_version:
   - ">=9.1.0,<10"
 

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -45,7 +45,8 @@ requirements:
     - cuda-nvrtc ={{ cuda_version }}
     - cuda-nvrtc-dev ={{ cuda_version }}
     - cuda-nvtx ={{ cuda_version }}
-    - libcurand-dev
+    - libcurand {{ libcurand_host_version }}
+    - libcurand-dev {{ libcurand_host_version }}
     - libarrow {{ libarrow_version }}
     - dlpack {{ dlpack_version }}
     - librdkafka {{ librdkafka_version }}
@@ -386,6 +387,7 @@ outputs:
         - {{ pin_subpackage('libcudf', exact=True) }}
         - {{ pin_subpackage('libcudf_kafka', exact=True) }}
         - cudatoolkit {{ cuda_spec }}
+        - libcurand {{ libcurand_run_version }}
     about:
       home: https://rapids.ai/
       license: Apache-2.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -263,21 +263,34 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              cuda: "11.2"
+              cuda: "11.8"
             packages:
-              - cudatoolkit=11.2
-          - matrix:
-              cuda: "11.4"
-            packages:
-              - cudatoolkit=11.4
+              - cudatoolkit=11.8
+              - libcurand-dev=10.3.0.86
+              - libcurand=10.3.0.86
           - matrix:
               cuda: "11.5"
             packages:
               - cudatoolkit=11.5
+                # Can't hard pin the version since 11.x is missing many
+                # packages for specific versions
+              - libcurand-dev>=10.2.6.48,<=10.2.7.107
+              - libcurand>=10.2.6.48,<=10.2.7.107
           - matrix:
-              cuda: "11.8"
+              cuda: "11.4"
             packages:
-              - cudatoolkit=11.8
+              - cudatoolkit=11.4
+              - &libcurand_dev114 libcurand-dev>=10.2.5.43,<=10.2.5.120
+              - &libcurand114 libcurand>=10.2.5.43,<=10.2.5.120
+          - matrix:
+              cuda: "11.2"
+            packages:
+              - cudatoolkit=11.2
+                # The NVIDIA channel doesn't publish pkgs older than 11.4 for
+                # these libs, so 11.2 uses 11.4 packages (the oldest
+                # available).
+              - *libcurand_dev114
+              - *libcurand114
   develop:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.04` that creates a PR to keep `branch-23.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.