### PR TITLE
Enforce merge validation deprecation for unequal levels

### DIFF
--- a/python/cudf/cudf/core/join/join.py
+++ b/python/cudf/cudf/core/join/join.py
@@ -1,7 +1,6 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 from __future__ import annotations
 
-import warnings
 from typing import Any, ClassVar, List, Optional
 
 import cudf
@@ -422,11 +421,10 @@ class Merge:
             # modified in the size 0 case.
             and max(lhs._data.nlevels, 1) != max(rhs._data.nlevels, 1)
         ):
-            warnings.warn(
-                "merging between different levels is deprecated and will be "
-                f"removed in a future version. ({lhs._data.nlevels} levels on "
-                f"the left, {rhs._data.nlevels} on the right)",
-                FutureWarning,
+            raise ValueError(
+                "Not allowed to merge between different levels. "
+                f"({lhs._data.nlevels} levels on "
+                f"the left, {rhs._data.nlevels} on the right)"
             )
 
 


### PR DESCRIPTION
## Description
This PR raises an error when a merge is being performed between data consisting of different levels.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
