### PR TITLE
[REVIEW] Fix `is_string_dtype` to adapt to `pandas-2.0` changes

### DIFF
--- a/python/cudf/cudf/api/types.py
+++ b/python/cudf/cudf/api/types.py
@@ -104,13 +104,20 @@ def is_string_dtype(obj):
         Whether or not the array or dtype is of the string dtype.
     """
     return (
-        pd.api.types.is_string_dtype(obj)
-        # Reject all cudf extension types.
-        and not is_categorical_dtype(obj)
-        and not is_decimal_dtype(obj)
-        and not is_list_dtype(obj)
-        and not is_struct_dtype(obj)
-        and not is_interval_dtype(obj)
+        (
+            isinstance(obj, (cudf.Index, cudf.Series))
+            and obj.dtype == cudf.dtype("O")
+        )
+        or (isinstance(obj, cudf.core.column.StringColumn))
+        or (
+            pd.api.types.is_string_dtype(obj)
+            # Reject all cudf extension types.
+            and not is_categorical_dtype(obj)
+            and not is_decimal_dtype(obj)
+            and not is_list_dtype(obj)
+            and not is_struct_dtype(obj)
+            and not is_interval_dtype(obj)
+        )
     )
 
 

--- a/python/cudf/cudf/tests/test_api_types.py
+++ b/python/cudf/cudf/tests/test_api_types.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 import numpy as np
 import pandas as pd
@@ -6,6 +6,7 @@ import pytest
 from pandas.api import types as pd_types
 
 import cudf
+from cudf.core._compat import PANDAS_GE_200
 from cudf.api import types
 
 
@@ -497,8 +498,8 @@ def test_is_integer(obj, expect):
         (pd.Series(dtype="int"), False),
         (pd.Series(dtype="float"), False),
         (pd.Series(dtype="complex"), False),
-        (pd.Series(dtype="str"), True),
-        (pd.Series(dtype="unicode"), True),
+        (pd.Series(dtype="str"), not PANDAS_GE_200),
+        (pd.Series(dtype="unicode"), not PANDAS_GE_200),
         (pd.Series(dtype="datetime64[s]"), False),
         (pd.Series(dtype="timedelta64[s]"), False),
         (pd.Series(dtype="category"), False),


### PR DESCRIPTION
## Description
With `pandas-2.0`, `pd.api.types.is_string_dtype(obj)` is going to perform a data-introspection to determine the true dtype of the underlying data. This path won't work for gpu objects, hence this PR adds special handling for GPU objects before we hit `pd.api.types.is_string_dtype(obj)` API.

This PR fixes 56 pytests:
```
= 927 failed, 86333 passed, 2034 skipped, 992 xfailed, 165 xpassed in 506.69s (0:08:26) =
```
On `pandas_2.0_feature_branch`:
```
= 983 failed, 86277 passed, 2034 skipped, 992 xfailed, 165 xpassed in 557.07s (0:09:17) =
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
