### PR TITLE
Adding identify minimum version requirement

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -36,6 +36,7 @@ dependencies:
 - gmock>=1.13.0
 - gtest>=1.13.0
 - hypothesis
+- identify>=2.5.20
 - ipython
 - libarrow==11.0.0.*
 - libcufile-dev=1.4.0.31

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -37,6 +37,7 @@ dependencies:
 - gmock>=1.13.0
 - gtest>=1.13.0
 - hypothesis
+- identify>=2.5.20
 - ipython
 - libarrow==11.0.0.*
 - libcufile-dev

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -364,6 +364,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - pre-commit
+          - identify>=2.5.20
       - output_types: conda
         packages:
           - doxygen=1.8.20 # pre-commit hook needs a specific version.

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -364,6 +364,8 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - pre-commit
+          # pre-commit requires identify minimum version 1.0, but clang-format requires textproto support and that was
+          # added in 2.5.20, so we need to call out the minimum version needed for our plugins
           - identify>=2.5.20
       - output_types: conda
         packages:


### PR DESCRIPTION
## Description
I ran into an issue with `clang-format` not being able to run due to the version of identify I had installed.
```
$ pre-commit 
An error has occurred: InvalidManifestError: 
==> At Hook(id='clang-format')
==> At key: types_or
==> At index 9
=====> Type tag 'textproto' is not recognized.  Try upgrading identify and pre-commit?
```
This led me to find out that `pre-commit` only requires version 1, but we require a newer version to work with `clang-format`. We don't specify that version anywhere, so I tracked down the minimum requirement and added it in our `dependencies.yaml` and ran `pre-commit` to update the conda environment files.

I verified that version [2.5.19](https://github.com/pre-commit/identify/blob/v2.5.19/identify/extensions.py#L226) did not have textproto, but [2.5.20](https://github.com/pre-commit/identify/blob/v2.5.20/identify/extensions.py#L226) did have it and that is why 2.5.20 is the minimum required version.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
