### PR TITLE
Implement top/bottom-k aggregations in sort-based groupby

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -343,6 +343,7 @@ add_library(
   src/groupby/sort/group_rank_scan.cu
   src/groupby/sort/group_replace_nulls.cu
   src/groupby/sort/group_sum_scan.cu
+  src/groupby/sort/group_topk.cu
   src/groupby/sort/sort_helper.cu
   src/hash/hashing.cu
   src/hash/md5_hash.cu

--- a/cpp/include/cudf/aggregation.hpp
+++ b/cpp/include/cudf/aggregation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,42 +83,43 @@ class aggregation {
    * @brief Possible aggregation operations
    */
   enum Kind {
-    SUM,             ///< sum reduction
-    PRODUCT,         ///< product reduction
-    MIN,             ///< min reduction
-    MAX,             ///< max reduction
-    COUNT_VALID,     ///< count number of valid elements
-    COUNT_ALL,       ///< count number of elements
-    ANY,             ///< any reduction
-    ALL,             ///< all reduction
-    SUM_OF_SQUARES,  ///< sum of squares reduction
-    MEAN,            ///< arithmetic mean reduction
-    M2,              ///< sum of squares of differences from the mean
-    VARIANCE,        ///< variance
-    STD,             ///< standard deviation
-    MEDIAN,          ///< median reduction
-    QUANTILE,        ///< compute specified quantile(s)
-    ARGMAX,          ///< Index of max element
-    ARGMIN,          ///< Index of min element
-    NUNIQUE,         ///< count number of unique elements
-    NTH_ELEMENT,     ///< get the nth element
-    ROW_NUMBER,      ///< get row-number of current index (relative to rolling window)
-    RANK,            ///< get rank of current index
-    COLLECT_LIST,    ///< collect values into a list
-    COLLECT_SET,     ///< collect values into a list without duplicate entries
-    LEAD,            ///< window function, accesses row at specified offset following current row
-    LAG,             ///< window function, accesses row at specified offset preceding current row
-    PTX,             ///< PTX  UDF based reduction
-    CUDA,            ///< CUDA UDF based reduction
-    MERGE_LISTS,     ///< merge multiple lists values into one list
-    MERGE_SETS,      ///< merge multiple lists values into one list then drop duplicate entries
-    MERGE_M2,        ///< merge partial values of M2 aggregation,
-    COVARIANCE,      ///< covariance between two sets of elements
-    CORRELATION,     ///< correlation between two sets of elements
-    TDIGEST,         ///< create a tdigest from a set of input values
-    MERGE_TDIGEST,   ///< create a tdigest by merging multiple tdigests together
-    HISTOGRAM,       ///< compute frequency of each element
-    MERGE_HISTOGRAM  ///< merge partial values of HISTOGRAM aggregation,
+    SUM,              ///< sum reduction
+    PRODUCT,          ///< product reduction
+    MIN,              ///< min reduction
+    MAX,              ///< max reduction
+    COUNT_VALID,      ///< count number of valid elements
+    COUNT_ALL,        ///< count number of elements
+    ANY,              ///< any reduction
+    ALL,              ///< all reduction
+    SUM_OF_SQUARES,   ///< sum of squares reduction
+    MEAN,             ///< arithmetic mean reduction
+    M2,               ///< sum of squares of differences from the mean
+    VARIANCE,         ///< variance
+    STD,              ///< standard deviation
+    MEDIAN,           ///< median reduction
+    QUANTILE,         ///< compute specified quantile(s)
+    ARGMAX,           ///< Index of max element
+    ARGMIN,           ///< Index of min element
+    NUNIQUE,          ///< count number of unique elements
+    NTH_ELEMENT,      ///< get the nth element
+    ROW_NUMBER,       ///< get row-number of current index (relative to rolling window)
+    RANK,             ///< get rank of current index
+    COLLECT_LIST,     ///< collect values into a list
+    COLLECT_SET,      ///< collect values into a list without duplicate entries
+    LEAD,             ///< window function, accesses row at specified offset following current row
+    LAG,              ///< window function, accesses row at specified offset preceding current row
+    PTX,              ///< PTX  UDF based reduction
+    CUDA,             ///< CUDA UDF based reduction
+    MERGE_LISTS,      ///< merge multiple lists values into one list
+    MERGE_SETS,       ///< merge multiple lists values into one list then drop duplicate entries
+    MERGE_M2,         ///< merge partial values of M2 aggregation,
+    COVARIANCE,       ///< covariance between two sets of elements
+    CORRELATION,      ///< correlation between two sets of elements
+    TDIGEST,          ///< create a tdigest from a set of input values
+    MERGE_TDIGEST,    ///< create a tdigest by merging multiple tdigests together
+    HISTOGRAM,        ///< compute frequency of each element
+    MERGE_HISTOGRAM,  ///< merge partial values of HISTOGRAM aggregation,
+    TOP_K,            ///< get the top-k values per group as a list column
   };
 
   aggregation() = delete;
@@ -526,6 +527,20 @@ std::unique_ptr<Base> make_collect_set_aggregation(
   null_policy null_handling = null_policy::INCLUDE,
   null_equality nulls_equal = null_equality::EQUAL,
   nan_equality nans_equal   = nan_equality::ALL_EQUAL);
+
+/**
+ * @brief Factory to create a TOP_K aggregation
+ *
+ * `TOP_K` returns a list column of the top-k elements in the
+ * group/series. If a group has fewer than k elements, the whole group
+ * is returned.
+ *
+ * @param k Number of values to return.
+ * @param order What order should the groups be sorted in.
+ * @return A TOP_K aggregation
+ */
+template <typename Base = aggregation>
+std::unique_ptr<Base> make_top_k_aggregation(size_type k, order order = order::DESCENDING);
 
 /**
  * @brief Factory to create a LAG aggregation

--- a/cpp/include/cudf/aggregation.hpp
+++ b/cpp/include/cudf/aggregation.hpp
@@ -119,7 +119,7 @@ class aggregation {
     MERGE_TDIGEST,    ///< create a tdigest by merging multiple tdigests together
     HISTOGRAM,        ///< compute frequency of each element
     MERGE_HISTOGRAM,  ///< merge partial values of HISTOGRAM aggregation,
-    TOP_K,            ///< get the top-k values per group as a list column
+    TOP_K             ///< get the top-k values per group as a list column
   };
 
   aggregation() = delete;
@@ -531,13 +531,15 @@ std::unique_ptr<Base> make_collect_set_aggregation(
 /**
  * @brief Factory to create a TOP_K aggregation
  *
- * `TOP_K` returns a list column of the top-k elements in the
- * group/series. If a group has fewer than k elements, the whole group
- * is returned.
+ * `TOP_K` returns a list column of the first k elements in the
+ * group/series, each group sorted in @p order, with null elements
+ * comparing smaller than non-null. If a group has fewer than k
+ * elements, the whole groupis returned.
  *
  * @param k Number of values to return.
- * @param order What order should the groups be sorted in.
- * @return A TOP_K aggregation
+ * @param order Controls the sorting order of the group, i.e., whether
+ * to return the k smallest or largest elements.
+ * @return A TOP_K aggregation object.
  */
 template <typename Base = aggregation>
 std::unique_ptr<Base> make_top_k_aggregation(size_type k, order order = order::DESCENDING);

--- a/cpp/src/aggregation/aggregation.cpp
+++ b/cpp/src/aggregation/aggregation.cpp
@@ -173,6 +173,12 @@ std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
 }
 
 std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
+  data_type col_type, top_k_aggregation const& agg)
+{
+  return visit(col_type, static_cast<aggregation const&>(agg));
+}
+
+std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
   data_type col_type, lead_lag_aggregation const& agg)
 {
   return visit(col_type, static_cast<aggregation const&>(agg));
@@ -344,6 +350,11 @@ void aggregation_finalizer::visit(collect_list_aggregation const& agg)
 }
 
 void aggregation_finalizer::visit(collect_set_aggregation const& agg)
+{
+  visit(static_cast<aggregation const&>(agg));
+}
+
+void aggregation_finalizer::visit(top_k_aggregation const& agg)
 {
   visit(static_cast<aggregation const&>(agg));
 }
@@ -727,6 +738,14 @@ template std::unique_ptr<groupby_aggregation> make_collect_set_aggregation<group
 template std::unique_ptr<reduce_aggregation> make_collect_set_aggregation<reduce_aggregation>(
   null_policy null_handling, null_equality nulls_equal, nan_equality nans_equal);
 
+template <typename Base>
+std::unique_ptr<Base> make_top_k_aggregation(size_type k, order order)
+{
+  return std::make_unique<detail::top_k_aggregation>(k, order);
+}
+
+template std::unique_ptr<aggregation> make_top_k_aggregation(size_type k, order order);
+template std::unique_ptr<groupby_aggregation> make_top_k_aggregation(size_type k, order order);
 /// Factory to create a LAG aggregation
 template <typename Base>
 std::unique_ptr<Base> make_lag_aggregation(size_type offset)

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -397,6 +397,7 @@ void aggregate_result_functor::operator()<aggregation::TOP_K>(aggregation const&
                                       stream,
                                       mr));
 }
+
 template <>
 void aggregate_result_functor::operator()<aggregation::NTH_ELEMENT>(aggregation const& agg)
 {

--- a/cpp/src/groupby/sort/group_reductions.hpp
+++ b/cpp/src/groupby/sort/group_reductions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -537,6 +537,27 @@ std::unique_ptr<column> group_correlation(column_view const& covariance,
                                           column_view const& stddev_1,
                                           rmm::cuda_stream_view stream,
                                           rmm::mr::device_memory_resource* mr);
+
+/**
+ * @brief Internal API to calculate topk in each group of  @p values
+ *
+ * @param values Grouped values to get top-k values from
+ * @param group_sizes Number of elements per group
+ * @param group_offsets Offsets of groups' starting points within @p values
+ * @param num_groups Number of groups ( unique values in @p group_labels )
+ * @param k How many elements to take from the front of each group of @p values
+ * @param order Sort order within each group (use ASCENDING for bottom-k, DESCENDING for top-k)
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ */
+std::unique_ptr<column> group_topk(column_view const& values,
+                                   cudf::device_span<size_type const> group_sizes,
+                                   cudf::device_span<size_type const> group_offsets,
+                                   size_type num_groups,
+                                   size_type k,
+                                   order order,
+                                   rmm::cuda_stream_view stream,
+                                   rmm::mr::device_memory_resource* mr);
 
 }  // namespace detail
 }  // namespace groupby

--- a/cpp/src/groupby/sort/group_reductions.hpp
+++ b/cpp/src/groupby/sort/group_reductions.hpp
@@ -539,15 +539,15 @@ std::unique_ptr<column> group_correlation(column_view const& covariance,
                                           rmm::mr::device_memory_resource* mr);
 
 /**
- * @brief Internal API to calculate topk in each group of  @p values
+ * @brief Internal API to calculate topk in each group of @p values.
  *
  * @param values Grouped values to get top-k values from
  * @param group_sizes Number of elements per group
  * @param group_offsets Offsets of groups' starting points within @p values
- * @param num_groups Number of groups ( unique values in @p group_labels )
+ * @param num_groups Number of groups (unique values in @p group_labels)
  * @param k How many elements to take from the front of each group of @p values
  * @param order Sort order within each group (use ASCENDING for bottom-k, DESCENDING for top-k)
- * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate the returned column's device memory
  */
 std::unique_ptr<column> group_topk(column_view const& values,

--- a/cpp/src/groupby/sort/group_topk.cu
+++ b/cpp/src/groupby/sort/group_topk.cu
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/detail/aggregation/aggregation.hpp>
+#include <cudf/detail/gather.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/detail/sizes_to_offsets_iterator.cuh>
+#include <cudf/detail/sorting.hpp>
+#include <cudf/detail/utilities/cuda.cuh>
+#include <cudf/types.hpp>
+#include <cudf/utilities/span.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+
+#include <cuda/functional>
+#include <thrust/transform_scan.h>
+
+#include <memory>
+
+namespace cudf {
+namespace groupby {
+namespace detail {
+
+__global__ void compute_topk_indices(cudf::device_span<size_type const> group_sizes,
+                                     cudf::device_span<size_type const> group_offsets,
+                                     cudf::device_span<size_type const> index_offsets,
+                                     cudf::device_span<size_type> indices,
+                                     size_type num_groups,
+                                     size_type k)
+{
+  // warp per group writes output indices
+  for (thread_index_type idx = threadIdx.x + blockDim.x * blockIdx.x;
+       idx < cudf::detail::warp_size * num_groups;
+       idx += gridDim.x * blockDim.x) {
+    auto const group{idx / cudf::detail::warp_size};
+    auto const lane{idx % cudf::detail::warp_size};
+    if (group >= num_groups) break;
+    auto const group_size   = group_sizes[group];
+    auto const k_loc        = min(group_size, k);
+    auto const index_offset = group_offsets[group];
+    auto const out_offset   = index_offsets[group];
+    for (size_type off = lane; off < k_loc; off += cudf::detail::warp_size) {
+      indices[out_offset + off] = index_offset + off;
+    }
+  }
+}
+
+std::unique_ptr<column> group_topk(column_view const& values,
+                                   cudf::device_span<size_type const> group_sizes,
+                                   cudf::device_span<size_type const> group_offsets,
+                                   size_type num_groups,
+                                   size_type k,
+                                   order order,
+                                   rmm::cuda_stream_view stream,
+                                   rmm::mr::device_memory_resource* mr)
+{
+  auto group_size_fn = cuda::proclaim_return_type<size_type>(
+    [group_sizes, num_groups, k] __device__(size_type i) -> size_type {
+      return i < num_groups ? min(k, group_sizes[i]) : size_type{0};
+    });
+  auto size_per_group = cudf::detail::make_counting_transform_iterator(0, group_size_fn);
+  auto [offsets_column, output_size] = cudf::detail::make_offsets_child_column(
+    size_per_group, size_per_group + num_groups, stream, mr);
+  auto indices = rmm::device_uvector<size_type>(output_size, stream);
+  cudf::detail::grid_1d const config{num_groups, 128};
+  compute_topk_indices<<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(
+    group_sizes, group_offsets, offsets_column->view(), indices, num_groups, k);
+
+  auto ordered_values = cudf::detail::segmented_sort_by_key(table_view{{values}},
+                                                            table_view{{values}},
+                                                            group_offsets,
+                                                            {order},
+                                                            {null_order::AFTER},
+                                                            stream,
+                                                            mr);
+  auto output_table   = cudf::detail::gather(ordered_values->view(),
+                                           indices,
+                                           out_of_bounds_policy::DONT_CHECK,
+                                           cudf::detail::negative_index_policy::NOT_ALLOWED,
+                                           stream,
+                                           mr);
+  return cudf::make_lists_column(num_groups,
+                                 std::move(offsets_column),
+                                 std::move(output_table->release()[0]),
+                                 0,
+                                 {},
+                                 stream,
+                                 mr);
+}
+}  // namespace detail
+}  // namespace groupby
+}  // namespace cudf

--- a/cpp/src/groupby/sort/group_topk.cu
+++ b/cpp/src/groupby/sort/group_topk.cu
@@ -81,7 +81,7 @@ std::unique_ptr<column> group_topk(column_view const& values,
   auto [offsets_column, output_size] = cudf::detail::make_offsets_child_column(
     size_per_group, size_per_group + num_groups, stream, mr);
   auto indices = rmm::device_uvector<size_type>(output_size, stream);
-  cudf::detail::grid_1d const config{num_groups, 128};
+  cudf::detail::grid_1d const config{num_groups * cudf::detail::warp_size, 128};
   compute_topk_indices<<<config.num_blocks, config.num_threads_per_block, 0, stream.value()>>>(
     group_sizes, group_offsets, offsets_column->view(), indices, num_groups, k);
 

--- a/cpp/src/groupby/sort/group_topk.cu
+++ b/cpp/src/groupby/sort/group_topk.cu
@@ -89,7 +89,7 @@ std::unique_ptr<column> group_topk(column_view const& values,
                                                             table_view{{values}},
                                                             group_offsets,
                                                             {order},
-                                                            {null_order::AFTER},
+                                                            {null_order::BEFORE},
                                                             stream,
                                                             mr);
   auto output_table   = cudf::detail::gather(ordered_values->view(),

--- a/python/cudf/cudf/_lib/aggregation.pyx
+++ b/python/cudf/cudf/_lib/aggregation.pyx
@@ -77,6 +77,17 @@ class Aggregation:
         return cls(pylibcudf.aggregation.nth_element(size))
 
     @classmethod
+    def top_k(cls, size, descending=True):
+        return cls(
+            pylibcudf.aggregation.top_k(
+                size,
+                pylibcudf.types.Order.DESCENDING
+                if descending
+                else pylibcudf.types.Order.ASCENDING
+            )
+        )
+
+    @classmethod
     def product(cls):
         return cls(pylibcudf.aggregation.product())
     prod = product

--- a/python/cudf/cudf/_lib/cpp/aggregation.pxd
+++ b/python/cudf/cudf/_lib/cpp/aggregation.pxd
@@ -43,6 +43,7 @@ cdef extern from "cudf/aggregation.hpp" namespace "cudf" nogil:
         RANK
         COLLECT_LIST
         COLLECT_SET
+        TOP_K
         PTX
         CUDA
         CORRELATION
@@ -133,6 +134,10 @@ cdef extern from "cudf/aggregation.hpp" namespace "cudf" nogil:
 
     cdef unique_ptr[T] make_collect_set_aggregation[T](
         null_policy null_handling, null_equality nulls_equal, nan_equality nans_equal
+    ) except +
+
+    cdef unique_ptr[T] make_top_k_aggregation[T](
+        size_type k, order order
     ) except +
 
     cdef unique_ptr[T] make_udf_aggregation[T](

--- a/python/cudf/cudf/_lib/pylibcudf/aggregation.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/aggregation.pxd
@@ -88,6 +88,8 @@ cpdef Aggregation collect_list(null_policy null_handling = *)
 
 cpdef Aggregation collect_set(null_handling = *, nulls_equal = *, nans_equal = *)
 
+cpdef Aggregation top_k(size_type k, order column_order = *)
+
 cpdef Aggregation udf(str operation, DataType output_type)
 
 cpdef Aggregation correlation(correlation_type type, size_type min_periods)

--- a/python/cudf/cudf/_lib/pylibcudf/aggregation.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/aggregation.pyx
@@ -31,6 +31,7 @@ from cudf._lib.cpp.aggregation cimport (
     make_std_aggregation,
     make_sum_aggregation,
     make_sum_of_squares_aggregation,
+    make_top_k_aggregation,
     make_udf_aggregation,
     make_variance_aggregation,
     rank_method,
@@ -456,6 +457,34 @@ cpdef Aggregation collect_set(
             )
         )
     )
+
+
+cpdef Aggregation top_k(
+    size_type k,
+    order column_order = order.DESCENDING
+):
+    """Create a top_k aggregation.
+
+    Parameters
+    ----------
+    k : size_type
+        Number of values to return.
+    column_order : order, default DESCENDING
+        Sort order within the groups.
+
+    Returns
+    -------
+    Aggregation
+        The top_k aggregation.
+    """
+    return Aggregation.from_libcudf(
+        move(
+            make_top_k_aggregation[aggregation](
+                k, column_order
+            )
+        )
+    )
+
 
 cpdef Aggregation udf(str operation, DataType output_type):
     """Create a udf aggregation.

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -948,6 +948,20 @@ class GroupBy(Serializable, Reducible, Scannable):
         return result
 
     @_cudf_nvtx_annotate
+    def topk(self, k, bottom=False):
+        """
+        Return the top-k values from each group
+
+        Parameters
+        ----------
+        k : int
+           Number of values to obtain
+        bottom : bool
+           Should one return the bottom-k values?
+        """
+        return self.agg(lambda x: x.top_k(k, descending=not bottom))
+
+    @_cudf_nvtx_annotate
     def ngroup(self, ascending=True):
         """
         Number each group from 0 to the number of groups - 1.


### PR DESCRIPTION
## Description

Provide an implementation of top_k/bottom_k in groupby-aggregations. Since there isn't currently an implementation of a segmented quickselect in thrust/cub, we do this by sorting the group segments and then extracting the pieces.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
