### PR TITLE
Set native handles to null on close in Java wrapper classes

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ChunkedPack.java
+++ b/java/src/main/java/ai/rapids/cudf/ChunkedPack.java
@@ -88,7 +88,11 @@ public class ChunkedPack implements AutoCloseable {
 
   @Override
   public void close() {
-    chunkedPackDelete(nativePtr);
+    try {
+      chunkedPackDelete(nativePtr);
+    } finally {
+      nativePtr = 0;
+    }
   }
 
   private static native long chunkedPackGetTotalContiguousSize(long nativePtr);

--- a/java/src/main/java/ai/rapids/cudf/ColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnVector.java
@@ -264,6 +264,7 @@ public final class ColumnVector extends ColumnView {
       eventHandler.onClosed(this, refCount);
     }
     if (refCount == 0) {
+      super.close();
       offHeap.clean(false);
     } else if (refCount < 0) {
       offHeap.logRefCountDebug("double free " + this);

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -6824,4 +6824,11 @@ public class ColumnVectorTest extends CudfTestBase {
       assertEquals(vector.getNullCount(), view.getNullCount());
     }
   }
+
+  @Test
+  public void testUseAfterFree() {
+    ColumnVector vector = ColumnVector.fromBoxedInts(1, 2, 3);
+    vector.close();
+    assertThrows(NullPointerException.class, vector::getDeviceMemorySize);
+  }
 }


### PR DESCRIPTION
## Description
This updates a few Java wrapper classes that track native resources to zero the native handles when they are closed to make it easier to track down use-after-close errors.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
