### PR TITLE
Ensure that `ctest` is called with `--no-tests=error`.

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -12,14 +12,14 @@ export GTEST_OUTPUT=xml:${RAPIDS_TESTS_DIR}/
 
 pushd $CONDA_PREFIX/bin/gtests/libcudf/
 rapids-logger "Run libcudf gtests"
-ctest -j20 --output-on-failure
+ctest -j20 --output-on-failure --no-tests=error
 SUITEERROR=$?
 popd
 
 if (( ${SUITEERROR} == 0 )); then
     pushd $CONDA_PREFIX/bin/gtests/libcudf_kafka/
     rapids-logger "Run libcudf_kafka gtests"
-    ctest -j20 --output-on-failure
+    ctest -j20 --output-on-failure --no-tests=error
     SUITEERROR=$?
     popd
 fi

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 source "$(dirname "$0")/test_cpp_common.sh"
 


### PR DESCRIPTION
This PR ensures that all calls to `ctest` include the flag `--no-tests=error`. See https://github.com/rapidsai/build-planning/issues/18.
