### PR TITLE
[WIP][RFC] Add sparse host buffer source

### DIFF
--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -505,6 +505,12 @@ std::unique_ptr<datasource> datasource::create(cudf::host_span<std::byte const> 
   return std::make_unique<host_buffer_source>(buffer);
 }
 
+std::unique_ptr<datasource> datasource::create(
+  std::map<size_t, cudf::host_span<std::byte const>> buffer_map)
+{
+  return std::make_unique<sparse_host_buffer_source>(buffer_map);
+}
+
 std::unique_ptr<datasource> datasource::create(cudf::device_span<std::byte const> buffer)
 {
   return std::make_unique<device_buffer_source>(buffer);


### PR DESCRIPTION
Related to https://github.com/rapidsai/cudf/issues/15919

**DISCLAIMER**: This is meant to be a rough RFC to illustrate my idea for a temporary mitigation strategy for `NativeFile` removal. I am probably not the right person to take the libcudf changes over the line but I still threw some C++ code together for fun :)

**Idea**: We don't need `NativeFile` support to get reasonable partial-IO performance from remote storage if we only transfer the necessary byte ranges into host memory with fsspec and libcudf is able to read from the sparse `<offset, byte-range>` mapping. The fsspec component is covered in https://github.com/rapidsai/cudf/pull/16166, but that PR currently wastes a lot of host-memory by copying the necessary byte ranges into a larger "proxy" byte range that matches the size of the actual file.

@vuule @vyasr - Does a "sparse" host buffer source seem like a reasonable approach for the near term?