### PR TITLE
MAINT: Adapt to numpy hiding flagsobject away

### DIFF
--- a/python/cudf/cudf/pandas/_wrappers/numpy.py
+++ b/python/cudf/cudf/pandas/_wrappers/numpy.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import cupy
 import cupy._core.flags
 import numpy
-import numpy.core.multiarray
+from packaging import version
 
 from ..fast_slow_proxy import (
     _FastSlowAttribute,
@@ -141,10 +141,15 @@ flatiter = make_final_proxy_type(
     },
 )
 
+if version.parse(numpy.__version__) >= version.parse("2.0"):
+    # NumPy 2 introduced `_core` and gives warnings for access to `core`.
+    from numpy._core.multiarray import flagsobj as _numpy_flagsobj
+else:
+    from numpy.core.multiarray import flagsobj as _numpy_flagsobj
 
 # Mapping flags between slow and fast types
 _ndarray_flags = make_intermediate_proxy_type(
     "_ndarray_flags",
     cupy._core.flags.Flags,
-    numpy.core.multiarray.flagsobj,
+    _numpy_flagsobj,
 )


### PR DESCRIPTION
NumPy hid the `flagsobj` type into the `_core` module.  It may make sense for NumPy to put it somewhere less "private", but I think it is fine to consider this semi-private.
However, we need to avoid the deprecation warning (oddly, found in the cuml test suite, and not here).

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
