### PR TITLE
Require numba >= 0.57

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -48,7 +48,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba>=0.56.4,<0.57
+- numba>=0.57
 - numpy>=1.21,<1.24
 - numpydoc
 - nvcc_linux-64=11.8

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - cython >=0.29,<0.30
     - scikit-build >=0.13.1
     - setuptools
-    - numba >=0.56.4,<0.57
+    - numba >=0.57
     - dlpack >=0.5,<0.6.0a0
     - pyarrow =11
     - libcudf ={{ version }}
@@ -65,7 +65,7 @@ requirements:
     - typing_extensions
     - pandas >=1.3,<1.6.0dev0
     - cupy >=12.0.0
-    - numba >=0.56.4,<0.57
+    - numba >=0.57
     - numpy >=1.21,<1.24  # Temporarily upper bound numpy to avoid overflow deprecations
     - {{ pin_compatible('pyarrow', max_pin='x.x.x') }}
     - libcudf {{ version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -350,7 +350,7 @@ dependencies:
         packages:
           - cachetools
           - cuda-python>=11.7.1,<12.0
-          - &numba numba>=0.56.4,<0.57
+          - numba>=0.57
           - nvtx>=0.2.1
           - packaging
           - rmm==23.6.*
@@ -507,4 +507,4 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - dask-cuda==23.6.*
-          - *numba
+          - numba>=0.57

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "cuda-python>=11.7.1,<12.0",
     "cupy-cuda11x>=12.0.0",
     "fsspec>=0.6.0",
-    "numba>=0.56.4,<0.57",
+    "numba>=0.57",
     "numpy>=1.21,<1.24",
     "nvtx>=0.2.1",
     "packaging",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -40,7 +40,7 @@ dynamic = ["entry-points"]
 [project.optional-dependencies]
 test = [
     "dask-cuda==23.6.*",
-    "numba>=0.56.4,<0.57",
+    "numba>=0.57",
     "pytest",
     "pytest-cov",
     "pytest-xdist",


### PR DESCRIPTION
This PR sets the lower bound for `numba` to version 0.57.