### PR TITLE
Refactor join benchmarks to target public APIs with the default stream

### DIFF
--- a/cpp/benchmarks/join/distinct_join.cu
+++ b/cpp/benchmarks/join/distinct_join.cu
@@ -22,15 +22,14 @@ void distinct_inner_join(nvbench::state& state,
 {
   auto join = [](cudf::table_view const& build_input,
                  cudf::table_view const& probe_input,
-                 cudf::null_equality compare_nulls,
-                 rmm::cuda_stream_view stream) {
+                 cudf::null_equality compare_nulls) {
     auto const has_nulls =
       cudf::has_nested_nulls(build_input) || cudf::has_nested_nulls(probe_input)
         ? cudf::nullable_join::YES
         : cudf::nullable_join::NO;
     auto hj_obj = cudf::distinct_hash_join<cudf::has_nested::NO>{
-      build_input, probe_input, has_nulls, compare_nulls, stream};
-    return hj_obj.inner_join(stream);
+      build_input, probe_input, has_nulls, compare_nulls};
+    return hj_obj.inner_join();
   };
 
   BM_join<Key, Nullable>(state, join);
@@ -42,15 +41,14 @@ void distinct_left_join(nvbench::state& state,
 {
   auto join = [](cudf::table_view const& build_input,
                  cudf::table_view const& probe_input,
-                 cudf::null_equality compare_nulls,
-                 rmm::cuda_stream_view stream) {
+                 cudf::null_equality compare_nulls) {
     auto const has_nulls =
       cudf::has_nested_nulls(build_input) || cudf::has_nested_nulls(probe_input)
         ? cudf::nullable_join::YES
         : cudf::nullable_join::NO;
     auto hj_obj = cudf::distinct_hash_join<cudf::has_nested::NO>{
-      build_input, probe_input, has_nulls, compare_nulls, stream};
-    return hj_obj.left_join(stream);
+      build_input, probe_input, has_nulls, compare_nulls};
+    return hj_obj.left_join();
   };
 
   BM_join<Key, Nullable>(state, join);

--- a/cpp/benchmarks/join/distinct_join.cu
+++ b/cpp/benchmarks/join/distinct_join.cu
@@ -20,8 +20,8 @@ template <typename Key, bool Nullable>
 void distinct_inner_join(nvbench::state& state,
                          nvbench::type_list<Key, nvbench::enum_type<Nullable>>)
 {
-  auto join = [](cudf::table_view const& build_input,
-                 cudf::table_view const& probe_input,
+  auto join = [](cudf::table_view const& probe_input,
+                 cudf::table_view const& build_input,
                  cudf::null_equality compare_nulls) {
     auto const has_nulls =
       cudf::has_nested_nulls(build_input) || cudf::has_nested_nulls(probe_input)
@@ -39,8 +39,8 @@ template <typename Key, bool Nullable>
 void distinct_left_join(nvbench::state& state,
                         nvbench::type_list<Key, nvbench::enum_type<Nullable>>)
 {
-  auto join = [](cudf::table_view const& build_input,
-                 cudf::table_view const& probe_input,
+  auto join = [](cudf::table_view const& probe_input,
+                 cudf::table_view const& build_input,
                  cudf::null_equality compare_nulls) {
     auto const has_nulls =
       cudf::has_nested_nulls(build_input) || cudf::has_nested_nulls(probe_input)

--- a/cpp/benchmarks/join/join.cu
+++ b/cpp/benchmarks/join/join.cu
@@ -22,15 +22,9 @@ void nvbench_inner_join(nvbench::state& state,
 {
   auto join = [](cudf::table_view const& left_input,
                  cudf::table_view const& right_input,
-                 cudf::null_equality compare_nulls,
-                 rmm::cuda_stream_view stream) {
-    auto const has_nulls = cudf::has_nested_nulls(left_input) || cudf::has_nested_nulls(right_input)
-                             ? cudf::nullable_join::YES
-                             : cudf::nullable_join::NO;
-    cudf::hash_join hj_obj(left_input, has_nulls, compare_nulls, stream);
-    return hj_obj.inner_join(right_input, std::nullopt, stream);
+                 cudf::null_equality compare_nulls) {
+    return cudf::inner_join(left_input, right_input, compare_nulls);
   };
-
   BM_join<Key, Nullable>(state, join);
 }
 
@@ -39,15 +33,9 @@ void nvbench_left_join(nvbench::state& state, nvbench::type_list<Key, nvbench::e
 {
   auto join = [](cudf::table_view const& left_input,
                  cudf::table_view const& right_input,
-                 cudf::null_equality compare_nulls,
-                 rmm::cuda_stream_view stream) {
-    auto const has_nulls = cudf::has_nested_nulls(left_input) || cudf::has_nested_nulls(right_input)
-                             ? cudf::nullable_join::YES
-                             : cudf::nullable_join::NO;
-    cudf::hash_join hj_obj(left_input, has_nulls, compare_nulls, stream);
-    return hj_obj.left_join(right_input, std::nullopt, stream);
+                 cudf::null_equality compare_nulls) {
+    return cudf::left_join(left_input, right_input, compare_nulls);
   };
-
   BM_join<Key, Nullable>(state, join);
 }
 
@@ -56,15 +44,9 @@ void nvbench_full_join(nvbench::state& state, nvbench::type_list<Key, nvbench::e
 {
   auto join = [](cudf::table_view const& left_input,
                  cudf::table_view const& right_input,
-                 cudf::null_equality compare_nulls,
-                 rmm::cuda_stream_view stream) {
-    auto const has_nulls = cudf::has_nested_nulls(left_input) || cudf::has_nested_nulls(right_input)
-                             ? cudf::nullable_join::YES
-                             : cudf::nullable_join::NO;
-    cudf::hash_join hj_obj(left_input, has_nulls, compare_nulls, stream);
-    return hj_obj.full_join(right_input, std::nullopt, stream);
+                 cudf::null_equality compare_nulls) {
+    return cudf::full_join(left_input, right_input, compare_nulls);
   };
-
   BM_join<Key, Nullable>(state, join);
 }
 

--- a/cpp/benchmarks/join/mixed_join.cu
+++ b/cpp/benchmarks/join/mixed_join.cu
@@ -25,8 +25,7 @@ void nvbench_mixed_inner_join(nvbench::state& state,
                  cudf::table_view const& left_conditional_input,
                  cudf::table_view const& right_conditional_input,
                  cudf::ast::operation binary_pred,
-                 cudf::null_equality compare_nulls,
-                 rmm::cuda_stream_view stream) {
+                 cudf::null_equality compare_nulls) {
     return cudf::mixed_inner_join(left_equality_input,
                                   right_equality_input,
                                   left_conditional_input,
@@ -47,8 +46,7 @@ void nvbench_mixed_left_join(nvbench::state& state,
                  cudf::table_view const& left_conditional_input,
                  cudf::table_view const& right_conditional_input,
                  cudf::ast::operation binary_pred,
-                 cudf::null_equality compare_nulls,
-                 rmm::cuda_stream_view stream) {
+                 cudf::null_equality compare_nulls) {
     return cudf::mixed_left_join(left_equality_input,
                                  right_equality_input,
                                  left_conditional_input,
@@ -69,8 +67,7 @@ void nvbench_mixed_full_join(nvbench::state& state,
                  cudf::table_view const& left_conditional_input,
                  cudf::table_view const& right_conditional_input,
                  cudf::ast::operation binary_pred,
-                 cudf::null_equality compare_nulls,
-                 rmm::cuda_stream_view stream) {
+                 cudf::null_equality compare_nulls) {
     return cudf::mixed_full_join(left_equality_input,
                                  right_equality_input,
                                  left_conditional_input,
@@ -91,8 +88,7 @@ void nvbench_mixed_left_semi_join(nvbench::state& state,
                  cudf::table_view const& left_conditional_input,
                  cudf::table_view const& right_conditional_input,
                  cudf::ast::operation binary_pred,
-                 cudf::null_equality compare_nulls,
-                 rmm::cuda_stream_view stream) {
+                 cudf::null_equality compare_nulls) {
     return cudf::mixed_left_semi_join(left_equality_input,
                                       right_equality_input,
                                       left_conditional_input,
@@ -113,8 +109,7 @@ void nvbench_mixed_left_anti_join(nvbench::state& state,
                  cudf::table_view const& left_conditional_input,
                  cudf::table_view const& right_conditional_input,
                  cudf::ast::operation binary_pred,
-                 cudf::null_equality compare_nulls,
-                 rmm::cuda_stream_view stream) {
+                 cudf::null_equality compare_nulls) {
     return cudf::mixed_left_anti_join(left_equality_input,
                                       right_equality_input,
                                       left_conditional_input,


### PR DESCRIPTION
## Description
This a followup of #15644.

It fixes the lhs/rhs input bug in the hash join and distinct join benchmarks.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
