### PR TITLE
Disable creation of `DatetimeIndex` when `freq` is passed to `cudf.date_range`

### DIFF
--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -833,6 +833,10 @@ def date_range(
         arr = cp.linspace(start=start, stop=end, num=periods)
         result = cudf.core.column.as_column(arr).astype("datetime64[ns]")
         return cudf.DatetimeIndex._from_data({name: result})
+    elif cudf.get_option("mode.pandas_compatible"):
+        raise NotImplementedError(
+            "`DatetimeIndex` with `freq` cannot be constructed."
+        )
 
     # The code logic below assumes `freq` is defined. It is first normalized
     # into `DateOffset` for further computation with timestamps.

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2139,7 +2139,10 @@ def test_daterange_pandas_compatibility():
     with cudf.option_context("mode.pandas_compatible", True):
         with pytest.raises(NotImplementedError):
             cudf.date_range("20010101", "20020215", freq="400h", name="times")
-    expected = pd.date_range("20010101", "20020215", freq="400h", name="times")
-    expected.freq = None
-    actual = cudf.date_range("20010101", "20020215", freq="400h", name="times")
+        expected = pd.date_range(
+            "2010-01-01", "2010-02-01", periods=10, name="times"
+        )
+        actual = cudf.date_range(
+            "2010-01-01", "2010-02-01", periods=10, name="times"
+        )
     assert_eq(expected, actual)

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2133,3 +2133,13 @@ def test_datetime_series_cmpops_pandas_compatibility(data1, data2, op):
 def test_datetime_getitem_na():
     s = cudf.Series([1, 2, None, 3], dtype="datetime64[ns]")
     assert s[2] is cudf.NaT
+
+
+def test_daterange_pandas_compatibility():
+    with cudf.option_context("mode.pandas_compatible", True):
+        with pytest.raises(NotImplementedError):
+            cudf.date_range("20010101", "20020215", freq="400h", name="times")
+    expected = pd.date_range("20010101", "20020215", freq="400h", name="times")
+    expected.freq = None
+    actual = cudf.date_range("20010101", "20020215", freq="400h", name="times")
+    assert_eq(expected, actual)


### PR DESCRIPTION
## Description
In https://github.com/rapidsai/cudf/pull/13857/, we disabled the construction of `DatetimeIndex` & `TimedeltaIndex` when their pandas counter-parts have `freq` set. However, when `freq` is passed to `date_range`, the expectation and pandas-behavior is to return a `DateTimeIndex` with `freq` set. This isn't possible with cudf currently, hence disabled the construction of `DatetimeIndex` in this case.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
