### PR TITLE
Ensure objects with __interface__ are converted to cupy/numpy arrays

### DIFF
--- a/python/cudf/benchmarks/API/bench_dataframe.py
+++ b/python/cudf/benchmarks/API/bench_dataframe.py
@@ -19,7 +19,7 @@ def bench_construction(benchmark, N):
 
 @pytest.mark.parametrize("N", [100, 100_000])
 def bench_construction_numba_device_array(benchmark, N):
-    benchmark(cudf.DataFrame, numba.cuda.to_device(numpy.ones(N)))
+    benchmark(cudf.DataFrame, numba.cuda.to_device(numpy.ones((100, N))))
 
 
 @benchmark_with_object(cls="dataframe", dtype="float", cols=6)

--- a/python/cudf/benchmarks/API/bench_dataframe.py
+++ b/python/cudf/benchmarks/API/bench_dataframe.py
@@ -18,6 +18,7 @@ def bench_construction(benchmark, N):
 
 
 @pytest.mark.parametrize("N", [100, 100_000])
+@pytest.mark.pandas_incompatible
 def bench_construction_numba_device_array(benchmark, N):
     benchmark(cudf.DataFrame, numba.cuda.to_device(numpy.ones((100, N))))
 

--- a/python/cudf/benchmarks/API/bench_dataframe.py
+++ b/python/cudf/benchmarks/API/bench_dataframe.py
@@ -4,6 +4,7 @@
 
 import string
 
+import numba.cuda
 import numpy
 import pytest
 import pytest_cases
@@ -14,6 +15,11 @@ from utils import benchmark_with_object
 @pytest.mark.parametrize("N", [100, 1_000_000])
 def bench_construction(benchmark, N):
     benchmark(cudf.DataFrame, {None: cupy.random.rand(N)})
+
+
+@pytest.mark.parametrize("N", [100, 100_000])
+def bench_construction_numba_device_array(benchmark, N):
+    benchmark(cudf.DataFrame, numba.cuda.to_device(numpy.ones(N)))
 
 
 @benchmark_with_object(cls="dataframe", dtype="float", cols=6)

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1843,7 +1843,7 @@ def as_column(
         else:
             mask = None
 
-        arbitrary = cupy.ascontiguousarray(arbitrary)
+        arbitrary = cupy.asarray(arbitrary, order="C")
 
         data = as_buffer(arbitrary, exposed=cudf.get_option("copy_on_write"))
         col = build_column(data, dtype=arbitrary.dtype, mask=mask)
@@ -2035,7 +2035,7 @@ def as_column(
         check_invalid_array(desc["shape"], np.dtype(desc["typestr"]))
 
         # CUDF assumes values are always contiguous
-        arbitrary = np.ascontiguousarray(arbitrary)
+        arbitrary = np.asarray(arbitrary, order="C")
 
         if arbitrary.ndim == 0:
             # TODO: Or treat as scalar?

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1843,7 +1843,6 @@ def as_column(
         else:
             mask = None
 
-        arbitrary = cupy.asarray(arbitrary)
         arbitrary = cupy.ascontiguousarray(arbitrary)
 
         data = as_buffer(arbitrary, exposed=cudf.get_option("copy_on_write"))
@@ -2036,7 +2035,7 @@ def as_column(
         check_invalid_array(desc["shape"], np.dtype(desc["typestr"]))
 
         # CUDF assumes values are always contiguous
-        arbitrary = np.asarray(arbitrary, order="C")
+        arbitrary = np.ascontiguousarray(arbitrary)
 
         if arbitrary.ndim == 0:
             # TODO: Or treat as scalar?

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -782,7 +782,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             )
         elif hasattr(data, "__cuda_array_interface__"):
             arr_interface = data.__cuda_array_interface__
-
+            data = cupy.asfortranarray(data)
             # descr is an optional field of the _cuda_ary_iface_
             if "descr" in arr_interface:
                 if len(arr_interface["descr"]) == 1:
@@ -801,6 +801,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
             self._check_data_index_length_match()
         elif hasattr(data, "__array_interface__"):
             arr_interface = data.__array_interface__
+            data = np.asfortranarray(data)
             if len(arr_interface["descr"]) == 1:
                 # not record arrays
                 new_df = self._from_arrays(data, index=index, columns=columns)

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5858,9 +5858,9 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         DataFrame
         """
         if hasattr(data, "__cuda_array_interface__"):
-            data = cupy.asfortranarray(data)
+            data = cupy.asarray(data, order="F")
         elif hasattr(data, "__array_interface__"):
-            data = np.asfortranarray(data)
+            data = np.asarray(data, order="F")
 
         if data.ndim not in {1, 2}:
             raise ValueError(

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5845,7 +5845,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         Parameters
         ----------
         data : object of ndim 1 or 2,
-            Object implementing __array_interface__ or __cuda_array_interface__
+            Object implementing ``__array_interface__`` or ``__cuda_array_interface__``
         index : Index or array-like
             Index to use for resulting frame. Will default to
             RangeIndex if no indexing information part of input data and

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5857,7 +5857,7 @@ class DataFrame(IndexedFrame, Serializable, GetAttrGetItemMixin):
         -------
         DataFrame
         """
-        array_data = np.ndarray | cupy.ndarray
+        array_data: np.ndarray | cupy.ndarray
         if hasattr(data, "__cuda_array_interface__"):
             array_data = cupy.asarray(data, order="F")
         elif hasattr(data, "__array_interface__"):


### PR DESCRIPTION
## Description
https://github.com/rapidsai/cudf/pull/16277 removed a universal cast to a `cupy.array` in `_from_array`. Although the typing suggested this method should only accept `np.ndarray` or `cupy.ndarray`, this method is called on any object implementing the `__cuda_array_inferface__` or `__array_interface__` (e.g. `numba.DeviceArray`) which caused a performance regression in cuspatial https://github.com/rapidsai/cuspatial/issues/1413

closes #16434


```python
In [1]: import cupy, numba.cuda

In [2]: import cudf

In [3]: cupy_array = cupy.ones((10_000, 100))

In [4]: %timeit cudf.DataFrame(cupy_array)
3.88 ms ± 52 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [5]: %timeit cudf.DataFrame(numba.cuda.to_device(cupy_array))
3.99 ms ± 35.4 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
