### PR TITLE
Remove -DNVBench_ENABLE_CUPTI=OFF.

### DIFF
--- a/conda/recipes/libcudf/build.sh
+++ b/conda/recipes/libcudf/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Copyright (c) 2018-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 
 export cudf_ROOT="$(realpath ./cpp/build)"
 
 ./build.sh -n -v \
     libcudf libcudf_kafka benchmarks tests \
     --build_metrics --incl_cache_stats \
-    --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib -DCUDF_ENABLE_ARROW_S3=ON -DNVBench_ENABLE_CUPTI=OFF\"
+    --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib -DCUDF_ENABLE_ARROW_S3=ON\"


### PR DESCRIPTION
## Description
The `-DNVBench_ENABLE_CUPTI=OFF` flag is no longer needed because of https://github.com/rapidsai/rapids-cmake/pull/504. NVBench CUPTI support is now disabled by default.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
