### PR TITLE
Temporarily avoid the current build of pydata-sphinx-theme

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -69,7 +69,7 @@ dependencies:
 - protobuf>=4.21,<5
 - ptxcompiler
 - pyarrow==12.0.1.*
-- pydata-sphinx-theme
+- pydata-sphinx-theme!=0.14.2
 - pytest
 - pytest-benchmark
 - pytest-cases

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -67,7 +67,7 @@ dependencies:
 - pre-commit
 - protobuf>=4.21,<5
 - pyarrow==12.0.1.*
-- pydata-sphinx-theme
+- pydata-sphinx-theme!=0.14.2
 - pytest
 - pytest-benchmark
 - pytest-cases

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -379,7 +379,7 @@ dependencies:
           - nbsphinx
           - numpydoc
           - pandoc
-          - pydata-sphinx-theme
+          - pydata-sphinx-theme!=0.14.2
           - scipy
           - sphinx
           - sphinx-autobuild


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
There appears to be a bug in the latest release of pydata-sphinx theme where a warning that was intended to be thrown conditionally is appearing unconditionally in our builds, triggering a doc build failure because we build with `-W`. See https://github.com/pydata/pydata-sphinx-theme/issues/1539 for more information. We should be OK to simply avoid the current version for now. If the next release is a minor release then the warning will be removed and we can automatically upgrade. If they have another patch release then we can reevaluate the pinning, but the current pinning seems like the most likely to require no additional work going forward.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
