### PR TITLE
Revert "Temporarily disable docs errors. (#15265)"

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -34,11 +34,6 @@ rapids-mamba-retry install \
 
 export RAPIDS_DOCS_DIR="$(mktemp -d)"
 
-# TODO: Disable hard errors until the docs site is accessible (network problems)
-EXITCODE=0
-trap "EXITCODE=1" ERR
-set +e
-
 rapids-logger "Build CPP docs"
 pushd cpp/doxygen
 aws s3 cp s3://rapidsai-docs/librmm/html/${RAPIDS_VERSION_NUMBER}/rmm.tag . || echo "Failed to download rmm Doxygen tag"
@@ -71,11 +66,4 @@ if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]]; then
 fi
 popd
 
-if [[ "${EXITCODE}" == "0" ]]; then
-  rapids-upload-docs
-else
-  rapids-logger "Docs script had errors resulting in exit code $EXITCODE"
-fi
-
-# TODO: Disable hard errors until the docs site is accessible (network problems)
-exit 0
+rapids-upload-docs


### PR DESCRIPTION
## Description
This reverts part of commit c794ce4968b69e0cffc97b3db9496a1cdeab78bc. This PR can be merged after the docs.rapids.ai issues are resolved. cc: @raydouglass @AyodeAwe

PR #15265 unblocked CI for cudf by disabling errors in the docs. However, it also included the diff from #15261 so that CI would pass. This reverts the docs build changes but leaves in the changes from #15261.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
