### PR TITLE
Fix a typo error in `where` pytest

### DIFF
--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -6108,7 +6108,7 @@ def test_df_sr_mask_where(data, condition, other, error, inplace):
             got_mask = gs_mask
 
         if hasattr(expect_where, "dtype") and isinstance(
-            expect_where, pd.CategoricalDtype
+            expect_where.dtype, pd.CategoricalDtype
         ):
             np.testing.assert_array_equal(
                 expect_where.cat.codes,


### PR DESCRIPTION
## Description
This PR fixes a typo in `isinstance` check, thus fixing 6 pytest failures.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
