### PR TITLE
Add timeout for `cudf.pandas` pandas tests

### DIFF
--- a/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
+++ b/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
@@ -193,7 +193,7 @@ and not test_numpy_ufuncs_basic[nullable_float-arctanh] \
 and not test_numpy_ufuncs_basic[nullable_float-deg2rad] \
 and not test_numpy_ufuncs_basic[nullable_float-rad2deg]"
 
-timeout 2m PANDAS_CI="1" python -m pytest -p cudf.pandas \
+PANDAS_CI="1" timeout 2m python -m pytest -p cudf.pandas \
     -v -m "not single_cpu and not db" \
     -k "not test_overwrite_warns and not test_complex_series_frame_alignment and not test_to_parquet_gcs_new_file and not test_qcut_nat and not test_add and not test_ismethods and $TEST_NUMPY_UFUNCS_BASIC_FLAKY" \
     --import-mode=importlib \

--- a/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
+++ b/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
@@ -193,7 +193,7 @@ and not test_numpy_ufuncs_basic[nullable_float-arctanh] \
 and not test_numpy_ufuncs_basic[nullable_float-deg2rad] \
 and not test_numpy_ufuncs_basic[nullable_float-rad2deg]"
 
-PANDAS_CI="1" timeout 2m python -m pytest -p cudf.pandas \
+PANDAS_CI="1" timeout 45m python -m pytest -p cudf.pandas \
     -v -m "not single_cpu and not db" \
     -k "not test_overwrite_warns and not test_complex_series_frame_alignment and not test_to_parquet_gcs_new_file and not test_qcut_nat and not test_add and not test_ismethods and $TEST_NUMPY_UFUNCS_BASIC_FLAKY" \
     --import-mode=importlib \

--- a/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
+++ b/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
@@ -193,7 +193,7 @@ and not test_numpy_ufuncs_basic[nullable_float-arctanh] \
 and not test_numpy_ufuncs_basic[nullable_float-deg2rad] \
 and not test_numpy_ufuncs_basic[nullable_float-rad2deg]"
 
-PANDAS_CI="1" python -m pytest -p cudf.pandas \
+timeout 2m PANDAS_CI="1" python -m pytest -p cudf.pandas \
     -v -m "not single_cpu and not db" \
     -k "not test_overwrite_warns and not test_complex_series_frame_alignment and not test_to_parquet_gcs_new_file and not test_qcut_nat and not test_add and not test_ismethods and $TEST_NUMPY_UFUNCS_BASIC_FLAKY" \
     --import-mode=importlib \

--- a/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
+++ b/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
@@ -193,7 +193,7 @@ and not test_numpy_ufuncs_basic[nullable_float-arctanh] \
 and not test_numpy_ufuncs_basic[nullable_float-deg2rad] \
 and not test_numpy_ufuncs_basic[nullable_float-rad2deg]"
 
-PANDAS_CI="1" timeout 45m python -m pytest -p cudf.pandas \
+PANDAS_CI="1" timeout 30m python -m pytest -p cudf.pandas \
     -v -m "not single_cpu and not db" \
     -k "not test_overwrite_warns and not test_complex_series_frame_alignment and not test_to_parquet_gcs_new_file and not test_qcut_nat and not test_add and not test_ismethods and $TEST_NUMPY_UFUNCS_BASIC_FLAKY" \
     --import-mode=importlib \


### PR DESCRIPTION
## Description
This PR adds `timeout` for the pytest command so that we can release the GPU resources if we detect a hang. Total suite usually takes 21 mins, I added 30 mins as the timeout.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
