### PR TITLE
Ensure cudf::ast::expressions api doesn't use detail types

### DIFF
--- a/cpp/include/cudf/ast/detail/expression_evaluator.cuh
+++ b/cpp/include/cudf/ast/detail/expression_evaluator.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/ast/expression_parser.hpp
+++ b/cpp/include/cudf/ast/expression_parser.hpp
@@ -29,9 +29,7 @@
 #include <numeric>
 #include <optional>
 
-namespace cudf {
-namespace ast {
-namespace detail {
+namespace cudf::ast {
 
 /**
  * @brief Node data reference types.
@@ -76,7 +74,7 @@ struct alignas(8) device_data_reference {
 
 // Type used for intermediate storage in expression evaluation.
 template <bool has_nulls>
-using IntermediateDataType = possibly_null_value_t<std::int64_t, has_nulls>;
+using IntermediateDataType = detail::possibly_null_value_t<std::int64_t, has_nulls>;
 
 /**
  * @brief A container of all device data required to evaluate an expression on tables.
@@ -87,7 +85,7 @@ using IntermediateDataType = possibly_null_value_t<std::int64_t, has_nulls>;
  *
  */
 struct expression_device_view {
-  device_span<detail::device_data_reference const> data_references;
+  device_span<device_data_reference const> data_references;
   device_span<generic_scalar_device_view const> literals;
   device_span<ast_operator const> operators;
   device_span<cudf::size_type const> operator_source_indices;
@@ -268,8 +266,8 @@ class expression_parser {
 
     // Create device pointers to components of plan
     auto device_data_buffer_ptr            = static_cast<char const*>(_device_data_buffer.data());
-    device_expression_data.data_references = device_span<detail::device_data_reference const>(
-      reinterpret_cast<detail::device_data_reference const*>(device_data_buffer_ptr +
+    device_expression_data.data_references = device_span<device_data_reference const>(
+      reinterpret_cast<device_data_reference const*>(device_data_buffer_ptr +
                                                              buffer_offsets[0]),
       _data_references.size());
     device_expression_data.literals = device_span<generic_scalar_device_view const>(
@@ -311,7 +309,7 @@ class expression_parser {
    *
    * @return The index of the added data reference in the internal data references list.
    */
-  cudf::size_type add_data_reference(detail::device_data_reference data_ref);
+  cudf::size_type add_data_reference(device_data_reference data_ref);
 
   rmm::device_buffer
     _device_data_buffer;  ///< The device-side data buffer containing the plan information, which is
@@ -322,14 +320,10 @@ class expression_parser {
   cudf::size_type _expression_count;
   intermediate_counter _intermediate_counter;
   bool _has_nulls;
-  std::vector<detail::device_data_reference> _data_references;
+  std::vector<device_data_reference> _data_references;
   std::vector<ast_operator> _operators;
   std::vector<cudf::size_type> _operator_source_indices;
   std::vector<generic_scalar_device_view> _literals;
 };
 
-}  // namespace detail
-
-}  // namespace ast
-
-}  // namespace cudf
+}  // namespace cudf::ast

--- a/cpp/include/cudf/ast/expression_parser.hpp
+++ b/cpp/include/cudf/ast/expression_parser.hpp
@@ -267,8 +267,7 @@ class expression_parser {
     // Create device pointers to components of plan
     auto device_data_buffer_ptr            = static_cast<char const*>(_device_data_buffer.data());
     device_expression_data.data_references = device_span<device_data_reference const>(
-      reinterpret_cast<device_data_reference const*>(device_data_buffer_ptr +
-                                                             buffer_offsets[0]),
+      reinterpret_cast<device_data_reference const*>(device_data_buffer_ptr + buffer_offsets[0]),
       _data_references.size());
     device_expression_data.literals = device_span<generic_scalar_device_view const>(
       reinterpret_cast<generic_scalar_device_view const*>(device_data_buffer_ptr +

--- a/cpp/include/cudf/ast/expression_transformer.hpp
+++ b/cpp/include/cudf/ast/expression_transformer.hpp
@@ -18,7 +18,7 @@
 
 #include <cudf/ast/expressions.hpp>
 
-namespace cudf::ast::detail {
+namespace cudf::ast {
 /**
  * @brief Base "visitor" pattern class with the `expression` class for expression transformer.
  *
@@ -61,4 +61,4 @@ class expression_transformer {
 
   virtual ~expression_transformer() {}
 };
-}  // namespace cudf::ast::detail
+}  // namespace cudf::ast

--- a/cpp/include/cudf/ast/expression_transformer.hpp
+++ b/cpp/include/cudf/ast/expression_transformer.hpp
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/ast/expressions.hpp
+++ b/cpp/include/cudf/ast/expressions.hpp
@@ -56,7 +56,8 @@ struct expression {
    * @param visitor The `expression_transformer` transforming this expression tree
    * @return Reference wrapper of transformed expression
    */
-  virtual std::reference_wrapper<expression const> accept(expression_transformer& visitor) const = 0;
+  virtual std::reference_wrapper<expression const> accept(
+    expression_transformer& visitor) const = 0;
 
   /**
    * @brief Returns true if the expression may evaluate to null.
@@ -320,8 +321,7 @@ class literal : public expression {
   /**
    * @copydoc expression::accept
    */
-  std::reference_wrapper<expression const> accept(
-    expression_transformer& visitor) const override;
+  std::reference_wrapper<expression const> accept(expression_transformer& visitor) const override;
 
   [[nodiscard]] bool may_evaluate_null(table_view const& left,
                                        table_view const& right,

--- a/cpp/include/cudf/ast/expressions.hpp
+++ b/cpp/include/cudf/ast/expressions.hpp
@@ -23,7 +23,7 @@
 
 #include <cstdint>
 
-namespace cudf {
+namespace CUDF_EXPORT cudf {
 namespace ast {
 /**
  * @addtogroup expressions
@@ -32,10 +32,8 @@ namespace ast {
  */
 
 // Forward declaration.
-namespace detail {
 class expression_parser;
 class expression_transformer;
-}  // namespace detail
 
 /**
  * @brief A generic expression that can be evaluated to return a value.
@@ -50,7 +48,7 @@ struct expression {
    * @param visitor The `expression_parser` parsing this expression tree
    * @return Index of device data reference for this instance
    */
-  virtual cudf::size_type accept(detail::expression_parser& visitor) const = 0;
+  virtual cudf::size_type accept(expression_parser& visitor) const = 0;
 
   /**
    * @brief Accepts a visitor class.
@@ -59,7 +57,7 @@ struct expression {
    * @return Reference wrapper of transformed expression
    */
   virtual std::reference_wrapper<expression const> accept(
-    detail::expression_transformer& visitor) const = 0;
+    expression_transformer& visitor) const = 0;
 
   /**
    * @brief Returns true if the expression may evaluate to null.
@@ -318,13 +316,13 @@ class literal : public expression {
   /**
    * @copydoc expression::accept
    */
-  cudf::size_type accept(detail::expression_parser& visitor) const override;
+  cudf::size_type accept(expression_parser& visitor) const override;
 
   /**
    * @copydoc expression::accept
    */
   std::reference_wrapper<expression const> accept(
-    detail::expression_transformer& visitor) const override;
+    expression_transformer& visitor) const override;
 
   [[nodiscard]] bool may_evaluate_null(table_view const& left,
                                        table_view const& right,
@@ -417,13 +415,13 @@ class column_reference : public expression {
   /**
    * @copydoc expression::accept
    */
-  cudf::size_type accept(detail::expression_parser& visitor) const override;
+  cudf::size_type accept(expression_parser& visitor) const override;
 
   /**
    * @copydoc expression::accept
    */
   std::reference_wrapper<expression const> accept(
-    detail::expression_transformer& visitor) const override;
+    expression_transformer& visitor) const override;
 
   [[nodiscard]] bool may_evaluate_null(table_view const& left,
                                        table_view const& right,
@@ -486,13 +484,13 @@ class operation : public expression {
   /**
    * @copydoc expression::accept
    */
-  cudf::size_type accept(detail::expression_parser& visitor) const override;
+  cudf::size_type accept(expression_parser& visitor) const override;
 
   /**
    * @copydoc expression::accept
    */
   std::reference_wrapper<expression const> accept(
-    detail::expression_transformer& visitor) const override;
+    expression_transformer& visitor) const override;
 
   [[nodiscard]] bool may_evaluate_null(table_view const& left,
                                        table_view const& right,
@@ -533,13 +531,13 @@ class column_name_reference : public expression {
   /**
    * @copydoc expression::accept
    */
-  cudf::size_type accept(detail::expression_parser& visitor) const override;
+  cudf::size_type accept(expression_parser& visitor) const override;
 
   /**
    * @copydoc expression::accept
    */
   std::reference_wrapper<expression const> accept(
-    detail::expression_transformer& visitor) const override;
+    expression_transformer& visitor) const override;
 
   [[nodiscard]] bool may_evaluate_null(table_view const& left,
                                        table_view const& right,
@@ -555,4 +553,4 @@ class column_name_reference : public expression {
 /** @} */  // end of group
 }  // namespace ast
 
-}  // namespace cudf
+}  // namespace CUDF_EXPORT cudf

--- a/cpp/include/cudf/ast/expressions.hpp
+++ b/cpp/include/cudf/ast/expressions.hpp
@@ -56,8 +56,7 @@ struct expression {
    * @param visitor The `expression_transformer` transforming this expression tree
    * @return Reference wrapper of transformed expression
    */
-  virtual std::reference_wrapper<expression const> accept(
-    expression_transformer& visitor) const = 0;
+  virtual std::reference_wrapper<expression const> accept(expression_transformer& visitor) const = 0;
 
   /**
    * @brief Returns true if the expression may evaluate to null.
@@ -420,8 +419,7 @@ class column_reference : public expression {
   /**
    * @copydoc expression::accept
    */
-  std::reference_wrapper<expression const> accept(
-    expression_transformer& visitor) const override;
+  std::reference_wrapper<expression const> accept(expression_transformer& visitor) const override;
 
   [[nodiscard]] bool may_evaluate_null(table_view const& left,
                                        table_view const& right,
@@ -489,8 +487,7 @@ class operation : public expression {
   /**
    * @copydoc expression::accept
    */
-  std::reference_wrapper<expression const> accept(
-    expression_transformer& visitor) const override;
+  std::reference_wrapper<expression const> accept(expression_transformer& visitor) const override;
 
   [[nodiscard]] bool may_evaluate_null(table_view const& left,
                                        table_view const& right,
@@ -536,8 +533,7 @@ class column_name_reference : public expression {
   /**
    * @copydoc expression::accept
    */
-  std::reference_wrapper<expression const> accept(
-    expression_transformer& visitor) const override;
+  std::reference_wrapper<expression const> accept(expression_transformer& visitor) const override;
 
   [[nodiscard]] bool may_evaluate_null(table_view const& left,
                                        table_view const& right,

--- a/cpp/src/ast/expressions.cpp
+++ b/cpp/src/ast/expressions.cpp
@@ -48,7 +48,7 @@ cudf::size_type column_reference::accept(expression_parser& visitor) const
 cudf::size_type operation::accept(expression_parser& visitor) const { return visitor.visit(*this); }
 cudf::size_type column_name_reference::accept(expression_parser& visitor) const
 {
-  return visitor.visit(*this)
+  return visitor.visit(*this);
 }
 
 auto literal::accept(expression_transformer& visitor) const -> decltype(visitor.visit(*this))

--- a/cpp/src/ast/expressions.cpp
+++ b/cpp/src/ast/expressions.cpp
@@ -41,15 +41,22 @@ operation::operation(ast_operator op, expression const& left, expression const& 
 }
 
 cudf::size_type literal::accept(expression_parser& visitor) const { return visitor.visit(*this); }
-cudf::size_type column_reference::accept(expression_parser& visitor) const { return visitor.visit(*this); }
+cudf::size_type column_reference::accept(expression_parser& visitor) const
+{
+  return visitor.visit(*this);
+}
 cudf::size_type operation::accept(expression_parser& visitor) const { return visitor.visit(*this); }
-cudf::size_type column_name_reference::accept(expression_parser& visitor) const { return visitor.visit(*this) }
+cudf::size_type column_name_reference::accept(expression_parser& visitor) const
+{
+  return visitor.visit(*this)
+}
 
 auto literal::accept(expression_transformer& visitor) const -> decltype(visitor.visit(*this))
 {
   return visitor.visit(*this);
 }
-auto column_reference::accept(expression_transformer& visitor) const -> decltype(visitor.visit(*this))
+auto column_reference::accept(expression_transformer& visitor) const
+  -> decltype(visitor.visit(*this))
 {
   return visitor.visit(*this);
 }
@@ -57,7 +64,8 @@ auto operation::accept(expression_transformer& visitor) const -> decltype(visito
 {
   return visitor.visit(*this);
 }
-auto column_name_reference::accept(expression_transformer& visitor) const -> decltype(visitor.visit(*this))
+auto column_name_reference::accept(expression_transformer& visitor) const
+  -> decltype(visitor.visit(*this))
 {
   return visitor.visit(*this);
 }

--- a/cpp/src/ast/expressions.cpp
+++ b/cpp/src/ast/expressions.cpp
@@ -13,18 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cudf/ast/detail/expression_parser.hpp>
-#include <cudf/ast/detail/expression_transformer.hpp>
 #include <cudf/ast/detail/operators.hpp>
+#include <cudf/ast/expression_parser.hpp>
 #include <cudf/ast/expressions.hpp>
+#include <cudf/ast/expression_transformer.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-namespace cudf {
-namespace ast {
+namespace cudf::ast{
 
 operation::operation(ast_operator op, expression const& input) : op(op), operands({input})
 {
@@ -41,43 +40,41 @@ operation::operation(ast_operator op, expression const& left, expression const& 
   }
 }
 
-cudf::size_type literal::accept(detail::expression_parser& visitor) const
+cudf::size_type literal::accept(expression_parser& visitor) const
 {
   return visitor.visit(*this);
 }
-cudf::size_type column_reference::accept(detail::expression_parser& visitor) const
+cudf::size_type column_reference::accept(expression_parser& visitor) const
 {
   return visitor.visit(*this);
 }
-cudf::size_type operation::accept(detail::expression_parser& visitor) const
+cudf::size_type operation::accept(expression_parser& visitor) const
 {
   return visitor.visit(*this);
 }
-cudf::size_type column_name_reference::accept(detail::expression_parser& visitor) const
+cudf::size_type column_name_reference::accept(expression_parser& visitor) const
 {
   return visitor.visit(*this);
 }
 
-auto literal::accept(detail::expression_transformer& visitor) const
+auto literal::accept(expression_transformer& visitor) const
   -> decltype(visitor.visit(*this))
 {
   return visitor.visit(*this);
 }
-auto column_reference::accept(detail::expression_transformer& visitor) const
+auto column_reference::accept(expression_transformer& visitor) const
   -> decltype(visitor.visit(*this))
 {
   return visitor.visit(*this);
 }
-auto operation::accept(detail::expression_transformer& visitor) const
+auto operation::accept(expression_transformer& visitor) const
   -> decltype(visitor.visit(*this))
 {
   return visitor.visit(*this);
 }
-auto column_name_reference::accept(detail::expression_transformer& visitor) const
+auto column_name_reference::accept(expression_transformer& visitor) const
   -> decltype(visitor.visit(*this))
 {
   return visitor.visit(*this);
 }
-}  // namespace ast
-
-}  // namespace cudf
+}  // namespace cudf::ast

--- a/cpp/src/ast/expressions.cpp
+++ b/cpp/src/ast/expressions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,15 @@
  */
 #include <cudf/ast/detail/operators.hpp>
 #include <cudf/ast/expression_parser.hpp>
-#include <cudf/ast/expressions.hpp>
 #include <cudf/ast/expression_transformer.hpp>
+#include <cudf/ast/expressions.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 
-namespace cudf::ast{
+namespace cudf::ast {
 
 operation::operation(ast_operator op, expression const& input) : op(op), operands({input})
 {
@@ -40,40 +40,24 @@ operation::operation(ast_operator op, expression const& left, expression const& 
   }
 }
 
-cudf::size_type literal::accept(expression_parser& visitor) const
-{
-  return visitor.visit(*this);
-}
-cudf::size_type column_reference::accept(expression_parser& visitor) const
-{
-  return visitor.visit(*this);
-}
-cudf::size_type operation::accept(expression_parser& visitor) const
-{
-  return visitor.visit(*this);
-}
-cudf::size_type column_name_reference::accept(expression_parser& visitor) const
-{
-  return visitor.visit(*this);
-}
+cudf::size_type literal::accept(expression_parser& visitor) const { return visitor.visit(*this); }
+cudf::size_type column_reference::accept(expression_parser& visitor) const { return visitor.visit(*this); }
+cudf::size_type operation::accept(expression_parser& visitor) const { return visitor.visit(*this); }
+cudf::size_type column_name_reference::accept(expression_parser& visitor) const { return visitor.visit(*this) }
 
-auto literal::accept(expression_transformer& visitor) const
-  -> decltype(visitor.visit(*this))
+auto literal::accept(expression_transformer& visitor) const -> decltype(visitor.visit(*this))
 {
   return visitor.visit(*this);
 }
-auto column_reference::accept(expression_transformer& visitor) const
-  -> decltype(visitor.visit(*this))
+auto column_reference::accept(expression_transformer& visitor) const -> decltype(visitor.visit(*this))
 {
   return visitor.visit(*this);
 }
-auto operation::accept(expression_transformer& visitor) const
-  -> decltype(visitor.visit(*this))
+auto operation::accept(expression_transformer& visitor) const -> decltype(visitor.visit(*this))
 {
   return visitor.visit(*this);
 }
-auto column_name_reference::accept(expression_transformer& visitor) const
-  -> decltype(visitor.visit(*this))
+auto column_name_reference::accept(expression_transformer& visitor) const -> decltype(visitor.visit(*this))
 {
   return visitor.visit(*this);
 }

--- a/cpp/src/io/parquet/predicate_pushdown.cpp
+++ b/cpp/src/io/parquet/predicate_pushdown.cpp
@@ -16,8 +16,8 @@
 #include "reader_impl_helpers.hpp"
 
 #include <cudf/ast/detail/operators.hpp>
-#include <cudf/ast/expressions.hpp>
 #include <cudf/ast/expression_transformer.hpp>
+#include <cudf/ast/expressions.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/transform.hpp>

--- a/cpp/src/io/parquet/predicate_pushdown.cpp
+++ b/cpp/src/io/parquet/predicate_pushdown.cpp
@@ -15,9 +15,9 @@
  */
 #include "reader_impl_helpers.hpp"
 
-#include <cudf/ast/detail/expression_transformer.hpp>
 #include <cudf/ast/detail/operators.hpp>
 #include <cudf/ast/expressions.hpp>
+#include <cudf/ast/expression_transformer.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/transform.hpp>
@@ -248,7 +248,7 @@ struct stats_caster {
  * statistics max value of a column is referenced by column_index*2+1
  *
  */
-class stats_expression_converter : public ast::detail::expression_transformer {
+class stats_expression_converter : public ast::expression_transformer {
  public:
   stats_expression_converter(ast::expression const& expr, size_type const& num_columns)
     : _num_columns{num_columns}
@@ -257,7 +257,7 @@ class stats_expression_converter : public ast::detail::expression_transformer {
   }
 
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::literal const& )
+   * @copydoc ast::expression_transformer::visit(ast::literal const& )
    */
   std::reference_wrapper<ast::expression const> visit(ast::literal const& expr) override
   {
@@ -266,7 +266,7 @@ class stats_expression_converter : public ast::detail::expression_transformer {
   }
 
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::column_reference const& )
+   * @copydoc ast::expression_transformer::visit(ast::column_reference const& )
    */
   std::reference_wrapper<ast::expression const> visit(ast::column_reference const& expr) override
   {
@@ -279,7 +279,7 @@ class stats_expression_converter : public ast::detail::expression_transformer {
   }
 
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::column_name_reference const& )
+   * @copydoc ast::expression_transformer::visit(ast::column_name_reference const& )
    */
   std::reference_wrapper<ast::expression const> visit(
     ast::column_name_reference const& expr) override
@@ -288,7 +288,7 @@ class stats_expression_converter : public ast::detail::expression_transformer {
   }
 
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::operation const& )
+   * @copydoc ast::expression_transformer::visit(ast::operation const& )
    */
   std::reference_wrapper<ast::expression const> visit(ast::operation const& expr) override
   {
@@ -561,7 +561,7 @@ named_to_reference_converter::visit_operands(
  * @brief Converts named columns to index reference columns
  *
  */
-class names_from_expression : public ast::detail::expression_transformer {
+class names_from_expression : public ast::expression_transformer {
  public:
   names_from_expression(std::optional<std::reference_wrapper<ast::expression const>> expr,
                         std::vector<std::string> const& skip_names)
@@ -572,21 +572,21 @@ class names_from_expression : public ast::detail::expression_transformer {
   }
 
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::literal const& )
+   * @copydoc ast::expression_transformer::visit(ast::literal const& )
    */
   std::reference_wrapper<ast::expression const> visit(ast::literal const& expr) override
   {
     return expr;
   }
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::column_reference const& )
+   * @copydoc ast::expression_transformer::visit(ast::column_reference const& )
    */
   std::reference_wrapper<ast::expression const> visit(ast::column_reference const& expr) override
   {
     return expr;
   }
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::column_name_reference const& )
+   * @copydoc ast::expression_transformer::visit(ast::column_name_reference const& )
    */
   std::reference_wrapper<ast::expression const> visit(
     ast::column_name_reference const& expr) override
@@ -597,7 +597,7 @@ class names_from_expression : public ast::detail::expression_transformer {
     return expr;
   }
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::operation const& )
+   * @copydoc ast::expression_transformer::visit(ast::operation const& )
    */
   std::reference_wrapper<ast::expression const> visit(ast::operation const& expr) override
   {

--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -18,8 +18,8 @@
 
 #include "parquet_gpu.hpp"
 
-#include <cudf/ast/detail/expression_transformer.hpp>
 #include <cudf/ast/expressions.hpp>
+#include <cudf/ast/expression_transformer.hpp>
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/io/datasource.hpp>
 #include <cudf/types.hpp>
@@ -321,26 +321,26 @@ class aggregate_reader_metadata {
  * @brief Converts named columns to index reference columns
  *
  */
-class named_to_reference_converter : public ast::detail::expression_transformer {
+class named_to_reference_converter : public ast::expression_transformer {
  public:
   named_to_reference_converter(std::optional<std::reference_wrapper<ast::expression const>> expr,
                                table_metadata const& metadata);
 
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::literal const& )
+   * @copydoc ast::expression_transformer::visit(ast::literal const& )
    */
   std::reference_wrapper<ast::expression const> visit(ast::literal const& expr) override;
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::column_reference const& )
+   * @copydoc ast::expression_transformer::visit(ast::column_reference const& )
    */
   std::reference_wrapper<ast::expression const> visit(ast::column_reference const& expr) override;
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::column_name_reference const& )
+   * @copydoc ast::expression_transformer::visit(ast::column_name_reference const& )
    */
   std::reference_wrapper<ast::expression const> visit(
     ast::column_name_reference const& expr) override;
   /**
-   * @copydoc ast::detail::expression_transformer::visit(ast::operation const& )
+   * @copydoc ast::expression_transformer::visit(ast::operation const& )
    */
   std::reference_wrapper<ast::expression const> visit(ast::operation const& expr) override;
 

--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -18,8 +18,8 @@
 
 #include "parquet_gpu.hpp"
 
-#include <cudf/ast/expressions.hpp>
 #include <cudf/ast/expression_transformer.hpp>
+#include <cudf/ast/expressions.hpp>
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/io/datasource.hpp>
 #include <cudf/types.hpp>

--- a/cpp/src/join/conditional_join.cu
+++ b/cpp/src/join/conditional_join.cu
@@ -64,8 +64,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_join_anti_semi(
 
   auto const has_nulls = binary_predicate.may_evaluate_null(left, right, stream);
 
-  auto const parser =
-    ast::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
+  auto const parser = ast::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
   CUDF_EXPECTS(parser.output_type().id() == type_id::BOOL8,
                "The expression must produce a Boolean output.");
 
@@ -175,8 +174,7 @@ conditional_join(table_view const& left,
   // path.
   auto const has_nulls = binary_predicate.may_evaluate_null(left, right, stream);
 
-  auto const parser =
-    ast::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
+  auto const parser = ast::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
   CUDF_EXPECTS(parser.output_type().id() == type_id::BOOL8,
                "The expression must produce a boolean output.");
 
@@ -327,8 +325,7 @@ std::size_t compute_conditional_join_output_size(table_view const& left,
   // performance, so we capture that information as well.
   auto const has_nulls = binary_predicate.may_evaluate_null(left, right, stream);
 
-  auto const parser =
-    ast::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
+  auto const parser = ast::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
   CUDF_EXPECTS(parser.output_type().id() == type_id::BOOL8,
                "The expression must produce a boolean output.");
 

--- a/cpp/src/join/conditional_join.cu
+++ b/cpp/src/join/conditional_join.cu
@@ -19,7 +19,7 @@
 #include "join/join_common_utils.cuh"
 #include "join/join_common_utils.hpp"
 
-#include <cudf/ast/detail/expression_parser.hpp>
+#include <cudf/ast/expression_parser.hpp>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/join.hpp>
@@ -65,7 +65,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_join_anti_semi(
   auto const has_nulls = binary_predicate.may_evaluate_null(left, right, stream);
 
   auto const parser =
-    ast::detail::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
+    ast::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
   CUDF_EXPECTS(parser.output_type().id() == type_id::BOOL8,
                "The expression must produce a Boolean output.");
 
@@ -176,7 +176,7 @@ conditional_join(table_view const& left,
   auto const has_nulls = binary_predicate.may_evaluate_null(left, right, stream);
 
   auto const parser =
-    ast::detail::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
+    ast::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
   CUDF_EXPECTS(parser.output_type().id() == type_id::BOOL8,
                "The expression must produce a boolean output.");
 
@@ -328,7 +328,7 @@ std::size_t compute_conditional_join_output_size(table_view const& left,
   auto const has_nulls = binary_predicate.may_evaluate_null(left, right, stream);
 
   auto const parser =
-    ast::detail::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
+    ast::expression_parser{binary_predicate, left, right, has_nulls, stream, mr};
   CUDF_EXPECTS(parser.output_type().id() == type_id::BOOL8,
                "The expression must produce a boolean output.");
 

--- a/cpp/src/join/conditional_join_kernels.cuh
+++ b/cpp/src/join/conditional_join_kernels.cuh
@@ -20,7 +20,8 @@
 #include "join/join_common_utils.hpp"
 
 #include <cudf/ast/detail/expression_evaluator.cuh>
-#include <cudf/ast/detail/expression_parser.hpp>
+#include <cudf/ast/expression_parser.hpp>
+#include <cudf/ast/expressions.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/table/table_device_view.cuh>
 
@@ -156,7 +157,7 @@ CUDF_KERNEL void compute_conditional_join_output_size(
   table_device_view left_table,
   table_device_view right_table,
   join_kind join_type,
-  ast::detail::expression_device_view device_expression_data,
+  cudf::ast::expression_device_view device_expression_data,
   bool const swap_tables,
   std::size_t* output_size)
 {
@@ -165,8 +166,8 @@ CUDF_KERNEL void compute_conditional_join_output_size(
   // workaround is to declare an arbitrary (here char) array type then cast it
   // after the fact to the appropriate type.
   extern __shared__ char raw_intermediate_storage[];
-  cudf::ast::detail::IntermediateDataType<has_nulls>* intermediate_storage =
-    reinterpret_cast<cudf::ast::detail::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
+  cudf::ast::IntermediateDataType<has_nulls>* intermediate_storage =
+    reinterpret_cast<cudf::ast::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
   auto thread_intermediate_storage =
     &intermediate_storage[threadIdx.x * device_expression_data.num_intermediates];
 
@@ -248,7 +249,7 @@ CUDF_KERNEL void conditional_join(table_device_view left_table,
                                   cudf::size_type* join_output_l,
                                   cudf::size_type* join_output_r,
                                   std::size_t* current_idx,
-                                  cudf::ast::detail::expression_device_view device_expression_data,
+                                  cudf::ast::expression_device_view device_expression_data,
                                   std::size_t const max_size,
                                   bool const swap_tables)
 {
@@ -262,8 +263,8 @@ CUDF_KERNEL void conditional_join(table_device_view left_table,
   // used to circumvent conflicts between arrays of different types between
   // different template instantiations due to the extern specifier.
   extern __shared__ char raw_intermediate_storage[];
-  cudf::ast::detail::IntermediateDataType<has_nulls>* intermediate_storage =
-    reinterpret_cast<cudf::ast::detail::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
+  cudf::ast::IntermediateDataType<has_nulls>* intermediate_storage =
+    reinterpret_cast<cudf::ast::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
   auto thread_intermediate_storage =
     &intermediate_storage[threadIdx.x * device_expression_data.num_intermediates];
 
@@ -382,7 +383,7 @@ CUDF_KERNEL void conditional_join_anti_semi(
   join_kind join_type,
   cudf::size_type* join_output_l,
   std::size_t* current_idx,
-  cudf::ast::detail::expression_device_view device_expression_data,
+  cudf::ast::expression_device_view device_expression_data,
   std::size_t const max_size)
 {
   constexpr int num_warps = block_size / detail::warp_size;
@@ -390,8 +391,8 @@ CUDF_KERNEL void conditional_join_anti_semi(
   __shared__ cudf::size_type join_shared_l[num_warps][output_cache_size];
 
   extern __shared__ char raw_intermediate_storage[];
-  cudf::ast::detail::IntermediateDataType<has_nulls>* intermediate_storage =
-    reinterpret_cast<cudf::ast::detail::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
+  cudf::ast::IntermediateDataType<has_nulls>* intermediate_storage =
+    reinterpret_cast<cudf::ast::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
   auto thread_intermediate_storage =
     &intermediate_storage[threadIdx.x * device_expression_data.num_intermediates];
 

--- a/cpp/src/join/mixed_join.cu
+++ b/cpp/src/join/mixed_join.cu
@@ -18,7 +18,7 @@
 #include "join_common_utils.hpp"
 #include "mixed_join_kernels.cuh"
 
-#include <cudf/ast/detail/expression_parser.hpp>
+#include <cudf/ast/expression_parser.hpp>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/hashing/detail/helper_functions.cuh>
@@ -112,7 +112,7 @@ mixed_join(
     cudf::has_nulls(left_equality) || cudf::has_nulls(right_equality) ||
     binary_predicate.may_evaluate_null(left_conditional, right_conditional, stream)};
 
-  auto const parser = ast::detail::expression_parser{
+  auto const parser = ast::expression_parser{
     binary_predicate, left_conditional, right_conditional, has_nulls, stream, mr};
   CUDF_EXPECTS(parser.output_type().id() == type_id::BOOL8,
                "The expression must produce a boolean output.");
@@ -377,7 +377,7 @@ compute_mixed_join_output_size(table_view const& left_equality,
     cudf::has_nulls(left_equality) || cudf::has_nulls(right_equality) ||
     binary_predicate.may_evaluate_null(left_conditional, right_conditional, stream)};
 
-  auto const parser = ast::detail::expression_parser{
+  auto const parser = ast::expression_parser{
     binary_predicate, left_conditional, right_conditional, has_nulls, stream, mr};
   CUDF_EXPECTS(parser.output_type().id() == type_id::BOOL8,
                "The expression must produce a boolean output.");

--- a/cpp/src/join/mixed_join_common_utils.cuh
+++ b/cpp/src/join/mixed_join_common_utils.cuh
@@ -18,6 +18,8 @@
 #include "join/join_common_utils.hpp"
 
 #include <cudf/ast/detail/expression_evaluator.cuh>
+#include <cudf/ast/expression_parser.hpp>
+#include <cudf/ast/expressions.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/table/experimental/row_operators.cuh>
 
@@ -48,7 +50,7 @@ template <bool has_nulls>
 struct expression_equality {
   __device__ expression_equality(
     cudf::ast::detail::expression_evaluator<has_nulls> const& evaluator,
-    cudf::ast::detail::IntermediateDataType<has_nulls>* thread_intermediate_storage,
+    cudf::ast::IntermediateDataType<has_nulls>* thread_intermediate_storage,
     bool const swap_tables,
     row_equality const& equality_probe)
     : evaluator{evaluator},
@@ -58,7 +60,7 @@ struct expression_equality {
   {
   }
 
-  cudf::ast::detail::IntermediateDataType<has_nulls>* thread_intermediate_storage;
+  cudf::ast::IntermediateDataType<has_nulls>* thread_intermediate_storage;
   cudf::ast::detail::expression_evaluator<has_nulls> const& evaluator;
   bool const swap_tables;
   row_equality const& equality_probe;

--- a/cpp/src/join/mixed_join_kernel.cu
+++ b/cpp/src/join/mixed_join_kernel.cu
@@ -30,7 +30,7 @@ template __global__ void mixed_join<DEFAULT_JOIN_BLOCK_SIZE, false>(
   cudf::detail::mixed_multimap_type::device_view hash_table_view,
   size_type* join_output_l,
   size_type* join_output_r,
-  cudf::ast::detail::expression_device_view device_expression_data,
+  cudf::ast::expression_device_view device_expression_data,
   cudf::size_type const* join_result_offsets,
   bool const swap_tables);
 

--- a/cpp/src/join/mixed_join_kernel.cu
+++ b/cpp/src/join/mixed_join_kernel.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/join/mixed_join_kernel.cuh
+++ b/cpp/src/join/mixed_join_kernel.cuh
@@ -21,7 +21,8 @@
 #include "mixed_join_common_utils.cuh"
 
 #include <cudf/ast/detail/expression_evaluator.cuh>
-#include <cudf/ast/detail/expression_parser.hpp>
+#include <cudf/ast/expression_parser.hpp>
+#include <cudf/ast/expressions.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/export.hpp>
@@ -50,7 +51,7 @@ CUDF_HIDDEN __launch_bounds__(block_size) __global__
                   cudf::detail::mixed_multimap_type::device_view hash_table_view,
                   size_type* join_output_l,
                   size_type* join_output_r,
-                  cudf::ast::detail::expression_device_view device_expression_data,
+                  cudf::ast::expression_device_view device_expression_data,
                   cudf::size_type const* join_result_offsets,
                   bool const swap_tables)
 {
@@ -59,8 +60,8 @@ CUDF_HIDDEN __launch_bounds__(block_size) __global__
   // used to circumvent conflicts between arrays of different types between
   // different template instantiations due to the extern specifier.
   extern __shared__ char raw_intermediate_storage[];
-  cudf::ast::detail::IntermediateDataType<has_nulls>* intermediate_storage =
-    reinterpret_cast<cudf::ast::detail::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
+  cudf::ast::IntermediateDataType<has_nulls>* intermediate_storage =
+    reinterpret_cast<cudf::ast::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
   auto thread_intermediate_storage =
     &intermediate_storage[threadIdx.x * device_expression_data.num_intermediates];
 

--- a/cpp/src/join/mixed_join_kernel_nulls.cu
+++ b/cpp/src/join/mixed_join_kernel_nulls.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/join/mixed_join_kernel_nulls.cu
+++ b/cpp/src/join/mixed_join_kernel_nulls.cu
@@ -30,7 +30,7 @@ template __global__ void mixed_join<DEFAULT_JOIN_BLOCK_SIZE, true>(
   cudf::detail::mixed_multimap_type::device_view hash_table_view,
   size_type* join_output_l,
   size_type* join_output_r,
-  cudf::ast::detail::expression_device_view device_expression_data,
+  cudf::ast::expression_device_view device_expression_data,
   cudf::size_type const* join_result_offsets,
   bool const swap_tables);
 

--- a/cpp/src/join/mixed_join_kernels.cuh
+++ b/cpp/src/join/mixed_join_kernels.cuh
@@ -19,7 +19,6 @@
 #include "join/join_common_utils.hpp"
 #include "join/mixed_join_common_utils.cuh"
 
-#include <cudf/ast/detail/expression_parser.hpp>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/span.hpp>
 
@@ -68,7 +67,7 @@ __global__ void compute_mixed_join_output_size(
   row_equality const equality_probe,
   join_kind const join_type,
   cudf::detail::mixed_multimap_type::device_view hash_table_view,
-  ast::detail::expression_device_view device_expression_data,
+  cudf::ast::expression_device_view device_expression_data,
   bool const swap_tables,
   std::size_t* output_size,
   cudf::device_span<cudf::size_type> matches_per_row);
@@ -115,7 +114,7 @@ __global__ void mixed_join(table_device_view left_table,
                            cudf::detail::mixed_multimap_type::device_view hash_table_view,
                            size_type* join_output_l,
                            size_type* join_output_r,
-                           cudf::ast::detail::expression_device_view device_expression_data,
+                           cudf::ast::expression_device_view device_expression_data,
                            cudf::size_type const* join_result_offsets,
                            bool const swap_tables);
 

--- a/cpp/src/join/mixed_join_kernels_semi.cu
+++ b/cpp/src/join/mixed_join_kernels_semi.cu
@@ -19,7 +19,8 @@
 #include "join/mixed_join_common_utils.cuh"
 
 #include <cudf/ast/detail/expression_evaluator.cuh>
-#include <cudf/ast/detail/expression_parser.hpp>
+#include <cudf/ast/expression_parser.hpp>
+#include <cudf/ast/expressions.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/export.hpp>
@@ -44,15 +45,15 @@ CUDF_HIDDEN __launch_bounds__(block_size) __global__
                        row_equality const equality_probe,
                        cudf::detail::semi_map_type::device_view hash_table_view,
                        cudf::device_span<bool> left_table_keep_mask,
-                       cudf::ast::detail::expression_device_view device_expression_data)
+                       cudf::ast::expression_device_view device_expression_data)
 {
   // Normally the casting of a shared memory array is used to create multiple
   // arrays of different types from the shared memory buffer, but here it is
   // used to circumvent conflicts between arrays of different types between
   // different template instantiations due to the extern specifier.
   extern __shared__ char raw_intermediate_storage[];
-  cudf::ast::detail::IntermediateDataType<has_nulls>* intermediate_storage =
-    reinterpret_cast<cudf::ast::detail::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
+  cudf::ast::IntermediateDataType<has_nulls>* intermediate_storage =
+    reinterpret_cast<cudf::ast::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
   auto thread_intermediate_storage =
     &intermediate_storage[threadIdx.x * device_expression_data.num_intermediates];
 
@@ -84,7 +85,7 @@ template __global__ void mixed_join_semi<DEFAULT_JOIN_BLOCK_SIZE, true>(
   row_equality const equality_probe,
   cudf::detail::semi_map_type::device_view hash_table_view,
   cudf::device_span<bool> left_table_keep_mask,
-  cudf::ast::detail::expression_device_view device_expression_data);
+  cudf::ast::expression_device_view device_expression_data);
 
 template __global__ void mixed_join_semi<DEFAULT_JOIN_BLOCK_SIZE, false>(
   table_device_view left_table,
@@ -95,7 +96,7 @@ template __global__ void mixed_join_semi<DEFAULT_JOIN_BLOCK_SIZE, false>(
   row_equality const equality_probe,
   cudf::detail::semi_map_type::device_view hash_table_view,
   cudf::device_span<bool> left_table_keep_mask,
-  cudf::ast::detail::expression_device_view device_expression_data);
+  cudf::ast::expression_device_view device_expression_data);
 
 }  // namespace detail
 

--- a/cpp/src/join/mixed_join_kernels_semi.cuh
+++ b/cpp/src/join/mixed_join_kernels_semi.cuh
@@ -19,7 +19,6 @@
 #include "join/join_common_utils.hpp"
 #include "join/mixed_join_common_utils.cuh"
 
-#include <cudf/ast/detail/expression_parser.hpp>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/span.hpp>
 
@@ -60,7 +59,7 @@ __global__ void mixed_join_semi(table_device_view left_table,
                                 row_equality const equality_probe,
                                 cudf::detail::semi_map_type::device_view hash_table_view,
                                 cudf::device_span<bool> left_table_keep_mask,
-                                cudf::ast::detail::expression_device_view device_expression_data);
+                                cudf::ast::expression_device_view device_expression_data);
 
 }  // namespace detail
 

--- a/cpp/src/join/mixed_join_semi.cu
+++ b/cpp/src/join/mixed_join_semi.cu
@@ -18,7 +18,7 @@
 #include "join_common_utils.hpp"
 #include "mixed_join_kernels_semi.cuh"
 
-#include <cudf/ast/detail/expression_parser.hpp>
+#include <cudf/ast/expression_parser.hpp>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
@@ -140,7 +140,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> mixed_join_semi(
     cudf::has_nulls(left_equality) || cudf::has_nulls(right_equality) ||
     binary_predicate.may_evaluate_null(left_conditional, right_conditional, stream)};
 
-  auto const parser = ast::detail::expression_parser{
+  auto const parser = ast::expression_parser{
     binary_predicate, left_conditional, right_conditional, has_nulls, stream, mr};
   CUDF_EXPECTS(parser.output_type().id() == type_id::BOOL8,
                "The expression must produce a boolean output.");

--- a/cpp/src/join/mixed_join_size_kernel.cu
+++ b/cpp/src/join/mixed_join_size_kernel.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/join/mixed_join_size_kernel.cu
+++ b/cpp/src/join/mixed_join_size_kernel.cu
@@ -28,7 +28,7 @@ template __global__ void compute_mixed_join_output_size<DEFAULT_JOIN_BLOCK_SIZE,
   row_equality const equality_probe,
   join_kind const join_type,
   cudf::detail::mixed_multimap_type::device_view hash_table_view,
-  ast::detail::expression_device_view device_expression_data,
+  cudf::ast::expression_device_view device_expression_data,
   bool const swap_tables,
   std::size_t* output_size,
   cudf::device_span<cudf::size_type> matches_per_row);

--- a/cpp/src/join/mixed_join_size_kernel.cuh
+++ b/cpp/src/join/mixed_join_size_kernel.cuh
@@ -19,7 +19,8 @@
 #include "mixed_join_common_utils.cuh"
 
 #include <cudf/ast/detail/expression_evaluator.cuh>
-#include <cudf/ast/detail/expression_parser.hpp>
+#include <cudf/ast/expression_parser.hpp>
+#include <cudf/ast/expressions.hpp>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/utilities/export.hpp>
@@ -55,8 +56,8 @@ CUDF_HIDDEN __launch_bounds__(block_size) __global__ void compute_mixed_join_out
   // workaround is to declare an arbitrary (here char) array type then cast it
   // after the fact to the appropriate type.
   extern __shared__ char raw_intermediate_storage[];
-  cudf::ast::detail::IntermediateDataType<has_nulls>* intermediate_storage =
-    reinterpret_cast<cudf::ast::detail::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
+  cudf::ast::IntermediateDataType<has_nulls>* intermediate_storage =
+    reinterpret_cast<cudf::ast::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
   auto thread_intermediate_storage =
     intermediate_storage + (threadIdx.x * device_expression_data.num_intermediates);
 

--- a/cpp/src/join/mixed_join_size_kernel_nulls.cu
+++ b/cpp/src/join/mixed_join_size_kernel_nulls.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/join/mixed_join_size_kernel_nulls.cu
+++ b/cpp/src/join/mixed_join_size_kernel_nulls.cu
@@ -28,7 +28,7 @@ template __global__ void compute_mixed_join_output_size<DEFAULT_JOIN_BLOCK_SIZE,
   row_equality const equality_probe,
   join_kind const join_type,
   cudf::detail::mixed_multimap_type::device_view hash_table_view,
-  ast::detail::expression_device_view device_expression_data,
+  cudf::ast::expression_device_view device_expression_data,
   bool const swap_tables,
   std::size_t* output_size,
   cudf::device_span<cudf::size_type> matches_per_row);

--- a/cpp/src/transform/compute_column.cu
+++ b/cpp/src/transform/compute_column.cu
@@ -15,7 +15,7 @@
  */
 
 #include <cudf/ast/detail/expression_evaluator.cuh>
-#include <cudf/ast/detail/expression_parser.hpp>
+#include <cudf/ast/expression_parser.hpp>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
@@ -57,7 +57,7 @@ namespace detail {
 template <cudf::size_type max_block_size, bool has_nulls>
 __launch_bounds__(max_block_size) CUDF_KERNEL
   void compute_column_kernel(table_device_view const table,
-                             ast::detail::expression_device_view device_expression_data,
+                             ast::expression_device_view device_expression_data,
                              mutable_column_device_view output_column)
 {
   // The (required) extern storage of the shared memory array leads to
@@ -65,8 +65,8 @@ __launch_bounds__(max_block_size) CUDF_KERNEL
   // workaround is to declare an arbitrary (here char) array type then cast it
   // after the fact to the appropriate type.
   extern __shared__ char raw_intermediate_storage[];
-  ast::detail::IntermediateDataType<has_nulls>* intermediate_storage =
-    reinterpret_cast<ast::detail::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
+  ast::IntermediateDataType<has_nulls>* intermediate_storage =
+    reinterpret_cast<ast::IntermediateDataType<has_nulls>*>(raw_intermediate_storage);
 
   auto thread_intermediate_storage =
     &intermediate_storage[threadIdx.x * device_expression_data.num_intermediates];
@@ -91,7 +91,7 @@ std::unique_ptr<column> compute_column(table_view const& table,
   // path.
   auto const has_nulls = expr.may_evaluate_null(table, stream);
 
-  auto const parser = ast::detail::expression_parser{expr, table, has_nulls, stream, mr};
+  auto const parser = ast::expression_parser{expr, table, has_nulls, stream, mr};
 
   auto const output_column_mask_state =
     has_nulls ? mask_state::UNINITIALIZED : mask_state::UNALLOCATED;


### PR DESCRIPTION
## Description
The public api of `cudf::ast::expression` required using `cudf::ast::detail` types which goes against the cudf programming guide. So we move the required types to use `cudf::ast::expression` into the public stable API.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
