### PR TITLE
Fix miscellaneous failures in pytests

### DIFF
--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -606,10 +606,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
             name_from_data = data.name
             column = as_column(data, nan_as_null=nan_as_null, dtype=dtype)
             if isinstance(data, (pd.Series, Series)):
-                if isinstance(data.index, pd.MultiIndex):
-                    index = cudf.from_pandas(data.index)
-                else:
-                    index = as_index(data.index)
+                index_from_data = as_index(data.index)
         elif isinstance(data, ColumnAccessor):
             raise TypeError(
                 "Use cudf.Series._from_data for constructing a Series from "

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -2800,7 +2800,9 @@ def test_rangeindex_join_user_option(default_integer_bitwidth):
     actual = idx1.join(idx2, how="inner", sort=True)
     expected = idx1.to_pandas().join(idx2.to_pandas(), how="inner", sort=True)
     assert actual.dtype == cudf.dtype(f"int{default_integer_bitwidth}")
-    assert_eq(expected, actual)
+    # exact=False to ignore dtype comparison,
+    # because `default_integer_bitwidth` is cudf only option
+    assert_eq(expected, actual, exact=False)
 
 
 def test_rangeindex_where_user_option(default_integer_bitwidth):

--- a/python/cudf/cudf/tests/test_joining.py
+++ b/python/cudf/cudf/tests/test_joining.py
@@ -2246,11 +2246,18 @@ def test_index_join_return_indexers_notimplemented():
 
 
 @pytest.mark.parametrize("how", ["inner", "outer"])
-def test_index_join_names(how):
+def test_index_join_names(request, how):
     idx1 = cudf.Index([10, 1, 2, 4, 2, 1], name="a")
     idx2 = cudf.Index([-10, 2, 3, 1, 2], name="b")
+    request.applymarker(
+        pytest.mark.xfail(
+            reason="https://github.com/pandas-dev/pandas/issues/57065",
+        )
+    )
+    pidx1 = idx1.to_pandas()
+    pidx2 = idx2.to_pandas()
 
-    expected = idx1.to_pandas().join(idx2.to_pandas(), how=how)
+    expected = pidx1.join(pidx2, how=how)
     actual = idx1.join(idx2, how=how)
     assert_join_results_equal(actual, expected, how=how)
 

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -2159,7 +2159,8 @@ def test_series_init_scalar_with_index(data, index):
     assert_eq(
         pandas_series,
         cudf_series,
-        check_index_type=False if data is None and index is None else True,
+        check_index_type=not (data is None and index is None),
+        check_dtype=data is not None,
     )
 
 

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -2159,7 +2159,7 @@ def test_series_init_scalar_with_index(data, index):
     assert_eq(
         pandas_series,
         cudf_series,
-        check_index_type=not (data is None and index is None),
+        check_index_type=data is not None or index is not None,
         check_dtype=data is not None,
     )
 

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 import warnings
 from collections.abc import Iterator
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 from pandas.api.types import is_scalar
-from pandas.core.tools.datetimes import is_datetime64tz_dtype
 
 import dask.dataframe as dd
 from dask import config
@@ -42,7 +41,7 @@ from dask.sizeof import sizeof as sizeof_dispatch
 from dask.utils import Dispatch, is_arraylike
 
 import cudf
-from cudf.api.types import is_string_dtype
+from cudf.api.types import _is_datetime64tz_dtype, is_string_dtype
 from cudf.utils.nvtx_annotation import _dask_cudf_nvtx_annotate
 
 from .core import DataFrame, Index, Series
@@ -127,7 +126,7 @@ def _get_non_empty_data(s):
         data = cudf.core.column.as_column(data, dtype=s.dtype)
     elif is_string_dtype(s.dtype):
         data = pa.array(["cat", "dog"])
-    elif is_datetime64tz_dtype(s.dtype):
+    elif _is_datetime64tz_dtype(s.dtype):
         from cudf.utils.dtypes import get_time_unit
 
         data = cudf.date_range("2001-01-01", periods=2, freq=get_time_unit(s))


### PR DESCRIPTION
## Description
This PR fixes miscellaneous corner cases in pytests

This PR:
```
= 27 failed, 101895 passed, 2091 skipped, 979 xfailed, 312 xpassed in 1360.28s (0:22:40) =
```

On `pandas_2.0_feature_branch`:

```
= 52 failed, 101872 passed, 2091 skipped, 977 xfailed, 312 xpassed in 1188.72s (0:19:48) =
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
