### PR TITLE
Ensure `astype("interval")` only matches the `"interval"` string

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -975,9 +975,12 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
             # TODO: Figure out why `cudf.dtype("category")`
             # astype's different than just the string
             return col.as_categorical_column(dtype)
-        elif dtype == "interval" and isinstance(
-            self.dtype, cudf.IntervalDtype
+        elif (
+            isinstance(dtype, str)
+            and dtype == "interval"
+            and isinstance(self.dtype, cudf.IntervalDtype)
         ):
+            # astype("interval") (the string only) should no-op
             return col
         was_object = dtype == object or dtype == np.dtype(object)
         dtype = cudf.dtype(dtype)


### PR DESCRIPTION
## Description
https://github.com/rapidsai/cudf/pull/15125 got merged first before https://github.com/rapidsai/cudf/pull/14961 and I forgot to rebase the former which had an impact on that PR 

This should unblock current cudf Python test failures

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
