### PR TITLE
Add coverage selecting len from a dataframe (number of rows)

### DIFF
--- a/python/cudf_polars/cudf_polars/containers/dataframe.py
+++ b/python/cudf_polars/cudf_polars/containers/dataframe.py
@@ -70,7 +70,7 @@ class DataFrame:
     @cached_property
     def num_rows(self) -> int:
         """Number of rows."""
-        return self.table.num_rows()
+        return 0 if len(self.columns) == 0 else self.table.num_rows()
 
     @classmethod
     def from_cudf(cls, df: cudf.DataFrame) -> Self:

--- a/python/cudf_polars/tests/expressions/test_len.py
+++ b/python/cudf_polars/tests/expressions/test_len.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+
+from cudf_polars.testing.asserts import assert_gpu_result_equal
+
+
+@pytest.mark.parametrize("dtype", [pl.UInt32, pl.Int32, None])
+@pytest.mark.parametrize("empty", [False, True])
+def test_len(dtype, empty):
+    if empty:
+        df = pl.LazyFrame({})
+    else:
+        df = pl.LazyFrame({"a": [1, 2, 3]})
+
+    if dtype is None:
+        q = df.select(pl.len())
+    else:
+        q = df.select(pl.len().cast(dtype))
+
+    # Workaround for https://github.com/pola-rs/polars/issues/16904
+    assert_gpu_result_equal(q, collect_kwargs={"projection_pushdown": False})


### PR DESCRIPTION
## Description
Fix bug (and report a polars issue) for the case that the dataframe is empty, and therefore we cannot ask a column for its length.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
