### PR TITLE
Allow empty input table in ast `compute_column`

### DIFF
--- a/cpp/src/transform/compute_column.cu
+++ b/cpp/src/transform/compute_column.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,6 +97,7 @@ std::unique_ptr<column> compute_column(table_view const& table,
 
   auto output_column = cudf::make_fixed_width_column(
     parser.output_type(), table.num_rows(), output_column_mask_state, stream, mr);
+  if (table.num_rows() == 0) { return output_column; }
   auto mutable_output_device =
     cudf::mutable_column_device_view::create(output_column->mutable_view(), stream);
 

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -110,6 +110,22 @@ TEST_F(TransformTest, BasicAddition)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
 }
 
+TEST_F(TransformTest, BasicAdditionEmptyTable)
+{
+  auto c_0   = column_wrapper<int32_t>{};
+  auto c_1   = column_wrapper<int32_t>{};
+  auto table = cudf::table_view{{c_0, c_1}};
+
+  auto col_ref_0  = cudf::ast::column_reference(0);
+  auto col_ref_1  = cudf::ast::column_reference(1);
+  auto expression = cudf::ast::operation(cudf::ast::ast_operator::ADD, col_ref_0, col_ref_1);
+
+  auto expected = column_wrapper<int32_t>{};
+  auto result   = cudf::compute_column(table, expression);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
+}
+
 TEST_F(TransformTest, BasicAdditionCast)
 {
   auto c_0   = column_wrapper<int64_t>{3, 20, 1, 50};

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -9757,9 +9757,19 @@ def test_empty_numeric_only(data):
     assert_eq(expected, actual)
 
 
-@pytest.fixture
-def df_eval():
-    N = 10
+@pytest.fixture(params=[0, 10], ids=["empty", "10"])
+def df_eval(request):
+    N = request.param
+    if N == 0:
+        value = np.zeros(0, dtype="int")
+        return cudf.DataFrame(
+            {
+                "a": value,
+                "b": value,
+                "c": value,
+                "d": value,
+            }
+        )
     int_max = 10
     rng = cupy.random.default_rng(0)
     return cudf.DataFrame(


### PR DESCRIPTION
## Description

If the input table is empty we can still produce an output of
appropriate type by letting the parser run and inferring types.
In this case though, we do not want to actually run a kernel,
since we would try and launch with zero blocks which is not
allowed.

Closes #13236.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
