### PR TITLE
Fix character counting when writing sliced tables into ORC

### DIFF
--- a/cpp/src/io/orc/dict_enc.cu
+++ b/cpp/src/io/orc/dict_enc.cu
@@ -39,10 +39,11 @@ __global__ void rowgroup_char_counts_kernel(device_2dspan<size_type> char_counts
   auto const row_group_idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (row_group_idx >= rowgroup_bounds.size().first) { return; }
 
-  auto const start_row = rowgroup_bounds[row_group_idx][col_idx].begin;
+  auto const& str_col  = orc_columns[col_idx];
+  auto const start_row = rowgroup_bounds[row_group_idx][col_idx].begin + str_col.offset();
   auto const num_rows  = rowgroup_bounds[row_group_idx][col_idx].size();
 
-  auto const& offsets = orc_columns[col_idx].child(strings_column_view::offsets_column_index);
+  auto const& offsets = str_col.child(strings_column_view::offsets_column_index);
   char_counts[str_col_idx][row_group_idx] =
     offsets.element<size_type>(start_row + num_rows) - offsets.element<size_type>(start_row);
 }

--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -1823,4 +1823,25 @@ TEST_F(OrcWriterTest, NoNullsAsNonNullable)
   EXPECT_NO_THROW(cudf::io::write_orc(out_opts));
 }
 
+TEST_F(OrcWriterTest, SlicedStringColumn)
+{
+  std::vector<char const*> strings{"a", "bc", "def", "longer", "strings", "at the end"};
+  str_col col(strings.begin(), strings.end());
+  table_view expected({col});
+
+  // Slice the table to include the longer strings
+  auto expected_slice = cudf::slice(expected, {2, 6});
+
+  auto filepath = temp_env->get_temp_filepath("SlicedTable.orc");
+  cudf::io::orc_writer_options out_opts =
+    cudf::io::orc_writer_options::builder(cudf::io::sink_info{filepath}, expected_slice);
+  cudf::io::write_orc(out_opts);
+
+  cudf::io::orc_reader_options in_opts =
+    cudf::io::orc_reader_options::builder(cudf::io::source_info{filepath});
+  auto result = cudf::io::read_orc(in_opts);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected_slice, result.tbl->view());
+}
+
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
## Description
ORC writer incorrectly counts characters in sliced string columns, ignoring the slice offset. This potentially leads to under-allocated stripes and errors.
This PR fixes the char counting kernel to take the string column offset into account.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
