### PR TITLE
Fix io reference in docs.

### DIFF
--- a/docs/cudf/source/user_guide/data-types.md
+++ b/docs/cudf/source/user_guide/data-types.md
@@ -136,7 +136,7 @@ dtype: struct
 StructDtype({'a': dtype('int64'), 'b': dtype('int64')})
 ```
 
-Or by reading them from disk, using a [file format that supports nested data](user_guide/io/index).
+Or by reading them from disk, using a [file format that supports nested data](/user_guide/io/index.md).
 
 ```python
 >>> pdf = pd.DataFrame({"a": [[1, 2], [3, 4, 5], [6, 7, 8]]})

--- a/docs/cudf/source/user_guide/data-types.md
+++ b/docs/cudf/source/user_guide/data-types.md
@@ -136,7 +136,7 @@ dtype: struct
 StructDtype({'a': dtype('int64'), 'b': dtype('int64')})
 ```
 
-Or by reading them from disk, using a [file format that supports nested data](io).
+Or by reading them from disk, using a [file format that supports nested data](user_guide/io/index).
 
 ```python
 >>> pdf = pd.DataFrame({"a": [[1, 2], [3, 4, 5], [6, 7, 8]]})


### PR DESCRIPTION
## Description
cuDF CI is failing to build docs due to an ambiguous reference `io`. This PR makes that reference unambiguous.

```
/__w/cudf/cudf/docs/cudf/source/user_guide/data-types.md:139: WARNING: Multiple matches found for 'io': pandas:std:label:io, pyarrow:std:label:io, python:py:module:io [myst.iref_ambiguous]
```

I used this output to help me find the object inventory that lists this.

```bash
python -m sphinx.ext.intersphinx https://docs.rapids.ai/api/cudf/stable/objects.inv
```

I also looked at the MyST docs on external references. https://mystmd.org/guide/external-references

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
