### PR TITLE
Requesting a clean build directory also clears Jitify cache

### DIFF
--- a/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
+++ b/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
@@ -69,3 +69,18 @@ add_custom_target(
   DEPENDS ${JIT_PREPROCESSED_FILES}
   COMMENT "Target representing jitified files."
 )
+
+# when a user requests CMake to clean the build directory
+#
+# * `cmake --build <dir> --target clean`
+# * `cmake --build <dir> --clean-first`
+# * ninja clean
+#
+# We also remove the jitify2 program cache as well. This ensures that we don't keep older versions
+# of the programs in cache
+set(cache_path "$ENV{HOME}/.cudf")
+if(ENV{LIBCUDF_KERNEL_CACHE_PATH})
+  set(cache_path "$ENV{LIBCUDF_KERNEL_CACHE_PATH}")
+endif()
+cmake_path(APPEND cache_path "${CUDF_VERSION}/")
+set_target_properties(jitify_preprocess_run PROPERTIES ADDITIONAL_CLEAN_FILES "${cache_path}")


### PR DESCRIPTION
## Description
Developers expect that 'cleaning' a build directory will remove all forms of cached files ( objects, libraries, jit cache, etc ). To ensure that happens consistenly we also need to remove the jitify cache objects for cudf.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
