### PR TITLE
Add overflow check when converting large strings to lists columns

### DIFF
--- a/cpp/src/io/utilities/column_buffer.cpp
+++ b/cpp/src/io/utilities/column_buffer.cpp
@@ -191,6 +191,10 @@ std::unique_ptr<column> make_column(column_buffer_base<string_policy>& buffer,
         auto data      = col_content.data.release();
         auto char_size = data->size();
 
+        CUDF_EXPECTS(char_size < static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
+                     "Cannot convert strings column to lists column due to size_type limit",
+                     std::overflow_error);
+
         auto uint8_col = std::make_unique<column>(
           data_type{type_id::UINT8}, char_size, std::move(*data), rmm::device_buffer{}, 0);
 

--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -137,7 +137,12 @@ struct byte_list_conversion_fn<T, std::enable_if_t<std::is_same_v<T, cudf::strin
 
     auto col_content     = std::make_unique<column>(input, stream, mr)->release();
     auto const num_chars = col_content.data->size();
-    auto uint8_col       = std::make_unique<column>(
+
+    CUDF_EXPECTS(num_chars < static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
+                 "Cannot convert strings column to lists column due to size_type limit",
+                 std::overflow_error);
+
+    auto uint8_col = std::make_unique<column>(
       output_type, num_chars, std::move(*(col_content.data)), rmm::device_buffer{}, 0);
 
     auto result = make_lists_column(

--- a/cpp/src/reshape/byte_cast.cu
+++ b/cpp/src/reshape/byte_cast.cu
@@ -135,12 +135,12 @@ struct byte_list_conversion_fn<T, std::enable_if_t<std::is_same_v<T, cudf::strin
         input.size(), output_type, stream, mr);
     }
 
-    auto col_content     = std::make_unique<column>(input, stream, mr)->release();
-    auto const num_chars = col_content.data->size();
-
-    CUDF_EXPECTS(num_chars < static_cast<std::size_t>(std::numeric_limits<size_type>::max()),
+    auto const num_chars = strings_column_view(input).chars_size(stream);
+    CUDF_EXPECTS(num_chars < static_cast<int64_t>(std::numeric_limits<size_type>::max()),
                  "Cannot convert strings column to lists column due to size_type limit",
                  std::overflow_error);
+
+    auto col_content = std::make_unique<column>(input, stream, mr)->release();
 
     auto uint8_col = std::make_unique<column>(
       output_type, num_chars, std::move(*(col_content.data)), rmm::device_buffer{}, 0);


### PR DESCRIPTION
## Description
Fixes a couple places where strings columns are converted to lists column as binary -- chars are represented as INT8.
Since lists columns only support `size_type` offsets type, this change will throw an error if the size of the chars exceeds max `size_type` values.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
