### PR TITLE
Enable `codes` dtype parity in pandas-compatibility mode for `factorize` API

### DIFF
--- a/python/cudf/cudf/core/algorithms.py
+++ b/python/cudf/cudf/core/algorithms.py
@@ -9,6 +9,7 @@ from cudf.core.index import Index, RangeIndex
 from cudf.core.indexed_frame import IndexedFrame
 from cudf.core.scalar import Scalar
 from cudf.core.series import Series
+from cudf.options import get_option
 
 
 def factorize(
@@ -137,7 +138,9 @@ def factorize(
         cats = cats.sort_values()
 
     labels = values._column._label_encoding(
-        cats=cats, na_sentinel=Scalar(na_sentinel)
+        cats=cats,
+        na_sentinel=Scalar(na_sentinel),
+        dtype="int64" if get_option("mode.pandas_compatible") else None,
     ).values
 
     return labels, cats.values if return_cupy_array else Index(cats)

--- a/python/cudf/cudf/tests/test_factorize.py
+++ b/python/cudf/cudf/tests/test_factorize.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 import cupy as cp
 import numpy as np
@@ -120,6 +120,23 @@ def test_cudf_factorize_array():
 
     np.testing.assert_array_equal(expect[0], got[0].get())
     np.testing.assert_array_equal(expect[1], got[1].get())
+
+
+@pytest.mark.parametrize("pandas_compatibility", [True, False])
+def test_factorize_code_pandas_compatibility(pandas_compatibility):
+
+    psr = pd.Series([1, 2, 3, 4, 5])
+    gsr = cudf.from_pandas(psr)
+
+    expect = pd.factorize(psr)
+    with cudf.option_context("mode.pandas_compatible", pandas_compatibility):
+        got = cudf.factorize(gsr)
+    assert_eq(got[0], expect[0])
+    assert_eq(got[1], expect[1])
+    if pandas_compatibility:
+        assert got[0].dtype == expect[0].dtype
+    else:
+        assert got[0].dtype == cudf.dtype("int8")
 
 
 def test_factorize_result_classes():


### PR DESCRIPTION
## Description
closes #13981 

This PR enables parity with pandas `factorize` API by returning `codes` with `int64` dtype only in pandas-compatibility mode. When the pandas-compatibility mode is turned off, `cudf` will calculate the appropriate dtype that needs to be returned to save memory usage.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
