### PR TITLE
Expose streams in public filling APIs for label_bins

### DIFF
--- a/cpp/include/cudf/labeling/label_bins.hpp
+++ b/cpp/include/cudf/labeling/label_bins.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,7 @@ std::unique_ptr<column> label_bins(
   inclusive left_inclusive,
   column_view const& right_edges,
   inclusive right_inclusive,
+  rmm::cuda_stream_view stream = cudf::get_default_stream(),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /** @} */  // end of group

--- a/cpp/src/labeling/label_bins.cu
+++ b/cpp/src/labeling/label_bins.cu
@@ -236,6 +236,7 @@ std::unique_ptr<column> label_bins(column_view const& input,
                                    inclusive left_inclusive,
                                    column_view const& right_edges,
                                    inclusive right_inclusive,
+                                   rmm::cuda_stream_view stream,
                                    rmm::mr::device_memory_resource* mr)
 {
   CUDF_FUNC_RANGE();
@@ -244,7 +245,7 @@ std::unique_ptr<column> label_bins(column_view const& input,
                             left_inclusive,
                             right_edges,
                             right_inclusive,
-                            cudf::get_default_stream(),
+                            stream,
                             mr);
 }
 }  // namespace cudf

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -666,7 +666,7 @@ ConfigureTest(
   streams/text/tokenize_test.cpp STREAM_MODE testing
 )
 ConfigureTest(STREAM_UNARY_TEST streams/unary_test.cpp STREAM_MODE testing)
-
+ConfigureTest(STREAM_LABELING_BINS_TEST streams/labeling_bins_test.cpp STREAM_MODE testing)
 # ##################################################################################################
 # Install tests ####################################################################################
 # ##################################################################################################

--- a/cpp/tests/labeling/label_bins_tests.cpp
+++ b/cpp/tests/labeling/label_bins_tests.cpp
@@ -61,7 +61,7 @@ TEST(BinColumnErrorTests, TestInvalidLeft)
   fwc_wrapper<float> input{0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5};
 
   EXPECT_THROW(
-    cudf::label_bins(input, left_edges, cudf::inclusive::YES, right_edges,  cudf::inclusive::NO),
+    cudf::label_bins(input, left_edges, cudf::inclusive::YES, right_edges, cudf::inclusive::NO),
     cudf::logic_error);
 };
 

--- a/cpp/tests/labeling/label_bins_tests.cpp
+++ b/cpp/tests/labeling/label_bins_tests.cpp
@@ -61,7 +61,7 @@ TEST(BinColumnErrorTests, TestInvalidLeft)
   fwc_wrapper<float> input{0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5};
 
   EXPECT_THROW(
-    cudf::label_bins(input, left_edges, cudf::inclusive::YES, right_edges, cudf::inclusive::NO),
+    cudf::label_bins(input, left_edges, cudf::inclusive::YES, right_edges,  cudf::inclusive::NO),
     cudf::logic_error);
 };
 

--- a/cpp/tests/streams/labeling_bins_test.cpp
+++ b/cpp/tests/streams/labeling_bins_test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Danial Javady (am i supposed to put my name here...?)
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/labeling/label_bins.hpp>
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/default_stream.hpp>
+
+class LabelingBinsStreamTest : public cudf::test::BaseFixture {};
+
+TEST_F(LabelingBinsStreamTest, SimpleStringsTest)
+{
+  cudf::test::strings_column_wrapper left_edges{"a", "b", "c", "d", "e"};
+  cudf::test::strings_column_wrapper right_edges{"b", "c", "d", "e", "f"};
+  cudf::test::strings_column_wrapper input{"abc", "bcd", "cde", "def", "efg"};
+
+  auto result =
+    cudf::label_bins(input, left_edges, cudf::inclusive::YES, right_edges, cudf::inclusive::NO, cudf::test::get_default_stream());
+}

--- a/cpp/tests/streams/labeling_bins_test.cpp
+++ b/cpp/tests/streams/labeling_bins_test.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, NVIDIA CORPORATION.
- * Danial Javady (am i supposed to put my name here...?)
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
## Description
Contributes to #925. Introduces cuda_stream parameter for downstream users to provide for `labeling_bins`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
