### PR TITLE
Split libarrow build dependencies.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -39,12 +39,15 @@ dependencies:
 - hypothesis
 - identify>=2.5.20
 - ipython
-- libarrow-all==14.0.1.*
+- libarrow-acero==14.0.1.*
+- libarrow-dataset==14.0.1.*
+- libarrow==14.0.1.*
 - libcufile-dev=1.4.0.31
 - libcufile=1.4.0.31
 - libcurand-dev=10.3.0.86
 - libcurand=10.3.0.86
 - libkvikio==24.2.*
+- libparquet==14.0.1.*
 - librdkafka>=1.9.0,<1.10.0a0
 - librmm==24.2.*
 - make

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -40,10 +40,13 @@ dependencies:
 - hypothesis
 - identify>=2.5.20
 - ipython
-- libarrow-all==14.0.1.*
+- libarrow-acero==14.0.1.*
+- libarrow-dataset==14.0.1.*
+- libarrow==14.0.1.*
 - libcufile-dev
 - libcurand-dev
 - libkvikio==24.2.*
+- libparquet==14.0.1.*
 - librdkafka>=1.9.0,<1.10.0a0
 - librmm==24.2.*
 - make

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -14,6 +14,7 @@ files:
       - cudatoolkit
       - develop
       - docs
+      - libarrow_build
       - notebooks
       - py_version
       - run_common
@@ -242,9 +243,6 @@ dependencies:
           - &gmock gmock>=1.13.0
           - librmm==24.2.*
           - libkvikio==24.2.*
-          # Hard pin the patch version used during the build. This must be kept
-          # in sync with the version pinned in get_arrow.cmake.
-          - libarrow-all==14.0.1.*
           - librdkafka>=1.9.0,<1.10.0a0
           # Align nvcomp version with rapids-cmake
           - nvcomp==3.0.4
@@ -304,13 +302,26 @@ dependencies:
       - output_types: pyproject
         matrices:
           - {matrix: null, packages: [*rmm_conda] }
+  libarrow_build:
+    common:
+      - output_types: conda
+        packages:
+          # Hard pin the Arrow patch version used during the build. This must
+          # be kept in sync with the version pinned in get_arrow.cmake.
+          - libarrow-acero==14.0.1.*
+          - libarrow-dataset==14.0.1.*
+          - libarrow==14.0.1.*
+          - libparquet==14.0.1.*
   libarrow_run:
     common:
       - output_types: conda
         packages:
           # Allow runtime version to float up to minor version
           # Disallow libarrow 14.0.0 due to a CVE
-          - libarrow-all>=14.0.1,<15.0.0a0
+          - libarrow-acero >=14.0.1,<15.0.0a0
+          - libarrow-dataset >=14.0.1,<15.0.0a0
+          - libarrow >=14.0.1,<15.0.0a0
+          - libparquet >=14.0.1,<15.0.0a0
   pyarrow_run:
     common:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
## Description
This PR splits the libarrow build dependencies, rather than using `libarrow-all`. This implements the proposal in https://github.com/rapidsai/cudf/issues/14370#issuecomment-1800885356 and closes #14370.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
