### PR TITLE
Support thread-safe for `prefetch_config::get` and `prefetch_config::set`

### DIFF
--- a/cpp/include/cudf/utilities/prefetch.hpp
+++ b/cpp/include/cudf/utilities/prefetch.hpp
@@ -21,7 +21,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <map>
-#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
 
@@ -53,7 +53,7 @@ class prefetch_config {
    * @param key The configuration key.
    * @return The value of the configuration key.
    */
-  bool get(std::string_view key) const;
+  bool get(std::string_view key);
   /**
    * @brief Set the value of a configuration key.
    *
@@ -73,7 +73,7 @@ class prefetch_config {
  private:
   prefetch_config() = default;                //< Private constructor to enforce singleton pattern
   std::map<std::string, bool> config_values;  //< Map of configuration keys to values
-  std::mutex config_mtx;                      //< Mutex for thread-safe config access
+  std::shared_mutex config_mtx;               //< Mutex for thread-safe config access
 };
 
 /**

--- a/cpp/include/cudf/utilities/prefetch.hpp
+++ b/cpp/include/cudf/utilities/prefetch.hpp
@@ -21,6 +21,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <map>
+#include <mutex>
 #include <string>
 #include <string_view>
 
@@ -47,12 +48,16 @@ class prefetch_config {
   /**
    * @brief Get the value of a configuration key.
    *
+   * If the key does not exist, a `false` value will be returned.
+   *
    * @param key The configuration key.
    * @return The value of the configuration key.
    */
-  bool get(std::string_view key);
+  bool get(std::string_view key) const;
   /**
    * @brief Set the value of a configuration key.
+   *
+   * This is a thread-safe operation.
    *
    * @param key The configuration key.
    * @param value The value to set.
@@ -68,6 +73,7 @@ class prefetch_config {
  private:
   prefetch_config() = default;                //< Private constructor to enforce singleton pattern
   std::map<std::string, bool> config_values;  //< Map of configuration keys to values
+  std::mutex config_mtx;                      //< Mutex for thread-safe config access
 };
 
 /**

--- a/cpp/src/utilities/prefetch.cpp
+++ b/cpp/src/utilities/prefetch.cpp
@@ -36,7 +36,7 @@ bool prefetch_config::get(std::string_view key) const
 {
   // Default to not prefetching
   if (config_values.find(key.data()) == config_values.end()) { return false; }
-  return config_values[key.data()];
+  return config_values.get(key.data());
 }
 
 void prefetch_config::set(std::string_view key, bool value)

--- a/cpp/src/utilities/prefetch.cpp
+++ b/cpp/src/utilities/prefetch.cpp
@@ -34,9 +34,10 @@ prefetch_config& prefetch_config::instance()
 
 bool prefetch_config::get(std::string_view key) const
 {
+  std::scoped_lock lock(config_mtx);
   // Default to not prefetching
   if (config_values.find(key.data()) == config_values.end()) { return false; }
-  return config_values.get(key.data());
+  return config_values.at(key.data());
 }
 
 void prefetch_config::set(std::string_view key, bool value)

--- a/cpp/src/utilities/prefetch.cpp
+++ b/cpp/src/utilities/prefetch.cpp
@@ -35,10 +35,8 @@ prefetch_config& prefetch_config::instance()
 bool prefetch_config::get(std::string_view key)
 {
   std::shared_lock<std::shared_mutex> lock(config_mtx);
-  if (config_values.find(key.data()) == config_values.end()) {
-    return false;  // default to not prefetching
-  }
-  return config_values.at(key.data());
+  auto const it = config_values.find(key.data());
+  return it == config_values.end() ? false : it->second;  // default to not prefetching
 }
 
 void prefetch_config::set(std::string_view key, bool value)

--- a/cpp/src/utilities/prefetch.cpp
+++ b/cpp/src/utilities/prefetch.cpp
@@ -32,15 +32,18 @@ prefetch_config& prefetch_config::instance()
   return instance;
 }
 
-bool prefetch_config::get(std::string_view key)
+bool prefetch_config::get(std::string_view key) const
 {
   // Default to not prefetching
-  if (config_values.find(key.data()) == config_values.end()) {
-    return (config_values[key.data()] = false);
-  }
+  if (config_values.find(key.data()) == config_values.end()) { return false; }
   return config_values[key.data()];
 }
-void prefetch_config::set(std::string_view key, bool value) { config_values[key.data()] = value; }
+
+void prefetch_config::set(std::string_view key, bool value)
+{
+  std::scoped_lock lock(config_mtx);
+  config_values[key.data()] = value;
+}
 
 cudaError_t prefetch_noexcept(std::string_view key,
                               void const* ptr,

--- a/cpp/src/utilities/prefetch.cpp
+++ b/cpp/src/utilities/prefetch.cpp
@@ -32,17 +32,18 @@ prefetch_config& prefetch_config::instance()
   return instance;
 }
 
-bool prefetch_config::get(std::string_view key) const
+bool prefetch_config::get(std::string_view key)
 {
-  std::scoped_lock lock(config_mtx);
-  // Default to not prefetching
-  if (config_values.find(key.data()) == config_values.end()) { return false; }
+  std::shared_lock<std::shared_mutex> lock(config_mtx);
+  if (config_values.find(key.data()) == config_values.end()) {
+    return false;  // default to not prefetching
+  }
   return config_values.at(key.data());
 }
 
 void prefetch_config::set(std::string_view key, bool value)
 {
-  std::scoped_lock lock(config_mtx);
+  std::lock_guard<std::shared_mutex> lock(config_mtx);
   config_values[key.data()] = value;
 }
 


### PR DESCRIPTION
This adds muti-thread support for `prefetch_config` getter and setter functions. This avoid the issue that the config map is corrupted in multi-thread environments.

Closes https://github.com/rapidsai/cudf/issues/16426.