### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -2137,7 +2137,8 @@ stripe_dictionaries build_dictionaries(orc_table_view& orc_table,
       }
     }
   }
-  stripe_dicts.host_to_device_async(stream);
+  // Synchronize to ensure the copy is complete before we clear `map_slots`
+  stripe_dicts.host_to_device_sync(stream);
 
   gpu::collect_map_entries(stripe_dicts, stream);
   gpu::get_dictionary_indices(stripe_dicts, orc_table.d_columns, stream);


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.