### PR TITLE
Introduce `GetJsonObjectOptions` in `getJSONObject` Java API

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2996,6 +2996,23 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
     return new ColumnVector(getJSONObject(getNativeView(), path.getScalarHandle(), options.isAllowSingleQuotes(), options.isStripQuotesFromSingleStrings(), options.isMissingFieldsAsNulls()));
   }
 
+   /**
+   * Apply a JSONPath string to all rows in an input strings column.
+   *
+   * Applies a JSONPath string to an incoming strings column where each row in the column
+   * is a valid json string.  The output is returned by row as a strings column.
+   *
+   * For reference, https://tools.ietf.org/id/draft-goessner-dispatch-jsonpath-00.html
+   * Note: Only implements the operators: $ . [] *
+   *
+   * @param path The JSONPath string to be applied to each row
+   * @return new strings ColumnVector containing the retrieved json object strings
+   */
+  public final ColumnVector getJSONObject(Scalar path) {
+    assert(type.equals(DType.STRING)) : "column type must be a String";
+    return getJSONObject(path, GetJsonObjectOptions.DEFAULT);
+  }
+
   /**
    * Returns a new strings column where target string within each string is replaced with the specified
    * replacement string.

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -2988,11 +2988,12 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Note: Only implements the operators: $ . [] *
    *
    * @param path The JSONPath string to be applied to each row
+   * @param path The GetJsonObjectOptions to control get_json_object behaviour
    * @return new strings ColumnVector containing the retrieved json object strings
    */
-  public final ColumnVector getJSONObject(Scalar path) {
+  public final ColumnVector getJSONObject(Scalar path, GetJsonObjectOptions options) {
     assert(type.equals(DType.STRING)) : "column type must be a String";
-    return new ColumnVector(getJSONObject(getNativeView(), path.getScalarHandle()));
+    return new ColumnVector(getJSONObject(getNativeView(), path.getScalarHandle(), options.isAllowSingleQuotes(), options.isStripQuotesFromSingleStrings(), options.isMissingFieldsAsNulls()));
   }
 
   /**
@@ -4194,7 +4195,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
     long repeatTimesHandle);
 
 
-  private static native long getJSONObject(long viewHandle, long scalarHandle) throws CudfException;
+  private static native long getJSONObject(long viewHandle, long scalarHandle, boolean allowSingleQuotes, boolean stripQuotesFromSingleStrings, boolean missingFieldsAsNulls) throws CudfException;
 
   /**
    * Native method to parse and convert a timestamp column vector to string column vector. A unix

--- a/java/src/main/java/ai/rapids/cudf/GetJsonObjectOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/GetJsonObjectOptions.java
@@ -1,0 +1,45 @@
+package ai.rapids.cudf;
+
+public class GetJsonObjectOptions {
+    private boolean allowSingleQuotes;
+    private boolean stripQuotesFromSingleStrings;
+    private boolean missingFieldsAsNulls;
+
+    // Constructor with parameters to set boolean values
+    public GetJsonObjectOptions(boolean allowSingleQuotes, boolean stripQuotesFromSingleStrings, boolean missingFieldsAsNulls) {
+        this.allowSingleQuotes = allowSingleQuotes;
+        this.stripQuotesFromSingleStrings = stripQuotesFromSingleStrings;
+        this.missingFieldsAsNulls = missingFieldsAsNulls;
+    }
+
+    public GetJsonObjectOptions() {
+        this(false, true, false); // Calls parameterized constructor with default values
+    }
+
+    // Getter and setter methods for allowSingleQuotes
+    public boolean isAllowSingleQuotes() {
+        return allowSingleQuotes;
+    }
+
+    public void setAllowSingleQuotes(boolean allowSingleQuotes) {
+        this.allowSingleQuotes = allowSingleQuotes;
+    }
+
+    // Getter and setter methods for stripQuotesFromSingleStrings
+    public boolean isStripQuotesFromSingleStrings() {
+        return stripQuotesFromSingleStrings;
+    }
+
+    public void setStripQuotesFromSingleStrings(boolean stripQuotesFromSingleStrings) {
+        this.stripQuotesFromSingleStrings = stripQuotesFromSingleStrings;
+    }
+
+    // Getter and setter methods for missingFieldsAsNulls
+    public boolean isMissingFieldsAsNulls() {
+        return missingFieldsAsNulls;
+    }
+
+    public void setMissingFieldsAsNulls(boolean missingFieldsAsNulls) {
+        this.missingFieldsAsNulls = missingFieldsAsNulls;
+    }
+}

--- a/java/src/main/java/ai/rapids/cudf/GetJsonObjectOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/GetJsonObjectOptions.java
@@ -1,3 +1,21 @@
+/*
+ *
+ *  Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 package ai.rapids.cudf;
 
 public class GetJsonObjectOptions {
@@ -5,18 +23,12 @@ public class GetJsonObjectOptions {
     private boolean stripQuotesFromSingleStrings;
     private boolean missingFieldsAsNulls;
 
-    // Constructor with parameters to set boolean values
     public GetJsonObjectOptions(boolean allowSingleQuotes, boolean stripQuotesFromSingleStrings, boolean missingFieldsAsNulls) {
         this.allowSingleQuotes = allowSingleQuotes;
         this.stripQuotesFromSingleStrings = stripQuotesFromSingleStrings;
         this.missingFieldsAsNulls = missingFieldsAsNulls;
     }
 
-    public GetJsonObjectOptions() {
-        this(false, true, false); // Calls parameterized constructor with default values
-    }
-
-    // Getter and setter methods for allowSingleQuotes
     public boolean isAllowSingleQuotes() {
         return allowSingleQuotes;
     }
@@ -25,7 +37,6 @@ public class GetJsonObjectOptions {
         this.allowSingleQuotes = allowSingleQuotes;
     }
 
-    // Getter and setter methods for stripQuotesFromSingleStrings
     public boolean isStripQuotesFromSingleStrings() {
         return stripQuotesFromSingleStrings;
     }
@@ -34,7 +45,6 @@ public class GetJsonObjectOptions {
         this.stripQuotesFromSingleStrings = stripQuotesFromSingleStrings;
     }
 
-    // Getter and setter methods for missingFieldsAsNulls
     public boolean isMissingFieldsAsNulls() {
         return missingFieldsAsNulls;
     }

--- a/java/src/main/java/ai/rapids/cudf/GetJsonObjectOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/GetJsonObjectOptions.java
@@ -18,38 +18,58 @@
 
 package ai.rapids.cudf;
 
-public class GetJsonObjectOptions {
-    private boolean allowSingleQuotes;
-    private boolean stripQuotesFromSingleStrings;
-    private boolean missingFieldsAsNulls;
+public final class GetJsonObjectOptions {
 
-    public GetJsonObjectOptions(boolean allowSingleQuotes, boolean stripQuotesFromSingleStrings, boolean missingFieldsAsNulls) {
-        this.allowSingleQuotes = allowSingleQuotes;
-        this.stripQuotesFromSingleStrings = stripQuotesFromSingleStrings;
-        this.missingFieldsAsNulls = missingFieldsAsNulls;
+    public static GetJsonObjectOptions DEFAULT = new GetJsonObjectOptions.Builder().build();
+
+    private final boolean allowSingleQuotes;
+    private final boolean stripQuotesFromSingleStrings;
+    private final boolean missingFieldsAsNulls;
+
+    private GetJsonObjectOptions(Builder builder) {
+        this.allowSingleQuotes = builder.allowSingleQuotes;
+        this.stripQuotesFromSingleStrings = builder.stripQuotesFromSingleStrings;
+        this.missingFieldsAsNulls = builder.missingFieldsAsNulls;
     }
 
     public boolean isAllowSingleQuotes() {
         return allowSingleQuotes;
     }
 
-    public void setAllowSingleQuotes(boolean allowSingleQuotes) {
-        this.allowSingleQuotes = allowSingleQuotes;
-    }
-
     public boolean isStripQuotesFromSingleStrings() {
         return stripQuotesFromSingleStrings;
-    }
-
-    public void setStripQuotesFromSingleStrings(boolean stripQuotesFromSingleStrings) {
-        this.stripQuotesFromSingleStrings = stripQuotesFromSingleStrings;
     }
 
     public boolean isMissingFieldsAsNulls() {
         return missingFieldsAsNulls;
     }
 
-    public void setMissingFieldsAsNulls(boolean missingFieldsAsNulls) {
-        this.missingFieldsAsNulls = missingFieldsAsNulls;
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private boolean allowSingleQuotes = false;
+        private boolean stripQuotesFromSingleStrings = true;
+        private boolean missingFieldsAsNulls = false;
+
+        public Builder allowSingleQuotes(boolean allowSingleQuotes) {
+            this.allowSingleQuotes = allowSingleQuotes;
+            return this;
+        }
+
+        public Builder stripQuotesFromSingleStrings(boolean stripQuotesFromSingleStrings) {
+            this.stripQuotesFromSingleStrings = stripQuotesFromSingleStrings;
+            return this;
+        }
+
+        public Builder missingFieldsAsNulls(boolean missingFieldsAsNulls) {
+            this.missingFieldsAsNulls = missingFieldsAsNulls;
+            return this;
+        }
+
+        public GetJsonObjectOptions build() {
+            return new GetJsonObjectOptions(this);
+        }
     }
 }

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -2448,8 +2448,10 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getJSONObject(
     cudf::column_view *n_column_view = reinterpret_cast<cudf::column_view *>(j_view_handle);
     cudf::strings_column_view n_strings_col_view(*n_column_view);
     cudf::string_scalar *n_scalar_path = reinterpret_cast<cudf::string_scalar *>(j_scalar_handle);
-    const auto options = get_json_object_options{
-        allow_single_quotes, strip_quotes_from_single_strings, missing_fields_as_nulls};
+    auto options = cudf::get_json_object_options{};
+    options.set_allow_single_quotes(allow_single_quotes);
+    options.set_strip_quotes_from_single_strings(strip_quotes_from_single_strings);
+    options.set_missing_fields_as_nulls(missing_fields_as_nulls);
     return release_as_jlong(cudf::get_json_object(n_strings_col_view, *n_scalar_path, options));
   }
   CATCH_STD(env, 0)

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -2436,9 +2436,9 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_copyColumnViewToCV(JNIEnv
   CATCH_STD(env, 0)
 }
 
-JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getJSONObject(JNIEnv *env, jclass,
-                                                                     jlong j_view_handle,
-                                                                     jlong j_scalar_handle) {
+JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getJSONObject(
+    JNIEnv *env, jclass, jlong j_view_handle, jlong j_scalar_handle, jboolean allow_single_quotes,
+    jboolean strip_quotes_from_single_strings, jboolean missing_fields_as_nulls) {
 
   JNI_NULL_CHECK(env, j_view_handle, "view cannot be null", 0);
   JNI_NULL_CHECK(env, j_scalar_handle, "path cannot be null", 0);
@@ -2448,7 +2448,9 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getJSONObject(JNIEnv *env
     cudf::column_view *n_column_view = reinterpret_cast<cudf::column_view *>(j_view_handle);
     cudf::strings_column_view n_strings_col_view(*n_column_view);
     cudf::string_scalar *n_scalar_path = reinterpret_cast<cudf::string_scalar *>(j_scalar_handle);
-    return release_as_jlong(cudf::get_json_object(n_strings_col_view, *n_scalar_path));
+    const auto options = get_json_object_options{
+        allow_single_quotes, strip_quotes_from_single_strings, missing_fields_as_nulls};
+    return release_as_jlong(cudf::get_json_object(n_strings_col_view, *n_scalar_path, options));
   }
   CATCH_STD(env, 0)
 }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -6385,7 +6385,7 @@ public class ColumnVectorTest extends CudfTestBase {
              "Waugh\",\"Herman Melville\",\"J. R. R. Tolkien\"]", "[\"Nigel Rees\",\"Evelyn " +
              "Waugh\",\"Herman Melville\",\"J. R. R. Tolkien\"]");
          Scalar path = Scalar.fromString("$.store.book[*].author");
-         ColumnVector gotAuthors = json.getJSONObject(path, GetJsonObjectOptions.DEFAULT)) {
+         ColumnVector gotAuthors = json.getJSONObject(path)) {
       assertColumnsAreEqual(expectedAuthors, gotAuthors);
     }
   }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -6379,15 +6379,31 @@ public class ColumnVectorTest extends CudfTestBase {
         "  }\n" +
         "}";
 
+
     try (ColumnVector json = ColumnVector.fromStrings(jsonString, jsonString);
          ColumnVector expectedAuthors = ColumnVector.fromStrings("[\"Nigel Rees\",\"Evelyn " +
              "Waugh\",\"Herman Melville\",\"J. R. R. Tolkien\"]", "[\"Nigel Rees\",\"Evelyn " +
              "Waugh\",\"Herman Melville\",\"J. R. R. Tolkien\"]");
          Scalar path = Scalar.fromString("$.store.book[*].author");
-         ColumnVector gotAuthors = json.getJSONObject(path)) {
+         ColumnVector gotAuthors = json.getJSONObject(path, GetJsonObjectOptions.DEFAULT)) {
       assertColumnsAreEqual(expectedAuthors, gotAuthors);
     }
   }
+
+  @Test
+  void testGetJSONObjectWithSingleQuotes() {
+    String jsonString =  "{" +
+          "\'a\': \'A\"\'" +
+        "}";
+
+    GetJsonObjectOptions options = GetJsonObjectOptions.builder().allowSingleQuotes(true).build();
+    try (ColumnVector json = ColumnVector.fromStrings(jsonString, jsonString);
+         ColumnVector expectedAuthors = ColumnVector.fromStrings("A\"", "A\"");
+         Scalar path = Scalar.fromString("$.a");
+         ColumnVector gotAuthors = json.getJSONObject(path, options)) {
+      assertColumnsAreEqual(expectedAuthors, gotAuthors);
+  }
+}
 
   @Test
   void testMakeStructEmpty() {


### PR DESCRIPTION
## Description
Resolves [10219](https://github.com/NVIDIA/spark-rapids/issues/10219)

This PR introduces a new class named `GetJsonObjectOptions` that holds the configurations to control the behavior of the underlying `cudf::get_json_object` function. It incorporates this new class into the `getJSONObject` JAVA API as an additional argument but also keeps the previous API to maintain backwards compatibility.  It also includes a test case, `testGetJSONObjectWithSingleQuotes`, validating the behavior of `getJSONObject` when single quotes are enabled.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
