### PR TITLE
Fix DataFrame.reindex removing column name

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2661,13 +2661,17 @@ class IndexedFrame(Frame):
             )
             for name in names
         }
+        if column_names is None:
+            level_names = self._data.level_names
+        elif isinstance(column_names, pd.Index):
+            level_names = tuple(column_names.names)
+        else:
+            level_names = None
         result = self.__class__._from_data(
             data=cudf.core.column_accessor.ColumnAccessor(
                 cols,
                 multiindex=self._data.multiindex,
-                level_names=tuple(column_names.names)
-                if isinstance(column_names, pd.Index)
-                else None,
+                level_names=level_names,
             ),
             index=index,
         )

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -10754,6 +10754,15 @@ def test_dataframe_series_dot():
     assert_eq(expected, actual)
 
 
+def test_dataframe_reindex_keep_colname():
+    gdf = cudf.DataFrame([1], columns=cudf.Index([1], name="foo"))
+    result = gdf.reindex(index=[0, 1])
+    expected = cudf.DataFrame(
+        [1, None], columns=cudf.Index([1], name="foo"), index=[0, 1]
+    )
+    assert_eq(result, expected)
+
+
 def test_dataframe_duplicate_index_reindex():
     gdf = cudf.DataFrame({"a": [0, 1, 2, 3]}, index=[0, 0, 1, 1])
     pdf = gdf.to_pandas()


### PR DESCRIPTION
## Description
Fixes the following behavior

```python
In [1]: import cudf
    
In [2]: import pandas as pd

In [3]: df = cudf.DataFrame([1], columns=cudf.Index([1], name="foo"))

In [4]: df
Out[4]: 
foo  1
0    1

In [5]: df = df.reindex(index=[0, 1])

In [6]: df
Out[6]: 
      1  <-- foo missing
0     1
1  <NA>
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
