### PR TITLE
Enable `dask_cudf/io` pytests in CI

### DIFF
--- a/ci/test_python_other.sh
+++ b/ci/test_python_other.sh
@@ -27,7 +27,7 @@ pytest \
   --cov=dask_cudf \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/dask-cudf-coverage.xml" \
   --cov-report=term \
-  tests
+  .
 popd
 
 rapids-logger "pytest custreamz"


### PR DESCRIPTION
## Description
@rjzamora recently identified and fixed(https://github.com/rapidsai/cudf/pull/14327/) an issue where `dask_cudf/io` pytests weren't being run in ci, however, this was fixed for wheels pytests. This PR fixes the same issue in `conda` pytests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
