### PR TITLE
Fix test_resample index dtype checking for pandas 2.2

### DIFF
--- a/python/cudf/cudf/tests/test_resampling.py
+++ b/python/cudf/cudf/tests/test_resampling.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_GE_200
+from cudf.core._compat import PANDAS_GE_200, PANDAS_GE_220
 from cudf.testing._utils import assert_eq
 
 
@@ -31,6 +31,7 @@ def test_series_downsample_simple(ts_resolution):
     assert_resample_results_equal(
         psr.resample("3min").sum(),
         gsr.resample("3min").sum(),
+        check_index=not PANDAS_GE_220,
     )
 
 
@@ -43,6 +44,7 @@ def test_series_upsample_simple():
     assert_resample_results_equal(
         psr.resample("3min").sum(),
         gsr.resample("3min").sum(),
+        check_index=not PANDAS_GE_220,
     )
 
 


### PR DESCRIPTION
## Description
I think this got unintentionally fixed in pandas 2.2, but `pandas.testing.assert_series_equal` will be strict about checking a Series's Index's dtype for date-likes. Since pandas always returns `ns` in resample and cudf tries to match the resolution frequency (IMO the better behavior), need to specify `check_index=False` in pandas 2.2

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
