### PR TITLE
Pin `dask` and `distributed` for `23.08` release

### DIFF
--- a/ci/test_wheel_dask_cudf.sh
+++ b/ci/test_wheel_dask_cudf.sh
@@ -11,7 +11,7 @@ RAPIDS_PY_WHEEL_NAME="cudf_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from
 python -m pip install --no-deps ./local-cudf-dep/cudf*.whl
 
 # Always install latest dask for testing
-python -m pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main git+https://github.com/rapidsai/dask-cuda.git@branch-23.08
+python -m pip install git+https://github.com/dask/dask.git@2023.7.1 git+https://github.com/dask/distributed.git@2023.7.1 git+https://github.com/rapidsai/dask-cuda.git@branch-23.08
 
 # echo to expand wildcard before adding `[extra]` requires for pip
 python -m pip install $(echo ./dist/dask_cudf*.whl)[test]

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -23,10 +23,10 @@ dependencies:
 - cupy>=12.0.0
 - cxx-compiler
 - cython>=0.29,<0.30
-- dask-core>=2023.5.1
+- dask-core==2023.7.1
 - dask-cuda==23.8.*
-- dask>=2023.5.1
-- distributed>=2023.5.1
+- dask==2023.7.1
+- distributed==2023.7.1
 - dlpack>=0.5,<0.6.0a0
 - doxygen=1.8.20
 - fastavro>=0.22.9

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -24,10 +24,10 @@ dependencies:
 - cupy>=12.0.0
 - cxx-compiler
 - cython>=0.29,<0.30
-- dask-core>=2023.5.1
+- dask-core==2023.7.1
 - dask-cuda==23.8.*
-- dask>=2023.5.1
-- distributed>=2023.5.1
+- dask==2023.7.1
+- distributed==2023.7.1
 - dlpack>=0.5,<0.6.0a0
 - doxygen=1.8.20
 - fastavro>=0.22.9

--- a/conda/recipes/custreamz/meta.yaml
+++ b/conda/recipes/custreamz/meta.yaml
@@ -45,9 +45,9 @@ requirements:
     - streamz
     - cudf ={{ version }}
     - cudf_kafka ={{ version }}
-    - dask >=2023.5.1
-    - dask-core >=2023.5.1
-    - distributed >=2023.5.1
+    - dask ==2023.7.1
+    - dask-core ==2023.7.1
+    - distributed ==2023.7.1
     - python-confluent-kafka >=1.9.0,<1.10.0a0
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
 

--- a/conda/recipes/dask-cudf/meta.yaml
+++ b/conda/recipes/dask-cudf/meta.yaml
@@ -38,16 +38,16 @@ requirements:
   host:
     - python
     - cudf ={{ version }}
-    - dask >=2023.5.1
-    - dask-core >=2023.5.1
-    - distributed >=2023.5.1
+    - dask ==2023.7.1
+    - dask-core ==2023.7.1
+    - distributed ==2023.7.1
     - cuda-version ={{ cuda_version }}
   run:
     - python
     - cudf ={{ version }}
-    - dask >=2023.5.1
-    - dask-core >=2023.5.1
-    - distributed >=2023.5.1
+    - dask ==2023.7.1
+    - dask-core ==2023.7.1
+    - distributed ==2023.7.1
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
 
 test:

--- a/conda/recipes/dask-cudf/run_test.sh
+++ b/conda/recipes/dask-cudf/run_test.sh
@@ -18,10 +18,10 @@ if [ "${ARCH}" = "aarch64" ]; then
 fi
 
 # Dask & Distributed option to install main(nightly) or `conda-forge` packages.
-export INSTALL_DASK_MAIN=1
+export INSTALL_DASK_MAIN=0
 
 # Dask version to install when `INSTALL_DASK_MAIN=0`
-export DASK_STABLE_VERSION="2023.5.1"
+export DASK_STABLE_VERSION="2023.7.1"
 
 # Install the conda-forge or nightly version of dask and distributed
 if [[ "${INSTALL_DASK_MAIN}" == 1 ]]; then

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -475,12 +475,12 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - dask>=2023.5.1
-          - distributed>=2023.5.1
+          - dask==2023.7.1
+          - distributed==2023.7.1
       - output_types: conda
         packages:
           - cupy>=12.0.0
-          - dask-core>=2023.5.1  # dask-core in conda is the actual package & dask is the meta package
+          - dask-core==2023.7.1  # dask-core in conda is the actual package & dask is the meta package
       - output_types: pyproject
         packages:
           - &cudf cudf==23.8.*

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -20,8 +20,8 @@ requires-python = ">=3.9"
 dependencies = [
     "cudf==23.8.*",
     "cupy-cuda11x>=12.0.0",
-    "dask>=2023.5.1",
-    "distributed>=2023.5.1",
+    "dask==2023.7.1",
+    "distributed==2023.7.1",
     "fsspec>=0.6.0",
     "numpy>=1.21",
     "pandas>=1.3,<1.6.0dev0",


### PR DESCRIPTION
## Description
This PR pins `dask` & `distributed` to `2023.7.1` version for `23.08` release.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
