### PR TITLE
[FEA] Enable tracing of proxied objects in cudf.pandas

### DIFF
--- a/python/cudf/cudf/pandas/fast_slow_proxy.py
+++ b/python/cudf/cudf/pandas/fast_slow_proxy.py
@@ -883,7 +883,7 @@ def _assert_fast_slow_eq(left, right):
 def print_trace(func_name, args, kwargs, path):
     color = (
         "\033[92m" if path == "FAST" else "\033[91m"
-    )  # green for fast, red for slow
+    )  # FAST: green, SLOW: red
     print(
         f"{color}Call to {func_name} with args={list(args)[0]} kwargs={dict(kwargs).keys()} ({path} PATH)\033[0m"
     )


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Closes #14502. I'm trying to imagine what this could look like.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

```python
import pandas as pd

data = {
    'player_id': [1, 2, 3, 4, 5, 6],
    'player_name': ['Tiger Woods', 'Rory McIlroy', 'Phil Mickelson', 'Jordan Spieth', 'Justin Thomas', 'Dustin Johnson'],
    'country': ['USA', 'UK', 'USA', 'USA', 'USA', 'USA'],
    'score': [70, 68, 72, 74, 69, 71]
}

df = pd.DataFrame(data)

result = df.groupby('country').agg(
    total_score=('score', 'sum'),
    average_score=('score', 'mean'),
    count_players=('player_id', 'size')
).reset_index()
```

```diff
+ Call to <lambda> with args=<class 'cudf.core.dataframe.DataFrame'> kwargs=dict_keys([]) (FAST PATH)
+ Call to call_operator with args=<function DataFrame.groupby at 0x7f93a7f88940> kwargs=dict_keys([]) (FAST PATH)
- Call to call_operator with args=<function DataFrameGroupBy.aggregate at 0x7f93bec3f5b0> kwargs=dict_keys([]) (SLOW PATH)
+ Call to call_operator with args=<function DataFrame.reset_index at 0x7f93a7fcf6d0> kwargs=dict_keys([]) (FAST PATH)
```