### PR TITLE
Fix pylibcudf Table.num_rows for 0 columns case and add interop to docs

### DIFF
--- a/docs/cudf/source/user_guide/api_docs/pylibcudf/index.rst
+++ b/docs/cudf/source/user_guide/api_docs/pylibcudf/index.rst
@@ -19,6 +19,7 @@ This page provides API documentation for pylibcudf.
     gpumemoryview
     groupby
     io/index.rst
+    interop
     join
     lists
     merge

--- a/docs/cudf/source/user_guide/api_docs/pylibcudf/interop.rst
+++ b/docs/cudf/source/user_guide/api_docs/pylibcudf/interop.rst
@@ -1,0 +1,6 @@
+=======
+interop
+=======
+
+.. automodule:: cudf._lib.pylibcudf.interop
+   :members:

--- a/python/cudf/cudf/_lib/pylibcudf/table.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/table.pyx
@@ -83,6 +83,8 @@ cdef class Table:
 
     cpdef int num_rows(self):
         """The number of rows in this table."""
+        if self.num_columns() == 0:
+            return 0
         return self._columns[0].size()
 
     cpdef list columns(self):

--- a/python/cudf/cudf/pylibcudf_tests/test_table.py
+++ b/python/cudf/cudf/pylibcudf_tests/test_table.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+import pyarrow as pa
+import pytest
+
+import cudf._lib.pylibcudf as plc
+
+
+@pytest.mark.parametrize(
+    "arrow_tbl",
+    [
+        pa.table([]),
+        pa.table({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]}),
+        pa.table({"a": [1, 2, 3]}),
+        pa.table({"a": [1], "b": [2], "c": [3]}),
+    ],
+)
+def test_table_shape(arrow_tbl):
+    plc_tbl = plc.interop.from_arrow(arrow_tbl)
+
+    plc_tbl_shape = (plc_tbl.num_rows(), plc_tbl.num_columns())
+    assert plc_tbl_shape == arrow_tbl.shape


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

There was a bug where Table.num_rows raised when we had 0 columns instead of returning 0.
I also added interop to the docs since that was missing.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
