### PR TITLE
Fix cudf::strings::strip for all-empty input column

### DIFF
--- a/cpp/include/cudf/strings/detail/strip.cuh
+++ b/cpp/include/cudf/strings/detail/strip.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ __device__ cudf::string_view strip(cudf::string_view const d_str,
                                    cudf::string_view const d_to_strip,
                                    side_type side = side_type::BOTH)
 {
+  if (d_str.empty()) { return cudf::string_view{}; }  // sanitize empty return
+
   auto is_strip_character = [d_to_strip](char_utf8 chr) -> bool {
     if (d_to_strip.empty()) return chr <= ' ';  // whitespace check
     for (auto c : d_to_strip) {

--- a/cpp/src/strings/strip.cu
+++ b/cpp/src/strings/strip.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/strings/strip.cu
+++ b/cpp/src/strings/strip.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ struct strip_transform_fn {
   {
     if (d_strings.is_null(idx)) { return string_index_pair{nullptr, 0}; }
     auto const d_str      = d_strings.element<string_view>(idx);
-    auto const d_stripped = strip(d_str, d_to_strip, side);
+    auto const d_stripped = d_str.empty() ? string_view{} : strip(d_str, d_to_strip, side);
     return string_index_pair{d_stripped.data(), d_stripped.size_bytes()};
   }
 };

--- a/cpp/src/strings/strip.cu
+++ b/cpp/src/strings/strip.cu
@@ -49,7 +49,7 @@ struct strip_transform_fn {
   {
     if (d_strings.is_null(idx)) { return string_index_pair{nullptr, 0}; }
     auto const d_str      = d_strings.element<string_view>(idx);
-    auto const d_stripped = d_str.empty() ? string_view{} : strip(d_str, d_to_strip, side);
+    auto const d_stripped = strip(d_str, d_to_strip, side);
     return string_index_pair{d_stripped.data(), d_stripped.size_bytes()};
   }
 };

--- a/cpp/tests/strings/strip_tests.cpp
+++ b/cpp/tests/strings/strip_tests.cpp
@@ -100,6 +100,14 @@ TEST_F(StringsStripTest, EmptyStringsColumn)
   cudf::test::expect_column_empty(results->view());
 }
 
+TEST_F(StringsStripTest, AllEmptyStrings)
+{
+  auto input = cudf::test::strings_column_wrapper({"", "", "", "", "", ""}, {1, 1, 0, 1, 1});
+  auto results =
+    cudf::strings::strip(cudf::strings_column_view(input), cudf::strings::side_type::BOTH);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, input);
+}
+
 TEST_F(StringsStripTest, InvalidParameter)
 {
   std::vector<char const*> h_strings{"string left intentionally blank"};

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -2092,6 +2092,15 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void testTrimEmptyStringsWithNulls() {
+    try (ColumnVector cv = ColumnVector.fromStrings("", null);
+         ColumnVector trimmed = cv.strip();
+         ColumnVector expected = ColumnVector.fromStrings("", null)) {
+      assertColumnsAreEqual(expected, trimmed);
+    }
+  }
+  
+  @Test
   void testAppendStrings() {
     try (HostColumnVector cv = HostColumnVector.build(10, 0, (b) -> {
       b.append("123456789");

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -2099,7 +2099,7 @@ public class ColumnVectorTest extends CudfTestBase {
       assertColumnsAreEqual(expected, trimmed);
     }
   }
-  
+
   @Test
   void testAppendStrings() {
     try (HostColumnVector cv = HostColumnVector.build(10, 0, (b) -> {


### PR DESCRIPTION
## Description
Fixes `cudf::strings::strip` logic when all the input strings are empty or all null. The logic was incorrectly incorrectly empty strings as null rows when producing the output column.
Also added a gtest for this special case.

Closes #13529 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
