### PR TITLE
Fix some pytests

### DIFF
--- a/python/cudf/cudf/tests/test_array_function.py
+++ b/python/cudf/cudf/tests/test_array_function.py
@@ -65,11 +65,10 @@ def test_array_func_cudf_series(np_ar, func):
     [
         lambda x: np.mean(x, axis=0),
         lambda x: np.sum(x, axis=0),
-        lambda x: np.var(x, ddof=1),
+        lambda x: np.var(x, ddof=1, axis=0),
         lambda x: np.dot(x, x.transpose()),
         lambda x: np.all(x),
         lambda x: np.any(x),
-        lambda x: np.product(x),
         lambda x: np.product(x, axis=0),
         lambda x: np.product(x, axis=1),
     ],

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -7,14 +7,16 @@ from functools import reduce
 
 import cupy as cp
 import numpy as np
+import pandas as pd
 import pytest
+from packaging import version
 
 import cudf
 from cudf.core._compat import PANDAS_GE_150, PANDAS_GE_200, PANDAS_GE_210
 from cudf.testing._utils import (
     assert_eq,
-    set_random_null_mask_inplace,
     expect_warning_if,
+    set_random_null_mask_inplace,
 )
 
 _UFUNCS = [
@@ -87,6 +89,13 @@ def test_ufunc_index(request, ufunc):
         pytest.mark.xfail(
             condition=not hasattr(cp, fname),
             reason=f"cupy has no support for '{fname}'",
+        )
+    )
+    request.applymarker(
+        pytest.mark.xfail(
+            condition=fname == "matmul"
+            and version.parse(pd.__version__) < version.parse("3.0"),
+            reason="Fixed by https://github.com/pandas-dev/pandas/pull/57079",
         )
     )
 

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -21,7 +21,7 @@ from packaging import version
 from pyarrow import fs as pa_fs, parquet as pq
 
 import cudf
-from cudf.core._compat import PANDAS_LT_153, PANDAS_GE_200
+from cudf.core._compat import PANDAS_GE_200, PANDAS_LT_153
 from cudf.io.parquet import (
     ParquetDatasetWriter,
     ParquetWriter,
@@ -2682,30 +2682,32 @@ def test_parquet_writer_decimal(decimal_type, data):
     assert_eq(gdf["dec_val"].to_pandas(), got["dec_val"])
 
 
-def test_parquet_writer_column_validation():
+def test_parquet_writer_column_validation(tmpdir):
+    cudf_parquet = tmpdir / "cudf.parquet"
+    pandas_parquet = tmpdir / "pandas.parquet"
     df = cudf.DataFrame({1: [1, 2, 3], "a": ["a", "b", "c"]})
     pdf = df.to_pandas()
 
     with cudf.option_context("mode.pandas_compatible", True):
         with pytest.warns(UserWarning):
-            df.to_parquet("cudf.parquet")
+            df.to_parquet(cudf_parquet)
 
     if PANDAS_GE_200:
         with pytest.warns(UserWarning):
-            pdf.to_parquet("pandas.parquet")
+            pdf.to_parquet(pandas_parquet)
 
         assert_eq(
-            pd.read_parquet("cudf.parquet"),
-            cudf.read_parquet("pandas.parquet"),
+            pd.read_parquet(cudf_parquet),
+            cudf.read_parquet(pandas_parquet),
         )
         assert_eq(
-            cudf.read_parquet("cudf.parquet"),
-            pd.read_parquet("pandas.parquet"),
+            cudf.read_parquet(cudf_parquet),
+            pd.read_parquet(pandas_parquet),
         )
 
     with cudf.option_context("mode.pandas_compatible", False):
         with pytest.raises(ValueError):
-            df.to_parquet("cudf.parquet")
+            df.to_parquet(cudf_parquet)
 
 
 def test_parquet_writer_nulls_pandas_read(tmpdir, pdf):

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -2682,9 +2682,9 @@ def test_parquet_writer_decimal(decimal_type, data):
     assert_eq(gdf["dec_val"].to_pandas(), got["dec_val"])
 
 
-def test_parquet_writer_column_validation(tmpdir):
-    cudf_parquet = tmpdir / "cudf.parquet"
-    pandas_parquet = tmpdir / "pandas.parquet"
+def test_parquet_writer_column_validation():
+    cudf_parquet = BytesIO()
+    pandas_parquet = BytesIO()
     df = cudf.DataFrame({1: [1, 2, 3], "a": ["a", "b", "c"]})
     pdf = df.to_pandas()
 


### PR DESCRIPTION
## Description
* `np.product` call I think will be redundant with the existing params, `np.var` call adjusted to what was tested before
* `matmul` failure existed upstream in pandas
* Snuck in a clean up files leftover by a parquet test (found these leftover when running the test suite locally)

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
