### PR TITLE
[WIP] Reading multi-line JSON in string columns using runtime configurable delimiter

### DIFF
--- a/cpp/include/cudf/io/json.hpp
+++ b/cpp/include/cudf/io/json.hpp
@@ -100,6 +100,8 @@ class json_reader_options {
   bool _lines = false;
   // Parse mixed types as a string column
   bool _mixed_types_as_string = false;
+  // Delimiter separating records in JSON lines
+  char _delimiter = '\n';
 
   // Bytes to skip from the start
   size_t _byte_range_offset = 0;

--- a/cpp/src/io/json/nested_json.hpp
+++ b/cpp/src/io/json/nested_json.hpp
@@ -57,6 +57,7 @@ enum class stack_behavior_t : char {
   PushPopWithoutReset,
 
   /// Opening brackets and braces, [, {, push onto the stack, closing brackets and braces, ], }, pop
+  /// TODO: not only newline, any delimiter chars
   /// from the stack. Newline characters are considered delimiters and therefore reset to an empty
   /// stack.
   ResetOnDelimiter

--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -330,7 +330,7 @@ enum class dfa_symbol_group_id : uint8_t {
   CLOSING_BRACKET,   ///< Closing bracket SG: ]
   QUOTE_CHAR,        ///< Quote character SG: "
   ESCAPE_CHAR,       ///< Escape character SG: '\'
-  NEWLINE_CHAR,      ///< Newline character SG: '\n'
+  DELIMITER_CHAR,    ///< Delimiter character SG: default '\n'
   OTHER_SYMBOLS,     ///< SG implicitly matching all other characters
   NUM_SYMBOL_GROUPS  ///< Total number of symbol groups
 };
@@ -338,13 +338,9 @@ enum class dfa_symbol_group_id : uint8_t {
 constexpr auto TT_NUM_STATES     = static_cast<StateT>(dfa_states::TT_NUM_STATES);
 constexpr auto NUM_SYMBOL_GROUPS = static_cast<uint32_t>(dfa_symbol_group_id::NUM_SYMBOL_GROUPS);
 
-// The i-th string representing all the characters of a symbol group
-std::array<std::string, NUM_SYMBOL_GROUPS - 1> const symbol_groups{
-  {{"{"}, {"["}, {"}"}, {"]"}, {"\""}, {"\\"}, {"\n"}}};
-
 // Transition table for the default JSON and JSON lines formats
 std::array<std::array<dfa_states, NUM_SYMBOL_GROUPS>, TT_NUM_STATES> const transition_table{
-  {/* IN_STATE          {       [       }       ]       "       \      \n    OTHER */
+  {/* IN_STATE          {       [       }       ]       "       \    <delim>  OTHER */
    /* TT_OOS    */ {{TT_OOS, TT_OOS, TT_OOS, TT_OOS, TT_STR, TT_OOS, TT_OOS, TT_OOS}},
    /* TT_STR    */ {{TT_STR, TT_STR, TT_STR, TT_STR, TT_OOS, TT_ESC, TT_STR, TT_STR}},
    /* TT_ESC    */ {{TT_STR, TT_STR, TT_STR, TT_STR, TT_STR, TT_STR, TT_STR, TT_STR}}}};
@@ -352,25 +348,97 @@ std::array<std::array<dfa_states, NUM_SYMBOL_GROUPS>, TT_NUM_STATES> const trans
 // Transition table for the JSON lines format that recovers from invalid JSON lines
 std::array<std::array<dfa_states, NUM_SYMBOL_GROUPS>, TT_NUM_STATES> const
   resetting_transition_table{
-    {/* IN_STATE          {       [       }       ]       "       \      \n    OTHER */
+    {/* IN_STATE          {       [       }       ]       "       \    <delim> OTHER */
      /* TT_OOS    */ {{TT_OOS, TT_OOS, TT_OOS, TT_OOS, TT_STR, TT_OOS, TT_OOS, TT_OOS}},
      /* TT_STR    */ {{TT_STR, TT_STR, TT_STR, TT_STR, TT_OOS, TT_ESC, TT_OOS, TT_STR}},
      /* TT_ESC    */ {{TT_STR, TT_STR, TT_STR, TT_STR, TT_STR, TT_STR, TT_OOS, TT_STR}}}};
 
-// Translation table for the default JSON and JSON lines formats
-std::array<std::array<std::vector<char>, NUM_SYMBOL_GROUPS>, TT_NUM_STATES> const translation_table{
-  {/* IN_STATE         {      [      }      ]      "      \     \n    OTHER */
-   /* TT_OOS    */ {{{'{'}, {'['}, {'}'}, {']'}, {}, {}, {}, {}}},
-   /* TT_STR    */ {{{}, {}, {}, {}, {}, {}, {}, {}}},
-   /* TT_ESC    */ {{{}, {}, {}, {}, {}, {}, {}, {}}}}};
+struct SymbolToSymbolGroupId {
+  SymbolT delimiter = '\n';
+  std::array<SymbolT, NUM_SYMBOL_GROUPS - 1> symbol_groups{{'{', '[', '}', ']', '"', '\\', '\n'}};
+  CUDF_HOST_DEVICE int32_t operator()(SymbolT symbol) const
+  {
+    auto it = thrust::find(thrust::device, symbol_groups.begin(), symbol_groups.end() - 1, symbol);
+    if (it != symbol_groups.end() - 1)
+      return static_cast<int32_t>(thrust::distance(symbol_groups.begin(), it));
+    if (symbol == delimiter) return static_cast<int32_t>(dfa_symbol_group_id::DELIMITER_CHAR);
+    return static_cast<int32_t>(dfa_symbol_group_id::OTHER_SYMBOLS);
+  }
+};
 
-// Translation table for the JSON lines format that recovers from invalid JSON lines
-std::array<std::array<std::vector<char>, NUM_SYMBOL_GROUPS>, TT_NUM_STATES> const
-  resetting_translation_table{
-    {/* IN_STATE         {      [      }      ]      "      \     \n    OTHER */
-     /* TT_OOS    */ {{{'{'}, {'['}, {'}'}, {']'}, {}, {}, {'\n'}, {}}},
-     /* TT_STR    */ {{{}, {}, {}, {}, {}, {}, {'\n'}, {}}},
-     /* TT_ESC    */ {{{}, {}, {}, {}, {}, {}, {'\n'}, {}}}}};
+struct TransduceToStackOp {
+  SymbolT delimiter               = '\n';
+  stack_behavior_t stack_behavior = stack_behavior_t::ResetOnDelimiter;
+  /**
+   * @brief Returns the <relative_offset>-th output symbol on the transition (state_id, match_id).
+   */
+  template <typename StateT, typename SymbolGroupT, typename RelativeOffsetT, typename SymbolT>
+  constexpr CUDF_HOST_DEVICE SymbolT operator()(StateT const state_id,
+                                                SymbolGroupT const match_id,
+                                                RelativeOffsetT const relative_offset,
+                                                SymbolT const read_symbol) const
+  {
+    /*
+      // Translation table for the default JSON and JSON lines formats
+      std::array<std::array<std::vector<SymbolT>, NUM_SYMBOL_GROUPS>, TT_NUM_STATES> const
+      translation_table{
+        {// IN_STATE       {      [      }      ]    "   \ <delim> OTHER
+         // TT_OOS     {{{'{'}, {'['}, {'}'}, {']'}, {}, {}, {}, {}}},
+         // TT_STR     {{{}, {}, {}, {}, {}, {}, {}, {}}},
+         // TT_ESC     {{{}, {}, {}, {}, {}, {}, {}, {}}}}};
+
+      // Translation table for the JSON lines format that recovers from invalid JSON lines
+      std::array<std::array<std::vector<SymbolT>, NUM_SYMBOL_GROUPS>, TT_NUM_STATES>
+        resetting_translation_table{
+          {// IN_STATE       {      [      }      ]      "      \     \n    OTHER
+           // TT_OOS    {{{'{'}, {'['}, {'}'}, {']'}, {}, {}, {'\n'}, {}}},
+           // TT_STR    {{{}, {}, {}, {}, {}, {}, {'\n'}, {}}},
+           // TT_ESC    {{{}, {}, {}, {}, {}, {}, {'\n'}, {}}}}};
+    */
+    if (state_id == static_cast<StateT>(dfa_states::TT_STR) ||
+        state_id == static_cast<StateT>(dfa_states::TT_ESC)) {
+      if (stack_behavior == stack_behavior_t::ResetOnDelimiter &&
+          match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::DELIMITER_CHAR))
+        return read_symbol;
+    }
+    if (match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::OPENING_BRACE) ||
+        match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::OPENING_BRACKET) ||
+        match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::CLOSING_BRACE) ||
+        match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::CLOSING_BRACKET))
+      return read_symbol;
+    if (match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::DELIMITER_CHAR) &&
+        stack_behavior == stack_behavior_t::ResetOnDelimiter)
+      return read_symbol;
+
+    return 0;
+  }
+
+  /**
+   * @brief Returns the number of output characters for a given transition.
+   */
+  template <typename StateT, typename SymbolGroupT, typename SymbolT>
+  constexpr CUDF_HOST_DEVICE uint32_t operator()(StateT const state_id,
+                                                 SymbolGroupT const match_id,
+                                                 SymbolT const read_symbol) const
+  {
+    if (state_id == static_cast<StateT>(dfa_states::TT_STR) ||
+        state_id == static_cast<StateT>(dfa_states::TT_ESC)) {
+      if (stack_behavior == stack_behavior_t::ResetOnDelimiter &&
+          match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::DELIMITER_CHAR))
+        return 1;
+    }
+    if (match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::OPENING_BRACE) ||
+        match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::OPENING_BRACKET) ||
+        match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::CLOSING_BRACE) ||
+        match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::CLOSING_BRACKET))
+      return 1;
+    if (match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::DELIMITER_CHAR) &&
+        stack_behavior == stack_behavior_t::ResetOnDelimiter)
+      return 1;
+
+    return 0;
+  }
+};
 
 // The DFA's starting state
 constexpr auto start_state = static_cast<StateT>(TT_OOS);
@@ -1419,24 +1487,17 @@ void get_stack_context(device_span<SymbolT const> json_in,
   rmm::device_uvector<SymbolOffsetT> stack_op_indices{json_in.size(), stream};
 
   // Prepare finite-state transducer that only selects '{', '}', '[', ']' outside of quotes
-  constexpr auto max_translation_table_size =
-    to_stack_op::NUM_SYMBOL_GROUPS * to_stack_op::TT_NUM_STATES;
-
+  auto symbol_groups = to_stack_op::SymbolToSymbolGroupId{};
   // Transition table specialized on the choice of whether to reset on newlines
-  const auto transition_table = (stack_behavior == stack_behavior_t::ResetOnDelimiter)
-                                  ? to_stack_op::resetting_transition_table
-                                  : to_stack_op::transition_table;
+  auto transition_table = (stack_behavior == stack_behavior_t::ResetOnDelimiter)
+                            ? to_stack_op::resetting_transition_table
+                            : to_stack_op::transition_table;
 
-  // Translation table specialized on the choice of whether to reset on newlines
-  const auto translation_table = (stack_behavior == stack_behavior_t::ResetOnDelimiter)
-                                   ? to_stack_op::resetting_translation_table
-                                   : to_stack_op::translation_table;
-
-  auto json_to_stack_ops_fst = fst::detail::make_fst(
-    fst::detail::make_symbol_group_lut(to_stack_op::symbol_groups),
-    fst::detail::make_transition_table(transition_table),
-    fst::detail::make_translation_table<max_translation_table_size>(translation_table),
-    stream);
+  auto json_to_stack_ops_fst =
+    fst::detail::make_fst(fst::detail::make_symbol_group_lookup_op(symbol_groups),
+                          fst::detail::make_transition_table(transition_table),
+                          fst::detail::make_translation_functor(to_stack_op::TransduceToStackOp{}),
+                          stream);
 
   // "Search" for relevant occurrence of brackets and braces that indicate the beginning/end
   // of structs/lists
@@ -1538,16 +1599,15 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
   // Range of encapsulating function that parses to internal columnar data representation
   CUDF_FUNC_RANGE();
 
-  auto const new_line_delimited_json = options.is_enabled_lines();
+  auto const delimited_json = options.is_enabled_lines();
 
-  // (!new_line_delimited_json)                         => JSON
-  // (new_line_delimited_json and recover_from_error)   => JSON_LINES_RECOVER
-  // (new_line_delimited_json and !recover_from_error)  => JSON_LINES
-  auto format = new_line_delimited_json
-                  ? (options.recovery_mode() == json_recovery_mode_t::RECOVER_WITH_NULL
-                       ? tokenizer_pda::json_format_cfg_t::JSON_LINES_RECOVER
-                       : tokenizer_pda::json_format_cfg_t::JSON_LINES)
-                  : tokenizer_pda::json_format_cfg_t::JSON;
+  // (!delimited_json)                         => JSON
+  // (delimited_json and recover_from_error)   => JSON_LINES_RECOVER
+  // (delimited_json and !recover_from_error)  => JSON_LINES
+  auto format = delimited_json ? (options.recovery_mode() == json_recovery_mode_t::RECOVER_WITH_NULL
+                                    ? tokenizer_pda::json_format_cfg_t::JSON_LINES_RECOVER
+                                    : tokenizer_pda::json_format_cfg_t::JSON_LINES)
+                               : tokenizer_pda::json_format_cfg_t::JSON;
 
   // Prepare for PDA transducer pass, merging input symbols with stack symbols
   auto const recover_from_error = (format == tokenizer_pda::json_format_cfg_t::JSON_LINES_RECOVER);


### PR DESCRIPTION
## Description
Addresses #15277
Given a JSON lines buffer with records separated by a delimiter passed at runtime, the idea is to modify the JSON tokenization FST to consider the passed delimiter to generate EOL token instead of the newline character currently hard-coded. 
This PR does not modify the whitespace normalization FST to [strip out unquoted `\n` and `\r`](https://github.com/rapidsai/cudf/issues/14865#issuecomment-1917575436). Whitespace normalization will be handled in follow-up works.
Note that this is not a multi-object JSON reader since we are not using the offsets data in the string column, and hence there is no resetting of the start state at every row offset.

Current status:
- [X] Semantic bracket/brace DFA 
-

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
