### PR TITLE
Fix typo in parquet/page_decode.cuh

### DIFF
--- a/cpp/src/io/parquet/page_decode.cuh
+++ b/cpp/src/io/parquet/page_decode.cuh
@@ -444,7 +444,7 @@ __device__ size_type gpuInitStringDescriptors(page_state_s volatile* s,
  * @brief Decode values out of a definition or repetition stream
  *
  * @param[in,out] s Page state input/output
- * @param[in] t target_count Target count of stream values on output
+ * @param[in] target_count Target count of stream values on output
  * @param[in] t Warp0 thread ID (0..31)
  * @param[in] lvl The level type we are decoding - DEFINITION or REPETITION
  */

--- a/cpp/src/io/parquet/page_decode.cuh
+++ b/cpp/src/io/parquet/page_decode.cuh
@@ -443,8 +443,8 @@ __device__ size_type gpuInitStringDescriptors(page_state_s volatile* s,
 /**
  * @brief Decode values out of a definition or repetition stream
  *
- * @param[in,out] s Page state input/output
  * @param[out] output Level buffer output
+ * @param[in,out] s Page state input/output
  * @param[in] target_count Target count of stream values on output
  * @param[in] t Warp0 thread ID (0..31)
  * @param[in] lvl The level type we are decoding - DEFINITION or REPETITION

--- a/cpp/src/io/parquet/page_decode.cuh
+++ b/cpp/src/io/parquet/page_decode.cuh
@@ -444,6 +444,7 @@ __device__ size_type gpuInitStringDescriptors(page_state_s volatile* s,
  * @brief Decode values out of a definition or repetition stream
  *
  * @param[in,out] s Page state input/output
+ * @param[out] output Level buffer output
  * @param[in] target_count Target count of stream values on output
  * @param[in] t Warp0 thread ID (0..31)
  * @param[in] lvl The level type we are decoding - DEFINITION or REPETITION


### PR DESCRIPTION
## Description
This PR fixes a typo in the parquet page decoding doc and adds a missing doc.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
