### PR TITLE
Fix unused parameter warning/error in grouped_rolling.cu

### DIFF
--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -277,7 +277,7 @@ __device__ T subtract_safe(T const& value, T const& delta)
 template <typename ElementT, typename ElementIter>
 __device__ ElementT compute_lowest_in_window(ElementIter orderby_iter,
                                              size_type idx,
-                                             ElementT delta)
+                                             [[maybe_unused]] ElementT delta)
 {
   if constexpr (std::is_same_v<ElementT, cudf::string_view>) {
     return orderby_iter[idx];
@@ -293,7 +293,7 @@ __device__ ElementT compute_lowest_in_window(ElementIter orderby_iter,
 template <typename ElementT, typename ElementIter>
 __device__ ElementT compute_highest_in_window(ElementIter orderby_iter,
                                               size_type idx,
-                                              ElementT delta)
+                                              [[maybe_unused]] ElementT delta)
 {
   if constexpr (std::is_same_v<ElementT, cudf::string_view>) {
     return orderby_iter[idx];


### PR DESCRIPTION
## Description
Fixes unused parameter warning/error introduced by #13143 in `grouped_rolling.cu`
```
CMakeFiles/cudf.dir/src/rolling/grouped_rolling.cu.o
/cudf/cpp/src/rolling/grouped_rolling.cu(280): error #177-D: parameter "delta" was declared but never referenced
```
This was found when building with nvcc 11.5.
I was hoping there would be some clever partial specialization or function overloading that could be done here but none were as clean as the current implementation. Solution was to just add `[[maybe_unused]]` to offending parameter declaration.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
