### PR TITLE
Validate types in pylibcudf Column/Table constructors

### DIFF
--- a/python/cudf/cudf/_lib/pylibcudf/column.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/column.pxd
@@ -21,7 +21,7 @@ cdef class Column:
         gpumemoryview _mask
         size_type _null_count
         size_type _offset
-        # children: List[Column]
+        # _children: List[Column]
         list _children
         size_type _num_children
 

--- a/python/cudf/cudf/_lib/pylibcudf/column.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/column.pyx
@@ -45,6 +45,8 @@ cdef class Column:
         gpumemoryview mask, size_type null_count, size_type offset,
         list children
     ):
+        if not all(isinstance(c, Column) for c in children):
+            raise ValueError("All children must be pylibcudf Column objects")
         self._data_type = data_type
         self._size = size
         self._data = data

--- a/python/cudf/cudf/_lib/pylibcudf/table.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/table.pyx
@@ -28,6 +28,8 @@ cdef class Table:
         The columns in this table.
     """
     def __init__(self, list columns):
+        if not all(isinstance(c, Column) for c in columns):
+            raise ValueError("All columns must be pylibcudf Column objects")
         self._columns = columns
 
     cdef table_view view(self) nogil:


### PR DESCRIPTION
## Description

Otherwise, someone can pass any random object to the constructor and will receive an unfriendly segfault when interacting with libcudf.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
