### PR TITLE
Fix writing of ORC files with empty rowgroups

### DIFF
--- a/cpp/src/io/orc/stripe_enc.cu
+++ b/cpp/src/io/orc/stripe_enc.cu
@@ -1108,11 +1108,10 @@ __global__ void __launch_bounds__(compact_streams_block_size)
       for (uint32_t i = t; i < len; i += blockDim.x) {
         dst_ptr[i] = src_ptr[i];
       }
-
       __syncthreads();
-      if (t == 0) { streams[ss.column_id][group].data_ptrs[cid] = dst_ptr; }
-      dst_ptr += len;
     }
+    if (t == 0) { streams[ss.column_id][group].data_ptrs[cid] = dst_ptr; }
+    dst_ptr += len;
   }
 }
 


### PR DESCRIPTION
## Description
Issue #13460

Fixes the bug in `gpuCompactOrcDataStreams` where stream pointer would not get updated for empty row groups.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
