### PR TITLE
Fix out-of-bounds memory write in cudf::dictionary::detail::concatenate

### DIFF
--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -266,7 +266,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
     children_offsets.begin() + 1,
     children_offsets.end(),
     indices_itr,
-    indices_itr + indices_size + 1,
+    indices_itr + indices_size,
     map_to_keys.begin(),
     [] __device__(auto const& lhs, auto const& rhs) { return lhs.second < rhs.second; });
 


### PR DESCRIPTION
## Description
Fixes memcheck error found by the cudf nightly memcheck in `cudf::dictionary::detail::concatenate`
```
========= COMPUTE-SANITIZER
Note: Google Test filter = DictionaryConcatTest.StringsKeys
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DictionaryConcatTest
[ RUN      ] DictionaryConcatTest.StringsKeys
========= Invalid __global__ write of size 4 bytes
=========     at 0x420 in void thrust::cuda_cub::core::_kernel_agent<thrust::cuda_cub::__parallel_for::ParallelForAgent<thrust::cuda_cub::for_each_f<thrust::zip_iterator<thrust::tuple<thrust::transform_iterator<cudf::dictionary::detail::concatenate(cudf::host_span<const cudf::column_view, (unsigned long)18446744073709551615>, rmm::cuda_stream_view, rmm::mr::device_memory_resource *)::[lambda(int) (instance 1)], thrust::counting_iterator<int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::use_default, thrust::use_default>, int *, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type>>, thrust::detail::wrapped_function<thrust::system::detail::generic::detail::binary_search_functor<thrust::pair<int, int> *, cudf::dictionary::detail::concatenate(cudf::host_span<const cudf::column_view, (unsigned long)18446744073709551615>, rmm::cuda_stream_view, rmm::mr::device_memory_resource *)::[lambda(const T1 &, const T2 &) (instance 1)], thrust::system::detail::generic::detail::lbf>, void>>, long>, thrust::cuda_cub::for_each_f<thrust::zip_iterator<thrust::tuple<thrust::transform_iterator<cudf::dictionary::detail::concatenate(cudf::host_span<const cudf::column_view, (unsigned long)18446744073709551615>, rmm::cuda_stream_view, rmm::mr::device_memory_resource *)::[lambda(int) (instance 1)], thrust::counting_iterator<int, thrust::use_default, thrust::use_default, thrust::use_default>, thrust::use_default, thrust::use_default>, int *, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type, thrust::null_type>>, thrust::detail::wrapped_function<thrust::system::detail::generic::detail::binary_search_functor<thrust::pair<int, int> *, cudf::dictionary::detail::concatenate(cudf::host_span<const cudf::column_view, (unsigned long)18446744073709551615>, rmm::cuda_stream_view, rmm::mr::device_memory_resource *)::[lambda(const T1 &, const T2 &) (instance 1)], thrust::system::detail::generic::detail::lbf>, void>>, long>(T2, T3)
=========     by thread (11,0,0) in block (0,0,0)
=========     Address 0x7f584b000e2c is out of bounds
=========     and is 1 bytes after the nearest allocation at 0x7f584b000e00 of size 44 bytes
=========     Saved host backtrace up to driver entry point at kernel launch time
=========     Host Frame: [0x30b492]
=========                in /lib/x86_64-linux-gnu/libcuda.so.1
```

The end iterator should not exceed the `map_to_keys` size (i.e. `indices_size`).
The `indices_itr` already includes an offset of 1 in the `make_counting_transform_iterator` in the call to `thrust::lower_bound`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
