### PR TITLE
Correctly detect the BOM mark in `read_csv` with compressed input

### DIFF
--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -410,7 +410,8 @@ std::pair<rmm::device_uvector<char>, selected_rows_offsets> select_data_and_row_
 
   // Transfer source data to GPU
   if (!source->is_empty()) {
-    auto buffer = source->host_read(range_offset, range_size_padded != 0 ? range_size_padded : source->size());
+    auto buffer =
+      source->host_read(range_offset, range_size_padded != 0 ? range_size_padded : source->size());
     auto h_data =
       host_span<char const>(reinterpret_cast<char const*>(buffer->data()), buffer->size());
 

--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -410,12 +410,9 @@ std::pair<rmm::device_uvector<char>, selected_rows_offsets> select_data_and_row_
 
   // Transfer source data to GPU
   if (!source->is_empty()) {
-    auto buffer = [&]() {
-      auto const data_size = (range_size_padded != 0) ? range_size_padded : source->size();
-      return source->host_read(range_offset, data_size);
-    }();
+    auto buffer = source->host_read(range_offset, range_size_padded != 0 ? range_size_padded : source->size());
     auto h_data =
-      host_span<char const>(reinterpret_cast<const char*>(buffer->data()), buffer->size());
+      host_span<char const>(reinterpret_cast<char const*>(buffer->data()), buffer->size());
 
     std::vector<uint8_t> h_uncomp_data_owner;
     if (reader_opts.get_compression() != compression_type::NONE) {

--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -410,28 +410,29 @@ std::pair<rmm::device_uvector<char>, selected_rows_offsets> select_data_and_row_
 
   // Transfer source data to GPU
   if (!source->is_empty()) {
-    auto data_size = (range_size_padded != 0) ? range_size_padded : source->size();
-    auto buffer    = source->host_read(range_offset, data_size);
-
-    // check for and skip UTF-8 BOM
-    auto buffer_data         = buffer->data();
-    auto buffer_size         = buffer->size();
-    uint8_t const UTF8_BOM[] = {0xEF, 0xBB, 0xBF};
-    if (buffer_size > sizeof(UTF8_BOM) && memcmp(buffer_data, UTF8_BOM, sizeof(UTF8_BOM)) == 0) {
-      buffer_data += sizeof(UTF8_BOM);
-      buffer_size -= sizeof(UTF8_BOM);
-    }
-
-    auto h_data = host_span<char const>(reinterpret_cast<char const*>(buffer_data), buffer_size);
+    auto buffer = [&]() {
+      auto const data_size = (range_size_padded != 0) ? range_size_padded : source->size();
+      return source->host_read(range_offset, data_size);
+    }();
+    auto h_data =
+      host_span<char const>(reinterpret_cast<const char*>(buffer->data()), buffer->size());
 
     std::vector<uint8_t> h_uncomp_data_owner;
-
     if (reader_opts.get_compression() != compression_type::NONE) {
       h_uncomp_data_owner =
         decompress(reader_opts.get_compression(), {buffer->data(), buffer->size()});
       h_data = {reinterpret_cast<char const*>(h_uncomp_data_owner.data()),
                 h_uncomp_data_owner.size()};
+      buffer.reset();
     }
+
+    // check for and skip UTF-8 BOM
+    uint8_t const UTF8_BOM[] = {0xEF, 0xBB, 0xBF};
+    if (h_data.size() >= sizeof(UTF8_BOM) &&
+        memcmp(h_data.data(), UTF8_BOM, sizeof(UTF8_BOM)) == 0) {
+      h_data = h_data.subspan(sizeof(UTF8_BOM), h_data.size() - sizeof(UTF8_BOM));
+    }
+
     // None of the parameters for row selection is used, we are parsing the entire file
     bool const load_whole_file = range_offset == 0 && range_size == 0 && skip_rows <= 0 &&
                                  skip_end_rows <= 0 && num_rows == -1;

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -2188,6 +2188,43 @@ def test_default_float_bitwidth_partial(default_float_bitwidth):
     assert read["float2"].dtype == np.dtype("f8")
 
 
+@pytest.mark.parametrize(
+    "usecols,names",
+    [
+        # selection using indices; only names of selected columns are specified
+        ([1, 2], ["b", "c"]),
+        # selection using indices; names of all columns are specified
+        ([1, 2], ["a", "b", "c"]),
+        # selection using indices; duplicates
+        ([2, 2], ["a", "b", "c"]),
+        # selection using indices; out of order
+        ([2, 1], ["a", "b", "c"]),
+        # selection using names
+        (["b"], ["a", "b", "c"]),
+        # selection using names; multiple columns
+        (["b", "c"], ["a", "b", "c"]),
+        # selection using names; duplicates
+        (["c", "c"], ["a", "b", "c"]),
+        # selection using names; out of order
+        (["c", "b"], ["a", "b", "c"]),
+    ],
+)
+def test_column_selection_plus_column_names(usecols, names):
+    lines = [
+        "num,datetime,text",
+        "123,2018-11-13T12:00:00,abc",
+        "456,2018-11-14T12:35:01,def",
+        "789,2018-11-15T18:02:59,ghi",
+    ]
+
+    buffer = "\n".join(lines) + "\n"
+
+    assert_eq(
+        pd.read_csv(StringIO(buffer), usecols=usecols, names=names),
+        cudf.read_csv(StringIO(buffer), usecols=usecols, names=names),
+    )
+
+
 def test_read_compressed_BOM(tmpdir):
     buffer = 'int, string\n1, "a"\n2, "b"\n3, "c"\n'
 


### PR DESCRIPTION
## Description
We currently detect the BOM mark at the start of the file and then decompress the data, if compressed. This leads to a problem with compressed files that have a BOM mark, as we are trying to detect the mark in the compressed data.
This PR moves the BOM detection until after decompression. Also cleaned up the surrounding code slightly.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
