### PR TITLE
[REVIEW] Deprecate `pad` and `backfill` methods

### DIFF
--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -1948,6 +1948,28 @@ class GroupBy(Serializable, Reducible, Scannable):
     def pad(self, limit=None):
         """Forward fill NA values.
 
+        .. deprecated:: 23.06
+           `pad` is deprecated, use `ffill` instead.
+
+        Parameters
+        ----------
+        limit : int, default None
+            Unsupported
+        """
+
+        if limit is not None:
+            raise NotImplementedError("Does not support limit param yet.")
+
+        warnings.warn(
+            "pad is deprecated and will be removed in a future version. "
+            "Use ffill instead.",
+            FutureWarning,
+        )
+        return self._scan_fill("ffill", limit)
+
+    def ffill(self, limit=None):
+        """Forward fill NA values.
+
         Parameters
         ----------
         limit : int, default None
@@ -1959,9 +1981,28 @@ class GroupBy(Serializable, Reducible, Scannable):
 
         return self._scan_fill("ffill", limit)
 
-    ffill = pad
-
     def backfill(self, limit=None):
+        """Backward fill NA values.
+
+        .. deprecated:: 23.06
+           `backfill` is deprecated, use `bfill` instead.
+
+        Parameters
+        ----------
+        limit : int, default None
+            Unsupported
+        """
+        if limit is not None:
+            raise NotImplementedError("Does not support limit param yet.")
+
+        warnings.warn(
+            "backfill is deprecated and will be removed in a future version. "
+            "Use bfill instead.",
+            FutureWarning,
+        )
+        return self._scan_fill("bfill", limit)
+
+    def bfill(self, limit=None):
         """Backward fill NA values.
 
         Parameters
@@ -1973,8 +2014,6 @@ class GroupBy(Serializable, Reducible, Scannable):
             raise NotImplementedError("Does not support limit param yet.")
 
         return self._scan_fill("bfill", limit)
-
-    bfill = backfill
 
     def fillna(
         self,

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1994,7 +1994,24 @@ class IndexedFrame(Frame):
             limit=limit,
         )
 
-    backfill = bfill
+    @_cudf_nvtx_annotate
+    def backfill(self, value=None, axis=None, inplace=None, limit=None):
+        """
+        Synonym for :meth:`Series.fillna` with ``method='bfill'``.
+
+        .. deprecated:: 23.06
+           Use `DataFrame.bfill/Series.bfill` instead.
+
+        Returns
+        -------
+            Object with missing values filled or None if ``inplace=True``.
+        """
+        warnings.warn(
+            "DataFrame.backfill/Series.backfill is deprecated. Use "
+            "DataFrame.bfill/Series.bfill instead",
+            FutureWarning,
+        )
+        return self.bfill(value=value, axis=axis, inplace=inplace, limit=limit)
 
     @_cudf_nvtx_annotate
     def ffill(self, value=None, axis=None, inplace=None, limit=None):
@@ -2013,7 +2030,24 @@ class IndexedFrame(Frame):
             limit=limit,
         )
 
-    pad = ffill
+    @_cudf_nvtx_annotate
+    def pad(self, value=None, axis=None, inplace=None, limit=None):
+        """
+        Synonym for :meth:`Series.fillna` with ``method='ffill'``.
+
+        .. deprecated:: 23.06
+           Use `DataFrame.ffill/Series.ffill` instead.
+
+        Returns
+        -------
+            Object with missing values filled or None if ``inplace=True``.
+        """
+        warnings.warn(
+            "DataFrame.pad/Series.pad is deprecated. Use "
+            "DataFrame.ffill/Series.ffill instead",
+            FutureWarning,
+        )
+        return self.ffill(value=value, axis=axis, inplace=inplace, limit=limit)
 
     def add_prefix(self, prefix):
         """

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -7574,11 +7574,13 @@ def test_dataframe_append_dataframe_lists(df, other, sort, ignore_index):
         pd.Series([1, 2, 3, None, np.nan, 5, 6, np.nan]),
     ],
 )
-def test_dataframe_bfill(df):
+@pytest.mark.parametrize("alias", ["bfill", "backfill"])
+def test_dataframe_bfill(df, alias):
     gdf = cudf.from_pandas(df)
 
-    actual = df.bfill()
-    expected = gdf.bfill()
+    actual = getattr(df, alias)()
+    with expect_warning_if(alias == "backfill"):
+        expected = getattr(gdf, alias)()
     assert_eq(expected, actual)
 
 
@@ -7589,11 +7591,13 @@ def test_dataframe_bfill(df):
         pd.Series([1, 2, 3, None, np.nan, 5, 6, np.nan]),
     ],
 )
-def test_dataframe_ffill(df):
+@pytest.mark.parametrize("alias", ["ffill", "pad"])
+def test_dataframe_ffill(df, alias):
     gdf = cudf.from_pandas(df)
 
-    actual = df.ffill()
-    expected = gdf.ffill()
+    actual = getattr(df, alias)()
+    with expect_warning_if(alias == "pad"):
+        expected = getattr(gdf, alias)()
     assert_eq(expected, actual)
 
 

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -2538,7 +2538,8 @@ def test_groupby_fillna_method(nelem, method):
     gdf = cudf.from_pandas(pdf)
 
     expect = pdf.groupby(key_col).fillna(method=method)
-    got = gdf.groupby(key_col).fillna(method=method)
+    with expect_warning_if(method in {"pad", "backfill"}):
+        got = gdf.groupby(key_col).fillna(method=method)
 
     assert_groupby_results_equal(
         expect[value_cols], got[value_cols], sort=False


### PR DESCRIPTION
## Description
This PR deprecates `pad` and `backfill` methods in favor of `ffill` and `bfill` methods.

Pandas recently deprecated these:
https://github.com/pandas-dev/pandas/pull/51221
https://github.com/pandas-dev/pandas/pull/45076

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
