### PR TITLE
Fix `dask_cudf` pytest failures for `pandas-2.0` upgrade

### DIFF
--- a/python/cudf/cudf/testing/testing.py
+++ b/python/cudf/cudf/testing/testing.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Union
-
 import cupy as cp
 import numpy as np
 import pandas as pd
@@ -101,7 +99,6 @@ def assert_column_equal(
     right,
     check_dtype=True,
     check_column_type="equiv",
-    check_less_precise=False,
     check_exact=False,
     check_datetimelike_compat=False,
     check_categorical=True,
@@ -129,8 +126,6 @@ def assert_column_equal(
         Whether to check the columns class, dtype and
         inferred_type are identical. Currently it is idle,
         and similar to pandas.
-    check_less_precise : bool or int, default False
-        Not yet supported
     check_exact : bool, default False
         Whether to compare number exactly.
     check_datetime_like_compat : bool, default False
@@ -292,7 +287,6 @@ def assert_index_equal(
     right,
     exact="equiv",
     check_names: bool = True,
-    check_less_precise: Union[bool, int] = False,
     check_exact: bool = True,
     check_categorical: bool = True,
     check_order: bool = True,
@@ -319,8 +313,6 @@ def assert_index_equal(
         for Index with an int8/int32/int64 dtype as well.
     check_names : bool, default True
         Whether to check the names attribute.
-    check_less_precise : bool or int, default False
-        Not yet supported
     check_exact : bool, default False
         Whether to compare number exactly.
     check_categorical : bool, default True
@@ -404,7 +396,6 @@ def assert_index_equal(
                 exact=check_exact,
                 check_names=check_names,
                 check_exact=check_exact,
-                check_less_precise=check_less_precise,
                 check_order=check_order,
                 rtol=rtol,
                 atol=atol,
@@ -433,7 +424,6 @@ def assert_series_equal(
     check_dtype=True,
     check_index_type="equiv",
     check_series_type=True,
-    check_less_precise=False,
     check_names=True,
     check_exact=False,
     check_datetimelike_compat=False,
@@ -465,8 +455,6 @@ def assert_series_equal(
         Whether to check the series class, dtype and
         inferred_type are identical. Currently it is idle,
         and similar to pandas.
-    check_less_precise : bool or int, default False
-        Not yet supported
     check_names : bool, default True
         Whether to check that the names attribute for both the index
         and column attributes of the Series is identical.
@@ -530,7 +518,6 @@ def assert_series_equal(
         right.index,
         exact=check_index_type,
         check_names=check_names,
-        check_less_precise=check_less_precise,
         check_exact=check_exact,
         check_categorical=check_categorical,
         rtol=rtol,
@@ -543,7 +530,6 @@ def assert_series_equal(
         right._column,
         check_dtype=check_dtype,
         check_column_type=check_series_type,
-        check_less_precise=check_less_precise,
         check_exact=check_exact,
         check_datetimelike_compat=check_datetimelike_compat,
         check_categorical=check_categorical,

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -57,8 +57,6 @@ def _nonempty_index(idx):
         data = np.array([start, "1970-01-02"], dtype=idx.dtype)
         values = cudf.core.column.as_column(data)
         return cudf.core.index.DatetimeIndex(values, name=idx.name)
-    elif isinstance(idx._column, cudf.core.column.StringColumn):
-        return cudf.Index(["cat", "dog"], name=idx.name)
     elif isinstance(idx, cudf.core.index.CategoricalIndex):
         key = tuple(idx._data.keys())
         assert len(key) == 1
@@ -69,15 +67,17 @@ def _nonempty_index(idx):
             categories=categories, codes=codes, ordered=ordered
         )
         return cudf.core.index.CategoricalIndex(values, name=idx.name)
-    elif isinstance(idx, cudf.core.index.Index):
-        return cudf.core.index.Index(
-            np.arange(2, dtype=idx.dtype), name=idx.name
-        )
     elif isinstance(idx, cudf.core.multiindex.MultiIndex):
         levels = [meta_nonempty(lev) for lev in idx.levels]
         codes = [[0, 0] for i in idx.levels]
         return cudf.core.multiindex.MultiIndex(
             levels=levels, codes=codes, names=idx.names
+        )
+    elif isinstance(idx._column, cudf.core.column.StringColumn):
+        return cudf.Index(["cat", "dog"], name=idx.name)
+    elif isinstance(idx, cudf.core.index.Index):
+        return cudf.core.index.Index(
+            np.arange(2, dtype=idx.dtype), name=idx.name
         )
 
     raise TypeError(f"Don't know how to handle index of type {type(idx)}")

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -269,9 +269,12 @@ class DataFrame(_Frame, dd.core.DataFrame):
         dtype=None,
         out=None,
         naive=False,
+        numeric_only=False,
     ):
         axis = self._validate_axis(axis)
-        meta = self._meta_nonempty.var(axis=axis, skipna=skipna)
+        meta = self._meta_nonempty.var(
+            axis=axis, skipna=skipna, numeric_only=numeric_only
+        )
         if axis == 1:
             result = map_partitions(
                 M.var,
@@ -281,6 +284,7 @@ class DataFrame(_Frame, dd.core.DataFrame):
                 axis=axis,
                 skipna=skipna,
                 ddof=ddof,
+                numeric_only=numeric_only,
             )
             return handle_out(out, result)
         elif naive:
@@ -421,7 +425,7 @@ def _naive_var(ddf, meta, skipna, ddof, split_every, out):
 def _parallel_var(ddf, meta, skipna, split_every, out):
     def _local_var(x, skipna):
         if skipna:
-            n = x.count(skipna=skipna)
+            n = x.count()
             avg = x.mean(skipna=skipna)
         else:
             # Not skipping nulls, so might as well

--- a/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
@@ -13,6 +13,7 @@ from dask import dataframe as dd
 from dask.utils import natural_sort_key
 
 import cudf
+from cudf.core._compat import PANDAS_GE_200
 
 import dask_cudf
 
@@ -173,7 +174,9 @@ def test_dask_timeseries_from_pandas(tmpdir):
     pdf = ddf2.compute()
     pdf.to_parquet(fn, engine="pyarrow")
     read_df = dask_cudf.read_parquet(fn)
-    dd.assert_eq(ddf2, read_df.compute())
+    # Workaround until following issue is fixed:
+    # https://github.com/apache/arrow/issues/33321
+    dd.assert_eq(ddf2, read_df.compute(), check_index_type=not PANDAS_GE_200)
 
 
 @pytest.mark.parametrize("index", [False, None])

--- a/python/dask_cudf/dask_cudf/tests/test_accessor.py
+++ b/python/dask_cudf/dask_cudf/tests/test_accessor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 
 import numpy as np
 import pandas as pd
@@ -53,8 +53,8 @@ def test_dt_series(data, field):
     sr = Series(pdsr)
     dsr = dgd.from_cudf(sr, npartitions=5)
     base = getattr(pdsr.dt, field)
-    test = getattr(dsr.dt, field).compute().to_pandas().astype("int64")
-    assert_series_equal(base, test)
+    test = getattr(dsr.dt, field).compute()
+    assert_eq(base, test, check_dtype=False)
 
 
 @pytest.mark.parametrize("data", [data_dt_1()])

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -809,7 +809,7 @@ def test_series_describe():
     dd.assert_eq(
         dsr.describe(),
         pdsr.describe(),
-        check_less_precise=3,
+        rtol=1e-3,
     )
 
 
@@ -838,7 +838,7 @@ def test_zero_std_describe():
     ddf = dgd.from_cudf(df, npartitions=4)
     pddf = dd.from_pandas(pdf, npartitions=4)
 
-    dd.assert_eq(ddf.describe(), pddf.describe(), check_less_precise=3)
+    dd.assert_eq(ddf.describe(), pddf.describe(), rtol=1e-3)
 
 
 def test_large_numbers_var():
@@ -853,7 +853,7 @@ def test_large_numbers_var():
     ddf = dgd.from_cudf(df, npartitions=4)
     pddf = dd.from_pandas(pdf, npartitions=4)
 
-    dd.assert_eq(ddf.var(), pddf.var(), check_less_precise=3)
+    dd.assert_eq(ddf.var(), pddf.var(), rtol=1e-3)
 
 
 def test_index_map_partitions():

--- a/python/dask_cudf/dask_cudf/tests/test_reductions.py
+++ b/python/dask_cudf/dask_cudf/tests/test_reductions.py
@@ -78,8 +78,8 @@ def test_rowwise_reductions(data, op):
         got = getattr(pddf, op)(numeric_only=True, axis=1)
 
     dd.assert_eq(
-        expected.compute(),
-        got.compute(),
+        expected,
+        got,
         check_exact=False,
         check_dtype=op not in ("var", "std"),
     )

--- a/python/dask_cudf/dask_cudf/tests/test_reductions.py
+++ b/python/dask_cudf/dask_cudf/tests/test_reductions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 
 import numpy as np
 import pandas as pd
@@ -71,10 +71,15 @@ def test_rowwise_reductions(data, op):
     pddf = gddf.to_dask_dataframe()
 
     if op in ("var", "std"):
-        expected = getattr(pddf, op)(axis=1, ddof=0)
-        got = getattr(gddf, op)(axis=1, ddof=0)
+        expected = getattr(pddf, op)(axis=1, numeric_only=True, ddof=0)
+        got = getattr(gddf, op)(axis=1, numeric_only=True, ddof=0)
     else:
-        expected = getattr(pddf, op)(axis=1)
-        got = getattr(pddf, op)(axis=1)
+        expected = getattr(pddf, op)(numeric_only=True, axis=1)
+        got = getattr(pddf, op)(numeric_only=True, axis=1)
 
-    dd.assert_eq(expected.compute(), got.compute(), check_exact=False)
+    dd.assert_eq(
+        expected.compute(),
+        got.compute(),
+        check_exact=False,
+        check_dtype=op not in ("var", "std"),
+    )


### PR DESCRIPTION
## Description
This PR fixes all `dask_cudf` side failures that happen due to `pandas-2.0` upgrade. The fixes are trivial to be broken down into separate PRs. 

- [x] `check_less_precise` is removed in `pandas-2.0`, since it is a parameter that we never supported and just had it for the sake of matching signature I removed it from all the methods.
- [x] Due to the removal of `StringIndex`, we had to perform some re-ordering of `if/elif` logic in `_nonempty_index`.
- [x] `dask_cudf.DataFrame.var` got `numeric_only` support.
- [x] `Series.count` doesn't have `skipna` support. Hence removed it from the call.


This PR fixes 56 pytest failures:

```
== 1100 passed, 13 skipped, 8 xfailed, 5 xpassed, 114 warnings in 57.10s ==
```

On `pandas_2.0_feature_branch`:

```
== 56 failed, 1044 passed, 13 skipped, 8 xfailed, 5 xpassed, 114 warnings in 73.73s (0:01:13) ==
```


<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
