### PR TITLE
[DRAFT] refactor to grid stride for data_type_detection kernel

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -658,6 +658,21 @@ set_source_files_properties(
   PROPERTIES COMPILE_DEFINITIONS "_FILE_OFFSET_BITS=64"
 )
 
+set_source_files_properties(
+  src/io/csv/csv_gpu.cu src/io/csv/durations.cu src/io/csv/reader_impl.cu src/io/csv/writer_impl.cu
+)
+
+set_source_files_properties(
+  src/binaryop/binaryop.cpp
+  src/jit/cache.cpp
+  src/rolling/detail/rolling_fixed_window.cu
+  src/rolling/detail/rolling_variable_window.cu
+  src/rolling/grouped_rolling.cu
+  src/rolling/rolling.cu
+  src/transform/transform.cpp
+  PROPERTIES COMPILE_DEFINITIONS "_FILE_OFFSET_BITS=64"
+)
+
 set_target_properties(
   cudf
   PROPERTIES BUILD_RPATH "\$ORIGIN"

--- a/cpp/src/io/csv/csv_gpu.cu
+++ b/cpp/src/io/csv/csv_gpu.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Just a small draft to make sure i am not misunderstanding anything before I modify more code. Please lmk if this is not how the grid stride is to be implemented. Addresses #14066  

this benchmark is with higher occupancy, using the row count as a guide for grid size
```
## csv_read_data_type
### [0] NVIDIA GeForce RTX 3080

| data_type |      io       | Samples |  CPU Time  | Noise |  GPU Time  | Noise | bytes_per_second | peak_memory_usage | encoded_file_size |
|-----------|---------------|---------|------------|-------|------------|-------|------------------|-------------------|-------------------|
|  INTEGRAL | DEVICE_BUFFER |     45x | 335.173 ms | 5.05% | 335.136 ms | 5.05% |        800975115 |         1.202 GiB |       668.564 MiB |
|     FLOAT | DEVICE_BUFFER |     35x | 430.598 ms | 3.25% | 430.556 ms | 3.25% |        623463015 |         1.041 GiB |       713.885 MiB |
|   DECIMAL | DEVICE_BUFFER |     26x | 594.638 ms | 3.35% | 594.632 ms | 3.35% |        451431261 |         1.501 GiB |       783.420 MiB |
| TIMESTAMP | DEVICE_BUFFER |     22x | 686.076 ms | 3.85% | 686.071 ms | 3.85% |        391264596 |         2.281 GiB |       814.268 MiB |
|  DURATION | DEVICE_BUFFER |     18x | 839.339 ms | 3.25% | 839.347 ms | 3.25% |        319814809 |         2.588 GiB |       971.320 MiB |
|    STRING | DEVICE_BUFFER |     76x | 198.889 ms | 4.69% | 198.884 ms | 4.69% |       1349709651 |       859.526 MiB |       277.082 MiB |
```
below is with static grid_size at 256, much lower occupancy at 15.7%

```
# Benchmark Results
## csv_read_data_type
### [0] NVIDIA GeForce RTX 3080

| data_type |      io       | Samples |  CPU Time  | Noise |  GPU Time  | Noise | bytes_per_second | peak_memory_usage | encoded_file_size |
|-----------|---------------|---------|------------|-------|------------|-------|------------------|-------------------|-------------------|
|  INTEGRAL | DEVICE_BUFFER |     53x | 287.857 ms | 7.67% | 287.807 ms | 7.67% |        932692483 |         1.202 GiB |       668.564 MiB |
|     FLOAT | DEVICE_BUFFER |     46x | 330.720 ms | 6.69% | 330.697 ms | 6.69% |        811726551 |         1.041 GiB |       713.885 MiB |
|   DECIMAL | DEVICE_BUFFER |     34x | 449.532 ms | 6.43% | 449.526 ms | 6.43% |        597151885 |         1.501 GiB |       783.420 MiB |
| TIMESTAMP | DEVICE_BUFFER |     30x | 514.682 ms | 2.84% | 514.679 ms | 2.84% |        521559027 |         2.281 GiB |       814.268 MiB |
|  DURATION | DEVICE_BUFFER |     24x | 630.456 ms | 3.94% | 630.444 ms | 3.94% |        425788224 |         2.588 GiB |       971.320 MiB |
|    STRING | DEVICE_BUFFER |     90x | 166.848 ms | 2.63% | 166.836 ms | 2.63% |       1608974352 |       859.526 MiB |       277.082 MiB |
```
`cudaOccupancyMaxPotentialBlockSize` returns that 128 for block size and 612 for grid size is what achieves max occupancy btw. 

Some findings:

On my 3080, I am noticing better performance at 15.7% occupancy than I am at 65-75% occupancy. I do not have access to a workstation GPU so I cannot profile on what would be a practical scenario for a user using cuIO. Given that this kernel is largely memory bound, it is hard for me to simulate a real scenario. I hesitate drawing conclusions from my benchmarking on my consumer gpu.

I am also a bit curious to know what kind of performance gains should be derived from transition towards a grid stride. From my understanding, the main problems that exist(and are compounding off eachother) are:

1) Non coalesced memory access patterns, consequence of having a thread process an entire row. Scales with avg row size. I think more threads per row would help.  
2) Suboptimal caching
3) Heavy reliance on atomicAdds
4) Heavy divergence, since the kernel is generic, it has to deal with a variety of types and a lot of optimizations are lost due to this generic nature
5) Work balancing between threads varies too much, also a consequence of variable lengths. 

So im curious to know, would it make more sense to prioritize modernizing the CSV reader? I don't have perspective on the timeline for that to be achieved so I can't comment.  

From this [paper](https://arxiv.org/pdf/1905.13415.pdf), IIUC, I see a lot of interest in transitioning towards DFAs ,and converting to columnar format for example. A lot of interesting strategies like using bitmaps store positions of different symbols,  scanning that to find what col and row the symbol belongs to, and then using a stable radix sort so you can convert to columnar format. This would solve a lot of the problems I mentioned earlier because the data layout will be converted to something much easier to operate on.   With that being said I imagine the DFA needs to be worked and will be a challenge to get right. Since I lack context / experience with these workflows I'm curious to know how progress is faring on that and if I could help somehow. 	


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
