### PR TITLE
Revert "Fix docs for IO readers and strings_convert"

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -46,11 +46,9 @@ pushd docs/cudf
 make dirhtml
 mkdir -p "${RAPIDS_DOCS_DIR}/cudf/html"
 mv build/dirhtml/* "${RAPIDS_DOCS_DIR}/cudf/html"
-if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]]; then
-  make text
-  mkdir -p "${RAPIDS_DOCS_DIR}/cudf/txt"
-  mv build/text/* "${RAPIDS_DOCS_DIR}/cudf/txt"
-fi
+make text
+mkdir -p "${RAPIDS_DOCS_DIR}/cudf/txt"
+mv build/text/* "${RAPIDS_DOCS_DIR}/cudf/txt"
 popd
 
 rapids-logger "Build dask-cuDF Sphinx docs"
@@ -58,11 +56,9 @@ pushd docs/dask_cudf
 make dirhtml
 mkdir -p "${RAPIDS_DOCS_DIR}/dask-cudf/html"
 mv build/dirhtml/* "${RAPIDS_DOCS_DIR}/dask-cudf/html"
-if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]]; then
-  make text
-  mkdir -p "${RAPIDS_DOCS_DIR}/dask-cudf/txt"
-  mv build/text/* "${RAPIDS_DOCS_DIR}/dask-cudf/txt"
-fi
+make text
+mkdir -p "${RAPIDS_DOCS_DIR}/dask-cudf/txt"
+mv build/text/* "${RAPIDS_DOCS_DIR}/dask-cudf/txt"
 popd
 
 rapids-upload-docs

--- a/docs/cudf/source/libcudf_docs/api_docs/io_readers.rst
+++ b/docs/cudf/source/libcudf_docs/api_docs/io_readers.rst
@@ -2,4 +2,4 @@ Io Readers
 ==========
 
 .. doxygengroup:: io_readers
-   :members:
+   :desc-only:

--- a/docs/cudf/source/libcudf_docs/api_docs/strings_convert.rst
+++ b/docs/cudf/source/libcudf_docs/api_docs/strings_convert.rst
@@ -2,4 +2,4 @@ Strings Convert
 ===============
 
 .. doxygengroup:: strings_convert
-   :members:
+   :desc-only:


### PR DESCRIPTION
Reverts rapidsai/cudf#15842

The files the original PR added documentation for appear to contain some text that is problematic for the Sphinx parser to extract from doxygen. My best guess is that it's something in a table, since parsing doxygen tables via Breathe is something I know can be tricky. We didn't catch this issue because [we currently only build the text docs in nightly builds, not PRs](https://github.com/rapidsai/cudf/blob/branch-24.08/ci/build_docs.sh#L49), and this issue only arises in those text builds. We can revisit adding these docs in 24.08. For the sake of correctness, I have added back building text docs in PRs in this PR (see #14856 for context on the removal).