### PR TITLE
Remove get_mem_info functions from custom memory resources

### DIFF
--- a/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
+++ b/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,16 +71,6 @@ class stream_checking_resource_adaptor final : public rmm::mr::device_memory_res
    */
   bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
 
-  /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return Whether or not the upstream resource supports get_mem_info
-   */
-  bool supports_get_mem_info() const noexcept override
-  {
-    return upstream_->supports_get_mem_info();
-  }
-
  private:
   /**
    * @brief Allocates memory of size at least `bytes` using the upstream
@@ -129,21 +119,6 @@ class stream_checking_resource_adaptor final : public rmm::mr::device_memory_res
     auto cast = dynamic_cast<stream_checking_resource_adaptor<Upstream> const*>(&other);
     return cast != nullptr ? upstream_->is_equal(*cast->get_upstream())
                            : upstream_->is_equal(other);
-  }
-
-  /**
-   * @brief Get free and available memory from upstream resource.
-   *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
-   * @throws `cudf::logic_error` if attempted on a default stream
-   *
-   * @param stream Stream on which to get the mem info.
-   * @return std::pair with available and free memory for resource
-   */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(rmm::cuda_stream_view stream) const override
-  {
-    verify_stream(stream);
-    return upstream_->get_mem_info(stream);
   }
 
   /**

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,8 +96,6 @@ public:
     return scoped_max_total_allocated;
   }
 
-  bool supports_get_mem_info() const noexcept override { return resource->supports_get_mem_info(); }
-
   bool supports_streams() const noexcept override { return resource->supports_streams(); }
 
 private:
@@ -143,10 +141,6 @@ private:
       total_allocated -= size;
       scoped_allocated -= size;
     }
-  }
-
-  std::pair<size_t, size_t> do_get_mem_info(rmm::cuda_stream_view stream) const override {
-    return resource->get_mem_info(stream);
   }
 };
 
@@ -213,8 +207,6 @@ public:
 
   device_memory_resource *get_wrapped_resource() { return resource; }
 
-  bool supports_get_mem_info() const noexcept override { return resource->supports_get_mem_info(); }
-
   bool supports_streams() const noexcept override { return resource->supports_streams(); }
 
 private:
@@ -275,10 +267,6 @@ private:
         }
       }
     }
-  }
-
-  std::pair<size_t, size_t> do_get_mem_info(rmm::cuda_stream_view stream) const override {
-    return resource->get_mem_info(stream);
   }
 
 protected:


### PR DESCRIPTION
## Description
Part of rapidsai/rmm#1388. This removes now-optional and soon-to-be deprecated functions from cuDF's custom device_memory_resource implementations:
 * `supports_get_mem_info()`
 * `do_get_mem_info()`

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
