### PR TITLE
Fix compile warning for unused variable in split_re.cu

### DIFF
--- a/cpp/src/strings/split/split_re.cu
+++ b/cpp/src/strings/split/split_re.cu
@@ -80,7 +80,7 @@ struct token_reader_fn {
       auto const match = prog.find(prog_idx, d_str, itr);
       if (!match) { break; }
 
-      auto const [start_pos, end_pos] = match_positions_to_bytes(*match, d_str, last_pos);
+      auto const start_pos = thrust::get<0>(match_positions_to_bytes(*match, d_str, last_pos));
 
       // get the token (characters just before this match)
       auto const token = string_index_pair{d_str.data() + last_pos.byte_offset(),


### PR DESCRIPTION
## Description

Fixes compile warning found in `cpp/src/strings/split/split_re.cu` for unused declared variable
```
/cudf/cpp/src/strings/split/split_re.cu(83): error #177-D: structured binding "end_pos" was declared but never referenced
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
