### PR TITLE
Fix testchunkedPackTwoPasses to copy from the bounce buffer

### DIFF
--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -3745,9 +3745,9 @@ public class TableTest extends CudfTestBase {
     // this test packes ~2MB worth of long into a 1MB bounce buffer
     // this is 3 iterations because of the validity buffer
     Long[] longs = new Long[256*1024];
-    for (int i = 0; i < longs.length; i++) {
-      // fill the column and set every other value to null
-      longs[i] = i % 2 == 0 ? null : (long)i;
+    // Initialize elements at odd-numbered indices
+    for (int i = 1; i < longs.length; i += 2) {
+      longs[i] = (long)i;
     }
     try (Table t1 = new Table.TestBuilder().column(longs).build();
          DeviceMemoryBuffer bounceBuffer = DeviceMemoryBuffer.allocate(1L*1024*1024);

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -3739,12 +3739,16 @@ public class TableTest extends CudfTestBase {
       }
     }
   }
-/*
+
   @Test
   void testChunkedPackTwoPasses() {
     // this test packes ~2MB worth of long into a 1MB bounce buffer
     // this is 3 iterations because of the validity buffer
     Long[] longs = new Long[256*1024];
+    for (int i = 0; i < longs.length; i++) {
+      // fill the column and set every other value to null
+      longs[i] = i % 2 == 0 ? null : (long)i;
+    }
     try (Table t1 = new Table.TestBuilder().column(longs).build();
          DeviceMemoryBuffer bounceBuffer = DeviceMemoryBuffer.allocate(1L*1024*1024);
          ChunkedPack cp = t1.makeChunkedPack(1L*1024*1024);
@@ -3757,7 +3761,7 @@ public class TableTest extends CudfTestBase {
       while (cp.hasNext()) {
         long copied = cp.next(bounceBuffer);
         target.copyFromDeviceBufferAsync(
-          offset, target, 0, copied, Cuda.DEFAULT_STREAM);
+          offset, bounceBuffer, 0, copied, Cuda.DEFAULT_STREAM);
         offset += copied;
       }
 
@@ -3768,7 +3772,6 @@ public class TableTest extends CudfTestBase {
       }
     }
   }
-*/
 
   @Test
   void testContiguousSplitWithStrings() {


### PR DESCRIPTION
This is a follow on from https://github.com/rapidsai/cudf/pull/15210. We bring back the test and fix it so it copies from the right buffer this time. I also set the original column to have some values and nulls, to make sure we are checking something interesting.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
