### PR TITLE
Introduce utility function to calculate inputs to rolling_window

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -631,6 +631,7 @@ add_library(
   src/rolling/detail/rolling_collect_list.cu
   src/rolling/detail/rolling_fixed_window.cu
   src/rolling/detail/rolling_variable_window.cu
+  src/rolling/detail/window_utils.cu
   src/rolling/grouped_rolling.cu
   src/rolling/range_window_bounds.cpp
   src/rolling/rolling.cu

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -631,7 +631,7 @@ add_library(
   src/rolling/detail/rolling_collect_list.cu
   src/rolling/detail/rolling_fixed_window.cu
   src/rolling/detail/rolling_variable_window.cu
-  src/rolling/detail/window_utils.cu
+  src/rolling/window_utils.cu
   src/rolling/grouped_rolling.cu
   src/rolling/range_window_bounds.cpp
   src/rolling/rolling.cu

--- a/cpp/include/cudf/detail/rolling.hpp
+++ b/cpp/include/cudf/detail/rolling.hpp
@@ -19,12 +19,12 @@
 #include <cudf/aggregation.hpp>
 #include <cudf/rolling.hpp>
 #include <cudf/types.hpp>
-#include <cudf/utilities/default_stream.hpp>
-#include <cudf/utilities/memory_resource.hpp>
 
+#include <rmm/resource_ref.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
 #include <memory>
+#include <utility>
 
 namespace CUDF_EXPORT cudf {
 namespace detail {
@@ -47,6 +47,15 @@ std::unique_ptr<column> rolling_window(column_view const& input,
                                        rolling_aggregation const& agg,
                                        rmm::cuda_stream_view stream,
                                        rmm::device_async_resource_ref mr);
+
+std::pair<std::unique_ptr<column>, std::unique_ptr<column>> windows_from_offset(
+  column_view const& input,
+  scalar const& length,
+  scalar const& offset,
+  window_type const window_type,
+  bool only_preceding,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
 
 }  // namespace detail
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/include/cudf/rolling.hpp
+++ b/cpp/include/cudf/rolling.hpp
@@ -634,10 +634,11 @@ std::unique_ptr<column> rolling_window(
  *
  * This function computes preceding and following window bounds, suitable for passing to
  * `rolling_window` from a pair of scalars providing the window `length` and the `offset` of the
- * window. Consider an element `p[i]` at index `i` of `input`. The window defined by `length` and
+ * window. Consider an element `pi` at index `i` of `input`. The window defined by `length` and
  * `offset` is the ordered set of indices `Sj[i] := {j : input[j] \in [[pi + offset, ..., pi +
  * offset + length]]}`. The returned `preceding_window` column is an INT32 column whose ith entry is
- * `inf Sj[i]`, the returned `following_window` column contains as its ith entry `sup Sj[i]`.
+ * `inf Sj[i] + 1` (the `+ 1` accounts for the usage in `rolling_window`), the returned
+ * `following_window` column contains as its ith entry `sup Sj[i]`.
  *
  * The endpoints of each window can be controlled via the `window_type` parameter:
  * - If the window is `LEFT_CLOSED`, the condition is `input[j] \in [pi + offset, pi + offset +
@@ -647,7 +648,7 @@ std::unique_ptr<column> rolling_window(
  * - If the window is `CLOSED`, the condition is `input[j] \in [pi + offset, pi + offset + length]`
  * - If the window is `OPEN`, the condition is `input[j] \in (pi + offset, pi + offset + length)`
  *
- * The input column can either be a timestamp type in which caselength and offset must be durations
+ * The input column can either be a timestamp type in which case length and offset must be durations
  * of the same resolution as the timestamp; or a signed index type in which case length and offset
  * must have the same index type.
  *

--- a/cpp/include/cudf/rolling.hpp
+++ b/cpp/include/cudf/rolling.hpp
@@ -655,6 +655,11 @@ std::unique_ptr<column> rolling_window(
  * The input column must be sorted in ascending order (not checked), behaviour is undefined if this
  * is not upheld.
  *
+ * @throw cudf::data_type_error if input column is not a timestamp type or a signed integer type.
+ * @throw std::invalid_argument if the input column is nullable
+ * @throw cudf::data_type_error if the input column, length, and offset arguments have incompatible
+ * types (as described above).
+ *
  * @param[in] input The input column, must be non-nullable.
  * @param[in] length The length of the windows.
  * @param[in] offset The offset of the windows.

--- a/cpp/src/rolling/detail/window_utils.cu
+++ b/cpp/src/rolling/detail/window_utils.cu
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/detail/rolling.hpp>
+#include <cudf/rolling.hpp>
+#include <cudf/utilities/traits.hpp>
+#include <cudf/utilities/type_checks.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/binary_search.h>
+#include <thrust/distance.h>
+
+#include <memory>
+#include <utility>
+
+namespace cudf {
+namespace detail {
+
+enum class which : bool {
+  PRECEDING,
+  FOLLOWING,
+};
+
+template <which Which>
+struct window_offset_impl {
+  template <typename T,
+            CUDF_ENABLE_IF(!(cudf::is_timestamp<T>() or
+                             (cudf::is_index_type<T>() and !cudf::is_unsigned<T>())))>
+  std::unique_ptr<column> operator()(column_view const&,
+                                     scalar const& length,
+                                     scalar const& offset,
+                                     window_type const window_type,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::device_async_resource_ref mr) const
+  {
+    CUDF_FAIL("Unsupported rolling window type.");
+  }
+
+  template <typename InputType, typename OffsetType, typename StrictWeakOrdering>
+  struct distance_kernel {
+    OffsetType const* length;
+    OffsetType const* offset;
+    cudf::column_device_view::const_iterator<InputType> begin;
+    cudf::column_device_view::const_iterator<InputType> end;
+    __device__ size_type operator()(size_type i)
+    {
+      if constexpr (Which == which::PRECEDING) {
+        return 1 + thrust::distance(
+                     thrust::lower_bound(
+                       thrust::seq, begin, end, *(begin + i) + *offset, StrictWeakOrdering{}),
+                     begin + i);
+      } else {
+        return thrust::distance(begin + i,
+                                thrust::lower_bound(thrust::seq,
+                                                    begin,
+                                                    end,
+                                                    *(begin + i) + (*offset + *length),
+                                                    StrictWeakOrdering{})) -
+               1;
+      }
+    }
+  };
+
+  template <typename T, CUDF_ENABLE_IF(cudf::is_timestamp<T>())>
+  std::unique_ptr<column> operator()(column_view const& input,
+                                     scalar const& length,
+                                     scalar const& offset,
+                                     window_type const window_type,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::device_async_resource_ref mr) const
+  {
+    using OffsetType = typename T::duration;
+    CUDF_EXPECTS(cudf::is_duration(length.type()), "Length and offset must be duration types.");
+    CUDF_EXPECTS(length.type().id() == type_to_id<OffsetType>(),
+                 "Length must have same resolution as input.");
+    auto result = cudf::make_numeric_column(
+      cudf::data_type(type_to_id<size_type>()), input.size(), mask_state::UNALLOCATED, stream, mr);
+    auto const d_input_device_view = cudf::column_device_view::create(input, stream);
+    auto input_begin               = d_input_device_view->begin<T>();
+    auto input_end                 = d_input_device_view->end<T>();
+    auto const d_length = dynamic_cast<duration_scalar<OffsetType> const&>(length).data();
+    auto const d_offset = dynamic_cast<duration_scalar<OffsetType> const&>(offset).data();
+    switch (window_type) {
+      case window_type::LEFT_CLOSED:
+      case window_type::OPEN:
+        thrust::copy_n(rmm::exec_policy(stream),
+                       cudf::detail::make_counting_transform_iterator(
+                         0,
+                         distance_kernel<T, OffsetType, thrust::less<T>>{
+                           d_length, d_offset, input_begin, input_end}),
+                       input.size(),
+                       result->mutable_view().begin<size_type>());
+      case window_type::RIGHT_CLOSED:
+      case window_type::CLOSED:
+        thrust::copy_n(rmm::exec_policy(stream),
+                       cudf::detail::make_counting_transform_iterator(
+                         0,
+                         distance_kernel<T, OffsetType, thrust::less_equal<T>>{
+                           d_length, d_offset, input_begin, input_end}),
+                       input.size(),
+                       result->mutable_view().begin<size_type>());
+    }
+    return result;
+  }
+
+  template <typename T, CUDF_ENABLE_IF(cudf::is_index_type<T>() and !cudf::is_unsigned<T>())>
+  std::unique_ptr<column> operator()(column_view const& input,
+                                     scalar const& length,
+                                     scalar const& offset,
+                                     window_type const window_type,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::device_async_resource_ref mr) const
+  {
+    CUDF_EXPECTS(have_same_types(input, length),
+                 "Input column, length, and offset must have same type.");
+    auto result = cudf::make_numeric_column(
+      cudf::data_type(type_to_id<size_type>()), input.size(), mask_state::UNALLOCATED, stream, mr);
+    auto const d_input_device_view = cudf::column_device_view::create(input, stream);
+    auto input_begin               = d_input_device_view->begin<T>();
+    auto input_end                 = d_input_device_view->end<T>();
+    auto const d_length            = dynamic_cast<numeric_scalar<T> const&>(length).data();
+    auto const d_offset            = dynamic_cast<numeric_scalar<T> const&>(offset).data();
+    switch (window_type) {
+      case window_type::LEFT_CLOSED:
+      case window_type::OPEN:
+        thrust::copy_n(
+          rmm::exec_policy(stream),
+          cudf::detail::make_counting_transform_iterator(
+            0, distance_kernel<T, T, thrust::less<T>>{d_length, d_offset, input_begin, input_end}),
+          input.size(),
+          result->mutable_view().begin<size_type>());
+      case window_type::RIGHT_CLOSED:
+      case window_type::CLOSED:
+        thrust::copy_n(rmm::exec_policy(stream),
+                       cudf::detail::make_counting_transform_iterator(
+                         0,
+                         distance_kernel<T, T, thrust::less_equal<T>>{
+                           d_length, d_offset, input_begin, input_end}),
+                       input.size(),
+                       result->mutable_view().begin<size_type>());
+    }
+    return result;
+  }
+};
+
+std::pair<std::unique_ptr<column>, std::unique_ptr<column>> windows_from_offset(
+  column_view const& input,
+  scalar const& length,
+  scalar const& offset,
+  window_type const window_type,
+  bool only_preceding,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  CUDF_EXPECTS(!input.has_nulls(), "Input column cannot have nulls.");
+  CUDF_EXPECTS(have_same_types(length, offset), "Length and offset must have the same type.");
+  auto preceding = type_dispatcher(input.type(),
+                                   window_offset_impl<which::PRECEDING>{},
+                                   input,
+                                   length,
+                                   offset,
+                                   window_type,
+                                   stream,
+                                   mr);
+  if (only_preceding) {
+    return {std::move(preceding), nullptr};
+  } else {
+    auto following = type_dispatcher(input.type(),
+                                     window_offset_impl<which::FOLLOWING>{},
+                                     input,
+                                     length,
+                                     offset,
+                                     window_type,
+                                     stream,
+                                     mr);
+    return {std::move(preceding), std::move(following)};
+  }
+}
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/src/rolling/rolling.cu
+++ b/cpp/src/rolling/rolling.cu
@@ -80,18 +80,4 @@ std::unique_ptr<column> rolling_window(column_view const& input,
     input, preceding_window, following_window, min_periods, agg, stream, mr);
 }
 
-std::pair<std::unique_ptr<column>, std::unique_ptr<column>> windows_from_offset(
-  column_view const& input,
-  scalar const& length,
-  scalar const& offset,
-  window_type const window_type,
-  bool only_preceding,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr)
-{
-  CUDF_FUNC_RANGE();
-  return detail::windows_from_offset(
-    input, length, offset, window_type, only_preceding, stream, mr);
-}
-
 }  // namespace cudf

--- a/cpp/src/rolling/rolling.cu
+++ b/cpp/src/rolling/rolling.cu
@@ -18,9 +18,13 @@
 
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/detail/rolling.hpp>
 #include <cudf/rolling.hpp>
-#include <cudf/utilities/default_stream.hpp>
-#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/resource_ref.hpp>
+
+#include <memory>
+#include <utility>
 
 namespace cudf {
 
@@ -74,6 +78,20 @@ std::unique_ptr<column> rolling_window(column_view const& input,
   CUDF_FUNC_RANGE();
   return detail::rolling_window(
     input, preceding_window, following_window, min_periods, agg, stream, mr);
+}
+
+std::pair<std::unique_ptr<column>, std::unique_ptr<column>> windows_from_offset(
+  column_view const& input,
+  scalar const& length,
+  scalar const& offset,
+  window_type const window_type,
+  bool only_preceding,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::windows_from_offset(
+    input, length, offset, window_type, only_preceding, stream, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/rolling/window_utils.cu
+++ b/cpp/src/rolling/window_utils.cu
@@ -17,6 +17,7 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/rolling.hpp>
 #include <cudf/rolling.hpp>
 #include <cudf/utilities/error.hpp>
@@ -196,4 +197,19 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> windows_from_offset(
   }
 }
 }  // namespace detail
+
+std::pair<std::unique_ptr<column>, std::unique_ptr<column>> windows_from_offset(
+  column_view const& input,
+  scalar const& length,
+  scalar const& offset,
+  window_type const window_type,
+  bool only_preceding,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::windows_from_offset(
+    input, length, offset, window_type, only_preceding, stream, mr);
+}
+
 }  // namespace cudf

--- a/cpp/src/rolling/window_utils.cu
+++ b/cpp/src/rolling/window_utils.cu
@@ -36,7 +36,7 @@
 namespace cudf {
 namespace detail {
 
-enum class which : bool {
+enum class which : int8_t {
   PRECEDING,
   FOLLOWING,
 };

--- a/cpp/src/rolling/window_utils.cu
+++ b/cpp/src/rolling/window_utils.cu
@@ -19,6 +19,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/rolling.hpp>
 #include <cudf/rolling.hpp>
+#include <cudf/utilities/error.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_checks.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>

--- a/cpp/src/rolling/window_utils.cu
+++ b/cpp/src/rolling/window_utils.cu
@@ -29,6 +29,7 @@
 
 #include <thrust/binary_search.h>
 #include <thrust/distance.h>
+#include <thrust/functional.h>
 
 #include <memory>
 #include <utility>
@@ -50,27 +51,27 @@ struct op_impl {};
 
 template <which Which>
 struct op_impl<Which, window_type::LEFT_CLOSED> {
-  using type = std::less<>;
+  using type = thrust::less<>;
 };
 template <which Which>
 struct op_impl<Which, window_type::RIGHT_CLOSED> {
-  using type = std::less_equal<>;
+  using type = thrust::less_equal<>;
 };
 template <>
 struct op_impl<which::PRECEDING, window_type::OPEN> {
-  using type = std::less_equal<>;
+  using type = thrust::less_equal<>;
 };
 template <>
 struct op_impl<which::FOLLOWING, window_type::OPEN> {
-  using type = std::less<>;
+  using type = thrust::less<>;
 };
 template <>
 struct op_impl<which::PRECEDING, window_type::CLOSED> {
-  using type = std::less<>;
+  using type = thrust::less<>;
 };
 template <>
 struct op_impl<which::FOLLOWING, window_type::CLOSED> {
-  using type = std::less_equal<>;
+  using type = thrust::less_equal<>;
 };
 template <which Which, window_type WindowType>
 using op_t = typename op_impl<Which, WindowType>::type;

--- a/cpp/src/rolling/window_utils.cu
+++ b/cpp/src/rolling/window_utils.cu
@@ -218,6 +218,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> windows_from_offset(
                                    stream,
                                    mr);
   if (only_preceding) {
+    stream.synchronize();
     return {std::move(preceding), nullptr};
   } else {
     auto following = type_dispatcher(input.type(),
@@ -228,6 +229,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> windows_from_offset(
                                      window_type,
                                      stream,
                                      mr);
+    stream.synchronize();
     return {std::move(preceding), std::move(following)};
   }
 }
@@ -243,10 +245,8 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> windows_from_offset(
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
-  auto result =
-    detail::windows_from_offset(input, length, offset, window_type, only_preceding, stream, mr);
-  stream.synchronize();
-  return result;
+  return detail::windows_from_offset(
+    input, length, offset, window_type, only_preceding, stream, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/rolling/window_utils.cu
+++ b/cpp/src/rolling/window_utils.cu
@@ -133,7 +133,7 @@ struct window_offset_impl {
     auto const d_length          = dynamic_cast<ScalarType const&>(length).data();
     auto const d_offset          = dynamic_cast<ScalarType const&>(offset).data();
     auto copy_n                  = [&](auto kernel) {
-      thrust::copy_n(rmm::exec_policy(stream),
+      thrust::copy_n(rmm::exec_policy_nosync(stream),
                      cudf::detail::make_counting_transform_iterator(0, kernel),
                      input.size(),
                      result->mutable_view().begin<size_type>());
@@ -235,8 +235,10 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> windows_from_offset(
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
-  return detail::windows_from_offset(
-    input, length, offset, window_type, only_preceding, stream, mr);
+  auto result =
+    detail::windows_from_offset(input, length, offset, window_type, only_preceding, stream, mr);
+  stream.synchronize();
+  return result;
 }
 
 }  // namespace cudf

--- a/cpp/src/rolling/window_utils.cu
+++ b/cpp/src/rolling/window_utils.cu
@@ -38,54 +38,102 @@
 namespace cudf {
 namespace detail {
 
-enum class which : int8_t {
-  PRECEDING,
-  FOLLOWING,
+enum class window_type : std::int8_t {
+  BOUNDED,      // Window covers a finite interval
+  UNBOUNDED,    // Window covers up to first (respectively last) row in the group
+  CURRENT_ROW,  // Window covers all values that are the same as the current row
+};
+
+enum class window_endpoint : std::int8_t {
+  OPEN,    // For BOUNDED windows, the endpoint of the interval is excluded
+  CLOSED,  // For BOUNDED windows, the endpoint of the interval is included
+};
+
+enum class window_side : std::int8_t {
+  PRECEDING,  // Calculating the preceding window
+  FOLLOWING,  // Calculating the following window
 };
 
 /*
- * Select the appropriate ordering comparator for the window type and if we're computing the
- * preceding or following window.
+ * Select the appropriate ordering comparator for the window type and if we're
+ * computing the preceding or following window.
  */
-template <which Which, window_type WindowType>
-struct op_impl {};
+template <window_side Side, window_endpoint Endpoint>
+struct op_impl {
+  using type     = void;
+  using type_rev = void;
+};
 
-template <which Which>
-struct op_impl<Which, window_type::LEFT_CLOSED> {
-  using type = thrust::less<>;
-};
-template <which Which>
-struct op_impl<Which, window_type::RIGHT_CLOSED> {
-  using type = thrust::less_equal<>;
+template <>
+struct op_impl<window_side::PRECEDING, window_endpoint::CLOSED> {
+  using type     = thrust::less<>;
+  using type_rev = thrust::greater<>;
 };
 template <>
-struct op_impl<which::PRECEDING, window_type::OPEN> {
-  using type = thrust::less_equal<>;
+struct op_impl<window_side::FOLLOWING, window_endpoint::OPEN> {
+  using type     = thrust::less<>;
+  using type_rev = thrust::greater<>;
 };
 template <>
-struct op_impl<which::FOLLOWING, window_type::OPEN> {
-  using type = thrust::less<>;
+struct op_impl<window_side::PRECEDING, window_endpoint::OPEN> {
+  using type     = thrust::less_equal<>;
+  using type_rev = thrust::greater_equal<>;
 };
 template <>
-struct op_impl<which::PRECEDING, window_type::CLOSED> {
-  using type = thrust::less<>;
+struct op_impl<window_side::FOLLOWING, window_endpoint::CLOSED> {
+  using type     = thrust::less_equal<>;
+  using type_rev = thrust::greater_equal<>;
 };
-template <>
-struct op_impl<which::FOLLOWING, window_type::CLOSED> {
-  using type = thrust::less_equal<>;
-};
-template <which Which, window_type WindowType>
-using op_t = typename op_impl<Which, WindowType>::type;
 
-template <which Which>
+template <window_side Side, window_endpoint Endpoint, order Order>
+using op_t = std::conditional_t<Order == order::ASCENDING,
+                                typename op_impl<Side, Endpoint>::type,
+                                typename op_impl<Side, Endpoint>::type_rev>;
+
+template <typename T, typename V>
+[[nodiscard]] constexpr T add_sat(T x, V y) noexcept
+{
+  if constexpr (cudf::is_timestamp_t<T>()) {
+    using RepT = typename T::rep;
+    static_assert(cudf::is_duration_t<V>(), "Can only add durations to timestamps");
+    static_assert(cuda::std::is_same_v<typename T::duration, V>,
+                  "Duration resolution must match timestamp resolution");
+    return T{add_sat(x.time_since_epoch(), y)};
+  } else {
+    static_assert(cuda::std::is_same_v<T, V>, "Cannot add mismatching types");
+    if constexpr (cuda::std::is_signed_v<T>) {
+      using U  = std::make_unsigned_t<T>;
+      U ux     = static_cast<U>(x);
+      U uy     = static_cast<U>(y);
+      U result = ux + uy;
+      ux = (ux >> std::numeric_limits<T>::digits) + static_cast<U>(std::numeric_limits<T>::max());
+      // Note: this cast is implementation defined (until C++20) but all
+      // the platforms we care about do the twos-complement thing.
+      return static_cast<T>((ux ^ uy) | ~(uy ^ result)) >= 0 ? ux : result;
+    } else if constexpr (cuda::std::is_unsigned_v<T>) {
+      T result = x + y;
+      // Only way we can overflow is in the positive direction
+      // in which case result will be less than both of x and y.
+      // To saturate, we bit-or with (T)-1 in this case
+      return result | (-static_cast<T>(result < x));
+    } else if constexpr (cudf::is_duration_t<T>()) {
+      return T{add_sat(x.count(), y.count())};
+    } else {
+      static_assert(std::integral_constant<T, false>(),
+                    "Saturating addition only for signed, unsigned integers, "
+                    "durations, or timestamps.");
+    }
+  }
+}
+
+template <window_type Type, window_side Side, order Order>
 struct window_offset_impl {
   template <typename T,
             CUDF_ENABLE_IF(!(cudf::is_timestamp<T>() or
                              (cudf::is_index_type<T>() and !cudf::is_unsigned<T>())))>
   std::unique_ptr<column> operator()(column_view const&,
-                                     scalar const& length,
-                                     scalar const& offset,
-                                     window_type const window_type,
+                                     scalar const& row_delta,
+                                     window_endpoint const endpoint,
                                      rmm::cuda_stream_view stream,
                                      rmm::device_async_resource_ref mr) const
   {
@@ -94,25 +142,60 @@ struct window_offset_impl {
 
   template <typename InputType, typename OffsetType, typename StrictWeakOrdering>
   struct distance_kernel {
-    OffsetType const* length;
-    OffsetType const* offset;
+    // Delta from current row that defines the interval endpoint.
+    // The endpoint is always current_row_value + row_delta, saturated
+    // at the datatype bounds.
+    // Note that these are always value-wise, so if you have a
+    // descending ordered column you often want row_delta to be
+    // negative for the following window.
+    OffsetType const* row_delta;
+    size_type num_rows;
     cudf::column_device_view::const_iterator<InputType> begin;
     cudf::column_device_view::const_iterator<InputType> end;
+
     __device__ size_type operator()(size_type i)
     {
-      if constexpr (Which == which::PRECEDING) {
-        return 1 + thrust::distance(
-                     thrust::lower_bound(
-                       thrust::seq, begin, end, *(begin + i) + *offset, StrictWeakOrdering{}),
-                     begin + i);
-      } else {
+      if constexpr (Side == window_side::PRECEDING && Type == window_type::UNBOUNDED) {
+        return i + 1;
+      } else if constexpr (Side == window_side::PRECEDING && Type == window_type::BOUNDED) {
+        return 1 + thrust::distance(thrust::lower_bound(thrust::seq,
+                                                        begin,
+                                                        end,
+                                                        add_sat(*(begin + i), *row_delta),
+                                                        StrictWeakOrdering{}),
+                                    begin + i);
+      } else if constexpr (Side == window_side::PRECEDING && Type == window_type::CURRENT_ROW) {
+        return 1 +
+               thrust::distance(thrust::lower_bound(
+                                  thrust::seq, begin, begin + i, *(begin + i), thrust::equal_to{}),
+                                begin + i);
+      } else if constexpr (Side == window_side::FOLLOWING && Type == window_type::UNBOUNDED) {
+        return num_rows - i - 1;
+      } else if (Side == window_side::FOLLOWING && Type == window_type::CURRENT_ROW) {
         return thrust::distance(begin + i,
-                                thrust::lower_bound(thrust::seq,
-                                                    begin,
-                                                    end,
-                                                    *(begin + i) + (*offset + *length),
-                                                    StrictWeakOrdering{})) -
+                                thrust::upper_bound(
+                                  thrust::seq, begin + i, end, *(begin + i), thrust::equal_to{})) -
                1;
+      } else if constexpr (Side == window_side::FOLLOWING && Type == window_type::BOUNDED) {
+        if constexpr (Order == order::ASCENDING) {
+          return thrust::distance(begin + i,
+                                  thrust::lower_bound(thrust::seq,
+                                                      begin,
+                                                      end,
+                                                      add_sat(*(begin + i), *row_delta),
+                                                      StrictWeakOrdering{})) -
+                 1;
+        } else {
+          return thrust::distance(begin + i,
+                                  thrust::lower_bound(thrust::seq,
+                                                      begin,
+                                                      end,
+                                                      add_sat(*(begin + i), *row_delta),
+                                                      StrictWeakOrdering{})) -
+                 1;
+        }
+      } else {
+        CUDF_UNREACHABLE("Unhandled combination of window_side and window_type.");
       }
     }
   };
@@ -120,9 +203,8 @@ struct window_offset_impl {
   template <typename T, typename OffsetType, typename ScalarType>
   [[nodiscard]] std::unique_ptr<column> compute_window_bounds(
     column_view const& input,
-    scalar const& length,
-    scalar const& offset,
-    window_type const window_type,
+    scalar const& row_delta,
+    window_endpoint const endpoint,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const
   {
@@ -131,106 +213,416 @@ struct window_offset_impl {
     auto const input_device_view = cudf::column_device_view::create(input, stream);
     auto input_begin             = input_device_view->begin<T>();
     auto input_end               = input_device_view->end<T>();
-    auto const d_length          = dynamic_cast<ScalarType const&>(length).data();
-    auto const d_offset          = dynamic_cast<ScalarType const&>(offset).data();
+    auto const d_row_delta       = dynamic_cast<ScalarType const&>(row_delta).data();
     auto copy_n                  = [&](auto kernel) {
       thrust::copy_n(rmm::exec_policy_nosync(stream),
                      cudf::detail::make_counting_transform_iterator(0, kernel),
                      input.size(),
                      result->mutable_view().begin<size_type>());
     };
-    if (window_type == window_type::LEFT_CLOSED) {
-      copy_n(distance_kernel<T, OffsetType, op_t<Which, window_type::LEFT_CLOSED>>{
-        d_length, d_offset, input_begin, input_end});
-    } else if (window_type == window_type::OPEN) {
-      copy_n(distance_kernel<T, OffsetType, op_t<Which, window_type::OPEN>>{
-        d_length, d_offset, input_begin, input_end});
-    } else if (window_type == window_type::RIGHT_CLOSED) {
-      copy_n(distance_kernel<T, OffsetType, op_t<Which, window_type::RIGHT_CLOSED>>{
-        d_length, d_offset, input_begin, input_end});
-    } else if (window_type == window_type::CLOSED) {
-      copy_n(distance_kernel<T, OffsetType, op_t<Which, window_type::CLOSED>>{
-        d_length, d_offset, input_begin, input_end});
+    if (endpoint == window_endpoint::OPEN) {
+      copy_n(distance_kernel<T, OffsetType, op_t<Side, window_endpoint::OPEN, Order>>{
+        d_row_delta, input.size(), input_begin, input_end});
+    } else if (endpoint == window_endpoint::CLOSED) {
+      copy_n(distance_kernel<T, OffsetType, op_t<Side, window_endpoint::CLOSED, Order>>{
+        d_row_delta, input.size(), input_begin, input_end});
     } else {
       // Unreachable.
-      CUDF_FAIL("Unhandled window type.");
+      CUDF_FAIL("Unhandled window type.", std::invalid_argument);
     }
     return result;
   }
 
   template <typename T, CUDF_ENABLE_IF(cudf::is_timestamp<T>())>
   [[nodiscard]] std::unique_ptr<column> operator()(column_view const& input,
-                                                   scalar const& length,
-                                                   scalar const& offset,
-                                                   window_type const window_type,
+                                                   scalar const& row_delta,
+                                                   window_endpoint const endpoint,
                                                    rmm::cuda_stream_view stream,
                                                    rmm::device_async_resource_ref mr) const
   {
     using OffsetType = typename T::duration;
     using ScalarType = duration_scalar<OffsetType>;
-    CUDF_EXPECTS(cudf::is_duration(length.type()),
+    CUDF_EXPECTS(cudf::is_duration(row_delta.type()),
                  "Length and offset must be duration types.",
                  cudf::data_type_error);
-    CUDF_EXPECTS(length.type().id() == type_to_id<OffsetType>(),
+    CUDF_EXPECTS(row_delta.type().id() == type_to_id<OffsetType>(),
                  "Length must have same the resolution as the input.",
                  cudf::data_type_error);
-    return compute_window_bounds<T, OffsetType, ScalarType>(
-      input, length, offset, window_type, stream, mr);
+    return compute_window_bounds<T, OffsetType, ScalarType>(input, row_delta, endpoint, stream, mr);
   }
 
   template <typename T, CUDF_ENABLE_IF(cudf::is_index_type<T>() and !cudf::is_unsigned<T>())>
   [[nodiscard]] std::unique_ptr<column> operator()(column_view const& input,
-                                                   scalar const& length,
-                                                   scalar const& offset,
-                                                   window_type const window_type,
+                                                   scalar const& row_delta,
+                                                   window_endpoint const endpoint,
                                                    rmm::cuda_stream_view stream,
                                                    rmm::device_async_resource_ref mr) const
   {
     using OffsetType = T;
     using ScalarType = numeric_scalar<OffsetType>;
-    CUDF_EXPECTS(have_same_types(input, length),
+    CUDF_EXPECTS(have_same_types(input, row_delta),
                  "Input column, length, and offset must have the same type.",
                  cudf::data_type_error);
-    return compute_window_bounds<T, OffsetType, ScalarType>(
-      input, length, offset, window_type, stream, mr);
+    return compute_window_bounds<T, OffsetType, ScalarType>(input, row_delta, endpoint, stream, mr);
   }
 };
 
+template <window_type Type, window_side Side, order Order>
+struct grouped_window_offset_impl {
+  template <typename T,
+            CUDF_ENABLE_IF(!(cudf::is_timestamp<T>() or
+                             (cudf::is_index_type<T>() and !cudf::is_unsigned<T>())))>
+  std::unique_ptr<column> operator()(column_view const&,
+                                     device_span<size_type const> const& group_labels,
+                                     device_span<size_type const> const& group_offsets,
+                                     scalar const& row_delta,
+                                     window_endpoint const endpoint,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::device_async_resource_ref mr) const
+  {
+    CUDF_FAIL("Unsupported rolling window type.", cudf::data_type_error);
+  }
+
+  template <typename InputType, typename OffsetType, typename StrictWeakOrdering>
+  struct distance_kernel {
+    device_span<size_type const> group_labels;
+    device_span<size_type const> group_offsets;
+    // Delta from current row that defines the interval endpoint.
+    // The endpoint is always current_row_value + row_delta, saturated
+    // at the datatype bounds.
+    // Note that these are always value-wise, so if you have a
+    // descending ordered column you often want row_delta to be
+    // negative for the following window.
+    OffsetType const* row_delta;
+    size_type num_rows;
+    cudf::column_device_view::const_iterator<InputType> begin;
+    cudf::column_device_view::const_iterator<InputType> end;
+
+    __device__ size_type operator()(size_type i)
+    {
+      auto const group       = group_labels[i];
+      auto const group_start = group_offsets[group];
+      auto const group_end   = group_offsets[group + 1];
+      if constexpr (Side == window_side::PRECEDING && Type == window_type::UNBOUNDED) {
+        return i - group_start + 1;
+      } else if constexpr (Side == window_side::PRECEDING && Type == window_type::BOUNDED) {
+        return 1 + thrust::distance(thrust::lower_bound(thrust::seq,
+                                                        begin + group_start,
+                                                        begin + group_end,
+                                                        add_sat(*(begin + i), *row_delta),
+                                                        StrictWeakOrdering{}),
+                                    begin + i);
+      } else if constexpr (Side == window_side::PRECEDING && Type == window_type::CURRENT_ROW) {
+        return 1 +
+               thrust::distance(
+                 thrust::lower_bound(
+                   thrust::seq, begin + group_start, begin + i, *(begin + i), thrust::equal_to{}),
+                 begin + i);
+      } else if constexpr (Side == window_side::FOLLOWING && Type == window_type::UNBOUNDED) {
+        return group_end - i - 1;
+      } else if (Side == window_side::FOLLOWING && Type == window_type::CURRENT_ROW) {
+        return thrust::distance(
+                 begin + i,
+                 thrust::upper_bound(
+                   thrust::seq, begin + i, begin + group_end, *(begin + i), thrust::equal_to{})) -
+               1;
+      } else if constexpr (Side == window_side::FOLLOWING && Type == window_type::BOUNDED) {
+        if constexpr (Order == order::ASCENDING) {
+          return thrust::distance(begin + i,
+                                  thrust::lower_bound(thrust::seq,
+                                                      begin + group_start,
+                                                      begin + group_end,
+                                                      add_sat(*(begin + i), *row_delta),
+                                                      StrictWeakOrdering{})) -
+                 1;
+        } else {
+          return thrust::distance(begin + i,
+                                  thrust::lower_bound(thrust::seq,
+                                                      begin + group_start,
+                                                      begin + group_end,
+                                                      add_sat(*(begin + i), *row_delta),
+                                                      StrictWeakOrdering{})) -
+                 1;
+        }
+      } else {
+        CUDF_UNREACHABLE("Unhandled combination of window_side and window_type.");
+      }
+    }
+  };
+
+  template <typename T, typename OffsetType, typename ScalarType>
+  [[nodiscard]] std::unique_ptr<column> compute_window_bounds(
+    column_view const& input,
+    device_span<size_type const> const& group_labels,
+    device_span<size_type const> const& group_offsets,
+    scalar const& row_delta,
+    window_endpoint const endpoint,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const
+  {
+    auto result = cudf::make_numeric_column(
+      cudf::data_type(type_to_id<size_type>()), input.size(), mask_state::UNALLOCATED, stream, mr);
+    auto const input_device_view = cudf::column_device_view::create(input, stream);
+    auto input_begin             = input_device_view->begin<T>();
+    auto input_end               = input_device_view->end<T>();
+    auto const d_row_delta       = dynamic_cast<ScalarType const&>(row_delta).data();
+    auto copy_n                  = [&](auto kernel) {
+      thrust::copy_n(rmm::exec_policy_nosync(stream),
+                     cudf::detail::make_counting_transform_iterator(0, kernel),
+                     input.size(),
+                     result->mutable_view().begin<size_type>());
+    };
+    if (endpoint == window_endpoint::OPEN) {
+      copy_n(distance_kernel<T, OffsetType, op_t<Side, window_endpoint::OPEN, Order>>{
+        group_labels, group_offsets, d_row_delta, input.size(), input_begin, input_end});
+    } else if (endpoint == window_endpoint::CLOSED) {
+      copy_n(distance_kernel<T, OffsetType, op_t<Side, window_endpoint::CLOSED, Order>>{
+        group_labels, group_offsets, d_row_delta, input.size(), input_begin, input_end});
+    } else {
+      // Unreachable.
+      CUDF_FAIL("Unhandled window type.", std::invalid_argument);
+    }
+    return result;
+  }
+
+  template <typename T, CUDF_ENABLE_IF(cudf::is_timestamp<T>())>
+  [[nodiscard]] std::unique_ptr<column> operator()(
+    column_view const& input,
+    device_span<size_type const> const& group_labels,
+    device_span<size_type const> const& group_offsets,
+    scalar const& row_delta,
+    window_endpoint const endpoint,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const
+  {
+    using OffsetType = typename T::duration;
+    using ScalarType = duration_scalar<OffsetType>;
+    CUDF_EXPECTS(cudf::is_duration(row_delta.type()),
+                 "Length and offset must be duration types.",
+                 cudf::data_type_error);
+    CUDF_EXPECTS(row_delta.type().id() == type_to_id<OffsetType>(),
+                 "Length must have same the resolution as the input.",
+                 cudf::data_type_error);
+    return compute_window_bounds<T, OffsetType, ScalarType>(
+      input, group_labels, group_offsets, row_delta, endpoint, stream, mr);
+  }
+
+  template <typename T, CUDF_ENABLE_IF(cudf::is_index_type<T>() and !cudf::is_unsigned<T>())>
+  [[nodiscard]] std::unique_ptr<column> operator()(
+    column_view const& input,
+    device_span<size_type const> const& group_labels,
+    device_span<size_type const> const& group_offsets,
+    scalar const& row_delta,
+    window_endpoint const endpoint,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const
+  {
+    using OffsetType = T;
+    using ScalarType = numeric_scalar<OffsetType>;
+    CUDF_EXPECTS(have_same_types(input, row_delta),
+                 "Input column, length, and offset must have the same type.",
+                 cudf::data_type_error);
+    return compute_window_bounds<T, OffsetType, ScalarType>(
+      input, group_labels, group_offsets, row_delta, endpoint, stream, mr);
+  }
+};
+
+template <window_side Side>
+std::unique_ptr<column> dispatch_window_offset_impl(column_view const& input,
+                                                    order order,
+                                                    null_order null_order,
+                                                    scalar const& row_delta,
+                                                    std::tuple<window_type, window_endpoint> window,
+                                                    rmm::cuda_stream_view stream,
+                                                    rmm::device_async_resource_ref mr)
+{
+  auto [type, endpoint] = window;
+  if (type == window_type::UNBOUNDED && order == order::ASCENDING) {
+    return type_dispatcher(input.type(),
+                           window_offset_impl<window_type::UNBOUNDED, Side, order::ASCENDING>{},
+                           input,
+                           row_delta,
+                           endpoint,
+                           stream,
+                           mr);
+  } else if (type == window_type::UNBOUNDED && order == order::DESCENDING) {
+    return type_dispatcher(input.type(),
+                           window_offset_impl<window_type::UNBOUNDED, Side, order::DESCENDING>{},
+                           input,
+                           row_delta,
+                           endpoint,
+                           stream,
+                           mr);
+  } else if (type == window_type::BOUNDED && order == order::ASCENDING) {
+    return type_dispatcher(input.type(),
+                           window_offset_impl<window_type::BOUNDED, Side, order::ASCENDING>{},
+                           input,
+                           row_delta,
+                           endpoint,
+                           stream,
+                           mr);
+  } else if (type == window_type::BOUNDED && order == order::DESCENDING) {
+    return type_dispatcher(input.type(),
+                           window_offset_impl<window_type::BOUNDED, Side, order::DESCENDING>{},
+                           input,
+                           row_delta,
+                           endpoint,
+                           stream,
+                           mr);
+  } else if (type == window_type::CURRENT_ROW) {
+    // Doesn't matter what order things are sorted in for CURRENT_ROW.
+    return type_dispatcher(input.type(),
+                           window_offset_impl<window_type::CURRENT_ROW, Side, order::ASCENDING>{},
+                           input,
+                           row_delta,
+                           endpoint,
+                           stream,
+                           mr);
+  } else {
+    CUDF_FAIL("Unhandled window_type and order combination");
+  }
+}
+template <window_side Side>
+std::unique_ptr<column> grouped_dispatch_window_offset_impl(
+  column_view const& input,
+  device_span<size_type const> const& group_labels,
+  device_span<size_type const> const& group_offsets,
+  order order,
+  null_order null_order,
+  scalar const& row_delta,
+  std::tuple<window_type, window_endpoint> window,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto [type, endpoint] = window;
+  if (type == window_type::UNBOUNDED && order == order::ASCENDING) {
+    return type_dispatcher(
+      input.type(),
+      grouped_window_offset_impl<window_type::UNBOUNDED, Side, order::ASCENDING>{},
+      input,
+      group_labels,
+      group_offsets,
+      row_delta,
+      endpoint,
+      stream,
+      mr);
+  } else if (type == window_type::UNBOUNDED && order == order::DESCENDING) {
+    return type_dispatcher(
+      input.type(),
+      grouped_window_offset_impl<window_type::UNBOUNDED, Side, order::DESCENDING>{},
+      input,
+      group_labels,
+      group_offsets,
+      row_delta,
+      endpoint,
+      stream,
+      mr);
+  } else if (type == window_type::BOUNDED && order == order::ASCENDING) {
+    return type_dispatcher(
+      input.type(),
+      grouped_window_offset_impl<window_type::BOUNDED, Side, order::ASCENDING>{},
+      input,
+      group_labels,
+      group_offsets,
+      row_delta,
+      endpoint,
+      stream,
+      mr);
+  } else if (type == window_type::BOUNDED && order == order::DESCENDING) {
+    return type_dispatcher(
+      input.type(),
+      grouped_window_offset_impl<window_type::BOUNDED, Side, order::DESCENDING>{},
+      input,
+      group_labels,
+      group_offsets,
+      row_delta,
+      endpoint,
+      stream,
+      mr);
+  } else if (type == window_type::CURRENT_ROW) {
+    // Doesn't matter what order things are sorted in for CURRENT_ROW.
+    return type_dispatcher(
+      input.type(),
+      grouped_window_offset_impl<window_type::CURRENT_ROW, Side, order::ASCENDING>{},
+      input,
+      group_labels,
+      group_offsets,
+      row_delta,
+      endpoint,
+      stream,
+      mr);
+  } else {
+    CUDF_FAIL("Unhandled window_type and order combination");
+  }
+}
+
 std::pair<std::unique_ptr<column>, std::unique_ptr<column>> windows_from_offset(
   column_view const& input,
-  scalar const& length,
-  scalar const& offset,
-  window_type const window_type,
-  bool only_preceding,
+  order order,
+  null_order null_order,
+  scalar const& preceding_delta,
+  scalar const& following_delta,
+  std::tuple<window_type, window_endpoint> preceding,
+  std::optional<std::tuple<window_type, window_endpoint>> following,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_EXPECTS(!input.has_nulls(), "Input column cannot have nulls.", std::invalid_argument);
-  CUDF_EXPECTS(have_same_types(length, offset),
-               "Length and offset must have the same type.",
-               cudf::data_type_error);
-  auto preceding = type_dispatcher(input.type(),
-                                   window_offset_impl<which::PRECEDING>{},
-                                   input,
-                                   length,
-                                   offset,
-                                   window_type,
-                                   stream,
-                                   mr);
-  if (only_preceding) {
-    stream.synchronize();
-    return {std::move(preceding), nullptr};
+  auto preceding_col = dispatch_window_offset_impl<window_side::PRECEDING>(
+    input, order, null_order, preceding_delta, preceding, stream, mr);
+  if (following.has_value()) {
+    auto following_col = dispatch_window_offset_impl<window_side::FOLLOWING>(
+      input, order, null_order, following_delta, *following, stream, mr);
+    return {std::move(preceding_col), std::move(following_col)};
   } else {
-    auto following = type_dispatcher(input.type(),
-                                     window_offset_impl<which::FOLLOWING>{},
-                                     input,
-                                     length,
-                                     offset,
-                                     window_type,
-                                     stream,
-                                     mr);
-    stream.synchronize();
-    return {std::move(preceding), std::move(following)};
+    return {std::move(preceding_col), nullptr};
+  }
+}
+
+std::pair<std::unique_ptr<column>, std::unique_ptr<column>> grouped_windows_from_offset(
+  table_view const& group_keys,
+  column_view const& input,
+  order order,
+  null_order null_order,
+  scalar const& preceding_delta,
+  scalar const& following_delta,
+  std::tuple<window_type, window_endpoint> preceding,
+  std::optional<std::tuple<window_type, window_endpoint>> following,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  CUDF_EXPECTS(!input.has_nulls(), "Input column cannot have nulls.", std::invalid_argument);
+  CUDF_EXPECTS(group_keys.num_columns() > 0,
+               "For grouped window calculation, need at least one grouping column",
+               std::invalid_argument);
+  using sort_helper = cudf::groupby::detail::sort::sort_groupby_helper;
+
+  // TODO: handle null precedence?
+  sort_helper helper{group_keys, cudf::null_policy::INCLUDE, cudf::sorted::YES, {}};
+  auto preceding_col =
+    grouped_dispatch_window_offset_impl<window_side::PRECEDING>(input,
+                                                                helper.group_labels(stream),
+                                                                helper.group_offsets(stream),
+                                                                order,
+                                                                null_order,
+                                                                preceding_delta,
+                                                                preceding,
+                                                                stream,
+                                                                mr);
+  if (following.has_value()) {
+    auto following_col =
+      grouped_dispatch_window_offset_impl<window_side::FOLLOWING>(input,
+                                                                  helper.group_labels(stream),
+                                                                  helper.group_offsets(stream),
+                                                                  order,
+                                                                  null_order,
+                                                                  following_delta,
+                                                                  *following,
+                                                                  stream,
+                                                                  mr);
+    return {std::move(preceding_col), std::move(following_col)};
+  } else {
+    return {std::move(preceding_col), nullptr};
   }
 }
 }  // namespace detail

--- a/python/pylibcudf/pylibcudf/libcudf/CMakeLists.txt
+++ b/python/pylibcudf/pylibcudf/libcudf/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 set(cython_sources
     aggregation.pyx binaryop.pyx copying.pyx datetime.pyx expressions.pyx labeling.pyx reduce.pyx
-    replace.pyx round.pyx stream_compaction.pyx types.pyx unary.pyx
+    replace.pyx rolling.pyx round.pyx stream_compaction.pyx types.pyx unary.pyx
 )
 
 set(linked_libraries cudf::cudf)

--- a/python/pylibcudf/pylibcudf/libcudf/rolling.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/rolling.pxd
@@ -1,13 +1,24 @@
 # Copyright (c) 2020-2024, NVIDIA CORPORATION.
+from libc.stdint cimport int32_t
+from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
+from libcpp.utility cimport pair
+
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.aggregation cimport rolling_aggregation
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
+from pylibcudf.libcudf.scalar.scalar cimport scalar
 from pylibcudf.libcudf.types cimport size_type
 
 
 cdef extern from "cudf/rolling.hpp" namespace "cudf" nogil:
+    cpdef enum class window_type(int32_t):
+        LEFT_CLOSED
+        RIGHT_CLOSED
+        CLOSED
+        OPEN
+
     cdef unique_ptr[column] rolling_window(
         column_view source,
         column_view preceding_window,
@@ -21,3 +32,10 @@ cdef extern from "cudf/rolling.hpp" namespace "cudf" nogil:
         size_type following_window,
         size_type min_periods,
         rolling_aggregation& agg) except +libcudf_exception_handler
+
+    cdef pair[unique_ptr[column], unique_ptr[column]] windows_from_offset(
+        column_view input,
+        scalar length,
+        scalar offset,
+        window_type,
+        bool) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/rolling.pxd
+++ b/python/pylibcudf/pylibcudf/rolling.pxd
@@ -1,19 +1,31 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
+from libc.stdint cimport int32_t
+from libcpp cimport bool
 
+from pylibcudf.libcudf.rolling cimport window_type
 from pylibcudf.libcudf.types cimport size_type
 
 from .aggregation cimport Aggregation
 from .column cimport Column
+from .scalar cimport Scalar
 
-ctypedef fused WindowType:
+ctypedef fused WindowArg:
     Column
     size_type
 
 
 cpdef Column rolling_window(
     Column source,
-    WindowType preceding_window,
-    WindowType following_window,
+    WindowArg preceding_window,
+    WindowArg following_window,
     size_type min_periods,
     Aggregation agg,
+)
+
+cpdef tuple[Column, Column] windows_from_offset(
+    Column input,
+    Scalar length,
+    Scalar offset,
+    window_type window_type,
+    bool only_preceding,
 )

--- a/python/pylibcudf/pylibcudf/rolling.pyx
+++ b/python/pylibcudf/pylibcudf/rolling.pyx
@@ -83,6 +83,30 @@ cpdef tuple[Column, Column] windows_from_offset(
     window_type typ,
     bool only_preceding,
 ):
+    """Compute rolling window bounds from a length and offset pair.
+
+    For details, see :cpp:func:`windows_from_offset`.
+
+    Parameters
+    ----------
+    input : Column
+        Column that will be rolled over to define the windows.
+    length : Scalar
+        Length of the window at each element.
+    offset : Scalar
+        Offset to start of the window at each element.
+    typ : WindowType
+        Type of window, indicating which endpoints are contained.
+    only_preceding : bool
+        If true, avoid calculating the following window column.
+
+    Returns
+    -------
+    tuple[Column, Column]
+        A two-tuple of the preceding and following window columns
+        suitable for passing to :func:`rolling_window`.
+        If `only_preceding` is true, then the second entry is ``None``.
+    """
     cdef pair[unique_ptr[column], unique_ptr[column]] result
     with nogil:
         result = cpp_rolling.windows_from_offset(


### PR DESCRIPTION
## Description

Both polars and pandas specify rolling window extents by providing a scalar window length, along with whether the interval is open, closed, left-half-open, or right-half-open, and (for polars) a scalar offset. We currently use a numba kernel to convert this information into the pair of `preceding_window` and `following_window` columns that are the arguments to `rolling_window`. This kernel has a few problems:

- For large window extents it has poor performance scaling as $\mathcal{O}(n * \text{window\\_size})$;
- It doesn't support different end point handling;
- Since pandas doesn't require it (although it kind of does via the `center` parameter), it doesn't support computing `following_window` information;
- If we want to use it in cudf-polars, it introduces another dependency (numba).

To address these concerns, implement a utility function in libcudf that takes window length and offset and computes the matching preceding/following columns. This implementation exploits the fact that the column we are rolling over must be sorted in ascending order and uses `thrust::lower_bound` to provide an $\mathcal{O}(n \log n)$ run time for all window sizes. We also now support all endpoint handling required for cudf-polars.

This provides the infrastructure to work on addressing (at least partially):

- #12774
- #14334
- #15086
- #15119
- #15192

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
