### PR TITLE
Add throughput metrics for REDUCTION_BENCH/REDUCTION_NVBENCH benchmarks

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -40,12 +40,13 @@ target_include_directories(
 
 # Use an OBJECT library so we only compile these helper source files only once
 add_library(
-  cudf_benchmark_common OBJECT "${CUDF_SOURCE_DIR}/tests/utilities/random_seed.cpp"
-                               synchronization/synchronization.cpp
-                               io/cuio_common.cpp
-                               common/table_utilities.cpp
-                               common/benchmark_utilities.cpp
-                               common/nvbench_utilities.cpp
+  cudf_benchmark_common OBJECT
+  "${CUDF_SOURCE_DIR}/tests/utilities/random_seed.cpp"
+  synchronization/synchronization.cpp
+  io/cuio_common.cpp
+  common/table_utilities.cpp
+  common/benchmark_utilities.cpp
+  common/nvbench_utilities.cpp
 )
 target_link_libraries(cudf_benchmark_common PRIVATE cudf_datagen $<TARGET_NAME_IF_EXISTS:conda_env>)
 add_custom_command(

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -41,7 +41,11 @@ target_include_directories(
 # Use an OBJECT library so we only compile these helper source files only once
 add_library(
   cudf_benchmark_common OBJECT "${CUDF_SOURCE_DIR}/tests/utilities/random_seed.cpp"
-                               synchronization/synchronization.cpp io/cuio_common.cpp
+                               synchronization/synchronization.cpp
+                               io/cuio_common.cpp
+                               common/table_utilities.cpp
+                               common/benchmark_utilities.cpp
+                               common/nvbench_utilities.cpp
 )
 target_link_libraries(cudf_benchmark_common PRIVATE cudf_datagen $<TARGET_NAME_IF_EXISTS:conda_env>)
 add_custom_command(

--- a/cpp/benchmarks/common/benchmark_utilities.cpp
+++ b/cpp/benchmarks/common/benchmark_utilities.cpp
@@ -16,10 +16,12 @@
 
 #include "benchmark_utilities.hpp"
 
-void set_items_processed(::benchmark::State& state, int64_t items_processed_per_iteration) {
+void set_items_processed(::benchmark::State& state, int64_t items_processed_per_iteration)
+{
   state.SetItemsProcessed(state.iterations() * items_processed_per_iteration);
 }
 
-void set_bytes_processed(::benchmark::State& state, int64_t bytes_processed_per_iteration) {
+void set_bytes_processed(::benchmark::State& state, int64_t bytes_processed_per_iteration)
+{
   state.SetBytesProcessed(state.iterations() * bytes_processed_per_iteration);
 }

--- a/cpp/benchmarks/common/benchmark_utilities.cpp
+++ b/cpp/benchmarks/common/benchmark_utilities.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/common/benchmark_utilities.cpp
+++ b/cpp/benchmarks/common/benchmark_utilities.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmark_utilities.hpp"
+
+void set_items_processed(::benchmark::State& state, int64_t items_processed_per_iteration) {
+  state.SetItemsProcessed(state.iterations() * items_processed_per_iteration);
+}
+
+void set_bytes_processed(::benchmark::State& state, int64_t bytes_processed_per_iteration) {
+  state.SetBytesProcessed(state.iterations() * bytes_processed_per_iteration);
+}

--- a/cpp/benchmarks/common/benchmark_utilities.hpp
+++ b/cpp/benchmarks/common/benchmark_utilities.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <benchmark/benchmark.h>
+
+/**
+ * @brief Sets the number of items processed during the benchmark.
+ * 
+ * This function could be used instead of ::benchmark::State.SetItemsProcessed()
+ * to avoid repeatedly computing ::benchmark::State.iterations() * items_processed_per_iteration.
+ * 
+ * @param state the benchmark state
+ * @param items_processed_per_iteration number of items processed per iteration
+ */
+void set_items_processed(::benchmark::State& state, int64_t items_processed_per_iteration);
+
+/**
+ * @brief Sets the number of bytes processed during the benchmark.
+ * 
+ * This function could be used instead of ::benchmark::State.SetItemsProcessed()
+ * to avoid repeatedly computing ::benchmark::State.iterations() * bytes_processed_per_iteration.
+ * 
+ * @param state the benchmark state
+ * @param bytes_processed_per_iteration number of bytes processed per iteration
+ */
+void set_bytes_processed(::benchmark::State& state, int64_t bytes_processed_per_iteration);

--- a/cpp/benchmarks/common/benchmark_utilities.hpp
+++ b/cpp/benchmarks/common/benchmark_utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/common/benchmark_utilities.hpp
+++ b/cpp/benchmarks/common/benchmark_utilities.hpp
@@ -20,10 +20,10 @@
 
 /**
  * @brief Sets the number of items processed during the benchmark.
- * 
+ *
  * This function could be used instead of ::benchmark::State.SetItemsProcessed()
  * to avoid repeatedly computing ::benchmark::State.iterations() * items_processed_per_iteration.
- * 
+ *
  * @param state the benchmark state
  * @param items_processed_per_iteration number of items processed per iteration
  */
@@ -31,10 +31,10 @@ void set_items_processed(::benchmark::State& state, int64_t items_processed_per_
 
 /**
  * @brief Sets the number of bytes processed during the benchmark.
- * 
+ *
  * This function could be used instead of ::benchmark::State.SetItemsProcessed()
  * to avoid repeatedly computing ::benchmark::State.iterations() * bytes_processed_per_iteration.
- * 
+ *
  * @param state the benchmark state
  * @param bytes_processed_per_iteration number of bytes processed per iteration
  */

--- a/cpp/benchmarks/common/nvbench_utilities.cpp
+++ b/cpp/benchmarks/common/nvbench_utilities.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/common/nvbench_utilities.cpp
+++ b/cpp/benchmarks/common/nvbench_utilities.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nvbench_utilities.hpp"
+
+#include <nvbench/nvbench.cuh>
+
+// This function is copied over from https://github.com/NVIDIA/nvbench/blob/a171514056e5d6a7f52a035dd6c812fa301d4f4f/nvbench/detail/measure_cold.cu#L190-L224.
+void set_throughputs(nvbench::state& state)
+{
+  double avg_cuda_time = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
+
+  if (const auto items = state.get_element_count(); items != 0)
+  {
+    auto &summ = state.add_summary("nv/cold/bw/item_rate");
+    summ.set_string("name", "Elem/s");
+    summ.set_string("hint", "item_rate");
+    summ.set_string("description", "Number of input elements processed per second");
+    summ.set_float64("value", static_cast<double>(items) / avg_cuda_time);
+  }
+
+  if (const auto bytes = state.get_global_memory_rw_bytes(); bytes != 0)
+  {
+    const auto avg_used_gmem_bw = static_cast<double>(bytes) / avg_cuda_time;
+    {
+      auto &summ = state.add_summary("nv/cold/bw/global/bytes_per_second");
+      summ.set_string("name", "GlobalMem BW");
+      summ.set_string("hint", "byte_rate");
+      summ.set_string("description",
+                      "Number of bytes read/written per second to the CUDA "
+                      "device's global memory");
+      summ.set_float64("value", avg_used_gmem_bw);
+    }
+
+    {
+      const auto peak_gmem_bw =
+        static_cast<double>(state.get_device()->get_global_memory_bus_bandwidth());
+
+      auto &summ = state.add_summary("nv/cold/bw/global/utilization");
+      summ.set_string("name", "BWUtil");
+      summ.set_string("hint", "percentage");
+      summ.set_string("description",
+                      "Global device memory utilization as a percentage of the "
+                      "device's peak bandwidth");
+      summ.set_float64("value", avg_used_gmem_bw / peak_gmem_bw);
+    }
+  } // bandwidth
+}

--- a/cpp/benchmarks/common/nvbench_utilities.cpp
+++ b/cpp/benchmarks/common/nvbench_utilities.cpp
@@ -18,25 +18,24 @@
 
 #include <nvbench/nvbench.cuh>
 
-// This function is copied over from https://github.com/NVIDIA/nvbench/blob/a171514056e5d6a7f52a035dd6c812fa301d4f4f/nvbench/detail/measure_cold.cu#L190-L224.
+// This function is copied over from
+// https://github.com/NVIDIA/nvbench/blob/a171514056e5d6a7f52a035dd6c812fa301d4f4f/nvbench/detail/measure_cold.cu#L190-L224.
 void set_throughputs(nvbench::state& state)
 {
   double avg_cuda_time = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
 
-  if (const auto items = state.get_element_count(); items != 0)
-  {
-    auto &summ = state.add_summary("nv/cold/bw/item_rate");
+  if (const auto items = state.get_element_count(); items != 0) {
+    auto& summ = state.add_summary("nv/cold/bw/item_rate");
     summ.set_string("name", "Elem/s");
     summ.set_string("hint", "item_rate");
     summ.set_string("description", "Number of input elements processed per second");
     summ.set_float64("value", static_cast<double>(items) / avg_cuda_time);
   }
 
-  if (const auto bytes = state.get_global_memory_rw_bytes(); bytes != 0)
-  {
+  if (const auto bytes = state.get_global_memory_rw_bytes(); bytes != 0) {
     const auto avg_used_gmem_bw = static_cast<double>(bytes) / avg_cuda_time;
     {
-      auto &summ = state.add_summary("nv/cold/bw/global/bytes_per_second");
+      auto& summ = state.add_summary("nv/cold/bw/global/bytes_per_second");
       summ.set_string("name", "GlobalMem BW");
       summ.set_string("hint", "byte_rate");
       summ.set_string("description",
@@ -49,7 +48,7 @@ void set_throughputs(nvbench::state& state)
       const auto peak_gmem_bw =
         static_cast<double>(state.get_device()->get_global_memory_bus_bandwidth());
 
-      auto &summ = state.add_summary("nv/cold/bw/global/utilization");
+      auto& summ = state.add_summary("nv/cold/bw/global/utilization");
       summ.set_string("name", "BWUtil");
       summ.set_string("hint", "percentage");
       summ.set_string("description",
@@ -57,5 +56,5 @@ void set_throughputs(nvbench::state& state)
                       "device's peak bandwidth");
       summ.set_float64("value", avg_used_gmem_bw / peak_gmem_bw);
     }
-  } // bandwidth
+  }
 }

--- a/cpp/benchmarks/common/nvbench_utilities.hpp
+++ b/cpp/benchmarks/common/nvbench_utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/common/nvbench_utilities.hpp
+++ b/cpp/benchmarks/common/nvbench_utilities.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace nvbench {
+struct state;
+}
+
+/**
+ * @brief Sets throughput statistics, such as "Elem/s", "GlobalMem BW", and "BWUtil" for the
+ * nvbench results summary.
+ * 
+ * This function could be used to work around a known issue that the throughput statistics
+ * should be added before the nvbench::state.exec() call, otherwise they will not be printed
+ * in the summary. See https://github.com/NVIDIA/nvbench/issues/175 for more details.
+ */
+void set_throughputs(nvbench::state& state);

--- a/cpp/benchmarks/common/nvbench_utilities.hpp
+++ b/cpp/benchmarks/common/nvbench_utilities.hpp
@@ -23,7 +23,7 @@ struct state;
 /**
  * @brief Sets throughput statistics, such as "Elem/s", "GlobalMem BW", and "BWUtil" for the
  * nvbench results summary.
- * 
+ *
  * This function could be used to work around a known issue that the throughput statistics
  * should be added before the nvbench::state.exec() call, otherwise they will not be printed
  * in the summary. See https://github.com/NVIDIA/nvbench/issues/175 for more details.

--- a/cpp/benchmarks/common/table_utilities.cpp
+++ b/cpp/benchmarks/common/table_utilities.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/common/table_utilities.cpp
+++ b/cpp/benchmarks/common/table_utilities.cpp
@@ -16,14 +16,14 @@
 
 #include "table_utilities.hpp"
 
-#include <cudf/transform.hpp>
 #include <cudf/reduction.hpp>
+#include <cudf/transform.hpp>
 
 #include <cmath>
 
 int64_t estimate_size(cudf::column_view const& col)
 {
-  return estimate_size( cudf::table_view( {col} ) );
+  return estimate_size(cudf::table_view({col}));
 }
 
 int64_t estimate_size(cudf::table_view const& view)
@@ -34,7 +34,8 @@ int64_t estimate_size(cudf::table_view const& view)
   auto const agg = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
   cudf::data_type sum_dtype{cudf::type_id::INT64};
   auto const total_size_scalar = cudf::reduce(*row_sizes, *agg, sum_dtype);
-  auto const total_size_in_bits = static_cast<cudf::numeric_scalar<int64_t>*>(total_size_scalar.get())->value();
+  auto const total_size_in_bits =
+    static_cast<cudf::numeric_scalar<int64_t>*>(total_size_scalar.get())->value();
   // Convert the size in bits to the size in bytes.
   return static_cast<int64_t>(std::ceil(static_cast<double>(total_size_in_bits) / 8));
 }

--- a/cpp/benchmarks/common/table_utilities.cpp
+++ b/cpp/benchmarks/common/table_utilities.cpp
@@ -19,12 +19,9 @@
 #include <cudf/transform.hpp>
 #include <cudf/reduction.hpp>
 
-int64_t estimate_size(std::unique_ptr<cudf::column> column)
+int64_t estimate_size(cudf::column_view const& col)
 {
-  std::vector<std::unique_ptr<cudf::column>> columns;
-  columns.emplace_back(std::move(column));
-  cudf::table table{std::move(columns)};
-  return estimate_size(table.view());
+  return estimate_size( cudf::table_view( {col} ) );
 }
 
 int64_t estimate_size(cudf::table_view const& view)

--- a/cpp/benchmarks/common/table_utilities.cpp
+++ b/cpp/benchmarks/common/table_utilities.cpp
@@ -19,6 +19,8 @@
 #include <cudf/transform.hpp>
 #include <cudf/reduction.hpp>
 
+#include <cmath>
+
 int64_t estimate_size(cudf::column_view const& col)
 {
   return estimate_size( cudf::table_view( {col} ) );
@@ -34,5 +36,5 @@ int64_t estimate_size(cudf::table_view const& view)
   auto const total_size_scalar = cudf::reduce(*row_sizes, *agg, sum_dtype);
   auto const total_size_in_bits = static_cast<cudf::numeric_scalar<int64_t>*>(total_size_scalar.get())->value();
   // Convert the size in bits to the size in bytes.
-  return static_cast<int64_t>(static_cast<double>(total_size_in_bits) / 8);
+  return static_cast<int64_t>(std::ceil(static_cast<double>(total_size_in_bits) / 8));
 }

--- a/cpp/benchmarks/common/table_utilities.cpp
+++ b/cpp/benchmarks/common/table_utilities.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "table_utilities.hpp"
+
+#include <cudf/transform.hpp>
+#include <cudf/reduction.hpp>
+
+int64_t estimate_size(std::unique_ptr<cudf::column> column)
+{
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.emplace_back(std::move(column));
+  cudf::table table{std::move(columns)};
+  return estimate_size(table.view());
+}
+
+int64_t estimate_size(cudf::table_view const& view)
+{
+  // Compute the size in bits for each row.
+  auto const row_sizes = cudf::row_bit_count(view);
+  // Accumulate the row sizes to compute a sum.
+  auto const agg = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+  cudf::data_type sum_dtype{cudf::type_id::INT64};
+  auto const total_size_scalar = cudf::reduce(*row_sizes, *agg, sum_dtype);
+  auto const total_size_in_bits = static_cast<cudf::numeric_scalar<int64_t>*>(total_size_scalar.get())->value();
+  // Convert the size in bits to the size in bytes.
+  return static_cast<int64_t>(static_cast<double>(total_size_in_bits) / 8);
+}

--- a/cpp/benchmarks/common/table_utilities.hpp
+++ b/cpp/benchmarks/common/table_utilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/common/table_utilities.hpp
+++ b/cpp/benchmarks/common/table_utilities.hpp
@@ -25,9 +25,9 @@
  * and accumulates them, the returned estimate may be an inexact approximation in some
  * cases. See cudf::row_bit_count() for more details.
  * 
- * @param column The column to estimate its size
+ * @param view The column view to estimate its size
  */
-int64_t estimate_size(std::unique_ptr<cudf::column> column);
+int64_t estimate_size(cudf::column_view const& view);
 
 /**
  * @brief Estimates the table size in bytes.
@@ -36,6 +36,6 @@ int64_t estimate_size(std::unique_ptr<cudf::column> column);
  * and accumulates them, the returned estimate may be an inexact approximation in some
  * cases. See cudf::row_bit_count() for more details.
  * 
- * @param view The view to estimate its size
+ * @param view The table view to estimate its size
  */
 int64_t estimate_size(cudf::table_view const& view);

--- a/cpp/benchmarks/common/table_utilities.hpp
+++ b/cpp/benchmarks/common/table_utilities.hpp
@@ -20,22 +20,22 @@
 
 /**
  * @brief Estimates the column size in bytes.
- * 
+ *
  * @remark As this function internally uses cudf::row_bit_count() to estimate each row size
  * and accumulates them, the returned estimate may be an inexact approximation in some
  * cases. See cudf::row_bit_count() for more details.
- * 
+ *
  * @param view The column view to estimate its size
  */
 int64_t estimate_size(cudf::column_view const& view);
 
 /**
  * @brief Estimates the table size in bytes.
- * 
+ *
  * @remark As this function internally uses cudf::row_bit_count() to estimate each row size
  * and accumulates them, the returned estimate may be an inexact approximation in some
  * cases. See cudf::row_bit_count() for more details.
- * 
+ *
  * @param view The table view to estimate its size
  */
 int64_t estimate_size(cudf::table_view const& view);

--- a/cpp/benchmarks/common/table_utilities.hpp
+++ b/cpp/benchmarks/common/table_utilities.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/table/table_view.hpp>
+
+/**
+ * @brief Estimates the column size in bytes.
+ * 
+ * @remark As this function internally uses cudf::row_bit_count() to estimate each row size
+ * and accumulates them, the returned estimate may be an inexact approximation in some
+ * cases. See cudf::row_bit_count() for more details.
+ * 
+ * @param column The column to estimate its size
+ */
+int64_t estimate_size(std::unique_ptr<cudf::column> column);
+
+/**
+ * @brief Estimates the table size in bytes.
+ * 
+ * @remark As this function internally uses cudf::row_bit_count() to estimate each row size
+ * and accumulates them, the returned estimate may be an inexact approximation in some
+ * cases. See cudf::row_bit_count() for more details.
+ * 
+ * @param view The view to estimate its size
+ */
+int64_t estimate_size(cudf::table_view const& view);

--- a/cpp/benchmarks/reduction/anyall.cpp
+++ b/cpp/benchmarks/reduction/anyall.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/reduction/anyall.cpp
+++ b/cpp/benchmarks/reduction/anyall.cpp
@@ -36,7 +36,7 @@ void BM_reduction_anyall(benchmark::State& state,
   auto const dtype           = cudf::type_to_id<type>();
   data_profile const profile = data_profile_builder().no_validity().distribution(
     dtype, distribution_id::UNIFORM, 0, agg->kind == cudf::aggregation::ANY ? 0 : 100);
-  auto values = create_random_column(dtype, row_count{column_size}, profile);
+  auto const values = create_random_column(dtype, row_count{column_size}, profile);
 
   cudf::data_type output_dtype{cudf::type_id::BOOL8};
 
@@ -47,7 +47,7 @@ void BM_reduction_anyall(benchmark::State& state,
 
   // The benchmark takes a column and produces one scalar.
   set_items_processed(state, column_size + 1);
-  set_bytes_processed(state, estimate_size(std::move(values)) + cudf::size_of(output_dtype));
+  set_bytes_processed(state, estimate_size(values->view()) + cudf::size_of(output_dtype));
 }
 
 #define concat(a, b, c) a##b##c

--- a/cpp/benchmarks/reduction/anyall.cpp
+++ b/cpp/benchmarks/reduction/anyall.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+#include <benchmarks/common/benchmark_utilities.hpp>
 #include <benchmarks/common/generate_input.hpp>
+#include <benchmarks/common/table_utilities.hpp>
 #include <benchmarks/fixture/benchmark_fixture.hpp>
 #include <benchmarks/synchronization/synchronization.hpp>
 
@@ -34,7 +36,7 @@ void BM_reduction_anyall(benchmark::State& state,
   auto const dtype           = cudf::type_to_id<type>();
   data_profile const profile = data_profile_builder().no_validity().distribution(
     dtype, distribution_id::UNIFORM, 0, agg->kind == cudf::aggregation::ANY ? 0 : 100);
-  auto const values = create_random_column(dtype, row_count{column_size}, profile);
+  auto values = create_random_column(dtype, row_count{column_size}, profile);
 
   cudf::data_type output_dtype{cudf::type_id::BOOL8};
 
@@ -42,6 +44,10 @@ void BM_reduction_anyall(benchmark::State& state,
     cuda_event_timer timer(state, true);
     auto result = cudf::reduce(*values, *agg, output_dtype);
   }
+
+  // The benchmark takes a column and produces one scalar.
+  set_items_processed(state, column_size + 1);
+  set_bytes_processed(state, estimate_size(std::move(values)) + cudf::size_of(output_dtype));
 }
 
 #define concat(a, b, c) a##b##c

--- a/cpp/benchmarks/reduction/dictionary.cpp
+++ b/cpp/benchmarks/reduction/dictionary.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <benchmarks/common/benchmark_utilities.hpp>
 #include <benchmarks/common/generate_input.hpp>
 #include <benchmarks/fixture/benchmark_fixture.hpp>
 #include <benchmarks/synchronization/synchronization.hpp>
@@ -52,6 +53,13 @@ void BM_reduction_dictionary(benchmark::State& state,
     cuda_event_timer timer(state, true);
     auto result = cudf::reduce(*values, *agg, output_dtype);
   }
+
+  // The benchmark takes a column and produces two scalars.
+  set_items_processed(state, column_size + 1);
+  
+  // We don't set the metrics for the size read/written as row_bit_count() doesn't
+  // support the dictionary type yet (and so is estimate_size()).
+  // See https://github.com/rapidsai/cudf/issues/16121 for details.
 }
 
 #define concat(a, b, c) a##b##c

--- a/cpp/benchmarks/reduction/dictionary.cpp
+++ b/cpp/benchmarks/reduction/dictionary.cpp
@@ -56,7 +56,7 @@ void BM_reduction_dictionary(benchmark::State& state,
 
   // The benchmark takes a column and produces two scalars.
   set_items_processed(state, column_size + 1);
-  
+
   // We don't set the metrics for the size read/written as row_bit_count() doesn't
   // support the dictionary type yet (and so is estimate_size()).
   // See https://github.com/rapidsai/cudf/issues/16121 for details.

--- a/cpp/benchmarks/reduction/dictionary.cpp
+++ b/cpp/benchmarks/reduction/dictionary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/reduction/minmax.cpp
+++ b/cpp/benchmarks/reduction/minmax.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/reduction/minmax.cpp
+++ b/cpp/benchmarks/reduction/minmax.cpp
@@ -31,7 +31,7 @@ void BM_reduction(benchmark::State& state)
 {
   cudf::size_type const column_size{(cudf::size_type)state.range(0)};
   auto const dtype_id = cudf::type_to_id<type>();
-  auto input_column =
+  auto const input_column =
     create_random_column(dtype_id, row_count{column_size}, data_profile_builder().no_validity());
 
   for (auto _ : state) {
@@ -42,7 +42,7 @@ void BM_reduction(benchmark::State& state)
   // The benchmark takes a column and produces two scalars.
   set_items_processed(state, column_size + 2);
   cudf::data_type dtype = cudf::data_type{dtype_id};
-  set_bytes_processed(state, estimate_size(std::move(input_column)) + 2 * cudf::size_of(dtype));
+  set_bytes_processed(state, estimate_size(input_column->view()) + 2 * cudf::size_of(dtype));
 }
 
 #define concat(a, b, c) a##b##c

--- a/cpp/benchmarks/reduction/rank.cpp
+++ b/cpp/benchmarks/reduction/rank.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/reduction/rank.cpp
+++ b/cpp/benchmarks/reduction/rank.cpp
@@ -15,8 +15,8 @@
  */
 
 #include <benchmarks/common/generate_input.hpp>
-#include <benchmarks/common/table_utilities.hpp>
 #include <benchmarks/common/nvbench_utilities.hpp>
+#include <benchmarks/common/table_utilities.hpp>
 
 #include <cudf/detail/scan.hpp>
 #include <cudf/filling.hpp>
@@ -42,16 +42,18 @@ static void nvbench_reduction_scan(nvbench::state& state, nvbench::type_list<typ
   cudf::column_view input(new_tbl->view().column(0));
 
   int64_t result_size = 0;
-  state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
-    rmm::cuda_stream_view stream_view{launch.get_stream()};
-    timer.start();
-    auto result = cudf::detail::inclusive_dense_rank_scan(
-      input, stream_view, rmm::mr::get_current_device_resource());
-    timer.stop();
+  state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
+             [&](nvbench::launch& launch, auto& timer) {
+               rmm::cuda_stream_view stream_view{launch.get_stream()};
+               timer.start();
+               auto result = cudf::detail::inclusive_dense_rank_scan(
+                 input, stream_view, rmm::mr::get_current_device_resource());
+               timer.stop();
 
-    // Estimating the result size will launch a kernel. Do not include it in measuring time.
-    result_size += estimate_size(result->view());
-  });
+               // Estimating the result size will launch a kernel. Do not include it in measuring
+               // time.
+               result_size += estimate_size(result->view());
+             });
 
   state.add_element_count(input.size());
   state.add_global_memory_reads(estimate_size(input));

--- a/cpp/benchmarks/reduction/rank.cpp
+++ b/cpp/benchmarks/reduction/rank.cpp
@@ -41,23 +41,16 @@ static void nvbench_reduction_scan(nvbench::state& state, nvbench::type_list<typ
   auto const new_tbl = cudf::repeat(table->view(), 2);
   cudf::column_view input(new_tbl->view().column(0));
 
-  int64_t result_size = 0;
-  state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
-             [&](nvbench::launch& launch, auto& timer) {
-               rmm::cuda_stream_view stream_view{launch.get_stream()};
-               timer.start();
-               auto result = cudf::detail::inclusive_dense_rank_scan(
-                 input, stream_view, rmm::mr::get_current_device_resource());
-               timer.stop();
-
-               // Estimating the result size will launch a kernel. Do not include it in measuring
-               // time.
-               result_size += estimate_size(result->view());
-             });
+  std::unique_ptr<cudf::column> result = nullptr;
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+    rmm::cuda_stream_view stream_view{launch.get_stream()};
+    result = cudf::detail::inclusive_dense_rank_scan(
+      input, stream_view, rmm::mr::get_current_device_resource());
+  });
 
   state.add_element_count(input.size());
   state.add_global_memory_reads(estimate_size(input));
-  state.add_global_memory_writes(result_size);
+  state.add_global_memory_writes(estimate_size(result->view()));
 
   set_throughputs(state);
 }

--- a/cpp/benchmarks/reduction/rank.cpp
+++ b/cpp/benchmarks/reduction/rank.cpp
@@ -50,11 +50,11 @@ static void nvbench_reduction_scan(nvbench::state& state, nvbench::type_list<typ
     timer.stop();
 
     // Estimating the result size will launch a kernel. Do not include it in measuring time.
-    result_size += estimate_size(std::move(result));
+    result_size += estimate_size(result->view());
   });
 
-  state.add_element_count(new_tbl->num_rows());
-  state.add_global_memory_reads(estimate_size(new_tbl->view()));
+  state.add_element_count(input.size());
+  state.add_global_memory_reads(estimate_size(input));
   state.add_global_memory_writes(result_size);
 
   set_throughputs(state);

--- a/cpp/benchmarks/reduction/reduce.cpp
+++ b/cpp/benchmarks/reduction/reduce.cpp
@@ -36,7 +36,7 @@ void BM_reduction(benchmark::State& state, std::unique_ptr<cudf::reduce_aggregat
   auto const dtype = cudf::type_to_id<type>();
   data_profile const profile =
     data_profile_builder().no_validity().distribution(dtype, distribution_id::UNIFORM, 0, 100);
-  auto input_column = create_random_column(dtype, row_count{column_size}, profile);
+  auto const input_column = create_random_column(dtype, row_count{column_size}, profile);
 
   cudf::data_type output_dtype =
     (agg->kind == cudf::aggregation::MEAN || agg->kind == cudf::aggregation::VARIANCE ||
@@ -51,7 +51,7 @@ void BM_reduction(benchmark::State& state, std::unique_ptr<cudf::reduce_aggregat
 
   // The benchmark takes a column and produces two scalars.
   set_items_processed(state, column_size + 1);
-  set_bytes_processed(state, estimate_size(std::move(input_column)) + cudf::size_of(output_dtype));
+  set_bytes_processed(state, estimate_size(input_column->view()) + cudf::size_of(output_dtype));
 }
 
 #define concat(a, b, c) a##b##c

--- a/cpp/benchmarks/reduction/reduce.cpp
+++ b/cpp/benchmarks/reduction/reduce.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/reduction/scan.cpp
+++ b/cpp/benchmarks/reduction/scan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/reduction/scan.cpp
+++ b/cpp/benchmarks/reduction/scan.cpp
@@ -33,7 +33,7 @@ static void BM_reduction_scan(benchmark::State& state, bool include_nulls)
 {
   cudf::size_type const n_rows{(cudf::size_type)state.range(0)};
   auto const dtype  = cudf::type_to_id<type>();
-  auto column = create_random_column(dtype, row_count{n_rows});
+  auto const column = create_random_column(dtype, row_count{n_rows});
   if (!include_nulls) column->set_null_mask(rmm::device_buffer{}, 0);
 
   int64_t result_size = 0;
@@ -44,12 +44,12 @@ static void BM_reduction_scan(benchmark::State& state, bool include_nulls)
       result = cudf::scan(
         *column, *cudf::make_min_aggregation<cudf::scan_aggregation>(), cudf::scan_type::INCLUSIVE);
     }
-    result_size = estimate_size(std::move(result));
+    result_size = estimate_size(result->view());
   }
 
   // The benchmark takes a column and produces a new column of the same size as input.
   set_items_processed(state, n_rows * 2);
-  set_bytes_processed(state, estimate_size(std::move(column)) + result_size);
+  set_bytes_processed(state, estimate_size(column->view()) + result_size);
 }
 
 #define SCAN_BENCHMARK_DEFINE(name, type, nulls)                          \

--- a/cpp/benchmarks/reduction/scan.cpp
+++ b/cpp/benchmarks/reduction/scan.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+#include <benchmarks/common/benchmark_utilities.hpp>
 #include <benchmarks/common/generate_input.hpp>
+#include <benchmarks/common/table_utilities.hpp>
 #include <benchmarks/fixture/benchmark_fixture.hpp>
 #include <benchmarks/synchronization/synchronization.hpp>
 
@@ -31,14 +33,23 @@ static void BM_reduction_scan(benchmark::State& state, bool include_nulls)
 {
   cudf::size_type const n_rows{(cudf::size_type)state.range(0)};
   auto const dtype  = cudf::type_to_id<type>();
-  auto const column = create_random_column(dtype, row_count{n_rows});
+  auto column = create_random_column(dtype, row_count{n_rows});
   if (!include_nulls) column->set_null_mask(rmm::device_buffer{}, 0);
 
+  int64_t result_size = 0;
   for (auto _ : state) {
-    cuda_event_timer timer(state, true);
-    auto result = cudf::scan(
-      *column, *cudf::make_min_aggregation<cudf::scan_aggregation>(), cudf::scan_type::INCLUSIVE);
+    std::unique_ptr<cudf::column> result = nullptr;
+    {
+      cuda_event_timer timer(state, true);
+      result = cudf::scan(
+        *column, *cudf::make_min_aggregation<cudf::scan_aggregation>(), cudf::scan_type::INCLUSIVE);
+    }
+    result_size = estimate_size(std::move(result));
   }
+
+  // The benchmark takes a column and produces a new column of the same size as input.
+  set_items_processed(state, n_rows * 2);
+  set_bytes_processed(state, estimate_size(std::move(column)) + result_size);
 }
 
 #define SCAN_BENCHMARK_DEFINE(name, type, nulls)                          \

--- a/cpp/benchmarks/reduction/scan_structs.cpp
+++ b/cpp/benchmarks/reduction/scan_structs.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <benchmarks/common/generate_input.hpp>
+#include <benchmarks/common/table_utilities.hpp>
+#include <benchmarks/common/nvbench_utilities.hpp>
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/scan.hpp>
@@ -43,18 +45,33 @@ static void nvbench_structs_scan(nvbench::state& state)
     row_count{size},
     profile);
   auto [null_mask, null_count] = create_random_null_mask(size, null_probability);
-  auto const input             = cudf::make_structs_column(
+  auto input                   = cudf::make_structs_column(
     size, std::move(data_table->release()), null_count, std::move(null_mask));
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.emplace_back(std::move(input));
+  cudf::table input_table{std::move(columns)};
 
   auto const agg         = cudf::make_min_aggregation<cudf::scan_aggregation>();
   auto const null_policy = static_cast<cudf::null_policy>(state.get_int64("null_policy"));
   auto const stream      = cudf::get_default_stream();
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
-  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    auto const result = cudf::detail::scan_inclusive(
-      *input, *agg, null_policy, stream, rmm::mr::get_current_device_resource());
+  int64_t result_size = 0;
+  state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
+    timer.start();
+    auto result = cudf::detail::scan_inclusive(
+      input_table.view().column(0), *agg, null_policy, stream, rmm::mr::get_current_device_resource());
+    timer.stop();
+
+    // Estimating the result size will launch a kernel. Do not include it in measuring time.
+    result_size += estimate_size(std::move(result));
   });
+
+  state.add_element_count(input_table.num_rows());
+  state.add_global_memory_reads(estimate_size(input_table.view()));
+  state.add_global_memory_writes(result_size);
+
+  set_throughputs(state);
 }
 
 NVBENCH_BENCH(nvbench_structs_scan)

--- a/cpp/benchmarks/reduction/scan_structs.cpp
+++ b/cpp/benchmarks/reduction/scan_structs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/benchmarks/reduction/scan_structs.cpp
+++ b/cpp/benchmarks/reduction/scan_structs.cpp
@@ -15,8 +15,8 @@
  */
 
 #include <benchmarks/common/generate_input.hpp>
-#include <benchmarks/common/table_utilities.hpp>
 #include <benchmarks/common/nvbench_utilities.hpp>
+#include <benchmarks/common/table_utilities.hpp>
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/scan.hpp>
@@ -55,15 +55,17 @@ static void nvbench_structs_scan(nvbench::state& state)
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
   int64_t result_size = 0;
-  state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer, [&](nvbench::launch& launch, auto& timer) {
-    timer.start();
-    auto const result = cudf::detail::scan_inclusive(
-      input_view, *agg, null_policy, stream, rmm::mr::get_current_device_resource());
-    timer.stop();
+  state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
+             [&](nvbench::launch& launch, auto& timer) {
+               timer.start();
+               auto const result = cudf::detail::scan_inclusive(
+                 input_view, *agg, null_policy, stream, rmm::mr::get_current_device_resource());
+               timer.stop();
 
-    // Estimating the result size will launch a kernel. Do not include it in measuring time.
-    result_size += estimate_size(result->view());
-  });
+               // Estimating the result size will launch a kernel. Do not include it in measuring
+               // time.
+               result_size += estimate_size(result->view());
+             });
 
   state.add_element_count(input_view.size());
   state.add_global_memory_reads(estimate_size(input_view));


### PR DESCRIPTION
## Description

This PR addresses https://github.com/rapidsai/cudf/issues/13735 for reduction benchmarks. There are 3 new utils added.

- `int64_t estimate_size(cudf::table_view)` returns a size estimate for the given table. https://github.com/rapidsai/cudf/pull/13984 was a previous attempt to add a similar utility, but this implementation uses `cudf::row_bit_count()` as suggested in https://github.com/rapidsai/cudf/pull/13984#issuecomment-2189916570 instead of manually estimating the size.
- `void set_items_processed(State& state, int64_t items_processed_per_iteration)` is a thin wrapper of `State.SetItemsProcessed()`. This wrapper takes `items_processed_per_iteration` as a parameter instead of `total_items_processed`. This could be useful to avoid repeating `State.iterations() * items_processed_per_iteration` in each benchmark class.
- `void set_throughputs(nvbench::state& state)` is added as a workaround for https://github.com/NVIDIA/nvbench/issues/175. We sometimes want to set throughput statistics after `state.exec()` calls especially when it is hard to estimate the result size upfront.

Here are snippets of reduction benchmarks after this change.

```
$ cpp/build/benchmarks/REDUCTION_BENCH
...
-----------------------------------------------------------------------------------------------------------------
Benchmark                                                       Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------------
Reduction/bool_all/10000/manual_time                        10257 ns        26845 ns        68185 bytes_per_second=929.907M/s items_per_second=975.078M/s
Reduction/bool_all/100000/manual_time                       11000 ns        27454 ns        63634 bytes_per_second=8.46642G/s items_per_second=9.09075G/s
Reduction/bool_all/1000000/manual_time                      12671 ns        28658 ns        55261 bytes_per_second=73.5018G/s items_per_second=78.922G/s
...

$ cpp/build/benchmarks/REDUCTION_NVBENCH
...
## rank_scan

### [0] NVIDIA RTX A5500

|        T        | null_probability | data_size | Samples |  CPU Time  | Noise  |  GPU Time  | Noise |  Elem/s  | GlobalMem BW |  BWUtil   |
|-----------------|------------------|-----------|---------|------------|--------|------------|-------|----------|--------------|-----------|
|             I32 |                0 |     10000 |  16992x |  33.544 us | 14.95% |  29.446 us | 5.58% |  82.321M |   5.596 TB/s |   728.54% |
|             I32 |              0.1 |     10000 |  16512x |  34.358 us | 13.66% |  30.292 us | 2.87% |  80.020M |   5.286 TB/s |   688.17% |
|             I32 |              0.5 |     10000 |  16736x |  34.058 us | 14.31% |  29.890 us | 3.40% |  81.097M |   5.430 TB/s |   706.89% |
...
```

Note that, when the data type is a 1-byte-width type in the google benchmark result summary, `bytes_per_second` appears to be smaller than `items_per_second`. This is because the former is a multiple of 1000 whereas the latter is a multiple of 1024. They are in fact the same number.

Implementation-wise, these are what I'm not sure if I made a best decision.
- Each of new utils above is declared and defined in different files. I did this because I could not find a good place to have them all, and they seem to belong to different utilities. Please let me know if there is a better place for them.
- All the new utils are defined in the global namespace since other util functions seem to have been defined in the same way. Please let me know if this is not the convention.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
