### PR TITLE
Deprecate `is_datetime64tz_dtype` and `is_interval_dtype`

### DIFF
--- a/python/cudf/cudf/_lib/column.pyx
+++ b/python/cudf/cudf/_lib/column.pyx
@@ -11,7 +11,7 @@ import rmm
 import cudf
 import cudf._lib as libcudf
 from cudf._lib import pylibcudf
-from cudf.api.types import is_categorical_dtype, is_datetime64tz_dtype
+from cudf.api.types import _is_datetime64tz_dtype, is_categorical_dtype
 from cudf.core.buffer import (
     Buffer,
     ExposureTrackedBuffer,
@@ -334,7 +334,7 @@ cdef class Column:
         if is_categorical_dtype(self.dtype):
             col = self.base_children[0]
             data_dtype = col.dtype
-        elif is_datetime64tz_dtype(self.dtype):
+        elif _is_datetime64tz_dtype(self.dtype):
             col = self
             data_dtype = _get_base_dtype(col.dtype)
         else:
@@ -397,7 +397,7 @@ cdef class Column:
         if is_categorical_dtype(self.dtype):
             col = self.base_children[0]
             data_dtype = col.dtype
-        elif is_datetime64tz_dtype(self.dtype):
+        elif _is_datetime64tz_dtype(self.dtype):
             col = self
             data_dtype = _get_base_dtype(col.dtype)
         else:

--- a/python/cudf/cudf/_lib/groupby.pyx
+++ b/python/cudf/cudf/_lib/groupby.pyx
@@ -5,7 +5,7 @@ from pandas.core.groupby.groupby import DataError
 from cudf.api.types import (
     is_categorical_dtype,
     is_decimal_dtype,
-    is_interval_dtype,
+    _is_interval_dtype,
     is_list_dtype,
     is_string_dtype,
     is_struct_dtype,
@@ -191,7 +191,7 @@ cdef class GroupBy:
                 else _STRING_AGGS if is_string_dtype(dtype)
                 else _CATEGORICAL_AGGS if is_categorical_dtype(dtype)
                 else _STRUCT_AGGS if is_struct_dtype(dtype)
-                else _INTERVAL_AGGS if is_interval_dtype(dtype)
+                else _INTERVAL_AGGS if _is_interval_dtype(dtype)
                 else _DECIMAL_AGGS if is_decimal_dtype(dtype)
                 else "ALL"
             )
@@ -262,7 +262,7 @@ cdef class GroupBy:
                 else _STRING_AGGS if is_string_dtype(dtype)
                 else _CATEGORICAL_AGGS if is_categorical_dtype(dtype)
                 else _STRUCT_AGGS if is_struct_dtype(dtype)
-                else _INTERVAL_AGGS if is_interval_dtype(dtype)
+                else _INTERVAL_AGGS if _is_interval_dtype(dtype)
                 else _DECIMAL_AGGS if is_decimal_dtype(dtype)
                 else "ALL"
             )

--- a/python/cudf/cudf/api/types.py
+++ b/python/cudf/cudf/api/types.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from collections import abc
 from functools import wraps
 from inspect import isclass
@@ -23,6 +25,7 @@ from cudf.core.dtypes import (  # noqa: F401
     is_decimal64_dtype,
     is_decimal128_dtype,
     is_decimal_dtype,
+    _is_interval_dtype,
     is_interval_dtype,
     is_list_dtype,
     is_struct_dtype,
@@ -116,7 +119,7 @@ def is_string_dtype(obj):
             and not is_decimal_dtype(obj)
             and not is_list_dtype(obj)
             and not is_struct_dtype(obj)
-            and not is_interval_dtype(obj)
+            and not _is_interval_dtype(obj)
         )
     )
 
@@ -451,6 +454,22 @@ def is_any_real_numeric_dtype(arr_or_dtype) -> bool:
     )
 
 
+def _is_datetime64tz_dtype(obj):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return _wrap_pandas_is_dtype_api(pd_types.is_datetime64tz_dtype)(obj)
+
+
+def is_datetime64tz_dtype(obj):
+    # Do not remove until pandas 3.0 support is added.
+    warnings.warn(
+        "is_datetime64tz_dtype is deprecated and will be removed in a future "
+        "version.",
+        FutureWarning,
+    )
+    return _is_datetime64tz_dtype(obj)
+
+
 # TODO: The below alias is removed for now since improving cudf categorical
 # support is ongoing and we don't want to introduce any ambiguities. The above
 # method _union_categoricals will take its place once exposed.
@@ -464,9 +483,6 @@ is_datetime64_any_dtype = pd_types.is_datetime64_any_dtype
 is_datetime64_dtype = _wrap_pandas_is_dtype_api(pd_types.is_datetime64_dtype)
 is_datetime64_ns_dtype = _wrap_pandas_is_dtype_api(
     pd_types.is_datetime64_ns_dtype
-)
-is_datetime64tz_dtype = _wrap_pandas_is_dtype_api(
-    pd_types.is_datetime64tz_dtype
 )
 is_extension_array_dtype = pd_types.is_extension_array_dtype
 is_int64_dtype = pd_types.is_int64_dtype

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -16,7 +16,7 @@ import cudf
 from cudf import _lib as libcudf
 from cudf._lib.transform import bools_to_mask
 from cudf._typing import ColumnBinaryOperand, ColumnLike, Dtype, ScalarLike
-from cudf.api.types import is_categorical_dtype, is_interval_dtype
+from cudf.api.types import _is_interval_dtype, is_categorical_dtype
 from cudf.core.buffer import Buffer
 from cudf.core.column import column
 from cudf.core.column.methods import ColumnMethods
@@ -802,7 +802,7 @@ class CategoricalColumn(column.ColumnBase):
             .fillna(_DEFAULT_CATEGORICAL_VALUE)
             .values_host
         )
-        if is_interval_dtype(col.categories.dtype):
+        if _is_interval_dtype(col.categories.dtype):
             # leaving out dropna because it temporarily changes an interval
             # index into a struct and throws off results.
             # TODO: work on interval index dropna

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -49,19 +49,19 @@ from cudf._lib.transform import bools_to_mask
 from cudf._lib.types import size_type_dtype
 from cudf._typing import ColumnLike, Dtype, ScalarLike
 from cudf.api.types import (
+    _is_interval_dtype,
+    _is_datetime64tz_dtype,
     _is_non_decimal_numeric_dtype,
     infer_dtype,
     is_bool_dtype,
     is_categorical_dtype,
     is_datetime64_dtype,
-    is_datetime64tz_dtype,
     is_decimal32_dtype,
     is_decimal64_dtype,
     is_decimal128_dtype,
     is_decimal_dtype,
     is_dtype_equal,
     is_integer_dtype,
-    is_interval_dtype,
     is_list_dtype,
     is_scalar,
     is_string_dtype,
@@ -1014,7 +1014,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
                     "Casting struct columns not currently supported"
                 )
             return self
-        elif is_interval_dtype(self.dtype):
+        elif _is_interval_dtype(self.dtype):
             return self.as_interval_column(dtype, **kwargs)
         elif is_decimal_dtype(dtype):
             return self.as_decimal_column(dtype, **kwargs)
@@ -1579,7 +1579,7 @@ def build_column(
             offset=offset,
             null_count=null_count,
         )
-    elif is_datetime64tz_dtype(dtype):
+    elif _is_datetime64tz_dtype(dtype):
         if data is None:
             raise TypeError("Must specify data buffer")
         return cudf.core.column.datetime.DatetimeTZColumn(
@@ -1618,7 +1618,7 @@ def build_column(
             null_count=null_count,
             children=children,
         )
-    elif is_interval_dtype(dtype):
+    elif _is_interval_dtype(dtype):
         return cudf.core.column.IntervalColumn(
             dtype=dtype,
             mask=mask,
@@ -1675,7 +1675,7 @@ def build_column(
             null_count=null_count,
             children=children,
         )
-    elif is_interval_dtype(dtype):
+    elif _is_interval_dtype(dtype):
         return cudf.core.column.IntervalColumn(
             dtype=dtype,
             mask=mask,
@@ -2045,7 +2045,7 @@ def as_column(
                     "cuDF does not yet support timezone-aware datetimes"
                 )
             data = as_column(pa.array(arbitrary, from_pandas=True))
-        elif is_interval_dtype(arbitrary.dtype):
+        elif _is_interval_dtype(arbitrary.dtype):
             if isinstance(arbitrary.dtype.subtype, pd.DatetimeTZDtype):
                 raise NotImplementedError(
                     "cuDF does not yet support timezone-aware datetimes"
@@ -2287,7 +2287,7 @@ def as_column(
         )
         or (
             isinstance(arbitrary, pd.IntervalIndex)
-            and is_datetime64tz_dtype(arbitrary.dtype.subtype)
+            and _is_datetime64tz_dtype(arbitrary.dtype.subtype)
         )
         or (
             isinstance(arbitrary, pd.CategoricalIndex)
@@ -2347,9 +2347,11 @@ def as_column(
             np_type = None
             try:
                 if dtype is not None:
-                    if is_categorical_dtype(dtype) or is_interval_dtype(dtype):
+                    if is_categorical_dtype(dtype) or _is_interval_dtype(
+                        dtype
+                    ):
                         raise TypeError
-                    if is_datetime64tz_dtype(dtype):
+                    if _is_datetime64tz_dtype(dtype):
                         raise NotImplementedError(
                             "Use `tz_localize()` to construct "
                             "timezone aware data."
@@ -2497,7 +2499,7 @@ def as_column(
                 elif np_type == np.str_:
                     sr = pd.Series(arbitrary, dtype="str")
                     data = as_column(sr, nan_as_null=nan_as_null)
-                elif is_interval_dtype(dtype):
+                elif _is_interval_dtype(dtype):
                     sr = pd.Series(arbitrary, dtype="interval")
                     data = as_column(sr, nan_as_null=nan_as_null, dtype=dtype)
                 elif (

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -22,8 +22,8 @@ from cudf._typing import (
     ScalarLike,
 )
 from cudf.api.types import (
+    _is_datetime64tz_dtype,
     is_datetime64_dtype,
-    is_datetime64tz_dtype,
     is_scalar,
     is_timedelta64_dtype,
 )
@@ -566,7 +566,7 @@ class DatetimeColumn(column.ColumnBase):
             return False
 
     def _with_type_metadata(self, dtype):
-        if is_datetime64tz_dtype(dtype):
+        if _is_datetime64tz_dtype(dtype):
             return DatetimeTZColumn(
                 data=self.base_data,
                 dtype=dtype,

--- a/python/cudf/cudf/core/column/interval.py
+++ b/python/cudf/cudf/core/column/interval.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pyarrow as pa
 
 import cudf
-from cudf.api.types import is_categorical_dtype, is_interval_dtype
+from cudf.api.types import _is_interval_dtype, is_categorical_dtype
 from cudf.core.column import StructColumn
 from cudf.core.dtypes import IntervalDtype
 
@@ -101,11 +101,11 @@ class IntervalColumn(StructColumn):
         )
 
     def as_interval_column(self, dtype, **kwargs):
-        if is_interval_dtype(dtype):
+        if _is_interval_dtype(dtype):
             if is_categorical_dtype(self):
                 new_struct = self._get_decategorized_column()
                 return IntervalColumn.from_struct_column(new_struct)
-            if is_interval_dtype(dtype):
+            if _is_interval_dtype(dtype):
                 # a user can directly input the string `interval` as the dtype
                 # when creating an interval series or interval dataframe
                 if dtype == "interval":

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -4,6 +4,7 @@ import decimal
 import operator
 import pickle
 import textwrap
+import warnings
 from functools import cached_property
 from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
@@ -260,7 +261,7 @@ class CategoricalDtype(_BaseDtype):
     def _init_categories(self, categories: Any):
         if categories is None:
             return categories
-        if len(categories) == 0 and not is_interval_dtype(categories):
+        if len(categories) == 0 and not _is_interval_dtype(categories):
             dtype = "object"  # type: Any
         else:
             dtype = None
@@ -1091,21 +1092,7 @@ def is_decimal_dtype(obj):
     )
 
 
-def is_interval_dtype(obj):
-    """Check whether an array-like or dtype is of the interval dtype.
-
-    Parameters
-    ----------
-    obj : array-like or dtype
-        The array-like or dtype to check.
-
-    Returns
-    -------
-    bool
-        Whether or not the array-like or dtype is of the interval dtype.
-    """
-    # TODO: Should there be any branch in this function that calls
-    # pd.api.types.is_interval_dtype?
+def _is_interval_dtype(obj):
     return (
         isinstance(
             obj,
@@ -1119,8 +1106,29 @@ def is_interval_dtype(obj):
         or (
             isinstance(obj, str) and obj == cudf.core.dtypes.IntervalDtype.name
         )
-        or (hasattr(obj, "dtype") and is_interval_dtype(obj.dtype))
+        or (hasattr(obj, "dtype") and _is_interval_dtype(obj.dtype))
     )
+
+
+def is_interval_dtype(obj):
+    """Check whether an array-like or dtype is of the interval dtype.
+
+    Parameters
+    ----------
+    obj : array-like or dtype
+        The array-like or dtype to check.
+
+    Returns
+    -------
+    bool
+        Whether or not the array-like or dtype is of the interval dtype.
+    """
+    warnings.warn(
+        "is_interval_dtype is deprecated and will be removed in a "
+        "future version. Use `isinstance(dtype, cudf.IntervalDtype)` instead",
+        FutureWarning,
+    )
+    return _is_interval_dtype(obj)
 
 
 def is_decimal32_dtype(obj):

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -33,7 +33,7 @@ from cudf.api.types import (
     _is_non_decimal_numeric_dtype,
     is_categorical_dtype,
     is_dtype_equal,
-    is_interval_dtype,
+    _is_interval_dtype,
     is_list_like,
     is_scalar,
 )
@@ -2713,7 +2713,7 @@ class IntervalIndex(Index):
 
         if isinstance(data, IntervalColumn):
             data = data
-        elif isinstance(data, pd.Series) and (is_interval_dtype(data.dtype)):
+        elif isinstance(data, pd.Series) and (_is_interval_dtype(data.dtype)):
             data = column.as_column(data, data.dtype)
         elif isinstance(data, (pd._libs.interval.Interval, pd.IntervalIndex)):
             data = column.as_column(

--- a/python/cudf/cudf/testing/testing.py
+++ b/python/cudf/cudf/testing/testing.py
@@ -11,7 +11,7 @@ from cudf._lib.unary import is_nan
 from cudf.api.types import (
     is_categorical_dtype,
     is_decimal_dtype,
-    is_interval_dtype,
+    _is_interval_dtype,
     is_list_dtype,
     is_numeric_dtype,
     is_string_dtype,
@@ -28,7 +28,7 @@ def dtype_can_compare_equal_to_other(dtype):
         or is_list_dtype(dtype)
         or is_struct_dtype(dtype)
         or is_decimal_dtype(dtype)
-        or is_interval_dtype(dtype)
+        or _is_interval_dtype(dtype)
     )
 
 


### PR DESCRIPTION
## Description
This PR deprecates `is_datetime64tz_dtype` and `is_interval_dtype` to have parity with pandas-2.x: https://github.com/pandas-dev/pandas/pull/52607, alternatively this PR internalizes these utilities.

This PR:
```
= 1584 failed, 98570 passed, 2069 skipped, 776 xfailed, 312 xpassed, 20 errors in 737.24s (0:12:17) =
```

On `pandas_2.0_feature_branch`:
```
= 23835 failed, 5698 passed, 1613 skipped, 288 xfailed, 423 errors in 1976.84s (0:32:56) =
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
