### PR TITLE
Deprecate setting of incompatible dtypes to an existing column

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -3004,7 +3004,7 @@ def _get_indexer_basic(index, positions, method, target_col, tolerance):
         # sentinel for missing values
     else:
         # Mark indices to the right of the largest value as not found
-        positions[positions == len(index)] = -1
+        positions[positions == len(index)] = np.int32(-1)
 
     if tolerance is not None:
         distance = abs(index[positions] - target_col)

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -284,6 +284,15 @@ class _SeriesIlocIndexer(_FrameIndexer):
             to_dtype = np.result_type(value.dtype, self._frame._column.dtype)
             value = value.astype(to_dtype)
             if to_dtype != self._frame._column.dtype:
+                # Do not remove until pandas-3.0 support is added.
+                warnings.warn(
+                    f"Setting an item of incompatible dtype is deprecated "
+                    "and will raise in a future error of pandas. "
+                    f"Value '{value}' has dtype incompatible with "
+                    f"{self._frame._column.dtype}, "
+                    "please explicitly cast to a compatible dtype first.",
+                    FutureWarning,
+                )
                 self._frame._column._mimic_inplace(
                     self._frame._column.astype(to_dtype), inplace=True
                 )

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -930,8 +930,17 @@ def test_series_setitem_basics(key, value, nulls):
     elif nulls == "all":
         psr[:] = None
     gsr = cudf.from_pandas(psr)
-    psr[key] = value
-    gsr[key] = value
+    with expect_warning_if(
+        PANDAS_GE_210
+        and isinstance(value, list)
+        and len(value) == 0
+        and nulls == "none"
+    ):
+        psr[key] = value
+    with expect_warning_if(
+        isinstance(value, list) and len(value) == 0 and nulls == "none"
+    ):
+        gsr[key] = value
     assert_eq(psr, gsr, check_dtype=False)
 
 
@@ -974,8 +983,17 @@ def test_series_setitem_iloc(key, value, nulls):
     elif nulls == "all":
         psr[:] = None
     gsr = cudf.from_pandas(psr)
-    psr.iloc[key] = value
-    gsr.iloc[key] = value
+    with expect_warning_if(
+        PANDAS_GE_210
+        and isinstance(value, list)
+        and len(value) == 0
+        and nulls == "none"
+    ):
+        psr.iloc[key] = value
+    with expect_warning_if(
+        isinstance(value, list) and len(value) == 0 and nulls == "none"
+    ):
+        gsr.iloc[key] = value
     assert_eq(psr, gsr, check_dtype=False)
 
 
@@ -994,8 +1012,12 @@ def test_series_setitem_iloc(key, value, nulls):
 def test_series_setitem_dtype(key, value):
     psr = pd.Series([1, 2, 3], dtype="int32")
     gsr = cudf.from_pandas(psr)
-    psr[key] = value
-    gsr[key] = value
+
+    with expect_warning_if(isinstance(value, (float, list))):
+        psr[key] = value
+    with expect_warning_if(isinstance(value, (float, list))):
+        gsr[key] = value
+
     assert_eq(psr, gsr)
 
 

--- a/python/cudf/cudf/tests/test_setitem.py
+++ b/python/cudf/cudf/tests/test_setitem.py
@@ -5,8 +5,12 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_GE_150
-from cudf.testing._utils import assert_eq, assert_exceptions_equal
+from cudf.core._compat import PANDAS_GE_150, PANDAS_GE_210
+from cudf.testing._utils import (
+    assert_eq,
+    assert_exceptions_equal,
+    expect_warning_if,
+)
 
 
 @pytest.mark.parametrize("df", [pd.DataFrame({"a": [1, 2, 3]})])
@@ -310,8 +314,10 @@ def test_series_setitem_upcasting(dtype, indices):
     # column dtype.
     new_value = np.float64(np.pi)
     col_ref = cr._column
-    sr[indices] = new_value
-    cr[indices] = new_value
+    with expect_warning_if(PANDAS_GE_210 and dtype != np.float64):
+        sr[indices] = new_value
+    with expect_warning_if(dtype != np.float64):
+        cr[indices] = new_value
     if PANDAS_GE_150:
         assert_eq(sr, cr)
     else:


### PR DESCRIPTION
## Description
This PR deprecates the setting of a value that is not of same dtype as that of a column.


On `pandas_2.0_feature_branch`:
```
= 198 failed, 101241 passed, 2091 skipped, 954 xfailed, 312 xpassed in 1098.81s (0:18:18) =
```

This PR:
```
= 176 failed, 101263 passed, 2091 skipped, 954 xfailed, 312 xpassed in 1096.08s (0:18:16) =
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
