### PR TITLE
Bring parity with pandas for `datetime` & `timedelta` comparison operations

### DIFF
--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -474,7 +474,7 @@ class DatetimeColumn(column.ColumnBase):
         if cudf.get_option(
             "mode.pandas_compatible"
         ) and out_dtype == cudf.dtype(np.bool_):
-            result = result.fillna(True if op == "__ne__" else False)
+            result = result.fillna(op == "__ne__")
         return result
 
     def fillna(

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -460,14 +460,22 @@ class DatetimeColumn(column.ColumnBase):
             if isinstance(other, ColumnBase) and not isinstance(
                 other, DatetimeColumn
             ):
-                return _all_bools_with_nulls(
+                result = _all_bools_with_nulls(
                     self, other, bool_fill_value=op == "__ne__"
                 )
+                if cudf.get_option("mode.pandas_compatible"):
+                    result = result.fillna(op == "__ne__")
+                return result
 
         if out_dtype is None:
             return NotImplemented
 
-        return libcudf.binaryop.binaryop(lhs, rhs, op, out_dtype)
+        result = libcudf.binaryop.binaryop(lhs, rhs, op, out_dtype)
+        if cudf.get_option(
+            "mode.pandas_compatible"
+        ) and out_dtype == cudf.dtype(np.bool_):
+            result = result.fillna(True if op == "__ne__" else False)
+        return result
 
     def fillna(
         self,

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2107,3 +2107,20 @@ def test_datetime_binop_tz_timestamp(op):
     date_scalar = datetime.datetime.now(datetime.timezone.utc)
     with pytest.raises(NotImplementedError):
         op(s, date_scalar)
+
+
+@pytest.mark.parametrize("data1", [["20110101", "20120101", None]])
+@pytest.mark.parametrize("data2", [["20110101", "20120101", "20130101"]])
+@pytest.mark.parametrize("op", _cmpops)
+def test_datetime_series_cmpops_pandas_compatibility(data1, data2, op):
+    gsr1 = cudf.Series(data=data1, dtype="datetime64[ns]")
+    psr1 = gsr1.to_pandas()
+
+    gsr2 = cudf.Series(data=data2, dtype="datetime64[ns]")
+    psr2 = gsr2.to_pandas()
+
+    expect = op(psr1, psr2)
+    with cudf.option_context("mode.pandas_compatible", True):
+        got = op(gsr1, gsr2)
+
+    assert_eq(expect, got)

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2109,8 +2109,8 @@ def test_datetime_binop_tz_timestamp(op):
         op(s, date_scalar)
 
 
-@pytest.mark.parametrize("data1", [["20110101", "20120101", None]])
-@pytest.mark.parametrize("data2", [["20110101", "20120101", "20130101"]])
+@pytest.mark.parametrize("data1", [["20110101", "20120101", None, "20140101", None]])
+@pytest.mark.parametrize("data2", [["20110101", "20120101", "20130101", None, None]])
 @pytest.mark.parametrize("op", _cmpops)
 def test_datetime_series_cmpops_pandas_compatibility(data1, data2, op):
     gsr1 = cudf.Series(data=data1, dtype="datetime64[ns]")

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2109,8 +2109,12 @@ def test_datetime_binop_tz_timestamp(op):
         op(s, date_scalar)
 
 
-@pytest.mark.parametrize("data1", [["20110101", "20120101", None, "20140101", None]])
-@pytest.mark.parametrize("data2", [["20110101", "20120101", "20130101", None, None]])
+@pytest.mark.parametrize(
+    "data1", [["20110101", "20120101", None, "20140101", None]]
+)
+@pytest.mark.parametrize(
+    "data2", [["20110101", "20120101", "20130101", None, None]]
+)
 @pytest.mark.parametrize("op", _cmpops)
 def test_datetime_series_cmpops_pandas_compatibility(data1, data2, op):
     gsr1 = cudf.Series(data=data1, dtype="datetime64[ns]")

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -57,6 +57,15 @@ _TIMEDELTA_DATA_NON_OVERFLOW = [
     [12, 11, 2.32, 2234.32411, 2343.241, 23432.4, 23234],
 ]
 
+_cmpops = [
+    operator.lt,
+    operator.gt,
+    operator.le,
+    operator.ge,
+    operator.eq,
+    operator.ne,
+]
+
 
 @pytest.mark.parametrize(
     "data",
@@ -1442,3 +1451,20 @@ def test_timdelta_binop_tz_timestamp(op):
 def test_timedelta_getitem_na():
     s = cudf.Series([1, 2, None, 3], dtype="timedelta64[ns]")
     assert s[2] is cudf.NA
+
+
+@pytest.mark.parametrize("data1", [[123, 456, None]])
+@pytest.mark.parametrize("data2", [[123, 456, 789]])
+@pytest.mark.parametrize("op", _cmpops)
+def test_timedelta_series_cmpops_pandas_compatibility(data1, data2, op):
+    gsr1 = cudf.Series(data=data1, dtype="timedelta64[ns]")
+    psr1 = gsr1.to_pandas()
+
+    gsr2 = cudf.Series(data=data2, dtype="timedelta64[ns]")
+    psr2 = gsr2.to_pandas()
+
+    expect = op(psr1, psr2)
+    with cudf.option_context("mode.pandas_compatible", True):
+        got = op(gsr1, gsr2)
+
+    assert_eq(expect, got)

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -1453,8 +1453,8 @@ def test_timedelta_getitem_na():
     assert s[2] is cudf.NA
 
 
-@pytest.mark.parametrize("data1", [[123, 456, None]])
-@pytest.mark.parametrize("data2", [[123, 456, 789]])
+@pytest.mark.parametrize("data1", [[123, 456, None, 321, None]])
+@pytest.mark.parametrize("data2", [[123, 456, 789, None, None]])
 @pytest.mark.parametrize("op", _cmpops)
 def test_timedelta_series_cmpops_pandas_compatibility(data1, data2, op):
     gsr1 = cudf.Series(data=data1, dtype="timedelta64[ns]")


### PR DESCRIPTION
## Description
Resolves: #13876 

This PR brings parity with pandas `datetime` & `timedelta` comparison operations by filling the null locations of results with `True`/`False` according to the binary operation.

**Note: This is only enabled in pandas-compatibility mode.**

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
