### PR TITLE
Make HostColumnVector.getRefCount public

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
+++ b/java/src/main/java/ai/rapids/cudf/HostColumnVector.java
@@ -199,7 +199,7 @@ public final class HostColumnVector extends HostColumnVectorCore {
   /**
    * Returns this column's current refcount
    */
-  synchronized int getRefCount() {
+  public synchronized int getRefCount() {
     return refCount;
   }
 


### PR DESCRIPTION
This is a small PR to make HostColumnVector.getRefCount public. 

This is useful in figuring out spillability for a `HostColumnVector` (plugin issue: https://github.com/NVIDIA/spark-rapids/issues/8882)