### PR TITLE
Fix memcheck error found in PARQUET_TEST

### DIFF
--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -48,6 +48,10 @@ constexpr size_type MAX_DICT_SIZE = (1 << MAX_DICT_BITS) - 1;
 // level decode buffer size.
 constexpr int LEVEL_DECODE_BUF_SIZE = 2048;
 
+// amount of padding to add to data buffers to allow for fast
+// copying of unaligned data
+constexpr int ALIGN_PADDING = 8;
+
 /**
  * @brief Struct representing an input column in the file.
  */

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -264,7 +264,8 @@ template <typename T = uint8_t>
       } else {
         auto const buffer = source->host_read(io_offset, io_size);
         auto dbuffer      = rmm::device_buffer(io_size + ALIGN_PADDING, stream);
-        cudaMemcpyAsync(dbuffer.data(), buffer->data(), buffer->size(), cudaMemcpyDefault, stream);
+        CUDF_CUDA_TRY(cudaMemcpyAsync(
+          dbuffer.data(), buffer->data(), buffer->size(), cudaMemcpyDefault, stream));
         page_data[chunk] = datasource::buffer::create(std::move(dbuffer));
       }
       auto d_compdata = page_data[chunk]->data();

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -1831,8 +1831,8 @@ auto convert_table_to_parquet_data(table_input_metadata& table_meta,
   // Initialize data pointers in batch
   uint32_t const num_stats_bfr =
     (stats_granularity != statistics_freq::STATISTICS_NONE) ? num_pages + num_chunks : 0;
-  rmm::device_buffer uncomp_bfr(max_uncomp_bfr_size, stream);
-  rmm::device_buffer comp_bfr(max_comp_bfr_size, stream);
+  rmm::device_buffer uncomp_bfr(max_uncomp_bfr_size + ALIGN_PADDING, stream);
+  rmm::device_buffer comp_bfr(max_comp_bfr_size + ALIGN_PADDING, stream);
   rmm::device_buffer col_idx_bfr(column_index_bfr_size, stream);
   rmm::device_uvector<gpu::EncPage> pages(num_pages, stream);
 


### PR DESCRIPTION
## Description
Memcheck found invalid memory reads in the Parquet reader. The read overruns were caused by reading beyond the end of misaligned buffers during copy operations such as [this](https://github.com/rapidsai/cudf/blob/67efaf62c7314fbda56d39ea5f60bb893c406084/cpp/src/io/parquet/page_data.cu#L654). This PR adds padding to the end of buffers used to store column chunk data to allow these copies to succeed without reading unallocated memory.

Closes #13571
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
