### PR TITLE
Fix function name typo in `cudf.pandas` profiler

### DIFF
--- a/python/cudf/cudf/pandas/__main__.py
+++ b/python/cudf/cudf/pandas/__main__.py
@@ -33,7 +33,7 @@ def profile(function_profile, line_profile, fn):
     elif function_profile:
         with Profiler() as profiler:
             yield fn
-        profiler.print_per_func_stats()
+        profiler.print_per_function_stats()
     else:
         yield fn
 

--- a/python/cudf/cudf_pandas_tests/data/profile_basic.py
+++ b/python/cudf/cudf_pandas_tests/data/profile_basic.py
@@ -2,8 +2,12 @@
 
 import pandas as pd
 
-URL = "https://github.com/plotly/datasets/raw/master/tips.csv"
-df = pd.read_csv(URL)
+df = pd.DataFrame(
+    {
+        "size": [10, 11, 12, 10, 11, 12, 10, 6, 11, 10],
+        "total_bill": [100, 200, 100, 200, 100, 100, 200, 50, 10, 560],
+    }
+)
 df["size"].value_counts()
 df.groupby("size").total_bill.mean()
 df.apply(list, axis=1)

--- a/python/cudf/cudf_pandas_tests/data/profile_basic.py
+++ b/python/cudf/cudf_pandas_tests/data/profile_basic.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+import pandas as pd
+
+URL = "https://github.com/plotly/datasets/raw/master/tips.csv"
+df = pd.read_csv(URL)
+df["size"].value_counts()
+df.groupby("size").total_bill.mean()
+df.apply(list, axis=1)


### PR DESCRIPTION
## Description
Fixes: #14512 

This PR fixes a function name typo in `cudf.pandas` profiler.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
