### PR TITLE
Fix DataFrame.values with no columns but index

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -437,7 +437,7 @@ class Frame(BinaryOperand, Scannable):
         ncol = self._num_columns
         if ncol == 0:
             return make_empty_matrix(
-                shape=(0, 0), dtype=np.dtype("float64"), order="F"
+                shape=(len(self), ncol), dtype=np.dtype("float64"), order="F"
             )
 
         if dtype is None:

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -10374,3 +10374,9 @@ def test_dataframe_init_from_nested_dict():
     pdf = pd.DataFrame(regular_dict)
     gdf = cudf.DataFrame(regular_dict)
     assert_eq(pdf, gdf)
+
+
+def test_data_frame_values_no_cols_but_index():
+    result = cudf.DataFrame(index=range(5)).values
+    expected = cupy.empty((5, 0), dtype=np.dtype("float64"), order="F")
+    assert_eq(result, expected)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -10378,5 +10378,5 @@ def test_dataframe_init_from_nested_dict():
 
 def test_data_frame_values_no_cols_but_index():
     result = cudf.DataFrame(index=range(5)).values
-    expected = cupy.empty((5, 0), dtype=np.dtype("float64"), order="F")
+    expected = pd.DataFrame(index=range(5)).values
     assert_eq(result, expected)


### PR DESCRIPTION
## Description
Fixes the following

```python
In [32]: cudf.DataFrame(index=range(10)).values
Out[32]: array([], shape=(0, 0), dtype=float64)
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
