### PR TITLE
Add libcufile to dependencies.yaml.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -36,6 +36,8 @@ dependencies:
 - hypothesis
 - ipython
 - libarrow==11.0.0.*
+- libcufile-dev=1.4.0.31
+- libcufile=1.4.0.31
 - libcurand-dev=10.3.0.86
 - libcurand=10.3.0.86
 - libkvikio==23.8.*

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -320,6 +320,9 @@ dependencies:
               # so 11.2 uses 11.4 packages (the oldest available).
               - *libcufile_114
               - *libcufile_dev114
+          # Fallback matrix for aarch64, which doesn't support libcufile.
+          - matrix:
+            packages:
   develop:
     common:
       - output_types: [conda, requirements]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -292,6 +292,34 @@ dependencies:
                 # available).
               - *libcurand_dev114
               - *libcurand114
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "11.8"
+              arch: x86_64
+            packages:
+              - libcufile=1.4.0.31
+              - libcufile-dev=1.4.0.31
+          - matrix:
+              cuda: "11.5"
+              arch: x86_64
+            packages:
+              - libcufile>=1.1.0.37,<=1.1.1.25
+              - libcufile-dev>=1.1.0.37,<=1.1.1.25
+          - matrix:
+              cuda: "11.4"
+              arch: x86_64
+            packages:
+              - &libcufile_114 libcufile>=1.0.0.82,<=1.0.2.10
+              - &libcufile_dev114 libcufile-dev>=1.0.0.82,<=1.0.2.10
+          - matrix:
+              cuda: "11.2"
+              arch: x86_64
+            packages:
+              # The NVIDIA channel doesn't publish pkgs older than 11.4 for these libs,
+              # so 11.2 uses 11.4 packages (the oldest available).
+              - *libcufile_114
+              - *libcufile_dev114
   develop:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
## Description
This PR adds a libcufile dependency specification, only for x86_64 (the package is not available on ARM). This aligns with the conda recipe specification, previously updated in #13231.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
