### PR TITLE
Raise for pyarrow array that is tz-aware

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1931,7 +1931,7 @@ def as_column(
             and arbitrary.type.tz is not None
         ):
             raise NotImplementedError(
-                "cuDF does not yet support timezone-aware " "datetimes"
+                "cuDF does not yet support timezone-aware datetimes"
             )
         elif (nan_as_null is None or nan_as_null) and pa.types.is_floating(
             arbitrary.type

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1926,6 +1926,13 @@ def as_column(
                 "yet supported in pyarrow, see: "
                 "https://github.com/apache/arrow/issues/20213"
             )
+        elif (
+            pa.types.is_timestamp(arbitrary.type)
+            and arbitrary.type.tz is not None
+        ):
+            raise NotImplementedError(
+                "cuDF does not yet support timezone-aware " "datetimes"
+            )
         elif (nan_as_null is None or nan_as_null) and pa.types.is_floating(
             arbitrary.type
         ):

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2468,3 +2468,12 @@ def test_datetime_raise_warning(freqstr):
     )
     with pytest.warns(FutureWarning):
         t.dt.ceil(freqstr)
+
+
+def test_timezone_array_notimplemented():
+    pa_array = pa.array(
+        [datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)],
+        type=pa.timestamp("ns", "UTC"),
+    )
+    with pytest.raises(NotImplementedError):
+        cudf.Series(pa_array)


### PR DESCRIPTION
## Description
Similar to the where pandas inputs that are tz-aware raise a `NotImplementedError`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
