### PR TITLE
Add tab as literal to cudf::test::to_string output

### DIFF
--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -1099,10 +1099,13 @@ struct column_view_printer {
           out.replace(pos, 1, repl);
         }
       };
+      replace_char(out, '\a', "\\a");
       replace_char(out, '\b', "\\b");
-      replace_char(out, '\t', "\\t");
+      replace_char(out, '\f', "\\f");
       replace_char(out, '\r', "\\r");
+      replace_char(out, '\t', "\\t");
       replace_char(out, '\n', "\\n");
+      replace_char(out, '\v', "\\v");
       return out;
     };
 

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -1091,7 +1091,7 @@ struct column_view_printer {
     if (col.is_empty()) return;
     auto h_data = cudf::test::to_host<std::string>(col);
 
-    // explicitly replace '\r' and '\n' characters with "\r" and "\n" strings respectively.
+    // explicitly replace some special whitespace characters with their literal equivalents
     auto cleaned = [](std::string_view in) {
       std::string out(in);
       auto replace_char = [](std::string& out, char c, std::string_view repl) {
@@ -1099,6 +1099,8 @@ struct column_view_printer {
           out.replace(pos, 1, repl);
         }
       };
+      replace_char(out, '\b', "\\b");
+      replace_char(out, '\t', "\\t");
       replace_char(out, '\r', "\\r");
       replace_char(out, '\n', "\\n");
       return out;

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -274,6 +274,14 @@ TEST_F(ColumnUtilitiesStringsTest, StringsToString)
   EXPECT_EQ(cudf::test::to_string(strings, delimiter), tmp.str());
 }
 
+TEST_F(ColumnUtilitiesStringsTest, PrintEscapeStrings)
+{
+  char const* delimiter = ",";
+  cudf::test::strings_column_wrapper input({"e\te\ne", "é\bé\ré"});
+  std::string expected{"e\\te\\ne,é\\bé\\ré"};
+  EXPECT_EQ(cudf::test::to_string(input, delimiter), expected);
+}
+
 TYPED_TEST(ColumnUtilitiesTestFixedPoint, NonNullableToHost)
 {
   using namespace numeric;

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -277,8 +277,8 @@ TEST_F(ColumnUtilitiesStringsTest, StringsToString)
 TEST_F(ColumnUtilitiesStringsTest, PrintEscapeStrings)
 {
   char const* delimiter = ",";
-  cudf::test::strings_column_wrapper input({"e\te\ne", "é\bé\ré"});
-  std::string expected{"e\\te\\ne,é\\bé\\ré"};
+  cudf::test::strings_column_wrapper input({"e\te\ne", "é\bé\ré", "e\vé\fé\abell"});
+  std::string expected{"e\\te\\ne,é\\bé\\ré,e\\vé\\fé\\abell"};
   EXPECT_EQ(cudf::test::to_string(input, delimiter), expected);
 }
 


### PR DESCRIPTION
## Description
Adds escaped `\\t` to the `cudf::test::to_string()` output.
Found this while working on #13891 where the output included tabs but was shown as a various number of spaces in the console when using `cudf::test::print()`.
Also added `\\b` for good measure as well as a gtest for all the supported escape sequences.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
