### PR TITLE
Avoid importing dask-expr if "query-planning" config is `False`

### DIFF
--- a/python/dask_cudf/dask_cudf/expr/__init__.py
+++ b/python/dask_cudf/dask_cudf/expr/__init__.py
@@ -7,12 +7,12 @@ from dask import config
 QUERY_PLANNING_ON = config.get("dataframe.query-planning", None) is not False
 
 # Register custom expressions and collections
-try:
-    import dask_cudf.expr._collection
-    import dask_cudf.expr._expr
+if QUERY_PLANNING_ON:
+    try:
+        import dask_cudf.expr._collection
+        import dask_cudf.expr._expr
 
-except ImportError as err:
-    if QUERY_PLANNING_ON:
+    except ImportError as err:
         # Dask *should* raise an error before this.
         # However, we can still raise here to be certain.
         raise RuntimeError(

--- a/python/dask_cudf/dask_cudf/expr/__init__.py
+++ b/python/dask_cudf/dask_cudf/expr/__init__.py
@@ -11,6 +11,7 @@ if QUERY_PLANNING_ON:
     try:
         import dask_cudf.expr._collection
         import dask_cudf.expr._expr
+
     except ImportError as err:
         # Dask *should* raise an error before this.
         # However, we can still raise here to be certain.

--- a/python/dask_cudf/dask_cudf/expr/__init__.py
+++ b/python/dask_cudf/dask_cudf/expr/__init__.py
@@ -11,7 +11,6 @@ if QUERY_PLANNING_ON:
     try:
         import dask_cudf.expr._collection
         import dask_cudf.expr._expr
-
     except ImportError as err:
         # Dask *should* raise an error before this.
         # However, we can still raise here to be certain.


### PR DESCRIPTION
## Description
During some offline debugging with @bdice and @divyegala, we discovered that some cuml tests are somehow failing after `dask_expr` is imported - Even if `dask_expr` is not actually being used. I'd like to figure out exactly what is causing that problem, but the first thing we can/should do is avoid the import altogether when the "query-planning" config is set to `False`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
