### PR TITLE
Enable tests/io/test_user_agent.py in cudf pandas tests

### DIFF
--- a/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
+++ b/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
@@ -22,8 +22,7 @@ set -euo pipefail
 # of Pandas installed.
 PANDAS_VERSION=$(python -c "import pandas; print(pandas.__version__)")
 
-PYTEST_IGNORES="--ignore=tests/io/test_user_agent.py \
---ignore=tests/interchange/test_impl.py \
+PYTEST_IGNORES="--ignore=tests/interchange/test_impl.py \
 --ignore=tests/window/test_dtypes.py \
 --ignore=tests/strings/test_api.py \
 --ignore=tests/window/test_numba.py \


### PR DESCRIPTION
## Description
This test was renamed in `test_https_headers.py` in 2.2.0. https://github.com/pandas-dev/pandas/pull/56057

Also this test now "runs", but is skipped because it's marked as a `single_cpu` test which we skip when running these tests.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
