### PR TITLE
[REVIEW] Fix datetime pytests & raise errors for timezone un-aware typecasting

### DIFF
--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -580,11 +580,15 @@ def infer_format(element: str, **kwargs) -> str:
         raise ValueError("Unable to infer the timestamp format from the data")
 
     if len(second_parts) > 1:
-        # "Z" indicates Zulu time(widely used in aviation) - Which is
-        # UTC timezone that currently cudf only supports. Having any other
-        # unsupported timezone will let the code fail below
-        # with a ValueError.
-        second_parts.remove("Z")
+        if "Z" in second_parts:
+            # "Z" indicates Zulu time(widely used in aviation) - Which is
+            # UTC timezone that currently cudf only supports. Having any other
+            # unsupported timezone will let the code fail below
+            # with a ValueError.
+            raise NotImplementedError(
+                "cuDF does not yet support " "timezone-aware datetimes"
+            )
+        # second_parts.remove("Z")
         second_part = "".join(second_parts[1:])
 
         if len(second_part) > 1:

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -586,9 +586,9 @@ def infer_format(element: str, **kwargs) -> str:
             # unsupported timezone will let the code fail below
             # with a ValueError.
             raise NotImplementedError(
-                "cuDF does not yet support " "timezone-aware datetimes"
+                "cuDF does not yet support timezone-aware datetimes"
             )
-        # second_parts.remove("Z")
+
         second_part = "".join(second_parts[1:])
 
         if len(second_part) > 1:

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5525,10 +5525,10 @@ class StringColumn(column.ColumnBase):
                 format = datetime.infer_format(
                     self.apply_boolean_mask(self.notnull()).element_indexing(0)
                 )
-        print(format)
+
         if format.endswith("%z"):
             raise NotImplementedError(
-                "cuDF does not yet support " "timezone-aware datetimes"
+                "cuDF does not yet support timezone-aware datetimes"
             )
         return self._as_datetime_or_timedelta_column(out_dtype, format)
 

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5525,7 +5525,11 @@ class StringColumn(column.ColumnBase):
                 format = datetime.infer_format(
                     self.apply_boolean_mask(self.notnull()).element_indexing(0)
                 )
-
+        print(format)
+        if format.endswith("%z"):
+            raise NotImplementedError(
+                "cuDF does not yet support " "timezone-aware datetimes"
+            )
         return self._as_datetime_or_timedelta_column(out_dtype, format)
 
     def as_timedelta_column(

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -10,6 +10,7 @@ import pyarrow as pa
 import pytest
 
 import cudf
+import warnings
 import cudf.testing.dataset_generator as dataset_generator
 from cudf import DataFrame, Series
 from cudf.core._compat import PANDAS_GE_150, PANDAS_LT_140
@@ -680,12 +681,14 @@ def test_to_datetime_errors(data):
     else:
         gd_data = pd_data
 
-    assert_exceptions_equal(
-        pd.to_datetime,
-        cudf.to_datetime,
-        ([pd_data],),
-        ([gd_data],),
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert_exceptions_equal(
+            pd.to_datetime,
+            cudf.to_datetime,
+            ([pd_data],),
+            ([gd_data],),
+        )
 
 
 def test_to_datetime_not_implemented():
@@ -785,14 +788,19 @@ def test_to_datetime_format(data, format, infer_datetime_format):
     else:
         gd_data = pd_data
 
-    expected = pd.to_datetime(
-        pd_data, format=format, infer_datetime_format=infer_datetime_format
-    )
-    actual = cudf.to_datetime(
-        gd_data, format=format, infer_datetime_format=infer_datetime_format
-    )
+    with expect_warning_if(True, UserWarning):
+        expected = pd.to_datetime(
+            pd_data, format=format, infer_datetime_format=infer_datetime_format
+        )
+    with expect_warning_if(not infer_datetime_format):
+        actual = cudf.to_datetime(
+            gd_data, format=format, infer_datetime_format=infer_datetime_format
+        )
+    # TODO: Remove typecast to `ns` after following
+    # issue is fixed:
+    # https://github.com/pandas-dev/pandas/issues/52449
 
-    assert_eq(actual, expected)
+    assert_eq(actual.astype("datetime64[ns]"), expected)
 
 
 def test_datetime_can_cast_safely():
@@ -847,7 +855,11 @@ def test_datetime_scalar_timeunit_cast(timeunit):
 
     gs = Series(testscalar)
     ps = pd.Series(testscalar)
-    assert_eq(ps, gs)
+    # TODO: Remove typecast to `ns` after following
+    # issue is fixed:
+    # https://github.com/pandas-dev/pandas/issues/52449
+
+    assert_eq(ps, gs.astype("datetime64[ns]"))
 
     gdf = DataFrame()
     gdf["a"] = np.arange(5)
@@ -857,6 +869,11 @@ def test_datetime_scalar_timeunit_cast(timeunit):
     pdf["a"] = np.arange(5)
     pdf["b"] = testscalar
 
+    assert gdf["b"].dtype == cudf.dtype("datetime64[s]")
+    # TODO: Remove typecast to `ns` after following
+    # issue is fixed:
+    # https://github.com/pandas-dev/pandas/issues/52449
+    gdf["b"] = gdf["b"].astype("datetime64[ns]")
     assert_eq(pdf, gdf)
 
 
@@ -1268,10 +1285,6 @@ def test_datetime_reductions(data, op, dtype):
     "data",
     [
         np.datetime_as_string(
-            np.arange("2002-10-27T04:30", 4 * 60, 60, dtype="M8[m]"),
-            timezone="UTC",
-        ),
-        np.datetime_as_string(
             np.arange("2002-10-27T04:30", 10 * 60, 1, dtype="M8[m]"),
             timezone="UTC",
         ),
@@ -1294,10 +1307,13 @@ def test_datetime_infer_format(data, dtype):
     sr = cudf.Series(data)
     psr = pd.Series(data)
 
-    expected = psr.astype(dtype)
-    actual = sr.astype(dtype)
-
-    assert_eq(expected, actual)
+    assert_exceptions_equal(
+        lfunc=psr.astype,
+        rfunc=sr.astype,
+        lfunc_args_and_kwargs=([], {"dtype": dtype}),
+        rfunc_args_and_kwargs=([], {"dtype": dtype}),
+        check_exception_type=False,
+    )
 
 
 def test_dateoffset_instance_subclass_check():


### PR DESCRIPTION
## Description

This PR fixes some of the `to_datetime` related pytests and also raises error while constructing a time-zone un-aware type to datetime types.

This PR fixes 62 pytests:
```
= 745 failed, 87877 passed, 2044 skipped, 956 xfailed, 165 xpassed in 492.06s (0:08:12) =
```
On `pandas_2.0_feature_branch`:
```
= 807 failed, 87819 passed, 2044 skipped, 956 xfailed, 165 xpassed in 488.43s (0:08:08) =
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
