### PR TITLE
Refactor `hostdevice_vector` `hostdevice_2dvector` and `hostdevice_span`

### DIFF
--- a/cpp/src/io/comp/uncomp.cpp
+++ b/cpp/src/io/comp/uncomp.cpp
@@ -513,17 +513,17 @@ size_t decompress_zstd(host_span<uint8_t const> src,
     cudf::detail::make_device_uvector_async(src, stream, rmm::mr::get_current_device_resource());
   auto hd_srcs = hostdevice_vector<device_span<uint8_t const>>(1, stream);
   hd_srcs[0]   = d_src;
-  hd_srcs.host_to_device(stream);
+  hd_srcs.host_to_device_async(stream);
 
   // Init device span of spans (temporary destination)
   auto d_dst   = rmm::device_uvector<uint8_t>(dst.size(), stream);
   auto hd_dsts = hostdevice_vector<device_span<uint8_t>>(1, stream);
   hd_dsts[0]   = d_dst;
-  hd_dsts.host_to_device(stream);
+  hd_dsts.host_to_device_async(stream);
 
   auto hd_stats = hostdevice_vector<compression_result>(1, stream);
   hd_stats[0]   = compression_result{0, compression_status::FAILURE};
-  hd_stats.host_to_device(stream);
+  hd_stats.host_to_device_async(stream);
   auto const max_uncomp_page_size = dst.size();
   nvcomp::batched_decompress(nvcomp::compression_type::ZSTD,
                              hd_srcs,
@@ -533,7 +533,7 @@ size_t decompress_zstd(host_span<uint8_t const> src,
                              max_uncomp_page_size,
                              stream);
 
-  hd_stats.device_to_host(stream, true);
+  hd_stats.device_to_host_sync(stream);
   CUDF_EXPECTS(hd_stats[0].status == compression_status::SUCCESS, "ZSTD decompression failed");
 
   // Copy temporary output to `dst`

--- a/cpp/src/io/fst/lookup_tables.cuh
+++ b/cpp/src/io/fst/lookup_tables.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/io/fst/lookup_tables.cuh
+++ b/cpp/src/io/fst/lookup_tables.cuh
@@ -104,7 +104,7 @@ class SingleSymbolSmemLUT {
     // Alias memory / return memory requirements
     sgid_init.host_ptr()->num_valid_entries = max_base_match_val + 1;
 
-    sgid_init.host_to_device(stream);
+    sgid_init.host_to_device_async(stream);
   }
 
   _TempStorage& temp_storage;
@@ -190,7 +190,7 @@ class TransitionTable {
     }
 
     // Copy transition table to device
-    transition_table_init.host_to_device(stream);
+    transition_table_init.host_to_device_async(stream);
   }
 
   constexpr CUDF_HOST_DEVICE TransitionTable(const KernelParameter& kernel_param,
@@ -364,7 +364,7 @@ class TransducerLookupTable {
               translation_table_init.host_ptr()->d_out_symbols);
 
     // Copy data to device
-    translation_table_init.host_to_device(stream);
+    translation_table_init.host_to_device_async(stream);
   }
 
  private:

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -117,15 +117,15 @@ void reader::impl::decode_page_data(size_t skip_rows, size_t num_rows)
     page_count += chunks[c].max_num_pages;
   }
 
-  chunks.host_to_device(_stream);
-  chunk_nested_valids.host_to_device(_stream);
-  chunk_nested_data.host_to_device(_stream);
+  chunks.host_to_device_async(_stream);
+  chunk_nested_valids.host_to_device_async(_stream);
+  chunk_nested_data.host_to_device_async(_stream);
 
   gpu::DecodePageData(pages, chunks, num_rows, skip_rows, _file_itm_data.level_type_size, _stream);
 
-  pages.device_to_host(_stream);
-  page_nesting.device_to_host(_stream);
-  page_nesting_decode.device_to_host(_stream);
+  pages.device_to_host_async(_stream);
+  page_nesting.device_to_host_async(_stream);
+  page_nesting_decode.device_to_host_async(_stream);
   _stream.synchronize();
 
   // for list columns, add the final offset to every offset buffer.

--- a/cpp/src/io/utilities/hostdevice_span.hpp
+++ b/cpp/src/io/utilities/hostdevice_span.hpp
@@ -144,18 +144,28 @@ class hostdevice_span {
     return hostdevice_span<T>(_host_data + offset, _device_data + offset, count);
   }
 
-  void host_to_device(rmm::cuda_stream_view stream, bool synchronize = false)
+  void host_to_device_async(rmm::cuda_stream_view stream)
   {
     CUDF_CUDA_TRY(
       cudaMemcpyAsync(device_ptr(), host_ptr(), size_bytes(), cudaMemcpyDefault, stream.value()));
-    if (synchronize) { stream.synchronize(); }
   }
 
-  void device_to_host(rmm::cuda_stream_view stream, bool synchronize = false)
+  void host_to_device_sync(rmm::cuda_stream_view stream)
+  {
+    host_to_device_async(stream);
+    stream.synchronize();
+  }
+
+  void device_to_host_async(rmm::cuda_stream_view stream)
   {
     CUDF_CUDA_TRY(
       cudaMemcpyAsync(host_ptr(), device_ptr(), size_bytes(), cudaMemcpyDefault, stream.value()));
-    if (synchronize) { stream.synchronize(); }
+  }
+
+  void device_to_host_sync(rmm::cuda_stream_view stream)
+  {
+    device_to_host_async(stream);
+    stream.synchronize();
   }
 
  private:

--- a/cpp/tests/io/comp/decomp_test.cpp
+++ b/cpp/tests/io/comp/decomp_test.cpp
@@ -53,20 +53,20 @@ struct DecompressTest : public cudf::test::BaseFixture {
 
     hostdevice_vector<device_span<uint8_t const>> inf_in(1, stream);
     inf_in[0] = {static_cast<uint8_t const*>(src.data()), src.size()};
-    inf_in.host_to_device(stream);
+    inf_in.host_to_device_async(stream);
 
     hostdevice_vector<device_span<uint8_t>> inf_out(1, stream);
     inf_out[0] = dst;
-    inf_out.host_to_device(stream);
+    inf_out.host_to_device_async(stream);
 
     hostdevice_vector<cudf::io::compression_result> inf_stat(1, stream);
     inf_stat[0] = {};
-    inf_stat.host_to_device(stream);
+    inf_stat.host_to_device_async(stream);
 
     static_cast<Decompressor*>(this)->dispatch(inf_in, inf_out, inf_stat);
     CUDF_CUDA_TRY(cudaMemcpyAsync(
       decompressed->data(), dst.data(), dst.size(), cudaMemcpyDefault, stream.value()));
-    inf_stat.device_to_host(stream, true);
+    inf_stat.device_to_host_sync(stream);
     ASSERT_EQ(inf_stat[0].status, cudf::io::compression_status::SUCCESS);
   }
 };

--- a/cpp/tests/io/fst/fst_test.cu
+++ b/cpp/tests/io/fst/fst_test.cu
@@ -179,9 +179,9 @@ TEST_F(FstTest, GroundTruth)
                    stream.value());
 
   // Async copy results from device to host
-  output_gpu.device_to_host(stream.view());
-  out_indexes_gpu.device_to_host(stream.view());
-  output_gpu_size.device_to_host(stream.view());
+  output_gpu.device_to_host_async(stream.view());
+  out_indexes_gpu.device_to_host_async(stream.view());
+  output_gpu_size.device_to_host_async(stream.view());
 
   // Prepare CPU-side results for verification
   std::string output_cpu{};

--- a/cpp/tests/io/fst/logical_stack_test.cu
+++ b/cpp/tests/io/fst/logical_stack_test.cu
@@ -226,7 +226,7 @@ TEST_F(LogicalStackTest, GroundTruth)
                                                     stream.value());
 
   // Async copy results from device to host
-  top_of_stack_gpu.device_to_host(stream_view);
+  top_of_stack_gpu.device_to_host_async(stream_view);
 
   // Get CPU-side results for verification
   std::string top_of_stack_cpu{};

--- a/cpp/tests/io/nested_json_test.cpp
+++ b/cpp/tests/io/nested_json_test.cpp
@@ -166,7 +166,7 @@ TEST_F(JsonTest, StackContext)
   cuio_json::detail::get_stack_context(d_input, stack_context.device_ptr(), stream);
 
   // Copy back the results
-  stack_context.device_to_host(stream);
+  stack_context.device_to_host_async(stream);
 
   // Make sure we copied back the stack context
   stream.synchronize();
@@ -214,7 +214,7 @@ TEST_F(JsonTest, StackContextUtf8)
   cuio_json::detail::get_stack_context(d_input, stack_context.device_ptr(), stream);
 
   // Copy back the results
-  stack_context.device_to_host(stream);
+  stack_context.device_to_host_async(stream);
 
   // Make sure we copied back the stack context
   stream.synchronize();

--- a/cpp/tests/utilities_tests/span_tests.cu
+++ b/cpp/tests/utilities_tests/span_tests.cu
@@ -291,7 +291,7 @@ TEST(MdSpanTest, DeviceReadWrite)
 
   readwrite_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(vector);
   readwrite_kernel<<<1, 1, 0, cudf::get_default_stream().value()>>>(vector);
-  vector.device_to_host(cudf::get_default_stream(), true);
+  vector.device_to_host_sync(cudf::get_default_stream());
   EXPECT_EQ(vector[5][6], 30);
 }
 
@@ -425,7 +425,7 @@ TEST(HostDeviceSpanTest, CanSendToDevice)
 {
   auto message = get_test_hostdevice_vector();
 
-  message.host_to_device(cudf::get_default_stream(), true);
+  message.host_to_device_sync(cudf::get_default_stream());
 
   char d_message[12];
   cudaMemcpy(d_message, message.device_ptr(), 11, cudaMemcpyDefault);
@@ -446,10 +446,10 @@ __global__ void simple_device_char_kernel(device_span<char> result)
 TEST(HostDeviceSpanTest, CanGetFromDevice)
 {
   auto message = get_test_hostdevice_vector();
-  message.host_to_device(cudf::get_default_stream(), true);
+  message.host_to_device_sync(cudf::get_default_stream());
   simple_device_char_kernel<<<1, 1, 0, cudf::get_default_stream()>>>(message);
 
-  message.device_to_host(cudf::get_default_stream(), true);
+  message.device_to_host_sync(cudf::get_default_stream());
   expect_match("world hello", hostdevice_span<char>(message));
 }
 


### PR DESCRIPTION
The classes `hostdevice_vector` `hostdevice_2dvector` and `hostdevice_span` have the following APIs:
 * `host_to_device(..., bool synchronize = false)`
 * `device_to_host(..., bool synchronize = false)`

Using them is a bit awkward. For example: `buffer.device_to_host(stream)` or `buffer.device_to_host(stream, true)` which do not explicitly say about stream synchronization.

This PR modify them, removing the `bool synchronize` parameter. Now each of them becomes two separate functions instead:
 * `host_to_device_async(...)` and `host_to_device_sync(...)`.
 * `device_to_host_async(...)` and `device_to_host_sync(...)`.

Their usage (such as `buffer.device_to_host_async(stream)`) will be very straightforward and obvious about the stream synchronization. 

In addition, this modification also make the related APIs become aligned/consistent with other APIs such as `make_device_uvector_async`/`make_device_uvector_sync`.