### PR TITLE
Reduce conditional_join nvbench configurations

### DIFF
--- a/cpp/benchmarks/join/conditional_join.cu
+++ b/cpp/benchmarks/join/conditional_join.cu
@@ -16,7 +16,7 @@
 
 #include "join_common.hpp"
 
-auto const CONDITIONAL_JOIN_SIZE_RANGE = std::vector<nvbench::int64_t>{100'000, 10'000'000};
+auto const CONDITIONAL_JOIN_SIZE_RANGE = std::vector<nvbench::int64_t>{1000, 100'000};
 
 template <typename Key, bool Nullable>
 void nvbench_conditional_inner_join(nvbench::state& state,

--- a/cpp/benchmarks/join/conditional_join.cu
+++ b/cpp/benchmarks/join/conditional_join.cu
@@ -16,6 +16,8 @@
 
 #include "join_common.hpp"
 
+auto const CONDITIONAL_JOIN_SIZE_RANGE = std::vector<nvbench::int64_t>{100'000, 10'000'000};
+
 template <typename Key, bool Nullable>
 void nvbench_conditional_inner_join(nvbench::state& state,
                                     nvbench::type_list<Key, nvbench::enum_type<Nullable>>)
@@ -46,12 +48,12 @@ NVBENCH_BENCH_TYPES(nvbench_conditional_inner_join,
                     NVBENCH_TYPE_AXES(JOIN_KEY_TYPE_RANGE, JOIN_NULLABLE_RANGE))
   .set_name("conditional_inner_join")
   .set_type_axes_names({"Key", "Nullable"})
-  .add_int64_axis("left_size", JOIN_SIZE_RANGE)
-  .add_int64_axis("right_size", JOIN_SIZE_RANGE);
+  .add_int64_axis("left_size", CONDITIONAL_JOIN_SIZE_RANGE)
+  .add_int64_axis("right_size", CONDITIONAL_JOIN_SIZE_RANGE);
 
 NVBENCH_BENCH_TYPES(nvbench_conditional_left_join,
                     NVBENCH_TYPE_AXES(JOIN_KEY_TYPE_RANGE, JOIN_NULLABLE_RANGE))
   .set_name("conditional_left_join")
   .set_type_axes_names({"Key", "Nullable"})
-  .add_int64_axis("left_size", JOIN_SIZE_RANGE)
-  .add_int64_axis("right_size", JOIN_SIZE_RANGE);
+  .add_int64_axis("left_size", CONDITIONAL_JOIN_SIZE_RANGE)
+  .add_int64_axis("right_size", CONDITIONAL_JOIN_SIZE_RANGE);


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

The current **JOIN_NVBENCH** uses three table sizes `1000, 100'000, 10'000'000` for all the **join** benchmarks.

But, **coditional** **joins** perform **X * Y** operations, and the large table size explodes the bench runtime. Hence we need to benchmark on smaller tables only.

This PR reduces **nvbench configurations** from **36** to **16** by using only two smaller table sizes `1000, 100'000` which lowers the overall benchmark runtime significantly.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
