### PR TITLE
Ensure libcudf searches for our patched version of CCCL first

### DIFF
--- a/cpp/cmake/thirdparty/get_cccl.cmake
+++ b/cpp/cmake/thirdparty/get_cccl.cmake
@@ -26,9 +26,6 @@ function(find_and_configure_cccl)
   set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/libcudf")
   set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_INCLUDEDIR}/lib")
 
-  # Find or install CCCL with our custom set of patches
-  rapids_cpm_cccl(BUILD_EXPORT_SET cudf-exports INSTALL_EXPORT_SET cudf-exports)
-
   # Store where CMake can find our custom CCCL install
   include("${rapids-cmake-dir}/export/find_package_root.cmake")
   rapids_export_find_package_root(
@@ -36,6 +33,10 @@ function(find_and_configure_cccl)
     EXPORT_SET cudf-exports
     CONDITION CCCL_SOURCE_DIR
   )
+
+  # Find or install CCCL with our custom set of patches
+  rapids_cpm_cccl(BUILD_EXPORT_SET cudf-exports INSTALL_EXPORT_SET cudf-exports)
+
 endfunction()
 
 find_and_configure_cccl()


### PR DESCRIPTION
## Description
Previously we searched for the rapids-cmake version of CCCL first which isn't desired as it doesn't have the patches CUDF ( and consumers ) require.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
