### PR TITLE
Fix unsanitized nulls produced by libcudf dictionary decode

### DIFF
--- a/cpp/src/dictionary/decode.cu
+++ b/cpp/src/dictionary/decode.cu
@@ -34,7 +34,7 @@ struct indices_handler_fn {
   cudf::detail::input_indexalator const d_iterator;
   column_device_view const d_indices;
   size_type oob_index;  // out-of-bounds index identifies nulls
-  __device__ size_type operator()(size_type idx)
+  __device__ size_type operator()(size_type idx) const
   {
     return d_indices.is_null(idx) ? oob_index : d_iterator[idx];
   }

--- a/cpp/tests/dictionary/slice_test.cpp
+++ b/cpp/tests/dictionary/slice_test.cpp
@@ -30,7 +30,7 @@ struct DictionarySliceTest : public cudf::test::BaseFixture {};
 TEST_F(DictionarySliceTest, SliceColumn)
 {
   cudf::test::strings_column_wrapper strings{
-    {"eee", "aaa", "ddd", "bbb", "ccc", "ccc", "ccc", "eee", "aaa"}, {1, 1, 1, 1, 1, 0, 1, 1, 1}};
+    {"eee", "aaa", "ddd", "bbb", "ccc", "", "ccc", "eee", "aaa"}, {1, 1, 1, 1, 1, 0, 1, 1, 1}};
   auto dictionary = cudf::dictionary::encode(strings);
 
   std::vector<cudf::size_type> splits{1, 6};


### PR DESCRIPTION
## Description
Fixes `cudf::dictionary::decode` logic to produced sanitized null entries for compound column types.

Reference: #14559 -- fixes many of the errors found here concerning dictionary column gtests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
