### PR TITLE
Relax protobuf pinnings.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -64,7 +64,8 @@ dependencies:
 - pandoc
 - pip
 - pre-commit
-- protobuf>=4.21.6,<4.22
+- protobuf==4.21
+- protobuf>=4.21,<5
 - ptxcompiler
 - pyarrow==11.0.0.*
 - pydata-sphinx-theme

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -62,7 +62,8 @@ dependencies:
 - pandoc
 - pip
 - pre-commit
-- protobuf>=4.21.6,<4.22
+- protobuf==4.21
+- protobuf>=4.21,<5
 - pyarrow==11.0.0.*
 - pydata-sphinx-theme
 - pyorc

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - cuda-version ={{ cuda_version }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
-    - protobuf >=4.21.6,<4.22
+    - protobuf =4.21
     - python
     - cython >=0.29,<0.30
     - scikit-build >=0.13.1
@@ -73,7 +73,7 @@ requirements:
     {% endif %}
     - cuda-version ={{ cuda_version }}
   run:
-    - protobuf >=4.21.6,<4.22
+    - {{ pin_compatible('protobuf', min_pin='x.x', max_pin='x') }}
     - python
     - typing_extensions >=4.0.0
     - pandas >=1.3,<1.6.0dev0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -263,7 +263,9 @@ dependencies:
           - rmm==23.8.*
       - output_types: conda
         packages:
-          - &protobuf protobuf>=4.21.6,<4.22
+          # We pin an exact protobuf minor version here for building but allow
+          # any greater minor version at runtime.
+          - protobuf==4.21
       - output_types: pyproject
         packages:
           - protoc-wheel
@@ -424,7 +426,7 @@ dependencies:
           - packaging
           - rmm==23.8.*
           - typing_extensions>=4.0.0
-          - *protobuf
+          - protobuf>=4.21,<5
       - output_types: conda
         packages:
           - cupy>=12.0.0

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "nvtx>=0.2.1",
     "packaging",
     "pandas>=1.3,<1.6.0dev0",
-    "protobuf>=4.21.6,<4.22",
+    "protobuf>=4.21,<5",
     "ptxcompiler",
     "pyarrow==11.*",
     "rmm==23.8.*",


### PR DESCRIPTION
## Description
This PR relaxes cudf's protobuf pinnings to help with compatibility issues. `cudf` uses `protobuf` in two places.

The first place `protobuf` is used is at build time, to generate a Python module from a `.proto` file in `python/cudf/cmake/Modules/ProtobufHelpers.cmake`: https://github.com/rapidsai/cudf/blob/f8e5a89e983065e1202f1151dd499bea3102a537/python/cudf/cmake/Modules/ProtobufHelpers.cmake#L16-L17

The second place `protobuf` is used is in the generated file `python/cudf/cudf/utils/metadata/orc_column_statistics_pb2.py` which is [imported here](https://github.com/rapidsai/cudf/blob/f8e5a89e983065e1202f1151dd499bea3102a537/python/cudf/cudf/io/orc.py#L14-L16).

The generated Python module used at runtime should be compatible with newer versions of `protobuf` than the version used to build the Python module, from my understanding of https://protobuf.dev/support/cross-version-runtime-guarantee/. Therefore, we only require that the runtime pinning of `protobuf` is of the same major version and an equal-or-greater minor version. That allows us to relax this pinning.

Follow-up to #12864, see that PR for more context.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
