### PR TITLE
Fix dask-cudf `isin` support

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1951,6 +1951,7 @@ def as_column(
                 "string",
                 "empty",
                 "boolean",
+                "integer",
             ):
                 raise TypeError(
                     f"Cannot convert a {inferred_dtype} of object type"

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -1724,6 +1724,7 @@ def test_series_truncate_datetimeindex():
     "values",
     [
         np.random.randint(-100, 100, 10),
+        np.fromiter([12, 14, None, 100], dtype=object),
         [],
         [np.nan, None, -1, 2, 3],
         [1.0, 12.0, None, None, 120],

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -971,3 +971,13 @@ def test_implicit_array_conversion_cupy_sparse():
     # NOTE: The calculation here doesn't need to make sense.
     # We just need to make sure we get the right type back.
     assert type(result) == type(expect)
+
+
+def test_isin():
+    ser = cudf.Series([1, 2, 3])
+    ds = dd.from_pandas(ser, npartitions=1)
+    values = [1, 5]
+    dd.assert_eq(
+        ser.isin(values),
+        ds.isin(values),
+    )


### PR DESCRIPTION
## Description
Updates `as_column` to handle an inferred "integer" dtype from an "object" array.
This pattern is currently required for `isin` support in dask.

Closes https://github.com/rapidsai/cudf/issues/15768

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
