### PR TITLE
Remove NVBench SHA override.

### DIFF
--- a/cpp/cmake/thirdparty/get_nvbench.cmake
+++ b/cpp/cmake/thirdparty/get_nvbench.cmake
@@ -18,7 +18,6 @@ function(find_and_configure_nvbench)
   include(${rapids-cmake-dir}/cpm/nvbench.cmake)
   include(${rapids-cmake-dir}/cpm/package_override.cmake)
 
-  set(cudf_patch_dir "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/patches")
 
   rapids_cpm_nvbench(BUILD_STATIC)
 

--- a/cpp/cmake/thirdparty/get_nvbench.cmake
+++ b/cpp/cmake/thirdparty/get_nvbench.cmake
@@ -19,7 +19,6 @@ function(find_and_configure_nvbench)
   include(${rapids-cmake-dir}/cpm/package_override.cmake)
 
   set(cudf_patch_dir "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/patches")
-  rapids_cpm_package_override("${cudf_patch_dir}/nvbench_override.json")
 
   rapids_cpm_nvbench(BUILD_STATIC)
 

--- a/cpp/cmake/thirdparty/get_nvbench.cmake
+++ b/cpp/cmake/thirdparty/get_nvbench.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,6 @@ function(find_and_configure_nvbench)
 
   include(${rapids-cmake-dir}/cpm/nvbench.cmake)
   include(${rapids-cmake-dir}/cpm/package_override.cmake)
-
 
   rapids_cpm_nvbench(BUILD_STATIC)
 

--- a/cpp/cmake/thirdparty/patches/nvbench_override.json
+++ b/cpp/cmake/thirdparty/patches/nvbench_override.json
@@ -1,9 +1,0 @@
-
-{
-  "packages" : {
-    "nvbench" : {
-      "git_url": "https://github.com/NVIDIA/nvbench.git",
-      "git_tag": "555d628e9b250868c9da003e4407087ff1982e8e"
-    }
-  }
-}


### PR DESCRIPTION
## Description

The override is no longer necessary as rapids-cmake now uses the same version that was set by the override.

Refs rapidsai/rapids-cmake#584, #15492

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [N/a] New or existing tests cover these changes.
- [N/a] The documentation is up to date with these changes.
