### PR TITLE
Raise error when trying to construct a `DataFrame` with mixed types

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2214,8 +2214,15 @@ def as_column(
             )
         elif arb_dtype.kind in ("O", "U"):
             pyarrow_array = pa.Array.from_pandas(arbitrary)
-            if isinstance(
-                pyarrow_array, (pa.DurationArray, pa.TimestampArray)
+            if not isinstance(
+                pyarrow_array,
+                (
+                    pa.ListArray,
+                    pa.StructArray,
+                    pa.NullArray,
+                    pa.Decimal128Array,
+                    pa.StringArray,
+                ),
             ):
                 raise MixedTypeError("Cannot create column with mixed types")
             data = as_column(pyarrow_array, dtype=arb_dtype)

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2222,6 +2222,7 @@ def as_column(
                     pa.NullArray,
                     pa.Decimal128Array,
                     pa.StringArray,
+                    pa.BooleanArray,
                 ),
             ):
                 raise MixedTypeError("Cannot create column with mixed types")

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2213,7 +2213,12 @@ def as_column(
                 pa.Array.from_pandas(interval_series), dtype=arb_dtype
             )
         elif arb_dtype.kind in ("O", "U"):
-            data = as_column(pa.Array.from_pandas(arbitrary), dtype=arb_dtype)
+            pyarrow_array = pa.Array.from_pandas(arbitrary)
+            if isinstance(
+                pyarrow_array, (pa.DurationArray, pa.TimestampArray)
+            ):
+                raise MixedTypeError("Cannot create column with mixed types")
+            data = as_column(pyarrow_array, dtype=arb_dtype)
         else:
             data = as_column(
                 pa.array(

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -10279,3 +10279,10 @@ def test_dataframe_constructor_from_namedtuple():
         cudf.DataFrame(data, index=idx)
     with pytest.raises(ValueError):
         pd.DataFrame(data, index=idx)
+
+
+@pytest.mark.parametrize("dtype", ["datetime64[ns]", "timedelta64[ns]"])
+def test_dataframe_mixed_dtype_error(dtype):
+    pdf = pd.Series([1, 2, 3], dtype=dtype).to_frame().astype(object)
+    with pytest.raises(TypeError):
+        cudf.from_pandas(pdf)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -10281,7 +10281,9 @@ def test_dataframe_constructor_from_namedtuple():
         pd.DataFrame(data, index=idx)
 
 
-@pytest.mark.parametrize("dtype", ["datetime64[ns]", "timedelta64[ns]"])
+@pytest.mark.parametrize(
+    "dtype", ["datetime64[ns]", "timedelta64[ns]", "int64", "float32"]
+)
 def test_dataframe_mixed_dtype_error(dtype):
     pdf = pd.Series([1, 2, 3], dtype=dtype).to_frame().astype(object)
     with pytest.raises(TypeError):


### PR DESCRIPTION
## Description

Continuation to https://github.com/rapidsai/cudf/pull/13768/, In #13768 we prevented construction of mixed types in `Index` & `Series`. This PR implements the same for `DataFrame`.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
