### PR TITLE
Make Series/Index.is_monotonic_*/is_unique consistently cached properties

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -110,8 +110,8 @@ class BaseIndex(Serializable):
     def empty(self):
         return self.size == 0
 
-    @property
-    def is_unique(self):
+    @cached_property
+    def is_unique(self) -> bool:
         """Return if the index has unique values."""
         raise NotImplementedError
 
@@ -368,8 +368,8 @@ class BaseIndex(Serializable):
         """
         raise NotImplementedError
 
-    @property
-    def is_monotonic_increasing(self):
+    @cached_property
+    def is_monotonic_increasing(self) -> bool:
         """Return boolean if values in the object are monotonically increasing.
 
         Returns
@@ -378,8 +378,8 @@ class BaseIndex(Serializable):
         """
         raise NotImplementedError
 
-    @property
-    def is_monotonic_decreasing(self):
+    @cached_property
+    def is_monotonic_decreasing(self) -> bool:
         """Return boolean if values in the object are monotonically decreasing.
 
         Returns

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1449,7 +1449,7 @@ class Frame(BinaryOperand, Scannable):
         )
 
     @_cudf_nvtx_annotate
-    def _is_sorted(self, ascending=None, null_position=None):
+    def _is_sorted(self, ascending=None, null_position=None) -> bool:
         """
         Returns a boolean indicating whether the data of the Frame are sorted
         based on the parameters given. Does not account for the index.

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -511,14 +511,14 @@ class RangeIndex(BaseIndex, BinaryOperand):
     def is_unique(self) -> bool:
         return True
 
-    @cached_property  # type: ignore
+    @cached_property
     @_cudf_nvtx_annotate
     def is_monotonic_increasing(self) -> bool:
         return self.step > 0 or len(self) <= 1
 
-    @cached_property  # type: ignore
+    @cached_property
     @_cudf_nvtx_annotate
-    def is_monotonic_decreasing(self):
+    def is_monotonic_decreasing(self) -> bool:
         return self.step < 0 or len(self) <= 1
 
     @_cudf_nvtx_annotate
@@ -1066,14 +1066,6 @@ class Index(SingleColumnFrame, BaseIndex, metaclass=IndexMeta):
             # Try interpreting object as a MultiIndex before failing.
             return cudf.MultiIndex.from_arrow(obj)
 
-    @cached_property
-    def is_monotonic_increasing(self):
-        return super().is_monotonic_increasing
-
-    @cached_property
-    def is_monotonic_decreasing(self):
-        return super().is_monotonic_decreasing
-
     def _binaryop(
         self,
         other: Frame,
@@ -1173,9 +1165,9 @@ class Index(SingleColumnFrame, BaseIndex, metaclass=IndexMeta):
     def memory_usage(self, deep=False):
         return self._column.memory_usage
 
-    @cached_property  # type: ignore
+    @cached_property
     @_cudf_nvtx_annotate
-    def is_unique(self):
+    def is_unique(self) -> bool:
         return self._column.is_unique
 
     @_cudf_nvtx_annotate

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1626,27 +1626,27 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
             levels=levels, codes=multiindex.codes, names=multiindex.names
         )
 
-    @cached_property  # type: ignore
+    @cached_property
     @_cudf_nvtx_annotate
-    def is_unique(self):
+    def is_unique(self) -> bool:
         return len(self) == len(self.unique())
 
     @property
     def dtype(self):
         return np.dtype("O")
 
-    @cached_property  # type: ignore
+    @cached_property
     @_cudf_nvtx_annotate
-    def is_monotonic_increasing(self):
+    def is_monotonic_increasing(self) -> bool:
         """
         Return if the index is monotonic increasing
         (only equal or increasing) values.
         """
         return self._is_sorted(ascending=None, null_position=None)
 
-    @cached_property  # type: ignore
+    @cached_property
     @_cudf_nvtx_annotate
-    def is_monotonic_decreasing(self):
+    def is_monotonic_decreasing(self) -> bool:
         """
         Return if the index is monotonic decreasing
         (only equal or decreasing) values.

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -733,9 +733,9 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
             result = cls(s, nan_as_null=nan_as_null)
         return result
 
-    @property  # type: ignore
+    @functools.cached_property
     @_cudf_nvtx_annotate
-    def is_unique(self):
+    def is_unique(self) -> bool:
         """Return boolean if values in the object are unique.
 
         Returns

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from functools import cached_property
 from typing import Any, Dict, Optional, Tuple, Union
 
 import cupy
@@ -194,9 +195,9 @@ class SingleColumnFrame(Frame, NotIterable):
         """
         return self._column.to_arrow()
 
-    @property  # type: ignore
+    @cached_property
     @_cudf_nvtx_annotate
-    def is_unique(self):
+    def is_unique(self) -> bool:
         """Return boolean if values in the object are unique.
 
         Returns
@@ -205,9 +206,9 @@ class SingleColumnFrame(Frame, NotIterable):
         """
         return self._column.is_unique
 
-    @property  # type: ignore
+    @cached_property
     @_cudf_nvtx_annotate
-    def is_monotonic_increasing(self):
+    def is_monotonic_increasing(self) -> bool:
         """Return boolean if values in the object are monotonically increasing.
 
         Returns
@@ -216,9 +217,9 @@ class SingleColumnFrame(Frame, NotIterable):
         """
         return self._column.is_monotonic_increasing
 
-    @property  # type: ignore
+    @cached_property
     @_cudf_nvtx_annotate
-    def is_monotonic_decreasing(self):
+    def is_monotonic_decreasing(self) -> bool:
         """Return boolean if values in the object are monotonically decreasing.
 
         Returns


### PR DESCRIPTION
## Description
ref https://github.com/rapidsai/cudf/issues/5695

Appears `is_monotonic_*`, `is_unique` was sometimes cached and sometimes not. For consistency, these might as well always be `cached_properties`.

There's an argument that the `Column` version should also be cached, but that could be a follow up

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
