### PR TITLE
Fix memcheck error in ORC reader call to cudf::io::copy_uncompressed_kernel

### DIFF
--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -1122,6 +1122,8 @@ table_with_metadata reader::impl::read(uint64_t skip_rows,
         CUDF_EXPECTS(not is_stripe_data_empty or stripe_info->indexLength == 0,
                      "Invalid index rowgroup stream data");
 
+        // Buffer needs to be padded.
+        // Required by `copy_uncompressed_kernel`.
         stripe_data.emplace_back(
           cudf::util::round_up_safe(total_data_size, BUFFER_PADDING_MULTIPLE), _stream);
         auto dst_base = static_cast<uint8_t*>(stripe_data.back().data());

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -1122,7 +1122,8 @@ table_with_metadata reader::impl::read(uint64_t skip_rows,
         CUDF_EXPECTS(not is_stripe_data_empty or stripe_info->indexLength == 0,
                      "Invalid index rowgroup stream data");
 
-        stripe_data.emplace_back(total_data_size, _stream);
+        stripe_data.emplace_back(
+          cudf::util::round_up_safe(total_data_size, BUFFER_PADDING_MULTIPLE), _stream);
         auto dst_base = static_cast<uint8_t*>(stripe_data.back().data());
 
         // Coalesce consecutive streams into one read


### PR DESCRIPTION
## Description
Fixes memcheck regression in ORC reader uncompressed logic. The regression was introduced in #13396.
The original fix is copied from #13586 

The error was caught by the nightly build here: https://github.com/rapidsai/cudf/actions/runs/5409203449/jobs/9829059618

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
