### PR TITLE
Expose stable versions of libcudf sort routines

### DIFF
--- a/python/cudf/cudf/_lib/cpp/sorting.pxd
+++ b/python/cudf/cudf/_lib/cpp/sorting.pxd
@@ -20,9 +20,8 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         vector[libcudf_types.order] column_order,
         vector[libcudf_types.null_order] null_precedence) except +
 
-    cdef unique_ptr[table] stable_sort_by_key(
-        const table_view& values,
-        const table_view& keys,
+    cdef unique_ptr[column] stable_sorted_order(
+        table_view source_table,
         vector[libcudf_types.order] column_order,
         vector[libcudf_types.null_order] null_precedence) except +
 
@@ -43,6 +42,25 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         const table_view& values,
         const table_view& keys,
         const column_view& segment_offsets,
+        vector[libcudf_types.order] column_order,
+        vector[libcudf_types.null_order] null_precedence) except +
+
+    cdef unique_ptr[table] stable_segmented_sort_by_key(
+        const table_view& values,
+        const table_view& keys,
+        const column_view& segment_offsets,
+        vector[libcudf_types.order] column_order,
+        vector[libcudf_types.null_order] null_precedence) except +
+
+    cdef unique_ptr[table] sort_by_key(
+        const table_view& values,
+        const table_view& keys,
+        vector[libcudf_types.order] column_order,
+        vector[libcudf_types.null_order] null_precedence) except +
+
+    cdef unique_ptr[table] stable_sort_by_key(
+        const table_view& values,
+        const table_view& keys,
         vector[libcudf_types.order] column_order,
         vector[libcudf_types.null_order] null_precedence) except +
 

--- a/python/cudf/cudf/_lib/sort.pyx
+++ b/python/cudf/cudf/_lib/sort.pyx
@@ -161,10 +161,10 @@ def order_by(
         Columns from the table which will be sorted
     ascending : sequence[bool]
          Sequence of boolean values which correspond to each column
-         in the to-be-sorted table signifying order of each column
+         in the table to be sorted signifying the order of each column
          True - Ascending and False - Descending
     na_position : str
-        whether null value should show up at the "first" or "last"
+        Whether null values should show up at the "first" or "last"
         position of **all** sorted column.
     stable : bool
         Should the sort be stable? (no default)
@@ -252,10 +252,10 @@ def sort_by_key(
     keys : list[Column]
         Columns making up the sort key
     ascending : list[bool]
-        Sequence of boolean values which correspond to each column in
-        keys providing the sort order (default all True).
-        With True <=> ascending; False <=> descending.
-    null_precedence : list[str]
+        Sequence of boolean values which correspond to each column
+        in the table to be sorted signifying the order of each column
+        True - Ascending and False - Descending
+    na_position : list[str]
         Sequence of "first" or "last" values (default "first")
         indicating the position of null values when sorting the keys.
     stable : bool

--- a/python/cudf/cudf/_lib/sort.pyx
+++ b/python/cudf/cudf/_lib/sort.pyx
@@ -157,13 +157,17 @@ def order_by(
 
     Parameters
     ----------
-    columns_from_table : columns from the table which will be sorted
-    ascending : sequence of boolean values which correspond to each column
-                in source_table signifying order of each column
-                True - Ascending and False - Descending
-    na_position : whether null value should show up at the "first" or "last"
-                position of **all** sorted column.
-    stable : should the sort be stable? (no default)
+    columns_from_table : list[Column]
+        Columns from the table which will be sorted
+    ascending : sequence[bool]
+         Sequence of boolean values which correspond to each column
+         in the to-be-sorted table signifying order of each column
+         True - Ascending and False - Descending
+    na_position : str
+        whether null value should show up at the "first" or "last"
+        position of **all** sorted column.
+    stable : bool
+        Should the sort be stable? (no default)
 
     Returns
     -------
@@ -255,7 +259,7 @@ def sort_by_key(
         Sequence of "first" or "last" values (default "first")
         indicating the position of null values when sorting the keys.
     stable : bool
-        Should the sort be stable?
+        Should the sort be stable? (no default)
 
     Returns
     -------
@@ -312,9 +316,8 @@ def segmented_sort_by_key(
     null_precedence : list[str], optional
         Sequence of "first" or "last" values (default "first")
         indicating the position of null values when sorting the keys.
-
     stable : bool
-        Should the sort be stable?
+        Should the sort be stable? (no default)
 
     Returns
     -------

--- a/python/cudf/cudf/_lib/sort.pyx
+++ b/python/cudf/cudf/_lib/sort.pyx
@@ -149,7 +149,8 @@ def order_by(
     list columns_from_table,
     object ascending,
     str na_position,
-    bool stable=False
+    *,
+    bool stable
 ):
     """
     Get index to sort the table in ascending/descending order.
@@ -162,7 +163,7 @@ def order_by(
                 True - Ascending and False - Descending
     na_position : whether null value should show up at the "first" or "last"
                 position of **all** sorted column.
-    stable : should the sort be stable?
+    stable : should the sort be stable? (no default)
 
     Returns
     -------
@@ -234,7 +235,8 @@ def sort_by_key(
     list keys,
     object ascending,
     object na_position,
-    bool stable=False,
+    *,
+    bool stable,
 ):
     """
     Sort a table by given keys
@@ -245,15 +247,14 @@ def sort_by_key(
         Columns of the table which will be sorted
     keys : list[Column]
         Columns making up the sort key
-    ascending : list[bool], optional
+    ascending : list[bool]
         Sequence of boolean values which correspond to each column in
         keys providing the sort order (default all True).
         With True <=> ascending; False <=> descending.
-    null_precedence : list[str], optional
+    null_precedence : list[str]
         Sequence of "first" or "last" values (default "first")
         indicating the position of null values when sorting the keys.
-
-    stable : bool, optional
+    stable : bool
         Should the sort be stable?
 
     Returns
@@ -290,7 +291,8 @@ def segmented_sort_by_key(
     Column segment_offsets,
     list column_order=None,
     list null_precedence=None,
-    bool stable=False,
+    *,
+    bool stable,
 ):
     """
     Sort segments of a table by given keys
@@ -311,7 +313,7 @@ def segmented_sort_by_key(
         Sequence of "first" or "last" values (default "first")
         indicating the position of null values when sorting the keys.
 
-    stable : bool, optional
+    stable : bool
         Should the sort be stable?
 
     Returns

--- a/python/cudf/cudf/_lib/sort.pyx
+++ b/python/cudf/cudf/_lib/sort.pyx
@@ -22,7 +22,11 @@ from cudf._lib.cpp.sorting cimport (
     rank,
     segmented_sort_by_key as cpp_segmented_sort_by_key,
     sort as cpp_sort,
+    sort_by_key as cpp_sort_by_key,
     sorted_order,
+    stable_segmented_sort_by_key as cpp_stable_segmented_sort_by_key,
+    stable_sort_by_key as cpp_stable_sort_by_key,
+    stable_sorted_order,
 )
 from cudf._lib.cpp.table.table cimport table
 from cudf._lib.cpp.table.table_view cimport table_view
@@ -141,7 +145,12 @@ cdef pair[vector[order], vector[null_order]] ordering(
 
 
 @acquire_spill_lock()
-def order_by(list columns_from_table, object ascending, str na_position):
+def order_by(
+    list columns_from_table,
+    object ascending,
+    str na_position,
+    bool stable=False
+):
     """
     Get index to sort the table in ascending/descending order.
 
@@ -153,6 +162,11 @@ def order_by(list columns_from_table, object ascending, str na_position):
                 True - Ascending and False - Descending
     na_position : whether null value should show up at the "first" or "last"
                 position of **all** sorted column.
+    stable : should the sort be stable?
+
+    Returns
+    -------
+    Column of indices that sorts the table
     """
     cdef table_view source_table_view = table_view_from_columns(
         columns_from_table
@@ -161,10 +175,16 @@ def order_by(list columns_from_table, object ascending, str na_position):
         ascending, repeat(na_position)
     )
     cdef unique_ptr[column] c_result
-    with nogil:
-        c_result = move(sorted_order(source_table_view,
-                                     order.first,
-                                     order.second))
+    if stable:
+        with nogil:
+            c_result = move(stable_sorted_order(source_table_view,
+                                                order.first,
+                                                order.second))
+    else:
+        with nogil:
+            c_result = move(sorted_order(source_table_view,
+                                         order.first,
+                                         order.second))
 
     return Column.from_unique_ptr(move(c_result))
 
@@ -209,12 +229,68 @@ def sort(
 
 
 @acquire_spill_lock()
+def sort_by_key(
+    list values,
+    list keys,
+    object ascending,
+    object na_position,
+    bool stable=False,
+):
+    """
+    Sort a table by given keys
+
+    Parameters
+    ----------
+    values : list[Column]
+        Columns of the table which will be sorted
+    keys : list[Column]
+        Columns making up the sort key
+    ascending : list[bool], optional
+        Sequence of boolean values which correspond to each column in
+        keys providing the sort order (default all True).
+        With True <=> ascending; False <=> descending.
+    null_precedence : list[str], optional
+        Sequence of "first" or "last" values (default "first")
+        indicating the position of null values when sorting the keys.
+
+    stable : bool, optional
+        Should the sort be stable?
+
+    Returns
+    -------
+    list[Column]
+        list of value columns sorted by keys
+    """
+    cdef table_view value_view = table_view_from_columns(values)
+    cdef table_view key_view = table_view_from_columns(keys)
+    cdef pair[vector[order], vector[null_order]] order = ordering(
+        ascending, na_position
+    )
+    cdef unique_ptr[table] c_result
+    if stable:
+        with nogil:
+            c_result = move(cpp_stable_sort_by_key(value_view,
+                                                   key_view,
+                                                   order.first,
+                                                   order.second))
+    else:
+        with nogil:
+            c_result = move(cpp_sort_by_key(value_view,
+                                            key_view,
+                                            order.first,
+                                            order.second))
+
+    return columns_from_unique_ptr(move(c_result))
+
+
+@acquire_spill_lock()
 def segmented_sort_by_key(
     list values,
     list keys,
     Column segment_offsets,
     list column_order=None,
     list null_precedence=None,
+    bool stable=False,
 ):
     """
     Sort segments of a table by given keys
@@ -235,6 +311,9 @@ def segmented_sort_by_key(
         Sequence of "first" or "last" values (default "first")
         indicating the position of null values when sorting the keys.
 
+    stable : bool, optional
+        Should the sort be stable?
+
     Returns
     -------
     list[Column]
@@ -249,16 +328,28 @@ def segmented_sort_by_key(
         column_order or repeat(True, ncol),
         null_precedence or repeat("first", ncol),
     )
-    with nogil:
-        result = move(
-            cpp_segmented_sort_by_key(
-                values_view,
-                keys_view,
-                offsets_view,
-                order.first,
-                order.second,
+    if stable:
+        with nogil:
+            result = move(
+                cpp_stable_segmented_sort_by_key(
+                    values_view,
+                    keys_view,
+                    offsets_view,
+                    order.first,
+                    order.second,
+                )
             )
-        )
+    else:
+        with nogil:
+            result = move(
+                cpp_segmented_sort_by_key(
+                    values_view,
+                    keys_view,
+                    offsets_view,
+                    order.first,
+                    order.second,
+                )
+            )
     return columns_from_unique_ptr(move(result))
 
 

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1580,7 +1580,13 @@ class Frame(BinaryOperand, Scannable):
         if np.isscalar(ascending):
             ascending = [ascending] * len(to_sort)
 
-        return libcudf.sort.order_by(to_sort, ascending, na_position)
+        # Only use a stable sort in pandas-compat mode
+        return libcudf.sort.order_by(
+            to_sort,
+            ascending,
+            na_position,
+            stable=cudf.get_option("mode.pandas_compatible"),
+        )
 
     @_cudf_nvtx_annotate
     def abs(self):

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1580,12 +1580,11 @@ class Frame(BinaryOperand, Scannable):
         if np.isscalar(ascending):
             ascending = [ascending] * len(to_sort)
 
-        # Only use a stable sort in pandas-compat mode
         return libcudf.sort.order_by(
             to_sort,
             ascending,
             na_position,
-            stable=cudf.get_option("mode.pandas_compatible"),
+            stable=True,
         )
 
     @_cudf_nvtx_annotate

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -1030,6 +1030,7 @@ class GroupBy(Serializable, Reducible, Scannable):
                     as_column(group_offsets),
                     [],
                     [],
+                    stable=cudf.get_option("mode.pandas_compatible"),
                 )
                 indices = cp.asarray(indices.data_array_view(mode="read"))
             # Which indices are we going to want?

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -1030,7 +1030,7 @@ class GroupBy(Serializable, Reducible, Scannable):
                     as_column(group_offsets),
                     [],
                     [],
-                    stable=cudf.get_option("mode.pandas_compatible"),
+                    stable=True,
                 )
                 indices = cp.asarray(indices.data_array_view(mode="read"))
             # Which indices are we going to want?


### PR DESCRIPTION
## Description

As preparation for addressing parts of #13557, this just exposes the existing sort-by and stable-sort-by routines from libcudf.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
