### PR TITLE
Fix typo in `Series.value_counts`

### DIFF
--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -3120,7 +3120,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         if dropna and self.null_count == len(self):
             return Series(
                 [],
-                dtype=np.int34,
+                dtype=np.int64,
                 name=result_name,
                 index=cudf.Index([], dtype=self.dtype, name=self.name),
             )


### PR DESCRIPTION
## Description
This PR fixes the return type of `Series.value_counts` to return `int64`, correcting a typo that was `int34`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
