### PR TITLE
Fix an issue with `loc` when column names is `MultiIndex`

### DIFF
--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -511,7 +511,7 @@ class ColumnAccessor(abc.MutableMapping):
     def _select_by_label_grouped(self, key: Any) -> ColumnAccessor:
         result = self._grouped_data[key]
         if isinstance(result, cudf.core.column.ColumnBase):
-            return self.__class__({key: result})
+            return self.__class__({key: result}, multiindex=self.multiindex)
         else:
             if self.multiindex:
                 result = _to_flat_dict(result)

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -2076,13 +2076,17 @@ class TestLocIndexWithOrder:
         (slice(None, None, None), ("two", "first")),
         (1, ("one", "first")),
         (slice(None, None, None), ("two", "second")),
+        (slice(None, None, None), ("two", "first", "three")),
+        (3, ("two", "first", "three")),
+        (slice(None, None, None), ("two",)),
+        (0, ("two",)),
     ],
 )
 def test_loc_dataframe_column_multiindex(arg):
     gdf = cudf.DataFrame(
         [list("abcd"), list("efgh"), list("ijkl"), list("mnop")],
         columns=cudf.MultiIndex.from_product(
-            [["one", "two"], ["first", "second"]]
+            [["one", "two"], ["first", "second"], ["three"]]
         ),
     )
     pdf = gdf.to_pandas()

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -2067,3 +2067,24 @@ class TestLocIndexWithOrder:
             expect = pdf.loc[lo:hi:take_order]
             actual = df.loc[lo:hi:take_order]
             assert_eq(expect, actual)
+
+
+@pytest.mark.parametrize(
+    "arg",
+    [
+        (2, ("one", "second")),
+        (slice(None, None, None), ("two", "first")),
+        (1, ("one", "first")),
+        (slice(None, None, None), ("two", "second")),
+    ],
+)
+def test_loc_dataframe_column_multiindex(arg):
+    gdf = cudf.DataFrame(
+        [list("abcd"), list("efgh"), list("ijkl"), list("mnop")],
+        columns=cudf.MultiIndex.from_product(
+            [["one", "two"], ["first", "second"]]
+        ),
+    )
+    pdf = gdf.to_pandas()
+
+    assert_eq(gdf.loc[arg], pdf.loc[arg])

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -2095,8 +2095,6 @@ def test_loc_dataframe_column_multiindex(arg):
 
 
 @pytest.mark.parametrize(
-    "arg",
-    [  
     "arg", [slice(2, 4), slice(2, 5), slice(2.3, 5), slice(4.6, 6)]
 )
 def test_series_iloc_float_int(arg):


### PR DESCRIPTION
## Description
Fixes: #13864 

This PR fixes an issue with `loc` indexer where some special handling needs to be done when `columns` is of type `MultiIndex`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
