### PR TITLE
Disable compute-sanitizer usage in CI tests with CUDA<11.6

### DIFF
--- a/ci/run_cudf_examples.sh
+++ b/ci/run_cudf_examples.sh
@@ -9,6 +9,12 @@ trap "EXITCODE=1" ERR
 # Support customizing the examples' install location
 cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/examples/libcudf/";
 
+# compute-sanitizer not available before CUDA 11.6
+if [[ "${RAPIDS_CUDA_VERSION%.*}" < "11.6" ]]; then
+  echo "computer-sanitizer unavailable pre 11.6"
+  exit 0
+fi
+
 compute-sanitizer --tool memcheck basic_example
 
 compute-sanitizer --tool memcheck deduplication

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -599,10 +599,6 @@ dependencies:
               cuda: "11.8"
             packages:
               - cuda-sanitizer-api=11.8.86
-          - matrix:
-              cuda: "11.4"
-            packages:
-              - cuda-sanitizer-api=11.4.120
           - matrix:  # Fallback for CUDA 11 or no matrix
             packages:
   test_java:


### PR DESCRIPTION
## Description
Undoes changes in 15573 since `compute-sanitizer` is not available in the CI test environment with CUDA 11.4.
This disables the example scripts for tests with CUDA < 11.6 only to unblock the nightly builds.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
