### PR TITLE
Use cuda-nvtx-dev CUDA 12 package.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -16,6 +16,7 @@ dependencies:
 - cachetools
 - cmake>=3.26.4
 - cubinlinker
+- cuda-nvtx=11.8
 - cuda-python>=11.7.1,<12.0a0
 - cuda-sanitizer-api=11.8.86
 - cuda-version=11.8

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -18,6 +18,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvrtc-dev
+- cuda-nvtx-dev
 - cuda-python>=12.0,<13.0a0
 - cuda-sanitizer-api
 - cuda-version=12.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -289,12 +289,14 @@ dependencies:
               - cuda-version=12.0
               - cuda-cudart-dev
               - cuda-nvrtc-dev
+              - cuda-nvtx-dev
               - libcurand-dev
           - matrix:
               cuda: "11.8"
             packages:
               - cuda-version=11.8
               - cudatoolkit
+              - cuda-nvtx=11.8
               - libcurand-dev=10.3.0.86
               - libcurand=10.3.0.86
           - matrix:
@@ -302,6 +304,7 @@ dependencies:
             packages:
               - cuda-version=11.5
               - cudatoolkit
+              - cuda-nvtx=11.5
                 # Can't hard pin the version since 11.x is missing many
                 # packages for specific versions
               - libcurand-dev>=10.2.6.48,<=10.2.7.107
@@ -311,6 +314,7 @@ dependencies:
             packages:
               - cuda-version=11.4
               - cudatoolkit
+              - &cudanvtx114 cuda-nvtx=11.4
               - &libcurand_dev114 libcurand-dev>=10.2.5.43,<=10.2.5.120
               - &libcurand114 libcurand>=10.2.5.43,<=10.2.5.120
           - matrix:
@@ -321,6 +325,7 @@ dependencies:
                 # The NVIDIA channel doesn't publish pkgs older than 11.4 for
                 # these libs, so 11.2 uses 11.4 packages (the oldest
                 # available).
+              - *cudanvtx114
               - *libcurand_dev114
               - *libcurand114
       - output_types: conda
@@ -535,22 +540,6 @@ dependencies:
           - *cmake_ver
           - maven
           - openjdk=8.*
-    specific:
-      - output_types: conda
-        matrices:
-          - matrix:
-              cuda: "12.0"
-            packages:
-              - cuda-version=12.0
-              - cuda-nvtx-dev
-          - matrix:
-              cuda: "11.8"
-            packages:
-              - cuda-nvtx=11.8
-          - matrix:
-              cuda: "11.5"
-            packages:
-              - cuda-nvtx=11.5
   test_python_common:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -542,7 +542,7 @@ dependencies:
               cuda: "12.0"
             packages:
               - cuda-version=12.0
-              - cuda-nvtx
+              - cuda-nvtx-dev
           - matrix:
               cuda: "11.8"
             packages:


### PR DESCRIPTION
## Description
Fixes the CUDA 12 `cuda-nvtx-dev` package name. This issue was found by @davidwendt and I verified that this fixes it.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
