### PR TITLE
Limit runtime dependency to `libarrow>=16.0.0,<16.1.0a0`

### DIFF
--- a/conda/recipes/libcudf/meta.yaml
+++ b/conda/recipes/libcudf/meta.yaml
@@ -86,6 +86,9 @@ outputs:
         {% else %}
         - {{ compiler('cuda') }}
         {% endif %}
+        # TODO: start taking libarrow's run exports again wwhen they're correct for 16.0
+        # ref: https://github.com/conda-forge/arrow-cpp-feedstock/issues/1418
+        - libarrow
     requirements:
       build:
         - cmake {{ cmake_version }}
@@ -105,6 +108,12 @@ outputs:
         - librmm ={{ minor_version }}
         - libkvikio ={{ minor_version }}
         - dlpack {{ dlpack_version }}
+        # TODO: start taking libarrow's run exports again wwhen they're correct for 16.0
+        # ref: https://github.com/conda-forge/arrow-cpp-feedstock/issues/1418
+        - libarrow>=16.0.0,<16.1.0a0
+        - libarrow-acero>=16.0.0,<16.1.0a0
+        - libarrow-dataset>=16.0.0,<16.1.0a0
+        - libparquet>=16.0.0,<16.1.0a0
     test:
       commands:
         - test -f $PREFIX/lib/libcudf.so

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -341,10 +341,10 @@ dependencies:
       - output_types: conda
         packages:
           # Allow runtime version to float up to minor version
-          - libarrow-acero>=16.0.0,<17.0.0a0
-          - libarrow-dataset>=16.0.0,<17.0.0a0
-          - libarrow>=16.0.0,<17.0.0a0
-          - libparquet>=16.0.0,<17.0.0a0
+          - libarrow-acero>=16.0.0,<16.1.0a0
+          - libarrow-dataset>=16.0.0,<16.1.0a0
+          - libarrow>=16.0.0,<16.1.0a0
+          - libparquet>=16.0.0,<16.1.0a0
   pyarrow_run:
     common:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
Fix `libarrow` runtime dependency which is currently broken due to the release of `libarrow=16.1.0`:

```python
$ python -c "import cudf"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/conda/envs/rapids/lib/python3.10/site-packages/cudf/__init__.py", line 9, in <module>
    _setup_numba()
  File "/opt/conda/envs/rapids/lib/python3.10/site-packages/cudf/utils/_numba.py", line 124, in _setup_numba
    _get_cc_60_ptx_file()
  File "/opt/conda/envs/rapids/lib/python3.10/site-packages/cudf/utils/_numba.py", line 16, in _get_cc_60_ptx_file
    from cudf._lib import strings_udf
  File "/opt/conda/envs/rapids/lib/python3.10/site-packages/cudf/_lib/__init__.py", line 4, in <module>
    from . import (
ImportError: libarrow.so.1600: cannot open shared object file: No such file or directory
```