### PR TITLE
Add exception to string_scalar if input string exceeds size_type

### DIFF
--- a/cpp/include/cudf/scalar/scalar.hpp
+++ b/cpp/include/cudf/scalar/scalar.hpp
@@ -457,6 +457,8 @@ class string_scalar : public scalar {
   /**
    * @brief Construct a new string scalar object.
    *
+   * @throws std::overflow_error If the size of the input string exceeds cudf::size_type
+   *
    * @param string The value of the string.
    * @param is_valid Whether the value held by the scalar is valid.
    * @param stream CUDA stream used for device memory operations.

--- a/cpp/src/scalar/scalar.cpp
+++ b/cpp/src/scalar/scalar.cpp
@@ -66,6 +66,10 @@ string_scalar::string_scalar(std::string const& string,
   : scalar(data_type(type_id::STRING), is_valid, stream, mr),
     _data(string.data(), string.size(), stream, mr)
 {
+  CUDF_EXPECTS(
+    string.size() <= static_cast<std::size_t>(std::numeric_limits<cudf::size_type>::max()),
+    "Data exceeds the string size limit",
+    std::overflow_error);
 }
 
 string_scalar::string_scalar(string_scalar const& other,


### PR DESCRIPTION
## Description

Adds an exception to the `cudf::string_scalar` constructor if the input `std::string` size exceeds the maximum `cudf::size_type`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
