### PR TITLE
Fix gtests/ERROR_TEST errors when run in Debug

### DIFF
--- a/cpp/tests/error/error_handling_test.cu
+++ b/cpp/tests/error/error_handling_test.cu
@@ -97,7 +97,8 @@ TEST(DebugAssertDeathTest, cudf_assert_false)
   testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   auto call_kernel = []() {
-    assert_false_kernel<<<1, 1>>>();
+    auto const stream = cudf::get_default_stream().value();
+    assert_false_kernel<<<1, 1, 0, stream>>>();
 
     // Kernel should fail with `cudaErrorAssert`
     // This error invalidates the current device context, so we need to kill
@@ -114,7 +115,8 @@ TEST(DebugAssertDeathTest, cudf_assert_false)
 
 TEST(DebugAssert, cudf_assert_true)
 {
-  assert_true_kernel<<<1, 1>>>();
+  auto const stream = cudf::get_default_stream().value();
+  assert_true_kernel<<<1, 1, 0, stream>>>();
   ASSERT_EQ(cudaSuccess, cudaDeviceSynchronize());
 }
 
@@ -136,6 +138,7 @@ int main(int argc, char** argv)
     auto adaptor                       = make_stream_checking_resource_adaptor(
       resource, error_on_invalid_stream, check_default_stream);
     rmm::mr::set_current_device_resource(&adaptor);
+    return RUN_ALL_TESTS();
   }
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Description
Fixes errors reported by `gtests/ERROR_TEST` when run with a Debug build. Both errors occur due to invalid stream usage.
```
[ RUN      ] DebugAssert.cudf_assert_true
libcudf was not built with stacktrace support.
unknown file: Failure
C++ exception with description "cudf_identify_stream_usage found unexpected stream!" thrown in the test body.

[ RUN      ] DebugAssertDeathTest.cudf_assert_false
libcudf was not built with stacktrace support.
/cudf/cpp/tests/error/error_handling_test.cu:112: Failure
Death test: call_kernel()
    Result: threw an exception.
 Error msg:
[  DEATH   ] 
[  DEATH   ] /cudf/cpp/tests/error/error_handling_test.cu:112:: Caught std::exception-derived exception escaping the death test statement. Exception message: cudf_identify_stream_usage found unexpected stream!

```
Fixes the test logic to use the correct stream. These tests are only built/run with a Debug build.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
