### PR TITLE
Raise an error on import for unsupported GPUs.

### DIFF
--- a/python/cudf/cudf/utils/gpu_utils.py
+++ b/python/cudf/cudf/utils/gpu_utils.py
@@ -86,7 +86,7 @@ def validate_setup():
             minor_version = getDeviceAttribute(
                 cudaDeviceAttr.cudaDevAttrComputeCapabilityMinor, 0
             )
-            warnings.warn(
+            raise UnsupportedCUDAError(
                 "A GPU with NVIDIA Volta™ (Compute Capability 7.0) "
                 "or newer architecture is required.\n"
                 f"Detected GPU 0: {device_name}\n"


### PR DESCRIPTION
## Description
RAPIDS 24.02 dropped support for Pascal GPUs. When using an unsupported GPU, the behavior of cudf is undefined and sometimes produces results that appear valid (and empty) but conceal CUDA kernel launch errors. This PR changes the behavior to error on import if unsupported GPUs are detected.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
