### PR TITLE
Unconditionally export the CCCL path

### DIFF
--- a/cpp/cmake/thirdparty/get_cccl.cmake
+++ b/cpp/cmake/thirdparty/get_cccl.cmake
@@ -31,7 +31,6 @@ function(find_and_configure_cccl)
   rapids_export_find_package_root(
     INSTALL CCCL [=[${CMAKE_CURRENT_LIST_DIR}/../../../include/libcudf/lib/rapids/cmake/cccl]=]
     EXPORT_SET cudf-exports
-    CONDITION CCCL_SOURCE_DIR
   )
 
   # Find or install CCCL with our custom set of patches

--- a/cpp/cmake/thirdparty/get_cccl.cmake
+++ b/cpp/cmake/thirdparty/get_cccl.cmake
@@ -23,8 +23,8 @@ function(find_and_configure_cccl)
 
   # Make sure we install cccl into the `include/libcudf` subdirectory instead of the default
   include(GNUInstallDirs)
-  set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/include")
   set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/lib")
+  set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/include")
 
   # Store where CMake can find our custom CCCL install
   include("${rapids-cmake-dir}/export/find_package_root.cmake")

--- a/cpp/cmake/thirdparty/get_cccl.cmake
+++ b/cpp/cmake/thirdparty/get_cccl.cmake
@@ -23,8 +23,8 @@ function(find_and_configure_cccl)
 
   # Make sure we install cccl into the `include/libcudf` subdirectory instead of the default
   include(GNUInstallDirs)
-  set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/lib")
-  set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/include")
+  set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/libcudf")
+  set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_INCLUDEDIR}/lib")
 
   # Store where CMake can find our custom CCCL install
   include("${rapids-cmake-dir}/export/find_package_root.cmake")

--- a/cpp/cmake/thirdparty/get_cccl.cmake
+++ b/cpp/cmake/thirdparty/get_cccl.cmake
@@ -23,8 +23,8 @@ function(find_and_configure_cccl)
 
   # Make sure we install cccl into the `include/libcudf` subdirectory instead of the default
   include(GNUInstallDirs)
-  set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/libcudf")
-  set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_INCLUDEDIR}/lib")
+  set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/include")
+  set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_INCLUDEDIR}/libcudf/lib")
 
   # Store where CMake can find our custom CCCL install
   include("${rapids-cmake-dir}/export/find_package_root.cmake")

--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -11,8 +11,6 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
-set(rapids-cmake-repo robertmaynard/rapids-cmake)
-set(rapids-cmake-branch bug/cccl-only-run-install-rules-once)
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-24.02/RAPIDS.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake

--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -11,6 +11,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
+set(rapids-cmake-repo robertmaynard/rapids-cmake)
+set(rapids-cmake-branch bug/cccl-only-run-install-rules-once)
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-24.02/RAPIDS.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/CUDF_RAPIDS.cmake


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
We need to unconditionally export the CCCL path because the condition can no longer be evaluated since the export is happening before the call to `rapids_cpm_cccl` as of #14655. Since cudf should in practice always be getting its own local copy of CCCL, it should be safe to have this export unconditionally; we will never use an externally provided copy of CCCL.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
