### PR TITLE
WIP,API: Enable full Numpy2 compat

### DIFF
--- a/python/cudf/cudf/core/_internals/where.py
+++ b/python/cudf/cudf/core/_internals/where.py
@@ -85,8 +85,10 @@ def _check_and_cast_columns_with_other(
             )
         return _normalize_categorical(source_col, other.astype(source_dtype))
 
-    if _is_non_decimal_numeric_dtype(source_dtype) and _can_cast(
-        other, source_dtype
+    if (
+        _is_non_decimal_numeric_dtype(source_dtype)
+        and not other_is_scalar  # can-cast fails for Python scalars
+        and _can_cast(other, source_dtype)
     ):
         common_dtype = source_dtype
     elif (

--- a/python/cudf/cudf/core/_internals/where.py
+++ b/python/cudf/cudf/core/_internals/where.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 
 import warnings
 from typing import Tuple, Union
@@ -51,13 +51,17 @@ def _check_and_cast_columns_with_other(
 
     other_is_scalar = is_scalar(other)
     if other_is_scalar:
-        if (isinstance(other, float) and not np.isnan(other)) and (
-            source_dtype.type(other) != other
-        ):
-            raise TypeError(
-                f"Cannot safely cast non-equivalent "
-                f"{type(other).__name__} to {source_dtype.name}"
-            )
+        if isinstance(other, float) and not np.isnan(other):
+            try:
+                is_safe = source_dtype.type(other) == other
+            except OverflowError:
+                is_safe = False
+
+            if not is_safe:
+                raise TypeError(
+                    f"Cannot safely cast non-equivalent "
+                    f"{type(other).__name__} to {source_dtype.name}"
+                )
 
         if cudf.utils.utils.is_na_like(other):
             return _normalize_categorical(

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -39,7 +39,9 @@ if TYPE_CHECKING:
     )
 
 
-_DEFAULT_CATEGORICAL_VALUE = -1
+# Using np.int8(-1) to allow silent wrap-around when casting to uint
+# it may make sense to make this dtype specific or a function.
+_DEFAULT_CATEGORICAL_VALUE = np.int8(-1)
 
 
 class CategoricalAccessor(ColumnMethods):

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -291,15 +291,28 @@ class NumericalColumn(NumericalBaseColumn):
         if isinstance(other, cudf.Scalar):
             if self.dtype == other.dtype:
                 return other
+
             # expensive device-host transfer just to
             # adjust the dtype
             other = other.value
+
+            # NumPy 2 needs a Python scalar to do weak promotion, but
+            # pandas forces weak promotion always
+            # TODO: We could use 0, 0.0, and 0j for promotion to avoid copies.
+            if other.dtype.kind in "ifc":
+                other = other.item()
+        elif not isinstance(other, (int, float, complex)):
+            # Go via NumPy to get the value
+            other = np.array(other)
+            if other.dtype.kind in "ifc":
+                other = other.item()
+
         # Try and match pandas and hence numpy. Deduce the common
-        # dtype via the _value_ of other, and the dtype of self. TODO:
-        # When NEP50 is accepted, this might want changed or
-        # simplified.
-        # This is not at all simple:
-        # np.result_type(np.int64(0), np.uint8)
+        # dtype via the _value_ of other, and the dtype of self on NumPy 1.x
+        # with NumPy 2, we force weak promotion even for our/NumPy scalars
+        # to match pandas 2.2.
+        # Weak promotion is not at all simple:
+        # np.result_type(0, np.uint8)
         #   => np.uint8
         # np.result_type(np.asarray([0], dtype=np.int64), np.uint8)
         #   => np.int64

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -662,7 +662,9 @@ class NumericalColumn(NumericalBaseColumn):
             min_, max_ = iinfo.min, iinfo.max
 
             # best we can do is hope to catch it here and avoid compare
-            if (self.min() >= min_) and (self.max() <= max_):
+            # Use Python floats, which have precise comparison for float64.
+            # NOTE(seberg): it would make sense to limit to the mantissa range.
+            if (float(self.min()) >= min_) and (float(self.max()) <= max_):
                 filled = self.fillna(0)
                 return (cudf.Series(filled) % 1 == 0).all()
             else:

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -540,7 +540,14 @@ def test_series_reflected_ops_scalar(func, dtype, obj_class):
     if obj_class == "Index":
         gs = as_index(gs)
 
-    gs_result = func(gs)
+    try:
+        gs_result = func(gs)
+    except OverflowError:
+        # An error is fine, if pandas raises the same error:
+        with pytest.raises(OverflowError):
+            func(random_series)
+
+        return
 
     # class typing
     if obj_class == "Index":
@@ -590,7 +597,14 @@ def test_series_reflected_ops_cudf_scalar(funcs, dtype, obj_class):
     if obj_class == "Index":
         gs = as_index(gs)
 
-    gs_result = gpu_func(gs)
+    try:
+        gs_result = gpu_func(gs)
+    except OverflowError:
+        # An error is fine, if pandas raises the same error:
+        with pytest.raises(OverflowError):
+            cpu_func(random_series)
+
+        return
 
     # class typing
     if obj_class == "Index":
@@ -771,7 +785,8 @@ def test_operator_func_series_and_scalar(
         fill_value=fill_value,
     )
     pdf_series_result = getattr(pdf_series, func)(
-        scalar, fill_value=fill_value
+        np.array(scalar)[()] if use_cudf_scalar else scalar,
+        fill_value=fill_value
     )
 
     utils.assert_eq(pdf_series_result, gdf_series_result)

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -1280,6 +1280,9 @@ def test_concat_join_empty_dataframes(
 @pytest.mark.parametrize("sort", [True, False])
 @pytest.mark.parametrize("join", ["inner", "outer"])
 @pytest.mark.parametrize("axis", [1])
+@pytest.mark.filterwarnings(
+    "ignore:No codes are cached because compilation:UserWarning"
+)
 def test_concat_join_empty_dataframes_axis_1(
     df, other, ignore_index, axis, join, sort
 ):

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -8332,6 +8332,9 @@ def test_dataframe_init_with_columns(data, columns):
         pd.Index(["abc"], name="custom_name"),
     ],
 )
+@pytest.mark.filterwarnings(
+    "ignore:No codes are cached because compilation:UserWarning"
+)
 def test_dataframe_init_from_series_list(data, ignore_dtype, columns):
     gd_data = [cudf.from_pandas(obj) for obj in data]
 
@@ -8430,6 +8433,9 @@ def test_dataframe_init_from_series_list(data, ignore_dtype, columns):
 )
 @pytest.mark.parametrize(
     "columns", [None, ["0"], [0], ["abc"], [144, 13], [2, 1, 0]]
+)
+@pytest.mark.filterwarnings(
+    "ignore:No codes are cached because compilation:UserWarning"
 )
 def test_dataframe_init_from_series_list_with_index(
     data,

--- a/python/cudf/cudf/tests/test_doctests.py
+++ b/python/cudf/cudf/tests/test_doctests.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 import contextlib
 import doctest
 import inspect
@@ -79,6 +79,16 @@ class TestDoctests:
         os.chdir(tmp_path)
         yield
         os.chdir(original_directory)
+
+    @pytest.fixture(autouse=True)
+    def prinoptions(cls):
+        # TODO: NumPy now prints scalars as `np.int8(1)`, etc. this should
+        #       be adapted evantually.
+        if np.lib.NumpyVersion(np.__version__) >= "2.0.0rc1":
+            with np.printoptions(legacy="1.25"):
+                yield
+        else:
+            yield
 
     @pytest.mark.parametrize(
         "docstring",

--- a/python/cudf/cudf/tests/test_dtypes.py
+++ b/python/cudf/cudf/tests/test_dtypes.py
@@ -341,7 +341,6 @@ def test_dtype(in_dtype, expect):
         np.complex128,
         complex,
         "S",
-        "a",
         "V",
         "float16",
         np.float16,

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -798,6 +798,9 @@ def test_index_to_series(data):
     "name_data,name_other",
     [("abc", "c"), (None, "abc"), ("abc", pd.NA), ("abc", "abc")],
 )
+@pytest.mark.filterwarnings(
+    "ignore:No codes are cached because compilation:UserWarning"
+)
 def test_index_difference(data, other, sort, name_data, name_other):
     pd_data = pd.Index(data, name=name_data)
     pd_other = pd.Index(other, name=name_other)
@@ -2327,6 +2330,9 @@ def test_range_index_concat(objs):
     ],
 )
 @pytest.mark.parametrize("sort", [None, False, True])
+@pytest.mark.filterwarnings(
+    "ignore:No codes are cached because compilation:UserWarning"
+)
 def test_union_index(idx1, idx2, sort):
     expected = idx1.union(idx2, sort=sort)
 
@@ -2387,6 +2393,9 @@ def test_union_unsigned_vs_signed(dtype1, dtype2):
 )
 @pytest.mark.parametrize("sort", [None, False, True])
 @pytest.mark.parametrize("pandas_compatible", [True, False])
+@pytest.mark.filterwarnings(
+    "ignore:No codes are cached because compilation:UserWarning"
+)
 def test_intersection_index(idx1, idx2, sort, pandas_compatible):
     expected = idx1.intersection(idx2, sort=sort)
 
@@ -2668,6 +2677,9 @@ def test_index_constructor_float(default_float_bitwidth):
     assert_eq(expect, got)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:No codes are cached because compilation:UserWarning"
+)
 def test_rangeindex_union_default_user_option(default_integer_bitwidth):
     # Test that RangeIndex is materialized into 32 bit index under user
     # configuration for union operation.
@@ -2680,6 +2692,9 @@ def test_rangeindex_union_default_user_option(default_integer_bitwidth):
     assert_eq(expected, actual)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:No codes are cached because compilation:UserWarning"
+)
 def test_rangeindex_intersection_default_user_option(default_integer_bitwidth):
     # Test that RangeIndex is materialized into 32 bit index under user
     # configuration for intersection operation.
@@ -2792,6 +2807,9 @@ def test_rangeindex_where_user_option(default_integer_bitwidth):
     assert_eq(expected, actual)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:No codes are cached because compilation:UserWarning"
+)
 def test_rangeindex_append_return_rangeindex():
     idx = cudf.RangeIndex(0, 10)
     result = idx.append([])
@@ -2830,6 +2848,9 @@ def index(request):
         "notna",
         "append",
     ],
+)
+@pytest.mark.filterwarnings(
+    "ignore:No codes are cached because compilation:UserWarning"
 )
 def test_index_methods(index, func):
     gidx = index

--- a/python/cudf/cudf/tests/test_transform.py
+++ b/python/cudf/cudf/tests/test_transform.py
@@ -23,6 +23,10 @@ def _generic_function(a):
     ],
 )
 def test_apply_python_lambda(dtype, udf, testfunc):
+    # TODO: Remove again when NumPy is fixed:
+    np_ver = np.lib.NumpyVersion(np.__version__)
+    if dtype == "uint64" and (np_ver == "2.0.0rc1" or np_ver == "2.0.0rc2"):
+        pytest.skip("test fails due to a NumPy bug on 2.0 rc versions")
     size = 500
 
     lhs_arr = np.random.random(size).astype(dtype)

--- a/python/cudf/cudf/tests/test_unaops.py
+++ b/python/cudf/cudf/tests/test_unaops.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 import itertools
 import operator
@@ -81,7 +81,10 @@ def generate_valid_scalar_unaop_combos():
 @pytest.mark.parametrize("slr,dtype,op", generate_valid_scalar_unaop_combos())
 def test_scalar_unary_operations(slr, dtype, op):
     slr_host = np.array([slr])[0].astype(cudf.dtype(dtype))
-    slr_device = cudf.Scalar(slr, dtype=dtype)
+    # The scalar may be out of bounds, so go via array force-cast
+    # NOTE: This is a change in behavior
+    slr = np.array(slr).astype(dtype)[()]
+    slr_device = cudf.Scalar(slr)
 
     expect = op(slr_host)
     got = op(slr_device)


### PR DESCRIPTION
This PR has a few more changes with which tests seem to pass (except the new comparison tests) on NumPy 2 (there is a chance of issues on NumPy 1 for now).
*I won't have much time next week to update/work on this* but could continue after that, please don't hesitate to push/take over.
It's not a big PR huge now, but it probably makes sense to split out some more changes that seem obvious OK.

I'll add some inline comments after opening the PR.  It may make sense to split out more of the changes.

Most important checks:
* [ ] This does include the API break for e.g. `Scalar(-1, dtype=np.uint8)` to fail, rather than wrap around.  I suspect that is fine, but it is a breaking change.  (Necessary/helpful because it matches pandas behavior e.g. for `uint8_series + 1000` with NumPy 2.
* [ ] The comparison paths need fixing.  I have ommitted them, because I wasn't sure how to best deal with them:
  * Getting them perfectly right, requires new comparison loops in `libcudf` to compare `uint64` and `int64`.
  * Getting them perfectly right for scalar integers could be done via logic like `if other > np.iinfo(self.dtype).max: return full_series_like(self, dtype=bool, value=False)`.
  * I guess cudf currently used the NumPy promotion, so one could use custom value-based logic.  That logic may exist elsewhere or be stolen from pandas.  Such logic would be useful to exactly match e.g. `pandas.Series.where()`.

Ping @vyasr, this is to get the ball rolling and simplify discussion.

<details>  <summary> Tested via (hack but sharing) creating a custom env, since we need a patched cupy version (that artifact is from the conda-forge PR): </summary>


```
set -eu

echo "fetching artifact"
cd conda
curl https://artprodeus21.artifacts.visualstudio.com/A910fa339-c7c2-46e8-a579-7ea247548706/84710dde-1620-425b-80d0-4cf5baca359d/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2NvbmRhLWZvcmdlL3Byb2plY3RJZC84NDcxMGRkZS0xNjIwLTQyNWItODBkMC00Y2Y1YmFjYTM1OWQvYnVpbGRJZC85NDE1NDgvYXJ0aWZhY3ROYW1lL2NvbmRhX2FydGlmYWN0c18yMDI0MDUyMy4xMC4xX2xpbnV4XzY0X2NfY29tcGlsZXJfdmVyc2lvbjEyY3VkYV9jX2gxMzE0MjdkMmRh0/content?format=zip --output artifact.zip
unzip artifact.zip
rm artifact.zip
mv conda_artifacts_* conda_artifact
cd conda_artifact
unzip *.zip
rm *.zip
cd ../..

ARTIFACT_PATH = `pwd`/conda/conda_artifact/build_artifacts
echo "Modifying channels"
sed -i "s$  - conda-forge$  - file://$ARTIFACT_PATH\n  - conda-forge$" dependencies.yaml
rapids-dependency-file-generator

echo "To finalize, please create a new dev environment, for example with:"
echo ""
echo "conda env create --name cudf_dev --file conda/environments/all_cuda-122_arch-x86_64.yaml"
echo "pip install --force-reinstall --pre pyarrow numpy numba"
```

</details>

xref: https://github.com/rapidsai/build-planning/issues/38