### PR TITLE
Disable dask-expr in docs builds.

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -41,6 +41,9 @@ mkdir -p "${RAPIDS_DOCS_DIR}/libcudf/html"
 mv html/* "${RAPIDS_DOCS_DIR}/libcudf/html"
 popd
 
+# TODO: Remove this once dask-expr works in the 10min notebook
+export DASK_DATAFRAME__QUERY_PLANNING=False
+
 rapids-logger "Build Python docs"
 pushd docs/cudf
 make dirhtml


### PR DESCRIPTION
## Description
Fixes CI blocked by dask-expr.

xref:
- https://github.com/rapidsai/cudf/pull/14805
- https://github.com/rapidsai/rapids-dask-dependency/pull/33

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
