### PR TITLE
Preserve DataFrame.columns RangeIndex and type after .select_dtypes

### DIFF
--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -517,12 +517,19 @@ class ColumnAccessor(abc.MutableMapping):
             )
         else:
             data = {k: self._grouped_data[k] for k in key}
+        is_rangeindex = False
         if self.multiindex:
             data = dict(_to_flat_dict_inner(data))
-        return self.__class__(
+        elif self.rangeindex:
+            # TODO: Any contiguous key of labels should return True
+            is_rangeindex = len(key) in {0, len(self)}
+        return type(self)(
             data,
             multiindex=self.multiindex,
             level_names=self.level_names,
+            rangeindex=is_rangeindex,
+            label_dtype=self.label_dtype,
+            verify=False,
         )
 
     def _select_by_label_grouped(self, key: Any) -> ColumnAccessor:

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -501,7 +501,6 @@ class _DataFrameIlocIndexer(_DataFrameIndexer):
                 ),
                 index=index,
             )
-
         else:
             frame = self._frame
         if isinstance(row_spec, indexing_utils.MapIndexer):

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -4725,7 +4725,19 @@ def test_dataframe_fillna_preserves_column_rangeindex():
     result = cudf.DataFrame([1, None], columns=range(1))
     result = result.fillna(2).columns
     expected = pd.RangeIndex(1)
-    assert_eq(result, expected)
+    pd.testing.assert_index_equal(result, expected, exact=True)
+
+
+@pytest.mark.parametrize("column", [range(1), np.array([1], dtype=np.int8)])
+def test_select_dtypes_preserves_column_dtypes(column):
+    df = cudf.DataFrame([1], columns=column)
+    result = df.select_dtypes(include="integer").columns
+    expected = pd.Index(column)
+    pd.testing.assert_index_equal(result, expected, exact=True)
+
+    result = df.select_dtypes(include="string").columns
+    expected = pd.Index(column)[:0]
+    pd.testing.assert_index_equal(result, expected, exact=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Previously `.select_dtypes` created an empty `DataFrame` and added columns one-by-one, losing column metadata information like `RangeIndex` or the `dtype`.

Now `.select_dtypes` just calls `loc` after the columns locations are identified

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
