### PR TITLE
WIP: Repro for issue 14282

### DIFF
--- a/java/src/test/resources/teachers.json
+++ b/java/src/test/resources/teachers.json
@@ -1,0 +1,512 @@
+{"teacher":null}
+{"teacher": "Svesfw","student": {"name": "Iseuqn", "age": 15}}
+{"teacher": "Fdxwtf","student": {"name": "Rtjuup", "age": 18}}
+{"teacher":null}
+{"teacher": "Tvortb","student": {"name": "Sqfbod", "age": 15}}
+{"teacher": "Zommix","student": {"name": "Fkxyzl", "age": 18}}
+{"teacher": "Zlmaga","student": {"name": "Xuocrr", "age": 12}}
+{"teacher":null}
+{"teacher": "Hfdemc","student": {"name": "Jvgbnp", "age": 10}}
+{"teacher":null}
+{"teacher": "Mkdxau","student": {"name": "Aysedc", "age": 13}}
+{"teacher": "Hkytcb","student": {"name": "Edcxwc", "age": 17}}
+{"teacher":null}
+{"teacher": "Iypzuz","student": {"name": "Jxonph", "age": 12}}
+{"teacher": "Svygti","student": {"name": "Eclqwx", "age": 16}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Azvpgb","student": {"name": "Drqwsc", "age": 19}}
+{"teacher": "Aoeghp","student": {"name": "Wqbric", "age": 13}}
+{"teacher":null}
+{"teacher": "Phiyqe","student": {"name": "Slvxwv", "age": 12}}
+{"teacher": "Sgyaom","student": {"name": "Zoyycs", "age": 11}}
+{"teacher":null}
+{"teacher": "Epnhiv","student": {"name": "Tonfwb", "age": 13}}
+{"teacher":null}
+{"teacher": "Lgfjpq","student": {"name": "Iftuby", "age": 13}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Lhnzbx","student": {"name": "Zxqvdi", "age": 18}}
+{"teacher": "Cnbmcy","student": {"name": "Osadts", "age": 12}}
+{"teacher": "Ujkamv","student": {"name": "Ndsown", "age": 19}}
+{"teacher": "Xinrwa","student": {"name": "Dxlcof", "age": 12}}
+{"teacher": "Ytehwi","student": {"name": "Uorryr", "age": 17}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Tfqpze","student": {"name": "Wmeprb", "age": 19}}
+{"teacher": "Apetrj","student": {"name": "Lowkyq", "age": 16}}
+{"teacher":null}
+{"teacher": "Dxtzj","student": {"name": "Ymoozt", "age": 15}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Gmgxsu","student": {"name": "Wgttul", "age": 11}}
+{"teacher": "Dlejus","student": {"name": "Mtcspe", "age": 13}}
+{"teacher":null}
+{"teacher": "Zalugx","student": {"name": "Uhhudx", "age": 11}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Xkdiwt","student": {"name": "Kchztt", "age": 11}}
+{"teacher":null}
+{"teacher": "Zjibqe","student": {"name": "Zbgcmn", "age": 17}}
+{"teacher":null}
+{"teacher": "Moemju","student": {"name": "Mbvipw", "age": 12}}
+{"teacher": "Zwdqrf","student": {"name": "Xibxcf", "age": 11}}
+{"teacher": "Kxcmyg","student": {"name": "Khluah", "age": 19}}
+{"teacher":null}
+{"teacher": "Byybeo","student": {"name": "Eatmbi", "age": 12}}
+{"teacher":null}
+{"teacher": "Rofiwr","student": {"name": "Qrkrdr", "age": 10}}
+{"teacher":null}
+{"teacher": "Uictst","student": {"name": "Wcpaat", "age": 11}}
+{"teacher":null}
+{"teacher": "Ogcvfd","student": {"name": "Niubxj", "age": 13}}
+{"teacher": "Loebpt","student": {"name": "Grkimi", "age": 10}}
+{"teacher": "Aeyxoj","student": {"name": "Hqwxpz", "age": 16}}
+{"teacher": "Xbfair","student": {"name": "Vizmrn", "age": 14}}
+{"teacher": "Bslknx","student": {"name": "Ffujkt", "age": 15}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Wegoit","student": {"name": "Tqziew", "age": 16}}
+{"teacher":null}
+{"teacher": "Krmjoq","student": {"name": "Vopuip", "age": 14}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Cqlqvt","student": {"name": "Yurlsw", "age": 12}}
+{"teacher": "Awqssf","student": {"name": "Pcsqfn", "age": 10}}
+{"teacher": "Euecay","student": {"name": "Rthumx", "age": 13}}
+{"teacher":null}
+{"teacher": "Tmyzjc","student": {"name": "Iyfwlb", "age": 13}}
+{"teacher": "Yakcxa","student": {"name": "Ohpry", "age": 14}}
+{"teacher": "Erdejk","student": {"name": "Vbcmwf", "age": 17}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Fabhen","student": {"name": "Surqqw", "age": 17}}
+{"teacher": "Prwiyj","student": {"name": "Wmgwmp", "age": 12}}
+{"teacher": "Pwvukn","student": {"name": "Eygbgu", "age": 17}}
+{"teacher":null}
+{"teacher": "Tzoobe","student": {"name": "Avrdpp", "age": 17}}
+{"teacher": "Jssvdo","student": {"name": "Yjrxhq", "age": 17}}
+{"teacher":null}
+{"teacher": "Qqqllo","student": {"name": "Fvorpp", "age": 17}}
+{"teacher": "Gvoekl","student": {"name": "Vwxbrv", "age": 19}}
+{"teacher": "Dlyjpc","student": {"name": "Ttdtkn", "age": 16}}
+{"teacher":null}
+{"teacher": "Gaqrrm","student": {"name": "Diqitp", "age": 19}}
+{"teacher": "Ifbwgi","student": {"name": "Feckqr", "age": 19}}
+{"teacher":null}
+{"teacher": "Nvqxre","student": {"name": "Diobwi", "age": 19}}
+{"teacher":null}
+{"teacher": "Lemzo","student": {"name": "Nqxhye", "age": 14}}
+{"teacher": "Qavgru","student": {"name": "Cdheyz", "age": 10}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Xghcd","student": {"name": "Kfujey", "age": 17}}
+{"teacher": "Ffpfyv","student": {"name": "Jckoci", "age": 13}}
+{"teacher":null}
+{"teacher": "Ylkgqd","student": {"name": "Wgnpg", "age": 17}}
+{"teacher": "Kahwjv","student": {"name": "Cyfqye", "age": 18}}
+{"teacher":null}
+{"teacher": "Qffgnt","student": {"name": "Qclqog", "age": 19}}
+{"teacher":null}
+{"teacher": "Hybfzr","student": {"name": "Nsotdz", "age": 11}}
+{"teacher": "Goyfbi","student": {"name": "Jltdfj", "age": 10}}
+{"teacher": "Zzfyfr","student": {"name": "Ixibor", "age": 12}}
+{"teacher": "Mroouk","student": {"name": "Cbqaiy", "age": 14}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Dhdqmz","student": {"name": "Ssuufa", "age": 19}}
+{"teacher": "Hvlvxd","student": {"name": "Tegfqv", "age": 14}}
+{"teacher": "Fveugz","student": {"name": "Gntftn", "age": 11}}
+{"teacher": "Pjddwp","student": {"name": "Dtuibp", "age": 13}}
+{"teacher":null}
+{"teacher": "Gyaody","student": {"name": "Xjtbby", "age": 10}}
+{"teacher": "Vtjxzp","student": {"name": "Rrbhiz", "age": 11}}
+{"teacher":null}
+{"teacher": "Rvkuup","student": {"name": "Xcjyzn", "age": 16}}
+{"teacher": "Qznnty","student": {"name": "Sidzxj", "age": 15}}
+{"teacher":null}
+{"teacher": "Shsbfk","student": {"name": "Mvtgyb", "age": 15}}
+{"teacher":null}
+{"teacher": "Avotws","student": {"name": "Uifrao", "age": 13}}
+{"teacher": "Hdxwzy","student": {"name": "Ugcxrx", "age": 16}}
+{"teacher":null}
+{"teacher": "Lgmnay","student": {"name": "Ovqnvg", "age": 13}}
+{"teacher": "Qhlfdl","student": {"name": "Ruzpkj", "age": 17}}
+{"teacher": "Arbgge","student": {"name": "Hjarsz", "age": 13}}
+{"teacher": "Wpiesg","student": {"name": "Jztiaw", "age": 19}}
+{"teacher": "Vzkcfh","student": {"name": "Mmld", "age": 17}}
+{"teacher": "Iniyzx","student": {"name": "Mcquky", "age": 17}}
+{"teacher": "Fqcmrr","student": {"name": "Dynwpm", "age": 10}}
+{"teacher": "Jzslly","student": {"name": "Orlfrz", "age": 10}}
+{"teacher": "Fznxmv","student": {"name": "Vjtjpp", "age": 14}}
+{"teacher": "Zacpir","student": {"name": "Ggenh", "age": 15}}
+{"teacher":null}
+{"teacher": "Wtctyo","student": {"name": "Eljqdj", "age": 12}}
+{"teacher":null}
+{"teacher": "Muxcmv","student": {"name": "Lvbemx", "age": 14}}
+{"teacher": "Dkmzeb","student": {"name": "Rsglis", "age": 10}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Blbxgr","student": {"name": "Awjahu", "age": 12}}
+{"teacher": "Negbrd","student": {"name": "Uxmwrm", "age": 18}}
+{"teacher": "Icfiki","student": {"name": "Bdnozx", "age": 11}}
+{"teacher": "Xrost","student": {"name": "Paaubs", "age": 14}}
+{"teacher": "Yqxbji","student": {"name": "Hdomuv", "age": 11}}
+{"teacher":null}
+{"teacher": "Rpozef","student": {"name": "Qcmthc", "age": 17}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Zapsbh","student": {"name": "Tfxdal", "age": 12}}
+{"teacher": "Vpqjjx","student": {"name": "Qkyxmk", "age": 12}}
+{"teacher": "Aicdlo","student": {"name": "Tcshcw", "age": 19}}
+{"teacher": "Yczomj","student": {"name": "Tqtbdl", "age": 11}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Twqjjb","student": {"name": "Wtubfa", "age": 15}}
+{"teacher":null}
+{"teacher": "Ppxqqb","student": {"name": "Qlgbdl", "age": 10}}
+{"teacher": "Ajnchn","student": {"name": "Uknehr", "age": 19}}
+{"teacher": "Vnvact","student": {"name": "Oulvgj", "age": 11}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Rxdlqs","student": {"name": "Cwnbim", "age": 18}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Aklynp","student": {"name": "Crnqjv", "age": 16}}
+{"teacher": "Rvzmwe","student": {"name": "Bjkpag", "age": 15}}
+{"teacher":null}
+{"teacher": "Nwebsp","student": {"name": "Vmszle", "age": 19}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Qhznqn","student": {"name": "Bjexty", "age": 13}}
+{"teacher": "Dcpyym","student": {"name": "Lsikwf", "age": 13}}
+{"teacher": "Jhszci","student": {"name": "Oyakyz", "age": 12}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Ccpxib","student": {"name": "Okjuae", "age": 11}}
+{"teacher": "Vawbua","student": {"name": "Ughcyw", "age": 19}}
+{"teacher": "Xqvwu","student": {"name": "Ajvdwq", "age": 10}}
+{"teacher": "Dywcof","student": {"name": "Lmicrf", "age": 15}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Rzgsqe","student": {"name": "Fykdza", "age": 13}}
+{"teacher": "Zhtdqn","student": {"name": "Zeplnr", "age": 15}}
+{"teacher": "Bdpapr","student": {"name": "Bcowad", "age": 11}}
+{"teacher": "Aphsik","student": {"name": "Rfbvcx", "age": 10}}
+{"teacher": "Jwqzfl","student": {"name": "Gmaasn", "age": 11}}
+{"teacher": "Vkjxsj","student": {"name": "Vvdkhw", "age": 17}}
+{"teacher": "Ujruhh","student": {"name": "Uduaeh", "age": 12}}
+{"teacher": "Mlwsts","student": {"name": "Jrmauu", "age": 18}}
+{"teacher": "Tocmla","student": {"name": "Qrdkme", "age": 10}}
+{"teacher": "Ajnnpx","student": {"name": "Mwhbiy", "age": 16}}
+{"teacher": "Ksjdlk","student": {"name": "Fgdvpd", "age": 17}}
+{"teacher": "Gevtjh","student": {"name": "Kzfsho", "age": 17}}
+{"teacher": "Mwtsqi","student": {"name": "Smbvhq", "age": 19}}
+{"teacher": "Droesk","student": {"name": "Jhwzkp", "age": 14}}
+{"teacher":null}
+{"teacher": "Zvertg","student": {"name": "Kkmvka", "age": 10}}
+{"teacher":null}
+{"teacher": "Hkwypa","student": {"name": "Fbioql", "age": 15}}
+{"teacher": "Stbxiu","student": {"name": "Dvspqg", "age": 10}}
+{"teacher":null}
+{"teacher": "Updsqp","student": {"name": "Bhahog", "age": 10}}
+{"teacher":null}
+{"teacher": "Oogafa","student": {"name": "Jdchpu", "age": 19}}
+{"teacher":null}
+{"teacher": "Vnhqiy","student": {"name": "Cgeuwk", "age": 11}}
+{"teacher": "Rnyqau","student": {"name": "Xhrpyj", "age": 16}}
+{"teacher": "Gupkug","student": {"name": "Uqivls", "age": 14}}
+{"teacher": "Wyihbe","student": {"name": "Oqjldm", "age": 18}}
+{"teacher": "Mlprrd","student": {"name": "Zigbks", "age": 10}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Bfbzes","student": {"name": "Pawtto", "age": 18}}
+{"teacher": "Jeecwh","student": {"name": "Tufgrm", "age": 10}}
+{"teacher": "Dgaqdo","student": {"name": "Ehvrfr", "age": 10}}
+{"teacher": "Rnohdk","student": {"name": "Mbzfmf", "age": 10}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Vqokfm","student": {"name": "Ehsdjr", "age": 12}}
+{"teacher": "Vqarme","student": {"name": "Tnesgl", "age": 17}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Pggphw","student": {"name": "Tpfoir", "age": 12}}
+{"teacher":null}
+{"teacher": "Crbgzj","student": {"name": "Qvwuto", "age": 13}}
+{"teacher":null}
+{"teacher": "Ccrqti","student": {"name": "Xhtgjy", "age": 12}}
+{"teacher": "Fscnhq","student": {"name": "Ehjbfv", "age": 13}}
+{"teacher":null}
+{"teacher": "Buyzak","student": {"name": "Txjojh", "age": 10}}
+{"teacher": "Husxnz","student": {"name": "Rkuscd", "age": 13}}
+{"teacher": "Mqfhvt","student": {"name": "Pqhtcx", "age": 11}}
+{"teacher":null}
+{"teacher": "Oivtvk","student": {"name": "Bqjjaa", "age": 12}}
+{"teacher":null}
+{"teacher": "Lucoqu","student": {"name": "Umyfje", "age": 10}}
+{"teacher":null}
+{"teacher": "Zypoif","student": {"name": "Gvbxbg", "age": 10}}
+{"teacher": "Vdljuf","student": {"name": "Xdbzdn", "age": 16}}
+{"teacher": "Huyolf","student": {"name": "Eoxhbb", "age": 11}}
+{"teacher": "Kcmbmw","student": {"name": "Dcbtyi", "age": 17}}
+{"teacher": "Najskj","student": {"name": "Tzdxho", "age": 14}}
+{"teacher": "Hiaec","student": {"name": "Yqlicr", "age": 10}}
+{"teacher": "Lhbkox","student": {"name": "Pqvgya", "age": 14}}
+{"teacher":null}
+{"teacher": "Uerjjd","student": {"name": "Kglfog", "age": 13}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Wkrfva","student": {"name": "Ltqbqy", "age": 16}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Nsrywh","student": {"name": "Easrob", "age": 15}}
+{"teacher": "Uxkygu","student": {"name": "Yoznat", "age": 11}}
+{"teacher": "Gfcfdx","student": {"name": "Hcekvx", "age": 17}}
+{"teacher": "Oggjma","student": {"name": "Igkbqf", "age": 12}}
+{"teacher": "Mqvswl","student": {"name": "Huuweg", "age": 17}}
+{"teacher": "Sxcyfk","student": {"name": "Bbiavf", "age": 10}}
+{"teacher": "Krlbix","student": {"name": "Aouspd", "age": 18}}
+{"teacher":null}
+{"teacher": "Rkckbd","student": {"name": "Csycvf", "age": 14}}
+{"teacher":null}
+{"teacher": "Umnkxn","student": {"name": "Smfqad", "age": 18}}
+{"teacher":null}
+{"teacher": "Ysmneh","student": {"name": "Mfmtev", "age": 10}}
+{"teacher": "Wficga","student": {"name": "Rlpido", "age": 17}}
+{"teacher": "Fynvpt","student": {"name": "Jldraw", "age": 14}}
+{"teacher": "Cliejx","student": {"name": "Mydapp", "age": 17}}
+{"teacher": "Ucrxrr","student": {"name": "Iidhrn", "age": 18}}
+{"teacher": "Arjsp","student": {"name": "Estxer", "age": 19}}
+{"teacher":null}
+{"teacher": "Fdkzld","student": {"name": "Xugglk", "age": 10}}
+{"teacher":null}
+{"teacher": "Wrowfw","student": {"name": "Oxxhub", "age": 15}}
+{"teacher":null}
+{"teacher": "Vvchmp","student": {"name": "Wfiumr", "age": 13}}
+{"teacher": "Fuktoj","student": {"name": "Ukcezt", "age": 16}}
+{"teacher": "Rylorq","student": {"name": "Fygqvh", "age": 15}}
+{"teacher": "Wmpgjc","student": {"name": "Kbjdqe", "age": 17}}
+{"teacher": "Bqjwol","student": {"name": "Qrupfg", "age": 18}}
+{"teacher":null}
+{"teacher": "Baedpr","student": {"name": "Mijbfi", "age": 16}}
+{"teacher": "Fcfxmh","student": {"name": "Yjeert", "age": 11}}
+{"teacher":null}
+{"teacher": "Tzahqk","student": {"name": "Wobrmj", "age": 11}}
+{"teacher": "Gcjcfp","student": {"name": "Oyugnz", "age": 13}}
+{"teacher": "Aopqrn","student": {"name": "Zqeqma", "age": 14}}
+{"teacher": "Zdokqf","student": {"name": "Ntndaa", "age": 17}}
+{"teacher": "Lbiale","student": {"name": "Cgqgqx", "age": 17}}
+{"teacher":null}
+{"teacher": "Whsvga","student": {"name": "Knlcno", "age": 15}}
+{"teacher": "Cdanhx","student": {"name": "Rkawwn", "age": 12}}
+{"teacher": "Dgqbpi","student": {"name": "Cixbjb", "age": 14}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Ihfrzm","student": {"name": "Khabpw", "age": 11}}
+{"teacher": "Vmpsgf","student": {"name": "Tmstr", "age": 13}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Feoonl","student": {"name": "Teuxnx", "age": 13}}
+{"teacher": "Voihzx","student": {"name": "Jczefv", "age": 15}}
+{"teacher":null}
+{"teacher": "Phzycd","student": {"name": "Wfklvo", "age": 17}}
+{"teacher":null}
+{"teacher": "Xtpwaw","student": {"name": "Ixucly", "age": 17}}
+{"teacher": "Gsxoeh","student": {"name": "Ekyski", "age": 11}}
+{"teacher": "Ugzywp","student": {"name": "Dyynbn", "age": 14}}
+{"teacher": "Yjycn","student": {"name": "Tigqlf", "age": 14}}
+{"teacher": "Thqnge","student": {"name": "Jilvls", "age": 14}}
+{"teacher":null}
+{"teacher": "Eyngjw","student": {"name": "Jnwtco", "age": 16}}
+{"teacher":null}
+{"teacher": "Xjnkcx","student": {"name": "Lynubb", "age": 10}}
+{"teacher":null}
+{"teacher": "Fozftc","student": {"name": "Zoianx", "age": 17}}
+{"teacher": "Pjphda","student": {"name": "Ahsigv", "age": 13}}
+{"teacher": "Sdzkzu","student": {"name": "Lsaqas", "age": 19}}
+{"teacher": "Sgmmek","student": {"name": "Cpqrnt", "age": 18}}
+{"teacher":null}
+{"teacher": "Vralqx","student": {"name": "Canvjn", "age": 17}}
+{"teacher":null}
+{"teacher": "Tqwqdl","student": {"name": "Gvvlpj", "age": 12}}
+{"teacher":null}
+{"teacher": "Kqbvzt","student": {"name": "Rmezlm", "age": 10}}
+{"teacher": "Upgefw","student": {"name": "Xadkcl", "age": 10}}
+{"teacher": "Ozitan","student": {"name": "Soinxn", "age": 11}}
+{"teacher": "Aiblnw","student": {"name": "Xpfrkf", "age": 17}}
+{"teacher": "Chnutt","student": {"name": "Ikoqfo", "age": 14}}
+{"teacher": "Zyekry","student": {"name": "Mausbc", "age": 15}}
+{"teacher": "Epdkhe","student": {"name": "Hcvpgv", "age": 11}}
+{"teacher": "Hmkgnn","student": {"name": "Fwsdan", "age": 18}}
+{"teacher": "Pzyxuf","student": {"name": "Hbkspu", "age": 15}}
+{"teacher":null}
+{"teacher": "Vfbtuv","student": {"name": "Vchzov", "age": 12}}
+{"teacher": "Xxbwxn","student": {"name": "Gsjhnc", "age": 19}}
+{"teacher": "Askwms","student": {"name": "Qimvsb", "age": 19}}
+{"teacher": "Ijjjmk","student": {"name": "Tcvrml", "age": 18}}
+{"teacher":null}
+{"teacher": "Illzkc","student": {"name": "Mvuonh", "age": 12}}
+{"teacher": "Mrwrrz","student": {"name": "Kywugi", "age": 17}}
+{"teacher": "Nytxfr","student": {"name": "Xuvasp", "age": 10}}
+{"teacher": "Gssezj","student": {"name": "Ybmyue", "age": 18}}
+{"teacher": "Tiqzbz","student": {"name": "Gyrxg", "age": 19}}
+{"teacher": "Twpalt","student": {"name": "Vcwdzl", "age": 15}}
+{"teacher": "Ajimoz","student": {"name": "Rxouti", "age": 10}}
+{"teacher": "Icpqi","student": {"name": "Qnvqrj", "age": 18}}
+{"teacher": "Arhksh","student": {"name": "Sxxdpi", "age": 14}}
+{"teacher": "Oduhji","student": {"name": "Sttnnf", "age": 14}}
+{"teacher": "Nsvciw","student": {"name": "Cgcjzs", "age": 19}}
+{"teacher": "Sofiro","student": {"name": "Hjmkk", "age": 12}}
+{"teacher": "Wzfqbt","student": {"name": "Zkpudk", "age": 11}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Oldabr","student": {"name": "Ouzrvm", "age": 16}}
+{"teacher": "Wkkrvb","student": {"name": "Tylrwf", "age": 17}}
+{"teacher": "Pevtsn","student": {"name": "Dtamig", "age": 15}}
+{"teacher": "Tyfldt","student": {"name": "Kbhhcf", "age": 17}}
+{"teacher": "Uovhkv","student": {"name": "Idyzwe", "age": 10}}
+{"teacher": "Tnhwxf","student": {"name": "Syshcp", "age": 17}}
+{"teacher": "Qcvspd","student": {"name": "Eqbdbp", "age": 14}}
+{"teacher": "Xnfbvc","student": {"name": "Uviote", "age": 19}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Aapnrw","student": {"name": "Bhqmuo", "age": 11}}
+{"teacher":null}
+{"teacher": "Wjdhks","student": {"name": "Uwedjo", "age": 17}}
+{"teacher": "Yagchn","student": {"name": "Sluucf", "age": 12}}
+{"teacher":null}
+{"teacher": "Yqtlye","student": {"name": "Bnlrhd", "age": 17}}
+{"teacher": "Vpmaau","student": {"name": "Pnjtr", "age": 17}}
+{"teacher": "Hjtoa","student": {"name": "Lxrujr", "age": 11}}
+{"teacher": "Lwwnij","student": {"name": "Edukbj", "age": 16}}
+{"teacher": "Zftgeb","student": {"name": "Lnocqt", "age": 16}}
+{"teacher": "Lphyca","student": {"name": "Jldkwn", "age": 11}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Epjhdg","student": {"name": "Psriah", "age": 18}}
+{"teacher":null}
+{"teacher": "Rsomwe","student": {"name": "Wpyvdk", "age": 12}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Ovbxdw","student": {"name": "Jrdhg", "age": 17}}
+{"teacher": "Zcemuq","student": {"name": "Xeodzh", "age": 11}}
+{"teacher": "Ffdwcj","student": {"name": "Uwtwdk", "age": 15}}
+{"teacher": "Xpoara","student": {"name": "Hbjpss", "age": 15}}
+{"teacher": "Scwynu","student": {"name": "Kljdaf", "age": 12}}
+{"teacher": "Tpftal","student": {"name": "Jjhija", "age": 17}}
+{"teacher":null}
+{"teacher": "Fnamww","student": {"name": "Ulrfnf", "age": 19}}
+{"teacher": "Npfxbb","student": {"name": "Stgimy", "age": 16}}
+{"teacher": "Lvzous","student": {"name": "Kdujqq", "age": 19}}
+{"teacher": "Sxwtts","student": {"name": "Ggvbxe", "age": 14}}
+{"teacher":null}
+{"teacher": "Ikhodj","student": {"name": "Eihkcd", "age": 18}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Fhqfct","student": {"name": "Ouysnw", "age": 11}}
+{"teacher": "Zitfxm","student": {"name": "Njzdqi", "age": 16}}
+{"teacher": "Fvnarw","student": {"name": "Oacnan", "age": 17}}
+{"teacher": "Xpybhh","student": {"name": "Vmckwm", "age": 15}}
+{"teacher": "Tkykdp","student": {"name": "Xrvdbm", "age": 12}}
+{"teacher": "Nazzok","student": {"name": "Cqnedk", "age": 13}}
+{"teacher": "Kneqvn","student": {"name": "Qwaonv", "age": 13}}
+{"teacher":null}
+{"teacher": "Bgcqee","student": {"name": "Akhgii", "age": 12}}
+{"teacher": "Kawxjg","student": {"name": "Szzmpu", "age": 13}}
+{"teacher": "Mzdvmp","student": {"name": "Eready", "age": 13}}
+{"teacher":null}
+{"teacher": "Mdpckv","student": {"name": "Sysaio", "age": 19}}
+{"teacher": "Fbzmag","student": {"name": "Fzrebx", "age": 18}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Xibuzg","student": {"name": "Gxrgth", "age": 11}}
+{"teacher": "Zftgoq","student": {"name": "Fyobjg", "age": 16}}
+{"teacher":null}
+{"teacher": "Qwubld","student": {"name": "Zjjesr", "age": 19}}
+{"teacher":null}
+{"teacher": "Ymkctr","student": {"name": "Rgzyfl", "age": 18}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Gknqax","student": {"name": "Yyedtr", "age": 17}}
+{"teacher": "Tcttm","student": {"name": "Qlbmbj", "age": 10}}
+{"teacher": "Sqpagx","student": {"name": "Bfohaq", "age": 18}}
+{"teacher":null}
+{"teacher": "Dgpedb","student": {"name": "Sjydxq", "age": 10}}
+{"teacher": "Gxhcgh","student": {"name": "Lggrss", "age": 13}}
+{"teacher":null}
+{"teacher": "Qrwezj","student": {"name": "Lziaes", "age": 13}}
+{"teacher": "Lvnphz","student": {"name": "Pnazvn", "age": 14}}
+{"teacher": "Kljtcg","student": {"name": "Bmlxda", "age": 15}}
+{"teacher":null}
+{"teacher": "Etuufm","student": {"name": "Yexhnq", "age": 13}}
+{"teacher": "Esxnge","student": {"name": "Mjngot", "age": 10}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Hziihd","student": {"name": "Hiekln", "age": 11}}
+{"teacher": "Ttpihm","student": {"name": "Mokrec", "age": 10}}
+{"teacher": "Thosbf","student": {"name": "Nvoxrj", "age": 12}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Bnrmeo","student": {"name": "Rhzxwe", "age": 12}}
+{"teacher": "Ljifcj","student": {"name": "Uriyrs", "age": 13}}
+{"teacher":null}
+{"teacher": "Qbqglw","student": {"name": "Nyrrns", "age": 15}}
+{"teacher":null}
+{"teacher": "Qmcfdf","student": {"name": "Rrsmxu", "age": 13}}
+{"teacher":null}
+{"teacher": "Hkgjlk","student": {"name": "Hhiqli", "age": 16}}
+{"teacher": "Yugwln","student": {"name": "Eamyth", "age": 14}}
+{"teacher": "Xzwqpn","student": {"name": "Mpkjsy", "age": 13}}
+{"teacher": "Zfecba","student": {"name": "Rseawb", "age": 16}}
+{"teacher": "Pzyxdc","student": {"name": "Ugxum", "age": 10}}
+{"teacher":null}
+{"teacher": "Xlystl","student": {"name": "Diwlhh", "age": 15}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Oropu","student": {"name": "Dsvnmg", "age": 14}}
+{"teacher": "Pmnxlc","student": {"name": "Uylavx", "age": 11}}
+{"teacher": "Wndhxx","student": {"name": "Firsob", "age": 17}}
+{"teacher": "Nrqtum","student": {"name": "Sfeelr", "age": 11}}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Kehuxw","student": {"name": "Puhknc", "age": 14}}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher":null}
+{"teacher": "Sezejr","student": {"name": "Xjyotp", "age": 10}}
+{"teacher": "Aeysc","student": {"name": "Fbzkoa", "age": 17}}
+{"teacher": "Yixzpz","student": {"name": "Dmgtvi", "age": 18}}
+{"teacher": "Yjzfki","student": {"name": "Eafiom", "age": 14}}
+{"teacher": "Qauubv","student": {"name": "Vtutmi", "age": 11}}
+{"teacher":null}
+{"teacher": "Saswxl","student": {"name": "Rethgn", "age": 10}}
+{"teacher":null}
+{"teacher": "Pusoou","student": {"name": "Dathbl", "age": 13}}
+{"teacher": "Pmaluq","student": {"name": "Ywmxkq", "age": 10}}
+{"teacher": "Ebzrll","student": {"name": "Lhjogd", "age": 18}}
+{"teacher":null}


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
This PR adds a failing test as a repro for issue 14282.

It fails for me with:

```
java.lang.AssertionError: Expected 'Xkdiwt' at index 51 but found 'NULL'
	at ai.rapids.cudf.TableTest.testReadTeachersJSON(TableTest.java:357)
```

We cannot merge this PR until the underlying bug has been fixed.

<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
