### PR TITLE
Use column_empty over as_column([])

### DIFF
--- a/python/cudf/cudf/_lib/string_casting.pyx
+++ b/python/cudf/cudf/_lib/string_casting.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 from cudf._lib.column cimport Column
 
@@ -569,10 +569,7 @@ def timestamp2int(Column input_col, dtype, format):
     return Column.from_unique_ptr(move(c_result))
 
 
-def istimestamp(
-        Column input_col,
-        object format,
-        **kwargs):
+def istimestamp(Column input_col, str format):
     """
     Check input string column matches the specified timestamp format
 
@@ -588,7 +585,7 @@ def istimestamp(
 
     """
     if input_col.size == 0:
-        return cudf.core.column.as_column([], dtype=kwargs.get('dtype'))
+        return cudf.core.column.column_empty(0, dtype=cudf.dtype("bool"))
     cdef column_view input_column_view = input_col.view()
     cdef string c_timestamp_format = <string>str(format).encode('UTF-8')
     cdef unique_ptr[column] c_result

--- a/python/cudf/cudf/core/column/decimal.py
+++ b/python/cudf/cudf/core/column/decimal.py
@@ -16,7 +16,7 @@ from cudf._lib.strings.convert.convert_fixed_point import (
 from cudf._typing import ColumnBinaryOperand, Dtype
 from cudf.api.types import is_integer_dtype, is_scalar
 from cudf.core.buffer import as_buffer
-from cudf.core.column import ColumnBase, as_column
+from cudf.core.column import ColumnBase
 from cudf.core.dtypes import (
     Decimal32Dtype,
     Decimal64Dtype,
@@ -58,7 +58,8 @@ class DecimalBaseColumn(NumericalBaseColumn):
             return cpp_from_decimal(self)
         else:
             return cast(
-                "cudf.core.column.StringColumn", as_column([], dtype="object")
+                cudf.core.column.StringColumn,
+                cudf.core.column.column_empty(0, dtype="object"),
             )
 
     def __pow__(self, other):

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -347,7 +347,8 @@ class NumericalColumn(NumericalBaseColumn):
             ](self)
         else:
             return cast(
-                "cudf.core.column.StringColumn", as_column([], dtype="object")
+                cudf.core.column.StringColumn,
+                column.column_empty(0, dtype="object"),
             )
 
     def as_datetime_column(

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5495,7 +5495,7 @@ class StringColumn(column.ColumnBase):
             # all nulls-column:
             offsets = column.full(size + 1, 0, dtype=size_type_dtype)
 
-            chars = cudf.core.column.as_column([], dtype="int8")
+            chars = cudf.core.column.column_empty(0, dtype="int8")
             children = (offsets, chars)
 
         super().__init__(
@@ -5659,7 +5659,7 @@ class StringColumn(column.ColumnBase):
 
     def _as_datetime_or_timedelta_column(self, dtype, format):
         if len(self) == 0:
-            return cudf.core.column.as_column([], dtype=dtype)
+            return cudf.core.column.column_empty(0, dtype=dtype)
 
         # Check for None strings
         if (self == "None").any():

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -6080,7 +6080,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                     source = self._get_columns_by_label(numeric_cols)
                     if source.empty:
                         if axis == 2:
-                            return getattr(as_column([]), op)(**kwargs)
+                            return getattr(column_empty(0), op)(**kwargs)
                         else:
                             return Series(index=cudf.Index([], dtype="str"))
                     try:

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -398,7 +398,7 @@ class SingleColumnFrame(Frame, NotIterable):
         else:
             arg = as_column(arg)
             if len(arg) == 0:
-                arg = as_column([], dtype="int32")
+                arg = cudf.core.column.column_empty(0, dtype="int32")
             if is_integer_dtype(arg.dtype):
                 return self._column.take(arg)
             if is_bool_dtype(arg.dtype):

--- a/python/cudf/cudf/tests/test_column.py
+++ b/python/cudf/cudf/tests/test_column.py
@@ -8,7 +8,7 @@ import pytest
 
 import cudf
 from cudf._lib.transform import mask_to_bools
-from cudf.core.column.column import as_column
+from cudf.core.column.column import arange, as_column
 from cudf.testing._utils import assert_eq, assert_exceptions_equal
 from cudf.utils import dtypes as dtypeutils
 
@@ -398,7 +398,7 @@ def test_column_view_string_slice(slc):
         ),
         (
             cp.array([], dtype="uint8"),
-            cudf.core.column.as_column([], dtype="uint8"),
+            cudf.core.column.column_empty(0, dtype="uint8"),
         ),
         (
             cp.array([255], dtype="uint8"),
@@ -552,3 +552,9 @@ def test_astype_with_aliases(alias, expect_dtype, data):
     gd_data = cudf.Series.from_pandas(pd_data)
 
     assert_eq(pd_data.astype(expect_dtype), gd_data.astype(alias))
+
+
+def test_arange_empty():
+    result = arange(0)
+    assert len(result) == 0
+    assert result.dtype == np.dtype(np.int64)

--- a/python/cudf/cudf/tests/test_string.py
+++ b/python/cudf/cudf/tests/test_string.py
@@ -2656,6 +2656,13 @@ def test_string_istimestamp():
     assert_eq(expected, got)
 
 
+def test_istimestamp_empty():
+    gsr = cudf.Series([], dtype="object")
+    result = gsr.str.istimestamp("%Y%m%d")
+    expected = cudf.Series([], dtype="bool")
+    assert_eq(result, expected)
+
+
 def test_string_ip4_to_int():
     gsr = cudf.Series(
         ["", None, "hello", "41.168.0.1", "127.0.0.1", "41.197.0.1"]


### PR DESCRIPTION
## Description
Remove unnecessary "inference" on `[]` in as_column. Additionally fixed a bug in `arange` and `istimestamp` to return an int and bool type respectively for empty inputs for consistency with non-empty inputs

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
