### PR TITLE
Add fallback matrix for nvcomp.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -241,6 +241,9 @@ dependencies:
               cuda: "11.8"
             packages:
               - *nvcomp
+          # Fallback matrix for aarch64 CUDA 12
+          - matrix:
+            packages:
   build_wheels:
     common:
       - output_types: pyproject

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -241,7 +241,8 @@ dependencies:
               cuda: "11.8"
             packages:
               - *nvcomp
-          # Fallback matrix for aarch64 CUDA 12
+          # TODO: Fallback matrix for aarch64 CUDA 12. After migrating to nvcomp 3,
+          # all CUDA/arch combinations should be supported by existing packages.
           - matrix:
             packages:
   build_wheels:


### PR DESCRIPTION
## Description
Some platforms (such as aarch64 + CUDA 12) don't have a matching matrix entry for nvcomp. This PR adds a fallback matrix entry so it is possible to attempt local development on aarch64 with CUDA 12.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.