### PR TITLE
cudf::detail::pinned_allocator doesn't throw from `deallocate`

### DIFF
--- a/cpp/include/cudf/detail/utilities/pinned_host_vector.hpp
+++ b/cpp/include/cudf/detail/utilities/pinned_host_vector.hpp
@@ -173,7 +173,7 @@ class pinned_allocator {
   {
     auto dealloc_worked = cudaFreeHost(p);
     (void)dealloc_worked;
-    assert(status__ == cudaSuccess);
+    assert(dealloc_worked == cudaSuccess);
   }
 
   /**

--- a/cpp/include/cudf/detail/utilities/pinned_host_vector.hpp
+++ b/cpp/include/cudf/detail/utilities/pinned_host_vector.hpp
@@ -169,7 +169,12 @@ class pinned_allocator {
    *        It is the responsibility of the caller to destroy
    *        the objects stored at \p p.
    */
-  __host__ inline void deallocate(pointer p, size_type /*cnt*/) { CUDF_CUDA_TRY(cudaFreeHost(p)); }
+  __host__ inline void deallocate(pointer p, size_type /*cnt*/)
+  {
+    auto dealloc_worked = cudaFreeHost(p);
+    (void)dealloc_worked;
+    assert(status__ == cudaSuccess);
+  }
 
   /**
    * @brief This method returns the maximum size of the \c cnt parameter


### PR DESCRIPTION
## Description
Fixes #14165

The deallocate function is called by the `pinned_host_vector`. Throwing from destructors is bad since they can't be caught, and generally get converted into runtime sig aborts.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
