### PR TITLE
Backport: Relax protobuf lower bound to 3.20. (#15506)

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -68,7 +68,7 @@ dependencies:
 - pandoc
 - pip
 - pre-commit
-- protobuf>=4.21,<5
+- protobuf>=3.20,<5
 - ptxcompiler
 - pyarrow==14.0.2.*
 - pydata-sphinx-theme!=0.14.2

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -66,7 +66,7 @@ dependencies:
 - pandoc
 - pip
 - pre-commit
-- protobuf>=4.21,<5
+- protobuf>=3.20,<5
 - pyarrow==14.0.2.*
 - pydata-sphinx-theme!=0.14.2
 - pynvjitlink

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -78,7 +78,7 @@ requirements:
     {% endif %}
     - cuda-version ={{ cuda_version }}
   run:
-    - {{ pin_compatible('protobuf', min_pin='x.x', max_pin='x') }}
+    - protobuf >=3.20,<5.0a0
     - python
     - typing_extensions >=4.0.0
     - pandas >=2.0,<2.2.2dev0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -276,7 +276,7 @@ dependencies:
       - output_types: conda
         packages:
           - &rmm_conda rmm==24.4.*
-          - &protobuf protobuf>=4.21,<5
+          - &protobuf protobuf>=3.20,<5
           - pip
           - pip:
               - git+https://github.com/python-streamz/streamz.git@master

--- a/python/cudf/cudf/tests/pytest.ini
+++ b/python/cudf/cudf/tests/pytest.ini
@@ -8,5 +8,7 @@ filterwarnings =
     error
     ignore:::.*xdist.*
     ignore:::.*pytest.*
+    # Deprecation warning from Pyarrow Table.to_pandas() with pandas-2.2+
     ignore:Passing a BlockManager to DataFrame is deprecated:DeprecationWarning
-    # Above deprecation warning comes from Pyarrow Table.to_pandas() with pandas-2.2+
+    # PerformanceWarning from cupy warming up the JIT cache
+    ignore:Jitify is performing a one-time only warm-up to populate the persistent cache:cupy._util.PerformanceWarning

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "nvtx>=0.2.1",
     "packaging",
     "pandas>=2.0,<2.2.2dev0",
-    "protobuf>=4.21,<5",
+    "protobuf>=3.20,<5",
     "ptxcompiler",
     "pyarrow>=14.0.1,<15.0.0a0",
     "rich",


### PR DESCRIPTION
Backport of https://github.com/rapidsai/cudf/pull/15506 to cuDF 24.04.

Also backports #15574 to ignore a warning from newer cupy releases.