### PR TITLE
xfail tests in test_udf_masked_ops due to pandas 2.2 bug

### DIFF
--- a/python/cudf/cudf/tests/test_udf_masked_ops.py
+++ b/python/cudf/cudf/tests/test_udf_masked_ops.py
@@ -7,6 +7,7 @@ import pytest
 from numba import cuda
 
 import cudf
+from cudf.core._compat import PANDAS_GE_220
 from cudf.core.missing import NA
 from cudf.core.udf._ops import (
     arith_ops,
@@ -482,6 +483,9 @@ def test_series_apply_basic(data, name):
     run_masked_udf_series(func, data, check_dtype=False)
 
 
+@pytest.mark.xfail(
+    PANDAS_GE_220, reason="https://github.com/pandas-dev/pandas/issues/57390"
+)
 def test_series_apply_null_conditional():
     def func(x):
         if x is NA:
@@ -506,6 +510,9 @@ def test_series_arith_masked_vs_masked(op):
     run_masked_udf_series(func, data, check_dtype=False)
 
 
+@pytest.mark.xfail(
+    PANDAS_GE_220, reason="https://github.com/pandas-dev/pandas/issues/57390"
+)
 @pytest.mark.parametrize("op", comparison_ops)
 def test_series_compare_masked_vs_masked(op):
     """
@@ -562,6 +569,9 @@ def test_series_arith_masked_vs_constant_reflected(request, op, constant):
     run_masked_udf_series(func, data, check_dtype=False)
 
 
+@pytest.mark.xfail(
+    PANDAS_GE_220, reason="https://github.com/pandas-dev/pandas/issues/57390"
+)
 def test_series_masked_is_null_conditional():
     def func(x):
         if x is NA:
@@ -742,8 +752,14 @@ def test_mask_udf_scalar_args_binops_series(data, op):
     ],
 )
 @pytest.mark.parametrize("op", arith_ops + comparison_ops)
-def test_masked_udf_scalar_args_binops_multiple_series(data, op):
+def test_masked_udf_scalar_args_binops_multiple_series(request, data, op):
     data = cudf.Series(data)
+    request.applymarker(
+        pytest.mark.xfail(
+            op in comparison_ops and PANDAS_GE_220 and data.dtype.kind != "b",
+            reason="https://github.com/pandas-dev/pandas/issues/57390",
+        )
+    )
 
     def func(data, c, k):
         x = op(data, c)


### PR DESCRIPTION
## Description
Due to a change in pandas 2.2 with how NA is handled (incorrectly) in UDFs https://github.com/pandas-dev/pandas/issues/57390

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
