### PR TITLE
Add more complete type annotations in polars interpreter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,7 +134,7 @@ repos:
       - id: rapids-dependency-file-generator
         args: ["--clean"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.3
+    rev: v0.4.8
     hooks:
       - id: ruff
         files: python/.*$

--- a/python/cudf_polars/cudf_polars/__init__.py
+++ b/python/cudf_polars/cudf_polars/__init__.py
@@ -10,4 +10,7 @@ pylibcudf to execute the plans on device.
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from cudf_polars.callback import execute_with_cudf
+from cudf_polars.dsl.translate import translate_ir
+
+__all__: list[str] = ["execute_with_cudf", "translate_ir"]

--- a/python/cudf_polars/cudf_polars/callback.py
+++ b/python/cudf_polars/cudf_polars/callback.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     import polars as pl
 
     from cudf_polars.dsl.ir import IR
+    from cudf_polars.typing import NodeTraverser
 
 __all__: list[str] = ["execute_with_cudf"]
 
@@ -33,7 +34,7 @@ def _callback(
         return ir.evaluate(cache={}).to_polars()
 
 
-def execute_with_cudf(nt, *, raise_on_fail: bool = False) -> None:
+def execute_with_cudf(nt: NodeTraverser, *, raise_on_fail: bool = False) -> None:
     """
     A post optimization callback that attempts to execute the plan with cudf.
 

--- a/python/cudf_polars/cudf_polars/containers/dataframe.py
+++ b/python/cudf_polars/cudf_polars/containers/dataframe.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import polars as pl
 
@@ -17,6 +17,7 @@ from cudf_polars.containers.column import NamedColumn
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence, Set
 
+    import pyarrow as pa
     from typing_extensions import Self
 
     import cudf
@@ -44,12 +45,12 @@ class DataFrame:
 
     def to_polars(self) -> pl.DataFrame:
         """Convert to a polars DataFrame."""
-        return pl.from_arrow(
-            plc.interop.to_arrow(
-                self.table,
-                [plc.interop.ColumnMetadata(name=c.name) for c in self.columns],
-            )
+        table: pa.Table = plc.interop.to_arrow(
+            self.table,
+            [plc.interop.ColumnMetadata(name=c.name) for c in self.columns],
         )
+
+        return cast(pl.DataFrame, pl.from_arrow(table))
 
     @cached_property
     def column_names_set(self) -> frozenset[str]:

--- a/python/cudf_polars/cudf_polars/testing/asserts.py
+++ b/python/cudf_polars/cudf_polars/testing/asserts.py
@@ -28,7 +28,7 @@ def assert_gpu_result_equal(
     rtol: float = 1e-05,
     atol: float = 1e-08,
     categorical_as_str: bool = False,
-):
+) -> None:
     """
     Assert that collection of a lazyframe on GPU produces correct results.
 

--- a/python/cudf_polars/cudf_polars/typing/__init__.py
+++ b/python/cudf_polars/cudf_polars/typing/__init__.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typing utilities for cudf_polars."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Protocol, TypeAlias
+
+from polars.polars import _expr_nodes as pl_expr, _ir_nodes as pl_ir
+
+import cudf._lib.pylibcudf as plc
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    import polars as pl
+
+IR: TypeAlias = (
+    pl_ir.PythonScan
+    | pl_ir.Scan
+    | pl_ir.Cache
+    | pl_ir.DataFrameScan
+    | pl_ir.Select
+    | pl_ir.GroupBy
+    | pl_ir.Join
+    | pl_ir.HStack
+    | pl_ir.Distinct
+    | pl_ir.Sort
+    | pl_ir.Slice
+    | pl_ir.Filter
+    | pl_ir.SimpleProjection
+    | pl_ir.MapFunction
+    | pl_ir.Union
+    | pl_ir.HConcat
+    | pl_ir.ExtContext
+)
+
+Expr: TypeAlias = (
+    pl_expr.Function
+    | pl_expr.Window
+    | pl_expr.Literal
+    | pl_expr.Sort
+    | pl_expr.SortBy
+    | pl_expr.Gather
+    | pl_expr.Filter
+    | pl_expr.Cast
+    | pl_expr.Column
+    | pl_expr.Agg
+    | pl_expr.BinaryExpr
+    | pl_expr.Len
+    | pl_expr.PyExprIR
+)
+
+Schema: TypeAlias = Mapping[str, plc.DataType]
+
+
+class NodeTraverser(Protocol):
+    """Abstract protocol for polars NodeTraverser."""
+
+    def get_node(self) -> int:
+        """Return current plan node id."""
+        ...
+
+    def set_node(self, n: int) -> None:
+        """Set the current plan node to n."""
+        ...
+
+    def view_current_node(self) -> IR:
+        """Convert current plan node to python rep."""
+        ...
+
+    def get_schema(self) -> Mapping[str, pl.DataType]:
+        """Get the schema of the current plan node."""
+        ...
+
+    def get_dtype(self, n: int) -> pl.DataType:
+        """Get the datatype of the given expression id."""
+        ...
+
+    def view_expression(self, n: int) -> Expr:
+        """Convert the given expression to python rep."""
+        ...
+
+    def set_udf(
+        self,
+        callback: Callable[[list[str] | None, str | None, int | None], pl.DataFrame],
+    ) -> None:
+        """Set the callback replacing the current node in the plan."""
+        ...

--- a/python/cudf_polars/pyproject.toml
+++ b/python/cudf_polars/pyproject.toml
@@ -62,8 +62,6 @@ target-version = "py39"
 fix = true
 
 [tool.ruff.lint]
-# __init__.py must re-export everything it imports
-ignore-init-module-imports = false
 select = [
   "E", # pycodestyle
   "W", # pycodestyle


### PR DESCRIPTION
## Description

We can check this with:

    pyright --verifytypes cudf_polars --ignoreexternal

Which reports a "type completeness" score of around 94%. This will
improve once pylibcudf gets type stubs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
