### PR TITLE
Add `num_multiprocessors` utility

### DIFF
--- a/cpp/benchmarks/join/generate_input_tables.cuh
+++ b/cpp/benchmarks/join/generate_input_tables.cuh
@@ -150,13 +150,8 @@ void generate_input_tables(key_type* const build_tbl,
   CUDF_CUDA_TRY(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
     &num_blocks_init_probe_tbl, init_probe_tbl<key_type, size_type>, block_size, 0));
 
-  int dev_id{-1};
-  CUDF_CUDA_TRY(cudaGetDevice(&dev_id));
-
-  int num_sms{-1};
-  CUDF_CUDA_TRY(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
-
-  int const num_states =
+  auto const num_sms = cudf::detail::num_multiprocessors();
+  auto const num_states =
     num_sms * std::max(num_blocks_init_build_tbl, num_blocks_init_probe_tbl) * block_size;
   rmm::device_uvector<curandState> devStates(num_states, cudf::get_default_stream());
 

--- a/cpp/include/cudf/detail/utilities/cuda.cuh
+++ b/cpp/include/cudf/detail/utilities/cuda.cuh
@@ -192,7 +192,7 @@ __device__ T single_lane_block_sum_reduce(T lane_value)
 /**
  * @brief Get the number of multiprocessors on the device
  */
-cudf::size_type num_multiprocessors()
+inline cudf::size_type num_multiprocessors()
 {
   int device = 0;
   CUDF_CUDA_TRY(cudaGetDevice(&device));

--- a/cpp/src/io/comp/debrotli.cu
+++ b/cpp/src/io/comp/debrotli.cu
@@ -2050,8 +2050,8 @@ size_t __host__ get_gpu_debrotli_scratch_size(int max_num_inputs)
 {
   uint32_t max_fb_size, min_fb_size, fb_size;
   auto const sm_count = cudf::detail::num_multiprocessors();
-  max_num_inputs      = std::min(max_num_inputs,
-                            sm_count * 3);  // no more than 3 blocks/sm at most due to 32KB smem use
+  // no more than 3 blocks/sm at most due to 32KB smem use
+  max_num_inputs = std::min(max_num_inputs, sm_count * 3);
   if (max_num_inputs <= 0) {
     max_num_inputs = sm_count * 2;  // Target 2 blocks/SM by default for scratch mem computation
   }


### PR DESCRIPTION
## Description
This PR introduces a new `num_multiprocessors` utility and refines the existing CUDA API calls. 

Needed by #16619.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
