### PR TITLE
[REVIEW] Fix `DataFrame.__getitem__` to work with `pandas-2.0`

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1168,14 +1168,13 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             mask = arg
             if is_list_like(mask):
                 dtype = None
-                if len(mask) == 0:
-                    if not PANDAS_GE_200:
-                        # An explicit dtype is needed to avoid pandas
-                        # warnings from empty sets of columns. This
-                        # shouldn't be needed in pandas 2.0, we don't
-                        # need to specify a dtype when we know we're not
-                        # trying to match any columns so the default is fine.
-                        dtype = "float64"
+                if len(mask) == 0 and not PANDAS_GE_200:
+                    # An explicit dtype is needed to avoid pandas
+                    # warnings from empty sets of columns. This
+                    # shouldn't be needed in pandas 2.0, we don't
+                    # need to specify a dtype when we know we're not
+                    # trying to match any columns so the default is fine.
+                    dtype = "float64"
                 mask = pd.Series(mask, dtype=dtype)
             if mask.dtype == "bool":
                 return self._apply_boolean_mask(mask)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -32,7 +32,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 from nvtx import annotate
-from packaging.version import Version
 from pandas._config import get_option
 from pandas.core.dtypes.common import is_float, is_integer
 from pandas.io.formats import console
@@ -104,6 +103,7 @@ from cudf.utils.utils import (
     _cudf_nvtx_annotate,
     _external_only_api,
 )
+from cudf.core._compat import PANDAS_GE_200
 
 T = TypeVar("T", bound="DataFrame")
 
@@ -1167,14 +1167,15 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         elif can_convert_to_column(arg):
             mask = arg
             if is_list_like(mask):
-                # An explicit dtype is needed to avoid pandas warnings from
-                # empty sets of columns. This shouldn't be needed in pandas
-                # 2.0, we don't need to specify a dtype when we know we're not
-                # trying to match any columns so the default is fine.
                 dtype = None
                 if len(mask) == 0:
-                    assert Version(pd.__version__) < Version("2.0.0")
-                    dtype = "float64"
+                    if not PANDAS_GE_200:
+                        # An explicit dtype is needed to avoid pandas
+                        # warnings from empty sets of columns. This
+                        # shouldn't be needed in pandas 2.0, we don't
+                        # need to specify a dtype when we know we're not
+                        # trying to match any columns so the default is fine.
+                        dtype = "float64"
                 mask = pd.Series(mask, dtype=dtype)
             if mask.dtype == "bool":
                 return self._apply_boolean_mask(mask)


### PR DESCRIPTION

## Description
This PR updates `DataFrame.__getitem__` to be able to work with pandas-2.0. For which, we conditionally pass `dtype` to `pandas.Series` constructor so that we don't get a warning in `<2.0` versions.

This PR also fixes 76 pytests:
```
= 907 failed, 86353 passed, 2034 skipped, 992 xfailed, 165 xpassed in 504.93s (0:08:24) =
```
on `pandas_2.0_feature_branch`:
```
= 983 failed, 86277 passed, 2034 skipped, 992 xfailed, 165 xpassed in 515.47s (0:08:35) =
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
