### PR TITLE
Add pandas compatibility note to DataFrame.query docstring

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -4160,6 +4160,12 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         ...          local_dict={'search_date': search_date2})
            datetimes
         1 2018-10-08
+
+        .. pandas-compat::
+            **DataFrame.query**
+
+            unlike pandas, DataFrame.query currently only supports
+            numeric, datetime, timedelta, or bool dtypes.
         """
         # can't use `annotate` decorator here as we inspect the calling
         # environment.

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -4164,8 +4164,8 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         .. pandas-compat::
             **DataFrame.query**
 
-            unlike pandas, DataFrame.query currently only supports
-            numeric, datetime, timedelta, or bool dtypes.
+            One difference from pandas is that DataFrame.query currently only
+            supports numeric, datetime, timedelta, or bool dtypes.
         """
         # can't use `annotate` decorator here as we inspect the calling
         # environment.

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -4164,7 +4164,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         .. pandas-compat::
             **DataFrame.query**
 
-            One difference from pandas is that DataFrame.query currently only
+            One difference from pandas is that ``query`` currently only
             supports numeric, datetime, timedelta, or bool dtypes.
         """
         # can't use `annotate` decorator here as we inspect the calling


### PR DESCRIPTION
This PR:
- Adds a pandas compatibility note to the DataFrame.query docstring that indicates query only supports a subset of the canonical dtypes (e.g., not strings). A user ran into this and mentioned it would be nice to document it.

![query-pandas-compat](https://github.com/rapidsai/cudf/assets/8457388/b6357120-3a41-4f7d-9560-d178fb1f9986)