### PR TITLE
Update JNI build to support nvcomp4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2019-2023, NVIDIA CORPORATION.
+  Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -590,8 +590,6 @@
                                         <include>libcudfjni.so</include>
                                         <include>libcufilejni.so</include>
                                         <include>libnvcomp.so</include>
-                                        <include>libnvcomp_gdeflate.so</include>
-                                        <include>libnvcomp_bitcomp.so</include>
                                     </includes>
                                 </resource>
                                 <resource>

--- a/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
+++ b/java/src/main/java/ai/rapids/cudf/NativeDepsLoader.java
@@ -55,9 +55,6 @@ public class NativeDepsLoader {
    */
   private static final String[][] loadOrder = new String[][]{
       new String[]{
-          "nvcomp_bitcomp", "nvcomp_gdeflate"
-      },
-      new String[]{
           "nvcomp"
       },
       new String[]{

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -263,8 +263,7 @@ if(TARGET nvcomp::nvcomp)
     TARGET cudfjni
     PRE_LINK
     COMMAND
-      ${CMAKE_COMMAND} -E copy $<TARGET_FILE:nvcomp::nvcomp> $<TARGET_FILE:nvcomp::nvcomp_gdeflate>
-      $<TARGET_FILE:nvcomp::nvcomp_bitcomp> "${PROJECT_BINARY_DIR}"
+      ${CMAKE_COMMAND} -E copy $<TARGET_FILE:nvcomp::nvcomp> "${PROJECT_BINARY_DIR}/libnvcomp.so"
     COMMENT "Copying nvcomp libraries to ${PROJECT_BINARY_DIR}"
   )
 endif()


### PR DESCRIPTION
## Description
Prepare the PR to support bumping up nvcomp version to 4.0+
Some notable changes:
1. libnvcomp_gdeflate.so and libnvcomp_bitcomp.so have been absorbed into libnvcomp.so
2. libnvcomp.so is now a symlink in nvcomp tarball, so we copy the actual `libnvcomp.so.x.y.z` as `libnvcomp.so` during static linking to avoid breaking the following builds.

These changes have been verified internally

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
