### PR TITLE
Disable parallel build

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -40,8 +40,8 @@ popd
 
 rapids-logger "Build Python docs"
 pushd docs/cudf
-make dirhtml O="-j 4"
-make text O="-j 4"
+make dirhtml
+make text
 mkdir -p "${RAPIDS_DOCS_DIR}/cudf/"{html,txt}
 mv build/dirhtml/* "${RAPIDS_DOCS_DIR}/cudf/html"
 mv build/text/* "${RAPIDS_DOCS_DIR}/cudf/txt"


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
A new release of `pydata_sphinx_theme` [from last night](https://github.com/pydata/pydata-sphinx-theme/releases/tag/v0.15.2) includes https://github.com/pydata/pydata-sphinx-theme/pull/1642, which marks the theme as unsafe for parallel writing.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
