### PR TITLE
Concatenate dictionary of objects along axis=1

### DIFF
--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -314,7 +314,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
                         result.columns = cudf.MultiIndex.from_tuples(
                             [
                                 (k, *c) if isinstance(c, tuple) else (k, c)
-                                for c in result.columns
+                                for c in result._column_names
                             ]
                         )
 

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -425,7 +425,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
                         df[(k, *name)] = col
 
             # MultiIndex construction here
-            result_columns = cudf.MultiIndex.from_tuples(df.columns)
+            result_columns = cudf.MultiIndex.from_tuples(df._column_names)
 
         if ignore_index:
             # with ignore_index the column names change to numbers

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -319,7 +319,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
                         )
 
                     result.columns = cudf.MultiIndex.from_product(
-                        [keys, result.columns]
+                        [keys, result._column_names]
                     )
 
         if isinstance(result, cudf.Series) and axis == 0:

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -236,7 +236,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
     >>> d = {'first': df1, 'second': df2}
     >>> cudf.concat(d, axis=1)
       first           second
-      letter  number  letter  number 
+      letter  number  letter  number
     0      a       1       c       3
     1      b       2       d       4
     """
@@ -312,13 +312,15 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
                     if isinstance(result, cudf.DataFrame):
                         k = keys[0]
                         result.columns = cudf.MultiIndex.from_tuples(
-                            [(k, *c) if isinstance(c, tuple) else (k, c) for c in result.columns]
+                            [
+                                (k, *c) if isinstance(c, tuple) else (k, c)
+                                for c in result.columns
+                            ]
                         )
 
-                    result.columns = cudf.MultiIndex.from_product([
-                        keys,
-                        result.columns
-                    ])
+                    result.columns = cudf.MultiIndex.from_product(
+                        [keys, result.columns]
+                    )
 
         if isinstance(result, cudf.Series) and axis == 0:
             # sort has no effect for series concatted along axis 0
@@ -407,7 +409,7 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
                 .append([obj._data.to_pandas_index() for obj in objs[1:]])
                 .unique()
             )
-        
+
         # need to create a MultiIndex column
         else:
             for k, o in zip(keys, objs):
@@ -425,7 +427,6 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
             # MultiIndex construction here
             result_columns = cudf.MultiIndex.from_tuples(df.columns)
 
-
         if ignore_index:
             # with ignore_index the column names change to numbers
             df.columns = pd.RangeIndex(len(result_columns))
@@ -438,7 +439,6 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
             return df.head(0)
 
         return df
-
 
     # If we get here, we are always concatenating along axis 0 (the rows).
     if keys is not None:

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -1905,6 +1905,10 @@ def test_concat_mixed_list_types_error(s1, s2):
             "third": cudf.DataFrame({"C": [1, 2, 3]}),
         },
         {"first": cudf.Series([1, 2, 3]), "second": cudf.Series([4, 5, 6])},
+        {
+            "first": cudf.DataFrame({"A": [1, 2], "B": [3, 4]}),
+            "second": cudf.Series([5, 6], name="C"),
+        },
     ],
 )
 def test_concat_dictionary(d):

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -1895,33 +1895,32 @@ def test_concat_mixed_list_types_error(s1, s2):
     "d",
     [
         {
-            'first': cudf.DataFrame({'A': [1, 2], 'B': [3, 4]}),
-            'second': cudf.DataFrame({'A': [5, 6], 'B': [7, 8]})
+            "first": cudf.DataFrame({"A": [1, 2], "B": [3, 4]}),
+            "second": cudf.DataFrame({"A": [5, 6], "B": [7, 8]}),
         },
+        {"first": cudf.DataFrame({"A": [1, 2], "B": [3, 4]})},
         {
-            'first': cudf.DataFrame({'A': [1, 2], 'B': [3, 4]})
+            "first": cudf.DataFrame({"A": [1, 2], "B": [3, 4]}),
+            "second": cudf.DataFrame({"A": [5, 6], "B": [7, 8]}),
+            "third": cudf.DataFrame({"C": [1, 2, 3]}),
         },
-        {
-            'first': cudf.DataFrame({'A': [1, 2], 'B': [3, 4]}),
-            'second': cudf.DataFrame({'A': [5, 6], 'B': [7, 8]}),
-            'third': cudf.DataFrame({'C': [1, 2, 3]})
-        },
-        {
-            'first': cudf.Series([1, 2, 3]),
-            'second': cudf.Series([4, 5, 6])
-        }
-    ]
+        {"first": cudf.Series([1, 2, 3]), "second": cudf.Series([4, 5, 6])},
+    ],
 )
 def test_concat_dictionary(d):
     result1 = cudf.concat(d, axis=1)
-    expected1 = cudf.from_pandas(pd.concat({k: df.to_pandas() for k,df in d.items()}, axis=1))
+    expected1 = cudf.from_pandas(
+        pd.concat({k: df.to_pandas() for k, df in d.items()}, axis=1)
+    )
     assert_eq(expected1, result1)
-
 
 
 def test_concat_dict_incorrect_type():
     d = {
-            'first': cudf.Index([1, 2, 3]),
-        }
-    with pytest.raises(TypeError, match=f"cannot concatenate object of type {type(d['first'])}"):
+        "first": cudf.Index([1, 2, 3]),
+    }
+    with pytest.raises(
+        TypeError,
+        match=f"cannot concatenate object of type {type(d['first'])}",
+    ):
         cudf.concat(d, axis=1)

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -1889,3 +1889,39 @@ def test_concat_mixed_list_types_error(s1, s2):
 
     with pytest.raises(NotImplementedError):
         cudf.concat([s1, s2], ignore_index=True)
+
+
+@pytest.mark.parametrize(
+    "d",
+    [
+        {
+            'first': cudf.DataFrame({'A': [1, 2], 'B': [3, 4]}),
+            'second': cudf.DataFrame({'A': [5, 6], 'B': [7, 8]})
+        },
+        {
+            'first': cudf.DataFrame({'A': [1, 2], 'B': [3, 4]})
+        },
+        {
+            'first': cudf.DataFrame({'A': [1, 2], 'B': [3, 4]}),
+            'second': cudf.DataFrame({'A': [5, 6], 'B': [7, 8]}),
+            'third': cudf.DataFrame({'C': [1, 2, 3]})
+        },
+        {
+            'first': cudf.Series([1, 2, 3]),
+            'second': cudf.Series([4, 5, 6])
+        }
+    ]
+)
+def test_concat_dictionary(d):
+    result1 = cudf.concat(d, axis=1)
+    expected1 = cudf.from_pandas(pd.concat({k: df.to_pandas() for k,df in d.items()}, axis=1))
+    assert_eq(expected1, result1)
+
+
+
+def test_concat_dict_incorrect_type():
+    d = {
+            'first': cudf.Index([1, 2, 3]),
+        }
+    with pytest.raises(TypeError, match=f"cannot concatenate object of type {type(d['first'])}"):
+        cudf.concat(d, axis=1)


### PR DESCRIPTION
Closes #15115.

Unlike `pandas.concat`, `cudf.concat` doesn't work with a dictionary of objects. The following code raises an error.

```python
d = {
    'first': cudf.DataFrame({'A': [1, 2], 'B': [3, 4]}),
    'second': cudf.DataFrame({'A': [5, 6], 'B': [7, 8]}),
}

cudf.concat(d, axis=1)
```

This commit resolves this issue.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.