### PR TITLE
Add xfailures for test_applymap for pandas 2.2

### DIFF
--- a/python/cudf/cudf/tests/test_applymap.py
+++ b/python/cudf/cudf/tests/test_applymap.py
@@ -43,10 +43,12 @@ def test_applymap_dataframe(data, func, na_action, request):
     )
     gdf = DataFrame(data)
     pdf = gdf.to_pandas(nullable=True)
+
     with utils.expect_warning_if(PANDAS_GE_210):
         expect = pdf.applymap(func, na_action=na_action)
     with pytest.warns(FutureWarning):
         got = gdf.applymap(func, na_action=na_action)
+
     utils.assert_eq(expect, got, check_dtype=False)
 
 


### PR DESCRIPTION
## Description
There were regressions in the `map` methods on the pandas side that is causing some of these applymap tests to fail on pandas 2.2

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
