### PR TITLE
Allow compilation with any GTest version 1.10+

### DIFF
--- a/cpp/include/cudf_test/cudf_gtest.hpp
+++ b/cpp/include/cudf_test/cudf_gtest.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 /**
  * @file cudf_gtest.hpp
- * @brief Work around for GTests emulation of variadic templates in
+ * @brief Work around for GTests( <=v1.10 ) emulation of variadic templates in
  * @verbatim ::Testing::Types @endverbatim
  *
  * @note Instead of including `gtest/gtest.h`, all libcudf test files should
@@ -35,6 +35,10 @@
  */
 
 // @cond
+#if __has_include(<gtest/internal/gtest-type-util.h.pump>)
+// gtest doesn't provide a version header so we need to
+// use a file existence trick.
+// gtest-type-util.h.pump only exists in versions < 1.11
 #define Types      Types_NOT_USED
 #define Types0     Types0_NOT_USED
 #define TypeList   TypeList_NOT_USED
@@ -90,6 +94,7 @@ struct TypeList<Types<TYPES...>> {
 
 }  // namespace internal
 }  // namespace testing
+#endif  // gtest < 1.11
 // @endcond
 
 #include <gmock/gmock.h>

--- a/cpp/include/cudf_test/type_list_utilities.hpp
+++ b/cpp/include/cudf_test/type_list_utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,11 @@ namespace test {
 // Types -----------------------------------------
 using ::testing::Types;
 
+template <typename T>
+struct at_type {
+  using type = T;
+};
+
 // @cond
 template <class T, int D>
 struct GetTypeImpl {
@@ -90,14 +95,19 @@ template <class... T, int D>
 struct GetTypeImpl<Types<T...>, D> {
   static_assert(D < sizeof...(T), "Out of bounds");
 
-  using type = typename GetTypeImpl<typename Types<T...>::Tail, D - 1>::type;
+  using type = decltype(std::get<D>(std::declval<std::tuple<T...>>()));
 };
-
-template <class... ARGS>
-struct GetTypeImpl<Types<ARGS...>, 0> {
-  static_assert(sizeof...(ARGS) > 0, "Out of bounds");
-
-  using type = typename Types<ARGS...>::Head;
+template <class T, class U, class V, class... ARGS>
+struct GetTypeImpl<Types<T, U, V, ARGS...>, 2> {
+  using type = V;
+};
+template <class T, class U, class... ARGS>
+struct GetTypeImpl<Types<T, U, ARGS...>, 1> {
+  using type = U;
+};
+template <class T, class... ARGS>
+struct GetTypeImpl<Types<T, ARGS...>, 0> {
+  using type = T;
 };
 // @endcond
 

--- a/cpp/tests/iterator/optional_iterator_test_numeric.cu
+++ b/cpp/tests/iterator/optional_iterator_test_numeric.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,16 @@
 
 using TestingTypes = cudf::test::NumericTypes;
 
+namespace cudf {
+// To print meanvar for debug.
+// Needs to be in the cudf namespace for ADL
+template <typename T>
+std::ostream& operator<<(std::ostream& os, cudf::meanvar<T> const& rhs)
+{
+  return os << "[" << rhs.value << ", " << rhs.value_squared << ", " << rhs.count << "] ";
+};
+}  // namespace cudf
+
 template <typename T>
 struct NumericOptionalIteratorTest : public IteratorTest<T> {
 };
@@ -34,13 +44,6 @@ TYPED_TEST(NumericOptionalIteratorTest, nonull_optional_iterator)
   nonull_optional_iterator(*this);
 }
 TYPED_TEST(NumericOptionalIteratorTest, null_optional_iterator) { null_optional_iterator(*this); }
-
-// to print meanvar for debug.
-template <typename T>
-std::ostream& operator<<(std::ostream& os, cudf::meanvar<T> const& rhs)
-{
-  return os << "[" << rhs.value << ", " << rhs.value_squared << ", " << rhs.count << "] ";
-};
 
 // Transformers and Operators for optional_iterator test
 template <typename ElementType>

--- a/cpp/tests/iterator/pair_iterator_test_numeric.cu
+++ b/cpp/tests/iterator/pair_iterator_test_numeric.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,16 @@
 
 using TestingTypes = cudf::test::NumericTypes;
 
+namespace cudf {
+// To print meanvar for debug.
+// Needs to be in the cudf namespace for ADL
+template <typename T>
+std::ostream& operator<<(std::ostream& os, cudf::meanvar<T> const& rhs)
+{
+  return os << "[" << rhs.value << ", " << rhs.value_squared << ", " << rhs.count << "] ";
+};
+}  // namespace cudf
+
 template <typename T>
 struct NumericPairIteratorTest : public IteratorTest<T> {
 };
@@ -29,13 +39,6 @@ struct NumericPairIteratorTest : public IteratorTest<T> {
 TYPED_TEST_SUITE(NumericPairIteratorTest, TestingTypes);
 TYPED_TEST(NumericPairIteratorTest, nonull_pair_iterator) { nonull_pair_iterator(*this); }
 TYPED_TEST(NumericPairIteratorTest, null_pair_iterator) { null_pair_iterator(*this); }
-
-// to print meanvar for debug.
-template <typename T>
-std::ostream& operator<<(std::ostream& os, cudf::meanvar<T> const& rhs)
-{
-  return os << "[" << rhs.value << ", " << rhs.value_squared << ", " << rhs.count << "] ";
-};
 
 // Transformers and Operators for pair_iterator test
 template <typename ElementType>


### PR DESCRIPTION
## Description
GTest max support for `Types` was removed in 1.11, so we remove the workarounds in cudf_gtest.

Since we need to support our custom `Types` and the GTest 1.11+ version rework the type_list_utilities to be generic and not depend on specific traits.

Also corrected the `<<` overloads for GTest printing so that they work with GTest 1.11.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
