### PR TITLE
Improve options docs

### DIFF
--- a/docs/cudf/source/cudf_pandas/how-it-works.md
+++ b/docs/cudf/source/cudf_pandas/how-it-works.md
@@ -34,6 +34,5 @@ correct result. Data is automatically transferred from host to device
 transfers.
 
 When using `cudf.pandas`, cuDF's [pandas compatibility
-mode](https://docs.rapids.ai/api/cudf/stable/api_docs/options/#available-options)
-is automatically enabled, ensuring consistency with pandas-specific
-semantics like default sort ordering.
+mode](api.options) is automatically enabled, ensuring consistency with
+pandas-specific semantics like default sort ordering.

--- a/docs/cudf/source/user_guide/api_docs/options.rst
+++ b/docs/cudf/source/user_guide/api_docs/options.rst
@@ -12,6 +12,19 @@ Options and settings
    cudf.describe_option
    cudf.option_context
 
+Display options are controlled by pandas
+----------------------------------------
+
+Options for display are inherited from pandas. This includes commonly accessed options such as:
+
+- ``display.max_columns``
+- ``display.max_info_rows``
+- ``display.max_rows``
+- ``display.max_seq_items``
+
+For example, to show all rows of a DataFrame or Series in a Jupyter notebook, call ``pandas.set_option("display.max_rows", None)``.
+
+See also the :ref:`full list of pandas display options <pandas:options.available>`.
 
 Available options
 -----------------

--- a/docs/cudf/source/user_guide/options.md
+++ b/docs/cudf/source/user_guide/options.md
@@ -11,4 +11,4 @@ When no argument is provided,
 all options are printed.
 To set value to a option, use {py:func}`cudf.set_option`.
 
-See the [API reference](api.options) for more details.
+See the [options API reference](api.options) for descriptions of the available options.


### PR DESCRIPTION
## Description
Recently I have answered a few user questions about how to use cudf options for display. We were missing documentation that explained that display options are inherited from pandas. I also found a broken link in the docs. This PR fixes both of those doc-related issues.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
