### PR TITLE
Workaround nvcc atomic bug in pre-12 compilers

### DIFF
--- a/cpp/cmake/Modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/Modules/ConfigureCUDA.cmake
@@ -31,6 +31,8 @@ if(DISABLE_DEPRECATION_WARNINGS)
   list(APPEND CUDF_CUDA_FLAGS -Xcompiler=-Wno-deprecated-declarations)
 endif()
 
+list(APPEND CUDF_CUDA_FLAGS -Xcicc --Xllc,-nv-disable-new-remat=1)
+
 # make sure we produce smallest binary size
 list(APPEND CUDF_CUDA_FLAGS -Xfatbin=-compress-all)
 


### PR DESCRIPTION
## Description

For benchmarking purposes at the moment.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
