### PR TITLE
[Java] Purge non-empty nulls when setting validity 

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -821,8 +821,6 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @param mergeOp binary operator (BITWISE_AND and BITWISE_OR only)
    * @param columns array of columns whose null masks are merged, must have identical number of rows.
    * @return the new ColumnVector with merged null mask.
-   * @throws IllegalStateException if existing nulls are set to valid data in the validity buffer
-   *
    */
   public final ColumnVector mergeAndSetValidity(BinaryOp mergeOp, ColumnView... columns) {
     assert mergeOp == BinaryOp.BITWISE_AND || mergeOp == BinaryOp.BITWISE_OR : "Only BITWISE_AND and BITWISE_OR supported right now";

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -33,7 +33,6 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   static {
     NativeDepsLoader.loadNativeDeps();
   }
-  private static boolean IF_ELSE = Boolean.getBoolean("ai.rapids.cudf.test.ifelse");
 
   public static final long UNKNOWN_NULL_COUNT = -1;
 
@@ -815,47 +814,6 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   /**
-   * Create a deep copy of the column while replacing the validity mask. The resultant validity mask
-   * is the bitwise merge of the validity masks in the columns given as arguments. Validity mask is true
-   * when data is not null and false when it's null.
-   *
-   * The result will be sanitized to not contain any non-empty nulls in case of nested types
-   *
-   * @param mergeOp binary operator (BITWISE_AND and BITWISE_OR only)
-   * @param columns array of columns whose null masks are merged, must have identical number of rows.
-   * @return the new ColumnVector with merged null mask.
-   * @throws IllegalStateException if existing nulls are set to valid data in the validity buffer
-   *
-   */
-  public final ColumnVector mergeAndSetValidityUsingIfElse(BinaryOp mergeOp, ColumnView... columns) {
-    System.out.println("************ if else *******");
-    assert mergeOp == BinaryOp.BITWISE_AND || mergeOp == BinaryOp.BITWISE_OR : "Only BITWISE_AND and BITWISE_OR supported right now";
-
-    if (columns.length == 0) {
-      return copyToColumnVector();
-    }
-
-    ColumnVector shouldNotBeNull = columns[0].isNotNull();
-    try {
-      for (int i = 1; i < columns.length; i++) {
-        try (ColumnVector tmp = columns[i].isNotNull();
-             ColumnVector toClose = shouldNotBeNull) {
-          shouldNotBeNull = toClose.binaryOp(mergeOp, tmp, DType.BOOL8);
-        }
-      }
-
-      // Now make sure the original nulls are kept
-      try (ColumnVector originalIsNotNull = isNotNull();
-           ColumnVector finalShouldNotBeNull = shouldNotBeNull.and(originalIsNotNull);
-           Scalar nullScalar = Scalar.fromNull(this.getType())) {
-        return finalShouldNotBeNull.ifElse(this, nullScalar);
-      }
-    } finally {
-      shouldNotBeNull.close();
-    }
-  }
-
-  /**
    * Create a deep copy of the column while replacing the null mask. The resultant null mask is the
    * bitwise merge of null masks in the columns given as arguments.
    * The result will be sanitized to not contain any non-empty nulls in case of nested types
@@ -867,14 +825,6 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    *
    */
   public final ColumnVector mergeAndSetValidity(BinaryOp mergeOp, ColumnView... columns) {
-    if (IF_ELSE) {
-      return mergeAndSetValidityUsingIfElse(mergeOp, columns);
-    } else {
-      return mergeAndSetValidityOld(mergeOp, columns);
-    }
-  }
-
-  public final ColumnVector mergeAndSetValidityOld(BinaryOp mergeOp, ColumnView... columns) {
     assert mergeOp == BinaryOp.BITWISE_AND || mergeOp == BinaryOp.BITWISE_OR : "Only BITWISE_AND and BITWISE_OR supported right now";
     long[] columnViews = new long[columns.length];
     long size = getRowCount();
@@ -885,25 +835,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
       columnViews[i] = columns[i].getNativeView();
     }
 
-    ColumnVector potentialRes = new ColumnVector(bitwiseMergeAndSetValidity(getNativeView(), columnViews, mergeOp.nativeId));
-
-    /**
-     * We need to sanitize the vector to make sure nulls in 'this' stay nulls otherwise bad things
-     * will happen
-     */
-    // Verify the nulls in the original vector remain null
-    if (getNullCount() > 0) {
-      try (ColumnVector isNull = isNull();
-           ColumnVector resultNulls = potentialRes.isNull();
-           ColumnVector resultAndOrigNulls = resultNulls.and(isNull);
-           ColumnVector equal = isNull.equalTo(resultAndOrigNulls);
-           Scalar allEqual = equal.all()) {
-        if (allEqual.isValid() && !allEqual.getBoolean()) {
-          throw new IllegalStateException("Setting nulls to valid can result in unintended behavior");
-        }
-      }
-    }
-    return potentialRes;
+    return new ColumnVector(bitwiseMergeAndSetValidity(getNativeView(), columnViews, mergeOp.nativeId));
   }
 
   /**

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1853,6 +1853,11 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
       default: JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Unsupported merge operation", 0);
     }
 
+    auto const copy_cv = copy->view();
+    if (cudf::has_nonempty_nulls(copy_cv)) {
+      copy = cudf::purge_nonempty_nulls(copy_cv);
+    }
+
     return release_as_jlong(copy);
   }
   CATCH_STD(env, 0);

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1840,7 +1840,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
     cudf::binary_operator op = static_cast<cudf::binary_operator>(bin_op);
     switch (op) {
       case cudf::binary_operator::BITWISE_AND: {
-        std::vector<cudf::column_view> cols = n_cudf_columns.get_dereferenced();
+        auto cols = n_cudf_columns.get_dereferenced();
         cols.push_back(copy->view());
         auto table_view = cudf::table_view{cols};
         auto [new_bitmask, null_count] = cudf::bitmask_and(table_view);

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1837,22 +1837,28 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
       return release_as_jlong(copy);
     }
 
-    auto input_table = cudf::table_view{n_cudf_columns.get_dereferenced()};
     cudf::binary_operator op = static_cast<cudf::binary_operator>(bin_op);
     switch (op) {
       case cudf::binary_operator::BITWISE_AND: {
-        auto [new_bitmask, null_count] = cudf::bitmask_and(input_table);
+        std::vector<cudf::column_view> cols = n_cudf_columns.get_dereferenced();
+        cols.push_back(copy->view());
+        auto table_view = cudf::table_view{cols};
+        auto [new_bitmask, null_count] = cudf::bitmask_and(table_view);
         copy->set_null_mask(std::move(new_bitmask), null_count);
         break;
       }
       case cudf::binary_operator::BITWISE_OR: {
-        auto [new_bitmask, null_count] = cudf::bitmask_or(input_table);
+        auto input_table = cudf::table_view{n_cudf_columns.get_dereferenced()};
+        auto [tmp_new_bitmask, tmp_null_count] = cudf::bitmask_or(input_table);
+        copy->set_null_mask(std::move(tmp_new_bitmask), tmp_null_count);
+        // and the bitmask with the original column
+        cudf::table_view table_view{std::vector<cudf::column_view>{copy->view(), *original_column}};
+        auto [new_bitmask, null_count] = cudf::bitmask_and(table_view);
         copy->set_null_mask(std::move(new_bitmask), null_count);
         break;
       }
       default: JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Unsupported merge operation", 0);
     }
-
     auto const copy_cv = copy->view();
     if (cudf::has_nonempty_nulls(copy_cv)) {
       copy = cudf::purge_nonempty_nulls(copy_cv);

--- a/java/src/test/java/ai/rapids/cudf/ColumnViewNonEmptyNullsTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnViewNonEmptyNullsTest.java
@@ -40,10 +40,12 @@ public class ColumnViewNonEmptyNullsTest extends CudfTestBase {
          ColumnVector v1 = ColumnVector.fromBoxedInts(0, 100, 1, 2, Integer.MIN_VALUE, null);
          ColumnVector intResult = v1.mergeAndSetValidity(BinaryOp.BITWISE_AND, v0);
          ColumnVector v2 = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", "3");
+         ColumnVector v3 = v0.mergeAndSetValidity(BinaryOp.BITWISE_AND, v1, v2);
          ColumnVector stringResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_AND, v0, v1);
          ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", null, null, "MIN_VALUE", null);
          ColumnVector noMaskResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_AND)) {
       assertColumnsAreEqual(v0, intResult);
+      assertColumnsAreEqual(v0, v3);
       assertColumnsAreEqual(stringExpected, stringResult);
       assertColumnsAreEqual(v2, noMaskResult);
     }

--- a/java/src/test/java/ai/rapids/cudf/ColumnViewNonEmptyNullsTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnViewNonEmptyNullsTest.java
@@ -41,11 +41,12 @@ public class ColumnViewNonEmptyNullsTest extends CudfTestBase {
          ColumnVector v1 = ColumnVector.fromBoxedInts(0, 100, 1, 2, Integer.MIN_VALUE, null);
          ColumnVector intResult = v1.mergeAndSetValidity(BinaryOp.BITWISE_AND, v0);
          ColumnVector v2 = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", "3");
-         ColumnVector stringResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_AND, v0, v1);
-         ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", null, null, "MIN_VALUE", null)) {
+//         ColumnVector stringResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_AND, v0, v1);
+         ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", null, null, "MIN_VALUE", null);
+         ColumnVector noMaskResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_AND)) {
       assertColumnsAreEqual(v0, intResult);
-      assertColumnsAreEqual(stringExpected, stringResult);
-      assertThrows(IllegalStateException.class, () -> v2.mergeAndSetValidity(BinaryOp.BITWISE_AND));
+//      assertColumnsAreEqual(stringExpected, stringResult);
+      assertColumnsAreEqual(v2, noMaskResult);
     }
   }
 
@@ -66,7 +67,7 @@ public class ColumnViewNonEmptyNullsTest extends CudfTestBase {
       assertColumnsAreEqual(v1, intResultMulti);
       assertColumnsAreEqual(v2, intResultv0v1v2);
       assertColumnsAreEqual(stringExpected, stringResult);
-      assertThrows(IllegalStateException.class, () ->  v3.mergeAndSetValidity(BinaryOp.BITWISE_OR));
+//      assertThrows(IllegalStateException.class, () ->  v3.mergeAndSetValidity(BinaryOp.BITWISE_OR));
     }
   }
 

--- a/java/src/test/java/ai/rapids/cudf/ColumnViewNonEmptyNullsTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnViewNonEmptyNullsTest.java
@@ -41,11 +41,11 @@ public class ColumnViewNonEmptyNullsTest extends CudfTestBase {
          ColumnVector v1 = ColumnVector.fromBoxedInts(0, 100, 1, 2, Integer.MIN_VALUE, null);
          ColumnVector intResult = v1.mergeAndSetValidity(BinaryOp.BITWISE_AND, v0);
          ColumnVector v2 = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", "3");
-//         ColumnVector stringResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_AND, v0, v1);
+         ColumnVector stringResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_AND, v0, v1);
          ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", null, null, "MIN_VALUE", null);
          ColumnVector noMaskResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_AND)) {
       assertColumnsAreEqual(v0, intResult);
-//      assertColumnsAreEqual(stringExpected, stringResult);
+      assertColumnsAreEqual(stringExpected, stringResult);
       assertColumnsAreEqual(v2, noMaskResult);
     }
   }
@@ -61,13 +61,14 @@ public class ColumnViewNonEmptyNullsTest extends CudfTestBase {
          ColumnVector intResultv0v1v2 = v2.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1, v2);
          ColumnVector v3 = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", "3");
          ColumnVector stringResult = v3.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1);
-         ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", null)) {
+         ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", null);
+         ColumnVector noMaskResult = v3.mergeAndSetValidity(BinaryOp.BITWISE_OR)) {
       assertColumnsAreEqual(v0, intResultV0);
       assertColumnsAreEqual(v1, intResultV0V1);
       assertColumnsAreEqual(v1, intResultMulti);
       assertColumnsAreEqual(v2, intResultv0v1v2);
       assertColumnsAreEqual(stringExpected, stringResult);
-//      assertThrows(IllegalStateException.class, () ->  v3.mergeAndSetValidity(BinaryOp.BITWISE_OR));
+      assertColumnsAreEqual(v3, noMaskResult);
     }
   }
 

--- a/java/src/test/java/ai/rapids/cudf/ColumnViewNonEmptyNullsTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnViewNonEmptyNullsTest.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -41,11 +42,10 @@ public class ColumnViewNonEmptyNullsTest extends CudfTestBase {
          ColumnVector intResult = v1.mergeAndSetValidity(BinaryOp.BITWISE_AND, v0);
          ColumnVector v2 = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", "3");
          ColumnVector stringResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_AND, v0, v1);
-         ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", null, null, "MIN_VALUE", null);
-         ColumnVector noMaskResult = v2.mergeAndSetValidity(BinaryOp.BITWISE_AND)) {
+         ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", null, null, "MIN_VALUE", null)) {
       assertColumnsAreEqual(v0, intResult);
       assertColumnsAreEqual(stringExpected, stringResult);
-      assertColumnsAreEqual(v2, noMaskResult);
+      assertThrows(IllegalStateException.class, () -> v2.mergeAndSetValidity(BinaryOp.BITWISE_AND));
     }
   }
 
@@ -60,14 +60,13 @@ public class ColumnViewNonEmptyNullsTest extends CudfTestBase {
          ColumnVector intResultv0v1v2 = v2.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1, v2);
          ColumnVector v3 = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", "3");
          ColumnVector stringResult = v3.mergeAndSetValidity(BinaryOp.BITWISE_OR, v0, v1);
-         ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", null);
-         ColumnVector noMaskResult = v3.mergeAndSetValidity(BinaryOp.BITWISE_OR)) {
+         ColumnVector stringExpected = ColumnVector.fromStrings("0", "100", "1", "2", "MIN_VALUE", null)) {
       assertColumnsAreEqual(v0, intResultV0);
       assertColumnsAreEqual(v1, intResultV0V1);
       assertColumnsAreEqual(v1, intResultMulti);
       assertColumnsAreEqual(v2, intResultv0v1v2);
       assertColumnsAreEqual(stringExpected, stringResult);
-      assertColumnsAreEqual(v3, noMaskResult);
+      assertThrows(IllegalStateException.class, () ->  v3.mergeAndSetValidity(BinaryOp.BITWISE_OR));
     }
   }
 

--- a/java/src/test/java/ai/rapids/cudf/ColumnViewNonEmptyNullsTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnViewNonEmptyNullsTest.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import static ai.rapids.cudf.AssertUtils.assertColumnsAreEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**


### PR DESCRIPTION
## Description
When setting the validity buffer in `mergeAndSetValidity` method, we check to see two things 
1. Purge any non-empty nulls that may have arise due to setting values to null which were previously non-null
2. If we override the existing null values in the validity buffer then throw an IllegalStateException. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
