### PR TITLE
Ensure cudf.Series(cudf.Series(...)) creates a reference to the same index

### DIFF
--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -595,8 +595,10 @@ class Series(SingleColumnFrame, IndexedFrame, Serializable):
                 data = data.copy(deep=True)
             name_from_data = data.name
             column = as_column(data, nan_as_null=nan_as_null, dtype=dtype)
-            if isinstance(data, (pd.Series, Series)):
+            if isinstance(data, pd.Series):
                 index_from_data = as_index(data.index)
+            elif isinstance(data, Series):
+                index_from_data = data.index
         elif isinstance(data, ColumnAccessor):
             raise TypeError(
                 "Use cudf.Series._from_data for constructing a Series from "

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -2835,3 +2835,9 @@ def test_timedelta_series_init(data):
     actual = cudf.Series(scalar)
 
     assert_eq(expected, actual)
+
+
+def test_series_from_series_index_no_shallow_copy():
+    ser1 = cudf.Series(range(3), index=list("abc"))
+    ser2 = cudf.Series(ser1)
+    assert ser1.index is ser2.index


### PR DESCRIPTION
## Description

Aligns these behaviors

```python
In [1]: import pandas as pd

In [3]: ser1 = pd.Series(range(3), index=list("Abc"))

In [4]: ser2 = pd.Series(ser1)

In [5]: ser1.index is ser2.index
Out[5]: True

In [6]: import cudf

In [7]: ser1 = cudf.Series(range(3), index=list("Abc"))

In [8]: ser2 = cudf.Series(ser1)

In [9]: ser1.index is ser2.index
Out[9]: False
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
