### PR TITLE
[Docs] Add link to conda installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,7 @@ cd $CUDF_HOME
 **Note:** Using a conda environment is the easiest way to satisfy the library's dependencies.
 Instructions for a minimal build environment without conda are included below.
 
+- [Install conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) if needed.
 - Create the conda development environment:
 
 ```bash


### PR DESCRIPTION
Add a link to the instructions for installing conda to the build instructions. I didn't have conda installed on my system, and it wasn't as straightforward as `aptitude install conda` to get it. 