### PR TITLE
[HOTFIX] Unpin numba<0.58

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -78,8 +78,7 @@ requirements:
     - typing_extensions >=4.0.0
     - pandas >=1.3,<1.6.0dev0
     - cupy >=12.0.0
-    # TODO: Pin to numba<0.58 until #14160 is resolved
-    - numba >=0.57,<0.58
+    - numba >=0.57
     # TODO: Pin to numpy<1.25 until cudf requires pandas 2
     - numpy >=1.21,<1.25
     - {{ pin_compatible('pyarrow', max_pin='x') }}


### PR DESCRIPTION
I think unpinning `numba` in the conda recipe was just missed in #14616.

I discovered this issue [trying to build the `24.02` release](https://github.com/rapidsai/cudf/actions/runs/7878153691/job/21496377912#step:7:1674).

PRs & nightly builds are working because the `rapidsai-nightly` channel has an older version of `pynvjitlink` that supported `numba>=0.57` whereas the `rapidsai` channel only has the latest version which pins to `numba>=0.58`.
