### PR TITLE
`strings::contains()` for multiple scalar search targets

### DIFF
--- a/cpp/include/cudf/strings/find.hpp
+++ b/cpp/include/cudf/strings/find.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,6 +136,31 @@ std::unique_ptr<column> find(
 std::unique_ptr<column> contains(
   strings_column_view const& input,
   string_scalar const& target,
+  rmm::cuda_stream_view stream        = cudf::get_default_stream(),
+  rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
+
+/**
+ * @brief Returns a table of columns of boolean values for each string where true indicates
+ * the target string was found within that string in the provided column.
+ *
+ * Each column in the result table corresponds to the result for the target string at the same
+ * ordinal. i.e. 0th column is the boolean-column result for the 0th target string, 1th for 1th,
+ * etc.
+ *
+ * If the target is not found for a string, false is returned for that entry in the output column.
+ * If the target is an empty string, true is returned for all non-null entries in the output column.
+ *
+ * Any null string entries return corresponding null entries in the output columns.
+ *
+ * @param input Strings instance for this operation
+ * @param targets UTF-8 encoded strings to search for in each string in `input`
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return New BOOL8 column
+ */
+std::unique_ptr<table> contains(
+  strings_column_view const& input,
+  std::vector<std::reference_wrapper<string_scalar>> const& targets,
   rmm::cuda_stream_view stream        = cudf::get_default_stream(),
   rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource());
 

--- a/cpp/src/strings/search/find.cu
+++ b/cpp/src/strings/search/find.cu
@@ -387,8 +387,8 @@ CUDF_KERNEL void multi_contains_warp_parallel_fn(column_device_view const d_stri
   if (idx >= (num_rows * cudf::detail::warp_size * num_targets)) { return; }
 
   auto const lane_idx   = idx % cudf::detail::warp_size;
-  auto const str_idx    = (idx / cudf::detail::warp_size) % num_rows;
-  auto const target_idx = (idx / cudf::detail::warp_size) / num_rows;
+  auto const str_idx    = (idx / cudf::detail::warp_size) / num_targets;
+  auto const target_idx = (idx / cudf::detail::warp_size) % num_targets;
 
   if (d_strings.is_null(str_idx)) { return; }
 

--- a/cpp/src/strings/search/find.cu
+++ b/cpp/src/strings/search/find.cu
@@ -390,13 +390,22 @@ CUDF_KERNEL void multi_contains_warp_parallel_fn(column_device_view const d_stri
   auto const str_idx    = (idx / cudf::detail::warp_size) / num_targets;
   auto const target_idx = (idx / cudf::detail::warp_size) % num_targets;
 
-  if (d_strings.is_null(str_idx)) { return; }
+  if (d_strings.is_null(str_idx)) {
+    d_results[target_idx][str_idx] = false; // Will be considered `null` because of the bitmask.
+    return;
+  }
 
   // Identify the target.
   auto const d_target = d_targets[target_idx];
 
   // get the string for this warp
   auto const d_str = d_strings.element<string_view>(str_idx);
+
+  if (d_target.size_bytes() > d_str.size_bytes()) {
+      d_results[target_idx][str_idx] = false; // The target can't possibly fit in the input string.
+      return;
+  }
+
   // each thread of the warp will check just part of the string
   auto found = false;
   for (auto i = static_cast<size_type>(idx % cudf::detail::warp_size);
@@ -463,7 +472,7 @@ std::vector<std::unique_ptr<column>> multi_contains_warp_parallel(
     targets.begin(), targets.end(), host_device_targets.begin(), [&](auto const& target) {
       return string_view{target.get().data(), target.get().size()};
     });
-  host_device_targets.host_to_device_sync(stream);
+  host_device_targets.host_to_device_async(stream);
 
   // Create output columns.
   auto const results_iter =
@@ -474,11 +483,6 @@ std::vector<std::unique_ptr<column>> multi_contains_warp_parallel(
                                              input.null_count(),
                                              stream,
                                              mr);
-      auto bool_column_view = bool_column->mutable_view();
-      thrust::fill(rmm::exec_policy(stream),
-                   bool_column_view.begin<bool>(),
-                   bool_column_view.end<bool>(),
-                   target.get().size() == 0);
       return bool_column;
     });
   auto results_list =
@@ -490,7 +494,7 @@ std::vector<std::unique_ptr<column>> multi_contains_warp_parallel(
                  [&](auto const& results_column) {
                    return results_column->mutable_view().template data<bool>();
                  });
-  host_device_results_list.host_to_device_sync(stream);
+  host_device_results_list.host_to_device_async(stream);
 
   constexpr int block_size = 256;
   // launch warp per string

--- a/cpp/tests/strings/find_tests.cpp
+++ b/cpp/tests/strings/find_tests.cpp
@@ -17,15 +17,13 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 
-#include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/attributes.hpp>
 #include <cudf/strings/find.hpp>
 #include <cudf/strings/strings_column_view.hpp>
-
-#include <thrust/iterator/transform_iterator.h>
 
 #include <vector>
 
@@ -195,6 +193,42 @@ TEST_F(StringsFindTest, ContainsLongStrings)
   results  = cudf::strings::contains(strings_view, cudf::string_scalar("~"));
   expected = cudf::test::fixed_width_column_wrapper<bool>({0, 0, 0, 0, 0, 0, 1, 0});
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*results, expected);
+}
+
+TEST_F(StringsFindTest, MultiContains)
+{
+  using cudf::test::iterators::null_at;
+  auto const strings = cudf::test::strings_column_wrapper{
+    {"Héllo, there world and goodbye",
+     "quick brown fox jumped over the lazy brown dog; the fat cats jump in place without moving",
+     "the following code snippet demonstrates how to use search for values in an ordered range",
+     "it returns the last position where value could be inserted without violating the ordering",
+     "algorithms execution is parallelized as determined by an execution policy. t",
+     "he this is a continuation of previous row to make sure string boundaries are honored",
+     "abcdefghijklmnopqrstuvwxyz 0123456789 ABCDEFGHIJKLMNOPQRSTUVWXYZ !@#$%^&*()~",
+     "",
+     ""},
+    null_at(8)};
+  auto strings_view = cudf::strings_column_view(strings);
+
+  auto search_key_0 = cudf::string_scalar{" the "};
+  auto search_key_1 = cudf::string_scalar{"a"};
+  auto search_key_2 = cudf::string_scalar{""};
+  auto search_keys  = std::vector<std::reference_wrapper<cudf::string_scalar>>{};
+  search_keys.emplace_back(search_key_0);
+  search_keys.emplace_back(search_key_1);
+  search_keys.emplace_back(search_key_2);
+
+  auto results = cudf::strings::contains(strings_view, search_keys);
+  auto expected_0 =
+    cudf::test::fixed_width_column_wrapper<bool>({0, 1, 0, 1, 0, 0, 0, 0, 0}, null_at(8));
+  auto expected_1 =
+    cudf::test::fixed_width_column_wrapper<bool>({1, 1, 1, 1, 1, 1, 1, 0, 0}, null_at(8));
+  auto expected_2 =
+    cudf::test::fixed_width_column_wrapper<bool>({1, 1, 1, 1, 1, 1, 1, 1, 0}, null_at(8));
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->get_column(0), expected_0);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->get_column(1), expected_1);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(results->get_column(2), expected_2);
 }
 
 TEST_F(StringsFindTest, StartsWith)

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -1391,6 +1391,36 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringContains(JNIEnv *en
   CATCH_STD(env, 0);
 }
 
+JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringContainsMulti(
+    JNIEnv *env, jobject j_object, jlong j_view_handle, jlongArray j_comp_strings) {
+  JNI_NULL_CHECK(env, j_view_handle, "column is null", 0);
+  JNI_NULL_CHECK(env, j_comp_strings, "array of comparison scalars is null", 0);
+
+  try {
+    cudf::jni::auto_set_device(env);
+    auto *column_view = reinterpret_cast<cudf::column_view *>(j_view_handle);
+    auto const strings_column = cudf::strings_column_view(*column_view);
+    auto comp_string_pointers =
+        cudf::jni::native_jpointerArray<cudf::string_scalar>{env, j_comp_strings};
+    auto comp_strings = std::vector<cudf::string_scalar>{};
+    std::transform(comp_string_pointers.begin(), comp_string_pointers.end(),
+                   std::back_inserter(comp_strings), [](auto i) { return *i; });
+    auto comp_strings_refs = std::vector<std::reference_wrapper<cudf::string_scalar>>(
+        comp_strings.begin(), comp_strings.end());
+    auto contains_results = cudf::strings::contains(strings_column, comp_strings_refs);
+    //    auto comp_strings_iter = thrust::make_transform_iterator(comp_string_pointers.begin(),
+    //    [](auto i) -> cudf::string_scalar const& { return *i; }); auto comp_strings =
+    //    std::vector<std::reference_wrapper<cudf::string_scalar>>(comp_strings_iter,
+    //                                                                                 comp_strings_iter
+    //                                                                                 +
+    //                                                                                 comp_string_pointers.size());
+    //    auto contains_results = cudf::strings::contains(strings_column, comp_strings);
+    return cudf::jni::convert_table_for_return(env, std::move(contains_results));
+    //     return 0;
+  }
+  CATCH_STD(env, 0);
+}
+
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_matchesRe(JNIEnv *env, jobject j_object,
                                                                  jlong j_view_handle,
                                                                  jstring pattern_obj,

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -3828,6 +3828,33 @@ public class ColumnVectorTest extends CudfTestBase {
   }
 
   @Test
+  void testStringContainsMulti() {
+      ColumnVector[] results = null;
+      try (ColumnVector haystack = ColumnVector.fromStrings("All the leaves are brown",
+              "And the sky is grey",
+              "I've been for a walk",
+              "On a winter's day",
+              null,
+              "");
+           Scalar needle0 = Scalar.fromString("the");
+           Scalar needle1 = Scalar.fromString("a");
+           ColumnVector expected0 = ColumnVector.fromBoxedBooleans(true, true, false, false, null, false);
+           ColumnVector expected1 = ColumnVector.fromBoxedBooleans(true, false, true, true, null, false)) {
+
+          results = haystack.stringContains(new Scalar[]{needle0, needle1});
+          assertColumnsAreEqual(results[0], expected0);
+          assertColumnsAreEqual(results[1], expected1);
+
+      } finally {
+          if (results != null) {
+              for (ColumnVector c : results) {
+                  c.close();
+              }
+          }
+      }
+  }
+
+  @Test
   void testStringFindOperations() {
     try (ColumnVector testStrings = ColumnVector.fromStrings("", null, "abCD", "1a\"\u0100B1", "a\"\u0100B1", "1a\"\u0100B",
                                       "1a\"\u0100B1\n\t\'", "1a\"\u0100B1\u0453\u1322\u5112", "1a\"\u0100B1Fg26",


### PR DESCRIPTION
## Description

This commit adds a new `strings::contains()` overload that allows for the search of multiple scalar search targets in the same call.

The trick here is that a new kernel has been introduced, to extend the "string-per-warp" approach to search for multiple search keys in the same kernel.

This approach allows CUDF to potentially reduce the number of kernels launched for `string::contains()` by a factor of `N`, if all the search keys can be specified in the same call.  This helps reduce the kernel-launch overheads for processes that do large numbers of calls to `string::contains()`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
