### PR TITLE
Correctly reorder and reindex scan groupbys with null keys

### DIFF
--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -2131,6 +2131,35 @@ def test_groupby_rank_fails():
         gdf.groupby(["a"]).rank(method="min", axis=1)
 
 
+@pytest.mark.parametrize(
+    "with_nan", [False, True], ids=["just-NA", "also-NaN"]
+)
+@pytest.mark.parametrize("dropna", [False, True], ids=["keepna", "dropna"])
+@pytest.mark.parametrize(
+    "duplicate_index", [False, True], ids=["rangeindex", "dupindex"]
+)
+def test_groupby_scan_null_keys(with_nan, dropna, duplicate_index):
+    key_col = [None, 1, 2, None, 3, None, 3, 1, None, 1]
+    if with_nan:
+        df = pd.DataFrame(
+            {"key": pd.Series(key_col, dtype="float32"), "value": range(10)}
+        )
+    else:
+        df = pd.DataFrame(
+            {"key": pd.Series(key_col, dtype="Int32"), "value": range(10)}
+        )
+
+    if duplicate_index:
+        # Non-default index with duplicates
+        df.index = [1, 2, 3, 1, 3, 2, 4, 1, 6, 10]
+
+    cdf = cudf.from_pandas(df)
+
+    expect = df.groupby("key", dropna=dropna).cumsum()
+    got = cdf.groupby("key", dropna=dropna).cumsum()
+    assert_eq(expect, got)
+
+
 def test_groupby_mix_agg_scan():
     err_msg = "Cannot perform both aggregation and scan in one operation"
     func = ["cumsum", "sum"]

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -76,7 +76,18 @@ def test_groupby_basic(series, aggregation, pdf):
 
 # TODO: explore adding support with `.agg()`
 @pytest.mark.parametrize("series", [True, False])
-@pytest.mark.parametrize("aggregation", ["cumsum", "cumcount"])
+@pytest.mark.parametrize(
+    "aggregation",
+    [
+        "cumsum",
+        pytest.param(
+            "cumcount",
+            marks=pytest.mark.xfail(
+                reason="https://github.com/rapidsai/cudf/issues/13390"
+            ),
+        ),
+    ],
+)
 def test_groupby_cumulative(aggregation, pdf, series):
     gdf = cudf.DataFrame.from_pandas(pdf)
     ddf = dask_cudf.from_cudf(gdf, npartitions=5)

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2021-2023, NVIDIA CORPORATION.
 
-import contextlib
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -90,17 +88,10 @@ def test_groupby_cumulative(aggregation, pdf, series):
         gdf_grouped = gdf_grouped.xx
         ddf_grouped = ddf_grouped.xx
 
-    if pdf.isna().sum().any():
-        # https://github.com/rapidsai/cudf/issues/12055
-        gdf_grouped = gdf.groupby("xx")
-        context = pytest.raises(ValueError)
-    else:
-        context = contextlib.nullcontext()
-    with context:
-        a = getattr(gdf_grouped, aggregation)()
-        b = getattr(ddf_grouped, aggregation)()
+    a = getattr(gdf_grouped, aggregation)()
+    b = getattr(ddf_grouped, aggregation)()
 
-        dd.assert_eq(a, b)
+    dd.assert_eq(a, b)
 
 
 @pytest.mark.parametrize("aggregation", OPTIMIZED_AGGS)
@@ -136,7 +127,6 @@ def test_groupby_agg(func, aggregation, pdf):
 
 @pytest.mark.parametrize("split_out", [1, 3])
 def test_groupby_agg_empty_partition(tmpdir, split_out):
-
     # Write random and empty cudf DataFrames
     # to two distinct files.
     df = cudf.datasets.randomdata()
@@ -496,7 +486,6 @@ def test_groupby_mean_sort_false():
 
 
 def test_groupby_reset_index_dtype():
-
     # Make sure int8 dtype is properly preserved
     # Through various cudf/dask_cudf ops
     #


### PR DESCRIPTION
## Description

Scan-based groupbys are massaged back into pandas (original dataframe)
order by a post-processing step. Previously, this did the wrong thing
if the grouping key contained null (or nan) keys. In this situation
dropna=True will cause libcudf to produce an output table that is
smaller than the input frame. To mimic pandas we need to expand this
output to the original frame size, inserting nulls in the missing rows
and reordering correctly.

Furthermore, the previous reordering code had an out-of-bounds memory
access when there were null keys, since we were asking to group a
column of the same length as the result, but the grouping object expects
columns of length of the original input (which is larger with
dropna=True and null keys).

To fix these issues, compute the reordering on a column of appropriate
size, and, if dropna is true and any of the key columns have nulls, go
down a more expensive reordering path that inserts nulls correctly by
reindexing the result.

- Closes #13349
- Closes #12055


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
