### PR TITLE
Fix nightly memcheck error for empty STREAM_INTEROP_TEST

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -689,7 +689,10 @@ ConfigureTest(STREAM_DICTIONARY_TEST streams/dictionary_test.cpp STREAM_MODE tes
 ConfigureTest(STREAM_FILLING_TEST streams/filling_test.cpp STREAM_MODE testing)
 ConfigureTest(STREAM_GROUPBY_TEST streams/groupby_test.cpp STREAM_MODE testing)
 ConfigureTest(STREAM_HASHING_TEST streams/hash_test.cpp STREAM_MODE testing)
-ConfigureTest(STREAM_INTEROP_TEST streams/interop_test.cpp STREAM_MODE testing)
+# Deprecation from 16297 and fixes in 16379 caused this test to be empty This will be reenabled once
+# the deprecated APIs have been replaced in 24.10.
+#
+# ConfigureTest(STREAM_INTEROP_TEST streams/interop_test.cpp STREAM_MODE testing)
 ConfigureTest(STREAM_JSONIO_TEST streams/io/json_test.cpp STREAM_MODE testing)
 ConfigureTest(STREAM_LABELING_BINS_TEST streams/labeling_bins_test.cpp STREAM_MODE testing)
 ConfigureTest(STREAM_LISTS_TEST streams/lists_test.cpp STREAM_MODE testing)


### PR DESCRIPTION
## Description
The `STREAM_INTEROP_TEST` code was commented out in #16379 so the `compute-sanitizer` returns an error for this test in the nightly cpp-memcheck tests. https://github.com/rapidsai/cudf/actions/runs/10107041505/job/27950193878#step:9:62177

This PR comments out the empty test so it is not built. The test will be re-enabled in a future release when the deprecated functions are replaced.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
