### PR TITLE
Remove `_from_data_like_self` in favor of `_from_columns_like_self`

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -1991,7 +1991,6 @@ class BaseIndex(Serializable):
                 keep=keep,
                 nulls_are_equal=nulls_are_equal,
             ),
-            self._column_names,
         )
 
     def duplicated(self, keep="first"):
@@ -2077,7 +2076,6 @@ class BaseIndex(Serializable):
                 how=how,
                 keys=range(len(data_columns)),
             ),
-            self._column_names,
         )
 
     def _gather(self, gather_map, nullify=False, check_bounds=True):
@@ -2100,7 +2098,6 @@ class BaseIndex(Serializable):
 
         return self._from_columns_like_self(
             gather(list(self._columns), gather_map, nullify=nullify),
-            self._column_names,
         )
 
     def take(self, indices, axis=0, allow_fill=True, fill_value=None):
@@ -2149,7 +2146,6 @@ class BaseIndex(Serializable):
 
         return self._from_columns_like_self(
             apply_boolean_mask(list(self._columns), boolean_mask),
-            column_names=self._column_names,
         )
 
     def repeat(self, repeats, axis=None):

--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import itertools
+import sys
 from collections import abc
 from functools import cached_property, reduce
 from typing import (
@@ -173,6 +174,31 @@ class ColumnAccessor(abc.MutableMapping):
             [f"{name}: {col.dtype}" for name, col in self.items()]
         )
         return f"{type_info}\n{column_info}"
+
+    def _from_columns_like_self(
+        self, columns: abc.Iterable[ColumnBase], verify: bool = True
+    ):
+        """
+        Return a new ColumnAccessor with columns and the properties of self.
+        """
+        if sys.version_info.major >= 3 and sys.version_info.minor >= 10:
+            data = zip(self.names, columns, strict=True)
+        else:
+            columns = list(columns)
+            if len(columns) != len(self.names):
+                raise ValueError(
+                    f"The number of columns ({len(columns)}) must match "
+                    f"the number of existing column labels ({len(self.names)})."
+                )
+            data = zip(self.names, columns)
+        return type(self)(
+            data=dict(data),
+            multiindex=self.multiindex,
+            level_names=self.level_names,
+            rangeindex=self.rangeindex,
+            label_dtype=self.label_dtype,
+            verify=verify,
+        )
 
     @property
     def level_names(self) -> Tuple[Any, ...]:

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1632,7 +1632,7 @@ class Frame(BinaryOperand, Scannable):
                 col.unary_operator("not")
                 if col.dtype.kind == "b"
                 else -1 * col
-                for col in self._data.columns()
+                for col in self._data.columns
             )
         )
 
@@ -1899,7 +1899,7 @@ class Frame(BinaryOperand, Scannable):
     def __invert__(self):
         """Bitwise invert (~) for integral dtypes, logical NOT for bools."""
         return self._from_columns_like_self(
-            (_apply_inverse_column(col) for col in self._data.columns())
+            (_apply_inverse_column(col) for col in self._data.columns)
         )
 
     @_cudf_nvtx_annotate

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -1210,7 +1210,6 @@ class GroupBy(Serializable, Reducible, Scannable):
             to_drop = (self.grouping.keys.name,)
         grouped_values = self.obj._from_columns_like_self(
             grouped_value_cols,
-            column_names=self.obj._column_names,
             index_names=self.obj._index_names,
         )
         if not include_groups:

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -1068,7 +1068,8 @@ class Index(SingleColumnFrame, BaseIndex, metaclass=IndexMeta):
         binop_result = self._colwise_binop(operands, op)
 
         if isinstance(other, cudf.Series):
-            ret = other._from_data_like_self(binop_result)
+            ret = other._from_data(binop_result, other._index)
+            ret._data._level_names = ret._data._level_names
             other_name = other.name
         else:
             ret = _index_from_data(binop_result)
@@ -1490,7 +1491,7 @@ class Index(SingleColumnFrame, BaseIndex, metaclass=IndexMeta):
 
     def repeat(self, repeats, axis=None):
         return self._from_columns_like_self(
-            Frame._repeat([*self._columns], repeats, axis), self._column_names
+            Frame._repeat([*self._columns], repeats, axis),
         )
 
     @_cudf_nvtx_annotate

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1902,7 +1902,7 @@ class IndexedFrame(Frame):
             col.nans_to_nulls()
             if isinstance(col, cudf.core.column.NumericalColumn)
             else col.copy()
-            for col in self._data.columns()
+            for col in self._data.columns
         )
         return self._from_columns_like_self(result)
 

--- a/python/cudf/cudf/core/join/join.py
+++ b/python/cudf/cudf/core/join/join.py
@@ -421,7 +421,7 @@ class Merge:
                 stable=True,
             )
             result = result._from_columns_like_self(
-                result_columns, result._column_names, index_names
+                result_columns, index_names
             )
         return result
 

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -2089,5 +2089,5 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
 
     def repeat(self, repeats, axis=None):
         return self._from_columns_like_self(
-            Frame._repeat([*self._columns], repeats, axis), self._column_names
+            Frame._repeat([*self._columns], repeats, axis)
         )

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -862,7 +862,6 @@ def _merge_sorted(
             ascending=ascending,
             na_position=na_position,
         ),
-        column_names=objs[0]._column_names,
         index_names=None if ignore_index else objs[0]._index_names,
     )
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -3654,7 +3654,7 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
     def where(self, cond, other=None, inplace=False):
         result_col = super().where(cond, other, inplace)
         return self._mimic_inplace(
-            self._from_data_like_self({self.name: result_col}),
+            self._from_columns_like_self([result_col]),
             inplace=inplace,
         )
 


### PR DESCRIPTION
## Description
Some column-wise operations are iterating on both the column-labels and columns and returning their result through `_from_data_like_self`. We can instead just iterate through the columns and return the result through `_from_columns_like_self`

This PR also works towards these column-wise operations preserving the `column` metadata (RangeIndex, index dtype, etc), but there are some methods like `_copy_type_metadata` that undo the metadata preservation of `_from_columns_like_self`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
