### PR TITLE
Compile-time ipow computation with array lookup

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -5,3 +5,4 @@ auto_merger: true
 branch_checker: true
 label_checker: true
 release_drafter: true
+forward_merger: true

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -22,6 +22,7 @@
 
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
+#include <cuda/std/utility>
 
 #include <algorithm>
 #include <cassert>
@@ -82,39 +83,60 @@ constexpr inline auto is_supported_construction_value_type()
 
 // Helper functions for `fixed_point` type
 namespace detail {
+
 /**
- * @brief A function for integer exponentiation by squaring
+ * @brief Recursively computes integer exponentiation
  *
- * https://simple.wikipedia.org/wiki/Exponentiation_by_squaring <br>
- * Note: this is the iterative equivalent of the recursive definition (faster) <br>
- * Quick-bench: http://quick-bench.com/Wg7o7HYQC9FW5M0CO0wQAjSwP_Y
+ * Note: This is intended to be run at compile time
+ * 
+ * @tparam Rep Representation type for return type
+ * @tparam Base The base to be exponentiated
+ * @param exp The exponent to be used for exponentiation
+ * @return Result of `Base` to the power of `exponent` of type `Rep`
+ */
+template <typename Rep, int32_t Base>
+CUDF_HOST_DEVICE inline constexpr Rep get_power(int32_t exp)
+{
+  return (exp > 0) ? Rep(Base) * get_power<Rep, Base>(exp - 1) : 1;
+}
+
+/**
+ * @brief Implementation of integer exponentiation by array lookup
+ *
+ * @tparam Rep Representation type for return type
+ * @tparam Base The base to be exponentiated
+ * @tparam Exponents The exponents for the array entries
+ * @param exponent The exponent to be used for exponentiation
+ * @return Result of `Base` to the power of `exponent` of type `Rep`
+ */
+template <typename Rep, int32_t Base, std::size_t... Exponents>
+CUDF_HOST_DEVICE inline Rep ipow_impl(int32_t exponent, cuda::std::index_sequence<Exponents...>)
+{
+  static constexpr Rep powers[] = { get_power<Rep, Base>(Exponents)... };
+  return powers[exponent];
+}
+
+/**
+ * @brief A function for integer exponentiation by array lookup
  *
  * @tparam Rep Representation type for return type
  * @tparam Base The base to be exponentiated
  * @param exponent The exponent to be used for exponentiation
  * @return Result of `Base` to the power of `exponent` of type `Rep`
  */
-template <typename Rep,
-          Radix Base,
-          typename T,
+template <typename Rep, Radix Base, typename T,
           typename cuda::std::enable_if_t<(cuda::std::is_same_v<int32_t, T> &&
                                            is_supported_representation_type<Rep>())>* = nullptr>
 CUDF_HOST_DEVICE inline Rep ipow(T exponent)
 {
   cudf_assert(exponent >= 0 && "integer exponentiation with negative exponent is not possible.");
-  if (exponent == 0) { return static_cast<Rep>(1); }
-
-  auto extra  = static_cast<Rep>(1);
-  auto square = static_cast<Rep>(Base);
-  while (exponent > 1) {
-    if (exponent & 1 /* odd */) {
-      extra *= square;
-      exponent -= 1;
-    }
-    exponent /= 2;
-    square *= square;
+  if constexpr (Base == numeric::Radix::BASE_2) {
+    return static_cast<Rep>(1) << exponent;
+  } else { //BASE_10
+    static constexpr auto max_exp = cuda::std::numeric_limits<Rep>::digits10;
+    static constexpr auto exponents = cuda::std::make_index_sequence<max_exp + 1>{};
+    return ipow_impl<Rep, static_cast<int32_t>(Base)>(exponent, exponents);
   }
-  return square * extra;
 }
 
 /** @brief Function that performs a `right shift` scale "times" on the `val`

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -88,7 +88,7 @@ namespace detail {
  * @brief Recursively computes integer exponentiation
  *
  * Note: This is intended to be run at compile time
- * 
+ *
  * @tparam Rep Representation type for return type
  * @tparam Base The base to be exponentiated
  * @param exp The exponent to be used for exponentiation
@@ -97,7 +97,7 @@ namespace detail {
 template <typename Rep, int32_t Base>
 CUDF_HOST_DEVICE inline constexpr Rep get_power(int32_t exp)
 {
-  //Compute power recursively
+  // Compute power recursively
   return (exp > 0) ? Rep(Base) * get_power<Rep, Base>(exp - 1) : 1;
 }
 
@@ -113,8 +113,8 @@ CUDF_HOST_DEVICE inline constexpr Rep get_power(int32_t exp)
 template <typename Rep, int32_t Base, std::size_t... Exponents>
 CUDF_HOST_DEVICE inline Rep ipow_impl(int32_t exponent, cuda::std::index_sequence<Exponents...>)
 {
-  //Compute powers at compile time, storing into array
-  static constexpr Rep powers[] = { get_power<Rep, Base>(Exponents)... };
+  // Compute powers at compile time, storing into array
+  static constexpr Rep powers[] = {get_power<Rep, Base>(Exponents)...};
   return powers[exponent];
 }
 
@@ -126,7 +126,9 @@ CUDF_HOST_DEVICE inline Rep ipow_impl(int32_t exponent, cuda::std::index_sequenc
  * @param exponent The exponent to be used for exponentiation
  * @return Result of `Base` to the power of `exponent` of type `Rep`
  */
-template <typename Rep, Radix Base, typename T,
+template <typename Rep,
+          Radix Base,
+          typename T,
           typename cuda::std::enable_if_t<(cuda::std::is_same_v<int32_t, T> &&
                                            is_supported_representation_type<Rep>())>* = nullptr>
 CUDF_HOST_DEVICE inline Rep ipow(T exponent)
@@ -134,12 +136,12 @@ CUDF_HOST_DEVICE inline Rep ipow(T exponent)
   cudf_assert(exponent >= 0 && "integer exponentiation with negative exponent is not possible.");
   if constexpr (Base == numeric::Radix::BASE_2) {
     return static_cast<Rep>(1) << exponent;
-  } else { //BASE_10
-    //Build index sequence for building power array at compile time
-    static constexpr auto max_exp = cuda::std::numeric_limits<Rep>::digits10;
+  } else {  // BASE_10
+    // Build index sequence for building power array at compile time
+    static constexpr auto max_exp   = cuda::std::numeric_limits<Rep>::digits10;
     static constexpr auto exponents = cuda::std::make_index_sequence<max_exp + 1>{};
 
-    //Get compile-time result
+    // Get compile-time result
     return ipow_impl<Rep, static_cast<int32_t>(Base)>(exponent, exponents);
   }
 }

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -87,7 +87,7 @@ namespace detail {
 /**
  * @brief Recursively computes integer exponentiation
  *
- * Note: This is intended to be run at compile time
+ * @note This is intended to be run at compile time
  *
  * @tparam Rep Representation type for return type
  * @tparam Base The base to be exponentiated

--- a/cpp/include/cudf/round.hpp
+++ b/cpp/include/cudf/round.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,9 @@ namespace cudf {
 /**
  * @brief Different rounding methods for `cudf::round`
  *
- * Info on HALF_UP   rounding: https://en.wikipedia.org/wiki/Rounding#Round_half_up
- * Info on HALF_EVEN rounding: https://en.wikipedia.org/wiki/Rounding#Round_half_to_even
+ * Info on HALF_EVEN rounding: https://en.wikipedia.org/wiki/Rounding#Rounding_half_to_even
+ * Info on HALF_UP   rounding: https://en.wikipedia.org/wiki/Rounding#Rounding_half_away_from_zero
+ * Note: HALF_UP means up in MAGNITUDE: Away from zero! Because of how Java and python define it
  */
 enum class rounding_method : int32_t { HALF_UP, HALF_EVEN };
 

--- a/cpp/tests/strings/fixed_point_tests.cpp
+++ b/cpp/tests/strings/fixed_point_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/strings/fixed_point_tests.cpp
+++ b/cpp/tests/strings/fixed_point_tests.cpp
@@ -324,7 +324,7 @@ TEST_F(StringsConvertTest, DISABLED_FixedPointStringConversionOperator)
 {
   auto const max = cuda::std::numeric_limits<__int128_t>::max();
 
-  //Must use scaled_integer, else shift (multiply) is undefined behavior (integer overflow)
+  // Must use scaled_integer, else shift (multiply) is undefined behavior (integer overflow)
   auto const x = numeric::decimal128(numeric::scaled_integer{max, numeric::scale_type{-10}});
   EXPECT_EQ(static_cast<std::string>(x), "17014118346046923173168730371.5884105727");
 

--- a/cpp/tests/strings/fixed_point_tests.cpp
+++ b/cpp/tests/strings/fixed_point_tests.cpp
@@ -324,7 +324,8 @@ TEST_F(StringsConvertTest, DISABLED_FixedPointStringConversionOperator)
 {
   auto const max = cuda::std::numeric_limits<__int128_t>::max();
 
-  auto const x = numeric::decimal128{max, numeric::scale_type{-10}};
+  //Must use scaled_integer, else shift (multiply) is undefined behavior (integer overflow)
+  auto const x = numeric::decimal128(numeric::scaled_integer{max, numeric::scale_type{-10}});
   EXPECT_EQ(static_cast<std::string>(x), "17014118346046923173168730371.5884105727");
 
   auto const y = numeric::decimal128{max, numeric::scale_type{10}};


### PR DESCRIPTION
## Description
Compile-time ipow() computation with array lookup.  Results in up to 8% speed improvement for decimal64 -> double conversions.  Improvement is negligible for other conversions but is not worse.  New benchmark test will be in a separate PR.  Fix fixed_point -> string conversion test. Also fix rounding comments. Closes #9346

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
