### PR TITLE
fix libcudf wheel publishing, make package-type explicit in wheel publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,6 +86,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: libcudf
+      package-type: cpp
   wheel-build-pylibcudf:
     needs: [wheel-publish-libcudf]
     secrets: inherit
@@ -106,6 +107,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: pylibcudf
+      package-type: python
   wheel-build-cudf:
     needs: wheel-publish-pylibcudf
     secrets: inherit
@@ -126,6 +128,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: cudf
+      package-type: python
   wheel-build-dask-cudf:
     needs: wheel-publish-cudf
     secrets: inherit
@@ -148,6 +151,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: dask_cudf
+      package-type: python
   wheel-build-cudf-polars:
     needs: wheel-publish-pylibcudf
     secrets: inherit
@@ -170,6 +174,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       package-name: cudf_polars
+      package-type: python
   trigger-pandas-tests:
     if: inputs.build_type == 'nightly'
     needs: wheel-build-cudf


### PR DESCRIPTION
## Description

Follow-up to #15483.

Contributes to https://github.com/rapidsai/build-planning/issues/33

Wheel publishing for `libcudf` is failing like this:

```text
Error:  File "./dist/*.whl" does not exist
```

([build link](https://github.com/rapidsai/cudf/actions/runs/10528569930/job/29176811683))

Because the `package-type` was not set to `cpp` in the `wheels-publish` CI workflow, and that workflow defaults to `python`. ([shared-workflows code link](https://github.com/rapidsai/shared-workflows/blob/157e9824e6e2181fca9aa5c4bea4defd4cc322b0/.github/workflows/wheels-publish.yaml#L23-L26)).

This fixes that, and makes that choice explicit for all wheel publishing jobs.

References for this `package-type` argument:

* https://github.com/rapidsai/shared-workflows/pull/209
* https://github.com/rapidsai/gha-tools/pull/105

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
