### PR TITLE
Preserve empty index types in parquet reader

### DIFF
--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -110,6 +110,7 @@ cdef class BufferArrayFromVector:
 def _parse_metadata(meta):
     file_is_range_index = False
     file_index_cols = None
+    file_column_dtype = None
 
     if 'index_columns' in meta and len(meta['index_columns']) > 0:
         file_index_cols = meta['index_columns']
@@ -117,7 +118,9 @@ def _parse_metadata(meta):
         if isinstance(file_index_cols[0], dict) and \
                 file_index_cols[0]['kind'] == 'range':
             file_is_range_index = True
-    return file_is_range_index, file_index_cols
+    if 'column_indexes' in meta and len(meta['column_indexes']) == 1:
+        file_column_dtype = meta['column_indexes'][0]["numpy_type"]
+    return file_is_range_index, file_index_cols, file_column_dtype
 
 
 cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
@@ -185,6 +188,7 @@ cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
     cdef vector[unordered_map[string, string]] per_file_user_data = \
         c_result.metadata.per_file_user_data
 
+    column_index_type = None
     index_col_names = None
     is_range_index = True
     for single_file in per_file_user_data:
@@ -192,7 +196,7 @@ cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
         meta = None
         if json_str != "":
             meta = json.loads(json_str)
-            file_is_range_index, index_col = _parse_metadata(meta)
+            file_is_range_index, index_col, column_index_type = _parse_metadata(meta)
             is_range_index &= file_is_range_index
 
             if not file_is_range_index and index_col is not None \
@@ -302,6 +306,9 @@ cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
             if use_pandas_metadata:
                 df.index.names = index_col
 
+    # Set column dtype for empty types.
+    if len(df._data.names) == 0 and column_index_type is not None:
+        df._data.label_dtype = cudf.dtype(column_index_type)
     return df
 
 


### PR DESCRIPTION
## Description
This PR preserves types of empty column index objects whose metadata is already present in the parquet file.

This PR:
```
= 107 failed, 101869 passed, 2091 skipped, 976 xfailed, 312 xpassed in 1265.57s (0:21:05) =
```

On `pandas_2.0_feature_branch`:
```
= 111 failed, 101865 passed, 2091 skipped, 976 xfailed, 312 xpassed in 1292.26s (0:21:32) =
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
