### PR TITLE
Raise error when trying to construct time-zone aware timestamps

### DIFF
--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -244,7 +244,7 @@ class DatetimeColumn(column.ColumnBase):
 
         if isinstance(other, pd.Timestamp):
             if other.tz is not None:
-                raise TypeError(
+                raise NotImplementedError(
                     "Cannot perform binary operation on timezone-naive columns"
                     " and timezone-aware timestamps. "
                 )

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -242,14 +242,20 @@ class DatetimeColumn(column.ColumnBase):
         if isinstance(other, (cudf.Scalar, ColumnBase, cudf.DateOffset)):
             return other
 
-        if isinstance(other, datetime.datetime):
-            other = np.datetime64(other)
-        elif isinstance(other, datetime.timedelta):
-            other = np.timedelta64(other)
-        elif isinstance(other, pd.Timestamp):
+        if isinstance(other, pd.Timestamp):
+            if other.tz is not None:
+                raise TypeError(
+                    "Cannot perform binary operation on timezone-naive columns"
+                    " and timezone-aware timestamps. For that, "
+                    "use `tz_localize`."
+                )
             other = other.to_datetime64()
         elif isinstance(other, pd.Timedelta):
             other = other.to_timedelta64()
+        elif isinstance(other, datetime.datetime):
+            other = np.datetime64(other)
+        elif isinstance(other, datetime.timedelta):
+            other = np.timedelta64(other)
 
         if isinstance(other, np.datetime64):
             if np.isnat(other):

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -242,16 +242,19 @@ class DatetimeColumn(column.ColumnBase):
         if isinstance(other, (cudf.Scalar, ColumnBase, cudf.DateOffset)):
             return other
 
+        tz_error_msg = (
+            "Cannot perform binary operation on timezone-naive columns"
+            " and timezone-aware timestamps."
+        )
         if isinstance(other, pd.Timestamp):
             if other.tz is not None:
-                raise NotImplementedError(
-                    "Cannot perform binary operation on timezone-naive columns"
-                    " and timezone-aware timestamps."
-                )
+                raise NotImplementedError(tz_error_msg)
             other = other.to_datetime64()
         elif isinstance(other, pd.Timedelta):
             other = other.to_timedelta64()
         elif isinstance(other, datetime.datetime):
+            if other.tzinfo is not None:
+                raise NotImplementedError(tz_error_msg)
             other = np.datetime64(other)
         elif isinstance(other, datetime.timedelta):
             other = np.timedelta64(other)

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -246,8 +246,7 @@ class DatetimeColumn(column.ColumnBase):
             if other.tz is not None:
                 raise TypeError(
                     "Cannot perform binary operation on timezone-naive columns"
-                    " and timezone-aware timestamps. For that, "
-                    "use `tz_localize`."
+                    " and timezone-aware timestamps. "
                 )
             other = other.to_datetime64()
         elif isinstance(other, pd.Timedelta):

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -246,7 +246,7 @@ class DatetimeColumn(column.ColumnBase):
             if other.tz is not None:
                 raise NotImplementedError(
                     "Cannot perform binary operation on timezone-naive columns"
-                    " and timezone-aware timestamps. "
+                    " and timezone-aware timestamps."
                 )
             other = other.to_datetime64()
         elif isinstance(other, pd.Timedelta):

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -214,17 +214,20 @@ class TimeDeltaColumn(ColumnBase):
         if isinstance(other, (ColumnBase, cudf.Scalar)):
             return other
 
+        tz_error_msg = (
+            "Cannot perform binary operation on timezone-naive columns"
+            " and timezone-aware timestamps."
+        )
         if isinstance(other, pd.Timestamp):
             if other.tz is not None:
-                raise NotImplementedError(
-                    "Cannot perform binary operation on timezone-naive columns"
-                    " and timezone-aware timestamps."
-                )
+                raise NotImplementedError(tz_error_msg)
             other = other.to_datetime64()
         elif isinstance(other, pd.Timedelta):
             other = other.to_timedelta64()
         elif isinstance(other, datetime.timedelta):
             other = np.timedelta64(other)
+        elif isinstance(other, datetime.datetime) and other.tzinfo is not None:
+            raise NotImplementedError(tz_error_msg)
 
         if isinstance(other, np.timedelta64):
             other_time_unit = cudf.utils.dtypes.get_time_unit(other)

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -213,12 +213,20 @@ class TimeDeltaColumn(ColumnBase):
     def normalize_binop_value(self, other) -> ColumnBinaryOperand:
         if isinstance(other, (ColumnBase, cudf.Scalar)):
             return other
-        if isinstance(other, datetime.timedelta):
-            other = np.timedelta64(other)
-        elif isinstance(other, pd.Timestamp):
+
+        if isinstance(other, pd.Timestamp):
+            if other.tz is not None:
+                raise TypeError(
+                    "Cannot perform binary operation on timezone-naive columns"
+                    " and timezone-aware timestamps. For that, "
+                    "use `tz_localize`."
+                )
             other = other.to_datetime64()
         elif isinstance(other, pd.Timedelta):
             other = other.to_timedelta64()
+        elif isinstance(other, datetime.timedelta):
+            other = np.timedelta64(other)
+
         if isinstance(other, np.timedelta64):
             other_time_unit = cudf.utils.dtypes.get_time_unit(other)
             if np.isnat(other):

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -218,8 +218,7 @@ class TimeDeltaColumn(ColumnBase):
             if other.tz is not None:
                 raise NotImplementedError(
                     "Cannot perform binary operation on timezone-naive columns"
-                    " and timezone-aware timestamps. For that, "
-                    "use `tz_localize`."
+                    " and timezone-aware timestamps."
                 )
             other = other.to_datetime64()
         elif isinstance(other, pd.Timedelta):

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -216,7 +216,7 @@ class TimeDeltaColumn(ColumnBase):
 
         if isinstance(other, pd.Timestamp):
             if other.tz is not None:
-                raise TypeError(
+                raise NotImplementedError(
                     "Cannot perform binary operation on timezone-naive columns"
                     " and timezone-aware timestamps. For that, "
                     "use `tz_localize`."

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2101,3 +2101,7 @@ def test_datetime_binop_tz_timestamp(op):
     pd_tz_timestamp = pd.Timestamp("1970-01-01 00:00:00.000000001", tz="utc")
     with pytest.raises(NotImplementedError):
         op(s, pd_tz_timestamp)
+
+    date_scalar = datetime.datetime.now(datetime.timezone.utc)
+    with pytest.raises(NotImplementedError):
+        op(s, date_scalar)

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2099,5 +2099,5 @@ def test_construction_from_tz_timestamps(data):
 def test_datetime_binop_tz_timestamp(op):
     s = cudf.Series([1, 2, 3], dtype="datetime64[ns]")
     pd_tz_timestamp = pd.Timestamp("1970-01-01 00:00:00.000000001", tz="utc")
-    with pytest.raises(TypeError):
+    with pytest.raises(NotImplementedError):
         op(s, pd_tz_timestamp)

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2093,3 +2093,11 @@ def test_construction_from_tz_timestamps(data):
         _ = cudf.Series(data)
     with pytest.raises(NotImplementedError):
         _ = cudf.Index(data)
+
+
+@pytest.mark.parametrize("op", _cmpops)
+def test_datetime_binop_tz_timestamp(op):
+    s = cudf.Series([1, 2, 3], dtype="datetime64[ns]")
+    pd_tz_timestamp = pd.Timestamp("1970-01-01 00:00:00.000000001", tz="utc")
+    with pytest.raises(TypeError):
+        op(s, pd_tz_timestamp)

--- a/python/cudf/cudf/tests/test_scalar.py
+++ b/python/cudf/cudf/tests/test_scalar.py
@@ -456,3 +456,7 @@ def test_construct_timezone_scalar_error():
     pd_scalar = pd.Timestamp("1970-01-01 00:00:00.000000001", tz="utc")
     with pytest.raises(NotImplementedError):
         cudf.utils.dtypes.to_cudf_compatible_scalar(pd_scalar)
+
+    date_scalar = datetime.datetime.now(datetime.timezone.utc)
+    with pytest.raises(NotImplementedError):
+        cudf.utils.dtypes.to_cudf_compatible_scalar(date_scalar)

--- a/python/cudf/cudf/tests/test_scalar.py
+++ b/python/cudf/cudf/tests/test_scalar.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 
 import datetime
 import re
@@ -450,3 +450,9 @@ def test_scalar_numpy_casting():
     s1 = cudf.Scalar(1, dtype=np.int32)
     s2 = np.int64(2)
     assert s1 < s2
+
+
+def test_construct_timezone_scalar_error():
+    pd_scalar = pd.Timestamp("1970-01-01 00:00:00.000000001", tz="utc")
+    with pytest.raises(TypeError):
+        cudf.utils.dtypes.to_cudf_compatible_scalar(pd_scalar)

--- a/python/cudf/cudf/tests/test_scalar.py
+++ b/python/cudf/cudf/tests/test_scalar.py
@@ -454,5 +454,5 @@ def test_scalar_numpy_casting():
 
 def test_construct_timezone_scalar_error():
     pd_scalar = pd.Timestamp("1970-01-01 00:00:00.000000001", tz="utc")
-    with pytest.raises(TypeError):
+    with pytest.raises(NotImplementedError):
         cudf.utils.dtypes.to_cudf_compatible_scalar(pd_scalar)

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -1426,3 +1426,11 @@ def test_timedelta_constructor(data, dtype):
     actual = cudf.TimedeltaIndex(data=cudf.Series(data), dtype=dtype)
 
     assert_eq(expected, actual)
+
+
+@pytest.mark.parametrize("op", [operator.add, operator.sub])
+def test_timdelta_binop_tz_timestamp(op):
+    s = cudf.Series([1, 2, 3], dtype="timedelta64[ns]")
+    pd_tz_timestamp = pd.Timestamp("1970-01-01 00:00:00.000000001", tz="utc")
+    with pytest.raises(TypeError):
+        op(s, pd_tz_timestamp)

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -1432,5 +1432,5 @@ def test_timedelta_constructor(data, dtype):
 def test_timdelta_binop_tz_timestamp(op):
     s = cudf.Series([1, 2, 3], dtype="timedelta64[ns]")
     pd_tz_timestamp = pd.Timestamp("1970-01-01 00:00:00.000000001", tz="utc")
-    with pytest.raises(TypeError):
+    with pytest.raises(NotImplementedError):
         op(s, pd_tz_timestamp)

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -1434,3 +1434,6 @@ def test_timdelta_binop_tz_timestamp(op):
     pd_tz_timestamp = pd.Timestamp("1970-01-01 00:00:00.000000001", tz="utc")
     with pytest.raises(NotImplementedError):
         op(s, pd_tz_timestamp)
+    date_tz_scalar = datetime.datetime.now(datetime.timezone.utc)
+    with pytest.raises(NotImplementedError):
+        op(s, date_tz_scalar)

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -274,8 +274,7 @@ def to_cudf_compatible_scalar(val, dtype=None):
         if val.tz is not None:
             raise NotImplementedError(
                 "Cannot covert a timezone-aware timestamp to"
-                " timezone-naive scalar. For that, "
-                "use `tz_localize`."
+                " timezone-naive scalar."
             )
         val = val.to_datetime64()
     elif isinstance(val, pd.Timedelta):

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -270,16 +270,18 @@ def to_cudf_compatible_scalar(val, dtype=None):
             # the string value directly (cudf.DeviceScalar will DTRT)
             return val
 
+    tz_error_msg = (
+        "Cannot covert a timezone-aware timestamp to timezone-naive scalar."
+    )
     if isinstance(val, pd.Timestamp):
         if val.tz is not None:
-            raise NotImplementedError(
-                "Cannot covert a timezone-aware timestamp to"
-                " timezone-naive scalar."
-            )
+            raise NotImplementedError(tz_error_msg)
         val = val.to_datetime64()
     elif isinstance(val, pd.Timedelta):
         val = val.to_timedelta64()
     elif isinstance(val, datetime.datetime):
+        if val.tzinfo is not None:
+            raise NotImplementedError(tz_error_msg)
         val = np.datetime64(val)
     elif isinstance(val, datetime.timedelta):
         val = np.timedelta64(val)

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -272,7 +272,7 @@ def to_cudf_compatible_scalar(val, dtype=None):
 
     if isinstance(val, pd.Timestamp):
         if val.tz is not None:
-            raise TypeError(
+            raise NotImplementedError(
                 "Cannot covert a timezone-aware timestamp to"
                 " timezone-naive scalar. For that, "
                 "use `tz_localize`."

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -270,14 +270,20 @@ def to_cudf_compatible_scalar(val, dtype=None):
             # the string value directly (cudf.DeviceScalar will DTRT)
             return val
 
-    if isinstance(val, datetime.datetime):
-        val = np.datetime64(val)
-    elif isinstance(val, datetime.timedelta):
-        val = np.timedelta64(val)
-    elif isinstance(val, pd.Timestamp):
+    if isinstance(val, pd.Timestamp):
+        if val.tz is not None:
+            raise TypeError(
+                "Cannot covert a timezone-aware timestamp to"
+                " timezone-naive scalar. For that, "
+                "use `tz_localize`."
+            )
         val = val.to_datetime64()
     elif isinstance(val, pd.Timedelta):
         val = val.to_timedelta64()
+    elif isinstance(val, datetime.datetime):
+        val = np.datetime64(val)
+    elif isinstance(val, datetime.timedelta):
+        val = np.timedelta64(val)
 
     val = _maybe_convert_to_default_type(
         cudf.api.types.pandas_dtype(type(val))


### PR DESCRIPTION
## Description

Fixes: #13825 This PR raises an error when a time-zone-aware scalar is passed to binops or cudf scalar construction.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
