### PR TITLE
[REVIEW] Update parameter ordering in `DataFrame.pivot`

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -104,6 +104,7 @@ from cudf.utils.utils import (
     _external_only_api,
 )
 from cudf.core._compat import PANDAS_GE_200
+from cudf.api.extensions import no_default
 
 T = TypeVar("T", bound="DataFrame")
 
@@ -6636,7 +6637,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
     @_cudf_nvtx_annotate
     @copy_docstring(reshape.pivot)
-    def pivot(self, index, columns, values=None):
+    def pivot(self, *, columns, index=no_default, values=no_default):
         return cudf.core.reshape.pivot(
             self, index=index, columns=columns, values=values
         )

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -906,7 +906,7 @@ def _pivot(df, index, columns):
     )
 
 
-def pivot(data, index=no_default, columns=None, values=no_default):
+def pivot(data, columns=None, index=no_default, values=no_default):
     """
     Return reshaped DataFrame organized by the given index and column values.
 

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -13,6 +13,7 @@ from cudf._lib.types import size_type_dtype
 from cudf._typing import Dtype
 from cudf.core.column import ColumnBase, as_column, column_empty_like
 from cudf.core.column.categorical import CategoricalColumn
+from cudf.api.extensions import no_default
 
 _AXIS_MAP = {0: 0, 1: 1, "index": 0, "columns": 1}
 
@@ -905,7 +906,7 @@ def _pivot(df, index, columns):
     )
 
 
-def pivot(data, index=None, columns=None, values=None):
+def pivot(data, index=no_default, columns=None, values=no_default):
     """
     Return reshaped DataFrame organized by the given index and column values.
 
@@ -915,10 +916,10 @@ def pivot(data, index=None, columns=None, values=None):
 
     Parameters
     ----------
-    index : column name, optional
-        Column used to construct the index of the result.
     columns : column name, optional
         Column used to construct the columns of the result.
+    index : column name, optional
+        Column used to construct the index of the result.
     values : column name or list of column names, optional
         Column(s) whose values are rearranged to produce the result.
         If not specified, all remaining columns of the DataFrame
@@ -957,7 +958,7 @@ def pivot(data, index=None, columns=None, values=None):
     """
     df = data
     values_is_list = True
-    if values is None:
+    if values is no_default:
         values = df._columns_view(
             col for col in df._column_names if col not in (index, columns)
         )
@@ -966,7 +967,7 @@ def pivot(data, index=None, columns=None, values=None):
             values = [values]
             values_is_list = False
         values = df._columns_view(values)
-    if index is None:
+    if index is no_default:
         index = df.index
     else:
         index = cudf.core.index.Index(df.loc[:, index])

--- a/python/cudf/cudf/tests/test_reshape.py
+++ b/python/cudf/cudf/tests/test_reshape.py
@@ -382,14 +382,8 @@ def test_pivot_simple(index, column, data):
     pdf = pd.DataFrame({"index": index, "column": column, "data": data})
     gdf = cudf.from_pandas(pdf)
 
-    # In pandas 2.0 this will be a failure because pandas will require all of
-    # these as keyword arguments. Matching that check in cudf is a bit
-    # cumbersome and not worth the effort to match the warning, so this code
-    # just catches pandas's warning (rather than updating the signature) so
-    # that when it starts failing we know to update our impl of pivot.
-    with pytest.warns(FutureWarning):
-        expect = pdf.pivot("index", "column")
-    got = gdf.pivot("index", "column")
+    expect = pdf.pivot(columns="column", index="index")
+    got = gdf.pivot(columns="column", index="index")
 
     check_index_and_columns = expect.shape != (0, 0)
     assert_eq(


### PR DESCRIPTION
## Description
This PR updates parameter ordering in `DataFrame.pivot` to match pandas-2.0.

This PR fixes 7 related pytests:
```
= 477 failed, 88169 passed, 2044 skipped, 932 xfailed, 165 xpassed in 438.55s (0:07:18) =
```
On `pandas_2.0_feature_branch`:
```
= 484 failed, 88162 passed, 2044 skipped, 932 xfailed, 165 xpassed in 457.87s (0:07:37) =
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
