### PR TITLE
Use offsetalator in cudf::interleave_columns()

### DIFF
--- a/cpp/src/reshape/interleave_columns.cu
+++ b/cpp/src/reshape/interleave_columns.cu
@@ -17,6 +17,7 @@
 #include <cudf/copying.hpp>
 #include <cudf/detail/copy.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/detail/offsets_iterator_factory.cuh>
 #include <cudf/detail/reshape.hpp>
 #include <cudf/detail/valid_if.cuh>
 #include <cudf/lists/detail/interleave_columns.hpp>
@@ -188,9 +189,10 @@ struct interleave_columns_impl<T, std::enable_if_t<std::is_same_v<T, cudf::strin
       });
     auto offsets_transformer_itr = thrust::make_transform_iterator(
       thrust::make_counting_iterator<size_type>(0), offsets_transformer);
-    auto [offsets_column, bytes] = cudf::detail::make_offsets_child_column(
+    auto [offsets_column, bytes] = cudf::strings::detail::make_offsets_child_column(
       offsets_transformer_itr, offsets_transformer_itr + num_strings, stream, mr);
-    auto d_results_offsets = offsets_column->view().template data<int32_t>();
+    auto d_results_offsets =
+      cudf::detail::offsetalator_factory::make_input_iterator(offsets_column->view());
 
     // Create the chars column
     rmm::device_uvector<char> chars(bytes, stream, mr);


### PR DESCRIPTION
## Description
Updates `cudf::interleave_columns()` to use the new `make_offsets_child_column` utility and the offsetalator to build the output strings column.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
