### PR TITLE
Use test default stream

### DIFF
--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -34,6 +34,7 @@
 
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/cudf_gtest.hpp>
+#include <cudf_test/default_stream.hpp>
 
 #include <rmm/device_buffer.hpp>
 
@@ -170,7 +171,8 @@ rmm::device_buffer make_elements(InputIterator begin, InputIterator end)
   auto transform_begin = thrust::make_transform_iterator(begin, transformer);
   auto const size      = cudf::distance(begin, end);
   auto const elements  = thrust::host_vector<ElementTo>(transform_begin, transform_begin + size);
-  return rmm::device_buffer{elements.data(), size * sizeof(ElementTo), cudf::get_default_stream()};
+  return rmm::device_buffer{
+    elements.data(), size * sizeof(ElementTo), cudf::test::get_default_stream()};
 }
 
 /**
@@ -196,7 +198,8 @@ rmm::device_buffer make_elements(InputIterator begin, InputIterator end)
   auto transform_begin = thrust::make_transform_iterator(begin, transformer);
   auto const size      = cudf::distance(begin, end);
   auto const elements  = thrust::host_vector<RepType>(transform_begin, transform_begin + size);
-  return rmm::device_buffer{elements.data(), size * sizeof(RepType), cudf::get_default_stream()};
+  return rmm::device_buffer{
+    elements.data(), size * sizeof(RepType), cudf::test::get_default_stream()};
 }
 
 /**
@@ -223,7 +226,8 @@ rmm::device_buffer make_elements(InputIterator begin, InputIterator end)
   auto transformer_begin = thrust::make_transform_iterator(begin, to_rep);
   auto const size        = cudf::distance(begin, end);
   auto const elements = thrust::host_vector<RepType>(transformer_begin, transformer_begin + size);
-  return rmm::device_buffer{elements.data(), size * sizeof(RepType), cudf::get_default_stream()};
+  return rmm::device_buffer{
+    elements.data(), size * sizeof(RepType), cudf::test::get_default_stream()};
 }
 
 /**
@@ -279,7 +283,7 @@ std::pair<rmm::device_buffer, cudf::size_type> make_null_mask(ValidityIterator b
   auto [null_mask, null_count] = make_null_mask_vector(begin, end);
   auto d_mask                  = rmm::device_buffer{null_mask.data(),
                                    cudf::bitmask_allocation_size_bytes(cudf::distance(begin, end)),
-                                   cudf::get_default_stream()};
+                                   cudf::test::get_default_stream()};
   return {std::move(d_mask), null_count};
 }
 
@@ -561,7 +565,7 @@ class fixed_point_column_wrapper : public detail::column_wrapper {
     wrapped.reset(new cudf::column{
       data_type,
       size,
-      rmm::device_buffer{elements.data(), size * sizeof(Rep), cudf::get_default_stream()},
+      rmm::device_buffer{elements.data(), size * sizeof(Rep), cudf::test::get_default_stream()},
       rmm::device_buffer{},
       0});
   }
@@ -627,7 +631,7 @@ class fixed_point_column_wrapper : public detail::column_wrapper {
     wrapped.reset(new cudf::column{
       data_type,
       size,
-      rmm::device_buffer{elements.data(), size * sizeof(Rep), cudf::get_default_stream()},
+      rmm::device_buffer{elements.data(), size * sizeof(Rep), cudf::test::get_default_stream()},
       std::move(null_mask),
       null_count});
   }
@@ -749,9 +753,9 @@ class strings_column_wrapper : public detail::column_wrapper {
     auto all_valid        = thrust::make_constant_iterator(true);
     auto [chars, offsets] = detail::make_chars_and_offsets(begin, end, all_valid);
     auto d_chars          = cudf::detail::make_device_uvector_sync(
-      chars, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
+      chars, cudf::test::get_default_stream(), rmm::mr::get_current_device_resource());
     auto d_offsets = cudf::detail::make_device_uvector_sync(
-      offsets, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
+      offsets, cudf::test::get_default_stream(), rmm::mr::get_current_device_resource());
     wrapped = cudf::make_strings_column(d_chars, d_offsets, {}, 0);
   }
 
@@ -791,11 +795,11 @@ class strings_column_wrapper : public detail::column_wrapper {
     auto [chars, offsets]        = detail::make_chars_and_offsets(begin, end, v);
     auto [null_mask, null_count] = detail::make_null_mask_vector(v, v + num_strings);
     auto d_chars                 = cudf::detail::make_device_uvector_sync(
-      chars, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
+      chars, cudf::test::get_default_stream(), rmm::mr::get_current_device_resource());
     auto d_offsets = cudf::detail::make_device_uvector_sync(
-      offsets, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
+      offsets, cudf::test::get_default_stream(), rmm::mr::get_current_device_resource());
     auto d_bitmask = cudf::detail::make_device_uvector_sync(
-      null_mask, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
+      null_mask, cudf::test::get_default_stream(), rmm::mr::get_current_device_resource());
     wrapped = cudf::make_strings_column(d_chars, d_offsets, d_bitmask, null_count);
   }
 

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -756,7 +756,8 @@ class strings_column_wrapper : public detail::column_wrapper {
       chars, cudf::test::get_default_stream(), rmm::mr::get_current_device_resource());
     auto d_offsets = cudf::detail::make_device_uvector_sync(
       offsets, cudf::test::get_default_stream(), rmm::mr::get_current_device_resource());
-    wrapped = cudf::make_strings_column(d_chars, d_offsets, {}, 0);
+    wrapped =
+      cudf::make_strings_column(d_chars, d_offsets, {}, 0, cudf::test::get_default_stream());
   }
 
   /**

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -33,6 +33,7 @@
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/cudf_gtest.hpp>
+#include <cudf_test/default_stream.hpp>
 #include <cudf_test/detail/column_utilities.hpp>
 
 #include <rmm/exec_policy.hpp>
@@ -63,9 +64,9 @@ namespace {
 
 std::unique_ptr<column> generate_all_row_indices(size_type num_rows)
 {
-  auto indices =
-    cudf::make_fixed_width_column(data_type{type_id::INT32}, num_rows, mask_state::UNALLOCATED);
-  thrust::sequence(rmm::exec_policy(cudf::get_default_stream()),
+  auto indices = cudf::make_fixed_width_column(
+    data_type{type_id::INT32}, num_rows, mask_state::UNALLOCATED, cudf::test::get_default_stream());
+  thrust::sequence(rmm::exec_policy(cudf::test::get_default_stream()),
                    indices->mutable_view().begin<size_type>(),
                    indices->mutable_view().end<size_type>(),
                    0);
@@ -102,7 +103,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   // if we are checking for exact equality, we should be checking for "unsanitized" data that may
   // be hiding underneath nulls. so check all rows instead of just non-null rows
   if (check_exact_equality) {
-    return generate_all_row_indices(c.get_sliced_child(cudf::get_default_stream()).size());
+    return generate_all_row_indices(c.get_sliced_child(cudf::test::get_default_stream()).size());
   }
 
   // Example input
@@ -131,7 +132,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
                ? (offsets[true_index + 1] - offsets[true_index])
                : 0;
     });
-  auto const output_size = thrust::reduce(rmm::exec_policy(cudf::get_default_stream()),
+  auto const output_size = thrust::reduce(rmm::exec_policy(cudf::test::get_default_stream()),
                                           row_size_iter,
                                           row_size_iter + row_indices.size());
   // no output. done.
@@ -146,7 +147,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   //
   auto output_row_start = cudf::make_fixed_width_column(
     data_type{type_id::INT32}, row_indices.size(), mask_state::UNALLOCATED);
-  thrust::exclusive_scan(rmm::exec_policy(cudf::get_default_stream()),
+  thrust::exclusive_scan(rmm::exec_policy(cudf::test::get_default_stream()),
                          row_size_iter,
                          row_size_iter + row_indices.size(),
                          output_row_start->mutable_view().begin<size_type>());
@@ -155,7 +156,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   //
   // result = [1, 1, 1, 1, 1]
   //
-  thrust::generate(rmm::exec_policy(cudf::get_default_stream()),
+  thrust::generate(rmm::exec_policy(cudf::test::get_default_stream()),
                    result->mutable_view().begin<size_type>(),
                    result->mutable_view().end<size_type>(),
                    [] __device__() { return 1; });
@@ -170,11 +171,11 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
      offsets      = c.offsets().begin<offset_type>(),
      offset       = c.offset(),
      first_offset = cudf::detail::get_value<offset_type>(
-       c.offsets(), c.offset(), cudf::get_default_stream())] __device__(int index) {
+       c.offsets(), c.offset(), cudf::test::get_default_stream())] __device__(int index) {
       auto const true_index = row_indices[index] + offset;
       return offsets[true_index] - first_offset;
     });
-  thrust::scatter_if(rmm::exec_policy(cudf::get_default_stream()),
+  thrust::scatter_if(rmm::exec_policy(cudf::test::get_default_stream()),
                      output_row_iter,
                      output_row_iter + row_indices.size(),
                      output_row_start->view().begin<size_type>(),
@@ -188,18 +189,18 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   //
   auto keys =
     cudf::make_fixed_width_column(data_type{type_id::INT32}, output_size, mask_state::UNALLOCATED);
-  thrust::generate(rmm::exec_policy(cudf::get_default_stream()),
+  thrust::generate(rmm::exec_policy(cudf::test::get_default_stream()),
                    keys->mutable_view().begin<size_type>(),
                    keys->mutable_view().end<size_type>(),
                    [] __device__() { return 0; });
-  thrust::scatter_if(rmm::exec_policy(cudf::get_default_stream()),
+  thrust::scatter_if(rmm::exec_policy(cudf::test::get_default_stream()),
                      row_size_iter,
                      row_size_iter + row_indices.size(),
                      output_row_start->view().begin<size_type>(),
                      row_size_iter,
                      keys->mutable_view().begin<size_type>(),
                      [] __device__(auto row_size) { return row_size != 0; });
-  thrust::inclusive_scan(rmm::exec_policy(cudf::get_default_stream()),
+  thrust::inclusive_scan(rmm::exec_policy(cudf::test::get_default_stream()),
                          keys->view().begin<size_type>(),
                          keys->view().end<size_type>(),
                          keys->mutable_view().begin<size_type>());
@@ -212,7 +213,7 @@ std::unique_ptr<column> generate_child_row_indices(lists_column_view const& c,
   // output
   //    result = [6, 7, 11, 12, 13]
   //
-  thrust::inclusive_scan_by_key(rmm::exec_policy(cudf::get_default_stream()),
+  thrust::inclusive_scan_by_key(rmm::exec_policy(cudf::test::get_default_stream()),
                                 keys->view().begin<size_type>(),
                                 keys->view().end<size_type>(),
                                 result->view().begin<size_type>(),
@@ -255,7 +256,7 @@ struct column_property_comparator {
         auto const true_index = row_indices[index] + offset;
         return !validity || cudf::bit_is_set(validity, true_index) ? 0 : 1;
       });
-    return thrust::reduce(rmm::exec_policy(cudf::get_default_stream()),
+    return thrust::reduce(rmm::exec_policy(cudf::test::get_default_stream()),
                           validity_iter,
                           validity_iter + row_indices.size());
   }
@@ -327,8 +328,8 @@ struct column_property_comparator {
     auto lhs_child_indices =
       generate_child_row_indices(lhs_l, lhs_row_indices, check_exact_equality);
     if (lhs_child_indices->size() > 0) {
-      auto lhs_child = lhs_l.get_sliced_child(cudf::get_default_stream());
-      auto rhs_child = rhs_l.get_sliced_child(cudf::get_default_stream());
+      auto lhs_child = lhs_l.get_sliced_child(cudf::test::get_default_stream());
+      auto rhs_child = rhs_l.get_sliced_child(cudf::test::get_default_stream());
       auto rhs_child_indices =
         generate_child_row_indices(rhs_l, rhs_row_indices, check_exact_equality);
       return cudf::type_dispatcher(lhs_child.type(),
@@ -489,7 +490,8 @@ std::string stringify_column_differences(cudf::device_span<int const> difference
   CUDF_EXPECTS(not differences.empty(), "Shouldn't enter this function if `differences` is empty");
   std::string const depth_str = depth > 0 ? "depth " + std::to_string(depth) + '\n' : "";
   // move the differences to the host.
-  auto h_differences = cudf::detail::make_host_vector_sync(differences, cudf::get_default_stream());
+  auto h_differences =
+    cudf::detail::make_host_vector_sync(differences, cudf::test::get_default_stream());
   if (verbosity == debug_output_level::ALL_ERRORS) {
     std::ostringstream buffer;
     buffer << depth_str << "differences:" << std::endl;
@@ -510,9 +512,9 @@ std::string stringify_column_differences(cudf::device_span<int const> difference
     auto const index = h_differences[0];  // only stringify first difference
 
     auto const lhs_index =
-      cudf::detail::get_value<size_type>(lhs_row_indices, index, cudf::get_default_stream());
+      cudf::detail::get_value<size_type>(lhs_row_indices, index, cudf::test::get_default_stream());
     auto const rhs_index =
-      cudf::detail::get_value<size_type>(rhs_row_indices, index, cudf::get_default_stream());
+      cudf::detail::get_value<size_type>(rhs_row_indices, index, cudf::test::get_default_stream());
     auto diff_lhs = cudf::slice(lhs, {lhs_index, lhs_index + 1}).front();
     auto diff_rhs = cudf::slice(rhs, {rhs_index, rhs_index + 1}).front();
     return depth_str + "first difference: " + "lhs[" + std::to_string(index) +
@@ -532,17 +534,17 @@ struct column_comparator_impl {
                   size_type fp_ulps,
                   int depth)
   {
-    auto d_lhs_row_indices = cudf::column_device_view::create(lhs_row_indices);
-    auto d_rhs_row_indices = cudf::column_device_view::create(rhs_row_indices);
+    auto d_lhs_row_indices = cudf::column_device_view::create(lhs_row_indices, cudf::test::get_default_stream());
+    auto d_rhs_row_indices = cudf::column_device_view::create(rhs_row_indices, cudf::test::get_default_stream());
 
-    auto d_lhs = cudf::column_device_view::create(lhs);
-    auto d_rhs = cudf::column_device_view::create(rhs);
+    auto d_lhs = cudf::column_device_view::create(lhs, cudf::test::get_default_stream());
+    auto d_rhs = cudf::column_device_view::create(rhs, cudf::test::get_default_stream());
 
     auto lhs_tview = table_view{{lhs}};
     auto rhs_tview = table_view{{rhs}};
 
     auto const comparator = cudf::experimental::row::equality::two_table_comparator{
-      lhs_tview, rhs_tview, cudf::get_default_stream()};
+      lhs_tview, rhs_tview, cudf::test::get_default_stream()};
     auto const has_nulls = cudf::has_nulls(lhs_tview) or cudf::has_nulls(rhs_tview);
 
     auto const device_comparator = comparator.equal_to<false>(cudf::nullate::DYNAMIC{has_nulls});
@@ -553,13 +555,13 @@ struct column_comparator_impl {
                          corresponding_rows_not_equivalent<decltype(device_comparator)>>;
 
     auto differences = rmm::device_uvector<int>(
-      lhs_row_indices.size(), cudf::get_default_stream());  // worst case: everything different
+      lhs_row_indices.size(), cudf::test::get_default_stream());  // worst case: everything different
     auto input_iter = thrust::make_counting_iterator(0);
 
-    auto diff_map = rmm::device_uvector<bool>(lhs_row_indices.size(), cudf::get_default_stream());
+    auto diff_map = rmm::device_uvector<bool>(lhs_row_indices.size(), cudf::test::get_default_stream());
 
     thrust::transform(
-      rmm::exec_policy(cudf::get_default_stream()),
+      rmm::exec_policy(cudf::test::get_default_stream()),
       input_iter,
       input_iter + lhs_row_indices.size(),
       diff_map.begin(),
@@ -574,7 +576,7 @@ struct column_comparator_impl {
                                      thrust::identity<bool>{});
 
     differences.resize(thrust::distance(differences.begin(), diff_iter),
-                       cudf::get_default_stream());  // shrink back down
+                       cudf::test::get_default_stream());  // shrink back down
 
     if (not differences.is_empty()) {
       if (verbosity != debug_output_level::QUIET) {
@@ -612,13 +614,13 @@ struct column_comparator_impl<list_view, check_exact_equality> {
     if (lhs_row_indices.is_empty()) { return true; }
 
     // worst case - everything is different
-    rmm::device_uvector<int> differences(lhs_row_indices.size(), cudf::get_default_stream());
+    rmm::device_uvector<int> differences(lhs_row_indices.size(), cudf::test::get_default_stream());
 
     // compare offsets, taking slicing into account
 
     // left side
     size_type lhs_shift = cudf::detail::get_value<size_type>(
-      lhs_l.offsets(), lhs_l.offset(), cudf::get_default_stream());
+      lhs_l.offsets(), lhs_l.offset(), cudf::test::get_default_stream());
     auto lhs_offsets = thrust::make_transform_iterator(
       lhs_l.offsets().begin<size_type>() + lhs_l.offset(),
       [lhs_shift] __device__(size_type offset) { return offset - lhs_shift; });
@@ -630,7 +632,7 @@ struct column_comparator_impl<list_view, check_exact_equality> {
 
     // right side
     size_type rhs_shift = cudf::detail::get_value<size_type>(
-      rhs_l.offsets(), rhs_l.offset(), cudf::get_default_stream());
+      rhs_l.offsets(), rhs_l.offset(), cudf::test::get_default_stream());
     auto rhs_offsets = thrust::make_transform_iterator(
       rhs_l.offsets().begin<size_type>() + rhs_l.offset(),
       [rhs_shift] __device__(size_type offset) { return offset - rhs_shift; });
@@ -658,7 +660,7 @@ struct column_comparator_impl<list_view, check_exact_equality> {
     //
     auto input_iter = thrust::make_counting_iterator(0);
     auto diff_iter  = thrust::copy_if(
-      rmm::exec_policy(cudf::get_default_stream()),
+      rmm::exec_policy(cudf::test::get_default_stream()),
       input_iter,
       input_iter + lhs_row_indices.size(),
       differences.begin(),
@@ -694,7 +696,7 @@ struct column_comparator_impl<list_view, check_exact_equality> {
       });
 
     differences.resize(thrust::distance(differences.begin(), diff_iter),
-                       cudf::get_default_stream());  // shrink back down
+                       cudf::test::get_default_stream());  // shrink back down
 
     if (not differences.is_empty()) {
       if (verbosity != debug_output_level::QUIET) {
@@ -713,8 +715,8 @@ struct column_comparator_impl<list_view, check_exact_equality> {
     auto lhs_child_indices =
       generate_child_row_indices(lhs_l, lhs_row_indices, check_exact_equality);
     if (lhs_child_indices->size() > 0) {
-      auto lhs_child = lhs_l.get_sliced_child(cudf::get_default_stream());
-      auto rhs_child = rhs_l.get_sliced_child(cudf::get_default_stream());
+      auto lhs_child = lhs_l.get_sliced_child(cudf::test::get_default_stream());
+      auto rhs_child = rhs_l.get_sliced_child(cudf::test::get_default_stream());
       auto rhs_child_indices =
         generate_child_row_indices(rhs_l, rhs_row_indices, check_exact_equality);
       return cudf::type_dispatcher(lhs_child.type(),
@@ -881,8 +883,10 @@ void expect_equal_buffers(void const* lhs, void const* rhs, std::size_t size_byt
   }
   auto typed_lhs = static_cast<char const*>(lhs);
   auto typed_rhs = static_cast<char const*>(rhs);
-  EXPECT_TRUE(thrust::equal(
-    rmm::exec_policy(cudf::get_default_stream()), typed_lhs, typed_lhs + size_bytes, typed_rhs));
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cudf::test::get_default_stream()),
+                            typed_lhs,
+                            typed_lhs + size_bytes,
+                            typed_rhs));
 }
 }  // namespace detail
 
@@ -979,20 +983,20 @@ std::string nested_offsets_to_string(NestedColumnView const& c, std::string cons
 
   // the first offset value to normalize everything against
   size_type first =
-    cudf::detail::get_value<size_type>(offsets, c.offset(), cudf::get_default_stream());
-  rmm::device_uvector<size_type> shifted_offsets(output_size, cudf::get_default_stream());
+    cudf::detail::get_value<size_type>(offsets, c.offset(), cudf::test::get_default_stream());
+  rmm::device_uvector<size_type> shifted_offsets(output_size, cudf::test::get_default_stream());
 
   // normalize the offset values for the column offset
   size_type const* d_offsets = offsets.head<size_type>() + c.offset();
   thrust::transform(
-    rmm::exec_policy(cudf::get_default_stream()),
+    rmm::exec_policy(cudf::test::get_default_stream()),
     d_offsets,
     d_offsets + output_size,
     shifted_offsets.begin(),
     [first] __device__(int32_t offset) { return static_cast<size_type>(offset - first); });
 
   auto const h_shifted_offsets =
-    cudf::detail::make_host_vector_sync(shifted_offsets, cudf::get_default_stream());
+    cudf::detail::make_host_vector_sync(shifted_offsets, cudf::test::get_default_stream());
   std::ostringstream buffer;
   for (size_t idx = 0; idx < h_shifted_offsets.size(); idx++) {
     buffer << h_shifted_offsets[idx];
@@ -1162,7 +1166,7 @@ struct column_view_printer {
     lists_column_view lcv(col);
 
     // propagate slicing to the child if necessary
-    column_view child    = lcv.get_sliced_child(cudf::get_default_stream());
+    column_view child    = lcv.get_sliced_child(cudf::test::get_default_stream());
     bool const is_sliced = lcv.offset() > 0 || child.offset() > 0;
 
     std::string tmp =

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -534,8 +534,10 @@ struct column_comparator_impl {
                   size_type fp_ulps,
                   int depth)
   {
-    auto d_lhs_row_indices = cudf::column_device_view::create(lhs_row_indices, cudf::test::get_default_stream());
-    auto d_rhs_row_indices = cudf::column_device_view::create(rhs_row_indices, cudf::test::get_default_stream());
+    auto d_lhs_row_indices =
+      cudf::column_device_view::create(lhs_row_indices, cudf::test::get_default_stream());
+    auto d_rhs_row_indices =
+      cudf::column_device_view::create(rhs_row_indices, cudf::test::get_default_stream());
 
     auto d_lhs = cudf::column_device_view::create(lhs, cudf::test::get_default_stream());
     auto d_rhs = cudf::column_device_view::create(rhs, cudf::test::get_default_stream());
@@ -555,10 +557,12 @@ struct column_comparator_impl {
                          corresponding_rows_not_equivalent<decltype(device_comparator)>>;
 
     auto differences = rmm::device_uvector<int>(
-      lhs_row_indices.size(), cudf::test::get_default_stream());  // worst case: everything different
+      lhs_row_indices.size(),
+      cudf::test::get_default_stream());  // worst case: everything different
     auto input_iter = thrust::make_counting_iterator(0);
 
-    auto diff_map = rmm::device_uvector<bool>(lhs_row_indices.size(), cudf::test::get_default_stream());
+    auto diff_map =
+      rmm::device_uvector<bool>(lhs_row_indices.size(), cudf::test::get_default_stream());
 
     thrust::transform(
       rmm::exec_policy(cudf::test::get_default_stream()),

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -356,8 +356,8 @@ struct column_property_comparator {
     structs_column_view r_scv(rhs);
 
     for (size_type i = 0; i < lhs.num_children(); i++) {
-      column_view lhs_child = l_scv.get_sliced_child(i, cudf::get_default_stream());
-      column_view rhs_child = r_scv.get_sliced_child(i, cudf::get_default_stream());
+      column_view lhs_child = l_scv.get_sliced_child(i, cudf::test::get_default_stream());
+      column_view rhs_child = r_scv.get_sliced_child(i, cudf::test::get_default_stream());
       if (!cudf::type_dispatcher(lhs_child.type(),
                                  column_property_comparator<check_exact_equality>{},
                                  lhs_child,
@@ -572,7 +572,7 @@ struct column_comparator_impl {
       ComparatorType(
         *d_lhs_row_indices, *d_rhs_row_indices, fp_ulps, device_comparator, *d_lhs, *d_rhs));
 
-    auto diff_iter = thrust::copy_if(rmm::exec_policy(cudf::get_default_stream()),
+    auto diff_iter = thrust::copy_if(rmm::exec_policy(cudf::test::get_default_stream()),
                                      input_iter,
                                      input_iter + lhs_row_indices.size(),
                                      diff_map.begin(),
@@ -752,8 +752,8 @@ struct column_comparator_impl<struct_view, check_exact_equality> {
     structs_column_view r_scv(rhs);
 
     for (size_type i = 0; i < lhs.num_children(); i++) {
-      column_view lhs_child = l_scv.get_sliced_child(i, cudf::get_default_stream());
-      column_view rhs_child = r_scv.get_sliced_child(i, cudf::get_default_stream());
+      column_view lhs_child = l_scv.get_sliced_child(i, cudf::test::get_default_stream());
+      column_view rhs_child = r_scv.get_sliced_child(i, cudf::test::get_default_stream());
       if (!cudf::type_dispatcher(lhs_child.type(),
                                  column_comparator<check_exact_equality>{},
                                  lhs_child,
@@ -1213,7 +1213,7 @@ struct column_view_printer {
       iter + view.num_children(),
       std::ostream_iterator<std::string>(out_stream, "\n"),
       [&](size_type index) {
-        auto child = view.get_sliced_child(index, cudf::get_default_stream());
+        auto child = view.get_sliced_child(index, cudf::test::get_default_stream());
 
         // non-nested types don't typically display their null masks, so do it here for convenience.
         return (!is_nested(child.type()) && child.nullable()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
For the purpose of verifying that streams are properly forwarded through all libcudf APIs, libcudf tests will be rewritten to use `cudf::test::get_default_stream()` (introduced in #12089) instead of `cudf::get_default_stream()`. By default, these are identical, so this change is typically a no-op, but when using the preload library features added in #12089 we will be able to use a custom (non CUDA-default) stream in tests and verify that it is the only stream used. This PR contains a subset of changes needed to existing test functionality without making any changes to libcudf public APIs. These changes are extracted from #12090.

Contributes to #11943.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
