### PR TITLE
Fix a pytest typo in `test_kurt_skew_error`

### DIFF
--- a/python/cudf/cudf/tests/test_stats.py
+++ b/python/cudf/cudf/tests/test_stats.py
@@ -272,7 +272,7 @@ def test_kurt_skew_error(op):
     gs = cudf.Series(["ab", "cd"])
     ps = gs.to_pandas()
 
-    with pytest.raises(FutureWarning):
+    with pytest.warns(FutureWarning):
         assert_exceptions_equal(
             getattr(gs, op),
             getattr(ps, op),


### PR DESCRIPTION
## Description
This PR fixes a pytest typo that pytest framework somehow conveniently ignores and continues to execute.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
