### PR TITLE
Performance improvement for cudf::strings::like 

### DIFF
--- a/cpp/benchmarks/string/like.cpp
+++ b/cpp/benchmarks/string/like.cpp
@@ -21,6 +21,7 @@
 
 #include <cudf/copying.hpp>
 #include <cudf/filling.hpp>
+#include <cudf/strings/combine.hpp>
 #include <cudf/strings/contains.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -28,22 +29,33 @@
 #include <nvbench/nvbench.cuh>
 
 namespace {
-std::unique_ptr<cudf::column> build_input_column(cudf::size_type n_rows, int32_t hit_rate)
+std::unique_ptr<cudf::column> build_input_column(cudf::size_type n_rows,
+                                                 cudf::size_type row_width,
+                                                 int32_t hit_rate)
 {
   // build input table using the following data
-  auto data      = cudf::test::strings_column_wrapper({
-    "123 abc 4567890 DEFGHI 0987 5W43",  // matches always;
-    "012345 6789 01234 56789 0123 456",  // the rest do not match
-    "abc 4567890 DEFGHI 0987 Wxyz 123",
-    "abcdefghijklmnopqrstuvwxyz 01234",
-    "",
-    "AbcéDEFGHIJKLMNOPQRSTUVWXYZ 01",
-    "9876543210,abcdefghijklmnopqrstU",
-    "9876543210,abcdefghijklmnopqrstU",
-    "123 édf 4567890 DéFG 0987 X5",
-    "1",
-  });
-  auto data_view = cudf::column_view(data);
+  auto raw_data = cudf::test::strings_column_wrapper(
+                    {
+                      "123 abc 4567890 DEFGHI 0987 5W43",  // matches always;
+                      "012345 6789 01234 56789 0123 456",  // the rest do not match
+                      "abc 4567890 DEFGHI 0987 Wxyz 123",
+                      "abcdefghijklmnopqrstuvwxyz 01234",
+                      "",
+                      "AbcéDEFGHIJKLMNOPQRSTUVWXYZ 01",
+                      "9876543210,abcdefghijklmnopqrstU",
+                      "9876543210,abcdefghijklmnopqrstU",
+                      "123 édf 4567890 DéFG 0987 X5",
+                      "1",
+                    })
+                    .release();
+  if (row_width / 32 > 1) {
+    std::vector<cudf::column_view> columns;
+    for (int i = 0; i < row_width / 32; ++i) {
+      columns.push_back(raw_data->view());
+    }
+    raw_data = cudf::strings::concatenate(cudf::table_view(columns));
+  }
+  auto data_view = raw_data->view();
 
   // compute number of rows in n_rows that should match
   auto matches = static_cast<int32_t>(n_rows * hit_rate) / 100;
@@ -71,14 +83,20 @@ std::unique_ptr<cudf::column> build_input_column(cudf::size_type n_rows, int32_t
 
 static void bench_like(nvbench::state& state)
 {
-  auto const n_rows   = static_cast<cudf::size_type>(state.get_int64("num_rows"));
-  auto const hit_rate = static_cast<int32_t>(state.get_int64("hit_rate"));
+  auto const n_rows    = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const row_width = static_cast<cudf::size_type>(state.get_int64("row_width"));
+  auto const hit_rate  = static_cast<int32_t>(state.get_int64("hit_rate"));
 
-  auto col   = build_input_column(n_rows, hit_rate);
+  if (static_cast<std::size_t>(n_rows) * static_cast<std::size_t>(row_width) >=
+      static_cast<std::size_t>(std::numeric_limits<cudf::size_type>::max())) {
+    state.skip("Skip benchmarks greater than size_type limit");
+  }
+
+  auto col   = build_input_column(n_rows, row_width, hit_rate);
   auto input = cudf::strings_column_view(col->view());
 
   // This pattern forces reading the entire target string (when matched expected)
-  auto pattern = std::string("% 5W4_");  // regex equivalent: ".* 5W4."
+  auto pattern = std::string("% 5W4_");  // regex equivalent: ".* 5W4.$"
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   // gather some throughput statistics as well
@@ -93,5 +111,6 @@ static void bench_like(nvbench::state& state)
 
 NVBENCH_BENCH(bench_like)
   .set_name("strings_like")
-  .add_int64_axis("num_rows", {4096, 32768, 262144, 2097152, 16777216})
-  .add_int64_axis("hit_rate", {1, 5, 10, 25, 70, 100});
+  .add_int64_axis("row_width", {32, 64, 128, 256, 512})
+  .add_int64_axis("num_rows", {32768, 262144, 2097152, 16777216})
+  .add_int64_axis("hit_rate", {10, 25, 70, 100});


### PR DESCRIPTION
## Description

Minimizes character counting in the kernel logic for `cudf::strings::like` to improve overall performance especially for longer strings.
The nvbench benchmark is updated to include measurements for various strings sizes.

Reference #13048 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
