### PR TITLE
Batched allocations for device reads of parquet files

### DIFF
--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -289,7 +289,8 @@ template <typename T = uint8_t>
   }();
 
   auto compressed_buffer = [&]() {
-    return compressed_read_size > 0 ? rmm::device_buffer(compressed_read_size, stream) : rmm::device_buffer(0, stream);
+    return compressed_read_size > 0 ? rmm::device_buffer(compressed_read_size, stream)
+                                    : rmm::device_buffer(0, stream);
   }();
 
   auto compressed_buffer_data   = static_cast<uint8_t*>(compressed_buffer.data());
@@ -301,9 +302,6 @@ template <typename T = uint8_t>
     page_data.emplace_back(datasource::buffer::create(std::move(uncompressed_buffer)));
   }
 
-  size_t compressed_done   = 0;
-  size_t uncompressed_done = 0;
-
   // queue reads
   for (auto const& r : reads) {
     auto d_compdata = [&]() -> const uint8_t* {
@@ -314,10 +312,8 @@ template <typename T = uint8_t>
         read_tasks.emplace_back(std::move(fut_read_size));
         if (r.compressed) {
           compressed_buffer_data += r.io_size;
-          compressed_done += r.io_size;
         } else {
           uncompressed_buffer_data += r.io_size;
-          uncompressed_done += r.io_size;
         }
         return ptr;
       } else {

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -283,15 +283,9 @@ template <typename T = uint8_t>
     chunk = next_chunk;
   }
 
-  auto uncompressed_buffer = [&]() {
-    return uncompressed_read_size > 0 ? rmm::device_buffer(uncompressed_read_size, stream)
-                                      : rmm::device_buffer(0, stream);
-  }();
+  auto uncompressed_buffer = rmm::device_buffer(uncompressed_read_size, stream);
 
-  auto compressed_buffer = [&]() {
-    return compressed_read_size > 0 ? rmm::device_buffer(compressed_read_size, stream)
-                                    : rmm::device_buffer(0, stream);
-  }();
+  auto compressed_buffer = rmm::device_buffer(compressed_read_size, stream);
 
   auto compressed_buffer_data   = static_cast<uint8_t*>(compressed_buffer.data());
   auto uncompressed_buffer_data = static_cast<uint8_t*>(uncompressed_buffer.data());


### PR DESCRIPTION
## Description
I noticed while profiling that parquet compressed reads result in quite a few allocations due to compression boundaries. When compression is desired, the cudf parquet writer will not write a block as compressed if it doesn't compress to a smaller size. Interestingly, this occurs frequently in our benchmarks and tests. Each red block is a memcpy in parquet read which is broken on these boundaries.

![image](https://user-images.githubusercontent.com/3506308/235567638-9b54d21b-88c7-4790-a24d-7db643a4c416.png)

As part of the pipeline work, I attempted an optimization to these allocations by batching them into a single allocation for compressed data and one for uncompressed data. The difference is due to the free for compressed data after it is decompressed. This improves baseline and the pipeline changes equally so it seemed something worth adding. Benchmark results seem to agree:

```
# parquet_read_decode

## [0] Quadro RTX 6000

|  data_type  |      io       |  cardinality  |  run_length  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |          Diff |   %Diff |  Status  |
|-------------|---------------|---------------|--------------|------------|-------------|------------|-------------|---------------|---------|----------|
|  INTEGRAL   | DEVICE_BUFFER |       0       |      1       |  56.010 ms |       0.10% |  47.278 ms |       0.17% |  -8731.973 us | -15.59% |   FAIL   |
|  INTEGRAL   | DEVICE_BUFFER |     1000      |      1       |  45.559 ms |       3.18% |  39.932 ms |       3.43% |  -5627.040 us | -12.35% |   FAIL   |
|  INTEGRAL   | DEVICE_BUFFER |       0       |      32      |  36.395 ms |       0.12% |  34.462 ms |       0.17% |  -1933.081 us |  -5.31% |   FAIL   |
|  INTEGRAL   | DEVICE_BUFFER |     1000      |      32      |  34.194 ms |       0.12% |  33.935 ms |       0.11% |   -258.860 us |  -0.76% |   FAIL   |
|    FLOAT    | DEVICE_BUFFER |       0       |      1       |  37.989 ms |       0.10% |  38.093 ms |       0.27% |    103.950 us |   0.27% |   FAIL   |
|    FLOAT    | DEVICE_BUFFER |     1000      |      1       |  32.307 ms |       0.13% |  30.364 ms |       0.25% |  -1942.460 us |  -6.01% |   FAIL   |
|    FLOAT    | DEVICE_BUFFER |       0       |      32      |  26.307 ms |       0.32% |  26.258 ms |       0.14% |    -48.421 us |  -0.18% |   FAIL   |
|    FLOAT    | DEVICE_BUFFER |     1000      |      32      |  26.498 ms |       0.08% |  26.617 ms |       0.17% |    119.089 us |   0.45% |   FAIL   |
|   DECIMAL   | DEVICE_BUFFER |       0       |      1       |  76.804 ms |       0.11% |  59.495 ms |       0.10% | -17309.463 us | -22.54% |   FAIL   |
|   DECIMAL   | DEVICE_BUFFER |     1000      |      1       |  32.414 ms |       0.27% |  29.245 ms |       0.26% |  -3168.500 us |  -9.78% |   FAIL   |
|   DECIMAL   | DEVICE_BUFFER |       0       |      32      |  29.741 ms |       2.89% |  28.007 ms |       0.50% |  -1733.407 us |  -5.83% |   FAIL   |
|   DECIMAL   | DEVICE_BUFFER |     1000      |      32      |  24.749 ms |       0.50% |  24.583 ms |       0.19% |   -165.979 us |  -0.67% |   FAIL   |
|  TIMESTAMP  | DEVICE_BUFFER |       0       |      1       |  72.163 ms |       0.20% |  63.764 ms |       0.22% |  -8399.110 us | -11.64% |   FAIL   |
|  TIMESTAMP  | DEVICE_BUFFER |     1000      |      1       |  32.680 ms |       2.94% |  29.797 ms |       0.14% |  -2882.649 us |  -8.82% |   FAIL   |
|  TIMESTAMP  | DEVICE_BUFFER |       0       |      32      |  30.863 ms |       0.37% |  29.706 ms |       4.06% |  -1156.692 us |  -3.75% |   FAIL   |
|  TIMESTAMP  | DEVICE_BUFFER |     1000      |      32      |  26.213 ms |       0.40% |  26.063 ms |       0.16% |   -149.889 us |  -0.57% |   FAIL   |
|  DURATION   | DEVICE_BUFFER |       0       |      1       |  48.992 ms |       0.25% |  41.513 ms |       0.14% |  -7479.005 us | -15.27% |   FAIL   |
|  DURATION   | DEVICE_BUFFER |     1000      |      1       |  31.616 ms |       0.29% |  30.049 ms |       0.23% |  -1567.287 us |  -4.96% |   FAIL   |
|  DURATION   | DEVICE_BUFFER |       0       |      32      |  28.911 ms |       0.17% |  27.876 ms |       0.22% |  -1035.533 us |  -3.58% |   FAIL   |
|  DURATION   | DEVICE_BUFFER |     1000      |      32      |  26.970 ms |       0.50% |  26.875 ms |       0.30% |    -95.557 us |  -0.35% |   FAIL   |
|   STRING    | DEVICE_BUFFER |       0       |      1       | 120.749 ms |       0.14% | 131.004 ms |       0.48% |     10.255 ms |   8.49% |   FAIL   |
|   STRING    | DEVICE_BUFFER |     1000      |      1       |  65.865 ms |       0.10% |  65.847 ms |       0.09% |    -17.882 us |  -0.03% |   PASS   |
|   STRING    | DEVICE_BUFFER |       0       |      32      | 120.238 ms |       0.06% | 130.616 ms |       0.22% |     10.378 ms |   8.63% |   FAIL   |
|   STRING    | DEVICE_BUFFER |     1000      |      32      |  61.847 ms |       0.12% |  61.927 ms |       0.32% |     79.908 us |   0.13% |   FAIL   |
|    LIST     | DEVICE_BUFFER |       0       |      1       | 139.698 ms |       0.48% | 147.797 ms |       0.08% |      8.099 ms |   5.80% |   FAIL   |
|    LIST     | DEVICE_BUFFER |     1000      |      1       | 128.197 ms |       0.23% | 131.158 ms |       0.44% |      2.961 ms |   2.31% |   FAIL   |
|    LIST     | DEVICE_BUFFER |       0       |      32      | 111.946 ms |       0.44% | 112.171 ms |       0.50% |    225.020 us |   0.20% |   PASS   |
|    LIST     | DEVICE_BUFFER |     1000      |      32      | 112.450 ms |       0.47% | 112.391 ms |       0.29% |    -59.294 us |  -0.05% |   PASS   |
|   STRUCT    | DEVICE_BUFFER |       0       |      1       | 163.747 ms |       0.49% | 158.659 ms |       0.47% |  -5088.401 us |  -3.11% |   FAIL   |
|   STRUCT    | DEVICE_BUFFER |     1000      |      1       | 112.440 ms |       0.18% | 113.153 ms |       0.12% |    712.775 us |   0.63% |   FAIL   |
|   STRUCT    | DEVICE_BUFFER |       0       |      32      | 147.105 ms |       0.34% | 153.885 ms |       0.39% |      6.780 ms |   4.61% |   FAIL   |
|   STRUCT    | DEVICE_BUFFER |     1000      |      32      | 106.359 ms |       0.83% | 106.465 ms |       0.80% |    105.600 us |   0.10% |   PASS   |

# parquet_read_io_compression

## [0] Quadro RTX 6000

|      io       |  compression  |  cardinality  |  run_length  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |         Diff |   %Diff |  Status  |
|---------------|---------------|---------------|--------------|------------|-------------|------------|-------------|--------------|---------|----------|
|   FILEPATH    |    SNAPPY     |       0       |      1       |    1.947 s |       0.67% |    1.945 s |       0.38% | -2271.875 us |  -0.12% |   PASS   |
|   FILEPATH    |    SNAPPY     |     1000      |      1       |    1.811 s |       0.14% |    1.810 s |       0.35% | -1717.017 us |  -0.09% |   PASS   |
|   FILEPATH    |    SNAPPY     |       0       |      32      |    1.506 s |       0.43% |    1.506 s |       0.33% |   732.568 us |   0.05% |   PASS   |
|   FILEPATH    |    SNAPPY     |     1000      |      32      |    1.515 s |       0.47% |    1.517 s |       0.43% |     2.007 ms |   0.13% |   PASS   |
|   FILEPATH    |     NONE      |       0       |      1       |    1.723 s |       0.36% |    1.730 s |       0.27% |     7.329 ms |   0.43% |   FAIL   |
|   FILEPATH    |     NONE      |     1000      |      1       |    1.711 s |       0.37% |    1.711 s |       0.25% |   242.700 us |   0.01% |   PASS   |
|   FILEPATH    |     NONE      |       0       |      32      |    1.479 s |       0.27% |    1.477 s |       0.40% | -2368.286 us |  -0.16% |   PASS   |
|   FILEPATH    |     NONE      |     1000      |      32      |    1.458 s |       0.12% |    1.452 s |       0.49% | -5574.878 us |  -0.38% |   FAIL   |
|  HOST_BUFFER  |    SNAPPY     |       0       |      1       |    1.901 s |       0.10% |    1.903 s |       0.15% |     2.791 ms |   0.15% |   FAIL   |
|  HOST_BUFFER  |    SNAPPY     |     1000      |      1       |    1.792 s |       0.08% |    1.791 s |       0.17% |  -611.646 us |  -0.03% |   PASS   |
|  HOST_BUFFER  |    SNAPPY     |       0       |      32      |    1.501 s |       0.52% |    1.500 s |       0.34% |  -959.460 us |  -0.06% |   PASS   |
|  HOST_BUFFER  |    SNAPPY     |     1000      |      32      |    1.512 s |       0.36% |    1.515 s |       0.19% |     3.274 ms |   0.22% |   FAIL   |
|  HOST_BUFFER  |     NONE      |       0       |      1       |    1.673 s |       0.10% |    1.673 s |       0.11% |   725.659 us |   0.04% |   PASS   |
|  HOST_BUFFER  |     NONE      |     1000      |      1       |    1.689 s |       0.28% |    1.690 s |       0.21% |     1.425 ms |   0.08% |   PASS   |
|  HOST_BUFFER  |     NONE      |       0       |      32      |    1.470 s |       0.08% |    1.466 s |       0.29% | -4066.968 us |  -0.28% |   FAIL   |
|  HOST_BUFFER  |     NONE      |     1000      |      32      |    1.453 s |       0.12% |    1.448 s |       0.45% | -5403.125 us |  -0.37% |   FAIL   |
| DEVICE_BUFFER |    SNAPPY     |       0       |      1       |    1.839 s |       0.20% |    1.835 s |       0.13% | -4403.003 us |  -0.24% |   FAIL   |
| DEVICE_BUFFER |    SNAPPY     |     1000      |      1       |    1.769 s |       0.32% |    1.768 s |       0.32% | -1386.816 us |  -0.08% |   PASS   |
| DEVICE_BUFFER |    SNAPPY     |       0       |      32      |    1.491 s |       0.25% |    1.492 s |       0.36% |   717.676 us |   0.05% |   PASS   |
| DEVICE_BUFFER |    SNAPPY     |     1000      |      32      |    1.507 s |       0.40% |    1.510 s |       0.45% |     3.504 ms |   0.23% |   PASS   |
| DEVICE_BUFFER |     NONE      |       0       |      1       |    1.614 s |       0.10% |    1.614 s |       0.09% |   144.263 us |   0.01% |   PASS   |
| DEVICE_BUFFER |     NONE      |     1000      |      1       |    1.664 s |       0.34% |    1.672 s |       0.08% |     7.593 ms |   0.46% |   FAIL   |
| DEVICE_BUFFER |     NONE      |       0       |      32      |    1.457 s |       0.46% |    1.458 s |       0.44% |     1.292 ms |   0.09% |   PASS   |
| DEVICE_BUFFER |     NONE      |     1000      |      32      |    1.445 s |       0.44% |    1.444 s |       0.20% |  -668.286 us |  -0.05% |   PASS   |

# parquet_read_column_selection

# parquet_read_misc_options

# Summary

- Total Matches: 56
  - Pass    (diff <= min_noise): 20
  - Unknown (infinite noise):    0
  - Failure (diff > min_noise):  36
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
