### PR TITLE
Fix typo in docstring: metadata.

### DIFF
--- a/cpp/include/cudf/contiguous_split.hpp
+++ b/cpp/include/cudf/contiguous_split.hpp
@@ -28,7 +28,7 @@ namespace cudf {
  * @addtogroup column_copy
  * @{
  * @file
- * @brief Table APIs for contiguous_split, pack, unpack, and metadadata
+ * @brief Table APIs for contiguous_split, pack, unpack, and metadata
  */
 
 /**


### PR DESCRIPTION
## Description
Fix for a typo in a docstring for `contiguous_split`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
