### PR TITLE
Fix url-decode benchmark to use offsetalator

### DIFF
--- a/cpp/benchmarks/string/url_decode.cu
+++ b/cpp/benchmarks/string/url_decode.cu
@@ -20,6 +20,7 @@
 #include <cudf_test/column_wrapper.hpp>
 
 #include <cudf/column/column_view.hpp>
+#include <cudf/detail/offsets_iterator_factory.cuh>
 #include <cudf/filling.hpp>
 #include <cudf/strings/convert/convert_urls.hpp>
 #include <cudf/strings/strings_column_view.hpp>
@@ -43,7 +44,7 @@ struct url_string_generator {
   {
   }
 
-  __device__ void operator()(thrust::tuple<cudf::size_type, cudf::size_type> str_begin_end)
+  __device__ void operator()(thrust::tuple<int64_t, int64_t> str_begin_end)
   {
     auto begin = thrust::get<0>(str_begin_end);
     auto end   = thrust::get<1>(str_begin_end);
@@ -69,11 +70,11 @@ auto generate_column(cudf::size_type num_rows, cudf::size_type chars_per_row, do
   auto result_col = std::move(table_a->release()[0]);  // string column with num_rows  aaa...
   auto chars_data = static_cast<char*>(result_col->mutable_view().head());
   auto offset_col = result_col->child(cudf::strings_column_view::offsets_column_index).view();
+  auto offset_itr = cudf::detail::offsetalator_factory::make_input_iterator(offset_col);
 
   auto engine = thrust::default_random_engine{};
   thrust::for_each_n(thrust::device,
-                     thrust::make_zip_iterator(offset_col.begin<cudf::size_type>(),
-                                               offset_col.begin<cudf::size_type>() + 1),
+                     thrust::make_zip_iterator(offset_itr, offset_itr + 1),
                      num_rows,
                      url_string_generator{chars_data, esc_seq_chance, engine});
   return result_col;


### PR DESCRIPTION
## Description
Fixes the logic for generating URLs in the url-decoder benchmark to use the offsetalator instead of hardcoding `size_type`.
This will allow benchmarking with large strings column in the future.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
