### PR TITLE
Remove unsanitized null from input strings column in rank_tests.cpp

### DIFF
--- a/cpp/tests/reductions/rank_tests.cpp
+++ b/cpp/tests/reductions/rank_tests.cpp
@@ -140,7 +140,7 @@ auto make_input_column()
 auto make_strings_column()
 {
   return cudf::test::strings_column_wrapper{
-    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "6c", "9", "9", "10d"},
+    {"0a", "0a", "2a", "2a", "3b", "5", "6c", "6c", "", "9", "9", "10d"},
     cudf::test::iterators::null_at(8)};
 }
 


### PR DESCRIPTION
## Description
Removes a non-empty null entry from a test strings column utility in `rank_tests.cpp`.
Behavior with unsanitized nulls in at best UB and should not be included in unit tests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
