### PR TITLE
Fix valid count computation in offset_bitmask_binop kernel

### DIFF
--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -66,7 +66,6 @@ __global__ void offset_bitmask_binop(Binop op,
                                      size_type source_size_bits,
                                      size_type* count_ptr)
 {
-  // constexpr auto const word_size{detail::size_in_bits<bitmask_type>()};
   auto const tid = threadIdx.x + blockIdx.x * blockDim.x;
 
   auto const last_bit_index  = source_size_bits - 1;

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -91,7 +91,10 @@ __global__ void offset_bitmask_binop(Binop op,
     if (destination_word_index == last_word_index) {
       // mask out any bits not part of this word
       auto const num_bits_in_last_word = intra_word_index(last_bit_index);
-      destination_word &= set_least_significant_bits(num_bits_in_last_word + 1);
+      if (num_bits_in_last_word <
+          static_cast<size_type>(detail::size_in_bits<bitmask_type>() - 1)) {
+        destination_word &= set_least_significant_bits(num_bits_in_last_word + 1);
+      }
     }
 
     destination[destination_word_index] = destination_word;

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -69,9 +69,8 @@ __global__ void offset_bitmask_binop(Binop op,
   constexpr auto const word_size{detail::size_in_bits<bitmask_type>()};
   auto const tid = threadIdx.x + blockIdx.x * blockDim.x;
 
-  size_type const last_bit_index  = source_size_bits - 1;
-  size_type const num_slack_bits  = word_size - (last_bit_index % word_size) - 1;
-  size_type const last_word_index = cudf::word_index(last_bit_index);
+  auto const last_bit_index  = source_size_bits - 1;
+  auto const last_word_index = cudf::word_index(last_bit_index);
 
   size_type thread_count = 0;
 
@@ -90,11 +89,14 @@ __global__ void offset_bitmask_binop(Binop op,
                                                          source_begin_bits[i] + source_size_bits));
     }
 
+    if (destination_word_index == last_word_index) {
+      // mask out any bits not part of this word
+      auto const num_bits_in_last_word = word_size - intra_word_index(last_bit_index) - 1;
+      destination_word &= set_least_significant_bits(word_size - num_bits_in_last_word);
+    }
+
     destination[destination_word_index] = destination_word;
     thread_count += __popc(destination_word);
-    if (destination_word_index == last_word_index) {
-      thread_count -= __popc(destination_word & set_most_significant_bits(num_slack_bits));
-    }
   }
 
   using BlockReduce = cub::BlockReduce<size_type, block_size>;

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -66,7 +66,7 @@ __global__ void offset_bitmask_binop(Binop op,
                                      size_type source_size_bits,
                                      size_type* count_ptr)
 {
-  constexpr auto const word_size{detail::size_in_bits<bitmask_type>()};
+  // constexpr auto const word_size{detail::size_in_bits<bitmask_type>()};
   auto const tid = threadIdx.x + blockIdx.x * blockDim.x;
 
   auto const last_bit_index  = source_size_bits - 1;
@@ -91,8 +91,8 @@ __global__ void offset_bitmask_binop(Binop op,
 
     if (destination_word_index == last_word_index) {
       // mask out any bits not part of this word
-      auto const num_bits_in_last_word = word_size - intra_word_index(last_bit_index) - 1;
-      destination_word &= set_least_significant_bits(word_size - num_bits_in_last_word);
+      auto const num_bits_in_last_word = intra_word_index(last_bit_index);
+      destination_word &= set_least_significant_bits(num_bits_in_last_word + 1);
     }
 
     destination[destination_word_index] = destination_word;


### PR DESCRIPTION
## Description
Fixes the valid count calculation in the `offset_bitmask_binop` kernel when the mask may contain slack bits. The slack bits must be accounted for in the final bitmask word to correctly compute the valid count.

Closes #13479 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
