### PR TITLE
Make DefaultHostMemoryAllocator settable

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/DefaultHostMemoryAllocator.java
+++ b/java/src/main/java/ai/rapids/cudf/DefaultHostMemoryAllocator.java
@@ -19,9 +19,23 @@
 package ai.rapids.cudf;
 
 public class DefaultHostMemoryAllocator implements HostMemoryAllocator {
-  private static final HostMemoryAllocator INSTANCE = new DefaultHostMemoryAllocator();
+  private static volatile HostMemoryAllocator instance = new DefaultHostMemoryAllocator();
+
+  /**
+   * Retrieve current host memory allocator used by default if not passed directly to API
+   *
+   * @return current default HostMemoryAllocator implementation
+   */
   public static HostMemoryAllocator get() {
-    return INSTANCE;
+    return instance;
+  }
+
+  /**
+   * Sets a new default host memory allocator implementation by default.
+   * @param hostMemoryAllocator
+   */
+  public static void set(HostMemoryAllocator hostMemoryAllocator) {
+    instance = hostMemoryAllocator;
   }
 
   @Override


### PR DESCRIPTION
spark-rapids requires the ability to set DefaultHostMemoryAllocator

Contributes to NVIDIA/spark-rapids#9862

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
