### PR TITLE
Remove unparseable attributes from all nodes

### DIFF
--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -113,6 +113,9 @@ def clean_definitions(root):
         if node.text is not None:
             for string in strings_to_remove:
                 node.text = node.text.replace(string, "")
+        for attr, val in node.items():
+            if attr == "kind" and "friend" in val:
+                node.set(attr, "")
 
 
 def clean_all_xml_files(path):

--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -110,13 +110,10 @@ def clean_definitions(root):
     # For friend, see https://github.com/breathe-doc/breathe/issues/916
     strings_to_remove = ("__forceinline__", "CUDF_HOST_DEVICE", "decltype(auto)", "friend")
     for node in root.iter():
-        if node.text is not None:
-            for string in strings_to_remove:
-                node.text = node.text.replace(string, "")
-        for attr, val in node.items():
-            if attr == "kind" and "friend" in val:
-                node.set(attr, "")
-
+        for attr in ("text", "tail"):
+            if (val := getattr(node, attr)) is not None:
+                for string in strings_to_remove:
+                    setattr(node, attr, val.replace(string, ""))
 
 def clean_all_xml_files(path):
     for fn in glob.glob(os.path.join(path, "*.xml")):

--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -110,11 +110,10 @@ def clean_definitions(root):
     # For friend, see https://github.com/breathe-doc/breathe/issues/916
     strings_to_remove = ("__forceinline__", "CUDF_HOST_DEVICE", "decltype(auto)", "friend")
     for node in root.iter():
-        if node.text is not None:
-            for string in strings_to_remove:
+        for string in strings_to_remove:
+            if node.text is not None:
                 node.text = node.text.replace(string, "")
-        if node.tail is not None:
-            for string in strings_to_remove:
+            if node.tail is not None:
                 node.tail = node.tail.replace(string, "")
 
 def clean_all_xml_files(path):

--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -110,10 +110,12 @@ def clean_definitions(root):
     # For friend, see https://github.com/breathe-doc/breathe/issues/916
     strings_to_remove = ("__forceinline__", "CUDF_HOST_DEVICE", "decltype(auto)", "friend")
     for node in root.iter():
-        for attr in ("text", "tail"):
-            if (val := getattr(node, attr)) is not None:
-                for string in strings_to_remove:
-                    setattr(node, attr, val.replace(string, ""))
+        if node.text is not None:
+            for string in strings_to_remove:
+                node.text = node.text.replace(string, "")
+        if node.tail is not None:
+            for string in strings_to_remove:
+                node.tail = node.tail.replace(string, "")
 
 def clean_all_xml_files(path):
     for fn in glob.glob(os.path.join(path, "*.xml")):

--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -109,11 +109,10 @@ def clean_definitions(root):
     # All of these in type declarations cause Breathe to choke.
     # For friend, see https://github.com/breathe-doc/breathe/issues/916
     strings_to_remove = ("__forceinline__", "CUDF_HOST_DEVICE", "decltype(auto)", "friend")
-    for field in (".//type", ".//definition"):
-        for type_ in root.findall(field):
-            if type_.text is not None:
-                for string in strings_to_remove:
-                    type_.text = type_.text.replace(string, "")
+    for node in root.iter():
+        if node.text is not None:
+            for string in strings_to_remove:
+                node.text = node.text.replace(string, "")
 
 
 def clean_all_xml_files(path):


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
In my initial pass through enabling Breathe I tried to leave a minimal footprint of external modification to the generated files. In this particular case it looks like the problematic attributes can appear in more places than I originally observed. I never observed this behavior in that PR, but I don't know if these now appear due to something that merged after #13846 or something else changing in the environment (e.g. a Sphinx or doxygen behavior etc). Nonetheless, blanket wiping these is the simpler and safer option. The docs build successfully locally with this change.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
