### PR TITLE
Preserve Index and grouped columns in `Groupby.nth`

### DIFF
--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -821,8 +821,8 @@ class GroupBy(Serializable, Reducible, Scannable):
         col_idxs = [
             i for i, x in enumerate(self.obj._data.names) if x in grouping_cols
         ]
-        result = result.sort_index()
-        sizes = self.size().sort_index()
+        result = result
+        sizes = self.size().reindex(result.index)
 
         result = result[sizes > n]
         for idx, name, col in zip(

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -799,10 +799,42 @@ class GroupBy(Serializable, Reducible, Scannable):
         """
         Return the nth row from each group.
         """
-        result = self.agg(lambda x: x.nth(n)).sort_index()
+
+        new_df = self.obj.copy(deep=False)
+        new_df["__groupbynth_order__"] = range(0, len(self.obj))
+        gb = new_df.groupby(
+            by=self._by,
+            level=self._level,
+            sort=self._sort,
+            as_index=self._as_index,
+            dropna=self._dropna,
+            group_keys=self._group_keys,
+        )
+        result = gb.agg(lambda x: x.nth(n))
+        grouping_cols = (
+            self._by
+            if isinstance(self._by, tuple)
+            else tuple(
+                self._by,
+            )
+        )
+        col_idxs = [
+            i for i, x in enumerate(self.obj._data.names) if x in grouping_cols
+        ]
+        result = result.sort_index()
         sizes = self.size().sort_index()
 
-        return result[sizes > n]
+        result = result[sizes > n]
+        for idx, name, col in zip(
+            col_idxs, result._index._data.names, result._index._data.columns
+        ):
+            result._data.insert(name, col, loc=idx)
+
+        result._index = self.obj.index.take(
+            result._data["__groupbynth_order__"]
+        )
+        del result._data["__groupbynth_order__"]
+        return result
 
     @_cudf_nvtx_annotate
     def ngroup(self, ascending=True):

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -801,6 +801,8 @@ class GroupBy(Serializable, Reducible, Scannable):
         """
 
         self.obj["__groupbynth_order__"] = range(0, len(self.obj))
+        # We perform another groupby here to have the grouping columns
+        # be a part of dataframe columns.
         result = self.obj.groupby(self.grouping.keys).agg(lambda x: x.nth(n))
         sizes = self.size().reindex(result.index)
 


### PR DESCRIPTION
In pandas-2.0 `groupby.nth` behavior has changed: https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#dataframegroupby-nth-and-seriesgroupby-nth-now-behave-as-filtrations

This PR enables preserving the callers index in the end result and returns grouping columns as part of the result.

This PR fixes all 12 pytests in `python/cudf/cudf/tests/test_groupby.py::test_groupby_nth`


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
