### PR TITLE
Fix ptx file discovery in editable installs

### DIFF
--- a/python/cudf/cudf/core/udf/utils.py
+++ b/python/cudf/cudf/core/udf/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 import os
 from typing import Any, Callable, Dict
@@ -17,10 +17,7 @@ from numba.types import CPointer, Poison, Record, Tuple, boolean, int64, void
 
 import rmm
 
-from cudf._lib.strings_udf import (
-    column_from_udf_string_array,
-    column_to_string_view_array,
-)
+from cudf._lib import strings_udf
 from cudf.api.types import is_scalar
 from cudf.core.column.column import as_column
 from cudf.core.dtypes import dtype
@@ -63,7 +60,10 @@ MASK_BITSIZE = np.dtype("int32").itemsize * 8
 precompiled: cachetools.LRUCache = cachetools.LRUCache(maxsize=32)
 launch_arg_getters: Dict[Any, Any] = {}
 
-_PTX_FILE = _get_ptx_file(os.path.dirname(__file__), "shim_")
+_PTX_FILE = _get_ptx_file(
+    os.path.join(os.path.dirname(strings_udf.__file__), "..", "core", "udf"),
+    "shim_",
+)
 
 
 @_cudf_nvtx_annotate
@@ -319,7 +319,7 @@ def _return_arr_from_dtype(dtype, size):
 
 def _post_process_output_col(col, retty):
     if retty == _cudf_str_dtype:
-        return column_from_udf_string_array(col)
+        return strings_udf.column_from_udf_string_array(col)
     return as_column(col, retty)
 
 
@@ -361,7 +361,7 @@ def set_malloc_heap_size(size=None):
 
 def column_to_string_view_array_init_heap(col):
     # lazily allocate heap only when a string needs to be returned
-    return column_to_string_view_array(col)
+    return strings_udf.column_to_string_view_array(col)
 
 
 class UDFError(RuntimeError):

--- a/python/cudf/udf_cpp/CMakeLists.txt
+++ b/python/cudf/udf_cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -104,10 +104,10 @@ foreach(arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
   target_compile_options(${tgt} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:${SHIM_CUDA_FLAGS}>")
   target_link_libraries(${tgt} PUBLIC cudf::cudf)
 
-  copy_ptx_to_location(${tgt} "${CMAKE_CURRENT_BINARY_DIR}/../udf" ${tgt}.ptx)
+  copy_ptx_to_location(${tgt} "${CMAKE_CURRENT_BINARY_DIR}/../cudf/core/udf" ${tgt}.ptx)
   install(
     FILES $<TARGET_OBJECTS:${tgt}>
-    DESTINATION ./cudf/core/udf/
+    DESTINATION cudf/core/udf/
     RENAME ${tgt}.ptx
   )
 endforeach()

--- a/python/cudf/udf_cpp/CMakeLists.txt
+++ b/python/cudf/udf_cpp/CMakeLists.txt
@@ -55,30 +55,6 @@ target_compile_options(
 target_link_libraries(cudf_strings_udf PUBLIC cudf::cudf)
 install(TARGETS cudf_strings_udf DESTINATION ./cudf/_lib/)
 
-# This function will copy the generated PTX file from its generator-specific location in the build
-# tree into a specified location in the build tree from which we can install it.
-function(copy_ptx_to_location target destination new_name)
-  set(cmake_generated_file
-      "${CMAKE_CURRENT_BINARY_DIR}/cmake/cp_${target}_$<LOWER_CASE:$<CONFIG>>_ptx.cmake"
-  )
-  file(
-    GENERATE
-    OUTPUT "${cmake_generated_file}"
-    CONTENT
-      "
-set(ptx_path \"$<TARGET_OBJECTS:${target}>\")
-file(MAKE_DIRECTORY \"${destination}\")
-file(COPY_FILE \${ptx_path} \"${destination}/${new_name}\")"
-  )
-
-  add_custom_target(
-    ${target}_cp_ptx ALL
-    COMMAND ${CMAKE_COMMAND} -P "${cmake_generated_file}"
-    DEPENDS $<TARGET_OBJECTS:${target}>
-    COMMENT "Copying PTX files to '${destination}'"
-  )
-endfunction()
-
 # Create the shim library for each architecture.
 set(SHIM_CUDA_FLAGS --expt-relaxed-constexpr -rdc=true)
 
@@ -104,7 +80,6 @@ foreach(arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
   target_compile_options(${tgt} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:${SHIM_CUDA_FLAGS}>")
   target_link_libraries(${tgt} PUBLIC cudf::cudf)
 
-  copy_ptx_to_location(${tgt} "${CMAKE_CURRENT_BINARY_DIR}/../cudf/core/udf" ${tgt}.ptx)
   install(
     FILES $<TARGET_OBJECTS:${tgt}>
     DESTINATION cudf/core/udf/


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The behavior of editable installs changed when we transitioned to scikit-build-core, and it affects where the ptx files created during the build can be discovered. Editable installs no longer place built files directly alongside source files. Instead, Python's import machinery is leveraged to add built files to the search path. Since ptx files are not Python files, the loader logic isn't relevant, but we now need to ensure that we always search for the ptx files alongside built artifacts (namely Cython compiled modules) rather than Python source files. I'm guessing that nobody has encountered this yet due to preexisting build artifacts in their source directories.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
