### PR TITLE
[REVIEW] Fix pytests where empty column indexes are compared

### DIFF
--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -305,16 +305,6 @@ cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
             if use_pandas_metadata:
                 df.index.names = index_col
 
-    if meta is not None:
-        columns_meta = meta['column_indexes']
-        if len(columns_meta) == 1:
-            if columns_meta[0]['numpy_type'] is not None \
-                    and cudf.dtype(
-                    columns_meta[0]['numpy_type']) != cudf.dtype("O"):
-                # Parquet metadata store integer column names as strings.
-                # This special handling is to restore the types of column
-                # names.
-                df.columns = df.columns.astype(columns_meta[0]['numpy_type'])
     return df
 
 

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -305,6 +305,16 @@ cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
             if use_pandas_metadata:
                 df.index.names = index_col
 
+    if meta is not None:
+        columns_meta = meta['column_indexes']
+        if len(columns_meta) == 1:
+            if columns_meta[0]['numpy_type'] is not None \
+                    and cudf.dtype(
+                    columns_meta[0]['numpy_type']) != cudf.dtype("O"):
+                # Parquet metadata store integer column names as strings.
+                # This special handling is to restore the types of column
+                # names.
+                df.columns = df.columns.astype(columns_meta[0]['numpy_type'])
     return df
 
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -6325,12 +6325,22 @@ def test_dataframe_init_1d_list(data, columns):
     expect = pd.DataFrame(data, columns=columns)
     actual = cudf.DataFrame(data, columns=columns)
 
-    assert_eq(expect, actual, check_index_type=len(data) != 0)
+    assert_eq(
+        expect,
+        actual,
+        check_index_type=len(data) != 0,
+        check_column_type=not PANDAS_GE_200 and len(data) == 0,
+    )
 
     expect = pd.DataFrame(data, columns=None)
     actual = cudf.DataFrame(data, columns=None)
 
-    assert_eq(expect, actual, check_index_type=len(data) != 0)
+    assert_eq(
+        expect,
+        actual,
+        check_index_type=len(data) != 0,
+        check_column_type=not PANDAS_GE_200 and len(data) == 0,
+    )
 
 
 @pytest.mark.parametrize(
@@ -7660,7 +7670,12 @@ def test_dataframe_concat_lists(df, other, sort, ignore_index):
             check_column_type=not gdf.empty,
         )
     else:
-        assert_eq(expected, actual, check_index_type=not gdf.empty)
+        assert_eq(
+            expected,
+            actual,
+            check_index_type=not gdf.empty,
+            check_column_type=PANDAS_GE_200 and len(gdf.columns) != 0,
+        )
 
 
 def test_dataframe_concat_series_without_name():

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -18,7 +18,7 @@ import rmm
 
 import cudf
 from cudf import DataFrame, Series
-from cudf.core._compat import PANDAS_GE_150, PANDAS_LT_140
+from cudf.core._compat import PANDAS_GE_150, PANDAS_LT_140, PANDAS_GE_200
 from cudf.core.udf.groupby_typing import SUPPORTED_GROUPBY_NUMPY_TYPES
 from cudf.core.udf.utils import precompiled
 from cudf.testing._utils import (
@@ -1971,11 +1971,16 @@ def test_groupby_apply_return_series_dataframe(func, args):
 )
 def test_groupby_no_keys(pdf):
     gdf = cudf.from_pandas(pdf)
+    if isinstance(pdf, pd.DataFrame):
+        kwargs = {"check_column_type": not PANDAS_GE_200}
+    else:
+        kwargs = {}
     assert_groupby_results_equal(
         pdf.groupby([]).max(),
         gdf.groupby([]).max(),
         check_dtype=False,
         check_index_type=False,  # Int64Index v/s Float64Index
+        **kwargs,
     )
 
 
@@ -1985,10 +1990,15 @@ def test_groupby_no_keys(pdf):
 )
 def test_groupby_apply_no_keys(pdf):
     gdf = cudf.from_pandas(pdf)
+    if isinstance(pdf, pd.DataFrame):
+        kwargs = {"check_column_type": not PANDAS_GE_200}
+    else:
+        kwargs = {}
     assert_groupby_results_equal(
         pdf.groupby([], group_keys=False).apply(lambda x: x.max()),
         gdf.groupby([]).apply(lambda x: x.max()),
         check_index_type=False,  # Int64Index v/s Float64Index
+        **kwargs,
     )
 
 

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -2812,11 +2812,3 @@ def test_parquet_writer_schema_nullability(data, force_nullable_schema):
     assert pa.parquet.read_schema(file_obj).field(0).nullable == (
         force_nullable_schema or df.isnull().any().any()
     )
-
-
-def test_parquet_roundtrip_int_columns():
-    file_obj = BytesIO()
-    expected = pd.DataFrame({0: [1, 2, 3], 10: [10, 11, 12]})
-    expected.to_parquet(file_obj)
-    actual = cudf.read_parquet(file_obj)
-    assert_eq(expected, actual, check_column_type=True)

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -311,7 +311,7 @@ def test_parquet_reader_empty_pandas_dataframe(tmpdir, engine):
     expect = expect.reset_index(drop=True)
     got = got.reset_index(drop=True)
 
-    assert_eq(expect, got)
+    assert_eq(expect, got, check_column_type=not PANDAS_GE_200)
 
 
 @pytest.mark.parametrize("has_null", [False, True])
@@ -2210,7 +2210,12 @@ def run_parquet_index(pdf, index):
     expected = pd.read_parquet(pandas_buffer)
     actual = cudf.read_parquet(cudf_buffer)
 
-    assert_eq(expected, actual, check_index_type=True)
+    assert_eq(
+        expected,
+        actual,
+        check_index_type=True,
+        check_column_type=not PANDAS_GE_200,
+    )
 
 
 @pytest.mark.parametrize(
@@ -2807,3 +2812,11 @@ def test_parquet_writer_schema_nullability(data, force_nullable_schema):
     assert pa.parquet.read_schema(file_obj).field(0).nullable == (
         force_nullable_schema or df.isnull().any().any()
     )
+
+
+def test_parquet_roundtrip_int_columns():
+    file_obj = BytesIO()
+    expected = pd.DataFrame({0: [1, 2, 3], 10: [10, 11, 12]})
+    expected.to_parquet(file_obj)
+    actual = cudf.read_parquet(file_obj)
+    assert_eq(expected, actual, check_column_type=True)


### PR DESCRIPTION
## Description
This PR fixes pytests where empty column object comparisons fail, this is because of the following inconsistency between pandas & cudf:
```python
In [1]: import pandas as pd

In [2]: import cudf

In [3]: pd.DataFrame().columns
Out[3]: RangeIndex(start=0, stop=0, step=1)

In [4]: cudf.DataFrame().columns
Out[4]: Index([], dtype='object')

In [5]: pd.DataFrame().columns.dtype
Out[5]: dtype('int64')

In [6]: cudf.DataFrame().columns.dtype
Out[6]: dtype('O')

```

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
