### PR TITLE
Add missing `stream` param to dictionary factory APIs

### DIFF
--- a/cpp/include/cudf/dictionary/dictionary_factories.hpp
+++ b/cpp/include/cudf/dictionary/dictionary_factories.hpp
@@ -87,12 +87,17 @@ std::unique_ptr<column> make_dictionary_column(
  * @param indices_column Indices to use for the new dictionary column.
  * @param null_mask Null mask for the output column.
  * @param null_count Number of nulls for the output column.
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param mr Device memory resource used to allocate the returned column's device memory.
  * @return New dictionary column.
  */
-std::unique_ptr<column> make_dictionary_column(std::unique_ptr<column> keys_column,
-                                               std::unique_ptr<column> indices_column,
-                                               rmm::device_buffer&& null_mask,
-                                               size_type null_count);
+std::unique_ptr<column> make_dictionary_column(
+  std::unique_ptr<column> keys_column,
+  std::unique_ptr<column> indices_column,
+  rmm::device_buffer&& null_mask,
+  size_type null_count,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Construct a dictionary column by taking ownership of the provided keys

--- a/cpp/tests/streams/dictionary_test.cpp
+++ b/cpp/tests/streams/dictionary_test.cpp
@@ -29,7 +29,7 @@ class DictionaryTest : public cudf::test::BaseFixture {};
 TEST_F(DictionaryTest, FactoryColumnViews)
 {
   cudf::test::strings_column_wrapper keys({"aaa", "ccc", "ddd", "www"});
-  cudf::test::fixed_width_column_wrapper<uint32_t> values{2, 0, 3, 1, 2, 2, 2, 3, 0};
+  cudf::test::fixed_width_column_wrapper<uint8_t> values{2, 0, 3, 1, 2, 2, 2, 3, 0};
 
   auto dictionary = cudf::make_dictionary_column(keys, values, cudf::test::get_default_stream());
   cudf::dictionary_column_view view(dictionary->view());
@@ -38,20 +38,36 @@ TEST_F(DictionaryTest, FactoryColumnViews)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(view.indices(), values);
 }
 
+TEST_F(DictionaryTest, FactoryColumns)
+{
+  std::vector<std::string> h_keys{"aaa", "ccc", "ddd", "www"};
+  cudf::test::strings_column_wrapper keys(h_keys.begin(), h_keys.end());
+  std::vector<uint8_t> h_values{2, 0, 3, 1, 2, 2, 2, 3, 0};
+  cudf::test::fixed_width_column_wrapper<uint8_t> values(h_values.begin(), h_values.end());
+
+  auto dictionary = cudf::make_dictionary_column(
+    keys.release(), values.release(), cudf::test::get_default_stream());
+  cudf::dictionary_column_view view(dictionary->view());
+
+  cudf::test::strings_column_wrapper keys_expected(h_keys.begin(), h_keys.end());
+  cudf::test::fixed_width_column_wrapper<uint8_t> values_expected(h_values.begin(), h_values.end());
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(view.keys(), keys_expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(view.indices(), values_expected);
+}
+
 TEST_F(DictionaryTest, FactoryColumnsNullMaskCount)
 {
   std::vector<std::string> h_keys{"aaa", "ccc", "ddd", "www"};
   cudf::test::strings_column_wrapper keys(h_keys.begin(), h_keys.end());
-  std::vector<uint32_t> h_values{2, 0, 3, 1, 2, 2, 2, 3, 0};
-  cudf::test::fixed_width_column_wrapper<uint32_t> values(h_values.begin(), h_values.end());
+  std::vector<uint8_t> h_values{2, 0, 3, 1, 2, 2, 2, 3, 0};
+  cudf::test::fixed_width_column_wrapper<uint8_t> values(h_values.begin(), h_values.end());
 
   auto dictionary = cudf::make_dictionary_column(
     keys.release(), values.release(), rmm::device_buffer{}, 0, cudf::test::get_default_stream());
   cudf::dictionary_column_view view(dictionary->view());
 
   cudf::test::strings_column_wrapper keys_expected(h_keys.begin(), h_keys.end());
-  cudf::test::fixed_width_column_wrapper<uint32_t> values_expected(h_values.begin(),
-                                                                   h_values.end());
+  cudf::test::fixed_width_column_wrapper<uint8_t> values_expected(h_values.begin(), h_values.end());
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(view.keys(), keys_expected);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(view.indices(), values_expected);
 }


### PR DESCRIPTION
## Description
Add `stream` param to dictionary column factory functions. Partially solves #13744

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
