### PR TITLE
Add tests of implemented StringFunctions

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -689,7 +689,9 @@ class StringFunction(Expr):
                 )
             )
         else:
-            raise NotImplementedError(f"StringFunction {self.name}")
+            raise NotImplementedError(
+                f"StringFunction {self.name}"
+            )  # pragma: no cover; handled by init raising
 
 
 class Sort(Expr):

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+
+from cudf_polars import translate_ir
+from cudf_polars.testing.asserts import assert_gpu_result_equal
+
+
+def test_supported_stringfunction_expression():
+    ldf = pl.LazyFrame(
+        {
+            "a": ["a", "b", "cdefg", "h", "Wıth ünιcοde"],  # noqa: RUF001
+            "b": [0, 3, 1, -1, None],
+        }
+    )
+
+    query = ldf.select(
+        pl.col("a").str.starts_with("Z"),
+        pl.col("a").str.ends_with("h").alias("endswith_h"),
+        pl.col("a").str.to_lowercase().alias("lower"),
+        pl.col("a").str.to_uppercase().alias("upper"),
+    )
+    assert_gpu_result_equal(query)
+
+
+def test_unsupported_stringfunction():
+    ldf = pl.LazyFrame(
+        {
+            "a": ["a", "b", "cdefg", "h", "Wıth ünιcοde"],  # noqa: RUF001
+            "b": [0, 3, 1, -1, None],
+        }
+    )
+
+    q = ldf.select(pl.col("a").str.count_matches("e", literal=True))
+
+    with pytest.raises(NotImplementedError):
+        _ = translate_ir(q._ldf.visit())


### PR DESCRIPTION
## Description
Additionally, assert that we raise during translation for an unhandled function.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
