### PR TITLE
Sort `Index.difference` & `union` results for early exit scenarios

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -630,7 +630,7 @@ class BaseIndex(Serializable):
                 [self.dtype, other.dtype]
             )
             res = self._get_reconciled_name_object(other).astype(common_dtype)
-            if sort is True:
+            if sort:
                 return res.sort_values()
             return res
         elif not len(self):
@@ -638,7 +638,7 @@ class BaseIndex(Serializable):
                 [self.dtype, other.dtype]
             )
             res = other._get_reconciled_name_object(self).astype(common_dtype)
-            if sort is True:
+            if sort:
                 return res.sort_values()
             return res
 
@@ -1098,12 +1098,12 @@ class BaseIndex(Serializable):
 
         if not len(other):
             res = self._get_reconciled_name_object(other)
-            if sort is True:
+            if sort:
                 return res.sort_values()
             return res
         elif self.equals(other):
             res = self[:0]._get_reconciled_name_object(other)
-            if sort is True:
+            if sort:
                 return res.sort_values()
             return res
 

--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -629,12 +629,18 @@ class BaseIndex(Serializable):
             common_dtype = cudf.utils.dtypes.find_common_type(
                 [self.dtype, other.dtype]
             )
-            return self._get_reconciled_name_object(other).astype(common_dtype)
+            res = self._get_reconciled_name_object(other).astype(common_dtype)
+            if sort is True:
+                return res.sort_values()
+            return res
         elif not len(self):
             common_dtype = cudf.utils.dtypes.find_common_type(
                 [self.dtype, other.dtype]
             )
-            return other._get_reconciled_name_object(self).astype(common_dtype)
+            res = other._get_reconciled_name_object(self).astype(common_dtype)
+            if sort is True:
+                return res.sort_values()
+            return res
 
         result = self._union(other, sort=sort)
         result.name = _get_result_name(self.name, other.name)

--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -1091,9 +1091,15 @@ class BaseIndex(Serializable):
         other = cudf.Index(other, name=getattr(other, "name", self.name))
 
         if not len(other):
-            return self._get_reconciled_name_object(other)
+            res = self._get_reconciled_name_object(other)
+            if sort is True:
+                return res.sort_values()
+            return res
         elif self.equals(other):
-            return self[:0]._get_reconciled_name_object(other)
+            res = self[:0]._get_reconciled_name_object(other)
+            if sort is True:
+                return res.sort_values()
+            return res
 
         res_name = _get_result_name(self.name, other.name)
 


### PR DESCRIPTION
## Description
This PR sorts results in `Index.difference` & `union` in the early exit scenarios similar to: https://github.com/pandas-dev/pandas/pull/51346/

On `pandas_2.0_feature_branch`:
```
= 110 failed, 101331 passed, 2091 skipped, 952 xfailed, 312 xpassed in 1064.30s (0:17:44) =
```

This PR:
```
= 87 failed, 101354 passed, 2091 skipped, 952 xfailed, 312 xpassed in 1004.34s (0:16:44) =
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
