### PR TITLE
Fix CUDA 12 conda environment to remove cubinlinker and ptxcompiler.

### DIFF
--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -15,7 +15,6 @@ dependencies:
 - c-compiler
 - cachetools
 - cmake>=3.26.4
-- cubinlinker
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvrtc-dev
@@ -63,7 +62,6 @@ dependencies:
 - pip
 - pre-commit
 - protobuf>=4.21.6,<4.22
-- ptxcompiler
 - pyarrow==11.0.0.*
 - pydata-sphinx-theme
 - pyorc

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -424,20 +424,16 @@ dependencies:
           - *protobuf
       - output_types: conda
         packages:
-          - cubinlinker
           - cupy>=12.0.0
           - pip
           - pip:
               - git+https://github.com/python-streamz/streamz.git@master
-          - ptxcompiler
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
           # This index is needed for rmm, cubinlinker, ptxcompiler.
           - --extra-index-url=https://pypi.ngc.nvidia.com
-          - cubinlinker-cu11
           - git+https://github.com/python-streamz/streamz.git@master
-          - ptxcompiler-cu11
           - &cupy_pip cupy-cuda11x>=12.0.0
       - output_types: pyproject
         packages:
@@ -454,6 +450,24 @@ dependencies:
           - matrix: # All CUDA 11 versions
             packages:
               - cuda-python>=11.7.1,<12.0a0
+      - output_types: [conda, pyproject]
+        matrices:
+          - matrix:
+              cuda: "12.0"
+            packages:
+          - matrix: # All CUDA 11 versions
+            packages:
+              - cubinlinker
+              - ptxcompiler
+      - output_types: requirements
+        matrices:
+          - matrix:
+              cuda: "12.0"
+            packages:
+          - matrix: # All CUDA 11 versions
+            packages:
+              - cubinlinker-cu11
+              - ptxcompiler-cu11
   run_dask_cudf:
     common:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
## Description
The CUDA 12 developer conda environment contains `cubinlinker` and `ptxcompiler`. These are unneeded and make the environment unsolvable, because they depend on `cudatoolkit`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
