### PR TITLE
Ignore numba CEC warning for now

### DIFF
--- a/python/cudf/cudf/tests/pytest.ini
+++ b/python/cudf/cudf/tests/pytest.ini
@@ -8,3 +8,4 @@ filterwarnings =
     error
     ignore:::.*xdist.*
     ignore:::.*pytest.*
+    ignore:CUDA Toolkit is newer than CUDA driver:UserWarning


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
We currently warning CEC situations that are unsupported by numba until pynvjitlink becomes available. In the interim, this changes ensures that developers can still run the rest of the test suite locally. Without this change all local runs in the unsupported situations will immediately fail on importing cudf.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
