### PR TITLE
Update docs for top-level API.

### DIFF
--- a/docs/cudf/source/api_docs/general_functions.rst
+++ b/docs/cudf/source/api_docs/general_functions.rst
@@ -26,13 +26,23 @@ Top-level conversions
    :toctree: api/
 
     cudf.to_numeric
+    cudf.from_dataframe
     cudf.from_dlpack
     cudf.from_pandas
 
-Top-level dealing with datetimelike
------------------------------------
+Top-level dealing with datetimelike data
+----------------------------------------
 
 .. autosummary::
    :toctree: api/
 
     cudf.to_datetime
+    cudf.date_range
+
+Top-level dealing with Interval data
+------------------------------------
+
+.. autosummary::
+   :toctree: api/
+
+    cudf.interval_range

--- a/docs/cudf/source/api_docs/general_functions.rst
+++ b/docs/cudf/source/api_docs/general_functions.rst
@@ -14,6 +14,7 @@ Data manipulations
    cudf.cut
    cudf.factorize
    cudf.get_dummies
+   cudf.is_close
    cudf.melt
    cudf.merge
    cudf.pivot

--- a/docs/cudf/source/api_docs/general_functions.rst
+++ b/docs/cudf/source/api_docs/general_functions.rst
@@ -14,7 +14,7 @@ Data manipulations
    cudf.cut
    cudf.factorize
    cudf.get_dummies
-   cudf.is_close
+   cudf.isclose
    cudf.melt
    cudf.merge
    cudf.pivot

--- a/docs/cudf/source/api_docs/general_functions.rst
+++ b/docs/cudf/source/api_docs/general_functions.rst
@@ -14,7 +14,6 @@ Data manipulations
    cudf.cut
    cudf.factorize
    cudf.get_dummies
-   cudf.isclose
    cudf.melt
    cudf.merge
    cudf.pivot


### PR DESCRIPTION
## Description
This PR adds documentation for `cudf.from_dataframe`, `cudf.date_range`, and `cudf.interval_range`. These are exposed in the top-level API of the `cudf` module but lacked docstrings.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
