### PR TITLE
Fix chunked Parquet reader benchmark

### DIFF
--- a/cpp/benchmarks/io/parquet/parquet_reader_input.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_input.cpp
@@ -140,7 +140,6 @@ void BM_parquet_read_chunks(
 
   cudf::io::parquet_reader_options read_opts =
     cudf::io::parquet_reader_options::builder(source_sink.make_source_info());
-  auto reader = cudf::io::chunked_parquet_reader(byte_limit, read_opts);
 
   auto mem_stats_logger = cudf::memory_stats_logger();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
@@ -149,8 +148,9 @@ void BM_parquet_read_chunks(
                try_drop_l3_cache();
 
                timer.start();
+               auto reader = cudf::io::chunked_parquet_reader(byte_limit, read_opts);
                do {
-                 auto chunk = reader.read_chunk();
+                 [[maybe_unused]] auto const chunk = reader.read_chunk();
                } while (reader.has_next());
                timer.stop();
              });


### PR DESCRIPTION
## Description
Currently, chunked Parquet reader benchmark creates the chunked reader object once and reuses it for all iterations.
After the first iteration the source is fully read so each subsequent iteration returns a single, empty, chunk. 

This PR fixes the use of the chunked reader object.
The creation of the object is included in the benchmark timing.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
