### PR TITLE
No support for producing dataframes with Empty columns

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -202,6 +202,7 @@ class Scan(IR):
 
     def __post_init__(self) -> None:
         """Validate preconditions."""
+        super().__post_init__()
         if self.typ not in ("csv", "parquet", "ndjson"):  # pragma: no cover
             # This line is unhittable ATM since IPC/Anonymous scan raise
             # on the polars side
@@ -537,6 +538,7 @@ class GroupBy(IR):
 
     def __post_init__(self) -> None:
         """Check whether all the aggregations are implemented."""
+        super().__post_init__()
         if self.options.rolling:
             raise NotImplementedError(
                 "rolling window/groupby"
@@ -649,6 +651,7 @@ class Join(IR):
 
     def __post_init__(self) -> None:
         """Validate preconditions."""
+        super().__post_init__()
         if any(
             isinstance(e.value, expr.Literal)
             for e in itertools.chain(self.left_on, self.right_on)
@@ -1075,6 +1078,7 @@ class MapFunction(IR):
 
     def __post_init__(self) -> None:
         """Validate preconditions."""
+        super().__post_init__()
         if self.name not in MapFunction._NAMES:
             raise NotImplementedError(f"Unhandled map function {self.name}")
         if self.name == "explode":
@@ -1127,6 +1131,7 @@ class Union(IR):
 
     def __post_init__(self) -> None:
         """Validate preconditions."""
+        super().__post_init__()
         schema = self.dfs[0].schema
         if not all(s.schema == schema for s in self.dfs[1:]):
             raise NotImplementedError("Schema mismatch")

--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -133,8 +133,7 @@ class IR:
 
     def __post_init__(self):
         """Validate preconditions."""
-        if any(dtype.id() == plc.TypeId.EMPTY for dtype in self.schema.values()):
-            raise NotImplementedError("Cannot make empty columns.")
+        pass  # noqa: PIE790
 
     def evaluate(self, *, cache: MutableMapping[int, DataFrame]) -> DataFrame:
         """

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -337,16 +337,17 @@ def translate_ir(visitor: NodeTraverser, *, n: int | None = None) -> ir.IR:
 
     with ctx:
         polars_schema = visitor.get_schema()
+        node = visitor.view_current_node()
+        schema = {k: dtypes.from_polars(v) for k, v in polars_schema.items()}
+        result = _translate_ir(node, visitor, schema)
         if any(
             isinstance(dtype, pl.Null)
             for dtype in pl.datatypes.unpack_dtypes(*polars_schema.values())
         ):
             raise NotImplementedError(
-                "No support for computing GPU dataframes with Null column dtype"
+                f"No GPU support for {result} with Null column dtype."
             )
-        node = visitor.view_current_node()
-        schema = {k: dtypes.from_polars(v) for k, v in polars_schema.items()}
-        return _translate_ir(node, visitor, schema)
+        return result
 
 
 def translate_named_expr(

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -336,8 +336,16 @@ def translate_ir(visitor: NodeTraverser, *, n: int | None = None) -> ir.IR:
         )  # pragma: no cover; no such version for now.
 
     with ctx:
+        polars_schema = visitor.get_schema()
+        if any(
+            isinstance(dtype, pl.Null)
+            for dtype in pl.datatypes.unpack_dtypes(*polars_schema.values())
+        ):
+            raise NotImplementedError(
+                "No support for computing GPU dataframes with Null column dtype"
+            )
         node = visitor.view_current_node()
-        schema = {k: dtypes.from_polars(v) for k, v in visitor.get_schema().items()}
+        schema = {k: dtypes.from_polars(v) for k, v in polars_schema.items()}
         return _translate_ir(node, visitor, schema)
 
 

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -305,3 +305,13 @@ def test_scan_ndjson_unsupported(df, tmp_path):
     make_source(df, tmp_path / "file", "ndjson")
     q = pl.scan_ndjson(tmp_path / "file", ignore_errors=True)
     assert_ir_translation_raises(q, NotImplementedError)
+
+
+def test_scan_parquet_nested_null_raises(tmp_path):
+    df = pl.DataFrame({"a": pl.Series([None], dtype=pl.List(pl.Null))})
+
+    df.write_parquet(tmp_path / "file.pq")
+
+    q = pl.scan_parquet(tmp_path / "file.pq")
+
+    assert_ir_translation_raises(q, NotImplementedError)


### PR DESCRIPTION
## Description

Although it is possible to construct an `EMPTY` column in libcudf, we can't do anything with it (even export it to arrow). This is the case even if the emptiness is part of a nested type. Previously we were not sufficiently diligent at noticing this case when translating polars queries, and would fail (with `abort`) at runtime in some cases.

Fix this by checking the unique set of dtypes in the schema of each query node and raising if any such dtype would be `EMPTY`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
