### PR TITLE
Deprecate cudf::hashing::spark_murmurhash3_x86_32

### DIFF
--- a/cpp/include/cudf/hashing.hpp
+++ b/cpp/include/cudf/hashing.hpp
@@ -63,7 +63,7 @@ static constexpr uint32_t DEFAULT_HASH_SEED = 0;
  *
  * @returns A column where each row is the hash of a column from the input
  */
-std::unique_ptr<column> hash(
+[[deprecated]] std::unique_ptr<column> hash(
   table_view const& input,
   hash_id hash_function               = hash_id::HASH_MURMUR3,
   uint32_t seed                       = DEFAULT_HASH_SEED,
@@ -115,6 +115,8 @@ std::unique_ptr<table> murmurhash3_x64_128(
 /**
  * @brief Computes the MurmurHash3 32-bit hash value of each row in the given table
  *
+ * @deprecated Since 24.04
+ *
  * This function computes the hash similar to MurmurHash3_x86_32 with special processing
  * to match Spark's implementation results.
  *
@@ -125,7 +127,7 @@ std::unique_ptr<table> murmurhash3_x64_128(
  *
  * @returns A column where each row is the hash of a row from the input
  */
-std::unique_ptr<column> spark_murmurhash3_x86_32(
+[[deprecated]] std::unique_ptr<column> spark_murmurhash3_x86_32(
   table_view const& input,
   uint32_t seed                       = DEFAULT_HASH_SEED,
   rmm::cuda_stream_view stream        = cudf::get_default_stream(),

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -175,7 +175,6 @@ ConfigureTest(
   hashing/sha256_test.cpp
   hashing/sha384_test.cpp
   hashing/sha512_test.cpp
-  hashing/spark_murmurhash3_x86_32_test.cpp
   hashing/xxhash_64_test.cpp
 )
 


### PR DESCRIPTION
## Description

The `cudf::hashing::spark_murmurhash3_x86_32()` function was moved to the Spark plugin since it had common code with the Spark implementation of `xxhash_64` (also implemented in the plugin).
This change deprecates the API and the generic `cudf::hashing::hash()` function to removed in a follow-on release.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
