### PR TITLE
Update dependencies.yaml to support CUDA 12.*.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,7 +145,7 @@ repos:
                     ^CHANGELOG.md$
                   )
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.7.1
+        rev: v1.8.0
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean"]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -214,9 +214,8 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              cuda: "12.0"
+              cuda: "12.*"
             packages:
-              - cuda-version=12.0
               - cuda-nvcc
           - matrix:
               arch: x86_64
@@ -228,6 +227,14 @@ dependencies:
               cuda: "11.8"
             packages:
               - nvcc_linux-aarch64=11.8
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "12.0"
+            packages:
+              - cuda-version=12.0
+          - matrix:  # Fallback for CUDA 11 or no matrix
+            packages:
   build_cpp:
     common:
       - output_types: conda
@@ -288,17 +295,12 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.2"}
+          - matrix: {cuda: "12.*"}
             packages: &build_python_packages_cu12
               - &rmm_cu12 rmm-cu12==24.2.*
-          - {matrix: {cuda: "12.1"}, packages: *build_python_packages_cu12}
-          - {matrix: {cuda: "12.0"}, packages: *build_python_packages_cu12}
-          - matrix: {cuda: "11.8"}
+          - matrix: {cuda: "11.*"}
             packages: &build_python_packages_cu11
               - &rmm_cu11 rmm-cu11==24.2.*
-          - {matrix: {cuda: "11.5"}, packages: *build_python_packages_cu11}
-          - {matrix: {cuda: "11.4"}, packages: *build_python_packages_cu11}
-          - {matrix: {cuda: "11.2"}, packages: *build_python_packages_cu11}
           - {matrix: null, packages: null }
       - output_types: pyproject
         matrices:
@@ -335,18 +337,25 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              cuda: "12.0"
+              cuda: "12.*"
             packages:
-              - cuda-version=12.0
               - cuda-cudart-dev
               - cuda-nvrtc-dev
               - cuda-nvtx-dev
               - libcurand-dev
+          - matrix:  # Fallback for CUDA 11 or no matrix
+            packages:
+              - cudatoolkit
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "12.0"
+            packages:
+              - cuda-version=12.0
           - matrix:
               cuda: "11.8"
             packages:
               - cuda-version=11.8
-              - cudatoolkit
               - cuda-nvtx=11.8
               - libcurand-dev=10.3.0.86
               - libcurand=10.3.0.86
@@ -382,7 +391,7 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              cuda: "12.0"
+              cuda: "12.*"
               arch: x86_64
             packages:
               - libcufile-dev
@@ -500,43 +509,30 @@ dependencies:
     specific:
       - output_types: [conda, requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.2"}
-            packages: &run_cudf_packages_all_cu12
+          - matrix: {cuda: "12.*"}
+            packages:
               - cuda-python>=12.0,<13.0a0
-          - {matrix: {cuda: "12.1"}, packages: *run_cudf_packages_all_cu12}
-          - {matrix: {cuda: "12.0"}, packages: *run_cudf_packages_all_cu12}
-          - matrix: {cuda: "11.8"}
+          - matrix: {cuda: "11.*"}
             packages: &run_cudf_packages_all_cu11
               - cuda-python>=11.7.1,<12.0a0
-          - {matrix: {cuda: "11.5"}, packages: *run_cudf_packages_all_cu11}
-          - {matrix: {cuda: "11.4"}, packages: *run_cudf_packages_all_cu11}
-          - {matrix: {cuda: "11.2"}, packages: *run_cudf_packages_all_cu11}
           - {matrix: null, packages: *run_cudf_packages_all_cu11}
       - output_types: conda
         matrices:
-          - matrix: {cuda: "11.8"}
-            packages: &run_cudf_packages_conda_cu11
+          - matrix: {cuda: "11.*"}
+            packages:
               - cubinlinker
               - ptxcompiler
-          - {matrix: {cuda: "11.5"}, packages: *run_cudf_packages_conda_cu11}
-          - {matrix: {cuda: "11.4"}, packages: *run_cudf_packages_conda_cu11}
-          - {matrix: {cuda: "11.2"}, packages: *run_cudf_packages_conda_cu11}
           - {matrix: null, packages: null}
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.2"}
-            packages: &run_cudf_packages_pip_cu12
+          - matrix: {cuda: "12.*"}
+            packages:
               - rmm-cu12==24.2.*
-          - {matrix: {cuda: "12.1"}, packages: *run_cudf_packages_pip_cu12}
-          - {matrix: {cuda: "12.0"}, packages: *run_cudf_packages_pip_cu12}
-          - matrix: {cuda: "11.8"}
-            packages: &run_cudf_packages_pip_cu11
+          - matrix: {cuda: "11.*"}
+            packages:
               - rmm-cu11==24.2.*
               - cubinlinker-cu11
               - ptxcompiler-cu11
-          - {matrix: {cuda: "11.5"}, packages: *run_cudf_packages_pip_cu11}
-          - {matrix: {cuda: "11.4"}, packages: *run_cudf_packages_pip_cu11}
-          - {matrix: {cuda: "11.2"}, packages: *run_cudf_packages_pip_cu11}
           - {matrix: null, packages: null}
       - output_types: pyproject
         matrices:
@@ -569,10 +565,17 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
+              cuda: "12.*"
+            packages:
+              - cuda-sanitizer-api
+          - matrix:  # Fallback for CUDA 11 or no matrix
+            packages:
+      - output_types: conda
+        matrices:
+          - matrix:
               cuda: "12.0"
             packages:
               - cuda-version=12.0
-              - cuda-sanitizer-api
           - matrix:
               cuda: "11.8"
             packages:
@@ -654,17 +657,12 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.2"}
-            packages: &cudf_packages_pip_cu12
+          - matrix: {cuda: "12.*"}
+            packages:
               - cudf-cu12==24.2.*
-          - {matrix: {cuda: "12.1"}, packages: *cudf_packages_pip_cu12}
-          - {matrix: {cuda: "12.0"}, packages: *cudf_packages_pip_cu12}
-          - matrix: {cuda: "11.8"}
-            packages: &cudf_packages_pip_cu11
+          - matrix: {cuda: "11.*"}
+            packages:
               - cudf-cu11==24.2.*
-          - {matrix: {cuda: "11.5"}, packages: *cudf_packages_pip_cu11}
-          - {matrix: {cuda: "11.4"}, packages: *cudf_packages_pip_cu11}
-          - {matrix: {cuda: "11.2"}, packages: *cudf_packages_pip_cu11}
           - {matrix: null, packages: [*cudf_conda]}
   depends_on_cudf_kafka:
     common:
@@ -680,17 +678,12 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          - matrix: {cuda: "12.2"}
-            packages: &cudf_kafka_packages_pip_cu12
+          - matrix: {cuda: "12.*"}
+            packages:
               - cudf_kafka-cu12==24.2.*
-          - {matrix: {cuda: "12.1"}, packages: *cudf_kafka_packages_pip_cu12}
-          - {matrix: {cuda: "12.0"}, packages: *cudf_kafka_packages_pip_cu12}
-          - matrix: {cuda: "11.8"}
-            packages: &cudf_kafka_packages_pip_cu11
+          - matrix: {cuda: "11.*"}
+            packages:
               - cudf_kafka-cu11==24.2.*
-          - {matrix: {cuda: "11.5"}, packages: *cudf_kafka_packages_pip_cu11}
-          - {matrix: {cuda: "11.4"}, packages: *cudf_kafka_packages_pip_cu11}
-          - {matrix: {cuda: "11.2"}, packages: *cudf_kafka_packages_pip_cu11}
           - {matrix: null, packages: [*cudf_kafka_conda]}
   depends_on_cupy:
     common:
@@ -700,19 +693,12 @@ dependencies:
     specific:
       - output_types: [requirements, pyproject]
         matrices:
-          # All CUDA 12 versions
-          - matrix: {cuda: "12.2"}
-            packages: &cupy_packages_cu12
+          - matrix: {cuda: "12.*"}
+            packages:
               - cupy-cuda12x>=12.0.0
-          - {matrix: {cuda: "12.1"}, packages: *cupy_packages_cu12}
-          - {matrix: {cuda: "12.0"}, packages: *cupy_packages_cu12}
-          # All CUDA 11 versions
-          - matrix: {cuda: "11.8"}
+          - matrix: {cuda: "11.*"}
             packages: &cupy_packages_cu11
               - cupy-cuda11x>=12.0.0
-          - {matrix: {cuda: "11.5"}, packages: *cupy_packages_cu11}
-          - {matrix: {cuda: "11.4"}, packages: *cupy_packages_cu11}
-          - {matrix: {cuda: "11.2"}, packages: *cupy_packages_cu11}
           - {matrix: null, packages: *cupy_packages_cu11}
   test_python_pandas_cudf:
     common:


### PR DESCRIPTION
## Description
This PR updates `dependencies.yaml` so that generic CUDA 12.* dependencies can be specified with a glob, like `cuda: "12.*"`. This feature requires `rapids-dependency-file-generator>=1.8.0`, so the pre-commit hook has been updated.

I have not yet added support for a specific CUDA version like 12.1 or 12.2. That can be done separately.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
