### PR TITLE
Expose reflection to check if casting between two types is supported

### DIFF
--- a/cpp/include/cudf/detail/unary.hpp
+++ b/cpp/include/cudf/detail/unary.hpp
@@ -87,11 +87,6 @@ std::unique_ptr<column> cast(column_view const& input,
                              rmm::device_async_resource_ref mr);
 
 /**
- * @copydoc cudf::is_supported_cast
- */
-bool is_supported_cast(data_type from, data_type to) noexcept;
-
-/**
  * @copydoc cudf::is_nan
  */
 std::unique_ptr<column> is_nan(cudf::column_view const& input,

--- a/cpp/include/cudf/detail/unary.hpp
+++ b/cpp/include/cudf/detail/unary.hpp
@@ -87,6 +87,11 @@ std::unique_ptr<column> cast(column_view const& input,
                              rmm::device_async_resource_ref mr);
 
 /**
+ * @copydoc cudf::is_supported_cast
+ */
+bool is_supported_cast(data_type from, data_type to) noexcept;
+
+/**
  * @copydoc cudf::is_nan
  */
 std::unique_ptr<column> is_nan(cudf::column_view const& input,

--- a/cpp/include/cudf/unary.hpp
+++ b/cpp/include/cudf/unary.hpp
@@ -203,6 +203,16 @@ std::unique_ptr<column> cast(
   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
+ * @brief Check if a cast between two datatypes is supported.
+ *
+ * @param from source type
+ * @param to   target type
+ *
+ * @returns true if the cast is supported.
+ */
+bool is_supported_cast(data_type from, data_type to) noexcept;
+
+/**
  * @brief Creates a column of `type_id::BOOL8` elements indicating the presence of `NaN` values
  * in a column of floating point values.
  * The output element at row `i` is `true` if the element in `input` at row i is `NAN`, else `false`

--- a/cpp/src/unary/cast_ops.cu
+++ b/cpp/src/unary/cast_ops.cu
@@ -468,11 +468,6 @@ struct is_supported_cast_impl {
   }
 };
 
-bool is_supported_cast(data_type from, data_type to) noexcept
-{
-  return double_type_dispatcher(from, to, is_supported_cast_impl{});
-}
-
 }  // namespace detail
 
 std::unique_ptr<column> cast(column_view const& input,
@@ -486,8 +481,9 @@ std::unique_ptr<column> cast(column_view const& input,
 
 bool is_supported_cast(data_type from, data_type to) noexcept
 {
-  CUDF_FUNC_RANGE();
-  return detail::is_supported_cast(from, to);
+  // No matching detail API call/nvtx annotation, since this doesn't
+  // launch a kernel.
+  return double_type_dispatcher(from, to, detail::is_supported_cast_impl{});
 }
 
 }  // namespace cudf

--- a/python/cudf/cudf/_lib/pylibcudf/libcudf/unary.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/libcudf/unary.pxd
@@ -43,5 +43,6 @@ cdef extern from "cudf/unary.hpp" namespace "cudf" nogil:
     cdef extern unique_ptr[column] cast(
         column_view input,
         data_type out_type) except +
+    cdef extern bool is_supported_cast(data_type from_, data_type to) noexcept
     cdef extern unique_ptr[column] is_nan(column_view input) except +
     cdef extern unique_ptr[column] is_not_nan(column_view input) except +

--- a/python/cudf/cudf/_lib/pylibcudf/libcudf/unary.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/libcudf/unary.pxd
@@ -1,6 +1,7 @@
 # Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 from libc.stdint cimport int32_t
+from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
 
 from cudf._lib.pylibcudf.libcudf.column.column cimport column

--- a/python/cudf/cudf/_lib/pylibcudf/unary.pxd
+++ b/python/cudf/cudf/_lib/pylibcudf/unary.pxd
@@ -1,5 +1,7 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
+from libcpp cimport bool
+
 from cudf._lib.pylibcudf.libcudf.unary cimport unary_operator
 
 from .column cimport Column
@@ -17,3 +19,5 @@ cpdef Column cast(Column input, DataType data_type)
 cpdef Column is_nan(Column input)
 
 cpdef Column is_not_nan(Column input)
+
+cpdef bool is_supported_cast(DataType from_, DataType to)

--- a/python/cudf/cudf/_lib/pylibcudf/unary.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/unary.pyx
@@ -154,3 +154,23 @@ cpdef Column is_not_nan(Column input):
         result = move(cpp_unary.is_not_nan(input.view()))
 
     return Column.from_libcudf(move(result))
+
+cpdef bool is_supported_cast(DataType from_, DataType to):
+    """Check if a cast between datatypes is supported.
+
+    For details, see :cpp:func:`is_supported_cast`.
+
+    Parameters
+    ----------
+    from_
+        The source datatype
+    to
+        The target datatype
+
+    Returns
+    -------
+    bool
+        True if the cast is supported.
+    """
+    with nogil:
+        return cpp_unary.is_supported_cast(from_, to)

--- a/python/cudf/cudf/_lib/pylibcudf/unary.pyx
+++ b/python/cudf/cudf/_lib/pylibcudf/unary.pyx
@@ -1,5 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
+from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 
@@ -173,4 +174,4 @@ cpdef bool is_supported_cast(DataType from_, DataType to):
         True if the cast is supported.
     """
     with nogil:
-        return cpp_unary.is_supported_cast(from_, to)
+        return cpp_unary.is_supported_cast(from_.c_obj, to.c_obj)

--- a/python/cudf/cudf/pylibcudf_tests/test_unary.py
+++ b/python/cudf/cudf/pylibcudf_tests/test_unary.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+from cudf._lib import pylibcudf as plc
+
+
+def test_is_supported_cast():
+    assert plc.unary.is_supported_cast(
+        plc.DataType(plc.TypeId.INT8), plc.DataType(plc.TypeId.UINT64)
+    )
+    assert plc.unary.is_supported_cast(
+        plc.DataType(plc.TypeId.DURATION_MILLISECONDS),
+        plc.DataType(plc.TypeId.UINT64),
+    )
+    assert not plc.unary.is_supported_cast(
+        plc.DataType(plc.TypeId.INT32), plc.DataType(plc.TypeId.TIMESTAMP_DAYS)
+    )
+    assert not plc.unary.is_supported_cast(
+        plc.DataType(plc.TypeId.INT32), plc.DataType(plc.TypeId.STRING)
+    )


### PR DESCRIPTION
## Description

In cudf-polars we need to check if a cast between two datatypes is supported (and fallback, or generate different code if not).

Let's ask libcudf to be the source of truth for when a cast is supported.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
