### PR TITLE
Use explicit construction of column subclass instead of `build_column` when type is known

### DIFF
--- a/python/cudf/cudf/core/_internals/where.py
+++ b/python/cudf/cudf/core/_internals/where.py
@@ -110,7 +110,7 @@ def _make_categorical_like(result, column):
     if isinstance(column, cudf.core.column.CategoricalColumn):
         result = cudf.core.column.build_categorical_column(
             categories=column.categories,
-            codes=cudf.core.column.build_column(
+            codes=cudf.core.column.NumericalColumn(
                 result.base_data, dtype=result.dtype
             ),
             mask=result.base_mask,

--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -572,13 +572,10 @@ class CategoricalColumn(column.ColumnBase):
             codes_column = self.base_children[0]
             start = self.offset * codes_column.dtype.itemsize
             end = start + self.size * codes_column.dtype.itemsize
-            codes_column = cast(
-                cudf.core.column.NumericalColumn,
-                column.build_column(
-                    data=codes_column.base_data[start:end],
-                    dtype=codes_column.dtype,
-                    size=self.size,
-                ),
+            codes_column = cudf.core.column.NumericalColumn(
+                data=codes_column.base_data[start:end],
+                dtype=codes_column.dtype,
+                size=self.size,
             )
             self._children = (codes_column,)
         return self._children
@@ -660,8 +657,9 @@ class CategoricalColumn(column.ColumnBase):
             Self,
             cudf.core.column.build_categorical_column(
                 categories=self.categories,
-                codes=cudf.core.column.build_column(
-                    codes.base_data, dtype=codes.dtype
+                codes=cudf.core.column.NumericalColumn(
+                    codes.base_data,  # type: ignore[arg-type]
+                    dtype=codes.dtype,
                 ),
                 mask=codes.base_mask,
                 ordered=self.ordered,
@@ -734,7 +732,10 @@ class CategoricalColumn(column.ColumnBase):
         codes = self.codes.sort_values(ascending, na_position)
         col = column.build_categorical_column(
             categories=self.dtype.categories._values,
-            codes=column.build_column(codes.base_data, dtype=codes.dtype),
+            codes=cudf.core.column.NumericalColumn(
+                codes.base_data,  # type: ignore[arg-type]
+                dtype=codes.dtype,
+            ),
             mask=codes.base_mask,
             size=codes.size,
             ordered=self.dtype.ordered,
@@ -842,7 +843,10 @@ class CategoricalColumn(column.ColumnBase):
         codes = self.codes.unique()
         return column.build_categorical_column(
             categories=self.categories,
-            codes=column.build_column(codes.base_data, dtype=codes.dtype),
+            codes=cudf.core.column.NumericalColumn(
+                codes.base_data,  # type: ignore[arg-type]
+                dtype=codes.dtype,
+            ),
             mask=codes.base_mask,
             offset=codes.offset,
             size=codes.size,
@@ -980,7 +984,9 @@ class CategoricalColumn(column.ColumnBase):
 
         result = column.build_categorical_column(
             categories=new_cats["cats"],
-            codes=column.build_column(output.base_data, dtype=output.dtype),
+            codes=cudf.core.column.NumericalColumn(
+                output.base_data, dtype=output.dtype
+            ),
             mask=output.base_mask,
             offset=output.offset,
             size=output.size,
@@ -1176,8 +1182,9 @@ class CategoricalColumn(column.ColumnBase):
 
         return column.build_categorical_column(
             categories=column.as_column(cats),
-            codes=column.build_column(
-                codes_col.base_data, dtype=codes_col.dtype
+            codes=cudf.core.column.NumericalColumn(
+                codes_col.base_data,  # type: ignore[arg-type]
+                dtype=codes_col.dtype,
             ),
             mask=codes_col.base_mask,
             size=codes_col.size,
@@ -1190,8 +1197,9 @@ class CategoricalColumn(column.ColumnBase):
         if isinstance(dtype, CategoricalDtype):
             return column.build_categorical_column(
                 categories=dtype.categories._values,
-                codes=column.build_column(
-                    self.codes.base_data, dtype=self.codes.dtype
+                codes=cudf.core.column.NumericalColumn(
+                    self.codes.base_data,  # type: ignore[arg-type]
+                    dtype=self.codes.dtype,
                 ),
                 mask=self.codes.base_mask,
                 ordered=dtype.ordered,
@@ -1339,7 +1347,7 @@ class CategoricalColumn(column.ColumnBase):
             Self,
             column.build_categorical_column(
                 categories=new_cats,
-                codes=column.build_column(
+                codes=cudf.core.column.NumericalColumn(
                     new_codes.base_data, dtype=new_codes.dtype
                 ),
                 mask=new_codes.base_mask,
@@ -1472,7 +1480,9 @@ def pandas_categorical_as_column(
 
     return column.build_categorical_column(
         categories=categorical.categories,
-        codes=column.build_column(codes.base_data, codes.dtype),
+        codes=cudf.core.column.NumericalColumn(
+            codes.base_data, dtype=codes.dtype
+        ),
         size=codes.size,
         mask=mask,
         ordered=categorical.ordered,

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -317,7 +317,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         >>> import pyarrow as pa
         >>> import cudf
         >>> cudf.core.column.ColumnBase.from_arrow(pa.array([1, 2, 3, 4]))
-        <cudf.core.column.numerical.NumericalColumn object at 0x7f8865497ef0>
+        <cudf.core.column.NumericalColumn object at 0x7f8865497ef0>
         """
         if not isinstance(array, (pa.Array, pa.ChunkedArray)):
             raise TypeError("array should be PyArrow array or chunked array")
@@ -1368,7 +1368,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         >>> col = as_column(['foo', 'bar', 'foo', 'baz'])
         >>> cats = as_column(['foo', 'bar', 'baz'])
         >>> col._label_encoding(cats)
-        <cudf.core.column.numerical.NumericalColumn object at 0x7f99bf3155c0>
+        <cudf.core.column.NumericalColumn object at 0x7f99bf3155c0>
         [
           0,
           1,
@@ -1378,7 +1378,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         dtype: int8
         >>> cats = as_column(['foo', 'bar'])
         >>> col._label_encoding(cats)
-        <cudf.core.column.numerical.NumericalColumn object at 0x7f99bfde0e40>
+        <cudf.core.column.NumericalColumn object at 0x7f99bfde0e40>
         [
           0,
           1,
@@ -1506,7 +1506,7 @@ def column_empty(
     elif isinstance(dtype, CategoricalDtype):
         data = None
         children = (
-            build_column(
+            cudf.core.column.NumericalColumn(
                 data=as_buffer(
                     rmm.DeviceBuffer(
                         size=row_count

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -317,7 +317,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         >>> import pyarrow as pa
         >>> import cudf
         >>> cudf.core.column.ColumnBase.from_arrow(pa.array([1, 2, 3, 4]))
-        <cudf.core.column.NumericalColumn object at 0x7f8865497ef0>
+        <cudf.core.column.numerical.NumericalColumn object at 0x7f8865497ef0>
         """
         if not isinstance(array, (pa.Array, pa.ChunkedArray)):
             raise TypeError("array should be PyArrow array or chunked array")
@@ -1368,7 +1368,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         >>> col = as_column(['foo', 'bar', 'foo', 'baz'])
         >>> cats = as_column(['foo', 'bar', 'baz'])
         >>> col._label_encoding(cats)
-        <cudf.core.column.NumericalColumn object at 0x7f99bf3155c0>
+        <cudf.core.column.numerical.NumericalColumn object at 0x7f99bf3155c0>
         [
           0,
           1,
@@ -1378,7 +1378,7 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         dtype: int8
         >>> cats = as_column(['foo', 'bar'])
         >>> col._label_encoding(cats)
-        <cudf.core.column.NumericalColumn object at 0x7f99bfde0e40>
+        <cudf.core.column.numerical.NumericalColumn object at 0x7f99bfde0e40>
         [
           0,
           1,

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -473,15 +473,15 @@ class DatetimeColumn(column.ColumnBase):
 
     def as_numerical_column(
         self, dtype: Dtype
-    ) -> "cudf.core.column.NumericalColumn":
-        col = column.build_column(
-            data=self.base_data,
-            dtype=np.int64,
+    ) -> cudf.core.column.NumericalColumn:
+        col = cudf.core.column.NumericalColumn(
+            data=self.base_data,  # type: ignore[arg-type]
+            dtype=np.dtype(np.int64),
             mask=self.base_mask,
             offset=self.offset,
             size=self.size,
         )
-        return cast("cudf.core.column.NumericalColumn", col.astype(dtype))
+        return cast(cudf.core.column.NumericalColumn, col.astype(dtype))
 
     def strftime(self, format: str) -> cudf.core.column.StringColumn:
         if len(self) == 0:

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -13,13 +13,7 @@ import cudf
 from cudf import _lib as libcudf
 from cudf._lib import pylibcudf
 from cudf.api.types import is_integer, is_scalar
-from cudf.core.column import (
-    ColumnBase,
-    as_column,
-    build_column,
-    column,
-    string,
-)
+from cudf.core.column import ColumnBase, as_column, column, string
 from cudf.core.dtypes import CategoricalDtype
 from cudf.core.mixins import BinaryOperand
 from cudf.errors import MixedTypeError
@@ -338,29 +332,23 @@ class NumericalColumn(NumericalBaseColumn):
     def as_datetime_column(
         self, dtype: Dtype
     ) -> cudf.core.column.DatetimeColumn:
-        return cast(
-            "cudf.core.column.DatetimeColumn",
-            build_column(
-                data=self.astype("int64").base_data,
-                dtype=dtype,
-                mask=self.base_mask,
-                offset=self.offset,
-                size=self.size,
-            ),
+        return cudf.core.column.DatetimeColumn(
+            data=self.astype("int64").base_data,  # type: ignore[arg-type]
+            dtype=dtype,
+            mask=self.base_mask,
+            offset=self.offset,
+            size=self.size,
         )
 
     def as_timedelta_column(
         self, dtype: Dtype
     ) -> cudf.core.column.TimeDeltaColumn:
-        return cast(
-            "cudf.core.column.TimeDeltaColumn",
-            build_column(
-                data=self.astype("int64").base_data,
-                dtype=dtype,
-                mask=self.base_mask,
-                offset=self.offset,
-                size=self.size,
-            ),
+        return cudf.core.column.TimeDeltaColumn(
+            data=self.astype("int64").base_data,  # type: ignore[arg-type]
+            dtype=dtype,
+            mask=self.base_mask,
+            offset=self.offset,
+            size=self.size,
         )
 
     def as_decimal_column(
@@ -637,7 +625,10 @@ class NumericalColumn(NumericalBaseColumn):
         if isinstance(dtype, CategoricalDtype):
             return column.build_categorical_column(
                 categories=dtype.categories._values,
-                codes=build_column(self.base_data, dtype=self.dtype),
+                codes=cudf.core.column.NumericalColumn(
+                    self.base_data,  # type: ignore[arg-type]
+                    dtype=self.dtype,
+                ),
                 mask=self.base_mask,
                 ordered=dtype.ordered,
                 size=self.size,

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -5934,9 +5934,9 @@ class StringColumn(column.ColumnBase):
 
         n_bytes_to_view = str_end_byte_offset - str_byte_offset
 
-        to_view = column.build_column(
-            self.base_data,
-            dtype=cudf.api.types.dtype("int8"),
+        to_view = cudf.core.column.NumericalColumn(
+            self.base_data,  # type: ignore[arg-type]
+            dtype=np.dtype(np.int8),
             offset=str_byte_offset,
             size=n_bytes_to_view,
         )

--- a/python/cudf/cudf/core/column/timedelta.py
+++ b/python/cudf/cudf/core/column/timedelta.py
@@ -265,10 +265,10 @@ class TimeDeltaColumn(ColumnBase):
 
     def as_numerical_column(
         self, dtype: Dtype
-    ) -> "cudf.core.column.NumericalColumn":
-        col = column.build_column(
-            data=self.base_data,
-            dtype=np.int64,
+    ) -> cudf.core.column.NumericalColumn:
+        col = cudf.core.column.NumericalColumn(
+            data=self.base_data,  # type: ignore[arg-type]
+            dtype=np.dtype(np.int64),
             mask=self.base_mask,
             offset=self.offset,
             size=self.size,

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -46,10 +46,10 @@ from cudf.core.abc import Serializable
 from cudf.core.column import (
     CategoricalColumn,
     ColumnBase,
+    NumericalColumn,
     StructColumn,
     as_column,
     build_categorical_column,
-    build_column,
     column_empty,
     concat_columns,
 )
@@ -8543,7 +8543,7 @@ def _reassign_categories(categories, cols, col_idxs):
         if idx in categories:
             cols[name] = build_categorical_column(
                 categories=categories[idx],
-                codes=build_column(
+                codes=NumericalColumn(
                     cols[name].base_data, dtype=cols[name].dtype
                 ),
                 mask=cols[name].base_mask,

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2434,12 +2434,10 @@ class DatetimeIndex(Index):
         return result
 
     @_performance_tracking
-    def _get_dt_field(self, field):
+    def _get_dt_field(self, field: str) -> Index:
+        """Return an Index of a numerical component of the DatetimeIndex."""
         out_column = self._values.get_dt_field(field)
-        # column.column_empty_like always returns a Column object
-        # but we need a NumericalColumn for Index..
-        # how should this be handled?
-        out_column = column.build_column(
+        out_column = NumericalColumn(
             data=out_column.base_data,
             dtype=out_column.dtype,
             mask=out_column.base_mask,
@@ -3412,7 +3410,7 @@ class IntervalIndex(Index):
         left_col = breaks.slice(0, len(breaks) - 1)
         right_col = breaks.slice(1, len(breaks))
         # For indexing, children should both have 0 offset
-        right_col = column.build_column(
+        right_col = type(right_col)(
             data=right_col.data,
             dtype=right_col.dtype,
             size=right_col.size,

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -3410,7 +3410,7 @@ class IntervalIndex(Index):
         left_col = breaks.slice(0, len(breaks) - 1)
         right_col = breaks.slice(1, len(breaks))
         # For indexing, children should both have 0 offset
-        right_col = type(right_col)(
+        right_col = column.build_column(
             data=right_col.data,
             dtype=right_col.dtype,
             size=right_col.size,


### PR DESCRIPTION
## Description
When we need to construct a column with a specific type, we do not need to go through the indirection of `build_column`, which matches a column subclass to a passed type, and instead construct directly from the class instead

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
