### PR TITLE
Add more validation to `MultiIndex.to_frame`

### DIFF
--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1028,6 +1028,10 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
                 for level, name in enumerate(self.names)
             ]
         else:
+            if not is_list_like(name):
+                raise TypeError(
+                    "'name' must be a list / sequence of column names."
+                )
             if len(name) != len(self.levels):
                 raise ValueError(
                     "'name' should have the same length as "

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -1953,13 +1953,13 @@ def test_multiindex_to_frame_allow_duplicates(
 ):
     gidx = cudf.from_pandas(pidx)
 
-    if (
+    if name is None or (
         (
             len(pidx.names) != len(set(pidx.names))
             and not all(x is None for x in pidx.names)
         )
         and not allow_duplicates
-        and (name is None or name is no_default)
+        and name is no_default
     ):
         assert_exceptions_equal(
             pidx.to_frame,


### PR DESCRIPTION
## Description
This PR adds validation to `name` inputs in `MultiIndex.to_frame` API.

On `pandas_2.0_feature_branch`:

```
= 198 failed, 101241 passed, 2091 skipped, 954 xfailed, 312 xpassed in 1098.81s (0:18:18) =
```

This PR:
```
= 180 failed, 101247 passed, 2091 skipped, 954 xfailed, 312 xpassed in 1025.07s (0:17:05) =
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
