### PR TITLE
Change mixed type as string to have higher priority over JSON schema

### DIFF
--- a/cpp/include/cudf/io/json.hpp
+++ b/cpp/include/cudf/io/json.hpp
@@ -376,6 +376,7 @@ class json_reader_options {
   /**
    * @brief Set whether to parse mixed types as a string column.
    * Also enables forcing to read a struct as string column using schema.
+   * If enable, mixed types are parsed a string column regardless of schema.
    *
    * @param val Boolean value to enable/disable parsing mixed types as a string column
    */

--- a/cpp/src/io/json/json_column.cu
+++ b/cpp/src/io/json/json_column.cu
@@ -987,15 +987,15 @@ std::pair<std::unique_ptr<column>, std::vector<column_name_info>> device_json_co
 
       data_type target_type{};
 
-      if (schema.has_value()) {
+      if (json_col.forced_as_string_column) {
+        target_type = data_type{type_id::STRING};
+      } else if (schema.has_value()) {
 #ifdef NJP_DEBUG_PRINT
         std::cout << "-> explicit type: "
                   << (schema.has_value() ? std::to_string(static_cast<int>(schema->type.id()))
                                          : "n/a");
 #endif
         target_type = schema.value().type;
-      } else if (json_col.forced_as_string_column) {
-        target_type = data_type{type_id::STRING};
       }
       // Infer column type, if we don't have an explicit type for it
       else {

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -2788,10 +2788,7 @@ TEST_F(JsonReaderTest, MixedTypesWithSchema)
     cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
       .dtypes(data_types)
       .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
-      .normalize_single_quotes(true)
-      .normalize_whitespace(true)
       .mixed_types_as_string(true)
-      .strict_validation(true)
       .keep_quotes(true)
       .lines(true);
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
@@ -2800,7 +2797,7 @@ TEST_F(JsonReaderTest, MixedTypesWithSchema)
   EXPECT_EQ(result.tbl->num_rows(), 2);
   EXPECT_EQ(result.tbl->get_column(0).type().id(), cudf::type_id::STRING);
   // expected output without whitespace
-  cudf::test::strings_column_wrapper expected({R"({"A":0,"B":1})", "[1,0]"});
+  cudf::test::strings_column_wrapper expected({R"({"A": 0, "B": 1})", "[1,0]"});
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result.tbl->get_column(0));
 }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/rapidsai/cudf/issues/15260
Prefer mixed type as string than input schema in json reader, to fix the issue.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
