### PR TITLE
Add cuda-sanitizer-api dependency for test-cpp matrix 11.4

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -604,6 +604,10 @@ dependencies:
               cuda: "11.8"
             packages:
               - cuda-sanitizer-api=11.8.86
+          - matrix:
+              cuda: "11.4"
+            packages:
+              - cuda-sanitizer-api=11.4.120
           - matrix:  # Fallback for CUDA 11 or no matrix
             packages:
   test_java:


### PR DESCRIPTION
## Description
Fixes dependency issue with nightly builds running 11.4.3 cpp tests requiring the compute-sanitizer tool.

Closes #15571 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
