### PR TITLE
Add JNI for ORC/Parquet writer compression statistics

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -894,20 +894,19 @@ public final class Table implements AutoCloseable {
 
   private static native void endWriteCSVToBuffer(long writerHandle);
 
-  private static class CSVTableWriter implements TableWriter {
-    private long writerHandle;
+  private static class CSVTableWriter extends TableWriter {
     private HostBufferConsumer consumer;
 
     private CSVTableWriter(CSVWriterOptions options, HostBufferConsumer consumer) {
-      this.writerHandle = startWriteCSVToBuffer(options.getColumnNames(),
-                                                options.getIncludeHeader(),
-                                                options.getRowDelimiter(),
-                                                options.getFieldDelimiter(),
-                                                options.getNullValue(),
-                                                options.getTrueValue(),
-                                                options.getFalseValue(),
-                                                options.getQuoteStyle().nativeId,
-                                                consumer);
+      super(startWriteCSVToBuffer(options.getColumnNames(),
+          options.getIncludeHeader(),
+          options.getRowDelimiter(),
+          options.getFieldDelimiter(),
+          options.getNullValue(),
+          options.getTrueValue(),
+          options.getFalseValue(),
+          options.getQuoteStyle().nativeId,
+          consumer));
       this.consumer = consumer;
     }
 
@@ -1287,82 +1286,61 @@ public final class Table implements AutoCloseable {
         opts.getDecimal128Columns()));
   }
 
-  private static class ParquetTableWriter implements TableWriter {
-    private long handle;
+  private static class ParquetTableWriter extends TableWriter {
     HostBufferConsumer consumer;
 
     private ParquetTableWriter(ParquetWriterOptions options, File outputFile) {
-      String[] columnNames = options.getFlatColumnNames();
-      boolean[] columnNullabilities = options.getFlatIsNullable();
-      boolean[] timeInt96Values = options.getFlatIsTimeTypeInt96();
-      boolean[] isMapValues = options.getFlatIsMap();
-      boolean[] isBinaryValues = options.getFlatIsBinary();
-      int[] precisions = options.getFlatPrecision();
-      boolean[] hasParquetFieldIds = options.getFlatHasParquetFieldId();
-      int[] parquetFieldIds = options.getFlatParquetFieldId();
-      int[] flatNumChildren = options.getFlatNumChildren();
-
-      this.consumer = null;
-      this.handle = writeParquetFileBegin(columnNames,
+      super(writeParquetFileBegin(options.getFlatColumnNames(),
           options.getTopLevelChildren(),
-          flatNumChildren,
-          columnNullabilities,
+          options.getFlatNumChildren(),
+          options.getFlatIsNullable(),
           options.getMetadataKeys(),
           options.getMetadataValues(),
           options.getCompressionType().nativeId,
           options.getStatisticsFrequency().nativeId,
-          timeInt96Values,
-          precisions,
-          isMapValues,
-          isBinaryValues,
-          hasParquetFieldIds,
-          parquetFieldIds,
-          outputFile.getAbsolutePath());
+          options.getFlatIsTimeTypeInt96(),
+          options.getFlatPrecision(),
+          options.getFlatIsMap(),
+          options.getFlatIsBinary(),
+          options.getFlatHasParquetFieldId(),
+          options.getFlatParquetFieldId(),
+          outputFile.getAbsolutePath()));
+      this.consumer = null;
     }
 
     private ParquetTableWriter(ParquetWriterOptions options, HostBufferConsumer consumer) {
-      String[] columnNames = options.getFlatColumnNames();
-      boolean[] columnNullabilities = options.getFlatIsNullable();
-      boolean[] timeInt96Values = options.getFlatIsTimeTypeInt96();
-      boolean[] isMapValues = options.getFlatIsMap();
-      boolean[] isBinaryValues = options.getFlatIsBinary();
-      int[] precisions = options.getFlatPrecision();
-      boolean[] hasParquetFieldIds = options.getFlatHasParquetFieldId();
-      int[] parquetFieldIds = options.getFlatParquetFieldId();
-      int[] flatNumChildren = options.getFlatNumChildren();
-
-      this.consumer = consumer;
-      this.handle = writeParquetBufferBegin(columnNames,
+      super(writeParquetBufferBegin(options.getFlatColumnNames(),
           options.getTopLevelChildren(),
-          flatNumChildren,
-          columnNullabilities,
+          options.getFlatNumChildren(),
+          options.getFlatIsNullable(),
           options.getMetadataKeys(),
           options.getMetadataValues(),
           options.getCompressionType().nativeId,
           options.getStatisticsFrequency().nativeId,
-          timeInt96Values,
-          precisions,
-          isMapValues,
-          isBinaryValues,
-          hasParquetFieldIds,
-          parquetFieldIds,
-          consumer);
+          options.getFlatIsTimeTypeInt96(),
+          options.getFlatPrecision(),
+          options.getFlatIsMap(),
+          options.getFlatIsBinary(),
+          options.getFlatHasParquetFieldId(),
+          options.getFlatParquetFieldId(),
+          consumer));
+      this.consumer = consumer;
     }
 
     @Override
     public void write(Table table) {
-      if (handle == 0) {
+      if (writerHandle == 0) {
         throw new IllegalStateException("Writer was already closed");
       }
-      writeParquetChunk(handle, table.nativeHandle, table.getDeviceMemorySize());
+      writeParquetChunk(writerHandle, table.nativeHandle, table.getDeviceMemorySize());
     }
 
     @Override
     public void close() throws CudfException {
-      if (handle != 0) {
-        writeParquetEnd(handle);
+      if (writerHandle != 0) {
+        writeParquetEnd(writerHandle);
       }
-      handle = 0;
+      writerHandle = 0;
       if (consumer != null) {
         consumer.done();
         consumer = null;
@@ -1425,19 +1403,18 @@ public final class Table implements AutoCloseable {
         for (ColumnView cv : columnViews) {
           total += cv.getDeviceMemorySize();
         }
-        writeParquetChunk(writer.handle, nativeHandle, total);
+        writeParquetChunk(writer.writerHandle, nativeHandle, total);
       }
     } finally {
       deleteCudfTable(nativeHandle);
     }
   }
 
-  private static class ORCTableWriter implements TableWriter {
-    private long handle;
+  private static class ORCTableWriter extends TableWriter {
     HostBufferConsumer consumer;
 
     private ORCTableWriter(ORCWriterOptions options, File outputFile) {
-      this.handle = writeORCFileBegin(options.getFlatColumnNames(),
+      super(writeORCFileBegin(options.getFlatColumnNames(),
           options.getTopLevelChildren(),
           options.getFlatNumChildren(),
           options.getFlatIsNullable(),
@@ -1446,12 +1423,12 @@ public final class Table implements AutoCloseable {
           options.getCompressionType().nativeId,
           options.getFlatPrecision(),
           options.getFlatIsMap(),
-          outputFile.getAbsolutePath());
+          outputFile.getAbsolutePath()));
       this.consumer = null;
     }
 
     private ORCTableWriter(ORCWriterOptions options, HostBufferConsumer consumer) {
-      this.handle = writeORCBufferBegin(options.getFlatColumnNames(),
+      super(writeORCBufferBegin(options.getFlatColumnNames(),
           options.getTopLevelChildren(),
           options.getFlatNumChildren(),
           options.getFlatIsNullable(),
@@ -1460,24 +1437,24 @@ public final class Table implements AutoCloseable {
           options.getCompressionType().nativeId,
           options.getFlatPrecision(),
           options.getFlatIsMap(),
-          consumer);
+          consumer));
       this.consumer = consumer;
     }
 
     @Override
     public void write(Table table) {
-      if (handle == 0) {
+      if (writerHandle == 0) {
         throw new IllegalStateException("Writer was already closed");
       }
-      writeORCChunk(handle, table.nativeHandle, table.getDeviceMemorySize());
+      writeORCChunk(writerHandle, table.nativeHandle, table.getDeviceMemorySize());
     }
 
     @Override
     public void close() throws CudfException {
-      if (handle != 0) {
-        writeORCEnd(handle);
+      if (writerHandle != 0) {
+        writeORCEnd(writerHandle);
       }
-      handle = 0;
+      writerHandle = 0;
       if (consumer != null) {
         consumer.done();
         consumer = null;
@@ -1506,41 +1483,34 @@ public final class Table implements AutoCloseable {
     return new ORCTableWriter(options, consumer);
   }
 
-  private static class ArrowIPCTableWriter implements TableWriter {
+  private static class ArrowIPCTableWriter extends TableWriter {
     private final ArrowIPCWriterOptions.DoneOnGpu callback;
-    private long handle;
     private HostBufferConsumer consumer;
     private long maxChunkSize;
 
-    private ArrowIPCTableWriter(ArrowIPCWriterOptions options,
-                                File outputFile) {
+    private ArrowIPCTableWriter(ArrowIPCWriterOptions options, File outputFile) {
+      super(writeArrowIPCFileBegin(options.getColumnNames(), outputFile.getAbsolutePath()));
       this.callback = options.getCallback();
       this.consumer = null;
       this.maxChunkSize = options.getMaxChunkSize();
-      this.handle = writeArrowIPCFileBegin(
-              options.getColumnNames(),
-              outputFile.getAbsolutePath());
     }
 
-    private ArrowIPCTableWriter(ArrowIPCWriterOptions options,
-                                HostBufferConsumer consumer) {
+    private ArrowIPCTableWriter(ArrowIPCWriterOptions options, HostBufferConsumer consumer) {
+      super(writeArrowIPCBufferBegin(options.getColumnNames(), consumer));
       this.callback = options.getCallback();
       this.consumer = consumer;
       this.maxChunkSize = options.getMaxChunkSize();
-      this.handle = writeArrowIPCBufferBegin(
-              options.getColumnNames(),
-              consumer);
     }
 
     @Override
     public void write(Table table) {
-      if (handle == 0) {
+      if (writerHandle == 0) {
         throw new IllegalStateException("Writer was already closed");
       }
-      long arrowHandle = convertCudfToArrowTable(handle, table.nativeHandle);
+      long arrowHandle = convertCudfToArrowTable(writerHandle, table.nativeHandle);
       try {
         callback.doneWithTheGpu(table);
-        writeArrowIPCArrowChunk(handle, arrowHandle, maxChunkSize);
+        writeArrowIPCArrowChunk(writerHandle, arrowHandle, maxChunkSize);
       } finally {
         closeArrowTable(arrowHandle);
       }
@@ -1548,10 +1518,10 @@ public final class Table implements AutoCloseable {
 
     @Override
     public void close() throws CudfException {
-      if (handle != 0) {
-        writeArrowIPCEnd(handle);
+      if (writerHandle != 0) {
+        writeArrowIPCEnd(writerHandle);
       }
-      handle = 0;
+      writerHandle = 0;
       if (consumer != null) {
         consumer.done();
         consumer = null;

--- a/java/src/main/java/ai/rapids/cudf/TableWriter.java
+++ b/java/src/main/java/ai/rapids/cudf/TableWriter.java
@@ -55,8 +55,9 @@ public abstract class TableWriter implements AutoCloseable {
   }
 
   /**
-   * Get the write statistics for the last write call. Currently, only ORC writer and Parquet
-   * writers support write statistics. Calling this on other writers will return null.
+   * Get the write statistics for the writer up to the last write call.
+   * Currently, only ORC and Parquet writers support write statistics.
+   * Calling this method on other writers will return null.
    * @return The write statistics for the last write call.
    */
   public WriteStatistics getWriteStatistics() {

--- a/java/src/main/java/ai/rapids/cudf/TableWriter.java
+++ b/java/src/main/java/ai/rapids/cudf/TableWriter.java
@@ -1,37 +1,65 @@
 /*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
- *  Copyright (c) 2020, NVIDIA CORPORATION.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package ai.rapids.cudf;
 
 /**
  * Provides an interface for writing out Table information in multiple steps.
- * A TableWriter will be returned from one of various factory functions in Table that
- * let you set the format of the data and its destination.  After that write can be called one or
- * more times.  When you are done writing call close to finish.
+ * A TableWriter will be returned from one of various factory functions in the Table class that
+ * let you set the format of the data and its destination. After that write can be called one or
+ * more times. When you are done writing call close to finish.
  */
-public interface TableWriter extends AutoCloseable {
+public abstract class TableWriter implements AutoCloseable {
+  protected long writerHandle;
+
+  TableWriter(long writerHandle) { this.writerHandle = writerHandle; }
+
   /**
-   * Write out a table.  Note that all columns must be in the same order each time this is called
+   * Write out a table. Note that all columns must be in the same order each time this is called
    * and the format of each table cannot change.
    * @param table what to write out.
    */
-  void write(Table table) throws CudfException;
+  abstract public void write(Table table) throws CudfException;
 
   @Override
-  void close() throws CudfException;
+  abstract public void close() throws CudfException;
+
+  public static class WriteStatistics {
+    public final long numCompressedBytes; // The number of bytes that were successfully compressed
+    public final long numFailedBytes;     // The number of bytes that failed to compress
+    public final long numSkippedBytes;    // The number of bytes that were skipped during compression
+    public final double compressionRatio; // The compression ratio for the successfully compressed data
+
+    public WriteStatistics(long numCompressedBytes, long numFailedBytes, long numSkippedBytes,
+        double compressionRatio) {
+      this.numCompressedBytes = numCompressedBytes;
+      this.numFailedBytes = numFailedBytes;
+      this.numSkippedBytes = numSkippedBytes;
+      this.compressionRatio = compressionRatio;
+    }
+
+    private static native WriteStatistics getWriteStatistics(long writerHandle);
+  }
+
+  /**
+   * Get the write statistics for the last write call. Currently, only ORC writer and Parquet
+   * writers support write statistics. Calling this on other writers will return null.
+   * @return The write statistics for the last write call.
+   */
+  public WriteStatistics getWriteStatistics() {
+    return WriteStatistics.getWriteStatistics(writerHandle);
+  }
 }

--- a/java/src/main/java/ai/rapids/cudf/TableWriter.java
+++ b/java/src/main/java/ai/rapids/cudf/TableWriter.java
@@ -67,7 +67,7 @@ public abstract class TableWriter implements AutoCloseable {
 
   /**
    * Get the write statistics for the writer up to the last write call.
-   * The data returned from native methods is encoded as an array of doubles.
+   * The data returned from native method is encoded as an array of doubles.
    * @param writerHandle The handle to the writer.
    * @return The write statistics.
    */

--- a/java/src/main/java/ai/rapids/cudf/TableWriter.java
+++ b/java/src/main/java/ai/rapids/cudf/TableWriter.java
@@ -56,11 +56,20 @@ public abstract class TableWriter implements AutoCloseable {
    * Get the write statistics for the writer up to the last write call.
    * Currently, only ORC and Parquet writers support write statistics.
    * Calling this method on other writers will return null.
-   * @return The write statistics for the last write call.
+   * @return The write statistics.
    */
   public WriteStatistics getWriteStatistics() {
-    return getWriteStatistics(writerHandle);
+    double[] statsData = getWriteStatistics(writerHandle);
+    assert statsData.length == 4 : "Unexpected write statistics data length";
+    return new WriteStatistics((long) statsData[0], (long) statsData[1], (long) statsData[2],
+        statsData[3]);
   }
 
-  private static native WriteStatistics getWriteStatistics(long writerHandle);
+  /**
+   * Get the write statistics for the writer up to the last write call.
+   * The data returned from native methods is encoded as an array of doubles.
+   * @param writerHandle The handle to the writer.
+   * @return The write statistics.
+   */
+  private static native double[] getWriteStatistics(long writerHandle);
 }

--- a/java/src/main/java/ai/rapids/cudf/TableWriter.java
+++ b/java/src/main/java/ai/rapids/cudf/TableWriter.java
@@ -50,8 +50,6 @@ public abstract class TableWriter implements AutoCloseable {
       this.numSkippedBytes = numSkippedBytes;
       this.compressionRatio = compressionRatio;
     }
-
-    private static native WriteStatistics getWriteStatistics(long writerHandle);
   }
 
   /**
@@ -61,6 +59,8 @@ public abstract class TableWriter implements AutoCloseable {
    * @return The write statistics for the last write call.
    */
   public WriteStatistics getWriteStatistics() {
-    return WriteStatistics.getWriteStatistics(writerHandle);
+    return getWriteStatistics(writerHandle);
   }
+
+  private static native WriteStatistics getWriteStatistics(long writerHandle);
 }

--- a/java/src/main/native/src/CudfJni.cpp
+++ b/java/src/main/native/src/CudfJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/main/native/src/CudfJni.cpp
+++ b/java/src/main/native/src/CudfJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,7 +195,7 @@ JNIEXPORT void JNI_OnUnload(JavaVM *vm, void *) {
   cudf::jni::release_host_memory_buffer_jni(env);
 }
 
-JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Cuda_isPtdsEnabled(JNIEnv *env, jclass) {
+JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Cuda_isPtdsEnabled(JNIEnv *env, jclass, jlong size) {
   return cudf::jni::is_ptds_enabled;
 }
 

--- a/java/src/main/native/src/CudfJni.cpp
+++ b/java/src/main/native/src/CudfJni.cpp
@@ -195,7 +195,7 @@ JNIEXPORT void JNI_OnUnload(JavaVM *vm, void *) {
   cudf::jni::release_host_memory_buffer_jni(env);
 }
 
-JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Cuda_isPtdsEnabled(JNIEnv *env, jclass, jlong size) {
+JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Cuda_isPtdsEnabled(JNIEnv *env, jclass) {
   return cudf::jni::is_ptds_enabled;
 }
 

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -58,6 +58,13 @@
 namespace cudf {
 namespace jni {
 
+/**
+ * @brief The base class for table writer.
+ *
+ * By storing a pointer to this base class instead of pointer to specific writer class, we can
+ * retrieve common data like `sink` and `stats` for any derived writer class without the need of
+ * casting or knowing its type.
+ */
 struct jni_table_writer_handle_base {
   explicit jni_table_writer_handle_base(
       std::unique_ptr<jni_writer_data_sink> &&sink_,

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -1922,10 +1922,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeORCEnd(JNIEnv *env, jclass
   CATCH_STD(env, )
 }
 
-// `00024` is the unicode translation for `$` because we need to write native method for
-// nested class `TableWriter$WriteStatistics`.
-JNIEXPORT jobject JNICALL Java_ai_rapids_cudf_TableWriter_00024WriteStatistics_getWriteStatistics(
-    JNIEnv *env, jclass, jlong j_state) {
+JNIEXPORT jobject JNICALL Java_ai_rapids_cudf_TableWriter_getWriteStatistics(JNIEnv *env, jclass,
+                                                                             jlong j_state) {
   JNI_NULL_CHECK(env, j_state, "null state", nullptr);
 
   using namespace cudf::io;

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -8264,6 +8264,11 @@ public class TableTest extends CudfTestBase {
         writer.write(table0);
         writer.write(table0);
         writer.write(table0);
+        TableWriter.WriteStatistics statistics = writer.getWriteStatistics();
+        System.err.println("numCompressedBytes: " + statistics.numCompressedBytes);
+        System.err.println("numFailedBytes: " + statistics.numFailedBytes);
+        System.err.println("numSkippedBytes: " + statistics.numSkippedBytes);
+        System.err.println("compressionRatio: " + statistics.compressionRatio);
       }
       try (Table table1 = Table.readORC(ORCOptions.DEFAULT, consumer.buffer, 0, consumer.offset);
            Table concat = Table.concatenate(table0, table0, table0)) {

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -67,6 +67,7 @@ import static ai.rapids.cudf.Table.removeNullMasksIfNeeded;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -7891,16 +7892,34 @@ public class TableTest extends CudfTestBase {
     columns.add(Columns.STRUCT.name);
     WriteUtils.buildWriterOptions(optBuilder, columns);
     ParquetWriterOptions options = optBuilder.build();
+    ParquetWriterOptions optionsNoCompress = optBuilder.withCompressionType(CompressionType.NONE).build();
     try (Table table0 = getExpectedFileTable(columns);
          MyBufferConsumer consumer = new MyBufferConsumer()) {
       try (TableWriter writer = Table.writeParquetChunked(options, consumer)) {
         writer.write(table0);
         writer.write(table0);
         writer.write(table0);
+
+        TableWriter.WriteStatistics statistics = writer.getWriteStatistics();
+        assertNotEquals(0, statistics.numCompressedBytes);
+        assertEquals(0, statistics.numFailedBytes);
+        assertEquals(0, statistics.numSkippedBytes);
+        assertNotEquals(Double.NaN, statistics.compressionRatio);
       }
       try (Table table1 = Table.readParquet(ParquetOptions.DEFAULT, consumer.buffer, 0, consumer.offset);
            Table concat = Table.concatenate(table0, table0, table0)) {
         assertTablesAreEqual(concat, table1);
+      }
+      try (TableWriter writer = Table.writeParquetChunked(optionsNoCompress, consumer)) {
+        writer.write(table0);
+        writer.write(table0);
+        writer.write(table0);
+
+        TableWriter.WriteStatistics statistics = writer.getWriteStatistics();
+        assertEquals(0, statistics.numCompressedBytes);
+        assertEquals(0, statistics.numFailedBytes);
+        assertEquals(0, statistics.numSkippedBytes);
+        assertEquals(Double.NaN, statistics.compressionRatio);
       }
     }
   }
@@ -8260,19 +8279,32 @@ public class TableTest extends CudfTestBase {
       ORCWriterOptions.Builder builder = ORCWriterOptions.builder();
       WriteUtils.buildWriterOptions(builder, selectedColumns);
       ORCWriterOptions opts = builder.build();
+      ORCWriterOptions optsNoCompress = builder.withCompressionType(CompressionType.NONE).build();
       try (TableWriter writer = Table.writeORCChunked(opts, consumer)) {
         writer.write(table0);
         writer.write(table0);
         writer.write(table0);
+
         TableWriter.WriteStatistics statistics = writer.getWriteStatistics();
-        System.err.println("numCompressedBytes: " + statistics.numCompressedBytes);
-        System.err.println("numFailedBytes: " + statistics.numFailedBytes);
-        System.err.println("numSkippedBytes: " + statistics.numSkippedBytes);
-        System.err.println("compressionRatio: " + statistics.compressionRatio);
+        assertNotEquals(0, statistics.numCompressedBytes);
+        assertEquals(0, statistics.numFailedBytes);
+        assertEquals(0, statistics.numSkippedBytes);
+        assertNotEquals(Double.NaN, statistics.compressionRatio);
       }
       try (Table table1 = Table.readORC(ORCOptions.DEFAULT, consumer.buffer, 0, consumer.offset);
            Table concat = Table.concatenate(table0, table0, table0)) {
         assertTablesAreEqual(concat, table1);
+      }
+      try (TableWriter writer = Table.writeORCChunked(optsNoCompress, consumer)) {
+        writer.write(table0);
+        writer.write(table0);
+        writer.write(table0);
+
+        TableWriter.WriteStatistics statistics = writer.getWriteStatistics();
+        assertEquals(0, statistics.numCompressedBytes);
+        assertEquals(0, statistics.numFailedBytes);
+        assertEquals(0, statistics.numSkippedBytes);
+        assertEquals(Double.NaN, statistics.compressionRatio);
       }
     }
   }


### PR DESCRIPTION
This adds JNI to expose compression statistics for ORC and Parquet writer, which was implemented in https://github.com/rapidsai/cudf/pull/13294.

For doing so, `TableWriter` has been changed from an interface into an abstract class. Related derived writer classes are also updated accordingly.

Closes https://github.com/rapidsai/cudf/issues/13252.