### PR TITLE
Expunge as_frame conversions in Column algorithms 

### DIFF
--- a/python/cudf/cudf/core/column/numerical_base.py
+++ b/python/cudf/cudf/core/column/numerical_base.py
@@ -182,15 +182,12 @@ class NumericalBaseColumn(ColumnBase, Scannable):
         self, q: np.ndarray, interpolation: str, exact: bool
     ) -> NumericalBaseColumn:
         # get sorted indices and exclude nulls
-        sorted_indices = self.as_frame()._get_sorted_inds(
-            ascending=True, na_position="first"
-        )
-        sorted_indices = sorted_indices.slice(
-            self.null_count, len(sorted_indices)
-        )
+        indices = libcudf.sort.order_by(
+            [self], [True], "first", stable=True
+        ).slice(self.null_count, len(self))
 
         return libcudf.quantiles.quantile(
-            self, q, interpolation, sorted_indices, exact
+            self, q, interpolation, indices, exact
         )
 
     def cov(self, other: NumericalBaseColumn) -> float:

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -3260,8 +3260,11 @@ class IndexedFrame(Frame):
             # is on the end of the offset. See pandas gh29623 for detail.
             to_search = to_search - pd_offset.base
             return self.loc[:to_search]
+        needle = as_column(to_search, dtype=self._index.dtype)
         end_point = int(
-            self._index._column.searchsorted(to_search, side=side)[0]
+            self._index._column.searchsorted(
+                needle, side=side
+            ).element_indexing(0)
         )
         return slice_func(end_point)
 

--- a/python/cudf/cudf/tests/test_search.py
+++ b/python/cudf/cudf/tests/test_search.py
@@ -38,7 +38,10 @@ def test_searchsorted(side, obj_class, vals_class):
     pvals = vals.to_pandas()
 
     expect = psr.searchsorted(pvals, side)
-    got = sr.searchsorted(vals, side)
+    if obj_class == "column":
+        got = sr.searchsorted(vals._column, side)
+    else:
+        got = sr.searchsorted(vals, side)
 
     assert_eq(expect, cupy.asnumpy(got))
 


### PR DESCRIPTION
## Description
Previously a number of algorithms on Columns first converted to a single column frame and called a frame-based algorithm (which calls directly into libcudf using the column we first thought of). This is unnecessary since we already have the column to hand when calling the same algorithm at the column level. Moreover, in many cases where the algorithm is a user-facing API, the frame-based approach does more work (for example conversions and dtype matching).

By removing this round trip we reduce some (unnecessary) overhead, and also make the memory footprint and behaviour of column-based methods more transparent.

- Closes #13565

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
