### PR TITLE
Fix deprecation warnings for deprecated hash() calls

### DIFF
--- a/cpp/benchmarks/hashing/hash.cpp
+++ b/cpp/benchmarks/hashing/hash.cpp
@@ -97,12 +97,6 @@ static void bench_hash(nvbench::state& state)
 
     state.exec(nvbench::exec_tag::sync,
                [&](nvbench::launch& launch) { auto result = cudf::hashing::sha512(data->view()); });
-  } else if (hash_name == "spark_murmurhash3_x86_32") {
-    state.add_global_memory_writes<nvbench::int32_t>(num_rows);
-
-    state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-      auto result = cudf::hashing::spark_murmurhash3_x86_32(data->view());
-    });
   } else {
     state.skip(hash_name + ": unknown hash name");
   }
@@ -113,11 +107,4 @@ NVBENCH_BENCH(bench_hash)
   .add_int64_axis("num_rows", {65536, 16777216})
   .add_float64_axis("nulls", {0.0, 0.1})
   .add_string_axis("hash_name",
-                   {"murmurhash3_x86_32",
-                    "md5",
-                    "sha1",
-                    "sha224",
-                    "sha256",
-                    "sha384",
-                    "sha512",
-                    "spark_murmurhash3_x86_32"});
+                   {"murmurhash3_x86_32", "md5", "sha1", "sha224", "sha256", "sha384", "sha512"});

--- a/cpp/tests/partitioning/hash_partition_test.cpp
+++ b/cpp/tests/partitioning/hash_partition_test.cpp
@@ -309,11 +309,11 @@ void run_fixed_width_test(size_t cols,
   cudf::table_view partitions_table({partitions_col});
 
   // Sort partition numbers by the corresponding row hashes of each output
-  auto hash1 = cudf::hash(output1->view());
+  auto hash1 = cudf::hashing::murmurhash3_x86_32(output1->view());
   cudf::table_view hash1_table({hash1->view()});
   auto sorted_partitions1 = cudf::sort_by_key(partitions_table, hash1_table);
 
-  auto hash2 = cudf::hash(output2->view());
+  auto hash2 = cudf::hashing::murmurhash3_x86_32(output2->view());
   cudf::table_view hash2_table({hash2->view()});
   auto sorted_partitions2 = cudf::sort_by_key(partitions_table, hash2_table);
 

--- a/cpp/tests/streams/hash_test.cpp
+++ b/cpp/tests/streams/hash_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,6 @@ TEST_F(HashTest, MultiValue)
 
   auto const input1 = cudf::table_view({strings_col, ints_col, bools_col1, secs_col});
 
-  auto const output1 = cudf::hash(
-    input1, cudf::hash_id::HASH_MURMUR3, cudf::DEFAULT_HASH_SEED, cudf::test::get_default_stream());
+  auto const output1 = cudf::hashing::murmurhash3_x86_32(
+    input1, cudf::DEFAULT_HASH_SEED, cudf::test::get_default_stream());
 }


### PR DESCRIPTION
## Description
Merged #15074 too soon and missed fixing these now deprecated call warnings.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
