### PR TITLE
Rename PrefetchConfig to prefetch_config.

### DIFF
--- a/cpp/include/cudf/utilities/prefetch.hpp
+++ b/cpp/include/cudf/utilities/prefetch.hpp
@@ -31,17 +31,17 @@ namespace detail {
 /**
  * @brief A singleton class that manages the prefetching configuration.
  */
-class PrefetchConfig {
+class prefetch_config {
  public:
-  PrefetchConfig& operator=(const PrefetchConfig&) = delete;
-  PrefetchConfig(const PrefetchConfig&)            = delete;
+  prefetch_config& operator=(const prefetch_config&) = delete;
+  prefetch_config(const prefetch_config&)            = delete;
 
   /**
    * @brief Get the singleton instance of the prefetching configuration.
    *
    * @return The singleton instance of the prefetching configuration.
    */
-  static PrefetchConfig& instance();
+  static prefetch_config& instance();
 
   /**
    * @brief Get the value of a configuration key.
@@ -65,7 +65,7 @@ class PrefetchConfig {
   bool debug{false};
 
  private:
-  PrefetchConfig() = default;                 //< Private constructor to enforce singleton pattern
+  prefetch_config() = default;                //< Private constructor to enforce singleton pattern
   std::map<std::string, bool> config_values;  //< Map of configuration keys to values
 };
 

--- a/cpp/src/column/column_view.cpp
+++ b/cpp/src/column/column_view.cpp
@@ -39,7 +39,7 @@ namespace {
 template <typename ColumnView>
 void prefetch_col_data(ColumnView& col, void const* data_ptr, std::string_view key) noexcept
 {
-  if (cudf::experimental::prefetch::detail::PrefetchConfig::instance().get(key)) {
+  if (cudf::experimental::prefetch::detail::prefetch_config::instance().get(key)) {
     if (cudf::is_fixed_width(col.type())) {
       cudf::experimental::prefetch::detail::prefetch_noexcept(
         key, data_ptr, col.size() * size_of(col.type()), cudf::get_default_stream());

--- a/cpp/src/utilities/prefetch.cpp
+++ b/cpp/src/utilities/prefetch.cpp
@@ -26,13 +26,13 @@ namespace cudf::experimental::prefetch {
 
 namespace detail {
 
-PrefetchConfig& PrefetchConfig::instance()
+prefetch_config& prefetch_config::instance()
 {
-  static PrefetchConfig instance;
+  static prefetch_config instance;
   return instance;
 }
 
-bool PrefetchConfig::get(std::string_view key)
+bool prefetch_config::get(std::string_view key)
 {
   // Default to not prefetching
   if (config_values.find(key.data()) == config_values.end()) {
@@ -40,7 +40,7 @@ bool PrefetchConfig::get(std::string_view key)
   }
   return config_values[key.data()];
 }
-void PrefetchConfig::set(std::string_view key, bool value) { config_values[key.data()] = value; }
+void prefetch_config::set(std::string_view key, bool value) { config_values[key.data()] = value; }
 
 cudaError_t prefetch_noexcept(std::string_view key,
                               void const* ptr,
@@ -48,8 +48,8 @@ cudaError_t prefetch_noexcept(std::string_view key,
                               rmm::cuda_stream_view stream,
                               rmm::cuda_device_id device_id) noexcept
 {
-  if (PrefetchConfig::instance().get(key)) {
-    if (PrefetchConfig::instance().debug) {
+  if (prefetch_config::instance().get(key)) {
+    if (prefetch_config::instance().debug) {
       std::cerr << "Prefetching " << size << " bytes for key " << key << " at location " << ptr
                 << std::endl;
     }
@@ -78,12 +78,15 @@ void prefetch(std::string_view key,
 
 }  // namespace detail
 
-void enable_prefetching(std::string_view key) { detail::PrefetchConfig::instance().set(key, true); }
+void enable_prefetching(std::string_view key)
+{
+  detail::prefetch_config::instance().set(key, true);
+}
 
 void disable_prefetching(std::string_view key)
 {
-  detail::PrefetchConfig::instance().set(key, false);
+  detail::prefetch_config::instance().set(key, false);
 }
 
-void prefetch_debugging(bool enable) { detail::PrefetchConfig::instance().debug = enable; }
+void prefetch_debugging(bool enable) { detail::prefetch_config::instance().debug = enable; }
 }  // namespace cudf::experimental::prefetch


### PR DESCRIPTION
## Description
This PR addresses a comment requesting a rename of `PrefetchConfig` to `prefetch_config`.

See: https://github.com/rapidsai/cudf/pull/16020#discussion_r1686284151

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
