### PR TITLE
Deprecate `method` in `fillna` API

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -7031,7 +7031,9 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                 "'bfill', or 'backfill'."
             )
 
-        data = self.fillna(method=fill_method, limit=limit)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            data = self.fillna(method=fill_method, limit=limit)
 
         return data.diff(periods=periods) / data.shift(
             periods=periods, freq=freq

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -735,12 +735,13 @@ class Frame(BinaryOperand, Scannable):
             are filled with values in corresponding indices.
             A dict can be used to provide different values to fill nulls
             in different columns. Cannot be used with ``method``.
-
         method : {'ffill', 'bfill'}, default None
             Method to use for filling null values in the dataframe or series.
             `ffill` propagates the last non-null values forward to the next
             non-null value. `bfill` propagates backward with the next non-null
             value. Cannot be used with ``value``.
+            .. deprecated:: 23.12
+                `method` is deprecated.
 
         Returns
         -------

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -740,6 +740,7 @@ class Frame(BinaryOperand, Scannable):
             `ffill` propagates the last non-null values forward to the next
             non-null value. `bfill` propagates backward with the next non-null
             value. Cannot be used with ``value``.
+
             .. deprecated:: 23.12
                 `method` is deprecated.
 

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -2183,6 +2183,7 @@ class GroupBy(Serializable, Reducible, Scannable):
         if method is not None:
             if method not in {"ffill", "bfill"}:
                 raise ValueError("Method can only be of 'ffill', 'bfill'.")
+            # Do not remove until pandas 3.0 support is added.
             warnings.warn(
                 f"{type(self).__name__}.fillna with 'method' is "
                 "deprecated and will raise in a future version. "

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -2183,6 +2183,13 @@ class GroupBy(Serializable, Reducible, Scannable):
         if method is not None:
             if method not in {"ffill", "bfill"}:
                 raise ValueError("Method can only be of 'ffill', 'bfill'.")
+            warnings.warn(
+                f"{type(self).__name__}.fillna with 'method' is "
+                "deprecated and will raise in a future version. "
+                "Use obj.ffill() or obj.bfill() instead.",
+                FutureWarning,
+            )
+
             return getattr(self, method, limit)()
 
         values = self.obj.__class__._from_data(
@@ -2295,7 +2302,10 @@ class GroupBy(Serializable, Reducible, Scannable):
                 FutureWarning,
             )
 
-        filled = self.fillna(method=fill_method, limit=limit)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            filled = self.fillna(method=fill_method, limit=limit)
+
         fill_grp = filled.groupby(self.grouping)
         shifted = fill_grp.shift(periods=periods, freq=freq)
         return (filled / shifted) - 1

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2148,6 +2148,13 @@ class IndexedFrame(Frame):
     def fillna(
         self, value=None, method=None, axis=None, inplace=False, limit=None
     ):  # noqa: D102
+        if method is not None:
+            warnings.warn(
+                f"{type(self).__name__}.fillna with 'method' is "
+                "deprecated and will raise in a future version. "
+                "Use obj.ffill() or obj.bfill() instead.",
+                FutureWarning,
+            )
         old_index = self._index
         ret = super().fillna(value, method, axis, inplace, limit)
         if inplace:

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2149,6 +2149,7 @@ class IndexedFrame(Frame):
         self, value=None, method=None, axis=None, inplace=False, limit=None
     ):  # noqa: D102
         if method is not None:
+            # Do not remove until pandas 3.0 support is added.
             warnings.warn(
                 f"{type(self).__name__}.fillna with 'method' is "
                 "deprecated and will raise in a future version. "

--- a/python/cudf/cudf/core/resample.py
+++ b/python/cudf/cudf/core/resample.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import pickle
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -73,7 +74,9 @@ class _Resampler(GroupBy):
         )
 
         # fill the gaps:
-        filled = upsampled.fillna(method=method)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            filled = upsampled.fillna(method=method)
 
         # filter the result to only include the values corresponding
         # to the bin labels:

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -3506,7 +3506,9 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
                 "'bfill', or 'backfill'."
             )
 
-        data = self.fillna(method=fill_method, limit=limit)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            data = self.fillna(method=fill_method, limit=limit)
         diff = data.diff(periods=periods)
         change = diff / data.shift(periods=periods, freq=freq)
         return change

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -2646,10 +2646,12 @@ def test_groupby_various_by_fillna(by, data, args):
     ps = pd.Series(data)
     gs = cudf.from_pandas(ps)
 
-    expect = ps.groupby(by).fillna(**args)
+    with expect_warning_if(PANDAS_GE_210 and "method" in args):
+        expect = ps.groupby(by).fillna(**args)
     if isinstance(by, pd.Grouper):
         by = cudf.Grouper(level=by.level)
-    got = gs.groupby(by).fillna(**args)
+    with expect_warning_if("method" in args):
+        got = gs.groupby(by).fillna(**args)
 
     assert_groupby_results_equal(expect, got, check_dtype=False)
 
@@ -2693,8 +2695,10 @@ def test_groupby_fillna_method(nelem, method):
     pdf = t.to_pandas()
     gdf = cudf.from_pandas(pdf)
 
-    expect = pdf.groupby(key_col).fillna(method=method)
-    got = gdf.groupby(key_col).fillna(method=method)
+    with expect_warning_if(PANDAS_GE_210):
+        expect = pdf.groupby(key_col).fillna(method=method)
+    with pytest.warns(FutureWarning):
+        got = gdf.groupby(key_col).fillna(method=method)
 
     assert_groupby_results_equal(
         expect[value_cols], got[value_cols], sort=False

--- a/python/cudf/cudf/tests/test_replace.py
+++ b/python/cudf/cudf/tests/test_replace.py
@@ -8,13 +8,19 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_GE_134, PANDAS_GE_150, PANDAS_GE_200
+from cudf.core._compat import (
+    PANDAS_GE_134,
+    PANDAS_GE_150,
+    PANDAS_GE_200,
+    PANDAS_GE_210,
+)
 from cudf.core.dtypes import Decimal32Dtype, Decimal64Dtype, Decimal128Dtype
 from cudf.testing._utils import (
     INTEGER_TYPES,
     NUMERIC_TYPES,
     assert_eq,
     assert_exceptions_equal,
+    expect_warning_if,
 )
 
 
@@ -348,8 +354,10 @@ def test_fillna_method_numerical(data, container, data_dtype, method, inplace):
     # Explicitly using nans_as_nulls=True
     gdata = cudf.from_pandas(pdata, nan_as_null=True)
 
-    expected = pdata.fillna(method=method, inplace=inplace)
-    actual = gdata.fillna(method=method, inplace=inplace)
+    with expect_warning_if(PANDAS_GE_210):
+        expected = pdata.fillna(method=method, inplace=inplace)
+    with pytest.warns(FutureWarning):
+        actual = gdata.fillna(method=method, inplace=inplace)
 
     if inplace:
         expected = pdata
@@ -665,8 +673,10 @@ def test_fillna_method_fixed_width_non_num(data, container, method, inplace):
     # Explicitly using nans_as_nulls=True
     gdata = cudf.from_pandas(pdata, nan_as_null=True)
 
-    expected = pdata.fillna(method=method, inplace=inplace)
-    actual = gdata.fillna(method=method, inplace=inplace)
+    with expect_warning_if(PANDAS_GE_210):
+        expected = pdata.fillna(method=method, inplace=inplace)
+    with pytest.warns(FutureWarning):
+        actual = gdata.fillna(method=method, inplace=inplace)
 
     if inplace:
         expected = pdata


### PR DESCRIPTION
## Description

This PR deprecates `method` parameter in all public `fillna` APIs to match pandas: https://github.com/pandas-dev/pandas/pull/53496/

This PR:
```
= 1056 failed, 99098 passed, 2069 skipped, 776 xfailed, 312 xpassed, 20 errors in 670.87s (0:11:10) =
```

On `pandas_2.0_feature_branch`:
```
= 1584 failed, 98570 passed, 2069 skipped, 776 xfailed, 312 xpassed, 20 errors in 737.24s (0:12:17) =
```


<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
