### PR TITLE
[REVIEW] Drop support for `pad` and `backfill` in `GroupBy`

### DIFF
--- a/docs/cudf/source/api_docs/groupby.rst
+++ b/docs/cudf/source/api_docs/groupby.rst
@@ -42,7 +42,6 @@ Computations / descriptive stats
    :toctree: api/
 
    GroupBy.bfill
-   GroupBy.backfill
    GroupBy.count
    GroupBy.cumcount
    GroupBy.cummax
@@ -63,7 +62,6 @@ Computations / descriptive stats
    GroupBy.ngroup
    GroupBy.nth
    GroupBy.nunique
-   GroupBy.pad
    GroupBy.prod
    GroupBy.shift
    GroupBy.size

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -1945,28 +1945,6 @@ class GroupBy(Serializable, Reducible, Scannable):
         result = self._mimic_pandas_order(result)
         return result._copy_type_metadata(values)
 
-    def pad(self, limit=None):
-        """Forward fill NA values.
-
-        .. deprecated:: 23.06
-           `pad` is deprecated, use `ffill` instead.
-
-        Parameters
-        ----------
-        limit : int, default None
-            Unsupported
-        """
-
-        if limit is not None:
-            raise NotImplementedError("Does not support limit param yet.")
-
-        warnings.warn(
-            "pad is deprecated and will be removed in a future version. "
-            "Use ffill instead.",
-            FutureWarning,
-        )
-        return self._scan_fill("ffill", limit)
-
     def ffill(self, limit=None):
         """Forward fill NA values.
 
@@ -1980,27 +1958,6 @@ class GroupBy(Serializable, Reducible, Scannable):
             raise NotImplementedError("Does not support limit param yet.")
 
         return self._scan_fill("ffill", limit)
-
-    def backfill(self, limit=None):
-        """Backward fill NA values.
-
-        .. deprecated:: 23.06
-           `backfill` is deprecated, use `bfill` instead.
-
-        Parameters
-        ----------
-        limit : int, default None
-            Unsupported
-        """
-        if limit is not None:
-            raise NotImplementedError("Does not support limit param yet.")
-
-        warnings.warn(
-            "backfill is deprecated and will be removed in a future version. "
-            "Use bfill instead.",
-            FutureWarning,
-        )
-        return self._scan_fill("bfill", limit)
 
     def bfill(self, limit=None):
         """Backward fill NA values.
@@ -2030,11 +1987,11 @@ class GroupBy(Serializable, Reducible, Scannable):
         ----------
         value : scalar, dict
             Value to use to fill the holes. Cannot be specified with method.
-        method : {'backfill', 'bfill', 'pad', 'ffill', None}, default None
+        method : { 'bfill', 'ffill', None}, default None
             Method to use for filling holes in reindexed Series
 
-            - pad/ffill: propagate last valid observation forward to next valid
-            - backfill/bfill: use next valid observation to fill gap
+            - ffill: propagate last valid observation forward to next valid
+            - bfill: use next valid observation to fill gap
         axis : {0 or 'index', 1 or 'columns'}
             Unsupported
         inplace : bool, default False
@@ -2064,11 +2021,8 @@ class GroupBy(Serializable, Reducible, Scannable):
             raise ValueError("Cannot specify both 'value' and 'method'.")
 
         if method is not None:
-            if method not in {"pad", "ffill", "backfill", "bfill"}:
-                raise ValueError(
-                    "Method can only be of 'pad', 'ffill',"
-                    "'backfill', 'bfill'."
-                )
+            if method not in {"ffill", "bfill"}:
+                raise ValueError("Method can only be of 'ffill', 'bfill'.")
             return getattr(self, method, limit)()
 
         values = self.obj.__class__._from_data(

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -2499,7 +2499,7 @@ def test_groupby_various_by_fillna(by, data, args):
 
 
 @pytest.mark.parametrize("nelem", [10, 100, 1000])
-@pytest.mark.parametrize("method", ["pad", "ffill", "backfill", "bfill"])
+@pytest.mark.parametrize("method", ["ffill", "bfill"])
 def test_groupby_fillna_method(nelem, method):
     t = rand_dataframe(
         dtypes_meta=[
@@ -2538,8 +2538,7 @@ def test_groupby_fillna_method(nelem, method):
     gdf = cudf.from_pandas(pdf)
 
     expect = pdf.groupby(key_col).fillna(method=method)
-    with expect_warning_if(method in {"pad", "backfill"}):
-        got = gdf.groupby(key_col).fillna(method=method)
+    got = gdf.groupby(key_col).fillna(method=method)
 
     assert_groupby_results_equal(
         expect[value_cols], got[value_cols], sort=False
@@ -2879,19 +2878,17 @@ def test_groupby_transform_maintain_index(by):
     ],
 )
 @pytest.mark.parametrize("periods", [-5, -2, 0, 2, 5])
-@pytest.mark.parametrize("fill_method", ["ffill", "bfill", "pad", "backfill"])
+@pytest.mark.parametrize("fill_method", ["ffill", "bfill"])
 def test_groupby_pct_change(data, gkey, periods, fill_method):
     gdf = cudf.DataFrame(data)
     pdf = gdf.to_pandas()
 
-    with expect_warning_if(fill_method in ("pad", "backfill")):
-        actual = gdf.groupby(gkey).pct_change(
-            periods=periods, fill_method=fill_method
-        )
-    with expect_warning_if(fill_method in ("pad", "backfill")):
-        expected = pdf.groupby(gkey).pct_change(
-            periods=periods, fill_method=fill_method
-        )
+    actual = gdf.groupby(gkey).pct_change(
+        periods=periods, fill_method=fill_method
+    )
+    expected = pdf.groupby(gkey).pct_change(
+        periods=periods, fill_method=fill_method
+    )
 
     assert_eq(expected, actual)
 


### PR DESCRIPTION
## Description
This PR drops support for `pad` and `backfill` in `GroupBy`.

This PR:
```
= 881 failed, 86383 passed, 2034 skipped, 956 xfailed, 165 xpassed in 522.05s (0:08:42) =
```
On `pandas_2.0_feature_branch`:
```
= 911 failed, 86389 passed, 2034 skipped, 956 xfailed, 165 xpassed in 521.12s (0:08:41) =
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
