### PR TITLE
Return `Timestamp` & `Timedelta` for fetching scalars in `DatetimeIndex` & `TimedeltaIndex`

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2115,8 +2115,7 @@ class DatetimeIndex(GenericIndex):
             value, np.datetime64
         ):
             return pd.Timestamp(value)
-        else:
-            return value
+        return value
 
     def searchsorted(
         self,
@@ -2782,8 +2781,7 @@ class TimedeltaIndex(GenericIndex):
             value, np.timedelta64
         ):
             return pd.Timedelta(value)
-        else:
-            return value
+        return value
 
     @_cudf_nvtx_annotate
     def to_pandas(self, nullable=False):

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2109,6 +2109,15 @@ class DatetimeIndex(GenericIndex):
 
         super().__init__(data, **kwargs)
 
+    def __getitem__(self, index):
+        value = super().__getitem__(index)
+        if cudf.get_option("mode.pandas_compatible") and isinstance(
+            value, np.datetime64
+        ):
+            return pd.Timestamp(value)
+        else:
+            return value
+
     def searchsorted(
         self,
         value,
@@ -2766,6 +2775,15 @@ class TimedeltaIndex(GenericIndex):
             data = data.copy()
 
         super().__init__(data, **kwargs)
+
+    def __getitem__(self, index):
+        value = super().__getitem__(index)
+        if cudf.get_option("mode.pandas_compatible") and isinstance(
+            value, np.timedelta64
+        ):
+            return pd.Timedelta(value)
+        else:
+            return value
 
     @_cudf_nvtx_annotate
     def to_pandas(self, nullable=False):

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -2682,3 +2682,15 @@ def test_index_date_duration_freq_error(cls):
     with cudf.option_context("mode.pandas_compatible", True):
         with pytest.raises(NotImplementedError):
             cudf.Index(s)
+
+
+@pytest.mark.parametrize("dtype", ["datetime64[ns]", "timedelta64[ns]"])
+def test_index_getitem_time_duration(dtype):
+    gidx = cudf.Index([1, 2, 3, 4, None], dtype=dtype)
+    pidx = gidx.to_pandas()
+    with cudf.option_context("mode.pandas_compatible", True):
+        for i in range(len(gidx)):
+            if i == 4:
+                assert gidx[i] is pidx[i]
+            else:
+                assert_eq(gidx[i], pidx[i])


### PR DESCRIPTION
## Description
This PR returns `pd.Timestamp` & `pd.Timdelta` respectively for `DatetimeIndex` & `TimedeltaIndex` `__getitem__` in pandas-compatibility mode.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
