### PR TITLE
Use cuda-version to constrain cudatoolkit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Please see the [Demo Docker Repository](https://hub.docker.com/r/rapidsai/rapids
 
 ### Conda
 
-cuDF can be installed with conda ([miniconda](https://conda.io/miniconda.html), or the full [Anaconda distribution](https://www.anaconda.com/download)) from the `rapidsai` channel:
+cuDF can be installed with conda (via [miniconda](https://conda.io/miniconda.html) or the full [Anaconda distribution](https://www.anaconda.com/download)) from the `rapidsai` channel:
 
 ```bash
 conda install -c rapidsai -c conda-forge -c nvidia \
-    cudf=23.08 python=3.10 cudatoolkit=11.8
+    cudf=23.08 python=3.10 cuda-version=11.8
 ```
 
 We also provide [nightly Conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -18,7 +18,8 @@ dependencies:
 - cubinlinker
 - cuda-python>=11.7.1,<12.0a0
 - cuda-sanitizer-api=11.8.86
-- cudatoolkit=11.8
+- cuda-version=11.8
+- cudatoolkit
 - cupy>=12.0.0
 - cxx-compiler
 - cython>=0.29,<0.30

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -65,7 +65,7 @@ requirements:
     - libcudf ={{ version }}
     - rmm ={{ minor_version }}
     {% if cuda_major == "11" %}
-    - cudatoolkit ={{ cuda_version }}
+    - cudatoolkit
     {% else %}
     - cuda-cudart-dev
     - cuda-nvrtc
@@ -85,7 +85,7 @@ requirements:
     - {{ pin_compatible('rmm', max_pin='x.x') }}
     - fsspec >=0.6.0
     {% if cuda_major == "11" %}
-    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+    - cudatoolkit
     - ptxcompiler >=0.7.0
     - cubinlinker  # CUDA enhanced compatibility.
     - cuda-python >=11.7.1,<12.0a0
@@ -102,7 +102,7 @@ requirements:
 
 test:
   requires:
-    - cudatoolkit ={{ cuda_version }}
+    - cuda-version ={{ cuda_version }}
   imports:
     - cudf
 

--- a/conda/recipes/cudf_kafka/meta.yaml
+++ b/conda/recipes/cudf_kafka/meta.yaml
@@ -56,9 +56,6 @@ requirements:
 
 test:
   requires:
-    {% if cuda_major == "11" %}
-    - cudatoolkit ={{ cuda_version }}
-    {% endif %}
     - cuda-version ={{ cuda_version }}
   imports:
     - cudf_kafka

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -53,9 +53,6 @@ requirements:
 
 test:
   requires:
-    {% if cuda_major == "11" %}
-    - cudatoolkit ={{ cuda_version }}
-    {% endif %}
     - cuda-version ={{ cuda_version }}
   imports:
     - custreamz

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -41,9 +41,6 @@ requirements:
     - dask >=2023.5.1
     - dask-core >=2023.5.1
     - distributed >=2023.5.1
-    {% if cuda_major == "11" %}
-    - cudatoolkit ={{ cuda_version }}
-    {% endif %}
     - cuda-version ={{ cuda_version }}
   run:
     - python
@@ -51,16 +48,10 @@ requirements:
     - dask >=2023.5.1
     - dask-core >=2023.5.1
     - distributed >=2023.5.1
-    {% if cuda_major == "11" %}
-    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
-    {% endif %}
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
 
 test:
   requires:
-    {% if cuda_major == "11" %}
-    - cudatoolkit ={{ cuda_version }}
-    {% endif %}
     - cuda-version ={{ cuda_version }}
   imports:
     - dask_cudf

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - librmm ={{ minor_version }}
     - libkvikio ={{ minor_version }}
     {% if cuda_major == "11" %}
-    - cudatoolkit ={{ cuda_version }}
+    - cudatoolkit
     - libcufile {{ cuda11_libcufile_host_version }}  # [linux64]
     - libcufile-dev {{ cuda11_libcufile_host_version }}  # [linux64]
     - libcurand {{ cuda11_libcurand_host_version }}
@@ -91,7 +91,7 @@ outputs:
         - cmake {{ cmake_version }}
       run:
         {% if cuda_major == "11" %}
-        - cudatoolkit {{ cuda_spec }}
+        - cudatoolkit
         - libcufile {{ cuda11_libcufile_run_version }}  # [linux64]
         {% else %}
         - cuda-nvrtc

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -279,13 +279,15 @@ dependencies:
           - matrix:
               cuda: "11.8"
             packages:
-              - cudatoolkit=11.8
+              - cuda-version=11.8
+              - cudatoolkit
               - libcurand-dev=10.3.0.86
               - libcurand=10.3.0.86
           - matrix:
               cuda: "11.5"
             packages:
-              - cudatoolkit=11.5
+              - cuda-version=11.5
+              - cudatoolkit
                 # Can't hard pin the version since 11.x is missing many
                 # packages for specific versions
               - libcurand-dev>=10.2.6.48,<=10.2.7.107
@@ -293,13 +295,15 @@ dependencies:
           - matrix:
               cuda: "11.4"
             packages:
-              - cudatoolkit=11.4
+              - cuda-version=11.4
+              - cudatoolkit
               - &libcurand_dev114 libcurand-dev>=10.2.5.43,<=10.2.5.120
               - &libcurand114 libcurand>=10.2.5.43,<=10.2.5.120
           - matrix:
               cuda: "11.2"
             packages:
-              - cudatoolkit=11.2
+              - cuda-version=11.2
+              - cudatoolkit
                 # The NVIDIA channel doesn't publish pkgs older than 11.4 for
                 # these libs, so 11.2 uses 11.4 packages (the oldest
                 # available).


### PR DESCRIPTION
## Description
This PR changes CUDA 11 packaging to rely on `cuda-version` pinnings to constrain the installed version of `cudatoolkit`.

Resolves #13613. Resolves #13607.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
