### PR TITLE
Exclude some tests from running with the compute sanitizer

### DIFF
--- a/java/src/test/java/ai/rapids/cudf/CudaTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CudaTest.java
@@ -16,6 +16,7 @@
 
 package ai.rapids.cudf;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,6 +34,7 @@ public class CudaTest {
     assertEquals(Cuda.getNativeComputeMode(), Cuda.getComputeMode().nativeId);
   }
 
+  @Tag("noSanitizer")
   @Test
   public void testCudaException() {
     assertThrows(CudaException.class, () -> {

--- a/java/src/test/java/ai/rapids/cudf/RmmTest.java
+++ b/java/src/test/java/ai/rapids/cudf/RmmTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/src/test/java/ai/rapids/cudf/RmmTest.java
+++ b/java/src/test/java/ai/rapids/cudf/RmmTest.java
@@ -18,6 +18,7 @@ package ai.rapids.cudf;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -187,6 +188,7 @@ public class RmmTest {
     }
   }
 
+  @Tag("noSanitizer")
   @ParameterizedTest
   @ValueSource(ints = {
       RmmAllocationMode.CUDA_DEFAULT,
@@ -257,6 +259,7 @@ public class RmmTest {
     assertEquals(1024, totalDeallocated.get());
   }
 
+  @Tag("noSanitizer")
   @Test
   public void testSetEventHandlerTwice() {
     Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, Rmm.logToStderr(), 0L);
@@ -278,6 +281,7 @@ public class RmmTest {
     assertThrows(RmmException.class, () -> Rmm.setEventHandler(otherHandler));
   }
 
+  @Tag("noSanitizer")
   @Test
   public void testClearEventHandler() {
     Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, Rmm.logToStderr(), 0L);
@@ -304,6 +308,7 @@ public class RmmTest {
     }
   }
 
+  @Tag("noSanitizer")
   @Test
   public void testAllocOnlyThresholds() {
     final AtomicInteger allocInvocations = new AtomicInteger(0);
@@ -367,6 +372,7 @@ public class RmmTest {
     assertEquals(0, deallocInvocations.get());
   }
 
+  @Tag("noSanitizer")
   @Test
   public void testThresholds() {
     final AtomicInteger allocInvocations = new AtomicInteger(0);
@@ -451,6 +457,7 @@ public class RmmTest {
     assertEquals(2, deallocInvocations.get());
   }
 
+  @Tag("noSanitizer")
   @Test
   public void testExceptionHandling() {
     Rmm.initialize(RmmAllocationMode.POOL, Rmm.logToStderr(), 1024 * 1024L);
@@ -511,6 +518,7 @@ public class RmmTest {
     }
   }
 
+  @Tag("noSanitizer")
   @ParameterizedTest
   @ValueSource(ints = {
       RmmAllocationMode.CUDA_DEFAULT,
@@ -523,6 +531,7 @@ public class RmmTest {
     Cuda.autoSetDevice();
   }
 
+  @Tag("noSanitizer")
   @Test
   public void testPoolSize() {
     Rmm.initialize(RmmAllocationMode.POOL, Rmm.logToStderr(), 1024);
@@ -535,6 +544,7 @@ public class RmmTest {
     }
   }
 
+  @Tag("noSanitizer")
   @Test
   public void testCudaAsyncMemoryResourceSize() {
     try {
@@ -553,6 +563,7 @@ public class RmmTest {
     }
   }
 
+  @Tag("noSanitizer")
   @Test
   public void testCudaAsyncIsIncompatibleWithManaged() {
     assertThrows(IllegalArgumentException.class,

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -40,6 +40,7 @@ import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.OriginalType;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -8603,6 +8603,8 @@ public class TableTest extends CudfTestBase {
     }
   }
 
+  // https://github.com/NVIDIA/spark-rapids-jni/issues/1338
+  // Need to remove this tag if #1338 is fixed.
   @Tag("noSanitizer")
   @Test
   void testORCReadAndWriteForDecimal128() throws IOException {

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -8603,6 +8603,7 @@ public class TableTest extends CudfTestBase {
     }
   }
 
+  @Tag("noSanitizer")
   @Test
   void testORCReadAndWriteForDecimal128() throws IOException {
     File tempFile = File.createTempFile("test", ".orc");

--- a/java/src/test/java/ai/rapids/cudf/UnsafeMemoryAccessorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/UnsafeMemoryAccessorTest.java
@@ -18,11 +18,13 @@
 
 package ai.rapids.cudf;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+@Tag("noSanitizer")
 public class UnsafeMemoryAccessorTest {
   @Test
   public void testAllocate() {

--- a/java/src/test/java/ai/rapids/cudf/UnsafeMemoryAccessorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/UnsafeMemoryAccessorTest.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids-jni/issues/1221.

In PR https://github.com/NVIDIA/spark-rapids-jni/pull/1321, we are going to enable the Compute Sanitizer in memcheck mode to help detect some possible kernel errors in the JNI unit tests. But not all the tests are suitable to run with the Compute Sanitizer. This PR is to add these exclusions.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
