### PR TITLE
Add about rmm modes in `cudf.pandas` docs

### DIFF
--- a/docs/cudf/source/cudf_pandas/how-it-works.md
+++ b/docs/cudf/source/cudf_pandas/how-it-works.md
@@ -41,13 +41,13 @@ pandas-specific semantics like default sort ordering.
 `cudf.pandas` uses a managed memory pool by default. This allows `cudf.pandas` to process datasets larger than the memory of the GPU(s) it is running on. Managed memory prefetching is also enabled by default to improve memory access performance. For more information on CUDA Unified Memory (managed memory), performance and prefetching, see [this NVIDIA Developer blog post](https://developer.nvidia.com/blog/improving-gpu-memory-oversubscription-performance/).
 prefetching <<LINK to prefetch tutorial/demo>>.
 
-Other memory allocators can be used by changing the environment
-variable `CUDF_PANDAS_RMM_MODE` to one of the following.
-
 Pool allocators improve allocation performance. Without using one, memory
 allocation may be a bottleneck depending on the workload. Managed memory
 enables oversubscribing GPU memory. This allows cudf.pandas to process
 data larger than GPU memory in many cases, without CPU (Pandas) fallback.
+
+Other memory allocators can be used by changing the environment
+variable `CUDF_PANDAS_RMM_MODE` to one of the following.
 
 1. "managed_pool" (default): CUDA Unified Memory (managed memory) with RMM's asynchronous pool allocator.
 2. "managed": CUDA Unified Memory, (managed memory) with no pool allocator.

--- a/docs/cudf/source/cudf_pandas/how-it-works.md
+++ b/docs/cudf/source/cudf_pandas/how-it-works.md
@@ -51,6 +51,6 @@ data larger than GPU memory in many cases, without CPU (Pandas) fallback.
 
 1. "managed_pool" (default): CUDA Unified Memory (managed memory) with RMM's asynchronous pool allocator.
 2. "managed": CUDA Unified Memory, (managed memory) with no pool allocator.
-3. "async": CUDA's built-in pool asynchronous pool allocator with normal CUDA device memory. 
+3. "async": CUDA's built-in pool asynchronous pool allocator with normal CUDA device memory.
 4. "pool": RMM's asynchronous pool allocator with normal CUDA device memory.
 5. "cuda": normal CUDA device memory with no pool allocator.

--- a/docs/cudf/source/cudf_pandas/how-it-works.md
+++ b/docs/cudf/source/cudf_pandas/how-it-works.md
@@ -37,8 +37,7 @@ When using `cudf.pandas`, cuDF's [pandas compatibility
 mode](api.options) is automatically enabled, ensuring consistency with
 pandas-specific semantics like default sort ordering.
 
-
-`cudf.pandas` uses a managed memory pool by default. This allows `cudf.pandas` to process datasets larger than the memory of the GPU(s) it is running on. Managed memory prefetching is also enabled by default to improve memory access performance. For more information on CUDA Unified Memory (managed memory), performance and prefetching, see [this NVIDIA Developer blog post](https://developer.nvidia.com/blog/improving-gpu-memory-oversubscription-performance/).
+`cudf.pandas` uses a managed memory pool by default. This allows `cudf.pandas` to process datasets larger than the memory of the GPU it is running on. Managed memory prefetching is also enabled by default to improve memory access performance. For more information on CUDA Unified Memory (managed memory), performance, and prefetching, see [this NVIDIA Developer blog post](https://developer.nvidia.com/blog/improving-gpu-memory-oversubscription-performance/).
 
 Pool allocators improve allocation performance. Without using one, memory
 allocation may be a bottleneck depending on the workload. Managed memory

--- a/docs/cudf/source/cudf_pandas/how-it-works.md
+++ b/docs/cudf/source/cudf_pandas/how-it-works.md
@@ -39,7 +39,6 @@ pandas-specific semantics like default sort ordering.
 
 
 `cudf.pandas` uses a managed memory pool by default. This allows `cudf.pandas` to process datasets larger than the memory of the GPU(s) it is running on. Managed memory prefetching is also enabled by default to improve memory access performance. For more information on CUDA Unified Memory (managed memory), performance and prefetching, see [this NVIDIA Developer blog post](https://developer.nvidia.com/blog/improving-gpu-memory-oversubscription-performance/).
-prefetching <<LINK to prefetch tutorial/demo>>.
 
 Pool allocators improve allocation performance. Without using one, memory
 allocation may be a bottleneck depending on the workload. Managed memory

--- a/docs/cudf/source/cudf_pandas/how-it-works.md
+++ b/docs/cudf/source/cudf_pandas/how-it-works.md
@@ -38,14 +38,19 @@ mode](api.options) is automatically enabled, ensuring consistency with
 pandas-specific semantics like default sort ordering.
 
 
-`cudf.pandas` uses a managed pool memory by default, that will also enable
+`cudf.pandas` uses a managed memory pool by default. This allows `cudf.pandas` to process datasets larger than the memory of the GPU(s) it is running on. Managed memory prefetching is also enabled by default to improve memory access performance. For more information on CUDA Unified Memory (managed memory), performance and prefetching, see [this NVIDIA Developer blog post](https://developer.nvidia.com/blog/improving-gpu-memory-oversubscription-performance/).
 prefetching <<LINK to prefetch tutorial/demo>>.
 
-There are various memory allocators that can be used by changing the environment
-variable `CUDF_PANDAS_RMM_MODE`. It supports:
+Other memory allocators can be used by changing the environment
+variable `CUDF_PANDAS_RMM_MODE` to one of the following.
 
-1. "pool"
-2. "async"
-3. "managed" (default)
-4. "managed_pool"
-5. "cuda"
+Pool allocators improve allocation performance. Without using one, memory 
+allocation may be a bottleneck depending on the workload. Managed memory
+enables oversubscribing GPU memory. This allows cudf.pandas to process 
+data larger than GPU memory in many cases, without CPU (Pandas) fallback.
+
+1. "managed_pool" (default): CUDA Unified Memory (managed memory) with RMM's asynchronous pool allocator.
+2. "managed": CUDA Unified Memory, (managed memory) with no pool allocator.
+3. "async": CUDA's built-in pool asynchronous pool allocator with normal CUDA device memory. 
+4. "pool": RMM's asynchronous pool allocator with normal CUDA device memory.
+5. "cuda": normal CUDA device memory with no pool allocator.

--- a/docs/cudf/source/cudf_pandas/how-it-works.md
+++ b/docs/cudf/source/cudf_pandas/how-it-works.md
@@ -36,3 +36,16 @@ transfers.
 When using `cudf.pandas`, cuDF's [pandas compatibility
 mode](api.options) is automatically enabled, ensuring consistency with
 pandas-specific semantics like default sort ordering.
+
+
+`cudf.pandas` uses a managed pool memory by default, that will also enable
+prefetching <<LINK to prefetch tutorial/demo>>.
+
+There are various memory allocators that can be used by changing the environment
+variable `CUDF_PANDAS_RMM_MODE`. It supports:
+
+1. "pool"
+2. "async"
+3. "managed" (default)
+4. "managed_pool"
+5. "cuda"

--- a/docs/cudf/source/cudf_pandas/how-it-works.md
+++ b/docs/cudf/source/cudf_pandas/how-it-works.md
@@ -44,9 +44,9 @@ prefetching <<LINK to prefetch tutorial/demo>>.
 Other memory allocators can be used by changing the environment
 variable `CUDF_PANDAS_RMM_MODE` to one of the following.
 
-Pool allocators improve allocation performance. Without using one, memory 
+Pool allocators improve allocation performance. Without using one, memory
 allocation may be a bottleneck depending on the workload. Managed memory
-enables oversubscribing GPU memory. This allows cudf.pandas to process 
+enables oversubscribing GPU memory. This allows cudf.pandas to process
 data larger than GPU memory in many cases, without CPU (Pandas) fallback.
 
 1. "managed_pool" (default): CUDA Unified Memory (managed memory) with RMM's asynchronous pool allocator.


### PR DESCRIPTION
## Description
This PR adds user facing docs for rmm memory modes and prefetching.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
