### PR TITLE
Remove deprecated strings functions

### DIFF
--- a/cpp/include/cudf/column/column_factories.hpp
+++ b/cpp/include/cudf/column/column_factories.hpp
@@ -411,63 +411,6 @@ std::unique_ptr<column> make_strings_column(
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 
 /**
- * @brief Construct a STRING type column given a device span of chars encoded as UTF-8, a device
- * span of byte offsets identifying individual strings within the char vector, and an optional
- * null bitmask.
- *
- * @deprecated Since 24.02
- *
- * `offsets.front()` must always be zero.
- *
- * The total number of char bytes must not exceed the maximum size of size_type. Use the
- * strings_column_view class to perform strings operations on this type of column.
- *
- * This function makes a deep copy of the strings, offsets, null_mask to create a new column.
- *
- * @param strings The device span of chars in device memory. This char vector is expected to be
- *  UTF-8 encoded characters.
- * @param offsets The device span of byte offsets in device memory. The number of elements is
- *  one more than the total number of strings so the `offsets.back()` is the total number of bytes
- *  in the strings array. `offsets.front()` must always be 0 to point to the beginning of `strings`.
- * @param null_mask Device span containing the null element indicator bitmask. Arrow format for
- *  nulls is used for interpreting this bitmask.
- * @param null_count The number of null string entries
- * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used for allocation of the column's `null_mask` and children
- * columns' device memory
- * @return Constructed strings column
- */
-[[deprecated]] std::unique_ptr<column> make_strings_column(
-  cudf::device_span<char const> strings,
-  cudf::device_span<size_type const> offsets,
-  cudf::device_span<bitmask_type const> null_mask,
-  size_type null_count,
-  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
-  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
-
-/**
- * @brief Construct a STRING type column given offsets column, chars columns, and null mask and null
- * count.
- *
- * The columns and mask are moved into the resulting strings column.
- *
- * @param num_strings The number of strings the column represents.
- * @param offsets_column The column of offset values for this column. The number of elements is
- *  one more than the total number of strings so the `offset[last] - offset[0]` is the total number
- *  of bytes in the strings vector.
- * @param chars_column The column of char bytes for all the strings for this column. Individual
- *  strings are identified by the offsets and the nullmask.
- * @param null_count The number of null string entries.
- * @param null_mask The bits specifying the null strings in device memory. Arrow format for
- *  nulls is used for interpreting this bitmask.
- * @return Constructed strings column
- */
-[[deprecated]] std::unique_ptr<column> make_strings_column(size_type num_strings,
-                                                           std::unique_ptr<column> offsets_column,
-                                                           std::unique_ptr<column> chars_column,
-                                                           size_type null_count,
-                                                           rmm::device_buffer&& null_mask);
-/**
  * @brief Construct a STRING type column given offsets column, chars columns, and null mask and null
  * count.
  *
@@ -489,29 +432,6 @@ std::unique_ptr<column> make_strings_column(size_type num_strings,
                                             rmm::device_buffer&& chars_buffer,
                                             size_type null_count,
                                             rmm::device_buffer&& null_mask);
-
-/**
- * @brief Construct a STRING type column given offsets, columns, and optional null count and null
- * mask.
- *
- * @deprecated Since 24.02
- *
- * @param[in] num_strings The number of strings the column represents.
- * @param[in] offsets The offset values for this column. The number of elements is one more than the
- * total number of strings so the `offset[last] - offset[0]` is the total number of bytes in the
- * strings vector.
- * @param[in] chars The char bytes for all the strings for this column. Individual strings are
- * identified by the offsets and the nullmask.
- * @param[in] null_mask The bits specifying the null strings in device memory. Arrow format for
- *  nulls is used for interpreting this bitmask.
- * @param[in] null_count The number of null string entries.
- * @return Constructed strings column
- */
-[[deprecated]] std::unique_ptr<column> make_strings_column(size_type num_strings,
-                                                           rmm::device_uvector<size_type>&& offsets,
-                                                           rmm::device_uvector<char>&& chars,
-                                                           rmm::device_buffer&& null_mask,
-                                                           size_type null_count);
 
 /**
  * @brief Construct a LIST type column given offsets column, child column, null mask and null

--- a/cpp/include/cudf/strings/strings_column_view.hpp
+++ b/cpp/include/cudf/strings/strings_column_view.hpp
@@ -104,16 +104,6 @@ class strings_column_view : private column_view {
   [[nodiscard]] offset_iterator offsets_end() const;
 
   /**
-   * @brief Returns the internal column of chars
-   *
-   * @throw cudf::logic_error if this is an empty column
-   * @param stream CUDA stream used for device memory operations and kernel launches
-   * @return The chars column
-   */
-  [[deprecated]] [[nodiscard]] column_view chars(
-    rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
-
-  /**
    * @brief Returns the number of bytes in the chars child column.
    *
    * This accounts for empty columns but does not reflect a sliced parent column

--- a/cpp/src/strings/strings_column_view.cpp
+++ b/cpp/src/strings/strings_column_view.cpp
@@ -45,13 +45,6 @@ strings_column_view::offset_iterator strings_column_view::offsets_end() const
   return offsets_begin() + size() + 1;
 }
 
-column_view strings_column_view::chars(rmm::cuda_stream_view stream) const
-{
-  CUDF_EXPECTS(num_children() > 0, "strings column has no children");
-  return column_view(
-    data_type{type_id::INT8}, chars_size(stream), chars_begin(stream), nullptr, 0, 0);
-}
-
 size_type strings_column_view::chars_size(rmm::cuda_stream_view stream) const noexcept
 {
   if (size() == 0) return 0;


### PR DESCRIPTION
## Description
Removes the functions deprecated in 24.02 in #14202.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
