### PR TITLE
Avoid dict normalization in ``__dask_tokenize__``

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1958,7 +1958,7 @@ class Frame(BinaryOperand, Scannable):
 
         return [
             type(self),
-            normalize_token(self._dtypes),
+            str(self._dtypes),
             normalize_token(self.to_pandas()),
         ]
 


### PR DESCRIPTION
## Description
There are  currently [CI failures](https://github.com/rapidsai/cudf/actions/runs/8089269486/job/22105880070?pr=15181#step:7:1050) that seem to be caused by non-deterministic `dict` normalization in `Frame.__dask_tokenize__`. This PR avoids normalizing that dictionary.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
