### PR TITLE
Fix default stream use in the CSV reader

### DIFF
--- a/cpp/tests/streams/io/csv_test.cpp
+++ b/cpp/tests/streams/io/csv_test.cpp
@@ -62,7 +62,6 @@ TEST_F(CSVTest, CSVWriter)
 
   auto const filepath = temp_env->get_temp_dir() + "multicolumn.csv";
   auto w_options      = cudf::io::csv_writer_options::builder(cudf::io::sink_info{filepath}, tab)
-                     .include_header(false)
                      .inter_column_delimiter(',');
   cudf::io::write_csv(w_options.build(), cudf::test::get_default_stream());
 }
@@ -96,7 +95,10 @@ TEST_F(CSVTest, CSVReader)
 
   auto const filepath = temp_env->get_temp_dir() + "multicolumn.csv";
   auto w_options      = cudf::io::csv_writer_options::builder(cudf::io::sink_info{filepath}, tab)
-                     .include_header(false)
                      .inter_column_delimiter(',');
   cudf::io::write_csv(w_options.build(), cudf::test::get_default_stream());
+
+  auto const r_options =
+    cudf::io::csv_reader_options::builder(cudf::io::source_info{filepath}).build();
+  cudf::io::read_csv(r_options, cudf::test::get_default_stream());
 }


### PR DESCRIPTION
## Description
String scalars, used to replace double quotes, are implicitly created from `std::string`s, using the default stream. In addition, these scalars are created for each string column.

This PR changes how these objects are created to avoid redundant H2D copies and the use of the default stream.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
