### PR TITLE
Fix return type of prefix increment overloads

### DIFF
--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -852,7 +852,11 @@ struct dst_offset_output_iterator {
 
   dst_offset_output_iterator operator+ __host__ __device__(int i) { return {c + i}; }
 
-  void operator++ __host__ __device__() { c++; }
+  dst_offset_output_iterator& operator++ __host__ __device__()
+  {
+    c++;
+    return *this;
+  }
 
   reference operator[] __device__(int i) { return dereference(c + i); }
   reference operator* __device__() { return dereference(c); }
@@ -873,12 +877,13 @@ struct dst_valid_count_output_iterator {
   using reference         = size_type&;
   using iterator_category = thrust::output_device_iterator_tag;
 
-  dst_valid_count_output_iterator operator+ __host__ __device__(int i)
-  {
-    return dst_valid_count_output_iterator{c + i};
-  }
+  dst_valid_count_output_iterator operator+ __host__ __device__(int i) { return {c + i}; }
 
-  void operator++ __host__ __device__() { c++; }
+  dst_valid_count_output_iterator& operator++ __host__ __device__()
+  {
+    c++;
+    return *this;
+  }
 
   reference operator[] __device__(int i) { return dereference(c + i); }
   reference operator* __device__() { return dereference(c); }

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -908,12 +908,13 @@ struct chunk_row_output_iter {
   using reference         = size_type&;
   using iterator_category = thrust::output_device_iterator_tag;
 
-  __host__ __device__ chunk_row_output_iter operator+(int i)
-  {
-    return chunk_row_output_iter{p + i};
-  }
+  __host__ __device__ chunk_row_output_iter operator+(int i) { return {p + i}; }
 
-  __host__ __device__ void operator++() { p++; }
+  __host__ __device__ chunk_row_output_iter& operator++()
+  {
+    p++;
+    return *this;
+  }
 
   __device__ reference operator[](int i) { return p[i].chunk_row; }
   __device__ reference operator*() { return p->chunk_row; }
@@ -948,11 +949,14 @@ struct start_offset_output_iterator {
 
   constexpr start_offset_output_iterator operator+(size_t i)
   {
-    return start_offset_output_iterator{
-      pages, page_indices, cur_index + i, input_cols, max_depth, num_pages};
+    return {pages, page_indices, cur_index + i, input_cols, max_depth, num_pages};
   }
 
-  constexpr void operator++() { cur_index++; }
+  constexpr start_offset_output_iterator& operator++()
+  {
+    cur_index++;
+    return *this;
+  }
 
   __device__ reference operator[](size_t i) { return dereference(cur_index + i); }
   __device__ reference operator*() { return dereference(cur_index); }
@@ -1087,12 +1091,13 @@ struct page_offset_output_iter {
   using reference         = size_type&;
   using iterator_category = thrust::output_device_iterator_tag;
 
-  __host__ __device__ page_offset_output_iter operator+(int i)
-  {
-    return page_offset_output_iter{p, index + i};
-  }
+  __host__ __device__ page_offset_output_iter operator+(int i) { return {p, index + i}; }
 
-  __host__ __device__ void operator++() { index++; }
+  __host__ __device__ page_offset_output_iter& operator++()
+  {
+    index++;
+    return *this;
+  }
 
   __device__ reference operator[](int i) { return p[index[i]].str_offset; }
   __device__ reference operator*() { return p[*index].str_offset; }


### PR DESCRIPTION
## Description
Prefix increment operators should return a reference to the object. Some of our iterators don't return anything.
This PR fixes those iterators to be in line with what C++ expects.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
