### PR TITLE
[REVIEW] Fix `DataFrame.describe` pytests

### DIFF
--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -8273,8 +8273,8 @@ def test_dataframe_iterrows_itertuples():
 def test_describe_misc_include(df, include):
     pdf = df.to_pandas()
 
-    expected = pdf.describe(include=include, datetime_is_numeric=True)
-    actual = df.describe(include=include, datetime_is_numeric=True)
+    expected = pdf.describe(include=include)
+    actual = df.describe(include=include)
 
     for col in expected.columns:
         if expected[col].dtype == np.dtype("object"):


### PR DESCRIPTION
## Description
https://github.com/rapidsai/cudf/pull/12890 dropped support for `datetime_is_numeric` from `describe` API. This PR cleans-up a remaining pytest that was using this parameter.

This PR fixes 20 pytests:
```
= 464 failed, 88182 passed, 2044 skipped, 932 xfailed, 165 xpassed in 440.68s (0:07:20) =
```
On `pandas_2.0_feature_branch`:
```
= 484 failed, 88162 passed, 2044 skipped, 932 xfailed, 165 xpassed in 457.87s (0:07:37) =
```


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
