### PR TITLE
WIP: add pandas.to_numeric link

### DIFF
--- a/python/cudf/cudf/core/tools/numeric.py
+++ b/python/cudf/cudf/core/tools/numeric.py
@@ -85,7 +85,7 @@ def to_numeric(arg, errors="raise", downcast=None):
     dtype: float64
 
     .. pandas-compat::
-        **cudf.to_numeric**
+        :func:`pandas.to_numeric`
 
         An important difference from pandas is that this function does not
         accept mixed numeric/non-numeric type sequences.


### PR DESCRIPTION
I feel https://github.com/rapidsai/cudf/pull/15846 was getting too large to review and there also seem to be issues with duplicated pandas-compat notes that may have to be resolved in a separate PR.

This PR gives an example of add a pandas hyperlink to the pandas-compat box.

Happy to follow up https://github.com/rapidsai/cudf/pull/15846 with smaller PRs to help the switch to the new sphinx extension.