### PR TITLE
Add cpp/doxygen/xml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ cpp/thirdparty/googletest/
 
 ## Doxygen
 cpp/doxygen/html
+cpp/doxygen/xml
 
 #Java
 target


### PR DESCRIPTION
## Description
Adds `cpp/doxygen/xml` to `.gitignore`. This directory is created with a docs build.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
