### PR TITLE
Use Index._column in favor of Index._values

### DIFF
--- a/python/cudf/cudf/_lib/utils.pyx
+++ b/python/cudf/cudf/_lib/utils.pyx
@@ -110,14 +110,14 @@ cpdef generate_pandas_metadata(table, index):
                 else:
                     materialize_index = True
                     # When `index=True`, RangeIndex needs to be materialized.
-                    materialized_idx = cudf.Index(idx._values, name=idx.name)
+                    materialized_idx = idx._as_int_index()
                     descr = _index_level_name(
                         index_name=materialized_idx.name,
                         level=level,
                         column_names=col_names
                     )
                     index_levels.append(materialized_idx)
-                    columns_to_convert.append(materialized_idx._values)
+                    columns_to_convert.append(materialized_idx._column)
                     col_names.append(descr)
                     types.append(np_to_pa_dtype(materialized_idx.dtype))
             else:
@@ -126,7 +126,7 @@ cpdef generate_pandas_metadata(table, index):
                     level=level,
                     column_names=col_names
                 )
-                columns_to_convert.append(idx._values)
+                columns_to_convert.append(idx._column)
                 col_names.append(descr)
                 if isinstance(idx.dtype, cudf.CategoricalDtype):
                     raise ValueError(

--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -48,7 +48,7 @@ class BaseIndex(Serializable):
         raise NotImplementedError
 
     @cached_property
-    def _values(self) -> ColumnBase:
+    def _column(self) -> ColumnBase:
         raise NotImplementedError
 
     def copy(self, deep: bool = True) -> Self:
@@ -275,7 +275,7 @@ class BaseIndex(Serializable):
         raise NotImplementedError()
 
     def __contains__(self, item):
-        return item in self._values
+        return item in self._column
 
     def _copy_type_metadata(
         self, other: Self, *, override_dtypes=None
@@ -856,7 +856,7 @@ class BaseIndex(Serializable):
             col_name = name
 
         return cudf.DataFrame(
-            {col_name: self._values}, index=self if index else None
+            {col_name: self._column}, index=self if index else None
         )
 
     def to_arrow(self):
@@ -1862,7 +1862,7 @@ class BaseIndex(Serializable):
             )
         else:
             try:
-                left, right = self._values._find_first_and_last(label)
+                left, right = self._column._find_first_and_last(label)
             except ValueError:
                 raise KeyError(f"{label=} not in index")
             if left != right:

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -612,7 +612,7 @@ class CategoricalColumn(column.ColumnBase):
 
     @property
     def categories(self) -> ColumnBase:
-        return self.dtype.categories._values
+        return self.dtype.categories._column
 
     @categories.setter
     def categories(self, value):
@@ -733,7 +733,7 @@ class CategoricalColumn(column.ColumnBase):
             self._encode(other), length=len(self), dtype=self.codes.dtype
         )
         return column.build_categorical_column(
-            categories=self.dtype.categories._values,
+            categories=self.dtype.categories._column,
             codes=column.as_column(ary),
             mask=self.base_mask,
             ordered=self.dtype.ordered,
@@ -744,7 +744,7 @@ class CategoricalColumn(column.ColumnBase):
     ) -> CategoricalColumn:
         codes = self.codes.sort_values(ascending, na_position)
         col = column.build_categorical_column(
-            categories=self.dtype.categories._values,
+            categories=self.dtype.categories._column,
             codes=column.build_column(codes.base_data, dtype=codes.dtype),
             mask=codes.base_mask,
             size=codes.size,
@@ -1120,7 +1120,7 @@ class CategoricalColumn(column.ColumnBase):
         if not isinstance(dtype, CategoricalDtype):
             raise ValueError("dtype must be CategoricalDtype")
 
-        if not isinstance(self.categories, type(dtype.categories._values)):
+        if not isinstance(self.categories, type(dtype.categories._column)):
             # If both categories are of different Column types,
             # return a column full of Nulls.
             return _create_empty_categorical_column(self, dtype)
@@ -1236,7 +1236,7 @@ class CategoricalColumn(column.ColumnBase):
     ) -> CategoricalColumn:
         if isinstance(dtype, CategoricalDtype):
             return column.build_categorical_column(
-                categories=dtype.categories._values,
+                categories=dtype.categories._column,
                 codes=column.build_column(
                     self.codes.base_data, dtype=self.codes.dtype
                 ),

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1775,10 +1775,8 @@ def as_column(
         return column
     elif isinstance(arbitrary, (ColumnBase, cudf.Series, cudf.BaseIndex)):
         # Ignoring nan_as_null per the docstring
-        if isinstance(arbitrary, cudf.Series):
+        if isinstance(arbitrary, (cudf.Series, cudf.BaseIndex)):
             arbitrary = arbitrary._column
-        elif isinstance(arbitrary, cudf.BaseIndex):
-            arbitrary = arbitrary._values
         if dtype is not None:
             return arbitrary.astype(dtype)
         return arbitrary

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -672,7 +672,7 @@ class NumericalColumn(NumericalBaseColumn):
     def _with_type_metadata(self: ColumnBase, dtype: Dtype) -> ColumnBase:
         if isinstance(dtype, CategoricalDtype):
             return column.build_categorical_column(
-                categories=dtype.categories._values,
+                categories=dtype.categories._column,
                 codes=build_column(self.base_data, dtype=self.dtype),
                 mask=self.base_mask,
                 ordered=dtype.ordered,

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1768,10 +1768,10 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
                 indices[:first_data_column_position],
             )
             if not isinstance(out._index, MultiIndex) and isinstance(
-                out._index._values.dtype, cudf.CategoricalDtype
+                out._index._column.dtype, cudf.CategoricalDtype
             ):
                 out = out.set_index(
-                    cudf.core.index.as_index(out.index._values)
+                    cudf.core.index.as_index(out.index._column)
                 )
         for name, col in out._data.items():
             out._data[name] = col._with_type_metadata(
@@ -3576,9 +3576,10 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         )
 
         if index:
-            if (
-                any(isinstance(item, str) for item in index.values())
-                and type(self.index._values) != cudf.core.column.StringColumn
+            if any(
+                isinstance(item, str) for item in index.values()
+            ) and not isinstance(
+                self.index._column, cudf.core.column.StringColumn
             ):
                 raise NotImplementedError(
                     "Implicit conversion of index to "

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -2847,7 +2847,7 @@ class _Grouping(Serializable):
 
     def _handle_level(self, by):
         level_values = self._obj.index.get_level_values(by)
-        self._key_columns.append(level_values._values)
+        self._key_columns.append(level_values._column)
         self.names.append(level_values.name)
 
     def _handle_misc(self, by):

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -174,7 +174,7 @@ def _indices_from_labels(obj, labels):
 
         if isinstance(obj.index.dtype, cudf.CategoricalDtype):
             labels = labels.astype("category")
-            codes = labels.codes.astype(obj.index._values.codes.dtype)
+            codes = labels.codes.astype(obj.index._column.codes.dtype)
             labels = cudf.core.column.build_categorical_column(
                 categories=labels.dtype.categories,
                 codes=codes,

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -356,7 +356,7 @@ class _SeriesLocIndexer(_FrameIndexer):
                 else:
                     if isinstance(idx_copy, cudf.RangeIndex):
                         idx_copy = idx_copy._as_int_index()
-                    _append_new_row_inplace(idx_copy._values, key)
+                    _append_new_row_inplace(idx_copy._column, key)
                 self._frame._index = idx_copy
                 _append_new_row_inplace(self._frame._column, value)
                 return

--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -1076,7 +1076,7 @@ def _to_iso_calendar(arg):
         )
     if isinstance(arg, cudf.Index):
         iso_params = [
-            arg._column.as_string_column(arg._values.dtype, fmt)
+            arg._column.as_string_column(arg._column.dtype, fmt)
             for fmt in formats
         ]
         index = arg._column

--- a/python/cudf/cudf/core/window/rolling.py
+++ b/python/cudf/cudf/core/window/rolling.py
@@ -480,7 +480,7 @@ class Rolling(GetAttrGetItemMixin, Reducible):
         else:
             with acquire_spill_lock():
                 return cudautils.window_sizes_from_offset(
-                    self.obj.index._values.data_array_view(mode="write"),
+                    self.obj.index._column.data_array_view(mode="write"),
                     window,
                 )
 
@@ -527,7 +527,7 @@ class RollingGroupby(Rolling):
             )
         else:
             return cudautils.grouped_window_sizes_from_offset(
-                self.obj.index._values.data_array_view(mode="read"),
+                self.obj.index._column.data_array_view(mode="read"),
                 self._group_starts,
                 window,
             )

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -1360,7 +1360,7 @@ def test_dataframe_append_to_empty():
 def test_dataframe_setitem_index_len1():
     gdf = cudf.DataFrame()
     gdf["a"] = [1]
-    gdf["b"] = gdf.index._values
+    gdf["b"] = gdf.index._column
 
     np.testing.assert_equal(gdf.b.to_numpy(), [0])
 
@@ -2848,12 +2848,12 @@ def test_gpu_memory_usage_with_boolmask():
     cudaDF = cudaDF[boolmask]
 
     assert (
-        cudaDF.index._values.data_array_view(mode="read").device_ctypes_pointer
-        == cudaDF["col0"].index._values.data_array_view.device_ctypes_pointer
+        cudaDF.index._column.data_array_view(mode="read").device_ctypes_pointer
+        == cudaDF["col0"].index._column.data_array_view.device_ctypes_pointer
     )
     assert (
-        cudaDF.index._values.data_array_view(mode="read").device_ctypes_pointer
-        == cudaDF["col1"].index._values.data_array_view.device_ctypes_pointer
+        cudaDF.index._column.data_array_view(mode="read").device_ctypes_pointer
+        == cudaDF["col1"].index._column.data_array_view.device_ctypes_pointer
     )
 
     assert memory_used == query_GPU_memory()

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -261,13 +261,13 @@ def test_index_rename_inplace():
     # inplace=False should yield a deep copy
     gds_renamed_deep = gds.rename("new_name", inplace=False)
 
-    assert gds_renamed_deep._values.data_ptr != gds._values.data_ptr
+    assert gds_renamed_deep._column.data_ptr != gds._column.data_ptr
 
     # inplace=True returns none
-    expected_ptr = gds._values.data_ptr
+    expected_ptr = gds._column.data_ptr
     gds.rename("new_name", inplace=True)
 
-    assert expected_ptr == gds._values.data_ptr
+    assert expected_ptr == gds._column.data_ptr
 
 
 def test_index_rename_preserves_arg():
@@ -377,7 +377,7 @@ def test_index_copy_category(name, deep=True):
     pidx_copy = pidx.copy(name=name, deep=deep)
     cidx_copy = cidx.copy(name=name, deep=deep)
 
-    assert_column_memory_ne(cidx._values, cidx_copy._values)
+    assert_column_memory_ne(cidx._column, cidx_copy._column)
     assert_eq(pidx_copy, cidx_copy)
 
 
@@ -400,7 +400,7 @@ def test_index_copy_deep(idx, deep, copy_on_write):
     original_cow_setting = cudf.get_option("copy_on_write")
     cudf.set_option("copy_on_write", copy_on_write)
     if (
-        isinstance(idx._values, cudf.core.column.StringColumn)
+        isinstance(idx._column, cudf.core.column.StringColumn)
         or not deep
         or (cudf.get_option("copy_on_write") and not deep)
     ):
@@ -410,9 +410,9 @@ def test_index_copy_deep(idx, deep, copy_on_write):
         # When `copy_on_write` is turned on, Index objects will
         # have unique column object but they all point to same
         # data pointers.
-        assert_column_memory_eq(idx._values, idx_copy._values)
+        assert_column_memory_eq(idx._column, idx_copy._column)
     else:
-        assert_column_memory_ne(idx._values, idx_copy._values)
+        assert_column_memory_ne(idx._column, idx_copy._column)
     cudf.set_option("copy_on_write", original_cow_setting)
 
 

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -979,7 +979,7 @@ def test_timedelta_index_properties(data, dtype, name):
     pdi = gdi.to_pandas()
 
     def local_assert(expected, actual):
-        if actual._values.null_count:
+        if actual._column.null_count:
             assert_eq(expected, actual.astype("float64"))
         else:
             assert_eq(expected, actual)


### PR DESCRIPTION
## Description
The base definition is

```python
    @property  # type: ignore
    @_cudf_nvtx_annotate
    def _values(self):
        return self._column
```

So I think it's just more straightforward to use `self._columns`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
