### PR TITLE
Fix unbounded sequence issue in `DataFrame` constructor

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -843,8 +843,13 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             data = DataFrame.from_pandas(pd.DataFrame(data))
             self._data = data._data
         else:
-            data = list(itertools.zip_longest(*data))
-
+            if all(
+                isinstance(a, abc.Iterable) or isinstance(a, abc.Sequence)
+                for a in data
+            ):
+                data = list(itertools.zip_longest(*data))
+            else:
+                raise TypeError("Inputs should be a bounded-sequence.")
             if columns is not None and len(data) == 0:
                 data = [
                     cudf.core.column.column_empty(row_count=0, dtype=None)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -843,13 +843,14 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             data = DataFrame.from_pandas(pd.DataFrame(data))
             self._data = data._data
         else:
-            if all(
-                isinstance(col, (abc.Iterable, abc.Sequence))
+            if any(
+                not isinstance(col, (abc.Iterable, abc.Sequence))
                 for col in data
             ):
-                data = list(itertools.zip_longest(*data))
-            else:
                 raise TypeError("Inputs should be an iterable or sequence.")
+
+            data = list(itertools.zip_longest(*data))
+
             if columns is not None and len(data) == 0:
                 data = [
                     cudf.core.column.column_empty(row_count=0, dtype=None)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -844,12 +844,12 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             self._data = data._data
         else:
             if all(
-                isinstance(a, abc.Iterable) or isinstance(a, abc.Sequence)
+                isinstance(a, (abc.Iterable, abc.Sequence))
                 for a in data
             ):
                 data = list(itertools.zip_longest(*data))
             else:
-                raise TypeError("Inputs should be a bounded-sequence.")
+                raise TypeError("Inputs should be an iterable or sequence.")
             if columns is not None and len(data) == 0:
                 data = [
                     cudf.core.column.column_empty(row_count=0, dtype=None)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -844,8 +844,8 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             self._data = data._data
         else:
             if all(
-                isinstance(a, (abc.Iterable, abc.Sequence))
-                for a in data
+                isinstance(col, (abc.Iterable, abc.Sequence))
+                for col in data
             ):
                 data = list(itertools.zip_longest(*data))
             else:

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -10243,3 +10243,15 @@ def test_dataframe_init_columns_named_index():
     pdf = pd.DataFrame(data, columns=columns)
 
     assert_eq(gdf, pdf)
+
+
+def test_dataframe_constructor_unbounded_sequence():
+    class A:
+        def __getitem__(self, key):
+            return 1
+
+    with pytest.raises(TypeError):
+        cudf.DataFrame([A()])
+
+    with pytest.raises(TypeError):
+        cudf.DataFrame({"a": A()})


### PR DESCRIPTION
## Description
In `cudf`, we currently have a hang in this scenario:
```python
In [1]: import cudf

In [2]:     class A:
   ...:         def __getitem__(self, key):
   ...:             return 1
   ...: 

In [3]: cudf.DataFrame([A()])
```

This PR introduces additional checks before letting the list-like inputs pass onto `itertools` for transposing.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
