### PR TITLE
JSON validation of Values

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -392,6 +392,7 @@ add_library(
   src/io/json/nested_json_gpu.cu
   src/io/json/read_json.cu
   src/io/json/parser_features.cpp
+  src/io/json/process_tokens.cu
   src/io/json/write_json.cu
   src/io/orc/aggregate_orc_metadata.cpp
   src/io/orc/dict_enc.cu

--- a/cpp/include/cudf/io/json.hpp
+++ b/cpp/include/cudf/io/json.hpp
@@ -129,6 +129,14 @@ class json_reader_options {
   // Whether to recover after an invalid JSON line
   json_recovery_mode_t _recovery_mode = json_recovery_mode_t::FAIL;
 
+  // Validation checks for spark
+  // Allow leading zeros for numeric values.
+  bool _allow_numeric_leading_zeros = true;
+  // Allow unquoted control characters
+  bool allowUnquotedControlChars = true;
+  // Additional values to recognize as null values
+  std::vector<std::string> _na_values;
+
   /**
    * @brief Constructor from source info.
    *
@@ -299,6 +307,20 @@ class json_reader_options {
   json_recovery_mode_t recovery_mode() const { return _recovery_mode; }
 
   /**
+   * @brief Whether leading zeros are allowed in numeric values.
+   *
+   * @return true if leading zeros are allowed in numeric values
+   */
+  [[nodiscard]] bool is_allowed_numeric_leading_zeros() const { return _allow_numeric_leading_zeros; }
+
+  /**
+   * @brief Returns additional values to recognize as null values.
+   *
+   * @return Additional values to recognize as null values
+   */
+  [[nodiscard]] std::vector<std::string> const& get_na_values() const { return _na_values; }
+
+  /**
    * @brief Set data types for columns to be read.
    *
    * @param types Vector of dtypes
@@ -427,6 +449,20 @@ class json_reader_options {
    * @param val An enum value to indicate the JSON reader's behavior on invalid JSON lines.
    */
   void set_recovery_mode(json_recovery_mode_t val) { _recovery_mode = val; }
+
+  /**
+   * @brief Set Whether leading zeros are allowed in numeric values.
+   *
+   * @param val Boolean value to indicate whether leading zeros are allowed in numeric values
+   */
+  void allow_numeric_leading_zeros(bool val) { _allow_numeric_leading_zeros = val; }
+
+  /**
+   * @brief Sets additional values to recognize as null values.
+   *
+   * @param vals Vector of values to be considered to be null
+   */
+  void set_na_values(std::vector<std::string> vals) { _na_values = std::move(vals); }
 };
 
 /**
@@ -635,6 +671,29 @@ class json_reader_options_builder {
   json_reader_options_builder& recovery_mode(json_recovery_mode_t val)
   {
     options._recovery_mode = val;
+    return *this;
+  }
+
+  /**
+   * @brief Set Whether leading zeros are allowed in numeric values.
+   *
+   * @param val Boolean value to indicate whether leading zeros are allowed in numeric values
+   */
+  json_reader_options_builder& numeric_leading_zeros(bool val)
+  {
+    options.allow_numeric_leading_zeros(val);
+    return *this;
+  }
+
+  /**
+   * @brief Sets additional values to recognize as null values.
+   *
+   * @param vals Vector of values to be considered to be null
+   * @return this for chaining
+   */
+  json_reader_options_builder& na_values(std::vector<std::string> vals)
+  {
+    options.set_na_values(std::move(vals));
     return *this;
   }
 

--- a/cpp/src/io/json/nested_json.hpp
+++ b/cpp/src/io/json/nested_json.hpp
@@ -222,6 +222,22 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> pr
   rmm::cuda_stream_view stream);
 
 /**
+ * @brief Validate the tokens conforming to behavior given in options.
+ * 
+ * @param d_input The string of input characters
+ * @param tokens The tokens to be post-processed
+ * @param token_indices The tokens' corresponding indices that are post-processed
+ * @param options Parsing options specifying the parsing behaviour
+ * @param stream The cuda stream to dispatch GPU kernels to
+ */
+void validate_token_stream(
+  device_span<char const> d_input,
+  device_span<PdaTokenT> tokens,
+  device_span<SymbolOffsetT> token_indices,
+  cudf::io::json_reader_options const& options,
+  rmm::cuda_stream_view stream);
+
+/**
  * @brief Parses the given JSON string and generates a tree representation of the given input.
  *
  * @param tokens Vector of token types in the json string

--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -1655,6 +1655,7 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
 
   if (delimiter_offset == 1) {
     tokens.set_element(0, token_t::LineEnd, stream);
+    validate_token_stream(json_in, tokens, tokens_indices, options, stream);
     auto [filtered_tokens, filtered_tokens_indices] =
       process_token_stream(tokens, tokens_indices, stream);
     tokens         = std::move(filtered_tokens);
@@ -2079,7 +2080,9 @@ cudf::io::parse_options parsing_options(cudf::io::json_reader_options const& opt
   parse_opts.keepquotes = options.is_enabled_keep_quotes();
   parse_opts.trie_true  = cudf::detail::create_serialized_trie({"true"}, stream);
   parse_opts.trie_false = cudf::detail::create_serialized_trie({"false"}, stream);
-  parse_opts.trie_na    = cudf::detail::create_serialized_trie({"", "null"}, stream);
+  std::vector<std::string> na_values{"", "null"};
+  na_values.insert(na_values.end(), options.get_na_values().begin(), options.get_na_values().end());
+  parse_opts.trie_na    = cudf::detail::create_serialized_trie(na_values, stream);
   return parse_opts;
 }
 

--- a/cpp/src/io/json/output_writer_iterator.h
+++ b/cpp/src/io/json/output_writer_iterator.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Output writer iterator
+#pragma once
+
+#include <thrust/iterator/iterator_adaptor.h>
+
+THRUST_NAMESPACE_BEGIN
+namespace detail {
+
+// Proxy reference that calls BinaryFunction with Iterator value and the rhs of assignment operator
+template <typename BinaryFunction, typename Iterator>
+class output_writer_iterator_proxy {
+ public:
+  __host__ __device__ output_writer_iterator_proxy(const Iterator& index_iter, BinaryFunction fun)
+    : index_iter(index_iter), fun(fun)
+  {
+  }
+  template <typename T>
+  __host__ __device__ output_writer_iterator_proxy operator=(const T& x)
+  {
+    fun(*index_iter, x);
+    return *this;
+  }
+
+ private:
+  Iterator index_iter;
+  BinaryFunction fun;
+};
+
+// Register output_writer_iterator_proxy with 'is_proxy_reference' from
+// type_traits to enable its use with algorithms.
+template <class BinaryFunction, class Iterator>
+struct is_proxy_reference<output_writer_iterator_proxy<BinaryFunction, Iterator>>
+  : public thrust::detail::true_type {
+};
+
+}  // namespace detail
+
+/**
+ * @brief Transform output iterator with custom writer binary function which takes index and value.
+ *
+ * @code {.cpp}
+ * #include <thrust/iterator/output_writer_iterator.cuh>
+ * #include <thrust/device_vector.h>
+ * #include <thrust/iterator/counting_iterator.h>
+ * #include <thrust/iterator/transform_iterator.h>
+ *
+ * struct set_bits_field {
+ *   int* bitfield;
+ *   __device__ inline void set_bit(size_t bit_index)
+ *   {
+ *     atomicOr(&bitfield[bit_index/32], (int{1} << (bit_index % 32)));
+ *   }
+ *   __device__ inline void clear_bit(size_t bit_index)
+ *   {
+ *     atomicAnd(&bitfield[bit_index / 32], ~(int{1} << (bit_index % 32)));
+ *   }
+ *   // Index, value
+ *   __device__ void operator()(size_t i, bool x)
+ *   {
+ *     if (x)
+ *       set_bit(i);
+ *     else
+ *       clear_bit(i);
+ *   }
+ * };
+ *
+ * thrust::device_vector<int> v(1, 0x00000000);
+ * auto result_begin = thrust::make_output_writer_iterator(thrust::make_counting_iterator(0),
+ *                                                 set_bits_field{v.data().get()});
+ * auto value = thrust::make_transform_iterator(thrust::make_counting_iterator(0),
+ *   [] __device__ (int x) {   return x%2; });
+ * thrust::copy(thrust::device, value, value+32, result_begin);
+ * assert(v[0] == 0xaaaaaaaa);
+ * @endcode
+ *
+ *
+ * @tparam BinaryFunction Binary function to be called with the Iterator value and the rhs of
+ * assignment operator.
+ * @tparam Iterator iterator type that acts as index of the output.
+ */
+template <typename BinaryFunction, typename Iterator>
+class output_writer_iterator
+  : public thrust::iterator_adaptor<
+      output_writer_iterator<BinaryFunction, Iterator>,
+      Iterator,
+      thrust::use_default,
+      thrust::use_default,
+      thrust::use_default,
+      thrust::detail::output_writer_iterator_proxy<BinaryFunction, Iterator>> {
+ public:
+  // parent class.
+  typedef thrust::iterator_adaptor<
+    output_writer_iterator<BinaryFunction, Iterator>,
+    Iterator,
+    thrust::use_default,
+    thrust::use_default,
+    thrust::use_default,
+    thrust::detail::output_writer_iterator_proxy<BinaryFunction, Iterator>>
+    super_t;
+  // friend thrust::iterator_core_access to allow it access to the private interface dereference()
+  friend class thrust::iterator_core_access;
+  __host__ __device__ output_writer_iterator(Iterator const& x, BinaryFunction fun)
+    : super_t(x), fun(fun)
+  {
+  }
+
+ private:
+  BinaryFunction fun;
+
+  // thrust::iterator_core_access accesses this function
+  __host__ __device__ typename super_t::reference dereference() const
+  {
+    return thrust::detail::output_writer_iterator_proxy<BinaryFunction, Iterator>(
+      this->base_reference(), fun);
+  }
+};
+
+template <typename BinaryFunction, typename Iterator>
+output_writer_iterator<BinaryFunction, Iterator> __host__ __device__
+make_output_writer_iterator(Iterator out, BinaryFunction fun)
+{
+  return output_writer_iterator<BinaryFunction, Iterator>(out, fun);
+}  // end make_output_writer_iterator
+THRUST_NAMESPACE_END

--- a/cpp/src/io/json/process_tokens.cu
+++ b/cpp/src/io/json/process_tokens.cu
@@ -1,0 +1,161 @@
+
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nested_json.hpp"
+// #include "tabulate_output_iterator.cuh"
+#include "output_writer_iterator.h"
+
+#include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/io/detail/tokenize_json.hpp>
+
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cuda/functional>
+#include <thrust/scan.h>
+#include <thrust/transform_scan.h>
+#include <thrust/tuple.h>
+
+#include <sys/types.h>
+
+namespace cudf::io::json {
+namespace detail {
+
+struct write_if {
+  using token_t   = cudf::io::json::token_t;
+  using scan_type = thrust::pair<token_t, bool>;
+  PdaTokenT* tokens;
+  size_t n;
+  // Index, value
+  __device__ void operator()(size_type i, scan_type x)
+  {
+    if (i == n - 1 or tokens[i + 1] == token_t::LineEnd) {
+      if (x.first == token_t::ErrorBegin and tokens[i] != token_t::ErrorBegin) {
+        tokens[i] = token_t::ErrorBegin;
+        // printf("writing\n");
+      }
+    }
+  }
+};
+
+void validate_token_stream(device_span<char const> d_input,
+                           device_span<PdaTokenT> tokens,
+                           device_span<SymbolOffsetT> token_indices,
+                           cudf::io::json_reader_options const& options,
+                           rmm::cuda_stream_view stream)
+{
+  if (getenv("SPARK_JSON")) {
+    using token_t = cudf::io::json::token_t;
+    auto validate_tokens =
+      [data = d_input.data(),
+       allow_numeric_leading_zeros =
+         options.is_allowed_numeric_leading_zeros()] __device__(SymbolOffsetT start,
+                                                                SymbolOffsetT end) -> bool {
+      // Leading zeros.
+      if (!allow_numeric_leading_zeros and data[start] == '0') return false;
+      return true;
+    };
+    auto num_tokens = tokens.size();
+    auto count_it   = thrust::make_counting_iterator(0);
+    auto predicate  = [tokens        = tokens.begin(),
+                      token_indices = token_indices.begin(),
+                      validate_tokens] __device__(auto i) -> bool {
+      if (tokens[i] == token_t::ValueEnd) {
+        return !validate_tokens(token_indices[i - 1], token_indices[i]);
+      }
+      return false;
+    };
+
+    using scan_type        = write_if::scan_type;
+    auto conditional_write = write_if{tokens.begin(), num_tokens};
+    // auto conditional_output_it = tokens.begin();
+    // auto conditional_output_it = thrust::make_tabulate_output_iterator(conditional_write);
+    auto conditional_output_it =
+      thrust::make_output_writer_iterator(thrust::make_counting_iterator(0), conditional_write);
+    auto transform_op = cuda::proclaim_return_type<scan_type>(
+      [predicate, tokens = tokens.begin()] __device__(auto i) -> scan_type {
+        if (predicate(i)) return {token_t::ErrorBegin, tokens[i] == token_t::LineEnd};
+        return {static_cast<token_t>(tokens[i]), tokens[i] == token_t::LineEnd};
+      });
+    auto binary_op = cuda::proclaim_return_type<scan_type>(
+      [] __device__(scan_type prev, scan_type curr) -> scan_type {
+        auto op_result = (prev.first == token_t::ErrorBegin ? prev.first : curr.first);
+        return scan_type((curr.second ? curr.first : op_result), prev.second | curr.second);
+      });
+    rmm::device_uvector<int8_t> error(num_tokens, stream);
+    thrust::transform(rmm::exec_policy(stream),
+                      count_it,
+                      count_it + num_tokens,
+                      error.begin(),
+                      predicate);  // in-place scan
+    printf("error:");
+    for (auto tk : cudf::detail::make_std_vector_sync(error, stream))
+      printf("%d ", tk);
+    printf("\n");
+
+    thrust::transform_inclusive_scan(rmm::exec_policy(stream),
+                                     count_it,
+                                     count_it + num_tokens,
+                                     conditional_output_it,
+                                     transform_op,
+                                     binary_op);  // in-place scan
+  }
+  printf("pre_process_token:");
+  for (auto tk : cudf::detail::make_std_vector_sync(device_span<PdaTokenT const>(tokens), stream))
+    printf("%d ", tk);
+  printf("\n");
+
+  // LE SB FB FE VB VE SE LE SB ER LE SB LB VB VE SE LE LE
+  // 1   0  0  0  0  0  0  1  0  0  0  0  0  0  0  0  1  1
+  // 1   1  1  1  1  1  1  2  2  2  2  2  2  2  2  2  3  4
+  // auto unary_op = [] __device__ (auto) -> token_t { return token_t::ErrorBegin; };
+  // thrust::transform_if(rmm::exec_policy(stream), count_it, count_it + num_tokens, tokens.begin(),
+  // unary_op, predicate); auto num_rows = thrust::count(rmm::exec_policy(stream), tokens.begin(),
+  // tokens.end(), token_t::LineEnd); rmm::device_uvector<bool> row_is_error(num_rows, stream);
+  // rmm::device_uvector<SymbolOffsetT> row_index(num_tokens, stream);
+  // auto is_LineEnd = [] __device__ (auto token) -> SymbolOffsetT { return token ==
+  // token_t::LineEnd; }; thrust::transform_inclusive_scan(rmm::exec_policy(stream),
+  //   tokens.begin(), tokens.end(), row_index.begin(), is_LineEnd, thrust::plus<SymbolOffsetT>{});
+  // auto is_error_it = thrust::make_transform_iterator(tokens.begin(), [] __device__ (auto token)
+  // -> bool { return token == token_t::ErrorBegin; });
+  // thrust::reduce_by_key(rmm::exec_policy(stream), row_index.begin(), row_index.end(),
+  // is_error_it, thrust::make_discard_iterator(), row_is_error.begin());
+
+  // if current == ErrorBegin and tokens[i+1]==LE or i==n-1) then write ErrorBegin to tokens[i],
+  // else nothing. if VB, or SB, then if validate(token[i], token[i+1])==false,
+  //
+  // Transform_if to errors tokens
+  // Count LE (num_rows)
+  // create int vector [num_rows], bool[num_rows]
+  // TODO: fuse them together with single scan algorithm.
+  // LE==1, to scan to row_index.
+  // reduce_by_key, to check if it has any error, and number of non-errors tokens.
+  // reduce them to get output tokens count.
+  // copy_if -> use cub cub::DeviceSelect::If(d_data, d_num_selected_out, num_items, select_op)
+}
+
+// corner cases: empty LE,
+// alternate Decoupled look back idea:
+// count LineEnd, allocate bool[num_rows] as is_error.
+// decoupled look back for LineEnd tokens for row indices,
+//  transform_if to error tokens and write to bool[row_index] atomically (reduce and write within
+//  warp/block?)
+// decoupled look back for LineEnd tokens for row indices,
+//  (if not error row & not lineEnd token) -> decoupled look back for output indices,
+//  CopyIf (if not error row & not lineEnd token) write to output.
+}  // namespace detail
+}  // namespace cudf::io::json

--- a/cpp/tests/io/json_test.cpp
+++ b/cpp/tests/io/json_test.cpp
@@ -2161,6 +2161,84 @@ TEST_F(JsonReaderTest, JSONLinesRecoveringSync)
   cudf::io::set_host_memory_resource(last_mr);
 }
 
+// Validation
+TEST_F(JsonReaderTest, ValueValidation)
+{
+  // parsing error as null rows
+  std::string data =
+    // 0 -> a: -2 (valid)
+    R"({"a":-2 }{})"
+    "\n"
+    // 1 -> (invalid)
+    R"({"b":{}should_be_invalid})"
+    "\n"
+    // 2 -> b (valid)
+    R"({"b":{"a":3} })"
+    "\n"
+    // 3 -> c: (valid/null based on option)
+    R"({"a": 1, "c":nan, "d": "null" } )"
+    "\n"
+    "\n"
+    // 4 -> (valid/null based on option)
+    R"({"a":04, "c": 1.23, "d": "abc"} 123)"
+    "\n"
+    // 5 -> (valid)
+    R"({"a":5}//Comment after record)"
+    "\n"
+    // 6 -> ((valid/null based on option)
+    R"({"a":06} //Comment after whitespace)"
+    "\n"
+    // 7 -> (invalid)
+    R"({"a":5 //Invalid Comment within record})";
+
+  // leadingZeros allowed
+  // na_values,
+  {
+    cudf::io::json_reader_options in_options =
+      cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+        .lines(true)
+        .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL);
+    cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
+
+    EXPECT_EQ(result.tbl->num_columns(), 4);
+    EXPECT_EQ(result.tbl->num_rows(), 8);
+    auto b_a_col  = int64_wrapper({0, 0, 3, 0, 0, 0, 0, 0});
+    auto a_column = int64_wrapper{{-2, 0, 0, 1, 4, 5, 6, 0},
+                                  {true, false, false, true, true, true, true, false}};
+    auto b_column = cudf::test::structs_column_wrapper(
+      {b_a_col}, {false, false, true, false, false, false, false, false});
+    auto c_column = float64_wrapper({0.0, 0.0, 0.0, 0.0, 1.23, 0.0, 0.0, 0.0},
+                                    {false, false, false, false, true, false, false, false});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(0), a_column);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(1), b_column);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(2), c_column);
+  }
+  // leadingZeros not allowed, NaN allowed
+  {
+    cudf::io::json_reader_options in_options =
+      cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+        .lines(true)
+        .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+        .numeric_leading_zeros(false)
+        .na_values({"nan"});
+    cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
+
+    EXPECT_EQ(result.tbl->num_columns(), 4);
+    EXPECT_EQ(result.tbl->num_rows(), 8);
+    EXPECT_EQ(result.tbl->get_column(2).type().id(), cudf::type_id::INT8); // empty column
+    auto b_a_col  = int64_wrapper({0, 0, 3, 0, 0, 0, 0, 0});
+    auto a_column = int64_wrapper{{-2, 0, 0, 1, 4, 5, 6, 0},
+                                  {true, false, false, true, false, true, false, false}};
+    auto b_column = cudf::test::structs_column_wrapper(
+      {b_a_col}, {false, false, true, false, false, false, false, false});
+    auto c_column = int8_wrapper({0, 0, 0, 0, 0, 0, 0, 0},
+                                    {false, false, false, false, false, false, false, false});
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(0), a_column);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(1), b_column);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(2), c_column);
+  }
+}
+
 TEST_F(JsonReaderTest, MixedTypes)
 {
   using LCWS    = cudf::test::lists_column_wrapper<cudf::string_view>;


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This change adds validation stage in JSON reader at tokens level. If any validation fails in a row, it will make the entire row as null.
TODO: 
- [ ] validation functor - implement spark validation rules. (only leading zeros check is added).
- [ ] move output iterator to thrust.
- [ ] Fix failing tests and infer data type for Float.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
