### PR TITLE
Update to CMake 3.26.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Compilers:
 
 * `gcc` version 9.3+
 * `nvcc` version 11.5+
-* `cmake` version 3.23.1+
+* `cmake` version 3.26.4+
 
 CUDA/GPU:
 

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -13,7 +13,7 @@ dependencies:
 - botocore>=1.24.21
 - c-compiler
 - cachetools
-- cmake>=3.23.1,!=3.25.0
+- cmake>=3.26.4
 - cubinlinker
 - cuda-python>=11.7.1,<12.0
 - cuda-sanitizer-api=11.8.86

--- a/conda/recipes/cudf/conda_build_config.yaml
+++ b/conda/recipes/cudf/conda_build_config.yaml
@@ -8,7 +8,7 @@ sysroot_version:
   - "2.17"
 
 cmake_version:
-  - ">=3.23.1,!=3.25.0"
+  - ">=3.26.4"
 
 cuda_compiler:
   - nvcc

--- a/conda/recipes/cudf_kafka/conda_build_config.yaml
+++ b/conda/recipes/cudf_kafka/conda_build_config.yaml
@@ -6,3 +6,6 @@ cxx_compiler_version:
 
 sysroot_version:
   - "2.17"
+
+cmake_version:
+  - ">=3.26.4"

--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -35,7 +35,7 @@ build:
 
 requirements:
   build:
-    - cmake >=3.23.1,!=3.25.0
+    - cmake {{ cmake_version }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - ninja

--- a/conda/recipes/libcudf/conda_build_config.yaml
+++ b/conda/recipes/libcudf/conda_build_config.yaml
@@ -11,7 +11,7 @@ sysroot_version:
   - "2.17"
 
 cmake_version:
-  - ">=3.23.1,!=3.25.0"
+  - ">=3.26.4"
 
 gtest_version:
   - ">=1.13.0"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
 include(../fetch_rapids.cmake)
 include(rapids-cmake)

--- a/cpp/examples/basic/CMakeLists.txt
+++ b/cpp/examples/basic/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
-cmake_minimum_required(VERSION 3.23.1)
+cmake_minimum_required(VERSION 3.26.4)
 
 project(
   basic_example

--- a/cpp/examples/strings/CMakeLists.txt
+++ b/cpp/examples/strings/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2022-2023, NVIDIA CORPORATION.
 
-cmake_minimum_required(VERSION 3.23.1)
+cmake_minimum_required(VERSION 3.26.4)
 
 project(
   strings_examples

--- a/cpp/libcudf_kafka/CMakeLists.txt
+++ b/cpp/libcudf_kafka/CMakeLists.txt
@@ -11,7 +11,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
-cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
 include(../../fetch_rapids.cmake)
 include(rapids-cmake)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -172,7 +172,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &cmake_ver cmake>=3.23.1,!=3.25.0
+          - &cmake_ver cmake>=3.26.4
           - ninja
       - output_types: conda
         packages:

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -11,7 +11,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
-cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
 include(../../../../fetch_rapids.cmake)
 include(rapids-cmake)

--- a/python/cudf/CMakeLists.txt
+++ b/python/cudf/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
 set(cudf_version 23.08.00)
 

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -3,7 +3,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "cmake>=3.23.1,!=3.25.0",
+    "cmake>=3.26.4",
     "cython>=0.29,<0.30",
     "ninja",
     "numpy>=1.21",

--- a/python/cudf/udf_cpp/CMakeLists.txt
+++ b/python/cudf/udf_cpp/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.23.1)
+cmake_minimum_required(VERSION 3.26.4)
 
 include(rapids-cmake)
 include(rapids-cpm)


### PR DESCRIPTION
Updates minimum required CMake version to 3.26.4. This will allow us to take advantage of a variety of new features in the last three minor releases, particularly with respect to better CUDA and Python support. See https://github.com/rapidsai/rapids-cmake/issues/315 for more information.