### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -75,7 +75,7 @@ dependencies:
 - pydata-sphinx-theme!=0.14.2
 - pytest
 - pytest-benchmark
-- pytest-cases<3.8.2
+- pytest-cases>=3.8.2
 - pytest-cov
 - pytest-xdist
 - python-confluent-kafka>=1.9.0,<1.10.0a0

--- a/conda/environments/all_cuda-120_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-120_arch-x86_64.yaml
@@ -72,7 +72,7 @@ dependencies:
 - pydata-sphinx-theme!=0.14.2
 - pytest
 - pytest-benchmark
-- pytest-cases<3.8.2
+- pytest-cases>=3.8.2
 - pytest-cov
 - pytest-xdist
 - python-confluent-kafka>=1.9.0,<1.10.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -620,7 +620,7 @@ dependencies:
           - fastavro>=0.22.9
           - hypothesis
           - pytest-benchmark
-          - pytest-cases<3.8.2
+          - pytest-cases>=3.8.2
           - python-snappy>=0.6.0
           - scipy
       - output_types: conda

--- a/python/cudf/benchmarks/API/bench_dataframe.py
+++ b/python/cudf/benchmarks/API/bench_dataframe.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 """Benchmarks of DataFrame methods."""
 
@@ -178,6 +178,8 @@ def bench_nsmallest(benchmark, dataframe, num_cols_to_sort, n):
     benchmark(dataframe.nsmallest, n, by)
 
 
-@pytest_cases.parametrize_with_cases("dataframe, cond, other", prefix="where")
+@pytest_cases.parametrize_with_cases(
+    "dataframe, cond, other", prefix="where", cases="cases_dataframe"
+)
 def bench_where(benchmark, dataframe, cond, other):
     benchmark(dataframe.where, cond, other)

--- a/python/cudf/benchmarks/API/bench_functions.py
+++ b/python/cudf/benchmarks/API/bench_functions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 """Benchmarks of free functions that accept cudf objects."""
 
@@ -9,7 +9,9 @@ from config import NUM_ROWS, cudf, cupy
 from utils import benchmark_with_object
 
 
-@pytest_cases.parametrize_with_cases("objs", prefix="concat")
+@pytest_cases.parametrize_with_cases(
+    "objs", prefix="concat", cases="cases_functions"
+)
 @pytest.mark.parametrize(
     "axis",
     [

--- a/python/cudf/benchmarks/API/cases_dataframe.py
+++ b/python/cudf/benchmarks/API/cases_dataframe.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 from utils import benchmark_with_object
 

--- a/python/cudf/benchmarks/API/cases_functions.py
+++ b/python/cudf/benchmarks/API/cases_functions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 """Test cases for benchmarks in bench_functions.py."""
 

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -59,7 +59,7 @@ test = [
     "msgpack",
     "pytest",
     "pytest-benchmark",
-    "pytest-cases<3.8.2",
+    "pytest-cases>=3.8.2",
     "pytest-cov",
     "pytest-xdist",
     "python-snappy>=0.6.0",


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.