### PR TITLE
Simplify null count checking in column equality comparator

### DIFF
--- a/cpp/tests/copying/get_value_tests.cpp
+++ b/cpp/tests/copying/get_value_tests.cpp
@@ -756,7 +756,7 @@ TYPED_TEST(ListGetStructValueTest, NestedGetNonNullEmpty)
     this->make_test_lists_column(3, {0, 1, 1, 2}, std::move(list_column), {1, 1, 1});
 
   auto expected_data =
-    this->make_test_lists_column(0, {0}, this->zero_length_struct().release(), {1});
+    this->make_test_lists_column(0, {0}, this->zero_length_struct().release(), {});
 
   cudf::size_type index = 1;
   auto s                = cudf::get_element(list_column_nested->view(), index);

--- a/cpp/tests/copying/segmented_gather_list_tests.cpp
+++ b/cpp/tests/copying/segmented_gather_list_tests.cpp
@@ -301,27 +301,6 @@ TYPED_TEST(SegmentedGatherTest, GatherNegatives)
   }
 }
 
-TYPED_TEST(SegmentedGatherTest, GatherOnNonCompactedNullLists)
-{
-  using T          = TypeParam;
-  auto constexpr X = -1;  // Signifies null value.
-
-  // List<T>
-  auto list = LCW<T>{{{1, 2, 3, 4}, {5}, {6, 7}, {8, 9, 0}, {}, {1, 2}, {3, 4, 5}}, no_nulls()};
-  auto const input = list.release();
-
-  // Set non-empty list row at index 5 to null.
-  cudf::detail::set_null_mask(
-    input->mutable_view().null_mask(), 5, 6, false, cudf::get_default_stream());
-
-  auto const gather_map = LCW<int>{{-1, 2, 1, -4}, {0}, {-2, 1}, {0, 2, 1}, {}, {0}, {1, 2}};
-  auto const expected =
-    LCW<T>{{{4, 3, 2, 1}, {5}, {6, 7}, {8, 0, 9}, {}, {{X}, all_nulls()}, {4, 5}}, null_at(5)};
-  auto const results = cudf::lists::segmented_gather(cudf::lists_column_view{*input},
-                                                     cudf::lists_column_view{gather_map});
-  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->view(), expected);
-}
-
 TYPED_TEST(SegmentedGatherTest, GatherNestedNulls)
 {
   using T = TypeParam;

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -1950,11 +1950,11 @@ TEST_F(ContiguousSplitTableCornerCases, PreSplitTable)
 
   using LCW = cudf::test::lists_column_wrapper<int>;
 
-  cudf::test::lists_column_wrapper<int> col0{{{{1, 2, 3}, valids}, {4, 5}},
+  cudf::test::lists_column_wrapper<int> col0{{{1, 2, 3}, {4, 5}},
                                              {{LCW{}, LCW{}, {7, 8}, LCW{}}, valids},
                                              {{{6}}},
-                                             {{{7, 8}, {{9, 10, 11}, valids}, LCW{}}, valids},
-                                             {{LCW{}, {-1, -2, -3, -4, -5}}, valids},
+                                             {{{7, 8}, LCW{}, {{9, 10, 11}, valids}}, valids},
+                                             {{{-1, -2, -3, -4, -5}, LCW{}}, valids},
                                              {LCW{}},
                                              {{-10}, {-100, -200}}};
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR removes an extra code path used for checking the equality of the null count when verifying if columns are equivalent (not equal). The purpose of this code path was to verify a specific definition of equivalence for columns containing unsanitized nulls, i.e. by ignoring the stored null count and directly verifying the validity of the underlying null mask. This is no longer necessary because we required sanitized null masks to be output from all libcudf APIs now (see the "libcudf expects nested types to have sanitized null masks" section in the [developer guide](https://docs.rapids.ai/api/libcudf/stable/developer_guide)), and this requirement will be enforced with the merge of #14559.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
