### PR TITLE
Require fixed width types for casting in `cudf-polars`

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -1196,9 +1196,6 @@ class Cast(Expr):
             raise NotImplementedError(
                 f"Can't cast {self.dtype.id().name} to {value.dtype.id().name}"
             )
-            raise NotImplementedError(
-                f"Can't cast {self.dtype.id().name} to {value.dtype.id().name}"
-            )
 
     def do_evaluate(
         self,

--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -1188,7 +1188,11 @@ class Cast(Expr):
     def __init__(self, dtype: plc.DataType, value: Expr) -> None:
         super().__init__(dtype)
         self.children = (value,)
-        if not plc.unary.is_supported_cast(self.dtype, value.dtype):
+        if (
+            not plc.traits.is_fixed_width(self.dtype)
+            and plc.traits.is_fixed_width(value.dtype)
+            and plc.unary.is_supported_cast(self.dtype, value.dtype)
+        ):
             raise NotImplementedError(
                 f"Can't cast {self.dtype.id().name} to {value.dtype.id().name}"
             )

--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -1188,11 +1188,14 @@ class Cast(Expr):
     def __init__(self, dtype: plc.DataType, value: Expr) -> None:
         super().__init__(dtype)
         self.children = (value,)
-        if (
-            not plc.traits.is_fixed_width(self.dtype)
+        if not (
+            plc.traits.is_fixed_width(self.dtype)
             and plc.traits.is_fixed_width(value.dtype)
-            and plc.unary.is_supported_cast(self.dtype, value.dtype)
+            and plc.unary.is_supported_cast(value.dtype, self.dtype)
         ):
+            raise NotImplementedError(
+                f"Can't cast {self.dtype.id().name} to {value.dtype.id().name}"
+            )
             raise NotImplementedError(
                 f"Can't cast {self.dtype.id().name} to {value.dtype.id().name}"
             )

--- a/python/cudf_polars/tests/expressions/test_numeric_binops.py
+++ b/python/cudf_polars/tests/expressions/test_numeric_binops.py
@@ -6,7 +6,10 @@ import pytest
 
 import polars as pl
 
-from cudf_polars.testing.asserts import assert_gpu_result_equal
+from cudf_polars.testing.asserts import (
+    assert_gpu_result_equal,
+    assert_ir_translation_raises,
+)
 
 dtypes = [
     pl.Int8,
@@ -111,3 +114,12 @@ def test_binop_with_scalar(left_scalar, right_scalar):
     q = df.select(lop / rop)
 
     assert_gpu_result_equal(q)
+
+
+def test_numeric_to_string_cast_fails():
+    df = pl.DataFrame(
+        {"a": [1, 1, 2, 3, 3, 4, 1], "b": [None, 2, 3, 4, 5, 6, 7]}
+    ).lazy()
+    q = df.select(pl.col("a").cast(pl.String))
+
+    assert_ir_translation_raises(q, NotImplementedError)

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -34,7 +34,9 @@ def ldf(with_nulls):
     if with_nulls:
         a[4] = None
         a[-3] = None
-    return pl.LazyFrame({"a": a, "b": range(len(a))})
+    return pl.LazyFrame(
+        {"a": a, "b": range(len(a)), "c": [str(i) for i in range(len(a))]}
+    )
 
 
 slice_cases = [
@@ -84,7 +86,7 @@ def test_contains_re_non_strict_raises(ldf):
 
 
 def test_contains_re_non_literal_raises(ldf):
-    q = ldf.select(pl.col("a").str.contains(pl.col("b"), literal=False))
+    q = ldf.select(pl.col("a").str.contains(pl.col("c"), literal=False))
 
     assert_ir_translation_raises(q, NotImplementedError)
 


### PR DESCRIPTION
Fixes a bug where numeric <-> string casts are not being properly rejected at the cudf-polars level. 