### PR TITLE
Remove stable rapidsai conda channel (non-release jobs)

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 rapids-configure-conda-channels
+conda config --system --remove channels rapidsai
 
 source rapids-configure-sccache
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 rapids-configure-conda-channels
+conda config --system --remove channels rapidsai
 
 source rapids-configure-sccache
 

--- a/ci/configure_cpp_static.sh
+++ b/ci/configure_cpp_static.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 rapids-configure-conda-channels
+conda config --system --remove channels rapidsai
 
 source rapids-date-string
 


### PR DESCRIPTION
This PR tests the removal of the rapidsai conda channel. PR should not be merged.
