### PR TITLE
Fix parquet_field_list read_func lambda capture invalid this pointer

### DIFF
--- a/cpp/src/io/parquet/compact_protocol_reader.cpp
+++ b/cpp/src/io/parquet/compact_protocol_reader.cpp
@@ -395,7 +395,7 @@ struct parquet_field_binary_list
   : public parquet_field_list<std::vector<uint8_t>, FieldType::BINARY> {
   parquet_field_binary_list(int f, std::vector<std::vector<uint8_t>>& v) : parquet_field_list(f, v)
   {
-    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) mutable {
+    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) {
       auto const l = cpr->get_u32();
       CUDF_EXPECTS(l <= static_cast<size_t>(cpr->m_end - cpr->m_cur), "binary length mismatch");
 

--- a/cpp/src/io/parquet/compact_protocol_reader.cpp
+++ b/cpp/src/io/parquet/compact_protocol_reader.cpp
@@ -137,7 +137,7 @@ class parquet_field_bool : public parquet_field {
 struct parquet_field_bool_list : public parquet_field_list<bool, FieldType::BOOLEAN_TRUE> {
   parquet_field_bool_list(int f, std::vector<bool>& v) : parquet_field_list(f, v)
   {
-    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) mutable {
+    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) {
       auto const current_byte = cpr->getb();
       assert_bool_field_type(current_byte);
       val[i] = current_byte == static_cast<int>(FieldType::BOOLEAN_TRUE);
@@ -188,7 +188,7 @@ template <typename T, FieldType EXPECTED_TYPE>
 struct parquet_field_int_list : public parquet_field_list<T, EXPECTED_TYPE> {
   parquet_field_int_list(int f, std::vector<T>& v) : parquet_field_list<T, EXPECTED_TYPE>(f, v)
   {
-    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) mutable {
+    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) {
       val[i] = cpr->get_zigzag<T>();
     };
     this->bind_read_func(read_value);
@@ -229,7 +229,7 @@ class parquet_field_string : public parquet_field {
 struct parquet_field_string_list : public parquet_field_list<std::string, FieldType::BINARY> {
   parquet_field_string_list(int f, std::vector<std::string>& v) : parquet_field_list(f, v)
   {
-    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) mutable {
+    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) {
       auto const l = cpr->get_u32();
       CUDF_EXPECTS(l < static_cast<size_t>(cpr->m_end - cpr->m_cur), "string length mismatch");
 
@@ -269,7 +269,7 @@ struct parquet_field_enum_list : public parquet_field_list<Enum, FieldType::I32>
   parquet_field_enum_list(int f, std::vector<Enum>& v)
     : parquet_field_list<Enum, FieldType::I32>(f, v)
   {
-    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) mutable {
+    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) {
       val[i] = static_cast<Enum>(cpr->get_i32());
     };
     this->bind_read_func(read_value);
@@ -354,7 +354,7 @@ struct parquet_field_struct_list : public parquet_field_list<T, FieldType::STRUC
   parquet_field_struct_list(int f, std::vector<T>& v)
     : parquet_field_list<T, FieldType::STRUCT>(f, v)
   {
-    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) mutable {
+    auto const read_value = [&val = v](uint32_t i, CompactProtocolReader* cpr) {
       cpr->read(&val[i]);
     };
     this->bind_read_func(read_value);


### PR DESCRIPTION
## Description
Fixes internal parquet_field_list subclass constructors capturing invalid this pointer when passing objects to std::make_tuple. The std::make_tuple usage creates a parameter object that is constructed, moved, and destroyed. The this pointer is captured during constructor call. The move constructor is called which creates its own separate this pointer (all member data is moved/copied appropriately). The original this pointer is invalidated by the following destructor. The lambda that was captured in the constructor no longer contains a valid this value in the final moved object.

This PR removes the dependency on the this pointer in the lambda and captures the vector reference instead which is preserved correctly in the object move. The ctor, move, dtor pattern occurs because of how std::make_tuple is implemented by the standard library.

Closes https://github.com/rapidsai/cudf/issues/16408

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
