### PR TITLE
Filter deprecation warning in `ffill` and `bfill` APIs

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2174,13 +2174,15 @@ class IndexedFrame(Frame):
         -------
             Object with missing values filled or None if ``inplace=True``.
         """
-        return self.fillna(
-            method="bfill",
-            value=value,
-            axis=axis,
-            inplace=inplace,
-            limit=limit,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return self.fillna(
+                method="bfill",
+                value=value,
+                axis=axis,
+                inplace=inplace,
+                limit=limit,
+            )
 
     @_cudf_nvtx_annotate
     def backfill(self, value=None, axis=None, inplace=None, limit=None):
@@ -2211,13 +2213,15 @@ class IndexedFrame(Frame):
         -------
             Object with missing values filled or None if ``inplace=True``.
         """
-        return self.fillna(
-            method="ffill",
-            value=value,
-            axis=axis,
-            inplace=inplace,
-            limit=limit,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return self.fillna(
+                method="ffill",
+                value=value,
+                axis=axis,
+                inplace=inplace,
+                limit=limit,
+            )
 
     @_cudf_nvtx_annotate
     def pad(self, value=None, axis=None, inplace=None, limit=None):


### PR DESCRIPTION
## Description
This PR doesn't let the `fillna` warnings propagate to the user when `ffill` and `bfill` APIs are invoked.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
