### PR TITLE
Lossless float <--> decimal conversion

### DIFF
--- a/cpp/include/cudf/round.hpp
+++ b/cpp/include/cudf/round.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,9 @@ namespace cudf {
 /**
  * @brief Different rounding methods for `cudf::round`
  *
- * Info on HALF_UP   rounding: https://en.wikipedia.org/wiki/Rounding#Round_half_up
- * Info on HALF_EVEN rounding: https://en.wikipedia.org/wiki/Rounding#Round_half_to_even
+ * Info on HALF_EVEN rounding: https://en.wikipedia.org/wiki/Rounding#Rounding_half_to_even
+ * Info on HALF_UP   rounding: https://en.wikipedia.org/wiki/Rounding#Rounding_half_away_from_zero
+ * Note: HALF_UP means up in magnitude: Away from zero! Because this how Java and python define HALF_UP. 
  */
 enum class rounding_method : int32_t { HALF_UP, HALF_EVEN };
 

--- a/cpp/src/round/round.cu
+++ b/cpp/src/round/round.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,6 +184,7 @@ struct half_even_negative {
   template <typename U = T, std::enable_if_t<cuda::std::is_integral_v<U>>* = nullptr>
   __device__ U operator()(U e)
   {
+    cudf_assert(n > 1 && "Doesn't work for n=1, but is never called with it.");
     auto const down_over_n = e / n;            // use this to determine HALF_EVEN case
     auto const down        = down_over_n * n;  // result from rounding down
     auto const diff        = generic_abs(e - down);


### PR DESCRIPTION
## Description
Lossless floating <--> decimal conversion for [Issue 14169](https://github.com/rapidsai/cudf/issues/14169) 
Note: Only lossless if you use a small enough scaling factor to preserve the precision.  If too small defaults back to the old algorithm. 
Also small cleanup in rounding code

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
