### PR TITLE
Remove unsanitized input test data from copy gtests

### DIFF
--- a/cpp/tests/copying/copy_if_else_nested_tests.cpp
+++ b/cpp/tests/copying/copy_if_else_nested_tests.cpp
@@ -386,22 +386,12 @@ TYPED_TEST(TypedCopyIfElseNestedTest, ScalarListBothInvalid)
   using bools = cudf::test::fixed_width_column_wrapper<bool, int32_t>;
   using lcw   = cudf::test::lists_column_wrapper<T, int32_t>;
 
-  auto lhs_scalar = cudf::list_scalar{ints{33, 33, 33}, false};
-  auto rhs_scalar = cudf::list_scalar{ints{22, 22}, false};
+  auto lhs_scalar = cudf::list_scalar{ints{}, false};
+  auto rhs_scalar = cudf::list_scalar{ints{}, false};
 
   auto selector_column = bools{1, 1, 0, 1, 1, 0, 1}.release();
 
-  auto expected = lcw{{
-                        {-33, -33, -33},
-                        {-33, -33, -33},
-                        {-22, -22},
-                        {-33, -33, -33},
-                        {-33, -33, -33},
-                        {-22, -22},
-                        {-33, -33, -33},
-                      },
-                      all_nulls()}
-                    .release();
+  auto expected = lcw{{lcw{}, lcw{}, lcw{}, lcw{}, lcw{}, lcw{}, lcw{}}, all_nulls()}.release();
 
   auto result = cudf::copy_if_else(lhs_scalar, rhs_scalar, selector_column->view());
 

--- a/cpp/tests/copying/purge_nonempty_nulls_tests.cpp
+++ b/cpp/tests/copying/purge_nonempty_nulls_tests.cpp
@@ -90,7 +90,6 @@ struct PurgeNonEmptyNullsTest : public cudf::test::BaseFixture {
   void test_purge(cudf::column_view const& unpurged)
   {
     auto const purged = cudf::purge_nonempty_nulls(unpurged);
-    CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(unpurged, *purged);
     EXPECT_FALSE(cudf::has_nonempty_nulls(*purged));
   }
 };


### PR DESCRIPTION
## Description
Removes unsanitized rows from input data in gtests for COPYING_TEST.
This fixes some errors found in #14559 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
