### PR TITLE
Fix handling of values=None in pylibcudf GroupBy.get_groups

### DIFF
--- a/python/cudf/cudf/_lib/groupby.pyx
+++ b/python/cudf/cudf/_lib/groupby.pyx
@@ -136,7 +136,10 @@ cdef class GroupBy:
         return (
             offsets,
             columns_from_pylibcudf_table(grouped_keys),
-            columns_from_pylibcudf_table(grouped_values),
+            (
+                columns_from_pylibcudf_table(grouped_values)
+                if grouped_values is not None else []
+            ),
         )
 
     def aggregate(self, values, aggregations):

--- a/python/cudf/cudf/_lib/groupby.pyx
+++ b/python/cudf/cudf/_lib/groupby.pyx
@@ -120,23 +120,23 @@ cdef class GroupBy:
 
         Returns
         -------
+        offsets: list of integers
+            Integer offsets such that offsets[i+1] - offsets[i]
+            represents the size of group `i`.
         grouped_keys: list of Columns
             The grouped key columns
         grouped_values: list of Columns
             The grouped value columns
-        offsets: list of integers
-            Integer offsets such that offsets[i+1] - offsets[i]
-            represents the size of group `i`.
         """
-        grouped_keys, grouped_values, offsets = self._groupby.get_groups(
+        offsets, grouped_keys, grouped_values = self._groupby.get_groups(
             pylibcudf.table.Table([c.to_pylibcudf(mode="read") for c in values])
             if values else None
         )
 
         return (
+            offsets,
             columns_from_pylibcudf_table(grouped_keys),
             columns_from_pylibcudf_table(grouped_values),
-            offsets,
         )
 
     def aggregate(self, values, aggregations):

--- a/python/cudf/cudf/_lib/pylibcudf/groupby.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/groupby.pxd
@@ -37,6 +37,7 @@ cdef class GroupByRequest:
 
 cdef class GroupBy:
     cdef unique_ptr[groupby] c_obj
+    cdef Table _keys
     cpdef tuple aggregate(self, list requests)
     cpdef tuple scan(self, list requests)
     cpdef tuple shift(self, Table values, list offset, list fill_values)

--- a/python/cudf/cudf/_lib/pylibcudf/groupby.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/groupby.pyx
@@ -268,11 +268,16 @@ cdef class GroupBy:
         cdef groups c_groups
         if values:
             c_groups = dereference(self.c_obj).get_groups(values.view())
+            return (
+                Table.from_libcudf(move(c_groups.keys)),
+                Table.from_libcudf(move(c_groups.values)),
+                c_groups.offsets,
+            )
         else:
+            # c_groups.values is nullptr
             c_groups = dereference(self.c_obj).get_groups()
-
-        return (
-            Table.from_libcudf(move(c_groups.keys)),
-            Table.from_libcudf(move(c_groups.values)),
-            c_groups.offsets,
-        )
+            return (
+                Table.from_libcudf(move(c_groups.keys)),
+                Table([]),
+                c_groups.offsets,
+            )

--- a/python/cudf/cudf/_lib/pylibcudf/groupby.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/groupby.pyx
@@ -253,8 +253,8 @@ cdef class GroupBy:
         Parameters
         ----------
         values : Table, optional
-            The columns to get group labels for. If not specified, the group
-            labels for the group keys are returned.
+            The columns to get group labels for. If not specified,
+            an empty table is returned for the group values.
 
         Returns
         -------

--- a/python/cudf/cudf/_lib/pylibcudf/groupby.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/groupby.pyx
@@ -261,26 +261,26 @@ cdef class GroupBy:
 
         Returns
         -------
-        Tuple[Table, Table, List[int]]
+        Tuple[List[int], Table, Table]]
             A tuple of tables containing three items:
+                - A list of integer offsets into the group keys/values
                 - A table of group keys
                 - A table of group values or None
-                - A list of integer offsets into the tables
         """
 
         cdef groups c_groups
         if values:
             c_groups = dereference(self.c_obj).get_groups(values.view())
             return (
+                c_groups.offsets,
                 Table.from_libcudf(move(c_groups.keys)),
                 Table.from_libcudf(move(c_groups.values)),
-                c_groups.offsets,
             )
         else:
             # c_groups.values is nullptr
             c_groups = dereference(self.c_obj).get_groups()
             return (
+                c_groups.offsets,
                 Table.from_libcudf(move(c_groups.keys)),
                 None,
-                c_groups.offsets,
             )

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -790,7 +790,7 @@ class GroupBy(Serializable, Reducible, Scannable):
             # Can't use _mimic_pandas_order because we need to
             # subsample the gather map from the full input ordering,
             # rather than permuting the gather map of the output.
-            _, (ordering,), _ = self._groupby.groups(
+            _, _, (ordering,) = self._groupby.groups(
                 [as_column(range(0, len(self.obj)))]
             )
             # Invert permutation from original order to groups on the
@@ -2583,7 +2583,7 @@ class GroupBy(Serializable, Reducible, Scannable):
         # result coming back from libcudf has null_count few rows than
         # the input, so we must produce an ordering from the full
         # input range.
-        _, (ordering,), _ = self._groupby.groups(
+        _, _, (ordering,) = self._groupby.groups(
             [as_column(range(0, len(self.obj)))]
         )
         if self._dropna and any(

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -1179,7 +1179,7 @@ class GroupBy(Serializable, Reducible, Scannable):
         return cls(obj, grouping, **kwargs)
 
     def _grouped(self):
-        grouped_key_cols, grouped_value_cols, offsets = self._groupby.groups(
+        offsets, grouped_key_cols, grouped_value_cols = self._groupby.groups(
             [*self.obj._index._columns, *self.obj._columns]
         )
         grouped_keys = cudf.core.index._index_from_columns(grouped_key_cols)

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -3758,8 +3758,8 @@ def test_group_by_value_counts_with_count_column():
         df.groupby("a", as_index=False).value_counts()
 
 
-def test_groupby_internal_get_groups_empty(gdf):
+def test_groupby_internal_groups_empty(gdf):
     # test that we don't segfault when calling the internal
-    # get_groups() method with an empty list:
+    # .groups() method with an empty list:
     gb = gdf.groupby("y")._groupby
     gb.groups([])

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -3763,4 +3763,4 @@ def test_groupby_internal_groups_empty(gdf):
     # .groups() method with an empty list:
     gb = gdf.groupby("y")._groupby
     _, _, grouped_vals = gb.groups([])
-    assert grouped_vals is None
+    assert grouped_vals == []

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -3762,4 +3762,5 @@ def test_groupby_internal_groups_empty(gdf):
     # test that we don't segfault when calling the internal
     # .groups() method with an empty list:
     gb = gdf.groupby("y")._groupby
-    gb.groups([])
+    _, grouped_vals, _ = gb.groups([])
+    assert grouped_vals is None

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -3762,5 +3762,5 @@ def test_groupby_internal_groups_empty(gdf):
     # test that we don't segfault when calling the internal
     # .groups() method with an empty list:
     gb = gdf.groupby("y")._groupby
-    _, grouped_vals, _ = gb.groups([])
+    _, _, grouped_vals = gb.groups([])
     assert grouped_vals is None

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -3756,3 +3756,10 @@ def test_group_by_value_counts_with_count_column():
     df = cudf.DataFrame({"a": [1, 5, 3], "count": [2, 5, 2]})
     with pytest.raises(ValueError):
         df.groupby("a", as_index=False).value_counts()
+
+
+def test_groupby_internal_get_groups_empty(gdf):
+    # test that we don't segfault when calling the internal
+    # get_groups() method with an empty list:
+    gb = gdf.groupby("y")._groupby
+    gb.groups([])


### PR DESCRIPTION
A small bug in our previous implementation leads to a segfault when calling `.get_groups()` with no `values`. Thankfully, the cuDF Python API always calls this function with a value, but it's possible `pylibcudf` consumers will not.
