### PR TITLE
Add move_to function to cudf::string_view iterator

### DIFF
--- a/cpp/include/cudf/strings/string_view.cuh
+++ b/cpp/include/cudf/strings/string_view.cuh
@@ -223,6 +223,13 @@ __device__ inline string_view::const_iterator string_view::const_iterator::opera
   return tmp;
 }
 
+__device__ inline string_view::const_iterator& string_view::const_iterator::move_to(
+  size_type new_pos)
+{
+  *this += (new_pos - char_pos);
+  return *this;
+}
+
 __device__ inline bool string_view::const_iterator::operator==(
   const string_view::const_iterator& rhs) const
 {
@@ -272,7 +279,7 @@ __device__ inline size_type string_view::const_iterator::byte_offset() const { r
 
 __device__ inline string_view::const_iterator string_view::begin() const
 {
-  return const_iterator(*this, 0);
+  return const_iterator(*this, 0, 0);
 }
 
 __device__ inline string_view::const_iterator string_view::end() const

--- a/cpp/include/cudf/strings/string_view.hpp
+++ b/cpp/include/cudf/strings/string_view.hpp
@@ -93,6 +93,7 @@ class string_view {
     __device__ inline const_iterator operator--(int);
     __device__ inline const_iterator& operator-=(difference_type);
     __device__ inline const_iterator operator-(difference_type) const;
+    __device__ inline const_iterator& move_to(size_type);
     __device__ inline bool operator==(const const_iterator&) const;
     __device__ inline bool operator!=(const const_iterator&) const;
     __device__ inline bool operator<(const const_iterator&) const;


### PR DESCRIPTION
## Description
Adds a `move_to()` function the `cudf::string_view::const_iterator` class to help minimize character counting when creating and incrementing the iterator on multi-byte UTF8 characters.
The function simply moves the iterator from the current character position to the given one. This is just a shortcut for the form
```
itr += (new_position - itr.position());
```
This pattern is repeated many times in #13322 and likely future PRs that require the same behavior.
The PR also includes an update to the `string_view::begin()` to set the byte-offset directly rather than waste instructions calculating it.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
