### PR TITLE
Don't proxy non-bound class functions in cudf.pandas

### DIFF
--- a/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
+++ b/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
@@ -1220,3 +1220,14 @@ def test_apply_slow_path_udf_references_global_module():
     result = df.apply(my_apply, axis=1, unused=True)
     expected = xpd.Series([1])
     tm.assert_series_equal(result, expected)
+
+
+def test_dont_proxy_class_methods():
+    # https://github.com/rapidsai/cudf/issues/15637
+    class Foo:
+        @xpd.util._decorators.deprecate_kwarg("not", "important")
+        def __init__(self, val, important=None):
+            self.val = val
+
+    foo = Foo(2)
+    assert foo.val == 2


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/15637

If a user has code like

```python
    class Foo:
        @pd.util._decorators.deprecate_kwarg("not", "important")
        def __init__(self, val, important=None):
            self.val = val
```

`cudf.pandas` will attempt to proxy `Foo.__init__` as an unbound function. Unfortunately when this method is called i.e. `Foo(2)` we are unable to pass the instance along, `self`, and call this as `Foo.__init__(2)`.

I'm unsure how we would be able to pass the instance along, so for now I am avoiding proxying these functions (by hackily checking for `self` in the signature). Open to better solutions

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
