### PR TITLE
Ensure to_* IO methods respect pandas 2.2 keyword only deprecation

### DIFF
--- a/python/cudf/cudf/_fuzz_testing/utils.py
+++ b/python/cudf/cudf/_fuzz_testing/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 import random
 
@@ -216,7 +216,7 @@ def pandas_to_avro(df, file_name=None, file_io_obj=None):
     schema = get_avro_schema(df)
     avro_schema = fastavro.parse_schema(schema)
 
-    records = df.to_dict("records")
+    records = df.to_dict(orient="records")
     records = convert_nulls_to_none(records, df)
 
     if file_name is not None:

--- a/python/cudf/cudf/io/hdf.py
+++ b/python/cudf/cudf/io/hdf.py
@@ -27,4 +27,4 @@ def to_hdf(path_or_buf, key, value, *args, **kwargs):
         "be GPU accelerated in the future"
     )
     pd_value = value.to_pandas()
-    pd_value.to_hdf(path_or_buf, key, *args, **kwargs)
+    pd_value.to_hdf(path_or_buf, key=key, *args, **kwargs)

--- a/python/cudf/cudf/tests/test_hdf.py
+++ b/python/cudf/cudf/tests/test_hdf.py
@@ -63,7 +63,7 @@ def hdf_files(request, tmp_path_factory, pdf):
         pdf = pdf.drop("col_category", axis=1)
 
     fname_df = tmp_path_factory.mktemp("hdf") / "test_df.hdf"
-    pdf.to_hdf(fname_df, "hdf_df_tests", format=request.param)
+    pdf.to_hdf(fname_df, key="hdf_df_tests", format=request.param)
 
     fname_series = {}
     for column in pdf.columns:
@@ -71,7 +71,7 @@ def hdf_files(request, tmp_path_factory, pdf):
             tmp_path_factory.mktemp("hdf") / "test_series.hdf"
         )
         pdf[column].to_hdf(
-            fname_series[column], "hdf_series_tests", format=request.param
+            fname_series[column], key="hdf_series_tests", format=request.param
         )
     return (fname_df, fname_series, request.param, nrows)
 
@@ -116,8 +116,8 @@ def test_hdf_writer(tmpdir, pdf, gdf, complib, format):
     pdf_df_fname = tmpdir.join("pdf_df.hdf")
     gdf_df_fname = tmpdir.join("gdf_df.hdf")
 
-    pdf.to_hdf(pdf_df_fname, "hdf_tests", format=format, complib=complib)
-    gdf.to_hdf(gdf_df_fname, "hdf_tests", format=format, complib=complib)
+    pdf.to_hdf(pdf_df_fname, key="hdf_tests", format=format, complib=complib)
+    gdf.to_hdf(gdf_df_fname, key="hdf_tests", format=format, complib=complib)
 
     assert os.path.exists(pdf_df_fname)
     assert os.path.exists(gdf_df_fname)
@@ -135,10 +135,10 @@ def test_hdf_writer(tmpdir, pdf, gdf, complib, format):
         gdf_series_fname = tmpdir.join(column + "_" + "gdf_series.hdf")
 
         pdf[column].to_hdf(
-            pdf_series_fname, "hdf_tests", format=format, complib=complib
+            pdf_series_fname, key="hdf_tests", format=format, complib=complib
         )
         gdf[column].to_hdf(
-            gdf_series_fname, "hdf_tests", format=format, complib=complib
+            gdf_series_fname, key="hdf_tests", format=format, complib=complib
         )
 
         assert os.path.exists(pdf_series_fname)


### PR DESCRIPTION
## Description
This only really affected `to_hdf`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
