### PR TITLE
Add `bytes_per_second` to groupby max benchmark.

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -40,8 +40,9 @@ target_include_directories(
 
 # Use an OBJECT library so we only compile these helper source files only once
 add_library(
-  cudf_benchmark_common OBJECT "${CUDF_SOURCE_DIR}/tests/utilities/base_fixture.cpp"
-                               synchronization/synchronization.cpp io/cuio_common.cpp
+  cudf_benchmark_common OBJECT
+  "${CUDF_SOURCE_DIR}/tests/utilities/base_fixture.cpp" synchronization/synchronization.cpp
+  io/cuio_common.cpp common/memory_statistics.cpp
 )
 target_link_libraries(cudf_benchmark_common PRIVATE cudf_datagen $<TARGET_NAME_IF_EXISTS:conda_env>)
 add_custom_command(

--- a/cpp/benchmarks/common/memory_statistics.cpp
+++ b/cpp/benchmarks/common/memory_statistics.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "memory_statistics.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/dictionary/dictionary_column_view.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+
+#include <numeric>
+
+namespace {
+
+/**
+ * @brief Calculate the payload size of a string column.
+ */
+inline uint64_t required_bytes_string(const cudf::column_view& column)
+{
+  CUDF_EXPECTS(column.type().id() == cudf::type_id::STRING, "Input not a STRING column");
+  cudf::strings_column_view input(column);
+
+  uint64_t num_bytes = input.chars_size();
+  if (column.nullable()) { num_bytes += cudf::bitmask_allocation_size_bytes(column.size()); }
+  return num_bytes;
+}
+
+/**
+ * @brief Calculate the payload size of a struct column.
+ */
+inline uint64_t required_bytes_struct(const cudf::column_view& column)
+{
+  CUDF_EXPECTS(column.type().id() == cudf::type_id::STRUCT, "Input not a STRUCT column");
+
+  uint64_t num_bytes =
+    std::accumulate(column.child_begin(), column.child_end(), 0, [](uint64_t acc, const auto& col) {
+      return acc + required_bytes(col);
+    });
+  if (column.nullable()) { num_bytes += cudf::bitmask_allocation_size_bytes(column.size()); }
+  return num_bytes;
+}
+
+/**
+ * @brief Calculate the payload size of a list column.
+ */
+inline uint64_t required_bytes_list(const cudf::column_view& column)
+{
+  CUDF_EXPECTS(column.type().id() == cudf::type_id::LIST, "Input not a LIST column");
+
+  uint64_t num_bytes =
+    std::accumulate(column.child_begin(), column.child_end(), 0, [](uint64_t acc, const auto& col) {
+      return acc + required_bytes(col);
+    });
+  if (column.nullable()) { num_bytes += cudf::bitmask_allocation_size_bytes(column.size()); }
+  return num_bytes;
+}
+
+/**
+ * @brief Calculate the payload size of a dict column.
+ */
+inline uint64_t required_bytes_dict(const cudf::column_view& column)
+{
+  CUDF_EXPECTS(column.type().id() == cudf::type_id::DICTIONARY32,
+               "Input not a DICTIONARY32 column");
+
+  cudf::dictionary_column_view input(column);
+  uint64_t num_bytes = required_bytes(input.keys());
+  num_bytes += required_bytes(input.indices());
+  if (column.nullable()) { num_bytes += cudf::bitmask_allocation_size_bytes(column.size()); }
+  return num_bytes;
+}
+
+/**
+ * @brief Calculate the payload size of a column containing fixed width types.
+ */
+inline uint64_t required_bytes_fixed_width_type(const cudf::column_view& column)
+{
+  CUDF_EXPECTS(cudf::is_fixed_width(column.type()), "Invalid element type");
+
+  uint64_t num_bytes = column.size() * cudf::size_of(column.type());
+  if (column.nullable()) { num_bytes += cudf::bitmask_allocation_size_bytes(column.size()); }
+  return num_bytes;
+}
+
+}  // namespace
+
+uint64_t required_bytes(const cudf::column_view& column)
+{
+  uint64_t num_bytes = 0;
+
+  switch (column.type().id()) {
+    case cudf::type_id::STRING: num_bytes = required_bytes_string(column); break;
+    case cudf::type_id::STRUCT: num_bytes = required_bytes_struct(column); break;
+    case cudf::type_id::LIST: num_bytes = required_bytes_list(column); break;
+    case cudf::type_id::DICTIONARY32: num_bytes = required_bytes_dict(column); break;
+    default: num_bytes = required_bytes_fixed_width_type(column);
+  }
+
+  return num_bytes;
+}
+
+uint64_t required_bytes(const cudf::table_view& table)
+{
+  return std::accumulate(table.begin(), table.end(), 0, [](uint64_t acc, const auto& col) {
+    return acc + required_bytes(col);
+  });
+}
+
+uint64_t required_bytes(
+  const cudf::host_span<cudf::groupby::aggregation_result>& aggregation_results)
+{
+  uint64_t read_bytes = 0;
+
+  for (auto const& aggregation : aggregation_results) {  // vector of aggregation results
+    for (auto const& col : aggregation.results) {        // vector of columns per result
+      read_bytes += required_bytes(col->view());
+    }
+  }
+
+  return read_bytes;
+}

--- a/cpp/benchmarks/common/memory_statistics.hpp
+++ b/cpp/benchmarks/common/memory_statistics.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/groupby.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/span.hpp>
+
+/**
+ * @brief Calculate the number of bytes needed to completely read/write the provided column.
+ *
+ * The functions computes only the size of the payload of the column in bytes, it excludes
+ * any metadata.
+ *
+ * @param column View of the input column
+ * @returns Number of bytes needed to read or write the column.
+ */
+uint64_t required_bytes(const cudf::column_view& column);
+
+/**
+ * @brief Calculate the number of bytes needed to completely read/write the provided table.
+ *
+ * The functions computes only the size of the payload of the table in bytes, it excludes
+ * any metadata.
+ *
+ * @param table View of the input table.
+ * @returns Number of bytes needed to read or write the table.
+ */
+uint64_t required_bytes(const cudf::table_view& table);
+
+/**
+ * @brief Calculate the number of bytes needed to completely read/write the provided sequence of
+ * aggregation results.
+ *
+ * The functions computes only the size of the payload of the aggregation results in bytes, it
+ * excludes any metadata.
+ *
+ * @param aggregation_results Sequence of aggregation results from groupby execution.
+ * @returns Number of bytes needed to read or write the aggregation results.
+ */
+uint64_t required_bytes(
+  const cudf::host_span<cudf::groupby::aggregation_result>& aggregation_results);


### PR DESCRIPTION
This patch adds memory statistics for the `GROUPBY_NVBENCH` benchmark using the `max` aggregation.

For this purpose helper functions are introduced to compute the payload size for:
  - Column
  - Table
  - Groupby execution results

This patch relates to #13735.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
