### PR TITLE
Fix `to_pandas` calls in pytests

### DIFF
--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -2661,7 +2661,6 @@ def test_parquet_writer_decimal(decimal_type, data):
     gdf.to_parquet(buff)
 
     got = pd.read_parquet(buff, dtype_backend="numpy_nullable")
-    assert_eq(gdf.to_pandas(nullable=True), got)
     assert_eq(gdf["val"].to_pandas(nullable=True), got["val"])
     assert_eq(gdf["dec_val"].to_pandas(), got["dec_val"])
 

--- a/python/cudf/cudf/tests/test_udf_masked_ops.py
+++ b/python/cudf/cudf/tests/test_udf_masked_ops.py
@@ -185,14 +185,13 @@ def test_arith_masked_vs_masked_datelike(op, dtype_l, dtype_r):
     gdf["a"] = gdf["a"].astype(dtype_l)
     gdf["b"] = gdf["b"].astype(dtype_r)
 
-    pdf = gdf.to_pandas(nullable=True)
-
+    pdf = gdf.to_pandas()
     expect = op(pdf["a"], pdf["b"])
     obtain = gdf.apply(func, axis=1)
     assert_eq(expect, obtain, check_dtype=False)
     # TODO: After the following pandas issue is
     # fixed, uncomment the following line and delete
-    # through `to_pandas(nullable=True)` statement.
+    # through `to_pandas()` statement.
     # https://github.com/pandas-dev/pandas/issues/52411
 
     # run_masked_udf_test(func, gdf, nullable=False, check_dtype=False)


### PR DESCRIPTION
## Description
This PR removes `nullable=True` in two pytests as we error when `nullable` is passed when there is decimal / list / struct data.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
