### PR TITLE
Add test coverage for slicing with "out of bounds" negative indices

### DIFF
--- a/python/cudf_polars/cudf_polars/containers/dataframe.py
+++ b/python/cudf_polars/cudf_polars/containers/dataframe.py
@@ -96,7 +96,7 @@ class DataFrame:
 
         Returns
         -------
-        New dataframe sharing  data with the input table.
+        New dataframe sharing data with the input table.
 
         Raises
         ------
@@ -205,15 +205,18 @@ class DataFrame:
 
         Returns
         -------
-        New dataframe (if zlice is not None) other self (if it is)
+        New dataframe (if zlice is not None) otherwise self (if it is)
         """
         if zlice is None:
             return self
         start, length = zlice
         if start < 0:
             start += self.num_rows
-        # Polars slice takes an arbitrary positive integer and slice
-        # to the end of the frame if it is larger.
-        end = min(start + length, self.num_rows)
+        # Polars implementation wraps negative start by num_rows, then
+        # adds length to start to get the end, then clamps both to
+        # [0, num_rows)
+        end = start + length
+        start = max(min(start, self.num_rows), 0)
+        end = max(min(end, self.num_rows), 0)
         (table,) = plc.copying.slice(self.table, [start, end])
         return type(self).from_table(table, self.column_names).sorted_like(self)

--- a/python/cudf_polars/cudf_polars/typing/__init__.py
+++ b/python/cudf_polars/cudf_polars/typing/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias
 
 from polars.polars import _expr_nodes as pl_expr, _ir_nodes as pl_ir
 
@@ -89,3 +89,16 @@ class NodeTraverser(Protocol):
     ) -> None:
         """Set the callback replacing the current node in the plan."""
         ...
+
+
+OptimizationArgs: TypeAlias = Literal[
+    "type_coercion",
+    "predicate_pushdown",
+    "projection_pushdown",
+    "simplify_expression",
+    "slice_pushdown",
+    "comm_subplan_elim",
+    "comm_subexpr_elim",
+    "cluster_with_columns",
+    "no_optimization",
+]

--- a/python/cudf_polars/tests/test_slice.py
+++ b/python/cudf_polars/tests/test_slice.py
@@ -14,11 +14,11 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
     [0, 1, 2, -10, -20, -1, -2, 20],
 )
 @pytest.mark.parametrize(
-    "len",
+    "length",
     [0, 2, 12, 11],
 )
 @pytest.mark.parametrize("slice_pushdown", [False, True])
-def test_slice(offset, len, slice_pushdown):
+def test_slice(offset, length, slice_pushdown):
     ldf = pl.DataFrame(
         {
             "a": [1, 2, 3, 4, 5, 6, 7],
@@ -30,6 +30,6 @@ def test_slice(offset, len, slice_pushdown):
         ldf.group_by(pl.col("a"))
         .agg(pl.col("b").sum())
         .sort(by=pl.col("a"))
-        .slice(offset, len)
+        .slice(offset, length)
     )
     assert_gpu_result_equal(query, collect_kwargs={"slice_pushdown": slice_pushdown})

--- a/python/cudf_polars/tests/test_slice.py
+++ b/python/cudf_polars/tests/test_slice.py
@@ -11,13 +11,14 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 @pytest.mark.parametrize(
     "offset",
-    [0, 1, 2],
+    [0, 1, 2, -10, -20, -1, -2, 20],
 )
 @pytest.mark.parametrize(
     "len",
-    [0, 2, 12],
+    [0, 2, 12, 11],
 )
-def test_slice(offset, len):
+@pytest.mark.parametrize("slice_pushdown", [False, True])
+def test_slice(offset, len, slice_pushdown):
     ldf = pl.DataFrame(
         {
             "a": [1, 2, 3, 4, 5, 6, 7],
@@ -31,4 +32,4 @@ def test_slice(offset, len):
         .sort(by=pl.col("a"))
         .slice(offset, len)
     )
-    assert_gpu_result_equal(query)
+    assert_gpu_result_equal(query, collect_kwargs={"slice_pushdown": slice_pushdown})


### PR DESCRIPTION
## Description

Polars wraps negative starts and then clamps both the resulting start
and length to [0, num_rows), so we should do that.

Add tests of this behaviour as well.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
