### PR TITLE
Add [[maybe_unused]] to nvbench environment.

### DIFF
--- a/cpp/cmake/thirdparty/patches/nvbench_global_setup.diff
+++ b/cpp/cmake/thirdparty/patches/nvbench_global_setup.diff
@@ -21,7 +21,7 @@ index 0ba82d7..7ab02c1 100644
      printer.set_total_state_count(total_states);                                                   \
                                                                                                     \
      printer.set_completed_state_count(0);                                                          \
-+    auto env_state = NVBENCH_ENVIRONMENT();                                                        \
++    [[maybe_unused]] auto env_state = NVBENCH_ENVIRONMENT();                                       \
      for (auto &bench_ptr : benchmarks)                                                             \
      {                                                                                              \
        bench_ptr->set_printer(printer);                                                             \


### PR DESCRIPTION
## Description
Fixes a build warning encountered by @nvdbaranec.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
