### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -78,8 +78,7 @@ requirements:
     - typing_extensions >=4.0.0
     - pandas >=1.3,<1.6.0dev0
     - cupy >=12.0.0
-    # TODO: Pin to numba<0.58 until #14160 is resolved
-    - numba >=0.57,<0.58
+    - numba >=0.57
     # TODO: Pin to numpy<1.25 until cudf requires pandas 2
     - numpy >=1.21,<1.25
     - {{ pin_compatible('pyarrow', max_pin='x') }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.