### PR TITLE
Fix `has_nonempty_nulls` ignoring column offset

### DIFF
--- a/cpp/src/copying/purge_nonempty_nulls.cu
+++ b/cpp/src/copying/purge_nonempty_nulls.cu
@@ -42,11 +42,10 @@ bool has_nonempty_null_rows(cudf::column_view const& input, rmm::cuda_stream_vie
 
   // Cross-reference nullmask and offsets.
   auto const type         = input.type().id();
-  auto const offsets      = (type == type_id::STRING) ? (strings_column_view{input}).offsets()
-                                                      : (lists_column_view{input}).offsets();
+  auto const offsets      = (type == type_id::STRING) ? (strings_column_view{input}).offsets_begin()
+                                                      : (lists_column_view{input}).offsets_begin();
   auto const d_input      = cudf::column_device_view::create(input, stream);
-  auto const is_dirty_row = [d_input = *d_input, offsets = offsets.begin<size_type>()] __device__(
-                              size_type const& row_idx) {
+  auto const is_dirty_row = [d_input = *d_input, offsets] __device__(size_type const& row_idx) {
     return d_input.is_null_nocheck(row_idx) && (offsets[row_idx] != offsets[row_idx + 1]);
   };
 


### PR DESCRIPTION
This fixes `has_nonempty_nulls` that always access the column offsets without considering the starting offset. As such, it may give wrong answer if the input column is sliced.

Closes https://github.com/rapidsai/cudf/issues/13638.