### PR TITLE
Preemptive fix for hive-partitioning change in dask

### DIFF
--- a/python/dask_cudf/dask_cudf/io/parquet.py
+++ b/python/dask_cudf/dask_cudf/io/parquet.py
@@ -167,6 +167,12 @@ class CudfEngine(ArrowDatasetEngine):
 
             for i, (name, index2) in enumerate(partition_keys):
 
+                if not len(partitions[i].keys):
+                    # Non-categorical case
+                    if name not in df.columns:
+                        df[name] = as_column(index2, length=len(df))
+                    continue
+
                 # Build the column from `codes` directly
                 # (since the category is often a larger dtype)
                 codes = as_column(

--- a/python/dask_cudf/dask_cudf/io/parquet.py
+++ b/python/dask_cudf/dask_cudf/io/parquet.py
@@ -167,25 +167,23 @@ class CudfEngine(ArrowDatasetEngine):
 
             for i, (name, index2) in enumerate(partition_keys):
 
-                if not len(partitions[i].keys):
-                    # Non-categorical case
-                    if name not in df.columns:
-                        df[name] = as_column(index2, length=len(df))
-                    continue
-
-                # Build the column from `codes` directly
-                # (since the category is often a larger dtype)
-                codes = as_column(
-                    partitions[i].keys.get_loc(index2),
-                    length=len(df),
-                )
-                df[name] = build_categorical_column(
-                    categories=partitions[i].keys,
-                    codes=codes,
-                    size=codes.size,
-                    offset=codes.offset,
-                    ordered=False,
-                )
+                if len(partitions[i].keys):
+                    # Build a categorical column from `codes` directly
+                    # (since the category is often a larger dtype)
+                    codes = as_column(
+                        partitions[i].keys.get_loc(index2),
+                        length=len(df),
+                    )
+                    df[name] = build_categorical_column(
+                        categories=partitions[i].keys,
+                        codes=codes,
+                        size=codes.size,
+                        offset=codes.offset,
+                        ordered=False,
+                    )
+                elif name not in df.columns:
+                    # Add non-categorical partition column
+                    df[name] = as_column(index2, length=len(df))
 
         return df
 


### PR DESCRIPTION
## Description
Preemptive fix for incoming dask PR: https://github.com/dask/dask/pull/10353

Adds handling for the case that the array of known hive-partitioning keys is empty. This will happen when we **don't** want to convert a hive-partitioned column into a categorical column.
