### PR TITLE
Fix binary operation column ordering and missing column issues

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1845,7 +1845,8 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                 self._data.to_pandas_index()
             )
             can_use_self_column_name = (
-                equal_columns or can_use_self_column_name
+                equal_columns
+                or list(other._index._data.names) == self._data._level_names
             )
         elif isinstance(other, DataFrame):
             if (

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1841,6 +1841,22 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             # For keys in right but not left, perform binops between NaN (not
             # NULL!) and the right value (result is NaN).
             left_default = as_column(np.nan, length=len(self))
+            can_use_self_column_name = (
+                list(other._index._data.names) == self._data._level_names
+            )
+            if cudf.get_option("mode.pandas_compatible"):
+                equal_columns = other.index.to_pandas().equals(
+                    self._data.to_pandas_index()
+                )
+                can_use_self_column_name = (
+                    equal_columns or can_use_self_column_name
+                )
+            else:
+
+                if not can_use_self_column_name:
+                    can_use_self_column_name = other.index.to_pandas().equals(
+                        self._data.to_pandas_index()
+                    )
             equal_columns = other.index.to_pandas().equals(
                 self._data.to_pandas_index()
             )

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1852,7 +1852,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                     equal_columns or can_use_self_column_name
                 )
             else:
-
                 if not can_use_self_column_name:
                     can_use_self_column_name = other.index.to_pandas().equals(
                         self._data.to_pandas_index()

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1856,12 +1856,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                     can_use_self_column_name = other.index.to_pandas().equals(
                         self._data.to_pandas_index()
                     )
-            equal_columns = other.index.to_pandas().equals(
-                self._data.to_pandas_index()
-            )
-            can_use_self_column_name = equal_columns or (
-                list(other._index._data.names) == self._data._level_names
-            )
         elif isinstance(other, DataFrame):
             if (
                 not can_reindex

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1891,7 +1891,8 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             for k, v in rhs.items():
                 if k not in lhs:
                     operands[k] = (left_default, v, reflect, None)
-        if not equal_columns:
+
+        if cudf.get_option("mode.pandas_compatible") and not equal_columns:
             if isinstance(other, DataFrame):
                 column_names_list = self._data.to_pandas_index().join(
                     other._data.to_pandas_index(), how="outer"
@@ -1900,8 +1901,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                 column_names_list = self._data.to_pandas_index().join(
                     other.index.to_pandas(), how="outer"
                 )
-            else:
-                raise TypeError("Impossible")
+
             sorted_dict = {}
             for key in column_names_list:
                 sorted_dict[key] = operands[key]

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1901,10 +1901,10 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                 column_names_list = self._data.to_pandas_index().join(
                     other.index.to_pandas(), how="outer"
                 )
+            else:
+                raise ValueError("other must be a DataFrame or Series.")
 
-            sorted_dict = {}
-            for key in column_names_list:
-                sorted_dict[key] = operands[key]
+            sorted_dict = {key: operands[key] for key in column_names_list}
             return sorted_dict, index, can_use_self_column_name
         return operands, index, can_use_self_column_name
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1472,6 +1472,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
             NotImplementedType,
         ],
         Optional[BaseIndex],
+        bool,
     ]:
         # Specialize binops to align indices.
         if isinstance(other, Series):
@@ -1484,11 +1485,13 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
                     "Can only compare identically-labeled Series objects"
                 )
             lhs, other = _align_indices([self, other], allow_non_unique=True)
+            can_use_self_column_name = self.name == other.name
         else:
             lhs = self
+            can_use_self_column_name = False
 
         operands = lhs._make_operands_for_binop(other, fill_value, reflect)
-        return operands, lhs._index
+        return operands, lhs._index, can_use_self_column_name
 
     @copy_docstring(CategoricalAccessor)  # type: ignore
     @property

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -5381,10 +5381,7 @@ def test_cov_nans():
         cudf.Series([4, 2, 3], index=["a", "b", "d"]),
         cudf.Series([4, 2], index=["a", "b"]),
         cudf.Series([4, 2, 3], index=cudf.core.index.RangeIndex(0, 3)),
-        pytest.param(
-            cudf.Series([4, 2, 3, 4, 5], index=["a", "b", "d", "0", "12"]),
-            marks=pytest_xfail,
-        ),
+        cudf.Series([4, 2, 3, 4, 5], index=["a", "b", "d", "0", "12"]),
     ],
 )
 @pytest.mark.parametrize("colnames", [["a", "b", "c"], [0, 1, 2]])
@@ -10147,3 +10144,26 @@ def test_dataframe_init_length_error(data, index):
             {"data": data, "index": index},
         ),
     )
+
+
+def test_dataframe_binop_with_column_types():
+    df = pd.DataFrame(
+        np.random.rand(2, 2),
+        columns=pd.Index(["2000-01-03", "2000-01-04"], dtype="datetime64[ns]"),
+    )
+    ser = pd.Series(np.random.rand(3), index=[0, 1, 2])
+    gdf = cudf.from_pandas(df)
+    gser = cudf.from_pandas(ser)
+    expected = df - ser
+    got = gdf - gser
+    assert_eq(expected, got)
+
+
+def test_dataframe_binop_with_boolean_names():
+    df = pd.DataFrame(np.random.rand(2, 2), columns=pd.Index([True, False]))
+    gdf = cudf.from_pandas(df)
+
+    expected = df > 1
+    got = gdf > 1
+
+    assert_eq(expected, got)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -5396,6 +5396,7 @@ def test_cov_nans():
         cudf.Series([4, 2, 3], index=["a", "b", "d"]),
         cudf.Series([4, 2], index=["a", "b"]),
         cudf.Series([4, 2, 3], index=cudf.core.index.RangeIndex(0, 3)),
+        cudf.Series([4, 2, 3, 4, 5], index=["a", "b", "d", "0", "12"]),
     ],
 )
 @pytest.mark.parametrize("colnames", [["a", "b", "c"], [0, 1, 2]])
@@ -5449,69 +5450,6 @@ def test_df_sr_binop(gsr, colnames, op):
 
         expect = op(psr, pdf)
         got = op(gsr, gdf).to_pandas(nullable=True)
-        assert_eq(expect, got, check_dtype=False)
-
-
-@pytest_unmark_spilling
-@pytest.mark.parametrize(
-    "gsr",
-    [
-        cudf.Series([4, 2, 3, 4, 5], index=["a", "b", "d", "0", "12"]),
-    ],
-)
-@pytest.mark.parametrize("colnames", [["a", "b", "c"], [0, 1, 2]])
-@pytest.mark.parametrize(
-    "op",
-    [
-        operator.add,
-        operator.mul,
-        operator.floordiv,
-        operator.truediv,
-        operator.mod,
-        operator.pow,
-        operator.eq,
-        operator.lt,
-        operator.le,
-        operator.gt,
-        operator.ge,
-        operator.ne,
-    ],
-)
-def test_df_sr_binop_preserve_pandas_order(gsr, colnames, op):
-    # Anywhere that the column names of the DataFrame don't match the index
-    # names of the Series will trigger a deprecated reindexing. Since this
-    # behavior is deprecated in pandas, this test is temporarily silencing
-    # those warnings until cudf updates to pandas 2.0 as its compatibility
-    # target, at which point a large number of the parametrizations can be
-    # removed altogether (along with this warnings filter).
-    with warnings.catch_warnings():
-        assert version.parse(pd.__version__) < version.parse("2.0.0")
-        warnings.filterwarnings(
-            action="ignore",
-            category=FutureWarning,
-            message=(
-                "Automatic reindexing on DataFrame vs Series comparisons is "
-                "deprecated"
-            ),
-        )
-        data = [[3.0, 2.0, 5.0], [3.0, None, 5.0], [6.0, 7.0, np.nan]]
-        data = dict(zip(colnames, data))
-
-        gsr = gsr.astype("float64")
-
-        gdf = cudf.DataFrame(data)
-        pdf = gdf.to_pandas(nullable=True)
-
-        psr = gsr.to_pandas(nullable=True)
-
-        expect = op(pdf, psr)
-        with cudf.option_context("mode.pandas_compatible", True):
-            got = op(gdf, gsr).to_pandas(nullable=True)
-        assert_eq(expect, got, check_dtype=False)
-
-        expect = op(psr, pdf)
-        with cudf.option_context("mode.pandas_compatible", True):
-            got = op(gsr, gdf).to_pandas(nullable=True)
         assert_eq(expect, got, check_dtype=False)
 
 
@@ -10246,8 +10184,7 @@ def test_dataframe_binop_with_mixed_string_types():
     gdf2 = cudf.from_pandas(df2)
 
     expected = df2 + df1
-    with cudf.option_context("mode.pandas_compatible", True):
-        got = gdf2 + gdf1
+    got = gdf2 + gdf1
 
     assert_eq(expected, got)
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -10250,3 +10250,25 @@ def test_dataframe_binop_and_where():
     got = gdf[gdf > 1]
 
     assert_eq(expected, got)
+
+
+def test_dataframe_binop_with_datetime_index():
+    df = pd.DataFrame(
+        np.random.rand(2, 2),
+        columns=pd.Index(["2000-01-03", "2000-01-04"], dtype="datetime64[ns]"),
+    )
+    ser = pd.Series(
+        np.random.rand(2),
+        index=pd.Index(
+            [
+                "2000-01-04",
+                "2000-01-03",
+            ],
+            dtype="datetime64[ns]",
+        ),
+    )
+    gdf = cudf.from_pandas(df)
+    gser = cudf.from_pandas(ser)
+    expected = df - ser
+    got = gdf - gser
+    assert_eq(expected, got)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -10146,7 +10146,7 @@ def test_dataframe_init_length_error(data, index):
     )
 
 
-def test_dataframe_binop_with_column_types():
+def test_dataframe_binop_with_mixed_date_types():
     df = pd.DataFrame(
         np.random.rand(2, 2),
         columns=pd.Index(["2000-01-03", "2000-01-04"], dtype="datetime64[ns]"),
@@ -10159,11 +10159,31 @@ def test_dataframe_binop_with_column_types():
     assert_eq(expected, got)
 
 
-def test_dataframe_binop_with_boolean_names():
+def test_dataframe_binop_with_mixed_string_types():
+    df1 = pd.DataFrame(np.random.rand(3, 3), columns=pd.Index([0, 1, 2]))
+    df2 = pd.DataFrame(
+        np.random.rand(6, 6),
+        columns=pd.Index([0, 1, 2, "VhDoHxRaqt", "X0NNHBIPfA", "5FbhPtS0D1"]),
+    )
+    gdf1 = cudf.from_pandas(df1)
+    gdf2 = cudf.from_pandas(df2)
+
+    expected = df2 + df1
+    got = gdf2 + gdf1
+
+    assert_eq(expected, got)
+
+
+def test_dataframe_binop_and_where():
     df = pd.DataFrame(np.random.rand(2, 2), columns=pd.Index([True, False]))
     gdf = cudf.from_pandas(df)
 
     expected = df > 1
     got = gdf > 1
+
+    assert_eq(expected, got)
+
+    expected = df[df > 1]
+    got = gdf[gdf > 1]
 
     assert_eq(expected, got)


### PR DESCRIPTION
## Description
This PR fixes various cases in binary operations where columns are of certain dtypes and the binary operations on those dataframes and series don't yield correct results, correct resulting column types, or have missing columns altogether. 
This PR also introduces ensuring column ordering to match pandas binary ops column ordering when pandas compatibility mode is enabled.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
