### PR TITLE
Raise TypeError for any non-parseable argument in to_datetime

### DIFF
--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -294,12 +294,8 @@ def to_datetime(
 def _process_col(col, unit, dayfirst, infer_datetime_format, format):
     if col.dtype.kind == "M":
         return col
-    elif col.dtype.kind == "m":
-        raise TypeError(
-            f"dtype {col.dtype} cannot be converted to {_unit_dtype_map[unit]}"
-        )
 
-    if col.dtype.kind in ("f"):
+    elif col.dtype.kind in ("f"):
         if unit not in (None, "ns"):
             factor = cudf.Scalar(
                 column.datetime._unit_to_nanoseconds_conversion[unit]
@@ -325,8 +321,9 @@ def _process_col(col, unit, dayfirst, infer_datetime_format, format):
             )
         else:
             col = col.as_datetime_column(dtype="datetime64[ns]")
+        return col
 
-    if col.dtype.kind in ("i"):
+    elif col.dtype.kind in ("i"):
         if unit in ("D", "h", "m"):
             factor = cudf.Scalar(
                 column.datetime._unit_to_nanoseconds_conversion[unit]
@@ -340,6 +337,7 @@ def _process_col(col, unit, dayfirst, infer_datetime_format, format):
             )
         else:
             col = col.as_datetime_column(dtype=_unit_dtype_map[unit])
+        return col
 
     elif col.dtype.kind in ("O"):
         if unit not in (None, "ns") or col.null_count == len(col):
@@ -364,11 +362,13 @@ def _process_col(col, unit, dayfirst, infer_datetime_format, format):
                 format = column.datetime.infer_format(
                     element=col.element_indexing(0)
                 )
-            col = col.as_datetime_column(
+            return col.as_datetime_column(
                 dtype=_unit_dtype_map[unit],
                 format=format,
             )
-    return col
+    raise TypeError(
+        f"dtype {col.dtype} cannot be converted to {_unit_dtype_map[unit]}"
+    )
 
 
 def get_units(value):

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2156,3 +2156,9 @@ def test_format_timezone_not_implemented(code):
         cudf.to_datetime(
             ["2020-01-01 00:00:00 UTC"], format=f"%Y-%m-%d %H:%M:%S %{code}"
         )
+
+
+@pytest.mark.parametrize("arg", [True, False])
+def test_args_not_datetime_typerror(arg):
+    with pytest.raises(TypeError):
+        cudf.to_datetime([arg])


### PR DESCRIPTION
## Description
Avoids the following incorrect behavior

```python
In [7]: cudf.to_datetime([True])
Out[7]: GenericIndex([True], dtype='bool')

In [1]: import pandas

In [2]: pandas.to_datetime([True])
TypeError: <class 'bool'> is not convertible to datetime
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
