### PR TITLE
Raise instances of NotImplementedError

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -43,17 +43,17 @@ class BaseIndex(Serializable):
 
     @property
     def _columns(self) -> tuple[Any, ...]:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @cached_property
     def _values(self) -> ColumnBase:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def copy(self, deep: bool = True) -> Self:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def __len__(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def __bool__(self):
         raise ValueError(
@@ -96,18 +96,18 @@ class BaseIndex(Serializable):
         >>> index.astype('float64')
         Index([1.0, 2.0, 3.0], dtype='float64')
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def argsort(self, *args, **kwargs) -> cupy.ndarray:
         """Return the integer indices that would sort the index.
 
         Parameters vary by subclass.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @property
     def dtype(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @property
     def empty(self):
@@ -116,7 +116,7 @@ class BaseIndex(Serializable):
     @property
     def is_unique(self):
         """Return if the index has unique values."""
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def memory_usage(self, deep=False):
         """Return the memory usage of an object.
@@ -131,7 +131,7 @@ class BaseIndex(Serializable):
         -------
         The total bytes used.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def tolist(self):  # noqa: D102
         raise TypeError(
@@ -145,7 +145,7 @@ class BaseIndex(Serializable):
     @property
     def name(self):
         """Returns the name of the Index."""
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @property  # type: ignore
     def ndim(self) -> int:  # noqa: D401
@@ -162,11 +162,11 @@ class BaseIndex(Serializable):
             True if "other" is an Index and it has the same elements
             as calling index; False otherwise.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def shift(self, periods=1, freq=None):
         """Not yet implemented"""
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @property
     def shape(self):
@@ -176,11 +176,11 @@ class BaseIndex(Serializable):
     @property
     def str(self):
         """Not yet implemented."""
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @property
     def values(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def get_indexer(self, target, method=None, limit=None, tolerance=None):
         """
@@ -220,7 +220,7 @@ class BaseIndex(Serializable):
         >>> index.get_indexer(['a', 'b', 'x'])
         array([ 1,  2, -1], dtype=int32)
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def get_loc(self, key):
         """
@@ -269,11 +269,11 @@ class BaseIndex(Serializable):
 
     def max(self):
         """The maximum value of the index."""
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def min(self):
         """The minimum value of the index."""
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def __getitem__(self, key):
         raise NotImplementedError()
@@ -283,7 +283,7 @@ class BaseIndex(Serializable):
         return item in self._values
 
     def _copy_type_metadata(self: Self, other: Self) -> Self:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def get_level_values(self, level):
         """
@@ -367,7 +367,7 @@ class BaseIndex(Serializable):
         methods using this method to replace or handle representation
         of the actual types correctly.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @property
     def is_monotonic_increasing(self):
@@ -377,7 +377,7 @@ class BaseIndex(Serializable):
         -------
         bool
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @property
     def is_monotonic_decreasing(self):
@@ -387,7 +387,7 @@ class BaseIndex(Serializable):
         -------
         bool
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @property
     def hasnans(self):
@@ -418,7 +418,7 @@ class BaseIndex(Serializable):
         >>> index.hasnans
         True
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @property
     def nlevels(self):
@@ -518,10 +518,10 @@ class BaseIndex(Serializable):
             A copy of self with values replaced from other
             where the condition is False.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def factorize(self, sort: bool = False, use_na_sentinel: bool = True):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def union(self, other, sort=None):
         """
@@ -858,21 +858,21 @@ class BaseIndex(Serializable):
 
     def to_arrow(self):
         """Convert to a suitable Arrow object."""
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def to_cupy(self):
         """Convert to a cupy array."""
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def to_numpy(self):
         """Convert to a numpy array."""
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def any(self):
         """
         Return whether any elements is True in Index.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def isna(self):
         """
@@ -889,7 +889,7 @@ class BaseIndex(Serializable):
             A boolean array to indicate which entries are NA.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def notna(self):
         """
@@ -905,7 +905,7 @@ class BaseIndex(Serializable):
         numpy.ndarray[bool]
             A boolean array to indicate which entries are not NA.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def to_pandas(self, *, nullable: bool = False, arrow_type: bool = False):
         """
@@ -943,7 +943,7 @@ class BaseIndex(Serializable):
         >>> idx.to_pandas(arrow_type=True)
         Index([-3, 10, 15, 20], dtype='int64[pyarrow]')
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def isin(self, values):
         """Return a boolean array where the index values are in values.
@@ -977,7 +977,7 @@ class BaseIndex(Serializable):
         # supposed to be passed, only scalars throw errors. Other types (like
         # dicts) just transparently return False (see the implementation of
         # ColumnBase.isin).
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def unique(self):
         """
@@ -987,7 +987,7 @@ class BaseIndex(Serializable):
         -------
         Index without duplicates
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def to_series(self, index=None, name=None):
         """
@@ -1048,7 +1048,7 @@ class BaseIndex(Serializable):
         >>> idx.append([other, other])
         Index([1, 2, 10, 100, 200, 400, 50, 200, 400, 50], dtype='int64')
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def difference(self, other, sort=None):
         """
@@ -1192,7 +1192,7 @@ class BaseIndex(Serializable):
         return self._is_numeric()
 
     def _is_numeric(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def is_boolean(self):
         """
@@ -1237,7 +1237,7 @@ class BaseIndex(Serializable):
         return self._is_boolean()
 
     def _is_boolean(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def is_integer(self):
         """
@@ -1282,7 +1282,7 @@ class BaseIndex(Serializable):
         return self._is_integer()
 
     def _is_integer(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def is_floating(self):
         """
@@ -1334,7 +1334,7 @@ class BaseIndex(Serializable):
         return self._is_floating()
 
     def _is_floating(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def is_object(self):
         """
@@ -1380,7 +1380,7 @@ class BaseIndex(Serializable):
         return self._is_object()
 
     def _is_object(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def is_categorical(self):
         """
@@ -1433,7 +1433,7 @@ class BaseIndex(Serializable):
         return self._is_categorical()
 
     def _is_categorical(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def is_interval(self):
         """
@@ -1480,7 +1480,7 @@ class BaseIndex(Serializable):
         return self._is_interval()
 
     def _is_interval(self):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def _union(self, other, sort=None):
         # TODO: As a future optimization we should explore
@@ -1759,7 +1759,7 @@ class BaseIndex(Serializable):
         -------
         Column of indices
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def find_label_range(self, loc: slice) -> slice:
         """
@@ -1833,7 +1833,7 @@ class BaseIndex(Serializable):
         As a precondition the index must be sorted in the same order
         as requested by the `ascending` flag.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def get_slice_bound(
         self,
@@ -2183,7 +2183,7 @@ class BaseIndex(Serializable):
                     33, 33, 33, 33, 55, 55, 55, 55, 55],
                 dtype='int64')
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def _new_index_for_reset_index(
         self, levels: tuple | None, name
@@ -2202,7 +2202,7 @@ class BaseIndex(Serializable):
         )
 
     def _split(self, splits):
-        raise NotImplementedError
+        raise NotImplementedError()
 
 
 def _get_result_name(left_name, right_name):

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -236,7 +236,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         replacement: ColumnLike,
         all_nan: bool = False,
     ) -> Self:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def clip(self, lo: ScalarLike, hi: ScalarLike) -> ColumnBase:
         return libcudf.replace.clip(self, lo, hi)
@@ -1069,30 +1069,30 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
     def as_numerical_column(
         self, dtype: Dtype
     ) -> "cudf.core.column.NumericalColumn":
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def as_datetime_column(
         self, dtype: Dtype
     ) -> cudf.core.column.DatetimeColumn:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def as_interval_column(
         self, dtype: Dtype
     ) -> "cudf.core.column.IntervalColumn":
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def as_timedelta_column(
         self, dtype: Dtype
     ) -> cudf.core.column.TimeDeltaColumn:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def as_string_column(self) -> cudf.core.column.StringColumn:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def as_decimal_column(
         self, dtype: Dtype
     ) -> "cudf.core.column.decimal.DecimalBaseColumn":
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def apply_boolean_mask(self, mask) -> ColumnBase:
         mask = as_column(mask)
@@ -1283,7 +1283,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
     def normalize_binop_value(
         self, other: ScalarLike
     ) -> ColumnBase | ScalarLike:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def _reduce(
         self,

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -261,7 +261,7 @@ class Frame(BinaryOperand, Scannable):
         -------
         The total bytes used.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @_performance_tracking
     def __len__(self) -> int:
@@ -608,7 +608,7 @@ class Frame(BinaryOperand, Scannable):
             2    <NA>
             dtype: int64
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @_performance_tracking
     def fillna(

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -1870,7 +1870,7 @@ class GroupBy(Serializable, Reducible, Scannable):
 
         """
         if exclude is not None and include is not None:
-            raise NotImplementedError
+            raise NotImplementedError()
 
         res = self.agg(
             [

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2839,7 +2839,7 @@ class IndexedFrame(Frame):
         >>> s.memory_usage(index=False)
         24
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def hash_values(self, method="murmur3", seed=None):
         """Compute the hash of values in this column.
@@ -3461,7 +3461,7 @@ class IndexedFrame(Frame):
         2       3       5
         3       4       6
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @acquire_spill_lock()
     @_performance_tracking

--- a/python/cudf/cudf/core/mixins/binops.py
+++ b/python/cudf/cudf/core/mixins/binops.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 from .mixin_factory import _create_delegating_mixin
 
@@ -59,7 +59,7 @@ def _binaryop(self, other, op: str):
     Must be overridden by subclasses, the default implementation raises a
     NotImplementedError.
     """
-    raise NotImplementedError
+    raise NotImplementedError()
 
 
 def _check_reflected_op(op):

--- a/python/cudf/cudf/core/mixins/mixin_factory.py
+++ b/python/cudf/cudf/core/mixins/mixin_factory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 import inspect
 
@@ -246,7 +246,7 @@ def _create_delegating_mixin(
     OperationMixin.__doc__ = docstring
 
     def _operation(self, op: str, *args, **kwargs):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     _operation.__name__ = base_operation_name
     _operation.__qualname__ = ".".join([mixin_name, base_operation_name])


### PR DESCRIPTION
## Description
Currently there are several places in cuDF where we are raising the *class* `NotImplementedError` rather than an *instance* of the class. This PR fixes those.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
