### PR TITLE
Ensure `single_lane_block_sum_reduce` is safe to call in a loop

### DIFF
--- a/cpp/include/cudf/detail/utilities/cuda.cuh
+++ b/cpp/include/cudf/detail/utilities/cuda.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,6 +106,10 @@ __device__ T single_lane_block_sum_reduce(T lane_value)
     lane_value = (lane_id < warps_per_block) ? lane_values[lane_id] : T{0};
     result     = cub::WarpReduce<T>(temp).Sum(lane_value);
   }
+  // Shared memory has block scope, so sync here to ensure no data
+  // races between successive calls to this function in the same
+  // kernel.
+  __syncthreads();
   return result;
 }
 


### PR DESCRIPTION
## Description

Since shared memory declarations have a lifetime tied to the
block they are executed on (and not the function scope), we must
sync the block before returning the result to ensure that there
are no RAW/WAR-conflicts between successive invocations of
single_lane_block_sum_reduce within a kernel. Previously, it was
possible for the i+1th call to conflict with the ith call in a
loop.

- Closes #13485.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
