### PR TITLE
Use merge base when calculating changed files

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -81,8 +81,6 @@ jobs:
               - '!java/**'
               - '!notebooks/**'
               - '!python/**'
-              # TODO: Remove before merging
-              - '!.github/**'
             java:
               - '**'
               - '!CONTRIBUTING.md'
@@ -91,15 +89,11 @@ jobs:
               - '!img/**'
               - '!notebooks/**'
               - '!python/**'
-              # TODO: Remove before merging
-              - '!.github/**'
             notebooks:
               - '**'
               - '!CONTRIBUTING.md'
               - '!README.md'
               - '!java/**'
-              # TODO: Remove before merging
-              - '!.github/**'
             python:
               - '**'
               - '!CONTRIBUTING.md'
@@ -108,8 +102,6 @@ jobs:
               - '!img/**'
               - '!java/**'
               - '!notebooks/**'
-              # TODO: Remove before merging
-              - '!.github/**'
   checks:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,22 +53,28 @@ jobs:
       - name: Get PR info
         id: get-pr-info
         uses: rapidsai/shared-actions/get-pr-info@main
-      - name: Calculate number of commits to fetch
-        id: calculate-num-commits
-        env:
-          COMMITS: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).commits }}
-        run: echo "commits=$(( "$COMMITS" + 1 ))" >> "$GITHUB_OUTPUT"
-      - name: Checkout code repo
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
+          persist-credentials: false
+      - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.sha }}
-          fetch-depth: ${{ steps.calculate-num-commits.outputs.commits }}
           persist-credentials: false
+      - name: Calculate merge base
+        idD: calculate-merge-base
+        env:
+          PR_SHA: ${{ input.sha }}
+          BASE_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
+        run: |
+          (echo -n "merge-base="; git merge-base "$BASE_SHA" "$PR_SHA") > "$GITHUB_OUTPUT"
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45
         with:
-          base_sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
+          base_sha: ${{ steps.calculate-merge-base.outputs.merge-base }}
           files_yaml: |
             cpp:
               - '**'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,6 +53,17 @@ jobs:
       - name: Get PR info
         id: get-pr-info
         uses: rapidsai/shared-actions/get-pr-info@main
+      - name: Calculate number of commits to fetch
+        id: calculate-num-commits
+        env:
+          COMMITS: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).commits }}
+        run: echo "commits=$(( "$COMMITS" + 1 ))" >> "$GITHUB_OUTPUT"
+      - name: Checkout code repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+          fetch-depth: ${{ steps.calculate-num-commits.outputs.commits }}
+          persist-credentials: false
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,18 +56,18 @@ jobs:
       - name: Checkout base branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
+          ref: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
           persist-credentials: false
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.sha }}
+          ref: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
           persist-credentials: false
       - name: Calculate merge base
         id: calculate-merge-base
         env:
-          PR_SHA: ${{ inputs.sha }}
-          BASE_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
+          PR_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
+          BASE_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
         run: |
           (echo -n "merge-base="; git merge-base "$BASE_SHA" "$PR_SHA") > "$GITHUB_OUTPUT"
       - name: Get changed files

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,17 +53,6 @@ jobs:
       - name: Get PR info
         id: get-pr-info
         uses: rapidsai/shared-actions/get-pr-info@main
-      - name: Calculate number of commits to fetch
-        id: calculate-num-commits
-        env:
-          COMMITS: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).commits }}
-        run: echo "commits=$(( "$COMMITS" + 1 ))" >> "$GITHUB_OUTPUT"
-      - name: Checkout code repo
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.sha }}
-          fetch-depth: ${{ steps.calculate-num-commits.outputs.commits }}
-          persist-credentials: false
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -81,6 +81,8 @@ jobs:
               - '!java/**'
               - '!notebooks/**'
               - '!python/**'
+              # TODO: Remove before merging
+              - '!.github/**'
             java:
               - '**'
               - '!CONTRIBUTING.md'
@@ -89,11 +91,15 @@ jobs:
               - '!img/**'
               - '!notebooks/**'
               - '!python/**'
+              # TODO: Remove before merging
+              - '!.github/**'
             notebooks:
               - '**'
               - '!CONTRIBUTING.md'
               - '!README.md'
               - '!java/**'
+              # TODO: Remove before merging
+              - '!.github/**'
             python:
               - '**'
               - '!CONTRIBUTING.md'
@@ -102,6 +108,8 @@ jobs:
               - '!img/**'
               - '!java/**'
               - '!notebooks/**'
+              # TODO: Remove before merging
+              - '!.github/**'
   checks:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -64,7 +64,7 @@ jobs:
           ref: ${{ inputs.sha }}
           persist-credentials: false
       - name: Calculate merge base
-        idD: calculate-merge-base
+        id: calculate-merge-base
         env:
           PR_SHA: ${{ input.sha }}
           BASE_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,6 +67,8 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45
+        env:
+          ACTIONS_STEP_DEBUG: true
         with:
           base_sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
           files_yaml: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.sha }}
-          fetch-depth: ${{ steps.calculate-num-commits.outputs.commit }}
+          fetch-depth: ${{ steps.calculate-num-commits.outputs.commits }}
           persist-credentials: false
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,15 +53,10 @@ jobs:
       - name: Get PR info
         id: get-pr-info
         uses: rapidsai/shared-actions/get-pr-info@main
-      - name: Checkout base branch
+      - name: Checkout code repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
-          persist-credentials: false
-      - name: Checkout PR branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
+          fetch-depth: 0
           persist-credentials: false
       - name: Calculate merge base
         id: calculate-merge-base

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.sha }}
-          fetch-depth: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).commits }}
+          fetch-depth: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).commits + 1 }}
           persist-credentials: false
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Calculate merge base
         id: calculate-merge-base
         env:
-          PR_SHA: ${{ input.sha }}
+          PR_SHA: ${{ inputs.sha }}
           BASE_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
         run: |
           (echo -n "merge-base="; git merge-base "$BASE_SHA" "$PR_SHA") > "$GITHUB_OUTPUT"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,11 +53,16 @@ jobs:
       - name: Get PR info
         id: get-pr-info
         uses: rapidsai/shared-actions/get-pr-info@main
+      - name: Calculate number of commits to fetch
+        id: calculate-num-commits
+        env:
+          COMMITS: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).commits }}
+        run: echo "commits=$(( "$COMMITS" + 1 ))" >> "$GITHUB_OUTPUT"
       - name: Checkout code repo
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.sha }}
-          fetch-depth: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).commits + 1 }}
+          fetch-depth: ${{ steps.calculate-num-commits.outputs.commit }}
           persist-credentials: false
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,8 +67,6 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45
-        env:
-          ACTIONS_STEP_DEBUG: true
         with:
           base_sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
           files_yaml: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -70,6 +70,7 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           base_sha: ${{ steps.calculate-merge-base.outputs.merge-base }}
+          sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
           files_yaml: |
             cpp:
               - '**'


### PR DESCRIPTION
## Description
`get-pr-info.outputs.base.sha` does not actually give the merge base, but merely the tip of the target branch. Calculate the merge base and pass it to the `changed-files` step.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
