### PR TITLE
Explicitly build for all GPU architectures

### DIFF
--- a/conda/recipes/libcudf/build.sh
+++ b/conda/recipes/libcudf/build.sh
@@ -5,5 +5,5 @@ export cudf_ROOT="$(realpath ./cpp/build)"
 
 ./build.sh -n -v \
     libcudf libcudf_kafka benchmarks tests \
-    --build_metrics --incl_cache_stats \
+    --build_metrics --incl_cache_stats --allgpuarch \
     --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib -DCUDF_ENABLE_ARROW_S3=ON\"


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The libcudf conda package is not specifying to build for all supported architectures and is instead letting build.sh fall back to NATIVE. However, because the default behavior of rapids-cmake is to build SASS for all supported architectures if NATIVE is specified but no local architecture is detected, we're still ending up with all of the RAPIDS architectures having SASS built for them. The problem is that we are failing to build PTX for the latest version, which would be produced if we used RAPIDS instead of NATIVE. This PR should resolve that issue.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
