### PR TITLE
Throw error if UNITIALIZED is passed to cudf::state_null_count

### DIFF
--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -36,6 +36,8 @@ namespace cudf {
  * @brief Returns the null count for a null mask of the specified `state`
  * representing `size` elements.
  *
+ * @throw std::invalid_argument if state is UNINITIALIZED
+ *
  * @param state The state of the null mask
  * @param size The number of elements represented by the mask
  * @return The count of null elements

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,10 +50,9 @@ size_type state_null_count(mask_state state, size_type size)
 {
   switch (state) {
     case mask_state::UNALLOCATED: return 0;
-    case mask_state::UNINITIALIZED: return UNKNOWN_NULL_COUNT;
     case mask_state::ALL_NULL: return size;
     case mask_state::ALL_VALID: return 0;
-    default: CUDF_FAIL("Invalid null mask state.");
+    default: CUDF_FAIL("Invalid null mask state.", std::invalid_argument);
   }
 }
 

--- a/cpp/src/column/column_factories.cpp
+++ b/cpp/src/column/column_factories.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,12 +81,13 @@ std::unique_ptr<column> make_numeric_column(data_type type,
   CUDF_EXPECTS(is_numeric(type), "Invalid, non-numeric type.");
   CUDF_EXPECTS(size >= 0, "Column size cannot be negative.");
 
-  return std::make_unique<column>(type,
-                                  size,
-                                  rmm::device_buffer{size * cudf::size_of(type), stream, mr},
-                                  detail::create_null_mask(size, state, stream, mr),
-                                  state_null_count(state, size),
-                                  std::vector<std::unique_ptr<column>>{});
+  return std::make_unique<column>(
+    type,
+    size,
+    rmm::device_buffer{size * cudf::size_of(type), stream, mr},
+    detail::create_null_mask(size, state, stream, mr),
+    state == mask_state::UNINITIALIZED ? 0 : state_null_count(state, size),
+    std::vector<std::unique_ptr<column>>{});
 }
 
 // Allocate storage for a specified number of numeric elements
@@ -100,12 +101,13 @@ std::unique_ptr<column> make_fixed_point_column(data_type type,
   CUDF_EXPECTS(is_fixed_point(type), "Invalid, non-fixed_point type.");
   CUDF_EXPECTS(size >= 0, "Column size cannot be negative.");
 
-  return std::make_unique<column>(type,
-                                  size,
-                                  rmm::device_buffer{size * cudf::size_of(type), stream, mr},
-                                  detail::create_null_mask(size, state, stream, mr),
-                                  state_null_count(state, size),
-                                  std::vector<std::unique_ptr<column>>{});
+  return std::make_unique<column>(
+    type,
+    size,
+    rmm::device_buffer{size * cudf::size_of(type), stream, mr},
+    detail::create_null_mask(size, state, stream, mr),
+    state == mask_state::UNINITIALIZED ? 0 : state_null_count(state, size),
+    std::vector<std::unique_ptr<column>>{});
 }
 
 // Allocate storage for a specified number of timestamp elements
@@ -119,12 +121,13 @@ std::unique_ptr<column> make_timestamp_column(data_type type,
   CUDF_EXPECTS(is_timestamp(type), "Invalid, non-timestamp type.");
   CUDF_EXPECTS(size >= 0, "Column size cannot be negative.");
 
-  return std::make_unique<column>(type,
-                                  size,
-                                  rmm::device_buffer{size * cudf::size_of(type), stream, mr},
-                                  detail::create_null_mask(size, state, stream, mr),
-                                  state_null_count(state, size),
-                                  std::vector<std::unique_ptr<column>>{});
+  return std::make_unique<column>(
+    type,
+    size,
+    rmm::device_buffer{size * cudf::size_of(type), stream, mr},
+    detail::create_null_mask(size, state, stream, mr),
+    state == mask_state::UNINITIALIZED ? 0 : state_null_count(state, size),
+    std::vector<std::unique_ptr<column>>{});
 }
 
 // Allocate storage for a specified number of duration elements
@@ -138,12 +141,13 @@ std::unique_ptr<column> make_duration_column(data_type type,
   CUDF_EXPECTS(is_duration(type), "Invalid, non-duration type.");
   CUDF_EXPECTS(size >= 0, "Column size cannot be negative.");
 
-  return std::make_unique<column>(type,
-                                  size,
-                                  rmm::device_buffer{size * cudf::size_of(type), stream, mr},
-                                  detail::create_null_mask(size, state, stream, mr),
-                                  state_null_count(state, size),
-                                  std::vector<std::unique_ptr<column>>{});
+  return std::make_unique<column>(
+    type,
+    size,
+    rmm::device_buffer{size * cudf::size_of(type), stream, mr},
+    detail::create_null_mask(size, state, stream, mr),
+    state == mask_state::UNINITIALIZED ? 0 : state_null_count(state, size),
+    std::vector<std::unique_ptr<column>>{});
 }
 
 // Allocate storage for a specified number of fixed width elements

--- a/cpp/src/copying/copy.cpp
+++ b/cpp/src/copying/copy.cpp
@@ -129,7 +129,7 @@ std::unique_ptr<column> allocate_like(column_view const& input,
                                   size,
                                   rmm::device_buffer(size * size_of(input.type()), stream, mr),
                                   detail::create_null_mask(size, allocate_mask, stream, mr),
-                                  state_null_count(allocate_mask, input.size()));
+                                  0);
 }
 
 }  // namespace detail

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -37,6 +37,7 @@ TEST_F(BitmaskUtilitiesTest, StateNullCount)
   EXPECT_EQ(0, cudf::state_null_count(cudf::mask_state::UNALLOCATED, 42));
   EXPECT_EQ(42, cudf::state_null_count(cudf::mask_state::ALL_NULL, 42));
   EXPECT_EQ(0, cudf::state_null_count(cudf::mask_state::ALL_VALID, 42));
+  EXPECT_THROW(cudf::state_null_count(cudf::mask_state::UNINITIALIZED, 42), std::invalid_argument);
 }
 
 TEST_F(BitmaskUtilitiesTest, BitmaskAllocationSize)


### PR DESCRIPTION
## Description
Changes `cudf::state_null_count` to throw a `std::invalid_argument` error which `mask_state::UNINITIALIZED` is passed. This change is part of removing `UNKNOWN_NULL_COUNT` from cudf/libcudf.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
