### PR TITLE
Fix multiindex loc ordering in pandas-compat mode

### DIFF
--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -779,7 +779,7 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
         # TODO: Remove this after merge/join
         # obtain deterministic ordering.
         if cudf.get_option("mode.pandas_compatible"):
-            lookup_order = "_" + "_".join(map(str, lookup.columns))
+            lookup_order = "_" + "_".join(map(str, lookup._data.names))
             lookup[lookup_order] = column.arange(len(lookup))
             postprocess = operator.methodcaller(
                 "sort_values", by=[lookup_order, "idx"]

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import itertools
 import numbers
+import operator
 import pickle
 import warnings
 from collections import abc
@@ -762,6 +763,20 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
             if isinstance(row, slice) and row == slice(None):
                 continue
             lookup[i] = cudf.Series(row)
+        # Sort indices in pandas compatible mode
+        # because we want the indices to be fetched
+        # in a deterministic order.
+        # TODO: Remove this after merge/join
+        # obtain deterministic ordering.
+        should_sort = cudf.get_option("mode.pandas_compatible")
+        if should_sort:
+            lookup_order = "_" + "_".join(map(str, lookup.columns))
+            lookup[lookup_order] = column.arange(len(lookup))
+            postprocess = operator.methodcaller(
+                "sort_values", by=[lookup_order, "idx"]
+            )
+        else:
+            postprocess = lambda r: r  # noqa: E731
         frame = cudf.DataFrame(dict(enumerate(index._data.columns)))
         data_table = cudf.concat(
             [
@@ -772,7 +787,7 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
             ],
             axis=1,
         )
-        result = lookup.merge(data_table)["idx"]
+        result = postprocess(lookup.merge(data_table))["idx"]
         # Avoid computing levels unless the result of the merge is empty,
         # which suggests that a KeyError should be raised.
         if len(result) == 0:
@@ -901,13 +916,6 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
             df.index, row_tuple, len(df.index)
         )
         indices = cudf.Series(valid_indices)
-        if cudf.get_option("mode.pandas_compatible"):
-            # Sort indices in pandas compatible mode
-            # because we want the indices to be fetched
-            # in a deterministic order.
-            # TODO: Remove this after merge/join
-            # obtain deterministic ordering.
-            indices = indices.sort_values()
         result = df.take(indices)
         final = self._index_and_downcast(result, result.index, row_tuple)
         return final

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -348,6 +348,24 @@ def test_multiindex_loc(pdf, gdf, pdfIndex, key_tuple):
 
 
 @pytest.mark.parametrize(
+    "indexer",
+    [
+        (([1, 1], [0, 1]), slice(None)),
+        (([1, 1], [1, 0]), slice(None)),
+    ],
+)
+def test_multiindex_compatible_ordering(indexer):
+    df = pd.DataFrame(
+        {"a": [1, 1, 2, 3], "b": [1, 0, 1, 1], "c": [1, 2, 3, 4]}
+    ).set_index(["a", "b"])
+    cdf = cudf.from_pandas(df)
+    expect = df.loc[indexer]
+    with cudf.option_context("mode.pandas_compatible", True):
+        actual = cdf.loc[indexer]
+    assert_eq(actual, expect)
+
+
+@pytest.mark.parametrize(
     "arg",
     [
         slice(("a", "store"), ("b", "house")),


### PR DESCRIPTION
## Description

#13657 attempted to provide pandas-compatible ordering to the return value from multiindex-based `loc`-indexing. However, one must sort by keys corresponding to both the left and right gather maps of the join, rather than just the right gather map, to ensure that  correct ordering is maintained.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
