### PR TITLE
Fix combined filtering and column projection in `read_parquet`

### DIFF
--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -558,10 +558,10 @@ def read_parquet(
                 "for full CPU-based filtering functionality."
             )
 
-    # Make sure we read in the "filtered" columns needed for
-    # row-wise filtering after IO. This means that one or
-    # more columns will be dropped almost immediately after IO.
-    # However, we do NEED these columns for accurate filtering.
+    # Make sure we read in the columns needed for row-wise
+    # filtering after IO. This means that one or more columns
+    # will be dropped almost immediately after IO. However,
+    # we do NEED these columns for accurate filtering.
     projection = None
     if columns and filters:
         filtered_columns = _filtered_columns(filters)


### PR DESCRIPTION
## Description
Follow-up to https://github.com/rapidsai/cudf/pull/13334 for the special case that the `filters` argument includes column names that are **not** included in the current column projection (i.e. the `columns` argument). Although this pattern is not a common case at the moment, it is perfectly valid, and will become more common when cudf is used as a dask-expr backend (since the predicate-pushdown optimizations in dask-expr are significantly more advanced than those in dask-dataframe).

**Note**:
Prior to #13334, the special case targeted by this PR would not have produced any run-time errors, but it also wouldn't have produced proper filtering in many cases. Now that `cudf.read_parquet` **does** produce proper row-wise filtering, it turns out that we now need to sacrifice a bit of IO in cases like this. Although this is unfortunate, I personally feel that it is still worthwhile to enforce row-wise filtering.


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
