### PR TITLE
Add pre-commit hook for correct multi-line Cython docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,6 +81,33 @@ repos:
             ^python/cudf/cudf/core/dtypes.py|
             ^python/cudf/cudf/tests/pytest.ini
           )
+      - id: cython-docstrings
+        name: cython-docstrings
+        description: 'Enforce multi-line Cython docstrings start on line two'
+        # We want to allow """One line docstring"""
+        # But disallow
+        # """This is the first line
+        #    Here is the second line"""
+        # Since in REPL help, the indentation is wrong.
+        # It should instead be
+        # """
+        # This is the first line
+        # This is the second line
+        # """
+        # So we want a regex that fires for the middle condition.
+        # To do this, we use PCRE regex features, specifically,
+        # conditionals and negative lookahead
+        # The regex reads:
+        # - If a line starts with any whitespace followed by literal """
+        # - Then
+        # - If the next character is not a line ending character
+        # - Then
+        # - If the line does not match either any number of characters
+        # followed by literal """ or a noqa comment, followed by end of line
+        # - Then we have a match
+        entry: '(^\s*""")(?(1)((?!$))(?(2)(?!(.*"""|\s*# noqa.*)$)))'
+        language: pygrep
+        types: [cython]
       - id: no-programmatic-xfail
         name: no-programmatic-xfail
         description: 'Enforce that pytest.xfail is not introduced (see dev docs for details)'

--- a/docs/cudf/source/developer_guide/pylibcudf.md
+++ b/docs/cudf/source/developer_guide/pylibcudf.md
@@ -242,3 +242,33 @@ cpdef ColumnOrTable empty_like(ColumnOrTable input)
 
 [Cython supports specializing the contents of fused-type functions based on the argument types](https://cython.readthedocs.io/en/latest/src/userguide/fusedtypes.html#type-checking-specializations), so any type-specific logic may be encoded using the appropriate conditionals.
 See the pylibcudf source for examples of how to implement such functions.
+
+### Docstring conventions
+
+We use
+[numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html)-style
+docstrings. For correct indentation in the REPL, make sure that
+multi-line docstrings start on line two. That is, write:
+
+```cython
+def some_function(...):
+    """
+    Short summary.
+
+    More detail
+    """
+```
+
+Rather than
+
+```cython
+def some_function(...):
+    """Short summary.
+
+    More detail
+    """
+```
+
+Single-line docstrings can start on line one, as long as the closing
+quotes also do. These conventions are enforced as part of a pre-commit
+hook, though it uses regular expressions, so is not perfect.

--- a/python/cudf/cudf/_lib/column.pyx
+++ b/python/cudf/cudf/_lib/column.pyx
@@ -459,7 +459,8 @@ cdef class Column:
     # publicly.  User requests to convert to pylibcudf must assume that the
     # data may be modified afterwards.
     cpdef to_pylibcudf(self, mode: Literal["read", "write"]):
-        """Convert this Column to a pylibcudf.Column.
+        """
+        Convert this Column to a pylibcudf.Column.
 
         This function will generate a pylibcudf Column pointing to the same
         data, mask, and children as this one.
@@ -530,7 +531,8 @@ cdef class Column:
     cdef Column from_unique_ptr(
         unique_ptr[column] c_col, bint data_ptr_exposed=False
     ):
-        """Create a Column from a column
+        """
+        Create a Column from a column
 
         Typically, this is called on the result of a libcudf operation.
         If the data of the libcudf result has been exposed, set
@@ -600,7 +602,8 @@ cdef class Column:
     def from_pylibcudf(
         col, bint data_ptr_exposed=False
     ):
-        """Create a Column from a pylibcudf.Column.
+        """
+        Create a Column from a pylibcudf.Column.
 
         This function will generate a Column pointing to the provided pylibcudf
         Column.  It will directly access the data and mask buffers of the

--- a/python/cudf/cudf/_lib/copying.pyx
+++ b/python/cudf/cudf/_lib/copying.pyx
@@ -49,7 +49,8 @@ def _gather_map_is_valid(
     check_bounds: bool,
     nullify: bool,
 ) -> bool:
-    """Returns true if gather map is valid.
+    """
+    Returns true if gather map is valid.
 
     A gather map is valid if empty or all indices are within the range
     ``[-nrows, nrows)``, except when ``nullify`` is specified.
@@ -285,7 +286,8 @@ def copy_if_else(object lhs, object rhs, Column boolean_mask):
 @acquire_spill_lock()
 def boolean_mask_scatter(list input_, list target_columns,
                          Column boolean_mask):
-    """Copy the target columns, replacing masked rows with input data.
+    """
+    Copy the target columns, replacing masked rows with input data.
 
     The ``input_`` data can be a list of columns or as a list of scalars.
     A list of input columns will be used to replace corresponding rows in the

--- a/python/cudf/cudf/_lib/datetime.pyx
+++ b/python/cudf/cudf/_lib/datetime.pyx
@@ -166,7 +166,8 @@ def round_datetime(Column col, object freq):
 
 @acquire_spill_lock()
 def is_leap_year(Column col):
-    """Returns a boolean indicator whether the year of the date is a leap year
+    """
+    Returns a boolean indicator whether the year of the date is a leap year
     """
     cdef unique_ptr[column] c_result
     cdef column_view col_view = col.view()
@@ -212,7 +213,8 @@ def extract_quarter(Column col):
 
 @acquire_spill_lock()
 def days_in_month(Column col):
-    """Extracts the number of days in the month of the date
+    """
+    Extracts the number of days in the month of the date
     """
     cdef unique_ptr[column] c_result
     cdef column_view col_view = col.view()

--- a/python/cudf/cudf/_lib/interop.pyx
+++ b/python/cudf/cudf/_lib/interop.pyx
@@ -127,7 +127,8 @@ def _set_col_children_metadata(dtype, col_meta):
 
 @acquire_spill_lock()
 def to_arrow(list source_columns, object column_dtypes):
-    """Convert a list of columns from
+    """
+    Convert a list of columns from
     cudf Frame to a PyArrow Table.
 
     Parameters
@@ -148,7 +149,8 @@ def to_arrow(list source_columns, object column_dtypes):
 
 @acquire_spill_lock()
 def from_arrow(object input_table):
-    """Convert from PyArrow Table to a list of columns.
+    """
+    Convert from PyArrow Table to a list of columns.
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/merge.pyx
+++ b/python/cudf/cudf/_lib/merge.pyx
@@ -13,7 +13,8 @@ def merge_sorted(
     bool ascending=True,
     str na_position="last",
 ):
-    """Merge multiple lists of lexicographically sorted columns into one list
+    """
+    Merge multiple lists of lexicographically sorted columns into one list
     of sorted columns. `input_columns` is a list of lists of columns to be
     merged.
     """

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -729,8 +729,10 @@ cdef class ParquetWriter:
         self.close()
 
     def _initialize_chunked_state(self, table, num_partitions=1):
-        """ Prepares all the values required to build the
-        chunked_parquet_writer_options and creates a writer"""
+        """
+        Prepares all the values required to build the
+        chunked_parquet_writer_options and creates a writer.
+        """
         cdef table_view tv
 
         # Set the table_metadata

--- a/python/cudf/cudf/_lib/partitioning.pyx
+++ b/python/cudf/cudf/_lib/partitioning.pyx
@@ -25,7 +25,8 @@ cimport cudf._lib.pylibcudf.libcudf.types as libcudf_types
 @acquire_spill_lock()
 def partition(list source_columns, Column partition_map,
               object num_partitions):
-    """Partition source columns given a partitioning map
+    """
+    Partition source columns given a partitioning map
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/pylibcudf/aggregation.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/aggregation.pyx
@@ -64,7 +64,8 @@ from .types cimport DataType
 
 
 cdef class Aggregation:
-    """A type of aggregation to perform.
+    """
+    A type of aggregation to perform.
 
     Aggregations are passed to APIs like
     :py:func:`~cudf._lib.pylibcudf.groupby.GroupBy.aggregate` to indicate what
@@ -151,7 +152,8 @@ cdef class Aggregation:
 
 
 cpdef Aggregation sum():
-    """Create a sum aggregation.
+    """
+    Create a sum aggregation.
 
     For details, see :cpp:func:`make_sum_aggregation`.
 
@@ -164,7 +166,8 @@ cpdef Aggregation sum():
 
 
 cpdef Aggregation product():
-    """Create a product aggregation.
+    """
+    Create a product aggregation.
 
     For details, see :cpp:func:`make_product_aggregation`.
 
@@ -177,7 +180,8 @@ cpdef Aggregation product():
 
 
 cpdef Aggregation min():
-    """Create a min aggregation.
+    """
+    Create a min aggregation.
 
     For details, see :cpp:func:`make_min_aggregation`.
 
@@ -190,7 +194,8 @@ cpdef Aggregation min():
 
 
 cpdef Aggregation max():
-    """Create a max aggregation.
+    """
+    Create a max aggregation.
 
     For details, see :cpp:func:`make_max_aggregation`.
 
@@ -203,7 +208,8 @@ cpdef Aggregation max():
 
 
 cpdef Aggregation count(null_policy null_handling = null_policy.EXCLUDE):
-    """Create a count aggregation.
+    """
+    Create a count aggregation.
 
     For details, see :cpp:func:`make_count_aggregation`.
 
@@ -223,7 +229,8 @@ cpdef Aggregation count(null_policy null_handling = null_policy.EXCLUDE):
 
 
 cpdef Aggregation any():
-    """Create an any aggregation.
+    """
+    Create an any aggregation.
 
     For details, see :cpp:func:`make_any_aggregation`.
 
@@ -236,7 +243,8 @@ cpdef Aggregation any():
 
 
 cpdef Aggregation all():
-    """Create an all aggregation.
+    """
+    Create an all aggregation.
 
     For details, see :cpp:func:`make_all_aggregation`.
 
@@ -249,7 +257,8 @@ cpdef Aggregation all():
 
 
 cpdef Aggregation sum_of_squares():
-    """Create a sum_of_squares aggregation.
+    """
+    Create a sum_of_squares aggregation.
 
     For details, see :cpp:func:`make_sum_of_squares_aggregation`.
 
@@ -264,7 +273,8 @@ cpdef Aggregation sum_of_squares():
 
 
 cpdef Aggregation mean():
-    """Create a mean aggregation.
+    """
+    Create a mean aggregation.
 
     For details, see :cpp:func:`make_mean_aggregation`.
 
@@ -277,7 +287,8 @@ cpdef Aggregation mean():
 
 
 cpdef Aggregation variance(size_type ddof=1):
-    """Create a variance aggregation.
+    """
+    Create a variance aggregation.
 
     For details, see :cpp:func:`make_variance_aggregation`.
 
@@ -295,7 +306,8 @@ cpdef Aggregation variance(size_type ddof=1):
 
 
 cpdef Aggregation std(size_type ddof=1):
-    """Create a std aggregation.
+    """
+    Create a std aggregation.
 
     For details, see :cpp:func:`make_std_aggregation`.
 
@@ -313,7 +325,8 @@ cpdef Aggregation std(size_type ddof=1):
 
 
 cpdef Aggregation median():
-    """Create a median aggregation.
+    """
+    Create a median aggregation.
 
     For details, see :cpp:func:`make_median_aggregation`.
 
@@ -326,7 +339,8 @@ cpdef Aggregation median():
 
 
 cpdef Aggregation quantile(list quantiles, interpolation interp = interpolation.LINEAR):
-    """Create a quantile aggregation.
+    """
+    Create a quantile aggregation.
 
     For details, see :cpp:func:`make_quantile_aggregation`.
 
@@ -349,7 +363,8 @@ cpdef Aggregation quantile(list quantiles, interpolation interp = interpolation.
 
 
 cpdef Aggregation argmax():
-    """Create an argmax aggregation.
+    """
+    Create an argmax aggregation.
 
     For details, see :cpp:func:`make_argmax_aggregation`.
 
@@ -362,7 +377,8 @@ cpdef Aggregation argmax():
 
 
 cpdef Aggregation argmin():
-    """Create an argmin aggregation.
+    """
+    Create an argmin aggregation.
 
     For details, see :cpp:func:`make_argmin_aggregation`.
 
@@ -375,7 +391,8 @@ cpdef Aggregation argmin():
 
 
 cpdef Aggregation nunique(null_policy null_handling = null_policy.EXCLUDE):
-    """Create a nunique aggregation.
+    """
+    Create a nunique aggregation.
 
     For details, see :cpp:func:`make_nunique_aggregation`.
 
@@ -397,7 +414,8 @@ cpdef Aggregation nunique(null_policy null_handling = null_policy.EXCLUDE):
 cpdef Aggregation nth_element(
     size_type n, null_policy null_handling = null_policy.INCLUDE
 ):
-    """Create a nth_element aggregation.
+    """
+    Create a nth_element aggregation.
 
     For details, see :cpp:func:`make_nth_element_aggregation`.
 
@@ -417,7 +435,8 @@ cpdef Aggregation nth_element(
 
 
 cpdef Aggregation collect_list(null_policy null_handling = null_policy.INCLUDE):
-    """Create a collect_list aggregation.
+    """
+    Create a collect_list aggregation.
 
     For details, see :cpp:func:`make_collect_list_aggregation`.
 
@@ -441,7 +460,8 @@ cpdef Aggregation collect_set(
     nulls_equal = null_equality.EQUAL,
     nans_equal = nan_equality.ALL_EQUAL,
 ):
-    """Create a collect_set aggregation.
+    """
+    Create a collect_set aggregation.
 
     For details, see :cpp:func:`make_collect_set_aggregation`.
 
@@ -468,7 +488,8 @@ cpdef Aggregation collect_set(
     )
 
 cpdef Aggregation udf(str operation, DataType output_type):
-    """Create a udf aggregation.
+    """
+    Create a udf aggregation.
 
     For details, see :cpp:func:`make_udf_aggregation`.
 
@@ -496,7 +517,8 @@ cpdef Aggregation udf(str operation, DataType output_type):
 
 
 cpdef Aggregation correlation(correlation_type type, size_type min_periods):
-    """Create a correlation aggregation.
+    """
+    Create a correlation aggregation.
 
     For details, see :cpp:func:`make_correlation_aggregation`.
 
@@ -519,7 +541,8 @@ cpdef Aggregation correlation(correlation_type type, size_type min_periods):
 
 
 cpdef Aggregation covariance(size_type min_periods, size_type ddof):
-    """Create a covariance aggregation.
+    """
+    Create a covariance aggregation.
 
     For details, see :cpp:func:`make_covariance_aggregation`.
 
@@ -548,7 +571,8 @@ cpdef Aggregation rank(
     null_order null_precedence = null_order.AFTER,
     rank_percentage percentage = rank_percentage.NONE,
 ):
-    """Create a rank aggregation.
+    """
+    Create a rank aggregation.
 
     For details, see :cpp:func:`make_rank_aggregation`.
 

--- a/python/cudf/cudf/_lib/pylibcudf/binaryop.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/binaryop.pyx
@@ -23,7 +23,8 @@ cpdef Column binary_operation(
     binary_operator op,
     DataType output_type
 ):
-    """Perform a binary operation between a column and another column or scalar.
+    """
+    Perform a binary operation between a column and another column or scalar.
 
     ``lhs`` and ``rhs`` may be a
     :py:class:`~cudf._lib.pylibcudf.column.Column` or a

--- a/python/cudf/cudf/_lib/pylibcudf/column.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/column.pyx
@@ -24,7 +24,8 @@ import numpy as np
 
 
 cdef class Column:
-    """A container of nullable device data as a column of elements.
+    """
+    A container of nullable device data as a column of elements.
 
     This class is an implementation of `Arrow columnar data specification
     <https://arrow.apache.org/docs/format/Columnar.html>`__ for data stored on
@@ -67,7 +68,8 @@ cdef class Column:
         self._num_children = len(children)
 
     cdef column_view view(self) nogil:
-        """Generate a libcudf column_view to pass to libcudf algorithms.
+        """
+        Generate a libcudf column_view to pass to libcudf algorithms.
 
         This method is for pylibcudf's functions to use to generate inputs when
         calling libcudf algorithms, and should generally not be needed by users
@@ -104,7 +106,8 @@ cdef class Column:
         )
 
     cdef mutable_column_view mutable_view(self) nogil:
-        """Generate a libcudf mutable_column_view to pass to libcudf algorithms.
+        """
+        Generate a libcudf mutable_column_view to pass to libcudf algorithms.
 
         This method is for pylibcudf's functions to use to generate inputs when
         calling libcudf algorithms, and should generally not be needed by users
@@ -132,7 +135,8 @@ cdef class Column:
 
     @staticmethod
     cdef Column from_libcudf(unique_ptr[column] libcudf_col):
-        """Create a Column from a libcudf column.
+        """
+        Create a Column from a libcudf column.
 
         This method is for pylibcudf's functions to use to ingest outputs of
         calling libcudf algorithms, and should generally not be needed by users
@@ -177,7 +181,8 @@ cdef class Column:
 
     @staticmethod
     cdef Column from_column_view(const column_view& cv, Column owner):
-        """Create a Column from a libcudf column_view.
+        """
+        Create a Column from a libcudf column_view.
 
         This method accepts shared ownership of the underlying data from the
         owner and relies on the offset from the view.
@@ -209,7 +214,8 @@ cdef class Column:
 
     @staticmethod
     def from_scalar(Scalar slr, size_type size):
-        """Create a Column from a Scalar.
+        """
+        Create a Column from a Scalar.
 
         Parameters
         ----------
@@ -231,7 +237,8 @@ cdef class Column:
 
     @staticmethod
     def from_cuda_array_interface_obj(object obj):
-        """Create a Column from an object with a CUDA array interface.
+        """
+        Create a Column from an object with a CUDA array interface.
 
         Parameters
         ----------
@@ -279,7 +286,8 @@ cdef class Column:
         return self._data_type
 
     cpdef Column child(self, size_type index):
-        """Get a child column of this column.
+        """
+        Get a child column of this column.
 
         Parameters
         ----------
@@ -380,7 +388,8 @@ def _datatype_from_dtype_desc(desc):
 def is_c_contiguous(
     shape: Sequence[int], strides: Sequence[int], itemsize: int
 ) -> bool:
-    """Determine if shape and strides are C-contiguous
+    """
+    Determine if shape and strides are C-contiguous
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/pylibcudf/concatenate.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/concatenate.pyx
@@ -15,7 +15,8 @@ from .table cimport Table
 
 
 cpdef concatenate(list objects):
-    """Concatenate columns or tables.
+    """
+    Concatenate columns or tables.
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/pylibcudf/copying.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/copying.pyx
@@ -42,7 +42,8 @@ cpdef Table gather(
     Column gather_map,
     out_of_bounds_policy bounds_policy
 ):
-    """Select rows from source_table according to the provided gather_map.
+    """
+    Select rows from source_table according to the provided gather_map.
 
     For details, see :cpp:func:`gather`.
 
@@ -83,7 +84,8 @@ cpdef Table scatter(
     Column scatter_map,
     Table target_table
 ):
-    """Scatter from source into target_table according to scatter_map.
+    """
+    Scatter from source into target_table according to scatter_map.
 
     If source is a table, it specifies rows to scatter. If source is a list,
     each scalar is scattered into the corresponding column in the ``target_table``.
@@ -143,7 +145,8 @@ cpdef Table scatter(
 
 
 cpdef ColumnOrTable empty_like(ColumnOrTable input):
-    """Create an empty column or table with the same type as ``input``.
+    """
+    Create an empty column or table with the same type as ``input``.
 
     For details, see :cpp:func:`empty_like`.
 
@@ -172,7 +175,8 @@ cpdef ColumnOrTable empty_like(ColumnOrTable input):
 cpdef Column allocate_like(
     Column input_column, mask_allocation_policy policy, size=None
 ):
-    """Allocate a column with the same type as input_column.
+    """
+    Allocate a column with the same type as input_column.
 
     For details, see :cpp:func:`allocate_like`.
 
@@ -214,7 +218,8 @@ cpdef Column copy_range_in_place(
     size_type input_end,
     size_type target_begin,
 ):
-    """Copy a range of elements from input_column to target_column.
+    """
+    Copy a range of elements from input_column to target_column.
 
     The target_column is overwritten in place.
 
@@ -266,7 +271,8 @@ cpdef Column copy_range(
     size_type input_end,
     size_type target_begin,
 ):
-    """Copy a range of elements from input_column to target_column.
+    """
+    Copy a range of elements from input_column to target_column.
 
     For details on the implementation, see :cpp:func:`copy_range`.
 
@@ -311,7 +317,8 @@ cpdef Column copy_range(
 
 
 cpdef Column shift(Column input, size_type offset, Scalar fill_value):
-    """Shift the elements of input by offset.
+    """
+    Shift the elements of input by offset.
 
     For details on the implementation, see :cpp:func:`shift`.
 
@@ -349,7 +356,8 @@ cpdef Column shift(Column input, size_type offset, Scalar fill_value):
 
 
 cpdef list slice(ColumnOrTable input, list indices):
-    """Slice input according to indices.
+    """
+    Slice input according to indices.
 
     For details on the implementation, see :cpp:func:`slice`.
 
@@ -396,7 +404,8 @@ cpdef list slice(ColumnOrTable input, list indices):
 
 
 cpdef list split(ColumnOrTable input, list splits):
-    """Split input into multiple.
+    """
+    Split input into multiple.
 
     For details on the implementation, see :cpp:func:`split`.
 
@@ -440,7 +449,8 @@ cpdef Column copy_if_else(
     RightCopyIfElseOperand rhs,
     Column boolean_mask
 ):
-    """Copy elements from lhs or rhs into a new column according to boolean_mask.
+    """
+    Copy elements from lhs or rhs into a new column according to boolean_mask.
 
     For details on the implementation, see :cpp:func:`copy_if_else`.
 
@@ -506,7 +516,8 @@ cpdef Table boolean_mask_scatter(
     Table target,
     Column boolean_mask
 ):
-    """Scatter rows from input into target according to boolean_mask.
+    """
+    Scatter rows from input into target according to boolean_mask.
 
     If source is a table, it specifies rows to scatter. If source is a list,
     each scalar is scattered into the corresponding column in the ``target_table``.
@@ -564,7 +575,8 @@ cpdef Table boolean_mask_scatter(
 
 
 cpdef Scalar get_element(Column input_column, size_type index):
-    """Get the element at index from input_column.
+    """
+    Get the element at index from input_column.
 
     For details on the implementation, see :cpp:func:`get_element`.
 

--- a/python/cudf/cudf/_lib/pylibcudf/filling.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/filling.pyx
@@ -26,7 +26,8 @@ cpdef Column fill(
     Scalar value,
 ):
 
-    """Fill destination column from begin to end with value.
+    """
+    Fill destination column from begin to end with value.
 
     For details, see :cpp:func:`fill`.
 
@@ -66,7 +67,8 @@ cpdef void fill_in_place(
     Scalar value,
 ):
 
-    """Fill destination column in place from begin to end with value.
+    """
+    Fill destination column in place from begin to end with value.
 
     For details, see :cpp:func:`fill_in_place`.
 
@@ -91,7 +93,8 @@ cpdef void fill_in_place(
         )
 
 cpdef Column sequence(size_type size, Scalar init, Scalar step):
-    """Create a sequence column of size ``size`` with initial value ``init`` and step
+    """
+    Create a sequence column of size ``size`` with initial value ``init`` and step
     ``step``.
 
     For details, see :cpp:func:`sequence`.
@@ -127,7 +130,8 @@ cpdef Table repeat(
     Table input_table,
     ColumnOrSize count
 ):
-    """Repeat rows of a Table.
+    """
+    Repeat rows of a Table.
 
     If an integral value is specified for ``count``, every row is repeated ``count``
     times. If ``count`` is a column, the number of repetitions of each row is defined

--- a/python/cudf/cudf/_lib/pylibcudf/gpumemoryview.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/gpumemoryview.pyx
@@ -2,7 +2,8 @@
 
 
 cdef class gpumemoryview:
-    """Minimal representation of a memory buffer.
+    """
+    Minimal representation of a memory buffer.
 
     This class aspires to be a GPU equivalent of :py:class:`memoryview` for any
     objects exposing a `CUDA Array Interface

--- a/python/cudf/cudf/_lib/pylibcudf/groupby.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/groupby.pyx
@@ -27,7 +27,8 @@ from .utils cimport _as_vector
 
 
 cdef class GroupByRequest:
-    """A request for a groupby aggregation or scan.
+    """
+    A request for a groupby aggregation or scan.
 
     This class is functionally polymorphic and can represent either an
     aggregation or a scan depending on the algorithm it is used with. For
@@ -47,7 +48,8 @@ cdef class GroupByRequest:
         self._aggregations = aggregations
 
     cdef aggregation_request _to_libcudf_agg_request(self) except *:
-        """Convert to a libcudf aggregation_request object.
+        """
+        Convert to a libcudf aggregation_request object.
 
         This method is for internal use only. It creates a new libcudf
         :cpp:class:`cudf::groupby::aggregation_request` object each time it is
@@ -62,7 +64,8 @@ cdef class GroupByRequest:
         return move(c_obj)
 
     cdef scan_request _to_libcudf_scan_request(self) except *:
-        """Convert to a libcudf scan_request object.
+        """
+        Convert to a libcudf scan_request object.
 
         This method is for internal use only. It creates a new libcudf
         :cpp:class:`cudf::groupby::scan_request` object each time it is
@@ -78,7 +81,8 @@ cdef class GroupByRequest:
 
 
 cdef class GroupBy:
-    """Group values by keys and compute various aggregate quantities.
+    """
+    Group values by keys and compute various aggregate quantities.
 
     For details, see :cpp:class:`cudf::groupby::groupby`.
 
@@ -123,7 +127,8 @@ cdef class GroupBy:
         return group_keys, results
 
     cpdef tuple aggregate(self, list requests):
-        """Compute aggregations on columns.
+        """
+        Compute aggregations on columns.
 
         For details, see :cpp:func:`cudf::groupby::groupby::aggregate`.
 
@@ -155,7 +160,8 @@ cdef class GroupBy:
         return GroupBy._parse_outputs(move(c_res))
 
     cpdef tuple scan(self, list requests):
-        """Compute scans on columns.
+        """
+        Compute scans on columns.
 
         For details, see :cpp:func:`cudf::groupby::groupby::scan`.
 
@@ -184,7 +190,8 @@ cdef class GroupBy:
         return GroupBy._parse_outputs(move(c_res))
 
     cpdef tuple shift(self, Table values, list offset, list fill_values):
-        """Compute shifts on columns.
+        """
+        Compute shifts on columns.
 
         For details, see :cpp:func:`cudf::groupby::groupby::shift`.
 
@@ -219,7 +226,8 @@ cdef class GroupBy:
         )
 
     cpdef tuple replace_nulls(self, Table value, list replace_policies):
-        """Replace nulls in columns.
+        """
+        Replace nulls in columns.
 
         For details, see :cpp:func:`cudf::groupby::groupby::replace_nulls`.
 
@@ -249,7 +257,8 @@ cdef class GroupBy:
         )
 
     cpdef tuple get_groups(self, Table values=None):
-        """Get the grouped keys and values labels for each row.
+        """
+        Get the grouped keys and values labels for each row.
 
         For details, see :cpp:func:`cudf::groupby::groupby::get_groups`.
 

--- a/python/cudf/cudf/_lib/pylibcudf/interop.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/interop.pyx
@@ -63,7 +63,8 @@ LIBCUDF_TO_ARROW_TYPES = {
 }
 
 cdef column_metadata _metadata_to_libcudf(metadata):
-    """Convert a ColumnMetadata object to C++ column_metadata.
+    """
+    Convert a ColumnMetadata object to C++ column_metadata.
 
     Since this class is mutable and cheap, it is easier to create the C++
     object on the fly rather than have it directly backing the storage for
@@ -80,7 +81,8 @@ cdef column_metadata _metadata_to_libcudf(metadata):
 
 @dataclass
 class ColumnMetadata:
-    """Metadata associated with a column.
+    """
+    Metadata associated with a column.
 
     This is the Python representation of :cpp:class:`cudf::column_metadata`.
     """
@@ -90,7 +92,8 @@ class ColumnMetadata:
 
 @singledispatch
 def from_arrow(pyarrow_object, *, DataType data_type=None):
-    """Create a cudf object from a pyarrow object.
+    """
+    Create a cudf object from a pyarrow object.
 
     Parameters
     ----------
@@ -196,7 +199,8 @@ def _from_arrow_column(pyarrow_object, *, DataType data_type=None):
 
 @singledispatch
 def to_arrow(cudf_object, metadata=None):
-    """Convert to a PyArrow object.
+    """
+    Convert to a PyArrow object.
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/pylibcudf/io/types.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/io/types.pyx
@@ -16,7 +16,8 @@ import os
 
 
 cdef class TableWithMetadata:
-    """A container holding a table and its associated metadata
+    """
+    A container holding a table and its associated metadata
     (e.g. column names)
 
     For details, see :cpp:class:`cudf::io::table_with_metadata`.
@@ -50,7 +51,8 @@ cdef class TableWithMetadata:
         return out
 
 cdef class SourceInfo:
-    """A class containing details on a source to read from.
+    """
+    A class containing details on a source to read from.
 
     For details, see :cpp:class:`cudf::io::source_info`.
 

--- a/python/cudf/cudf/_lib/pylibcudf/join.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/join.pyx
@@ -42,7 +42,8 @@ cpdef tuple inner_join(
     Table right_keys,
     null_equality nulls_equal
 ):
-    """Perform an inner join between two tables.
+    """
+    Perform an inner join between two tables.
 
     For details, see :cpp:func:`inner_join`.
 
@@ -75,7 +76,8 @@ cpdef tuple left_join(
     Table right_keys,
     null_equality nulls_equal
 ):
-    """Perform a left join between two tables.
+    """
+    Perform a left join between two tables.
 
     For details, see :cpp:func:`left_join`.
 
@@ -109,7 +111,8 @@ cpdef tuple full_join(
     Table right_keys,
     null_equality nulls_equal
 ):
-    """Perform a full join between two tables.
+    """
+    Perform a full join between two tables.
 
     For details, see :cpp:func:`full_join`.
 
@@ -143,7 +146,8 @@ cpdef Column left_semi_join(
     Table right_keys,
     null_equality nulls_equal
 ):
-    """Perform a left semi join between two tables.
+    """
+    Perform a left semi join between two tables.
 
     For details, see :cpp:func:`left_semi_join`.
 
@@ -177,7 +181,8 @@ cpdef Column left_anti_join(
     Table right_keys,
     null_equality nulls_equal
 ):
-    """Perform a left anti join between two tables.
+    """
+    Perform a left anti join between two tables.
 
     For details, see :cpp:func:`left_anti_join`.
 

--- a/python/cudf/cudf/_lib/pylibcudf/lists.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/lists.pyx
@@ -11,7 +11,8 @@ from .table cimport Table
 
 
 cpdef Table explode_outer(Table input, size_type explode_column_idx):
-    """Explode a column of lists into rows.
+    """
+    Explode a column of lists into rows.
 
     All other columns will be duplicated for each element in the list.
 

--- a/python/cudf/cudf/_lib/pylibcudf/merge.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/merge.pyx
@@ -18,7 +18,8 @@ cpdef Table merge (
     list column_order,
     list null_precedence,
 ):
-    """Merge a set of sorted tables.
+    """
+    Merge a set of sorted tables.
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/pylibcudf/quantiles.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/quantiles.pyx
@@ -26,7 +26,8 @@ cpdef Column quantile(
     Column ordered_indices = None,
     bool exact=True
 ):
-    """Computes quantiles with interpolation.
+    """
+    Computes quantiles with interpolation.
 
     Computes the specified quantiles by interpolating values between which they lie,
     using the interpolation strategy specified in interp.
@@ -86,7 +87,8 @@ cpdef Table quantiles(
     list column_order = None,
     list null_precedence = None,
 ):
-    """Computes row quantiles with interpolation.
+    """
+    Computes row quantiles with interpolation.
 
     Computes the specified quantiles by retrieving the row corresponding to the
     specified quantiles. In the event a quantile lies in between rows, the specified

--- a/python/cudf/cudf/_lib/pylibcudf/reduce.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/reduce.pyx
@@ -23,7 +23,8 @@ from cudf._lib.pylibcudf.libcudf.reduce import \
 
 
 cpdef Scalar reduce(Column col, Aggregation agg, DataType data_type):
-    """Perform a reduction on a column
+    """
+    Perform a reduction on a column
 
     For details, see ``cudf::reduce`` documentation.
 
@@ -55,7 +56,8 @@ cpdef Scalar reduce(Column col, Aggregation agg, DataType data_type):
 
 
 cpdef Column scan(Column col, Aggregation agg, scan_type inclusive):
-    """Perform a scan on a column
+    """
+    Perform a scan on a column
 
     For details, see ``cudf::scan`` documentation.
 
@@ -87,7 +89,8 @@ cpdef Column scan(Column col, Aggregation agg, scan_type inclusive):
 
 
 cpdef tuple minmax(Column col):
-    """Compute the minimum and maximum of a column
+    """
+    Compute the minimum and maximum of a column
 
     For details, see ``cudf::minmax`` documentation.
 

--- a/python/cudf/cudf/_lib/pylibcudf/replace.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/replace.pyx
@@ -18,7 +18,8 @@ from .scalar cimport Scalar
 
 
 cpdef Column replace_nulls(Column source_column, ReplacementType replacement):
-    """Replace nulls in source_column.
+    """
+    Replace nulls in source_column.
 
     The values used to replace nulls depends on the type of replacement:
         - If replacement is a Column, the corresponding value from replacement
@@ -89,7 +90,8 @@ cpdef Column find_and_replace_all(
     Column values_to_replace,
     Column replacement_values,
 ):
-    """Replace all occurrences of values_to_replace with replacement_values.
+    """
+    Replace all occurrences of values_to_replace with replacement_values.
 
     For details, see :cpp:func:`find_and_replace_all`.
 
@@ -127,7 +129,8 @@ cpdef Column clamp(
     Scalar lo_replace=None,
     Scalar hi_replace=None,
 ):
-    """Clamp the values in source_column to the range [lo, hi].
+    """
+    Clamp the values in source_column to the range [lo, hi].
 
     For details, see :cpp:func:`clamp`.
 
@@ -178,7 +181,8 @@ cpdef Column clamp(
 
 
 cpdef Column normalize_nans_and_zeros(Column source_column, bool inplace=False):
-    """Normalize NaNs and zeros in source_column.
+    """
+    Normalize NaNs and zeros in source_column.
 
     For details, see :cpp:func:`normalize_nans_and_zeros`.
 

--- a/python/cudf/cudf/_lib/pylibcudf/reshape.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/reshape.pyx
@@ -16,7 +16,8 @@ from .table cimport Table
 
 
 cpdef Column interleave_columns(Table source_table):
-    """Interleave columns of a table into a single column.
+    """
+    Interleave columns of a table into a single column.
 
     Converts the column major table `input` into a row major column.
 
@@ -43,7 +44,8 @@ cpdef Column interleave_columns(Table source_table):
 
 
 cpdef Table tile(Table source_table, size_type count):
-    """Repeats the rows from input table count times to form a new table.
+    """
+    Repeats the rows from input table count times to form a new table.
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/pylibcudf/rolling.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/rolling.pyx
@@ -20,7 +20,8 @@ cpdef Column rolling_window(
     size_type min_periods,
     Aggregation agg,
 ):
-    """Perform a rolling window operation on a column
+    """
+    Perform a rolling window operation on a column
 
     For details, see ``cudf::rolling_window`` documentation.
 

--- a/python/cudf/cudf/_lib/pylibcudf/round.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/round.pyx
@@ -21,7 +21,8 @@ cpdef Column round(
     int32_t decimal_places = 0,
     rounding_method round_method = rounding_method.HALF_UP
 ):
-    """Rounds all the values in a column to the specified number of decimal places.
+    """
+    Rounds all the values in a column to the specified number of decimal places.
 
     For details, see :cpp:func:`round`.
 

--- a/python/cudf/cudf/_lib/pylibcudf/scalar.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/scalar.pyx
@@ -16,7 +16,8 @@ from .types cimport DataType
 # https://github.com/rapidsai/rmm/pull/931 for details.
 @no_gc_clear
 cdef class Scalar:
-    """A scalar value in device memory.
+    """
+    A scalar value in device memory.
 
     This is the Cython representation of :cpp:class:`cudf::scalar`.
     """
@@ -48,7 +49,8 @@ cdef class Scalar:
 
     @staticmethod
     cdef Scalar from_libcudf(unique_ptr[scalar] libcudf_scalar, dtype=None):
-        """Construct a Scalar object from a libcudf scalar.
+        """
+        Construct a Scalar object from a libcudf scalar.
 
         This method is for pylibcudf's functions to use to ingest outputs of
         calling libcudf algorithms, and should generally not be needed by users

--- a/python/cudf/cudf/_lib/pylibcudf/search.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/search.pyx
@@ -18,7 +18,8 @@ cpdef Column lower_bound(
     list column_order,
     list null_precedence,
 ):
-    """Find smallest indices in haystack where needles may be inserted to retain order.
+    """
+    Find smallest indices in haystack where needles may be inserted to retain order.
 
     Parameters
     ----------
@@ -57,7 +58,8 @@ cpdef Column upper_bound(
     list column_order,
     list null_precedence,
 ):
-    """Find largest indices in haystack where needles may be inserted to retain order.
+    """
+    Find largest indices in haystack where needles may be inserted to retain order.
 
     Parameters
     ----------
@@ -91,7 +93,8 @@ cpdef Column upper_bound(
 
 
 cpdef Column contains(Column haystack, Column needles):
-    """Check whether needles are present in haystack.
+    """
+    Check whether needles are present in haystack.
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/pylibcudf/sorting.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/sorting.pyx
@@ -15,7 +15,8 @@ from .table cimport Table
 
 
 cpdef Column sorted_order(Table source_table, list column_order, list null_precedence):
-    """Computes the row indices required to sort the table.
+    """
+    Computes the row indices required to sort the table.
 
     Parameters
     ----------
@@ -50,7 +51,8 @@ cpdef Column stable_sorted_order(
     list column_order,
     list null_precedence,
 ):
-    """Computes the row indices required to sort the table,
+    """
+    Computes the row indices required to sort the table,
     preserving order of equal elements.
 
     Parameters
@@ -89,7 +91,8 @@ cpdef Column rank(
     null_order null_precedence,
     bool percentage,
 ):
-    """Computes the rank of each element in the column.
+    """
+    Computes the rank of each element in the column.
 
     Parameters
     ----------
@@ -127,7 +130,8 @@ cpdef Column rank(
 
 
 cpdef bool is_sorted(Table tbl, list column_order, list null_precedence):
-    """Checks if the table is sorted.
+    """
+    Checks if the table is sorted.
 
     Parameters
     ----------
@@ -164,7 +168,8 @@ cpdef Table segmented_sort_by_key(
     list column_order,
     list null_precedence,
 ):
-    """Sorts the table by key, within segments.
+    """
+    Sorts the table by key, within segments.
 
     Parameters
     ----------
@@ -207,7 +212,8 @@ cpdef Table stable_segmented_sort_by_key(
     list column_order,
     list null_precedence,
 ):
-    """Sorts the table by key preserving order of equal elements,
+    """
+    Sorts the table by key preserving order of equal elements,
     within segments.
 
     Parameters
@@ -250,7 +256,8 @@ cpdef Table sort_by_key(
     list column_order,
     list null_precedence,
 ):
-    """Sorts the table by key.
+    """
+    Sorts the table by key.
 
     Parameters
     ----------
@@ -289,7 +296,8 @@ cpdef Table stable_sort_by_key(
     list column_order,
     list null_precedence,
 ):
-    """Sorts the table by key preserving order of equal elements.
+    """
+    Sorts the table by key preserving order of equal elements.
 
     Parameters
     ----------
@@ -323,7 +331,8 @@ cpdef Table stable_sort_by_key(
 
 
 cpdef Table sort(Table source_table, list column_order, list null_precedence):
-    """Sorts the table.
+    """
+    Sorts the table.
 
     Parameters
     ----------
@@ -354,7 +363,8 @@ cpdef Table sort(Table source_table, list column_order, list null_precedence):
 
 
 cpdef Table stable_sort(Table source_table, list column_order, list null_precedence):
-    """Sorts the table preserving order of equal elements.
+    """
+    Sorts the table preserving order of equal elements.
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/pylibcudf/stream_compaction.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/stream_compaction.pyx
@@ -28,7 +28,8 @@ from .table cimport Table
 
 
 cpdef Table drop_nulls(Table source_table, list keys, size_type keep_threshold):
-    """Filters out rows from the input table based on the presence of nulls.
+    """
+    Filters out rows from the input table based on the presence of nulls.
 
     Parameters
     ----------
@@ -56,7 +57,8 @@ cpdef Table drop_nulls(Table source_table, list keys, size_type keep_threshold):
 
 
 cpdef Table drop_nans(Table source_table, list keys, size_type keep_threshold):
-    """Filters out rows from the input table based on the presence of NaNs.
+    """
+    Filters out rows from the input table based on the presence of NaNs.
 
     Parameters
     ----------
@@ -84,7 +86,8 @@ cpdef Table drop_nans(Table source_table, list keys, size_type keep_threshold):
 
 
 cpdef Table apply_boolean_mask(Table source_table, Column boolean_mask):
-    """Filters out rows from the input table based on a boolean mask.
+    """
+    Filters out rows from the input table based on a boolean mask.
 
     Parameters
     ----------
@@ -114,7 +117,8 @@ cpdef Table unique(
     duplicate_keep_option keep,
     null_equality nulls_equal,
 ):
-    """Filter duplicate consecutive rows from the input table.
+    """
+    Filter duplicate consecutive rows from the input table.
 
     Parameters
     ----------
@@ -156,7 +160,8 @@ cpdef Table distinct(
     null_equality nulls_equal,
     nan_equality nans_equal,
 ):
-    """Get the distinct rows from the input table.
+    """
+    Get the distinct rows from the input table.
 
     Parameters
     ----------
@@ -194,7 +199,8 @@ cpdef Column distinct_indices(
     null_equality nulls_equal,
     nan_equality nans_equal,
 ):
-    """Get the indices of the distinct rows from the input table.
+    """
+    Get the indices of the distinct rows from the input table.
 
     Parameters
     ----------
@@ -229,7 +235,8 @@ cpdef Table stable_distinct(
     null_equality nulls_equal,
     nan_equality nans_equal,
 ):
-    """Get the distinct rows from the input table, preserving input order.
+    """
+    Get the distinct rows from the input table, preserving input order.
 
     Parameters
     ----------
@@ -266,7 +273,8 @@ cpdef size_type unique_count(
     null_policy null_handling,
     nan_policy nan_handling
 ):
-    """Returns the number of unique consecutive elements in the input column.
+    """
+    Returns the number of unique consecutive elements in the input column.
 
     Parameters
     ----------
@@ -297,7 +305,8 @@ cpdef size_type distinct_count(
     null_policy null_handling,
     nan_policy nan_handling
 ):
-    """Returns the number of distinct elements in the input column.
+    """
+    Returns the number of distinct elements in the input column.
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/pylibcudf/strings/contains.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/contains.pyx
@@ -12,7 +12,8 @@ cpdef Column contains_re(
     Column input,
     RegexProgram prog
 ):
-    """Returns a boolean column identifying rows which match the given
+    """
+    Returns a boolean column identifying rows which match the given
     regex_program object.
 
     For details, see :cpp:func:`cudf::strings::contains_re`.

--- a/python/cudf/cudf/_lib/pylibcudf/strings/find.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/find.pyx
@@ -18,7 +18,8 @@ cpdef Column find(
     size_type start=0,
     size_type stop=-1
 ):
-    """Returns a column of character position values where the target string is
+    """
+    Returns a column of character position values where the target string is
     first found in each string of the provided column.
 
     ``target`` may be a

--- a/python/cudf/cudf/_lib/pylibcudf/strings/replace.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/replace.pyx
@@ -24,7 +24,8 @@ cpdef Column replace(
     Scalar repl,
     size_type maxrepl = -1
 ):
-    """Replaces target string within each string with the specified replacement string.
+    """
+    Replaces target string within each string with the specified replacement string.
 
     Null string entries will return null output string entries.
 
@@ -72,7 +73,8 @@ cpdef Column replace_multiple(
     Column repl,
     size_type maxrepl = -1
 ):
-    """Replaces target string within each string with the specified replacement string.
+    """
+    Replaces target string within each string with the specified replacement string.
 
     Null string entries will return null output string entries.
 
@@ -116,7 +118,8 @@ cpdef Column replace_slice(
     size_type start = 0,
     size_type stop = -1
 ):
-    """Replaces each string in the column with the provided repl string
+    """
+    Replaces each string in the column with the provided repl string
     within the [start,stop) character position range.
 
     Null string entries will return null output string entries.

--- a/python/cudf/cudf/_lib/pylibcudf/table.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/table.pyx
@@ -13,7 +13,8 @@ from .column cimport Column
 
 
 cdef class Table:
-    """A list of columns of the same size.
+    """
+    A list of columns of the same size.
 
     Parameters
     ----------
@@ -26,7 +27,8 @@ cdef class Table:
         self._columns = columns
 
     cdef table_view view(self) nogil:
-        """Generate a libcudf table_view to pass to libcudf algorithms.
+        """
+        Generate a libcudf table_view to pass to libcudf algorithms.
 
         This method is for pylibcudf's functions to use to generate inputs when
         calling libcudf algorithms, and should generally not be needed by users
@@ -44,7 +46,8 @@ cdef class Table:
 
     @staticmethod
     cdef Table from_libcudf(unique_ptr[table] libcudf_tbl):
-        """Create a Table from a libcudf table.
+        """
+        Create a Table from a libcudf table.
 
         This method is for pylibcudf's functions to use to ingest outputs of
         calling libcudf algorithms, and should generally not be needed by users
@@ -62,7 +65,8 @@ cdef class Table:
 
     @staticmethod
     cdef Table from_table_view(const table_view& tv, Table owner):
-        """Create a Table from a libcudf table.
+        """
+        Create a Table from a libcudf table.
 
         This method accepts shared ownership of the underlying data from the
         owner and relies on the offset from the view.

--- a/python/cudf/cudf/_lib/pylibcudf/types.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/types.pyx
@@ -17,7 +17,8 @@ from cudf._lib.pylibcudf.libcudf.types import sorted as Sorted  # no-cython-lint
 
 
 cdef class DataType:
-    """Indicator for the logical data type of an element in a column.
+    """
+    Indicator for the logical data type of an element in a column.
 
     This is the Cython representation of :cpp:class:`cudf::data_type`.
 
@@ -57,7 +58,8 @@ cdef class DataType:
 
     @staticmethod
     cdef DataType from_libcudf(data_type dt):
-        """Create a DataType from a libcudf data_type.
+        """
+        Create a DataType from a libcudf data_type.
 
         This method is for pylibcudf's functions to use to ingest outputs of
         calling libcudf algorithms, and should generally not be needed by users

--- a/python/cudf/cudf/_lib/pylibcudf/unary.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/unary.pyx
@@ -15,7 +15,8 @@ from .types cimport DataType
 
 
 cpdef Column unary_operation(Column input, unary_operator op):
-    """Perform a unary operation on a column.
+    """
+    Perform a unary operation on a column.
 
     For details, see :cpp:func:`unary_operation`.
 
@@ -40,7 +41,8 @@ cpdef Column unary_operation(Column input, unary_operator op):
 
 
 cpdef Column is_null(Column input):
-    """Check whether elements of a column are null.
+    """
+    Check whether elements of a column are null.
 
     For details, see :cpp:func:`is_null`.
 
@@ -63,7 +65,8 @@ cpdef Column is_null(Column input):
 
 
 cpdef Column is_valid(Column input):
-    """Check whether elements of a column are valid.
+    """
+    Check whether elements of a column are valid.
 
     For details, see :cpp:func:`is_valid`.
 
@@ -86,7 +89,8 @@ cpdef Column is_valid(Column input):
 
 
 cpdef Column cast(Column input, DataType data_type):
-    """Cast a column to a different data type.
+    """
+    Cast a column to a different data type.
 
     For details, see :cpp:func:`cast`.
 
@@ -111,7 +115,8 @@ cpdef Column cast(Column input, DataType data_type):
 
 
 cpdef Column is_nan(Column input):
-    """Check whether elements of a column are nan.
+    """
+    Check whether elements of a column are nan.
 
     For details, see :cpp:func:`is_nan`.
 
@@ -134,7 +139,8 @@ cpdef Column is_nan(Column input):
 
 
 cpdef Column is_not_nan(Column input):
-    """Check whether elements of a column are not nan.
+    """
+    Check whether elements of a column are not nan.
 
     For details, see :cpp:func:`is_not_nan`.
 

--- a/python/cudf/cudf/_lib/scalar.pyx
+++ b/python/cudf/cudf/_lib/scalar.pyx
@@ -62,7 +62,8 @@ def _replace_nested(obj, check, replacement):
 
 
 def gather_metadata(dtypes):
-    """Convert a dict of dtypes to a list of ColumnMetadata objects.
+    """
+    Convert a dict of dtypes to a list of ColumnMetadata objects.
 
     The metadata is constructed recursively so that nested types are
     represented as nested ColumnMetadata objects.

--- a/python/cudf/cudf/_lib/search.pyx
+++ b/python/cudf/cudf/_lib/search.pyx
@@ -11,7 +11,8 @@ from cudf._lib import pylibcudf
 def search_sorted(
     list source, list values, side, ascending=True, na_position="last"
 ):
-    """Find indices where elements should be inserted to maintain order
+    """
+    Find indices where elements should be inserted to maintain order
 
     Parameters
     ----------
@@ -51,7 +52,8 @@ def search_sorted(
 
 @acquire_spill_lock()
 def contains(Column haystack, Column needles):
-    """Check whether column contains multiple values
+    """
+    Check whether column contains multiple values
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/transform.pyx
+++ b/python/cudf/cudf/_lib/transform.pyx
@@ -176,7 +176,8 @@ def one_hot_encode(Column input_column, Column categories):
 
 @acquire_spill_lock()
 def compute_column(list columns, tuple column_names, expr: str):
-    """Compute a new column by evaluating an expression on a set of columns.
+    """
+    Compute a new column by evaluating an expression on a set of columns.
 
     Parameters
     ----------

--- a/python/cudf/cudf/_lib/transpose.pyx
+++ b/python/cudf/cudf/_lib/transpose.pyx
@@ -12,7 +12,8 @@ from cudf._lib.utils cimport columns_from_table_view, table_view_from_columns
 
 
 def transpose(list source_columns):
-    """Transpose m n-row columns into n m-row columns
+    """
+    Transpose m n-row columns into n m-row columns
     """
     cdef pair[unique_ptr[column], table_view] c_result
     cdef table_view c_input = table_view_from_columns(source_columns)

--- a/python/cudf/cudf/_lib/utils.pyx
+++ b/python/cudf/cudf/_lib/utils.pyx
@@ -40,7 +40,8 @@ cdef table_view table_view_from_columns(columns) except*:
 
 
 cdef table_view table_view_from_table(tbl, ignore_index=False) except*:
-    """Create a cudf::table_view from a Table.
+    """
+    Create a cudf::table_view from a Table.
 
     Parameters
     ----------
@@ -205,7 +206,8 @@ def _index_level_name(index_name, level, column_names):
 cdef columns_from_unique_ptr(
     unique_ptr[table] c_tbl
 ):
-    """Convert a libcudf table into list of columns.
+    """
+    Convert a libcudf table into list of columns.
 
     Parameters
     ----------
@@ -229,7 +231,8 @@ cdef columns_from_unique_ptr(
 
 
 cdef columns_from_pylibcudf_table(tbl):
-    """Convert a pylibcudf table into list of columns.
+    """
+    Convert a pylibcudf table into list of columns.
 
     Parameters
     ----------
@@ -245,7 +248,8 @@ cdef columns_from_pylibcudf_table(tbl):
 
 
 cdef _data_from_columns(columns, column_names, index_names=None):
-    """Convert a list of columns into a dict with an index.
+    """
+    Convert a list of columns into a dict with an index.
 
     This method is intended to provide the bridge between the columns returned
     from calls to libcudf or pylibcudf APIs and the cuDF Python Frame objects, which


### PR DESCRIPTION
## Description
In the REPL, multi-line Cython docstrings are formatted badly if the first line starts on the same line as the opening quotes (the indentation of the rest of the docstring is not stripped). Fix this minor usability flaw, and enforce it going forward with a regex-based pre-commit hook.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
