### PR TITLE
Make improvements in pandas-test reporting

### DIFF
--- a/.github/workflows/status.yaml
+++ b/.github/workflows/status.yaml
@@ -85,13 +85,35 @@ jobs:
                 state: CUSTOM_STATE = 'success'
             } = contentJSON;
 
+            async function fetchAllJobs(owner, repo, run_id) {
+              let allJobs = [];
+              let page = 1;
+              const perPage = 100; // Adjust this value as needed, up to a maximum of 100
+
+              while (true) {
+                const response = await github.rest.actions.listJobsForWorkflowRun({
+                  owner: owner,
+                  repo: repo,
+                  run_id: run_id,
+                  per_page: perPage,
+                  page: page
+                });
+
+                allJobs = allJobs.concat(response.data.jobs);
+
+                if (response.data.jobs.length < perPage) {
+                  break; // No more jobs to fetch, exit the loop
+                }
+
+                page++; // Increment the page number to fetch the next set of jobs
+              }
+
+              return allJobs;
+            }
+            const jobs = await fetchAllJobs(context.repo.owner, context.repo.repo, process.env.WORKFLOW_RUN_ID);
+
             // Fetch the first job ID from the workflow run
-            const jobs = await github.rest.actions.listJobsForWorkflowRun({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: process.env.WORKFLOW_RUN_ID,
-            });
-            const job = jobs.data.jobs.find(job => job.name === JOB_NAME);
+            const job = jobs.find(job => job.name === JOB_NAME);
             const JOB_ID = job ? job.id : null;
 
             // Set default target URL if not defined

--- a/ci/cudf_pandas_scripts/pandas-tests/diff.sh
+++ b/ci/cudf_pandas_scripts/pandas-tests/diff.sh
@@ -10,12 +10,13 @@
 GH_JOB_NAME="pandas-tests-diff / build"
 rapids-logger "Github job name: ${GH_JOB_NAME}"
 
-MAIN_ARTIFACT=$(rapids-s3-path)cuda12_$(arch)_py310.main-results.json
-PR_ARTIFACT=$(rapids-s3-path)cuda12_$(arch)_py39.pr-results.json
+PY_VER=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
+MAIN_ARTIFACT=$(rapids-s3-path)cuda12_$(arch)_py${PY_VER}.main-results.json
+PR_ARTIFACT=$(rapids-s3-path)cuda12_$(arch)_py${PY_VER}.pr-results.json
 
 rapids-logger "Fetching latest available results from nightly"
 aws s3api list-objects-v2 --bucket rapids-downloads --prefix "nightly/" --query "sort_by(Contents[?ends_with(Key, '.main-results.json')], &LastModified)[::-1].[Key]" --output text > s3_output.txt
-cat s3_output.txt
+
 read -r COMPARE_ENV < s3_output.txt
 export COMPARE_ENV
 rapids-logger "Latest available results from nightly: ${COMPARE_ENV}"


### PR DESCRIPTION
## Description
This PR fixes an issue where `listJobsForWorkflowRun` returns only 30 jobs details by default and we need to paginate and load the rest all of the job details to be able to filter jobs.

This PR also address review comments in https://github.com/rapidsai/cudf/pull/15369/
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
