### PR TITLE
WIP: prevent path conflicts

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -17,6 +17,8 @@ version=$(rapids-generate-version)
 
 rapids-logger "Begin cpp build"
 
+conda config --set path_conflict prevent
+
 # With boa installed conda build forward to boa
 RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry mambabuild \
     conda/recipes/libcudf

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -24,6 +24,8 @@ done
 
 rapids-logger "Begin py build"
 
+conda config --set path_conflict prevent
+
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 # TODO: Remove `--no-test` flag once importing on a CPU


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/54

This will make builds fail when there are path conflicts