### PR TITLE
Make linking of nvtx3-cpp BUILD_LOCAL_INTERFACE

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -779,7 +779,7 @@ add_dependencies(cudf jitify_preprocess_run)
 target_link_libraries(
   cudf
   PUBLIC ${ARROW_LIBRARIES} CCCL::CCCL rmm::rmm
-  PRIVATE nvtx3-cpp cuco::cuco ZLIB::ZLIB nvcomp::nvcomp kvikio::kvikio
+  PRIVATE $<BUILD_LOCAL_INTERFACE:nvtx3-cpp> cuco::cuco ZLIB::ZLIB nvcomp::nvcomp kvikio::kvikio
           $<TARGET_NAME_IF_EXISTS:cuFile_interface>
 )
 


### PR DESCRIPTION
## Description
When building as static libraries, CMake tries to export the PRIVATE nvtx3-cpp dependency due to how it handles static library exports. Since nvtx3-cpp is a header-only library, and since cudf's public headers don't depend on it, make it BUILD_LOCAL_INTERFACE to avoid exporting the nvtx3-cpp dependency.

Issue: https://github.com/rapidsai/cudf/issues/15270

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
