### PR TITLE
Data generator - include offsets in the size estimate of list elments

### DIFF
--- a/cpp/benchmarks/common/generate_input.cu
+++ b/cpp/benchmarks/common/generate_input.cu
@@ -121,7 +121,7 @@ size_t non_fixed_width_size<cudf::string_view>(data_profile const& profile)
 double geometric_sum(size_t n, double p)
 {
   if (p == 1) { return n; }
-  return (1 - pow(p, n)) / (1 - p);
+  return (1 - std::pow(p, n)) / (1 - p);
 }
 
 template <>
@@ -131,7 +131,7 @@ size_t non_fixed_width_size<cudf::list_view>(data_profile const& profile)
   auto const single_level_mean = get_distribution_mean(dist_params.length_params);
 
   auto const element_size  = avg_element_size(profile, cudf::data_type{dist_params.element_type});
-  auto const element_count = pow(single_level_mean, dist_params.max_depth);
+  auto const element_count = std::pow(single_level_mean, dist_params.max_depth);
 
   // Each nesting level includes offsets, this is the sum of all levels
   // Also include an additional offset per level for the size of the last element

--- a/cpp/benchmarks/common/generate_input.cu
+++ b/cpp/benchmarks/common/generate_input.cu
@@ -118,13 +118,27 @@ size_t non_fixed_width_size<cudf::string_view>(data_profile const& profile)
   return get_distribution_mean(dist);
 }
 
+double geometric_sum(size_t n, double p)
+{
+  if (p == 1) { return n; }
+  return (1 - pow(p, n)) / (1 - p);
+}
+
 template <>
 size_t non_fixed_width_size<cudf::list_view>(data_profile const& profile)
 {
   auto const dist_params       = profile.get_distribution_params<cudf::list_view>();
   auto const single_level_mean = get_distribution_mean(dist_params.length_params);
-  auto const element_size = avg_element_size(profile, cudf::data_type{dist_params.element_type});
-  return element_size * pow(single_level_mean, dist_params.max_depth);
+
+  auto const element_size  = avg_element_size(profile, cudf::data_type{dist_params.element_type});
+  auto const element_count = pow(single_level_mean, dist_params.max_depth);
+
+  // Each nesting level includes offsets, this is the sum of all levels
+  // Also include an additional offset per level for the size of the last element
+  auto const total_offset_count =
+    geometric_sum(dist_params.max_depth, single_level_mean) + dist_params.max_depth;
+
+  return sizeof(cudf::size_type) * total_offset_count + element_size * element_count;
 }
 
 template <>


### PR DESCRIPTION
## Description
Currently the data generator only takes the element (leaf) size into account when estimating the size of a row in a list column.
This estimate can be lower by an order of magnitude for tall lists (many levels with few elements per row).
This PR expands the row size estimate to also include the offsets size.
A small impact on existing benchmarks with list types is expected because of reduced row count for a given data size.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
