### PR TITLE
fast_slow_proxy: Don't import assert_eq at top-level

### DIFF
--- a/docs/cudf/source/user_guide/api_docs/general_utilities.rst
+++ b/docs/cudf/source/user_guide/api_docs/general_utilities.rst
@@ -8,6 +8,8 @@ Testing functions
    :toctree: api/
 
    cudf.testing.testing.assert_column_equal
+   cudf.testing.testing.assert_eq
    cudf.testing.testing.assert_frame_equal
    cudf.testing.testing.assert_index_equal
+   cudf.testing.testing.assert_neq
    cudf.testing.testing.assert_series_equal

--- a/python/cudf/cudf/_fuzz_testing/tests/fuzz_test_csv.py
+++ b/python/cudf/cudf/_fuzz_testing/tests/fuzz_test_csv.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 import sys
 from io import StringIO
@@ -13,7 +13,7 @@ from cudf._fuzz_testing.utils import (
     compare_content,
     run_test,
 )
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pythonfuzz(data_handle=CSVReader)

--- a/python/cudf/cudf/_fuzz_testing/tests/fuzz_test_json.py
+++ b/python/cudf/cudf/_fuzz_testing/tests/fuzz_test_json.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 import io
 import sys
@@ -9,7 +9,7 @@ import cudf
 from cudf._fuzz_testing.json import JSONReader, JSONWriter
 from cudf._fuzz_testing.main import pythonfuzz
 from cudf._fuzz_testing.utils import ALL_POSSIBLE_VALUES, run_test
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pythonfuzz(data_handle=JSONReader)

--- a/python/cudf/cudf/_fuzz_testing/utils.py
+++ b/python/cudf/cudf/_fuzz_testing/utils.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pyarrow as pa
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 from cudf.utils.dtypes import (
     pandas_dtypes_to_np_dtypes,
     pyarrow_dtypes_to_pandas_dtypes,

--- a/python/cudf/cudf/pandas/fast_slow_proxy.py
+++ b/python/cudf/cudf/pandas/fast_slow_proxy.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, Literal, Mapping
 import numpy as np
 
 from ..options import _env_get_bool
-from ..testing.testing import assert_eq
+from ..testing import assert_eq
 from .annotation import nvtx
 
 

--- a/python/cudf/cudf/pandas/fast_slow_proxy.py
+++ b/python/cudf/cudf/pandas/fast_slow_proxy.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, Literal, Mapping
 import numpy as np
 
 from ..options import _env_get_bool
-from ..testing._utils import assert_eq
+from ..testing.testing import assert_eq
 from .annotation import nvtx
 
 

--- a/python/cudf/cudf/testing/__init__.py
+++ b/python/cudf/cudf/testing/__init__.py
@@ -1,7 +1,9 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 from cudf.testing.testing import (
+    assert_eq,
     assert_frame_equal,
     assert_index_equal,
+    assert_neq,
     assert_series_equal,
 )

--- a/python/cudf/cudf/testing/_utils.py
+++ b/python/cudf/cudf/testing/_utils.py
@@ -2,12 +2,10 @@
 
 import itertools
 import string
-import warnings
 from collections import abc
 from contextlib import contextmanager
 from decimal import Decimal
 
-import cupy
 import numpy as np
 import pandas as pd
 import pytest
@@ -15,13 +13,13 @@ from numba.core.typing import signature as nb_signature
 from numba.core.typing.templates import AbstractTemplate
 from numba.cuda.cudadecl import registry as cuda_decl_registry
 from numba.cuda.cudaimpl import lower as cuda_lower
-from pandas import testing as tm
 
 import cudf
 from cudf._lib.null_mask import bitmask_allocation_size_bytes
 from cudf.core.column.timedelta import _unit_to_nanoseconds_conversion
 from cudf.core.udf.strings_lowering import cast_string_view_to_udf_string
 from cudf.core.udf.strings_typing import StringView, string_view, udf_string
+from cudf.testing.testing import assert_eq, assert_neq  # noqa: F401
 from cudf.utils import dtypes as dtypeutils
 
 supported_numpy_dtypes = [
@@ -111,81 +109,6 @@ def expand_bits_to_bytes(arr):
 def count_zero(arr):
     arr = np.asarray(arr)
     return np.count_nonzero(arr == 0)
-
-
-def assert_eq(left, right, **kwargs):
-    """Assert that two cudf-like things are equivalent
-
-    This equality test works for pandas/cudf dataframes/series/indexes/scalars
-    in the same way, and so makes it easier to perform parametrized testing
-    without switching between assert_frame_equal/assert_series_equal/...
-    functions.
-    """
-    # dtypes that we support but Pandas doesn't will convert to
-    # `object`. Check equality before that happens:
-    if kwargs.get("check_dtype", True):
-        if hasattr(left, "dtype") and hasattr(right, "dtype"):
-            if isinstance(
-                left.dtype, cudf.core.dtypes._BaseDtype
-            ) and not isinstance(
-                left.dtype, cudf.CategoricalDtype
-            ):  # leave categorical comparison to Pandas
-                assert_eq(left.dtype, right.dtype)
-
-    if hasattr(left, "to_pandas"):
-        left = left.to_pandas()
-    if hasattr(right, "to_pandas"):
-        right = right.to_pandas()
-    if isinstance(left, cupy.ndarray):
-        left = cupy.asnumpy(left)
-    if isinstance(right, cupy.ndarray):
-        right = cupy.asnumpy(right)
-
-    if isinstance(left, (pd.DataFrame, pd.Series, pd.Index)):
-        # TODO: A warning is emitted from the function
-        # pandas.testing.assert_[series, frame, index]_equal for some inputs:
-        # "DeprecationWarning: elementwise comparison failed; this will raise
-        # an error in the future."
-        # or "FutureWarning: elementwise ..."
-        # This warning comes from a call from pandas to numpy. It is ignored
-        # here because it cannot be fixed within cudf.
-        with warnings.catch_warnings():
-            warnings.simplefilter(
-                "ignore", (DeprecationWarning, FutureWarning)
-            )
-            if isinstance(left, pd.DataFrame):
-                tm.assert_frame_equal(left, right, **kwargs)
-            elif isinstance(left, pd.Series):
-                tm.assert_series_equal(left, right, **kwargs)
-            else:
-                tm.assert_index_equal(left, right, **kwargs)
-
-    elif isinstance(left, np.ndarray) and isinstance(right, np.ndarray):
-        if np.issubdtype(left.dtype, np.floating) and np.issubdtype(
-            right.dtype, np.floating
-        ):
-            assert np.allclose(left, right, equal_nan=True)
-        else:
-            assert np.array_equal(left, right)
-    else:
-        # Use the overloaded __eq__ of the operands
-        if left == right:
-            return True
-        elif any(np.issubdtype(type(x), np.floating) for x in (left, right)):
-            np.testing.assert_almost_equal(left, right)
-        else:
-            np.testing.assert_equal(left, right)
-    return True
-
-
-def assert_neq(left, right, **kwargs):
-    __tracebackhide__ = True
-    try:
-        assert_eq(left, right, **kwargs)
-    except AssertionError:
-        pass
-    else:
-        raise AssertionError
 
 
 def assert_exceptions_equal(

--- a/python/cudf/cudf/testing/_utils.py
+++ b/python/cudf/cudf/testing/_utils.py
@@ -19,7 +19,6 @@ from cudf._lib.null_mask import bitmask_allocation_size_bytes
 from cudf.core.column.timedelta import _unit_to_nanoseconds_conversion
 from cudf.core.udf.strings_lowering import cast_string_view_to_udf_string
 from cudf.core.udf.strings_typing import StringView, string_view, udf_string
-from cudf.testing.testing import assert_eq, assert_neq  # noqa: F401
 from cudf.utils import dtypes as dtypeutils
 
 supported_numpy_dtypes = [

--- a/python/cudf/cudf/testing/testing.py
+++ b/python/cudf/cudf/testing/testing.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import warnings
+
 import cupy as cp
 import numpy as np
 import pandas as pd
+from pandas import testing as tm
 
 import cudf
 from cudf._lib.unary import is_nan
@@ -708,3 +711,78 @@ def assert_frame_equal(
             atol=atol,
             obj=f'Column name="{col}"',
         )
+
+
+def assert_eq(left, right, **kwargs):
+    """Assert that two cudf-like things are equivalent
+
+    This equality test works for pandas/cudf dataframes/series/indexes/scalars
+    in the same way, and so makes it easier to perform parametrized testing
+    without switching between assert_frame_equal/assert_series_equal/...
+    functions.
+    """
+    # dtypes that we support but Pandas doesn't will convert to
+    # `object`. Check equality before that happens:
+    if kwargs.get("check_dtype", True):
+        if hasattr(left, "dtype") and hasattr(right, "dtype"):
+            if isinstance(
+                left.dtype, cudf.core.dtypes._BaseDtype
+            ) and not isinstance(
+                left.dtype, cudf.CategoricalDtype
+            ):  # leave categorical comparison to Pandas
+                assert_eq(left.dtype, right.dtype)
+
+    if hasattr(left, "to_pandas"):
+        left = left.to_pandas()
+    if hasattr(right, "to_pandas"):
+        right = right.to_pandas()
+    if isinstance(left, cp.ndarray):
+        left = cp.asnumpy(left)
+    if isinstance(right, cp.ndarray):
+        right = cp.asnumpy(right)
+
+    if isinstance(left, (pd.DataFrame, pd.Series, pd.Index)):
+        # TODO: A warning is emitted from the function
+        # pandas.testing.assert_[series, frame, index]_equal for some inputs:
+        # "DeprecationWarning: elementwise comparison failed; this will raise
+        # an error in the future."
+        # or "FutureWarning: elementwise ..."
+        # This warning comes from a call from pandas to numpy. It is ignored
+        # here because it cannot be fixed within cudf.
+        with warnings.catch_warnings():
+            warnings.simplefilter(
+                "ignore", (DeprecationWarning, FutureWarning)
+            )
+            if isinstance(left, pd.DataFrame):
+                tm.assert_frame_equal(left, right, **kwargs)
+            elif isinstance(left, pd.Series):
+                tm.assert_series_equal(left, right, **kwargs)
+            else:
+                tm.assert_index_equal(left, right, **kwargs)
+
+    elif isinstance(left, np.ndarray) and isinstance(right, np.ndarray):
+        if np.issubdtype(left.dtype, np.floating) and np.issubdtype(
+            right.dtype, np.floating
+        ):
+            assert np.allclose(left, right, equal_nan=True)
+        else:
+            assert np.array_equal(left, right)
+    else:
+        # Use the overloaded __eq__ of the operands
+        if left == right:
+            return True
+        elif any(np.issubdtype(type(x), np.floating) for x in (left, right)):
+            np.testing.assert_almost_equal(left, right)
+        else:
+            np.testing.assert_equal(left, right)
+    return True
+
+
+def assert_neq(left, right, **kwargs):
+    __tracebackhide__ = True
+    try:
+        assert_eq(left, right, **kwargs)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError

--- a/python/cudf/cudf/testing/testing.py
+++ b/python/cudf/cudf/testing/testing.py
@@ -716,10 +716,28 @@ def assert_frame_equal(
 def assert_eq(left, right, **kwargs):
     """Assert that two cudf-like things are equivalent
 
+    Parameters
+    ----------
+    left
+        Object to compare
+    right
+        Object to compare
+    kwargs
+        Keyword arguments to control behaviour of comparisons. See
+        :func:`assert_frame_equal`, :func:`assert_series_equal`, and
+        :func:`assert_index_equal`.
+
+    Notes
+    -----
     This equality test works for pandas/cudf dataframes/series/indexes/scalars
     in the same way, and so makes it easier to perform parametrized testing
     without switching between assert_frame_equal/assert_series_equal/...
     functions.
+
+    Raises
+    ------
+    AssertionError
+        If the two objects do not compare equal.
     """
     # dtypes that we support but Pandas doesn't will convert to
     # `object`. Check equality before that happens:
@@ -779,6 +797,10 @@ def assert_eq(left, right, **kwargs):
 
 
 def assert_neq(left, right, **kwargs):
+    """Assert that two cudf-like things are not equal.
+
+    Provides the negation of the meaning of :func:`assert_eq`.
+    """
     __tracebackhide__ = True
     try:
         assert_eq(left, right, **kwargs)

--- a/python/cudf/cudf/tests/conftest.py
+++ b/python/cudf/cudf/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 import itertools
 import os
@@ -11,7 +11,7 @@ import pytest
 import rmm  # noqa: F401
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 _CURRENT_DIRECTORY = str(pathlib.Path(__file__).resolve().parent)
 

--- a/python/cudf/cudf/tests/dataframe/test_conversion.py
+++ b/python/cudf/cudf/tests/dataframe/test_conversion.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def test_convert_dtypes():

--- a/python/cudf/cudf/tests/dataframe/test_io_serialization.py
+++ b/python/cudf/cudf/tests/dataframe/test_io_serialization.py
@@ -8,7 +8,7 @@ import pyarrow.parquet as pq
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/groupby/test_computation.py
+++ b/python/cudf/cudf/tests/groupby/test_computation.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.mark.parametrize("method", ["average", "min", "max", "first", "dense"])

--- a/python/cudf/cudf/tests/groupby/test_groupby_obj.py
+++ b/python/cudf/cudf/tests/groupby/test_groupby_obj.py
@@ -2,7 +2,7 @@
 from numpy.testing import assert_array_equal
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def test_groupby_14955():

--- a/python/cudf/cudf/tests/groupby/test_indexing.py
+++ b/python/cudf/cudf/tests/groupby/test_indexing.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023-2024, NVIDIA CORPORATION.
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def test_rank_return_type_compatible_mode():

--- a/python/cudf/cudf/tests/groupby/test_transform.py
+++ b/python/cudf/cudf/tests/groupby/test_transform.py
@@ -4,7 +4,7 @@ import itertools
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.fixture(params=[False, True], ids=["no-null-keys", "null-keys"])

--- a/python/cudf/cudf/tests/indexes/datetime/test_indexing.py
+++ b/python/cudf/cudf/tests/indexes/datetime/test_indexing.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 import pandas as pd
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def test_slice_datetimetz_index():

--- a/python/cudf/cudf/tests/indexes/datetime/test_time_specific.py
+++ b/python/cudf/cudf/tests/indexes/datetime/test_time_specific.py
@@ -2,7 +2,7 @@
 import pandas as pd
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def test_tz_localize():

--- a/python/cudf/cudf/tests/indexes/test_interval.py
+++ b/python/cudf/cudf/tests/indexes/test_interval.py
@@ -7,7 +7,7 @@ import pytest
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.core.index import IntervalIndex, interval_range
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def test_interval_constructor_default_closed():

--- a/python/cudf/cudf/tests/input_output/test_text.py
+++ b/python/cudf/cudf/tests/input_output/test_text.py
@@ -1,11 +1,11 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 from io import StringIO
 
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.fixture(scope="module")

--- a/python/cudf/cudf/tests/series/test_conversion.py
+++ b/python/cudf/cudf/tests/series/test_conversion.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/series/test_datetimelike.py
+++ b/python/cudf/cudf/tests/series/test_datetimelike.py
@@ -7,7 +7,7 @@ import pytest
 
 import cudf
 from cudf import date_range
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def _get_all_zones():

--- a/python/cudf/cudf/tests/test_apply_rows.py
+++ b/python/cudf/cudf/tests/test_apply_rows.py
@@ -1,10 +1,11 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 import pytest
 
 import cudf
 from cudf.core.column import column
-from cudf.testing._utils import assert_eq, gen_rand_series
+from cudf.testing import assert_eq
+from cudf.testing._utils import gen_rand_series
 
 
 def _kernel_multiply(a, b, out):

--- a/python/cudf/cudf/tests/test_applymap.py
+++ b/python/cudf/cudf/tests/test_applymap.py
@@ -4,7 +4,7 @@ import pytest
 
 from cudf import NA, DataFrame
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
-from cudf.testing import _utils as utils
+from cudf.testing import assert_eq
 
 
 @pytest.mark.skipif(
@@ -46,7 +46,7 @@ def test_applymap_dataframe(data, func, na_action, request):
     with pytest.warns(FutureWarning):
         got = gdf.applymap(func, na_action=na_action)
 
-    utils.assert_eq(expect, got, check_dtype=False)
+    assert_eq(expect, got, check_dtype=False)
 
 
 def test_applymap_raise_cases():

--- a/python/cudf/cudf/tests/test_array_function.py
+++ b/python/cudf/cudf/tests/test_array_function.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 # To determine if NEP18 is available in the current version of NumPy we simply

--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -15,11 +15,8 @@ from cudf.core._compat import (
     PANDAS_LT_300,
     PANDAS_VERSION,
 )
-from cudf.testing._utils import (
-    assert_eq,
-    expect_warning_if,
-    set_random_null_mask_inplace,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import expect_warning_if, set_random_null_mask_inplace
 
 _UFUNCS = [
     obj

--- a/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
+++ b/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
@@ -23,7 +23,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 from cudf.testing.dataset_generator import rand_dataframe
 
 

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -318,7 +318,7 @@ def test_series_compare_nulls(cmpop, dtypes):
     expect[expect_mask] = cmpop(lser[expect_mask], rser[expect_mask])
 
     got = cmpop(lser, rser)
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
 
 @pytest.fixture
@@ -349,7 +349,7 @@ def test_str_series_compare_str(
         Series.from_pandas(str_series_cmp_data), "a"
     )
 
-    utils.assert_eq(expect, got.to_pandas(nullable=True))
+    assert_eq(expect, got.to_pandas(nullable=True))
 
 
 def test_str_series_compare_str_reflected(
@@ -360,7 +360,7 @@ def test_str_series_compare_str_reflected(
         "a", Series.from_pandas(str_series_cmp_data)
     )
 
-    utils.assert_eq(expect, got.to_pandas(nullable=True))
+    assert_eq(expect, got.to_pandas(nullable=True))
 
 
 def test_str_series_compare_num(
@@ -371,7 +371,7 @@ def test_str_series_compare_num(
         Series.from_pandas(str_series_cmp_data), cmp_scalar
     )
 
-    utils.assert_eq(expect, got.to_pandas(nullable=True))
+    assert_eq(expect, got.to_pandas(nullable=True))
 
 
 def test_str_series_compare_num_reflected(
@@ -382,7 +382,7 @@ def test_str_series_compare_num_reflected(
         cmp_scalar, Series.from_pandas(str_series_cmp_data)
     )
 
-    utils.assert_eq(expect, got.to_pandas(nullable=True))
+    assert_eq(expect, got.to_pandas(nullable=True))
 
 
 @pytest.mark.parametrize("obj_class", ["Series", "Index"])
@@ -612,12 +612,12 @@ def test_different_shapes_and_columns(binop):
     # Empty frame on the right side
     pd_frame = binop(pd.DataFrame({"x": [1, 2]}), pd.DataFrame({}))
     cd_frame = binop(cudf.DataFrame({"x": [1, 2]}), cudf.DataFrame({}))
-    utils.assert_eq(cd_frame, pd_frame)
+    assert_eq(cd_frame, pd_frame)
 
     # Empty frame on the left side
     pd_frame = pd.DataFrame({}) + pd.DataFrame({"x": [1, 2]})
     cd_frame = cudf.DataFrame({}) + cudf.DataFrame({"x": [1, 2]})
-    utils.assert_eq(cd_frame, pd_frame)
+    assert_eq(cd_frame, pd_frame)
 
     # Note: the below rely on a discrepancy between cudf and pandas
     # While pandas inserts columns in alphabetical order, cudf inserts in the
@@ -627,12 +627,12 @@ def test_different_shapes_and_columns(binop):
     # More rows on the left side
     pd_frame = pd.DataFrame({"x": [1, 2, 3]}) + pd.DataFrame({"y": [1, 2]})
     cd_frame = cudf.DataFrame({"x": [1, 2, 3]}) + cudf.DataFrame({"y": [1, 2]})
-    utils.assert_eq(cd_frame, pd_frame)
+    assert_eq(cd_frame, pd_frame)
 
     # More rows on the right side
     pd_frame = pd.DataFrame({"x": [1, 2]}) + pd.DataFrame({"y": [1, 2, 3]})
     cd_frame = cudf.DataFrame({"x": [1, 2]}) + cudf.DataFrame({"y": [1, 2, 3]})
-    utils.assert_eq(cd_frame, pd_frame)
+    assert_eq(cd_frame, pd_frame)
 
 
 @pytest.mark.parametrize("binop", _binops)
@@ -650,7 +650,7 @@ def test_different_shapes_and_same_columns(binop):
     )
     # cast x as float64 so it matches pandas dtype
     cd_frame["x"] = cd_frame["x"].astype(np.float64)
-    utils.assert_eq(cd_frame, pd_frame)
+    assert_eq(cd_frame, pd_frame)
 
 
 @pytest.mark.parametrize("binop", _binops)
@@ -680,7 +680,7 @@ def test_different_shapes_and_columns_with_unaligned_indices(binop):
     # cast x and y as float64 so it matches pandas dtype
     cd_frame["x"] = cd_frame["x"].astype(np.float64)
     cd_frame["y"] = cd_frame["y"].astype(np.float64)
-    utils.assert_eq(cd_frame, pd_frame)
+    assert_eq(cd_frame, pd_frame)
 
     pdf1 = pd.DataFrame({"x": [1, 1]}, index=["a", "a"])
     pdf2 = pd.DataFrame({"x": [2]}, index=["a"])
@@ -688,7 +688,7 @@ def test_different_shapes_and_columns_with_unaligned_indices(binop):
     gdf2 = cudf.DataFrame.from_pandas(pdf2)
     pd_frame = binop(pdf1, pdf2)
     cd_frame = binop(gdf1, gdf2)
-    utils.assert_eq(pd_frame, cd_frame)
+    assert_eq(pd_frame, cd_frame)
 
 
 @pytest.mark.parametrize(
@@ -717,12 +717,12 @@ def test_df_different_index_shape(df2, binop):
 def test_boolean_scalar_binop(op):
     psr = pd.Series(np.random.choice([True, False], 10))
     gsr = cudf.from_pandas(psr)
-    utils.assert_eq(op(psr, True), op(gsr, True))
-    utils.assert_eq(op(psr, False), op(gsr, False))
+    assert_eq(op(psr, True), op(gsr, True))
+    assert_eq(op(psr, False), op(gsr, False))
 
     # cuDF scalar
-    utils.assert_eq(op(psr, True), op(gsr, cudf.Scalar(True)))
-    utils.assert_eq(op(psr, False), op(gsr, cudf.Scalar(False)))
+    assert_eq(op(psr, True), op(gsr, cudf.Scalar(True)))
+    assert_eq(op(psr, False), op(gsr, cudf.Scalar(False)))
 
 
 @pytest.mark.parametrize("func", _operators_arithmetic)
@@ -747,7 +747,7 @@ def test_operator_func_between_series(dtype, func, has_nulls, fill_value):
         pdf_series_b, fill_value=fill_value
     )
 
-    utils.assert_eq(pdf_result, gdf_result)
+    assert_eq(pdf_result, gdf_result)
 
 
 @pytest.mark.parametrize("func", _operators_arithmetic)
@@ -773,7 +773,7 @@ def test_operator_func_series_and_scalar(
         scalar, fill_value=fill_value
     )
 
-    utils.assert_eq(pdf_series_result, gdf_series_result)
+    assert_eq(pdf_series_result, gdf_series_result)
 
 
 _permu_values = [0, 1, None, np.nan]
@@ -812,9 +812,9 @@ def test_operator_func_between_series_logical(
         and np.isnan(fill_value)
     ):
         with pytest.raises(AssertionError):
-            utils.assert_eq(expect, got)
+            assert_eq(expect, got)
         return
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
 
 @pytest.mark.parametrize("dtype", ["float32", "float64"])
@@ -851,7 +851,7 @@ def test_operator_func_series_and_scalar_logical(
     expect = pdf_series_result
     got = gdf_series_result.to_pandas(nullable=True)
 
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
 
 @pytest.mark.parametrize("func", _operators_arithmetic)
@@ -887,7 +887,7 @@ def test_operator_func_dataframe(func, nulls, fill_value, other):
     got = getattr(gdf1, func)(gdf2, fill_value=fill_value)
     expect = getattr(pdf1, func)(pdf2, fill_value=fill_value)[list(got._data)]
 
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
 
 @pytest.mark.parametrize("func", _operators_comparison)
@@ -923,7 +923,7 @@ def test_logical_operator_func_dataframe(func, nulls, other):
     got = getattr(gdf1, func)(gdf2)
     expect = getattr(pdf1, func)(pdf2)[list(got._data)]
 
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
 
 @pytest.mark.parametrize(
@@ -949,7 +949,7 @@ def test_logical_operator_func_dataframe(func, nulls, other):
 def test_binop_bool_uint(func, rhs):
     psr = pd.Series([True, False, False])
     gsr = cudf.from_pandas(psr)
-    utils.assert_eq(
+    assert_eq(
         getattr(psr, func)(rhs), getattr(gsr, func)(rhs), check_dtype=False
     )
 
@@ -977,7 +977,7 @@ def test_floordiv_zero_float64(series_dtype, divisor_dtype, scalar_divisor):
     else:
         pd_div = pd.Series([0], dtype=divisor_dtype)
         cudf_div = cudf.from_pandas(pd_div)
-    utils.assert_eq(sr // pd_div, cr // cudf_div)
+    assert_eq(sr // pd_div, cr // cudf_div)
 
 
 @pytest.mark.parametrize("scalar_divisor", [False, True])
@@ -1023,27 +1023,27 @@ def test_floordiv_zero_bool(scalar_divisor):
 def test_rmod_zero_nan(dtype):
     sr = pd.Series([1, 1, 0], dtype=dtype)
     cr = cudf.from_pandas(sr)
-    utils.assert_eq(1 % sr, 1 % cr)
+    assert_eq(1 % sr, 1 % cr)
     expected_dtype = np.float64 if cr.dtype.kind != "f" else dtype
-    utils.assert_eq(1 % cr, cudf.Series([0, 0, None], dtype=expected_dtype))
+    assert_eq(1 % cr, cudf.Series([0, 0, None], dtype=expected_dtype))
 
 
 def test_series_misc_binop():
     pds = pd.Series([1, 2, 4], name="abc xyz")
     gds = cudf.Series([1, 2, 4], name="abc xyz")
 
-    utils.assert_eq(pds + 1, gds + 1)
-    utils.assert_eq(1 + pds, 1 + gds)
+    assert_eq(pds + 1, gds + 1)
+    assert_eq(1 + pds, 1 + gds)
 
-    utils.assert_eq(pds + pds, gds + gds)
+    assert_eq(pds + pds, gds + gds)
 
     pds1 = pd.Series([1, 2, 4], name="hello world")
     gds1 = cudf.Series([1, 2, 4], name="hello world")
 
-    utils.assert_eq(pds + pds1, gds + gds1)
-    utils.assert_eq(pds1 + pds, gds1 + gds)
+    assert_eq(pds + pds1, gds + gds1)
+    assert_eq(pds1 + pds, gds1 + gds)
 
-    utils.assert_eq(pds1 + pds + 5, gds1 + gds + 5)
+    assert_eq(pds1 + pds + 5, gds1 + gds + 5)
 
 
 def test_int8_float16_binop():
@@ -1051,7 +1051,7 @@ def test_int8_float16_binop():
     b = np.float16(2)
     expect = cudf.Series([0.5])
     got = a / b
-    utils.assert_eq(expect, got, check_dtype=False)
+    assert_eq(expect, got, check_dtype=False)
 
 
 @pytest.mark.parametrize("dtype", ["int64", "float64", "str"])
@@ -1061,7 +1061,7 @@ def test_vector_to_none_binops(dtype):
     expect = Series([None] * 4).astype(dtype)
     got = data + None
 
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
 
 def dtype_scalar(val, dtype):
@@ -1747,12 +1747,12 @@ def test_datetime_dateoffset_binaryop(
     expect = op(psr, poffset)
     got = op(gsr, goffset)
 
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
     expect = op(psr, -poffset)
     got = op(gsr, -goffset)
 
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
 
 @pytest.mark.parametrize(
@@ -1793,7 +1793,7 @@ def test_datetime_dateoffset_binaryop_multiple(date_col, kwargs, op):
     expect = op(psr, poffset)
     got = op(gsr, goffset)
 
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
 
 @pytest.mark.parametrize("n_periods", [0, 1, -1, 12, -12])
@@ -1840,7 +1840,7 @@ def test_datetime_dateoffset_binaryop_reflected(
 
     # TODO: Remove check_dtype once we get some clarity on:
     # https://github.com/pandas-dev/pandas/issues/57448
-    utils.assert_eq(expect, got, check_dtype=False)
+    assert_eq(expect, got, check_dtype=False)
 
     with pytest.raises(TypeError):
         poffset - psr
@@ -1878,7 +1878,7 @@ def test_binops_with_lhs_numpy_scalar(frame, dtype):
     expected = data.to_pandas() == val
     got = data == val
 
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 @pytest.mark.parametrize(
@@ -2302,7 +2302,7 @@ def test_binops_decimal(op, lhs, l_dtype, rhs, r_dtype, expect, expect_dtype):
 
     got = op(a, b)
     assert expect.dtype == got.dtype
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
 
 @pytest.mark.parametrize(
@@ -2355,7 +2355,7 @@ def test_binops_reflect_decimal(
 
     got = getattr(a, op)(b)
     assert expect.dtype == got.dtype
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
 
 @pytest.mark.parametrize("powers", [0, 1, 2, 3])
@@ -2371,7 +2371,7 @@ def test_binops_decimal_pow(powers):
     )
     ps = s.to_pandas()
 
-    utils.assert_eq(s**powers, ps**powers, check_dtype=False)
+    assert_eq(s**powers, ps**powers, check_dtype=False)
 
 
 def test_binops_raise_error():
@@ -2554,7 +2554,7 @@ def test_binops_decimal_comp_mixed_integer(args, integer_dtype, reflected):
 
     actual = op(lhs, rhs)
 
-    utils.assert_eq(expected, actual)
+    assert_eq(expected, actual)
 
 
 @pytest.mark.parametrize(
@@ -2804,7 +2804,7 @@ def test_binops_decimal_scalar(args):
 
     got = op(lhs, rhs)
     assert expect.dtype == got.dtype
-    utils.assert_eq(expect, got)
+    assert_eq(expect, got)
 
 
 @pytest.mark.parametrize(
@@ -2979,7 +2979,7 @@ def test_binops_decimal_scalar_compare(args, reflected):
 
     actual = op(lhs, rhs)
 
-    utils.assert_eq(expected, actual)
+    assert_eq(expected, actual)
 
 
 @pytest.mark.parametrize(
@@ -3042,7 +3042,7 @@ def test_equality_ops_index_mismatch(fn):
     expected = getattr(pa, fn)(pb)
     actual = getattr(a, fn)(b).to_pandas(nullable=True)
 
-    utils.assert_eq(expected, actual)
+    assert_eq(expected, actual)
 
 
 def generate_test_null_equals_columnops_data():
@@ -3132,7 +3132,7 @@ def test_empty_column(binop, data, scalar):
     got = binop(gdf, scalar)
     expected = binop(pdf, scalar)
 
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 @pytest.mark.parametrize(
@@ -3179,7 +3179,7 @@ def test_binops_dot(df, other):
     expected = pdf @ host_other
     got = df @ other
 
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 def test_binop_dot_preserve_index():
@@ -3187,7 +3187,7 @@ def test_binop_dot_preserve_index():
     df = cudf.DataFrame(np.eye(2), columns=["A", "B"], index=["A", "B"])
     result = ser @ df
     expected = ser.to_pandas() @ df.to_pandas()
-    utils.assert_eq(result, expected)
+    assert_eq(result, expected)
 
 
 def test_binop_series_with_repeated_index():
@@ -3198,7 +3198,7 @@ def test_binop_series_with_repeated_index():
     gsr2 = cudf.from_pandas(psr2)
     expected = psr1 - psr2
     got = gsr1 - gsr2
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 def test_binop_integer_power_series_series():
@@ -3209,7 +3209,7 @@ def test_binop_integer_power_series_series():
     ps_exponent = gs_exponent.to_pandas()
     expected = ps_base**ps_exponent
     got = gs_base**gs_exponent
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 def test_binop_integer_power_series_scalar():
@@ -3219,7 +3219,7 @@ def test_binop_integer_power_series_scalar():
     ps_base = gs_base.to_pandas()
     expected = ps_base**exponent.value
     got = gs_base**exponent
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 def test_binop_integer_power_series_int():
@@ -3229,7 +3229,7 @@ def test_binop_integer_power_series_int():
     ps_base = gs_base.to_pandas()
     expected = ps_base**exponent
     got = gs_base**exponent
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 def test_binop_integer_power_scalar_series():
@@ -3239,7 +3239,7 @@ def test_binop_integer_power_scalar_series():
     ps_exponent = gs_exponent.to_pandas()
     expected = base.value**ps_exponent
     got = base**gs_exponent
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 def test_binop_integer_power_scalar_scalar():
@@ -3248,7 +3248,7 @@ def test_binop_integer_power_scalar_scalar():
     exponent = cudf.Scalar(1)
     expected = base.value**exponent.value
     got = base**exponent
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 def test_binop_integer_power_scalar_int():
@@ -3257,7 +3257,7 @@ def test_binop_integer_power_scalar_int():
     exponent = 1
     expected = base.value**exponent
     got = base**exponent
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 def test_binop_integer_power_int_series():
@@ -3267,7 +3267,7 @@ def test_binop_integer_power_int_series():
     ps_exponent = gs_exponent.to_pandas()
     expected = base**ps_exponent
     got = base**gs_exponent
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 def test_binop_integer_power_int_scalar():
@@ -3276,7 +3276,7 @@ def test_binop_integer_power_int_scalar():
     exponent = cudf.Scalar(1)
     expected = base**exponent.value
     got = base**exponent
-    utils.assert_eq(expected, got)
+    assert_eq(expected, got)
 
 
 def test_numpy_int_scalar_binop():
@@ -3291,7 +3291,7 @@ def test_binop_index_series(op):
     actual = op(gi, gs)
     expected = op(gi.to_pandas(), gs.to_pandas())
 
-    utils.assert_eq(expected, actual)
+    assert_eq(expected, actual)
 
 
 @pytest.mark.parametrize("name1", utils.SERIES_OR_INDEX_NAMES)
@@ -3307,7 +3307,7 @@ def test_binop_index_dt_td_series_with_names(name1, name2):
         expected = gi.to_pandas() + gs.to_pandas()
     actual = gi + gs
 
-    utils.assert_eq(expected, actual)
+    assert_eq(expected, actual)
 
 
 @pytest.mark.parametrize("data1", [[1, 2, 3], [10, 11, None]])
@@ -3319,9 +3319,9 @@ def test_binop_eq_ne_index_series(data1, data2):
     actual = gi == gs
     expected = gi.to_pandas() == gs.to_pandas()
 
-    utils.assert_eq(expected, actual)
+    assert_eq(expected, actual)
 
     actual = gi != gs
     expected = gi.to_pandas() != gs.to_pandas()
 
-    utils.assert_eq(expected, actual)
+    assert_eq(expected, actual)

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -15,7 +15,7 @@ import cudf
 from cudf import Index, Series
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.core.buffer.spill_manager import get_global_manager
-from cudf.testing import _utils as utils
+from cudf.testing import _utils as utils, assert_eq
 from cudf.utils.dtypes import (
     BOOL_TYPES,
     DATETIME_TYPES,
@@ -194,7 +194,7 @@ def test_series_binop(binop, obj_class):
     if obj_class == "Index":
         result = Series(result)
 
-    utils.assert_eq(result, expect)
+    assert_eq(result, expect)
 
 
 @pytest.mark.parametrize("binop", _binops)

--- a/python/cudf/cudf/tests/test_categorical.py
+++ b/python/cudf/cudf/tests/test_categorical.py
@@ -11,11 +11,8 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import (
-    NUMERIC_TYPES,
-    assert_eq,
-    assert_exceptions_equal,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import NUMERIC_TYPES, assert_exceptions_equal
 
 
 @contextmanager

--- a/python/cudf/cudf/tests/test_column.py
+++ b/python/cudf/cudf/tests/test_column.py
@@ -9,7 +9,8 @@ import pytest
 import cudf
 from cudf._lib.transform import mask_to_bools
 from cudf.core.column.column import as_column
-from cudf.testing._utils import assert_eq, assert_exceptions_equal
+from cudf.testing import assert_eq
+from cudf.testing._utils import assert_exceptions_equal
 from cudf.utils import dtypes as dtypeutils
 
 dtypes = sorted(

--- a/python/cudf/cudf/tests/test_column_accessor.py
+++ b/python/cudf/cudf/tests/test_column_accessor.py
@@ -6,7 +6,7 @@ import pytest
 
 import cudf
 from cudf.core.column_accessor import ColumnAccessor
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 simple_test_data = [
     {},

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -10,11 +10,8 @@ import pytest
 
 import cudf
 from cudf.core.dtypes import Decimal32Dtype, Decimal64Dtype, Decimal128Dtype
-from cudf.testing._utils import (
-    assert_eq,
-    assert_exceptions_equal,
-    expect_warning_if,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import assert_exceptions_equal, expect_warning_if
 
 
 @contextmanager

--- a/python/cudf/cudf/tests/test_contains.py
+++ b/python/cudf/cudf/tests/test_contains.py
@@ -9,12 +9,8 @@ import pytest
 import cudf
 from cudf import Series
 from cudf.core.index import Index, RangeIndex
-from cudf.testing._utils import (
-    DATETIME_TYPES,
-    NUMERIC_TYPES,
-    TIMEDELTA_TYPES,
-    assert_eq,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import DATETIME_TYPES, NUMERIC_TYPES, TIMEDELTA_TYPES
 
 
 def cudf_date_series(start, stop, freq):

--- a/python/cudf/cudf/tests/test_copying.py
+++ b/python/cudf/cudf/tests/test_copying.py
@@ -8,7 +8,8 @@ import pytest
 import cudf
 from cudf import Series
 from cudf.core.buffer.spill_manager import get_global_manager
-from cudf.testing._utils import NUMERIC_TYPES, OTHER_TYPES, assert_eq
+from cudf.testing import assert_eq
+from cudf.testing._utils import NUMERIC_TYPES, OTHER_TYPES
 
 pytestmark = pytest.mark.spilling
 

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -18,7 +18,8 @@ from pyarrow import fs as pa_fs
 import cudf
 from cudf import read_csv
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
-from cudf.testing._utils import assert_eq, assert_exceptions_equal
+from cudf.testing import assert_eq
+from cudf.testing._utils import assert_exceptions_equal
 
 
 def make_numeric_dataframe(nrows, dtype):

--- a/python/cudf/cudf/tests/test_cuda_apply.py
+++ b/python/cudf/cudf/tests/test_cuda_apply.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 
 """
 Test method that apply GPU kernel to a frame.
@@ -9,7 +9,7 @@ import pytest
 from numba import cuda
 
 from cudf import DataFrame
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.mark.parametrize("nelem", [1, 2, 64, 128, 129])

--- a/python/cudf/cudf/tests/test_cuda_array_interface.py
+++ b/python/cudf/cudf/tests/test_cuda_array_interface.py
@@ -11,12 +11,8 @@ import pytest
 
 import cudf
 from cudf.core.buffer.spill_manager import get_global_manager
-from cudf.testing._utils import (
-    DATETIME_TYPES,
-    NUMERIC_TYPES,
-    TIMEDELTA_TYPES,
-    assert_eq,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import DATETIME_TYPES, NUMERIC_TYPES, TIMEDELTA_TYPES
 
 
 @pytest.mark.parametrize("dtype", NUMERIC_TYPES + DATETIME_TYPES)

--- a/python/cudf/cudf/tests/test_custom_accessor.py
+++ b/python/cudf/cudf/tests/test_custom_accessor.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @cudf.api.extensions.register_dataframe_accessor("point")

--- a/python/cudf/cudf/tests/test_cut.py
+++ b/python/cudf/cudf/tests/test_cut.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 from cudf.core.cut import cut
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -30,14 +30,12 @@ from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.core.buffer.spill_manager import get_global_manager
 from cudf.core.column import column
 from cudf.errors import MixedTypeError
-from cudf.testing import _utils as utils
+from cudf.testing import _utils as utils, assert_eq, assert_neq
 from cudf.testing._utils import (
     ALL_TYPES,
     DATETIME_TYPES,
     NUMERIC_TYPES,
-    assert_eq,
     assert_exceptions_equal,
-    assert_neq,
     does_not_raise,
     expect_warning_if,
     gen_rand,

--- a/python/cudf/cudf/tests/test_dataframe_copy.py
+++ b/python/cudf/cudf/tests/test_dataframe_copy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 from copy import copy, deepcopy
 
 import cupy as cp
@@ -7,7 +7,8 @@ import pandas as pd
 import pytest
 
 from cudf.core.dataframe import DataFrame
-from cudf.testing._utils import ALL_TYPES, assert_eq, assert_neq
+from cudf.testing import assert_eq, assert_neq
+from cudf.testing._utils import ALL_TYPES
 
 """
 DataFrame copy expectations

--- a/python/cudf/cudf/tests/test_datasets.py
+++ b/python/cudf/cudf/tests/test_datasets.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def test_dataset_timeseries():

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -15,10 +15,10 @@ import cudf.testing.dataset_generator as dataset_generator
 from cudf import DataFrame, Series
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.core.index import DatetimeIndex
+from cudf.testing import assert_eq
 from cudf.testing._utils import (
     DATETIME_TYPES,
     NUMERIC_TYPES,
-    assert_eq,
     assert_exceptions_equal,
     expect_warning_if,
 )

--- a/python/cudf/cudf/tests/test_decimal.py
+++ b/python/cudf/cudf/tests/test_decimal.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 
 import decimal
 from decimal import Decimal
@@ -11,12 +11,12 @@ from packaging import version
 import cudf
 from cudf.core.column import Decimal32Column, Decimal64Column, NumericalColumn
 from cudf.core.dtypes import Decimal32Dtype, Decimal64Dtype
+from cudf.testing import assert_eq
 from cudf.testing._utils import (
     FLOAT_TYPES,
     INTEGER_TYPES,
     SIGNED_TYPES,
     _decimal_series,
-    assert_eq,
     expect_warning_if,
 )
 

--- a/python/cudf/cudf/tests/test_df_protocol.py
+++ b/python/cudf/cudf/tests/test_df_protocol.py
@@ -20,7 +20,7 @@ from cudf.core.df_protocol import (
     from_dataframe,
     protocol_dtype_to_cupy_dtype,
 )
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.fixture(

--- a/python/cudf/cudf/tests/test_dlpack.py
+++ b/python/cudf/cudf/tests/test_dlpack.py
@@ -9,7 +9,7 @@ import pytest
 from packaging import version
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 nelems = [0, 3, 10]
 dtype = [np.uint16, np.int32, np.float64]

--- a/python/cudf/cudf/tests/test_dropna.py
+++ b/python/cudf/cudf/tests/test_dropna.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_dtypes.py
+++ b/python/cudf/cudf/tests/test_dtypes.py
@@ -17,7 +17,7 @@ from cudf.core.dtypes import (
     ListDtype,
     StructDtype,
 )
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 from cudf.utils.dtypes import np_to_pa_dtype
 
 

--- a/python/cudf/cudf/tests/test_duplicates.py
+++ b/python/cudf/cudf/tests/test_duplicates.py
@@ -9,7 +9,8 @@ import pytest
 
 import cudf
 from cudf import concat
-from cudf.testing._utils import assert_eq, assert_exceptions_equal
+from cudf.testing import assert_eq
+from cudf.testing._utils import assert_exceptions_equal
 
 # most tests are similar to pandas drop_duplicates
 

--- a/python/cudf/cudf/tests/test_ewm.py
+++ b/python/cudf/cudf/tests/test_ewm.py
@@ -2,7 +2,7 @@
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_factorize.py
+++ b/python/cudf/cudf/tests/test_factorize.py
@@ -7,7 +7,7 @@ import pytest
 
 import cudf
 from cudf import DataFrame, Index
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.mark.parametrize("ncats,nelem", [(2, 2), (2, 10), (10, 100)])

--- a/python/cudf/cudf/tests/test_feather.py
+++ b/python/cudf/cudf/tests/test_feather.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 
 import os
 from string import ascii_letters
@@ -9,7 +9,8 @@ import pyarrow as pa
 import pytest
 
 import cudf
-from cudf.testing._utils import NUMERIC_TYPES, assert_eq
+from cudf.testing import assert_eq
+from cudf.testing._utils import NUMERIC_TYPES
 
 
 @pytest.fixture(params=[0, 1, 10, 100])

--- a/python/cudf/cudf/tests/test_gcs.py
+++ b/python/cudf/cudf/tests/test_gcs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 import io
 import os
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 gcsfs = pytest.importorskip("gcsfs")
 

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -28,11 +28,11 @@ from cudf.core._compat import (
 from cudf.core.udf._ops import arith_ops, comparison_ops, unary_ops
 from cudf.core.udf.groupby_typing import SUPPORTED_GROUPBY_NUMPY_TYPES
 from cudf.core.udf.utils import UDFError, precompiled
+from cudf.testing import assert_eq
 from cudf.testing._utils import (
     DATETIME_TYPES,
     SIGNED_TYPES,
     TIMEDELTA_TYPES,
-    assert_eq,
     assert_exceptions_equal,
     expect_warning_if,
 )

--- a/python/cudf/cudf/tests/test_hdf.py
+++ b/python/cudf/cudf/tests/test_hdf.py
@@ -8,7 +8,8 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import NUMERIC_TYPES, UNSIGNED_TYPES, assert_eq
+from cudf.testing import assert_eq
+from cudf.testing._utils import NUMERIC_TYPES, UNSIGNED_TYPES
 
 pytest.importorskip("tables")
 

--- a/python/cudf/cudf/tests/test_hdfs.py
+++ b/python/cudf/cudf/tests/test_hdfs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 import os
 from io import BytesIO
@@ -10,7 +10,7 @@ import pyarrow as pa
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 if not os.environ.get("RUN_HDFS_TESTS"):
     pytestmark = pytest.mark.skip("Env not configured to run HDFS tests")

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -18,6 +18,7 @@ import cudf
 from cudf.api.extensions import no_default
 from cudf.api.types import is_bool_dtype
 from cudf.core.index import CategoricalIndex, DatetimeIndex, Index, RangeIndex
+from cudf.testing import assert_eq
 from cudf.testing._utils import (
     ALL_TYPES,
     FLOAT_TYPES,
@@ -28,7 +29,6 @@ from cudf.testing._utils import (
     UNSIGNED_TYPES,
     assert_column_memory_eq,
     assert_column_memory_ne,
-    assert_eq,
     assert_exceptions_equal,
     expect_warning_if,
 )

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -11,10 +11,9 @@ import pytest
 
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
-from cudf.testing import _utils as utils
+from cudf.testing import _utils as utils, assert_eq
 from cudf.testing._utils import (
     INTEGER_TYPES,
-    assert_eq,
     assert_exceptions_equal,
     expect_warning_if,
 )

--- a/python/cudf/cudf/tests/test_interpolate.py
+++ b/python/cudf/cudf/tests/test_interpolate.py
@@ -4,11 +4,8 @@ import pytest
 
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
-from cudf.testing._utils import (
-    assert_eq,
-    assert_exceptions_equal,
-    expect_warning_if,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import assert_exceptions_equal, expect_warning_if
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_interval.py
+++ b/python/cudf/cudf/tests/test_interval.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_join_order.py
+++ b/python/cudf/cudf/tests/test_join_order.py
@@ -8,7 +8,7 @@ import pytest
 
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.fixture(params=[False, True], ids=["unsorted", "sorted"])

--- a/python/cudf/cudf/tests/test_joining.py
+++ b/python/cudf/cudf/tests/test_joining.py
@@ -9,11 +9,11 @@ import pytest
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.core.dtypes import CategoricalDtype, Decimal64Dtype, Decimal128Dtype
+from cudf.testing import assert_eq
 from cudf.testing._utils import (
     INTEGER_TYPES,
     NUMERIC_TYPES,
     TIMEDELTA_TYPES,
-    assert_eq,
     assert_exceptions_equal,
     expect_warning_if,
 )

--- a/python/cudf/cudf/tests/test_json.py
+++ b/python/cudf/cudf/tests/test_json.py
@@ -14,11 +14,11 @@ import pytest
 
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
+from cudf.testing import assert_eq
 from cudf.testing._utils import (
     DATETIME_TYPES,
     NUMERIC_TYPES,
     TIMEDELTA_TYPES,
-    assert_eq,
     expect_warning_if,
 )
 

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -12,12 +12,8 @@ import cudf
 from cudf import NA
 from cudf._lib.copying import get_element
 from cudf.api.types import is_scalar
-from cudf.testing._utils import (
-    DATETIME_TYPES,
-    NUMERIC_TYPES,
-    TIMEDELTA_TYPES,
-    assert_eq,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import DATETIME_TYPES, NUMERIC_TYPES, TIMEDELTA_TYPES
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_monotonic.py
+++ b/python/cudf/cudf/tests/test_monotonic.py
@@ -12,7 +12,7 @@ import pytest
 import cudf
 from cudf import Index, MultiIndex, Series
 from cudf.core.index import CategoricalIndex, DatetimeIndex, RangeIndex
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.mark.parametrize("testrange", [(10, 20, 1), (0, -10, -1), (5, 5, 1)])

--- a/python/cudf/cudf/tests/test_multiindex.py
+++ b/python/cudf/cudf/tests/test_multiindex.py
@@ -21,12 +21,8 @@ import pytest
 import cudf
 from cudf.api.extensions import no_default
 from cudf.core.column import as_column
-from cudf.testing._utils import (
-    assert_eq,
-    assert_exceptions_equal,
-    assert_neq,
-    expect_warning_if,
-)
+from cudf.testing import assert_eq, assert_neq
+from cudf.testing._utils import assert_exceptions_equal, expect_warning_if
 
 
 @contextmanager

--- a/python/cudf/cudf/tests/test_numerical.py
+++ b/python/cudf/cudf/tests/test_numerical.py
@@ -5,7 +5,8 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import NUMERIC_TYPES, assert_eq, expect_warning_if
+from cudf.testing import assert_eq
+from cudf.testing._utils import NUMERIC_TYPES, expect_warning_if
 from cudf.utils.dtypes import np_dtypes_to_pandas_dtypes
 
 

--- a/python/cudf/cudf/tests/test_numpy_interop.py
+++ b/python/cudf/cudf/tests/test_numpy_interop.py
@@ -1,10 +1,10 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 import numpy as np
 import pytest
 
 from cudf import DataFrame, Series
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def test_to_records_noindex():

--- a/python/cudf/cudf/tests/test_onehot.py
+++ b/python/cudf/cudf/tests/test_onehot.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 pytestmark = pytest.mark.spilling
 

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -15,9 +15,8 @@ import pytest
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.io.orc import ORCWriter
-from cudf.testing import assert_frame_equal
+from cudf.testing import assert_eq, assert_frame_equal
 from cudf.testing._utils import (
-    assert_eq,
     expect_warning_if,
     gen_rand_series,
     supported_numpy_dtypes,

--- a/python/cudf/cudf/tests/test_pack.py
+++ b/python/cudf/cudf/tests/test_pack.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 from cudf import DataFrame, Index, Series
 from cudf._lib.copying import pack, unpack
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def test_sizeof_packed_dataframe():

--- a/python/cudf/cudf/tests/test_pandas_interop.py
+++ b/python/cudf/cudf/tests/test_pandas_interop.py
@@ -1,11 +1,11 @@
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 
 import numpy as np
 import pandas as pd
 
 import cudf
 from cudf import DataFrame
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def test_to_pandas():

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -28,12 +28,8 @@ from cudf.io.parquet import (
     ParquetWriter,
     merge_parquet_filemetadata,
 )
-from cudf.testing import dataset_generator as dg
-from cudf.testing._utils import (
-    TIMEDELTA_TYPES,
-    assert_eq,
-    set_random_null_mask_inplace,
-)
+from cudf.testing import assert_eq, dataset_generator as dg
+from cudf.testing._utils import TIMEDELTA_TYPES, set_random_null_mask_inplace
 
 
 @contextmanager

--- a/python/cudf/cudf/tests/test_pickling.py
+++ b/python/cudf/cudf/tests/test_pickling.py
@@ -8,7 +8,7 @@ import pytest
 
 from cudf import DataFrame, Index, RangeIndex, Series
 from cudf.core.buffer import as_buffer
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 pytestmark = pytest.mark.spilling
 

--- a/python/cudf/cudf/tests/test_quantiles.py
+++ b/python/cudf/cudf/tests/test_quantiles.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 import re
 
@@ -6,7 +6,8 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq, assert_exceptions_equal
+from cudf.testing import assert_eq
+from cudf.testing._utils import assert_exceptions_equal
 
 
 def test_single_q():

--- a/python/cudf/cudf/tests/test_query.py
+++ b/python/cudf/cudf/tests/test_query.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 
 
 import datetime
@@ -11,7 +11,7 @@ import pytest
 
 import cudf
 from cudf import DataFrame
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 from cudf.utils import queryutils
 
 _params_query_parser = []

--- a/python/cudf/cudf/tests/test_query_mask.py
+++ b/python/cudf/cudf/tests/test_query_mask.py
@@ -1,11 +1,11 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 import numpy as np
 import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 _data = [
     {"a": [0, 1.0, 2.0, None, np.nan, None, 3, 5]},

--- a/python/cudf/cudf/tests/test_rank.py
+++ b/python/cudf/cudf/tests/test_rank.py
@@ -7,7 +7,8 @@ import pandas as pd
 import pytest
 
 from cudf import DataFrame
-from cudf.testing._utils import assert_eq, assert_exceptions_equal
+from cudf.testing import assert_eq
+from cudf.testing._utils import assert_exceptions_equal
 
 
 @pytest.fixture

--- a/python/cudf/cudf/tests/test_reductions.py
+++ b/python/cudf/cudf/tests/test_reductions.py
@@ -11,13 +11,8 @@ import pytest
 import cudf
 from cudf import Series
 from cudf.core.dtypes import Decimal32Dtype, Decimal64Dtype, Decimal128Dtype
-from cudf.testing import _utils as utils
-from cudf.testing._utils import (
-    NUMERIC_TYPES,
-    assert_eq,
-    expect_warning_if,
-    gen_rand,
-)
+from cudf.testing import _utils as utils, assert_eq
+from cudf.testing._utils import NUMERIC_TYPES, expect_warning_if, gen_rand
 
 params_dtype = NUMERIC_TYPES
 

--- a/python/cudf/cudf/tests/test_replace.py
+++ b/python/cudf/cudf/tests/test_replace.py
@@ -12,10 +12,10 @@ import pytest
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.core.dtypes import Decimal32Dtype, Decimal64Dtype, Decimal128Dtype
+from cudf.testing import assert_eq
 from cudf.testing._utils import (
     INTEGER_TYPES,
     NUMERIC_TYPES,
-    assert_eq,
     assert_exceptions_equal,
     expect_warning_if,
 )

--- a/python/cudf/cudf/tests/test_resampling.py
+++ b/python/cudf/cudf/tests/test_resampling.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def assert_resample_results_equal(lhs, rhs, **kwargs):

--- a/python/cudf/cudf/tests/test_reshape.py
+++ b/python/cudf/cudf/tests/test_reshape.py
@@ -10,12 +10,8 @@ import pytest
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.core.buffer.spill_manager import get_global_manager
-from cudf.testing._utils import (
-    ALL_TYPES,
-    DATETIME_TYPES,
-    NUMERIC_TYPES,
-    assert_eq,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import ALL_TYPES, DATETIME_TYPES, NUMERIC_TYPES
 
 pytest_xfail = pytest.mark.xfail
 pytestmark = pytest.mark.spilling

--- a/python/cudf/cudf/tests/test_rolling.py
+++ b/python/cudf/cudf/tests/test_rolling.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 from cudf.testing.dataset_generator import rand_dataframe
 
 

--- a/python/cudf/cudf/tests/test_s3.py
+++ b/python/cudf/cudf/tests/test_s3.py
@@ -12,7 +12,7 @@ import pytest
 from fsspec.core import get_fs_token_paths
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 moto = pytest.importorskip("moto", minversion="3.1.6")
 boto3 = pytest.importorskip("boto3")

--- a/python/cudf/cudf/tests/test_scan.py
+++ b/python/cudf/cudf/tests/test_scan.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 
 from itertools import product
 
@@ -8,12 +8,8 @@ import pytest
 
 import cudf
 from cudf.core.dtypes import Decimal32Dtype, Decimal64Dtype, Decimal128Dtype
-from cudf.testing._utils import (
-    INTEGER_TYPES,
-    NUMERIC_TYPES,
-    assert_eq,
-    gen_rand,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import INTEGER_TYPES, NUMERIC_TYPES, gen_rand
 
 params_sizes = [0, 1, 2, 5]
 

--- a/python/cudf/cudf/tests/test_search.py
+++ b/python/cudf/cudf/tests/test_search.py
@@ -5,7 +5,8 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing._utils import assert_eq, gen_rand, random_bitmask
+from cudf.testing import assert_eq
+from cudf.testing._utils import gen_rand, random_bitmask
 
 
 @pytest.mark.parametrize("side", ["left", "right"])

--- a/python/cudf/cudf/tests/test_serialize.py
+++ b/python/cudf/cudf/tests/test_serialize.py
@@ -9,8 +9,7 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing import _utils as utils
-from cudf.testing._utils import assert_eq
+from cudf.testing import _utils as utils, assert_eq
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -17,11 +17,11 @@ import cudf
 from cudf.api.extensions import no_default
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.errors import MixedTypeError
+from cudf.testing import assert_eq
 from cudf.testing._utils import (
     NUMERIC_TYPES,
     SERIES_OR_INDEX_NAMES,
     TIMEDELTA_TYPES,
-    assert_eq,
     assert_exceptions_equal,
     expect_warning_if,
     gen_rand,

--- a/python/cudf/cudf/tests/test_seriesmap.py
+++ b/python/cudf/cudf/tests/test_seriesmap.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 from itertools import product
 from math import floor
@@ -9,7 +9,8 @@ import pytest
 
 import cudf
 from cudf import Series
-from cudf.testing._utils import assert_eq, assert_exceptions_equal
+from cudf.testing import assert_eq
+from cudf.testing._utils import assert_exceptions_equal
 
 
 def test_series_map_basic():

--- a/python/cudf/cudf/tests/test_setitem.py
+++ b/python/cudf/cudf/tests/test_setitem.py
@@ -6,11 +6,8 @@ import pytest
 
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
-from cudf.testing._utils import (
-    assert_eq,
-    assert_exceptions_equal,
-    expect_warning_if,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import assert_exceptions_equal, expect_warning_if
 
 
 @pytest.mark.parametrize("df", [pd.DataFrame({"a": [1, 2, 3]})])

--- a/python/cudf/cudf/tests/test_sorting.py
+++ b/python/cudf/cudf/tests/test_sorting.py
@@ -10,10 +10,10 @@ import pytest
 from cudf import DataFrame, Series
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.core.column import NumericalColumn
+from cudf.testing import assert_eq
 from cudf.testing._utils import (
     DATETIME_TYPES,
     NUMERIC_TYPES,
-    assert_eq,
     assert_exceptions_equal,
     expect_warning_if,
 )

--- a/python/cudf/cudf/tests/test_spilling.py
+++ b/python/cudf/cudf/tests/test_spilling.py
@@ -39,7 +39,7 @@ from cudf.core.buffer.spillable_buffer import (
     SpillableBufferOwner,
     SpillLock,
 )
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 if get_global_manager() is not None:
     pytest.skip(

--- a/python/cudf/cudf/tests/test_stats.py
+++ b/python/cudf/cudf/tests/test_stats.py
@@ -11,11 +11,8 @@ import cudf
 from cudf.api.extensions import no_default
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.datasets import randomdata
-from cudf.testing._utils import (
-    assert_eq,
-    assert_exceptions_equal,
-    expect_warning_if,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import assert_exceptions_equal, expect_warning_if
 
 params_dtypes = [np.int32, np.uint32, np.float32, np.float64]
 methods = ["min", "max", "sum", "mean", "var", "std"]

--- a/python/cudf/cudf/tests/test_string.py
+++ b/python/cudf/cudf/tests/test_string.py
@@ -17,10 +17,10 @@ import cudf
 from cudf import concat
 from cudf.core.column.string import StringColumn
 from cudf.core.index import Index
+from cudf.testing import assert_eq
 from cudf.testing._utils import (
     DATETIME_TYPES,
     NUMERIC_TYPES,
-    assert_eq,
     assert_exceptions_equal,
 )
 from cudf.utils import dtypes as dtypeutils

--- a/python/cudf/cudf/tests/test_string_udfs.py
+++ b/python/cudf/cudf/tests/test_string_udfs.py
@@ -21,7 +21,8 @@ from cudf.core.udf.strings_typing import (
     udf_string,
 )
 from cudf.core.udf.utils import _get_extensionty_size, _ptx_file
-from cudf.testing._utils import assert_eq, sv_to_udf_str
+from cudf.testing import assert_eq
+from cudf.testing._utils import sv_to_udf_str
 from cudf.utils._numba import _CUDFNumbaConfig
 
 _PTX_FILE = _ptx_file()

--- a/python/cudf/cudf/tests/test_struct.py
+++ b/python/cudf/cudf/tests/test_struct.py
@@ -7,7 +7,8 @@ import pytest
 
 import cudf
 from cudf.core.dtypes import StructDtype
-from cudf.testing import DATETIME_TYPES, TIMEDELTA_TYPES, assert_eq
+from cudf.testing import assert_eq
+from cudf.testing._utils import DATETIME_TYPES, TIMEDELTA_TYPES
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_struct.py
+++ b/python/cudf/cudf/tests/test_struct.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 import numpy as np
 import pandas as pd
@@ -7,7 +7,7 @@ import pytest
 
 import cudf
 from cudf.core.dtypes import StructDtype
-from cudf.testing._utils import DATETIME_TYPES, TIMEDELTA_TYPES, assert_eq
+from cudf.testing import DATETIME_TYPES, TIMEDELTA_TYPES, assert_eq
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/test_testing.py
+++ b/python/cudf/cudf/tests/test_testing.py
@@ -17,9 +17,8 @@ from cudf.testing._utils import (
     OTHER_TYPES,
     assert_column_memory_eq,
     assert_column_memory_ne,
-    assert_eq,
 )
-from cudf.testing.testing import assert_column_equal
+from cudf.testing.testing import assert_column_equal, assert_eq
 
 
 @pytest.fixture(

--- a/python/cudf/cudf/tests/test_timedelta.py
+++ b/python/cudf/cudf/tests/test_timedelta.py
@@ -9,8 +9,8 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.testing import _utils as utils
-from cudf.testing._utils import assert_eq, assert_exceptions_equal
+from cudf.testing import _utils as utils, assert_eq
+from cudf.testing._utils import assert_exceptions_equal
 
 _TIMEDELTA_DATA = [
     [1000000, 200000, 3000000],

--- a/python/cudf/cudf/tests/test_udf_masked_ops.py
+++ b/python/cudf/cudf/tests/test_udf_masked_ops.py
@@ -17,9 +17,9 @@ from cudf.core.udf._ops import (
 )
 from cudf.core.udf.api import Masked
 from cudf.core.udf.utils import precompiled
+from cudf.testing import assert_eq
 from cudf.testing._utils import (
     _decimal_series,
-    assert_eq,
     parametrize_numeric_dtypes_pairwise,
     sv_to_udf_str,
 )

--- a/python/cudf/cudf/tests/test_unaops.py
+++ b/python/cudf/cudf/tests/test_unaops.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 import itertools
 import operator
@@ -10,7 +10,7 @@ import pytest
 
 import cudf
 from cudf import Series
-from cudf.testing import _utils as utils
+from cudf.testing import _utils as utils, assert_eq
 
 _unaops = [operator.abs, operator.invert, operator.neg, np.ceil, np.floor]
 
@@ -128,4 +128,4 @@ def test_scalar_no_negative_bools():
 def test_series_bool_neg():
     sr = Series([True, False, True, None, False, None, True, True])
     psr = sr.to_pandas(nullable=True)
-    utils.assert_eq((-sr).to_pandas(nullable=True), -psr, check_dtype=True)
+    assert_eq((-sr).to_pandas(nullable=True), -psr, check_dtype=True)

--- a/python/cudf/cudf/tests/text/test_subword_tokenizer.py
+++ b/python/cudf/cudf/tests/text/test_subword_tokenizer.py
@@ -7,7 +7,7 @@ import pytest
 
 import cudf
 from cudf.core.subword_tokenizer import SubwordTokenizer
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.fixture(scope="module")

--- a/python/cudf/cudf/tests/text/test_text_methods.py
+++ b/python/cudf/cudf/tests/text/test_text_methods.py
@@ -9,7 +9,7 @@ import pytest
 import cudf
 from cudf.core.byte_pair_encoding import BytePairEncoder
 from cudf.core.tokenize_vocabulary import TokenizeVocabulary
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 def test_tokenize():

--- a/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
+++ b/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
@@ -1175,7 +1175,7 @@ def test_intermediates_are_proxied():
 
 def test_from_dataframe():
     cudf = pytest.importorskip("cudf")
-    from cudf.testing._utils import assert_eq
+    from cudf.testing import assert_eq
 
     data = {"foo": [1, 2, 3], "bar": [4, 5, 6]}
 

--- a/python/custreamz/custreamz/tests/test_kafka.py
+++ b/python/custreamz/custreamz/tests/test_kafka.py
@@ -1,8 +1,8 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 import confluent_kafka as ck
 import pytest
 
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 
 @pytest.mark.parametrize("commit_offset", [1, 45, 100, 22, 1000, 10])

--- a/python/dask_cudf/dask_cudf/tests/test_accessor.py
+++ b/python/dask_cudf/dask_cudf/tests/test_accessor.py
@@ -9,7 +9,8 @@ import dask
 from dask import dataframe as dd
 
 from cudf import DataFrame, Series, date_range
-from cudf.testing._utils import assert_eq, does_not_raise
+from cudf.testing import assert_eq
+from cudf.testing._utils import does_not_raise
 
 import dask_cudf
 from dask_cudf.tests.utils import xfail_dask_expr

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -795,7 +795,7 @@ def test_dataframe_set_index():
         pddf = dd.from_pandas(pdf, npartitions=4)
         pddf = pddf.set_index("str")
 
-        from cudf.testing._utils import assert_eq
+        from cudf.testing import assert_eq
 
         assert_eq(ddf.compute(), pddf.compute())
 

--- a/python/dask_cudf/dask_cudf/tests/test_distributed.py
+++ b/python/dask_cudf/dask_cudf/tests/test_distributed.py
@@ -9,7 +9,7 @@ from dask.distributed import Client
 from distributed.utils_test import cleanup, loop, loop_in_thread  # noqa: F401
 
 import cudf
-from cudf.testing._utils import assert_eq
+from cudf.testing import assert_eq
 
 import dask_cudf
 


### PR DESCRIPTION
## Description
The testing._utils module imports pytest, which is not advertised as a default run dependency of cudf, so we must avoid importing it in the proxy wrappers at top-level.

Since what we need in the proxy wrappers for pandas debugging is the `assert_eq` function (which does not need pytest), move it to `testing.testing` (where it more naturally fits with the other assertion functions anyway). This removes the need for pytest when running the fast-slow-proxy wrappers.

- Closes #16062.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
