### PR TITLE
Fix wrong output for `collect_list`/`collect_set` of lists column

### DIFF
--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -177,15 +177,14 @@ std::unique_ptr<scalar> reduce(column_view const& col,
         std::move(*reduction::detail::make_empty_histogram_like(col.child(0))), true, stream, mr);
     }
 
-    if (output_dtype.id() == type_id::LIST) {
-      if (col.type() == output_dtype) { return make_empty_scalar_like(col, stream, mr); }
-      // Under some circumstance, the output type will become the List of input type,
-      // such as: collect_list or collect_set. So, we have to handcraft the default scalar.
+    if (agg.kind == aggregation::COLLECT_LIST || agg.kind == aggregation::COLLECT_SET) {
       auto scalar = make_list_scalar(empty_like(col)->view(), stream, mr);
       scalar->set_valid_async(false, stream);
       return scalar;
     }
-    if (output_dtype.id() == type_id::STRUCT) { return make_empty_scalar_like(col, stream, mr); }
+    if (output_dtype.id() == type_id::STRUCT || output_dtype.id() == type_id::LIST) {
+      return make_empty_scalar_like(col, stream, mr);
+    }
 
     auto result = make_default_constructed_scalar(output_dtype, stream, mr);
     if (agg.kind == aggregation::ANY || agg.kind == aggregation::ALL) {

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -182,6 +182,8 @@ std::unique_ptr<scalar> reduce(column_view const& col,
       scalar->set_valid_async(false, stream);
       return scalar;
     }
+
+    // `make_default_constructed_scalar` does not support nested type.
     if (output_dtype.id() == type_id::STRUCT || output_dtype.id() == type_id::LIST) {
       return make_empty_scalar_like(col, stream, mr);
     }

--- a/cpp/tests/reductions/collect_ops_tests.cpp
+++ b/cpp/tests/reductions/collect_ops_tests.cpp
@@ -373,7 +373,6 @@ TEST_F(CollectTest, CollectAllNulls)
   using int_col = cudf::test::fixed_width_column_wrapper<int32_t>;
   using namespace cudf::test::iterators;
 
-  // list<list<int>>
   auto const input    = int_col{{0, 0, 0, 0, 0, 0}, all_nulls()};
   auto const expected = int_col{};
 

--- a/cpp/tests/reductions/collect_ops_tests.cpp
+++ b/cpp/tests/reductions/collect_ops_tests.cpp
@@ -367,3 +367,53 @@ TEST_F(CollectTest, CollectEmptys)
   ret = collect_set(all_nulls, cudf::make_collect_set_aggregation<cudf::reduce_aggregation>());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(int_col{}, dynamic_cast<cudf::list_scalar*>(ret.get())->view());
 }
+
+TEST_F(CollectTest, CollectAllNulls)
+{
+  using int_col = cudf::test::fixed_width_column_wrapper<int32_t>;
+  using namespace cudf::test::iterators;
+
+  // list<list<int>>
+  auto const input    = int_col{{0, 0, 0, 0, 0, 0}, all_nulls()};
+  auto const expected = int_col{};
+
+  {
+    auto const agg =
+      cudf::make_collect_list_aggregation<cudf::reduce_aggregation>(cudf::null_policy::EXCLUDE);
+    auto const result = cudf::reduce(input, *agg, cudf::data_type{cudf::type_id::LIST});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected,
+                                   dynamic_cast<cudf::list_scalar*>(result.get())->view());
+  }
+  {
+    auto const agg = cudf::make_collect_set_aggregation<cudf::reduce_aggregation>(
+      cudf::null_policy::EXCLUDE, cudf::null_equality::UNEQUAL, cudf::nan_equality::ALL_EQUAL);
+    auto const result = cudf::reduce(input, *agg, cudf::data_type{cudf::type_id::LIST});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected,
+                                   dynamic_cast<cudf::list_scalar*>(result.get())->view());
+  }
+}
+
+TEST_F(CollectTest, CollectAllNullsWithLists)
+{
+  using LCW = cudf::test::lists_column_wrapper<int32_t>;
+  using namespace cudf::test::iterators;
+
+  // list<list<int>>
+  auto const input    = LCW{{LCW{LCW{1, 2, 3}, LCW{4, 5, 6}}, LCW{{1, 2, 3}}}, all_nulls()};
+  auto const expected = cudf::empty_like(input);
+
+  {
+    auto const agg =
+      cudf::make_collect_list_aggregation<cudf::reduce_aggregation>(cudf::null_policy::EXCLUDE);
+    auto const result = cudf::reduce(input, *agg, cudf::data_type{cudf::type_id::LIST});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected->view(),
+                                   dynamic_cast<cudf::list_scalar*>(result.get())->view());
+  }
+  {
+    auto const agg = cudf::make_collect_set_aggregation<cudf::reduce_aggregation>(
+      cudf::null_policy::EXCLUDE, cudf::null_equality::UNEQUAL, cudf::nan_equality::ALL_EQUAL);
+    auto const result = cudf::reduce(input, *agg, cudf::data_type{cudf::type_id::LIST});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected->view(),
+                                   dynamic_cast<cudf::list_scalar*>(result.get())->view());
+  }
+}


### PR DESCRIPTION
This fixes a bug in the reduction code that shows up specifically in `collect_list`/`collect_set` of lists column. In particular, the output of these reduction ops should be a list scalar holding a column that has exactly the same type structure as the input. However, when the input column contains all nulls, the output list scalar holds an empty column having wrong type structure.

Closes https://github.com/rapidsai/cudf/issues/14924.