### PR TITLE
Enable prefetching in cudf.pandas.install()

### DIFF
--- a/cpp/src/column/column_view.cpp
+++ b/cpp/src/column/column_view.cpp
@@ -45,7 +45,10 @@ void prefetch_col_data(ColumnView& col, void const* data_ptr, std::string_view k
         key, data_ptr, col.size() * size_of(col.type()), cudf::get_default_stream());
     } else if (col.type().id() == type_id::STRING) {
       strings_column_view scv{col};
-
+      if (data_ptr == nullptr) {
+        // Do not call chars_size if the data_ptr is nullptr.
+        return;
+      }
       cudf::experimental::prefetch::detail::prefetch_noexcept(
         key,
         data_ptr,

--- a/python/cudf/cudf/pandas/__main__.py
+++ b/python/cudf/cudf/pandas/__main__.py
@@ -72,17 +72,7 @@ def main():
 
     args = parser.parse_args()
 
-    rmm_mode = install()
-    if "managed" in rmm_mode:
-        for key in {
-            "column_view::get_data",
-            "mutable_column_view::get_data",
-            "gather",
-            "hash_join",
-        }:
-            from cudf._lib import pylibcudf
-
-            pylibcudf.experimental.enable_prefetching(key)
+    install()
     with profile(args.profile, args.line_profile, args.args[0]) as fn:
         args.args[0] = fn
         if args.module:


### PR DESCRIPTION
## Description
This PR enables `cudf.pandas` managed memory prefetching in `cudf.pandas.install()`, to ensure that prefetching is enabled for all methods of enabling `cudf.pandas`.

I also fixed a bug in libcudf's prefetching logic, where it tried to compute the number of characters in a strings column view even if the string column view's data is `nullptr`. This errors, so we must avoid the `chars_size()` call and stop the prefetch attempt early.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
