### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -168,6 +168,7 @@ build-dir = "build/{wheel_tag}"
 cmake.build-type = "Release"
 cmake.minimum-version = "3.26.4"
 ninja.make-fallback = true
+sdist.exclude = ["*tests*"]
 sdist.reproducible = true
 wheel.packages = ["cudf"]
 

--- a/python/cudf_kafka/pyproject.toml
+++ b/python/cudf_kafka/pyproject.toml
@@ -87,6 +87,7 @@ build-dir = "build/{wheel_tag}"
 cmake.build-type = "Release"
 cmake.minimum-version = "3.26.4"
 ninja.make-fallback = true
+sdist.exclude = ["*tests*"]
 sdist.reproducible = true
 wheel.packages = ["cudf_kafka"]
 

--- a/python/custreamz/pyproject.toml
+++ b/python/custreamz/pyproject.toml
@@ -56,6 +56,7 @@ include = [
     "custreamz",
     "custreamz.*",
 ]
+exclude = ["*tests*"]
 
 [tool.isort]
 line_length = 79

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -57,6 +57,9 @@ license-files = ["LICENSE"]
 [tool.setuptools.dynamic]
 version = {file = "dask_cudf/VERSION"}
 
+[tool.setuptools.packages.find]
+exclude = ["*tests*"]
+
 [tool.isort]
 line_length = 79
 multi_line_output = 3


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.