### PR TITLE
Don't require a full cython import to find PTX file

### DIFF
--- a/python/cudf/cudf/utils/_numba.py
+++ b/python/cudf/cudf/utils/_numba.py
@@ -3,15 +3,10 @@
 import glob
 import os
 import sys
-from functools import lru_cache
 
 from numba import config as numba_config
 
 
-# Use an lru_cache with a single value to allow a delayed import of
-# strings_udf. This is the easiest way to break an otherwise circular import
-# loop of _lib.*->cudautils->_numba->_lib.strings_udf
-@lru_cache
 def _get_cc_60_ptx_file():
     here = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(

--- a/python/cudf/cudf/utils/_numba.py
+++ b/python/cudf/cudf/utils/_numba.py
@@ -8,10 +8,9 @@ from numba import config as numba_config
 
 
 def _get_cc_60_ptx_file():
-    here = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(
-        here,
-        "../",
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
         "core",
         "udf",
         "shim_60.ptx",

--- a/python/cudf/cudf/utils/_numba.py
+++ b/python/cudf/cudf/utils/_numba.py
@@ -13,11 +13,10 @@ from numba import config as numba_config
 # loop of _lib.*->cudautils->_numba->_lib.strings_udf
 @lru_cache
 def _get_cc_60_ptx_file():
-    from cudf._lib import strings_udf
-
+    here = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(
-        os.path.dirname(strings_udf.__file__),
-        "..",
+        here,
+        "../",
         "core",
         "udf",
         "shim_60.ptx",


### PR DESCRIPTION
We shouldn't need to do a [full import of the cudf cython](https://github.com/rapidsai/cudf/blob/branch-24.06/python/cudf/cudf/utils/_numba.py#L16) for the purposes of computing a relative path. It leads to awkward import errors when things go wrong that are misleading as to what cuDF is trying to actually do. Here I've deliberately removed the arrow lib to cause an error. 

```
>>> import cudf
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/raid/brmiller/mambaforge/envs/cudf_dev/lib/python3.11/site-packages/cudf/__init__.py", line 9, in <module>
    _setup_numba()
  File "/raid/brmiller/mambaforge/envs/cudf_dev/lib/python3.11/site-packages/cudf/utils/_numba.py", line 124, in _setup_numba
    _get_cc_60_ptx_file()
  File "/raid/brmiller/mambaforge/envs/cudf_dev/lib/python3.11/site-packages/cudf/utils/_numba.py", line 16, in _get_cc_60_ptx_file
    from cudf._lib import strings_udf
  File "/raid/brmiller/mambaforge/envs/cudf_dev/lib/python3.11/site-packages/cudf/_lib/__init__.py", line 4, in <module>
    from . import (
ImportError: libarrow.so.1600: cannot open shared object file: No such file or directory
```

It also convolutes the purpose and effects of `_setup_numba`, which should aspire to configure numba independently of cuDF, and limits our ability to customize when and how we're importing the cython in cudf's main  `__init__`.

With this PR, the error will now be:

```
>>> import cudf
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/raid/brmiller/mambaforge/envs/cudf_dev/lib/python3.11/site-packages/cudf/__init__.py", line 19, in <module>
    from cudf import api, core, datasets, testing
  File "/raid/brmiller/mambaforge/envs/cudf_dev/lib/python3.11/site-packages/cudf/api/__init__.py", line 3, in <module>
    from cudf.api import extensions, types
  File "/raid/brmiller/mambaforge/envs/cudf_dev/lib/python3.11/site-packages/cudf/api/types.py", line 20, in <module>
    from cudf.core.dtypes import (  # noqa: F401
  File "/raid/brmiller/mambaforge/envs/cudf_dev/lib/python3.11/site-packages/cudf/core/dtypes.py", line 13, in <module>
    import pyarrow as pa
  File "/raid/brmiller/mambaforge/envs/cudf_dev/lib/python3.11/site-packages/pyarrow/__init__.py", line 65, in <module>
    import pyarrow.lib as _lib
ImportError: libarrow.so.1600: cannot open shared object file: No such file or directory
```
Which feels a bit more natural and easy to diagnose as something being wrong with arrow. 

