### PR TITLE
Remove strict=False from xfail marks

### DIFF
--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -2289,45 +2289,13 @@ def test_range_index_concat(objs):
     [
         (pd.RangeIndex(0, 10), pd.RangeIndex(3, 7)),
         (pd.RangeIndex(0, 10), pd.RangeIndex(10, 20)),
-        pytest.param(
-            pd.RangeIndex(0, 10, 2),
-            pd.RangeIndex(1, 5, 3),
-            marks=pytest.mark.xfail(
-                condition=PANDAS_GE_200,
-                reason="https://github.com/pandas-dev/pandas/issues/53490",
-                strict=False,
-            ),
-        ),
-        pytest.param(
-            pd.RangeIndex(1, 5, 3),
-            pd.RangeIndex(0, 10, 2),
-            marks=pytest.mark.xfail(
-                condition=PANDAS_GE_200,
-                reason="https://github.com/pandas-dev/pandas/issues/53490",
-                strict=False,
-            ),
-        ),
-        pytest.param(
-            pd.RangeIndex(1, 10, 3),
-            pd.RangeIndex(1, 5, 2),
-            marks=pytest.mark.xfail(
-                condition=PANDAS_GE_200,
-                reason="https://github.com/pandas-dev/pandas/issues/53490",
-                strict=False,
-            ),
-        ),
+        (pd.RangeIndex(0, 10, 2), pd.RangeIndex(1, 5, 3)),
+        (pd.RangeIndex(1, 5, 3), pd.RangeIndex(0, 10, 2)),
+        (pd.RangeIndex(1, 10, 3), pd.RangeIndex(1, 5, 2)),
         (pd.RangeIndex(1, 5, 2), pd.RangeIndex(1, 10, 3)),
         (pd.RangeIndex(1, 100, 3), pd.RangeIndex(1, 50, 3)),
         (pd.RangeIndex(1, 100, 3), pd.RangeIndex(1, 50, 6)),
-        pytest.param(
-            pd.RangeIndex(1, 100, 6),
-            pd.RangeIndex(1, 50, 3),
-            marks=pytest.mark.xfail(
-                condition=PANDAS_GE_200,
-                reason="https://github.com/pandas-dev/pandas/issues/53490",
-                strict=False,
-            ),
-        ),
+        (pd.RangeIndex(1, 100, 6), pd.RangeIndex(1, 50, 3)),
         (pd.RangeIndex(0, 10, name="a"), pd.RangeIndex(90, 100, name="b")),
         (pd.Index([0, 1, 2, 30], name="a"), pd.Index([90, 100])),
         (pd.Index([0, 1, 2, 30], name="a"), [90, 100]),

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -538,13 +538,7 @@ def test_timedelta_series_mod_with_scalar_zero(reverse):
         datetime.timedelta(seconds=768),
         datetime.timedelta(microseconds=7),
         np.timedelta64(4, "s"),
-        pytest.param(
-            np.timedelta64("nat", "s"),
-            marks=pytest.mark.xfail(
-                strict=False,
-                reason="https://github.com/pandas-dev/pandas/issues/52295",
-            ),
-        ),
+        np.timedelta64("nat", "s"),
         np.timedelta64(1, "s"),
         np.timedelta64(1, "ms"),
         np.timedelta64(1, "us"),


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This removes xpassing tests from the test output.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
