### PR TITLE
Deprecate `method` in `interpolate` and calculation on `object` dtype

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -26,11 +26,11 @@ from uuid import uuid4
 
 import cupy as cp
 import numpy as np
-import pandas as pd
 from typing_extensions import Self
 
 import cudf
 import cudf._lib as libcudf
+import pandas as pd
 from cudf._lib.types import size_type_dtype
 from cudf._typing import (
     ColumnLike,
@@ -40,8 +40,8 @@ from cudf._typing import (
 )
 from cudf.api.extensions import no_default
 from cudf.api.types import (
-    _is_non_decimal_numeric_dtype,
     _is_categorical_dtype,
+    _is_non_decimal_numeric_dtype,
     is_bool_dtype,
     is_decimal_dtype,
     is_dict_like,
@@ -1067,6 +1067,14 @@ class IndexedFrame(Frame):
                 f"`limit_direction` must be 'backward' for method `{method}`"
             )
 
+        if method.lower() in {"ffill", "bfill", "pad", "backfill"}:
+            warnings.warn(
+                f"{type(self).__name__}.interpolate with method={method} is "
+                "deprecated and will raise in a future version. "
+                "Use obj.ffill() or obj.bfill() instead.",
+                FutureWarning,
+            )
+
         data = self
 
         if not isinstance(data._index, cudf.RangeIndex):
@@ -1082,6 +1090,12 @@ class IndexedFrame(Frame):
         interpolator = cudf.core.algorithms.get_column_interpolator(method)
         columns = {}
         for colname, col in data._data.items():
+            if isinstance(col, cudf.core.column.StringColumn):
+                warnings.warn(
+                    f"{type(self).__name__}.interpolate with object dtype is "
+                    "deprecated and will raise in a future version.",
+                    FutureWarning,
+                )
             if col.nullable:
                 col = col.astype("float64").fillna(np.nan)
 

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -26,11 +26,11 @@ from uuid import uuid4
 
 import cupy as cp
 import numpy as np
+import pandas as pd
 from typing_extensions import Self
 
 import cudf
 import cudf._lib as libcudf
-import pandas as pd
 from cudf._lib.types import size_type_dtype
 from cudf._typing import (
     ColumnLike,


### PR DESCRIPTION
## Description
This PR:

- [x] Deprecates `method` in `interpolate`.
- [x] Deprecates performing `interpolate` on string columns.

On `pandas_2.0_feature_branch`:
```
= 198 failed, 101241 passed, 2091 skipped, 954 xfailed, 312 xpassed in 1098.81s (0:18:18) =
```

This PR:
```
= 187 failed, 101252 passed, 2091 skipped, 954 xfailed, 312 xpassed in 1090.48s (0:18:10) =
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
