### PR TITLE
Raise error when `astype(object)` is called in pandas compatibility mode

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -994,7 +994,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
                 dtype
             ).type in {np.object_}:
                 raise ValueError(
-                    f"{dtype} is an unsupported dtype to type-cast to, use "
+                    f"Casting to {dtype} is not supported, use "
                     "`.astype('str')` instead."
                 )
             return self.as_string_column(dtype, **kwargs)

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -990,9 +990,11 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
             np.object_,
             str,
         }:
-            if cudf.get_option("mode.pandas_compatible") and np.dtype(
-                dtype
-            ).type in {np.object_}:
+            if (
+                cudf.get_option("mode.pandas_compatible")
+                and not isinstance(self, cudf.core.column.StringColumn)
+                and np.dtype(dtype).type in {np.object_}
+            ):
                 raise ValueError(
                     f"{dtype} is an unsupported dtype to type-cast to, use "
                     "`.astype('str')` instead."

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -992,7 +992,6 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         }:
             if (
                 cudf.get_option("mode.pandas_compatible")
-                and not isinstance(self, cudf.core.column.StringColumn)
                 and np.dtype(dtype).type in {np.object_}
             ):
                 raise ValueError(

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -990,10 +990,9 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
             np.object_,
             str,
         }:
-            if (
-                cudf.get_option("mode.pandas_compatible")
-                and np.dtype(dtype).type in {np.object_}
-            ):
+            if cudf.get_option("mode.pandas_compatible") and np.dtype(
+                dtype
+            ).type in {np.object_}:
                 raise ValueError(
                     f"{dtype} is an unsupported dtype to type-cast to, use "
                     "`.astype('str')` instead."

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -990,6 +990,13 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
             np.object_,
             str,
         }:
+            if cudf.get_option("mode.pandas_compatible") and np.dtype(
+                dtype
+            ).type in {np.object_}:
+                raise ValueError(
+                    f"{dtype} is an unsupported dtype to type-cast to, use "
+                    "`.astype('str')` instead."
+                )
             return self.as_string_column(dtype, **kwargs)
         elif is_list_dtype(dtype):
             if not self.dtype == dtype:

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -2224,3 +2224,14 @@ def test_series_constructor_unbounded_sequence():
 def test_series_constructor_error_mixed_type():
     with pytest.raises(pa.ArrowTypeError):
         cudf.Series(["abc", np.nan, "123"], nan_as_null=False)
+
+
+def test_series_typecast_error():
+    actual = cudf.Series([1, 2, 3], dtype="datetime64[ns]")
+    with cudf.option_context("mode.pandas_compatible", True):
+        with pytest.raises(ValueError):
+            actual.astype(object)
+        with pytest.raises(ValueError):
+            actual.astype(np.dtype("object"))
+        new_series = actual.astype("str")
+        assert new_series[0] == "1970-01-01 00:00:00.000000001"

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -2226,7 +2226,7 @@ def test_series_constructor_error_mixed_type():
         cudf.Series(["abc", np.nan, "123"], nan_as_null=False)
 
 
-def test_series_typecast_error():
+def test_series_typecast_to_object_error():
     actual = cudf.Series([1, 2, 3], dtype="datetime64[ns]")
     with cudf.option_context("mode.pandas_compatible", True):
         with pytest.raises(ValueError):
@@ -2234,4 +2234,13 @@ def test_series_typecast_error():
         with pytest.raises(ValueError):
             actual.astype(np.dtype("object"))
         new_series = actual.astype("str")
+        assert new_series[0] == "1970-01-01 00:00:00.000000001"
+
+
+def test_series_typecast_to_object():
+    actual = cudf.Series([1, 2, 3], dtype="datetime64[ns]")
+    with cudf.option_context("mode.pandas_compatible", False):
+        new_series = actual.astype(object)
+        assert new_series[0] == "1970-01-01 00:00:00.000000001"
+        new_series = actual.astype(np.dtype("object"))
         assert new_series[0] == "1970-01-01 00:00:00.000000001"


### PR DESCRIPTION
## Description
This PR disables type-casting to `object` dtype for non-string columns. It's a no-op for string columns. We disable this only in pandas-compatibility mode since the usage of `np.dtype("O")` is wide-spread and not quite possible to remove it's support entirely at this point.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
