### PR TITLE
Remove WORKSPACE env var from cudf_test temp_directory class

### DIFF
--- a/cpp/include/cudf_test/file_utilities.hpp
+++ b/cpp/include/cudf_test/file_utilities.hpp
@@ -16,14 +16,13 @@
 
 #pragma once
 
+#include <cudf/utilities/error.hpp>
+
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
-#include <string>
-
 #include <ftw.h>
-
-#include <cudf/utilities/error.hpp>
+#include <string>
 
 /**
  * @brief RAII class for creating a temporary directory.
@@ -41,7 +40,6 @@ class temp_directory {
   temp_directory(std::string const& base_name)
   {
     std::string dir_template{std::filesystem::temp_directory_path().string()};
-    if (auto env_p = std::getenv("WORKSPACE")) dir_template = env_p;
 
     dir_template += "/" + base_name + ".XXXXXX";
     auto const tmpdirptr = mkdtemp(const_cast<char*>(dir_template.data()));


### PR DESCRIPTION
## Description
Removes the `WORKSPACE` env var check from the `cudf_test` `temp_directory` class. This env var is not being used. This is part of a larger effort to consolidate and document libcudf env vars.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
