### PR TITLE
Add CUDA 12.4 to supported PTX versions

### DIFF
--- a/python/cudf/cudf/utils/_numba.py
+++ b/python/cudf/cudf/utils/_numba.py
@@ -181,6 +181,7 @@ def _get_cuda_version_from_ptx_file(path):
         "8.1": (12, 1),
         "8.2": (12, 2),
         "8.3": (12, 3),
+        "8.4": (12, 4),
     }
 
     cuda_ver = ver_map.get(version)


### PR DESCRIPTION
This PR updates the mapping from PTX version to toolkit versions to cover CUDA 12.4.