### PR TITLE
Don't test strings shorter than the requested ngram size

### DIFF
--- a/python/cudf/cudf/tests/text/test_text_methods.py
+++ b/python/cudf/cudf/tests/text/test_text_methods.py
@@ -891,6 +891,8 @@ def _make_list_of_strings_of_random_length(
 
 
 def test_jaccard_index_random_strings():
+    # Seed the rng before random string generation.
+    random.seed(42)
     num_strings = 100
     jaccard_width = 5
     common_strings = _make_list_of_strings_of_random_length(

--- a/python/cudf/cudf/tests/text/test_text_methods.py
+++ b/python/cudf/cudf/tests/text/test_text_methods.py
@@ -878,11 +878,13 @@ def test_jaccard_index():
         str1.str.jaccard_index(str3, 5)
 
 
-def _make_list_of_strings_of_random_length(num_strings, max_length):
+def _make_list_of_strings_of_random_length(
+    num_strings, min_length, max_length
+):
     return [
         "".join(
             random.choice(string.ascii_lowercase)
-            for _ in range(random.randint(1, max_length))
+            for _ in range(random.randint(min_length, max_length))
         )
         for _ in range(num_strings)
     ]
@@ -890,15 +892,22 @@ def _make_list_of_strings_of_random_length(num_strings, max_length):
 
 def test_jaccard_index_random_strings():
     num_strings = 100
-    common_strings = _make_list_of_strings_of_random_length(num_strings, 50)
-    uncommon_strings1 = _make_list_of_strings_of_random_length(num_strings, 10)
-    uncommon_strings2 = _make_list_of_strings_of_random_length(num_strings, 20)
+    jaccard_width = 5
+    common_strings = _make_list_of_strings_of_random_length(
+        num_strings, jaccard_width, 50
+    )
+    uncommon_strings1 = _make_list_of_strings_of_random_length(
+        num_strings, jaccard_width, 10
+    )
+    uncommon_strings2 = _make_list_of_strings_of_random_length(
+        num_strings, jaccard_width, 20
+    )
     str1 = cudf.Series(uncommon_strings1).str.cat(cudf.Series(common_strings))
     str2 = cudf.Series(uncommon_strings2).str.cat(cudf.Series(common_strings))
 
     # adopted from https://github.com/rapidsai/rapids-deduplication/issues/36
-    da = str1.str.character_ngrams(5, True)
-    db = str2.str.character_ngrams(5, True)
+    da = str1.str.character_ngrams(jaccard_width, True)
+    db = str2.str.character_ngrams(jaccard_width, True)
     da = da.list.unique()
     db = db.list.unique()
     da = da.explode()
@@ -920,5 +929,5 @@ def test_jaccard_index_random_strings():
     res = res.values.astype("float32")
     expected = cudf.Series(res)
 
-    actual = str1.str.jaccard_index(str2, 5)
+    actual = str1.str.jaccard_index(str2, jaccard_width)
     assert_eq(expected, actual)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The random string generation was using a minimum length of 1 rather than the ngram size. While both the reference implementation and the libcudf code were robust to that case, they return different extreme values (0 vs 1) for those. Since testing that edge case isn't really in scope for this particular test, I've modified the generator to only generate strings whose length is at least the requested ngram size.

Resolves #13748 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
