### PR TITLE
Deprecate `strings_to_categorical` in `cudf.read_parquet`

### DIFF
--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -448,6 +448,12 @@ def read_parquet(
 ):
     """{docstring}"""
 
+    if strings_to_categorical is not False:
+        warnings.warn(
+            "`strings_to_categorical` is deprecated and will be removed in "
+            "a future version of cudf.",
+            FutureWarning,
+        )
     # Do not allow the user to set file-opening options
     # when `use_python_file_object=False` is specified
     if use_python_file_object is False:

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -31,6 +31,7 @@ from cudf.testing._utils import (
     TIMEDELTA_TYPES,
     assert_eq,
     assert_exceptions_equal,
+    expect_warning_if,
     set_random_null_mask_inplace,
 )
 
@@ -310,9 +311,12 @@ def test_parquet_reader_strings(tmpdir, strings_to_categorical, has_null):
     assert os.path.exists(fname)
 
     if strings_to_categorical is not None:
-        gdf = cudf.read_parquet(
-            fname, engine="cudf", strings_to_categorical=strings_to_categorical
-        )
+        with expect_warning_if(strings_to_categorical is not False):
+            gdf = cudf.read_parquet(
+                fname,
+                engine="cudf",
+                strings_to_categorical=strings_to_categorical,
+            )
     else:
         gdf = cudf.read_parquet(fname, engine="cudf")
 

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -169,6 +169,11 @@ row_groups : int, or list, or a list of lists default None
 strings_to_categorical : boolean, default False
     If True, return string columns as GDF_CATEGORY dtype; if False, return a
     as GDF_STRING dtype.
+
+    .. deprecated:: 23.08
+
+        This parameter is deprecated and will be removed in a future
+        version of cudf.
 categorical_partitions : boolean, default True
     Whether directory-partitioned columns should be interpreted as categorical
     or raw dtypes.


### PR DESCRIPTION
## Description
This PR deprecates `string_to_categorical` because of the ambiguous naming to the end users and no real use for this parameter at this point. Pandas or pyarrow don't have this parameter, it was exclusive to `cudf`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
