### PR TITLE
Validate ignore_index type in drop_duplicates

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1961,7 +1961,7 @@ class IndexedFrame(Frame):
         ignore_index: bool, default False
             If True, the resulting axis will be labeled 0, 1, ..., n - 1.
         """
-        if not isinstance(ignore_index, bool):
+        if not isinstance(ignore_index, (np.bool_, bool)):
             raise ValueError(
                 f"{ignore_index=} must be bool, "
                 f"not {type(ignore_index).__name__}"

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1961,6 +1961,11 @@ class IndexedFrame(Frame):
         ignore_index: bool, default False
             If True, the resulting axis will be labeled 0, 1, ..., n - 1.
         """
+        if not isinstance(ignore_index, bool):
+            raise ValueError(
+                f"{ignore_index=} must be bool, "
+                f"not {type(ignore_index).__name__}"
+            )
         subset = self._preprocess_subset(subset)
         subset_cols = [name for name in self._column_names if name in subset]
         if len(subset_cols) == 0:

--- a/python/cudf/cudf/tests/test_duplicates.py
+++ b/python/cudf/cudf/tests/test_duplicates.py
@@ -623,3 +623,9 @@ def test_drop_duplicates_multi_index():
             gdf[col].drop_duplicates().to_pandas(),
             pdf[col].drop_duplicates(),
         )
+
+
+def test_drop_duplicates_ignore_index_wrong_type():
+    gdf = cudf.DataFrame([1, 1, 2])
+    with pytest.raises(ValueError):
+        gdf.drop_duplicates(ignore_index="True")


### PR DESCRIPTION
## Description
Currently allows odd behavior like

```python
In [1]: import cudf

In [4]: df = cudf.DataFrame({"a": [1, 2, 1, 3]})

In [6]: df.drop_duplicates(ignore_index="True")
Out[6]: 
   a
0  1
1  2
2  3
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
