### PR TITLE
Fix Series.groupby.shift with a MultiIndex

### DIFF
--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -2037,7 +2037,8 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
         self: MultiIndex, other: MultiIndex, *, override_dtypes=None
     ) -> MultiIndex:
         res = super()._copy_type_metadata(other)
-        res._names = other._names
+        if isinstance(other, MultiIndex):
+            res._names = other._names
         return res
 
     @_cudf_nvtx_annotate

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -3813,7 +3813,7 @@ def test_groupby_internal_groups_empty(gdf):
     assert grouped_vals == []
 
 
-def test_groupby_shift_series_mi():
+def test_groupby_shift_series_multiindex():
     idx = cudf.MultiIndex.from_tuples(
         [("a", 1), ("a", 2), ("b", 1), ("b", 2)], names=["f", "s"]
     )

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -3308,7 +3308,6 @@ def test_groupby_pct_change(data, gkey, periods, fill_method):
     assert_eq(expected, actual)
 
 
-@pytest.mark.xfail(reason="https://github.com/rapidsai/cudf/issues/11259")
 @pytest.mark.parametrize("periods", [-5, 5])
 def test_groupby_pct_change_multiindex_dataframe(periods):
     gdf = cudf.DataFrame(
@@ -3812,3 +3811,13 @@ def test_groupby_internal_groups_empty(gdf):
     gb = gdf.groupby("y")._groupby
     _, _, grouped_vals = gb.groups([])
     assert grouped_vals == []
+
+
+def test_groupby_shift_series_mi():
+    idx = cudf.MultiIndex.from_tuples(
+        [("a", 1), ("a", 2), ("b", 1), ("b", 2)], names=["f", "s"]
+    )
+    ser = Series(range(4), index=idx)
+    result = ser.groupby(level=0).shift(1)
+    expected = Series([None, 0, None, 2], index=idx)
+    assert_eq(expected, result)

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -3819,5 +3819,5 @@ def test_groupby_shift_series_mi():
     )
     ser = Series(range(4), index=idx)
     result = ser.groupby(level=0).shift(1)
-    expected = Series([None, 0, None, 2], index=idx)
+    expected = ser.to_pandas().groupby(level=0).shift(1)
     assert_eq(expected, result)


### PR DESCRIPTION
## Description
closes #15087
closes #11259

(The typing annotation is incorrect, but I guess there needs to be a check somewhere to make `_copy_type_metadata` stricter)

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
