### PR TITLE
Disable dark mode in Python docs.

### DIFF
--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -98,6 +98,10 @@ exclude_patterns = ['venv', "**/includes/**",]
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
+html_context = {
+    "default_mode": "light",
+}
+
 html_theme_options = {
     "external_links": [],
     # https://github.com/pydata/pydata-sphinx-theme/issues/1220
@@ -107,6 +111,8 @@ html_theme_options = {
     "show_toc_level": 1,
     "navbar_align": "right",
     "navigation_with_keys": True,
+    # Note we have omitted `theme-switcher` below to disable dark mode
+    "navbar_end": ["navbar-icon-links"],
 }
 include_pandas_compat = True
 

--- a/docs/dask_cudf/source/conf.py
+++ b/docs/dask_cudf/source/conf.py
@@ -51,6 +51,10 @@ html_static_path = ["_static"]
 
 pygments_style = "sphinx"
 
+html_context = {
+    "default_mode": "light",
+}
+
 html_theme_options = {
     "external_links": [],
     "github_url": "https://github.com/rapidsai/cudf",
@@ -58,6 +62,8 @@ html_theme_options = {
     "show_toc_level": 1,
     "navbar_align": "right",
     "navigation_with_keys": True,
+    # Note we have omitted `theme-switcher` below to disable dark mode
+    "navbar_end": ["navbar-icon-links"],
 }
 include_pandas_compat = True
 


### PR DESCRIPTION
## Description
This PR disables dark mode in Python docs. The theme is not very legible due to its use of a custom color theme.

Closes #14463.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
