### PR TITLE
Expose libcudf filter expression in read_parquet

### DIFF
--- a/python/cudf/cudf/_lib/cpp/io/parquet.pxd
+++ b/python/cudf/cudf/_lib/cpp/io/parquet.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 from libc.stdint cimport uint8_t
 from libcpp cimport bool
@@ -52,6 +52,9 @@ cdef extern from "cudf/io/parquet.hpp" namespace "cudf::io" nogil:
         ) except +
         parquet_reader_options_builder& timestamp_type(
             data_type type
+        ) except +
+        parquet_reader_options_builder& filter(
+            const expression & f
         ) except +
         parquet_reader_options build() except +
 

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -37,11 +37,13 @@ cimport cudf._lib.cpp.io.data_sink as cudf_io_data_sink
 cimport cudf._lib.cpp.io.types as cudf_io_types
 cimport cudf._lib.cpp.types as cudf_types
 from cudf._lib.column cimport Column
+from cudf._lib.cpp.expressions cimport expression
 from cudf._lib.cpp.io.parquet cimport (
     chunked_parquet_writer_options,
     merge_row_group_metadata as parquet_merge_metadata,
     parquet_chunked_writer as cpp_parquet_chunked_writer,
     parquet_reader_options,
+    parquet_reader_options_builder,
     parquet_writer_options,
     read_parquet as parquet_reader,
     write_parquet as parquet_writer,
@@ -49,6 +51,7 @@ from cudf._lib.cpp.io.parquet cimport (
 from cudf._lib.cpp.io.types cimport column_in_metadata, table_input_metadata
 from cudf._lib.cpp.table.table_view cimport table_view
 from cudf._lib.cpp.types cimport data_type, size_type
+from cudf._lib.expressions cimport Expression
 from cudf._lib.io.datasource cimport NativeFileDatasource
 from cudf._lib.io.utils cimport (
     make_sinks_info,
@@ -119,9 +122,13 @@ def _parse_metadata(meta):
 
 
 cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
-                   use_pandas_metadata=True):
+                   use_pandas_metadata=True,
+                   Expression filters=None):
     """
     Cython function to call into libcudf API, see `read_parquet`.
+
+    filters, if not None, should be an Expression that evaluates to a
+    boolean predicate as a function of columns being read.
 
     See Also
     --------
@@ -148,19 +155,22 @@ cpdef read_parquet(filepaths_or_buffers, columns=None, row_groups=None,
     cdef data_type cpp_timestamp_type = cudf_types.data_type(
         cudf_types.type_id.EMPTY
     )
-
     if row_groups is not None:
         cpp_row_groups = row_groups
 
-    cdef parquet_reader_options args
     # Setup parquet reader arguments
-    args = move(
+    cdef parquet_reader_options args
+    cdef parquet_reader_options_builder builder
+    builder = (
         parquet_reader_options.builder(source)
         .row_groups(cpp_row_groups)
         .use_pandas_metadata(cpp_use_pandas_metadata)
         .timestamp_type(cpp_timestamp_type)
-        .build()
     )
+    if filters is not None:
+        builder = builder.filter(<expression &>dereference(filters.c_obj.get()))
+
+    args = move(builder.build())
     cdef vector[string] cpp_columns
     allow_range_index = True
     if columns is not None:


### PR DESCRIPTION
## Description

libcudf's parquet reader supports filtering rows of the input dataset based on a (restricted subset of) libcudf Expression. Previously this functionality was not exposed in Python-land, do so here.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
