### PR TITLE
Adjust test_datetime_infer_format for pandas 2.2

### DIFF
--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -1275,23 +1275,23 @@ def test_datetime_reductions(data, op, dtype):
         assert_eq(expected, actual)
 
 
-@pytest.mark.parametrize("timezone", ["naive", "UTC"])
+@pytest.mark.parametrize("timezone", ["", "Z"])
 @pytest.mark.parametrize(
     "data",
     [
-        np.arange("2002-10-27T04:30", 4 * 60, 60, dtype="M8[m]"),
-        np.arange("2002-10-27T04:30", 10 * 60, 1, dtype="M8[m]"),
-        np.arange("2002-10-27T04:30", 10 * 60, 1, dtype="M8[ns]"),
-        np.arange("2002-10-27T04:30", 10 * 60, 1, dtype="M8[us]"),
-        np.arange("2002-10-27T04:30", 4 * 60, 60, dtype="M8[s]"),
+        "2002-10-27T04:30",
+        "2002-10-27T04:30:00",
+        "2002-10-27T04:30:00.000",
+        "2002-10-27T04:30:00.000000",
+        "2002-10-27T04:30:00.000000000",
     ],
 )
 @pytest.mark.parametrize("dtype", DATETIME_TYPES)
 def test_datetime_infer_format(data, timezone, dtype):
-    ts_data = np.datetime_as_string(data, timezone=timezone)
+    ts_data = [data + timezone]
     sr = cudf.Series(ts_data)
     psr = pd.Series(ts_data)
-    if timezone == "naive":
+    if not timezone:
         expected = psr.astype(dtype)
         actual = sr.astype(dtype)
 


### PR DESCRIPTION
## Description
pandas 2.2 is stricter about converting from date string to datetime type if the resolution would lead to loss of precision. This affects `test_datetime_infer_format` where an `astype` is done, so adjusting the test such that the `astypes` don't lead to loss of precision.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
