### PR TITLE
Implement scan-based whole-frame aggregations for cudf-polars

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -1107,8 +1107,6 @@ class UnaryFunction(Expr):
                 agg = plc.aggregation.min()
             elif self.name == "cum_max":
                 agg = plc.aggregation.max()
-            elif self.name == "cum_count":
-                agg = plc.aggregation.count()
 
             return Column(plc.reduce.scan(plc_col, agg, plc.reduce.ScanType.INCLUSIVE))
         raise NotImplementedError(

--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -1059,34 +1059,25 @@ class UnaryFunction(Expr):
             return Column(plc.replace.replace_nulls(column.obj, arg))
         elif self.name in UnaryFunction._supported_cum_aggs:
             column = self.children[0].evaluate(df, context=context, mapping=mapping)
+            plc_col = column.obj
+            col_type = column.obj.type()
             # cum_sum casts
             # INT8, UInt8, Int16, UInt16 -> Int64 for overflow prevention
-            # (cum_prod does the same, but with Int32/UInt32 too)
-            # xref https://github.com/pola-rs/polars/blob/3dda47e578e0b50a5bb7c459ebee6c5c76d41c75/crates/polars-ops/src/series/ops/cum_agg.rs#L141-L142
-            plc_col = column.obj
-            # TODO: can simplify check with is_integral and size_of(type) <= 2
-            # when cudf::size_of is exposed
-            needs_i64_cast = {
-                "cum_sum": {
-                    plc.types.TypeId.INT8,
-                    plc.types.TypeId.UINT8,
-                    plc.types.TypeId.INT16,
-                    plc.types.TypeId.UINT16,
-                },
-                "cum_prod": {
-                    plc.types.TypeId.BOOL8,
-                    plc.types.TypeId.INT8,
-                    plc.types.TypeId.UINT8,
-                    plc.types.TypeId.INT16,
-                    plc.types.TypeId.UINT16,
-                    plc.types.TypeId.UINT32,
-                    plc.types.TypeId.INT32,
-                },
+            _cum_sum_cast_cond = self.name == "cum_sum" and col_type.id() in {
+                plc.types.TypeId.INT8,
+                plc.types.TypeId.UINT8,
+                plc.types.TypeId.INT16,
+                plc.types.TypeId.UINT16,
             }
-            if (
-                self.name in needs_i64_cast
-                and column.obj.type().id() in needs_i64_cast[self.name]
-            ):
+            # cum_prod casts integer dtypes < int64 and bool to int64
+            # note: bool counted in is_integral
+            # xref https://github.com/pola-rs/polars/blob/3dda47e578e0b50a5bb7c459ebee6c5c76d41c75/crates/polars-ops/src/series/ops/cum_agg.rs#L141-L142
+            _cum_prod_cast_cond = (
+                self.name == "cum_prod"
+                and plc.traits.is_integral(col_type)
+                and plc.types.size_of(col_type) <= 4
+            )
+            if _cum_sum_cast_cond or _cum_prod_cast_cond:
                 plc_col = plc.unary.cast(
                     plc_col, plc.types.DataType(plc.types.TypeId.INT64)
                 )

--- a/python/cudf_polars/tests/expressions/test_agg.py
+++ b/python/cudf_polars/tests/expressions/test_agg.py
@@ -14,7 +14,25 @@ from cudf_polars.testing.asserts import (
 
 
 @pytest.fixture(
-    params=sorted(expr.Agg._SUPPORTED | expr.UnaryFunction._supported_cum_aggs)
+    params=[
+        # regular aggs from Agg
+        "min",
+        "max",
+        "median",
+        "n_unique",
+        "first",
+        "last",
+        "mean",
+        "sum",
+        "count",
+        "std",
+        "var",
+        # scan aggs from UnaryFunction
+        "cum_min",
+        "cum_max",
+        "cum_prod",
+        "cum_sum",
+    ]
 )
 def agg(request):
     return request.param

--- a/python/cudf_polars/tests/testing/test_asserts.py
+++ b/python/cudf_polars/tests/testing/test_asserts.py
@@ -26,7 +26,7 @@ def test_translation_assert_raises():
     class E(Exception):
         pass
 
-    unsupported = df.group_by("a").agg(pl.col("a").cum_max().alias("b"))
+    unsupported = df.group_by("a").agg(pl.col("a").upper_bound().alias("b"))
     # Unsupported query should raise NotImplementedError
     assert_ir_translation_raises(unsupported, NotImplementedError)
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

contributes to #16478

This implements "cum_min", "cum_max", "cum_prod", "cum_sum"

"cum_count" is not implemented for now, since there's no exact libcudf match (I imagine the non-grouped case is also not used that much but haven't checked).
I suppose we could implement it by creating a column of 1s and copying the null mask over, and doing a cum_sum on that.
Let me know if you want to try that.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
