### PR TITLE
Remove conda channel setup from wheel CI image script.

### DIFF
--- a/ci/configure_cpp_static.sh
+++ b/ci/configure_cpp_static.sh
@@ -3,8 +3,6 @@
 
 set -euo pipefail
 
-rapids-configure-conda-channels
-
 source rapids-date-string
 
 rapids-logger "Configure static cpp build"


### PR DESCRIPTION
## Description

The new `configure_cpp_static.sh` script added in https://github.com/rapidsai/cudf/pull/15437 is calling `rapids-configure-conda-channels`. However, it is doing so on a `ci-wheel` image, which fails. This is causing CI issues and needs to be removed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
