### PR TITLE
Bring parity with pandas in Index.join

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -7,10 +7,10 @@ import warnings
 from functools import cached_property
 from typing import Any, Set
 
+import pandas as pd
 from typing_extensions import Self
 
 import cudf
-import pandas as pd
 from cudf._lib.copying import _gather_map_is_valid, gather
 from cudf._lib.stream_compaction import (
     apply_boolean_mask,

--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -7,10 +7,10 @@ import warnings
 from functools import cached_property
 from typing import Any, Set
 
-import pandas as pd
 from typing_extensions import Self
 
 import cudf
+import pandas as pd
 from cudf._lib.copying import _gather_map_is_valid, gather
 from cudf._lib.stream_compaction import (
     apply_boolean_mask,
@@ -1391,7 +1391,9 @@ class BaseIndex(Serializable):
         if self_is_multi and other_is_multi:
             return cudf.MultiIndex._from_data(output._data)
         else:
-            return cudf.core.index._index_from_data(output._data)
+            idx = cudf.core.index._index_from_data(output._data)
+            idx.name = self.name
+            return idx
 
     def rename(self, name, inplace=False):
         """

--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -1357,7 +1357,7 @@ class BaseIndex(Serializable):
         else:
             lhs = self.copy(deep=False)
             rhs = other.copy(deep=False)
-
+        same_names = lhs.names == rhs.names
         # There should be no `None` values in Joined indices,
         # so essentially it would be `left/right` or 'inner'
         # in case of MultiIndex
@@ -1377,7 +1377,7 @@ class BaseIndex(Serializable):
                 how = "inner"
         else:
             # Both are normal indices
-            on = rhs.names[0]
+            on = lhs.names[0]
             rhs.names = lhs.names
 
         lhs = lhs.to_frame()
@@ -1392,7 +1392,7 @@ class BaseIndex(Serializable):
             return cudf.MultiIndex._from_data(output._data)
         else:
             idx = cudf.core.index._index_from_data(output._data)
-            idx.name = self.name
+            idx.name = self.name if same_names else None
             return idx
 
     def rename(self, name, inplace=False):

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -20,10 +20,9 @@ from typing import (
 
 import cupy
 import numpy as np
-import pandas as pd
-from pandas._config import get_option
 
 import cudf
+import pandas as pd
 from cudf._lib.datetime import extract_quarter, is_leap_year
 from cudf._lib.filling import sequence
 from cudf._lib.search import search_sorted
@@ -63,6 +62,7 @@ from cudf.utils.dtypes import (
     numeric_normalize_types,
 )
 from cudf.utils.utils import _cudf_nvtx_annotate, search_range
+from pandas._config import get_option
 
 
 def _lexsorted_equal_range(
@@ -839,6 +839,27 @@ class RangeIndex(BaseIndex, BinaryOperand):
         # TODO: pandas supports directly merging RangeIndex objects and can
         # intelligently create RangeIndex outputs depending on the type of
         # join. We need to implement that for the supported special cases.
+        if isinstance(other, RangeIndex):
+            other_pd = other.to_pandas()
+            return cudf.from_pandas(
+                self.to_pandas().join(
+                    other_pd,
+                    how=how,
+                    level=level,
+                    return_indexers=return_indexers,
+                    sort=sort,
+                )
+            )
+        elif isinstance(other, pd.RangeIndex):
+            return cudf.from_pandas(
+                self.to_pandas().join(
+                    other,
+                    how=how,
+                    level=level,
+                    return_indexers=return_indexers,
+                    sort=sort,
+                )
+            )
         return self._as_int_index().join(
             other, how, level, return_indexers, sort
         )

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -836,31 +836,32 @@ class RangeIndex(BaseIndex, BinaryOperand):
     def join(
         self, other, how="left", level=None, return_indexers=False, sort=False
     ):
-        # pandas supports directly merging RangeIndex objects and can
-        # intelligently create RangeIndex outputs depending on the type of
-        # join. Hence falling back to performing a merge on pd.RangeIndex
-        # since the conversion is cheap.
-        if isinstance(other, RangeIndex):
-            other_pd = other.to_pandas()
-            return cudf.from_pandas(
-                self.to_pandas().join(
-                    other_pd,
-                    how=how,
-                    level=level,
-                    return_indexers=return_indexers,
-                    sort=sort,
+        if how in {"left", "right"}:
+            # pandas supports directly merging RangeIndex objects and can
+            # intelligently create RangeIndex outputs depending on the type of
+            # join. Hence falling back to performing a merge on pd.RangeIndex
+            # since the conversion is cheap.
+            if isinstance(other, RangeIndex):
+                other_pd = other.to_pandas()
+                return cudf.from_pandas(
+                    self.to_pandas().join(
+                        other_pd,
+                        how=how,
+                        level=level,
+                        return_indexers=return_indexers,
+                        sort=sort,
+                    )
                 )
-            )
-        elif isinstance(other, pd.RangeIndex):
-            return cudf.from_pandas(
-                self.to_pandas().join(
-                    other,
-                    how=how,
-                    level=level,
-                    return_indexers=return_indexers,
-                    sort=sort,
+            elif isinstance(other, pd.RangeIndex):
+                return cudf.from_pandas(
+                    self.to_pandas().join(
+                        other,
+                        how=how,
+                        level=level,
+                        return_indexers=return_indexers,
+                        sort=sort,
+                    )
                 )
-            )
         return self._as_int_index().join(
             other, how, level, return_indexers, sort
         )

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -844,9 +844,6 @@ class RangeIndex(BaseIndex, BinaryOperand):
             self_pd = self.to_pandas()
             if isinstance(other, RangeIndex):
                 other_pd = other.to_pandas()
-            else:
-                other_pd = None
-            if other_pd is not None:
                 result = self_pd.join(
                     other_pd,
                     how=how,

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -841,9 +841,8 @@ class RangeIndex(BaseIndex, BinaryOperand):
             # intelligently create RangeIndex outputs depending on the type of
             # join. Hence falling back to performing a merge on pd.RangeIndex
             # since the conversion is cheap.
-            self_pd = self.to_pandas()
             if isinstance(other, RangeIndex):
-                result = self_pd.join(
+                result = self.to_pandas().join(
                     other.to_pandas(),
                     how=how,
                     level=level,

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -843,9 +843,8 @@ class RangeIndex(BaseIndex, BinaryOperand):
             # since the conversion is cheap.
             self_pd = self.to_pandas()
             if isinstance(other, RangeIndex):
-                other_pd = other.to_pandas()
                 result = self_pd.join(
-                    other_pd,
+                    other.to_pandas(),
                     how=how,
                     level=level,
                     return_indexers=return_indexers,

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -836,7 +836,7 @@ class RangeIndex(BaseIndex, BinaryOperand):
     def join(
         self, other, how="left", level=None, return_indexers=False, sort=False
     ):
-        if how in {"left", "right"}:
+        if how in {"left", "right"} or self.equals(other):
             # pandas supports directly merging RangeIndex objects and can
             # intelligently create RangeIndex outputs depending on the type of
             # join. Hence falling back to performing a merge on pd.RangeIndex

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -844,8 +844,6 @@ class RangeIndex(BaseIndex, BinaryOperand):
             self_pd = self.to_pandas()
             if isinstance(other, RangeIndex):
                 other_pd = other.to_pandas()
-            elif isinstance(other, pd.RangeIndex):
-                other_pd = other
             else:
                 other_pd = None
             if other_pd is not None:

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -836,9 +836,10 @@ class RangeIndex(BaseIndex, BinaryOperand):
     def join(
         self, other, how="left", level=None, return_indexers=False, sort=False
     ):
-        # TODO: pandas supports directly merging RangeIndex objects and can
+        # pandas supports directly merging RangeIndex objects and can
         # intelligently create RangeIndex outputs depending on the type of
-        # join. We need to implement that for the supported special cases.
+        # join. Hence falling back to performing a merge on pd.RangeIndex
+        # since the conversion is cheap.
         if isinstance(other, RangeIndex):
             other_pd = other.to_pandas()
             return cudf.from_pandas(

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -20,9 +20,10 @@ from typing import (
 
 import cupy
 import numpy as np
+import pandas as pd
+from pandas._config import get_option
 
 import cudf
-import pandas as pd
 from cudf._lib.datetime import extract_quarter, is_leap_year
 from cudf._lib.filling import sequence
 from cudf._lib.search import search_sorted
@@ -62,7 +63,6 @@ from cudf.utils.dtypes import (
     numeric_normalize_types,
 )
 from cudf.utils.utils import _cudf_nvtx_annotate, search_range
-from pandas._config import get_option
 
 
 def _lexsorted_equal_range(

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -2692,14 +2692,12 @@ def test_rangeindex_binops_user_option(
 def test_rangeindex_join_user_option(default_integer_bitwidth):
     # Test that RangeIndex is materialized into 32 bit index under user
     # configuration for join.
-    idx1 = cudf.RangeIndex(0, 10)
-    idx2 = cudf.RangeIndex(5, 15)
+    idx1 = cudf.RangeIndex(0, 10, name="a")
+    idx2 = cudf.RangeIndex(5, 15, name="b")
 
     actual = idx1.join(idx2, how="inner", sort=True)
-    expected = cudf.Index(
-        [5, 6, 7, 8, 9], dtype=f"int{default_integer_bitwidth}", name=0
-    )
-
+    expected = idx1.to_pandas().join(idx2.to_pandas(), how="inner", sort=True)
+    assert actual.dtype == cudf.dtype(f"int{default_integer_bitwidth}")
     assert_eq(expected, actual)
 
 

--- a/python/cudf/cudf/tests/test_joining.py
+++ b/python/cudf/cudf/tests/test_joining.py
@@ -2219,3 +2219,13 @@ def test_dataframe_join_on():
     df = cudf.DataFrame({"a": [1, 2, 3]})
     with pytest.raises(NotImplementedError):
         df.join(df, on="a")
+
+
+@pytest.mark.parametrize("how", ["inner", "outer"])
+def test_index_join_names(how):
+    idx1 = cudf.Index([10, 1, 2, 4, 2, 1], name="a")
+    idx2 = cudf.Index([-10, 2, 3, 1, 2], name="b")
+
+    expected = idx1.to_pandas().join(idx2.to_pandas(), how=how)
+    actual = idx1.join(idx2, how=how)
+    assert_join_results_equal(actual, expected, how=how)


### PR DESCRIPTION
## Description
This PR removes materialization of certain `RangeIndex.join` combinations by falling back to pandas because it's not expensive to do so and also fixes an issue around mismatching index names while performing a join.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
