### PR TITLE
Coverage of binops where one or both operands are a scalar

### DIFF
--- a/python/cudf_polars/tests/expressions/test_numeric_binops.py
+++ b/python/cudf_polars/tests/expressions/test_numeric_binops.py
@@ -104,3 +104,15 @@ def test_numeric_binop(df, binop):
     q = df.select(binop(left, right))
 
     assert_gpu_result_equal(q)
+
+
+@pytest.mark.parametrize("left_scalar", [False, True])
+@pytest.mark.parametrize("right_scalar", [False, True])
+def test_binop_with_scalar(left_scalar, right_scalar):
+    df = pl.LazyFrame({"a": [1, 2, 3], "b": [5, 6, 7]})
+
+    lop = pl.lit(2) if left_scalar else pl.col("a")
+    rop = pl.lit(6) if right_scalar else pl.col("b")
+    q = df.select(lop / rop)
+
+    assert_gpu_result_equal(q)


### PR DESCRIPTION
## Description

Just needed the tests here.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
