### PR TITLE
No need to dlsym EnsureS3Finalized we can call it directly

### DIFF
--- a/cpp/tests/io/arrow_io_source_test.cpp
+++ b/cpp/tests/io/arrow_io_source_test.cpp
@@ -95,7 +95,7 @@ TEST_F(ArrowIOTest, S3FileSystem)
     // https://github.com/apache/arrow/issues/36974
     // This needs to be in a separate conditional to ensure we call
     // finalize after all arrow_io_source instances have been deleted.
-    arrow::fs::EnsureS3Finalized();
+    [[maybe_unused]] arrow::fs::EnsureS3Finalized();
   }
 #endif
 }

--- a/cpp/tests/io/arrow_io_source_test.cpp
+++ b/cpp/tests/io/arrow_io_source_test.cpp
@@ -95,7 +95,7 @@ TEST_F(ArrowIOTest, S3FileSystem)
     // https://github.com/apache/arrow/issues/36974
     // This needs to be in a separate conditional to ensure we call
     // finalize after all arrow_io_source instances have been deleted.
-    [[maybe_unused]] arrow::fs::EnsureS3Finalized();
+    [[maybe_unused]] auto _ = arrow::fs::EnsureS3Finalized();
   }
 #endif
 }

--- a/cpp/tests/io/arrow_io_source_test.cpp
+++ b/cpp/tests/io/arrow_io_source_test.cpp
@@ -27,6 +27,7 @@
 
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/io/api.h>
+#include <arrow/util/config.h>
 
 #include <fstream>
 #include <memory>
@@ -87,19 +88,16 @@ TEST_F(ArrowIOTest, S3FileSystem)
     ASSERT_EQ(1, tbl.tbl->num_columns());  // Only single column specified in reader_options
     ASSERT_EQ(244, tbl.tbl->num_rows());   // known number of rows from the S3 file
   }
+
+#ifdef ARROW_S3
   if (!s3_unsupported) {
     // Verify that we are using Arrow with S3, and call finalize
     // https://github.com/apache/arrow/issues/36974
     // This needs to be in a separate conditional to ensure we call
     // finalize after all arrow_io_source instances have been deleted.
-    void* whole_app                                       = dlopen(NULL, RTLD_LAZY);
-    decltype(arrow::fs::EnsureS3Finalized)* close_s3_func = nullptr;
-
-    close_s3_func = reinterpret_cast<decltype(close_s3_func)>(
-      dlsym(whole_app, "_ZN5arrow2fs17EnsureS3FinalizedEv"));
-    if (close_s3_func) { EXPECT_TRUE(close_s3_func().ok()); }
-    dlclose(whole_app);
+    arrow::fs::EnsureS3Finalized();
   }
+#endif
 }
 
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
## Description
Previously I didn't realize that the `ARROW_S3` define was provided to consumers via `arrow/util/config.h`. We can remove the dlopen hack and just guard the entire S3 logic.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
