### PR TITLE
Raise NotImplementedError for Categoricals with timezones

### DIFF
--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2095,6 +2095,8 @@ def test_construction_from_tz_timestamps(data):
         _ = cudf.Index(data)
     with pytest.raises(NotImplementedError):
         _ = cudf.DatetimeIndex(data)
+    with pytest.raises(NotImplementedError):
+        cudf.CategoricalIndex(data)
 
 
 @pytest.mark.parametrize("op", _cmpops)

--- a/python/cudf/cudf/tests/test_interval.py
+++ b/python/cudf/cudf/tests/test_interval.py
@@ -167,17 +167,18 @@ def test_interval_index_unique():
     assert_eq(expected, actual)
 
 
+@pytest.mark.parametrize("box", [pd.Series, pd.IntervalIndex])
 @pytest.mark.parametrize("tz", ["US/Eastern", None])
-def test_interval_with_datetime(tz):
+def test_interval_with_datetime(tz, box):
     dti = pd.date_range(
         start=pd.Timestamp("20180101", tz=tz),
         end=pd.Timestamp("20181231", tz=tz),
         freq="M",
     )
-    pidx = pd.IntervalIndex.from_breaks(dti)
+    pobj = box(pd.IntervalIndex.from_breaks(dti))
     if tz is None:
-        gidx = cudf.from_pandas(pidx)
-        assert_eq(pidx, gidx)
+        gobj = cudf.from_pandas(pobj)
+        assert_eq(pobj, gobj)
     else:
         with pytest.raises(NotImplementedError):
-            cudf.from_pandas(pidx)
+            cudf.from_pandas(pobj)


### PR DESCRIPTION
## Description
Currently `cudf.from_pandas` with a pandas Categorical with datetimetz type will drop the timezone information (due to pyarrow)

```python
In [5]: import pandas as pd

In [6]: ci = pd.CategoricalIndex(pd.date_range("2016-01-01 01:01:00", periods=5, freq="D").tz_localize("UTC"))

In [7]: ci
Out[7]: 
CategoricalIndex(['2016-01-01 01:01:00+00:00', '2016-01-02 01:01:00+00:00',
                  '2016-01-03 01:01:00+00:00', '2016-01-04 01:01:00+00:00',
                  '2016-01-05 01:01:00+00:00'],
                 categories=[2016-01-01 01:01:00+00:00, 2016-01-02 01:01:00+00:00, 2016-01-03 01:01:00+00:00, 2016-01-04 01:01:00+00:00, 2016-01-05 01:01:00+00:00], ordered=False, dtype='category')

In [8]: ci_cudf = cudf.from_pandas(ci)

In [10]: ci_cudf
Out[10]: 
CategoricalIndex(['2016-01-01 01:01:00', '2016-01-02 01:01:00',
                  '2016-01-03 01:01:00', '2016-01-04 01:01:00',
                  '2016-01-05 01:01:00'],
                 categories=[2016-01-01 01:01:00, 2016-01-02 01:01:00, 2016-01-03 01:01:00, 2016-01-04 01:01:00, 2016-01-05 01:01:00], ordered=False, dtype='category')
```

Like what is done with `IntervalIndex`, raises a `NotImplementedError` for now to avoid this wrong behavior.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
