### PR TITLE
Drop extraneous dependencies from cudf conda recipe.

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -53,7 +53,6 @@ requirements:
     - cython >=0.29,<0.30
     - scikit-build >=0.13.1
     - setuptools
-    - numba >=0.56.4,<0.57
     - dlpack >=0.5,<0.6.0a0
     - pyarrow =11
     - libcudf ={{ version }}
@@ -69,7 +68,6 @@ requirements:
     - numpy >=1.21,<1.24  # Temporarily upper bound numpy to avoid overflow deprecations
     - {{ pin_compatible('pyarrow', max_pin='x.x.x') }}
     - libcudf {{ version }}
-    - fastavro >=0.22.0
     - {{ pin_compatible('rmm', max_pin='x.x') }}
     - fsspec >=0.6.0
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}


### PR DESCRIPTION
## Description
This PR drops two dependencies from the cudf conda recipe.

- `numba` is only a `run` dependency and should not be listed in `host`.
- `fastavro` is only a test dependency. It is listed in `dependencies.yaml` but does not need to be listed in `meta.yaml` as a run dependency. This is already listed as a testing dependency in `pyproject.toml`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
