### PR TITLE
Enable `get_token_stream` to include `LineEnd` tokens with optional parameter.

### DIFF
--- a/cpp/include/cudf/io/detail/tokenize_json.hpp
+++ b/cpp/include/cudf/io/detail/tokenize_json.hpp
@@ -134,7 +134,8 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
   device_span<SymbolT const> json_in,
   cudf::io::json_reader_options const& options,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr);
+  rmm::device_async_resource_ref mr,
+  bool remove_line_end_token = true);
 
 }  // namespace detail
 

--- a/cpp/include/cudf/io/detail/tokenize_json.hpp
+++ b/cpp/include/cudf/io/detail/tokenize_json.hpp
@@ -130,6 +130,7 @@ enum class LineEndTokenOption { Keep, Discard };
  *
  * @param json_in The JSON input
  * @param options Parsing options specifying the parsing behaviour
+ * @param line_end_option option whether to keep or discard line_end_token
  * @param stream The CUDA stream to which kernels are dispatched
  * @param mr Optional, resource with which to allocate
  * @return Pair of device vectors, where the first vector represents the token types and the second
@@ -139,6 +140,23 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
   device_span<SymbolT const> json_in,
   cudf::io::json_reader_options const& options,
   cudf::io::json::detail::LineEndTokenOption line_end_option,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
+/**
+ * @brief Parses the given JSON string and emits a sequence of tokens that demarcate relevant
+ * sections from the input.
+ *
+ * @param json_in The JSON input
+ * @param options Parsing options specifying the parsing behaviour
+ * @param stream The CUDA stream to which kernels are dispatched
+ * @param mr Optional, resource with which to allocate
+ * @return Pair of device vectors, where the first vector represents the token types and the second
+ * vector represents the index within the input corresponding to each token
+ */
+std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> get_token_stream(
+  device_span<SymbolT const> json_in,
+  cudf::io::json_reader_options const& options,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr);
 

--- a/cpp/include/cudf/io/detail/tokenize_json.hpp
+++ b/cpp/include/cudf/io/detail/tokenize_json.hpp
@@ -120,6 +120,11 @@ enum token_t : PdaTokenT {
 namespace detail {
 
 /**
+ * @brief Decision to keep or discard LineEnd tokens in the output token stream
+ */
+enum class LineEndTokenOption { Keep, Discard };
+
+/**
  * @brief Parses the given JSON string and emits a sequence of tokens that demarcate relevant
  * sections from the input.
  *
@@ -133,9 +138,9 @@ namespace detail {
 std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> get_token_stream(
   device_span<SymbolT const> json_in,
   cudf::io::json_reader_options const& options,
+  cudf::io::json::detail::LineEndTokenOption option,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr,
-  bool remove_line_end_token = true);
+  rmm::device_async_resource_ref mr);
 
 }  // namespace detail
 

--- a/cpp/include/cudf/io/detail/tokenize_json.hpp
+++ b/cpp/include/cudf/io/detail/tokenize_json.hpp
@@ -138,7 +138,7 @@ enum class LineEndTokenOption { Keep, Discard };
 std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> get_token_stream(
   device_span<SymbolT const> json_in,
   cudf::io::json_reader_options const& options,
-  cudf::io::json::detail::LineEndTokenOption option,
+  cudf::io::json::detail::LineEndTokenOption line_end_option,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr);
 

--- a/cpp/src/io/json/json_column.cu
+++ b/cpp/src/io/json/json_column.cu
@@ -1058,7 +1058,11 @@ table_with_metadata device_parse_nested_json(device_span<SymbolT const> d_input,
   auto gpu_tree = [&]() {
     // Parse the JSON and get the token stream
     const auto [tokens_gpu, token_indices_gpu] =
-      get_token_stream(d_input, options, stream, rmm::mr::get_current_device_resource());
+      get_token_stream(d_input,
+                       options,
+                       LineEndTokenOption::Discard,
+                       stream,
+                       rmm::mr::get_current_device_resource());
     // gpu tree generation
     return get_tree_representation(tokens_gpu,
                                    token_indices_gpu,

--- a/cpp/src/io/json/nested_json.hpp
+++ b/cpp/src/io/json/nested_json.hpp
@@ -217,7 +217,8 @@ void get_stack_context(device_span<SymbolT const> json_in,
 std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> process_token_stream(
   device_span<PdaTokenT const> tokens,
   device_span<SymbolOffsetT const> token_indices,
-  rmm::cuda_stream_view stream);
+  rmm::cuda_stream_view stream,
+  bool remove_line_end_token = true);
 
 /**
  * @brief Parses the given JSON string and generates a tree representation of the given input.

--- a/cpp/src/io/json/nested_json.hpp
+++ b/cpp/src/io/json/nested_json.hpp
@@ -211,6 +211,7 @@ void get_stack_context(device_span<SymbolT const> json_in,
  *
  * @param tokens The tokens to be post-processed
  * @param token_indices The tokens' corresponding indices that are post-processed
+ * @param line_end_option option whether to keep or discard line_end_token
  * @param stream The cuda stream to dispatch GPU kernels to
  * @return Returns the post-processed token stream
  */

--- a/cpp/src/io/json/nested_json.hpp
+++ b/cpp/src/io/json/nested_json.hpp
@@ -217,8 +217,8 @@ void get_stack_context(device_span<SymbolT const> json_in,
 std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> process_token_stream(
   device_span<PdaTokenT const> tokens,
   device_span<SymbolOffsetT const> token_indices,
-  rmm::cuda_stream_view stream,
-  bool remove_line_end_token = true);
+  LineEndTokenOption line_end_option,
+  rmm::cuda_stream_view stream);
 
 /**
  * @brief Parses the given JSON string and generates a tree representation of the given input.

--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -1656,6 +1656,15 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
   return std::make_pair(std::move(tokens), std::move(tokens_indices));
 }
 
+std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> get_token_stream(
+  device_span<SymbolT const> json_in,
+  cudf::io::json_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  return get_token_stream(json_in, options, LineEndTokenOption::Discard, stream, mr);
+}
+
 /**
  * @brief Parses the given JSON string and generates a tree representation of the given input.
  *

--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -297,17 +297,16 @@ struct TransduceTokenKeepLineEnd {
 
     if (is_end_of_invalid_line) {
       switch (relative_offset) {
-        case 0 : return SymbolT{token_t::StructEnd, 0};
-        case 1 : return SymbolT{token_t::StructBegin, 0};
-        case 2 : return SymbolT{token_t::LineEnd, 0};
-        default: return SymbolT{token_t::LineEnd, 0}; // doesn't appear
+        case 0: return SymbolT{token_t::StructEnd, 0};
+        case 1: return SymbolT{token_t::StructBegin, 0};
+        case 2: return SymbolT{token_t::LineEnd, 0};
+        default: return SymbolT{token_t::LineEnd, 0};  // doesn't appear
       }
     } else if (is_end_of_valid_line) {
       return SymbolT{token_t::LineEnd, 0};
     } else {
       return read_symbol;
     }
-
   }
 
   template <typename SymbolT>
@@ -1539,34 +1538,63 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> pr
   // Instantiate FST for post-processing the token stream to remove all tokens that belong to an
   // invalid JSON line
   token_filter::UnwrapTokenFromSymbolOp sgid_op{};
-  auto filter_fst =
-    fst::detail::make_fst(fst::detail::make_symbol_group_lut(token_filter::symbol_groups, sgid_op),
-                          fst::detail::make_transition_table(token_filter::transition_table),
-                          fst::detail::make_translation_functor(token_filter::TransduceTokenKeepLineEnd{}),
-                          stream);
 
   auto const mr = rmm::mr::get_current_device_resource();
   rmm::device_scalar<SymbolOffsetT> d_num_selected_tokens(stream, mr);
   rmm::device_uvector<PdaTokenT> filtered_tokens_out{tokens.size(), stream, mr};
   rmm::device_uvector<SymbolOffsetT> filtered_token_indices_out{tokens.size(), stream, mr};
 
-  // The FST is run on the reverse token stream, discarding all tokens between ErrorBegin and the
-  // next LineEnd (LineEnd, inv_token_0, inv_token_1, ..., inv_token_n, ErrorBegin, LineEnd, ...),
-  // emitting a [StructBegin, StructEnd] pair on the end of such an invalid line. In that example,
-  // inv_token_i for i in [0, n] together with the ErrorBegin are removed and replaced with
-  // StructBegin, StructEnd. Also, all LineEnd are removed as well, as these are not relevant after
-  // this stage anymore
-  filter_fst.Transduce(
-    thrust::make_reverse_iterator(thrust::make_zip_iterator(tokens.data(), token_indices.data()) +
-                                  tokens.size()),
-    static_cast<SymbolOffsetT>(tokens.size()),
-    thrust::make_reverse_iterator(
-      thrust::make_zip_iterator(filtered_tokens_out.data(), filtered_token_indices_out.data()) +
-      tokens.size()),
-    thrust::make_discard_iterator(),
-    d_num_selected_tokens.data(),
-    token_filter::start_state,
-    stream);
+  if (remove_line_end_token) {
+    // The FST is run on the reverse token stream, discarding all tokens between ErrorBegin and the
+    // next LineEnd (LineEnd, inv_token_0, inv_token_1, ..., inv_token_n, ErrorBegin, LineEnd, ...),
+    // emitting a [StructBegin, StructEnd] pair on the end of such an invalid line. In that example,
+    // inv_token_i for i in [0, n] together with the ErrorBegin are removed and replaced with
+    // StructBegin, StructEnd. Also, all LineEnd are removed as well, as these are not relevant
+    // after this stage anymore
+
+    auto filter_fst = fst::detail::make_fst(
+      fst::detail::make_symbol_group_lut(token_filter::symbol_groups, sgid_op),
+      fst::detail::make_transition_table(token_filter::transition_table),
+      fst::detail::make_translation_functor(token_filter::TransduceToken{}),
+      stream);
+
+    filter_fst.Transduce(
+      thrust::make_reverse_iterator(thrust::make_zip_iterator(tokens.data(), token_indices.data()) +
+                                    tokens.size()),
+      static_cast<SymbolOffsetT>(tokens.size()),
+      thrust::make_reverse_iterator(
+        thrust::make_zip_iterator(filtered_tokens_out.data(), filtered_token_indices_out.data()) +
+        tokens.size()),
+      thrust::make_discard_iterator(),
+      d_num_selected_tokens.data(),
+      token_filter::start_state,
+      stream);
+  } else {
+    // The FST is run on the reverse token stream, discarding all tokens between ErrorBegin and the
+    // next LineEnd (LineEnd, inv_token_0, inv_token_1, ..., inv_token_n, ErrorBegin, LineEnd, ...),
+    // emitting a [LineEnd, StructBegin, StructEnd] on the end of such an invalid line. In that
+    // example, inv_token_i for i in [0, n] together with the ErrorBegin are removed and replaced
+    // with LineEnd, StructBegin, StructEnd. Unlike the previous case, LineEnd tokens are retained
+    // however, the corresponding token index is written as 0.
+
+    auto filter_fst = fst::detail::make_fst(
+      fst::detail::make_symbol_group_lut(token_filter::symbol_groups, sgid_op),
+      fst::detail::make_transition_table(token_filter::transition_table),
+      fst::detail::make_translation_functor(token_filter::TransduceTokenKeepLineEnd{}),
+      stream);
+
+    filter_fst.Transduce(
+      thrust::make_reverse_iterator(thrust::make_zip_iterator(tokens.data(), token_indices.data()) +
+                                    tokens.size()),
+      static_cast<SymbolOffsetT>(tokens.size()),
+      thrust::make_reverse_iterator(
+        thrust::make_zip_iterator(filtered_tokens_out.data(), filtered_token_indices_out.data()) +
+        tokens.size()),
+      thrust::make_discard_iterator(),
+      d_num_selected_tokens.data(),
+      token_filter::start_state,
+      stream);
+  }
 
   auto const num_total_tokens = d_num_selected_tokens.value(stream);
   rmm::device_uvector<PdaTokenT> tokens_out{num_total_tokens, stream, mr};

--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -291,12 +291,19 @@ struct TransduceTokenKeepLineEnd {
       (state_id == static_cast<StateT>(TT_INV) &&
        match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::DELIMITER));
 
+    const bool is_end_of_valid_line =
+      (state_id == static_cast<StateT>(TT_VLD) &&
+       match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::DELIMITER));
+
     if (is_end_of_invalid_line) {
       switch (relative_offset) {
         case 0 : return SymbolT{token_t::StructEnd, 0};
         case 1 : return SymbolT{token_t::StructBegin, 0};
         case 2 : return SymbolT{token_t::LineEnd, 0};
+        default: return SymbolT{token_t::LineEnd, 0}; // doesn't appear
       }
+    } else if (is_end_of_valid_line) {
+      return SymbolT{token_t::LineEnd, 0};
     } else {
       return read_symbol;
     }

--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -267,7 +267,7 @@ struct TransduceToken {
     const bool is_delimiter = match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::DELIMITER);
 
     // If state is either invalid or we're entering an invalid state, we discard tokens
-    const bool is_part_of_invalid_line =
+    const bool is_part_of_valid_line =
       (match_id != static_cast<SymbolGroupT>(dfa_symbol_group_id::ERROR) &&
        state_id == static_cast<StateT>(TT_VLD));
 
@@ -275,7 +275,54 @@ struct TransduceToken {
     const bool is_end_of_invalid_line = (state_id == static_cast<StateT>(TT_INV) && is_delimiter);
 
     int32_t const emit_count =
-      is_end_of_invalid_line ? num_inv_tokens : (is_part_of_invalid_line && !is_delimiter ? 1 : 0);
+      is_end_of_invalid_line ? num_inv_tokens : (is_part_of_valid_line && !is_delimiter ? 1 : 0);
+    return emit_count;
+  }
+};
+
+struct TransduceTokenKeepLineEnd {
+  template <typename RelativeOffsetT, typename SymbolT>
+  constexpr CUDF_HOST_DEVICE SymbolT operator()(StateT const state_id,
+                                                SymbolGroupT const match_id,
+                                                RelativeOffsetT const relative_offset,
+                                                SymbolT const read_symbol) const
+  {
+    const bool is_end_of_invalid_line =
+      (state_id == static_cast<StateT>(TT_INV) &&
+       match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::DELIMITER));
+
+    if (is_end_of_invalid_line) {
+      switch (relative_offset) {
+        case 0 : return SymbolT{token_t::StructEnd, 0};
+        case 1 : return SymbolT{token_t::StructBegin, 0};
+        case 2 : return SymbolT{token_t::LineEnd, 0};
+      }
+    } else {
+      return read_symbol;
+    }
+
+  }
+
+  template <typename SymbolT>
+  constexpr CUDF_HOST_DEVICE int32_t operator()(StateT const state_id,
+                                                SymbolGroupT const match_id,
+                                                SymbolT const read_symbol) const
+  {
+    // Number of tokens emitted on invalid lines
+    constexpr int32_t num_inv_tokens = 3;
+
+    const bool is_delimiter = match_id == static_cast<SymbolGroupT>(dfa_symbol_group_id::DELIMITER);
+
+    // If state is either invalid or we're entering an invalid state, we discard tokens
+    const bool is_part_of_valid_line =
+      (match_id != static_cast<SymbolGroupT>(dfa_symbol_group_id::ERROR) &&
+       state_id == static_cast<StateT>(TT_VLD));
+
+    // Indicates whether we transition from an invalid line to a potentially valid line
+    const bool is_end_of_invalid_line = (state_id == static_cast<StateT>(TT_INV) && is_delimiter);
+
+    int32_t const emit_count =
+      is_end_of_invalid_line ? num_inv_tokens : (is_part_of_valid_line || is_delimiter ? 1 : 0);
     return emit_count;
   }
 };
@@ -1479,7 +1526,8 @@ void get_stack_context(device_span<SymbolT const> json_in,
 std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> process_token_stream(
   device_span<PdaTokenT const> tokens,
   device_span<SymbolOffsetT const> token_indices,
-  rmm::cuda_stream_view stream)
+  rmm::cuda_stream_view stream,
+  bool remove_line_end_token)
 {
   // Instantiate FST for post-processing the token stream to remove all tokens that belong to an
   // invalid JSON line
@@ -1487,7 +1535,7 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> pr
   auto filter_fst =
     fst::detail::make_fst(fst::detail::make_symbol_group_lut(token_filter::symbol_groups, sgid_op),
                           fst::detail::make_transition_table(token_filter::transition_table),
-                          fst::detail::make_translation_functor(token_filter::TransduceToken{}),
+                          fst::detail::make_translation_functor(token_filter::TransduceTokenKeepLineEnd{}),
                           stream);
 
   auto const mr = rmm::mr::get_current_device_resource();
@@ -1532,7 +1580,8 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
   device_span<SymbolT const> json_in,
   cudf::io::json_reader_options const& options,
   rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr)
+  rmm::device_async_resource_ref mr,
+  bool remove_line_end_token)
 {
   check_input_size(json_in.size());
 
@@ -1632,7 +1681,7 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
   if (delimiter_offset == 1) {
     tokens.set_element(0, token_t::LineEnd, stream);
     auto [filtered_tokens, filtered_tokens_indices] =
-      process_token_stream(tokens, tokens_indices, stream);
+      process_token_stream(tokens, tokens_indices, stream, remove_line_end_token);
     tokens         = std::move(filtered_tokens);
     tokens_indices = std::move(filtered_tokens_indices);
   }

--- a/cpp/tests/io/json_tree.cpp
+++ b/cpp/tests/io/json_tree.cpp
@@ -591,8 +591,12 @@ TEST_F(JsonTest, TreeRepresentation)
   cudf::io::json_reader_options const options{};
 
   // Parse the JSON and get the token stream
-  auto const [tokens_gpu, token_indices_gpu] = cudf::io::json::detail::get_token_stream(
-    d_input, options, stream, rmm::mr::get_current_device_resource());
+  auto const [tokens_gpu, token_indices_gpu] =
+    cudf::io::json::detail::get_token_stream(d_input,
+                                             options,
+                                             cudf::io::json::detail::LineEndTokenOption::Discard,
+                                             stream,
+                                             rmm::mr::get_current_device_resource());
 
   // Get the JSON's tree representation
   auto gpu_tree = cuio_json::detail::get_tree_representation(
@@ -679,8 +683,12 @@ TEST_F(JsonTest, TreeRepresentation2)
   cudf::io::json_reader_options const options{};
 
   // Parse the JSON and get the token stream
-  auto const [tokens_gpu, token_indices_gpu] = cudf::io::json::detail::get_token_stream(
-    d_input, options, stream, rmm::mr::get_current_device_resource());
+  auto const [tokens_gpu, token_indices_gpu] =
+    cudf::io::json::detail::get_token_stream(d_input,
+                                             options,
+                                             cudf::io::json::detail::LineEndTokenOption::Discard,
+                                             stream,
+                                             rmm::mr::get_current_device_resource());
 
   // Get the JSON's tree representation
   auto gpu_tree = cuio_json::detail::get_tree_representation(
@@ -754,8 +762,12 @@ TEST_F(JsonTest, TreeRepresentation3)
   options.enable_lines(true);
 
   // Parse the JSON and get the token stream
-  auto const [tokens_gpu, token_indices_gpu] = cudf::io::json::detail::get_token_stream(
-    d_input, options, stream, rmm::mr::get_current_device_resource());
+  auto const [tokens_gpu, token_indices_gpu] =
+    cudf::io::json::detail::get_token_stream(d_input,
+                                             options,
+                                             cudf::io::json::detail::LineEndTokenOption::Discard,
+                                             stream,
+                                             rmm::mr::get_current_device_resource());
 
   // Get the JSON's tree representation
   auto gpu_tree = cuio_json::detail::get_tree_representation(
@@ -780,8 +792,12 @@ TEST_F(JsonTest, TreeRepresentationError)
   cudf::io::json_reader_options const options{};
 
   // Parse the JSON and get the token stream
-  auto const [tokens_gpu, token_indices_gpu] = cudf::io::json::detail::get_token_stream(
-    d_input, options, stream, rmm::mr::get_current_device_resource());
+  auto const [tokens_gpu, token_indices_gpu] =
+    cudf::io::json::detail::get_token_stream(d_input,
+                                             options,
+                                             cudf::io::json::detail::LineEndTokenOption::Discard,
+                                             stream,
+                                             rmm::mr::get_current_device_resource());
 
   // Get the JSON's tree representation
   // This JSON is invalid and will raise an exception.
@@ -863,8 +879,12 @@ TEST_P(JsonTreeTraversalTest, CPUvsGPUTraversal)
                                                              static_cast<size_t>(d_scalar.size())};
 
   // Parse the JSON and get the token stream
-  auto const [tokens_gpu, token_indices_gpu] = cudf::io::json::detail::get_token_stream(
-    d_input, options, stream, rmm::mr::get_current_device_resource());
+  auto const [tokens_gpu, token_indices_gpu] =
+    cudf::io::json::detail::get_token_stream(d_input,
+                                             options,
+                                             cudf::io::json::detail::LineEndTokenOption::Discard,
+                                             stream,
+                                             rmm::mr::get_current_device_resource());
   // host tree generation
   auto cpu_tree = get_tree_representation_cpu(tokens_gpu, token_indices_gpu, options, stream);
   bool const is_array_of_arrays =

--- a/cpp/tests/io/nested_json_test.cpp
+++ b/cpp/tests/io/nested_json_test.cpp
@@ -1225,7 +1225,7 @@ TEST_F(JsonTest, TokenStreamWithLineEnd)
   };
 
   // Verify the number of tokens matches
-  // ASSERT_EQ(golden_token_stream.size(), tokens_gpu.size());
+  ASSERT_EQ(golden_token_stream.size(), tokens_gpu.size());
 
   for (std::size_t i = 0; i < tokens_gpu.size(); i++) {
     // Ensure the token category is correct

--- a/cpp/tests/io/nested_json_test.cpp
+++ b/cpp/tests/io/nested_json_test.cpp
@@ -1162,7 +1162,7 @@ TEST_F(JsonTest, TokenStreamWithLineEnd)
   using cuio_json::SymbolOffsetT;
   using cuio_json::SymbolT;
   // Test input
-  std::string const input =  R"({"a":1}
+  std::string const input = R"({"a":1}
   {"b":2}
   {"c"
   {"d":4})";
@@ -1181,14 +1181,14 @@ TEST_F(JsonTest, TokenStreamWithLineEnd)
 
   // Parse the JSON and get the token stream
   auto [d_tokens_gpu, d_token_indices_gpu] = cuio_json::detail::get_token_stream(
-    d_input, default_options, stream, rmm::mr::get_current_device_resource());
+    d_input, default_options, stream, rmm::mr::get_current_device_resource(), false);
   // Copy back the number of tokens that were written
-  auto const tokens_gpu        = cudf::detail::make_std_vector_async(d_tokens_gpu, stream);
+  auto const tokens_gpu = cudf::detail::make_std_vector_async(d_tokens_gpu, stream);
 
   // // Golden token stream sample
-  using token_t = cuio_json::token_t;
+  using token_t                                               = cuio_json::token_t;
   std::vector<cuio_json::PdaTokenT> const golden_token_stream = {
-    //Line 1
+    // Line 1
     token_t::LineEnd,
     token_t::StructBegin,
     token_t::StructMemberBegin,
@@ -1198,7 +1198,7 @@ TEST_F(JsonTest, TokenStreamWithLineEnd)
     token_t::ValueEnd,
     token_t::StructMemberEnd,
     token_t::StructEnd,
-    //Line 2
+    // Line 2
     token_t::LineEnd,
     token_t::StructBegin,
     token_t::StructMemberBegin,
@@ -1208,11 +1208,11 @@ TEST_F(JsonTest, TokenStreamWithLineEnd)
     token_t::ValueEnd,
     token_t::StructMemberEnd,
     token_t::StructEnd,
-    //Error
+    // Error
     token_t::LineEnd,
     token_t::StructBegin,
     token_t::StructEnd,
-    //Line 3
+    // Line 3
     token_t::LineEnd,
     token_t::StructBegin,
     token_t::StructMemberBegin,
@@ -1232,7 +1232,5 @@ TEST_F(JsonTest, TokenStreamWithLineEnd)
     EXPECT_EQ(golden_token_stream[i], tokens_gpu[i]) << "Mismatch at #" << i;
   }
 }
-
-
 
 CUDF_TEST_PROGRAM_MAIN()

--- a/cpp/tests/io/nested_json_test.cpp
+++ b/cpp/tests/io/nested_json_test.cpp
@@ -436,12 +436,8 @@ TEST_F(JsonTest, TokenStream)
     cudf::device_span<SymbolT const>{d_scalar.data(), static_cast<size_t>(d_scalar.size())};
 
   // Parse the JSON and get the token stream
-  auto [d_tokens_gpu, d_token_indices_gpu] =
-    cuio_json::detail::get_token_stream(d_input,
-                                        default_options,
-                                        cuio_json::detail::LineEndTokenOption::Discard,
-                                        stream,
-                                        rmm::mr::get_current_device_resource());
+  auto [d_tokens_gpu, d_token_indices_gpu] = cuio_json::detail::get_token_stream(
+    d_input, default_options, stream, rmm::mr::get_current_device_resource());
   // Copy back the number of tokens that were written
   auto const tokens_gpu        = cudf::detail::make_std_vector_async(d_tokens_gpu, stream);
   auto const token_indices_gpu = cudf::detail::make_std_vector_async(d_token_indices_gpu, stream);


### PR DESCRIPTION
## Description

This PR adds parameter `LineEndTokenOption` to the `get_token_stream` and `process_token_stream` functions, enabling LineEnd tokens in the output.  Also retained original declaration of `get_token_stream` to maintain backward compatibility.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
