### PR TITLE
Enable writing INT96 stats

### DIFF
--- a/cpp/src/io/statistics/column_statistics.cuh
+++ b/cpp/src/io/statistics/column_statistics.cuh
@@ -99,13 +99,6 @@ struct calculate_group_statistics_functor {
                               !std::is_same_v<T, list_view>)>* = nullptr>
   __device__ void operator()(stats_state_s& s, uint32_t t)
   {
-    // Temporarily disable stats writing for int96 timestamps
-    // TODO: https://github.com/rapidsai/cudf/issues/10438
-    if constexpr (cudf::is_timestamp<T>() and IO == detail::io_file_format::PARQUET and
-                  INT96 == detail::is_int96_timestamp::YES) {
-      return;
-    }
-
     detail::storage_wrapper<block_size> storage(temp_storage);
 
     using type_convert = detail::type_conversion<detail::conversion_map<IO, INT96>>;
@@ -311,10 +304,7 @@ CUDF_KERNEL void __launch_bounds__(block_size, 1)
         calculate_group_statistics_functor<block_size, IO, detail::is_int96_timestamp::NO>(storage),
         state,
         threadIdx.x);
-    }
-    // Temporarily disable stats writing for int96 timestamps
-    // TODO: https://github.com/rapidsai/cudf/issues/10438
-    else {
+    } else {
       type_dispatcher(
         state.col.leaf_column->type(),
         calculate_group_statistics_functor<block_size, IO, detail::is_int96_timestamp::YES>(

--- a/cpp/tests/io/parquet_writer_test.cpp
+++ b/cpp/tests/io/parquet_writer_test.cpp
@@ -1398,10 +1398,10 @@ TEST_F(ParquetWriterTest, INT96Stats)
 
   // check that int96 timestamp min and max statistics are written properly
 
-  // 2020-3-21 14:20:13.000781 = 0x5a15e19b40c08 (1584800413781000) =
+  // 2020-3-21 14:20:13.000781 = 0x5a15e19b40c08 (1584800413781000)
   std::vector<uint8_t> expected_min{0x08, 0x0c, 0xb4, 0x19, 0x5e, 0xa1, 0x05, 0x00};
 
-  // 2025-7-14 7:38:45.418688 = 0x639debfe7aec0
+  // 2025-7-14 7:38:45.418688 = 0x639debfe7aec0 (1752478725418688)
   std::vector<uint8_t> expected_max{0xc0, 0xae, 0xe7, 0xbf, 0xde, 0x39, 0x06, 0x00};
 
   column_wrapper<cudf::timestamp_us> big_ts_col{

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -2545,6 +2545,10 @@ def normalized_equals(value1, value2):
         value1 = None
     if value2 is pd.NA or value2 is pd.NaT:
         value2 = None
+    if isinstance(value1, np.datetime64):
+        value1 = pd.Timestamp(value1).to_pydatetime()
+    if isinstance(value2, np.datetime64):
+        value2 = pd.Timestamp(value2).to_pydatetime()
     if isinstance(value1, pd.Timestamp):
         value1 = value1.to_pydatetime()
     if isinstance(value2, pd.Timestamp):


### PR DESCRIPTION
## Description

Closes #10438 

This PR enables computing and writing INT96 column stats in libcudf, adds relevant ctest and minor improvements to pytests when comparing timestamps from pyarrow and cudf. See  #10438 for more discussion and investigation on the issue.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
