### PR TITLE
Drop nvbench patch for nvml.

### DIFF
--- a/cpp/cmake/thirdparty/patches/nvbench_override.json
+++ b/cpp/cmake/thirdparty/patches/nvbench_override.json
@@ -7,11 +7,6 @@
           "file" : "${current_json_dir}/nvbench_global_setup.diff",
           "issue" : "Fix add support for global setup to initialize RMM in nvbench [https://github.com/NVIDIA/nvbench/pull/123]",
           "fixed_in" : ""
-        },
-        {
-          "file" : "nvbench/nvml_with_static_builds.diff",
-          "issue" : "Add support for nvml with static nvbench [https://github.com/NVIDIA/nvbench/pull/148]",
-          "fixed_in" : ""
         }
       ]
     }


### PR DESCRIPTION
## Description
We can drop a patch from nvbench for nvml support now that it has been upstreamed and dropped from rapids-cmake. https://github.com/rapidsai/rapids-cmake/pull/488

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
