### PR TITLE
Fix doxygen groups for io data sources and sinks

### DIFF
--- a/cpp/include/cudf/io/data_sink.hpp
+++ b/cpp/include/cudf/io/data_sink.hpp
@@ -30,6 +30,13 @@
 namespace cudf {
 //! IO interfaces
 namespace io {
+
+/**
+ * @addtogroup io_datasinks
+ * @{
+ * @file
+ */
+
 /**
  * @brief Interface class for storing the output data from the writers
  */
@@ -200,5 +207,6 @@ class data_sink {
   virtual size_t bytes_written() = 0;
 };
 
+/** @} */  // end of group
 }  // namespace io
 }  // namespace cudf

--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -59,6 +59,12 @@ namespace cudf {
 namespace io {
 
 /**
+ * @addtogroup io_datasources
+ * @{
+ * @file
+ */
+
+/**
  * @brief Interface class for providing input data to the readers.
  */
 class datasource {
@@ -508,5 +514,6 @@ class arrow_io_source : public datasource {
   std::shared_ptr<arrow::io::RandomAccessFile> arrow_file;
 };
 
+/** @} */  // end of group
 }  // namespace io
 }  // namespace cudf

--- a/cpp/include/doxygen_groups.h
+++ b/cpp/include/doxygen_groups.h
@@ -141,9 +141,10 @@
  * @}
  * @defgroup io_apis IO
  * @{
- *   @defgroup io_datasources Datasources
  *   @defgroup io_readers Readers
  *   @defgroup io_writers Writers
+ *   @defgroup io_datasources Data Sources
+ *   @defgroup io_datasinks Data Sinks
  * @}
  * @defgroup lists_apis Lists
  * @{


### PR DESCRIPTION
## Description
Adds the `cudf::io::datasource` source (header) to the doxygen IO Data Sources group/modules:
https://docs.rapids.ai/api/libcudf/stable/group__io__datasources.html

Found while working #13698 

Also created a Data Sinks group and added the `cudf::io::data_sink` source to it.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
