### PR TITLE
Introduce `NamedColumn` concept in cudf-polars

### DIFF
--- a/python/cudf_polars/cudf_polars/containers/__init__.py
+++ b/python/cudf_polars/cudf_polars/containers/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__all__: list[str] = ["DataFrame", "Column", "Scalar"]
+__all__: list[str] = ["DataFrame", "Column", "NamedColumn", "Scalar"]
 
-from cudf_polars.containers.column import Column
+from cudf_polars.containers.column import Column, NamedColumn
 from cudf_polars.containers.dataframe import DataFrame
 from cudf_polars.containers.scalar import Scalar

--- a/python/cudf_polars/cudf_polars/containers/column.py
+++ b/python/cudf_polars/cudf_polars/containers/column.py
@@ -13,24 +13,29 @@ import cudf._lib.pylibcudf as plc
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-__all__: list[str] = ["Column"]
+__all__: list[str] = ["Column", "NamedColumn"]
 
 
 class Column:
-    """A column, a name, and sortedness."""
+    """A column with sortedness metadata."""
 
     obj: plc.Column
-    name: str
     is_sorted: plc.types.Sorted
     order: plc.types.Order
     null_order: plc.types.NullOrder
 
-    def __init__(self, column: plc.Column, name: str):
+    def __init__(
+        self,
+        column: plc.Column,
+        *,
+        is_sorted: plc.types.Sorted = plc.types.Sorted.NO,
+        order: plc.types.Order = plc.types.Order.ASCENDING,
+        null_order: plc.types.NullOrder = plc.types.NullOrder.BEFORE,
+    ):
         self.obj = column
-        self.name = name
-        self.is_sorted = plc.types.Sorted.NO
-        self.order = plc.types.Order.ASCENDING
-        self.null_order = plc.types.NullOrder.BEFORE
+        self.is_sorted = is_sorted
+        self.order = order
+        self.null_order = null_order
 
     def sorted_like(self, like: Column, /) -> Self:
         """
@@ -81,22 +86,20 @@ class Column:
         self.null_order = null_order
         return self
 
-    def copy(self, *, new_name: str | None = None) -> Self:
+    def copy(self) -> Self:
         """
-        Return a shallow copy of the column.
-
-        Parameters
-        ----------
-        new_name
-            Optional new name for the copied column.
+        A shallow copy of the column.
 
         Returns
         -------
         New column sharing data with self.
         """
         return type(self)(
-            self.obj, self.name if new_name is None else new_name
-        ).sorted_like(self)
+            self.obj,
+            is_sorted=self.is_sorted,
+            order=self.order,
+            null_order=self.null_order,
+        )
 
     def mask_nans(self) -> Self:
         """Return a copy of self with nans masked out."""
@@ -117,3 +120,44 @@ class Column:
                 plc.DataType(plc.TypeId.INT32),
             )
         ).as_py()
+
+
+class NamedColumn(Column):
+    """A column with a name."""
+
+    name: str
+
+    def __init__(
+        self,
+        column: plc.Column,
+        name: str,
+        *,
+        is_sorted: plc.types.Sorted = plc.types.Sorted.NO,
+        order: plc.types.Order = plc.types.Order.ASCENDING,
+        null_order: plc.types.NullOrder = plc.types.NullOrder.BEFORE,
+    ) -> None:
+        super().__init__(
+            column, is_sorted=is_sorted, order=order, null_order=null_order
+        )
+        self.name = name
+
+    def copy(self, *, new_name: str | None = None) -> Self:
+        """
+        A shallow copy of the column.
+
+        Parameters
+        ----------
+        new_name
+            Optional new name for the copied column.
+
+        Returns
+        -------
+        New column sharing data with self.
+        """
+        return type(self)(
+            self.obj,
+            self.name if new_name is None else new_name,
+            is_sorted=self.is_sorted,
+            order=self.order,
+            null_order=self.null_order,
+        )

--- a/python/cudf_polars/cudf_polars/containers/dataframe.py
+++ b/python/cudf_polars/cudf_polars/containers/dataframe.py
@@ -101,8 +101,9 @@ class DataFrame:
 
         Raises
         ------
-        ValueError if the number of provided names does not match the
-        number of columns in the table.
+        ValueError
+            If the number of provided names does not match the
+            number of columns in the table.
         """
         if table.num_columns() != len(names):
             raise ValueError("Mismatching name and table length.")
@@ -130,7 +131,8 @@ class DataFrame:
 
         Raises
         ------
-        ValueError if there is a name mismatch between self and like.
+        ValueError
+            If there is a name mismatch between self and like.
         """
         if like.column_names != self.column_names:
             raise ValueError("Can only copy from identically named frame")

--- a/python/cudf_polars/cudf_polars/containers/dataframe.py
+++ b/python/cudf_polars/cudf_polars/containers/dataframe.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
     import cudf
 
-    from cudf_polars.containers import Column, Scalar
+    from cudf_polars.containers import Column
 
 
 __all__: list[str] = ["DataFrame"]
@@ -31,27 +31,19 @@ class DataFrame:
     """A representation of a dataframe."""
 
     columns: list[NamedColumn]
-    scalars: list[Scalar]
     table: plc.Table | None
 
-    def __init__(
-        self, columns: Sequence[NamedColumn], scalars: Sequence[Scalar]
-    ) -> None:
+    def __init__(self, columns: Sequence[NamedColumn]) -> None:
         self.columns = list(columns)
         self._column_map = {c.name: c for c in self.columns}
-        self.scalars = list(scalars)
-        if len(scalars) == 0:
-            self.table = plc.Table([c.obj for c in columns])
-        else:
-            self.table = None
+        self.table = plc.Table([c.obj for c in columns])
 
     def copy(self) -> Self:
         """Return a shallow copy of self."""
-        return type(self)(self.columns, self.scalars)
+        return type(self)(self.columns)
 
     def to_polars(self) -> pl.DataFrame:
         """Convert to a polars DataFrame."""
-        assert len(self.scalars) == 0
         return pl.from_arrow(
             plc.interop.to_arrow(
                 self.table,
@@ -88,8 +80,7 @@ class DataFrame:
             [
                 NamedColumn(c.to_pylibcudf(mode="read"), name)
                 for name, c in df._data.items()
-            ],
-            [],
+            ]
         )
 
     @classmethod
@@ -113,11 +104,11 @@ class DataFrame:
         ValueError if the number of provided names does not match the
         number of columns in the table.
         """
-        # TODO: strict=True when we drop py39
         if table.num_columns() != len(names):
             raise ValueError("Mismatching name and table length.")
         return cls(
-            [NamedColumn(c, name) for c, name in zip(table.columns(), names)], []
+            # TODO: strict=True when we drop py39
+            [NamedColumn(c, name) for c, name in zip(table.columns(), names)]
         )
 
     def sorted_like(
@@ -146,6 +137,7 @@ class DataFrame:
         subset = self.column_names_set if subset is None else subset
         self.columns = [
             c.sorted_like(other) if c.name in subset else c
+            # TODO: strict=True when we drop py39
             for c, other in zip(self.columns, like.columns)
         ]
         return self
@@ -167,33 +159,29 @@ class DataFrame:
         -----
         If column names overlap, newer names replace older ones.
         """
-        return type(self)([*self.columns, *columns], self.scalars)
+        return type(self)([*self.columns, *columns])
 
     def discard_columns(self, names: Set[str]) -> Self:
         """Drop columns by name."""
-        return type(self)(
-            [c for c in self.columns if c.name not in names], self.scalars
-        )
+        return type(self)([c for c in self.columns if c.name not in names])
 
     def select(self, names: Sequence[str]) -> Self:
         """Select columns by name returning DataFrame."""
         want = set(names)
         if not want.issubset(self.column_names_set):
             raise ValueError("Can't select missing names")
-        return type(self)([self._column_map[name] for name in names], self.scalars)
+        return type(self)([self._column_map[name] for name in names])
 
     def replace_columns(self, *columns: NamedColumn) -> Self:
         """Return a new dataframe with columns replaced by name."""
         new = {c.name: c for c in columns}
         if not set(new).issubset(self.column_names_set):
             raise ValueError("Cannot replace with non-existing names")
-        return type(self)([new.get(c.name, c) for c in self.columns], self.scalars)
+        return type(self)([new.get(c.name, c) for c in self.columns])
 
     def rename_columns(self, mapping: Mapping[str, str]) -> Self:
         """Rename some columns."""
-        return type(self)(
-            [c.copy(new_name=mapping.get(c.name)) for c in self.columns], self.scalars
-        )
+        return type(self)([c.copy(new_name=mapping.get(c.name)) for c in self.columns])
 
     def select_columns(self, names: Set[str]) -> list[NamedColumn]:
         """Select columns by name."""

--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -316,7 +316,7 @@ class NamedExpr:
         obj = self.value.evaluate(df, context=context, mapping=mapping)
         if isinstance(obj, Scalar):
             return NamedColumn(
-                plc.Column.from_scalar(obj.obj, df.num_rows),
+                plc.Column.from_scalar(obj.obj, 1),
                 self.name,
                 is_sorted=plc.types.Sorted.YES,
                 order=plc.types.Order.ASCENDING,

--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -192,9 +192,10 @@ class Expr:
 
         Raises
         ------
-        NotImplementedError if we couldn't evaluate the expression.
-        Ideally all these are returned during translation to the IR,
-        but for now we are not perfect.
+        NotImplementedError
+            If we couldn't evaluate the expression. Ideally all these
+            are returned during translation to the IR, but for now we
+            are not perfect.
         """
         raise NotImplementedError(f"Evaluation of {type(self).__name__}")
 
@@ -241,9 +242,10 @@ class Expr:
 
         Raises
         ------
-        NotImplementedError if we couldn't evaluate the expression.
-        Ideally all these are returned during translation to the IR,
-        but for now we are not perfect.
+        NotImplementedError
+            If we couldn't evaluate the expression. Ideally all these
+            are returned during translation to the IR, but for now we
+            are not perfect.
         """
         if mapping is None:
             return self.do_evaluate(df, context=context, mapping=mapping)
@@ -269,9 +271,9 @@ class Expr:
 
         Raises
         ------
-        NotImplementedError if we can't currently perform the
-        aggregation request (for example nested aggregations like
-        ``a.max().min()``).
+        NotImplementedError
+            If we can't currently perform the aggregation request, for
+            example nested aggregations like ``a.max().min()``.
         """
         raise NotImplementedError(
             f"Collecting aggregation info for {type(self).__name__}"
@@ -279,6 +281,9 @@ class Expr:
 
 
 class NamedExpr:
+    # NamedExpr does not inherit from Expr since it does not appear
+    # when evaluating expressions themselves, only when constructing
+    # named return values in dataframe (IR) nodes.
     __slots__ = ("name", "value")
 
     def __init__(self, name: str, value: Expr) -> None:

--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -656,7 +656,7 @@ class Sort(Expr):
         column = child.evaluate(df, context=context, mapping=mapping)
         (stable, nulls_last, descending) = self.options
         order, null_order = sorting.sort_order(
-            [descending], nulls_last=nulls_last, num_keys=1
+            [descending], nulls_last=[nulls_last], num_keys=1
         )
         do_sort = plc.sorting.stable_sort if stable else plc.sorting.sort
         table = do_sort(plc.Table([column.obj]), order, null_order)
@@ -672,7 +672,7 @@ class SortBy(Expr):
     def __init__(
         self,
         dtype: plc.DataType,
-        options: tuple[bool, bool, tuple[bool]],
+        options: tuple[bool, tuple[bool], tuple[bool]],
         column: Expr,
         *by: Expr,
     ):

--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -26,11 +26,11 @@ from polars.polars import _expr_nodes as pl_expr
 
 import cudf._lib.pylibcudf as plc
 
-from cudf_polars.containers import Column, Scalar
+from cudf_polars.containers import Column, NamedColumn, Scalar
 from cudf_polars.utils import sorting
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
     import polars.type_aliases as pl_types
 
@@ -110,7 +110,7 @@ class Expr:
         """
         return hash((type(self), self._ctor_arguments(self.children)))
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Hash of an expression with caching."""
         try:
             return self._hash_value
@@ -139,18 +139,18 @@ class Expr:
             other.children
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """Equality of expressions."""
         if type(self) != type(other) or hash(self) != hash(other):
             return False
         else:
             return self.is_equal(other)
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         """Inequality of expressions."""
         return not self.__eq__(other)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """String representation of an expression with caching."""
         try:
             return self._repr_value
@@ -164,7 +164,7 @@ class Expr:
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:  # TODO: return type is a lie for Literal
         """
         Evaluate this expression given a dataframe for context.
@@ -185,15 +185,6 @@ class Expr:
         Do not call this function directly, but rather
         :meth:`evaluate` which handles the mapping lookups.
 
-        The typed return value of :class:`Column` is not true when
-        evaluating :class:`Literal` nodes (which instead produce
-        :class:`Scalar` objects). However, these duck-type to having a
-        pylibcudf container object inside them, and usually they end
-        up appearing in binary expressions which pylibcudf handles
-        appropriately since there are overloads for (column, scalar)
-        pairs. We don't have to handle (scalar, scalar) in binops
-        since the polars optimizer has a constant-folding pass.
-
         Returns
         -------
         Column representing the evaluation of the expression (or maybe
@@ -212,7 +203,7 @@ class Expr:
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:  # TODO: return type is a lie for Literal
         """
         Evaluate this expression given a dataframe for context.
@@ -234,10 +225,19 @@ class Expr:
         this method provides logic to handle lookups in the
         substitution mapping.
 
+        The typed return value of :class:`Column` is not true when
+        evaluating :class:`Literal` nodes (which instead produce
+        :class:`Scalar` objects). However, these duck-type to having a
+        pylibcudf container object inside them, and usually they end
+        up appearing in binary expressions which pylibcudf handles
+        appropriately since there are overloads for (column, scalar)
+        pairs. We don't have to handle (scalar, scalar) in binops
+        since the polars optimizer has a constant-folding pass.
+
         Returns
         -------
         Column representing the evaluation of the expression (or maybe
-        a scalar, annoying!).
+        a scalar).
 
         Raises
         ------
@@ -278,32 +278,62 @@ class Expr:
         )
 
 
-class NamedExpr(Expr):
-    __slots__ = ("name", "children")
-    _non_child = ("dtype", "name")
+class NamedExpr:
+    __slots__ = ("name", "value")
 
-    def __init__(self, dtype: plc.DataType, name: str, value: Expr) -> None:
-        super().__init__(dtype)
+    def __init__(self, name: str, value: Expr) -> None:
         self.name = name
-        self.children = (value,)
+        self.value = value
 
-    def do_evaluate(
+    def __hash__(self) -> int:
+        """Hash of the expression."""
+        return hash((type(self), self.name, self.value))
+
+    def __repr__(self) -> str:
+        """Repr of the expression."""
+        return f"NamedExpr({self.name}, {self.value}"
+
+    def __eq__(self, other) -> bool:
+        """Equality of two expressions."""
+        return (
+            type(self) is type(other)
+            and self.name == other.name
+            and self.value == other.value
+        )
+
+    def __ne__(self, other) -> bool:
+        """Inequality of expressions."""
+        return not self.__eq__(other)
+
+    def evaluate(
         self,
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
-    ) -> Column:
+        mapping: Mapping[Expr, Column] | None = None,
+    ) -> NamedColumn:
         """Evaluate this expression given a dataframe for context."""
-        (child,) = self.children
-        return Column(
-            child.evaluate(df, context=context, mapping=mapping).obj, self.name
-        )
+        obj = self.value.evaluate(df, context=context, mapping=mapping)
+        if isinstance(obj, Scalar):
+            return NamedColumn(
+                plc.Column.from_scalar(obj.obj, df.num_rows),
+                self.name,
+                is_sorted=plc.types.Sorted.YES,
+                order=plc.types.Order.ASCENDING,
+                null_order=plc.types.NullOrder.BEFORE,
+            )
+        else:
+            return NamedColumn(
+                obj.obj,
+                self.name,
+                is_sorted=obj.is_sorted,
+                order=obj.order,
+                null_order=obj.null_order,
+            )
 
     def collect_agg(self, *, depth: int) -> AggInfo:
         """Collect information about aggregations in groupbys."""
-        (value,) = self.children
-        return value.collect_agg(depth=depth)
+        return self.value.collect_agg(depth=depth)
 
 
 class Literal(Expr):
@@ -311,21 +341,21 @@ class Literal(Expr):
     _non_child = ("dtype", "value")
     value: pa.Scalar
 
-    def __init__(self, dtype: plc.DataType, value: Any) -> None:
+    def __init__(self, dtype: plc.DataType, value: pa.Scalar) -> None:
         super().__init__(dtype)
-        self.value = pa.scalar(value)
+        assert value.type == plc.interop.to_arrow(dtype)
+        self.value = value
 
     def do_evaluate(
         self,
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
-        # TODO: obey dtype
-        obj = plc.interop.from_arrow(self.value)
-        return Scalar(obj)  # type: ignore
+        # datatype of pyarrow scalar is correct by construction.
+        return Scalar(plc.interop.from_arrow(self.value))  # type: ignore
 
 
 class Col(Expr):
@@ -342,7 +372,7 @@ class Col(Expr):
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
         return df._column_map[self.name]
@@ -358,7 +388,7 @@ class Len(Expr):
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
         # TODO: type is wrong, and dtype
@@ -415,8 +445,7 @@ class BooleanFunction(Expr):
                 [source_value],
                 indices,
                 plc.Table([plc.Column.from_scalar(target_value, table.num_rows())]),
-            ).columns()[0],
-            column.name,
+            ).columns()[0]
         )
 
     _BETWEEN_OPS: ClassVar[
@@ -448,7 +477,7 @@ class BooleanFunction(Expr):
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
         columns = [
@@ -467,18 +496,18 @@ class BooleanFunction(Expr):
             )
         if self.name == pl_expr.BooleanFunction.IsNull:
             (column,) = columns
-            return Column(plc.unary.is_null(column.obj), column.name)
+            return Column(plc.unary.is_null(column.obj))
         elif self.name == pl_expr.BooleanFunction.IsNotNull:
             (column,) = columns
-            return Column(plc.unary.is_valid(column.obj), column.name)
+            return Column(plc.unary.is_valid(column.obj))
         elif self.name == pl_expr.BooleanFunction.IsNan:
             # TODO: copy over null mask since is_nan(null) => null in polars
             (column,) = columns
-            return Column(plc.unary.is_nan(column.obj), column.name)
+            return Column(plc.unary.is_nan(column.obj))
         elif self.name == pl_expr.BooleanFunction.IsNotNan:
             # TODO: copy over null mask since is_not_nan(null) => null in polars
             (column,) = columns
-            return Column(plc.unary.is_not_nan(column.obj), column.name)
+            return Column(plc.unary.is_not_nan(column.obj))
         elif self.name == pl_expr.BooleanFunction.IsFirstDistinct:
             (column,) = columns
             return self._distinct(
@@ -528,7 +557,6 @@ class BooleanFunction(Expr):
                 ),
             )
         elif self.name == pl_expr.BooleanFunction.AllHorizontal:
-            name = columns[0].name
             if any(c.obj.null_count() > 0 for c in columns):
                 raise NotImplementedError("Kleene logic for all_horizontal")
             return Column(
@@ -539,11 +567,9 @@ class BooleanFunction(Expr):
                         output_type=self.dtype,
                     ),
                     (c.obj for c in columns),
-                ),
-                name,
+                )
             )
         elif self.name == pl_expr.BooleanFunction.AnyHorizontal:
-            name = columns[0].name
             if any(c.obj.null_count() > 0 for c in columns):
                 raise NotImplementedError("Kleene logic for any_horizontal")
             return Column(
@@ -554,8 +580,7 @@ class BooleanFunction(Expr):
                         output_type=self.dtype,
                     ),
                     (c.obj for c in columns),
-                ),
-                name,
+                )
             )
         elif self.name == pl_expr.BooleanFunction.IsBetween:
             column, lo, hi = columns
@@ -571,8 +596,7 @@ class BooleanFunction(Expr):
                     ),
                     plc.binaryop.BinaryOperator.LOGICAL_AND,
                     self.dtype,
-                ),
-                column.name,
+                )
             )
         else:
             raise NotImplementedError(f"BooleanFunction {self.name}")
@@ -606,7 +630,7 @@ class StringFunction(Expr):
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
         columns = [
@@ -615,20 +639,16 @@ class StringFunction(Expr):
         ]
         if self.name == pl_expr.StringFunction.Lowercase:
             (column,) = columns
-            return Column(plc.strings.case.to_lower(column.obj), column.name)
+            return Column(plc.strings.case.to_lower(column.obj))
         elif self.name == pl_expr.StringFunction.Uppercase:
             (column,) = columns
-            return Column(plc.strings.case.to_upper(column.obj), column.name)
+            return Column(plc.strings.case.to_upper(column.obj))
         elif self.name == pl_expr.StringFunction.EndsWith:
             column, suffix = columns
-            return Column(
-                plc.strings.find.ends_with(column.obj, suffix.obj), column.name
-            )
+            return Column(plc.strings.find.ends_with(column.obj, suffix.obj))
         elif self.name == pl_expr.StringFunction.StartsWith:
             column, suffix = columns
-            return Column(
-                plc.strings.find.starts_with(column.obj, suffix.obj), column.name
-            )
+            return Column(plc.strings.find.starts_with(column.obj, suffix.obj))
         else:
             raise NotImplementedError(f"StringFunction {self.name}")
 
@@ -649,7 +669,7 @@ class Sort(Expr):
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
         (child,) = self.children
@@ -660,8 +680,11 @@ class Sort(Expr):
         )
         do_sort = plc.sorting.stable_sort if stable else plc.sorting.sort
         table = do_sort(plc.Table([column.obj]), order, null_order)
-        return Column(table.columns()[0], column.name).set_sorted(
-            is_sorted=plc.types.Sorted.YES, order=order[0], null_order=null_order[0]
+        return Column(
+            table.columns()[0],
+            is_sorted=plc.types.Sorted.YES,
+            order=order[0],
+            null_order=null_order[0],
         )
 
 
@@ -685,7 +708,7 @@ class SortBy(Expr):
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
         column, *by = (
@@ -700,7 +723,7 @@ class SortBy(Expr):
         table = do_sort(
             plc.Table([column.obj]), plc.Table([c.obj for c in by]), order, null_order
         )
-        return Column(table.columns()[0], column.name)
+        return Column(table.columns()[0])
 
 
 class Gather(Expr):
@@ -716,7 +739,7 @@ class Gather(Expr):
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
         values, indices = (
@@ -741,7 +764,7 @@ class Gather(Expr):
             bounds_policy = plc.copying.OutOfBoundsPolicy.DONT_CHECK
             obj = indices.obj
         table = plc.copying.gather(plc.Table([values.obj]), obj, bounds_policy)
-        return Column(table.columns()[0], values.name)
+        return Column(table.columns()[0])
 
 
 class Filter(Expr):
@@ -757,7 +780,7 @@ class Filter(Expr):
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
         values, mask = (
@@ -767,7 +790,7 @@ class Filter(Expr):
         table = plc.stream_compaction.apply_boolean_mask(
             plc.Table([values.obj]), mask.obj
         )
-        return Column(table.columns()[0], values.name).sorted_like(values)
+        return Column(table.columns()[0]).sorted_like(values)
 
 
 class RollingWindow(Expr):
@@ -803,14 +826,12 @@ class Cast(Expr):
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
         (child,) = self.children
         column = child.evaluate(df, context=context, mapping=mapping)
-        return Column(plc.unary.cast(column.obj, self.dtype), column.name).sorted_like(
-            column
-        )
+        return Column(plc.unary.cast(column.obj, self.dtype)).sorted_like(column)
 
     def collect_agg(self, *, depth: int) -> AggInfo:
         """Collect information about aggregations in groupbys."""
@@ -907,7 +928,9 @@ class Agg(Expr):
                 plc.reduce.reduce(column.obj, request, self.dtype),
                 1,
             ),
-            column.name,
+            is_sorted=plc.types.Sorted.YES,
+            order=plc.types.Order.ASCENDING,
+            null_order=plc.types.NullOrder.BEFORE,
         )
 
     def _count(self, column: Column) -> Column:
@@ -921,7 +944,9 @@ class Agg(Expr):
                 ),
                 1,
             ),
-            column.name,
+            is_sorted=plc.types.Sorted.YES,
+            order=plc.types.Order.ASCENDING,
+            null_order=plc.types.NullOrder.BEFORE,
         )
 
     def _min(self, column: Column, *, propagate_nans: bool) -> Column:
@@ -933,7 +958,9 @@ class Agg(Expr):
                     ),
                     1,
                 ),
-                column.name,
+                is_sorted=plc.types.Sorted.YES,
+                order=plc.types.Order.ASCENDING,
+                null_order=plc.types.NullOrder.BEFORE,
             )
         if column.nan_count > 0:
             column = column.mask_nans()
@@ -948,25 +975,37 @@ class Agg(Expr):
                     ),
                     1,
                 ),
-                column.name,
+                is_sorted=plc.types.Sorted.YES,
+                order=plc.types.Order.ASCENDING,
+                null_order=plc.types.NullOrder.BEFORE,
             )
         if column.nan_count > 0:
             column = column.mask_nans()
         return self._reduce(column, request=plc.aggregation.max())
 
     def _first(self, column: Column) -> Column:
-        return Column(plc.copying.slice(column.obj, [0, 1])[0], column.name)
+        return Column(
+            plc.copying.slice(column.obj, [0, 1])[0],
+            is_sorted=plc.types.Sorted.YES,
+            order=plc.types.Order.ASCENDING,
+            null_order=plc.types.NullOrder.BEFORE,
+        )
 
     def _last(self, column: Column) -> Column:
         n = column.obj.size()
-        return Column(plc.copying.slice(column.obj, [n - 1, n])[0], column.name)
+        return Column(
+            plc.copying.slice(column.obj, [n - 1, n])[0],
+            is_sorted=plc.types.Sorted.YES,
+            order=plc.types.Order.ASCENDING,
+            null_order=plc.types.NullOrder.BEFORE,
+        )
 
     def do_evaluate(
         self,
         df,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
         if context is not ExecutionContext.FRAME:
@@ -1018,7 +1057,7 @@ class BinOp(Expr):
         df: DataFrame,
         *,
         context: ExecutionContext = ExecutionContext.FRAME,
-        mapping: dict[Expr, Column] | None = None,
+        mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
         left, right = (
@@ -1027,7 +1066,6 @@ class BinOp(Expr):
         )
         return Column(
             plc.binaryop.binary_operation(left.obj, right.obj, self.op, self.dtype),
-            "what",
         )
 
     def collect_agg(self, *, depth: int) -> AggInfo:

--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -115,9 +115,10 @@ class IR:
 
         Raises
         ------
-        NotImplementedError if we couldn't evaluate things. Ideally
-        this should not occur, since the translation phase should pick
-        up things that we cannot handle.
+        NotImplementedError
+            If we couldn't evaluate things. Ideally this should not occur,
+            since the translation phase should pick up things that we
+            cannot handle.
         """
         raise NotImplementedError
 
@@ -368,7 +369,8 @@ class GroupBy(IR):
 
         Raises
         ------
-        NotImplementedError for unsupported expression nodes.
+        NotImplementedError
+            For unsupported expression nodes.
         """
         if isinstance(agg, (expr.BinOp, expr.Cast)):
             return max(GroupBy.check_agg(child) for child in agg.children)

--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -243,19 +243,12 @@ class Select(IR):
 
     df: IR
     """Input dataframe."""
-    cse: list[expr.NamedExpr]
-    """
-    List of common subexpressions that will appear in the selected expressions.
-
-    These must be evaluated before the returned expressions.
-    """
     expr: list[expr.NamedExpr]
     """List of expressions to evaluate to form the new dataframe."""
 
     def evaluate(self, *, cache: dict[int, DataFrame]):
         """Evaluate and return a dataframe."""
         df = self.df.evaluate(cache=cache)
-        df = df.with_columns([e.evaluate(df) for e in self.cse])
         return DataFrame([e.evaluate(df) for e in self.expr])
 
 
@@ -541,20 +534,13 @@ class HStack(IR):
 
     df: IR
     """Input dataframe."""
-    cse: list[expr.NamedExpr]
-    """
-    List of common subexpressions that will appear in the selected expressions.
-
-    These must be evaluated before the returned expressions.
-    """
     columns: list[expr.NamedExpr]
     """List of expressions to produce new columns."""
 
     def evaluate(self, *, cache: dict[int, DataFrame]) -> DataFrame:
         """Evaluate and return a dataframe."""
         df = self.df.evaluate(cache=cache)
-        ctx = df.copy().with_columns([e.evaluate(df) for e in self.cse])
-        return df.with_columns([c.evaluate(ctx) for c in self.columns])
+        return df.with_columns([c.evaluate(df) for c in self.columns])
 
 
 @dataclass(slots=True)

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -246,8 +246,8 @@ def translate_ir(visitor: Any, *, n: int | None = None) -> ir.IR:
 
     Raises
     ------
-    NotImplementedError if we can't translate the nodes due to
-    unsupported functionality.
+    NotImplementedError
+        If we can't translate the nodes due to unsupported functionality.
     """
     ctx: AbstractContextManager = (
         set_node(visitor, n) if n is not None else noop_context
@@ -282,7 +282,8 @@ def translate_named_expr(visitor: Any, *, n: pl_expr.PyExprIR) -> expr.NamedExpr
 
     Raises
     ------
-    NotImplementedError if any translation fails due to unsupported functionality.
+    NotImplementedError
+        If any translation fails due to unsupported functionality.
     """
     return expr.NamedExpr(n.output_name, translate_expr(visitor, n=n.node))
 
@@ -427,7 +428,8 @@ def translate_expr(visitor: Any, *, n: int) -> expr.Expr:
 
     Raises
     ------
-    NotImplementedError if any translation fails due to unsupported functionality.
+    NotImplementedError
+        If any translation fails due to unsupported functionality.
     """
     node = visitor.view_expression(n)
     dtype = dtypes.from_polars(visitor.get_dtype(n))

--- a/python/cudf_polars/cudf_polars/testing/asserts.py
+++ b/python/cudf_polars/cudf_polars/testing/asserts.py
@@ -23,7 +23,7 @@ def assert_gpu_result_equal(
     *,
     check_row_order: bool = True,
     check_column_order: bool = True,
-    check_dtype: bool = True,
+    check_dtypes: bool = True,
     check_exact: bool = True,
     rtol: float = 1e-05,
     atol: float = 1e-08,
@@ -40,7 +40,7 @@ def assert_gpu_result_equal(
         Expect rows to be in same order
     check_column_order
         Expect columns to be in same order
-    check_dtype
+    check_dtypes
         Expect dtypes to match
     check_exact
         Require exact equality for floats, if `False` compare using
@@ -68,7 +68,7 @@ def assert_gpu_result_equal(
         got,
         check_row_order=check_row_order,
         check_column_order=check_column_order,
-        check_dtype=check_dtype,
+        check_dtypes=check_dtypes,
         check_exact=check_exact,
         rtol=rtol,
         atol=atol,

--- a/python/cudf_polars/cudf_polars/utils/dtypes.py
+++ b/python/cudf_polars/cudf_polars/utils/dtypes.py
@@ -32,7 +32,8 @@ def from_polars(dtype: pl.DataType) -> plc.DataType:
 
     Raises
     ------
-    NotImplementedError for unsupported conversions.
+    NotImplementedError
+        For unsupported conversions.
     """
     if isinstance(dtype, pl.Boolean):
         return plc.DataType(plc.TypeId.BOOL8)

--- a/python/cudf_polars/cudf_polars/utils/sorting.py
+++ b/python/cudf_polars/cudf_polars/utils/sorting.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 def sort_order(
-    descending: Sequence[bool], *, nulls_last: bool, num_keys: int
+    descending: Sequence[bool], *, nulls_last: Sequence[bool], num_keys: int
 ) -> tuple[list[plc.types.Order], list[plc.types.NullOrder]]:
     """
     Produce sort order arguments.
@@ -36,14 +36,18 @@ def sort_order(
     # Mimicking polars broadcast handling of descending
     if num_keys > (n := len(descending)) and n == 1:
         descending = [descending[0]] * num_keys
+    if num_keys > (n := len(nulls_last)) and n == 1:
+        nulls_last = [nulls_last[0]] * num_keys
     column_order = [
         plc.types.Order.DESCENDING if d else plc.types.Order.ASCENDING
         for d in descending
     ]
     null_precedence = []
-    for asc in column_order:
-        if (asc == plc.types.Order.ASCENDING) ^ (not nulls_last):
+    # TODO: use strict=True when we drop py39
+    assert len(descending) == len(nulls_last)
+    for asc, null_last in zip(column_order, nulls_last):
+        if (asc == plc.types.Order.ASCENDING) ^ (not null_last):
             null_precedence.append(plc.types.NullOrder.AFTER)
-        elif (asc == plc.types.Order.ASCENDING) ^ nulls_last:
+        elif (asc == plc.types.Order.ASCENDING) ^ null_last:
             null_precedence.append(plc.types.NullOrder.BEFORE)
     return column_order, null_precedence

--- a/python/cudf_polars/docs/overview.md
+++ b/python/cudf_polars/docs/overview.md
@@ -34,6 +34,8 @@ pip install --upgrade uv
 uv pip install --upgrade -r py-polars/requirements-dev.txt
 ```
 
+> ![NOTE] plain `pip install` works fine, but `uv` is _much_ faster!
+
 Now we have the necessary machinery to build polars
 ```sh
 cd py-polars
@@ -57,7 +59,7 @@ The executor for the polars logical plan lives in the cudf repo, in
 
 ```sh
 cd cudf/python/cudf_polars
-pip install --no-deps -e .
+uv pip install --no-build-isolation --no-deps -e .
 ```
 
 You should now be able to run the tests in the `cudf_polars` package:
@@ -95,6 +97,21 @@ result = q.collect(post_opt_callback=execute_with_cudf)
 This should either transparently run on the GPU and deliver a polars
 dataframe, or else fail (but be handled) and just run the normal CPU
 execution.
+
+If you want to fail during translation, set the keyword argument
+`raise_on_fail` to `True`:
+
+```python
+from functools import partial
+from cudf_polars.callback import execute_with_cudf
+
+result = q.collect(
+    post_opt_callback=partial(execute_with_cudf, raise_on_fail=True)
+)
+```
+
+This is mostly useful when writing tests, since in that case we want
+any failures to propagate, rather than falling back to the CPU mode.
 
 ## Adding a handler for a new plan node
 
@@ -153,22 +170,84 @@ the logical plan in any case, so is reasonably natural.
 # Containers
 
 Containers should be constructed as relatively lightweight objects
-around their pylibcudf counterparts. We have three (in
+around their pylibcudf counterparts. We have four (in
 `cudf_polars/containers/`):
 
-1. Scalar (a wrapper around a pylibcudf Scalar)
-2. Column (a wrapper around a pylibcudf Column)
-3. DataFrame (a wrapper around a pylibcudf Table)
+1. `Scalar` (a wrapper around a pylibcudf `Scalar`)
+2. `Column` (a wrapper around a pylibcudf `Column`)
+3. `NamedColumn` a `Column` with an additional name
+3. `DataFrame` (a wrapper around a pylibcudf `Table`)
 
 The interfaces offered by these are somewhat in flux, but broadly
-speaking, a `DataFrame` is just a list of `Column`s which each hold
-data plus a string `name`, along with a collection of `Scalar`s (this
-might go away).
+speaking, a `DataFrame` is just a list of `NamedColumn`s which each
+hold a `Column` plus a string `name`. `NamedColumn`s are only ever
+constructed via `NamedExpr`s, which are the top-level expression node
+that lives inside an `IR` node. This means that the expression
+evaluator never has to concern itself with column names: columns are
+only ever decorated with names when constructing a `DataFrame`.
 
 The columns keep track of metadata (for example, whether or not they
-are sorted).
+are sorted). We could imagine tracking more metadata, like minimum and
+maximum, though perhaps that is better left to libcudf itself.
 
 We offer some utility methods for transferring metadata when
 constructing new dataframes and columns, both `DataFrame` and `Column`
-offer a `with_metadata(*, like: Self)` call which copies metadata from
-the template.
+offer a `sorted_like(like: Self)` call which copies metadata from the
+template.
+
+All methods on containers that modify in place should return `self`,
+to facilitate use in a ["fluent"
+style](https://en.wikipedia.org/wiki/Fluent_interface). It makes it
+much easier to write iteration over objects and collect the results if
+everyone always returns a value.
+
+# Writing tests
+
+We use `pytest`, tests live in the `tests/` subdirectory,
+organisationally the top-level test files each handle one of the `IR`
+nodes. The goal is that they are parametrized over all the options
+each node will handle, to have reasonable coverage. Tests of
+expression functionality should live in `tests/expressions/`.
+
+To write a test an assert correctness, build a lazyframe as a query,
+and then use the utility assertion function from
+`cudf_polars.testing.asserts`. This runs the query using both the cudf
+executor and polars CPU, and checks that they match. So:
+
+```python
+from cudf_polars.testing.asserts import assert_gpu_result_equal
+
+
+def test_whatever():
+    query = pl.LazyFrame(...).(...)
+
+    assert_gpu_result_equal(query)
+```
+
+# Debugging
+
+If the callback execution fails during the polars `collect` call, we
+obtain an error, but are not able to drop into the debugger and
+inspect the stack properly: we can't cross the language barrier.
+
+However, we can drive the translation and execution of the DSL by
+hand. Given some `LazyFrame` representing a query, we can first
+translate it to our intermediate representation (IR), and then execute
+and convert back to polars:
+
+```python
+from cudf_polars.dsl.translate import translate_ir
+
+q = ...
+
+# Convert to our IR
+ir = translate_ir(q._ldf.visit())
+
+# DataFrame living on the device
+result = ir.evaluate(cache={})
+
+# Polars dataframe
+host_result = result.to_polars()
+```
+
+If we get any exceptions, we can then debug as normal in Python.

--- a/python/cudf_polars/docs/overview.md
+++ b/python/cudf_polars/docs/overview.md
@@ -176,7 +176,7 @@ around their pylibcudf counterparts. We have four (in
 1. `Scalar` (a wrapper around a pylibcudf `Scalar`)
 2. `Column` (a wrapper around a pylibcudf `Column`)
 3. `NamedColumn` a `Column` with an additional name
-3. `DataFrame` (a wrapper around a pylibcudf `Table`)
+4. `DataFrame` (a wrapper around a pylibcudf `Table`)
 
 The interfaces offered by these are somewhat in flux, but broadly
 speaking, a `DataFrame` is just a list of `NamedColumn`s which each

--- a/python/cudf_polars/tests/expressions/test_agg.py
+++ b/python/cudf_polars/tests/expressions/test_agg.py
@@ -56,8 +56,8 @@ def test_agg(df, agg):
     q = df.select(expr)
 
     # https://github.com/rapidsai/cudf/issues/15852
-    check_dtype = agg not in {"n_unique", "median"}
-    if not check_dtype and q.schema["a"] != pl.Float64:
+    check_dtypes = agg not in {"n_unique", "median"}
+    if not check_dtypes and q.schema["a"] != pl.Float64:
         with pytest.raises(AssertionError):
             assert_gpu_result_equal(q)
-    assert_gpu_result_equal(q, check_dtype=check_dtype, check_exact=False)
+    assert_gpu_result_equal(q, check_dtypes=check_dtypes, check_exact=False)

--- a/python/cudf_polars/tests/test_select.py
+++ b/python/cudf_polars/tests/test_select.py
@@ -36,3 +36,24 @@ def test_select_reduce():
     )
 
     assert_gpu_result_equal(query)
+
+
+def test_select_with_cse_no_agg():
+    df = pl.LazyFrame({"a": [1, 2, 3]})
+    expr = pl.col("a") + pl.col("a")
+
+    query = df.select(expr, (expr * 2).alias("b"), ((expr * 2) + 10).alias("c"))
+
+    assert_gpu_result_equal(query)
+
+
+def test_select_with_cse_with_agg():
+    df = pl.LazyFrame({"a": [1, 2, 3]})
+    expr = pl.col("a") + pl.col("a")
+    asum = pl.col("a").sum() + pl.col("a").sum()
+
+    query = df.select(
+        expr, (expr * 2).alias("b"), asum.alias("c"), (asum + 10).alias("d")
+    )
+
+    assert_gpu_result_equal(query)

--- a/python/cudf_polars/tests/test_union.py
+++ b/python/cudf_polars/tests/test_union.py
@@ -2,14 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import pytest
-
 import polars as pl
 
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
-@pytest.mark.xfail(reason="Need handling of null scalars that are cast")
 def test_union():
     ldf = pl.DataFrame(
         {
@@ -19,8 +16,6 @@ def test_union():
     ).lazy()
     ldf2 = ldf.select((pl.col("a") + pl.col("b")).alias("c"), pl.col("a"))
     query = pl.concat([ldf, ldf2], how="diagonal")
-    # Plan for this produces a `None`.astype(Int64) which we don't
-    # handle correctly right now
     assert_gpu_result_equal(query)
 
 


### PR DESCRIPTION
## Description

Simplify name tracking in expression evaluation by only requiring names for columns when putting them in to a `DataFrame`. At the same time, this allows us to have one place where we broadcast-expand `Scalar`s to the size of the `DataFrame`, so we can expunge tracking them in the `DataFrame` itself.

Additionally, adapt to minor changes on the polars side in terms of translating the DSL: we no longer need to handle CSE expressions specially, and sorting by multiple keys takes a list of `descending` flags, rather than a single bool as previously.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
