### PR TITLE
Extend coverage of groupby and rolling window nodes

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -845,6 +845,7 @@ class RollingWindow(Expr):
         super().__init__(dtype)
         self.options = options
         self.children = (agg,)
+        raise NotImplementedError("Rolling window not implemented")
 
 
 class GroupedRollingWindow(Expr):
@@ -856,6 +857,7 @@ class GroupedRollingWindow(Expr):
         super().__init__(dtype)
         self.options = options
         self.children = (agg, *by)
+        raise NotImplementedError("Grouped rolling window not implemented")
 
 
 class Cast(Expr):

--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -413,8 +413,6 @@ class GroupBy(IR):
         if isinstance(agg, (expr.BinOp, expr.Cast)):
             return max(GroupBy.check_agg(child) for child in agg.children)
         elif isinstance(agg, expr.Agg):
-            if agg.name == "implode":
-                raise NotImplementedError("implode in groupby")
             return 1 + max(GroupBy.check_agg(child) for child in agg.children)
         elif isinstance(agg, (expr.Len, expr.Col, expr.Literal)):
             return 0
@@ -426,7 +424,9 @@ class GroupBy(IR):
         if self.options.rolling is None and self.maintain_order:
             raise NotImplementedError("Maintaining order in groupby")
         if self.options.rolling:
-            raise NotImplementedError("rolling window/groupby")
+            raise NotImplementedError(
+                "rolling window/groupby"
+            )  # pragma: no cover; rollingwindow constructor has already raised
         if any(GroupBy.check_agg(a.value) > 1 for a in self.agg_requests):
             raise NotImplementedError("Nested aggregations in groupby")
         self.agg_infos = [req.collect_agg(depth=0) for req in self.agg_requests]

--- a/python/cudf_polars/tests/expressions/test_rolling.py
+++ b/python/cudf_polars/tests/expressions/test_rolling.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+
+from cudf_polars import translate_ir
+
+
+def test_rolling():
+    dates = [
+        "2020-01-01 13:45:48",
+        "2020-01-01 16:42:13",
+        "2020-01-01 16:45:09",
+        "2020-01-02 18:12:48",
+        "2020-01-03 19:45:32",
+        "2020-01-08 23:16:43",
+    ]
+    df = (
+        pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]})
+        .with_columns(pl.col("dt").str.strptime(pl.Datetime))
+        .lazy()
+    )
+    q = df.with_columns(
+        sum_a=pl.sum("a").rolling(index_column="dt", period="2d"),
+        min_a=pl.min("a").rolling(index_column="dt", period="2d"),
+        max_a=pl.max("a").rolling(index_column="dt", period="2d"),
+    )
+    with pytest.raises(NotImplementedError):
+        _ = translate_ir(q._ldf.visit())
+
+
+def test_grouped_rolling():
+    df = pl.LazyFrame({"a": [1, 2, 3, 4, 5, 6], "b": [1, 2, 1, 3, 1, 2]})
+
+    q = df.select(pl.col("a").min().over("b"))
+    with pytest.raises(NotImplementedError):
+        _ = translate_ir(q._ldf.visit())

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -6,6 +6,7 @@ import pytest
 
 import polars as pl
 
+from cudf_polars import translate_ir
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
@@ -43,6 +44,7 @@ def keys(request):
         [pl.col("float") + pl.col("int")],
         [pl.col("float").max() - pl.col("int").min()],
         [pl.col("float").mean(), pl.col("int").std()],
+        [(pl.col("float") - pl.lit(2)).max()],
     ],
     ids=lambda aggs: "-".join(map(str, aggs)),
 )
@@ -72,7 +74,28 @@ def test_groupby(df: pl.LazyFrame, maintain_order, keys, exprs):
     if not maintain_order:
         sort_keys = list(q.schema.keys())[: len(keys)]
         q = q.sort(*sort_keys)
-    # from cudf_polars.dsl.translate import translate_ir
-    # ir = translate_ir(q._ldf.visit())
-    # from IPython import embed; embed()
+
     assert_gpu_result_equal(q, check_exact=False)
+
+
+def test_groupby_len(df, keys):
+    q = df.group_by(*keys).agg(pl.len())
+
+    # TODO: polars returns UInt32, libcudf returns Int32
+    with pytest.raises(AssertionError):
+        assert_gpu_result_equal(q, check_row_order=False)
+    assert_gpu_result_equal(q, check_dtypes=False, check_row_order=False)
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pl.col("float").is_not_null(),
+        (pl.col("int").max() + pl.col("float").min()).max(),
+    ],
+)
+def test_groupby_unsupported(df, expr):
+    q = df.group_by("key1").agg(expr)
+
+    with pytest.raises(NotImplementedError):
+        _ = translate_ir(q._ldf.visit())


### PR DESCRIPTION
## Description
Just raise for the rolling expressions for now since we have yet to implement them.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
