### PR TITLE
Use fused types for overloaded function signatures

### DIFF
--- a/python/cudf/cudf/_lib/pylibcudf/binaryop.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/binaryop.pxd
@@ -3,12 +3,22 @@
 from cudf._lib.cpp.binaryop cimport binary_operator
 
 from .column cimport Column
+from .scalar cimport Scalar
 from .types cimport DataType
+
+# Need two separate fused types to generate the cartesian product of signatures.
+ctypedef fused LeftBinaryOperand:
+    Column
+    Scalar
+
+ctypedef fused RightBinaryOperand:
+    Column
+    Scalar
 
 
 cpdef Column binary_operation(
-    object lhs,
-    object rhs,
+    LeftBinaryOperand lhs,
+    RightBinaryOperand rhs,
     binary_operator op,
     DataType data_type
 )

--- a/python/cudf/cudf/_lib/pylibcudf/binaryop.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/binaryop.pyx
@@ -18,25 +18,25 @@ from .types cimport DataType
 
 
 cpdef Column binary_operation(
-    object lhs,
-    object rhs,
+    LeftBinaryOperand lhs,
+    RightBinaryOperand rhs,
     binary_operator op,
     DataType data_type
 ):
     """Perform a binary operation between a column and another column or scalar.
 
-    Either ``lhs`` or ``rhs`` must be a
-    :py:class:`~cudf._lib.pylibcudf.column.Column`. The other may be a
+    ``lhs`` and ``rhs`` may be a
     :py:class:`~cudf._lib.pylibcudf.column.Column` or a
-    :py:class:`~cudf._lib.pylibcudf.scalar.Scalar`.
+    :py:class:`~cudf._lib.pylibcudf.scalar.Scalar`, but at least one must be a
+    :py:class:`~cudf._lib.pylibcudf.column.Column`.
 
     For details, see :cpp:func:`binary_operation`.
 
     Parameters
     ----------
-    lhs : Column or Scalar
+    lhs : Union[Column, Scalar]
         The left hand side argument.
-    rhs : Column or Scalar
+    rhs : Union[Column, Scalar]
         The right hand side argument.
     op : BinaryOperator
         The operation to perform.
@@ -50,32 +50,32 @@ cpdef Column binary_operation(
     """
     cdef unique_ptr[column] result
 
-    if isinstance(lhs, Column) and isinstance(rhs, Column):
+    if LeftBinaryOperand is Column and RightBinaryOperand is Column:
         with nogil:
             result = move(
                 cpp_binaryop.binary_operation(
-                    (<Column> lhs).view(),
-                    (<Column> rhs).view(),
+                    lhs.view(),
+                    rhs.view(),
                     op,
                     data_type.c_obj
                 )
             )
-    elif isinstance(lhs, Column) and isinstance(rhs, Scalar):
+    elif LeftBinaryOperand is Column and RightBinaryOperand is Scalar:
         with nogil:
             result = move(
                 cpp_binaryop.binary_operation(
-                    (<Column> lhs).view(),
-                    dereference((<Scalar> rhs).c_obj),
+                    lhs.view(),
+                    dereference(rhs.c_obj),
                     op,
                     data_type.c_obj
                 )
             )
-    elif isinstance(lhs, Scalar) and isinstance(rhs, Column):
+    elif LeftBinaryOperand is Scalar and RightBinaryOperand is Column:
         with nogil:
             result = move(
                 cpp_binaryop.binary_operation(
-                    dereference((<Scalar> lhs).c_obj),
-                    (<Column> rhs).view(),
+                    dereference(lhs.c_obj),
+                    rhs.view(),
                     op,
                     data_type.c_obj
                 )

--- a/python/cudf/cudf/_lib/pylibcudf/copying.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/copying.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 from libcpp cimport bool as cbool
 
@@ -9,6 +9,26 @@ from .column cimport Column
 from .scalar cimport Scalar
 from .table cimport Table
 
+ctypedef fused ColumnOrTable:
+    Table
+    Column
+
+
+ctypedef fused TableOrListOfScalars:
+    Table
+    # The contents of the list must be validated as Scalars at runtime.
+    list
+
+
+# Need two separate fused types to generate the cartesian product of signatures.
+ctypedef fused LeftCopyIfElseOperand:
+    Column
+    Scalar
+
+ctypedef fused RightCopyIfElseOperand:
+    Column
+    Scalar
+
 
 cpdef Table gather(
     Table source_table,
@@ -16,13 +36,9 @@ cpdef Table gather(
     out_of_bounds_policy bounds_policy
 )
 
-cpdef Table scatter_table(Table source, Column scatter_map, Table target_table)
+cpdef Table scatter(TableOrListOfScalars source, Column scatter_map, Table target_table)
 
-cpdef Table scatter_scalars(list source, Column scatter_map, Table target_table)
-
-cpdef object empty_column_like(Column input)
-
-cpdef object empty_table_like(Table input)
+cpdef ColumnOrTable empty_like(ColumnOrTable input)
 
 cpdef Column allocate_like(Column input_column, mask_allocation_policy policy, size=*)
 
@@ -44,18 +60,20 @@ cpdef Column copy_range(
 
 cpdef Column shift(Column input, size_type offset, Scalar fill_values)
 
-cpdef list column_split(Column input_column, list splits)
+cpdef list split(ColumnOrTable input, list splits)
 
-cpdef list table_split(Table input_table, list splits)
+cpdef list slice(ColumnOrTable input, list indices)
 
-cpdef list column_slice(Column input_column, list indices)
+cpdef Column copy_if_else(
+    LeftCopyIfElseOperand lhs,
+    RightCopyIfElseOperand rhs,
+    Column boolean_mask
+)
 
-cpdef list table_slice(Table input_table, list indices)
-
-cpdef Column copy_if_else(object lhs, object rhs, Column boolean_mask)
-
-cpdef Table boolean_mask_table_scatter(Table input, Table target, Column boolean_mask)
-
-cpdef Table boolean_mask_scalars_scatter(list input, Table target, Column boolean_mask)
+cpdef Table boolean_mask_scatter(
+    TableOrListOfScalars input,
+    Table target,
+    Column boolean_mask
+)
 
 cpdef Scalar get_element(Column input_column, size_type index)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This change makes the pylibcudf API more convenient and a more faithful reproduction of the underlying libcudf APIs that offer overloaded signatures. In cases like binary ops where we were previously using runtime instance checks, this change also removes unnecessary runtime overhead if the calling code is Cython since in those cases the types at the call site are known at compile time.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
