### PR TITLE
Spill OOM Protection 

### DIFF
--- a/python/cudf/cudf/options.py
+++ b/python/cudf/cudf/options.py
@@ -279,6 +279,26 @@ _register_option(
 )
 
 _register_option(
+    "spill_oom_protection",
+    _env_get_int("CUDF_SPILL_OOM_PROTECTION", 100),
+    textwrap.dedent(
+        """
+        If not 0, enables out-of-memory protection. The value specifies at
+        which procent of total device memory the protection should kick in.
+            0    - disabled.
+            1-99 - enable OOM protection when reaching 1%% to 99%% of total
+                   device memory.
+            100  - enable OOM protection only on OOM errors (no headroom).
+
+        This has no effect if spill on demand is disabled, see the "spill"
+        and the "spill_on_demand" options.
+        Valid values are any positive integer. Default is 0 (disabled).
+        """
+    ),
+    _integer_validator,
+)
+
+_register_option(
     "spill_stats",
     _env_get_int("CUDF_SPILL_STATS", 0),
     textwrap.dedent(

--- a/python/cudf/cudf/options.py
+++ b/python/cudf/cudf/options.py
@@ -292,7 +292,7 @@ _register_option(
 
         This has no effect if spill on demand is disabled, see the "spill"
         and the "spill_on_demand" options.
-        Valid values are any positive integer. Default is 0 (disabled).
+        Valid values are any positive integer. Default is 100 (no headroom).
         """
     ),
     _integer_validator,


### PR DESCRIPTION
Depend on  https://github.com/rapidsai/rmm/pull/1665

Introduce the `spill_oom_protection` option that enables managed memory when spilling-on-demand would otherwise crash with an OOM error.  

This targets our `CUDF_SPILL` users, which have workflows that cudf-spilling can handle generally but might encounter few memory hotspots that sometime trigger an OOM crash. With `CUDF_SPILL_OOM_PROTECTION`, these hotspots will now use managed memory.  

Notice, if `CUDF_SPILL` can handle a workflow, this option does nothing. 

The target is not heavy oversubscribing workflows, in such cases using manager memory with prefetching is preferable. 


### Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
