### PR TITLE
Deprecate ignoring empty objects in `concat`

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -910,7 +910,9 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
 
             transpose = self.T
         else:
-            concat_df = cudf.concat(data, axis=1)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", FutureWarning)
+                concat_df = cudf.concat(data, axis=1)
 
             cols = concat_df._data.to_pandas_index()
             if cols.dtype == "object":
@@ -1920,9 +1922,11 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             lower_left = self.tail(lower_rows).iloc[:, :left_cols]
             lower_right = self.tail(lower_rows).iloc[:, right_cols:]
 
-            upper = cudf.concat([upper_left, upper_right], axis=1)
-            lower = cudf.concat([lower_left, lower_right], axis=1)
-            output = cudf.concat([upper, lower])
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", FutureWarning)
+                upper = cudf.concat([upper_left, upper_right], axis=1)
+                lower = cudf.concat([lower_left, lower_right], axis=1)
+                output = cudf.concat([upper, lower])
 
         output = self._clean_nulls_from_dataframe(output)
         output._index = output._index._clean_nulls_from_index()
@@ -5154,14 +5158,17 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                 None,
             )
 
-            return cudf.concat(
-                [
-                    series.reindex(names, copy=False)
-                    for series in describe_series_list
-                ],
-                axis=1,
-                sort=False,
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", FutureWarning)
+                res = cudf.concat(
+                    [
+                        series.reindex(names, copy=False)
+                        for series in describe_series_list
+                    ],
+                    axis=1,
+                    sort=False,
+                )
+            return res
 
     @_cudf_nvtx_annotate
     def to_pandas(self, *, nullable: bool = False) -> pd.DataFrame:
@@ -6258,7 +6265,10 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         if len(mode_results) == 0:
             return DataFrame()
 
-        df = cudf.concat(mode_results, axis=1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            df = cudf.concat(mode_results, axis=1)
+
         if isinstance(df, Series):
             df = df.to_frame()
 

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -1319,13 +1319,17 @@ class GroupBy(Serializable, Reducible, Scannable):
             # group is a row-like "Series" where the index labels
             # are the same as the original calling DataFrame
             if _is_row_of(chunk_results[0], self.obj):
-                result = cudf.concat(chunk_results, axis=1).T
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", FutureWarning)
+                    result = cudf.concat(chunk_results, axis=1).T
                 result.index = group_names
                 result.index.names = self.grouping.names
             # When the UDF is like df.x + df.y, the result for each
             # group is the same length as the original group
             elif len(self.obj) == sum(len(chk) for chk in chunk_results):
-                result = cudf.concat(chunk_results)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", FutureWarning)
+                    result = cudf.concat(chunk_results)
                 index_data = group_keys._data.copy(deep=True)
                 index_data[None] = grouped_values.index._column
                 result.index = cudf.MultiIndex._from_data(index_data)
@@ -1336,7 +1340,9 @@ class GroupBy(Serializable, Reducible, Scannable):
                     f"type {type(chunk_results[0])}"
                 )
         else:
-            result = cudf.concat(chunk_results)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", FutureWarning)
+                result = cudf.concat(chunk_results)
             if self._group_keys:
                 index_data = group_keys._data.copy(deep=True)
                 index_data[None] = grouped_values.index._column

--- a/python/cudf/cudf/core/join/_join_helpers.py
+++ b/python/cudf/cudf/core/join/_join_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections import abc
 from typing import TYPE_CHECKING, Any, Tuple, cast
 
@@ -170,9 +171,11 @@ def _match_categorical_dtypes_both(
         return lcol, rcol.astype(ltype)
     else:
         # merge categories
-        merged_categories = cudf.concat(
-            [ltype.categories, rtype.categories]
-        ).unique()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            merged_categories = cudf.concat(
+                [ltype.categories, rtype.categories]
+            ).unique()
         common_type = cudf.CategoricalDtype(
             categories=merged_categories, ordered=False
         )

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -6,6 +6,7 @@ import itertools
 import numbers
 import operator
 import pickle
+import warnings
 from collections import abc
 from functools import cached_property
 from numbers import Integral
@@ -717,15 +718,17 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
                 continue
             lookup[i] = cudf.Series(row)
         frame = cudf.DataFrame(dict(enumerate(index._data.columns)))
-        data_table = cudf.concat(
-            [
-                frame,
-                cudf.DataFrame(
-                    {"idx": cudf.Series(column.arange(len(frame)))}
-                ),
-            ],
-            axis=1,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            data_table = cudf.concat(
+                [
+                    frame,
+                    cudf.DataFrame(
+                        {"idx": cudf.Series(column.arange(len(frame)))}
+                    ),
+                ],
+                axis=1,
+            )
         # Sort indices in pandas compatible mode
         # because we want the indices to be fetched
         # in a deterministic order.

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1429,7 +1429,9 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
         if max_rows not in (0, None) and len(self) > max_rows:
             top = self.head(int(max_rows / 2 + 1))
             bottom = self.tail(int(max_rows / 2 + 1))
-            preprocess = cudf.concat([top, bottom])
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", FutureWarning)
+                preprocess = cudf.concat([top, bottom])
         else:
             preprocess = self.copy()
         preprocess.index = preprocess.index._clean_nulls_from_index()

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -794,13 +794,15 @@ def _parquet_to_frame(
                         dtype=_dtype,
                     )
 
-    # Concatenate dfs and return.
-    # Assume we can ignore the index if it has no name.
-    return (
-        cudf.concat(dfs, ignore_index=dfs[-1].index.name is None)
-        if len(dfs) > 1
-        else dfs[0]
-    )
+    if len(dfs) > 1:
+        # Concatenate dfs and return.
+        # Assume we can ignore the index if it has no name.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            res = cudf.concat(dfs, ignore_index=dfs[-1].index.name is None)
+        return res
+    else:
+        return dfs[0]
 
 
 @_cudf_nvtx_annotate

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -2,9 +2,12 @@
 
 from decimal import Decimal
 
+import warnings
 import numpy as np
 import pandas as pd
 import pytest
+
+from contextlib import contextmanager
 
 import cudf as gd
 from cudf.api.types import _is_categorical_dtype
@@ -15,6 +18,20 @@ from cudf.testing._utils import (
     assert_exceptions_equal,
     expect_warning_if,
 )
+
+
+@contextmanager
+def _hide_concat_empty_dtype_warning():
+    with warnings.catch_warnings():
+        # Ignoring warnings in this test as warnings are
+        # being caught and validated in other tests.
+        warnings.filterwarnings(
+            "ignore",
+            "The behavior of array concatenation with empty entries "
+            "is deprecated.",
+            category=FutureWarning,
+        )
+        yield
 
 
 def make_frames(index=None, nulls="none"):
@@ -66,8 +83,9 @@ def test_concat_dataframe(index, nulls, axis):
     df_empty1 = gdf_empty1.to_pandas()
 
     # DataFrame
-    res = gd.concat([gdf, gdf2, gdf, gdf_empty1], axis=axis).to_pandas()
-    sol = pd.concat([df, df2, df, df_empty1], axis=axis)
+    with _hide_concat_empty_dtype_warning():
+        res = gd.concat([gdf, gdf2, gdf, gdf_empty1], axis=axis).to_pandas()
+        sol = pd.concat([df, df2, df, df_empty1], axis=axis)
     assert_eq(
         res,
         sol,
@@ -476,8 +494,9 @@ def test_concat_series_dataframe_input(objs):
     pd_objs = objs
     gd_objs = [gd.from_pandas(obj) for obj in objs]
 
-    expected = pd.concat(pd_objs)
-    actual = gd.concat(gd_objs)
+    with _hide_concat_empty_dtype_warning():
+        expected = pd.concat(pd_objs)
+        actual = gd.concat(gd_objs)
 
     assert_eq(
         expected.fillna(-1),
@@ -843,23 +862,24 @@ def test_concat_join_many_df_and_empty_df(ignore_index, sort, join, axis):
     gdf3 = gd.from_pandas(pdf3)
     gdf_empty1 = gd.from_pandas(pdf_empty1)
 
-    assert_eq(
-        pd.concat(
-            [pdf1, pdf2, pdf3, pdf_empty1],
-            sort=sort,
-            join=join,
-            ignore_index=ignore_index,
-            axis=axis,
-        ),
-        gd.concat(
-            [gdf1, gdf2, gdf3, gdf_empty1],
-            sort=sort,
-            join=join,
-            ignore_index=ignore_index,
-            axis=axis,
-        ),
-        check_index_type=False,
-    )
+    with _hide_concat_empty_dtype_warning():
+        assert_eq(
+            pd.concat(
+                [pdf1, pdf2, pdf3, pdf_empty1],
+                sort=sort,
+                join=join,
+                ignore_index=ignore_index,
+                axis=axis,
+            ),
+            gd.concat(
+                [gdf1, gdf2, gdf3, gdf_empty1],
+                sort=sort,
+                join=join,
+                ignore_index=ignore_index,
+                axis=axis,
+            ),
+            check_index_type=False,
+        )
 
 
 @pytest.mark.parametrize("ignore_index", [True, False])
@@ -970,20 +990,21 @@ def test_concat_join_no_overlapping_columns_many_and_empty(
     gdf6 = gd.from_pandas(pdf6)
     gdf_empty = gd.from_pandas(pdf_empty)
 
-    expected = pd.concat(
-        [pdf4, pdf5, pdf6, pdf_empty],
-        sort=sort,
-        join=join,
-        ignore_index=ignore_index,
-        axis=axis,
-    )
-    actual = gd.concat(
-        [gdf4, gdf5, gdf6, gdf_empty],
-        sort=sort,
-        join=join,
-        ignore_index=ignore_index,
-        axis=axis,
-    )
+    with _hide_concat_empty_dtype_warning():
+        expected = pd.concat(
+            [pdf4, pdf5, pdf6, pdf_empty],
+            sort=sort,
+            join=join,
+            ignore_index=ignore_index,
+            axis=axis,
+        )
+        actual = gd.concat(
+            [gdf4, gdf5, gdf6, gdf_empty],
+            sort=sort,
+            join=join,
+            ignore_index=ignore_index,
+            axis=axis,
+        )
     assert_eq(
         expected,
         actual,
@@ -1042,20 +1063,21 @@ def test_concat_join_no_overlapping_columns_many_and_empty2(
 ):
     objs_gd = [gd.from_pandas(o) if o is not None else o for o in objs]
 
-    expected = pd.concat(
-        objs,
-        sort=sort,
-        join=join,
-        ignore_index=ignore_index,
-        axis=axis,
-    )
-    actual = gd.concat(
-        objs_gd,
-        sort=sort,
-        join=join,
-        ignore_index=ignore_index,
-        axis=axis,
-    )
+    with _hide_concat_empty_dtype_warning():
+        expected = pd.concat(
+            objs,
+            sort=sort,
+            join=join,
+            ignore_index=ignore_index,
+            axis=axis,
+        )
+        actual = gd.concat(
+            objs_gd,
+            sort=sort,
+            join=join,
+            ignore_index=ignore_index,
+            axis=axis,
+        )
     assert_eq(expected, actual, check_index_type=False)
 
 
@@ -1079,20 +1101,21 @@ def test_concat_join_no_overlapping_columns_empty_df_basic(
     gdf6 = gd.from_pandas(pdf6)
     gdf_empty = gd.from_pandas(pdf_empty)
 
-    expected = pd.concat(
-        [pdf6, pdf_empty],
-        sort=sort,
-        join=join,
-        ignore_index=ignore_index,
-        axis=axis,
-    )
-    actual = gd.concat(
-        [gdf6, gdf_empty],
-        sort=sort,
-        join=join,
-        ignore_index=ignore_index,
-        axis=axis,
-    )
+    with _hide_concat_empty_dtype_warning():
+        expected = pd.concat(
+            [pdf6, pdf_empty],
+            sort=sort,
+            join=join,
+            ignore_index=ignore_index,
+            axis=axis,
+        )
+        actual = gd.concat(
+            [gdf6, gdf_empty],
+            sort=sort,
+            join=join,
+            ignore_index=ignore_index,
+            axis=axis,
+        )
     assert_eq(
         expected,
         actual,
@@ -1109,7 +1132,7 @@ def test_concat_join_series(ignore_index, sort, join, axis):
     s1 = gd.Series(["a", "b", "c"])
     s2 = gd.Series(["a", "b"])
     s3 = gd.Series(["a", "b", "c", "d"])
-    s4 = gd.Series()
+    s4 = gd.Series(dtype="str")
 
     ps1 = s1.to_pandas()
     ps2 = s2.to_pandas()
@@ -1123,13 +1146,14 @@ def test_concat_join_series(ignore_index, sort, join, axis):
         ignore_index=ignore_index,
         axis=axis,
     )
-    actual = gd.concat(
-        [s1, s2, s3, s4],
-        sort=sort,
-        join=join,
-        ignore_index=ignore_index,
-        axis=axis,
-    )
+    with expect_warning_if(axis == 1):
+        actual = gd.concat(
+            [s1, s2, s3, s4],
+            sort=sort,
+            join=join,
+            ignore_index=ignore_index,
+            axis=axis,
+        )
 
     if PANDAS_GE_150:
         assert_eq(
@@ -1327,12 +1351,21 @@ def test_concat_join_empty_dataframes_axis_1(
     gdf = gd.from_pandas(df)
     other_gd = [gdf] + [gd.from_pandas(o) for o in other]
 
-    expected = pd.concat(
-        other_pd, ignore_index=ignore_index, axis=axis, join=join, sort=sort
-    )
-    actual = gd.concat(
-        other_gd, ignore_index=ignore_index, axis=axis, join=join, sort=sort
-    )
+    with _hide_concat_empty_dtype_warning():
+        expected = pd.concat(
+            other_pd,
+            ignore_index=ignore_index,
+            axis=axis,
+            join=join,
+            sort=sort,
+        )
+        actual = gd.concat(
+            other_gd,
+            ignore_index=ignore_index,
+            axis=axis,
+            join=join,
+            sort=sort,
+        )
     if expected.shape != df.shape:
         if axis == 0:
             for key, col in actual[actual.columns].items():


### PR DESCRIPTION
## Description
This PR deprecates ignoring `empty` objects for dtype calculation in `concat`.

On `pandas_2.0_feature_branch`:
```
= 198 failed, 101241 passed, 2091 skipped, 954 xfailed, 312 xpassed in 1098.81s (0:18:18) =
```

This PR:
```
= 179 failed, 101260 passed, 2091 skipped, 954 xfailed, 312 xpassed in 1225.23s (0:20:25) =
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
