### PR TITLE
Move pragma once in rolling/jit/operation.hpp.

### DIFF
--- a/cpp/src/rolling/jit/operation.hpp
+++ b/cpp/src/rolling/jit/operation.hpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include "rolling/jit/operation-udf.hpp"
 
 #include <cudf/types.hpp>
-
-#pragma once
 
 struct rolling_udf_ptx {
   template <typename OutType, typename InType>


### PR DESCRIPTION
## Description
I noticed from https://github.com/rapidsai/cudf/pull/16590#discussion_r1725842333 that there was one other file where `#pragma once` was not at the top. This PR fixes that.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
