### PR TITLE
Add java bindings for distinct count

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -3967,6 +3967,22 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
     return ((actualBytes + 63) >> 6) << 6;
   }
 
+  /**
+   * Count how many rows in the column are distinct from one another.
+   * @param nullPolicy if nulls should be included or not.
+   */
+  public int distinctCount(NullPolicy nullPolicy) {
+    return distinctCount(getNativeView(), nullPolicy.includeNulls, false);
+  }
+
+  /**
+   * Count how many rows in the column are distinct from one another.
+   * Nulls are included.
+   */
+  public int distinctCount() {
+    return distinctCount(getNativeView(), true, false);
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // INTERNAL/NATIVE ACCESS
   /////////////////////////////////////////////////////////////////////////////
@@ -3999,6 +4015,8 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   // Native Methods
+  private static native int distinctCount(long handle, boolean nullsIncluded, boolean nansAreNulls);
+
   /**
    * Native method to parse and convert a string column vector to unix timestamp. A unix
    * timestamp is a long value representing how many units since 1970-01-01 00:00:00.000 in either
@@ -4731,6 +4749,8 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   static native boolean hasNonEmptyNulls(long handle) throws CudfException;
 
   static native long purgeNonEmptyNulls(long handle) throws CudfException;
+
+
 
   /**
    * A utility class to create column vector like objects without refcounts and other APIs when

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -3972,7 +3972,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * @param nullPolicy if nulls should be included or not.
    */
   public int distinctCount(NullPolicy nullPolicy) {
-    return distinctCount(getNativeView(), nullPolicy.includeNulls, false);
+    return distinctCount(getNativeView(), nullPolicy.includeNulls);
   }
 
   /**
@@ -3980,7 +3980,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Nulls are included.
    */
   public int distinctCount() {
-    return distinctCount(getNativeView(), true, false);
+    return distinctCount(getNativeView(), true);
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -4015,7 +4015,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   }
 
   // Native Methods
-  private static native int distinctCount(long handle, boolean nullsIncluded, boolean nansAreNulls);
+  private static native int distinctCount(long handle, boolean nullsIncluded);
 
   /**
    * Native method to parse and convert a string column vector to unix timestamp. A unix
@@ -4749,8 +4749,6 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
   static native boolean hasNonEmptyNulls(long handle) throws CudfException;
 
   static native long purgeNonEmptyNulls(long handle) throws CudfException;
-
-
 
   /**
    * A utility class to create column vector like objects without refcounts and other APIs when

--- a/java/src/main/java/ai/rapids/cudf/Table.java
+++ b/java/src/main/java/ai/rapids/cudf/Table.java
@@ -751,6 +751,8 @@ public final class Table implements AutoCloseable {
 
   private static native long[] sample(long tableHandle, long n, boolean replacement, long seed);
 
+  private static native int distinctCount(long handle, boolean nullsEqual);
+
   /////////////////////////////////////////////////////////////////////////////
   // TABLE CREATION APIs
   /////////////////////////////////////////////////////////////////////////////
@@ -2158,6 +2160,22 @@ public final class Table implements AutoCloseable {
   public Table dropDuplicates(int[] keyColumns, DuplicateKeepOption keep, boolean nullsEqual) {
     assert keyColumns.length >= 1 : "Input keyColumns must contain indices of at least one column";
     return new Table(dropDuplicates(nativeHandle, keyColumns, keep.keepValue, nullsEqual));
+  }
+
+  /**
+   * Count how many rows in the table are distinct from one another.
+   * @param nullEqual if nulls should be considered equal to each other or not.
+   */
+  public int distinctCount(NullEquality nullsEqual) {
+    return distinctCount(nativeHandle, nullsEqual.nullsEqual);
+  }
+
+  /**
+   * Count how many rows in the table are distinct from one another.
+   * Nulls are considered to be equal to one another.
+   */
+  public int distinctCount() {
+    return distinctCount(nativeHandle, true);
   }
 
   /**

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -181,16 +181,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceNullsPolicy(JNIEnv
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_distinctCount(JNIEnv *env, jclass,
                                                                     jlong j_col,
-                                                                    jboolean nulls_included,
-                                                                    jboolean nan_is_null) {
-  JNI_NULL_CHECK(env,j_col, "column is null", 0);
+                                                                    jboolean nulls_included) {
+  JNI_NULL_CHECK(env, j_col, "column is null", 0);
   try {
     cudf::jni::auto_set_device(env);
     cudf::column_view col = *reinterpret_cast<cudf::column_view *>(j_col);
 
-    return cudf::distinct_count(col, 
-                       nulls_included ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE,
-                       nan_is_null ? cudf::nan_policy::NAN_IS_NULL : cudf::nan_policy::NAN_IS_VALID);
+    return cudf::distinct_count(
+        col, nulls_included ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE,
+        cudf::nan_policy::NAN_IS_VALID);
   }
   CATCH_STD(env, 0);
 }

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -46,6 +46,7 @@
 #include <cudf/round.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/search.hpp>
+#include <cudf/stream_compaction.hpp>
 #include <cudf/strings/attributes.hpp>
 #include <cudf/strings/capitalize.hpp>
 #include <cudf/strings/case.hpp>
@@ -174,6 +175,22 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceNullsPolicy(JNIEnv
     cudf::column_view col = *reinterpret_cast<cudf::column_view *>(j_col);
     return release_as_jlong(cudf::replace_nulls(
         col, is_preceding ? cudf::replace_policy::PRECEDING : cudf::replace_policy::FOLLOWING));
+  }
+  CATCH_STD(env, 0);
+}
+
+JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_distinctCount(JNIEnv *env, jclass,
+                                                                    jlong j_col,
+                                                                    jboolean nulls_included,
+                                                                    jboolean nan_is_null) {
+  JNI_NULL_CHECK(env,j_col, "column is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::column_view col = *reinterpret_cast<cudf::column_view *>(j_col);
+
+    return cudf::distinct_count(col, 
+                       nulls_included ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE,
+                       nan_is_null ? cudf::nan_policy::NAN_IS_NULL : cudf::nan_policy::NAN_IS_VALID);
   }
   CATCH_STD(env, 0);
 }

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -2921,6 +2921,20 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_filter(JNIEnv *env, jclas
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Table_distinctCount(JNIEnv *env, jclass,
+                                                              jlong input_jtable,
+                                                              jboolean nulls_equal) {
+  JNI_NULL_CHECK(env, input_jtable, "input table is null", 0);
+  try {
+    cudf::jni::auto_set_device(env);
+    auto const input = reinterpret_cast<cudf::table_view const *>(input_jtable);
+
+    return cudf::distinct_count(*input, 
+                       nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL);
+  }
+  CATCH_STD(env, 0);
+}
+
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_dropDuplicates(JNIEnv *env, jclass,
                                                                       jlong input_jtable,
                                                                       jintArray key_columns,

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -2922,15 +2922,15 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_filter(JNIEnv *env, jclas
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Table_distinctCount(JNIEnv *env, jclass,
-                                                              jlong input_jtable,
-                                                              jboolean nulls_equal) {
+                                                               jlong input_jtable,
+                                                               jboolean nulls_equal) {
   JNI_NULL_CHECK(env, input_jtable, "input table is null", 0);
   try {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::table_view const *>(input_jtable);
 
-    return cudf::distinct_count(*input, 
-                       nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL);
+    return cudf::distinct_count(*input, nulls_equal ? cudf::null_equality::EQUAL :
+                                                      cudf::null_equality::UNEQUAL);
   }
   CATCH_STD(env, 0);
 }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -98,6 +98,14 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void testDistinctCount() {
+    try (ColumnVector cv = ColumnVector.fromBoxedLongs(5L, 3L, null, null, 5L)) {
+      assertEquals(3, cv.distinctCount());
+      assertEquals(2, cv.distinctCount(NullPolicy.EXCLUDE));
+    }
+  }
+
+  @Test
   void testClampDouble() {
     try (ColumnVector cv = ColumnVector.fromDoubles(2.33d, 32.12d, -121.32d, 0.0d, 0.00001d,
         Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN);

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -131,6 +131,16 @@ public class TableTest extends CudfTestBase {
   }
 
   @Test
+  void testDistinctCount() {
+    try (Table table1 = new Table.TestBuilder()
+            .column(5, 3, null, null, 5)
+            .build()) {
+      assertEquals(3, table1.distinctCount());
+      assertEquals(4, table1.distinctCount(NullEquality.UNEQUAL));
+    }
+  }
+
+  @Test
   void testMergeSimple() {
     try (Table table1 = new Table.TestBuilder()
             .column(5, 3, 3, 1, 1)


### PR DESCRIPTION
## Description
This adds in java bindings for cudf::distinct_count for both table and column APIs.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
