### PR TITLE
Use east const in benchmarks files

### DIFF
--- a/cpp/benchmarks/copying/contiguous_split.cu
+++ b/cpp/benchmarks/copying/contiguous_split.cu
@@ -126,7 +126,7 @@ void BM_contiguous_split_strings(benchmark::State& state, ContiguousSplitImpl& i
   bool const include_validity       = state.range(3) != 0;
 
   constexpr int64_t string_len = 8;
-  std::vector<const char*> h_strings{
+  std::vector<char const*> h_strings{
     "aaaaaaaa", "bbbbbbbb", "cccccccc", "dddddddd", "eeeeeeee", "ffffffff", "gggggggg", "hhhhhhhh"};
 
   int64_t const col_len_bytes = total_desired_bytes / num_cols;

--- a/cpp/benchmarks/copying/gather.cu
+++ b/cpp/benchmarks/copying/gather.cu
@@ -32,7 +32,7 @@ template <class TypeParam, bool coalesce>
 void BM_gather(benchmark::State& state)
 {
   const cudf::size_type source_size{(cudf::size_type)state.range(0)};
-  const auto n_cols = (cudf::size_type)state.range(1);
+  auto const n_cols = (cudf::size_type)state.range(1);
 
   // Gather indices
   auto gather_map_table =

--- a/cpp/benchmarks/fixture/benchmark_fixture.hpp
+++ b/cpp/benchmarks/fixture/benchmark_fixture.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,17 +73,17 @@ class benchmark : public ::benchmark::Fixture {
  public:
   benchmark() : ::benchmark::Fixture()
   {
-    const char* env_iterations = std::getenv("CUDF_BENCHMARK_ITERATIONS");
+    char const* env_iterations = std::getenv("CUDF_BENCHMARK_ITERATIONS");
     if (env_iterations != nullptr) { this->Iterations(std::max(0L, atol(env_iterations))); }
   }
 
-  void SetUp(const ::benchmark::State& state) override
+  void SetUp(::benchmark::State const& state) override
   {
     mr = make_pool_instance();
     rmm::mr::set_current_device_resource(mr.get());  // set default resource to pool
   }
 
-  void TearDown(const ::benchmark::State& state) override
+  void TearDown(::benchmark::State const& state) override
   {
     // reset default resource to the initial resource
     rmm::mr::set_current_device_resource(nullptr);
@@ -91,10 +91,10 @@ class benchmark : public ::benchmark::Fixture {
   }
 
   // eliminate partial override warnings (see benchmark/benchmark.h)
-  void SetUp(::benchmark::State& st) override { SetUp(const_cast<const ::benchmark::State&>(st)); }
+  void SetUp(::benchmark::State& st) override { SetUp(const_cast<::benchmark::State const&>(st)); }
   void TearDown(::benchmark::State& st) override
   {
-    TearDown(const_cast<const ::benchmark::State&>(st));
+    TearDown(const_cast<::benchmark::State const&>(st));
   }
 
   std::shared_ptr<rmm::mr::device_memory_resource> mr;

--- a/cpp/benchmarks/fixture/templated_benchmark_fixture.hpp
+++ b/cpp/benchmarks/fixture/templated_benchmark_fixture.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ namespace cudf {
 template <class Fixture>
 class FunctionTemplateBenchmark : public Fixture {
  public:
-  FunctionTemplateBenchmark(const char* name, ::benchmark::internal::Function* func)
+  FunctionTemplateBenchmark(char const* name, ::benchmark::internal::Function* func)
     : Fixture(), func_(func)
   {
     this->SetName(name);

--- a/cpp/benchmarks/groupby/group_max.cpp
+++ b/cpp/benchmarks/groupby/group_max.cpp
@@ -24,7 +24,7 @@
 template <typename Type>
 void bench_groupby_max(nvbench::state& state, nvbench::type_list<Type>)
 {
-  const auto size = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const size = static_cast<cudf::size_type>(state.get_int64("num_rows"));
 
   auto const keys = [&] {
     data_profile const profile = data_profile_builder().cardinality(0).no_validity().distribution(

--- a/cpp/benchmarks/groupby/group_nunique.cpp
+++ b/cpp/benchmarks/groupby/group_nunique.cpp
@@ -40,7 +40,7 @@ auto make_aggregation_request_vector(cudf::column_view const& values, Args&&... 
 template <typename Type>
 void bench_groupby_nunique(nvbench::state& state, nvbench::type_list<Type>)
 {
-  const auto size = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const size = static_cast<cudf::size_type>(state.get_int64("num_rows"));
 
   auto const keys = [&] {
     data_profile profile = data_profile_builder().cardinality(0).no_validity().distribution(

--- a/cpp/benchmarks/groupby/group_shift.cpp
+++ b/cpp/benchmarks/groupby/group_shift.cpp
@@ -29,7 +29,7 @@ class Groupby : public cudf::benchmark {};
 void BM_group_shift(benchmark::State& state)
 {
   const cudf::size_type column_size{(cudf::size_type)state.range(0)};
-  const int num_groups = 100;
+  int const num_groups = 100;
 
   data_profile const profile =
     data_profile_builder().cardinality(0).null_probability(0.01).distribution(

--- a/cpp/benchmarks/groupby/group_struct_keys.cpp
+++ b/cpp/benchmarks/groupby/group_struct_keys.cpp
@@ -37,7 +37,7 @@ void bench_groupby_struct_keys(nvbench::state& state)
   const cudf::size_type n_rows{static_cast<cudf::size_type>(state.get_int64("NumRows"))};
   const cudf::size_type n_cols{1};
   const cudf::size_type depth{static_cast<cudf::size_type>(state.get_int64("Depth"))};
-  const bool nulls{static_cast<bool>(state.get_int64("Nulls"))};
+  bool const nulls{static_cast<bool>(state.get_int64("Nulls"))};
 
   // Create columns with values in the range [0,100)
   std::vector<column_wrapper> columns;

--- a/cpp/benchmarks/io/json/nested_json.cpp
+++ b/cpp/benchmarks/io/json/nested_json.cpp
@@ -192,7 +192,7 @@ void BM_NESTED_JSON_DEPTH(nvbench::state& state)
 
   auto d_scalar = cudf::string_scalar(
     generate_json(100'000'000, 10, depth, 10, 10, string_size), true, cudf::get_default_stream());
-  auto input = cudf::device_span<const char>(d_scalar.data(), d_scalar.size());
+  auto input = cudf::device_span<char const>(d_scalar.data(), d_scalar.size());
 
   state.add_element_count(input.size());
   auto const default_options = cudf::io::json_reader_options{};

--- a/cpp/benchmarks/join/generate_input_tables.cuh
+++ b/cpp/benchmarks/join/generate_input_tables.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@
 
 #include <cassert>
 
-__global__ static void init_curand(curandState* state, const int nstates)
+__global__ static void init_curand(curandState* state, int const nstates)
 {
   int ithread = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -41,9 +41,9 @@ __global__ static void init_curand(curandState* state, const int nstates)
 template <typename key_type, typename size_type>
 __global__ static void init_build_tbl(key_type* const build_tbl,
                                       const size_type build_tbl_size,
-                                      const int multiplicity,
+                                      int const multiplicity,
                                       curandState* state,
-                                      const int num_states)
+                                      int const num_states)
 {
   auto const start_idx = blockIdx.x * blockDim.x + threadIdx.x;
   auto const stride    = blockDim.x * gridDim.x;
@@ -52,7 +52,7 @@ __global__ static void init_build_tbl(key_type* const build_tbl,
   curandState localState = state[start_idx];
 
   for (size_type idx = start_idx; idx < build_tbl_size; idx += stride) {
-    const double x = curand_uniform_double(&localState);
+    double const x = curand_uniform_double(&localState);
 
     build_tbl[idx] = static_cast<key_type>(x * (build_tbl_size / multiplicity));
   }
@@ -65,10 +65,10 @@ __global__ void init_probe_tbl(key_type* const probe_tbl,
                                const size_type probe_tbl_size,
                                const size_type build_tbl_size,
                                const key_type rand_max,
-                               const double selectivity,
-                               const int multiplicity,
+                               double const selectivity,
+                               int const multiplicity,
                                curandState* state,
-                               const int num_states)
+                               int const num_states)
 {
   auto const start_idx = blockIdx.x * blockDim.x + threadIdx.x;
   auto const stride    = blockDim.x * gridDim.x;
@@ -126,8 +126,8 @@ void generate_input_tables(key_type* const build_tbl,
                            const size_type build_tbl_size,
                            key_type* const probe_tbl,
                            const size_type probe_tbl_size,
-                           const double selectivity,
-                           const int multiplicity)
+                           double const selectivity,
+                           int const multiplicity)
 {
   // With large values of rand_max the a lot of temporary storage is needed for the lottery. At the
   // expense of not being that accurate with applying the selectivity an especially more memory
@@ -152,7 +152,7 @@ void generate_input_tables(key_type* const build_tbl,
   int num_sms{-1};
   CUDF_CUDA_TRY(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
 
-  const int num_states =
+  int const num_states =
     num_sms * std::max(num_blocks_init_build_tbl, num_blocks_init_probe_tbl) * block_size;
   rmm::device_uvector<curandState> devStates(num_states, cudf::get_default_stream());
 

--- a/cpp/benchmarks/join/join_common.hpp
+++ b/cpp/benchmarks/join/join_common.hpp
@@ -96,8 +96,8 @@ void BM_join(state_type& state, Join JoinFunc)
     }
   }();
 
-  const double selectivity = 0.3;
-  const int multiplicity   = 1;
+  double const selectivity = 0.3;
+  int const multiplicity   = 1;
 
   // Generate build and probe tables
   auto build_random_null_mask = [](int size) {

--- a/cpp/benchmarks/lists/copying/scatter_lists.cu
+++ b/cpp/benchmarks/lists/copying/scatter_lists.cu
@@ -42,7 +42,7 @@ void BM_lists_scatter(::benchmark::State& state)
 
   const cudf::size_type base_size{(cudf::size_type)state.range(0)};
   const cudf::size_type num_elements_per_row{(cudf::size_type)state.range(1)};
-  const auto num_rows = (cudf::size_type)ceil(double(base_size) / num_elements_per_row);
+  auto const num_rows = (cudf::size_type)ceil(double(base_size) / num_elements_per_row);
 
   auto source_base_col = make_fixed_width_column(cudf::data_type{cudf::type_to_id<TypeParam>()},
                                                  base_size,

--- a/cpp/benchmarks/sort/nested_types_common.hpp
+++ b/cpp/benchmarks/sort/nested_types_common.hpp
@@ -57,7 +57,7 @@ inline std::unique_ptr<cudf::table> create_structs_data(nvbench::state& state,
 
   const cudf::size_type n_rows{static_cast<cudf::size_type>(state.get_int64("NumRows"))};
   const cudf::size_type depth{static_cast<cudf::size_type>(state.get_int64("Depth"))};
-  const bool nulls{static_cast<bool>(state.get_int64("Nulls"))};
+  bool const nulls{static_cast<bool>(state.get_int64("Nulls"))};
 
   // Create columns with values in the range [0,100)
   std::vector<column_wrapper> columns;

--- a/cpp/benchmarks/sort/rank_structs.cpp
+++ b/cpp/benchmarks/sort/rank_structs.cpp
@@ -26,7 +26,7 @@ void nvbench_rank_structs(nvbench::state& state, nvbench::type_list<nvbench::enu
 {
   auto const table = create_structs_data(state);
 
-  const bool nulls{static_cast<bool>(state.get_int64("Nulls"))};
+  bool const nulls{static_cast<bool>(state.get_int64("Nulls"))};
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::rank(table->view().column(0),

--- a/cpp/benchmarks/sort/sort_lists.cpp
+++ b/cpp/benchmarks/sort/sort_lists.cpp
@@ -84,7 +84,7 @@ void sort_lists_of_structs(nvbench::state& state)
 
 void nvbench_sort_lists(nvbench::state& state)
 {
-  const auto has_lists_of_structs = state.get_int64("lists_of_structs") > 0;
+  auto const has_lists_of_structs = state.get_int64("lists_of_structs") > 0;
   if (has_lists_of_structs) {
     sort_lists_of_structs(state);
   } else {

--- a/cpp/benchmarks/string/convert_fixed_point.cpp
+++ b/cpp/benchmarks/string/convert_fixed_point.cpp
@@ -38,14 +38,14 @@ class StringsToFixedPoint : public cudf::benchmark {};
 template <typename fixed_point_type>
 void convert_to_fixed_point(benchmark::State& state)
 {
-  const auto rows         = static_cast<cudf::size_type>(state.range(0));
-  const auto strings_col  = get_strings_column(rows);
-  const auto strings_view = cudf::strings_column_view(strings_col->view());
-  const auto dtype = cudf::data_type{cudf::type_to_id<fixed_point_type>(), numeric::scale_type{-2}};
+  auto const rows         = static_cast<cudf::size_type>(state.range(0));
+  auto const strings_col  = get_strings_column(rows);
+  auto const strings_view = cudf::strings_column_view(strings_col->view());
+  auto const dtype = cudf::data_type{cudf::type_to_id<fixed_point_type>(), numeric::scale_type{-2}};
 
   for (auto _ : state) {
     cuda_event_timer raii(state, true);
-    volatile auto results = cudf::strings::to_fixed_point(strings_view, dtype);
+    auto volatile results = cudf::strings::to_fixed_point(strings_view, dtype);
   }
 
   // bytes_processed = bytes_input + bytes_output
@@ -58,10 +58,10 @@ class StringsFromFixedPoint : public cudf::benchmark {};
 template <typename fixed_point_type>
 void convert_from_fixed_point(benchmark::State& state)
 {
-  const auto rows        = static_cast<cudf::size_type>(state.range(0));
-  const auto strings_col = get_strings_column(rows);
-  const auto dtype = cudf::data_type{cudf::type_to_id<fixed_point_type>(), numeric::scale_type{-2}};
-  const auto fp_col =
+  auto const rows        = static_cast<cudf::size_type>(state.range(0));
+  auto const strings_col = get_strings_column(rows);
+  auto const dtype = cudf::data_type{cudf::type_to_id<fixed_point_type>(), numeric::scale_type{-2}};
+  auto const fp_col =
     cudf::strings::to_fixed_point(cudf::strings_column_view(strings_col->view()), dtype);
 
   std::unique_ptr<cudf::column> results = nullptr;

--- a/cpp/benchmarks/synchronization/synchronization.cpp
+++ b/cpp/benchmarks/synchronization/synchronization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ cuda_event_timer::cuda_event_timer(benchmark::State& state,
     CUDF_CUDA_TRY(cudaDeviceGetAttribute(&l2_cache_bytes, cudaDevAttrL2CacheSize, current_device));
 
     if (l2_cache_bytes > 0) {
-      const int memset_value = 0;
+      int const memset_value = 0;
       rmm::device_buffer l2_cache_buffer(l2_cache_bytes, stream);
       CUDF_CUDA_TRY(
         cudaMemsetAsync(l2_cache_buffer.data(), memset_value, l2_cache_bytes, stream.value()));

--- a/cpp/benchmarks/text/subword.cpp
+++ b/cpp/benchmarks/text/subword.cpp
@@ -32,7 +32,7 @@
 static std::string create_hash_vocab_file()
 {
   std::string dir_template{std::filesystem::temp_directory_path().string()};
-  if (const char* env_p = std::getenv("WORKSPACE")) dir_template = env_p;
+  if (char const* env_p = std::getenv("WORKSPACE")) dir_template = env_p;
   std::string hash_file = dir_template + "/hash_vocab.txt";
   // create a fake hashed vocab text file for this test
   // this only works with words in the strings in the benchmark code below
@@ -57,7 +57,7 @@ static std::string create_hash_vocab_file()
 static void BM_subword_tokenizer(benchmark::State& state)
 {
   auto const nrows = static_cast<cudf::size_type>(state.range(0));
-  std::vector<const char*> h_strings(nrows, "This is a test ");
+  std::vector<char const*> h_strings(nrows, "This is a test ");
   cudf::test::strings_column_wrapper strings(h_strings.begin(), h_strings.end());
   std::string hash_file = create_hash_vocab_file();
   std::vector<uint32_t> offsets{14};

--- a/cpp/benchmarks/type_dispatcher/type_dispatcher.cu
+++ b/cpp/benchmarks/type_dispatcher/type_dispatcher.cu
@@ -169,9 +169,9 @@ void launch_kernel(cudf::mutable_table_view input, T** d_ptr, int work_per_threa
 template <class TypeParam, FunctorType functor_type, DispatchingType dispatching_type>
 void type_dispatcher_benchmark(::benchmark::State& state)
 {
-  const auto n_cols          = static_cast<cudf::size_type>(state.range(0));
-  const auto source_size     = static_cast<cudf::size_type>(state.range(1));
-  const auto work_per_thread = static_cast<cudf::size_type>(state.range(2));
+  auto const n_cols          = static_cast<cudf::size_type>(state.range(0));
+  auto const source_size     = static_cast<cudf::size_type>(state.range(1));
+  auto const work_per_thread = static_cast<cudf::size_type>(state.range(2));
 
   auto init = cudf::make_fixed_width_scalar<TypeParam>(static_cast<TypeParam>(0));
 


### PR DESCRIPTION
## Description
Use east const in _cpp/benchmarks/_ files
used clang-format `QualifierAlignment: Right` to do the clean up.

since https://clang.llvm.org/docs/ClangFormatStyleOptions.html#qualifieralignment has warning that 
`Setting QualifierAlignment to something other than Leave, COULD lead to incorrect code formatting due to incorrect decisions made due to clang-formats lack of complete semantic information. As such extra care should be taken to review code changes made by the use of this option.`
So it's not added to .clang-format

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
