### PR TITLE
Implement handlers for first/last in groupby

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -961,7 +961,7 @@ class TemporalFunction(Expr):
         self.name = name
         self.children = children
         if self.name != pl_expr.TemporalFunction.Year:
-            raise NotImplementedError(f"String function {self.name}")
+            raise NotImplementedError(f"Temporal function {self.name}")
 
     def do_evaluate(
         self,

--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -1540,6 +1540,10 @@ class Agg(Expr):
             raise NotImplementedError("Nan propagation in groupby for min/max")
         (child,) = self.children
         ((expr, _, _),) = child.collect_agg(depth=depth + 1).requests
+        request = self.request
+        # These are handled specially here because we don't set up the
+        # request for the whole-frame agg because we can avoid a
+        # reduce for these.
         if self.name == "first":
             request = plc.aggregation.nth_element(
                 0, null_handling=plc.types.NullPolicy.INCLUDE
@@ -1548,8 +1552,6 @@ class Agg(Expr):
             request = plc.aggregation.nth_element(
                 -1, null_handling=plc.types.NullPolicy.INCLUDE
             )
-        else:
-            request = self.request
         if request is None:
             raise NotImplementedError(
                 f"Aggregation {self.name} in groupby"

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -52,6 +52,7 @@ def keys(request):
         [(pl.col("float") - pl.lit(2)).max()],
         [pl.col("float").sum().round(decimals=1)],
         [pl.col("float").round(decimals=1).sum()],
+        [pl.col("int").first(), pl.col("float").last()],
     ],
     ids=lambda aggs: "-".join(map(str, aggs)),
 )


### PR DESCRIPTION
## Description

Since the full-frame `Agg` handler for first and last doesn't construct a request (because we can do it without a `from_scalar` call), we didn't handle these in a groupby context. Fortunately it is easy to add.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
