### PR TITLE
Remove create_chars_child_column utility

### DIFF
--- a/cpp/include/cudf/strings/detail/utilities.hpp
+++ b/cpp/include/cudf/strings/detail/utilities.hpp
@@ -26,19 +26,6 @@
 namespace cudf {
 namespace strings {
 namespace detail {
-/**
- * @brief Create a chars column to be a child of a strings column.
- *
- * This will return the properly sized column to be filled in by the caller.
- *
- * @param bytes Number of bytes for the chars column.
- * @param stream CUDA stream used for device memory operations and kernel launches.
- * @param mr Device memory resource used to allocate the returned column's device memory.
- * @return The chars child column for a strings column.
- */
-std::unique_ptr<column> create_chars_child_column(size_type bytes,
-                                                  rmm::cuda_stream_view stream,
-                                                  rmm::mr::device_memory_resource* mr);
 
 /**
  * @brief Creates a string_view vector from a strings column.

--- a/cpp/src/strings/utilities.cu
+++ b/cpp/src/strings/utilities.cu
@@ -65,14 +65,6 @@ rmm::device_uvector<string_view> create_string_vector_from_column(
   return strings_vector;
 }
 
-std::unique_ptr<column> create_chars_child_column(cudf::size_type total_bytes,
-                                                  rmm::cuda_stream_view stream,
-                                                  rmm::mr::device_memory_resource* mr)
-{
-  return make_numeric_column(
-    data_type{type_id::INT8}, total_bytes, mask_state::UNALLOCATED, stream, mr);
-}
-
 namespace {
 // The device variables are created here to avoid using a singleton that may cause issues
 // with RMM initialize/finalize. See PR #3159 for details on this approach.


### PR DESCRIPTION
## Description
Removes the `cudf::strings::detail::create_chars_child_column` utility. This is not longer needed or used.
Removing it helps prevent inadvertently using it to wrap chars data with a cudf column.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
