### PR TITLE
Change strings_column_view::char_size to return int64

### DIFF
--- a/cpp/benchmarks/string/case.cpp
+++ b/cpp/benchmarks/string/case.cpp
@@ -45,7 +45,9 @@ void bench_case(nvbench::state& state)
       cudf::type_id::INT8, distribution_id::UNIFORM, 32, 126);  // nice ASCII range
     auto input        = cudf::strings_column_view(col_view);
     auto ascii_column = create_random_column(
-      cudf::type_id::INT8, row_count{input.chars_size(cudf::get_default_stream())}, ascii_profile);
+      cudf::type_id::INT8,
+      row_count{static_cast<cudf::size_type>(input.chars_size(cudf::get_default_stream()))},
+      ascii_profile);
     auto ascii_data = ascii_column->view();
 
     col_view = cudf::column_view(col_view.type(),

--- a/cpp/include/cudf/strings/strings_column_view.hpp
+++ b/cpp/include/cudf/strings/strings_column_view.hpp
@@ -112,7 +112,7 @@ class strings_column_view : private column_view {
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @return Number of bytes in the chars child column
    */
-  [[nodiscard]] size_type chars_size(rmm::cuda_stream_view stream) const noexcept;
+  [[nodiscard]] int64_t chars_size(rmm::cuda_stream_view stream) const noexcept;
 
   /**
    * @brief Return an iterator for the chars child column.

--- a/cpp/src/strings/strings_column_view.cpp
+++ b/cpp/src/strings/strings_column_view.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <cudf/detail/get_value.cuh>
+#include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/error.hpp>
 
@@ -45,10 +45,10 @@ strings_column_view::offset_iterator strings_column_view::offsets_end() const
   return offsets_begin() + size() + 1;
 }
 
-size_type strings_column_view::chars_size(rmm::cuda_stream_view stream) const noexcept
+int64_t strings_column_view::chars_size(rmm::cuda_stream_view stream) const noexcept
 {
-  if (size() == 0) return 0;
-  return detail::get_value<size_type>(offsets(), offsets().size() - 1, stream);
+  if (size() == 0) { return 0L; }
+  return cudf::strings::detail::get_offset_value(offsets(), offsets().size() - 1, stream);
 }
 
 strings_column_view::chars_iterator strings_column_view::chars_begin(rmm::cuda_stream_view) const


### PR DESCRIPTION
## Description
Changes the `cudf::strings_column_view::chars_size()` function to return `int64_t` instead of `size_type`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
