### PR TITLE
Explicitly depend on zlib in conda recipes

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -95,7 +95,7 @@ dependencies:
 - tokenizers==0.13.1
 - transformers==4.24.0
 - typing_extensions>=4.0.0
-- zlib
+- zlib>=1.2.13
 - pip:
   - git+https://github.com/python-streamz/streamz.git@master
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -95,6 +95,7 @@ dependencies:
 - tokenizers==0.13.1
 - transformers==4.24.0
 - typing_extensions>=4.0.0
+- zlib
 - pip:
   - git+https://github.com/python-streamz/streamz.git@master
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -92,7 +92,7 @@ dependencies:
 - tokenizers==0.13.1
 - transformers==4.24.0
 - typing_extensions>=4.0.0
-- zlib
+- zlib>=1.2.13
 - pip:
   - git+https://github.com/python-streamz/streamz.git@master
 name: all_cuda-120_arch-x86_64

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -92,6 +92,7 @@ dependencies:
 - tokenizers==0.13.1
 - transformers==4.24.0
 - typing_extensions>=4.0.0
+- zlib
 - pip:
   - git+https://github.com/python-streamz/streamz.git@master
 name: all_cuda-120_arch-x86_64

--- a/conda/recipes/libcudf/conda_build_config.yaml
+++ b/conda/recipes/libcudf/conda_build_config.yaml
@@ -40,6 +40,8 @@ spdlog_version:
 nvcomp_version:
   - "=2.6.1"
 
+zlib_version:
+  - ">=1.2.13"
 # The CTK libraries below are missing from the conda-forge::cudatoolkit package
 # for CUDA 11. The "*_host_*" version specifiers correspond to `11.8` packages
 # and the "*_run_*" version specifiers correspond to `11.x` packages.

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -73,7 +73,7 @@ requirements:
     - benchmark {{ gbench_version }}
     - gtest {{ gtest_version }}
     - gmock {{ gtest_version }}
-    - zlib
+    - zlib {{ zlib_version }}
 
 outputs:
   - name: libcudf

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -45,6 +45,7 @@ requirements:
     - cuda-version ={{ cuda_version }}
     - ninja
     - sysroot_{{ target_platform }} {{ sysroot_version }}
+    - zlib
   host:
     - librmm ={{ minor_version }}
     - libkvikio ={{ minor_version }}
@@ -90,6 +91,7 @@ outputs:
     requirements:
       build:
         - cmake {{ cmake_version }}
+        - zlib
       run:
         {% if cuda_major == "11" %}
         - cudatoolkit

--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -45,7 +45,6 @@ requirements:
     - cuda-version ={{ cuda_version }}
     - ninja
     - sysroot_{{ target_platform }} {{ sysroot_version }}
-    - zlib
   host:
     - librmm ={{ minor_version }}
     - libkvikio ={{ minor_version }}
@@ -74,6 +73,7 @@ requirements:
     - benchmark {{ gbench_version }}
     - gtest {{ gtest_version }}
     - gmock {{ gtest_version }}
+    - zlib
 
 outputs:
   - name: libcudf
@@ -91,7 +91,6 @@ outputs:
     requirements:
       build:
         - cmake {{ cmake_version }}
-        - zlib
       run:
         {% if cuda_major == "11" %}
         - cudatoolkit

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -179,6 +179,7 @@ dependencies:
           - c-compiler
           - cxx-compiler
           - dlpack>=0.5,<0.6.0a0
+          - zlib
     specific:
       - output_types: conda
         matrices:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -179,7 +179,7 @@ dependencies:
           - c-compiler
           - cxx-compiler
           - dlpack>=0.5,<0.6.0a0
-          - zlib
+          - zlib>=1.2.13
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
## Description

We were previously obtaining zlib transitively through our cmake dependency, but since the 3.27.4 conda package, this dependency no longer exists. Therefore we must depend on zlib ourselves.

- Closes #14021 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
