### PR TITLE
Disable construction of Index when `freq` is set in pandas-compatibility mode

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2237,6 +2237,12 @@ def as_column(
         raise NotImplementedError(
             "cuDF does not yet support timezone-aware datetimes"
         )
+    elif (
+        cudf.get_option("mode.pandas_compatible")
+        and isinstance(arbitrary, (pd.DatetimeIndex, pd.TimedeltaIndex))
+        and arbitrary.freq is not None
+    ):
+        raise NotImplementedError("freq is not implemented yet")
     else:
         try:
             data = as_column(

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -2670,3 +2670,11 @@ def test_index_mixed_dtype_error(data):
     pi = pd.Index(data)
     with pytest.raises(TypeError):
         cudf.Index(pi)
+
+
+@pytest.mark.parametrize("cls", [pd.DatetimeIndex, pd.TimedeltaIndex])
+def test_index_date_duration_freq_error(cls):
+    s = cls([1, 2, 3], freq="infer")
+    with cudf.option_context("mode.pandas_compatible", True):
+        with pytest.raises(NotImplementedError):
+            cudf.Index(s)


### PR DESCRIPTION
## Description
This PR raises an error when a `cudf` column/series/Index is being constructed using a pandas Index that has a `freq` set. This error is raised only in pandas-compatibility mode, because we will have to switch to `cudf.date_range` everywhere in the code base and examples, and `cudf.date_range` still isn't at a full feature parity with `pd.date_range`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
