### PR TITLE
Raise NotImplementedError for to_datetime with z format

### DIFF
--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -147,8 +147,13 @@ def to_datetime(
     if utc:
         raise NotImplementedError("utc is not yet implemented")
 
-    if format is not None and "%f" in format:
-        format = format.replace("%f", "%9f")
+    if format is not None:
+        if "%Z" in format or "%z" in format:
+            raise NotImplementedError(
+                "cuDF does not yet support timezone-aware datetimes"
+            )
+        elif "%f" in format:
+            format = format.replace("%f", "%9f")
 
     try:
         if isinstance(arg, cudf.DataFrame):

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2154,5 +2154,5 @@ def test_daterange_pandas_compatibility():
 def test_format_timezone_not_implemented(code):
     with pytest.raises(NotImplementedError):
         cudf.to_datetime(
-            ["2020-01-01 00:00:00 UTC"], format=f"%Y-%m-%d %H-%M-%S %{code}"
+            ["2020-01-01 00:00:00 UTC"], format=f"%Y-%m-%d %H:%M:%S %{code}"
         )

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2148,3 +2148,11 @@ def test_daterange_pandas_compatibility():
             "2010-01-01", "2010-02-01", periods=10, name="times"
         )
     assert_eq(expected, actual)
+
+
+@pytest.mark.parametrize("code", ["z", "Z"])
+def test_format_timezone_not_implemented(code):
+    with pytest.raises(NotImplementedError):
+        cudf.to_datetime(
+            ["2020-01-01 00:00:00 UTC"], format=f"%Y-%m-%d %H-%M-%S %{code}"
+        )


### PR DESCRIPTION
## Description
Avoids timezone information from being dropped in `to_datetime` when the z directive is provided

```python
In [1]: import cudf

In [2]: fmt = '%Y-%m-%d %H:%M:%S %Z'
   ...: dates = ['2010-01-01 12:00:00 UTC', '2010-01-01 12:00:00 UTC']

In [3]: cudf.to_datetime(dates, format=fmt)
Out[3]: DatetimeIndex(['2010-01-01 12:00:00', '2010-01-01 12:00:00'], dtype='datetime64[ns]')
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
