### PR TITLE
Add `bytes_per_second` to compiled binaryop benchmark

### DIFF
--- a/cpp/benchmarks/binaryop/compiled_binaryop.cpp
+++ b/cpp/benchmarks/binaryop/compiled_binaryop.cpp
@@ -42,6 +42,10 @@ void BM_compiled_binaryop(benchmark::State& state, cudf::binary_operator binop)
     cuda_event_timer timer(state, true);
     cudf::binary_operation(lhs, rhs, binop, output_dtype);
   }
+
+  // use number of bytes read and written to global memory
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * column_size *
+                          (sizeof(TypeLhs) + sizeof(TypeRhs) + sizeof(TypeOut)));
 }
 
 // TODO tparam boolean for null.


### PR DESCRIPTION
To add `bytes_per_second`, a call to `.SetBytesProcessed()` with the number of written and read bytes is added to the benchmark.

This patch relates to #13735.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).