### PR TITLE
Migrate string `slice` APIs to `pylibcudf`

### DIFF
--- a/docs/cudf/source/user_guide/api_docs/pylibcudf/strings/index.rst
+++ b/docs/cudf/source/user_guide/api_docs/pylibcudf/strings/index.rst
@@ -6,3 +6,4 @@ strings
 
     contains
     replace
+    slice

--- a/docs/cudf/source/user_guide/api_docs/pylibcudf/strings/slice.rst
+++ b/docs/cudf/source/user_guide/api_docs/pylibcudf/strings/slice.rst
@@ -1,0 +1,6 @@
+=====
+slice
+=====
+
+.. automodule:: cudf._lib.pylibcudf.strings.slice
+   :members:

--- a/python/cudf/cudf/_lib/pylibcudf/libcudf/scalar/scalar_factories.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/libcudf/scalar/scalar_factories.pxd
@@ -8,3 +8,4 @@ from cudf._lib.pylibcudf.libcudf.scalar.scalar cimport scalar
 
 cdef extern from "cudf/scalar/scalar_factories.hpp" namespace "cudf" nogil:
     cdef unique_ptr[scalar] make_string_scalar(const string & _string) except +
+    cdef unique_ptr[scalar] make_fixed_width_scalar[T](T value) except +

--- a/python/cudf/cudf/_lib/pylibcudf/strings/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/CMakeLists.txt
@@ -13,7 +13,7 @@
 # =============================================================================
 
 set(cython_sources capitalize.pyx case.pyx char_types.pyx contains.pyx find.pyx regex_flags.pyx
-                   regex_program.pyx replace.pyx
+                   regex_program.pyx replace.pyx slice.pyx
 )
 
 set(linked_libraries cudf::cudf)

--- a/python/cudf/cudf/_lib/pylibcudf/strings/__init__.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/__init__.pxd
@@ -9,4 +9,5 @@ from . cimport (
     regex_flags,
     regex_program,
     replace,
+    slice,
 )

--- a/python/cudf/cudf/_lib/pylibcudf/strings/__init__.py
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/__init__.py
@@ -9,4 +9,5 @@ from . import (
     regex_flags,
     regex_program,
     replace,
+    slice,
 )

--- a/python/cudf/cudf/_lib/pylibcudf/strings/slice.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/slice.pxd
@@ -11,5 +11,5 @@ cpdef Column slice_strings(
     Column input,
     ColumnOrScalar start=*,
     ColumnOrScalar stop=*,
-    ColumnOrScalar step=*
+    Scalar step=*
 )

--- a/python/cudf/cudf/_lib/pylibcudf/strings/slice.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/slice.pxd
@@ -1,0 +1,15 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+from cudf._lib.pylibcudf.column cimport Column
+from cudf._lib.pylibcudf.scalar cimport Scalar
+
+ctypedef fused ColumnOrScalar:
+    Column
+    Scalar
+
+cpdef Column slice_strings(
+    Column input,
+    ColumnOrScalar start=*,
+    ColumnOrScalar stop=*,
+    ColumnOrScalar step=*
+)

--- a/python/cudf/cudf/_lib/pylibcudf/strings/slice.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/slice.pyx
@@ -20,8 +20,33 @@ cpdef Column slice_strings(
     Column input,
     ColumnOrScalar start=None,
     ColumnOrScalar stop=None,
-    ColumnOrScalar step=None
+    Scalar step=None
 ):
+    """Perform a slice operation on a strings column.
+
+    ``start`` and ``stop`` may be a
+    :py:class:`~cudf._lib.pylibcudf.column.Column` or a
+    :py:class:`~cudf._lib.pylibcudf.scalar.Scalar`. But ``step`` must be a
+    :py:class:`~cudf._lib.pylibcudf.column.Scalar`.
+
+    For details, see :cpp:func:`cudf::strings::slice_strings`.
+
+    Parameters
+    ----------
+    input : Column
+        Strings column for this operation
+    start : Union[Column, Scalar]
+        The start character position or positions.
+    stop : Union[Column, Scalar]
+        The end character position or positions
+    step : Scalar
+        Distance between input characters retrieved
+
+    Returns
+    -------
+    pylibcudf.Column
+        The result of the slice operation
+    """
     cdef unique_ptr[column] c_result
     cdef numeric_scalar[size_type]* cpp_start
     cdef numeric_scalar[size_type]* cpp_stop

--- a/python/cudf/cudf/_lib/pylibcudf/strings/slice.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/slice.pyx
@@ -27,7 +27,7 @@ cpdef Column slice_strings(
     ``start`` and ``stop`` may be a
     :py:class:`~cudf._lib.pylibcudf.column.Column` or a
     :py:class:`~cudf._lib.pylibcudf.scalar.Scalar`. But ``step`` must be a
-    :py:class:`~cudf._lib.pylibcudf.column.Scalar`.
+    :py:class:`~cudf._lib.pylibcudf.scalar.Scalar`.
 
     For details, see :cpp:func:`cudf::strings::slice_strings`.
 

--- a/python/cudf/cudf/_lib/pylibcudf/strings/slice.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/slice.pyx
@@ -1,0 +1,60 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+from libcpp.memory cimport unique_ptr
+from libcpp.utility cimport move
+
+from cudf._lib.pylibcudf.column cimport Column
+from cudf._lib.pylibcudf.libcudf.column.column cimport column
+from cudf._lib.pylibcudf.libcudf.scalar.scalar cimport numeric_scalar
+from cudf._lib.pylibcudf.libcudf.scalar.scalar_factories cimport (
+    make_fixed_width_scalar as cpp_make_fixed_width_scalar,
+)
+from cudf._lib.pylibcudf.libcudf.strings cimport substring as cpp_slice
+from cudf._lib.pylibcudf.libcudf.types cimport size_type
+from cudf._lib.pylibcudf.scalar cimport Scalar
+
+from cython.operator import dereference
+
+
+cpdef Column slice_strings(
+    Column input,
+    ColumnOrScalar start=None,
+    ColumnOrScalar stop=None,
+    ColumnOrScalar step=None
+):
+    cdef unique_ptr[column] c_result
+    cdef numeric_scalar[size_type]* cpp_start
+    cdef numeric_scalar[size_type]* cpp_stop
+    cdef numeric_scalar[size_type]* cpp_step
+
+    if ColumnOrScalar is Column:
+        pass
+    elif ColumnOrScalar is Scalar:
+        if start is None:
+            delimiters = Scalar.from_libcudf(
+                cpp_make_fixed_width_scalar(0)
+            )
+        if stop is None:
+            delimiters = Scalar.from_libcudf(
+                cpp_make_fixed_width_scalar(0)
+            )
+        if step is None:
+            delimiters = Scalar.from_libcudf(
+                cpp_make_fixed_width_scalar(1)
+            )
+
+        cpp_start = <numeric_scalar[size_type]*>start.c_obj.get()
+        cpp_stop = <numeric_scalar[size_type]*>stop.c_obj.get()
+        cpp_step = <numeric_scalar[size_type]*>step.c_obj.get()
+
+        with nogil:
+            c_result = cpp_slice.slice_strings(
+                input.view(),
+                dereference(cpp_start),
+                dereference(cpp_stop),
+                dereference(cpp_step)
+            )
+    else:
+        raise ValueError("start, stop, and step must be either Column or Scalar")
+
+    return Column.from_libcudf(move(c_result))

--- a/python/cudf/cudf/_lib/pylibcudf/strings/slice.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/strings/slice.pyx
@@ -28,7 +28,16 @@ cpdef Column slice_strings(
     cdef numeric_scalar[size_type]* cpp_step
 
     if ColumnOrScalar is Column:
-        pass
+        if step is not None:
+            raise ValueError("Column-wise slice does not support step")
+
+        with nogil:
+            c_result = cpp_slice.slice_strings(
+                input.view(),
+                start.view(),
+                stop.view()
+            )
+
     elif ColumnOrScalar is Scalar:
         if start is None:
             delimiters = Scalar.from_libcudf(

--- a/python/cudf/cudf/pylibcudf_tests/test_string_slice.py
+++ b/python/cudf/cudf/pylibcudf_tests/test_string_slice.py
@@ -19,10 +19,7 @@ def plc_col(pa_col):
 
 @pytest.fixture(
     scope="module",
-    params=[
-        (1, 3, 1),
-        (0, 3, -1),
-    ],
+    params=[(1, 3, 1), (0, 3, -1), (3, 2, 1), (1, 5, 5), (1, 100, 2)],
 )
 def pa_start_stop_step(request):
     return tuple(pa.scalar(x, type=pa.int32()) for x in request.param)

--- a/python/cudf/cudf/pylibcudf_tests/test_string_slice.py
+++ b/python/cudf/cudf/pylibcudf_tests/test_string_slice.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+import pyarrow as pa
+import pytest
+from utils import assert_column_eq
+
+import cudf._lib.pylibcudf as plc
+
+
+@pytest.fixture(scope="module")
+def string_col():
+    return pa.array(["AbC"])
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        (1, 3, 1),
+    ],
+)
+def pa_start_stop_step(request):
+    return (
+        pa.scalar(request.param[0], type=pa.int32()),
+        pa.scalar(request.param[1], type=pa.int32()),
+        pa.scalar(request.param[2], type=pa.int32()),
+    )
+
+
+@pytest.fixture(scope="module")
+def plc_start_stop_step(pa_start_stop_step):
+    return (
+        plc.interop.from_arrow(pa_start_stop_step[0]),
+        plc.interop.from_arrow(pa_start_stop_step[1]),
+        plc.interop.from_arrow(pa_start_stop_step[2]),
+    )
+
+
+def test_slice(string_col, pa_start_stop_step, plc_start_stop_step):
+    plc_col = plc.interop.from_arrow(string_col)
+
+    pa_start, pa_stop, pa_step = pa_start_stop_step
+    plc_start, plc_stop, plc_step = plc_start_stop_step
+
+    expected = pa.compute.utf8_slice_codeunits(
+        string_col, pa_start.as_py(), pa_stop.as_py(), pa_step.as_py()
+    )
+    got = plc.strings.slice.slice_strings(
+        plc_col, start=plc_start, stop=plc_stop, step=plc_step
+    )
+
+    assert_column_eq(expected, got)


### PR DESCRIPTION
This PR introduces pylibcudf string `slice` APIs and migrates the cuDF cython to use them. Part of https://github.com/rapidsai/cudf/issues/15162