### PR TITLE
Disable `Recently Updated` Check

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -5,4 +5,3 @@ auto_merger: true
 branch_checker: true
 label_checker: true
 release_drafter: true
-recently_updated: true


### PR DESCRIPTION
This check occasionally hangs for `cudf` for unknown reasons.

Upon checking the application logs, the GitHub API seems to be returning responses that aren't helpful in troubleshooting the problem.

Therefore, it's probably best to just remove the check to avoid confusion.

[skip ci]
