### PR TITLE
Deprecate `is_categorical_dtype`

### DIFF
--- a/python/cudf/cudf/_fuzz_testing/csv.py
+++ b/python/cudf/cudf/_fuzz_testing/csv.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 import logging
 import random
@@ -99,7 +99,7 @@ class CSVReader(IOFuzz):
                     if dtype_val is not None:
                         dtype_val = {
                             col_name: "category"
-                            if cudf.utils.dtypes.is_categorical_dtype(dtype)
+                            if cudf.utils.dtypes._is_categorical_dtype(dtype)
                             else pandas_dtypes_to_np_dtypes[dtype]
                             for col_name, dtype in dtype_val.items()
                         }

--- a/python/cudf/cudf/_fuzz_testing/json.py
+++ b/python/cudf/cudf/_fuzz_testing/json.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 import logging
 import random
@@ -27,7 +27,7 @@ def _get_dtype_param_value(dtype_val):
     if dtype_val is not None and isinstance(dtype_val, abc.Mapping):
         processed_dtypes = {}
         for col_name, dtype in dtype_val.items():
-            if cudf.utils.dtypes.is_categorical_dtype(dtype):
+            if cudf.utils.dtypes._is_categorical_dtype(dtype):
                 processed_dtypes[col_name] = "category"
             else:
                 processed_dtypes[col_name] = str(

--- a/python/cudf/cudf/_lib/column.pyx
+++ b/python/cudf/cudf/_lib/column.pyx
@@ -11,7 +11,7 @@ import rmm
 import cudf
 import cudf._lib as libcudf
 from cudf._lib import pylibcudf
-from cudf.api.types import is_categorical_dtype, is_datetime64tz_dtype
+from cudf.api.types import _is_categorical_dtype, is_datetime64tz_dtype
 from cudf.core.buffer import (
     Buffer,
     ExposureTrackedBuffer,
@@ -331,7 +331,7 @@ cdef class Column:
             )
 
     cdef mutable_column_view mutable_view(self) except *:
-        if is_categorical_dtype(self.dtype):
+        if _is_categorical_dtype(self.dtype):
             col = self.base_children[0]
             data_dtype = col.dtype
         elif is_datetime64tz_dtype(self.dtype):
@@ -394,7 +394,7 @@ cdef class Column:
         return self._view(c_null_count)
 
     cdef column_view _view(self, libcudf_types.size_type null_count) except *:
-        if is_categorical_dtype(self.dtype):
+        if _is_categorical_dtype(self.dtype):
             col = self.base_children[0]
             data_dtype = col.dtype
         elif is_datetime64tz_dtype(self.dtype):
@@ -469,7 +469,7 @@ cdef class Column:
         # categoricals because cudf supports ordered and unordered categoricals
         # while libcudf supports only unordered categoricals (see
         # https://github.com/rapidsai/cudf/pull/8567).
-        if is_categorical_dtype(self.dtype):
+        if _is_categorical_dtype(self.dtype):
             col = self.base_children[0]
         else:
             col = self
@@ -635,7 +635,7 @@ cdef class Column:
         """
         column_owner = isinstance(owner, Column)
         mask_owner = owner
-        if column_owner and is_categorical_dtype(owner.dtype):
+        if column_owner and _is_categorical_dtype(owner.dtype):
             owner = owner.base_children[0]
 
         size = cv.size()

--- a/python/cudf/cudf/_lib/csv.pyx
+++ b/python/cudf/cudf/_lib/csv.pyx
@@ -434,7 +434,7 @@ def read_csv(
     if dtype is not None:
         if isinstance(dtype, abc.Mapping):
             for k, v in dtype.items():
-                if cudf.api.types.is_categorical_dtype(v):
+                if cudf.api.types._is_categorical_dtype(v):
                     df._data[str(k)] = df._data[str(k)].astype(v)
         elif (
             cudf.api.types.is_scalar(dtype) or
@@ -442,11 +442,11 @@ def read_csv(
                 np.dtype, pd.api.extensions.ExtensionDtype, type
             ))
         ):
-            if cudf.api.types.is_categorical_dtype(dtype):
+            if cudf.api.types._is_categorical_dtype(dtype):
                 df = df.astype(dtype)
         elif isinstance(dtype, abc.Collection):
             for index, col_dtype in enumerate(dtype):
-                if cudf.api.types.is_categorical_dtype(col_dtype):
+                if cudf.api.types._is_categorical_dtype(col_dtype):
                     col_name = df._data.names[index]
                     df._data[col_name] = df._data[col_name].astype(col_dtype)
 
@@ -547,7 +547,7 @@ cdef data_type _get_cudf_data_type_from_dtype(object dtype) except *:
     # TODO: Remove this work-around Dictionary types
     # in libcudf are fully mapped to categorical columns:
     # https://github.com/rapidsai/cudf/issues/3960
-    if cudf.api.types.is_categorical_dtype(dtype):
+    if cudf.api.types._is_categorical_dtype(dtype):
         if isinstance(dtype, str):
             dtype = "str"
         else:

--- a/python/cudf/cudf/_lib/groupby.pyx
+++ b/python/cudf/cudf/_lib/groupby.pyx
@@ -3,7 +3,7 @@
 from pandas.core.groupby.groupby import DataError
 
 from cudf.api.types import (
-    is_categorical_dtype,
+    _is_categorical_dtype,
     is_decimal_dtype,
     is_interval_dtype,
     is_list_dtype,
@@ -189,7 +189,7 @@ cdef class GroupBy:
             valid_aggregations = (
                 _LIST_AGGS if is_list_dtype(dtype)
                 else _STRING_AGGS if is_string_dtype(dtype)
-                else _CATEGORICAL_AGGS if is_categorical_dtype(dtype)
+                else _CATEGORICAL_AGGS if _is_categorical_dtype(dtype)
                 else _STRUCT_AGGS if is_struct_dtype(dtype)
                 else _INTERVAL_AGGS if is_interval_dtype(dtype)
                 else _DECIMAL_AGGS if is_decimal_dtype(dtype)
@@ -260,7 +260,7 @@ cdef class GroupBy:
             valid_aggregations = (
                 _LIST_AGGS if is_list_dtype(dtype)
                 else _STRING_AGGS if is_string_dtype(dtype)
-                else _CATEGORICAL_AGGS if is_categorical_dtype(dtype)
+                else _CATEGORICAL_AGGS if _is_categorical_dtype(dtype)
                 else _STRUCT_AGGS if is_struct_dtype(dtype)
                 else _INTERVAL_AGGS if is_interval_dtype(dtype)
                 else _DECIMAL_AGGS if is_decimal_dtype(dtype)

--- a/python/cudf/cudf/_lib/json.pyx
+++ b/python/cudf/cudf/_lib/json.pyx
@@ -214,7 +214,7 @@ def write_json(
 cdef schema_element _get_cudf_schema_element_from_dtype(object dtype) except *:
     cdef schema_element s_element
     cdef data_type lib_type
-    if cudf.api.types.is_categorical_dtype(dtype):
+    if cudf.api.types._is_categorical_dtype(dtype):
         raise NotImplementedError(
             "CategoricalDtype as dtype is not yet "
             "supported in JSON reader"
@@ -237,7 +237,7 @@ cdef schema_element _get_cudf_schema_element_from_dtype(object dtype) except *:
 
 
 cdef data_type _get_cudf_data_type_from_dtype(object dtype) except *:
-    if cudf.api.types.is_categorical_dtype(dtype):
+    if cudf.api.types._is_categorical_dtype(dtype):
         raise NotImplementedError(
             "CategoricalDtype as dtype is not yet "
             "supported in JSON reader"

--- a/python/cudf/cudf/_lib/utils.pyx
+++ b/python/cudf/cudf/_lib/utils.pyx
@@ -23,7 +23,7 @@ except ImportError:
     import json
 
 from cudf.api.types import (
-    is_categorical_dtype,
+    _is_categorical_dtype,
     is_decimal_dtype,
     is_list_dtype,
     is_struct_dtype,
@@ -92,7 +92,7 @@ cpdef generate_pandas_metadata(table, index):
     # Columns
     for name, col in table._data.items():
         col_names.append(name)
-        if is_categorical_dtype(col):
+        if _is_categorical_dtype(col):
             raise ValueError(
                 "'category' column dtypes are currently not "
                 + "supported by the gpu accelerated parquet writer"
@@ -147,7 +147,7 @@ cpdef generate_pandas_metadata(table, index):
                         level=level,
                         column_names=col_names
                     )
-                if is_categorical_dtype(idx):
+                if _is_categorical_dtype(idx):
                     raise ValueError(
                         "'category' column dtypes are currently not "
                         + "supported by the gpu accelerated parquet writer"

--- a/python/cudf/cudf/api/types.py
+++ b/python/cudf/cudf/api/types.py
@@ -18,7 +18,7 @@ import cudf
 from cudf.core.dtypes import (  # noqa: F401
     _BaseDtype,
     dtype,
-    is_categorical_dtype,
+    _is_categorical_dtype,
     is_decimal32_dtype,
     is_decimal64_dtype,
     is_decimal128_dtype,
@@ -112,7 +112,7 @@ def is_string_dtype(obj):
         or (
             pd.api.types.is_string_dtype(obj)
             # Reject all cudf extension types.
-            and not is_categorical_dtype(obj)
+            and not _is_categorical_dtype(obj)
             and not is_decimal_dtype(obj)
             and not is_list_dtype(obj)
             and not is_struct_dtype(obj)
@@ -486,6 +486,7 @@ is_named_tuple = pd_types.is_named_tuple
 is_iterator = pd_types.is_iterator
 is_bool = pd_types.is_bool
 is_categorical = pd_types.is_categorical_dtype
+# TODO
 is_complex = pd_types.is_complex
 is_float = pd_types.is_float
 is_hashable = pd_types.is_hashable

--- a/python/cudf/cudf/core/_internals/where.py
+++ b/python/cudf/cudf/core/_internals/where.py
@@ -8,8 +8,8 @@ import numpy as np
 import cudf
 from cudf._typing import ScalarLike
 from cudf.api.types import (
+    _is_categorical_dtype,
     _is_non_decimal_numeric_dtype,
-    is_categorical_dtype,
     is_scalar,
 )
 from cudf.core.column import ColumnBase
@@ -45,7 +45,7 @@ def _check_and_cast_columns_with_other(
 ) -> Tuple[ColumnBase, Union[ScalarLike, ColumnBase]]:
     # Returns type-casted `source_col` & `other` based on `inplace`.
     source_dtype = source_col.dtype
-    if is_categorical_dtype(source_dtype):
+    if _is_categorical_dtype(source_dtype):
         return _normalize_categorical(source_col, other)
 
     other_is_scalar = is_scalar(other)

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -16,7 +16,7 @@ import cudf
 from cudf import _lib as libcudf
 from cudf._lib.transform import bools_to_mask
 from cudf._typing import ColumnBinaryOperand, ColumnLike, Dtype, ScalarLike
-from cudf.api.types import is_categorical_dtype, is_interval_dtype
+from cudf.api.types import _is_categorical_dtype, is_interval_dtype
 from cudf.core.buffer import Buffer
 from cudf.core.column import column
 from cudf.core.column.methods import ColumnMethods
@@ -98,7 +98,7 @@ class CategoricalAccessor(ColumnMethods):
     _column: CategoricalColumn
 
     def __init__(self, parent: SeriesOrSingleColumnIndex):
-        if not is_categorical_dtype(parent.dtype):
+        if not _is_categorical_dtype(parent.dtype):
             raise AttributeError(
                 "Can only use .cat accessor with a 'category' dtype"
             )

--- a/python/cudf/cudf/core/column/interval.py
+++ b/python/cudf/cudf/core/column/interval.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pyarrow as pa
 
 import cudf
-from cudf.api.types import is_categorical_dtype, is_interval_dtype
+from cudf.api.types import _is_categorical_dtype, is_interval_dtype
 from cudf.core.column import StructColumn
 from cudf.core.dtypes import IntervalDtype
 
@@ -102,7 +102,7 @@ class IntervalColumn(StructColumn):
 
     def as_interval_column(self, dtype, **kwargs):
         if is_interval_dtype(dtype):
-            if is_categorical_dtype(self):
+            if _is_categorical_dtype(self):
                 new_struct = self._get_decategorized_column()
                 return IntervalColumn.from_struct_column(new_struct)
             if is_interval_dtype(dtype):

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -4,6 +4,7 @@ import decimal
 import operator
 import pickle
 import textwrap
+import warnings
 from functools import cached_property
 from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
@@ -957,19 +958,7 @@ class IntervalDtype(StructDtype):
         return klass(subtype, closed=closed)
 
 
-def is_categorical_dtype(obj):
-    """Check whether an array-like or dtype is of the Categorical dtype.
-
-    Parameters
-    ----------
-    obj : array-like or dtype
-        The array-like or dtype to check.
-
-    Returns
-    -------
-    bool
-        Whether or not the array-like or dtype is of a categorical dtype.
-    """
+def _is_categorical_dtype(obj):
     if obj is None:
         return False
 
@@ -1013,13 +1002,37 @@ def is_categorical_dtype(obj):
             pd.Series,
         ),
     ):
-        return is_categorical_dtype(obj.dtype)
+        return _is_categorical_dtype(obj.dtype)
     if hasattr(obj, "type"):
         if obj.type is pd_CategoricalDtypeType:
             return True
     # TODO: A lot of the above checks are probably redundant and should be
     # farmed out to this function here instead.
-    return pd_types.is_categorical_dtype(obj)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return pd_types.is_categorical_dtype(obj)
+
+
+def is_categorical_dtype(obj):
+    """Check whether an array-like or dtype is of the Categorical dtype.
+
+    Parameters
+    ----------
+    obj : array-like or dtype
+        The array-like or dtype to check.
+
+    Returns
+    -------
+    bool
+        Whether or not the array-like or dtype is of a categorical dtype.
+    """
+    # Do not remove until pandas 3.0 support is added.
+    warnings.warn(
+        "is_categorical_dtype is deprecated and will be removed in a future "
+        "version. Use isinstance(dtype, cudf.CategoricalDtype) instead",
+        FutureWarning,
+    )
+    return _is_categorical_dtype(obj)
 
 
 def is_list_dtype(obj):

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -1016,6 +1016,9 @@ def _is_categorical_dtype(obj):
 def is_categorical_dtype(obj):
     """Check whether an array-like or dtype is of the Categorical dtype.
 
+    .. deprecated:: 23.12
+       Use isinstance(dtype, cudf.CategoricalDtype) instead
+
     Parameters
     ----------
     obj : array-like or dtype

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -31,7 +31,7 @@ from cudf._lib.types import size_type_dtype
 from cudf.api.extensions import no_default
 from cudf.api.types import (
     _is_non_decimal_numeric_dtype,
-    is_categorical_dtype,
+    _is_categorical_dtype,
     is_dtype_equal,
     is_interval_dtype,
     is_list_like,
@@ -2496,7 +2496,7 @@ class CategoricalIndex(Index):
         if isinstance(data, CategoricalColumn):
             data = data
         elif isinstance(data, pd.Series) and (
-            is_categorical_dtype(data.dtype)
+            _is_categorical_dtype(data.dtype)
         ):
             codes_data = column.as_column(data.cat.codes.values)
             data = column.build_categorical_column(

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -41,8 +41,8 @@ from cudf._typing import (
 from cudf.api.extensions import no_default
 from cudf.api.types import (
     _is_non_decimal_numeric_dtype,
+    _is_categorical_dtype,
     is_bool_dtype,
-    is_categorical_dtype,
     is_decimal_dtype,
     is_dict_like,
     is_list_dtype,
@@ -170,7 +170,7 @@ def _indices_from_labels(obj, labels):
     if not isinstance(labels, cudf.MultiIndex):
         labels = cudf.core.column.as_column(labels)
 
-        if is_categorical_dtype(obj.index):
+        if _is_categorical_dtype(obj.index):
             labels = labels.astype("category")
             codes = labels.codes.astype(obj.index._values.codes.dtype)
             labels = cudf.core.column.build_categorical_column(
@@ -5418,21 +5418,21 @@ def _is_same_dtype(lhs_dtype, rhs_dtype):
     if lhs_dtype == rhs_dtype:
         return True
     elif (
-        is_categorical_dtype(lhs_dtype)
-        and is_categorical_dtype(rhs_dtype)
+        _is_categorical_dtype(lhs_dtype)
+        and _is_categorical_dtype(rhs_dtype)
         and lhs_dtype.categories.dtype == rhs_dtype.categories.dtype
     ):
         # OK if categories are not all the same
         return True
     elif (
-        is_categorical_dtype(lhs_dtype)
-        and not is_categorical_dtype(rhs_dtype)
+        _is_categorical_dtype(lhs_dtype)
+        and not _is_categorical_dtype(rhs_dtype)
         and lhs_dtype.categories.dtype == rhs_dtype
     ):
         return True
     elif (
-        is_categorical_dtype(rhs_dtype)
-        and not is_categorical_dtype(lhs_dtype)
+        _is_categorical_dtype(rhs_dtype)
+        and not _is_categorical_dtype(lhs_dtype)
         and rhs_dtype.categories.dtype == lhs_dtype
     ):
         return True

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -540,7 +540,7 @@ def melt(
 
     # Error for unimplemented support for datatype
     dtypes = [frame[col].dtype for col in id_vars + value_vars]
-    if any(cudf.api.types.is_categorical_dtype(t) for t in dtypes):
+    if any(cudf.api.types._is_categorical_dtype(t) for t in dtypes):
         raise NotImplementedError(
             "Categorical columns are not yet supported for function"
         )

--- a/python/cudf/cudf/core/tools/numeric.py
+++ b/python/cudf/cudf/core/tools/numeric.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 import warnings
 
@@ -9,8 +9,8 @@ import cudf
 from cudf import _lib as libcudf
 from cudf._lib import strings as libstrings
 from cudf.api.types import (
+    _is_categorical_dtype,
     _is_non_decimal_numeric_dtype,
-    is_categorical_dtype,
     is_datetime_dtype,
     is_list_dtype,
     is_string_dtype,
@@ -110,7 +110,7 @@ def to_numeric(arg, errors="raise", downcast=None):
 
     if is_datetime_dtype(dtype) or is_timedelta_dtype(dtype):
         col = col.as_numerical_column(cudf.dtype("int64"))
-    elif is_categorical_dtype(dtype):
+    elif _is_categorical_dtype(dtype):
         cat_dtype = col.dtype.type
         if _is_non_decimal_numeric_dtype(cat_dtype):
             col = col.as_numerical_column(cat_dtype)

--- a/python/cudf/cudf/testing/testing.py
+++ b/python/cudf/cudf/testing/testing.py
@@ -9,7 +9,7 @@ import pandas as pd
 import cudf
 from cudf._lib.unary import is_nan
 from cudf.api.types import (
-    is_categorical_dtype,
+    _is_categorical_dtype,
     is_decimal_dtype,
     is_interval_dtype,
     is_list_dtype,
@@ -86,7 +86,7 @@ def _check_types(
     if (
         exact
         and not isinstance(left, cudf.MultiIndex)
-        and is_categorical_dtype(left)
+        and _is_categorical_dtype(left)
     ):
         if left.dtype != right.dtype:
             raise_assert_detail(
@@ -144,8 +144,8 @@ def assert_column_equal(
     """
     if check_dtype is True:
         if (
-            is_categorical_dtype(left)
-            and is_categorical_dtype(right)
+            _is_categorical_dtype(left)
+            and _is_categorical_dtype(right)
             and not check_categorical
         ):
             pass
@@ -173,7 +173,7 @@ def assert_column_equal(
             return
 
     if check_exact and check_categorical:
-        if is_categorical_dtype(left) and is_categorical_dtype(right):
+        if _is_categorical_dtype(left) and _is_categorical_dtype(right):
             left_cat = left.categories
             right_cat = right.categories
 
@@ -207,8 +207,8 @@ def assert_column_equal(
 
     if (
         not check_dtype
-        and is_categorical_dtype(left)
-        and is_categorical_dtype(right)
+        and _is_categorical_dtype(left)
+        and _is_categorical_dtype(right)
     ):
         left = left.astype(left.categories.dtype)
         right = right.astype(right.categories.dtype)
@@ -254,7 +254,7 @@ def assert_column_equal(
                 raise e
             else:
                 columns_equal = False
-            if is_categorical_dtype(left) and is_categorical_dtype(right):
+            if _is_categorical_dtype(left) and _is_categorical_dtype(right):
                 left = left.astype(left.categories.dtype)
                 right = right.astype(right.categories.dtype)
     if not columns_equal:

--- a/python/cudf/cudf/tests/test_api_types.py
+++ b/python/cudf/cudf/tests/test_api_types.py
@@ -116,7 +116,7 @@ from cudf.api import types
     ),
 )
 def test_is_categorical_dtype(obj, expect):
-    assert types.is_categorical_dtype(obj) == expect
+    assert types._is_categorical_dtype(obj) == expect
 
 
 @pytest.mark.parametrize(
@@ -1036,9 +1036,10 @@ def test_is_decimal_dtype(obj, expect):
     ),
 )
 def test_pandas_agreement(obj):
-    assert types.is_categorical_dtype(obj) == pd_types.is_categorical_dtype(
-        obj
-    )
+    with pytest.warns(FutureWarning):
+        assert types.is_categorical_dtype(
+            obj
+        ) == pd_types.is_categorical_dtype(obj)
     assert types.is_numeric_dtype(obj) == pd_types.is_numeric_dtype(obj)
     assert types.is_integer_dtype(obj) == pd_types.is_integer_dtype(obj)
     assert types.is_integer(obj) == pd_types.is_integer(obj)

--- a/python/cudf/cudf/tests/test_column.py
+++ b/python/cudf/cudf/tests/test_column.py
@@ -81,7 +81,7 @@ def test_column_offset_and_size(pandas_input, offset, size):
         children=col.base_children,
     )
 
-    if cudf.api.types.is_categorical_dtype(col.dtype):
+    if cudf.api.types._is_categorical_dtype(col.dtype):
         assert col.size == col.codes.size
         assert col.size == (col.codes.data.size / col.codes.dtype.itemsize)
     elif cudf.api.types.is_string_dtype(col.dtype):
@@ -120,7 +120,7 @@ def column_slicing_test(col, offset, size, cast_to_float=False):
     else:
         pd_series = series.to_pandas()
 
-    if cudf.api.types.is_categorical_dtype(col.dtype):
+    if cudf.api.types._is_categorical_dtype(col.dtype):
         # The cudf.Series is constructed from an already sliced column, whereas
         # the pandas.Series is constructed from the unsliced series and then
         # sliced, so the indexes should be different and we must ignore it.

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 import cudf as gd
-from cudf.api.types import is_categorical_dtype
+from cudf.api.types import _is_categorical_dtype
 from cudf.core._compat import PANDAS_GE_150, PANDAS_LT_140, PANDAS_GE_200
 from cudf.core.dtypes import Decimal32Dtype, Decimal64Dtype, Decimal128Dtype
 from cudf.testing._utils import (
@@ -582,8 +582,8 @@ def test_concat_empty_dataframes(df, other, ignore_index):
     actual = gd.concat(other_gd, ignore_index=ignore_index)
     if expected.shape != df.shape:
         for key, col in actual[actual.columns].items():
-            if is_categorical_dtype(col.dtype):
-                if not is_categorical_dtype(expected[key].dtype):
+            if _is_categorical_dtype(col.dtype):
+                if not _is_categorical_dtype(expected[key].dtype):
                     # TODO: Pandas bug:
                     # https://github.com/pandas-dev/pandas/issues/42840
                     expected[key] = expected[key].fillna("-1").astype("str")
@@ -1213,8 +1213,8 @@ def test_concat_join_empty_dataframes(
     if expected.shape != df.shape:
         if axis == 0:
             for key, col in actual[actual.columns].items():
-                if is_categorical_dtype(col.dtype):
-                    if not is_categorical_dtype(expected[key].dtype):
+                if _is_categorical_dtype(col.dtype):
+                    if not _is_categorical_dtype(expected[key].dtype):
                         # TODO: Pandas bug:
                         # https://github.com/pandas-dev/pandas/issues/42840
                         expected[key] = (
@@ -1336,7 +1336,7 @@ def test_concat_join_empty_dataframes_axis_1(
     if expected.shape != df.shape:
         if axis == 0:
             for key, col in actual[actual.columns].items():
-                if is_categorical_dtype(col.dtype):
+                if _is_categorical_dtype(col.dtype):
                     expected[key] = expected[key].fillna("-1")
                     actual[key] = col.astype("str").fillna("-1")
             # if not expected.empty:

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -5943,7 +5943,9 @@ def test_df_sr_mask_where(data, condition, other, error, inplace):
             expect_mask = ps_mask
             got_mask = gs_mask
 
-        if pd.api.types.is_categorical_dtype(expect_where):
+        if hasattr(expect_where, "dtype") and isinstance(
+            expect_where, pd.CategoricalDtype
+        ):
             np.testing.assert_array_equal(
                 expect_where.cat.codes,
                 got_where.cat.codes.astype(expect_where.cat.codes.dtype)

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -659,7 +659,7 @@ def test_index_where(data, condition, other, error):
         gs_other = other
 
     if error is None:
-        if pd.api.types.is_categorical_dtype(ps):
+        if hasattr(ps, "dtype") and isinstance(ps, pd.CategoricalDtype):
             expect = ps.where(ps_condition, other=ps_other)
             got = gs.where(gs_condition, other=gs_other)
             np.testing.assert_array_equal(

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -184,7 +184,7 @@ def cudf_dtype_from_pydata_dtype(dtype):
     Python dtype.
     """
 
-    if cudf.api.types.is_categorical_dtype(dtype):
+    if cudf.api.types._is_categorical_dtype(dtype):
         return cudf.core.dtypes.CategoricalDtype
     elif cudf.api.types.is_decimal32_dtype(dtype):
         return cudf.core.dtypes.Decimal32Dtype
@@ -202,7 +202,7 @@ def cudf_dtype_to_pa_type(dtype):
     """Given a cudf pandas dtype, converts it into the equivalent cuDF
     Python dtype.
     """
-    if cudf.api.types.is_categorical_dtype(dtype):
+    if cudf.api.types._is_categorical_dtype(dtype):
         raise NotImplementedError()
     elif (
         cudf.api.types.is_list_dtype(dtype)
@@ -427,9 +427,9 @@ def get_min_float_dtype(col):
 
 
 def is_mixed_with_object_dtype(lhs, rhs):
-    if cudf.api.types.is_categorical_dtype(lhs.dtype):
+    if cudf.api.types._is_categorical_dtype(lhs.dtype):
         return is_mixed_with_object_dtype(lhs.dtype.categories, rhs)
-    elif cudf.api.types.is_categorical_dtype(rhs.dtype):
+    elif cudf.api.types._is_categorical_dtype(rhs.dtype):
         return is_mixed_with_object_dtype(lhs, rhs.dtype.categories)
 
     return (lhs.dtype == "object" and rhs.dtype != "object") or (
@@ -529,10 +529,10 @@ def find_common_type(dtypes):
 
     # Early exit for categoricals since they're not hashable and therefore
     # can't be put in a set.
-    if any(cudf.api.types.is_categorical_dtype(dtype) for dtype in dtypes):
+    if any(cudf.api.types._is_categorical_dtype(dtype) for dtype in dtypes):
         if all(
             (
-                cudf.api.types.is_categorical_dtype(dtype)
+                cudf.api.types._is_categorical_dtype(dtype)
                 and (not dtype.ordered if hasattr(dtype, "ordered") else True)
             )
             for dtype in dtypes

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -312,7 +312,7 @@ def tolist_cudf(obj):
 )
 @_dask_cudf_nvtx_annotate
 def is_categorical_dtype_cudf(obj):
-    return cudf.api.types.is_categorical_dtype(obj)
+    return cudf.api.types._is_categorical_dtype(obj)
 
 
 @grouper_dispatch.register((cudf.Series, cudf.DataFrame))
@@ -341,7 +341,7 @@ try:
         if isinstance(q, Iterator):
             q = list(q)
 
-        if cudf.api.types.is_categorical_dtype(a.dtype):
+        if cudf.api.types._is_categorical_dtype(a.dtype):
             result = cp.percentile(a.cat.codes, q, interpolation=interpolation)
 
             return (

--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -15,7 +15,7 @@ from dask.highlevelgraph import HighLevelGraph
 from dask.utils import M
 
 import cudf as gd
-from cudf.api.types import is_categorical_dtype
+from cudf.api.types import _is_categorical_dtype
 from cudf.utils.utils import _dask_cudf_nvtx_annotate
 
 _SHUFFLE_SUPPORT = ("tasks", "p2p")  # "disk" not supported
@@ -203,7 +203,7 @@ def quantile_divisions(df, by, npartitions):
     if (
         len(columns) == 1
         and df[columns[0]].dtype != "object"
-        and not is_categorical_dtype(df[columns[0]].dtype)
+        and not _is_categorical_dtype(df[columns[0]].dtype)
     ):
         dtype = df[columns[0]].dtype
         divisions = divisions[columns[0]].astype("int64")


### PR DESCRIPTION
## Description
This PR deprecates `is_categorical_dtype` to match https://github.com/pandas-dev/pandas/pull/52527 which was introduced in `pandas-2.x`. This PR internalizes the public API since this is a needed utility in our code base.

This PR:
```
= 23835 failed, 5698 passed, 1613 skipped, 288 xfailed, 423 errors in 1976.84s (0:32:56) =
```

On `pandas_2.0_feature_branch`:
```
= 24297 failed, 5115 passed, 1613 skipped, 288 xfailed, 480 errors in 1980.46s (0:33:00) =
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
