### PR TITLE
Fix `DataFrame.sort_index` to respect `ignore_index` on all axis

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2608,12 +2608,15 @@ class IndexedFrame(Frame):
                     and self._data.multiindex
                 ):
                     out._set_column_names_like(self)
+            if ignore_index is True:
+                out = out.reset_index(drop=True)
         else:
             labels = sorted(self._data.names, reverse=not ascending)
             out = self[labels]
+            if ignore_index is True:
+                out._data.rangeindex = True
+                out._data.names = list(range(0, len(self._data.names)))
 
-        if ignore_index is True:
-            out = out.reset_index(drop=True)
         return self._mimic_inplace(out, inplace=inplace)
 
     def memory_usage(self, index=True, deep=False):

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2608,14 +2608,14 @@ class IndexedFrame(Frame):
                     and self._data.multiindex
                 ):
                     out._set_column_names_like(self)
-            if ignore_index is True:
+            if ignore_index:
                 out = out.reset_index(drop=True)
         else:
             labels = sorted(self._data.names, reverse=not ascending)
             out = self[labels]
-            if ignore_index is True:
+            if ignore_index:
                 out._data.rangeindex = True
-                out._data.names = list(range(0, len(self._data.names)))
+                out._data.names = list(range(len(self._data.names)))
 
         return self._mimic_inplace(out, inplace=inplace)
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -3632,8 +3632,7 @@ def test_dataframe_mulitindex_sort_index(
     )
     request.applymarker(
         pytest.mark.xfail(
-            condition=PANDAS_GE_220
-            and axis in (1, "columns")
+            condition=axis in (1, "columns")
             and level is None
             and not ascending
             and ignore_index,

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -3618,10 +3618,21 @@ def test_dataframe_mulitindex_sort_index(
 ):
     request.applymarker(
         pytest.mark.xfail(
-            condition=axis in (1, "columns")
+            condition=not PANDAS_GE_220
+            and axis in (1, "columns")
             and ignore_index
             and not (level is None and not ascending),
             reason="https://github.com/pandas-dev/pandas/issues/56478",
+        )
+    )
+    request.applymarker(
+        pytest.mark.xfail(
+            condition=PANDAS_GE_220
+            and axis in (1, "columns")
+            and level is None
+            and not ascending
+            and ignore_index,
+            reason="https://github.com/pandas-dev/pandas/issues/57293",
         )
     )
     pdf = pd.DataFrame(

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -25,7 +25,7 @@ from packaging import version
 
 import cudf
 from cudf.api.extensions import no_default
-from cudf.core._compat import PANDAS_GE_200, PANDAS_GE_210, PANDAS_LT_203
+from cudf.core._compat import PANDAS_GE_200, PANDAS_GE_210, PANDAS_GE_220, PANDAS_LT_203
 from cudf.core.buffer.spill_manager import get_global_manager
 from cudf.core.column import column
 from cudf.errors import MixedTypeError

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -25,7 +25,12 @@ from packaging import version
 
 import cudf
 from cudf.api.extensions import no_default
-from cudf.core._compat import PANDAS_GE_200, PANDAS_GE_210, PANDAS_GE_220, PANDAS_LT_203
+from cudf.core._compat import (
+    PANDAS_GE_200,
+    PANDAS_GE_210,
+    PANDAS_GE_220,
+    PANDAS_LT_203,
+)
 from cudf.core.buffer.spill_manager import get_global_manager
 from cudf.core.column import column
 from cudf.errors import MixedTypeError

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -3567,8 +3567,16 @@ def test_dataframe_empty_sort_index():
 @pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize("na_position", ["first", "last"])
 def test_dataframe_sort_index(
-    index, axis, ascending, inplace, ignore_index, na_position
+    request, index, axis, ascending, inplace, ignore_index, na_position
 ):
+    request.applymarker(
+        pytest.mark.xfail(
+            condition=not PANDAS_GE_220
+            and axis in (1, "columns")
+            and ignore_index,
+            reason="Bug fixed in pandas-2.2",
+        )
+    )
     pdf = pd.DataFrame(
         {"b": [1, 3, 2], "a": [1, 4, 3], "c": [4, 1, 5]},
         index=index,


### PR DESCRIPTION
## Description
This PR fixes `DataFrame.sort_index` to properly ignore indexes for all values of `axis`. This is fixed in pandas-2.2, hence xfailing the tests with a version check.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
