### PR TITLE
[TEST] Build with libcudacxx 2.1.0.

### DIFF
--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -11,6 +11,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
+set(rapids-cmake-repo bdice/rapids-cmake)
+set(rapids-cmake-branch libcudacxx-2.1.0)
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.12/RAPIDS.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake


### PR DESCRIPTION
This PR tests a rapids-cmake branch with libcudacxx updated to 2.1.0. **Do not merge this PR.** The changes will be merged upstream in rapids-cmake after all libraries pass CI.
