### PR TITLE
Fix docstring of `DataFrame.apply`

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -4525,7 +4525,6 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             If False, the funcs will be passed the whole Series at once.
 
             Currently not supported.
-
         engine : {'python', 'numba'}, default 'python'
             Unused. Added for compatibility with pandas.
         engine_kwargs : dict


### PR DESCRIPTION
## Description
This PR fixes docstring of `DataFrame.apply`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
