### PR TITLE
Fix empty string column construction

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2434,6 +2434,24 @@ def as_column(
                 )
 
                 if (
+                    isinstance(pyarrow_array, pa.NullArray)
+                    and pa_type is None
+                    and dtype is None
+                ):
+                    if getattr(arbitrary, "dtype", None) == cudf.dtype(
+                        "object"
+                    ):
+                        # pa.array constructor returns a NullArray
+                        # for empty arrays, instead of a StringArray.
+                        # This issue is only specific to this dtype,
+                        # all other dtypes, result in their corresponding
+                        # arrow array creation.
+                        dtype = cudf.dtype("str")
+                        pyarrow_array = pyarrow_array.cast(
+                            np_to_pa_dtype(dtype)
+                        )
+
+                if (
                     isinstance(arbitrary, pd.Index)
                     and arbitrary.dtype == cudf.dtype("object")
                     and isinstance(

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2437,19 +2437,16 @@ def as_column(
                     isinstance(pyarrow_array, pa.NullArray)
                     and pa_type is None
                     and dtype is None
+                    and getattr(arbitrary, "dtype", None)
+                    == cudf.dtype("object")
                 ):
-                    if getattr(arbitrary, "dtype", None) == cudf.dtype(
-                        "object"
-                    ):
-                        # pa.array constructor returns a NullArray
-                        # for empty arrays, instead of a StringArray.
-                        # This issue is only specific to this dtype,
-                        # all other dtypes, result in their corresponding
-                        # arrow array creation.
-                        dtype = cudf.dtype("str")
-                        pyarrow_array = pyarrow_array.cast(
-                            np_to_pa_dtype(dtype)
-                        )
+                    # pa.array constructor returns a NullArray
+                    # for empty arrays, instead of a StringArray.
+                    # This issue is only specific to this dtype,
+                    # all other dtypes, result in their corresponding
+                    # arrow array creation.
+                    dtype = cudf.dtype("str")
+                    pyarrow_array = pyarrow_array.cast(np_to_pa_dtype(dtype))
 
                 if (
                     isinstance(arbitrary, pd.Index)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -7256,10 +7256,7 @@ def test_dataframe_keys(df):
 def test_series_keys(ps):
     gds = cudf.from_pandas(ps)
 
-    if len(ps) == 0 and not isinstance(ps.index, pd.RangeIndex):
-        assert_eq(ps.keys().astype("float64"), gds.keys())
-    else:
-        assert_eq(ps.keys(), gds.keys())
+    assert_eq(ps.keys(), gds.keys())
 
 
 @pytest_unmark_spilling

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -20,13 +20,13 @@ from cudf.core.index import (
     as_index,
 )
 from cudf.testing._utils import (
+    ALL_TYPES,
     FLOAT_TYPES,
     NUMERIC_TYPES,
     OTHER_TYPES,
     SIGNED_INTEGER_TYPES,
     SIGNED_TYPES,
     UNSIGNED_TYPES,
-    ALL_TYPES,
     _create_pandas_series,
     assert_column_memory_eq,
     assert_column_memory_ne,

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -26,6 +26,7 @@ from cudf.testing._utils import (
     SIGNED_INTEGER_TYPES,
     SIGNED_TYPES,
     UNSIGNED_TYPES,
+    ALL_TYPES,
     _create_pandas_series,
     assert_column_memory_eq,
     assert_column_memory_ne,
@@ -2698,3 +2699,26 @@ def test_index_getitem_time_duration(dtype):
                 assert gidx[i] is pidx[i]
             else:
                 assert_eq(gidx[i], pidx[i])
+
+
+@pytest.mark.parametrize("dtype", ALL_TYPES)
+def test_index_empty_from_pandas(request, dtype):
+    request.node.add_marker(
+        pytest.mark.xfail(
+            condition=not PANDAS_GE_200
+            and dtype
+            in {
+                "datetime64[ms]",
+                "datetime64[s]",
+                "datetime64[us]",
+                "timedelta64[ms]",
+                "timedelta64[s]",
+                "timedelta64[us]",
+            },
+            reason="Fixed in pandas-2.0",
+        )
+    )
+    pidx = pd.Index([], dtype=dtype)
+    gidx = cudf.from_pandas(pidx)
+
+    assert_eq(pidx, gidx)


### PR DESCRIPTION
## Description
Fixes #14046 

This PR fixes empty string column construction that arises due to a corner-case in the way pyarrow constructs arrays.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
