### PR TITLE
Fix pytest condition to include more warning scenarios

### DIFF
--- a/python/cudf/cudf/tests/test_stats.py
+++ b/python/cudf/cudf/tests/test_stats.py
@@ -480,7 +480,7 @@ def test_corr1d(data1, data2, method):
     # Spearman allows for size 1 samples, but will error if all data in a
     # sample is identical since the covariance is zero and so the correlation
     # coefficient is not defined.
-    cond = (is_singular and method == "pearson") or (
+    cond = ((is_singular or is_identical) and method == "pearson") or (
         is_identical and not is_singular and method == "spearman"
     )
     if method == "spearman":


### PR DESCRIPTION
## Description
This PR fixes calculation of `cond` variable in `test_corr1d` which will include more cases for warnings. This change fixes, 9 pytest failures.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
