### PR TITLE
Add pandas compatible output to `Series.unique`

### DIFF
--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2970,6 +2970,8 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         dtype: object
         """
         res = self._column.unique()
+        if cudf.get_option("mode.pandas_compatible"):
+            return res.values
         return Series(res, name=self.name)
 
     @_cudf_nvtx_annotate

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -2254,3 +2254,12 @@ def test_series_nlargest_nsmallest_str_error(attr):
     assert_exceptions_equal(
         getattr(gs, attr), getattr(ps, attr), ([], {"n": 1}), ([], {"n": 1})
     )
+
+
+def test_series_unique_pandas_compatibility():
+    gs = cudf.Series([10, 11, 12, 11, 10])
+    ps = gs.to_pandas()
+    with cudf.option_context("mode.pandas_compatible", True):
+        actual = gs.unique()
+    expected = ps.unique()
+    assert_eq(actual, expected)


### PR DESCRIPTION
## Description
Partially addresses #8175
This PR makes changes to `Series.unique`, where a cupy array is returned to match `pd.Series.unique` where a numpy array is returned.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
