### PR TITLE
resolve dependency-file-generator warning, remove unnecessary rapids-build-backend configuration

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -13,12 +13,10 @@ export CMAKE_GENERATOR=Ninja
 
 rapids-print-env
 
-version=$(rapids-generate-version)
-
 rapids-logger "Begin cpp build"
 
 # With boa installed conda build forward to boa
-RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry mambabuild \
+RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry mambabuild \
     conda/recipes/libcudf
 
 rapids-upload-conda-to-s3 cpp

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -14,7 +14,7 @@ ENV_YAML_DIR="$(mktemp -d)"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key docs \
+  --file-key docs \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee "${ENV_YAML_DIR}/env.yaml"
 
 rapids-mamba-retry env create --yes -f "${ENV_YAML_DIR}/env.yaml" -n docs

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -10,7 +10,7 @@ ENV_YAML_DIR="$(mktemp -d)"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key checks \
+  --file-key checks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee "${ENV_YAML_DIR}/env.yaml"
 
 rapids-mamba-retry env create --yes -f "${ENV_YAML_DIR}/env.yaml" -n checks

--- a/ci/configure_cpp_static.sh
+++ b/ci/configure_cpp_static.sh
@@ -12,7 +12,7 @@ REQUIREMENTS_FILE="${ENV_YAML_DIR}/requirements.txt"
 
 rapids-dependency-file-generator \
   --output requirements \
-  --file_key test_static_build \
+  --file-key test_static_build \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch)" | tee "${REQUIREMENTS_FILE}"
 
 python -m pip install -r "${REQUIREMENTS_FILE}"

--- a/ci/test_cpp_common.sh
+++ b/ci/test_cpp_common.sh
@@ -11,7 +11,7 @@ ENV_YAML_DIR="$(mktemp -d)"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key test_cpp \
+  --file-key test_cpp \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch)" | tee "${ENV_YAML_DIR}/env.yaml"
 
 rapids-mamba-retry env create --yes -f "${ENV_YAML_DIR}/env.yaml" -n test

--- a/ci/test_java.sh
+++ b/ci/test_java.sh
@@ -11,7 +11,7 @@ ENV_YAML_DIR="$(mktemp -d)"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key test_java \
+  --file-key test_java \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch)" | tee "${ENV_YAML_DIR}/env.yaml"
 
 rapids-mamba-retry env create --yes -f "${ENV_YAML_DIR}/env.yaml" -n test

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -11,7 +11,7 @@ ENV_YAML_DIR="$(mktemp -d)"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key test_notebooks \
+  --file-key test_notebooks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee "${ENV_YAML_DIR}/env.yaml"
 
 rapids-mamba-retry env create --yes -f "${ENV_YAML_DIR}/env.yaml" -n test

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -13,7 +13,7 @@ ENV_YAML_DIR="$(mktemp -d)"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key test_python \
+  --file-key test_python \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee "${ENV_YAML_DIR}/env.yaml"
 
 rapids-mamba-retry env create --yes -f "${ENV_YAML_DIR}/env.yaml" -n test

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -119,7 +119,6 @@ skip = [
 
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
-commit-file = "cudf/GIT_COMMIT"
 dependencies-file = "../../dependencies.yaml"
 requires = [
     "cmake>=3.26.4",

--- a/python/cudf_kafka/pyproject.toml
+++ b/python/cudf_kafka/pyproject.toml
@@ -99,7 +99,6 @@ regex = "(?P<value>.*)"
 
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
-commit-file = "cudf_kafka/GIT_COMMIT"
 dependencies-file = "../../dependencies.yaml"
 requires = [
     "cmake>=3.26.4",

--- a/python/cudf_polars/pyproject.toml
+++ b/python/cudf_polars/pyproject.toml
@@ -174,7 +174,6 @@ docstring-code-format = true
 
 [tool.rapids-build-backend]
 build-backend = "setuptools.build_meta"
-commit-file = "cudf_polars/GIT_COMMIT"
 dependencies-file = "../../dependencies.yaml"
 # Pure python
 disable-cuda = true

--- a/python/custreamz/pyproject.toml
+++ b/python/custreamz/pyproject.toml
@@ -48,7 +48,6 @@ Homepage = "https://github.com/rapidsai/cudf"
 
 [tool.rapids-build-backend]
 build-backend = "setuptools.build_meta"
-commit-file = "custreamz/COMMIT_FILE"
 dependencies-file = "../../dependencies.yaml"
 
 [tool.setuptools]

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -57,7 +57,6 @@ Homepage = "https://github.com/rapidsai/cudf"
 
 [tool.rapids-build-backend]
 build-backend = "setuptools.build_meta"
-commit-file = "dask_cudf/GIT_COMMIT"
 dependencies-file = "../../dependencies.yaml"
 
 [tool.setuptools]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/31
Contributes to https://github.com/rapidsai/dependency-file-generator/issues/89

#15245 was one of the first `rapids-build-backend` PRs merged across RAPIDS. Since it was merged, we've made some small adjustments to the approach for `rapids-build-backend`. This catches `cudf` up with those changes:

* consolidates version-handling in `ci/build_cpp.sh`
* removes `commit-file` configuration in `pyproject.toml`
  - *as of https://github.com/rapidsai/rapids-build-backend/pull/30, this is no longer necessary if the project's top-level directory is `{project_name}.replace("-", "_")*
  - *and anyway, it was changed from `commit-file` to `commit-files` in that PR, so `commit-file` was being silently ignored here*
* uses `--file-key` instead of `--file_key` in `rapids-dependency-file-generator` calls

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
