### PR TITLE
Pin pytest-cases<3.8.2

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -74,7 +74,7 @@ dependencies:
 - pydata-sphinx-theme!=0.14.2
 - pytest
 - pytest-benchmark
-- pytest-cases
+- pytest-cases<3.8.2
 - pytest-cov
 - pytest-xdist
 - python-confluent-kafka>=1.9.0,<1.10.0a0

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -71,7 +71,7 @@ dependencies:
 - pydata-sphinx-theme!=0.14.2
 - pytest
 - pytest-benchmark
-- pytest-cases
+- pytest-cases<3.8.2
 - pytest-cov
 - pytest-xdist
 - python-confluent-kafka>=1.9.0,<1.10.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -619,7 +619,7 @@ dependencies:
           - fastavro>=0.22.9
           - hypothesis
           - pytest-benchmark
-          - pytest-cases
+          - pytest-cases<3.8.2
           - python-snappy>=0.6.0
           - scipy
       - output_types: conda

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -59,7 +59,7 @@ test = [
     "msgpack",
     "pytest",
     "pytest-benchmark",
-    "pytest-cases",
+    "pytest-cases<3.8.2",
     "pytest-cov",
     "pytest-xdist",
     "python-snappy>=0.6.0",


### PR DESCRIPTION
## Description
Appears in the pytest-cases 3.8.2, there's a requirement that automatically finding `cases` must be in a file named `test_*`, when historically looks like we use `bench_*` 

https://github.com/smarie/python-pytest-cases/pull/320/files

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
