### PR TITLE
Forward-merge branch-23.10 to branch-23.12

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -323,6 +323,7 @@ add_library(
   src/groupby/sort/group_collect.cu
   src/groupby/sort/group_correlation.cu
   src/groupby/sort/group_count.cu
+  src/groupby/sort/group_histogram.cu
   src/groupby/sort/group_m2.cu
   src/groupby/sort/group_max.cu
   src/groupby/sort/group_min.cu
@@ -471,6 +472,7 @@ add_library(
   src/reductions/all.cu
   src/reductions/any.cu
   src/reductions/collect_ops.cu
+  src/reductions/histogram.cu
   src/reductions/max.cu
   src/reductions/mean.cu
   src/reductions/min.cu

--- a/cpp/include/cudf/aggregation.hpp
+++ b/cpp/include/cudf/aggregation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,9 @@ class aggregation {
     COVARIANCE,      ///< covariance between two sets of elements
     CORRELATION,     ///< correlation between two sets of elements
     TDIGEST,         ///< create a tdigest from a set of input values
-    MERGE_TDIGEST    ///< create a tdigest by merging multiple tdigests together
+    MERGE_TDIGEST,   ///< create a tdigest by merging multiple tdigests together
+    HISTOGRAM,       ///< compute frequency of each element
+    MERGE_HISTOGRAM  ///< merge partial values of HISTOGRAM aggregation,
   };
 
   aggregation() = delete;
@@ -287,6 +289,11 @@ std::unique_ptr<Base> make_any_aggregation();
 /// @return A ALL aggregation object
 template <typename Base = aggregation>
 std::unique_ptr<Base> make_all_aggregation();
+
+/// Factory to create a HISTOGRAM aggregation
+/// @return A HISTOGRAM aggregation object
+template <typename Base = aggregation>
+std::unique_ptr<Base> make_histogram_aggregation();
 
 /// Factory to create a SUM_OF_SQUARES aggregation
 /// @return A SUM_OF_SQUARES aggregation object
@@ -609,6 +616,17 @@ std::unique_ptr<Base> make_merge_sets_aggregation(
  */
 template <typename Base = aggregation>
 std::unique_ptr<Base> make_merge_m2_aggregation();
+
+/**
+ * @brief Factory to create a MERGE_HISTOGRAM aggregation
+ *
+ * Merges the results of `HISTOGRAM` aggregations on independent sets into a new `HISTOGRAM` value
+ * equivalent to if a single `HISTOGRAM` aggregation was done across all of the sets at once.
+ *
+ * @return A MERGE_HISTOGRAM aggregation object
+ */
+template <typename Base = aggregation>
+std::unique_ptr<Base> make_merge_histogram_aggregation();
 
 /**
  * @brief Factory to create a COVARIANCE aggregation

--- a/cpp/include/cudf/detail/hash_reduce_by_row.cuh
+++ b/cpp/include/cudf/detail/hash_reduce_by_row.cuh
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
+#include <cudf/hashing/detail/hash_allocator.cuh>
+#include <cudf/hashing/detail/helper_functions.cuh>
 #include <cudf/table/experimental/row_operators.cuh>
 #include <cudf/types.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
+#include <rmm/mr/device/polymorphic_allocator.hpp>
 
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -29,6 +32,7 @@
 
 namespace cudf::detail {
 
+using hash_table_allocator_type = rmm::mr::stream_allocator_adaptor<default_allocator<char>>;
 using hash_map_type =
   cuco::static_map<size_type, size_type, cuda::thread_scope_device, hash_table_allocator_type>;
 

--- a/cpp/include/cudf/reduction/detail/histogram.hpp
+++ b/cpp/include/cudf/reduction/detail/histogram.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/table/table_view.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_uvector.hpp>
+
+#include <memory>
+#include <optional>
+
+namespace cudf::reduction::detail {
+
+/**
+ * @brief Compute the frequency for each distinct row in the input table.
+ *
+ * @param input The input table to compute histogram
+ * @param partial_counts An optional column containing count for each row
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate memory of the returned objects
+ * @return A pair of array contains the (stable-order) indices of the distinct rows in the input
+ * table, and their corresponding distinct counts
+ */
+[[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>, std::unique_ptr<column>>
+compute_row_frequencies(table_view const& input,
+                        std::optional<column_view> const& partial_counts,
+                        rmm::cuda_stream_view stream,
+                        rmm::mr::device_memory_resource* mr);
+
+/**
+ * @brief Create an empty histogram column.
+ *
+ * A histogram column is a structs column `STRUCT<T, int64_t>` where T is type of the input
+ * values.
+ *
+ * @returns An empty histogram column
+ */
+[[nodiscard]] std::unique_ptr<column> make_empty_histogram_like(column_view const& values);
+
+}  // namespace cudf::reduction::detail

--- a/cpp/include/cudf/reduction/detail/reduction_functions.hpp
+++ b/cpp/include/cudf/reduction/detail/reduction_functions.hpp
@@ -132,6 +132,33 @@ std::unique_ptr<scalar> all(column_view const& col,
                             rmm::mr::device_memory_resource* mr);
 
 /**
+ * @brief Compute frequency for each unique element in the input column.
+ *
+ * The result histogram is stored in structs column having two children. The first child contains
+ * unique elements from the input, and the second child contains their corresponding frequencies.
+ *
+ * @param input The column to compute histogram
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned scalar's device memory
+ * @return A list_scalar storing a structs column as the result histogram
+ */
+std::unique_ptr<scalar> histogram(column_view const& input,
+                                  rmm::cuda_stream_view stream,
+                                  rmm::mr::device_memory_resource* mr);
+
+/**
+ * @brief Merge multiple histograms together.
+ *
+ * @param input The input given as multiple histograms concatenated together
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned scalar's device memory
+ * @return A list_scalar storing the result histogram
+ */
+std::unique_ptr<scalar> merge_histogram(column_view const& input,
+                                        rmm::cuda_stream_view stream,
+                                        rmm::mr::device_memory_resource* mr);
+
+/**
  * @brief Computes product of elements in input column
  *
  * If all elements in input column are null, output scalar is null.

--- a/cpp/src/aggregation/aggregation.cpp
+++ b/cpp/src/aggregation/aggregation.cpp
@@ -65,6 +65,12 @@ std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
 }
 
 std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
+  data_type col_type, histogram_aggregation const& agg)
+{
+  return visit(col_type, static_cast<aggregation const&>(agg));
+}
+
+std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
   data_type col_type, any_aggregation const& agg)
 {
   return visit(col_type, static_cast<aggregation const&>(agg));
@@ -197,6 +203,12 @@ std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
 }
 
 std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
+  data_type col_type, merge_histogram_aggregation const& agg)
+{
+  return visit(col_type, static_cast<aggregation const&>(agg));
+}
+
+std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
   data_type col_type, covariance_aggregation const& agg)
 {
   return visit(col_type, static_cast<aggregation const&>(agg));
@@ -243,6 +255,10 @@ void aggregation_finalizer::visit(max_aggregation const& agg)
 }
 
 void aggregation_finalizer::visit(count_aggregation const& agg)
+{
+  visit(static_cast<aggregation const&>(agg));
+}
+void aggregation_finalizer::visit(histogram_aggregation const& agg)
 {
   visit(static_cast<aggregation const&>(agg));
 }
@@ -357,6 +373,11 @@ void aggregation_finalizer::visit(merge_m2_aggregation const& agg)
   visit(static_cast<aggregation const&>(agg));
 }
 
+void aggregation_finalizer::visit(merge_histogram_aggregation const& agg)
+{
+  visit(static_cast<aggregation const&>(agg));
+}
+
 void aggregation_finalizer::visit(covariance_aggregation const& agg)
 {
   visit(static_cast<aggregation const&>(agg));
@@ -459,6 +480,16 @@ template std::unique_ptr<groupby_aggregation> make_count_aggregation<groupby_agg
   null_policy null_handling);
 template std::unique_ptr<groupby_scan_aggregation> make_count_aggregation<groupby_scan_aggregation>(
   null_policy null_handling);
+
+/// Factory to create a HISTOGRAM aggregation
+template <typename Base>
+std::unique_ptr<Base> make_histogram_aggregation()
+{
+  return std::make_unique<detail::histogram_aggregation>();
+}
+template std::unique_ptr<aggregation> make_histogram_aggregation<aggregation>();
+template std::unique_ptr<groupby_aggregation> make_histogram_aggregation<groupby_aggregation>();
+template std::unique_ptr<reduce_aggregation> make_histogram_aggregation<reduce_aggregation>();
 
 /// Factory to create a ANY aggregation
 template <typename Base>
@@ -763,6 +794,17 @@ std::unique_ptr<Base> make_merge_m2_aggregation()
 }
 template std::unique_ptr<aggregation> make_merge_m2_aggregation<aggregation>();
 template std::unique_ptr<groupby_aggregation> make_merge_m2_aggregation<groupby_aggregation>();
+
+/// Factory to create a MERGE_HISTOGRAM aggregation
+template <typename Base>
+std::unique_ptr<Base> make_merge_histogram_aggregation()
+{
+  return std::make_unique<detail::merge_histogram_aggregation>();
+}
+template std::unique_ptr<aggregation> make_merge_histogram_aggregation<aggregation>();
+template std::unique_ptr<groupby_aggregation>
+make_merge_histogram_aggregation<groupby_aggregation>();
+template std::unique_ptr<reduce_aggregation> make_merge_histogram_aggregation<reduce_aggregation>();
 
 /// Factory to create a COVARIANCE aggregation
 template <typename Base>

--- a/cpp/src/groupby/groupby.cu
+++ b/cpp/src/groupby/groupby.cu
@@ -28,6 +28,7 @@
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/dictionary/dictionary_column_view.hpp>
 #include <cudf/groupby.hpp>
+#include <cudf/reduction/detail/histogram.hpp>
 #include <cudf/strings/string_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
@@ -109,6 +110,15 @@ struct empty_column_constructor {
       return make_lists_column(
         0, make_empty_column(type_to_id<size_type>()), empty_like(values), 0, {});
     }
+
+    if constexpr (k == aggregation::Kind::HISTOGRAM) {
+      return make_lists_column(0,
+                               make_empty_column(type_to_id<size_type>()),
+                               cudf::reduction::detail::make_empty_histogram_like(values),
+                               0,
+                               {});
+    }
+    if constexpr (k == aggregation::Kind::MERGE_HISTOGRAM) { return empty_like(values); }
 
     if constexpr (k == aggregation::Kind::RANK) {
       auto const& rank_agg = dynamic_cast<cudf::detail::rank_aggregation const&>(agg);

--- a/cpp/src/groupby/sort/group_histogram.cu
+++ b/cpp/src/groupby/sort/group_histogram.cu
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <lists/utilities.hpp>
+
+#include <cudf/aggregation.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/gather.hpp>
+#include <cudf/detail/labeling/label_segments.cuh>
+#include <cudf/reduction/detail/histogram.hpp>
+#include <cudf/structs/structs_column_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/span.hpp>
+
+#include <rmm/device_buffer.hpp>
+
+#include <thrust/gather.h>
+
+namespace cudf::groupby::detail {
+
+namespace {
+
+std::unique_ptr<column> build_histogram(column_view const& values,
+                                        cudf::device_span<size_type const> group_labels,
+                                        std::optional<column_view> const& partial_counts,
+                                        size_type num_groups,
+                                        rmm::cuda_stream_view stream,
+                                        rmm::mr::device_memory_resource* mr)
+{
+  CUDF_EXPECTS(static_cast<size_t>(values.size()) == group_labels.size(),
+               "Size of values column should be the same as that of group labels.",
+               std::invalid_argument);
+
+  // Attach group labels to the input values.
+  auto const labels_cv      = column_view{data_type{type_to_id<size_type>()},
+                                     static_cast<size_type>(group_labels.size()),
+                                     group_labels.data(),
+                                     nullptr,
+                                     0};
+  auto const labeled_values = table_view{{labels_cv, values}};
+
+  // Build histogram for the labeled values.
+  auto [distinct_indices, distinct_counts] =
+    cudf::reduction::detail::compute_row_frequencies(labeled_values, partial_counts, stream, mr);
+
+  // Gather the distinct rows for the output histogram.
+  auto out_table = cudf::detail::gather(labeled_values,
+                                        *distinct_indices,
+                                        out_of_bounds_policy::DONT_CHECK,
+                                        cudf::detail::negative_index_policy::NOT_ALLOWED,
+                                        stream,
+                                        mr);
+
+  // Build offsets for the output lists column containing output histograms.
+  // Each list will be a histogram corresponding to one value group.
+  auto out_offsets = cudf::lists::detail::reconstruct_offsets(
+    out_table->get_column(0).view(), num_groups, stream, mr);
+
+  std::vector<std::unique_ptr<column>> struct_children;
+  struct_children.emplace_back(std::move(out_table->release().back()));
+  struct_children.emplace_back(std::move(distinct_counts));
+  auto out_structs = make_structs_column(static_cast<size_type>(distinct_indices->size()),
+                                         std::move(struct_children),
+                                         0,
+                                         {},
+                                         stream,
+                                         mr);
+
+  return make_lists_column(
+    num_groups, std::move(out_offsets), std::move(out_structs), 0, {}, stream, mr);
+}
+
+}  // namespace
+
+std::unique_ptr<column> group_histogram(column_view const& values,
+                                        cudf::device_span<size_type const> group_labels,
+                                        size_type num_groups,
+                                        rmm::cuda_stream_view stream,
+                                        rmm::mr::device_memory_resource* mr)
+{
+  // Empty group should be handled before reaching here.
+  CUDF_EXPECTS(num_groups > 0, "Group should not be empty.", std::invalid_argument);
+
+  return build_histogram(values, group_labels, std::nullopt, num_groups, stream, mr);
+}
+
+std::unique_ptr<column> group_merge_histogram(column_view const& values,
+                                              cudf::device_span<size_type const> group_offsets,
+                                              size_type num_groups,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::mr::device_memory_resource* mr)
+{
+  // Empty group should be handled before reaching here.
+  CUDF_EXPECTS(num_groups > 0, "Group should not be empty.", std::invalid_argument);
+
+  // The input must be a lists column without nulls.
+  CUDF_EXPECTS(!values.has_nulls(), "The input column must not have nulls.", std::invalid_argument);
+  CUDF_EXPECTS(values.type().id() == type_id::LIST,
+               "The input of MERGE_HISTOGRAM aggregation must be a lists column.",
+               std::invalid_argument);
+
+  // Child of the input lists column must be a structs column without nulls,
+  // and its second child is a columns of integer type having no nulls.
+  auto const lists_cv     = lists_column_view{values};
+  auto const histogram_cv = lists_cv.get_sliced_child(stream);
+  CUDF_EXPECTS(!histogram_cv.has_nulls(),
+               "Child of the input lists column must not have nulls.",
+               std::invalid_argument);
+  CUDF_EXPECTS(histogram_cv.type().id() == type_id::STRUCT && histogram_cv.num_children() == 2,
+               "The input column has invalid histograms structure.",
+               std::invalid_argument);
+  CUDF_EXPECTS(
+    cudf::is_integral(histogram_cv.child(1).type()) && !histogram_cv.child(1).has_nulls(),
+    "The input column has invalid histograms structure.",
+    std::invalid_argument);
+
+  // Concatenate the histograms corresponding to the same key values.
+  // That is equivalent to creating a new lists column (view) from the input lists column
+  // with new offsets gathered as below.
+  auto new_offsets = rmm::device_uvector<size_type>(num_groups + 1, stream);
+  thrust::gather(rmm::exec_policy(stream),
+                 group_offsets.begin(),
+                 group_offsets.end(),
+                 lists_cv.offsets_begin(),
+                 new_offsets.begin());
+
+  // Generate labels for the new lists.
+  auto key_labels = rmm::device_uvector<size_type>(histogram_cv.size(), stream);
+  cudf::detail::label_segments(
+    new_offsets.begin(), new_offsets.end(), key_labels.begin(), key_labels.end(), stream);
+
+  auto const structs_cv   = structs_column_view{histogram_cv};
+  auto const input_values = structs_cv.get_sliced_child(0, stream);
+  auto const input_counts = structs_cv.get_sliced_child(1, stream);
+
+  return build_histogram(input_values, key_labels, input_counts, num_groups, stream, mr);
+}
+
+}  // namespace cudf::groupby::detail

--- a/cpp/src/reductions/histogram.cu
+++ b/cpp/src/reductions/histogram.cu
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/gather.hpp>
+#include <cudf/detail/hash_reduce_by_row.cuh>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/structs/structs_column_view.hpp>
+
+#include <thrust/copy.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/tuple.h>
+
+#include <cuda/atomic>
+
+#include <optional>
+
+namespace cudf::reduction::detail {
+
+namespace {
+
+// Always use 64-bit signed integer for storing count.
+using histogram_count_type = int64_t;
+
+/**
+ * @brief The functor to accumulate the frequency of each distinct rows in the input table.
+ */
+template <typename MapView, typename KeyHasher, typename KeyEqual, typename CountType>
+struct reduce_fn : cudf::detail::reduce_by_row_fn_base<MapView, KeyHasher, KeyEqual, CountType> {
+  CountType const* d_partial_output;
+
+  reduce_fn(MapView const& d_map,
+            KeyHasher const& d_hasher,
+            KeyEqual const& d_equal,
+            CountType* const d_output,
+            CountType const* const d_partial_output)
+    : cudf::detail::reduce_by_row_fn_base<MapView, KeyHasher, KeyEqual, CountType>{d_map,
+                                                                                   d_hasher,
+                                                                                   d_equal,
+                                                                                   d_output},
+      d_partial_output{d_partial_output}
+  {
+  }
+
+  // Count the number of rows in each group of rows that are compared equal.
+  __device__ void operator()(size_type const idx) const
+  {
+    auto const increment = d_partial_output ? d_partial_output[idx] : CountType{1};
+    auto const count =
+      cuda::atomic_ref<CountType, cuda::thread_scope_device>(*this->get_output_ptr(idx));
+    count.fetch_add(increment, cuda::std::memory_order_relaxed);
+  }
+};
+
+/**
+ * @brief The builder to construct an instance of `reduce_fn` functor.
+ */
+template <typename CountType>
+struct reduce_func_builder {
+  CountType const* const d_partial_output;
+
+  reduce_func_builder(CountType const* const d_partial_output) : d_partial_output{d_partial_output}
+  {
+  }
+
+  template <typename MapView, typename KeyHasher, typename KeyEqual>
+  auto build(MapView const& d_map,
+             KeyHasher const& d_hasher,
+             KeyEqual const& d_equal,
+             CountType* const d_output)
+  {
+    return reduce_fn<MapView, KeyHasher, KeyEqual, CountType>{
+      d_map, d_hasher, d_equal, d_output, d_partial_output};
+  }
+};
+
+/**
+ * @brief Specialized functor to check for not-zero of the second component of the input.
+ */
+struct is_not_zero {
+  template <typename Pair>
+  __device__ bool operator()(Pair const input) const
+  {
+    return thrust::get<1>(input) != 0;
+  }
+};
+
+/**
+ * @brief Building a histogram by gathering distinct rows from the input table and their
+ * corresponding distinct counts.
+ *
+ * @param input The input table
+ * @param distinct_indices Indices of the distinct rows
+ * @param distinct_counts Distinct counts corresponding to the distinct rows
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned object's device memory
+ * @return A list_scalar storing the output histogram
+ */
+auto gather_histogram(table_view const& input,
+                      device_span<size_type const> distinct_indices,
+                      std::unique_ptr<column>&& distinct_counts,
+                      rmm::cuda_stream_view stream,
+                      rmm::mr::device_memory_resource* mr)
+{
+  auto distinct_rows = cudf::detail::gather(input,
+                                            distinct_indices,
+                                            out_of_bounds_policy::DONT_CHECK,
+                                            cudf::detail::negative_index_policy::NOT_ALLOWED,
+                                            stream,
+                                            mr);
+
+  std::vector<std::unique_ptr<column>> struct_children;
+  struct_children.emplace_back(std::move(distinct_rows->release().front()));
+  struct_children.emplace_back(std::move(distinct_counts));
+  auto output_structs = make_structs_column(
+    static_cast<size_type>(distinct_indices.size()), std::move(struct_children), 0, {}, stream, mr);
+
+  return std::make_unique<cudf::list_scalar>(
+    std::move(*output_structs.release()), true, stream, mr);
+}
+
+}  // namespace
+
+std::unique_ptr<column> make_empty_histogram_like(column_view const& values)
+{
+  std::vector<std::unique_ptr<column>> struct_children;
+  struct_children.emplace_back(empty_like(values));
+  struct_children.emplace_back(make_numeric_column(data_type{type_id::INT64}, 0));
+  return std::make_unique<column>(data_type{type_id::STRUCT},
+                                  0,
+                                  rmm::device_buffer{},
+                                  rmm::device_buffer{},
+                                  0,
+                                  std::move(struct_children));
+}
+
+std::pair<std::unique_ptr<rmm::device_uvector<size_type>>, std::unique_ptr<column>>
+compute_row_frequencies(table_view const& input,
+                        std::optional<column_view> const& partial_counts,
+                        rmm::cuda_stream_view stream,
+                        rmm::mr::device_memory_resource* mr)
+{
+  auto const has_nested_columns = cudf::detail::has_nested_columns(input);
+
+  // Nested types are not tested, thus we just throw exception if we see such input for now.
+  // We should remove this check after having enough tests.
+  CUDF_EXPECTS(!has_nested_columns,
+               "Nested types are not yet supported in histogram aggregation.",
+               std::invalid_argument);
+
+  auto map = cudf::detail::hash_map_type{
+    compute_hash_table_size(input.num_rows()),
+    cuco::empty_key{-1},
+    cuco::empty_value{std::numeric_limits<size_type>::min()},
+    cudf::detail::hash_table_allocator_type{default_allocator<char>{}, stream},
+    stream.value()};
+
+  auto const preprocessed_input =
+    cudf::experimental::row::hash::preprocessed_table::create(input, stream);
+  auto const has_nulls = nullate::DYNAMIC{cudf::has_nested_nulls(input)};
+
+  auto const row_hasher = cudf::experimental::row::hash::row_hasher(preprocessed_input);
+  auto const key_hasher = row_hasher.device_hasher(has_nulls);
+  auto const row_comp   = cudf::experimental::row::equality::self_comparator(preprocessed_input);
+
+  auto const pair_iter = cudf::detail::make_counting_transform_iterator(
+    size_type{0}, [] __device__(size_type const i) { return cuco::make_pair(i, i); });
+
+  // Always compare NaNs as equal.
+  using nan_equal_comparator =
+    cudf::experimental::row::equality::nan_equal_physical_equality_comparator;
+  auto const value_comp = nan_equal_comparator{};
+
+  if (has_nested_columns) {
+    auto const key_equal = row_comp.equal_to<true>(has_nulls, null_equality::EQUAL, value_comp);
+    map.insert(pair_iter, pair_iter + input.num_rows(), key_hasher, key_equal, stream.value());
+  } else {
+    auto const key_equal = row_comp.equal_to<false>(has_nulls, null_equality::EQUAL, value_comp);
+    map.insert(pair_iter, pair_iter + input.num_rows(), key_hasher, key_equal, stream.value());
+  }
+
+  // Gather the indices of distinct rows.
+  auto distinct_indices = std::make_unique<rmm::device_uvector<size_type>>(
+    static_cast<size_type>(map.get_size()), stream, mr);
+
+  // Store the number of occurrences of each distinct row.
+  auto distinct_counts = make_numeric_column(data_type{type_to_id<histogram_count_type>()},
+                                             static_cast<size_type>(map.get_size()),
+                                             mask_state::UNALLOCATED,
+                                             stream,
+                                             mr);
+
+  // Compute frequencies (aka distinct counts) for the input rows.
+  // Note that we consider null and NaNs as always equal.
+  auto const reduction_results = cudf::detail::hash_reduce_by_row(
+    map,
+    preprocessed_input,
+    input.num_rows(),
+    has_nulls,
+    has_nested_columns,
+    null_equality::EQUAL,
+    nan_equality::ALL_EQUAL,
+    reduce_func_builder<histogram_count_type>{
+      partial_counts ? partial_counts.value().begin<histogram_count_type>() : nullptr},
+    histogram_count_type{0},
+    stream,
+    rmm::mr::get_current_device_resource());
+
+  auto const input_it = thrust::make_zip_iterator(
+    thrust::make_tuple(thrust::make_counting_iterator(0), reduction_results.begin()));
+  auto const output_it = thrust::make_zip_iterator(thrust::make_tuple(
+    distinct_indices->begin(), distinct_counts->mutable_view().begin<histogram_count_type>()));
+
+  // Reduction results above are either group sizes of equal rows, or `0`.
+  // The final output is non-zero group sizes only.
+  thrust::copy_if(
+    rmm::exec_policy(stream), input_it, input_it + input.num_rows(), output_it, is_not_zero{});
+
+  return {std::move(distinct_indices), std::move(distinct_counts)};
+}
+
+std::unique_ptr<cudf::scalar> histogram(column_view const& input,
+                                        rmm::cuda_stream_view stream,
+                                        rmm::mr::device_memory_resource* mr)
+{
+  // Empty group should be handled before reaching here.
+  CUDF_EXPECTS(input.size() > 0, "Input should not be empty.", std::invalid_argument);
+
+  auto const input_tv = table_view{{input}};
+  auto [distinct_indices, distinct_counts] =
+    compute_row_frequencies(input_tv, std::nullopt, stream, mr);
+  return gather_histogram(input_tv, *distinct_indices, std::move(distinct_counts), stream, mr);
+}
+
+std::unique_ptr<cudf::scalar> merge_histogram(column_view const& input,
+                                              rmm::cuda_stream_view stream,
+                                              rmm::mr::device_memory_resource* mr)
+{
+  // Empty group should be handled before reaching here.
+  CUDF_EXPECTS(input.size() > 0, "Input should not be empty.", std::invalid_argument);
+  CUDF_EXPECTS(!input.has_nulls(), "The input column must not have nulls.", std::invalid_argument);
+  CUDF_EXPECTS(input.type().id() == type_id::STRUCT && input.num_children() == 2,
+               "The input must be a structs column having two children.",
+               std::invalid_argument);
+  CUDF_EXPECTS(cudf::is_integral(input.child(1).type()) && !input.child(1).has_nulls(),
+               "The second child of the input column must be of integral type and without nulls.",
+               std::invalid_argument);
+
+  auto const structs_cv   = structs_column_view{input};
+  auto const input_values = structs_cv.get_sliced_child(0, stream);
+  auto const input_counts = structs_cv.get_sliced_child(1, stream);
+
+  auto const values_tv = table_view{{input_values}};
+  auto [distinct_indices, distinct_counts] =
+    compute_row_frequencies(values_tv, input_counts, stream, mr);
+  return gather_histogram(values_tv, *distinct_indices, std::move(distinct_counts), stream, mr);
+}
+
+}  // namespace cudf::reduction::detail

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -116,6 +116,7 @@ ConfigureTest(
   groupby/covariance_tests.cpp
   groupby/groupby_test_util.cpp
   groupby/groups_tests.cpp
+  groupby/histogram_tests.cpp
   groupby/keys_tests.cpp
   groupby/lists_tests.cpp
   groupby/m2_tests.cpp

--- a/cpp/tests/groupby/histogram_tests.cpp
+++ b/cpp/tests/groupby/histogram_tests.cpp
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
+#include <cudf_test/type_lists.hpp>
+
+#include <cudf/copying.hpp>
+#include <cudf/detail/aggregation/aggregation.hpp>
+#include <cudf/groupby.hpp>
+#include <cudf/lists/sorting.hpp>
+#include <cudf/sorting.hpp>
+
+using int32s_col  = cudf::test::fixed_width_column_wrapper<int32_t>;
+using int64s_col  = cudf::test::fixed_width_column_wrapper<int64_t>;
+using structs_col = cudf::test::structs_column_wrapper;
+
+auto groupby_histogram(cudf::column_view const& keys,
+                       cudf::column_view const& values,
+                       cudf::aggregation::Kind agg_kind)
+{
+  CUDF_EXPECTS(
+    agg_kind == cudf::aggregation::HISTOGRAM || agg_kind == cudf::aggregation::MERGE_HISTOGRAM,
+    "Aggregation must be either HISTOGRAM or MERGE_HISTOGRAM.");
+
+  std::vector<cudf::groupby::aggregation_request> requests;
+  requests.emplace_back();
+  requests[0].values = values;
+  if (agg_kind == cudf::aggregation::HISTOGRAM) {
+    requests[0].aggregations.push_back(
+      cudf::make_histogram_aggregation<cudf::groupby_aggregation>());
+  } else {
+    requests[0].aggregations.push_back(
+      cudf::make_merge_histogram_aggregation<cudf::groupby_aggregation>());
+  }
+
+  auto gb_obj              = cudf::groupby::groupby(cudf::table_view({keys}));
+  auto const agg_results   = gb_obj.aggregate(requests, cudf::test::get_default_stream());
+  auto const agg_histogram = agg_results.second[0].results[0]->view();
+  EXPECT_EQ(agg_histogram.type().id(), cudf::type_id::LIST);
+  EXPECT_EQ(agg_histogram.null_count(), 0);
+
+  auto const histograms = cudf::lists_column_view{agg_histogram}.child();
+  EXPECT_EQ(histograms.num_children(), 2);
+  EXPECT_EQ(histograms.null_count(), 0);
+  EXPECT_EQ(histograms.child(1).null_count(), 0);
+
+  auto const key_sort_order = cudf::sorted_order(agg_results.first->view(), {}, {});
+  auto sorted_keys =
+    std::move(cudf::gather(agg_results.first->view(), *key_sort_order)->release().front());
+  auto const sorted_vals =
+    std::move(cudf::gather(cudf::table_view{{agg_histogram}}, *key_sort_order)->release().front());
+  auto sorted_histograms = cudf::lists::sort_lists(cudf::lists_column_view{*sorted_vals},
+                                                   cudf::order::ASCENDING,
+                                                   cudf::null_order::BEFORE,
+                                                   rmm::mr::get_current_device_resource());
+
+  return std::pair{std::move(sorted_keys), std::move(sorted_histograms)};
+}
+
+template <typename T>
+struct GroupbyHistogramTest : public cudf::test::BaseFixture {};
+
+template <typename T>
+struct GroupbyMergeHistogramTest : public cudf::test::BaseFixture {};
+
+// Avoid unsigned types, as the tests below have negative values in their input.
+using HistogramTestTypes = cudf::test::Concat<cudf::test::Types<int8_t, int16_t, int32_t, int64_t>,
+                                              cudf::test::FloatingPointTypes,
+                                              cudf::test::FixedPointTypes,
+                                              cudf::test::ChronoTypes>;
+TYPED_TEST_SUITE(GroupbyHistogramTest, HistogramTestTypes);
+TYPED_TEST_SUITE(GroupbyMergeHistogramTest, HistogramTestTypes);
+
+TYPED_TEST(GroupbyHistogramTest, EmptyInput)
+{
+  using col_data = cudf::test::fixed_width_column_wrapper<TypeParam, int>;
+
+  auto const keys   = int32s_col{};
+  auto const values = col_data{};
+  auto const [res_keys, res_histogram] =
+    groupby_histogram(keys, values, cudf::aggregation::HISTOGRAM);
+
+  // The structure of the output is already verified in the function `groupby_histogram`.
+  ASSERT_EQ(res_histogram->size(), 0);
+}
+
+TYPED_TEST(GroupbyHistogramTest, SimpleInputNoNull)
+{
+  using col_data = cudf::test::fixed_width_column_wrapper<TypeParam, int>;
+
+  // key = 0: values = [2, 2, -3, -2, 2]
+  // key = 1: values = [2, 0, 5, 2, 1]
+  // key = 2: values = [-3, 1, 1, 2, 2]
+  auto const keys   = int32s_col{2, 0, 2, 1, 1, 1, 0, 0, 0, 1, 2, 2, 1, 0, 2};
+  auto const values = col_data{-3, 2, 1, 2, 0, 5, 2, -3, -2, 2, 1, 2, 1, 2, 2};
+
+  auto const expected_keys      = int32s_col{0, 1, 2};
+  auto const expected_histogram = [] {
+    auto structs = [] {
+      auto values = col_data{-3, -2, 2, 0, 1, 2, 5, -3, 1, 2};
+      auto counts = int64s_col{1, 1, 3, 1, 1, 2, 1, 1, 2, 2};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(
+      3, int32s_col{0, 3, 7, 10}.release(), structs.release(), 0, rmm::device_buffer{});
+  }();
+
+  auto const [res_keys, res_histogram] =
+    groupby_histogram(keys, values, cudf::aggregation::HISTOGRAM);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_keys, *res_keys);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_histogram, *res_histogram);
+}
+
+TYPED_TEST(GroupbyHistogramTest, SlicedInputNoNull)
+{
+  using col_data = cudf::test::fixed_width_column_wrapper<TypeParam, int>;
+
+  auto const keys_original = int32s_col{2, 0, 2, 1, 0, 2, 0, 2, 1, 1, 1, 0, 0, 0, 1, 2, 2, 1, 0, 2};
+  auto const values_original =
+    col_data{1, 2, 0, 2, 1, -3, 2, 1, 2, 0, 5, 2, -3, -2, 2, 1, 2, 1, 2, 2};
+  // key = 0: values = [2, 2, -3, -2, 2]
+  // key = 1: values = [2, 0, 5, 2, 1]
+  // key = 2: values = [-3, 1, 1, 2, 2]
+  auto const keys   = cudf::slice(keys_original, {5, 20})[0];
+  auto const values = cudf::slice(values_original, {5, 20})[0];
+
+  auto const expected_keys      = int32s_col{0, 1, 2};
+  auto const expected_histogram = [] {
+    auto structs = [] {
+      auto values = col_data{-3, -2, 2, 0, 1, 2, 5, -3, 1, 2};
+      auto counts = int64s_col{1, 1, 3, 1, 1, 2, 1, 1, 2, 2};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(
+      3, int32s_col{0, 3, 7, 10}.release(), structs.release(), 0, rmm::device_buffer{});
+  }();
+
+  auto const [res_keys, res_histogram] =
+    groupby_histogram(keys, values, cudf::aggregation::HISTOGRAM);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_keys, *res_keys);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_histogram, *res_histogram);
+}
+
+TYPED_TEST(GroupbyHistogramTest, InputWithNulls)
+{
+  using col_data = cudf::test::fixed_width_column_wrapper<TypeParam, int>;
+  using namespace cudf::test::iterators;
+  auto constexpr null{0};
+
+  // key = 0: values = [-3, null, 2, null, 2]
+  // key = 1: values = [1, 2, null, 5, 2, -3, 1, 1]
+  // key = 2: values = [null, 2, 0, -2, 2, null, 2]
+  auto const keys = int32s_col{2, 0, 2, 1, 1, 1, 2, 1, 1, 0, 1, 2, 0, 0, 1, 2, 2, 1, 0, 2};
+  auto const values =
+    col_data{{null, -3, 2, 1, 2, null, 0, 5, 2, null, -3, -2, 2, null, 1, 2, null, 1, 2, 2},
+             nulls_at({0, 5, 9, 13, 16})};
+
+  auto const expected_keys      = int32s_col{0, 1, 2};
+  auto const expected_histogram = [] {
+    auto structs = [] {
+      auto values = col_data{{null, -3, 2, null, -3, 1, 2, 5, null, -2, 0, 2}, nulls_at({0, 3, 8})};
+      auto counts = int64s_col{2, 1, 2, 1, 1, 3, 2, 1, 2, 1, 1, 3};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(
+      3, int32s_col{0, 3, 8, 12}.release(), structs.release(), 0, rmm::device_buffer{});
+  }();
+
+  auto const [res_keys, res_histogram] =
+    groupby_histogram(keys, values, cudf::aggregation::HISTOGRAM);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_keys, *res_keys);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_histogram, *res_histogram);
+}
+
+TYPED_TEST(GroupbyHistogramTest, SlicedInputWithNulls)
+{
+  using col_data = cudf::test::fixed_width_column_wrapper<TypeParam, int>;
+  using namespace cudf::test::iterators;
+  auto constexpr null{0};
+
+  auto const keys_original =
+    int32s_col{1, 0, 2, 2, 0, 2, 0, 2, 1, 1, 1, 2, 1, 1, 0, 1, 2, 0, 0, 1, 2, 2, 1, 0, 2, 0, 1, 2};
+  auto const values_original =
+    col_data{{null, 1,  1,  2, 1,    null, -3, 2,    1, 2, null, 0,    5, 2,
+              null, -3, -2, 2, null, 1,    2,  null, 1, 2, 2,    null, 1, 2},
+             nulls_at({0, 5, 10, 14, 18, 21, 25})};
+
+  // key = 0: values = [-3, null, 2, null, 2]
+  // key = 1: values = [1, 2, null, 5, 2, -3, 1, 1]
+  // key = 2: values = [null, 2, 0, -2, 2, null, 2]
+  auto const keys   = cudf::slice(keys_original, {5, 25})[0];
+  auto const values = cudf::slice(values_original, {5, 25})[0];
+
+  auto const expected_keys      = int32s_col{0, 1, 2};
+  auto const expected_histogram = [] {
+    auto structs = [] {
+      auto values = col_data{{null, -3, 2, null, -3, 1, 2, 5, null, -2, 0, 2}, nulls_at({0, 3, 8})};
+      auto counts = int64s_col{2, 1, 2, 1, 1, 3, 2, 1, 2, 1, 1, 3};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(
+      3, int32s_col{0, 3, 8, 12}.release(), structs.release(), 0, rmm::device_buffer{});
+  }();
+
+  auto const [res_keys, res_histogram] =
+    groupby_histogram(keys, values, cudf::aggregation::HISTOGRAM);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_keys, *res_keys);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_histogram, *res_histogram);
+}
+
+TYPED_TEST(GroupbyMergeHistogramTest, EmptyInput)
+{
+  using col_data = cudf::test::fixed_width_column_wrapper<TypeParam, int>;
+
+  auto const keys   = int32s_col{};
+  auto const values = [] {
+    auto structs = [] {
+      auto values = col_data{};
+      auto counts = int64s_col{};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(
+      0, int32s_col{}.release(), structs.release(), 0, rmm::device_buffer{});
+  }();
+  auto const [res_keys, res_histogram] =
+    groupby_histogram(keys, *values, cudf::aggregation::MERGE_HISTOGRAM);
+
+  // The structure of the output is already verified in the function `groupby_histogram`.
+  ASSERT_EQ(res_histogram->size(), 0);
+}
+
+TYPED_TEST(GroupbyMergeHistogramTest, SimpleInputNoNull)
+{
+  using col_data = cudf::test::fixed_width_column_wrapper<TypeParam, int>;
+
+  // key = 0: histograms = [[<-3, 1>, <-2, 1>, <2, 3>], [<0, 1>, <1, 1>], [<-3, 3>, <0, 1>, <1, 2>]]
+  // key = 1: histograms = [[<-2, 1>, <1, 3>, <2, 2>], [<0, 2>, <1, 1>, <2, 2>]]
+  auto const keys   = int32s_col{0, 1, 0, 1, 0};
+  auto const values = [] {
+    auto structs = [] {
+      auto values = col_data{-3, -2, 2, -2, 1, 2, 0, 1, 0, 1, 2, -3, 0, 1};
+      auto counts = int64s_col{1, 1, 3, 1, 3, 2, 1, 1, 2, 1, 2, 3, 1, 2};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(
+      5, int32s_col{0, 3, 6, 8, 11, 14}.release(), structs.release(), 0, rmm::device_buffer{});
+  }();
+
+  auto const expected_keys      = int32s_col{0, 1};
+  auto const expected_histogram = [] {
+    auto structs = [] {
+      auto values = col_data{-3, -2, 0, 1, 2, -2, 0, 1, 2};
+      auto counts = int64s_col{4, 1, 2, 3, 3, 1, 2, 4, 4};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(
+      2, int32s_col{0, 5, 9}.release(), structs.release(), 0, rmm::device_buffer{});
+  }();
+
+  auto const [res_keys, res_histogram] =
+    groupby_histogram(keys, *values, cudf::aggregation::MERGE_HISTOGRAM);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_keys, *res_keys);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_histogram, *res_histogram);
+}
+
+TYPED_TEST(GroupbyMergeHistogramTest, SlicedInputNoNull)
+{
+  using col_data = cudf::test::fixed_width_column_wrapper<TypeParam, int>;
+
+  // key = 0: histograms = [[<-3, 1>, <-2, 1>, <2, 3>], [<0, 1>, <1, 1>], [<-3, 3>, <0, 1>, <1, 2>]]
+  // key = 1: histograms = [[<-2, 1>, <1, 3>, <2, 2>], [<0, 2>, <1, 1>, <2, 2>]]
+  auto const keys_original   = int32s_col{0, 1, 0, 1, 0, 1, 0};
+  auto const values_original = [] {
+    auto structs = [] {
+      auto values = col_data{0, 2, -3, 1, -3, -2, 2, -2, 1, 2, 0, 1, 0, 1, 2, -3, 0, 1};
+      auto counts = int64s_col{1, 2, 3, 1, 1, 1, 3, 1, 3, 2, 1, 1, 2, 1, 2, 3, 1, 2};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(7,
+                                   int32s_col{0, 2, 4, 7, 10, 12, 15, 18}.release(),
+                                   structs.release(),
+                                   0,
+                                   rmm::device_buffer{});
+  }();
+  auto const keys   = cudf::slice(keys_original, {2, 7})[0];
+  auto const values = cudf::slice(*values_original, {2, 7})[0];
+
+  auto const expected_keys      = int32s_col{0, 1};
+  auto const expected_histogram = [] {
+    auto structs = [] {
+      auto values = col_data{-3, -2, 0, 1, 2, -2, 0, 1, 2};
+      auto counts = int64s_col{4, 1, 2, 3, 3, 1, 2, 4, 4};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(
+      2, int32s_col{0, 5, 9}.release(), structs.release(), 0, rmm::device_buffer{});
+  }();
+
+  auto const [res_keys, res_histogram] =
+    groupby_histogram(keys, values, cudf::aggregation::MERGE_HISTOGRAM);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_keys, *res_keys);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_histogram, *res_histogram);
+}
+
+TYPED_TEST(GroupbyMergeHistogramTest, InputWithNulls)
+{
+  using col_data = cudf::test::fixed_width_column_wrapper<TypeParam, int>;
+  using namespace cudf::test::iterators;
+  auto constexpr null{0};
+
+  // key = 0: histograms = [[<null, 1>, <2, 3>], [<null, 2>, <1, 1>], [<0, 1>, <1, 2>]]
+  // key = 1: histograms = [[<null, 1>, <1, 3>, <2, 2>], [<0, 2>, <1, 1>, <2, 2>]]
+  auto const keys   = int32s_col{0, 1, 1, 0, 0};
+  auto const values = [] {
+    auto structs = [] {
+      auto values = col_data{{null, 2, null, 1, 2, 0, 1, 2, null, 1, 0, 1}, nulls_at({0, 2, 8})};
+      auto counts = int64s_col{1, 3, 1, 3, 2, 2, 1, 2, 2, 1, 1, 2};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(
+      5, int32s_col{0, 2, 5, 8, 10, 12}.release(), structs.release(), 0, rmm::device_buffer{});
+  }();
+
+  auto const expected_keys      = int32s_col{0, 1};
+  auto const expected_histogram = [] {
+    auto structs = [] {
+      auto values = col_data{{null, 0, 1, 2, null, 0, 1, 2}, nulls_at({0, 4})};
+      auto counts = int64s_col{3, 1, 3, 3, 1, 2, 4, 4};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(
+      2, int32s_col{0, 4, 8}.release(), structs.release(), 0, rmm::device_buffer{});
+  }();
+
+  auto const [res_keys, res_histogram] =
+    groupby_histogram(keys, *values, cudf::aggregation::MERGE_HISTOGRAM);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_keys, *res_keys);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_histogram, *res_histogram);
+}
+
+TYPED_TEST(GroupbyMergeHistogramTest, SlicedInputWithNulls)
+{
+  using col_data = cudf::test::fixed_width_column_wrapper<TypeParam, int>;
+  using namespace cudf::test::iterators;
+  auto constexpr null{0};
+
+  // key = 0: histograms = [[<null, 1>, <2, 3>], [<null, 2>, <1, 1>], [<0, 1>, <1, 2>]]
+  // key = 1: histograms = [[<null, 1>, <1, 3>, <2, 2>], [<0, 2>, <1, 1>, <2, 2>]]
+  auto const keys_original   = int32s_col{0, 1, 0, 1, 1, 0, 0};
+  auto const values_original = [] {
+    auto structs = [] {
+      auto values = col_data{{null, 2, null, 1, null, 2, null, 1, 2, 0, 1, 2, null, 1, 0, 1},
+                             nulls_at({0, 2, 4, 6, 12})};
+      auto counts = int64s_col{1, 3, 2, 1, 1, 3, 1, 3, 2, 2, 1, 2, 2, 1, 1, 2};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(7,
+                                   int32s_col{0, 2, 4, 6, 9, 12, 14, 16}.release(),
+                                   structs.release(),
+                                   0,
+                                   rmm::device_buffer{});
+  }();
+  auto const keys   = cudf::slice(keys_original, {2, 7})[0];
+  auto const values = cudf::slice(*values_original, {2, 7})[0];
+
+  auto const expected_keys      = int32s_col{0, 1};
+  auto const expected_histogram = [] {
+    auto structs = [] {
+      auto values = col_data{{null, 0, 1, 2, null, 0, 1, 2}, nulls_at({0, 4})};
+      auto counts = int64s_col{3, 1, 3, 3, 1, 2, 4, 4};
+      return structs_col{{values, counts}};
+    }();
+    return cudf::make_lists_column(
+      2, int32s_col{0, 4, 8}.release(), structs.release(), 0, rmm::device_buffer{});
+  }();
+
+  auto const [res_keys, res_histogram] =
+    groupby_histogram(keys, values, cudf::aggregation::MERGE_HISTOGRAM);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_keys, *res_keys);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*expected_histogram, *res_histogram);
+}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.10` that creates a PR to keep `branch-23.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.