### PR TITLE
Add typing to single_column_frame

### DIFF
--- a/python/cudf/cudf/api/types.py
+++ b/python/cudf/cudf/api/types.py
@@ -8,7 +8,7 @@ import warnings
 from collections import abc
 from functools import wraps
 from inspect import isclass
-from typing import List, Union
+from typing import List, Union, cast
 
 import cupy as cp
 import numpy as np
@@ -238,7 +238,10 @@ def _union_categoricals(
         raise TypeError("ignore_order is not yet implemented")
 
     result_col = cudf.core.column.CategoricalColumn._concat(
-        [obj._column for obj in to_union]
+        [
+            cast(cudf.core.column.CategoricalColumn, obj._column)
+            for obj in to_union
+        ]
     )
     if sort_categories:
         sorted_categories = result_col.categories.sort_values(ascending=True)

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -212,7 +212,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
             return pd.Index(pa_array.to_pandas())
 
     @property
-    def values_host(self) -> "np.ndarray":
+    def values_host(self) -> np.ndarray:
         """
         Return a numpy representation of the Column.
         """
@@ -226,7 +226,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
             return self.data_array_view(mode="read").copy_to_host()
 
     @property
-    def values(self) -> "cupy.ndarray":
+    def values(self) -> cupy.ndarray:
         """
         Return a CuPy representation of the Column.
         """

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -11,7 +11,7 @@ import pyarrow as pa
 from typing_extensions import Self
 
 import cudf
-from cudf._typing import Dtype, NotImplementedType, ScalarLike
+from cudf._typing import NotImplementedType, ScalarLike
 from cudf.api.extensions import no_default
 from cudf.api.types import (
     _is_scalar_or_zero_d_array,
@@ -114,24 +114,6 @@ class SingleColumnFrame(Frame, NotIterable):
     @_cudf_nvtx_annotate
     def values_host(self) -> numpy.ndarray:  # noqa: D102
         return self._column.values_host
-
-    @_cudf_nvtx_annotate
-    def to_cupy(
-        self,
-        dtype: Union[Dtype, None] = None,
-        copy: bool = True,
-        na_value=None,
-    ) -> cupy.ndarray:  # noqa: D102
-        return super().to_cupy(dtype, copy, na_value)
-
-    @_cudf_nvtx_annotate
-    def to_numpy(
-        self,
-        dtype: Union[Dtype, None] = None,
-        copy: bool = True,
-        na_value=None,
-    ) -> numpy.ndarray:  # noqa: D102
-        return super().to_numpy(dtype, copy, na_value)
 
     @classmethod
     @_cudf_nvtx_annotate


### PR DESCRIPTION
## Description
Also removes an extra copy from `.flatten()` when calling `.values` or `.values_host`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
