### PR TITLE
Fix `sort_values` pytest failure with pandas-2.x regression

### DIFF
--- a/python/cudf/cudf/tests/test_sorting.py
+++ b/python/cudf/cudf/tests/test_sorting.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 from cudf import DataFrame, Series
-from cudf.core._compat import PANDAS_GE_200
+from cudf.core._compat import PANDAS_GE_220
 from cudf.core.column import NumericalColumn
 from cudf.testing._utils import (
     DATETIME_TYPES,


### PR DESCRIPTION
## Description
pandas-2.x seems to have introduced an ordering regression where the index order is not preserved for cases when there is a tie.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
