### PR TITLE
Change `io::detail::orc` namespace into `io::orc::detail`

### DIFF
--- a/cpp/include/cudf/io/detail/orc.hpp
+++ b/cpp/include/cudf/io/detail/orc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/io/detail/orc.hpp
+++ b/cpp/include/cudf/io/detail/orc.hpp
@@ -28,16 +28,14 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
-namespace cudf {
-namespace io {
+namespace cudf::io {
 
 // Forward declaration
 class orc_reader_options;
 class orc_writer_options;
 class chunked_orc_writer_options;
 
-namespace detail {
-namespace orc {
+namespace orc::detail {
 
 /**
  * @brief Class to read ORC dataset data into columns.
@@ -94,7 +92,7 @@ class writer {
    */
   explicit writer(std::unique_ptr<cudf::io::data_sink> sink,
                   orc_writer_options const& options,
-                  single_write_mode mode,
+                  cudf::io::detail::single_write_mode mode,
                   rmm::cuda_stream_view stream);
 
   /**
@@ -107,7 +105,7 @@ class writer {
    */
   explicit writer(std::unique_ptr<cudf::io::data_sink> sink,
                   chunked_orc_writer_options const& options,
-                  single_write_mode mode,
+                  cudf::io::detail::single_write_mode mode,
                   rmm::cuda_stream_view stream);
 
   /**
@@ -127,7 +125,5 @@ class writer {
    */
   void close();
 };
-}  // namespace orc
-}  // namespace detail
-}  // namespace io
-}  // namespace cudf
+}  // namespace orc::detail
+}  // namespace cudf::io

--- a/cpp/include/cudf/io/orc.hpp
+++ b/cpp/include/cudf/io/orc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/io/orc.hpp
+++ b/cpp/include/cudf/io/orc.hpp
@@ -1304,7 +1304,7 @@ class orc_chunked_writer {
   void close();
 
   /// Unique pointer to impl writer class
-  std::unique_ptr<cudf::io::detail::orc::writer> writer;
+  std::unique_ptr<cudf::io::orc::detail::writer> writer;
 };
 
 /** @} */  // end of group

--- a/cpp/include/cudf/io/orc.hpp
+++ b/cpp/include/cudf/io/orc.hpp
@@ -1304,7 +1304,7 @@ class orc_chunked_writer {
   void close();
 
   /// Unique pointer to impl writer class
-  std::unique_ptr<cudf::io::orc::detail::writer> writer;
+  std::unique_ptr<orc::detail::writer> writer;
 };
 
 /** @} */  // end of group

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -270,7 +270,7 @@ void write_csv(csv_writer_options const& options,
     mr);
 }
 
-namespace detail_orc = cudf::io::detail::orc;
+namespace orc_detail = cudf::io::orc::detail;
 
 raw_orc_statistics read_raw_orc_statistics(source_info const& src_info)
 {
@@ -418,7 +418,7 @@ table_with_metadata read_orc(orc_reader_options const& options, rmm::mr::device_
   CUDF_FUNC_RANGE();
 
   auto datasources = make_datasources(options.get_source());
-  auto reader      = std::make_unique<detail_orc::reader>(
+  auto reader      = std::make_unique<orc_detail::reader>(
     std::move(datasources), options, cudf::get_default_stream(), mr);
 
   return reader->read(options);
@@ -436,7 +436,7 @@ void write_orc(orc_writer_options const& options)
   auto sinks = make_datasinks(options.get_sink());
   CUDF_EXPECTS(sinks.size() == 1, "Multiple sinks not supported for ORC writing");
 
-  auto writer = std::make_unique<detail_orc::writer>(
+  auto writer = std::make_unique<orc_detail::writer>(
     std::move(sinks[0]), options, io_detail::single_write_mode::YES, cudf::get_default_stream());
 
   writer->write(options.get_table());
@@ -452,7 +452,7 @@ orc_chunked_writer::orc_chunked_writer(chunked_orc_writer_options const& options
   auto sinks = make_datasinks(options.get_sink());
   CUDF_EXPECTS(sinks.size() == 1, "Multiple sinks not supported for ORC writing");
 
-  writer = std::make_unique<detail_orc::writer>(
+  writer = std::make_unique<orc_detail::writer>(
     std::move(sinks[0]), options, io_detail::single_write_mode::NO, cudf::get_default_stream());
 }
 

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -38,8 +38,7 @@
 
 #include <algorithm>
 
-namespace cudf {
-namespace io {
+namespace cudf::io {
 // Returns builder for csv_reader_options
 csv_reader_options_builder csv_reader_options::builder(source_info src)
 {
@@ -270,8 +269,6 @@ void write_csv(csv_writer_options const& options,
     mr);
 }
 
-namespace orc_detail = cudf::io::orc::detail;
-
 raw_orc_statistics read_raw_orc_statistics(source_info const& src_info)
 {
   auto stream = cudf::get_default_stream();
@@ -322,7 +319,7 @@ raw_orc_statistics read_raw_orc_statistics(source_info const& src_info)
   return result;
 }
 
-column_statistics::column_statistics(cudf::io::orc::column_statistics&& cs)
+column_statistics::column_statistics(orc::column_statistics&& cs)
 {
   number_of_values = cs.number_of_values;
   has_null         = cs.has_null;
@@ -418,7 +415,7 @@ table_with_metadata read_orc(orc_reader_options const& options, rmm::mr::device_
   CUDF_FUNC_RANGE();
 
   auto datasources = make_datasources(options.get_source());
-  auto reader      = std::make_unique<orc_detail::reader>(
+  auto reader      = std::make_unique<orc::detail::reader>(
     std::move(datasources), options, cudf::get_default_stream(), mr);
 
   return reader->read(options);
@@ -436,7 +433,7 @@ void write_orc(orc_writer_options const& options)
   auto sinks = make_datasinks(options.get_sink());
   CUDF_EXPECTS(sinks.size() == 1, "Multiple sinks not supported for ORC writing");
 
-  auto writer = std::make_unique<orc_detail::writer>(
+  auto writer = std::make_unique<orc::detail::writer>(
     std::move(sinks[0]), options, io_detail::single_write_mode::YES, cudf::get_default_stream());
 
   writer->write(options.get_table());
@@ -452,7 +449,7 @@ orc_chunked_writer::orc_chunked_writer(chunked_orc_writer_options const& options
   auto sinks = make_datasinks(options.get_sink());
   CUDF_EXPECTS(sinks.size() == 1, "Multiple sinks not supported for ORC writing");
 
-  writer = std::make_unique<orc_detail::writer>(
+  writer = std::make_unique<orc::detail::writer>(
     std::move(sinks[0]), options, io_detail::single_write_mode::NO, cudf::get_default_stream());
 }
 
@@ -896,5 +893,4 @@ chunked_parquet_writer_options_builder::max_page_fragment_size(size_type val)
   return *this;
 }
 
-}  // namespace io
-}  // namespace cudf
+}  // namespace cudf::io

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -54,7 +54,6 @@
 
 namespace cudf::io::orc::detail {
 using namespace cudf::io::detail;
-using namespace cudf::io::orc;
 
 namespace {
 

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -622,7 +622,7 @@ void scan_null_counts(cudf::detail::hostdevice_2dvector<gpu::ColumnDesc> const& 
  * @brief Aggregate child metadata from parent column chunks.
  */
 void aggregate_child_meta(std::size_t level,
-                          cudf::io::orc::detail::column_hierarchy const& selected_columns,
+                          column_hierarchy const& selected_columns,
                           cudf::detail::host_2dspan<gpu::ColumnDesc> chunks,
                           cudf::detail::host_2dspan<gpu::RowGroup> row_groups,
                           host_span<orc_column_meta const> list_col,
@@ -775,7 +775,7 @@ constexpr type_id to_cudf_type(orc::TypeKind kind,
  * @brief Determines cuDF type of an ORC Decimal column.
  */
 type_id to_cudf_decimal_type(host_span<std::string const> decimal128_columns,
-                             cudf::io::orc::detail::aggregate_orc_metadata const& metadata,
+                             aggregate_orc_metadata const& metadata,
                              int column_index)
 {
   if (metadata.get_col_type(column_index).kind != DECIMAL) { return type_id::EMPTY; }
@@ -798,14 +798,13 @@ std::string get_map_child_col_name(std::size_t const idx) { return (idx == 0) ? 
 /**
  * @brief Create empty columns and respective schema information from the buffer.
  */
-std::unique_ptr<column> create_empty_column(
-  size_type orc_col_id,
-  cudf::io::orc::detail::aggregate_orc_metadata const& metadata,
-  host_span<std::string const> decimal128_columns,
-  bool use_np_dtypes,
-  data_type timestamp_type,
-  column_name_info& schema_info,
-  rmm::cuda_stream_view stream)
+std::unique_ptr<column> create_empty_column(size_type orc_col_id,
+                                            aggregate_orc_metadata const& metadata,
+                                            host_span<std::string const> decimal128_columns,
+                                            bool use_np_dtypes,
+                                            data_type timestamp_type,
+                                            column_name_info& schema_info,
+                                            rmm::cuda_stream_view stream)
 {
   schema_info.name = metadata.column_name(0, orc_col_id);
   auto const kind  = metadata.get_col_type(orc_col_id).kind;
@@ -891,8 +890,8 @@ std::unique_ptr<column> create_empty_column(
 column_buffer assemble_buffer(size_type orc_col_id,
                               std::size_t level,
                               reader_column_meta const& col_meta,
-                              cudf::io::orc::detail::aggregate_orc_metadata const& metadata,
-                              cudf::io::orc::detail::column_hierarchy const& selected_columns,
+                              aggregate_orc_metadata const& metadata,
+                              column_hierarchy const& selected_columns,
                               std::vector<std::vector<column_buffer>>& col_buffers,
                               rmm::cuda_stream_view stream,
                               rmm::mr::device_memory_resource* mr)

--- a/cpp/src/io/orc/reader_impl.cu
+++ b/cpp/src/io/orc/reader_impl.cu
@@ -52,7 +52,8 @@
 #include <algorithm>
 #include <iterator>
 
-namespace cudf::io::detail::orc {
+namespace cudf::io::orc::detail {
+using namespace cudf::io::detail;
 using namespace cudf::io::orc;
 
 namespace {
@@ -1363,4 +1364,4 @@ table_with_metadata reader::read(orc_reader_options const& options)
   return _impl->read(options.get_skip_rows(), options.get_num_rows(), options.get_stripes());
 }
 
-}  // namespace cudf::io::detail::orc
+}  // namespace cudf::io::orc::detail

--- a/cpp/src/io/orc/reader_impl.hpp
+++ b/cpp/src/io/orc/reader_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/io/orc/reader_impl.hpp
+++ b/cpp/src/io/orc/reader_impl.hpp
@@ -75,8 +75,8 @@ class reader::impl {
   rmm::mr::device_memory_resource* const _mr;
 
   std::vector<std::unique_ptr<datasource>> const _sources;  // Unused but owns data for `_metadata`
-  cudf::io::orc::detail::aggregate_orc_metadata _metadata;
-  cudf::io::orc::detail::column_hierarchy const _selected_columns;  // Need to be after _metadata
+  aggregate_orc_metadata _metadata;
+  column_hierarchy const _selected_columns;  // Need to be after _metadata
 
   data_type const _timestamp_type;  // Override output timestamp resolution
   bool const _use_index;            // Enable or disable attempt to use row index for parsing

--- a/cpp/src/io/orc/reader_impl.hpp
+++ b/cpp/src/io/orc/reader_impl.hpp
@@ -34,7 +34,7 @@
 #include <utility>
 #include <vector>
 
-namespace cudf::io::detail::orc {
+namespace cudf::io::orc::detail {
 using namespace cudf::io::orc;
 
 namespace {
@@ -86,4 +86,4 @@ class reader::impl {
   std::unique_ptr<reader_column_meta> const _col_meta;  // Track of orc mapping and child details
 };
 
-}  // namespace cudf::io::detail::orc
+}  // namespace cudf::io::orc::detail

--- a/cpp/src/io/orc/reader_impl.hpp
+++ b/cpp/src/io/orc/reader_impl.hpp
@@ -35,7 +35,6 @@
 #include <vector>
 
 namespace cudf::io::orc::detail {
-using namespace cudf::io::orc;
 
 namespace {
 struct reader_column_meta;

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -69,8 +69,6 @@
 #include <utility>
 
 namespace cudf::io::orc::detail {
-using namespace cudf::io::orc;
-using namespace cudf::io;
 
 template <typename T>
 [[nodiscard]] constexpr int varint_size(T val)

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -68,10 +68,7 @@
 #include <tuple>
 #include <utility>
 
-namespace cudf {
-namespace io {
-namespace detail {
-namespace orc {
+namespace cudf::io::orc::detail {
 using namespace cudf::io::orc;
 using namespace cudf::io;
 
@@ -2741,7 +2738,4 @@ void writer::write(table_view const& table) { _impl->write(table); }
 // Forward to implementation
 void writer::close() { _impl->close(); }
 
-}  // namespace orc
-}  // namespace detail
-}  // namespace io
-}  // namespace cudf
+}  // namespace cudf::io::orc::detail

--- a/cpp/src/io/orc/writer_impl.hpp
+++ b/cpp/src/io/orc/writer_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/io/orc/writer_impl.hpp
+++ b/cpp/src/io/orc/writer_impl.hpp
@@ -39,15 +39,13 @@
 #include <string>
 #include <vector>
 
-namespace cudf {
-namespace io {
-namespace detail {
-namespace orc {
+namespace cudf::io::orc::detail {
 // Forward internal classes
 class orc_column_view;
 
-using namespace cudf::io::orc;
 using namespace cudf::io;
+using namespace cudf::io::detail;
+using namespace cudf::io::orc;
 using cudf::detail::device_2dspan;
 using cudf::detail::host_2dspan;
 using cudf::detail::hostdevice_2dvector;
@@ -364,7 +362,4 @@ class writer::impl {
   bool _closed = false;  // To track if the output has been written to sink.
 };
 
-}  // namespace orc
-}  // namespace detail
-}  // namespace io
-}  // namespace cudf
+}  // namespace cudf::io::orc::detail

--- a/cpp/src/io/orc/writer_impl.hpp
+++ b/cpp/src/io/orc/writer_impl.hpp
@@ -354,8 +354,8 @@ class writer::impl {
 
   // Internal states, filled during `write()` and written to sink during `write` and `close()`.
   std::unique_ptr<table_input_metadata> _table_meta;
-  cudf::io::orc::FileFooter _ffooter;
-  cudf::io::orc::Metadata _orc_meta;
+  FileFooter _ffooter;
+  Metadata _orc_meta;
   persisted_statistics _persisted_stripe_statistics;  // Statistics data saved between calls.
   bool _closed = false;  // To track if the output has been written to sink.
 };

--- a/cpp/src/io/orc/writer_impl.hpp
+++ b/cpp/src/io/orc/writer_impl.hpp
@@ -43,9 +43,7 @@ namespace cudf::io::orc::detail {
 // Forward internal classes
 class orc_column_view;
 
-using namespace cudf::io;
 using namespace cudf::io::detail;
-using namespace cudf::io::orc;
 using cudf::detail::device_2dspan;
 using cudf::detail::host_2dspan;
 using cudf::detail::hostdevice_2dvector;


### PR DESCRIPTION
This PR simply changes the (sub) namespace `io::detail::orc` namespace into `io::orc::detail`. From now, the implementation of ORC reader and writer will be part of the `detail` namespace under the `io::orc` namespace.