### PR TITLE
Revise ``shuffle`` deprecation to align with dask/dask

### DIFF
--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -113,13 +113,7 @@ class DataFrame(_Frame, dd.core.DataFrame):
 
     @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
-    def merge(
-        self,
-        other,
-        shuffle=None,  # Deprecated
-        shuffle_method=None,
-        **kwargs,
-    ):
+    def merge(self, other, shuffle_method=None, **kwargs):
         on = kwargs.pop("on", None)
         if isinstance(on, tuple):
             on = list(on)
@@ -132,13 +126,7 @@ class DataFrame(_Frame, dd.core.DataFrame):
 
     @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
-    def join(
-        self,
-        other,
-        shuffle=None,  # Deprecated
-        shuffle_method=None,
-        **kwargs,
-    ):
+    def join(self, other, shuffle_method=None, **kwargs):
         # CuDF doesn't support "right" join yet
         how = kwargs.pop("how", "left")
         if how == "right":
@@ -162,7 +150,6 @@ class DataFrame(_Frame, dd.core.DataFrame):
         other,
         sorted=False,
         divisions=None,
-        shuffle=None,  # Deprecated
         shuffle_method=None,
         **kwargs,
     ):
@@ -245,7 +232,6 @@ class DataFrame(_Frame, dd.core.DataFrame):
         na_position="last",
         sort_function=None,
         sort_function_kwargs=None,
-        shuffle=None,  # Deprecated
         shuffle_method=None,
         **kwargs,
     ):
@@ -318,13 +304,7 @@ class DataFrame(_Frame, dd.core.DataFrame):
 
     @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
-    def shuffle(
-        self,
-        *args,
-        shuffle=None,  # Deprecated
-        shuffle_method=None,
-        **kwargs,
-    ):
+    def shuffle(self, *args, shuffle_method=None, **kwargs):
         """Wraps dask.dataframe DataFrame.shuffle method"""
         return super().shuffle(
             *args, shuffle_method=_get_shuffle_method(shuffle_method), **kwargs

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -26,7 +26,7 @@ from cudf.utils.nvtx_annotation import _dask_cudf_nvtx_annotate
 
 from dask_cudf import sorting
 from dask_cudf.accessors import ListMethods, StructMethods
-from dask_cudf.sorting import _get_shuffle_method
+from dask_cudf.sorting import _deprecate_shuffle_kwarg, _get_shuffle_method
 
 
 class _Frame(dd.core._Frame, OperatorMethodMixin):
@@ -111,8 +111,15 @@ class DataFrame(_Frame, dd.core.DataFrame):
             do_apply_rows, func, incols, outcols, kwargs, meta=meta
         )
 
+    @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
-    def merge(self, other, shuffle_method=None, **kwargs):
+    def merge(
+        self,
+        other,
+        shuffle=None,  # Deprecated
+        shuffle_method=None,
+        **kwargs,
+    ):
         on = kwargs.pop("on", None)
         if isinstance(on, tuple):
             on = list(on)
@@ -123,8 +130,15 @@ class DataFrame(_Frame, dd.core.DataFrame):
             **kwargs,
         )
 
+    @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
-    def join(self, other, shuffle_method=None, **kwargs):
+    def join(
+        self,
+        other,
+        shuffle=None,  # Deprecated
+        shuffle_method=None,
+        **kwargs,
+    ):
         # CuDF doesn't support "right" join yet
         how = kwargs.pop("how", "left")
         if how == "right":
@@ -141,12 +155,14 @@ class DataFrame(_Frame, dd.core.DataFrame):
             **kwargs,
         )
 
+    @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
     def set_index(
         self,
         other,
         sorted=False,
         divisions=None,
+        shuffle=None,  # Deprecated
         shuffle_method=None,
         **kwargs,
     ):
@@ -216,6 +232,7 @@ class DataFrame(_Frame, dd.core.DataFrame):
             **kwargs,
         )
 
+    @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
     def sort_values(
         self,
@@ -228,6 +245,7 @@ class DataFrame(_Frame, dd.core.DataFrame):
         na_position="last",
         sort_function=None,
         sort_function_kwargs=None,
+        shuffle=None,  # Deprecated
         shuffle_method=None,
         **kwargs,
     ):
@@ -298,8 +316,15 @@ class DataFrame(_Frame, dd.core.DataFrame):
         else:
             return _parallel_var(self, meta, skipna, split_every, out)
 
+    @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
-    def shuffle(self, *args, shuffle_method=None, **kwargs):
+    def shuffle(
+        self,
+        *args,
+        shuffle=None,  # Deprecated
+        shuffle_method=None,
+        **kwargs,
+    ):
         """Wraps dask.dataframe DataFrame.shuffle method"""
         return super().shuffle(
             *args, shuffle_method=_get_shuffle_method(shuffle_method), **kwargs

--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -17,6 +17,8 @@ from dask.utils import funcname
 import cudf
 from cudf.utils.nvtx_annotation import _dask_cudf_nvtx_annotate
 
+from dask_cudf.sorting import _deprecate_shuffle_kwarg
+
 # aggregations that are dask-cudf optimized
 OPTIMIZED_AGGS = (
     "count",
@@ -189,8 +191,16 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
             split_out,
         )
 
+    @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
-    def aggregate(self, arg, split_every=None, split_out=1, shuffle=None):
+    def aggregate(
+        self,
+        arg,
+        split_every=None,
+        split_out=1,
+        shuffle=None,  # Deprecated
+        shuffle_method=None,
+    ):
         if arg == "size":
             return self.size()
 
@@ -211,7 +221,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
                 sep=self.sep,
                 sort=self.sort,
                 as_index=self.as_index,
-                shuffle_method=shuffle,
+                shuffle_method=shuffle_method,
                 **self.dropna,
             )
 
@@ -219,7 +229,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
             arg,
             split_every=split_every,
             split_out=split_out,
-            shuffle=shuffle,
+            shuffle_method=shuffle_method,
         )
 
 
@@ -330,8 +340,16 @@ class CudfSeriesGroupBy(SeriesGroupBy):
             split_out,
         )[self._slice]
 
+    @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
-    def aggregate(self, arg, split_every=None, split_out=1, shuffle=None):
+    def aggregate(
+        self,
+        arg,
+        split_every=None,
+        split_out=1,
+        shuffle=None,  # Deprecated
+        shuffle_method=None,
+    ):
         if arg == "size":
             return self.size()
 
@@ -342,14 +360,14 @@ class CudfSeriesGroupBy(SeriesGroupBy):
 
         if _groupby_optimized(self) and _aggs_optimized(arg, OPTIMIZED_AGGS):
             return _make_groupby_agg_call(
-                self, arg, split_every, split_out, shuffle
+                self, arg, split_every, split_out, shuffle_method
             )[self._slice]
 
         return super().aggregate(
             arg,
             split_every=split_every,
             split_out=split_out,
-            shuffle=shuffle,
+            shuffle_method=shuffle_method,
         )
 
 

--- a/python/dask_cudf/dask_cudf/groupby.py
+++ b/python/dask_cudf/dask_cudf/groupby.py
@@ -194,12 +194,7 @@ class CudfDataFrameGroupBy(DataFrameGroupBy):
     @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
     def aggregate(
-        self,
-        arg,
-        split_every=None,
-        split_out=1,
-        shuffle=None,  # Deprecated
-        shuffle_method=None,
+        self, arg, split_every=None, split_out=1, shuffle_method=None
     ):
         if arg == "size":
             return self.size()
@@ -343,12 +338,7 @@ class CudfSeriesGroupBy(SeriesGroupBy):
     @_deprecate_shuffle_kwarg
     @_dask_cudf_nvtx_annotate
     def aggregate(
-        self,
-        arg,
-        split_every=None,
-        split_out=1,
-        shuffle=None,  # Deprecated
-        shuffle_method=None,
+        self, arg, split_every=None, split_out=1, shuffle_method=None
     ):
         if arg == "size":
             return self.size()

--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
+import warnings
 from collections.abc import Iterator
+from functools import wraps
 
 import cupy
 import numpy as np
@@ -19,6 +21,31 @@ from cudf.api.types import is_categorical_dtype
 from cudf.utils.nvtx_annotation import _dask_cudf_nvtx_annotate
 
 _SHUFFLE_SUPPORT = ("tasks", "p2p")  # "disk" not supported
+
+
+def _deprecate_shuffle_kwarg(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        old_arg_value = kwargs.pop("shuffle", None)
+
+        if old_arg_value is not None:
+            new_arg_value = old_arg_value
+            msg = (
+                "the 'shuffle' keyword is deprecated, "
+                "use 'shuffle_method' instead."
+            )
+
+            warnings.warn(msg, FutureWarning)
+            if kwargs.get("shuffle_method") is not None:
+                msg = (
+                    "Can only specify 'shuffle' "
+                    "or 'shuffle_method', not both."
+                )
+                raise TypeError(msg)
+            kwargs["shuffle_method"] = new_arg_value
+        return func(*args, **kwargs)
+
+    return wrapper
 
 
 @_dask_cudf_nvtx_annotate
@@ -229,6 +256,7 @@ def quantile_divisions(df, by, npartitions):
     return divisions
 
 
+@_deprecate_shuffle_kwarg
 @_dask_cudf_nvtx_annotate
 def sort_values(
     df,
@@ -239,6 +267,7 @@ def sort_values(
     ignore_index=False,
     ascending=True,
     na_position="last",
+    shuffle=None,  # Deprecated
     shuffle_method=None,
     sort_function=None,
     sort_function_kwargs=None,

--- a/python/dask_cudf/dask_cudf/sorting.py
+++ b/python/dask_cudf/dask_cudf/sorting.py
@@ -267,7 +267,6 @@ def sort_values(
     ignore_index=False,
     ascending=True,
     na_position="last",
-    shuffle=None,  # Deprecated
     shuffle_method=None,
     sort_function=None,
     sort_function_kwargs=None,

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -834,26 +834,38 @@ def test_groupby_shuffle():
 
     # Sorted aggregation, single-partition output
     # (sort=True, split_out=1)
-    got = gddf.groupby("a", sort=True).agg(spec, shuffle=True, split_out=1)
+    got = gddf.groupby("a", sort=True).agg(
+        spec, shuffle_method=True, split_out=1
+    )
     dd.assert_eq(expect, got)
 
     # Sorted aggregation, multi-partition output
     # (sort=True, split_out=2)
-    got = gddf.groupby("a", sort=True).agg(spec, shuffle=True, split_out=2)
+    got = gddf.groupby("a", sort=True).agg(
+        spec, shuffle_method=True, split_out=2
+    )
     dd.assert_eq(expect, got)
 
     # Un-sorted aggregation, single-partition output
     # (sort=False, split_out=1)
-    got = gddf.groupby("a", sort=False).agg(spec, shuffle=True, split_out=1)
+    got = gddf.groupby("a", sort=False).agg(
+        spec, shuffle_method=True, split_out=1
+    )
     dd.assert_eq(expect.sort_index(), got.compute().sort_index())
 
     # Un-sorted aggregation, multi-partition output
     # (sort=False, split_out=2)
-    # NOTE: `shuffle=True` should be default
+    # NOTE: `shuffle_method=True` should be default
     got = gddf.groupby("a", sort=False).agg(spec, split_out=2)
     dd.assert_eq(expect, got.compute().sort_index())
 
     # Sorted aggregation fails with split_out>1 when shuffle is False
-    # (sort=True, split_out=2, shuffle=False)
+    # (sort=True, split_out=2, shuffle_method=False)
     with pytest.raises(ValueError):
-        gddf.groupby("a", sort=True).agg(spec, shuffle=False, split_out=2)
+        gddf.groupby("a", sort=True).agg(
+            spec, shuffle_method=False, split_out=2
+        )
+
+    # Check shuffle kwarg deprecation
+    with pytest.warns(match="'shuffle' keyword is deprecated"):
+        gddf.groupby("a", sort=True).agg(spec, shuffle=False)


### PR DESCRIPTION
## Description
It seems that https://github.com/rapidsai/cudf/pull/14708 was a bit too aggressive in updating the `shuffle` kwarg to `shuffle_method`, and [gpu-CI is currently failing](https://github.com/dask/dask/issues/10809) in dask/dask.

This PR aligns dask-cudf with `dask.dataframe` by warning the user when the `shuffle` argument is used (rather than raising an error). I definitely don't think it makes sense for RAPIDS to be **more** strict than dask/dask about this argument.

This also fixes a bug in `groupby.aggregate()` (where we were still using `shuffle=`)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
