### PR TITLE
Fix an issue where casting null-array to `object` dtype will result in a failure

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1996,30 +1996,27 @@ def as_column(
         col = ColumnBase.from_arrow(arbitrary)
 
         if isinstance(arbitrary, pa.NullArray):
-            new_dtype = cudf.dtype(arbitrary.type.to_pandas_dtype())
             if dtype is not None:
                 # Cast the column to the `dtype` if specified.
-                cast_to_dtype = dtype
+                new_dtype = dtype
             elif len(arbitrary) == 0:
                 # If the column is empty, it has to be
                 # a `float64` dtype.
-                cast_to_dtype = cudf.dtype("float64")
+                new_dtype = cudf.dtype("float64")
             else:
                 # If the null column is not empty, it has to
                 # be of `object` dtype.
-                cast_to_dtype = new_dtype
+                new_dtype = cudf.dtype(arbitrary.type.to_pandas_dtype())
 
             if cudf.get_option("mode.pandas_compatible"):
                 # We internally raise if we do `astype("object")`, hence
                 # need to cast to `str` since this is safe to do so because
                 # it is a null-array.
-                cast_to_dtype = (
-                    "str"
-                    if cast_to_dtype == cudf.dtype("O")
-                    else cast_to_dtype
+                new_dtype = (
+                    "str" if new_dtype == cudf.dtype("O") else new_dtype
                 )
 
-            col = col.astype(cast_to_dtype)
+            col = col.astype(new_dtype)
 
         return col
 

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2008,13 +2008,13 @@ def as_column(
                 # be of `object` dtype.
                 new_dtype = cudf.dtype(arbitrary.type.to_pandas_dtype())
 
-            if cudf.get_option("mode.pandas_compatible"):
+            if cudf.get_option(
+                "mode.pandas_compatible"
+            ) and new_dtype == cudf.dtype("O"):
                 # We internally raise if we do `astype("object")`, hence
                 # need to cast to `str` since this is safe to do so because
                 # it is a null-array.
-                new_dtype = (
-                    "str" if new_dtype == cudf.dtype("O") else new_dtype
-                )
+                new_dtype = "str"
 
             col = col.astype(new_dtype)
 

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -1889,3 +1889,10 @@ def test_multiindex_levels():
 
     assert_eq(gidx.levels[0], pidx.levels[0])
     assert_eq(gidx.levels[1], pidx.levels[1])
+
+
+def test_multiindex_empty_slice_pandas_compatibility():
+    expected = pd.MultiIndex.from_tuples([("a", "b")])[:0]
+    with cudf.option_context("mode.pandas_compatible", True):
+        actual = cudf.from_pandas(expected)
+    assert_eq(expected, actual)

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -1895,4 +1895,4 @@ def test_multiindex_empty_slice_pandas_compatibility():
     expected = pd.MultiIndex.from_tuples([("a", "b")])[:0]
     with cudf.option_context("mode.pandas_compatible", True):
         actual = cudf.from_pandas(expected)
-    assert_eq(expected, actual)
+    assert_eq(expected, actual, exact=False)


### PR DESCRIPTION
## Description
closes #13992 

This PR fixes the construction of an empty `MultiIndex` from `pandas` to `cudf` was causing an error in pandas-compatibility mode, null-array is one such case where it is _okay_ to cast to any type because there is no data in it. Hence we pass `str` dtype to `astype`, whenever we encounter an `object` dtype.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
