### PR TITLE
Parquet Writer: Write `non-string` columns pandas-compatibility mode only

### DIFF
--- a/python/cudf/cudf/_lib/utils.pyx
+++ b/python/cudf/cudf/_lib/utils.pyx
@@ -85,7 +85,8 @@ cpdef generate_pandas_metadata(table, index):
 
     # Columns
     for name, col in table._data.items():
-        if not isinstance(name, str) and cudf.get_option("mode.pandas_compatible"):
+        if cudf.get_option("mode.pandas_compatible"):
+            # in pandas-compat mode, non-string column names are stringified.
             col_names.append(str(name))
         else:
             col_names.append(name)

--- a/python/cudf/cudf/_lib/utils.pyx
+++ b/python/cudf/cudf/_lib/utils.pyx
@@ -85,7 +85,11 @@ cpdef generate_pandas_metadata(table, index):
 
     # Columns
     for name, col in table._data.items():
-        col_names.append(name)
+        if not isinstance(name, str) and cudf.get_option("mode.pandas_compatible"):
+            col_names.append(str(name))
+        else:
+            col_names.append(name)
+
         if isinstance(col.dtype, cudf.CategoricalDtype):
             raise ValueError(
                 "'category' column dtypes are currently not "


### PR DESCRIPTION
## Description
This PR enables writing of non-string columns in parquet writer only in pandas-compatibility mode.

This PR:
```
= 8 failed, 102249 passed, 2090 skipped, 976 xfailed, 312 xpassed in 1363.59s (0:22:43) =
```
On `pandas_2.0_feature_branch`:
```
= 9 failed, 102247 passed, 2091 skipped, 976 xfailed, 312 xpassed in 1336.47s (0:22:16) =
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
