### PR TITLE
Replace _is_datetime64tz/interval_dtype with isinstance

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2261,9 +2261,14 @@ def as_column(
         np_type = None
         try:
             if dtype is not None:
-                dtype = cudf.dtype(dtype)
-                if isinstance(
-                    dtype, (cudf.CategoricalDtype, cudf.IntervalDtype)
+                if dtype in {"category", "interval"} or isinstance(
+                    dtype,
+                    (
+                        cudf.CategoricalDtype,
+                        cudf.IntervalDtype,
+                        pd.IntervalDtype,
+                        pd.CategoricalDtype,
+                    ),
                 ):
                     raise TypeError
                 if isinstance(dtype, pd.DatetimeTZDtype):
@@ -2414,7 +2419,9 @@ def as_column(
             elif np_type == np.str_:
                 sr = pd.Series(arbitrary, dtype="str")
                 data = as_column(sr, nan_as_null=nan_as_null)
-            elif isinstance(cudf.dtype(dtype), cudf.IntervalDtype):
+            elif dtype == "interval" or isinstance(
+                dtype, (pd.IntervalDtype, cudf.IntervalDtype)
+            ):
                 sr = pd.Series(arbitrary, dtype="interval")
                 data = as_column(sr, nan_as_null=nan_as_null, dtype=dtype)
             elif (

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -53,8 +53,6 @@ from cudf._lib.types import size_type_dtype
 from cudf._typing import ColumnLike, Dtype, ScalarLike
 from cudf.api.types import (
     _is_categorical_dtype,
-    _is_datetime64tz_dtype,
-    _is_interval_dtype,
     _is_non_decimal_numeric_dtype,
     _is_pandas_nullable_extension_dtype,
     infer_dtype,
@@ -2263,9 +2261,12 @@ def as_column(
         np_type = None
         try:
             if dtype is not None:
-                if _is_categorical_dtype(dtype) or _is_interval_dtype(dtype):
+                dtype = cudf.dtype(dtype)
+                if isinstance(
+                    dtype, (cudf.CategoricalDtype, cudf.IntervalDtype)
+                ):
                     raise TypeError
-                if _is_datetime64tz_dtype(dtype):
+                if isinstance(dtype, pd.DatetimeTZDtype):
                     raise NotImplementedError(
                         "Use `tz_localize()` to construct "
                         "timezone aware data."
@@ -2413,7 +2414,7 @@ def as_column(
             elif np_type == np.str_:
                 sr = pd.Series(arbitrary, dtype="str")
                 data = as_column(sr, nan_as_null=nan_as_null)
-            elif _is_interval_dtype(dtype):
+            elif isinstance(cudf.dtype(dtype), cudf.IntervalDtype):
                 sr = pd.Series(arbitrary, dtype="interval")
                 data = as_column(sr, nan_as_null=nan_as_null, dtype=dtype)
             elif (

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -22,12 +22,7 @@ from cudf._typing import (
     DtypeObj,
     ScalarLike,
 )
-from cudf.api.types import (
-    _is_datetime64tz_dtype,
-    is_datetime64_dtype,
-    is_scalar,
-    is_timedelta64_dtype,
-)
+from cudf.api.types import is_datetime64_dtype, is_scalar, is_timedelta64_dtype
 from cudf.core._compat import PANDAS_GE_200, PANDAS_GE_220
 from cudf.core.buffer import Buffer, cuda_array_interface_wrapper
 from cudf.core.column import ColumnBase, as_column, column, string
@@ -702,7 +697,7 @@ class DatetimeColumn(column.ColumnBase):
             return False
 
     def _with_type_metadata(self, dtype):
-        if _is_datetime64tz_dtype(dtype):
+        if isinstance(dtype, pd.DatetimeTZDtype):
             return DatetimeTZColumn(
                 data=self.base_data,
                 dtype=dtype,

--- a/python/cudf/cudf/core/column/interval.py
+++ b/python/cudf/cudf/core/column/interval.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pyarrow as pa
 
 import cudf
-from cudf.api.types import _is_interval_dtype
 from cudf.core.column import StructColumn
 from cudf.core.dtypes import CategoricalDtype, IntervalDtype
 
@@ -94,20 +93,13 @@ class IntervalColumn(StructColumn):
                 new_struct = self._get_decategorized_column()
                 return IntervalColumn.from_struct_column(new_struct)
             else:
-                # a user can directly input the string `interval` as the dtype
-                # when creating an interval series or interval dataframe
-                if _is_interval_dtype(dtype):
-                    dtype = IntervalDtype(
-                        self.dtype.subtype, self.dtype.closed
-                    )
-                children = self.children
                 return IntervalColumn(
                     size=self.size,
                     dtype=dtype,
                     mask=self.mask,
                     offset=self.offset,
                     null_count=self.null_count,
-                    children=children,
+                    children=self.children,
                 )
         else:
             raise ValueError("dtype must be IntervalDtype")

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -258,7 +258,8 @@ class CategoricalDtype(_BaseDtype):
         if categories is None:
             return categories
         if len(categories) == 0 and not isinstance(
-            categories.dtype, cudf.IntervalDtype
+            getattr(categories, "dtype", None),
+            (cudf.IntervalDtype, pd.IntervalDtype),
         ):
             dtype = "object"  # type: Any
         else:

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -261,7 +261,9 @@ class CategoricalDtype(_BaseDtype):
     def _init_categories(self, categories: Any):
         if categories is None:
             return categories
-        if len(categories) == 0 and not _is_interval_dtype(categories):
+        if len(categories) == 0 and not isinstance(
+            categories.dtype, cudf.IntervalDtype
+        ):
             dtype = "object"  # type: Any
         else:
             dtype = None

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -41,7 +41,7 @@ from dask.sizeof import sizeof as sizeof_dispatch
 from dask.utils import Dispatch, is_arraylike
 
 import cudf
-from cudf.api.types import _is_datetime64tz_dtype, is_string_dtype
+from cudf.api.types import is_string_dtype
 from cudf.utils.nvtx_annotation import _dask_cudf_nvtx_annotate
 
 from .core import DataFrame, Index, Series
@@ -126,7 +126,7 @@ def _get_non_empty_data(s):
         data = cudf.core.column.as_column(data, dtype=s.dtype)
     elif is_string_dtype(s.dtype):
         data = pa.array(["cat", "dog"])
-    elif _is_datetime64tz_dtype(s.dtype):
+    elif isinstance(s.dtype, pd.DatetimeTZDtype):
         from cudf.utils.dtypes import get_time_unit
 
         data = cudf.date_range("2001-01-01", periods=2, freq=get_time_unit(s))


### PR DESCRIPTION
## Description
This is more explicit than the methods which may allow array objects where we don't want to

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
