### PR TITLE
Translate column size overflow exception to JNI

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/CudfColumnOverflowException.java
+++ b/java/src/main/java/ai/rapids/cudf/CudfColumnOverflowException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.rapids.cudf;
+
+/**
+ * Exception thrown when CUDF operation results in a column size
+ * exceeding CUDF column size limits
+ */
+public class CudfColumnOverflowException extends CudfException {
+  CudfColumnOverflowException(String message) {
+    super(message);
+  }
+
+  CudfColumnOverflowException(String message, String nativeStacktrace) {
+    super(message, nativeStacktrace);
+  }
+
+  CudfColumnOverflowException(String message, String nativeStacktrace, Throwable cause) {
+    super(message, nativeStacktrace, cause);
+  }
+}

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -32,6 +32,7 @@ constexpr jint MINIMUM_JNI_VERSION = JNI_VERSION_1_6;
 constexpr char const *CUDA_ERROR_CLASS = "ai/rapids/cudf/CudaException";
 constexpr char const *CUDA_FATAL_ERROR_CLASS = "ai/rapids/cudf/CudaFatalException";
 constexpr char const *CUDF_ERROR_CLASS = "ai/rapids/cudf/CudfException";
+constexpr char const *CUDF_OVERFLOW_ERROR_CLASS = "ai/rapids/cudf/CudfColumnOverflowException";
 constexpr char const *CUDF_DTYPE_ERROR_CLASS = "ai/rapids/cudf/CudfException";
 constexpr char const *INDEX_OOB_CLASS = "java/lang/ArrayIndexOutOfBoundsException";
 constexpr char const *ILLEGAL_ARG_CLASS = "java/lang/IllegalArgumentException";
@@ -900,6 +901,10 @@ inline void jni_cuda_check(JNIEnv *const env, cudaError_t cuda_status) {
   catch (const cudf::data_type_error &e) {                                                         \
     JNI_CHECK_THROW_CUDF_EXCEPTION(env, cudf::jni::CUDF_DTYPE_ERROR_CLASS, e.what(),               \
                                    e.stacktrace(), ret_val);                                       \
+  }                                                                                                \
+  catch (std::overflow_error const& e) {                                                           \
+    JNI_CHECK_THROW_CUDF_EXCEPTION(env, cudf::jni::CUDF_OVERFLOW_ERROR_CLASS, e.what(),            \
+                                   "No native stacktrace is available.", ret_val);                 \
   }                                                                                                \
   catch (const std::exception &e) {                                                                \
     char const *stacktrace = "No native stacktrace is available.";                                 \

--- a/java/src/test/java/ai/rapids/cudf/LargeTableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/LargeTableTest.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package ai.rapids.cudf;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Executable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for operations on tables with large row counts.
+ */
+public class LargeTableTest extends CudfTestBase {
+
+  static final long RMM_POOL_SIZE_LARGE = 10L * 1024 * 1024 * 1024;
+
+  public LargeTableTest() {
+    // Set large RMM pool size. Ensure that the test does not run out of memory,
+    // for large row counts.
+    super(RmmAllocationMode.POOL, RMM_POOL_SIZE_LARGE);
+  }
+
+  /**
+   * Tests that exploding large array columns will result in CudfColumnOverflowException
+   * if the column size limit is crossed.
+   */
+  @Test
+  public void testExplodeOverflow() {
+    int numRows = 1000_000;
+    int arraySize = 1000;
+    String str = "abc";
+
+    // 1 Million rows, each row being { "abc", [ 0, 0, 0... ] },
+    // with 1000 elements in the array in each row.
+    // When the second column is exploded, it produces 1 Billion rows.
+    // The string row is repeated once for each element in the array,
+    // thus producing a 1 Billion row string column, with 3 Billion chars
+    // in the child column. This should cause an overflow exception.
+    boolean [] arrBools = new boolean[arraySize];
+    for (char i = 0; i < arraySize; ++i) { arrBools[i] = false; }
+    Exception exception = assertThrows(CudfColumnOverflowException.class, ()->{
+        try (Scalar strScalar = Scalar.fromString(str);
+             ColumnVector arrRow = ColumnVector.fromBooleans(arrBools);
+             Scalar arrScalar = Scalar.listFromColumnView(arrRow);
+             ColumnVector strVector = ColumnVector.fromScalar(strScalar, numRows);
+             ColumnVector arrVector = ColumnVector.fromScalar(arrScalar, numRows);
+             Table inputTable = new Table(strVector, arrVector);
+             Table outputTable = inputTable.explode(1)) {
+          assertEquals(outputTable.getColumns()[0].getRowCount(), numRows * arraySize);
+          fail("Exploding this large table should have caused a CudfColumnOverflowException.");
+        }});
+    assertTrue(exception.getMessage().contains("Size of output exceeds the column size limit"));
+  }
+}


### PR DESCRIPTION
When a CUDF operation causes a column's row count to exceed the size limit imposed by `cudf::size_type`, the operation throws a `std::overflow_error` exception. However, prior to this commit, CUDF JNI did not translate this to a separate Java exception. Because of handling this condition as any generic exception, there was no way to attempt case specific recovery for overflow conditions.

This commit translates `std::overflow_error` into a new Java exception (`CudfColumnOverflowException`) that may be caught in user space to attempt recovery/retry.

This is a non-breaking change. The user-facing change is minimal in that existing failure handling based on catching `CudfException` will continue to work as before. The user will now have more fine grained error handling by catching `CudfColumnOverflowException`.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
