### PR TITLE
Fixes a performance regression in FST 

### DIFF
--- a/cpp/src/io/fst/agent_dfa.cuh
+++ b/cpp/src/io/fst/agent_dfa.cuh
@@ -91,24 +91,16 @@ class DFASimulationCallbackWrapper {
                                                       SymbolT const read_symbol)
   {
     uint32_t const count = transducer_table(old_state, symbol_id, read_symbol);
+    if (write) {
 #if __CUDA_ARCH__ > 0
-    if (write) {
 #pragma unroll 1
-      for (uint32_t out_char = 0; out_char < count; out_char++) {
-        out_it[out_count + out_char] =
-          transducer_table(old_state, symbol_id, out_char, read_symbol);
-        out_idx_it[out_count + out_char] = offset + character_index;
-      }
-    }
-#else
-    if (write) {
-      for (uint32_t out_char = 0; out_char < count; out_char++) {
-        out_it[out_count + out_char] =
-          transducer_table(old_state, symbol_id, out_char, read_symbol);
-        out_idx_it[out_count + out_char] = offset + character_index;
-      }
-    }
 #endif
+      for (uint32_t out_char = 0; out_char < count; out_char++) {
+        out_it[out_count + out_char] =
+          transducer_table(old_state, symbol_id, out_char, read_symbol);
+        out_idx_it[out_count + out_char] = offset + character_index;
+      }
+    }
     out_count += count;
   }
 

--- a/cpp/src/io/fst/agent_dfa.cuh
+++ b/cpp/src/io/fst/agent_dfa.cuh
@@ -91,6 +91,16 @@ class DFASimulationCallbackWrapper {
                                                       SymbolT const read_symbol)
   {
     uint32_t const count = transducer_table(old_state, symbol_id, read_symbol);
+#if __CUDA_ARCH__ > 0
+    if (write) {
+#pragma unroll 1
+      for (uint32_t out_char = 0; out_char < count; out_char++) {
+        out_it[out_count + out_char] =
+          transducer_table(old_state, symbol_id, out_char, read_symbol);
+        out_idx_it[out_count + out_char] = offset + character_index;
+      }
+    }
+#else
     if (write) {
       for (uint32_t out_char = 0; out_char < count; out_char++) {
         out_it[out_count + out_char] =
@@ -98,6 +108,7 @@ class DFASimulationCallbackWrapper {
         out_idx_it[out_count + out_char] = offset + character_index;
       }
     }
+#endif
     out_count += count;
   }
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
https://github.com/rapidsai/cudf/pull/13344 introduced a performance regression to the FST benchmarks that showed as much as a 35% performance degradation. 

It seems that, after the refactor in the above PR, compiler optimization heuristics are deciding differently on loop unrolling in the part of the FST that's writing out transduced symbols. 

As a fix, we are enforcing to not unroll that loop.

<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.