### PR TITLE
Enable nested types for `lists::concatenate_list_elements`

### DIFF
--- a/cpp/include/cudf/lists/combine.hpp
+++ b/cpp/include/cudf/lists/combine.hpp
@@ -81,9 +81,7 @@ std::unique_ptr<column> concatenate_rows(
  * @endcode
  *
  * @throws std::invalid_argument if the input column is not at least two-level depth lists column
- * (i.e., each row must be a list of list).
- * @throws cudf::logic_error if the input lists column contains nested typed entries that are not
- * lists.
+ *         (i.e., each row must be a list of lists).
  *
  * @param input The lists column containing lists of list elements to concatenate.
  * @param null_policy The parameter to specify whether a null list element will be ignored from

--- a/cpp/src/lists/combine/concatenate_list_elements.cu
+++ b/cpp/src/lists/combine/concatenate_list_elements.cu
@@ -256,24 +256,18 @@ std::unique_ptr<column> concatenate_list_elements(column_view const& input,
                                                   rmm::cuda_stream_view stream,
                                                   rmm::mr::device_memory_resource* mr)
 {
-  auto type = input.type();  // Column that is lists of lists.
-  CUDF_EXPECTS(
-    type.id() == type_id::LIST, "Input column must be a lists column.", std::invalid_argument);
+  CUDF_EXPECTS(input.type().id() == type_id::LIST,
+               "Input column must be a lists column.",
+               std::invalid_argument);
 
-  auto col = lists_column_view(input).child();  // Rows, which are lists.
-  type     = col.type();
-  CUDF_EXPECTS(
-    type.id() == type_id::LIST, "Rows of the input column must be lists.", std::invalid_argument);
-
-  col  = lists_column_view(col).child();  // The last level entries what we need to check.
-  type = col.type();
-  CUDF_EXPECTS(type.id() == type_id::LIST || !cudf::is_nested(type),
-               "Entry of the input lists column must be of list or non-nested types.");
+  auto const child = lists_column_view(input).child();
+  CUDF_EXPECTS(child.type().id() == type_id::LIST,
+               "Rows of the input column must be lists of lists.",
+               std::invalid_argument);
 
   if (input.size() == 0) { return cudf::empty_like(input); }
 
-  bool has_null_list = lists_column_view(input).child().has_nulls();
-
+  bool const has_null_list = child.has_nulls();
   return (null_policy == concatenate_null_policy::IGNORE || !has_null_list)
            ? concatenate_lists_ignore_null(input, has_null_list, stream, mr)
            : concatenate_lists_nullifying_rows(input, stream, mr);

--- a/cpp/tests/lists/combine/concatenate_list_elements_tests.cpp
+++ b/cpp/tests/lists/combine/concatenate_list_elements_tests.cpp
@@ -492,3 +492,99 @@ TEST_F(ConcatenateListElementsTest, SlicedStringsColumnsInputWithNulls)
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, *results, verbosity);
   }
 }
+
+TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsNoNull)
+{
+  using structs_col = cudf::test::structs_column_wrapper;
+  using int32s_col  = cudf::test::fixed_width_column_wrapper<int32_t>;
+
+  auto const input = [] {
+    auto child = [] {
+      auto child1  = int32s_col{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+      auto child2  = int32s_col{11, 12, 13, 14, 15, 16, 17, 18, 19, 110};
+      auto structs = structs_col{{child1, child2}};
+      auto offsets = int32s_col{0, 2, 3, 6, 6, 8, 10};
+      return cudf::make_lists_column(6, offsets.release(), structs.release(), 0, {});
+    }();
+
+    auto offsets = int32s_col{0, 3, 4, 6};
+    return cudf::make_lists_column(3, offsets.release(), std::move(child), 0, {});
+  }();
+
+  auto const expected = [] {
+    auto child1  = int32s_col{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    auto child2  = int32s_col{11, 12, 13, 14, 15, 16, 17, 18, 19, 110};
+    auto structs = structs_col{{child1, child2}};
+    auto offsets = int32s_col{0, 6, 6, 10};
+    return cudf::make_lists_column(3, offsets.release(), structs.release(), 0, {});
+  }();
+
+  auto const results = cudf::lists::concatenate_list_elements(*input);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results, verbosity);
+}
+
+TEST_F(ConcatenateListElementsTest, ListsOfListsOfStructsWithNull)
+{
+  using structs_col = cudf::test::structs_column_wrapper;
+  using int32s_col  = cudf::test::fixed_width_column_wrapper<int32_t>;
+
+  // Input:
+  // [ [{1, 11}, {null, null}], [{3, 13}], NULL ]
+  // [ [{4, 14}, {5, 15}, {null, null}] ]
+  // [ [{7, 17}, {null, null}], [{9, 19}, {10, 110}] ]
+  //
+  auto const input = [] {
+    auto child = [] {
+      auto child1                  = int32s_col{1, null, 3, 4, 5, null, 7, null, 9, 10};
+      auto child2                  = int32s_col{11, null, 13, 14, 15, null, 17, null, 19, 110};
+      auto structs                 = structs_col{{child1, child2}, nulls_at({1, 5, 7})};
+      auto offsets                 = int32s_col{0, 2, 3, 3, 6, 8, 10};
+      auto const null_it           = null_at(2);  // null list
+      auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 6);
+      return cudf::make_lists_column(
+        6, offsets.release(), structs.release(), null_count, std::move(null_mask));
+    }();
+
+    auto offsets = int32s_col{0, 3, 4, 6};
+    return cudf::make_lists_column(3, offsets.release(), std::move(child), 0, {});
+  }();
+
+  {
+    // Output:
+    // [{1, 11}, {null, null}, {3, 13}]
+    // [{4, 14}, {5, 15}, {null, null}]
+    // [{7, 17}, {null, null}, {9, 19}, {10, 110}]
+    //
+    auto const expected = [] {
+      auto child1  = int32s_col{1, null, 3, 4, 5, null, 7, null, 9, 10};
+      auto child2  = int32s_col{11, null, 13, 14, 15, null, 17, null, 19, 110};
+      auto structs = structs_col{{child1, child2}, nulls_at({1, 5, 7})};
+      auto offsets = int32s_col{0, 3, 6, 10};
+      return cudf::make_lists_column(3, offsets.release(), structs.release(), 0, {});
+    }();
+
+    auto const results = cudf::lists::concatenate_list_elements(*input);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results, verbosity);
+  }
+  {
+    // Output:
+    // NULL
+    // [{4, 14}, {5, 15}, {null, null}]
+    // [{7, 17}, {null, null}, {9, 19}, {10, 110}]
+    //
+    auto const expected = [] {
+      auto child1                  = int32s_col{4, 5, null, 7, null, 9, 10};
+      auto child2                  = int32s_col{14, 15, null, 17, null, 19, 110};
+      auto structs                 = structs_col{{child1, child2}, nulls_at({2, 4})};
+      auto offsets                 = int32s_col{0, 0, 3, 7};
+      auto const null_it           = null_at(0);  // null row
+      auto [null_mask, null_count] = cudf::test::detail::make_null_mask(null_it, null_it + 3);
+      return cudf::make_lists_column(
+        3, offsets.release(), structs.release(), null_count, std::move(null_mask));
+    }();
+
+    auto const results = cudf::lists::concatenate_list_elements(
+      *input, cudf::lists::concatenate_null_policy::NULLIFY_OUTPUT_ROW);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected, *results, verbosity);
+  }
+}


### PR DESCRIPTION
When `lists::concatenate_list_elements` was implemented, it could not handle nested structs in the related APIs. Now nested structs can be properly processed thus this PR enables fully nested type input for that API.