### PR TITLE
Change copy_if_safe to call thrust instead of the overload function

### DIFF
--- a/cpp/include/cudf/detail/utilities/algorithm.cuh
+++ b/cpp/include/cudf/detail/utilities/algorithm.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,17 @@ OutputIterator copy_if_safe(InputIterator first,
                             Predicate pred,
                             rmm::cuda_stream_view stream)
 {
-  return copy_if_safe(first, last, first, result, pred, stream);
+  auto const copy_size = std::min(static_cast<std::size_t>(std::distance(first, last)),
+                                  static_cast<std::size_t>(std::numeric_limits<int>::max()));
+
+  auto itr = first;
+  while (itr != last) {
+    auto const copy_end =
+      static_cast<std::size_t>(std::distance(itr, last)) <= copy_size ? last : itr + copy_size;
+    result = thrust::copy_if(rmm::exec_policy(stream), itr, copy_end, result, pred);
+    itr    = copy_end;
+  }
+  return result;
 }
 
 }  // namespace cudf::detail


### PR DESCRIPTION
## Description
Found while working on large strings where copy-if is called. In places where `copy_if_safe` utility is called the non-stencil overload calls the stencil-ed function by forwarding the `first` iterator as the `stencil` parameter. This works logically because both values will return the same result. Unfortunately, this can be a performance issue if the iterator is complex/slow transform iterator since it would be called twice (an inlined twice). Changing the non-stencil version to call `thrust::copy_if` directly fixes the potential issue.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
