### PR TITLE
Fix gtests to always pass null-count to set_null_mask calls

### DIFF
--- a/cpp/include/cudf/lists/detail/scatter.cuh
+++ b/cpp/include/cudf/lists/detail/scatter.cuh
@@ -141,7 +141,7 @@ std::unique_ptr<column> scatter_impl(rmm::device_uvector<unbound_list_view> cons
                                   target.size(),
                                   rmm::device_buffer{},
                                   std::move(null_mask),
-                                  cudf::UNKNOWN_NULL_COUNT,
+                                  target.null_count(),
                                   std::move(children));
 }
 

--- a/cpp/tests/column/column_test.cu
+++ b/cpp/tests/column/column_test.cu
@@ -157,7 +157,8 @@ TYPED_TEST(TypedColumnTest, SetEmptyNullMaskNonZeroNullCount)
 {
   cudf::column col{this->type(), this->num_elements(), std::move(this->data)};
   rmm::device_buffer empty_null_mask{};
-  EXPECT_THROW(col.set_null_mask(empty_null_mask, this->num_elements()), cudf::logic_error);
+  EXPECT_THROW(col.set_null_mask(std::move(empty_null_mask), this->num_elements()),
+               cudf::logic_error);
 }
 
 TYPED_TEST(TypedColumnTest, SetInvalidSizeNullMaskNonZeroNullCount)
@@ -165,7 +166,9 @@ TYPED_TEST(TypedColumnTest, SetInvalidSizeNullMaskNonZeroNullCount)
   cudf::column col{this->type(), this->num_elements(), std::move(this->data)};
   auto invalid_size_null_mask =
     create_null_mask(std::min(this->num_elements() - 50, 0), cudf::mask_state::ALL_VALID);
-  EXPECT_THROW(col.set_null_mask(invalid_size_null_mask, this->num_elements()), cudf::logic_error);
+  EXPECT_THROW(
+    col.set_null_mask(invalid_size_null_mask, this->num_elements(), cudf::get_default_stream()),
+    cudf::logic_error);
 }
 
 TYPED_TEST(TypedColumnTest, SetNullCountEmptyMask)

--- a/cpp/tests/column/column_view_shallow_test.cpp
+++ b/cpp/tests/column/column_view_shallow_test.cpp
@@ -261,7 +261,8 @@ TYPED_TEST(ColumnViewShallowTests, shallow_hash_mutable)
   {
     if constexpr (cudf::is_nested<TypeParam>()) {
       col->child(0).set_null_mask(
-        cudf::create_null_mask(col->child(0).size(), cudf::mask_state::ALL_NULL));
+        cudf::create_null_mask(col->child(0).size(), cudf::mask_state::ALL_NULL),
+        col->child(0).size());
       auto col_child_updated = cudf::mutable_column_view{*col};
       EXPECT_NE(shallow_hash(col_view), shallow_hash(col_child_updated));
     }
@@ -427,7 +428,7 @@ TYPED_TEST(ColumnViewShallowTests, is_shallow_equivalent_mutable)
   {
     if constexpr (cudf::is_nested<TypeParam>()) {
       col->child(0).set_null_mask(
-        cudf::create_null_mask(col->child(0).size(), cudf::mask_state::ALL_NULL));
+        cudf::create_null_mask(col->child(0).size(), cudf::mask_state::ALL_NULL), col->size());
       auto col_child_updated = cudf::mutable_column_view{*col};
       EXPECT_FALSE(is_shallow_equivalent(col_view, col_child_updated));
     }

--- a/cpp/tests/column/column_view_shallow_test.cpp
+++ b/cpp/tests/column/column_view_shallow_test.cpp
@@ -159,7 +159,7 @@ TYPED_TEST(ColumnViewShallowTests, shallow_hash_update_data)
   }
   // add null_mask + new column_view = diff hash.
   {
-    col->set_null_mask(cudf::create_null_mask(col->size(), cudf::mask_state::ALL_VALID));
+    col->set_null_mask(cudf::create_null_mask(col->size(), cudf::mask_state::ALL_VALID), 0);
     auto col_view_new = cudf::column_view{*col};
     EXPECT_NE(shallow_hash(col_view), shallow_hash(col_view_new));
     [[maybe_unused]] auto const nulls = col_view_new.null_count();
@@ -326,7 +326,7 @@ TYPED_TEST(ColumnViewShallowTests, is_shallow_equivalent_update_data)
   }
   // add null_mask + new column_view = diff hash.
   {
-    col->set_null_mask(cudf::create_null_mask(col->size(), cudf::mask_state::ALL_VALID));
+    col->set_null_mask(cudf::create_null_mask(col->size(), cudf::mask_state::ALL_VALID), 0);
     auto col_view_new = cudf::column_view{*col};
     EXPECT_FALSE(is_shallow_equivalent(col_view, col_view_new));
     [[maybe_unused]] auto const nulls = col_view_new.null_count();

--- a/cpp/tests/groupby/rank_scan_tests.cpp
+++ b/cpp/tests/groupby/rank_scan_tests.cpp
@@ -355,7 +355,7 @@ TYPED_TEST(typed_groupby_rank_scan_test, structsWithNullPushdown)
   auto const definitely_null_structs = [&] {
     auto struct_column = get_struct_column();
     struct_column->set_null_mask(cudf::create_null_mask(num_rows, cudf::mask_state::ALL_NULL),
-                                 struct_column->size());
+                                 num_rows);
     return struct_column;
   }();
 

--- a/cpp/tests/groupby/rank_scan_tests.cpp
+++ b/cpp/tests/groupby/rank_scan_tests.cpp
@@ -354,7 +354,8 @@ TYPED_TEST(typed_groupby_rank_scan_test, structsWithNullPushdown)
 
   auto const definitely_null_structs = [&] {
     auto struct_column = get_struct_column();
-    struct_column->set_null_mask(cudf::create_null_mask(num_rows, cudf::mask_state::ALL_NULL));
+    struct_column->set_null_mask(cudf::create_null_mask(num_rows, cudf::mask_state::ALL_NULL),
+                                 struct_column->size());
     return struct_column;
   }();
 

--- a/cpp/tests/reductions/rank_tests.cpp
+++ b/cpp/tests/reductions/rank_tests.cpp
@@ -215,7 +215,8 @@ TYPED_TEST(TypedRankScanTest, StructsWithNullPushdown)
   // First, verify that if the structs column has only nulls, all output rows are ranked 1.
   {
     // Null mask not pushed down to members.
-    struct_col->set_null_mask(create_null_mask(12, cudf::mask_state::ALL_NULL), struct_col->size());
+    struct_col->set_null_mask(create_null_mask(struct_col->size(), cudf::mask_state::ALL_NULL),
+                              struct_col->size());
     auto const expected_null_result = rank_result_col{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
     auto const expected_percent_rank_null_result =
       percent_result_col{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};

--- a/cpp/tests/reductions/rank_tests.cpp
+++ b/cpp/tests/reductions/rank_tests.cpp
@@ -214,8 +214,8 @@ TYPED_TEST(TypedRankScanTest, StructsWithNullPushdown)
 
   // First, verify that if the structs column has only nulls, all output rows are ranked 1.
   {
-    struct_col->set_null_mask(
-      create_null_mask(12, cudf::mask_state::ALL_NULL));  // Null mask not pushed down to members.
+    // Null mask not pushed down to members.
+    struct_col->set_null_mask(create_null_mask(12, cudf::mask_state::ALL_NULL), struct_col->size());
     auto const expected_null_result = rank_result_col{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
     auto const expected_percent_rank_null_result =
       percent_result_col{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};

--- a/cpp/tests/rolling/grouped_rolling_range_test.cpp
+++ b/cpp/tests/rolling/grouped_rolling_range_test.cpp
@@ -167,7 +167,7 @@ struct GroupedRollingRangeOrderByDecimalTypedTest : BaseGroupedRollingRangeOrder
                           10,
                           12,
                           false);  // Nulls in third group.
-      col->set_null_mask(std::move(new_null_mask));
+      col->set_null_mask(std::move(new_null_mask), 6);
       return col;
     }();
 

--- a/cpp/tests/transform/nans_to_null_test.cpp
+++ b/cpp/tests/transform/nans_to_null_test.cpp
@@ -27,11 +27,11 @@ template <typename T>
 struct NaNsToNullTest : public cudf::test::BaseFixture {
   void run_test(cudf::column_view const& input, cudf::column_view const& expected)
   {
-    auto got_mask = cudf::nans_to_nulls(input);
+    auto [null_mask, null_count] = cudf::nans_to_nulls(input);
     cudf::column got(input);
-    got.set_null_mask(std::move(*(got_mask.first)));
+    got.set_null_mask(std::move(*(null_mask)), null_count);
 
-    EXPECT_EQ(expected.null_count(), got_mask.second);
+    EXPECT_EQ(expected.null_count(), null_count);
 
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, got.view());
   }

--- a/cpp/tests/transform/nans_to_null_test.cpp
+++ b/cpp/tests/transform/nans_to_null_test.cpp
@@ -29,7 +29,7 @@ struct NaNsToNullTest : public cudf::test::BaseFixture {
   {
     auto [null_mask, null_count] = cudf::nans_to_nulls(input);
     cudf::column got(input);
-    got.set_null_mask(std::move(*(null_mask)), null_count);
+    got.set_null_mask(std::move(*null_mask), null_count);
 
     EXPECT_EQ(expected.null_count(), null_count);
 


### PR DESCRIPTION
## Description
Fix calls to the `column::set_null_mask()` function to always pass the null-count value in gtests source files.

Contributes to: https://github.com/rapidsai/cudf/issues/11968

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
