### PR TITLE
Use offsetalator in strings shift functor

### DIFF
--- a/cpp/src/strings/copying/shift.cu
+++ b/cpp/src/strings/copying/shift.cu
@@ -67,9 +67,9 @@ struct shift_chars_fn {
     if (offset < 0) {
       auto const last_index = -offset;
       if (idx < last_index) {
-        auto const first_index =
-          offset + d_column.child(strings_column_view::offsets_column_index)
-                     .element<size_type>(d_column.offset() + d_column.size());
+        auto const offsets     = d_column.child(strings_column_view::offsets_column_index);
+        auto const off_itr     = cudf::detail::input_offsetalator(offsets.head(), offsets.type());
+        auto const first_index = offset + off_itr[d_column.offset() + d_column.size()];
         return d_column.head<char>()[idx + first_index];
       } else {
         auto const char_index = idx - last_index;
@@ -79,9 +79,9 @@ struct shift_chars_fn {
       if (idx < offset) {
         return d_filler.data()[idx % d_filler.size_bytes()];
       } else {
-        return d_column.head<char>()[idx - offset +
-                                     d_column.child(strings_column_view::offsets_column_index)
-                                       .element<size_type>(d_column.offset())];
+        auto const offsets = d_column.child(strings_column_view::offsets_column_index);
+        auto const off_itr = cudf::detail::input_offsetalator(offsets.head(), offsets.type());
+        return d_column.head<char>()[idx - offset + off_itr[d_column.offset()]];
       }
     }
   }


### PR DESCRIPTION
## Description
Replaces hardcoded `size_type` used for offset values in the `shift_chars_fn` functor with offsetalator.
Follow on to #15630 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
