### PR TITLE
Deprecate `DataFrame.applymap` and use `map` instead

### DIFF
--- a/docs/cudf/source/user_guide/api_docs/dataframe.rst
+++ b/docs/cudf/source/user_guide/api_docs/dataframe.rst
@@ -105,13 +105,14 @@ Function application, GroupBy & window
 .. autosummary::
    :toctree: api/
 
+   DataFrame.agg
    DataFrame.apply
    DataFrame.applymap
    DataFrame.apply_chunks
    DataFrame.apply_rows
-   DataFrame.pipe
-   DataFrame.agg
    DataFrame.groupby
+   DataFrame.map
+   DataFrame.pipe
    DataFrame.rolling
 
 .. _api.dataframe.stats:

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -4544,6 +4544,38 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         DataFrame
             Transformed DataFrame.
         """
+        # Do not remove until pandas 3.0 support is added.
+        warnings.warn(
+            "DataFrame.applymap has been deprecated. Use DataFrame.map "
+            "instead.",
+            FutureWarning,
+        )
+        return self.map(func=func, na_action=na_action, **kwargs)
+
+    def map(
+        self,
+        func: Callable[[Any], Any],
+        na_action: Union[str, None] = None,
+        **kwargs,
+    ) -> DataFrame:
+        """
+        Apply a function to a Dataframe elementwise.
+
+        This method applies a function that accepts and returns a scalar
+        to every element of a DataFrame.
+
+        Parameters
+        ----------
+        func : callable
+            Python function, returns a single value from a single value.
+        na_action : {None, 'ignore'}, default None
+            If 'ignore', propagate NaN values, without passing them to func.
+
+        Returns
+        -------
+        DataFrame
+            Transformed DataFrame.
+        """
 
         if kwargs:
             raise NotImplementedError(

--- a/python/cudf/cudf/tests/test_applymap.py
+++ b/python/cudf/cudf/tests/test_applymap.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION.
 
 import pytest
 
 from cudf import NA, DataFrame
 from cudf.testing import _utils as utils
+from cudf.core._compat import PANDAS_GE_210
 
 
 @pytest.mark.parametrize(
@@ -29,8 +30,10 @@ def test_applymap_dataframe(data, func, na_action):
     gdf = DataFrame(data)
     pdf = gdf.to_pandas(nullable=True)
 
-    expect = pdf.applymap(func, na_action=na_action)
-    got = gdf.applymap(func, na_action=na_action)
+    with utils.expect_warning_if(PANDAS_GE_210):
+        expect = pdf.applymap(func, na_action=na_action)
+    with pytest.warns(FutureWarning):
+        got = gdf.applymap(func, na_action=na_action)
 
     utils.assert_eq(expect, got, check_dtype=False)
 
@@ -41,8 +44,10 @@ def test_applymap_raise_cases():
     def f(x, some_kwarg=0):
         return x + some_kwarg
 
-    with pytest.raises(NotImplementedError):
-        df.applymap(f, some_kwarg=1)
+    with pytest.warns(FutureWarning):
+        with pytest.raises(NotImplementedError):
+            df.applymap(f, some_kwarg=1)
 
-    with pytest.raises(ValueError):
-        df.applymap(f, na_action="some_invalid_option")
+    with pytest.warns(FutureWarning):
+        with pytest.raises(ValueError):
+            df.applymap(f, na_action="some_invalid_option")

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -2823,7 +2823,7 @@ def test_parquet_reader_one_level_list2(datadir):
     fname = datadir / "one_level_list2.parquet"
 
     expect = pd.read_parquet(fname)
-    expect = expect.applymap(postprocess)
+    expect = expect.map(postprocess)
     got = cudf.read_parquet(fname)
 
     assert_eq(expect, got, check_dtype=False)


### PR DESCRIPTION
## Description
Pandas 2.1.0 deprecated `DataFrame.applymap`, This PR deprecated `applymap` and introduces `map` to be used as the new alternative API.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
