### PR TITLE
Replace raw device_memory_resource pointer in pylibcudf Cython

### DIFF
--- a/python/pylibcudf/pylibcudf/libcudf/interop.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/interop.pxd
@@ -71,7 +71,7 @@ cdef extern from *:
     ArrowArray* to_arrow_host_raw(
       cudf::table_view const& tbl,
       rmm::cuda_stream_view stream        = cudf::get_default_stream(),
-      rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource()) {
+      rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource()) {
       // Assumes the sync event is null and the data is already on the host.
       ArrowArray *arr = new ArrowArray();
       auto device_arr = cudf::to_arrow_host(tbl, stream, mr);


### PR DESCRIPTION
## Description
Replaces a single `device_memory_resource*` in pylibcudf Cython inline C++ function with `rmm::device_async_resource_ref` to help smooth RMM refactoring effort.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
