### PR TITLE
[JNI] Pass this ColumnVector to the onClosed event handler

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -50,10 +50,11 @@ public final class ColumnVector extends ColumnView {
      *
      * @note the callback is invoked with this `ColumnVector`'s lock held.
      *
+     * @param cv - a reference to the ColumnVector we are closing
      * @param refCount - the updated ref count for this ColumnVector at the time
      *                 of invocation
      */
-    void onClosed(int refCount);
+    void onClosed(ColumnVector cv, int refCount);
   }
 
   private static final Logger log = LoggerFactory.getLogger(ColumnVector.class);
@@ -260,7 +261,7 @@ public final class ColumnVector extends ColumnView {
     refCount--;
     offHeap.delRef();
     if (eventHandler != null) {
-      eventHandler.onClosed(refCount);
+      eventHandler.onClosed(this, refCount);
     }
     if (refCount == 0) {
       offHeap.clean(false);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -6730,7 +6730,10 @@ public class ColumnVectorTest extends CudfTestBase {
   public void testEventHandlerIsCalledForEachClose() {
     final AtomicInteger onClosedWasCalled = new AtomicInteger(0);
     try (ColumnVector cv = ColumnVector.fromInts(1,2,3,4)) {
-      cv.setEventHandler(refCount -> onClosedWasCalled.incrementAndGet());
+      cv.setEventHandler((col, refCount) -> {
+        assertEquals(cv, col);
+        onClosedWasCalled.incrementAndGet();
+      });
     }
     assertEquals(1, onClosedWasCalled.get());
   }
@@ -6744,7 +6747,9 @@ public class ColumnVectorTest extends CudfTestBase {
     assertEquals(0, onClosedWasCalled.get());
 
     try (ColumnVector cv = ColumnVector.fromInts(1,2,3,4)) {
-      cv.setEventHandler(refCount -> onClosedWasCalled.incrementAndGet());
+      cv.setEventHandler((col, refCount) -> {
+        onClosedWasCalled.incrementAndGet();
+      });
       cv.setEventHandler(null);
     }
     assertEquals(0, onClosedWasCalled.get());


### PR DESCRIPTION
Putting this up as an optimization for ColumnVector.EventHandler. 

As it stands today, code in the spark-rapids plugin that wants to use this is having to java objects that encapsulate state about the columns around reference counting and what represents the bag of `ColumnVector`s that are spillable at any given time. If we pass the `ColumnVector` instance in the event handler, one of these objects can be removed, and we can simplify the implementation in the plugin. I am putting this up as draft while my local tests pass, but I think it should be fairly straightforward.