### PR TITLE
Stop instantiate GPU objects in the parametrize test args

### DIFF
--- a/ci/test_instantiate_objs.sh
+++ b/ci/test_instantiate_objs.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+
+disallowed_classes=("cudf.Series(" "cudf.DataFrame(")
+
+test_directory="tests"
+
+for file in "$test_directory"/*.py; do
+    in_parametrize_block=false
+    block_content=""
+
+    while IFS='' read -r line; do
+        if [[ "$line" =~ @pytest\.mark\.parametrize\(+ ]]; then
+            in_parametrize_block=true
+            block_content="$line"
+        elif [[ $in_parametrize_block = true ]]; then
+            block_content+="$line"
+            if [[ "$line" == *")"* ]]; then
+                for class_name in "${disallowed_classes[@]}"; do
+                    if [[ "$block_content" =~ $class_name ]]; then
+                        echo "Error: $class_name instantiation found in $file within @pytest.mark.parametrize"
+                        exit 1
+                    fi
+                done
+                in_parametrize_block=false
+                block_content=""
+            fi
+        fi
+    done < "$file"
+done
+
+echo "All test files are clean."

--- a/python/cudf/cudf/tests/test_api_types.py
+++ b/python/cudf/cudf/tests/test_api_types.py
@@ -10,6 +10,7 @@ from cudf.api import types
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 
 
+# todo
 @pytest.mark.parametrize(
     "obj, expect",
     (
@@ -116,6 +117,7 @@ def test_is_categorical_dtype(obj, expect):
     assert types._is_categorical_dtype(obj) == expect
 
 
+# todo
 @pytest.mark.parametrize(
     "obj, expect",
     (
@@ -218,6 +220,7 @@ def test_is_numeric_dtype(obj, expect):
     assert types.is_numeric_dtype(obj) == expect
 
 
+# todo
 @pytest.mark.parametrize(
     "obj, expect",
     (
@@ -320,6 +323,7 @@ def test_is_integer_dtype(obj, expect):
     assert types.is_integer_dtype(obj) == expect
 
 
+# todo
 @pytest.mark.parametrize(
     "obj, expect",
     (
@@ -422,6 +426,7 @@ def test_is_integer(obj, expect):
     assert types.is_integer(obj) == expect
 
 
+# todo
 # TODO: Temporarily ignoring all cases of "object" until we decide what to do.
 @pytest.mark.parametrize(
     "obj, expect",
@@ -539,6 +544,7 @@ def test_is_string_dtype(obj, expect):
     assert types.is_string_dtype(obj) == expect
 
 
+# todo
 @pytest.mark.parametrize(
     "obj, expect",
     (
@@ -641,6 +647,7 @@ def test_is_datetime_dtype(obj, expect):
     assert types.is_datetime_dtype(obj) == expect
 
 
+# todo
 @pytest.mark.parametrize(
     "obj, expect",
     (
@@ -743,6 +750,7 @@ def test_is_list_dtype(obj, expect):
     assert types.is_list_dtype(obj) == expect
 
 
+# todo
 @pytest.mark.parametrize(
     "obj, expect",
     (
@@ -848,6 +856,7 @@ def test_is_struct_dtype(obj, expect):
     assert types.is_struct_dtype(obj) == expect
 
 
+# todo
 @pytest.mark.parametrize(
     "obj, expect",
     (

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -692,6 +692,7 @@ def test_different_shapes_and_columns_with_unaligned_indices(binop):
     utils.assert_eq(pd_frame, cd_frame)
 
 
+# todo
 @pytest.mark.parametrize(
     "df2",
     [
@@ -2382,6 +2383,7 @@ def test_binops_raise_error():
         s // 1
 
 
+# todo
 @pytest.mark.parametrize(
     "args",
     [
@@ -2808,6 +2810,7 @@ def test_binops_decimal_scalar(args):
     utils.assert_eq(expect, got)
 
 
+# todo
 @pytest.mark.parametrize(
     "args",
     [
@@ -3136,6 +3139,7 @@ def test_empty_column(binop, data, scalar):
     utils.assert_eq(expected, got)
 
 
+# todo
 @pytest.mark.parametrize(
     "df",
     [
@@ -3160,6 +3164,7 @@ def test_empty_column(binop, data, scalar):
         cudf.Series([14.15, 15.16, 16.17, 17.18]),
     ],
 )
+# todo
 @pytest.mark.parametrize(
     "other",
     [

--- a/python/cudf/cudf/tests/test_categorical.py
+++ b/python/cudf/cudf/tests/test_categorical.py
@@ -595,6 +595,7 @@ def test_categorical_dtype(categories, ordered):
     assert_eq(expected, got)
 
 
+# todo
 @pytest.mark.parametrize(
     ("data", "expected"),
     [
@@ -786,6 +787,7 @@ def test_series_construction_with_nulls(input_obj, dtype):
     assert_eq(expect, got)
 
 
+# todo
 @pytest.mark.parametrize(
     "data",
     [

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -1981,14 +1981,17 @@ def test_concat_dictionary(d, axis):
 @pytest.mark.parametrize(
     "d",
     [
-        {"first": cudf.Index([1, 2, 3])},
+        {"first": (cudf.Index, {"data": [1, 2, 3]})},
         {
-            "first": cudf.MultiIndex(
-                levels=[[1, 2], ["blue", "red"]],
-                codes=[[0, 0, 1, 1], [1, 0, 1, 0]],
+            "first": (
+                cudf.MultiIndex,
+                {
+                    "levels": [[1, 2], ["blue", "red"]],
+                    "codes": [[0, 0, 1, 1], [1, 0, 1, 0]],
+                },
             )
         },
-        {"first": cudf.CategoricalIndex([1, 2, 3])},
+        {"first": (cudf.CategoricalIndex, {"data": [1, 2, 3]})},
     ],
 )
 def test_concat_dict_incorrect_type_index(d):
@@ -1996,4 +1999,5 @@ def test_concat_dict_incorrect_type_index(d):
         TypeError,
         match="cannot concatenate a dictionary containing indices",
     ):
-        cudf.concat(d, axis=1)
+        _dict = {k: c(**v) for k, (c, v) in d.items()}
+        cudf.concat(_dict, axis=1)

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -109,6 +109,7 @@ def test_concat_dataframe(index, nulls, axis):
     assert_eq(res, sol, check_names=False, check_categorical=False)
 
 
+# todo
 @pytest.mark.parametrize(
     "values",
     [["foo", "bar"], [1.0, 2.0], pd.Series(["one", "two"], dtype="category")],
@@ -450,57 +451,91 @@ def test_concat_mixed_input():
 @pytest.mark.parametrize(
     "objs",
     [
-        [pd.Series([1, 2, 3]), pd.DataFrame({"a": [1, 2]})],
-        [pd.Series([1, 2, 3]), pd.DataFrame({"a": []})],
-        [pd.Series([], dtype="float64"), pd.DataFrame({"a": []})],
-        [pd.Series([], dtype="float64"), pd.DataFrame({"a": [1, 2]})],
         [
-            pd.Series([1, 2, 3.0, 1.2], name="abc"),
-            pd.DataFrame({"a": [1, 2]}),
+            (pd.Series, {"data": [1, 2, 3]}),
+            (pd.DataFrame, {"data": {"a": [1, 2]}}),
         ],
         [
-            pd.Series(
-                [1, 2, 3.0, 1.2], name="abc", index=[100, 110, 120, 130]
-            ),
-            pd.DataFrame({"a": [1, 2]}),
+            (pd.Series, {"data": [1, 2, 3]}),
+            (pd.DataFrame, {"data": {"a": []}}),
         ],
         [
-            pd.Series(
-                [1, 2, 3.0, 1.2], name="abc", index=["a", "b", "c", "d"]
-            ),
-            pd.DataFrame({"a": [1, 2]}, index=["a", "b"]),
+            (pd.Series, {"data": [], "dtype": "float64"}),
+            (pd.DataFrame, {"data": {"a": []}}),
         ],
         [
-            pd.Series(
-                [1, 2, 3.0, 1.2, 8, 100],
-                name="New name",
-                index=["a", "b", "c", "d", "e", "f"],
+            (pd.Series, {"data": [], "dtype": "float64"}),
+            (pd.DataFrame, {"data": {"a": [1, 2]}}),
+        ],
+        [
+            (pd.Series, {"data": [1, 2, 3.0, 1.2], "name": "abc"}),
+            (pd.DataFrame, {"data": {"a": [1, 2]}}),
+        ],
+        [
+            (
+                pd.Series,
+                {
+                    "data": [1, 2, 3.0, 1.2],
+                    "name": "abc",
+                    "index": [100, 110, 120, 130],
+                },
             ),
-            pd.DataFrame(
-                {"a": [1, 2, 4, 10, 11, 12]},
-                index=["a", "b", "c", "d", "e", "f"],
+            (pd.DataFrame, {"data": {"a": [1, 2]}}),
+        ],
+        [
+            (
+                pd.Series,
+                {
+                    "data": [1, 2, 3.0, 1.2],
+                    "name": "abc",
+                    "index": ["a", "b", "c", "d"],
+                },
+            ),
+            (pd.DataFrame, {"data": {"a": [1, 2]}, "index": ["a", "b"]}),
+        ],
+        [
+            (
+                pd.Series,
+                {
+                    "data": [1, 2, 3.0, 1.2, 8, 100],
+                    "name": "New name",
+                    "index": ["a", "b", "c", "d", "e", "f"],
+                },
+            ),
+            (
+                pd.DataFrame,
+                {
+                    "data": {"a": [1, 2, 4, 10, 11, 12]},
+                    "index": ["a", "b", "c", "d", "e", "f"],
+                },
             ),
         ],
         [
-            pd.Series(
-                [1, 2, 3.0, 1.2, 8, 100],
-                name="New name",
-                index=["a", "b", "c", "d", "e", "f"],
+            (
+                pd.Series,
+                {
+                    "data": [1, 2, 3.0, 1.2, 8, 100],
+                    "name": "New name",
+                    "index": ["a", "b", "c", "d", "e", "f"],
+                },
             ),
-            pd.DataFrame(
-                {"a": [1, 2, 4, 10, 11, 12]},
-                index=["a", "b", "c", "d", "e", "f"],
+            (
+                pd.DataFrame,
+                {
+                    "data": {"a": [1, 2, 4, 10, 11, 12]},
+                    "index": ["a", "b", "c", "d", "e", "f"],
+                },
             ),
         ]
         * 7,
     ],
 )
 def test_concat_series_dataframe_input(objs):
-    pd_objs = objs
+    _objs = [c(**d) for o in objs for c, d in o]
     gd_objs = [cudf.from_pandas(obj) for obj in objs]
 
     with _hide_concat_empty_dtype_warning():
-        expected = pd.concat(pd_objs)
+        expected = pd.concat(_objs)
         actual = cudf.concat(gd_objs)
 
     assert_eq(
@@ -511,6 +546,7 @@ def test_concat_series_dataframe_input(objs):
     )
 
 
+# todo
 @pytest.mark.parametrize(
     "objs",
     [
@@ -550,6 +586,7 @@ def test_concat_series_dataframe_input_str(objs):
     assert_eq(expected, actual, check_dtype=False, check_index_type=False)
 
 
+# todo
 @pytest.mark.parametrize(
     "df",
     [
@@ -566,6 +603,7 @@ def test_concat_series_dataframe_input_str(objs):
         pd.DataFrame({"cat": pd.Series(["one", "two"], dtype="category")}),
     ],
 )
+# todo
 @pytest.mark.parametrize(
     "other",
     [
@@ -665,6 +703,7 @@ def test_concat_two_empty_series(ignore_index, axis):
     assert_eq(got, expect, check_index_type=True)
 
 
+# todo
 @pytest.mark.parametrize(
     "df1,df2",
     [
@@ -701,6 +740,7 @@ def test_concat_dataframe_with_multiindex(df1, df2):
     )
 
 
+# todo
 @pytest.mark.parametrize(
     "objs",
     [
@@ -766,6 +806,7 @@ def test_concat_join(objs, ignore_index, sort, join, axis):
     )
 
 
+# todo
 @pytest.mark.parametrize(
     "objs",
     [
@@ -799,6 +840,7 @@ def test_concat_join_axis_1_dup_error(objs):
         )
 
 
+# todo
 @pytest.mark.parametrize(
     "objs",
     [
@@ -905,6 +947,7 @@ def test_concat_join_one_df(ignore_index, sort, join, axis):
     assert_eq(expected, actual, check_index_type=True)
 
 
+# todo
 @pytest.mark.parametrize(
     "pdf1,pdf2",
     [
@@ -995,6 +1038,7 @@ def test_concat_join_no_overlapping_columns_many_and_empty(
     )
 
 
+# todo
 @pytest.mark.parametrize(
     "objs",
     [
@@ -1144,6 +1188,7 @@ def test_concat_join_series(ignore_index, sort, join, axis):
     )
 
 
+# todo
 @pytest.mark.parametrize(
     "df",
     [
@@ -1160,6 +1205,7 @@ def test_concat_join_series(ignore_index, sort, join, axis):
         pd.DataFrame({"cat": pd.Series(["one", "two"], dtype="category")}),
     ],
 )
+# todo
 @pytest.mark.parametrize(
     "other",
     [
@@ -1231,6 +1277,7 @@ def test_concat_join_empty_dataframes(
     )
 
 
+#  todo
 @pytest.mark.parametrize(
     "df",
     [
@@ -1247,6 +1294,7 @@ def test_concat_join_empty_dataframes(
         pd.DataFrame({"cat": pd.Series(["one", "two"], dtype="category")}),
     ],
 )
+# todo
 @pytest.mark.parametrize(
     "other",
     [
@@ -1412,6 +1460,7 @@ def test_concat_decimal_series(ltype, rtype):
     assert_eq(expected, got, check_index_type=True)
 
 
+# todo
 @pytest.mark.parametrize(
     "df1, df2, df3, expected",
     [
@@ -1536,6 +1585,7 @@ def test_concat_decimal_numeric_dataframe(df1, df2, df3, expected):
     assert_eq(df.val.dtype, expected.val.dtype)
 
 
+# todo
 @pytest.mark.parametrize(
     "s1, s2, s3, expected",
     [
@@ -1653,6 +1703,7 @@ def test_concat_decimal_numeric_series(s1, s2, s3, expected):
     assert_eq(s, expected, check_index_type=True)
 
 
+# todo
 @pytest.mark.parametrize(
     "s1, s2, expected",
     [
@@ -1724,6 +1775,7 @@ def test_concat_decimal_non_numeric(s1, s2, expected):
     assert_eq(s, expected, check_index_type=True)
 
 
+# todo
 @pytest.mark.parametrize(
     "s1, s2, expected",
     [
@@ -1747,6 +1799,7 @@ def test_concat_struct_column(s1, s2, expected):
     assert_eq(s, expected, check_index_type=True)
 
 
+# todo
 @pytest.mark.parametrize(
     "frame1, frame2, expected",
     [

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -1805,6 +1805,7 @@ def test_csv_writer_chunksize(chunksize, dtype):
     assert_eq(cu_df, got)
 
 
+# todo
 @pytest.mark.parametrize(
     "df",
     [
@@ -1826,6 +1827,7 @@ def test_to_csv_empty_filename(df):
     assert actual == expected
 
 
+# todo
 @pytest.mark.parametrize(
     "df",
     [
@@ -1887,6 +1889,7 @@ def test_csv_write_no_caller_manipulation():
     assert_eq(df, df_copy)
 
 
+# todo
 @pytest.mark.parametrize(
     "df",
     [
@@ -1908,6 +1911,7 @@ def test_csv_write_empty_column_name(df, index, columns):
     assert expected == actual
 
 
+# todo
 @pytest.mark.parametrize(
     "df",
     [
@@ -2020,6 +2024,7 @@ def test_csv_reader_datetime_dtypes(dtype):
     assert_eq(expected, actual)
 
 
+# todo
 @pytest.mark.parametrize(
     "df",
     [

--- a/python/cudf/cudf/tests/test_custom_accessor.py
+++ b/python/cudf/cudf/tests/test_custom_accessor.py
@@ -65,6 +65,7 @@ class OddRowAccessor:
         return self._obj[2 * i - 1]
 
 
+# todo
 @pytest.mark.parametrize("gidx", [cudf.Index(list(range(0, 50)))])
 def test_index_accessor(gidx):
     pidx = gidx.to_pandas()
@@ -73,6 +74,7 @@ def test_index_accessor(gidx):
         assert_eq(gidx.odd[i], pidx.odd[i])
 
 
+# todo
 @pytest.mark.parametrize("gs", [cudf.Series(list(range(1, 50)))])
 def test_series_accessor(gs):
     ps = gs.to_pandas()
@@ -84,7 +86,9 @@ def test_series_accessor(gs):
 @pytest.mark.parametrize(
     "gdf", [cudf.datasets.randomdata(nrows=6, dtypes={"x": int, "y": int})]
 )
+# todo
 @pytest.mark.parametrize("gidx", [cudf.Index(list(range(1, 50)))])
+# todo
 @pytest.mark.parametrize("gs", [cudf.Series(list(range(1, 50)))])
 def test_accessor_space_separate(gdf, gidx, gs):
     assert not id(gdf._accessors) == id(gidx._accessors)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -1646,9 +1646,11 @@ def test_dataframe_concat_different_column_types():
         cudf.concat([df1, df2])
 
 
+# todo
 @pytest.mark.parametrize(
     "df_1", [cudf.DataFrame({"a": [1, 2], "b": [1, 3]}), cudf.DataFrame({})]
 )
+# todo
 @pytest.mark.parametrize(
     "df_2", [cudf.DataFrame({"a": [], "b": []}), cudf.DataFrame({})]
 )
@@ -2769,6 +2771,7 @@ def test_arrow_pandas_compat(pdf, gdf, preserve_index):
     assert_eq(pdf2, gdf2)
 
 
+# todo
 @pytest.mark.parametrize(
     "index",
     [
@@ -2927,6 +2930,7 @@ def test_dataframe_boolmask(mask_shape):
         )
 
 
+# todo
 @pytest.mark.parametrize(
     "mask",
     [
@@ -4661,6 +4665,7 @@ def test_create_dataframe_column():
     assert_eq(pdf, gdf)
 
 
+# todo
 @pytest.mark.parametrize(
     "data",
     [
@@ -5182,6 +5187,7 @@ def test_df_constructor_dtype(dtype):
 
 
 @pytest_unmark_spilling
+# todo
 @pytest.mark.parametrize(
     "data",
     [
@@ -5391,6 +5397,7 @@ def test_rowwise_ops_nullable_int_dtypes(op, expected):
     assert_eq(got, expected)
 
 
+# todo
 @pytest.mark.parametrize(
     "data",
     [
@@ -5640,6 +5647,7 @@ def test_cov_nans():
 
 
 @pytest_unmark_spilling
+# todo
 @pytest.mark.parametrize(
     "gsr",
     [
@@ -5894,6 +5902,7 @@ def test_setitem_diff_size_list(list_input, key):
         gdf[key] = list_input
 
 
+# todo
 @pytest.mark.parametrize(
     "series_input",
     [
@@ -8677,6 +8686,7 @@ def test_describe_misc_exclude(df, exclude):
     assert_eq(expected, actual)
 
 
+# todo
 @pytest.mark.parametrize(
     "df",
     [
@@ -8780,6 +8790,7 @@ def test_dataframe_error_equality(df1, df2, op):
     assert_exceptions_equal(op, op, ([df1, df2],), ([gdf1, gdf2],))
 
 
+# todo
 @pytest.mark.parametrize(
     "df,expected_pdf",
     [
@@ -9032,6 +9043,7 @@ def test_dataframe_from_pandas_duplicate_columns():
         pd.DataFrame(),
     ],
 )
+# todo
 @pytest.mark.parametrize(
     "columns",
     [
@@ -9289,6 +9301,7 @@ def test_update_for_data_overlap(errors):
     )
 
 
+# todo
 @pytest.mark.parametrize(
     "gdf",
     [
@@ -9316,6 +9329,7 @@ def test_dataframe_roundtrip_arrow_list_dtype(gdf):
     assert_eq(gdf, expected)
 
 
+# todo
 @pytest.mark.parametrize(
     "gdf",
     [
@@ -9474,6 +9488,7 @@ def test_explode(data, labels, ignore_index, p_index, label_to_explode):
     assert_eq(expect, got, check_dtype=False)
 
 
+# todo
 @pytest.mark.parametrize(
     "df,ascending,expected",
     [
@@ -10895,6 +10910,7 @@ def test_dataframe_columns_set_none_raises():
         df.columns = None
 
 
+# todo
 @pytest.mark.parametrize(
     "columns",
     [cudf.RangeIndex(1, name="foo"), pd.RangeIndex(1, name="foo"), range(1)],

--- a/python/cudf/cudf/tests/test_decimal.py
+++ b/python/cudf/cudf/tests/test_decimal.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 
 import decimal
 from decimal import Decimal
@@ -251,6 +251,7 @@ def test_typecast_from_decimal(data, from_dtype, to_dtype):
     assert_eq(got.dtype, expected.dtype)
 
 
+# todo
 @pytest.mark.parametrize(
     "args",
     [

--- a/python/cudf/cudf/tests/test_dropna.py
+++ b/python/cudf/cudf/tests/test_dropna.py
@@ -80,6 +80,7 @@ def test_dropna_dataframe(data, how, axis, inplace):
 
 
 @pytest.mark.parametrize("how", ["all", "any"])
+# todo
 @pytest.mark.parametrize(
     "data",
     [
@@ -203,6 +204,7 @@ def test_dropna_thresh_cols(thresh, subset, inplace):
     )
 
 
+# todo
 @pytest.mark.parametrize(
     "data",
     [

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -382,6 +382,7 @@ def test_index_copy_category(name, deep=True):
 
 
 @pytest.mark.parametrize("deep", [True, False])
+# todo
 @pytest.mark.parametrize(
     "idx",
     [
@@ -3132,6 +3133,7 @@ def test_from_pandas_rangeindex_return_rangeindex():
     assert_eq(result, expected, exact=True)
 
 
+# todo
 @pytest.mark.parametrize(
     "idx",
     [

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -53,6 +53,7 @@ def pdf_gdf_multi():
     return pdf, gdf
 
 
+# todo
 @pytest.mark.parametrize(
     "i1, i2, i3",
     (
@@ -827,6 +828,7 @@ def test_empty_boolean_mask(dtype):
         pd.Series(pd.date_range("2010-01-01", "2010-01-04")),
     ],
 )
+# todo
 @pytest.mark.parametrize(
     "mask",
     [
@@ -1337,6 +1339,7 @@ def test_loc_datetime_index_slice_not_in(sli):
         assert_eq(pd_data.loc[sli], gd_data.loc[sli])
 
 
+# todo
 @pytest.mark.parametrize(
     "gdf_kwargs",
     [
@@ -1390,6 +1393,7 @@ def test_dataframe_sliced(gdf_kwargs, slice):
     assert_eq(actual, expected)
 
 
+#  todo
 @pytest.mark.parametrize(
     "gdf",
     [

--- a/python/cudf/cudf/tests/test_joining.py
+++ b/python/cudf/cudf/tests/test_joining.py
@@ -1779,6 +1779,7 @@ def test_typecast_on_join_indexes_matching_categorical():
     assert_join_results_equal(expect, got, how="inner")
 
 
+# todo
 @pytest.mark.parametrize(
     "lhs",
     [
@@ -1786,6 +1787,7 @@ def test_typecast_on_join_indexes_matching_categorical():
         cudf.DataFrame({"a": [2, 3, 4], "c": [4, 5, 6]}),
     ],
 )
+# todo
 @pytest.mark.parametrize(
     "rhs",
     [

--- a/python/cudf/cudf/tests/test_replace.py
+++ b/python/cudf/cudf/tests/test_replace.py
@@ -19,6 +19,7 @@ from cudf.testing._utils import (
 )
 
 
+# todo
 @pytest.mark.parametrize(
     "gsr",
     [
@@ -27,6 +28,7 @@ from cudf.testing._utils import (
         cudf.Series(list(range(400)) + [None]),
     ],
 )
+# todo
 @pytest.mark.parametrize(
     "to_replace,value",
     [
@@ -405,6 +407,7 @@ def test_fillna_method_numerical(data, container, data_dtype, method, inplace):
         ).astype(Decimal128Dtype(20, 7)),
     ],
 )
+# todo
 @pytest.mark.parametrize(
     "fill_value",
     [
@@ -1312,6 +1315,7 @@ def test_series_replace_errors():
     )
 
 
+# todo
 @pytest.mark.parametrize(
     "gsr,old,new,expected",
     [

--- a/python/cudf/cudf/tests/test_repr.py
+++ b/python/cudf/cudf/tests/test_repr.py
@@ -235,6 +235,7 @@ def test_generic_index(length, dtype):
     assert repr(psr.index) == repr(gsr.index)
 
 
+# todo
 @pytest.mark.parametrize(
     "gdf",
     [
@@ -289,6 +290,7 @@ def test_dataframe_sliced(gdf, slice, max_seq_items, max_rows):
     pd.reset_option("display.max_seq_items")
 
 
+# todo
 @pytest.mark.parametrize(
     "index,expected_repr",
     [
@@ -591,6 +593,7 @@ def test_timedelta_series_s_us_repr(data, dtype):
     assert expected.split() == actual.split()
 
 
+# todo
 @pytest.mark.parametrize(
     "ser, expected_repr",
     [
@@ -1024,6 +1027,7 @@ def test_timedelta_dataframe_repr(df, expected_repr):
     assert actual_repr.split() == expected_repr.split()
 
 
+# todo
 @pytest.mark.parametrize(
     "index, expected_repr",
     [
@@ -1115,6 +1119,7 @@ def test_multiindex_repr(pmi, max_seq_items):
     pd.reset_option("display.max_seq_items")
 
 
+# todo
 @pytest.mark.parametrize(
     "gdi, expected_repr",
     [

--- a/python/cudf/cudf/tests/test_serialize.py
+++ b/python/cudf/cudf/tests/test_serialize.py
@@ -299,6 +299,7 @@ def test_serialize_string():
     assert_eq(recreated, df)
 
 
+# todo
 @pytest.mark.parametrize(
     "frames",
     [
@@ -401,6 +402,7 @@ def test_serialize_sliced_string():
     assert_eq(recreated.to_pandas(nullable=True), pd_series)
 
 
+# todo
 @pytest.mark.parametrize(
     "columns",
     [

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -649,6 +649,7 @@ def test_series_value_counts_optional_arguments(ascending, dropna, normalize):
     )
 
 
+# todo
 @pytest.mark.parametrize(
     "gs",
     [
@@ -753,6 +754,7 @@ def test_series_round_half_up():
     assert_eq(expect, got)
 
 
+# todo
 @pytest.mark.parametrize(
     "series",
     [
@@ -843,6 +845,7 @@ def test_series_memory_usage():
     assert sr[:1].memory_usage() == 19  # hello world
 
 
+# todo
 @pytest.mark.parametrize(
     "sr,expected_psr",
     [
@@ -998,10 +1001,12 @@ def test_series_pipe_error():
     )
 
 
+# todo
 @pytest.mark.parametrize(
     "data",
     [cudf.Series([1, 2, 3]), cudf.Series([10, 11, 12], index=[1, 2, 3])],
 )
+# todo
 @pytest.mark.parametrize(
     "other",
     [
@@ -1267,6 +1272,7 @@ def test_explode(data, ignore_index, p_index):
     assert_eq(expect, got, check_dtype=False)
 
 
+# todo
 @pytest.mark.parametrize(
     "data, expected",
     [
@@ -1571,6 +1577,7 @@ def test_series_add_suffix():
     assert_eq(got, expected)
 
 
+# todo
 @pytest.mark.parametrize(
     "cudf_series",
     [
@@ -2693,6 +2700,7 @@ def test_series_from_named_object_name_priority(klass):
     assert result.name == "b"
 
 
+# todo
 @pytest.mark.parametrize(
     "data",
     [
@@ -2707,6 +2715,7 @@ def test_series_from_object_with_index_index_arg_reindex(data):
     assert_eq(result, expected)
 
 
+# todo
 @pytest.mark.parametrize(
     "data",
     [

--- a/python/cudf/cudf/tests/test_setitem.py
+++ b/python/cudf/cudf/tests/test_setitem.py
@@ -137,6 +137,7 @@ def test_setitem_dataframe_series_inplace(index):
     assert_eq(expected, gdf)
 
 
+# todo
 @pytest.mark.parametrize(
     "replace_data",
     [

--- a/python/cudf/cudf/tests/test_stats.py
+++ b/python/cudf/cudf/tests/test_stats.py
@@ -280,6 +280,7 @@ def test_kurt_skew_error(op):
     )
 
 
+# todo
 @pytest.mark.parametrize(
     "data",
     [
@@ -344,6 +345,7 @@ def test_series_median(dtype, num_na):
     PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
     reason="warning not present in older pandas versions",
 )
+# todo
 @pytest.mark.parametrize(
     "data",
     [
@@ -379,6 +381,7 @@ def test_series_pct_change(data, periods, fill_method):
         )
 
 
+# todo
 @pytest.mark.parametrize(
     "data1",
     [
@@ -393,6 +396,7 @@ def test_series_pct_change(data, periods, fill_method):
         cudf.Series([-3]),
     ],
 )
+# todo
 @pytest.mark.parametrize(
     "data2",
     [
@@ -423,6 +427,7 @@ def test_cov1d(data1, data2):
     np.testing.assert_approx_equal(got, expected, significant=8)
 
 
+# todo
 @pytest.mark.parametrize(
     "data1",
     [
@@ -437,6 +442,7 @@ def test_cov1d(data1, data2):
         cudf.Series([-3]),
     ],
 )
+# todo
 @pytest.mark.parametrize(
     "data2",
     [

--- a/python/cudf/cudf/tests/test_string.py
+++ b/python/cudf/cudf/tests/test_string.py
@@ -3341,6 +3341,7 @@ def test_str_join_lists_error():
         sr.str.join(sep=cudf.DataFrame())
 
 
+# todo
 @pytest.mark.parametrize(
     "sr,sep,string_na_rep,sep_na_rep,expected",
     [
@@ -3411,6 +3412,7 @@ def test_str_join_lists(sr, sep, string_na_rep, sep_na_rep, expected):
     assert_eq(actual, expected)
 
 
+# todo
 @pytest.mark.parametrize(
     "patterns, expected",
     [

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -1051,6 +1051,7 @@ def test_timedelta_fillna(data, dtype, fill_value):
     assert_eq(expected, actual)
 
 
+# todo
 @pytest.mark.parametrize(
     "gsr,expected_series",
     [

--- a/python/cudf/cudf/tests/test_udf_masked_ops.py
+++ b/python/cudf/cudf/tests/test_udf_masked_ops.py
@@ -651,6 +651,7 @@ def test_masked_udf_subset_selection(data):
     run_masked_udf_test(func, data)
 
 
+# todo
 @pytest.mark.parametrize(
     "unsupported_col",
     [

--- a/python/dask_cudf/dask_cudf/tests/test_dispatch.py
+++ b/python/dask_cudf/dask_cudf/tests/test_dispatch.py
@@ -25,6 +25,7 @@ def test_is_categorical_dispatch():
 
 
 @pytest.mark.parametrize("preserve_index", [True, False])
+# todo
 @pytest.mark.parametrize("index", [None, cudf.RangeIndex(10, name="foo")])
 def test_pyarrow_conversion_dispatch(preserve_index, index):
     from dask.dataframe.dispatch import (


### PR DESCRIPTION
## Description
Closes #15651

GPU object instantiation within the parametrize arguments results in the test suite being slower to launch. We should refactor tests to prevent this.

This PR is based off https://github.com/rapidsai/cudf/commit/b5b91166a7cb8e865e4c989e0a67f930fe643d63

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
