### PR TITLE
Marginally reduce memory footprint of joins

### DIFF
--- a/python/cudf/cudf/core/join/join.py
+++ b/python/cudf/cudf/core/join/join.py
@@ -203,6 +203,7 @@ class Merge:
             if left_rows is not None
             else cudf.DataFrame._from_data({})
         )
+        del left_rows
         right_result = (
             self.rhs._gather(
                 GatherMap.from_column_unchecked(
@@ -213,7 +214,7 @@ class Merge:
             if right_rows is not None
             else cudf.DataFrame._from_data({})
         )
-
+        del right_rows
         result = cudf.DataFrame._from_data(
             *self._merge_results(left_result, right_result)
         )


### PR DESCRIPTION
## Description

If we drop the gather maps as soon as we are done with them, we have a little more headroom for joins that are close to hitting the device memory limit.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
