### PR TITLE
[REVIEW] Fix csv reader pytest to pass `date_format='mixed'`

### DIFF
--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -348,8 +348,6 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
         ... codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
         ... names=['Date', 'Symbol'])
         >>> idx2 = idx1.copy(
-        ... levels=[['day1', 'day2'], ['com1', 'com2']],
-        ... codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
         ... names=['col1', 'col2'])
 
         >>> df.index = idx1
@@ -363,13 +361,12 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
 
         >>> df.index = idx2
         >>> df
-                     Close
-        col1 col2
-        day1 com1  3400.00
-             com2   226.58
-        day2 com1  3401.80
-             com2   228.91
-
+                           Close
+        col1       col2
+        2020-08-27 AMZN  3400.00
+                   MSFT   226.58
+        2020-08-28 AMZN  3401.80
+                   MSFT   228.91
         """
 
         mi = MultiIndex._from_data(self._data.copy(deep=deep))

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -246,11 +246,14 @@ def test_csv_reader_datetime(parse_dates):
         parse_dates=parse_dates,
         dayfirst=True,
     )
+    # Need to used `date_format='mixed'`,
+    # https://github.com/pandas-dev/pandas/issues/53355
     pdf = pd.read_csv(
         StringIO(buffer),
         names=["date1", "date2", "bad"],
         parse_dates=parse_dates,
         dayfirst=True,
+        date_format="mixed",
     )
 
     assert_eq(gdf, pdf)


### PR DESCRIPTION
## Description
Pandas-2.0 moved to a very strict & consistent date format inference, we should plan to move similarly but meanwhile for the pytest to pass, we will need to pass `date_format='mixed'`.
This PR also fixes a miscellaneous issue with `MultiIndex.copy` docstring.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
