### PR TITLE
Fix copy creation of a `ColumnAccessor`

### DIFF
--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -366,11 +366,15 @@ class ColumnAccessor(abc.MutableMapping):
                 {k: v.copy(deep=deep) for k, v in self._data.items()},
                 multiindex=self.multiindex,
                 level_names=self.level_names,
+                rangeindex=self.rangeindex,
+                label_dtype=self.label_dtype,
             )
         return self.__class__(
             self._data.copy(),
             multiindex=self.multiindex,
             level_names=self.level_names,
+            rangeindex=self.rangeindex,
+            label_dtype=self.label_dtype,
         )
 
     def select_by_label(self, key: Any) -> ColumnAccessor:


### PR DESCRIPTION
## Description
This PR fixes a copy creation in `ColumnAccessor` by properly passing the `rangeindex` and `label_dtype` to it's newly constructed object.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
