### PR TITLE
Drop special handling of `min_periods` for `Rolling.count`

### DIFF
--- a/python/cudf/cudf/core/window/rolling.py
+++ b/python/cudf/cudf/core/window/rolling.py
@@ -543,8 +543,6 @@ class RollingGroupby(Rolling):
             )
 
     def _apply_agg(self, agg_name):
-        if agg_name == "count" and not self._time_window:
-            self.min_periods = 0
         index = cudf.MultiIndex.from_frame(
             cudf.DataFrame(
                 {

--- a/python/cudf/cudf/tests/test_rolling.py
+++ b/python/cudf/cudf/tests/test_rolling.py
@@ -8,14 +8,14 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_GE_150, PANDAS_LT_140
+from cudf.core._compat import PANDAS_GE_150, PANDAS_LT_140, PANDAS_GE_200
 from cudf.testing._utils import _create_pandas_series, assert_eq
 from cudf.testing.dataset_generator import rand_dataframe
 
 
 @contextmanager
 def _hide_pandas_rolling_min_periods_warning(agg):
-    if agg == "count":
+    if not PANDAS_GE_200 and agg == "count":
         with pytest.warns(
             FutureWarning,
             match="min_periods=None will default to the size of window "


### PR DESCRIPTION
## Description
This PR drops a special handling for `Rolling.count` where we always default to `min_periods=0`, this is an inconsistency that pandas-2.0 resolves in: https://github.com/pandas-dev/pandas/pull/48839

This PR fixes 2 pytest failures:
```
= 229 failed, 95769 passed, 2045 skipped, 764 xfailed, 300 xpassed in 458.04s (0:07:38) =
```
On `pandas_2.0_feature_branch`:
```
= 231 failed, 95767 passed, 2045 skipped, 764 xfailed, 300 xpassed in 457.58s (0:07:37) =
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
