### PR TITLE
Deprecate datelike isin casting strings to dates to match pandas 2.2

### DIFF
--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -767,6 +767,15 @@ def _isin_datetimelike(
     rhs = None
     try:
         rhs = cudf.core.column.as_column(values)
+        if len(rhs) and rhs.dtype.kind == "O":
+            warnings.warn(
+                f"The behavior of 'isin' with dtype={lhs.dtype} and "
+                "castable values (e.g. strings) is deprecated. In a "
+                "future version, these will not be considered matching "
+                "by isin. Explicitly cast to the appropriate dtype before "
+                "calling isin instead.",
+                FutureWarning,
+            )
 
         if rhs.dtype.kind in {"f", "i", "u"}:
             return cudf.core.column.full(len(lhs), False, dtype="bool")

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -1796,10 +1796,10 @@ def test_isin_datetime(data, values):
     psr = pd.Series(data)
     gsr = cudf.Series.from_pandas(psr)
 
-    is_str = isinstance(next(iter(values), None), str)
-    with expect_warning_if(is_str and len(data)):
+    is_len_str = isinstance(next(iter(values), None), str) and len(data)
+    with expect_warning_if(is_len_str):
         got = gsr.isin(values)
-    with expect_warning_if(PANDAS_GE_220 and is_str and len(data)):
+    with expect_warning_if(PANDAS_GE_220 and is_len_str):
         expected = psr.isin(values)
     assert_eq(got, expected)
 

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -15,6 +15,7 @@ import pytest
 
 import cudf
 from cudf.api.extensions import no_default
+from cudf.core._compat import PANDAS_GE_220
 from cudf.errors import MixedTypeError
 from cudf.testing._utils import (
     NUMERIC_TYPES,
@@ -1795,8 +1796,11 @@ def test_isin_datetime(data, values):
     psr = pd.Series(data)
     gsr = cudf.Series.from_pandas(psr)
 
-    got = gsr.isin(values)
-    expected = psr.isin(values)
+    is_str = isinstance(next(iter(values), None), str)
+    with expect_warning_if(is_str and len(data)):
+        got = gsr.isin(values)
+    with expect_warning_if(PANDAS_GE_220 and is_str and len(data)):
+        expected = psr.isin(values)
     assert_eq(got, expected)
 
 


### PR DESCRIPTION
## Description
Matching https://github.com/pandas-dev/pandas/pull/56427

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
