### PR TITLE
Fix structs_column_wrapper ctors to copy input column wrappers

### DIFF
--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -1807,7 +1807,9 @@ class structs_column_wrapper : public detail::column_wrapper {
     std::transform(child_column_wrappers.begin(),
                    child_column_wrappers.end(),
                    std::back_inserter(child_columns),
-                   [&](auto column_wrapper) { return column_wrapper.get().release(); });
+                   [&](auto const& column_wrapper) {
+                     return std::make_unique<cudf::column>(column_wrapper.get());
+                   });
     init(std::move(child_columns), validity);
   }
 
@@ -1841,7 +1843,9 @@ class structs_column_wrapper : public detail::column_wrapper {
     std::transform(child_column_wrappers.begin(),
                    child_column_wrappers.end(),
                    std::back_inserter(child_columns),
-                   [&](auto column_wrapper) { return column_wrapper.get().release(); });
+                   [&](auto const& column_wrapper) {
+                     return std::make_unique<cudf::column>(column_wrapper.get());
+                   });
     init(std::move(child_columns), validity_iter);
   }
 


### PR DESCRIPTION
## Description

Fixes the `cudf::test::structs_column_wrapper` constructors that accept `column_wrapper` instances to copy the underlying column rather than move it. The constructor signatures do not provide any indication that the passed wrappers will be destroyed. Also, the other nested column wrapper constructors make copies unless the parameters are decorated with move declarations (i.e. `&&`). 

Closes #13200

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
