### PR TITLE
Remove CCCL patch for PR 211.

### DIFF
--- a/cpp/cmake/thirdparty/patches/cccl_override.json
+++ b/cpp/cmake/thirdparty/patches/cccl_override.json
@@ -4,11 +4,6 @@
     "CCCL" : {
       "patches" : [
         {
-          "file" : "cccl/revert_pr_211.diff",
-          "issue" : "thrust::copy introduced a change in behavior that causes failures with cudaErrorInvalidValue.",
-          "fixed_in" : ""
-        },
-        {
           "file" : "${current_json_dir}/thrust_disable_64bit_dispatching.diff",
           "issue" : "Remove 64bit dispatching as not needed by libcudf and results in compiling twice as many kernels [https://github.com/rapidsai/cudf/pull/11437]",
           "fixed_in" : ""


### PR DESCRIPTION
## Description
While upgrading CCCL, we ran into a test failure in cuSpatial. We added a patch to revert some changes from CCCL but the root cause was a bug in cuSpatial. I have fixed that bug here: https://github.com/rapidsai/cuspatial/pull/1402

Once that PR is merged, we can remove this CCCL patch.

See also:
- rapids-cmake patch removal: https://github.com/rapidsai/rapids-cmake/pull/640
- Original rapids-cmake patch: https://github.com/rapidsai/rapids-cmake/pull/511
- CCCL epic to remove RAPIDS patches: https://github.com/NVIDIA/cccl/issues/1939

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
