### PR TITLE
Fix unused-return-value debug build error in from_arrow_stream_test.cpp

### DIFF
--- a/cpp/tests/interop/from_arrow_stream_test.cpp
+++ b/cpp/tests/interop/from_arrow_stream_test.cpp
@@ -46,7 +46,8 @@ struct VectorOfArrays {
   static int get_schema(ArrowArrayStream* stream, ArrowSchema* out_schema)
   {
     auto private_data = static_cast<VectorOfArrays*>(stream->private_data);
-    ArrowSchemaDeepCopy(private_data->schema.get(), out_schema);
+
+    [[maybe_unused]] auto rc = ArrowSchemaDeepCopy(private_data->schema.get(), out_schema);
     return 0;
   }
 


### PR DESCRIPTION
## Description
Fixes a debug build error reporting an unused return value in `from_arrow_stream_test.cpp`
```
g++ -DFMT_HEADER_ONLY=1 -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE -DNANOARROW_DEBUG -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DSPDLOG_FMT_EXTERNAL -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_DISABLE_ABI_NAMESPACE -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -DTHRUST_IGNORE_ABI_NAMESPACE_ERROR -I/cudf/cpp -I/cudf/cpp/src -I/cudf/cpp/build/_deps/dlpack-src/include -I/cudf/cpp/build/_deps/jitify-src -I/cudf/cpp/include -I/cudf/cpp/build/include -I/cudf/cpp/build/_deps/cccl-src/thrust/thrust/cmake/../.. -I/cudf/cpp/build/_deps/cccl-src/libcudacxx/lib/cmake/libcudacxx/../../../include -I/cudf/cpp/build/_deps/cccl-src/cub/cub/cmake/../.. -I/cudf/cpp/build/_deps/nanoarrow-src/src -I/cudf/cpp/build/_deps/nanoarrow-build/generated -isystem /cudf/cpp/build/_deps/gtest-src/googlemock/include -isystem /cudf/cpp/build/_deps/gtest-src/googlemock -isystem /cudf/cpp/build/_deps/gtest-src/googletest/include -isystem /cudf/cpp/build/_deps/gtest-src/googletest -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /conda/envs/rapids/include -fdiagnostics-color=always  -I/conda/envs/rapids/targets/x86_64-linux/include  -L/conda/envs/rapids/targets/x86_64-linux/lib -L/conda/envs/rapids/targets/x86_64-linux/lib/stubs -g -std=gnu++17 -fPIE -Wall -Werror -Wno-unknown-pragmas -Wno-error=deprecated-declarations -pthread -MD -MT tests/CMakeFiles/INTEROP_TEST.dir/interop/from_arrow_stream_test.cpp.o -MF tests/CMakeFiles/INTEROP_TEST.dir/interop/from_arrow_stream_test.cpp.o.d -o tests/CMakeFiles/INTEROP_TEST.dir/interop/from_arrow_stream_test.cpp.o -c /cudf/cpp/tests/interop/from_arrow_stream_test.cpp
/cudf/cpp/tests/interop/from_arrow_stream_test.cpp: In static member function 'static int VectorOfArrays::get_schema(ArrowArrayStream*, ArrowSchema*)':
/cudf/cpp/tests/interop/from_arrow_stream_test.cpp:49:24: error: ignoring return value of 'ArrowErrorCode cudfArrowSchemaDeepCopy(const ArrowSchema*, ArrowSchema*)' declared with attribute 'warn_unused_result' [-Werror=unused-result]
   49 |     ArrowSchemaDeepCopy(private_data->schema.get(), out_schema);
cc1plus: all warnings being treated as errors

```
Adding a variable decorated with `[[maybe_unused]]` clears the error.
Error introduced in #15904 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
