### PR TITLE
Add `bytes_per_second` to hash_partition benchmark

### DIFF
--- a/cpp/benchmarks/hashing/partition.cpp
+++ b/cpp/benchmarks/hashing/partition.cpp
@@ -43,6 +43,13 @@ void BM_hash_partition(benchmark::State& state)
     cuda_event_timer timer(state, true);
     auto output = cudf::hash_partition(input, columns_to_hash, num_partitions);
   }
+
+  auto const bytes_read      = num_rows * num_cols * sizeof(T);
+  auto const bytes_written   = num_rows * num_cols * sizeof(T);
+  auto const partition_bytes = num_partitions * sizeof(cudf::size_type);
+
+  state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) *
+                          (bytes_read + bytes_written + partition_bytes));
 }
 
 BENCHMARK_DEFINE_F(Hashing, hash_partition)


### PR DESCRIPTION
Adds `bytes_per_second` to the `PARTITION_BENCH` benchmark.

This patch relates to #13735.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
