### PR TITLE
Fix repeated words in doxygen text

### DIFF
--- a/cpp/include/cudf/contiguous_split.hpp
+++ b/cpp/include/cudf/contiguous_split.hpp
@@ -294,7 +294,7 @@ packed_columns pack(cudf::table_view const& input,
  *
  * The metadata from the `table_view` is copied into a host vector of bytes which can be used to
  * construct a `packed_columns` or `packed_table` structure. The caller is responsible for
- * guaranteeing that that all of the columns in the table point into `contiguous_buffer`.
+ * guaranteeing that all of the columns in the table point into `contiguous_buffer`.
  *
  * @param table View of the table to pack
  * @param contiguous_buffer A contiguous buffer of device memory which contains the data referenced

--- a/cpp/include/cudf/detail/nvtx/nvtx3.hpp
+++ b/cpp/include/cudf/detail/nvtx/nvtx3.hpp
@@ -1167,7 +1167,7 @@ class registered_message {
    * Registers `msg` with NVTX and associates a handle with the registered
    * message.
    *
-   * A particular message should should only be registered once and the handle
+   * A particular message should only be registered once and the handle
    * reused throughout the rest of the application.
    *
    * @param msg The contents of the message
@@ -1183,7 +1183,7 @@ class registered_message {
    * Registers `msg` with NVTX and associates a handle with the registered
    * message.
    *
-   * A particular message should should only be registered once and the handle
+   * A particular message should only be registered once and the handle
    * reused throughout the rest of the application.
    *
    * @param msg The contents of the message
@@ -1196,7 +1196,7 @@ class registered_message {
    * Registers `msg` with NVTX and associates a handle with the registered
    * message.
    *
-   * A particular message should should only be registered once and the handle
+   * A particular message should only be registered once and the handle
    * reused throughout the rest of the application.
    *
    * @param msg The contents of the message

--- a/cpp/include/cudf/io/parquet.hpp
+++ b/cpp/include/cudf/io/parquet.hpp
@@ -1407,7 +1407,7 @@ class chunked_parquet_writer_options_builder {
     std::vector<std::map<std::string, std::string>> metadata);
 
   /**
-   * @brief Sets Sets the level of statistics in chunked_parquet_writer_options.
+   * @brief Sets the level of statistics in chunked_parquet_writer_options.
    *
    * @param sf Level of statistics requested in the output file
    * @return this for chaining

--- a/cpp/include/cudf/rolling/range_window_bounds.hpp
+++ b/cpp/include/cudf/rolling/range_window_bounds.hpp
@@ -59,7 +59,7 @@ struct range_window_bounds {
    * @brief Factory method to construct a window boundary
    *  limited to the value of the current row
    *
-   * @param type type The datatype of the window boundary
+   * @param type The datatype of the window boundary
    * @return  A "current row" window boundary object
    */
   static range_window_bounds current_row(data_type type);
@@ -75,7 +75,7 @@ struct range_window_bounds {
   /**
    * @brief Factory method to construct an unbounded window boundary.
    *
-   * @param type type The datatype of the window boundary
+   * @param type The datatype of the window boundary
    * @return  An unbounded window boundary object
    */
   static range_window_bounds unbounded(data_type type);

--- a/cpp/include/cudf/types.hpp
+++ b/cpp/include/cudf/types.hpp
@@ -222,7 +222,7 @@ enum class type_id : int32_t {
 /**
  * @brief Indicator for the logical data type of an element in a column.
  *
- * Simple types can be be entirely described by their `id()`, but some types
+ * Simple types can be entirely described by their `id()`, but some types
  * require additional metadata to fully describe elements of that type.
  */
 class data_type {

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -1722,7 +1722,7 @@ class lists_column_wrapper : public detail::column_wrapper {
                          // "a List<List<List<int>>> that's empty at the top level"
                          //
                          // { {{{1, 2, 3}}}, {4, 5, 6} }
-                         // In this case, row 1 is a a concrete List<int> with actual values.
+                         // In this case, row 1 is a concrete List<int> with actual values.
                          // There is no way to rectify the differences so we will treat it as a
                          // true column mismatch.
                          CUDF_EXPECTS(l.wrapped->size() == 0, "Mismatch in column types!");

--- a/cpp/include/cudf_test/cudf_gtest.hpp
+++ b/cpp/include/cudf_test/cudf_gtest.hpp
@@ -130,7 +130,7 @@ struct TypeList<Types<TYPES...>> {
   }
 
 /**
- * @brief test macro comparing for equality of \p lhs and and \p rhs for the first \p size elements.
+ * @brief test macro comparing for equality of \p lhs and \p rhs for the first \p size elements.
  */
 #define CUDF_TEST_EXPECT_VECTOR_EQUAL(lhs, rhs, size)          \
   do {                                                         \

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -108,7 +108,7 @@ struct dst_buf_info {
   int num_rows;  // # of rows to be copied(which may be different from num_elements in the case of
                  // validity or offset buffers)
 
-  int src_element_index;   // element index to start reading from from my associated source buffer
+  int src_element_index;   // element index to start reading from my associated source buffer
   std::size_t dst_offset;  // my offset into the per-partition allocation
   int value_shift;         // amount to shift values down by (for offset buffers)
   int bit_shift;           // # of bits to shift right by (for validity buffers)

--- a/cpp/src/datetime/timezone.cpp
+++ b/cpp/src/datetime/timezone.cpp
@@ -124,7 +124,7 @@ struct timezone_file {
     }
     CUDF_EXPECTS(
       header.typecnt > 0 && header.typecnt <= file_size / sizeof(localtime_type_record_s),
-      "Invalid number number of time types in timezone file.");
+      "Invalid number of time types in timezone file.");
     CUDF_EXPECTS(header.timecnt <= file_size,
                  "Number of transition times is larger than the file size.");
   }

--- a/cpp/src/text/subword/wordpiece_tokenizer.cu
+++ b/cpp/src/text/subword/wordpiece_tokenizer.cu
@@ -61,7 +61,7 @@ namespace {
  * Memory required is 13 bytes per code point values:
  * - 4 bytes each for `start_word_indices` and `end_word_indices`
  * - 4 bytes for each `token_ids`
- * - 1 byte for each each `tokens_per_word`
+ * - 1 byte for each `tokens_per_word`
  * Also, there is a code point value for each byte in the input strings.
  *
  * @param[in] code_points A pointer to the code points in the strings after normalization.


### PR DESCRIPTION
## Description
Removes the repeated words in doxygen text in libcudf.

Similar to #13561, fixed repeated words.
https://github.com/rapidsai/cudf/pull/13561#issuecomment-1592147377

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
