### PR TITLE
Raise an error when timezone subtypes are encountered in `pd.IntervalDtype`

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2252,8 +2252,12 @@ def as_column(
         data = ColumnBase.from_scalar(arbitrary, length if length else 1)
     elif isinstance(arbitrary, pd.core.arrays.masked.BaseMaskedArray):
         data = as_column(pa.Array.from_pandas(arbitrary), dtype=dtype)
-    elif isinstance(arbitrary, pd.DatetimeIndex) and isinstance(
-        arbitrary.dtype, pd.DatetimeTZDtype
+    elif (
+        isinstance(arbitrary, pd.DatetimeIndex)
+        and isinstance(arbitrary.dtype, pd.DatetimeTZDtype)
+    ) or (
+        isinstance(arbitrary, pd.IntervalIndex)
+        and is_datetime64tz_dtype(arbitrary.dtype.subtype)
     ):
         raise NotImplementedError(
             "cuDF does not yet support timezone-aware datetimes"

--- a/python/cudf/cudf/tests/test_interval.py
+++ b/python/cudf/cudf/tests/test_interval.py
@@ -165,3 +165,19 @@ def test_interval_index_unique():
     actual = gi.unique()
 
     assert_eq(expected, actual)
+
+
+@pytest.mark.parametrize("tz", ["US/Eastern", None])
+def test_interval_with_datetime(tz):
+    dti = pd.date_range(
+        start=pd.Timestamp("20180101", tz=tz),
+        end=pd.Timestamp("20181231", tz=tz),
+        freq="M",
+    )
+    pidx = pd.IntervalIndex.from_breaks(dti)
+    if tz is None:
+        gidx = cudf.from_pandas(pidx)
+        assert_eq(pidx, gidx)
+    else:
+        with pytest.raises(NotImplementedError):
+            cudf.from_pandas(pidx)


### PR DESCRIPTION
## Description
closes #14004 

This PR raises an error when an `IntervalIndex` contains a timezone-aware sub-type so that we don't go into infinite recursion.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
