### PR TITLE
Fix typo bug in gather implementation

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -799,7 +799,7 @@ class Gather(Expr):
             obj = plc.replace.replace_nulls(
                 indices.obj,
                 plc.interop.from_arrow(
-                    pa.scalar(n, type=plc.interop.to_arrow(indices.obj.data_type()))
+                    pa.scalar(n, type=plc.interop.to_arrow(indices.obj.type()))
                 ),
             )
         else:

--- a/python/cudf_polars/tests/expressions/test_gather.py
+++ b/python/cudf_polars/tests/expressions/test_gather.py
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import pytest
+
 import polars as pl
 
+from cudf_polars import execute_with_cudf
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
@@ -17,3 +20,31 @@ def test_gather():
 
     query = ldf.select(pl.col("a").gather(pl.col("b")))
     assert_gpu_result_equal(query)
+
+
+def test_gather_with_nulls():
+    ldf = pl.LazyFrame(
+        {
+            "a": [1, 2, 3, 4, 5, 6, 7],
+            "b": [0, None, 1, None, 6, 1, 0],
+        }
+    )
+
+    query = ldf.select(pl.col("a").gather(pl.col("b")))
+
+    assert_gpu_result_equal(query)
+
+
+@pytest.mark.parametrize("negative", [False, True])
+def test_gather_out_of_bounds(negative):
+    ldf = pl.LazyFrame(
+        {
+            "a": [1, 2, 3, 4, 5, 6, 7],
+            "b": [0, -10 if negative else 10, 1, 2, 6, 1, 0],
+        }
+    )
+
+    query = ldf.select(pl.col("a").gather(pl.col("b")))
+
+    with pytest.raises(pl.exceptions.ComputeError):
+        query.collect(post_opt_callback=execute_with_cudf)


### PR DESCRIPTION
## Description
Pylibcudf calls the datatype accessor type(). Add tests to cover this case, and raising on out of bounds accesses.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
