### PR TITLE
unset `CUDF_SPILL` after a pytest

### DIFF
--- a/python/cudf/cudf/tests/test_spilling.py
+++ b/python/cudf/cudf/tests/test_spilling.py
@@ -255,6 +255,7 @@ def test_environment_variables(monkeypatch):
     assert isinstance(manager, SpillManager)
     assert manager.statistics.level == 2
     monkeypatch.delenv("CUDF_SPILL")
+    reload_options()
 
 
 def test_spill_device_memory(manager: SpillManager):

--- a/python/cudf/cudf/tests/test_spilling.py
+++ b/python/cudf/cudf/tests/test_spilling.py
@@ -223,38 +223,43 @@ def test_environment_variables(monkeypatch):
         cudf.core.buffer.spill_manager._global_manager_uninitialized = True
         importlib.reload(cudf.options)
 
-    monkeypatch.setenv("CUDF_SPILL_ON_DEMAND", "off")
-    monkeypatch.setenv("CUDF_SPILL", "off")
-    reload_options()
-    assert get_global_manager() is None
-
-    monkeypatch.setenv("CUDF_SPILL", "on")
-    reload_options()
-    manager = get_global_manager()
-    assert isinstance(manager, SpillManager)
-    assert manager._spill_on_demand is False
-    assert manager._device_memory_limit is None
-    assert manager.statistics.level == 0
-
-    monkeypatch.setenv("CUDF_SPILL_DEVICE_LIMIT", "1000")
-    reload_options()
-    manager = get_global_manager()
-    assert isinstance(manager, SpillManager)
-    assert manager._device_memory_limit == 1000
-    assert manager.statistics.level == 0
-
-    monkeypatch.setenv("CUDF_SPILL_STATS", "1")
-    reload_options()
-    manager = get_global_manager()
-    assert isinstance(manager, SpillManager)
-    assert manager.statistics.level == 1
-
-    monkeypatch.setenv("CUDF_SPILL_STATS", "2")
-    reload_options()
-    manager = get_global_manager()
-    assert isinstance(manager, SpillManager)
-    assert manager.statistics.level == 2
-    monkeypatch.delenv("CUDF_SPILL")
+    with monkeypatch.context() as m:
+        monkeypatch.setenv("CUDF_SPILL_ON_DEMAND", "off")
+        monkeypatch.setenv("CUDF_SPILL", "off")
+        reload_options()
+        assert get_global_manager() is None
+    
+        monkeypatch.setenv("CUDF_SPILL", "on")
+        reload_options()
+        manager = get_global_manager()
+        assert isinstance(manager, SpillManager)
+        assert manager._spill_on_demand is False
+        assert manager._device_memory_limit is None
+        assert manager.statistics.level == 0
+    
+        monkeypatch.setenv("CUDF_SPILL_DEVICE_LIMIT", "1000")
+        reload_options()
+        manager = get_global_manager()
+        assert isinstance(manager, SpillManager)
+        assert manager._device_memory_limit == 1000
+        assert manager.statistics.level == 0
+    
+        monkeypatch.setenv("CUDF_SPILL_STATS", "1")
+        reload_options()
+        manager = get_global_manager()
+        assert isinstance(manager, SpillManager)
+        assert manager.statistics.level == 1
+    
+        monkeypatch.setenv("CUDF_SPILL_STATS", "2")
+        reload_options()
+        manager = get_global_manager()
+        assert isinstance(manager, SpillManager)
+        assert manager.statistics.level == 2
+        monkeypatch.delenv("CUDF_SPILL")
+        monkeypatch.delenv("CUDF_SPILL_ON_DEMAND")
+        monkeypatch.delenv("CUDF_SPILL_DEVICE_LIMIT")
+        monkeypatch.delenv("CUDF_SPILL_STATS")
+        reload_options()
     reload_options()
 
 

--- a/python/cudf/cudf/tests/test_spilling.py
+++ b/python/cudf/cudf/tests/test_spilling.py
@@ -254,6 +254,7 @@ def test_environment_variables(monkeypatch):
     manager = get_global_manager()
     assert isinstance(manager, SpillManager)
     assert manager.statistics.level == 2
+    monkeypatch.delenv("CUDF_SPILL")
 
 
 def test_spill_device_memory(manager: SpillManager):

--- a/python/cudf/cudf/tests/test_spilling.py
+++ b/python/cudf/cudf/tests/test_spilling.py
@@ -529,6 +529,10 @@ def test_serialize_cuda_dataframe(manager: SpillManager):
     assert_eq(df1, df2)
 
 
+@pytest.mark.skip(
+    reason="This test is not safe because other tests may have enabled"
+    "spilling and already modified rmm's global state"
+)
 def test_get_rmm_memory_resource_stack():
     mr1 = rmm.mr.get_current_device_resource()
     assert all(

--- a/python/cudf/cudf/tests/test_spilling.py
+++ b/python/cudf/cudf/tests/test_spilling.py
@@ -238,8 +238,8 @@ def test_environment_variables_spill_off(monkeypatch):
     with _get_manager_in_env(
         monkeypatch,
         [("CUDF_SPILL", "off"), ("CUDF_SPILL_ON_DEMAND", "off")],
-    ):
-        assert get_global_manager() is None
+    ) as manager:
+        assert manager is None
 
 
 def test_environment_variables_spill_on(monkeypatch):


### PR DESCRIPTION
## Description
This PR updates spilling tests to limit the scope of all environment and cudf option modifications to the scope of the test to avoid interfering with other tests. This PR also temporary skips a test that is not currently safe to run in an environment where other tests may already have modified related global state (the rmm default memory resource).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
