### PR TITLE
Handle missing warning assertions for `concat` pytests

### DIFF
--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -1062,10 +1062,12 @@ def test_index_empty_append_name_conflict():
     non_empty = cudf.Index([1], name="bar")
     expected = cudf.Index([1])
 
-    result = non_empty.append(empty)
+    with pytest.warns(FutureWarning):
+        result = non_empty.append(empty)
     assert_eq(result, expected)
 
-    result = empty.append(non_empty)
+    with pytest.warns(FutureWarning):
+        result = empty.append(non_empty)
     assert_eq(result, expected)
 
 
@@ -2861,7 +2863,8 @@ def test_index_methods(index, func):
 
     if func == "append":
         expected = pidx.append(other=pidx)
-        actual = gidx.append(other=gidx)
+        with expect_warning_if(len(gidx) == 0):
+            actual = gidx.append(other=gidx)
     else:
         expected = getattr(pidx, func)()
         actual = getattr(gidx, func)()


### PR DESCRIPTION
## Description
This PR adds warning assertions that were missed in https://github.com/rapidsai/cudf/pull/14672

On `pandas_2.0_feature_branch`:
```
= 110 failed, 101331 passed, 2091 skipped, 952 xfailed, 312 xpassed in 1064.30s (0:17:44) =
```
This PR:
```
= 105 failed, 101336 passed, 2091 skipped, 952 xfailed, 312 xpassed in 1068.90s (0:17:48) =
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
