### PR TITLE
Correct invalid or missing return types

### DIFF
--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -213,7 +213,7 @@ struct delta_byte_array_decoder {
     using cudf::detail::warp_size;
     __shared__ __align__(8) uint8_t* so_ptr;
 
-    if (start_idx >= suffixes.value_count) { return; }
+    if (start_idx >= suffixes.value_count) { return 0; }
     auto end_idx = start_idx + min(suffixes.values_per_mb, num_values);
     end_idx      = min(end_idx, static_cast<uint32_t>(suffixes.value_count));
 

--- a/cpp/src/text/jaccard.cu
+++ b/cpp/src/text/jaccard.cu
@@ -113,7 +113,7 @@ struct sorted_intersect_fn {
   cudf::size_type* d_results;
 
   // warp per row
-  __device__ float operator()(cudf::size_type idx) const
+  __device__ void operator()(cudf::size_type idx) const
   {
     using warp_reduce = cub::WarpReduce<cudf::size_type>;
     __shared__ typename warp_reduce::TempStorage temp_storage;


### PR DESCRIPTION
## Description
Found some invalid return statements when compiling cudf with a newer gcc.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
