### PR TITLE
Enforce `Index.to_frame` deprecations

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -796,12 +796,6 @@ class BaseIndex(Serializable):
 
         return super().fillna(value=value)
 
-    def _get_level_names(self):
-        """
-        Return a name or list of names with None replaced by the level number.
-        """
-        return 0 if self.name is None else self.name
-
     def to_frame(self, index=True, name=no_default):
         """Create a DataFrame with a column containing this Index
 
@@ -852,7 +846,7 @@ class BaseIndex(Serializable):
         """
 
         if name is no_default:
-            col_name = self._get_level_names()
+            col_name = 0 if self.name is None else self.name
         else:
             col_name = name
 

--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -796,6 +796,12 @@ class BaseIndex(Serializable):
 
         return super().fillna(value=value)
 
+    def _get_level_names(self):
+        """
+        Return a name or list of names with None replaced by the level number.
+        """
+        return 0 if self.name is None else self.name
+
     def to_frame(self, index=True, name=no_default):
         """Create a DataFrame with a column containing this Index
 
@@ -844,22 +850,12 @@ class BaseIndex(Serializable):
         1  Bear
         2   Cow
         """
-        if name is None:
-            warnings.warn(
-                "Explicitly passing `name=None` currently preserves "
-                "the Index's name or uses a default name of 0. This "
-                "behaviour is deprecated, and in the future `None` "
-                "will be used as the name of the "
-                "resulting DataFrame column.",
-                FutureWarning,
-            )
-            name = no_default
-        if name is not no_default:
-            col_name = name
-        elif self.name is None:
-            col_name = 0
+
+        if name is no_default:
+            col_name = self._get_level_names()
         else:
-            col_name = self.name
+            col_name = name
+
         return cudf.DataFrame(
             {col_name: self._values}, index=self if index else None
         )

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -970,16 +970,6 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
         return result
 
     @_cudf_nvtx_annotate
-    def _get_level_names(self):
-        """
-        Return a name or list of names with None replaced by the level number.
-        """
-        return [
-            level if name is None else name
-            for level, name in enumerate(self.names)
-        ]
-
-    @_cudf_nvtx_annotate
     def to_frame(self, index=True, name=no_default, allow_duplicates=False):
         """
         Create a DataFrame with the levels of the MultiIndex as columns.
@@ -1033,7 +1023,10 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
         # incorrect. We want to make a deep copy, otherwise further
         # modifications of the resulting DataFrame will affect the MultiIndex.
         if name is no_default:
-            column_names = self._get_level_names()
+            column_names = [
+                level if name is None else name
+                for level, name in enumerate(self.names)
+            ]
         else:
             if len(name) != len(self.levels):
                 raise ValueError(

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -3098,10 +3098,9 @@ def test_index_to_frame(data, data_name, index, name):
     pidx = pd.Index(data, name=data_name)
     gidx = cudf.from_pandas(pidx)
 
-    with expect_warning_if(name is None):
+    with expect_warning_if(not PANDAS_GE_200 and name is None):
         expected = pidx.to_frame(index=index, name=name)
-    with expect_warning_if(name is None):
-        actual = gidx.to_frame(index=index, name=name)
+    actual = gidx.to_frame(index=index, name=name)
 
     assert_eq(expected, actual)
 

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -1989,22 +1989,20 @@ def test_multiindex_to_frame_allow_duplicates(
         ) or (isinstance(name, list) and len(name) != len(set(name))):
             # cudf doesn't have the ability to construct dataframes
             # with duplicate column names
-            with expect_warning_if(name is None):
-                with pytest.raises(ValueError):
-                    gidx.to_frame(
-                        index=index,
-                        name=name,
-                        allow_duplicates=allow_duplicates,
-                    )
+            with pytest.raises(ValueError):
+                gidx.to_frame(
+                    index=index,
+                    name=name,
+                    allow_duplicates=allow_duplicates,
+                )
         else:
-            with expect_warning_if(name is None):
+            with expect_warning_if(not PANDAS_GE_200 and name is None):
                 expected = pidx.to_frame(
                     index=index, name=name, allow_duplicates=allow_duplicates
                 )
-            with expect_warning_if(name is None):
-                actual = gidx.to_frame(
-                    index=index, name=name, allow_duplicates=allow_duplicates
-                )
+            actual = gidx.to_frame(
+                index=index, name=name, allow_duplicates=allow_duplicates
+            )
 
             assert_eq(expected, actual)
 


### PR DESCRIPTION
## Description
This PR enforces deprecations of `Index.to_frame` and updates pytests related to this API.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
