### PR TITLE
Fix logic in to_arrow for empty list column

### DIFF
--- a/cpp/src/interop/to_arrow.cu
+++ b/cpp/src/interop/to_arrow.cu
@@ -378,13 +378,22 @@ std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<cudf::list_view>(
   auto children_meta =
     metadata.children_meta.empty() ? std::vector<column_metadata>{{}, {}} : metadata.children_meta;
   auto child_arrays = fetch_child_array(input_view, children_meta, ar_mr, stream);
-  if (child_arrays.empty()) {
+  if (child_arrays.empty() || child_arrays[0]->data()->length == 0) {
     // Empty list will have only one value in offset of 4 bytes
     auto tmp_offset_buffer = allocate_arrow_buffer(sizeof(int32_t), ar_mr);
     memset(tmp_offset_buffer->mutable_data(), 0, sizeof(int32_t));
 
+    std::shared_ptr<arrow::Array> values{nullptr};
+    std::shared_ptr<arrow::DataType> element_type{nullptr};
+    if (child_arrays.empty()) {
+      element_type = arrow::null();
+      values       = std::make_shared<arrow::NullArray>(0);
+    } else {
+      element_type = child_arrays[1]->type();
+      values       = child_arrays[1];
+    }
     return std::make_shared<arrow::ListArray>(
-      arrow::list(arrow::null()), 0, std::move(tmp_offset_buffer), nullptr);
+      arrow::list(element_type), 0, std::move(tmp_offset_buffer), values);
   }
 
   auto offset_buffer = child_arrays[0]->data()->buffers[1];

--- a/cpp/src/interop/to_arrow.cu
+++ b/cpp/src/interop/to_arrow.cu
@@ -383,15 +383,8 @@ std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<cudf::list_view>(
     auto tmp_offset_buffer = allocate_arrow_buffer(sizeof(int32_t), ar_mr);
     memset(tmp_offset_buffer->mutable_data(), 0, sizeof(int32_t));
 
-    std::shared_ptr<arrow::Array> values{nullptr};
-    std::shared_ptr<arrow::DataType> element_type{nullptr};
-    if (child_arrays.empty()) {
-      element_type = arrow::null();
-      values       = std::make_shared<arrow::NullArray>(0);
-    } else {
-      element_type = child_arrays[1]->type();
-      values       = child_arrays[1];
-    }
+    std::shared_ptr<arrow::Array> values = child_arrays.empty() ?  std::make_shared<arrow::NullArray>(0) : child_arrays[1];
+    auto element_type = values->type();
     return std::make_shared<arrow::ListArray>(
       arrow::list(element_type), 0, std::move(tmp_offset_buffer), values);
   }

--- a/cpp/src/interop/to_arrow.cu
+++ b/cpp/src/interop/to_arrow.cu
@@ -383,10 +383,10 @@ std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<cudf::list_view>(
     auto tmp_offset_buffer = allocate_arrow_buffer(sizeof(int32_t), ar_mr);
     memset(tmp_offset_buffer->mutable_data(), 0, sizeof(int32_t));
 
-    std::shared_ptr<arrow::Array> values = child_arrays.empty() ?  std::make_shared<arrow::NullArray>(0) : child_arrays[1];
-    auto element_type = values->type();
+    std::shared_ptr<arrow::Array> data =
+      child_arrays.empty() ? std::make_shared<arrow::NullArray>(0) : child_arrays[1];
     return std::make_shared<arrow::ListArray>(
-      arrow::list(element_type), 0, std::move(tmp_offset_buffer), values);
+      arrow::list(data->type()), 0, std::move(tmp_offset_buffer), data);
   }
 
   auto offset_buffer = child_arrays[0]->data()->buffers[1];


### PR DESCRIPTION
## Description
An empty list column need not have empty children, it just needs to have zero length. In this case, the offsets array will have zero length, and we need to create a temporary buffer.

Now that this branch runs, fix two errors in the construction of the arrow array:

1. The element type, if there are children, should be taken from the child array;
2. If the child arrays are empty, we must make an empty null array, rather than passing a null pointer as the values array, otherwise we hit a segfault inside arrow.

The previous fix in #16201 correctly handled the empty children case (except for point two), but not the first case, which we do here.

Since we we're previously going down this code path (child_arrays was never empty), we never hit the latent segfault from point two.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
