### PR TITLE
Revert "Hide all gtest symbols in cudftestutil (#16546)"

### DIFF
--- a/cpp/cmake/thirdparty/get_gtest.cmake
+++ b/cpp/cmake/thirdparty/get_gtest.cmake
@@ -16,18 +16,9 @@
 function(find_and_configure_gtest)
   include(${rapids-cmake-dir}/cpm/gtest.cmake)
 
-  # Mark all the non explicit googletest symbols as hidden. This ensures that libcudftestutil can be
-  # used by consumers with a different shared gtest.
-  set(gtest_hide_internal_symbols ON)
-
   # Find or install GoogleTest
   rapids_cpm_gtest(BUILD_STATIC)
 
-  # Mark all the explicit googletest symbols as hidden. This ensures that libcudftestutil can be
-  # used by consumers with a different shared gtest.
-  if(TARGET gtest)
-    target_compile_definitions(gtest PUBLIC "$<BUILD_LOCAL_INTERFACE:GTEST_API_=>")
-  endif()
 endfunction()
 
 find_and_configure_gtest()


### PR DESCRIPTION
## Description

This reverts commit ac42bc870a65d807784cae63e25b9e9ca788eb23.

We need to revert #16546 as it broke the gtest builds for cudf. Therefore gtests that actually fail wouldn't properly report an error but silently continue and report as passed.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
