### PR TITLE
Implement remaining copying APIs in pylibcudf along with required helper functions

### DIFF
--- a/python/cudf/cudf/_lib/copying.pyx
+++ b/python/cudf/cudf/_lib/copying.pyx
@@ -425,16 +425,12 @@ def shift(Column input, int offset, object fill_value=None):
 
 @acquire_spill_lock()
 def get_element(Column input_column, size_type index):
-    cdef column_view col_view = input_column.view()
-
-    cdef unique_ptr[scalar] c_output
-    with nogil:
-        c_output = move(
-            cpp_copying.get_element(col_view, index)
-        )
-
-    return DeviceScalar.from_unique_ptr(
-        move(c_output), dtype=input_column.dtype
+    return DeviceScalar.from_pylibcudf(
+        pylibcudf.copying.get_element(
+            input_column.to_pylibcudf(mode="read"),
+            index,
+        ),
+        dtype=input_column.dtype,
     )
 
 

--- a/python/cudf/cudf/_lib/copying.pyx
+++ b/python/cudf/cudf/_lib/copying.pyx
@@ -29,7 +29,7 @@ from libcpp.memory cimport make_unique
 cimport cudf._lib.cpp.contiguous_split as cpp_contiguous_split
 cimport cudf._lib.cpp.copying as cpp_copying
 from cudf._lib.cpp.column.column cimport column
-from cudf._lib.cpp.column.column_view cimport column_view, mutable_column_view
+from cudf._lib.cpp.column.column_view cimport column_view
 from cudf._lib.cpp.lists.gather cimport (
     segmented_gather as cpp_segmented_gather,
 )
@@ -92,20 +92,13 @@ def _copy_range_in_place(Column input_column,
                          size_type input_begin,
                          size_type input_end,
                          size_type target_begin):
-
-    cdef column_view input_column_view = input_column.view()
-    cdef mutable_column_view target_column_view = target_column.mutable_view()
-    cdef size_type c_input_begin = input_begin
-    cdef size_type c_input_end = input_end
-    cdef size_type c_target_begin = target_begin
-
-    with nogil:
-        cpp_copying.copy_range_in_place(
-            input_column_view,
-            target_column_view,
-            c_input_begin,
-            c_input_end,
-            c_target_begin)
+    pylibcudf.copying.copy_range(
+        input_column.to_pylibcudf(mode="write"),
+        target_column.to_pylibcudf(mode="write"),
+        input_begin,
+        input_end,
+        target_begin
+    )
 
 
 def _copy_range(Column input_column,

--- a/python/cudf/cudf/_lib/copying.pyx
+++ b/python/cudf/cudf/_lib/copying.pyx
@@ -27,7 +27,6 @@ from cudf.core.abc import Serializable
 from libcpp.memory cimport make_unique
 
 cimport cudf._lib.cpp.contiguous_split as cpp_contiguous_split
-cimport cudf._lib.cpp.copying as cpp_copying
 from cudf._lib.cpp.column.column cimport column
 from cudf._lib.cpp.column.column_view cimport column_view
 from cudf._lib.cpp.lists.gather cimport (
@@ -271,92 +270,6 @@ def columns_split(list input_columns, object splits):
             list(splits),
         )
     ]
-
-
-def _copy_if_else_column_column(Column lhs, Column rhs, Column boolean_mask):
-
-    cdef column_view lhs_view = lhs.view()
-    cdef column_view rhs_view = rhs.view()
-    cdef column_view boolean_mask_view = boolean_mask.view()
-
-    cdef unique_ptr[column] c_result
-
-    with nogil:
-        c_result = move(
-            cpp_copying.copy_if_else(
-                lhs_view,
-                rhs_view,
-                boolean_mask_view
-            )
-        )
-
-    return Column.from_unique_ptr(move(c_result))
-
-
-def _copy_if_else_scalar_column(DeviceScalar lhs,
-                                Column rhs,
-                                Column boolean_mask):
-
-    cdef const scalar* lhs_scalar = lhs.get_raw_ptr()
-    cdef column_view rhs_view = rhs.view()
-    cdef column_view boolean_mask_view = boolean_mask.view()
-
-    cdef unique_ptr[column] c_result
-
-    with nogil:
-        c_result = move(
-            cpp_copying.copy_if_else(
-                lhs_scalar[0],
-                rhs_view,
-                boolean_mask_view
-            )
-        )
-
-    return Column.from_unique_ptr(move(c_result))
-
-
-def _copy_if_else_column_scalar(Column lhs,
-                                DeviceScalar rhs,
-                                Column boolean_mask):
-
-    cdef column_view lhs_view = lhs.view()
-    cdef const scalar* rhs_scalar = rhs.get_raw_ptr()
-    cdef column_view boolean_mask_view = boolean_mask.view()
-
-    cdef unique_ptr[column] c_result
-
-    with nogil:
-        c_result = move(
-            cpp_copying.copy_if_else(
-                lhs_view,
-                rhs_scalar[0],
-                boolean_mask_view
-            )
-        )
-
-    return Column.from_unique_ptr(move(c_result))
-
-
-def _copy_if_else_scalar_scalar(DeviceScalar lhs,
-                                DeviceScalar rhs,
-                                Column boolean_mask):
-
-    cdef const scalar* lhs_scalar = lhs.get_raw_ptr()
-    cdef const scalar* rhs_scalar = rhs.get_raw_ptr()
-    cdef column_view boolean_mask_view = boolean_mask.view()
-
-    cdef unique_ptr[column] c_result
-
-    with nogil:
-        c_result = move(
-            cpp_copying.copy_if_else(
-                lhs_scalar[0],
-                rhs_scalar[0],
-                boolean_mask_view
-            )
-        )
-
-    return Column.from_unique_ptr(move(c_result))
 
 
 @acquire_spill_lock()

--- a/python/cudf/cudf/_lib/copying.pyx
+++ b/python/cudf/cudf/_lib/copying.pyx
@@ -298,29 +298,19 @@ def column_split(Column input_column, object splits):
         Column.from_pylibcudf(c)
         for c in pylibcudf.copying.column_split(
             input_column.to_pylibcudf(mode="read"),
-            splits,
+            list(splits),
         )
     ]
 
 
 @acquire_spill_lock()
 def columns_split(list input_columns, object splits):
-
-    cdef table_view input_table_view = table_view_from_columns(input_columns)
-    cdef vector[size_type] c_splits = splits
-    cdef vector[table_view] c_result
-
-    with nogil:
-        c_result = move(
-            cpp_copying.split(
-                input_table_view,
-                c_splits)
-        )
-
     return [
-        columns_from_table_view(
-            c_result[i], input_columns
-        ) for i in range(c_result.size())
+        columns_from_pylibcudf_table(tbl)
+        for tbl in pylibcudf.copying.table_split(
+            pylibcudf.Table([col.to_pylibcudf(mode="read") for col in input_columns]),
+            list(splits),
+        )
     ]
 
 

--- a/python/cudf/cudf/_lib/copying.pyx
+++ b/python/cudf/cudf/_lib/copying.pyx
@@ -294,34 +294,13 @@ def columns_slice(list input_columns, list indices):
 
 @acquire_spill_lock()
 def column_split(Column input_column, object splits):
-
-    cdef column_view input_column_view = input_column.view()
-    cdef vector[size_type] c_splits
-    c_splits.reserve(len(splits))
-
-    cdef vector[column_view] c_result
-
-    cdef int split
-
-    for split in splits:
-        c_splits.push_back(split)
-
-    with nogil:
-        c_result = move(
-            cpp_copying.split(
-                input_column_view,
-                c_splits)
+    return [
+        Column.from_pylibcudf(c)
+        for c in pylibcudf.copying.column_split(
+            input_column.to_pylibcudf(mode="read"),
+            splits,
         )
-
-    num_of_result_cols = c_result.size()
-    result = [
-        Column.from_column_view(
-            c_result[i],
-            input_column
-        ) for i in range(num_of_result_cols)
     ]
-
-    return result
 
 
 @acquire_spill_lock()

--- a/python/cudf/cudf/_lib/pylibcudf/column.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/column.pxd
@@ -4,7 +4,7 @@ from libcpp.memory cimport unique_ptr
 from libcpp.vector cimport vector
 
 from cudf._lib.cpp.column.column cimport column
-from cudf._lib.cpp.column.column_view cimport column_view
+from cudf._lib.cpp.column.column_view cimport column_view, mutable_column_view
 from cudf._lib.cpp.types cimport bitmask_type, size_type
 
 from .gpumemoryview cimport gpumemoryview
@@ -26,6 +26,7 @@ cdef class Column:
         size_type _num_children
 
     cdef column_view view(self) nogil
+    cdef mutable_column_view mutable_view(self) nogil
 
     @staticmethod
     cdef Column from_libcudf(unique_ptr[column] libcudf_col)

--- a/python/cudf/cudf/_lib/pylibcudf/column.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/column.pxd
@@ -31,6 +31,9 @@ cdef class Column:
     @staticmethod
     cdef Column from_libcudf(unique_ptr[column] libcudf_col)
 
+    @staticmethod
+    cdef Column from_column_view(const column_view& libcudf_col, Column owner)
+
     cpdef DataType type(self)
     cpdef Column child(self, size_type index)
     cpdef size_type num_children(self)

--- a/python/cudf/cudf/_lib/pylibcudf/column.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/column.pyx
@@ -91,6 +91,33 @@ cdef class Column:
             self._null_count, self._offset, c_children
         )
 
+    cdef mutable_column_view mutable_view(self) nogil:
+        """Generate a libcudf mutable_column_view to pass to libcudf algorithms.
+
+        This method is for pylibcudf's functions to use to generate inputs when
+        calling libcudf algorithms, and should generally not be needed by users
+        (even direct pylibcudf Cython users).
+        """
+        cdef void * data = NULL
+        cdef bitmask_type * null_mask = NULL
+
+        if self._data is not None:
+            data = int_to_void_ptr(self._data.ptr)
+        if self._mask is not None:
+            null_mask = int_to_bitmask_ptr(self._mask.ptr)
+
+        cdef vector[mutable_column_view] c_children
+        with gil:
+            if self._children is not None:
+                for child in self._children:
+                    # See the view method for why this needs to be cast.
+                    c_children.push_back((<Column> child).mutable_view())
+
+        return mutable_column_view(
+            self._data_type.c_obj, self._size, data, null_mask,
+            self._null_count, self._offset, c_children
+        )
+
     @staticmethod
     cdef Column from_libcudf(unique_ptr[column] libcudf_col):
         """Create a Column from a libcudf column.

--- a/python/cudf/cudf/_lib/pylibcudf/copying.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/copying.pxd
@@ -48,6 +48,10 @@ cpdef list column_split(Column input_column, list splits)
 
 cpdef list table_split(Table input_table, list splits)
 
+cpdef list column_slice(Column input_column, list indices)
+
+cpdef list table_slice(Table input_table, list indices)
+
 cpdef Column copy_if_else(object lhs, object rhs, Column boolean_mask)
 
 cpdef Table boolean_mask_table_scatter(Table input, Table target, Column boolean_mask)

--- a/python/cudf/cudf/_lib/pylibcudf/copying.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/copying.pxd
@@ -44,6 +44,8 @@ cpdef Column copy_range(
 
 cpdef Column shift(Column input, size_type offset, Scalar fill_values)
 
+cpdef list column_split(Column input_column, list splits)
+
 cpdef Column copy_if_else(object lhs, object rhs, Column boolean_mask)
 
 cpdef Table boolean_mask_table_scatter(Table input, Table target, Column boolean_mask)

--- a/python/cudf/cudf/_lib/pylibcudf/copying.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/copying.pxd
@@ -26,6 +26,14 @@ cpdef object empty_table_like(Table input)
 
 cpdef Column allocate_like(Column input_column, mask_allocation_policy policy, size=*)
 
+cpdef Column copy_range_in_place(
+    Column input_column,
+    Column target_column,
+    size_type input_begin,
+    size_type input_end,
+    size_type target_begin,
+)
+
 cpdef Column copy_range(
     Column input_column,
     Column target_column,

--- a/python/cudf/cudf/_lib/pylibcudf/copying.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/copying.pxd
@@ -57,3 +57,5 @@ cpdef Column copy_if_else(object lhs, object rhs, Column boolean_mask)
 cpdef Table boolean_mask_table_scatter(Table input, Table target, Column boolean_mask)
 
 cpdef Table boolean_mask_scalars_scatter(list input, Table target, Column boolean_mask)
+
+cpdef Scalar get_element(Column input_column, size_type index)

--- a/python/cudf/cudf/_lib/pylibcudf/copying.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/copying.pxd
@@ -46,6 +46,8 @@ cpdef Column shift(Column input, size_type offset, Scalar fill_values)
 
 cpdef list column_split(Column input_column, list splits)
 
+cpdef list table_split(Table input_table, list splits)
+
 cpdef Column copy_if_else(object lhs, object rhs, Column boolean_mask)
 
 cpdef Table boolean_mask_table_scatter(Table input, Table target, Column boolean_mask)

--- a/python/cudf/cudf/_lib/pylibcudf/copying.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/copying.pyx
@@ -17,6 +17,7 @@ from cudf._lib.cpp.column.column_view cimport column_view, mutable_column_view
 from cudf._lib.cpp.copying cimport mask_allocation_policy, out_of_bounds_policy
 from cudf._lib.cpp.scalar.scalar cimport scalar
 from cudf._lib.cpp.table.table cimport table
+from cudf._lib.cpp.table.table_view cimport table_view
 from cudf._lib.cpp.types cimport size_type
 
 from cudf._lib.cpp.copying import \
@@ -228,6 +229,24 @@ cpdef list column_split(Column input_column, list splits):
     cdef int i
     return [
         Column.from_column_view(c_result[i], input_column)
+        for i in range(c_result.size())
+    ]
+
+
+cpdef list table_split(Table input_table, list splits):
+    cdef vector[size_type] c_splits = splits
+    cdef vector[table_view] c_result
+    with nogil:
+        c_result = move(
+            cpp_copying.split(
+                input_table.view(),
+                c_splits
+            )
+        )
+
+    cdef int i
+    return [
+        Table.from_table_view(c_result[i], input_table)
         for i in range(c_result.size())
     ]
 

--- a/python/cudf/cudf/_lib/pylibcudf/copying.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/copying.pyx
@@ -251,6 +251,42 @@ cpdef list table_split(Table input_table, list splits):
     ]
 
 
+cpdef list column_slice(Column input_column, list indices):
+    cdef vector[size_type] c_indices = indices
+    cdef vector[column_view] c_result
+    with nogil:
+        c_result = move(
+            cpp_copying.slice(
+                input_column.view(),
+                c_indices
+            )
+        )
+
+    cdef int i
+    return [
+        Column.from_column_view(c_result[i], input_column)
+        for i in range(c_result.size())
+    ]
+
+
+cpdef list table_slice(Table input_table, list indices):
+    cdef vector[size_type] c_indices = indices
+    cdef vector[table_view] c_result
+    with nogil:
+        c_result = move(
+            cpp_copying.slice(
+                input_table.view(),
+                c_indices
+            )
+        )
+
+    cdef int i
+    return [
+        Table.from_table_view(c_result[i], input_table)
+        for i in range(c_result.size())
+    ]
+
+
 cpdef Column copy_if_else(object lhs, object rhs, Column boolean_mask):
     cdef unique_ptr[column] result
 

--- a/python/cudf/cudf/_lib/pylibcudf/copying.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/copying.pyx
@@ -362,3 +362,12 @@ cpdef Table boolean_mask_scalars_scatter(list input, Table target, Column boolea
         )
 
     return Table.from_libcudf(move(result))
+
+cpdef Scalar get_element(Column input_column, size_type index):
+    cdef unique_ptr[scalar] c_output
+    with nogil:
+        c_output = move(
+            cpp_copying.get_element(input_column.view(), index)
+        )
+
+    return Scalar.from_libcudf(move(c_output))

--- a/python/cudf/cudf/_lib/pylibcudf/table.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/table.pxd
@@ -16,6 +16,9 @@ cdef class Table:
     @staticmethod
     cdef Table from_libcudf(unique_ptr[table] libcudf_tbl)
 
+    @staticmethod
+    cdef Table from_table_view(const table_view& tv, Table owner)
+
     cpdef list columns(self)
 
     cpdef pa.Table to_arrow(self, list metadata)

--- a/python/cudf/cudf/_lib/pylibcudf/table.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/table.pyx
@@ -65,6 +65,23 @@ cdef class Table:
             for i in range(c_columns.size())
         ])
 
+    @staticmethod
+    cdef Table from_table_view(const table_view& tv, Table owner):
+        """Create a Table from a libcudf table.
+
+        This method accepts shared ownership of the underlying data from the
+        owner and relies on the offset from the view.
+
+        This method is for pylibcudf's functions to use to ingest outputs of
+        calling libcudf algorithms, and should generally not be needed by users
+        (even direct pylibcudf Cython users).
+        """
+        cdef int i
+        return Table([
+            Column.from_column_view(tv.column(i), owner.columns()[i])
+            for i in range(tv.num_columns())
+        ])
+
     cpdef list columns(self):
         return self._columns
 

--- a/python/cudf/cudf/_lib/scalar.pxd
+++ b/python/cudf/cudf/_lib/scalar.pxd
@@ -22,4 +22,9 @@ cdef class DeviceScalar:
     @staticmethod
     cdef DeviceScalar from_unique_ptr(unique_ptr[scalar] ptr, dtype=*)
 
+    @staticmethod
+    cdef DeviceScalar from_pylibcudf(pylibcudf.Scalar scalar, dtype=*)
+
+    cdef void _set_dtype(self, dtype=*)
+
     cpdef bool is_valid(DeviceScalar s)

--- a/python/cudf/cudf/_lib/scalar.pyx
+++ b/python/cudf/cudf/_lib/scalar.pyx
@@ -217,13 +217,22 @@ cdef class DeviceScalar:
         Construct a Scalar object from a unique_ptr<cudf::scalar>.
         """
         cdef DeviceScalar s = DeviceScalar.__new__(DeviceScalar)
-        cdef libcudf_types.data_type cdtype
-
         s.c_value = pylibcudf.Scalar.from_libcudf(move(ptr))
-        cdtype = s.get_raw_ptr()[0].type()
+        s._set_dtype(dtype)
+        return s
+
+    @staticmethod
+    cdef DeviceScalar from_pylibcudf(pylibcudf.Scalar pscalar, dtype=None):
+        cdef DeviceScalar s = DeviceScalar.__new__(DeviceScalar)
+        s.c_value = pscalar
+        s._set_dtype(dtype)
+        return s
+
+    cdef void _set_dtype(self, dtype=None):
+        cdef libcudf_types.data_type cdtype = self.get_raw_ptr()[0].type()
 
         if dtype is not None:
-            s._dtype = dtype
+            self._dtype = dtype
         elif cdtype.id() in {
             libcudf_types.type_id.DECIMAL32,
             libcudf_types.type_id.DECIMAL64,
@@ -233,32 +242,31 @@ cdef class DeviceScalar:
                 "Must pass a dtype when constructing from a fixed-point scalar"
             )
         elif cdtype.id() == libcudf_types.type_id.STRUCT:
-            struct_table_view = (<struct_scalar*>s.get_raw_ptr())[0].view()
-            s._dtype = StructDtype({
+            struct_table_view = (<struct_scalar*>self.get_raw_ptr())[0].view()
+            self._dtype = StructDtype({
                 str(i): dtype_from_column_view(struct_table_view.column(i))
                 for i in range(struct_table_view.num_columns())
             })
         elif cdtype.id() == libcudf_types.type_id.LIST:
             if (
-                <list_scalar*>s.get_raw_ptr()
+                <list_scalar*>self.get_raw_ptr()
             )[0].view().type().id() == libcudf_types.type_id.LIST:
-                s._dtype = dtype_from_column_view(
-                    (<list_scalar*>s.get_raw_ptr())[0].view()
+                self._dtype = dtype_from_column_view(
+                    (<list_scalar*>self.get_raw_ptr())[0].view()
                 )
             else:
-                s._dtype = ListDtype(
+                self._dtype = ListDtype(
                     LIBCUDF_TO_SUPPORTED_NUMPY_TYPES[
                         <underlying_type_t_type_id>(
-                            (<list_scalar*>s.get_raw_ptr())[0]
+                            (<list_scalar*>self.get_raw_ptr())[0]
                             .view().type().id()
                         )
                     ]
                 )
         else:
-            s._dtype = LIBCUDF_TO_SUPPORTED_NUMPY_TYPES[
+            self._dtype = LIBCUDF_TO_SUPPORTED_NUMPY_TYPES[
                 <underlying_type_t_type_id>(cdtype.id())
             ]
-        return s
 
 
 # TODO: Currently the only uses of this function and the one below are in


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR implements the remaining parts of libcudf's copying APIs in pylibcudf, updating cuDF Python to use those as a backend. The cudf copying Cython module is now largely just a set of pylibcudf calls. This represents the general transition that we hope to make, and eventually once all of cudf looks like this we can refactor its internal data structures to be built directly around pylibcudf objects we can remove these thin translation layers.

This PR also implements a few core utility functions required for translating between pylibcudf and libcudf objects, namely for:
- Generating pylibcudf Columns from libcudf column_views (instead of owning `column`s)
- Creating libcudf mutable_column_view objects from pylibcudf.Columns
- Producing cudf DeviceScalar objects from pylibcudf Scalars.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
