### PR TITLE
Small clean up in `io::statistics`

### DIFF
--- a/cpp/src/io/statistics/statistics.cuh
+++ b/cpp/src/io/statistics/statistics.cuh
@@ -63,30 +63,24 @@ struct stats_column_desc {
   column_device_view const* parent_column;  //!< Pointer to parent column; nullptr if not list type
 };
 
-template <typename ReturnType, typename InternalType>
+template <typename ReturnType>
 struct t_array_stats {
-  InternalType const* ptr;  //!< ptr to data
-  size_type length;         //!< length of data
-  __host__ __device__ __forceinline__ volatile t_array_stats& operator=(
-    ReturnType const& val) volatile
+  using data_ptr_type = decltype(std::declval<ReturnType const>().data());
+  data_ptr_type ptr{};  //!< ptr to data
+  size_type length{};   //!< length of data
+
+  __host__ __device__ t_array_stats& operator=(ReturnType const& val)
   {
     ptr    = val.data();
     length = val.size_bytes();
     return *this;
   }
-  __host__ __device__ __forceinline__ operator ReturnType() volatile
-  {
-    return ReturnType(ptr, length);
-  }
-  __host__ __device__ __forceinline__ operator ReturnType() const
-  {
-    return ReturnType(ptr, length);
-  }
-  __host__ __device__ __forceinline__ operator ReturnType() { return ReturnType(ptr, length); }
+
+  __host__ __device__ operator ReturnType() const { return ReturnType(ptr, length); }
 };
-using string_stats     = t_array_stats<string_view, char>;
+using string_stats     = t_array_stats<string_view>;
 using byte_array_view  = statistics::byte_array_view;
-using byte_array_stats = t_array_stats<byte_array_view, byte_array_view::element_type>;
+using byte_array_stats = t_array_stats<byte_array_view>;
 
 union statistics_val {
   string_stats str_val;       //!< string columns


### PR DESCRIPTION
## Description
Removed the use of volatile, not required now that it's not used in ORC or Parquet.
Small template simplification.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
