### PR TITLE
Enable writing column names with mixed dtype in parquet writer when `mode.pandas_compatible=True`

### DIFF
--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -361,9 +361,12 @@ def write_parquet(
 
     for i, name in enumerate(table._column_names, num_index_cols_meta):
         if not isinstance(name, str):
-            raise ValueError("parquet must have string column names")
-
-        tbl_meta.get().column_metadata[i].set_name(name.encode())
+            if cudf.get_option("mode.pandas_compatible"):
+                tbl_meta.get().column_metadata[i].set_name(str(name).encode())
+            else:
+                raise ValueError("parquet must have string column names")
+        else:
+            tbl_meta.get().column_metadata[i].set_name(name.encode())
         _set_col_metadata(
             table[name]._column,
             tbl_meta.get().column_metadata[i],

--- a/python/cudf/cudf/_lib/utils.pyx
+++ b/python/cudf/cudf/_lib/utils.pyx
@@ -174,7 +174,7 @@ cpdef generate_pandas_metadata(table, index):
             for col in table._columns
         ],
         df=table,
-        column_names=col_names,
+        column_names=map(str, col_names),
         index_levels=index_levels,
         index_descriptors=index_descriptors,
         preserve_index=index,


### PR DESCRIPTION
## Description
This PR enables writing a dataframe that has column names that are of mixed types to a parquet file when pandas compatibility mode is enabled(`mode.pandas_compatible=True`).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
