### PR TITLE
Temporarily disable docs errors.

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -34,6 +34,11 @@ rapids-mamba-retry install \
 
 export RAPIDS_DOCS_DIR="$(mktemp -d)"
 
+# TODO: Disable hard errors until the docs site is accessible (network problems)
+EXITCODE=0
+trap "EXITCODE=1" ERR
+set +e
+
 rapids-logger "Build CPP docs"
 pushd cpp/doxygen
 aws s3 cp s3://rapidsai-docs/librmm/html/${RAPIDS_VERSION_NUMBER}/rmm.tag . || echo "Failed to download rmm Doxygen tag"
@@ -66,4 +71,11 @@ if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]]; then
 fi
 popd
 
-rapids-upload-docs
+if [[ "${EXITCODE}" == "0" ]]; then
+  rapids-upload-docs
+else
+  rapids-logger "Docs script had errors resulting in exit code $EXITCODE"
+fi
+
+# TODO: Disable hard errors until the docs site is accessible (network problems)
+exit 0

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -975,9 +975,12 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
             # TODO: Figure out why `cudf.dtype("category")`
             # astype's different than just the string
             return col.as_categorical_column(dtype)
-        elif dtype == "interval" and isinstance(
-            self.dtype, cudf.IntervalDtype
+        elif (
+            isinstance(dtype, str)
+            and dtype == "interval"
+            and isinstance(self.dtype, cudf.IntervalDtype)
         ):
+            # astype("interval") (the string only) should no-op
             return col
         was_object = dtype == object or dtype == np.dtype(object)
         dtype = cudf.dtype(dtype)


### PR DESCRIPTION
## Description
Currently there are some network issues affecting docs builds. To prevent this from causing complete CI blockage, we can temporarily allow errors in the docs build. This will allow us to monitor the network status and re-enable the docs builds when the network issues are resolved.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
