### PR TITLE
Use <NA> instead of null to match pandas.

### DIFF
--- a/python/cudf/cudf/_lib/transform.pyx
+++ b/python/cudf/cudf/_lib/transform.pyx
@@ -163,7 +163,7 @@ def one_hot_encode(Column input_column, Column categories):
         move(c_result.second),
         owner=owner,
         column_names=[
-            x if x is not None else 'null' for x in pylist_categories
+            x if x is not None else '<NA>' for x in pylist_categories
         ]
     )
     return encodings


### PR DESCRIPTION
## Description
This PR updates the behavior of one-hot encoding to use `<NA>` for null values rather than `null`. This aligns with pandas behavior.

This change is backported from #13174 since it applies to pandas 1.x as well as pandas 2.0.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
