### PR TITLE
Enable sanitizer check for a test case

### DIFF
--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -9058,9 +9058,6 @@ public class TableTest extends CudfTestBase {
     }
   }
 
-  // https://github.com/NVIDIA/spark-rapids-jni/issues/1338
-  // Need to remove this tag if #1338 is fixed.
-  @Tag("noSanitizer")
   @Test
   void testORCReadAndWriteForDecimal128() throws IOException {
     File tempFile = File.createTempFile("test", ".orc");


### PR DESCRIPTION
## Description
Enable sanitizer check for test case TableTest#testORCReadAndWriteForDecimal128
closes https://github.com/NVIDIA/spark-rapids-jni/issues/1338

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

The dependency cuDF issue was closed, so enable enable sanitizer check for this test case.