### PR TITLE
Use `conda mambabuild` rather than `mamba mambabuild`

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -12,7 +12,7 @@ rapids-print-env
 rapids-logger "Begin cpp build"
 
 # With boa installed conda build forward to boa
-rapids-conda-retry build \
+rapids-conda-retry mambabuild \
     conda/recipes/libcudf
 
 rapids-upload-conda-to-s3 cpp

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -11,7 +11,8 @@ rapids-print-env
 
 rapids-logger "Begin cpp build"
 
-rapids-mamba-retry mambabuild \
+# With boa installed mamba build forward to boa
+rapids-mamba-retry build \
     conda/recipes/libcudf
 
 rapids-upload-conda-to-s3 cpp

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -11,8 +11,8 @@ rapids-print-env
 
 rapids-logger "Begin cpp build"
 
-# With boa installed mamba build forward to boa
-rapids-mamba-retry build \
+# With boa installed conda build forward to boa
+rapids-conda-retry build \
     conda/recipes/libcudf
 
 rapids-upload-conda-to-s3 cpp

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -16,24 +16,24 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 # TODO: Remove `--no-test` flag once importing on a CPU
 # node works correctly
 # With boa installed conda build forwards to the boa builder
-rapids-conda-retry build \
+rapids-conda-retry mambabuild \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cudf
 
-rapids-conda-retry build \
+rapids-conda-retry mambabuild \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   --channel "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" \
   conda/recipes/dask-cudf
 
-rapids-conda-retry build \
+rapids-conda-retry mambabuild \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   --channel "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" \
   conda/recipes/cudf_kafka
 
-rapids-conda-retry build \
+rapids-conda-retry mambabuild \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   --channel "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" \

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -15,24 +15,25 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 # TODO: Remove `--no-test` flag once importing on a CPU
 # node works correctly
-rapids-mamba-retry mambabuild \
+# With boa install mamba build forwards to the boa builder
+rapids-mamba-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cudf
 
-rapids-mamba-retry mambabuild \
+rapids-mamba-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   --channel "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" \
   conda/recipes/dask-cudf
 
-rapids-mamba-retry mambabuild \
+rapids-mamba-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   --channel "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" \
   conda/recipes/cudf_kafka
 
-rapids-mamba-retry mambabuild \
+rapids-mamba-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   --channel "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" \

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -15,25 +15,25 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 # TODO: Remove `--no-test` flag once importing on a CPU
 # node works correctly
-# With boa install mamba build forwards to the boa builder
-rapids-mamba-retry build \
+# With boa installed conda build forwards to the boa builder
+rapids-conda-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/cudf
 
-rapids-mamba-retry build \
+rapids-conda-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   --channel "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" \
   conda/recipes/dask-cudf
 
-rapids-mamba-retry build \
+rapids-conda-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   --channel "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" \
   conda/recipes/cudf_kafka
 
-rapids-mamba-retry build \
+rapids-conda-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   --channel "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" \


### PR DESCRIPTION
## Description

Since Conda 23.7.3, the plugin mechanism changed, and mambabuild broke.

Since, with `boa` installed, `conda mambabuild` uses the `libmamba` solver, switch to that.

The general handling of subcommands with `mamba` was partially fixed in mamba-org/mamba#2732, but `mamba build` does not currently work due to mamba-org/mamba#2821.

- Closes #14068

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
