### PR TITLE
Add stream parameter to public cudf::strings::split APIs

### DIFF
--- a/cpp/include/cudf/strings/split/split.hpp
+++ b/cpp/include/cudf/strings/split/split.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,18 +43,20 @@ namespace strings {
  *
  * Any null string entries return corresponding null output columns.
  *
- * @param strings_column Strings instance for this operation.
- * @param delimiter UTF-8 encoded string indicating the split points in each string.
+ * @param strings_column Strings instance for this operation
+ * @param delimiter UTF-8 encoded string indicating the split points in each string;
  *        Default of empty string indicates split on whitespace.
- * @param maxsplit Maximum number of splits to perform.
+ * @param maxsplit Maximum number of splits to perform;
  *        Default of -1 indicates all possible splits on each string.
- * @param mr Device memory resource used to allocate the returned table's device memory.
- * @return New table of strings columns.
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned table's device memory
+ * @return New table of strings columns
  */
 std::unique_ptr<table> split(
   strings_column_view const& strings_column,
   string_scalar const& delimiter      = string_scalar(""),
   size_type maxsplit                  = -1,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -71,18 +73,20 @@ std::unique_ptr<table> split(
  *
  * Any null string entries return corresponding null output columns.
  *
- * @param strings_column Strings instance for this operation.
- * @param delimiter UTF-8 encoded string indicating the split points in each string.
+ * @param strings_column Strings instance for this operation
+ * @param delimiter UTF-8 encoded string indicating the split points in each string;
  *        Default of empty string indicates split on whitespace.
- * @param maxsplit Maximum number of splits to perform.
+ * @param maxsplit Maximum number of splits to perform;
  *        Default of -1 indicates all possible splits on each string.
- * @param mr Device memory resource used to allocate the returned table's device memory.
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned table's device memory
  * @return New strings columns.
  */
 std::unique_ptr<table> rsplit(
   strings_column_view const& strings_column,
   string_scalar const& delimiter      = string_scalar(""),
   size_type maxsplit                  = -1,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -141,20 +145,22 @@ std::unique_ptr<table> rsplit(
  *
  * @throw cudf:logic_error if `delimiter` is invalid.
  *
- * @param strings A column of string elements to be split.
- * @param delimiter The string to identify split points in each string.
+ * @param strings A column of string elements to be split
+ * @param delimiter The string to identify split points in each string;
  *        Default of empty string indicates split on whitespace.
- * @param maxsplit Maximum number of splits to perform.
- *        Default of -1 indicates all possible splits on each string.
- * @param mr Device memory resource used to allocate the returned result's device memory.
- * @return Lists column of strings
- *         Each vector of the lists column holds splits from a single row
+ * @param maxsplit Maximum number of splits to perform;
+ *        Default of -1 indicates all possible splits on each string
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned result's device memory
+ * @return Lists column of strings;
+ *         Each row of the lists column holds splits from a single row
  *         element of the input column.
  */
 std::unique_ptr<column> split_record(
   strings_column_view const& strings,
   string_scalar const& delimiter      = string_scalar(""),
   size_type maxsplit                  = -1,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
@@ -218,20 +224,22 @@ std::unique_ptr<column> split_record(
  *
  * @throw cudf:logic_error if `delimiter` is invalid.
  *
- * @param strings A column of string elements to be split.
- * @param delimiter The string to identify split points in each string.
+ * @param strings A column of string elements to be split
+ * @param delimiter The string to identify split points in each string;
  *        Default of empty string indicates split on whitespace.
- * @param maxsplit Maximum number of splits to perform.
- *        Default of -1 indicates all possible splits on each string.
- * @param mr Device memory resource used to allocate the returned result's device memory.
- * @return Lists column of strings
- *         Each vector of the lists column holds splits from a single row
+ * @param maxsplit Maximum number of splits to perform;
+ *        Default of -1 indicates all possible splits on each string
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned result's device memory
+ * @return Lists column of strings;
+ *         Each row of the lists column holds splits from a single row
  *         element of the input column.
  */
 std::unique_ptr<column> rsplit_record(
   strings_column_view const& strings,
   string_scalar const& delimiter      = string_scalar(""),
   size_type maxsplit                  = -1,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of doxygen group

--- a/cpp/src/strings/split/split.cu
+++ b/cpp/src/strings/split/split.cu
@@ -431,19 +431,21 @@ std::unique_ptr<table> rsplit(strings_column_view const& strings_column,
 std::unique_ptr<table> split(strings_column_view const& strings_column,
                              string_scalar const& delimiter,
                              size_type maxsplit,
+                             rmm::cuda_stream_view stream,
                              rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::split(strings_column, delimiter, maxsplit, cudf::get_default_stream(), mr);
+  return detail::split(strings_column, delimiter, maxsplit, stream, mr);
 }
 
 std::unique_ptr<table> rsplit(strings_column_view const& strings_column,
                               string_scalar const& delimiter,
                               size_type maxsplit,
+                              rmm::cuda_stream_view stream,
                               rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::rsplit(strings_column, delimiter, maxsplit, cudf::get_default_stream(), mr);
+  return detail::rsplit(strings_column, delimiter, maxsplit, stream, mr);
 }
 
 }  // namespace strings

--- a/cpp/src/strings/split/split_record.cu
+++ b/cpp/src/strings/split/split_record.cu
@@ -203,21 +203,22 @@ std::unique_ptr<column> split_record(strings_column_view const& strings,
 std::unique_ptr<column> split_record(strings_column_view const& strings,
                                      string_scalar const& delimiter,
                                      size_type maxsplit,
+                                     rmm::cuda_stream_view stream,
                                      rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::split_record<detail::Direction::FORWARD>(
-    strings, delimiter, maxsplit, cudf::get_default_stream(), mr);
+  return detail::split_record<detail::Direction::FORWARD>(strings, delimiter, maxsplit, stream, mr);
 }
 
 std::unique_ptr<column> rsplit_record(strings_column_view const& strings,
                                       string_scalar const& delimiter,
                                       size_type maxsplit,
+                                      rmm::cuda_stream_view stream,
                                       rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
   return detail::split_record<detail::Direction::BACKWARD>(
-    strings, delimiter, maxsplit, cudf::get_default_stream(), mr);
+    strings, delimiter, maxsplit, stream, mr);
 }
 
 }  // namespace strings


### PR DESCRIPTION
## Description
Adds a `stream` parameter to the libcudf `cudf:strings::split(), cudf:strings::rsplit(), cudf:strings::split_record(), cudf:strings::rsplit_record()` APIs.
Change needed for work in #13891 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
