### PR TITLE
Parse (non-MultiIndex) label-based keys to structured data

### DIFF
--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -404,6 +404,10 @@ class ColumnAccessor(abc.MutableMapping):
         ColumnAccessor
         """
         keys = self.get_labels_by_index(index)
+        if len(set(keys)) != len(keys):
+            raise NotImplementedError(
+                "cudf DataFrames do not support repeated column names"
+            )
         data = {k: self._data[k] for k in keys}
         return self.__class__(
             data,
@@ -499,6 +503,10 @@ class ColumnAccessor(abc.MutableMapping):
                 if keep
             )
         else:
+            if len(set(key)) != len(key):
+                raise NotImplementedError(
+                    "cudf DataFrames do not support repeated column names"
+                )
             data = {k: self._grouped_data[k] for k in key}
         if self.multiindex:
             data = _to_flat_dict(data)

--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -20,7 +20,6 @@ from typing import (
 import pandas as pd
 from packaging.version import Version
 from pandas.api.types import is_bool
-from typing_extensions import Self
 
 import cudf
 from cudf.core import column
@@ -480,13 +479,6 @@ class ColumnAccessor(abc.MutableMapping):
 
         self._data[key] = value
         self._clear_cache()
-
-    def _select_by_names(self, names: abc.Sequence) -> Self:
-        return self.__class__(
-            {key: self[key] for key in names},
-            multiindex=self.multiindex,
-            level_names=self.level_names,
-        )
 
     def _select_by_label_list_like(self, key: Any) -> ColumnAccessor:
         # Might be a generator

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -421,22 +421,16 @@ class _DataFrameIlocIndexer(_DataFrameIndexer):
     def __getitem__(self, arg):
         row_key, (
             col_is_scalar,
-            column_names,
+            ca,
         ) = indexing_utils.destructure_dataframe_iloc_indexer(arg, self._frame)
         row_spec = indexing_utils.parse_row_iloc_indexer(
             row_key, len(self._frame)
         )
-        ca = self._frame._data
-        index = self._frame.index
         if col_is_scalar:
-            s = Series._from_data(
-                ca._select_by_names(column_names), index=index
-            )
-            return s._getitem_preprocessed(row_spec)
-        if column_names != list(self._frame._column_names):
-            frame = self._frame._from_data(
-                ca._select_by_names(column_names), index=index
-            )
+            series = Series._from_data(ca, index=self._frame.index)
+            return series._getitem_preprocessed(row_spec)
+        if ca.names != self._frame._data.names:
+            frame = self._frame._from_data(ca, index=self._frame.index)
         else:
             frame = self._frame
         if isinstance(row_spec, indexing_utils.MapIndexer):
@@ -454,7 +448,7 @@ class _DataFrameIlocIndexer(_DataFrameIndexer):
                 # you only ask for one row.
                 new_name = result.index[0]
                 result = Series._concat(
-                    [result[name] for name in column_names],
+                    [result[name] for name in frame._data.names],
                     index=result.keys(),
                 )
                 result.name = new_name

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -121,6 +121,8 @@ def _shape_mismatch_error(x, y):
 
 
 class _DataFrameIndexer(_FrameIndexer):
+    _frame: DataFrame
+
     def __setitem__(self, key, value):
         if not isinstance(key, tuple):
             key = (key, slice(None))
@@ -363,8 +365,6 @@ class _DataFrameIlocIndexer(_DataFrameIndexer):
     """
     For selection by index.
     """
-
-    _frame: DataFrame
 
     def __getitem__(self, arg):
         row_key, (

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2129,6 +2129,11 @@ class DatetimeIndex(GenericIndex):
             value, side=side, ascending=ascending, na_position=na_position
         )
 
+    def get_slice_bound(self, label, side: str, kind=None) -> int:
+        if isinstance(label, str):
+            label = pd.to_datetime(label)
+        return super().get_slice_bound(label, side, kind=kind)
+
     @property  # type: ignore
     @_cudf_nvtx_annotate
     def year(self):

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -193,29 +193,6 @@ def _indices_from_labels(obj, labels):
     return lhs.join(rhs).sort_values(by=["__", "_"])["_"]
 
 
-def _get_label_range_or_mask(index, start, stop, step):
-    if (
-        not (start is None and stop is None)
-        and type(index) is cudf.core.index.DatetimeIndex
-        and index.is_monotonic_increasing is False
-    ):
-        start = pd.to_datetime(start)
-        stop = pd.to_datetime(stop)
-        if start is not None and stop is not None:
-            if start > stop:
-                return slice(0, 0, None)
-            # TODO: Once Index binary ops are updated to support logical_and,
-            # can use that instead of using cupy.
-            boolean_mask = cp.logical_and((index >= start), (index <= stop))
-        elif start is not None:
-            boolean_mask = index >= start
-        else:
-            boolean_mask = index <= stop
-        return boolean_mask
-    else:
-        return index.find_label_range(slice(start, stop, step))
-
-
 class _FrameIndexer:
     """Parent class for indexers."""
 

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1812,7 +1812,7 @@ class IndexedFrame(Frame):
         self,
         gather_map: GatherMap,
         keep_index=True,
-    ):
+    ) -> Self:
         """Gather rows of frame specified by indices in `gather_map`.
 
         Maintain the index if keep_index is True.

--- a/python/cudf/cudf/core/indexing_utils.py
+++ b/python/cudf/cudf/core/indexing_utils.py
@@ -3,19 +3,26 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Tuple, Union
+from typing import TYPE_CHECKING, Any, Tuple, Union
 
+import numpy as np
 from typing_extensions import TypeAlias
 
 import cudf
+import cudf._lib as libcudf
+from cudf._lib.types import size_type_dtype
 from cudf.api.types import (
     _is_scalar_or_zero_d_array,
     is_bool_dtype,
     is_integer,
     is_integer_dtype,
+    is_scalar,
 )
 from cudf.core.column_accessor import ColumnAccessor
 from cudf.core.copy_types import BooleanMask, GatherMap
+
+if TYPE_CHECKING:
+    from cudf.core.column import ColumnBase
 
 
 class EmptyIndexer:
@@ -234,3 +241,335 @@ def parse_row_iloc_indexer(key: Any, n: int) -> IndexingSpec:
                 "Cannot index by location "
                 f"with non-integer key of type {type(key)}"
             )
+
+
+def destructure_loc_key(
+    key: Any, frame: cudf.Series | cudf.DataFrame
+) -> tuple[Any, ...]:
+    """
+    Destructure a potentially tuple-typed key into row and column indexers
+
+    Tuple arguments to loc indexing are treated specially. They are
+    picked apart into indexers for the row and column. If the number
+    of entries is less than the number of modes of the frame, missing
+    entries are slice-expanded.
+
+    If the user-provided key is not a tuple, it is treated as if it
+    were a singleton tuple, and then slice-expanded.
+
+    Once this destructuring has occurred, any entries that are
+    callables are then called with the indexed frame. This should
+    return a valid indexing object for the rows (respectively
+    columns), namely one of:
+
+    - A boolean mask of the same length as the frame in the given
+      dimension
+    - A scalar label looked up in the index
+    - A scalar integer that indexes the frame
+    - An array-like of labels looked up in the index
+    - A slice of the index
+    - For multiindices, a tuple of per level indexers
+
+    Slice-based indexing is on the closed interval [start, end], rather
+    than the semi-open interval [start, end)
+
+    Parameters
+    ----------
+    key
+        The key to destructure
+    frame
+        DataFrame or Series to provide context
+
+    Returns
+    -------
+    tuple of indexers with length equal to the dimension of the frame
+
+    Raises
+    ------
+    IndexError
+        If there are too many indexers.
+    """
+    n = len(frame.shape)
+    if (
+        isinstance(frame.index, cudf.MultiIndex)
+        and n == 2
+        and isinstance(key, tuple)
+        and all(map(is_scalar, key))
+    ):
+        # This is "best-effort" and ambiguous
+        if len(key) == 2:
+            if key[1] in frame.index._columns[1]:
+                # key just indexes the rows
+                key = (key,)
+            elif key[1] in frame._data:
+                # key indexes rows and columns
+                key = key
+            else:
+                # key indexes rows and we will raise a keyerror
+                key = (key,)
+        else:
+            # key just indexes rows
+            key = (key,)
+    if isinstance(key, tuple):
+        # Key potentially indexes rows and columns, slice-expand to
+        # shape of frame
+        indexers = key + (slice(None),) * (n - len(key))
+        if len(indexers) > n:
+            raise IndexError(
+                f"Too many indexers: got {len(indexers)} expected {n}"
+            )
+    else:
+        # Key indexes rows, slice-expand to shape of frame
+        indexers = (key, *(slice(None),) * (n - 1))
+    return tuple(k(frame) if callable(k) else k for k in indexers)
+
+
+def destructure_dataframe_loc_indexer(
+    key: Any, frame: cudf.DataFrame
+) -> Tuple[Any, Tuple[bool, ColumnAccessor]]:
+    """Destructure an index key for DataFrame loc getitem.
+
+    Parameters
+    ----------
+    key
+        Key to destructure
+    frame
+        DataFrame to provide context context
+
+    Returns
+    -------
+    tuple
+        2-tuple of a key for the rows and tuple of
+        (column_index_is_scalar, column_names) for the columns
+
+    Raises
+    ------
+    TypeError
+        If the column indexer is invalid
+    IndexError
+        If the provided key does not destructure correctly
+    NotImplementedError
+        If the requested column indexer repeats columns
+    """
+    rows, cols = destructure_loc_key(key, frame)
+    if cols is Ellipsis:
+        cols = slice(None)
+    try:
+        scalar = cols in frame._data
+    except TypeError:
+        scalar = False
+    try:
+        ca = frame._data.select_by_label(cols)
+    except TypeError:
+        raise TypeError(
+            "Column indices must be names, slices, "
+            "list-like of names, or boolean mask"
+        )
+    if scalar:
+        assert (
+            len(ca) == 1
+        ), "Scalar column indexer should not produce more than one column"
+
+    return rows, (scalar, ca)
+
+
+def destructure_series_loc_indexer(key: Any, frame: cudf.Series) -> Any:
+    """Destructure an index key for Series loc getitem.
+
+    Parameters
+    ----------
+    key
+        Key to destructure
+    frame
+        Series for unpacking context
+
+    Returns
+    -------
+    Single key that will index the rows
+    """
+    (rows,) = destructure_loc_key(key, frame)
+    return rows
+
+
+def ordered_find(needles: "ColumnBase", haystack: "ColumnBase") -> GatherMap:
+    """Find locations of needles in a haystack preserving order
+
+    Parameters
+    ----------
+    needles
+        Labels to look for
+    haystack
+        Haystack to search in
+
+    Returns
+    -------
+    NumericalColumn
+        Integer gather map of locations needles were found in haystack
+
+    Raises
+    ------
+    KeyError
+        If not all needles were found in the haystack.
+        If needles cannot be converted to the dtype of haystack.
+
+    Notes
+    -----
+    This sorts the gather map so that the result comes back in the
+    order the needles were specified (and are found in the haystack).
+    """
+    # Pre-process to match dtypes
+    needle_kind = needles.dtype.kind
+    haystack_kind = haystack.dtype.kind
+    if haystack_kind == "O":
+        try:
+            needles = needles.astype(haystack.dtype)
+        except ValueError:
+            # Pandas raise KeyError here
+            raise KeyError("Dtype mismatch in label lookup")
+    elif needle_kind == haystack_kind or {
+        haystack_kind,
+        needle_kind,
+    }.issubset({"i", "u", "f"}):
+        needles = needles.astype(haystack.dtype)
+    elif needles.dtype != haystack.dtype:
+        # Pandas raise KeyError here
+        raise KeyError("Dtype mismatch in label lookup")
+    # Can't always do an inner join because then we can't check if we
+    # had missing keys (can't check the length because the entries in
+    # the needle might appear multiple times in the haystack).
+    lgather, rgather = libcudf.join.join([needles], [haystack], how="left")
+    (left_order,) = libcudf.copying.gather(
+        [cudf.core.column.arange(len(needles), dtype=size_type_dtype)],
+        lgather,
+        nullify=False,
+    )
+    (right_order,) = libcudf.copying.gather(
+        [cudf.core.column.arange(len(haystack), dtype=size_type_dtype)],
+        rgather,
+        nullify=True,
+    )
+    if right_order.null_count > 0:
+        raise KeyError("Not all keys in index")
+    (rgather,) = libcudf.sort.sort_by_key(
+        [rgather],
+        [left_order, right_order],
+        [True, True],
+        ["last", "last"],
+        stable=True,
+    )
+    return GatherMap.from_column_unchecked(
+        rgather, len(haystack), nullify=False
+    )
+
+
+def parse_single_row_loc_key(
+    key: Any,
+    index: cudf.BaseIndex,
+) -> IndexingSpec:
+    """
+    Turn a single label-based row indexer into structured information.
+
+    This converts label-based lookups into structured positional
+    lookups.
+
+    Valid values for the key are
+    - a slice (endpoints are looked up)
+    - a scalar label
+    - a boolean mask of the same length as the index
+    - a column of labels to look up (may be empty)
+
+    Parameters
+    ----------
+    key
+        Key for label-based row indexing
+    index
+        Index to act as haystack for labels
+
+    Returns
+    -------
+    IndexingSpec
+        Structured information for indexing
+
+    Raises
+    ------
+    KeyError
+        If any label is not found
+    ValueError
+        If labels cannot be coerced to index dtype
+    """
+    n = len(index)
+    if isinstance(key, slice):
+        # Convert label slice to index slice
+        # TODO: datetime index must be handled specially (unless we go for
+        # pandas 2 compatibility)
+        parsed_key = index.find_label_range(key)
+        if len(range(n)[parsed_key]) == 0:
+            return EmptyIndexer()
+        else:
+            return SliceIndexer(parsed_key)
+    else:
+        is_scalar = _is_scalar_or_zero_d_array(key)
+        if is_scalar and isinstance(key, np.ndarray):
+            key = cudf.core.column.as_column(key.item(), dtype=key.dtype)
+        else:
+            key = cudf.core.column.as_column(key)
+        if (
+            isinstance(key, cudf.core.column.CategoricalColumn)
+            and index.dtype != key.dtype
+        ):
+            # TODO: is this right?
+            key = key._get_decategorized_column()
+        if is_bool_dtype(key.dtype):
+            # The only easy one.
+            return MaskIndexer(BooleanMask(key, n))
+        elif len(key) == 0:
+            return EmptyIndexer()
+        else:
+            # TODO: promote to Index objects, so this can handle
+            # categoricals correctly?
+            (haystack,) = index._columns
+            if isinstance(index, cudf.DatetimeIndex):
+                # Try to turn strings into datetimes
+                key = cudf.core.column.as_column(key, dtype=index.dtype)
+            gather_map = ordered_find(key, haystack)
+            if is_scalar and len(gather_map.column) == 1:
+                return ScalarIndexer(gather_map)
+            else:
+                return MapIndexer(gather_map)
+
+
+def parse_row_loc_indexer(key: Any, index: cudf.BaseIndex) -> IndexingSpec:
+    """
+    Normalize to return structured information for a label-based row indexer.
+
+    Given a label-based row indexer that has already been destructured by
+    :func:`destructure_loc_key`, inspect further and produce structured
+    information for indexing operations to act upon.
+
+    Parameters
+    ----------
+    key
+        Suitably destructured key for row indexing
+    index
+        Index to provide context
+
+    Returns
+    -------
+    IndexingSpec
+        Structured data for indexing. A tag + parsed data.
+
+    Raises
+    ------
+    KeyError
+        If a valid type of indexer is provided, but not all keys are
+        found
+    TypeError
+        If the indexing key is otherwise invalid.
+    """
+    # TODO: multiindices need to be treated separately
+    if key is Ellipsis:
+        # Ellipsis is handled here because multiindex level-based
+        # indices don't handle ellipsis in pandas.
+        return SliceIndexer(slice(None))
+    else:
+        return parse_single_row_loc_key(key, index)

--- a/python/cudf/cudf/core/indexing_utils.py
+++ b/python/cudf/cudf/core/indexing_utils.py
@@ -19,7 +19,6 @@ from cudf.api.types import (
     is_bool_dtype,
     is_integer,
     is_integer_dtype,
-    is_scalar,
 )
 from cudf.core.column_accessor import ColumnAccessor
 from cudf.core.copy_types import BooleanMask, GatherMap
@@ -316,26 +315,6 @@ def destructure_loc_key(
     IndexError
         If there are too many indexers.
     """
-    if (
-        isinstance(frame.index, cudf.MultiIndex)
-        and len(frame.shape) == 2
-        and isinstance(key, tuple)
-        and all(map(is_scalar, key))
-    ):
-        # This is "best-effort" and ambiguous
-        if len(key) == 2:
-            if key[1] in frame.index._columns[1]:
-                # key just indexes the rows
-                key = (key,)
-            elif key[1] in frame._data:
-                # key indexes rows and columns
-                key = key
-            else:
-                # key indexes rows and we will raise a keyerror
-                key = (key,)
-        else:
-            # key just indexes rows
-            key = (key,)
     return expand_key(key, frame)
 
 

--- a/python/cudf/cudf/core/indexing_utils.py
+++ b/python/cudf/cudf/core/indexing_utils.py
@@ -630,6 +630,10 @@ def parse_row_loc_indexer(key: Any, index: cudf.BaseIndex) -> IndexingSpec:
     TypeError
         If the indexing key is otherwise invalid.
     """
+    if isinstance(index, cudf.MultiIndex):
+        raise NotImplementedError(
+            "This code path is not designed for multiindices"
+        )
     # TODO: multiindices need to be treated separately
     if key is Ellipsis:
         # Ellipsis is handled here because multiindex level-based

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -237,8 +237,18 @@ class _SeriesLocIndexer(_FrameIndexer):
     Label-based selection
     """
 
+    _frame: Series
+
     @_cudf_nvtx_annotate
     def __getitem__(self, arg: Any) -> Union[ScalarLike, DataFrameOrSeries]:
+        if not isinstance(self._frame.index, cudf.MultiIndex):
+            indexing_spec = indexing_utils.parse_row_loc_indexer(
+                indexing_utils.destructure_series_loc_indexer(
+                    arg, self._frame
+                ),
+                self._frame.index,
+            )
+            return self._frame._getitem_preprocessed(indexing_spec)
         if isinstance(arg, pd.MultiIndex):
             arg = cudf.from_pandas(arg)
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1362,6 +1362,17 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
     def __getitem__(self, arg):
         if isinstance(arg, slice):
             return self.iloc[arg]
+        elif is_integer(arg) and self.index.dtype.kind not in {"i", "u", "f"}:
+            # Series getitem looks up integers by position if the
+            # index is non-numeric, but is deprecated in pandas 2
+            # https://github.com/pandas-dev/pandas/issues/50617
+            # warnings.warn(
+            #     "Treating integer keys positionally is deprecated and "
+            #     "will be removed in a future version. To find a value "
+            #     "by position use ser.iloc[pos] instead",
+            #     FutureWarning,
+            # )
+            return self.iloc[arg]
         else:
             return self.loc[arg]
 

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -1824,7 +1824,6 @@ def test_loc_repeated_index_label_issue_8693():
     assert_eq(expect, actual)
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/cudf/issues/13268")
 @pytest.mark.parametrize(
     "indexer", [(..., 0), (0, ...)], ids=["row_ellipsis", "column_ellipsis"]
 )
@@ -1870,6 +1869,17 @@ def test_iloc_integer_categorical_issue_13013(indexer):
     expect = s.iloc[index]
     c = cudf.from_pandas(s)
     actual = c.iloc[index]
+    assert_eq(expect, actual)
+
+
+@pytest.mark.parametrize("indexer", [[1], [0, 2]])
+def test_loc_integer_categorical_issue_13014(indexer):
+    # https://github.com/rapidsai/cudf/issues/13014
+    s = pd.Series([0, 1, 2])
+    index = pd.Categorical(indexer)
+    expect = s.loc[index]
+    c = cudf.from_pandas(s)
+    actual = c.loc[index]
     assert_eq(expect, actual)
 
 
@@ -1959,7 +1969,6 @@ def test_loc_unsorted_index_slice_lookup_keyerror_issue_12833():
         cdf.loc[1:5]
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/cudf/issues/13379")
 @pytest.mark.parametrize("index", [range(5), list(range(5))])
 def test_loc_missing_label_keyerror_issue_13379(index):
     # https://github.com/rapidsai/cudf/issues/13379
@@ -1971,6 +1980,16 @@ def test_loc_missing_label_keyerror_issue_13379(index):
 
     with pytest.raises(KeyError):
         cdf.loc[[0, 5]]
+
+
+def test_loc_categorical_no_integer_fallback_issue_13653():
+    # https://github.com/rapidsai/cudf/issues/13653
+    s = cudf.Series(
+        [1, 2], index=cudf.CategoricalIndex([3, 4], categories=[3, 4])
+    )
+    actual = s.loc[3]
+    expect = s.to_pandas().loc[3]
+    assert_eq(actual, expect)
 
 
 @pytest.mark.parametrize("series", [True, False], ids=["Series", "DataFrame"])

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -1982,6 +1982,28 @@ def test_loc_missing_label_keyerror_issue_13379(index):
         cdf.loc[[0, 5]]
 
 
+@pytest.mark.parametrize("index_is_ordered", [False, True])
+@pytest.mark.parametrize("label_is_ordered", [False, True])
+def test_loc_categorical_ordering_mismatch_issue_13652(
+    index_is_ordered, label_is_ordered
+):
+    # https://github.com/rapidsai/cudf/issues/13652
+    s = cudf.Series(
+        [0, 2, 8, 4, 2],
+        index=cudf.CategoricalIndex(
+            [1, 2, 3, 4, 5],
+            categories=[1, 2, 3, 4, 5],
+            ordered=index_is_ordered,
+        ),
+    )
+    labels = cudf.CategoricalIndex(
+        [1, 4], categories=[1, 4], ordered=label_is_ordered
+    )
+    actual = s.loc[labels]
+    expect = s.to_pandas().loc[labels.to_pandas()]
+    assert_eq(actual, expect)
+
+
 def test_loc_categorical_no_integer_fallback_issue_13653():
     # https://github.com/rapidsai/cudf/issues/13653
     s = cudf.Series(


### PR DESCRIPTION
## Description

Following on from #13534, this extends the scheme to handle label-based lookups as long as the index is not a multiindex.

As is the case for positional indexing, all of the different ways one can index a frame with labels eventually boil down to indexing by slice, boolean mask, map, or scalar in libcudf. `loc`-based keys are parsed into information that tags them by type. Since this information is the same as is used for `iloc` indexing, we can then dispatch to the same "internal" calls that don't do further bounds-checking or normalisation: rather than converting a label-based lookup to an argument we can pass to `iloc`-getitem (which must reinterpret it), we just take the decision straight away.

The next stage (which will help to remove a bunch of code) will be to handle multiindex keys, but that will be sufficiently complicated that I'd rather do it separately.

- Closes #13014
- Closes #13268 
- Closes #13379 
- Closes #13652
- Closes #13653
- Closes #13658 (or at least, maintains the correctness)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
