### PR TITLE
Correctly export empty column names in DataFrame.to_polars

### DIFF
--- a/python/cudf_polars/tests/containers/test_dataframe.py
+++ b/python/cudf_polars/tests/containers/test_dataframe.py
@@ -144,6 +144,11 @@ def test_sorted_flags_preserved(with_nulls, nulls_last):
     assert df.flags == gf.to_polars().flags
 
 
-def test_empty_name_roundtrips():
+def test_empty_name_roundtrips_overlap():
     df = pl.LazyFrame({"": [1, 2, 3], "column_0": [4, 5, 6]})
+    assert_gpu_result_equal(df)
+
+
+def test_empty_name_roundtrips_no_overlap():
+    df = pl.LazyFrame({"": [1, 2, 3], "b": [4, 5, 6]})
     assert_gpu_result_equal(df)

--- a/python/cudf_polars/tests/containers/test_dataframe.py
+++ b/python/cudf_polars/tests/containers/test_dataframe.py
@@ -10,6 +10,7 @@ import polars as pl
 import cudf._lib.pylibcudf as plc
 
 from cudf_polars.containers import DataFrame, NamedColumn
+from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
 def test_select_missing_raises():
@@ -141,3 +142,8 @@ def test_sorted_flags_preserved(with_nulls, nulls_last):
     assert b.null_order == b_null_order
     assert c.is_sorted == plc.types.Sorted.NO
     assert df.flags == gf.to_polars().flags
+
+
+def test_empty_name_roundtrips():
+    df = pl.LazyFrame({"": [1, 2, 3], "column_0": [4, 5, 6]})
+    assert_gpu_result_equal(df)


### PR DESCRIPTION
## Description
polars.from_arrow renames empty column names (see https://github.com/pola-rs/polars/issues/11632). This causes problems when round-tripping specially crafted dataframes. Avoid the problem by constructing the table with fake names and then renaming.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
