### PR TITLE
refactor CUDA versions in dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -31,30 +31,30 @@ files:
     output: none
     includes:
       - cuda_version
-      - test_cpp
       - libarrow_run
+      - test_cpp
   test_python:
     output: none
     includes:
       - cuda_version
       - py_version
+      - pyarrow_run
       - test_python_common
       - test_python_cudf
       - test_python_dask_cudf
-      - pyarrow_run
   test_java:
     output: none
     includes:
       - build_all
-      - libarrow_run
       - cuda_version
+      - libarrow_run
       - test_java
   test_notebooks:
     output: none
     includes:
+      - cuda_version
       - notebooks
       - py_version
-      - cuda_version
   checks:
     output: none
     includes:
@@ -403,9 +403,6 @@ dependencies:
               - *cudanvtx114
               - *libcurand_dev114
               - *libcurand114
-          - matrix:  # Fallback for CUDA 11 or no matrix
-            packages:
-              - cudatoolkit
       - output_types: conda
         matrices:
           - matrix:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -46,6 +46,7 @@ files:
     output: none
     includes:
       - build_all
+      - cuda
       - cuda_version
       - libarrow_run
       - test_java

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -11,7 +11,8 @@ files:
       - build_wheels
       - build_python_common
       - build_python_cudf
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - develop
       - docs
       - libarrow_build
@@ -29,13 +30,13 @@ files:
   test_cpp:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - test_cpp
       - libarrow_run
   test_python:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - py_version
       - test_python_common
       - test_python_cudf
@@ -46,14 +47,14 @@ files:
     includes:
       - build_all
       - libarrow_run
-      - cudatoolkit
+      - cuda_version
       - test_java
   test_notebooks:
     output: none
     includes:
       - notebooks
       - py_version
-      - notebook_cuda_version
+      - cuda_version
   checks:
     output: none
     includes:
@@ -62,7 +63,8 @@ files:
   docs:
     output: none
     includes:
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - docs
       - libarrow_run
       - py_version
@@ -333,7 +335,31 @@ dependencies:
           # Allow runtime version to float up to minor version
           # Disallow pyarrow 14.0.0 due to a CVE
           - pyarrow>=14.0.1,<15.0.0a0
-  cudatoolkit:
+  cuda_version:
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "11.2"
+            packages:
+              - cuda-version=11.2
+          - matrix:
+              cuda: "11.4"
+            packages:
+              - cuda-version=11.4
+          - matrix:
+              cuda: "11.5"
+            packages:
+              - cuda-version=11.5
+          - matrix:
+              cuda: "11.8"
+            packages:
+              - cuda-version=11.8
+          - matrix:
+              cuda: "12.0"
+            packages:
+              - cuda-version=12.0
+  cuda:
     specific:
       - output_types: conda
         matrices:
@@ -344,26 +370,16 @@ dependencies:
               - cuda-nvrtc-dev
               - cuda-nvtx-dev
               - libcurand-dev
-          - matrix:  # Fallback for CUDA 11 or no matrix
-            packages:
-              - cudatoolkit
-      - output_types: conda
-        matrices:
-          - matrix:
-              cuda: "12.0"
-            packages:
-              - cuda-version=12.0
           - matrix:
               cuda: "11.8"
             packages:
-              - cuda-version=11.8
+              - cudatoolkit
               - cuda-nvtx=11.8
               - libcurand-dev=10.3.0.86
               - libcurand=10.3.0.86
           - matrix:
               cuda: "11.5"
             packages:
-              - cuda-version=11.5
               - cudatoolkit
               - cuda-nvtx=11.5
                 # Can't hard pin the version since 11.x is missing many
@@ -373,7 +389,6 @@ dependencies:
           - matrix:
               cuda: "11.4"
             packages:
-              - cuda-version=11.4
               - cudatoolkit
               - &cudanvtx114 cuda-nvtx=11.4
               - &libcurand_dev114 libcurand-dev>=10.2.5.43,<=10.2.5.120
@@ -381,7 +396,6 @@ dependencies:
           - matrix:
               cuda: "11.2"
             packages:
-              - cuda-version=11.2
               - cudatoolkit
                 # The NVIDIA channel doesn't publish pkgs older than 11.4 for
                 # these libs, so 11.2 uses 11.4 packages (the oldest
@@ -389,6 +403,9 @@ dependencies:
               - *cudanvtx114
               - *libcurand_dev114
               - *libcurand114
+          - matrix:  # Fallback for CUDA 11 or no matrix
+            packages:
+              - cudatoolkit
       - output_types: conda
         matrices:
           - matrix:
@@ -753,13 +770,3 @@ dependencies:
         packages:
           - ipython
           - openpyxl
-  notebook_cuda_version:
-    specific:
-       - output_types: conda
-         matrices:
-           - matrix: {cuda: "12.0"}
-             packages:
-               - cuda-version=12.0
-           - matrix: {cuda: "11.8"}
-             packages:
-               - cuda-version=11.8


### PR DESCRIPTION
## Description

Follow-up to #14644. 

Contributes to https://github.com/rapidsai/build-planning/issues/7.

Similar to https://github.com/rapidsai/rmm/pull/1422, this proposes splitting the `cuda-version` dependency in `dependencies.yaml` out to its own thing, separate from the bits of the CUDA Toolkit `cudf` needs.

Some other simplifications:

* removes the notebook-specific stuff added in #14722 (which I think were added specifically because `cuda-version` and CTK stuff was coupled)
* consolidates two sections with selectors only based on CUDA `{major}.{minor}`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
