### PR TITLE
Constrain CUDA in notebook testing to prevent CUDA 12.1 usage until we have pynvjitlink

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -53,6 +53,7 @@ files:
     includes:
       - notebooks
       - py_version
+      - notebook_cuda_version
   checks:
     output: none
     includes:
@@ -767,3 +768,8 @@ dependencies:
         packages:
           - ipython
           - openpyxl
+  notebook_cuda_version:
+    common:
+      - output_types: conda
+        packages:
+          - cuda-version=12.0


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Our notebook tests will currently fail to run because CUDA 12.1 is now available on conda-forge. We need to constrain the testing environment (we already do this for non-notebook testing environments).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
