### PR TITLE
fix [tool.setuptools] reference in custreamz config

### DIFF
--- a/python/custreamz/pyproject.toml
+++ b/python/custreamz/pyproject.toml
@@ -57,7 +57,7 @@ zip-safe = false
 [tool.setuptools.dynamic]
 version = {file = "custreamz/VERSION"}
 
-[tools.setuptools.packages.find]
+[tool.setuptools.packages.find]
 include = [
     "custreamz",
     "custreamz.*",


### PR DESCRIPTION
## Description

Noticed this warning in logs from #16183 

> _/python3.10/site-packages/setuptools/config/pyprojecttoml.py:70: _ToolsTypoInMetadata: Ignoring [tools.setuptools] in pyproject.toml, did you mean [tool.setuptools]?_

This fixes that.

## Notes for Reviewers

Intentionally targeting this at 24.10.

This misconfiguration has been in `custreamz` since the 23.04 release ([git blame link](https://github.com/rapidsai/cudf/blame/e6d412cba7c23df7ee500c28257ed9281cea49b9/python/custreamz/pyproject.toml#L60)).

I think the only effect might be that some test files are included in wheels when we don't want to.

I don't think the fix for it needs to be rushed into 24.08.

I searched across RAPIDS in case this was copied from somewhere else... don't see any other instances of this typo that need to be fixed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
