### PR TITLE
Fix a few clang-format style check errors

### DIFF
--- a/cpp/tests/stream_compaction/distinct_tests.cpp
+++ b/cpp/tests/stream_compaction/distinct_tests.cpp
@@ -890,7 +890,7 @@ TEST_F(DistinctKeepAny, ListsOfStructs)
                                       static_cast<cudf::bitmask_type const*>(null_mask.data()),
                                       null_count,
                                       0,
-                                              {offsets, structs});
+                                      {offsets, structs});
 
   auto const idx     = int32s_col{1, 1, 2, 2, 3, 4, 4, 4, 5, 6, 7, 8, 8, 9, 9, 10, 10};
   auto const input   = cudf::table_view{{idx, keys}};
@@ -976,7 +976,7 @@ TEST_F(DistinctKeepFirstLastNone, ListsOfStructs)
                                       static_cast<cudf::bitmask_type const*>(null_mask.data()),
                                       null_count,
                                       0,
-                                              {offsets, structs});
+                                      {offsets, structs});
 
   auto const idx     = int32s_col{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
   auto const input   = cudf::table_view{{idx, keys}};
@@ -1072,7 +1072,7 @@ TEST_F(DistinctKeepAny, SlicedListsOfStructs)
                                       static_cast<cudf::bitmask_type const*>(null_mask.data()),
                                       null_count,
                                       0,
-                                              {offsets, structs});
+                                      {offsets, structs});
 
   auto const idx            = int32s_col{1, 1, 2, 2, 3, 4, 4, 4, 5, 6, 7, 8, 8, 9, 9, 10, 10};
   auto const input_original = cudf::table_view{{idx, keys}};

--- a/cpp/tests/stream_compaction/unique_tests.cpp
+++ b/cpp/tests/stream_compaction/unique_tests.cpp
@@ -476,7 +476,7 @@ TEST_F(Unique, ListsOfStructsKeepAny)
                                       static_cast<cudf::bitmask_type const*>(null_mask.data()),
                                       null_count,
                                       0,
-                                              {offsets, structs});
+                                      {offsets, structs});
 
   auto const idx     = int32s_col{1, 1, 2, 2, 3, 4, 4, 4, 5, 6, 7, 8, 8, 9, 9, 10, 10};
   auto const input   = cudf::table_view{{idx, keys}};
@@ -559,7 +559,7 @@ TEST_F(Unique, ListsOfStructsKeepFirstLastNone)
                                       static_cast<cudf::bitmask_type const*>(null_mask.data()),
                                       null_count,
                                       0,
-                                              {offsets, structs});
+                                      {offsets, structs});
 
   auto const idx     = int32s_col{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
   auto const input   = cudf::table_view{{idx, keys}};


### PR DESCRIPTION
## Description
Fixes some build errors occuring after https://github.com/rapidsai/cudf/pull/13133 was merged. Looks like a couple files may have gotten mismerged perhaps. This should unblock several current PRs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
