### PR TITLE
Repect IntervalDtype and CategoricalDtype objects passed by users

### DIFF
--- a/python/cudf/cudf/core/column/interval.py
+++ b/python/cudf/cudf/core/column/interval.py
@@ -122,8 +122,9 @@ class IntervalColumn(StructColumn):
         # directly is problematic), so we're stuck with this for now.
         if nullable:
             raise NotImplementedError(f"{nullable=} is not implemented.")
+        pd_type = self.dtype.to_pandas()
         return pd.Series(
-            self.dtype.to_pandas().__from_arrow__(self.to_arrow()), index=index
+            pd_type.__from_arrow__(self.to_arrow()), index=index, dtype=pd_type
         )
 
     def element_indexing(self, index: int):

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -2659,6 +2659,22 @@ def test_series_duplicate_index_reindex():
     )
 
 
+def test_list_category_like_maintains_dtype():
+    dtype = cudf.CategoricalDtype(categories=[1, 2, 3, 4], ordered=True)
+    data = [1, 2, 3]
+    result = cudf.Series(cudf.core.column.as_column(data, dtype=dtype))
+    expected = pd.Series(data, dtype=dtype.to_pandas())
+    assert_eq(result, expected)
+
+
+def test_list_interval_like_maintains_dtype():
+    dtype = cudf.IntervalDtype(subtype=np.int8)
+    data = [pd.Interval(1, 2)]
+    result = cudf.Series(cudf.core.column.as_column(data, dtype=dtype))
+    expected = pd.Series(data, dtype=dtype.to_pandas())
+    assert_eq(result, expected)
+
+
 @pytest.mark.parametrize(
     "klass", [cudf.Series, cudf.Index, pd.Series, pd.Index]
 )


### PR DESCRIPTION
## Description
Broken off of https://github.com/rapidsai/cudf/pull/14636, these cases are strict about a `dtype` being set so no need to be in a try except

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
