### PR TITLE
Catch warnings in reduction pytest

### DIFF
--- a/python/cudf/cudf/tests/test_reductions.py
+++ b/python/cudf/cudf/tests/test_reductions.py
@@ -360,10 +360,9 @@ def test_reductions_axis_none_warning(op):
         FutureWarning,
     ):
         actual = getattr(df, op)(axis=None)
-    # with expect_warning_if(
-    #     op in {"kurt", "kurtosis", "skew", "min", "max", "mean", "median"},
-    #     FutureWarning,
-    # ):
-    
-    expected = getattr(pdf, op)(axis=None)
+    with expect_warning_if(
+        op in {"sum", "product", "std", "var"},
+        FutureWarning,
+    ):
+        expected = getattr(pdf, op)(axis=None)
     assert_eq(expected, actual, check_dtype=False)


### PR DESCRIPTION
## Description
This PR validates the warnings generated by certain reduction ops.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
