### PR TITLE
Fix type metadata issue preservation with `Column.unique`

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1162,7 +1162,9 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         """
         Get unique values in the data
         """
-        return drop_duplicates([self], keep="first")[0]
+        return drop_duplicates([self], keep="first")[0]._with_type_metadata(
+            self.dtype
+        )
 
     def serialize(self) -> Tuple[dict, list]:
         # data model:

--- a/python/cudf/cudf/tests/test_interval.py
+++ b/python/cudf/cudf/tests/test_interval.py
@@ -1,6 +1,7 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 import pandas as pd
+import numpy as np
 import pytest
 
 import cudf
@@ -132,3 +133,21 @@ def test_create_interval_df(data1, data2, data3, data4, closed):
         dtype="interval",
     )
     assert_eq(expect_three, got_three)
+
+
+def test_interval_index_unique():
+    interval_list = [
+        np.nan,
+        pd.Interval(2.0, 3.0, closed="right"),
+        pd.Interval(3.0, 4.0, closed="right"),
+        np.nan,
+        pd.Interval(3.0, 4.0, closed="right"),
+        pd.Interval(3.0, 4.0, closed="right"),
+    ]
+    pi = pd.Index(interval_list)
+    gi = cudf.from_pandas(pi)
+
+    expected = pi.unique()
+    actual = gi.unique()
+
+    assert_eq(expected, actual)

--- a/python/cudf/cudf/tests/test_interval.py
+++ b/python/cudf/cudf/tests/test_interval.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 import pytest
 
 import cudf


### PR DESCRIPTION
## Description
closes #13953 

This PR fixes an issue with `Column.unique` where the type-metadata wasn't being preserved in the end before returning the unique values. This lead to `IntervalColumn` being returned as a `StructColumn`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
