### PR TITLE
Correct dtype of count aggregations on empty dataframes

### DIFF
--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -592,7 +592,9 @@ class GroupBy(Serializable, Reducible, Scannable):
                     # Structs lose their labels which we reconstruct here
                     col = col._with_type_metadata(cudf.ListDtype(orig_dtype))
 
-                if (
+                if agg_kind in {"COUNT", "SIZE"}:
+                    data[key] = col.astype("int64")
+                elif (
                     self.obj.empty
                     and (
                         isinstance(agg_name, str)
@@ -609,8 +611,6 @@ class GroupBy(Serializable, Reducible, Scannable):
                     )
                 ):
                     data[key] = col.astype(orig_dtype)
-                elif agg_kind in {"COUNT", "SIZE"}:
-                    data[key] = col.astype("int64")
                 else:
                     data[key] = col
         data = ColumnAccessor(data, multiindex=multilevel)

--- a/python/cudf/cudf/tests/groupby/test_agg.py
+++ b/python/cudf/cudf/tests/groupby/test_agg.py
@@ -7,15 +7,7 @@ import cudf
 
 @pytest.mark.parametrize(
     "empty",
-    [
-        pytest.param(
-            True,
-            marks=pytest.mark.xfail(
-                reason="https://github.com/rapidsai/cudf/issues/14200"
-            ),
-        ),
-        False,
-    ],
+    [True, False],
     ids=["empty", "nonempty"],
 )
 def test_agg_count_dtype(empty):

--- a/python/cudf/cudf/tests/groupby/test_agg.py
+++ b/python/cudf/cudf/tests/groupby/test_agg.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+import numpy as np
+import pytest
+
+import cudf
+
+
+@pytest.mark.parametrize(
+    "empty",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="https://github.com/rapidsai/cudf/issues/14200"
+            ),
+        ),
+        False,
+    ],
+    ids=["empty", "nonempty"],
+)
+def test_agg_count_dtype(empty):
+    df = cudf.DataFrame({"a": [1, 2, 1], "c": ["a", "b", "c"]})
+    if empty:
+        df = df.iloc[:0]
+    result = df.groupby("a").agg({"c": "count"})
+    assert result["c"].dtype == np.dtype("int64")


### PR DESCRIPTION
## Description
A count aggregation should always return an int64 column, even if the grouped dataframe is empty. Previously we did not do this because the short-circuiting for empty inputs was hit before handling the count case. Fix this by reordering the conditions.

- Closes https://github.com/rapidsai/cudf/issues/14200

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
