### PR TITLE
Use offsetalator in orc rowgroup_char_counts_kernel

### DIFF
--- a/cpp/src/io/orc/dict_enc.cu
+++ b/cpp/src/io/orc/dict_enc.cu
@@ -16,6 +16,7 @@
 
 #include "orc_gpu.hpp"
 
+#include <cudf/detail/offsets_iterator.cuh>
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/io/orc_types.hpp>
 #include <cudf/table/experimental/row_operators.cuh>
@@ -43,11 +44,12 @@ CUDF_KERNEL void rowgroup_char_counts_kernel(device_2dspan<size_type> char_count
   auto const start_row = rowgroup_bounds[row_group_idx][col_idx].begin + str_col.offset();
   auto const num_rows  = rowgroup_bounds[row_group_idx][col_idx].size();
 
-  auto const& offsets = str_col.child(strings_column_view::offsets_column_index);
+  auto const& offsets    = str_col.child(strings_column_view::offsets_column_index);
+  auto const offsets_itr = cudf::detail::input_offsetalator(offsets.head(), offsets.type());
   char_counts[str_col_idx][row_group_idx] =
     (num_rows == 0)
       ? 0
-      : offsets.element<size_type>(start_row + num_rows) - offsets.element<size_type>(start_row);
+      : static_cast<size_type>(offsets_itr[start_row + num_rows] - offsets_itr[start_row]);
 }
 
 void rowgroup_char_counts(device_2dspan<size_type> counts,


### PR DESCRIPTION
## Description
Replaces hardcoded `size_type` for accessing strings offsets data with the offsetalator to compute the number of characters in a group in `cudf::io::orc::gpu::rowgroup_char_counts_kernel`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
