### PR TITLE
Fix docstring in `CategoricalDtype`

### DIFF
--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -228,11 +228,11 @@ class CategoricalDtype(_BaseDtype):
         >>> import pandas as pd
         >>> pd_dtype = pd.CategoricalDtype(categories=['b', 'a'], ordered=True)
         >>> pd_dtype
-        CategoricalDtype(categories=['b', 'a'], ordered=True)
+        CategoricalDtype(categories=['b', 'a'], ordered=True, categories_dtype=object)
         >>> cudf_dtype = cudf.CategoricalDtype.from_pandas(pd_dtype)
         >>> cudf_dtype
-        CategoricalDtype(categories=['b', 'a'], ordered=True)
-        """
+        CategoricalDtype(categories=['b', 'a'], ordered=True, categories_dtype=object)
+        """  # noqa: E501
         return CategoricalDtype(
             categories=dtype.categories, ordered=dtype.ordered
         )
@@ -246,10 +246,10 @@ class CategoricalDtype(_BaseDtype):
         >>> import cudf
         >>> dtype = cudf.CategoricalDtype(categories=['b', 'a'], ordered=True)
         >>> dtype
-        CategoricalDtype(categories=['b', 'a'], ordered=True)
+        CategoricalDtype(categories=['b', 'a'], ordered=True, categories_dtype=object)
         >>> dtype.to_pandas()
-        CategoricalDtype(categories=['b', 'a'], ordered=True)
-        """
+        CategoricalDtype(categories=['b', 'a'], ordered=True, categories_dtype=object)
+        """  # noqa: E501
         if self._categories is None:
             categories = None
         else:


### PR DESCRIPTION
## Description
This PR fixes the docstring in `CategoricalDtype` where the repr has added a new field (`categories_dtype`).

This PR fixes 2 doctest failures.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
