### PR TITLE
Avoid chained indexing in test_indexing for pandas 2.2

### DIFF
--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -1242,13 +1242,18 @@ def test_out_of_bounds_indexing():
         lambda: psr.__setitem__([0, 1, -4], 2),
         lambda: gsr.__setitem__([0, 1, -4], 2),
     )
+
+
+def test_out_of_bounds_indexing_empty():
+    psr = pd.Series(dtype="int64")
+    gsr = cudf.from_pandas(psr)
     assert_exceptions_equal(
-        lambda: psr[4:6].iloc.__setitem__(-1, 2),
-        lambda: gsr[4:6].iloc.__setitem__(-1, 2),
+        lambda: psr.iloc.__setitem__(-1, 2),
+        lambda: gsr.iloc.__setitem__(-1, 2),
     )
     assert_exceptions_equal(
-        lambda: psr[4:6].iloc.__setitem__(1, 2),
-        lambda: gsr[4:6].iloc.__setitem__(1, 2),
+        lambda: psr.iloc.__setitem__(1, 2),
+        lambda: gsr.iloc.__setitem__(1, 2),
     )
 
 


### PR DESCRIPTION
## Description
Chained indexing raises a `FutureWarning` in pandas 2.2. Since this test doesn't look to specifically test that, refactoring the test to avoid that

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
