### PR TITLE
Convert compression and io to string axis type in Parquet Reader benchmarks

### DIFF
--- a/cpp/benchmarks/io/cuio_common.cpp
+++ b/cpp/benchmarks/io/cuio_common.cpp
@@ -214,6 +214,8 @@ cudf::io::io_type retrieve_io_type_enum(std::string const& io_string)
     return cudf::io::io_type::VOID;
   } else if (io_string == "USER_IMPLEMENTED") {
     return cudf::io::io_type::USER_IMPLEMENTED;
+  } else {
+    return cudf::io::io_type::VOID;
   }
 }
 
@@ -243,5 +245,7 @@ cudf::io::compression_type retrieve_compression_type_enum(std::string const& com
     return cudf::io::compression_type::LZO;
   } else if (compression_string == "ZSTD") {
     return cudf::io::compression_type::ZSTD;
+  } else {
+    return cudf::io::compression_type::NONE;
   }
 }

--- a/cpp/benchmarks/io/cuio_common.cpp
+++ b/cpp/benchmarks/io/cuio_common.cpp
@@ -201,3 +201,47 @@ void try_drop_l3_cache()
                            [](auto& cmd) { return exec_cmd(cmd).empty(); }),
                "Failed to execute the drop cache command");
 }
+
+cudf::io::io_type retrieve_io_type_enum(std::string const& io_string)
+{
+  if (io_string == "FILEPATH") {
+    return cudf::io::io_type::FILEPATH;
+  } else if (io_string == "HOST_BUFFER") {
+    return cudf::io::io_type::HOST_BUFFER;
+  } else if (io_string == "DEVICE_BUFFER") {
+    return cudf::io::io_type::DEVICE_BUFFER;
+  } else if (io_string == "VOID") {
+    return cudf::io::io_type::VOID;
+  } else if (io_string == "USER_IMPLEMENTED") {
+    return cudf::io::io_type::USER_IMPLEMENTED;
+  }
+}
+
+cudf::io::compression_type retrieve_compression_type_enum(std::string const& compression_string)
+{
+  if (compression_string == "NONE") {
+    return cudf::io::compression_type::NONE;
+  } else if (compression_string == "AUTO") {
+    return cudf::io::compression_type::AUTO;
+  } else if (compression_string == "SNAPPY") {
+    return cudf::io::compression_type::SNAPPY;
+  } else if (compression_string == "GZIP") {
+    return cudf::io::compression_type::GZIP;
+  } else if (compression_string == "BZIP2") {
+    return cudf::io::compression_type::BZIP2;
+  } else if (compression_string == "BROTLI") {
+    return cudf::io::compression_type::BROTLI;
+  } else if (compression_string == "ZIP") {
+    return cudf::io::compression_type::ZIP;
+  } else if (compression_string == "XZ") {
+    return cudf::io::compression_type::XZ;
+  } else if (compression_string == "ZLIB") {
+    return cudf::io::compression_type::ZLIB;
+  } else if (compression_string == "LZ4") {
+    return cudf::io::compression_type::LZ4;
+  } else if (compression_string == "LZO") {
+    return cudf::io::compression_type::LZO;
+  } else if (compression_string == "ZSTD") {
+    return cudf::io::compression_type::ZSTD;
+  }
+}

--- a/cpp/benchmarks/io/cuio_common.cpp
+++ b/cpp/benchmarks/io/cuio_common.cpp
@@ -215,7 +215,7 @@ cudf::io::io_type retrieve_io_type_enum(std::string const& io_string)
   } else if (io_string == "USER_IMPLEMENTED") {
     return cudf::io::io_type::USER_IMPLEMENTED;
   } else {
-    return cudf::io::io_type::VOID;
+    CUDF_FAIL("Unsupported io_type.");
   }
 }
 
@@ -246,6 +246,6 @@ cudf::io::compression_type retrieve_compression_type_enum(std::string const& com
   } else if (compression_string == "ZSTD") {
     return cudf::io::compression_type::ZSTD;
   } else {
-    return cudf::io::compression_type::NONE;
+    CUDF_FAIL("Unsupported compression_type.");
   }
 }

--- a/cpp/benchmarks/io/cuio_common.hpp
+++ b/cpp/benchmarks/io/cuio_common.hpp
@@ -138,3 +138,27 @@ std::vector<cudf::size_type> segments_in_chunk(int num_segments, int num_chunks,
  * @throw cudf::logic_error if the environment variable is set and the command fails
  */
 void try_drop_l3_cache();
+
+/**
+ * @brief Convert a string to the corresponding io_type enum value.
+ *
+ * This function takes a string and returns the matching io_type enum value. It allows you to
+ * convert a string representation of an io_type into its corresponding enum value.
+ *
+ * @param io_string The input string representing the io_type
+ *
+ * @return The io_type enum value
+ */
+cudf::io::io_type retrieve_io_type_enum(std::string const& io_string);
+
+/**
+ * @brief Convert a string to the corresponding compression_type enum value.
+ *
+ * This function takes a string and returns the matching compression_type enum value. It allows you
+ * to convert a string representation of a compression_type into its corresponding enum value.
+ *
+ * @param compression_string The input string representing the compression_type
+ *
+ * @return The compression_type enum value
+ */
+cudf::io::compression_type retrieve_compression_type_enum(std::string const& compression_string);

--- a/cpp/benchmarks/io/parquet/parquet_reader_input.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_input.cpp
@@ -210,7 +210,8 @@ using compression_list =
 
 NVBENCH_BENCH_TYPES(BM_parquet_read_data, NVBENCH_TYPE_AXES(d_type_list))
   .set_name("parquet_read_decode")
-  .set_type_axes_names({"data_type", "io"})
+  .set_type_axes_names({"data_type"})
+  .add_string_axis("io_type", {"DEVICE_BUFFER"})
   .set_min_samples(4)
   .add_int64_axis("cardinality", {0, 1000})
   .add_int64_axis("run_length", {1, 32});
@@ -228,7 +229,6 @@ NVBENCH_BENCH_TYPES(BM_parquet_read_chunks,
   .set_name("parquet_read_chunks")
   .set_type_axes_names({"data_type", "io"})
   .set_min_samples(4)
-  .add_string_axis("io_type", {"DEVICE_BUFFER"})
   .add_int64_axis("cardinality", {0, 1000})
   .add_int64_axis("run_length", {1, 32})
   .add_int64_axis("byte_limit", {0, 500'000});

--- a/cpp/benchmarks/io/parquet/parquet_reader_input.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_input.cpp
@@ -57,7 +57,7 @@ void parquet_read_common(cudf::io::parquet_writer_options const& write_opts,
 }
 
 template <data_type DataType>
-void BM_parquet_read_data(nvbench::state& state, nvbench::type_list < nvbench::enum_type<DataType>)
+void BM_parquet_read_data(nvbench::state& state, nvbench::type_list<nvbench::enum_type<DataType>>)
 {
   auto const d_type                 = get_type_or_group(static_cast<int32_t>(DataType));
   cudf::size_type const cardinality = state.get_int64("cardinality");
@@ -208,9 +208,7 @@ using io_list = nvbench::enum_type_list<cudf::io::io_type::FILEPATH,
 using compression_list =
   nvbench::enum_type_list<cudf::io::compression_type::SNAPPY, cudf::io::compression_type::NONE>;
 
-NVBENCH_BENCH_TYPES(BM_parquet_read_data,
-                    NVBENCH_TYPE_AXES(d_type_list,
-                                      nvbench::enum_type_list<cudf::io::io_type::DEVICE_BUFFER>))
+NVBENCH_BENCH_TYPES(BM_parquet_read_data, NVBENCH_TYPE_AXES(d_type_list))
   .set_name("parquet_read_decode")
   .set_type_axes_names({"data_type", "io"})
   .set_min_samples(4)
@@ -224,7 +222,9 @@ NVBENCH_BENCH_TYPES(BM_parquet_read_io_compression, NVBENCH_TYPE_AXES(io_list, c
   .add_int64_axis("cardinality", {0, 1000})
   .add_int64_axis("run_length", {1, 32});
 
-NVBENCH_BENCH_TYPES(BM_parquet_read_chunks, NVBENCH_TYPE_AXES(d_type_list))
+NVBENCH_BENCH_TYPES(BM_parquet_read_chunks,
+                    NVBENCH_TYPE_AXES(d_type_list,
+                                      nvbench::enum_type_list<cudf::io::io_type::DEVICE_BUFFER>))
   .set_name("parquet_read_chunks")
   .set_type_axes_names({"data_type", "io"})
   .set_min_samples(4)


### PR DESCRIPTION
Addresses issue: [#12739](https://github.com/rapidsai/cudf/issues/12739)


This PR transforms compression and io into string axis types to enable the selection of different values via the CLI, eliminating the need to execute all values in an automation when required.  Additionally, this PR introduces two new functions, `retrieve_io_type_enum` and `retrieve_compression_type_enum`, which facilitate the conversion of string input into the corresponding enum type that can be used in benchmarking functions.

IO Benchmarks:
- [x] PARQUET READER 


For example:
`./PARQUET_READER_NVBENCH -b parquet_read_io_compression --axis io_type=[HOST_BUFFER] --axis compression_type=[NONE]`

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
