### PR TITLE
Fix memcheck error found in INTEROP_TEST

### DIFF
--- a/cpp/src/interop/from_arrow.cu
+++ b/cpp/src/interop/from_arrow.cu
@@ -238,7 +238,9 @@ std::unique_ptr<column> dispatch_to_cudf_column::operator()<bool>(
   rmm::mr::device_memory_resource* mr)
 {
   auto data_buffer = array.data()->buffers[1];
-  auto data        = rmm::device_buffer(data_buffer->size(), stream, mr);
+  // mask-to-bools expects the mask to be bitmask_type aligned/padded
+  auto data = rmm::device_buffer(
+    cudf::bitmask_allocation_size_bytes(data_buffer->size() * CHAR_BIT), stream, mr);
   CUDF_CUDA_TRY(cudaMemcpyAsync(data.data(),
                                 reinterpret_cast<uint8_t const*>(data_buffer->address()),
                                 data_buffer->size(),


### PR DESCRIPTION
## Description
The nightly tests found a memcheck error in `INTEROP_TEST` for `cudf::from_arrow` when the arrow bitmask is not padded to `bitmask_type` size. This causes a global memory read error when calling the `cudf::detail::mask_to_bools` function which expects the mask to be properly padded.
This fixes the device allocation size used when copying the arrow bool data to a temporary `rmm::device_buffer` which is used when calling `cudf::detail::mask_to_bools`.

All other tests in `INTEROP_TEST` now pass memcheck successfully.

Closes #13568

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
