### PR TITLE
Return boolean from config_host_memory_resource instead of throwing

### DIFF
--- a/cpp/include/cudf/io/memory_resource.hpp
+++ b/cpp/include/cudf/io/memory_resource.hpp
@@ -47,7 +47,7 @@ struct host_mr_options {
  * @return The previous resource that was in use
  */
 rmm::host_async_resource_ref set_host_memory_resource(
-  rmm::host_async_resource_ref mr, std::optional<host_mr_options> const& default_opts = nullopt);
+  rmm::host_async_resource_ref mr, std::optional<host_mr_options> const& default_opts = std::nullopt);
 
 /**
  * @brief Get the rmm resource being used for host memory allocations by
@@ -61,6 +61,6 @@ rmm::host_async_resource_ref set_host_memory_resource(
  * @return The rmm resource used for host-side allocations
  */
 rmm::host_async_resource_ref get_host_memory_resource(
-  std::optional<host_mr_options> const& default_opts = nullopt);
+  std::optional<host_mr_options> const& default_opts = std::nullopt);
 
 }  // namespace cudf::io

--- a/cpp/include/cudf/io/memory_resource.hpp
+++ b/cpp/include/cudf/io/memory_resource.hpp
@@ -23,27 +23,6 @@
 namespace cudf::io {
 
 /**
- * @brief Set the rmm resource to be used for host memory allocations by
- * cudf::detail::hostdevice_vector
- *
- * hostdevice_vector is a utility class that uses a pair of host and device-side buffers for
- * bouncing state between the cpu and the gpu. The resource set with this function (typically a
- * pinned memory allocator) is what it uses to allocate space for it's host-side buffer.
- *
- * @param mr The rmm resource to be used for host-side allocations
- * @return The previous resource that was in use
- */
-rmm::host_async_resource_ref set_host_memory_resource(rmm::host_async_resource_ref mr);
-
-/**
- * @brief Get the rmm resource being used for host memory allocations by
- * cudf::detail::hostdevice_vector
- *
- * @return The rmm resource used for host-side allocations
- */
-rmm::host_async_resource_ref get_host_memory_resource();
-
-/**
  * @brief Options to configure the default host memory resource
  */
 struct host_mr_options {
@@ -52,12 +31,36 @@ struct host_mr_options {
 };
 
 /**
- * @brief Configure the size of the default host memory resource.
+ * @brief Set the rmm resource to be used for host memory allocations by
+ * cudf::detail::hostdevice_vector
  *
- * @throws cudf::logic_error if called after the default host memory resource has been created
+ * hostdevice_vector is a utility class that uses a pair of host and device-side buffers for
+ * bouncing state between the cpu and the gpu. The resource set with this function (typically a
+ * pinned memory allocator) is what it uses to allocate space for it's host-side buffer.
  *
- * @param opts Options to configure the default host memory resource
+ * The default_opts parameter allows the caller to customize the default host memory resource
+ * if it hasn't been configured already, otherwise the argument is ignored.
+ * Omitting this argument (nullopt) means cuDF will use defaults to initialize a host pinned pool.
+ *
+ * @param mr The rmm resource to be used for host-side allocations
+ * @param default_opts Options to configure the default host memory resource
+ * @return The previous resource that was in use
  */
-void config_default_host_memory_resource(host_mr_options const& opts);
+rmm::host_async_resource_ref set_host_memory_resource(
+  rmm::host_async_resource_ref mr, std::optional<host_mr_options> const& default_opts = nullopt);
+
+/**
+ * @brief Get the rmm resource being used for host memory allocations by
+ * cudf::detail::hostdevice_vector
+ *
+ * The default_opts parameter allows the caller to customize the default host memory resource
+ * if it hasn't been configured already, otherwise the argument is ignored.
+ * Omitting this argument (nullopt) means cuDF will use defaults to initialize a host pinned pool.
+ *
+ * @param default_opts Options to configure the default host memory resource
+ * @return The rmm resource used for host-side allocations
+ */
+rmm::host_async_resource_ref get_host_memory_resource(
+  std::optional<host_mr_options> const& default_opts = nullopt);
 
 }  // namespace cudf::io

--- a/cpp/include/cudf/io/memory_resource.hpp
+++ b/cpp/include/cudf/io/memory_resource.hpp
@@ -57,6 +57,8 @@ struct host_mr_options {
  * @throws cudf::logic_error if called after the default host memory resource has been created
  *
  * @param opts Options to configure the default host memory resource
+ * @return True if this call successfully configured the host memory resource, false if a
+ * a resource was already configured.
  */
 bool config_default_host_memory_resource(host_mr_options const& opts);
 

--- a/cpp/include/cudf/io/memory_resource.hpp
+++ b/cpp/include/cudf/io/memory_resource.hpp
@@ -47,7 +47,8 @@ struct host_mr_options {
  * @return The previous resource that was in use
  */
 rmm::host_async_resource_ref set_host_memory_resource(
-  rmm::host_async_resource_ref mr, std::optional<host_mr_options> const& default_opts = std::nullopt);
+  rmm::host_async_resource_ref mr,
+  std::optional<host_mr_options> const& default_opts = std::nullopt);
 
 /**
  * @brief Get the rmm resource being used for host memory allocations by

--- a/cpp/include/cudf/io/memory_resource.hpp
+++ b/cpp/include/cudf/io/memory_resource.hpp
@@ -23,6 +23,27 @@
 namespace cudf::io {
 
 /**
+ * @brief Set the rmm resource to be used for host memory allocations by
+ * cudf::detail::hostdevice_vector
+ *
+ * hostdevice_vector is a utility class that uses a pair of host and device-side buffers for
+ * bouncing state between the cpu and the gpu. The resource set with this function (typically a
+ * pinned memory allocator) is what it uses to allocate space for it's host-side buffer.
+ *
+ * @param mr The rmm resource to be used for host-side allocations
+ * @return The previous resource that was in use
+ */
+rmm::host_async_resource_ref set_host_memory_resource(rmm::host_async_resource_ref mr);
+
+/**
+ * @brief Get the rmm resource being used for host memory allocations by
+ * cudf::detail::hostdevice_vector
+ *
+ * @return The rmm resource used for host-side allocations
+ */
+rmm::host_async_resource_ref get_host_memory_resource();
+
+/**
  * @brief Options to configure the default host memory resource
  */
 struct host_mr_options {
@@ -31,37 +52,12 @@ struct host_mr_options {
 };
 
 /**
- * @brief Set the rmm resource to be used for host memory allocations by
- * cudf::detail::hostdevice_vector
+ * @brief Configure the size of the default host memory resource.
  *
- * hostdevice_vector is a utility class that uses a pair of host and device-side buffers for
- * bouncing state between the cpu and the gpu. The resource set with this function (typically a
- * pinned memory allocator) is what it uses to allocate space for it's host-side buffer.
+ * @throws cudf::logic_error if called after the default host memory resource has been created
  *
- * The default_opts parameter allows the caller to customize the default host memory resource
- * if it hasn't been configured already, otherwise the argument is ignored.
- * Omitting this argument (nullopt) means cuDF will use defaults to initialize a host pinned pool.
- *
- * @param mr The rmm resource to be used for host-side allocations
- * @param default_opts Options to configure the default host memory resource
- * @return The previous resource that was in use
+ * @param opts Options to configure the default host memory resource
  */
-rmm::host_async_resource_ref set_host_memory_resource(
-  rmm::host_async_resource_ref mr,
-  std::optional<host_mr_options> const& default_opts = std::nullopt);
-
-/**
- * @brief Get the rmm resource being used for host memory allocations by
- * cudf::detail::hostdevice_vector
- *
- * The default_opts parameter allows the caller to customize the default host memory resource
- * if it hasn't been configured already, otherwise the argument is ignored.
- * Omitting this argument (nullopt) means cuDF will use defaults to initialize a host pinned pool.
- *
- * @param default_opts Options to configure the default host memory resource
- * @return The rmm resource used for host-side allocations
- */
-rmm::host_async_resource_ref get_host_memory_resource(
-  std::optional<host_mr_options> const& default_opts = std::nullopt);
+bool config_default_host_memory_resource(host_mr_options const& opts);
 
 }  // namespace cudf::io

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -257,7 +257,7 @@ rmm::host_async_resource_ref set_host_memory_resource(
 {
   std::scoped_lock lock{host_mr_mutex()};
   auto last_mr = host_mr(default_opts);
-  host_mr()    = mr;
+  host_mr(std::nullopt)    = mr;
   return last_mr;
 }
 

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -244,8 +244,8 @@ CUDF_EXPORT std::mutex& host_mr_mutex()
 }
 
 // Must be called with the host_mr_mutex mutex held
-CUDF_EXPORT std::pair<rmm::host_async_resource_ref*, bool> make_host_mr(
-  std::optional<host_mr_options> const& opts)
+CUDF_EXPORT rmm::host_async_resource_ref& make_host_mr(std::optional<host_mr_options> const& opts,
+                                                       bool* did_configure = nullptr)
 {
   static rmm::host_async_resource_ref* mr_ref = nullptr;
   bool configured                             = false;
@@ -253,13 +253,18 @@ CUDF_EXPORT std::pair<rmm::host_async_resource_ref*, bool> make_host_mr(
     configured = true;
     mr_ref     = &make_default_pinned_mr(opts ? opts->pool_size : std::nullopt);
   }
-  return std::make_pair(mr_ref, configured);
+
+  // If the user passed an out param to detect whether this call configured a resource
+  // set the result
+  if (did_configure != nullptr) { *did_configure = configured; }
+
+  return *mr_ref;
 }
 
 // Must be called with the host_mr_mutex mutex held
 CUDF_EXPORT rmm::host_async_resource_ref& host_mr()
 {
-  static rmm::host_async_resource_ref mr_ref = *std::get<0>(make_host_mr(std::nullopt));
+  static rmm::host_async_resource_ref mr_ref = make_host_mr(std::nullopt);
   return mr_ref;
 }
 
@@ -280,8 +285,9 @@ rmm::host_async_resource_ref get_host_memory_resource()
 bool config_default_host_memory_resource(host_mr_options const& opts)
 {
   std::scoped_lock lock{host_mr_mutex()};
-  auto configured = std::get<1>(make_host_mr(opts));
-  return configured;
+  auto did_configure = false;
+  make_host_mr(opts, &did_configure);
+  return did_configure;
 }
 
 }  // namespace cudf::io

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -209,7 +209,7 @@ static_assert(cuda::mr::resource_with<fixed_pinned_pool_memory_resource,
 
 }  // namespace
 
-CUDF_EXPORT rmm::host_async_resource_ref make_default_pinned_mr(std::optional<size_t> config_size)
+CUDF_EXPORT rmm::host_async_resource_ref& make_default_pinned_mr(std::optional<size_t> config_size)
 {
   static fixed_pinned_pool_memory_resource mr = [config_size]() {
     auto const size = [&config_size]() -> size_t {
@@ -244,28 +244,51 @@ CUDF_EXPORT std::mutex& host_mr_mutex()
 }
 
 // Must be called with the host_mr_mutex mutex held
-CUDF_EXPORT rmm::host_async_resource_ref& host_mr(
-  std::optional<host_mr_options> const& default_opts)
+CUDF_EXPORT rmm::host_async_resource_ref& make_host_mr(std::optional<host_mr_options> const& opts, bool* did_configure = nullptr)
 {
-  static rmm::host_async_resource_ref mr_ref =
-    make_default_pinned_mr(default_opts ? default_opts->pool_size : std::nullopt);
+  static rmm::host_async_resource_ref* mr_ref = nullptr;
+  bool configured = false;
+  if (mr_ref == nullptr) {
+    configured = true;
+    mr_ref = &make_default_pinned_mr(opts ? opts->pool_size : std::nullopt);
+  }
+
+  // If the user passed an out param to detect whether this call configured a resource
+  // set the result
+  if (did_configure != nullptr) {
+    *did_configure = configured;
+  }
+
+  return *mr_ref;
+}
+
+// Must be called with the host_mr_mutex mutex held
+CUDF_EXPORT rmm::host_async_resource_ref& host_mr()
+{
+  static rmm::host_async_resource_ref mr_ref = make_host_mr(std::nullopt);
   return mr_ref;
 }
 
-rmm::host_async_resource_ref set_host_memory_resource(
-  rmm::host_async_resource_ref mr, std::optional<host_mr_options> const& default_opts)
+rmm::host_async_resource_ref set_host_memory_resource(rmm::host_async_resource_ref mr)
 {
   std::scoped_lock lock{host_mr_mutex()};
-  auto last_mr          = host_mr(default_opts);
-  host_mr(std::nullopt) = mr;
+  auto last_mr = host_mr();
+  host_mr()    = mr;
   return last_mr;
 }
 
-rmm::host_async_resource_ref get_host_memory_resource(
-  std::optional<host_mr_options> const& default_opts)
+rmm::host_async_resource_ref get_host_memory_resource()
 {
   std::scoped_lock lock{host_mr_mutex()};
-  return host_mr(default_opts);
+  return host_mr();
+}
+
+bool config_default_host_memory_resource(host_mr_options const& opts)
+{
+  std::scoped_lock lock{host_mr_mutex()};
+  auto did_configure = false;
+  make_host_mr(opts, &did_configure);
+  return did_configure;
 }
 
 }  // namespace cudf::io

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -244,20 +244,19 @@ CUDF_EXPORT std::mutex& host_mr_mutex()
 }
 
 // Must be called with the host_mr_mutex mutex held
-CUDF_EXPORT rmm::host_async_resource_ref& make_host_mr(std::optional<host_mr_options> const& opts, bool* did_configure = nullptr)
+CUDF_EXPORT rmm::host_async_resource_ref& make_host_mr(std::optional<host_mr_options> const& opts,
+                                                       bool* did_configure = nullptr)
 {
   static rmm::host_async_resource_ref* mr_ref = nullptr;
-  bool configured = false;
+  bool configured                             = false;
   if (mr_ref == nullptr) {
     configured = true;
-    mr_ref = &make_default_pinned_mr(opts ? opts->pool_size : std::nullopt);
+    mr_ref     = &make_default_pinned_mr(opts ? opts->pool_size : std::nullopt);
   }
 
   // If the user passed an out param to detect whether this call configured a resource
   // set the result
-  if (did_configure != nullptr) {
-    *did_configure = configured;
-  }
+  if (did_configure != nullptr) { *did_configure = configured; }
 
   return *mr_ref;
 }

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -256,8 +256,8 @@ rmm::host_async_resource_ref set_host_memory_resource(
   rmm::host_async_resource_ref mr, std::optional<host_mr_options> const& default_opts)
 {
   std::scoped_lock lock{host_mr_mutex()};
-  auto last_mr = host_mr(default_opts);
-  host_mr(std::nullopt)    = mr;
+  auto last_mr          = host_mr(default_opts);
+  host_mr(std::nullopt) = mr;
   return last_mr;
 }
 

--- a/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
+++ b/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
@@ -252,4 +252,17 @@ public final class PinnedMemoryPool implements AutoCloseable {
   private synchronized void free(long address, long size) {
     Rmm.freeFromPinnedPool(this.poolHandle, address, size);
   }
+
+  /**
+   * Sets the size of the cuDF default pinned pool.
+   *
+   * @note This has to be called before cuDF functions are executed.
+   *
+   * @param size initial and maximum size for the cuDF default pinned pool.
+   *        Pass size=0 to disable the default pool.
+   */
+  public static synchronized void configureDefaultCudfPinnedPoolSize(long size) {
+    Rmm.configureDefaultCudfPinnedPoolSize(size);
+  }
+
 }

--- a/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
+++ b/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
@@ -260,9 +260,12 @@ public final class PinnedMemoryPool implements AutoCloseable {
    *
    * @param size initial and maximum size for the cuDF default pinned pool.
    *        Pass size=0 to disable the default pool.
+   * 
+   * @return true if we were able to setup the default resource, false if there was
+   *         a resource already set.
    */
-  public static synchronized void configureDefaultCudfPinnedPoolSize(long size) {
-    Rmm.configureDefaultCudfPinnedPoolSize(size);
+  public static synchronized boolean configureDefaultCudfPinnedPoolSize(long size) {
+    return Rmm.configureDefaultCudfPinnedPoolSize(size);
   }
 
 }

--- a/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
+++ b/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
@@ -260,7 +260,7 @@ public final class PinnedMemoryPool implements AutoCloseable {
    *
    * @param size initial and maximum size for the cuDF default pinned pool.
    *        Pass size=0 to disable the default pool.
-   * 
+   *
    * @return true if we were able to setup the default resource, false if there was
    *         a resource already set.
    */

--- a/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
+++ b/java/src/main/java/ai/rapids/cudf/PinnedMemoryPool.java
@@ -252,17 +252,4 @@ public final class PinnedMemoryPool implements AutoCloseable {
   private synchronized void free(long address, long size) {
     Rmm.freeFromPinnedPool(this.poolHandle, address, size);
   }
-
-  /**
-   * Sets the size of the cuDF default pinned pool.
-   *
-   * @note This has to be called before cuDF functions are executed.
-   *
-   * @param size initial and maximum size for the cuDF default pinned pool.
-   *        Pass size=0 to disable the default pool.
-   */
-  public static synchronized void configureDefaultCudfPinnedPoolSize(long size) {
-    Rmm.configureDefaultCudfPinnedPoolSize(size);
-  }
-
 }

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -267,6 +267,16 @@ public class Rmm {
   }
 
   /**
+   * Sets the size of the cuDF default pinned pool.
+   *
+   * @note This has to be called before cuDF functions are executed.
+   *
+   * @param size initial and maximum size for the cuDF default pinned pool.
+   *        Pass size=0 to disable the default pool.
+   */
+  public static synchronized native void configureDefaultCudfPinnedPoolSize(long size);
+
+  /**
    * Get the most recently set pool size or -1 if RMM has not been initialized or pooling is
    * not enabled.
    */

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -273,8 +273,11 @@ public class Rmm {
    *
    * @param size initial and maximum size for the cuDF default pinned pool.
    *        Pass size=0 to disable the default pool.
+   * 
+   * @return true if we were able to setup the default resource, false if there was
+   *         a resource already set.
    */
-  public static synchronized native void configureDefaultCudfPinnedPoolSize(long size);
+  public static synchronized native boolean configureDefaultCudfPinnedPoolSize(long size);
 
   /**
    * Get the most recently set pool size or -1 if RMM has not been initialized or pooling is

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -267,16 +267,6 @@ public class Rmm {
   }
 
   /**
-   * Sets the size of the cuDF default pinned pool.
-   *
-   * @note This has to be called before cuDF functions are executed.
-   *
-   * @param size initial and maximum size for the cuDF default pinned pool.
-   *        Pass size=0 to disable the default pool.
-   */
-  public static synchronized native void configureDefaultCudfPinnedPoolSize(long size);
-
-  /**
    * Get the most recently set pool size or -1 if RMM has not been initialized or pooling is
    * not enabled.
    */

--- a/java/src/main/java/ai/rapids/cudf/Rmm.java
+++ b/java/src/main/java/ai/rapids/cudf/Rmm.java
@@ -273,7 +273,7 @@ public class Rmm {
    *
    * @param size initial and maximum size for the cuDF default pinned pool.
    *        Pass size=0 to disable the default pool.
-   * 
+   *
    * @return true if we were able to setup the default resource, false if there was
    *         a resource already set.
    */

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -1108,4 +1108,15 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_freeFromFallbackPinnedPool(JNIEnv
   }
   CATCH_STD(env, )
 }
+
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_configureDefaultCudfPinnedPoolSize(JNIEnv* env,
+                                                                                  jclass clazz,
+                                                                                  jlong size)
+{
+  try {
+    cudf::jni::auto_set_device(env);
+    cudf::io::config_default_host_memory_resource(cudf::io::host_mr_options{size});
+  }
+  CATCH_STD(env, )
+}
 }

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -1106,15 +1106,4 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_freeFromFallbackPinnedPool(JNIEnv
   }
   CATCH_STD(env, )
 }
-
-JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_configureDefaultCudfPinnedPoolSize(JNIEnv* env,
-                                                                                  jclass clazz,
-                                                                                  jlong size)
-{
-  try {
-    cudf::jni::auto_set_device(env);
-    cudf::io::config_default_host_memory_resource(cudf::io::host_mr_options{size});
-  }
-  CATCH_STD(env, )
-}
 }

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -1036,7 +1036,9 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_setCuioPinnedPoolMemoryResource(J
     // if the regular pinned pool is exhausted
     pinned_fallback_mr.reset(new pinned_fallback_host_memory_resource(pool));
     // set the cuio host mr and store the prior resource in our static variable
-    prior_cuio_host_mr() = cudf::io::set_host_memory_resource(*pinned_fallback_mr);
+    // we pass host_mr_options{0} so we disable any default pinned pool creation from cuDF
+    prior_cuio_host_mr() =
+      cudf::io::set_host_memory_resource(*pinned_fallback_mr, cudf::io::host_mr_options{0});
   }
   CATCH_STD(env, )
 }

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -1035,10 +1035,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_setCuioPinnedPoolMemoryResource(J
     // create a pinned fallback pool that will allocate pinned memory
     // if the regular pinned pool is exhausted
     pinned_fallback_mr.reset(new pinned_fallback_host_memory_resource(pool));
-    // set the cuio host mr and store the prior resource in our static variable
-    // we pass host_mr_options{0} so we disable any default pinned pool creation from cuDF
-    prior_cuio_host_mr() =
-      cudf::io::set_host_memory_resource(*pinned_fallback_mr, cudf::io::host_mr_options{0});
+    prior_cuio_host_mr() = cudf::io::set_host_memory_resource(*pinned_fallback_mr);
   }
   CATCH_STD(env, )
 }
@@ -1109,14 +1106,14 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_freeFromFallbackPinnedPool(JNIEnv
   CATCH_STD(env, )
 }
 
-JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_configureDefaultCudfPinnedPoolSize(JNIEnv* env,
-                                                                                  jclass clazz,
-                                                                                  jlong size)
+JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Rmm_configureDefaultCudfPinnedPoolSize(JNIEnv* env,
+                                                                                      jclass clazz,
+                                                                                      jlong size)
 {
   try {
     cudf::jni::auto_set_device(env);
-    cudf::io::config_default_host_memory_resource(cudf::io::host_mr_options{size});
+    return cudf::io::config_default_host_memory_resource(cudf::io::host_mr_options{size});
   }
-  CATCH_STD(env, )
+  CATCH_STD(env, false)
 }
 }


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/15814

This adds a boolean return value from `cudf::io::config_host_memory_resource` to allow the caller to handle the case where the memory resource has already been configured in the past. Before this the function would throw, forcing callers to try/catch.