### PR TITLE
Use functools.lru_cache over cachetools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,6 @@ repos:
     rev: 'v1.3.0'
     hooks:
       - id: mypy
-        additional_dependencies: [types-cachetools]
         args: ["--config-file=pyproject.toml",
                "python/cudf/cudf",
                "python/custreamz/custreamz",

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -14,7 +14,6 @@ dependencies:
 - botocore>=1.24.21
 - breathe>=4.35.0
 - c-compiler
-- cachetools
 - clang-tools=16.0.6
 - clang==16.0.6
 - cmake>=3.26.4

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -14,7 +14,6 @@ dependencies:
 - botocore>=1.24.21
 - breathe>=4.35.0
 - c-compiler
-- cachetools
 - clang-tools=16.0.6
 - clang==16.0.6
 - cmake>=3.26.4

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -107,7 +107,6 @@ requirements:
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
     - nvtx >=0.2.1
     - packaging
-    - cachetools
     - rich
 
 test:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -502,7 +502,6 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - cachetools
           - &numba numba>=0.57
           - nvtx>=0.2.1
           - packaging

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -61,7 +61,6 @@ from cudf.core.missing import NA
 from cudf.core.multiindex import MultiIndex
 from cudf.core.resample import _Resampler
 from cudf.core.udf.utils import (
-    _compile_or_get,
     _get_input_args_from_frame,
     _post_process_output_col,
     _return_arr_from_dtype,
@@ -3307,18 +3306,12 @@ class IndexedFrame(Frame):
 
     @acquire_spill_lock()
     @_cudf_nvtx_annotate
-    def _apply(self, func, kernel_getter, *args, **kwargs):
+    def _apply(self, kernel, retty, *args, **kwargs):
         """Apply `func` across the rows of the frame."""
+        if not all(is_scalar(arg) for arg in args):
+            raise TypeError("only scalar valued args are supported by apply")
         if kwargs:
             raise ValueError("UDFs using **kwargs are not yet supported.")
-        try:
-            kernel, retty = _compile_or_get(
-                self, func, args, kernel_getter=kernel_getter
-            )
-        except Exception as e:
-            raise ValueError(
-                "user defined function compilation failed."
-            ) from e
 
         # Mask and data column preallocated
         ans_col = _return_arr_from_dtype(retty, len(self))

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -24,7 +24,6 @@ authors = [
 license = { text = "Apache 2.0" }
 requires-python = ">=3.9"
 dependencies = [
-    "cachetools",
     "cubinlinker",
     "cuda-python>=11.7.1,<12.0a0",
     "cupy-cuda11x>=12.0.0",


### PR DESCRIPTION
## Description
It appears the usage of `cachetools.LRUCache` looks largely replaceable with `functools.lru_cache`, but the cache key semantics might potentially change with using `functools.lru_cache`.

Open to hear if the cache key was crafted to capture specific information in mind.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
