### PR TITLE
Add dispatch for `cudf.Dataframe` to/from `pyarrow.Table` conversion

### DIFF
--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -372,6 +372,36 @@ try:
 except ImportError:
     pass
 
+try:
+    # Requires dask>2023.6.0
+    from dask.dataframe.dispatch import (
+        from_pyarrow_table_dispatch,
+        to_pyarrow_table_dispatch,
+    )
+
+    @to_pyarrow_table_dispatch.register(cudf.DataFrame)
+    def _cudf_to_table(obj, preserve_index=True, **kwargs):
+        if kwargs:
+            warnings.warn(
+                f"Ignoring the following arguments to "
+                f"`to_pyarrow_table_dispatch`: {list(kwargs)}"
+            )
+        return obj.to_arrow(preserve_index=preserve_index)
+
+    @from_pyarrow_table_dispatch.register(cudf.DataFrame)
+    def _table_to_cudf(obj, table, **kwargs):
+        # cudf must ignore self_destruct
+        kwargs.pop("self_destruct", None)
+        if kwargs:
+            warnings.warn(
+                f"Ignoring the following arguments to "
+                f"`from_pyarrow_table_dispatch`: {list(kwargs)}"
+            )
+        return obj.from_arrow(table)
+
+except ImportError:
+    pass
+
 
 @union_categoricals_dispatch.register((cudf.Series, cudf.BaseIndex))
 @_dask_cudf_nvtx_annotate

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -383,14 +383,14 @@ try:
     def _cudf_to_table(obj, preserve_index=True, **kwargs):
         if kwargs:
             warnings.warn(
-                f"Ignoring the following arguments to "
+                "Ignoring the following arguments to "
                 f"`to_pyarrow_table_dispatch`: {list(kwargs)}"
             )
         return obj.to_arrow(preserve_index=preserve_index)
 
     @from_pyarrow_table_dispatch.register(cudf.DataFrame)
-    def _table_to_cudf(obj, table, **kwargs):
-        # cudf must ignore self_destruct
+    def _table_to_cudf(obj, table, self_destruct=None, **kwargs):
+        # cudf ignores self_destruct.
         kwargs.pop("self_destruct", None)
         if kwargs:
             warnings.warn(

--- a/python/dask_cudf/dask_cudf/tests/test_dispatch.py
+++ b/python/dask_cudf/dask_cudf/tests/test_dispatch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 
 import numpy as np
 import pandas as pd

--- a/python/dask_cudf/dask_cudf/tests/test_dispatch.py
+++ b/python/dask_cudf/dask_cudf/tests/test_dispatch.py
@@ -1,7 +1,12 @@
 # Copyright (c) 2021-2022, NVIDIA CORPORATION.
 
+import numpy as np
 import pandas as pd
+import pytest
+from packaging import version
 
+import dask
+from dask.dataframe import assert_eq
 from dask.dataframe.methods import is_categorical_dtype
 
 import cudf
@@ -16,3 +21,20 @@ def test_is_categorical_dispatch():
 
     assert is_categorical_dtype(pd.Index([1, 2, 3], dtype="category"))
     assert is_categorical_dtype(cudf.Index([1, 2, 3], dtype="category"))
+
+
+@pytest.mark.skipif(
+    version.parse(dask.__version__) <= version.parse("2023.6.0"),
+    reason="Pyarrow-conversion dispatch requires dask>2023.6.0",
+)
+def test_pyarrow_conversion_dispatch():
+    from dask.dataframe.dispatch import (
+        from_pyarrow_table_dispatch,
+        to_pyarrow_table_dispatch,
+    )
+
+    df1 = cudf.DataFrame(np.random.randn(10, 3), columns=list("abc"))
+    df2 = from_pyarrow_table_dispatch(df1, to_pyarrow_table_dispatch(df1))
+
+    assert type(df1) == type(df2)
+    assert_eq(df1, df2)


### PR DESCRIPTION
## Description
Registers the necessary cudf-specific logic for the dispatch functions introduced in https://github.com/dask/dask/pull/10312. These dispatch functions are necessary to enable "p2p" shuffling with a cudf backend (see: https://github.com/dask/distributed/pull/7743)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
