### PR TITLE
Deprecate parameters similar to pandas 2.2

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2402,6 +2402,11 @@ class TimedeltaIndex(Index):
             raise NotImplementedError("freq is not yet supported")
 
         if unit is not None:
+            warnings.warn(
+                "The 'unit' keyword is "
+                "deprecated and will be removed in a future version. ",
+                FutureWarning,
+            )
             raise NotImplementedError(
                 "unit is not yet supported, alternatively "
                 "dtype parameter is supported"

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -3918,6 +3918,12 @@ class IndexedFrame(Frame):
         """
         import cudf.core.resample
 
+        if kind is not None:
+            warnings.warn(
+                "The 'kind' keyword in is "
+                "deprecated and will be removed in a future version. ",
+                FutureWarning,
+            )
         if (axis, convention, kind, loffset, base, origin, offset) != (
             0,
             "start",

--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -162,6 +162,14 @@ def to_datetime(
             f"{errors=} is not implemented when arg is not scalar-like"
         )
 
+    if errors == "ignore":
+        warnings.warn(
+            "errors='ignore' is deprecated and will raise in a future version. "
+            "Use to_datetime without passing `errors` and catch exceptions "
+            "explicitly instead",
+            FutureWarning,
+        )
+
     if infer_datetime_format in {None, False}:
         warnings.warn(
             "`infer_datetime_format` is deprecated and will "

--- a/python/cudf/cudf/core/tools/numeric.py
+++ b/python/cudf/cudf/core/tools/numeric.py
@@ -95,6 +95,13 @@ def to_numeric(arg, errors="raise", downcast=None):
 
     if errors not in {"raise", "ignore", "coerce"}:
         raise ValueError("invalid error value specified")
+    elif errors == "ignore":
+        warnings.warn(
+            "errors='ignore' is deprecated and will raise in a future version. "
+            "Use to_numeric without passing `errors` and catch exceptions "
+            "explicitly instead",
+            FutureWarning,
+        )
 
     if downcast not in {None, "integer", "signed", "unsigned", "float"}:
         raise ValueError("invalid downcasting method provided")

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -2468,3 +2468,8 @@ def test_datetime_raise_warning(freqstr):
     )
     with pytest.warns(FutureWarning):
         t.dt.ceil(freqstr)
+
+
+def test_to_datetime_errors_ignore_deprecated():
+    with pytest.warns(FutureWarning):
+        cudf.to_datetime("2001-01-01 00:04:45", errors="ignore")

--- a/python/cudf/cudf/tests/test_numerical.py
+++ b/python/cudf/cudf/tests/test_numerical.py
@@ -5,7 +5,8 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import NUMERIC_TYPES, assert_eq
+from cudf.core._compat import PANDAS_GE_220
+from cudf.testing._utils import NUMERIC_TYPES, assert_eq, expect_warning_if
 from cudf.utils.dtypes import np_dtypes_to_pandas_dtypes
 
 
@@ -372,8 +373,10 @@ def test_to_numeric_error(data, errors):
         ):
             cudf.to_numeric(data, errors=errors)
     else:
-        expect = pd.to_numeric(data, errors=errors)
-        got = cudf.to_numeric(data, errors=errors)
+        with expect_warning_if(PANDAS_GE_220 and errors == "ignore"):
+            expect = pd.to_numeric(data, errors=errors)
+        with expect_warning_if(errors == "ignore"):
+            got = cudf.to_numeric(data, errors=errors)
 
         assert_eq(expect, got)
 
@@ -422,8 +425,3 @@ def test_series_to_numeric_preserve_index_name(klass):
     result = cudf.to_numeric(ser)
     expected = cudf.Series([1] * 8, index=range(2, 10), name="name")
     assert_eq(result, expected)
-
-
-def test_to_datetime_errors_ignore_deprecated():
-    with pytest.warns(FutureWarning):
-        cudf.to_datetime("1", errors="ignore")

--- a/python/cudf/cudf/tests/test_numerical.py
+++ b/python/cudf/cudf/tests/test_numerical.py
@@ -422,3 +422,8 @@ def test_series_to_numeric_preserve_index_name(klass):
     result = cudf.to_numeric(ser)
     expected = cudf.Series([1] * 8, index=range(2, 10), name="name")
     assert_eq(result, expected)
+
+
+def test_to_datetime_errors_ignore_deprecated():
+    with pytest.warns(FutureWarning):
+        cudf.to_datetime("1", errors="ignore")


### PR DESCRIPTION
## Description
For comparison:

https://github.com/pandas-dev/pandas/pull/55856
https://github.com/pandas-dev/pandas/pull/55895
https://github.com/pandas-dev/pandas/issues/55499

The `errors="ignore"` parameter is the only one that is implemented so just added a test for that deprecation

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
