### PR TITLE
Fix writing of ORC files with empty child string columns

### DIFF
--- a/cpp/src/io/orc/dict_enc.cu
+++ b/cpp/src/io/orc/dict_enc.cu
@@ -45,7 +45,7 @@ __global__ void rowgroup_char_counts_kernel(device_2dspan<size_type> char_counts
 
   auto const& offsets = str_col.child(strings_column_view::offsets_column_index);
   char_counts[str_col_idx][row_group_idx] =
-    num_rows == 0
+    (num_rows == 0)
       ? 0
       : offsets.element<size_type>(start_row + num_rows) - offsets.element<size_type>(start_row);
 }

--- a/cpp/src/io/orc/dict_enc.cu
+++ b/cpp/src/io/orc/dict_enc.cu
@@ -45,7 +45,9 @@ __global__ void rowgroup_char_counts_kernel(device_2dspan<size_type> char_counts
 
   auto const& offsets = str_col.child(strings_column_view::offsets_column_index);
   char_counts[str_col_idx][row_group_idx] =
-    offsets.element<size_type>(start_row + num_rows) - offsets.element<size_type>(start_row);
+    num_rows == 0
+      ? 0
+      : offsets.element<size_type>(start_row + num_rows) - offsets.element<size_type>(start_row);
 }
 
 void rowgroup_char_counts(device_2dspan<size_type> counts,

--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -1844,4 +1844,21 @@ TEST_F(OrcWriterTest, SlicedStringColumn)
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected_slice, result.tbl->view());
 }
 
+TEST_F(OrcWriterTest, EmptyChildStringColumn)
+{
+  list_col<cudf::string_view> col{{}, {}};
+  table_view expected({col});
+
+  auto filepath = temp_env->get_temp_filepath("OrcEmptyChildStringColumn.orc");
+  cudf::io::orc_writer_options out_opts =
+    cudf::io::orc_writer_options::builder(cudf::io::sink_info{filepath}, expected);
+  cudf::io::write_orc(out_opts);
+
+  cudf::io::orc_reader_options in_opts =
+    cudf::io::orc_reader_options::builder(cudf::io::source_info{filepath}).use_index(false);
+  auto result = cudf::io::read_orc(in_opts);
+
+  CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
+}
+
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
## Description
Closes #13742
Fixes an OOB access in `rowgroup_char_counts_kernel` when the input column has no rows. This can happen with string columns with a parent list column.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
