### PR TITLE
Fix JSON reader pytests

### DIFF
--- a/python/cudf/cudf/tests/test_json.py
+++ b/python/cudf/cudf/tests/test_json.py
@@ -13,6 +13,7 @@ import pyarrow as pa
 import pytest
 
 import cudf
+from cudf.core._compat import PANDAS_GE_200
 from cudf.testing._utils import (
     DATETIME_TYPES,
     NUMERIC_TYPES,
@@ -212,6 +213,18 @@ def test_cudf_json_writer_read(gdf_writer_types):
     if pdf2.empty:
         pdf2.reset_index(drop=True, inplace=True)
         pdf2.columns = pdf2.columns.astype("object")
+    if PANDAS_GE_200:
+        # Pandas moved to consistent datetimes parsing format:
+        # https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#datetimes-are-now-parsed-with-a-consistent-format
+        for unit in ["s", "ms"]:
+            if f"col_datetime64[{unit}]" in pdf2.columns:
+                pdf2[f"col_datetime64[{unit}]"] = (
+                    pd.to_datetime(
+                        pdf2[f"col_datetime64[{unit}]"], format="mixed"
+                    )
+                    .dt.tz_localize(None)
+                    .astype(f"datetime64[{unit}]")
+                )
     assert_eq(pdf2, gdf2)
 
 


### PR DESCRIPTION
## Description
This PR fixes 3 json reader pytests:

This PR:
```
= 228 failed, 95770 passed, 2045 skipped, 764 xfailed, 300 xpassed in 473.29s (0:07:53) =
```

On `pandas_2.0_feature_branch`:
```
= 231 failed, 95767 passed, 2045 skipped, 764 xfailed, 300 xpassed in 445.90s (0:07:25) =
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
