### PR TITLE
Make codecov only informational (always pass).

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,7 @@ coverage:
       default:
         target: auto
         threshold: 5%
+        informational: true  # The coverage will always pass
 
 github_checks:
     annotations: true


### PR DESCRIPTION
## Description
This PR makes the codecov status always pass ✔️ so that it doesn't distract from actual CI failures in the commit CI summary.

https://docs.codecov.com/docs/commit-status#informational

cc: @davidwendt @mroeschke 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
