### PR TITLE
Remove `const` from `range_window_bounds::_extent`.

### DIFF
--- a/cpp/include/cudf/rolling/range_window_bounds.hpp
+++ b/cpp/include/cudf/rolling/range_window_bounds.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/rolling/range_window_bounds.hpp
+++ b/cpp/include/cudf/rolling/range_window_bounds.hpp
@@ -104,7 +104,7 @@ struct range_window_bounds {
   range_window_bounds() = default;  // Required for use as return types from dispatch functors.
 
  private:
-  const extent_type _extent{extent_type::UNBOUNDED};
+  extent_type _extent{extent_type::UNBOUNDED};
   std::shared_ptr<scalar> _range_scalar{nullptr};  // To enable copy construction/assignment.
 
   range_window_bounds(extent_type extent_, std::unique_ptr<scalar> range_scalar_);


### PR DESCRIPTION
Fixes #15131.

## Description
The `const` on the `_extent` member of `range_window_bounds` is superfluous. It provides no additional protection to `range_window_bounds`'s invariants, and prevents the class from being copy assignable.

This change removes the `const`, thus making `range_window_bounds` copy-assignable, and more readily usable from Cython.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
