### PR TITLE
Remove numba JIT kernel usage from dataframe copy tests

### DIFF
--- a/python/cudf/cudf/tests/test_dataframe_copy.py
+++ b/python/cudf/cudf/tests/test_dataframe_copy.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from cudf.core.dataframe import DataFrame
-from cudf.testing._utils import ALL_TYPES, assert_eq
+from cudf.testing._utils import ALL_TYPES, assert_eq, assert_neq
 
 """
 DataFrame copy expectations

--- a/python/cudf/cudf/tests/test_dataframe_copy.py
+++ b/python/cudf/cudf/tests/test_dataframe_copy.py
@@ -142,16 +142,18 @@ def test_deep_copy_write_in_place():
     # Write a value in-place on the deep copy.
     # This should only affect the copy and not the original.
     cp.asarray(sr._column)[1] = 42
+
     assert_neq(gdf, cdf)
 
 
-def test_kernel_shallow_copy():
+def test_shallow_copy_write_in_place():
     pdf = pd.DataFrame(
         [[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=["a", "b", "c"]
     )
     gdf = DataFrame.from_pandas(pdf)
     cdf = gdf.copy(deep=False)
     sr = gdf["a"]
+
     # Write a value in-place on the shallow copy.
     # This should change the copy and original.
     cp.asarray(sr._column)[1] = 42

--- a/python/cudf/cudf/tests/test_dataframe_copy.py
+++ b/python/cudf/cudf/tests/test_dataframe_copy.py
@@ -131,7 +131,7 @@ def test_cudf_dataframe_copy_then_insert(copy_fn, ncols, data_type):
     assert not copy_df.to_string().split() == df.to_string().split()
 
 
-def test_kernel_deep_copy():
+def test_deep_copy_write_in_place():
     pdf = pd.DataFrame(
         [[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=["a", "b", "c"]
     )
@@ -139,8 +139,10 @@ def test_kernel_deep_copy():
     cdf = gdf.copy(deep=True)
     sr = gdf["b"]
 
+    # Write a value in-place on the deep copy.
+    # This should only affect the copy and not the original.
     cp.asarray(sr._column)[1] = 42
-    assert not gdf.to_string().split() == cdf.to_string().split()
+    assert_neq(gdf, cdf)
 
 
 def test_kernel_shallow_copy():
@@ -150,6 +152,8 @@ def test_kernel_shallow_copy():
     gdf = DataFrame.from_pandas(pdf)
     cdf = gdf.copy(deep=False)
     sr = gdf["a"]
+    # Write a value in-place on the shallow copy.
+    # This should change the copy and original.
     cp.asarray(sr._column)[1] = 42
 
     assert_eq(gdf, cdf)


### PR DESCRIPTION
This modernizes a few copy tests that came up during conversation at https://github.com/rapidsai/cudf/pull/13337/files#r1197942788