### PR TITLE
Fix handling of typecasting in `searchsorted`

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1409,12 +1409,23 @@ class Frame(BinaryOperand, Scannable):
         if len(values) != len(self._data):
             raise ValueError("Mismatch number of columns to search for.")
 
-        sources = [
-            col
-            if is_dtype_equal(col.dtype, val.dtype)
-            else col.astype(val.dtype)
+        common_dtype_list = [
+            find_common_type([col.dtype, val.dtype])
             for col, val in zip(self._columns, values)
         ]
+        sources = [
+            col
+            if is_dtype_equal(col.dtype, common_dtype)
+            else col.astype(common_dtype)
+            for col, common_dtype in zip(self._columns, common_dtype_list)
+        ]
+        values = [
+            val
+            if is_dtype_equal(val.dtype, common_dtype)
+            else val.astype(common_dtype)
+            for val, common_dtype in zip(values, common_dtype_list)
+        ]
+
         outcol = libcudf.search.search_sorted(
             sources,
             values,

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1409,6 +1409,8 @@ class Frame(BinaryOperand, Scannable):
         if len(values) != len(self._data):
             raise ValueError("Mismatch number of columns to search for.")
 
+        # TODO: Change behavior based on the decision in
+        # https://github.com/pandas-dev/pandas/issues/54668
         common_dtype_list = [
             find_common_type([col.dtype, val.dtype])
             for col, val in zip(self._columns, values)

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -2067,3 +2067,16 @@ class TestLocIndexWithOrder:
             expect = pdf.loc[lo:hi:take_order]
             actual = df.loc[lo:hi:take_order]
             assert_eq(expect, actual)
+
+
+@pytest.mark.parametrize(
+    "arg", [slice(2, 4), slice(2, 5), slice(2.3, 5), slice(4.6, 6)]
+)
+def test_series_iloc_float_int(arg):
+    gs = cudf.Series(range(4), index=[2.0, 3.0, 4.5, 5.5])
+    ps = gs.to_pandas()
+
+    actual = gs.loc[arg]
+    expected = ps.loc[arg]
+
+    assert_eq(actual, expected)

--- a/python/cudf/cudf/tests/test_search.py
+++ b/python/cudf/cudf/tests/test_search.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 import cupy
 import numpy as np
 import pandas as pd
@@ -156,3 +156,15 @@ def test_searchsorted_misc():
         psr.searchsorted([-100, 3.00001, 2.2, 2.0, 2.000000001]),
         sr.searchsorted([-100, 3.00001, 2.2, 2.0, 2.000000001]),
     )
+
+
+@pytest.mark.xfail(reason="https://github.com/pandas-dev/pandas/issues/54668")
+def test_searchsorted_mixed_str_int():
+    psr = pd.Series([1, 2, 3], dtype="int")
+    sr = cudf.from_pandas(psr)
+
+    with pytest.raises(ValueError):
+        actual = sr.searchsorted("a")
+    with pytest.raises(ValueError):
+        expect = psr.searchsorted("a")
+    assert_eq(expect, actual)


### PR DESCRIPTION
## Description

Fixes: #13902 

This PR fixes a type-casting issue with `searchsorted` where typecast was done to the `values` dtype instead of inspecting both input and values columns and converting them to common dtypes.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
