### PR TITLE
Add condition for test_groupby_nulls_basic in pandas 2.2

### DIFF
--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -1433,7 +1433,7 @@ def test_groupby_nulls_basic(agg):
 
     # TODO: fillna() used here since we don't follow
     # Pandas' null semantics. Should we change it?
-    with expect_warning_if(agg in {"idxmax", "idxmin"}):
+    with expect_warning_if(agg in {"idxmax", "idxmin"} and not PANDAS_GE_220):
         assert_groupby_results_equal(
             getattr(pdf.groupby("a"), agg)().fillna(0),
             getattr(gdf.groupby("a"), agg)().fillna(0 if agg != "prod" else 1),


### PR DESCRIPTION
## Description
This case for some reason doesn't raise a FutureWarning in pandas in 2.2 while it does in pandas 2.1. It's likely a won't-fix so adding a condition

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
