### PR TITLE
Preserve columns `dtype` in dataframe constructor

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -797,6 +797,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             if is_list_like(data):
                 if len(data) > 0 and is_scalar(data[0]):
                     if columns is not None:
+                        label_dtype = getattr(columns, "dtype", None)
                         data = dict(zip(columns, [data]))
                         rangeindex = isinstance(
                             columns, (range, pd.RangeIndex, cudf.RangeIndex)
@@ -804,6 +805,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                     else:
                         data = dict(enumerate([data]))
                         rangeindex = True
+                        label_dtype = None
                     new_df = DataFrame(data=data, index=index)
 
                     self._data = new_df._data
@@ -814,6 +816,11 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                         else self._data._level_names
                     )
                     self._data.rangeindex = rangeindex
+                    self._data.label_dtype = (
+                        cudf.dtype(label_dtype)
+                        if label_dtype is not None
+                        else None
+                    )
                 elif len(data) > 0 and isinstance(data[0], Series):
                     self._init_from_series_list(
                         data=data, columns=columns, index=index


### PR DESCRIPTION
## Description
This PR preserves `columns` dtype in `DataFrame` constructor.

This PR:
```
= 52 failed, 101872 passed, 2091 skipped, 977 xfailed, 312 xpassed in 1188.72s (0:19:48) =
```

On `pandas_2.0_feature_branch`:
```
= 61 failed, 101866 passed, 2091 skipped, 976 xfailed, 312 xpassed in 1446.19s (0:24:06) =
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
