### PR TITLE
Test CI changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,7 @@ jobs:
     with:
       enable_check_generated_files: false
   conda-cpp-build:
-    needs: checks
+    needs: devcontainer
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-24.04
     with:
@@ -64,7 +64,7 @@ jobs:
     with:
       build_type: pull-request
   conda-python-cudf-tests:
-    needs: conda-python-build
+    needs: [conda-python-build, wheel-tests-cudf]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.04
     with:
@@ -72,7 +72,7 @@ jobs:
       test_script: "ci/test_python_cudf.sh"
   conda-python-other-tests:
     # Tests for dask_cudf, custreamz, cudf_kafka are separated for CI parallelism
-    needs: conda-python-build
+    needs: [conda-python-build, wheel-tests-dask-cudf]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.04
     with:
@@ -89,7 +89,7 @@ jobs:
       container_image: "rapidsai/ci-conda:latest"
       run_script: "ci/test_java.sh"
   conda-notebook-tests:
-    needs: conda-python-build
+    needs: [conda-python-build, wheel-tests-cudf]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.04
     with:
@@ -99,7 +99,7 @@ jobs:
       container_image: "rapidsai/ci-conda:latest"
       run_script: "ci/test_notebooks.sh"
   docs-build:
-    needs: conda-python-build
+    needs: [conda-python-build, wheel-tests-cudf]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.04
     with:
@@ -140,6 +140,7 @@ jobs:
       build_type: pull-request
       script: ci/test_wheel_dask_cudf.sh
   devcontainer:
+    needs: checks
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/build-in-devcontainer.yaml@branch-24.04
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,7 @@ jobs:
     with:
       enable_check_generated_files: false
   conda-cpp-build:
-    needs: devcontainer
+    needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@feat/reduce_runs
     with:
@@ -64,7 +64,7 @@ jobs:
     with:
       build_type: pull-request
   conda-python-cudf-tests:
-    needs: [conda-python-build, wheel-tests-cudf]
+    needs: conda-python-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@feat/reduce_runs
     with:
@@ -72,7 +72,7 @@ jobs:
       test_script: "ci/test_python_cudf.sh"
   conda-python-other-tests:
     # Tests for dask_cudf, custreamz, cudf_kafka are separated for CI parallelism
-    needs: [conda-python-build, wheel-tests-dask-cudf]
+    needs: conda-python-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@feat/reduce_runs
     with:
@@ -89,7 +89,7 @@ jobs:
       container_image: "rapidsai/ci-conda:latest"
       run_script: "ci/test_java.sh"
   conda-notebook-tests:
-    needs: [conda-python-build, wheel-tests-cudf]
+    needs: conda-python-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@feat/reduce_runs
     with:
@@ -99,7 +99,7 @@ jobs:
       container_image: "rapidsai/ci-conda:latest"
       run_script: "ci/test_notebooks.sh"
   docs-build:
-    needs: [conda-python-build, wheel-tests-cudf]
+    needs: conda-python-build
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@feat/reduce_runs
     with:
@@ -109,7 +109,7 @@ jobs:
       container_image: "rapidsai/ci-conda:latest"
       run_script: "ci/build_docs.sh"
   wheel-build-cudf:
-    needs: devcontainer
+    needs: checks
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@feat/reduce_runs
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -109,7 +109,7 @@ jobs:
       container_image: "rapidsai/ci-conda:latest"
       run_script: "ci/build_docs.sh"
   wheel-build-cudf:
-    needs: checks
+    needs: devcontainer
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@feat/reduce_runs
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,41 +32,41 @@ jobs:
       #- pandas-tests-diff
       #- pandas-tests-diff-comment
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@feat/reduce_runs
   checks:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@feat/reduce_runs
     with:
       enable_check_generated_files: false
   conda-cpp-build:
     needs: devcontainer
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@feat/reduce_runs
     with:
       build_type: pull-request
   conda-cpp-checks:
     needs: conda-cpp-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@feat/reduce_runs
     with:
       build_type: pull-request
       enable_check_symbols: true
   conda-cpp-tests:
     needs: conda-cpp-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@feat/reduce_runs
     with:
       build_type: pull-request
   conda-python-build:
     needs: conda-cpp-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@feat/reduce_runs
     with:
       build_type: pull-request
   conda-python-cudf-tests:
     needs: [conda-python-build, wheel-tests-cudf]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@feat/reduce_runs
     with:
       build_type: pull-request
       test_script: "ci/test_python_cudf.sh"
@@ -74,14 +74,14 @@ jobs:
     # Tests for dask_cudf, custreamz, cudf_kafka are separated for CI parallelism
     needs: [conda-python-build, wheel-tests-dask-cudf]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@feat/reduce_runs
     with:
       build_type: pull-request
       test_script: "ci/test_python_other.sh"
   conda-java-tests:
     needs: conda-cpp-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@feat/reduce_runs
     with:
       build_type: pull-request
       node_type: "gpu-v100-latest-1"
@@ -91,7 +91,7 @@ jobs:
   conda-notebook-tests:
     needs: [conda-python-build, wheel-tests-cudf]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@feat/reduce_runs
     with:
       build_type: pull-request
       node_type: "gpu-v100-latest-1"
@@ -101,7 +101,7 @@ jobs:
   docs-build:
     needs: [conda-python-build, wheel-tests-cudf]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@feat/reduce_runs
     with:
       build_type: pull-request
       node_type: "gpu-v100-latest-1"
@@ -111,7 +111,7 @@ jobs:
   wheel-build-cudf:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@feat/reduce_runs
     with:
       build_type: pull-request
       build-2_28-wheels: "true"
@@ -119,14 +119,14 @@ jobs:
   wheel-tests-cudf:
     needs: wheel-build-cudf
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@feat/reduce_runs
     with:
       build_type: pull-request
       script: ci/test_wheel_cudf.sh
   wheel-build-dask-cudf:
     needs: wheel-build-cudf
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@feat/reduce_runs
     with:
       matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.11" and (.CUDA_VER == "11.8.0" or .CUDA_VER == "12.2.2")))
       build_type: pull-request
@@ -134,7 +134,7 @@ jobs:
   wheel-tests-dask-cudf:
     needs: wheel-build-dask-cudf
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@feat/reduce_runs
     with:
       matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.11" and (.CUDA_VER == "11.8.0" or .CUDA_VER == "12.2.2")))
       build_type: pull-request
@@ -142,7 +142,7 @@ jobs:
   devcontainer:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/build-in-devcontainer.yaml@branch-24.04
+    uses: rapidsai/shared-action-workflows/.github/workflows/build-in-devcontainer.yaml@feat/reduce_runs
     with:
       build_command: |
         sccache -z;
@@ -151,7 +151,7 @@ jobs:
   unit-tests-cudf-pandas:
     needs: wheel-build-cudf
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.04
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@feat/reduce_runs
     with:
       matrix_filter: map(select(.ARCH == "amd64" and .PY_VER == "3.11" and (.CUDA_VER == "11.8.0" or .CUDA_VER == "12.2.2")))
       build_type: pull-request
@@ -160,7 +160,7 @@ jobs:
   #   # run the Pandas unit tests using PR branch
   #   needs: wheel-build-cudf
   #   secrets: inherit
-  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.04
+  #   uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@feat/reduce_runs
   #   with:
   #     matrix_filter: map(select(.ARCH == "amd64")) | max_by(.CUDA_VER) | [.]
   #     build_type: pull-request
@@ -172,7 +172,7 @@ jobs:
   #  needs: [pandas-tests-main, pandas-tests-pr]
   #  secrets: inherit
   #  # This branch exports a `job_output` output that the downstream job reads.
-  #  uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.04
+  #  uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@feat/reduce_runs
   #  with:
   #    node_type: cpu4
   #    build_type: pull-request


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR makes a number of changes in the hopes of alleviating the heavy load that we've been frequently observing in our CI queues of late. The changes are based on the following thoughts, and based on observations from PR #15194 (the most recent PR with passing CI) as the "other PR" below:
- Builds are cheaper than tests because they don't require GPU nodes, but they're still not completely free.
- Every PR still needs to build the full matrix to produce usable artifacts (we could reconsider this but was a more drastic step than I felt was necessary in this PR).
- Both wheels and devcontainers are much faster to build than conda packages due to the substantial overhead of conda-build.  devcontainer builds are slower than wheel builds, but they provide more complete coverage (devcontainers build C++ tests as well as all Python packages).
    - For PRs that don't change C++ code, devcontainer builds should effectively be fully cached and complete very fast (about 10 mins on the first run of this PR). For PRs that break builds, devcontainers will show that just as quickly as other builds. The main downside is in cases where builds are not cached but also succeed, in which case devcontainer builds can take significantly longer ([~50 mins on the other PR](https://github.com/rapidsai/cudf/actions/runs/8100993687/job/22140164606)) and will prevent other build jobs from starting.
- Wheel tests are much faster than conda tests because of various conda overheads.
    - In the other PR the fastest full wheel test run on x86 [took ~15](https://github.com/rapidsai/cudf/actions/runs/8100993687/job/22141831072) while the fastest conda test run [took ~30](https://github.com/rapidsai/cudf/actions/runs/8100993687/job/22143310430)).
- There is currently significant overlap between wheel and conda tests, but we rarely see failures in one without seeing them in the other unless they are due to something like a conda packaging/solver issue.
- Doc changes are infrequent but doc builds are expensive because they require GPU nodes
- cudf_kafka and custreamz are essentially static

Based on those observations, and in conjunction with rapidsai/shared-workflows#184 (used in this PR), this PR makes the following changes:
- devcontainer builds now require style checks.
- devcontainer builds now gate all other builds.
- Wheel tests now gate conda Python tests. 
- rapidsai/shared-workflows#184 also reduces the number of conda tests in PRs (nightlies are unchanged).
- The conda tests of dask_cudf, cudf_kafka, and custreamz remain independent of the conda tests of cudf, but they are now gated by the dask_cudf wheel tests.
- doc builds now require tests to pass.

The net result should be that while running the full CI workflow successfully for a single PR is now slower, CI failures are still observed almost as fast in almost all cases (exceptions include doc builds, python tests that only fail in conda, and build issues that only arise in conda-build or wheel builds) and overall CI resource usage by jobs that fail at any stage is substantially reduced. 

I'm happy to discuss all of these changes, and I think implementing even a subset of them will make a meaningful impact on our CI turnaround time. Once we're happy with this and churn on other RAPIDS-wide CI changes reduces, we can port these changes to other repos as well.

Contributes to rapidsai/build-planning#5.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
