### PR TITLE
Remove temporary functor overloads required by cuco version bump

### DIFF
--- a/cpp/include/cudf/detail/distinct_hash_join.cuh
+++ b/cpp/include/cudf/detail/distinct_hash_join.cuh
@@ -42,17 +42,6 @@ template <typename Equal>
 struct comparator_adapter {
   comparator_adapter(Equal const& d_equal) : _d_equal{d_equal} {}
 
-  // suppress "function was declared but never referenced warning"
-#pragma nv_diagnostic push
-#pragma nv_diag_suppress 177
-  __device__ constexpr auto operator()(
-    cuco::pair<hash_value_type, lhs_index_type> const&,
-    cuco::pair<hash_value_type, lhs_index_type> const&) const noexcept
-  {
-    // All build table keys are distinct thus `false` no matter what
-    return false;
-  }
-
   __device__ constexpr auto operator()(
     cuco::pair<hash_value_type, rhs_index_type> const&,
     cuco::pair<hash_value_type, rhs_index_type> const&) const noexcept
@@ -68,15 +57,6 @@ struct comparator_adapter {
     if (lhs.first != rhs.first) { return false; }
     return _d_equal(lhs.second, rhs.second);
   }
-
-  __device__ constexpr auto operator()(
-    cuco::pair<hash_value_type, rhs_index_type> const& lhs,
-    cuco::pair<hash_value_type, lhs_index_type> const& rhs) const noexcept
-  {
-    if (lhs.first != rhs.first) { return false; }
-    return _d_equal(lhs.second, rhs.second);
-  }
-#pragma nv_diagnostic pop
 
  private:
   Equal _d_equal;

--- a/cpp/src/search/contains_table.cu
+++ b/cpp/src/search/contains_table.cu
@@ -76,18 +76,6 @@ struct comparator_adapter {
   {
   }
 
-  // suppress "function was declared but never referenced warning"
-#pragma nv_diagnostic push
-#pragma nv_diag_suppress 177
-  __device__ constexpr auto operator()(lhs_index_type lhs_index,
-                                       lhs_index_type rhs_index) const noexcept
-  {
-    auto const lhs = static_cast<size_type>(lhs_index);
-    auto const rhs = static_cast<size_type>(rhs_index);
-
-    return _self_equal(lhs, rhs);
-  }
-
   __device__ constexpr auto operator()(rhs_index_type lhs_index,
                                        rhs_index_type rhs_index) const noexcept
   {
@@ -102,13 +90,6 @@ struct comparator_adapter {
   {
     return _two_table_equal(lhs_index, rhs_index);
   }
-
-  __device__ constexpr auto operator()(rhs_index_type lhs_index,
-                                       lhs_index_type rhs_index) const noexcept
-  {
-    return _two_table_equal(lhs_index, rhs_index);
-  }
-#pragma nv_diagnostic pop
 
  private:
   SelfEqual const _self_equal;

--- a/cpp/src/text/bpe/byte_pair_encoding.cuh
+++ b/cpp/src/text/bpe/byte_pair_encoding.cuh
@@ -89,14 +89,6 @@ struct bpe_equal {
     return lhs == rhs;  // all rows are unique
   }
   // used by find
-  __device__ bool operator()(cudf::size_type lhs, merge_pair_type const& rhs) const noexcept
-  {
-    lhs *= 2;
-    auto const left  = d_strings.element<cudf::string_view>(lhs);
-    auto const right = d_strings.element<cudf::string_view>(lhs + 1);
-    return (left == rhs.first) && (right == rhs.second);
-  }
-  // used by find
   __device__ bool operator()(merge_pair_type const& lhs, cudf::size_type rhs) const noexcept
   {
     rhs *= 2;
@@ -157,11 +149,6 @@ struct mp_equal {
     return left == right;
   }
   // used by find
-  __device__ bool operator()(cudf::size_type lhs, cudf::string_view const& rhs) const noexcept
-  {
-    auto const left = d_strings.element<cudf::string_view>(lhs);
-    return left == rhs;
-  }
   __device__ bool operator()(cudf::string_view const& lhs, cudf::size_type rhs) const noexcept
   {
     auto const right = d_strings.element<cudf::string_view>(rhs);

--- a/cpp/src/text/vocabulary_tokenize.cu
+++ b/cpp/src/text/vocabulary_tokenize.cu
@@ -86,18 +86,10 @@ struct vocab_equal {
     return lhs == rhs;  // all rows are expected to be unique
   }
   // used by find
-  // suppress "function was declared but never referenced warning"
-#pragma nv_diagnostic push
-#pragma nv_diag_suppress 177
-  __device__ bool operator()(cudf::size_type lhs, cudf::string_view const& rhs) const noexcept
-  {
-    return d_strings.element<cudf::string_view>(lhs) == rhs;
-  }
   __device__ bool operator()(cudf::string_view const& lhs, cudf::size_type rhs) const noexcept
   {
     return d_strings.element<cudf::string_view>(rhs) == lhs;
   }
-#pragma nv_diagnostic pop
 };
 
 using probe_scheme        = cuco::linear_probing<1, vocab_hasher>;


### PR DESCRIPTION
## Description
This is a follow-up of #15938. It removes the temporary workaround no longer needed after the cuco version bump.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
