### PR TITLE
Replace `thrust::tuple` with `cuda::std::tuple`

### DIFF
--- a/cpp/benchmarks/common/generate_input.cu
+++ b/cpp/benchmarks/common/generate_input.cu
@@ -51,7 +51,7 @@
 #include <thrust/scan.h>
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cuda/functional>
 
@@ -464,9 +464,9 @@ std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
 
 struct valid_or_zero {
   template <typename T>
-  __device__ T operator()(thrust::tuple<T, bool> len_valid) const
+  __device__ T operator()(cuda::std::tuple<T, bool> len_valid) const
   {
-    return thrust::get<1>(len_valid) ? thrust::get<0>(len_valid) : T{0};
+    return cuda::std::get<1>(len_valid) ? cuda::std::get<0>(len_valid) : T{0};
   }
 };
 
@@ -481,10 +481,10 @@ struct string_generator {
   // range 32-127 is ASCII; 127-136 will be multi-byte UTF-8
   {
   }
-  __device__ void operator()(thrust::tuple<cudf::size_type, cudf::size_type> str_begin_end)
+  __device__ void operator()(cuda::std::tuple<cudf::size_type, cudf::size_type> str_begin_end)
   {
-    auto begin = thrust::get<0>(str_begin_end);
-    auto end   = thrust::get<1>(str_begin_end);
+    auto begin = cuda::std::get<0>(str_begin_end);
+    auto end   = cuda::std::get<1>(str_begin_end);
     engine.discard(begin);
     for (auto i = begin; i < end; ++i) {
       auto ch = char_dist(engine);
@@ -519,7 +519,7 @@ std::unique_ptr<cudf::column> create_random_utf8_string_column(data_profile cons
     cuda::proclaim_return_type<cudf::size_type>([] __device__(auto) { return 0; }),
     thrust::logical_not<bool>{});
   auto valid_lengths = thrust::make_transform_iterator(
-    thrust::make_zip_iterator(thrust::make_tuple(lengths.begin(), null_mask.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(lengths.begin(), null_mask.begin())),
     valid_or_zero{});
   rmm::device_uvector<cudf::size_type> offsets(num_rows + 1, cudf::get_default_stream());
   thrust::exclusive_scan(

--- a/cpp/benchmarks/string/url_decode.cu
+++ b/cpp/benchmarks/string/url_decode.cu
@@ -31,7 +31,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/random.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 struct url_string_generator {
   char* chars;
@@ -43,10 +43,10 @@ struct url_string_generator {
   {
   }
 
-  __device__ void operator()(thrust::tuple<cudf::size_type, cudf::size_type> str_begin_end)
+  __device__ void operator()(cuda::std::tuple<cudf::size_type, cudf::size_type> str_begin_end)
   {
-    auto begin = thrust::get<0>(str_begin_end);
-    auto end   = thrust::get<1>(str_begin_end);
+    auto begin = cuda::std::get<0>(str_begin_end);
+    auto end   = cuda::std::get<1>(str_begin_end);
     engine.discard(begin);
     for (auto i = begin; i < end; ++i) {
       if (esc_seq_dist(engine) < esc_seq_chance and i < end - 3) {

--- a/cpp/include/cudf/detail/merge.hpp
+++ b/cpp/include/cudf/detail/merge.hpp
@@ -29,8 +29,8 @@ namespace detail {
 enum class side : bool { LEFT, RIGHT };
 
 /**
- * @brief Tagged index type: `thrust::get<0>` indicates left/right side,
- * `thrust::get<1>` indicates the row index
+ * @brief Tagged index type: `cuda::std::get<0>` indicates left/right side,
+ * `cuda::std::get<1>` indicates the row index
  */
 using index_type = thrust::pair<side, cudf::size_type>;
 

--- a/cpp/include/cudf/detail/null_mask.cuh
+++ b/cpp/include/cudf/detail/null_mask.cuh
@@ -35,7 +35,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cuda/functional>
 
@@ -334,8 +334,8 @@ rmm::device_uvector<size_type> segmented_count_bits(bitmask_type const* bitmask,
       thrust::make_zip_iterator(first_bit_indices_begin, last_bit_indices_begin);
     auto segment_length_iterator = thrust::transform_iterator(
       segments_begin, cuda::proclaim_return_type<size_type>([] __device__(auto const& segment) {
-        auto const begin = thrust::get<0>(segment);
-        auto const end   = thrust::get<1>(segment);
+        auto const begin = cuda::std::get<0>(segment);
+        auto const end   = cuda::std::get<1>(segment);
         return end - begin;
       }));
     thrust::transform(rmm::exec_policy(stream),
@@ -546,8 +546,8 @@ std::pair<rmm::device_buffer, size_type> segmented_null_mask_reduction(
     thrust::make_zip_iterator(first_bit_indices_begin, last_bit_indices_begin);
   auto const segment_length_iterator = thrust::make_transform_iterator(
     segments_begin, cuda::proclaim_return_type<size_type>([] __device__(auto const& segment) {
-      auto const begin = thrust::get<0>(segment);
-      auto const end   = thrust::get<1>(segment);
+      auto const begin = cuda::std::get<0>(segment);
+      auto const end   = cuda::std::get<1>(segment);
       return end - begin;
     }));
 
@@ -579,8 +579,8 @@ std::pair<rmm::device_buffer, size_type> segmented_null_mask_reduction(
     length_and_valid_count,
     length_and_valid_count + num_segments,
     [null_handling, valid_initial_value] __device__(auto const& length_and_valid_count) {
-      auto const length      = thrust::get<0>(length_and_valid_count);
-      auto const valid_count = thrust::get<1>(length_and_valid_count);
+      auto const length      = cuda::std::get<0>(length_and_valid_count);
+      auto const valid_count = cuda::std::get<1>(length_and_valid_count);
       return (null_handling == null_policy::EXCLUDE)
                ? (valid_initial_value.value_or(false) || valid_count > 0)
                : (valid_initial_value.value_or(length > 0) && valid_count == length);

--- a/cpp/include/cudf/detail/replace/nulls.cuh
+++ b/cpp/include/cudf/detail/replace/nulls.cuh
@@ -18,12 +18,12 @@
 #include <cudf/types.hpp>
 
 #include <thrust/functional.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace cudf {
 namespace detail {
 
-using idx_valid_pair_t = thrust::tuple<cudf::size_type, bool>;
+using idx_valid_pair_t = cuda::std::tuple<cudf::size_type, bool>;
 
 /**
  * @brief Functor used by `replace_nulls(replace_policy)` to determine the index to gather from in
@@ -36,7 +36,7 @@ using idx_valid_pair_t = thrust::tuple<cudf::size_type, bool>;
 struct replace_policy_functor {
   __device__ idx_valid_pair_t operator()(idx_valid_pair_t const& lhs, idx_valid_pair_t const& rhs)
   {
-    return thrust::get<1>(rhs) ? rhs : lhs;
+    return cuda::std::get<1>(rhs) ? rhs : lhs;
   }
 };
 

--- a/cpp/include/cudf/strings/detail/merge.cuh
+++ b/cpp/include/cudf/strings/detail/merge.cuh
@@ -30,7 +30,7 @@
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cuda/functional>
 
@@ -42,7 +42,7 @@ namespace detail {
  *
  * Caller must set the validity mask in the output column.
  *
- * @tparam row_order_iterator This must be an iterator for type thrust::tuple<side,size_type>.
+ * @tparam row_order_iterator This must be an iterator for type cuda::std::tuple<side,size_type>.
  *
  * @param lhs First column.
  * @param rhs Second column.

--- a/cpp/include/cudf/strings/detail/strings_column_factories.cuh
+++ b/cpp/include/cudf/strings/detail/strings_column_factories.cuh
@@ -35,7 +35,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/pair.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cuda/functional>
 
@@ -120,13 +120,13 @@ std::unique_ptr<column> make_strings_column(IndexPairIterator begin,
       auto chars_data = rmm::device_uvector<char>(bytes, stream, mr);
       auto d_chars    = chars_data.data();
       auto copy_chars = [d_chars] __device__(auto item) {
-        string_index_pair const str = thrust::get<0>(item);
-        size_type const offset      = thrust::get<1>(item);
+        string_index_pair const str = cuda::std::get<0>(item);
+        size_type const offset      = cuda::std::get<1>(item);
         if (str.first != nullptr) memcpy(d_chars + offset, str.first, str.second);
       };
       thrust::for_each_n(rmm::exec_policy(stream),
                          thrust::make_zip_iterator(
-                           thrust::make_tuple(begin, offsets_view.template begin<size_type>())),
+                           cuda::std::make_tuple(begin, offsets_view.template begin<size_type>())),
                          strings_count,
                          copy_chars);
       return chars_data;

--- a/cpp/include/cudf_test/tdigest_utilities.cuh
+++ b/cpp/include/cudf_test/tdigest_utilities.cuh
@@ -33,14 +33,14 @@
 #include <thrust/host_vector.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 // for use with groupby and reduction aggregation tests.
 
 namespace cudf {
 namespace test {
 
-using expected_value = thrust::tuple<size_type, double, double>;
+using expected_value = cuda::std::tuple<size_type, double, double>;
 
 /**
  * @brief Device functor to compute min of a sequence of values serially.

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -43,7 +43,7 @@
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cuda/functional>
 
@@ -947,7 +947,7 @@ struct size_of_helper {
  */
 struct num_batches_func {
   thrust::pair<std::size_t, std::size_t> const* const batches;
-  __device__ std::size_t operator()(size_type i) const { return thrust::get<0>(batches[i]); }
+  __device__ std::size_t operator()(size_type i) const { return cuda::std::get<0>(batches[i]); }
 };
 
 /**
@@ -1466,7 +1466,7 @@ std::unique_ptr<chunk_iteration_state> chunk_iteration_state::create(
      out_to_in_index] __device__(size_type i) {
       size_type const in_buf_index = out_to_in_index(i);
       size_type const batch_index  = i - d_batch_offsets[in_buf_index];
-      auto const batch_size        = thrust::get<1>(batches[in_buf_index]);
+      auto const batch_size        = cuda::std::get<1>(batches[in_buf_index]);
       dst_buf_info const& in       = d_orig_dst_buf_info[in_buf_index];
 
       // adjust info

--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -33,7 +33,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <type_traits>
 
@@ -187,7 +187,7 @@ std::unique_ptr<column> group_correlation(column_view const& covariance,
   CUDF_EXPECTS(covariance.type().id() == type_id::FLOAT64, "Covariance result must be FLOAT64");
   auto stddev0_ptr = stddev_0.begin<result_type>();
   auto stddev1_ptr = stddev_1.begin<result_type>();
-  auto stddev_iter = thrust::make_zip_iterator(thrust::make_tuple(stddev0_ptr, stddev1_ptr));
+  auto stddev_iter = thrust::make_zip_iterator(cuda::std::make_tuple(stddev0_ptr, stddev1_ptr));
   auto result      = make_numeric_column(covariance.type(),
                                     covariance.size(),
                                     cudf::detail::copy_bitmask(covariance, stream, mr),
@@ -201,7 +201,7 @@ std::unique_ptr<column> group_correlation(column_view const& covariance,
                     stddev_iter,
                     d_result,
                     [] __device__(auto const covariance, auto const stddev) {
-                      return covariance / thrust::get<0>(stddev) / thrust::get<1>(stddev);
+                      return covariance / cuda::std::get<0>(stddev) / cuda::std::get<1>(stddev);
                     });
 
   result->set_null_count(covariance.null_count());

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -32,7 +32,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace cudf {
 namespace groupby {
@@ -90,7 +90,7 @@ struct merge_fn {
     // This case should never happen, because all groups are non-empty as the results of
     // aggregation. Here we just to make sure we cover this case.
     if (start_idx == end_idx) {
-      return thrust::make_tuple(size_type{0}, result_type{0}, result_type{0}, int8_t{0});
+      return cuda::std::make_tuple(size_type{0}, result_type{0}, result_type{0}, int8_t{0});
     }
 
     // If `(n = d_counts[idx]) > 0` then `d_means[idx] != null` and `d_M2s[idx] != null`.
@@ -121,7 +121,7 @@ struct merge_fn {
     // zero), then the output is a null.
     auto const is_valid = int8_t{merge_vals.count > 0};
 
-    return thrust::make_tuple(merge_vals.count, merge_vals.mean, merge_vals.M2, is_valid);
+    return cuda::std::make_tuple(merge_vals.count, merge_vals.mean, merge_vals.M2, is_valid);
   }
 };
 
@@ -157,10 +157,10 @@ std::unique_ptr<column> group_merge_m2(column_view const& values,
 
   // Perform merging for all the aggregations. Their output (and their validity data) are written
   // out concurrently through an output zip iterator.
-  using iterator_tuple  = thrust::tuple<size_type*, result_type*, result_type*, int8_t*>;
+  using iterator_tuple  = cuda::std::tuple<size_type*, result_type*, result_type*, int8_t*>;
   using output_iterator = thrust::zip_iterator<iterator_tuple>;
   auto const out_iter =
-    output_iterator{thrust::make_tuple(result_counts->mutable_view().template data<size_type>(),
+    output_iterator{cuda::std::make_tuple(result_counts->mutable_view().template data<size_type>(),
                                        result_means->mutable_view().template data<result_type>(),
                                        result_M2s->mutable_view().template data<result_type>(),
                                        validities.begin())};

--- a/cpp/src/groupby/sort/group_replace_nulls.cu
+++ b/cpp/src/groupby/sort/group_replace_nulls.cu
@@ -28,7 +28,7 @@
 #include <thrust/iterator/reverse_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/scan.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <utility>
 
@@ -47,11 +47,11 @@ std::unique_ptr<column> group_replace_nulls(cudf::column_view const& grouped_val
   auto device_in = cudf::column_device_view::create(grouped_value, stream);
   auto index     = thrust::make_counting_iterator<cudf::size_type>(0);
   auto valid_it  = cudf::detail::make_validity_iterator(*device_in);
-  auto in_begin  = thrust::make_zip_iterator(thrust::make_tuple(index, valid_it));
+  auto in_begin  = thrust::make_zip_iterator(cuda::std::make_tuple(index, valid_it));
 
   rmm::device_uvector<cudf::size_type> gather_map(size, stream);
   auto gm_begin = thrust::make_zip_iterator(
-    thrust::make_tuple(gather_map.begin(), thrust::make_discard_iterator()));
+    cuda::std::make_tuple(gather_map.begin(), thrust::make_discard_iterator()));
 
   auto func = cudf::detail::replace_policy_functor();
   thrust::equal_to<cudf::size_type> eq;

--- a/cpp/src/io/comp/nvcomp_adapter.cu
+++ b/cpp/src/io/comp/nvcomp_adapter.cu
@@ -21,7 +21,7 @@
 
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace cudf::io::nvcomp {
 
@@ -39,7 +39,7 @@ batched_args create_batched_nvcomp_args(device_span<device_span<uint8_t const> c
   auto ins_it = thrust::make_zip_iterator(input_data_ptrs.begin(), input_data_sizes.begin());
   thrust::transform(
     rmm::exec_policy(stream), inputs.begin(), inputs.end(), ins_it, [] __device__(auto const& in) {
-      return thrust::make_tuple(in.data(), in.size());
+      return cuda::std::make_tuple(in.data(), in.size());
     });
 
   // Prepare the output vectors
@@ -49,7 +49,7 @@ batched_args create_batched_nvcomp_args(device_span<device_span<uint8_t const> c
     outputs.begin(),
     outputs.end(),
     outs_it,
-    [] __device__(auto const& out) { return thrust::make_tuple(out.data(), out.size()); });
+    [] __device__(auto const& out) { return cuda::std::make_tuple(out.data(), out.size()); });
 
   return {std::move(input_data_ptrs),
           std::move(input_data_sizes),

--- a/cpp/src/io/comp/statistics.cu
+++ b/cpp/src/io/comp/statistics.cu
@@ -39,7 +39,7 @@ writer_compression_statistics collect_compression_statistics(
 
   auto input_size_with_status = [inputs, results, stream](compression_status status) {
     auto const zipped_begin =
-      thrust::make_zip_iterator(thrust::make_tuple(inputs.begin(), results.begin()));
+      thrust::make_zip_iterator(cuda::std::make_tuple(inputs.begin(), results.begin()));
     auto const zipped_end = zipped_begin + inputs.size();
 
     return thrust::transform_reduce(
@@ -47,7 +47,7 @@ writer_compression_statistics collect_compression_statistics(
       zipped_begin,
       zipped_end,
       [status] __device__(auto tup) {
-        return thrust::get<1>(tup).status == status ? thrust::get<0>(tup).size() : 0;
+        return cuda::std::get<1>(tup).status == status ? cuda::std::get<0>(tup).size() : 0;
       },
       0ul,
       thrust::plus<size_t>());

--- a/cpp/src/io/json/json_column.cu
+++ b/cpp/src/io/json/json_column.cu
@@ -350,9 +350,9 @@ std::vector<std::string> copy_strings_to_host(device_span<SymbolT const> input,
                     thrust::make_zip_iterator(string_offsets.begin(), string_lengths.begin()),
                     [] __device__(auto const& offsets) {
                       // Note: first character for non-field columns
-                      return thrust::make_tuple(
-                        static_cast<size_type>(thrust::get<0>(offsets)),
-                        static_cast<size_type>(thrust::get<1>(offsets) - thrust::get<0>(offsets)));
+                      return cuda::std::make_tuple(
+                        static_cast<size_type>(cuda::std::get<0>(offsets)),
+                        static_cast<size_type>(cuda::std::get<1>(offsets) - cuda::std::get<0>(offsets)));
                     });
 
   cudf::io::parse_options_view options_view{};
@@ -546,7 +546,7 @@ void make_device_json_column(device_span<SymbolT const> input,
   auto h_range_col_id_it =
     thrust::make_zip_iterator(column_range_beg.begin(), unique_col_ids.begin());
   std::sort(h_range_col_id_it, h_range_col_id_it + num_columns, [](auto const& a, auto const& b) {
-    return thrust::get<0>(a) < thrust::get<0>(b);
+    return cuda::std::get<0>(a) < cuda::std::get<0>(b);
   });
 
   // use hash map because we may skip field name's col_ids
@@ -667,7 +667,7 @@ void make_device_json_column(device_span<SymbolT const> input,
 
   // restore unique_col_ids order
   std::sort(h_range_col_id_it, h_range_col_id_it + num_columns, [](auto const& a, auto const& b) {
-    return thrust::get<1>(a) < thrust::get<1>(b);
+    return cuda::std::get<1>(a) < cuda::std::get<1>(b);
   });
   // move columns data to device.
   std::vector<json_column_data> columns_data(num_columns);

--- a/cpp/src/io/json/json_tree.cu
+++ b/cpp/src/io/json/json_tree.cu
@@ -84,7 +84,7 @@ struct node_ranges {
   device_span<PdaTokenT const> tokens;
   device_span<SymbolOffsetT const> token_indices;
   bool include_quote_char;
-  __device__ auto operator()(size_type i) -> thrust::tuple<SymbolOffsetT, SymbolOffsetT>
+  __device__ auto operator()(size_type i) -> cuda::std::tuple<SymbolOffsetT, SymbolOffsetT>
   {
     // Whether a token expects to be followed by its respective end-of-* token partner
     auto const is_begin_of_section = [] __device__(PdaTokenT const token) {
@@ -129,7 +129,7 @@ struct node_ranges {
         range_end = get_token_index(tokens[i + 1], token_indices[i + 1]);
       }
     }
-    return thrust::make_tuple(range_begin, range_end);
+    return cuda::std::make_tuple(range_begin, range_end);
   }
 };
 

--- a/cpp/src/io/json/write_json.cu
+++ b/cpp/src/io/json/write_json.cu
@@ -700,8 +700,8 @@ struct column_to_strings_fn {
       i_col_begin + num_columns,
       std::back_inserter(str_column_vec),
       [this, &children_names](auto const& i_current_col) {
-        auto const i            = thrust::get<0>(i_current_col);
-        auto const& current_col = thrust::get<1>(i_current_col);
+        auto const i            = cuda::std::get<0>(i_current_col);
+        auto const& current_col = cuda::std::get<1>(i_current_col);
         // Struct needs children's column names
         if (current_col.type().id() == type_id::STRUCT) {
           return this->template operator()<cudf::struct_view>(current_col,

--- a/cpp/src/io/orc/stripe_enc.cu
+++ b/cpp/src/io/orc/stripe_enc.cu
@@ -35,7 +35,7 @@
 #include <thrust/for_each.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace cudf {
 namespace io {

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -41,7 +41,7 @@
 #include <thrust/merge.h>
 #include <thrust/scan.h>
 #include <thrust/scatter.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <bitset>
 

--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -245,7 +245,7 @@ class named_to_reference_converter : public ast::detail::expression_transformer 
                                 thrust::counting_iterator(metadata.schema_info.size())),
       std::inserter(column_name_to_index, column_name_to_index.end()),
       [](auto const& name_index) {
-        return std::make_pair(thrust::get<0>(name_index).name, thrust::get<1>(name_index));
+        return std::make_pair(cuda::std::get<0>(name_index).name, cuda::std::get<1>(name_index));
       });
 
     expr.value().get().accept(*this);

--- a/cpp/src/io/text/bgzip_data_chunk_source.cu
+++ b/cpp/src/io/text/bgzip_data_chunk_source.cu
@@ -50,14 +50,14 @@ struct bgzip_nvcomp_transform_functor {
   uint8_t const* compressed_ptr;
   uint8_t* decompressed_ptr;
 
-  __device__ thrust::tuple<device_span<uint8_t const>, device_span<uint8_t>> operator()(
-    thrust::tuple<std::size_t, std::size_t, std::size_t, std::size_t> t)
+  __device__ cuda::std::tuple<device_span<uint8_t const>, device_span<uint8_t>> operator()(
+    cuda::std::tuple<std::size_t, std::size_t, std::size_t, std::size_t> t)
   {
-    auto const compressed_begin   = thrust::get<0>(t);
-    auto const compressed_end     = thrust::get<1>(t);
-    auto const decompressed_begin = thrust::get<2>(t);
-    auto const decompressed_end   = thrust::get<3>(t);
-    return thrust::make_tuple(device_span<uint8_t const>{compressed_ptr + compressed_begin,
+    auto const compressed_begin   = cuda::std::get<0>(t);
+    auto const compressed_end     = cuda::std::get<1>(t);
+    auto const decompressed_begin = cuda::std::get<2>(t);
+    auto const decompressed_end   = cuda::std::get<3>(t);
+    return cuda::std::make_tuple(device_span<uint8_t const>{compressed_ptr + compressed_begin,
                                                          compressed_end - compressed_begin},
                               device_span<uint8_t>{decompressed_ptr + decompressed_begin,
                                                    decompressed_end - decompressed_begin});

--- a/cpp/src/io/utilities/data_casting.cu
+++ b/cpp/src/io/utilities/data_casting.cu
@@ -783,10 +783,10 @@ template <typename SymbolT>
 struct to_string_view_pair {
   SymbolT const* data;
   to_string_view_pair(SymbolT const* _data) : data(_data) {}
-  __device__ auto operator()(thrust::tuple<size_type, size_type> ip)
+  __device__ auto operator()(cuda::std::tuple<size_type, size_type> ip)
   {
-    return thrust::pair<char const*, std::size_t>{data + thrust::get<0>(ip),
-                                                  static_cast<std::size_t>(thrust::get<1>(ip))};
+    return thrust::pair<char const*, std::size_t>{data + cuda::std::get<0>(ip),
+                                                  static_cast<std::size_t>(cuda::std::get<1>(ip))};
   }
 };
 
@@ -908,7 +908,7 @@ static std::unique_ptr<column> parse_string(string_view_pair_it str_tuples,
 
 std::unique_ptr<column> parse_data(
   const char* data,
-  thrust::zip_iterator<thrust::tuple<const size_type*, const size_type*>> offset_length_begin,
+  thrust::zip_iterator<cuda::std::tuple<const size_type*, const size_type*>> offset_length_begin,
   size_type col_size,
   data_type col_type,
   rmm::device_buffer&& null_mask,

--- a/cpp/src/io/utilities/string_parsing.hpp
+++ b/cpp/src/io/utilities/string_parsing.hpp
@@ -23,7 +23,7 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace cudf::io {
 namespace detail {
@@ -45,7 +45,7 @@ namespace detail {
 cudf::data_type infer_data_type(
   cudf::io::json_inference_options_view const& options,
   device_span<char const> data,
-  thrust::zip_iterator<thrust::tuple<const size_type*, const size_type*>> offset_length_begin,
+  thrust::zip_iterator<cuda::std::tuple<const size_type*, const size_type*>> offset_length_begin,
   std::size_t const size,
   rmm::cuda_stream_view stream);
 }  // namespace detail
@@ -67,7 +67,7 @@ namespace json::detail {
  */
 std::unique_ptr<column> parse_data(
   const char* data,
-  thrust::zip_iterator<thrust::tuple<const size_type*, const size_type*>> offset_length_begin,
+  thrust::zip_iterator<cuda::std::tuple<const size_type*, const size_type*>> offset_length_begin,
   size_type col_size,
   data_type col_type,
   rmm::device_buffer&& null_mask,

--- a/cpp/src/io/utilities/type_inference.cu
+++ b/cpp/src/io/utilities/type_inference.cu
@@ -102,7 +102,7 @@ __device__ __inline__ bool is_like_float(std::size_t len,
  * @tparam BlockSize Number of threads in each block
  * @tparam OptionsView Type of inference options view
  * @tparam ColumnStringIter Iterator type whose `value_type` is a
- * `thrust::tuple<offset_t, length_t>`, where `offset_t` and `length_t` are of integral type and
+ * `cuda::std::tuple<offset_t, length_t>`, where `offset_t` and `length_t` are of integral type and
  * `offset_t` needs to be convertible to `std::size_t`.
  *
  * @param[in] options View of inference options
@@ -122,8 +122,8 @@ CUDF_KERNEL void infer_column_type_kernel(OptionsView options,
 
   for (auto idx = threadIdx.x + blockDim.x * blockIdx.x; idx < size;
        idx += gridDim.x * blockDim.x) {
-    auto const field_offset = thrust::get<0>(*(offset_length_begin + idx));
-    auto const field_len    = thrust::get<1>(*(offset_length_begin + idx));
+    auto const field_offset = cuda::std::get<0>(*(offset_length_begin + idx));
+    auto const field_len    = cuda::std::get<1>(*(offset_length_begin + idx));
     auto const field_begin  = data.begin() + field_offset;
 
     if (cudf::detail::serialized_trie_contains(
@@ -222,7 +222,7 @@ CUDF_KERNEL void infer_column_type_kernel(OptionsView options,
  *
  * @tparam OptionsView Type of inference options view
  * @tparam ColumnStringIter Iterator type whose `value_type` is a
- * `thrust::tuple<offset_t, length_t>`, where `offset_t` and `length_t` are of integral type and
+ * `cuda::std::tuple<offset_t, length_t>`, where `offset_t` and `length_t` are of integral type and
  * `offset_t` needs to be convertible to `std::size_t`.
  *
  * @param options View of inference options
@@ -255,7 +255,7 @@ cudf::io::column_type_histogram infer_column_type(OptionsView const& options,
 cudf::data_type infer_data_type(
   cudf::io::json_inference_options_view const& options,
   device_span<char const> data,
-  thrust::zip_iterator<thrust::tuple<const size_type*, const size_type*>> offset_length_begin,
+  thrust::zip_iterator<cuda::std::tuple<const size_type*, const size_type*>> offset_length_begin,
   std::size_t const size,
   rmm::cuda_stream_view stream)
 {

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -33,7 +33,7 @@
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/scatter.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 #include <thrust/uninitialized_fill.h>
 
 #include <cstddef>
@@ -194,9 +194,9 @@ probe_join_hash_table(
   cudf::size_type const probe_table_num_rows = probe_table.num_rows();
 
   auto const out1_zip_begin = thrust::make_zip_iterator(
-    thrust::make_tuple(thrust::make_discard_iterator(), left_indices->begin()));
+    cuda::std::make_tuple(thrust::make_discard_iterator(), left_indices->begin()));
   auto const out2_zip_begin = thrust::make_zip_iterator(
-    thrust::make_tuple(thrust::make_discard_iterator(), right_indices->begin()));
+    cuda::std::make_tuple(thrust::make_discard_iterator(), right_indices->begin()));
 
   auto const row_comparator =
     cudf::experimental::row::equality::two_table_comparator{preprocessed_probe, preprocessed_build};
@@ -296,9 +296,9 @@ std::size_t get_full_join_size(
   cudf::size_type const probe_table_num_rows = probe_table.num_rows();
 
   auto const out1_zip_begin = thrust::make_zip_iterator(
-    thrust::make_tuple(thrust::make_discard_iterator(), left_indices->begin()));
+    cuda::std::make_tuple(thrust::make_discard_iterator(), left_indices->begin()));
   auto const out2_zip_begin = thrust::make_zip_iterator(
-    thrust::make_tuple(thrust::make_discard_iterator(), right_indices->begin()));
+    cuda::std::make_tuple(thrust::make_discard_iterator(), right_indices->begin()));
 
   auto const row_comparator =
     cudf::experimental::row::equality::two_table_comparator{preprocessed_probe, preprocessed_build};

--- a/cpp/src/json/json_path.cu
+++ b/cpp/src/json/json_path.cu
@@ -41,7 +41,7 @@
 #include <thrust/optional.h>
 #include <thrust/pair.h>
 #include <thrust/scan.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/lists/dremel.cu
+++ b/cpp/src/lists/dremel.cu
@@ -318,13 +318,13 @@ dremel_data get_encoding(column_view h_col,
 
     // Zip the input and output value iterators so that merge operation is done only once
     auto input_parent_zip_it =
-      thrust::make_zip_iterator(thrust::make_tuple(input_parent_rep_it, input_parent_def_it));
+      thrust::make_zip_iterator(cuda::std::make_tuple(input_parent_rep_it, input_parent_def_it));
 
     auto input_child_zip_it =
-      thrust::make_zip_iterator(thrust::make_tuple(input_child_rep_it, input_child_def_it));
+      thrust::make_zip_iterator(cuda::std::make_tuple(input_child_rep_it, input_child_def_it));
 
     auto output_zip_it =
-      thrust::make_zip_iterator(thrust::make_tuple(rep_level.begin(), def_level.begin()));
+      thrust::make_zip_iterator(cuda::std::make_tuple(rep_level.begin(), def_level.begin()));
 
     auto ends = thrust::merge_by_key(rmm::exec_policy(stream),
                                      empties.begin(),
@@ -405,13 +405,13 @@ dremel_data get_encoding(column_view h_col,
 
     // Zip the input and output value iterators so that merge operation is done only once
     auto input_parent_zip_it =
-      thrust::make_zip_iterator(thrust::make_tuple(input_parent_rep_it, input_parent_def_it));
+      thrust::make_zip_iterator(cuda::std::make_tuple(input_parent_rep_it, input_parent_def_it));
 
     auto input_child_zip_it =
-      thrust::make_zip_iterator(thrust::make_tuple(temp_rep_vals.begin(), temp_def_vals.begin()));
+      thrust::make_zip_iterator(cuda::std::make_tuple(temp_rep_vals.begin(), temp_def_vals.begin()));
 
     auto output_zip_it =
-      thrust::make_zip_iterator(thrust::make_tuple(rep_level.begin(), def_level.begin()));
+      thrust::make_zip_iterator(cuda::std::make_tuple(rep_level.begin(), def_level.begin()));
 
     auto ends = thrust::merge_by_key(rmm::exec_policy(stream),
                                      transformed_empties,

--- a/cpp/src/merge/merge.cu
+++ b/cpp/src/merge/merge.cu
@@ -48,7 +48,7 @@
 #include <thrust/pair.h>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cuda/functional>
 
@@ -106,8 +106,8 @@ using index_type = detail::index_type;
  *
  * Merges the bits from two column_device_views into the destination validity buffer
  * according to `merged_indices` map such that bit `i` in `out_validity`
- * will be equal to bit `thrust::get<1>(merged_indices[i])` from `left_dcol`
- * if `thrust::get<0>(merged_indices[i])` equals `side::LEFT`; otherwise,
+ * will be equal to bit `cuda::std::get<1>(merged_indices[i])` from `left_dcol`
+ * if `cuda::std::get<0>(merged_indices[i])` equals `side::LEFT`; otherwise,
  * from `right_dcol`.
  *
  * `left_dcol` and `right_dcol` must not overlap.

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -38,7 +38,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/sequence.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cuda/functional>
 

--- a/cpp/src/reductions/histogram.cu
+++ b/cpp/src/reductions/histogram.cu
@@ -23,7 +23,7 @@
 
 #include <thrust/copy.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cuda/atomic>
 #include <cuda/functional>
@@ -96,7 +96,7 @@ struct is_not_zero {
   template <typename Pair>
   __device__ bool operator()(Pair const input) const
   {
-    return thrust::get<1>(input) != 0;
+    return cuda::std::get<1>(input) != 0;
   }
 };
 
@@ -223,8 +223,8 @@ compute_row_frequencies(table_view const& input,
     rmm::mr::get_current_device_resource());
 
   auto const input_it = thrust::make_zip_iterator(
-    thrust::make_tuple(thrust::make_counting_iterator(0), reduction_results.begin()));
-  auto const output_it = thrust::make_zip_iterator(thrust::make_tuple(
+    cuda::std::make_tuple(thrust::make_counting_iterator(0), reduction_results.begin()));
+  auto const output_it = thrust::make_zip_iterator(cuda::std::make_tuple(
     distinct_indices->begin(), distinct_counts->mutable_view().begin<histogram_count_type>()));
 
   // Reduction results above are either group sizes of equal rows, or `0`.

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -42,7 +42,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cuda/functional>
 
@@ -132,17 +132,17 @@ std::enable_if_t<cudf::is_fixed_width<T>(), std::unique_ptr<cudf::column>> clamp
     cudf::mutable_column_device_view::create(output->mutable_view(), stream);
   auto input_device_view = cudf::column_device_view::create(input, stream);
   auto scalar_zip_itr =
-    thrust::make_zip_iterator(thrust::make_tuple(lo_itr, lo_replace_itr, hi_itr, hi_replace_itr));
+    thrust::make_zip_iterator(cuda::std::make_tuple(lo_itr, lo_replace_itr, hi_itr, hi_replace_itr));
 
   auto trans =
     cuda::proclaim_return_type<T>([] __device__(auto element_optional, auto scalar_tuple) {
       if (element_optional.has_value()) {
-        auto lo_optional = thrust::get<0>(scalar_tuple);
-        auto hi_optional = thrust::get<2>(scalar_tuple);
+        auto lo_optional = cuda::std::get<0>(scalar_tuple);
+        auto hi_optional = cuda::std::get<2>(scalar_tuple);
         if (lo_optional.has_value() and (*element_optional < *lo_optional)) {
-          return *(thrust::get<1>(scalar_tuple));
+          return *(cuda::std::get<1>(scalar_tuple));
         } else if (hi_optional.has_value() and (*element_optional > *hi_optional)) {
-          return *(thrust::get<3>(scalar_tuple));
+          return *(cuda::std::get<3>(scalar_tuple));
         }
       }
 

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -50,7 +50,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace {  // anonymous
 
@@ -367,11 +367,11 @@ std::unique_ptr<cudf::column> replace_nulls_policy_impl(cudf::column_view const&
   auto device_in = cudf::column_device_view::create(input, stream);
   auto index     = thrust::make_counting_iterator<cudf::size_type>(0);
   auto valid_it  = cudf::detail::make_validity_iterator(*device_in);
-  auto in_begin  = thrust::make_zip_iterator(thrust::make_tuple(index, valid_it));
+  auto in_begin  = thrust::make_zip_iterator(cuda::std::make_tuple(index, valid_it));
 
   rmm::device_uvector<cudf::size_type> gather_map(input.size(), stream);
   auto gm_begin = thrust::make_zip_iterator(
-    thrust::make_tuple(gather_map.begin(), thrust::make_discard_iterator()));
+    cuda::std::make_tuple(gather_map.begin(), thrust::make_discard_iterator()));
 
   auto func = cudf::detail::replace_policy_functor();
   if (replace_policy == cudf::replace_policy::PRECEDING) {

--- a/cpp/src/replace/replace.cu
+++ b/cpp/src/replace/replace.cu
@@ -57,7 +57,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/find.h>
 #include <thrust/pair.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 namespace {  // anonymous
 

--- a/cpp/src/sort/rank.cu
+++ b/cpp/src/sort/rank.cu
@@ -42,7 +42,7 @@
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cuda/functional>
 #include <cuda/std/type_traits>
@@ -256,8 +256,8 @@ void rank_average(cudf::device_span<size_type const> group_keys,
                       rank_count1.second + rank_count2.second};
     }),
     cuda::proclaim_return_type<double>([] __device__(MinCount minrank_count) {  // min+(count-1)/2
-      return static_cast<double>(thrust::get<0>(minrank_count)) +
-             (static_cast<double>(thrust::get<1>(minrank_count)) - 1) / 2.0;
+      return static_cast<double>(cuda::std::get<0>(minrank_count)) +
+             (static_cast<double>(cuda::std::get<1>(minrank_count)) - 1) / 2.0;
     }),
     stream);
 }

--- a/cpp/src/strings/split/split_re.cu
+++ b/cpp/src/strings/split/split_re.cu
@@ -78,7 +78,7 @@ struct token_reader_fn {
       auto const match = prog.find(prog_idx, d_str, itr);
       if (!match) { break; }
 
-      auto const start_pos = thrust::get<0>(match_positions_to_bytes(*match, d_str, last_pos));
+      auto const start_pos = cuda::std::get<0>(match_positions_to_bytes(*match, d_str, last_pos));
 
       // get the token (characters just before this match)
       auto const token = string_index_pair{d_str.data() + last_pos.byte_offset(),

--- a/cpp/src/text/minhash.cu
+++ b/cpp/src/text/minhash.cu
@@ -112,7 +112,7 @@ CUDF_KERNEL void minhash_kernel(cudf::column_device_view const d_strings,
       } else {
         // This code path assumes the use of MurmurHash3_x64_128 which produces 2 uint64 values
         // but only uses the first uint64 value as requested by the LLM team.
-        auto const hvalue = thrust::get<0>(hasher(hash_str));
+        auto const hvalue = cuda::std::get<0>(hasher(hash_str));
         cuda::atomic_ref<hash_value_type, cuda::thread_scope_block> ref{*(d_output + seed_idx)};
         ref.fetch_min(hvalue, cuda::std::memory_order_relaxed);
       }

--- a/cpp/tests/io/json_type_cast_test.cu
+++ b/cpp/tests/io/json_type_cast_test.cu
@@ -44,9 +44,9 @@ struct JSONTypeCastTest : public cudf::test::BaseFixture {};
 
 namespace {
 struct offsets_to_length {
-  __device__ cudf::size_type operator()(thrust::tuple<cudf::size_type, cudf::size_type> const& p)
+  __device__ cudf::size_type operator()(cuda::std::tuple<cudf::size_type, cudf::size_type> const& p)
   {
-    return thrust::get<1>(p) - thrust::get<0>(p);
+    return cuda::std::get<1>(p) - cuda::std::get<0>(p);
   }
 };
 
@@ -55,7 +55,7 @@ auto string_offset_to_length(cudf::strings_column_view const& column, rmm::cuda_
 {
   auto offsets_begin = column.offsets_begin();
   auto offsets_pair =
-    thrust::make_zip_iterator(thrust::make_tuple(offsets_begin, thrust::next(offsets_begin)));
+    thrust::make_zip_iterator(cuda::std::make_tuple(offsets_begin, thrust::next(offsets_begin)));
   rmm::device_uvector<cudf::size_type> svs_length(column.size(), stream);
   thrust::transform(rmm::exec_policy(cudf::get_default_stream()),
                     offsets_pair,
@@ -96,7 +96,7 @@ TEST_F(JSONTypeCastTest, String)
 
   auto str_col = cudf::io::json::detail::parse_data(
     column.chars_begin(stream),
-    thrust::make_zip_iterator(thrust::make_tuple(column.offsets_begin(), svs_length.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(column.offsets_begin(), svs_length.begin())),
     column.size(),
     type,
     std::move(null_mask),
@@ -129,7 +129,7 @@ TEST_F(JSONTypeCastTest, Int)
 
   auto col = cudf::io::json::detail::parse_data(
     column.chars_begin(stream),
-    thrust::make_zip_iterator(thrust::make_tuple(column.offsets_begin(), svs_length.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(column.offsets_begin(), svs_length.begin())),
     column.size(),
     type,
     std::move(null_mask),
@@ -169,7 +169,7 @@ TEST_F(JSONTypeCastTest, StringEscapes)
 
   auto col = cudf::io::json::detail::parse_data(
     column.chars_begin(stream),
-    thrust::make_zip_iterator(thrust::make_tuple(column.offsets_begin(), svs_length.begin())),
+    thrust::make_zip_iterator(cuda::std::make_tuple(column.offsets_begin(), svs_length.begin())),
     column.size(),
     type,
     std::move(null_mask),
@@ -238,7 +238,7 @@ TEST_F(JSONTypeCastTest, ErrorNulls)
 
     auto str_col = cudf::io::json::detail::parse_data(
       column.chars_begin(stream),
-      thrust::make_zip_iterator(thrust::make_tuple(column.offsets_begin(), svs_length.begin())),
+      thrust::make_zip_iterator(cuda::std::make_tuple(column.offsets_begin(), svs_length.begin())),
       column.size(),
       type,
       std::move(null_mask),

--- a/cpp/tests/io/nested_json_test.cpp
+++ b/cpp/tests/io/nested_json_test.cpp
@@ -750,7 +750,7 @@ TEST_F(JsonTest, PostProcessTokenStream)
   // Golden token stream sample
   using token_t       = cuio_json::token_t;
   using token_index_t = cuio_json::SymbolOffsetT;
-  using tuple_t       = thrust::tuple<token_index_t, cuio_json::PdaTokenT>;
+  using tuple_t       = cuda::std::tuple<token_index_t, cuio_json::PdaTokenT>;
 
   std::vector<tuple_t> const input = {// Line 0 (invalid)
                                       {0, token_t::LineEnd},
@@ -861,9 +861,9 @@ TEST_F(JsonTest, PostProcessTokenStream)
 
   for (std::size_t i = 0; i < filtered_tokens.size(); i++) {
     // Ensure the index the tokens are pointing to do match
-    EXPECT_EQ(thrust::get<0>(expected_output[i]), filtered_indices[i]) << "Mismatch at #" << i;
+    EXPECT_EQ(cuda::std::get<0>(expected_output[i]), filtered_indices[i]) << "Mismatch at #" << i;
     // Ensure the token category is correct
-    EXPECT_EQ(thrust::get<1>(expected_output[i]), filtered_tokens[i]) << "Mismatch at #" << i;
+    EXPECT_EQ(cuda::std::get<1>(expected_output[i]), filtered_tokens[i]) << "Mismatch at #" << i;
   }
 }
 

--- a/cpp/tests/io/type_inference_test.cu
+++ b/cpp/tests/io/type_inference_test.cu
@@ -26,7 +26,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <cstddef>
 #include <string>
@@ -59,7 +59,7 @@ TEST_F(TypeInference, Basic)
     string_length, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   auto d_col_strings =
-    thrust::make_zip_iterator(thrust::make_tuple(d_string_offset.begin(), d_string_length.begin()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(d_string_offset.begin(), d_string_length.begin()));
 
   auto res_type =
     infer_data_type(options.json_view(),
@@ -92,7 +92,7 @@ TEST_F(TypeInference, Null)
     string_length, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   auto d_col_strings =
-    thrust::make_zip_iterator(thrust::make_tuple(d_string_offset.begin(), d_string_length.begin()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(d_string_offset.begin(), d_string_length.begin()));
 
   auto res_type =
     infer_data_type(options.json_view(),
@@ -125,7 +125,7 @@ TEST_F(TypeInference, AllNull)
     string_length, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   auto d_col_strings =
-    thrust::make_zip_iterator(thrust::make_tuple(d_string_offset.begin(), d_string_length.begin()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(d_string_offset.begin(), d_string_length.begin()));
 
   auto res_type =
     infer_data_type(options.json_view(),
@@ -158,7 +158,7 @@ TEST_F(TypeInference, String)
     string_length, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   auto d_col_strings =
-    thrust::make_zip_iterator(thrust::make_tuple(d_string_offset.begin(), d_string_length.begin()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(d_string_offset.begin(), d_string_length.begin()));
 
   auto res_type =
     infer_data_type(options.json_view(),
@@ -191,7 +191,7 @@ TEST_F(TypeInference, Bool)
     string_length, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   auto d_col_strings =
-    thrust::make_zip_iterator(thrust::make_tuple(d_string_offset.begin(), d_string_length.begin()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(d_string_offset.begin(), d_string_length.begin()));
 
   auto res_type =
     infer_data_type(options.json_view(),
@@ -224,7 +224,7 @@ TEST_F(TypeInference, Timestamp)
     string_length, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   auto d_col_strings =
-    thrust::make_zip_iterator(thrust::make_tuple(d_string_offset.begin(), d_string_length.begin()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(d_string_offset.begin(), d_string_length.begin()));
 
   auto res_type =
     infer_data_type(options.json_view(),
@@ -258,7 +258,7 @@ TEST_F(TypeInference, InvalidInput)
     string_length, cudf::get_default_stream(), rmm::mr::get_current_device_resource());
 
   auto d_col_strings =
-    thrust::make_zip_iterator(thrust::make_tuple(d_string_offset.begin(), d_string_length.begin()));
+    thrust::make_zip_iterator(cuda::std::make_tuple(d_string_offset.begin(), d_string_length.begin()));
 
   auto res_type =
     infer_data_type(options.json_view(),

--- a/cpp/tests/reductions/scan_tests.cpp
+++ b/cpp/tests/reductions/scan_tests.cpp
@@ -27,7 +27,7 @@
 
 #include <thrust/host_vector.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 #include <algorithm>
 #include <numeric>
@@ -168,14 +168,14 @@ struct ScanTest : public BaseScanTest<T> {
     bool const nullable = (b.size() > 0);
 
     auto masked_value = [identity](auto const& z) {
-      return thrust::get<1>(z) ? thrust::get<0>(z) : identity;
+      return cuda::std::get<1>(z) ? cuda::std::get<0>(z) : identity;
     };
 
     if (inclusive == scan_type::INCLUSIVE) {
       if (nullable) {
         std::transform_inclusive_scan(
-          thrust::make_zip_iterator(thrust::make_tuple(v.begin(), b.begin())),
-          thrust::make_zip_iterator(thrust::make_tuple(v.end(), b.end())),
+          thrust::make_zip_iterator(cuda::std::make_tuple(v.begin(), b.begin())),
+          thrust::make_zip_iterator(cuda::std::make_tuple(v.end(), b.end())),
           expected.begin(),
           op,
           masked_value);
@@ -189,8 +189,8 @@ struct ScanTest : public BaseScanTest<T> {
     } else {
       if (nullable) {
         std::transform_exclusive_scan(
-          thrust::make_zip_iterator(thrust::make_tuple(v.begin(), b.begin())),
-          thrust::make_zip_iterator(thrust::make_tuple(v.end(), b.end())),
+          thrust::make_zip_iterator(cuda::std::make_tuple(v.begin(), b.begin())),
+          thrust::make_zip_iterator(cuda::std::make_tuple(v.end(), b.end())),
           expected.begin(),
           identity,
           op,

--- a/cpp/tests/utilities/tdigest_utilities.cu
+++ b/cpp/tests/utilities/tdigest_utilities.cu
@@ -29,7 +29,7 @@
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/tuple.h>
+#include <cuda/std/tuple>
 
 // for use with groupby and reduction aggregation tests.
 
@@ -58,9 +58,9 @@ void tdigest_sample_compare(cudf::tdigest::tdigest_column_view const& tdv,
   {
     auto iter = thrust::make_counting_iterator(0);
     std::for_each_n(iter, h_expected.size(), [&](size_type const index) {
-      h_expected_src[index]    = thrust::get<0>(h_expected[index]);
-      h_expected_mean[index]   = thrust::get<1>(h_expected[index]);
-      h_expected_weight[index] = thrust::get<2>(h_expected[index]);
+      h_expected_src[index]    = cuda::std::get<0>(h_expected[index]);
+      h_expected_mean[index]   = cuda::std::get<1>(h_expected[index]);
+      h_expected_weight[index] = cuda::std::get<2>(h_expected[index]);
     });
   }
 


### PR DESCRIPTION
We want to move away from thrust types in API boundaries in favor of the more suited `cuda::std` types
