### PR TITLE
Add missing `is_categorical_dtype` to `cudf.api.types` namespace

### DIFF
--- a/python/cudf/cudf/api/types.py
+++ b/python/cudf/cudf/api/types.py
@@ -21,6 +21,7 @@ from cudf.core.dtypes import (  # noqa: F401
     _is_categorical_dtype,
     _is_interval_dtype,
     dtype,
+    is_categorical_dtype,
     is_decimal32_dtype,
     is_decimal64_dtype,
     is_decimal128_dtype,

--- a/python/cudf/cudf/tests/test_api_types.py
+++ b/python/cudf/cudf/tests/test_api_types.py
@@ -6,8 +6,10 @@ import pytest
 from pandas.api import types as pd_types
 
 import cudf
-from cudf.core._compat import PANDAS_GE_200
+from cudf.core._compat import PANDAS_GE_200, PANDAS_GE_210
 from cudf.api import types
+
+from cudf.testing._utils import expect_warning_if
 
 
 @pytest.mark.parametrize(
@@ -1036,10 +1038,11 @@ def test_is_decimal_dtype(obj, expect):
     ),
 )
 def test_pandas_agreement(obj):
+    with expect_warning_if(PANDAS_GE_210):
+        expected = pd_types.is_categorical_dtype(obj)
     with pytest.warns(FutureWarning):
-        assert types.is_categorical_dtype(
-            obj
-        ) == pd_types.is_categorical_dtype(obj)
+        actual = types.is_categorical_dtype(obj)
+    assert expected == actual
     assert types.is_numeric_dtype(obj) == pd_types.is_numeric_dtype(obj)
     assert types.is_integer_dtype(obj) == pd_types.is_integer_dtype(obj)
     assert types.is_integer(obj) == pd_types.is_integer(obj)


### PR DESCRIPTION
## Description

This PR adds back `cudf.api.types.is_categorical` that was missing due to a bad merge.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
