### PR TITLE
Polars 1.7 will change a minor thing in the IR, adapt to that

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -273,7 +273,7 @@ class Scan(IR):
             eol = chr(parse_options["eol_char"])
             if self.reader_options["schema"] is not None:
                 # Reader schema provides names
-                column_names = list(self.reader_options["schema"]["inner"].keys())
+                column_names = list(self.reader_options["schema"]["fields"].keys())
             else:
                 # file provides column names
                 column_names = None


### PR DESCRIPTION
## Description

This field renaming was due to a recent refactor in (as-yet-unreleased) polars 1.7.

Perhaps a safer option is that we hard-pin the release to 1.6.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
