### PR TITLE
Update cudf recipes to use GTest version to >=1.13

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -31,8 +31,8 @@ dependencies:
 - fmt>=9.1.0,<10
 - fsspec>=0.6.0
 - gcc_linux-64=11.*
-- gmock==1.13.0.*
-- gtest==1.13.0.*
+- gmock>=1.13.0.*
+- gtest>=1.13.0.*
 - hypothesis
 - ipython
 - libarrow==11.0.0.*

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -31,8 +31,8 @@ dependencies:
 - fmt>=9.1.0,<10
 - fsspec>=0.6.0
 - gcc_linux-64=11.*
-- gmock==1.10.0.*
-- gtest==1.10.0.*
+- gmock==1.13.0.*
+- gtest==1.13.0.*
 - hypothesis
 - ipython
 - libarrow==11.0.0.*

--- a/conda/recipes/libcudf/conda_build_config.yaml
+++ b/conda/recipes/libcudf/conda_build_config.yaml
@@ -14,7 +14,7 @@ cmake_version:
   - ">=3.23.1,!=3.25.0"
 
 gtest_version:
-  - "=1.13.0"
+  - ">=1.13.0"
 
 libarrow_version:
   - "=11"

--- a/conda/recipes/libcudf/conda_build_config.yaml
+++ b/conda/recipes/libcudf/conda_build_config.yaml
@@ -14,7 +14,7 @@ cmake_version:
   - ">=3.23.1,!=3.25.0"
 
 gtest_version:
-  - "=1.10.0"
+  - "=1.13.0"
 
 libarrow_version:
   - "=11"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -212,8 +212,8 @@ dependencies:
       - output_types: conda
         packages:
           - fmt>=9.1.0,<10
-          - &gtest gtest==1.10.0.*
-          - &gmock gmock==1.10.0.*
+          - &gtest gtest==1.13.0.*
+          - &gmock gmock==1.13.0.*
           # Hard pin the patch version used during the build. This must be kept
           # in sync with the version pinned in get_arrow.cmake.
           - libarrow==11.0.0.*

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -212,8 +212,8 @@ dependencies:
       - output_types: conda
         packages:
           - fmt>=9.1.0,<10
-          - &gtest gtest==1.13.0.*
-          - &gmock gmock==1.13.0.*
+          - &gtest gtest>=1.13.0.*
+          - &gmock gmock>=1.13.0.*
           # Hard pin the patch version used during the build. This must be kept
           # in sync with the version pinned in get_arrow.cmake.
           - libarrow==11.0.0.*


### PR DESCRIPTION
## Description
Since rapids-cmake will now pull GTest 1.13, update cudf recipes so we don't get two versions of GTest installed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
