### PR TITLE
Simplify the nvCOMP adapter

### DIFF
--- a/cpp/include/cudf/io/nvcomp_adapter.hpp
+++ b/cpp/include/cudf/io/nvcomp_adapter.hpp
@@ -36,7 +36,6 @@ struct feature_status_parameters {
   int lib_patch_version;                 ///< patch version
   bool are_all_integrations_enabled;     ///< all integrations
   bool are_stable_integrations_enabled;  ///< stable integrations
-  int compute_capability_major;          ///< cuda compute major version
 
   /**
    * @brief Default Constructor
@@ -59,8 +58,7 @@ struct feature_status_parameters {
       lib_minor_version{minor},
       lib_patch_version{patch},
       are_all_integrations_enabled{all_enabled},
-      are_stable_integrations_enabled{stable_enabled},
-      compute_capability_major{cc_major}
+      are_stable_integrations_enabled{stable_enabled}
   {
   }
 };
@@ -74,8 +72,7 @@ inline bool operator==(feature_status_parameters const& lhs, feature_status_para
          lhs.lib_minor_version == rhs.lib_minor_version and
          lhs.lib_patch_version == rhs.lib_patch_version and
          lhs.are_all_integrations_enabled == rhs.are_all_integrations_enabled and
-         lhs.are_stable_integrations_enabled == rhs.are_stable_integrations_enabled and
-         lhs.compute_capability_major == rhs.compute_capability_major;
+         lhs.are_stable_integrations_enabled == rhs.are_stable_integrations_enabled;
 }
 
 /**

--- a/cpp/include/cudf/io/nvcomp_adapter.hpp
+++ b/cpp/include/cudf/io/nvcomp_adapter.hpp
@@ -38,29 +38,18 @@ struct feature_status_parameters {
   bool are_stable_integrations_enabled;  ///< stable integrations
 
   /**
-   * @brief Default Constructor
+   * @brief Default Constructor, with the current version of nvcomp and current environment
+   * variables
    */
   feature_status_parameters();
 
   /**
-   * @brief feature_status_parameters Constructor
+   * @brief feature_status_parameters Constructor, with the current version of nvcomp
    *
-   * @param major positive integer representing major value of nvcomp
-   * @param minor positive integer representing minor value of nvcomp
-   * @param patch positive integer representing patch value of nvcomp
    * @param all_enabled if all integrations are enabled
    * @param stable_enabled if stable integrations are enabled
-   * @param cc_major CUDA compute capability
    */
-  feature_status_parameters(
-    int major, int minor, int patch, bool all_enabled, bool stable_enabled, int cc_major)
-    : lib_major_version{major},
-      lib_minor_version{minor},
-      lib_patch_version{patch},
-      are_all_integrations_enabled{all_enabled},
-      are_stable_integrations_enabled{stable_enabled}
-  {
-  }
+  feature_status_parameters(bool all_enabled, bool stable_enabled);
 };
 
 /**

--- a/cpp/include/cudf/io/nvcomp_adapter.hpp
+++ b/cpp/include/cudf/io/nvcomp_adapter.hpp
@@ -38,13 +38,13 @@ struct feature_status_parameters {
   bool are_stable_integrations_enabled;  ///< stable integrations
 
   /**
-   * @brief Default Constructor, with the current version of nvcomp and current environment
+   * @brief Default constructor using the current version of nvcomp and current environment
    * variables
    */
   feature_status_parameters();
 
   /**
-   * @brief feature_status_parameters Constructor, with the current version of nvcomp
+   * @brief Constructor using the current version of nvcomp
    *
    * @param all_enabled if all integrations are enabled
    * @param stable_enabled if stable integrations are enabled

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -29,13 +29,6 @@
 
 #include <mutex>
 
-// When building with nvcomp 4.0 or newer, map the new version macros to the old ones
-#ifndef NVCOMP_MAJOR_VERSION
-#define NVCOMP_MAJOR_VERSION NVCOMP_VER_MAJOR
-#define NVCOMP_MINOR_VERSION NVCOMP_VER_MINOR
-#define NVCOMP_PATCH_VERSION NVCOMP_VER_PATCH
-#endif
-
 namespace cudf::io::nvcomp {
 
 // Dispatcher for nvcompBatched<format>DecompressGetTempSizeEx
@@ -395,9 +388,9 @@ void batched_compress(compression_type compression,
 }
 
 feature_status_parameters::feature_status_parameters()
-  : lib_major_version{NVCOMP_MAJOR_VERSION},
-    lib_minor_version{NVCOMP_MINOR_VERSION},
-    lib_patch_version{NVCOMP_PATCH_VERSION},
+  : lib_major_version{NVCOMP_VER_MAJOR},
+    lib_minor_version{NVCOMP_VER_MINOR},
+    lib_patch_version{NVCOMP_VER_PATCH},
     are_all_integrations_enabled{nvcomp_integration::is_all_enabled()},
     are_stable_integrations_enabled{nvcomp_integration::is_stable_enabled()}
 {

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -43,7 +43,7 @@ std::optional<nvcompStatus_t> batched_decompress_get_temp_size_ex(compression_ty
       return nvcompBatchedZstdDecompressGetTempSizeEx(std::forward<Args>(args)...);
     case compression_type::LZ4:
       return nvcompBatchedLZ4DecompressGetTempSizeEx(std::forward<Args>(args)...);
-    case compression_type::DEFLATE: [[fallthrough]];
+    case compression_type::DEFLATE:
     default: return std::nullopt;
   }
   return std::nullopt;

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -401,10 +401,6 @@ feature_status_parameters::feature_status_parameters()
     are_all_integrations_enabled{nvcomp_integration::is_all_enabled()},
     are_stable_integrations_enabled{nvcomp_integration::is_stable_enabled()}
 {
-  int device;
-  CUDF_CUDA_TRY(cudaGetDevice(&device));
-  CUDF_CUDA_TRY(
-    cudaDeviceGetAttribute(&compute_capability_major, cudaDevAttrComputeCapabilityMajor, device));
 }
 
 // Represents all parameters required to determine status of a compression/decompression feature
@@ -433,27 +429,13 @@ std::optional<std::string> is_compression_disabled_impl(compression_type compres
       }
       return std::nullopt;
     }
-    case compression_type::SNAPPY: {
-      if (not params.are_stable_integrations_enabled) {
-        return "Snappy compression has been disabled through the `LIBCUDF_NVCOMP_POLICY` "
-               "environment variable.";
-      }
-      return std::nullopt;
-    }
-    case compression_type::ZSTD: {
-      if (not params.are_stable_integrations_enabled) {
-        return "Zstandard compression is experimental, you can enable it through "
-               "`LIBCUDF_NVCOMP_POLICY` environment variable.";
-      }
-      return std::nullopt;
-    }
     case compression_type::LZ4:
+    case compression_type::SNAPPY:
+    case compression_type::ZSTD:
       if (not params.are_stable_integrations_enabled) {
-        return "LZ4 compression has been disabled through the `LIBCUDF_NVCOMP_POLICY` "
-               "environment variable.";
+        return "nvCOMP use is disabled through the `LIBCUDF_NVCOMP_POLICY` environment variable.";
       }
       return std::nullopt;
-    default: return "Unsupported compression type";
   }
   return "Unsupported compression type";
 }
@@ -498,27 +480,14 @@ std::optional<std::string> is_decompression_disabled_impl(compression_type compr
       }
       return std::nullopt;
     }
-    case compression_type::SNAPPY: {
-      if (not params.are_stable_integrations_enabled) {
-        return "Snappy decompression has been disabled through the `LIBCUDF_NVCOMP_POLICY` "
-               "environment variable.";
-      }
-      return std::nullopt;
-    }
+    case compression_type::LZ4:
+    case compression_type::SNAPPY:
     case compression_type::ZSTD: {
       if (not params.are_stable_integrations_enabled) {
-        return "Zstandard decompression has been disabled through the `LIBCUDF_NVCOMP_POLICY` "
-               "environment variable.";
-      }
-    }
-    case compression_type::LZ4: {
-      if (not params.are_stable_integrations_enabled) {
-        return "LZ4 decompression has been disabled through the `LIBCUDF_NVCOMP_POLICY` "
-               "environment variable.";
+        return "nvCOMP use is disabled through the `LIBCUDF_NVCOMP_POLICY` environment variable.";
       }
       return std::nullopt;
     }
-    default: return "Unsupported compression type";
   }
   return "Unsupported compression type";
 }

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -388,11 +388,17 @@ void batched_compress(compression_type compression,
 }
 
 feature_status_parameters::feature_status_parameters()
+  : feature_status_parameters(nvcomp_integration::is_all_enabled(),
+                              nvcomp_integration::is_stable_enabled())
+{
+}
+
+feature_status_parameters::feature_status_parameters(bool all_enabled, bool stable_enabled)
   : lib_major_version{NVCOMP_VER_MAJOR},
     lib_minor_version{NVCOMP_VER_MINOR},
     lib_patch_version{NVCOMP_VER_PATCH},
-    are_all_integrations_enabled{nvcomp_integration::is_all_enabled()},
-    are_stable_integrations_enabled{nvcomp_integration::is_stable_enabled()}
+    are_all_integrations_enabled{all_enabled},
+    are_stable_integrations_enabled{stable_enabled}
 {
 }
 

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -43,6 +43,7 @@ auto batched_decompress_get_temp_size_ex(compression_type compression, Args&&...
     case compression_type::LZ4:
       return nvcompBatchedLZ4DecompressGetTempSizeEx(std::forward<Args>(args)...);
     case compression_type::DEFLATE:
+      return nvcompBatchedDeflateDecompressGetTempSizeEx(std::forward<Args>(args)...);
     default: CUDF_FAIL("Unsupported compression type");
   }
 }

--- a/cpp/src/io/comp/nvcomp_adapter.hpp
+++ b/cpp/src/io/comp/nvcomp_adapter.hpp
@@ -75,20 +75,12 @@ size_t batched_decompress_temp_size(compression_type compression,
                                                     uint32_t max_uncomp_chunk_size);
 
 /**
- * @brief Gets input alignment requirements for the given compression type.
+ * @brief Gets input and output alignment requirements for the given compression type.
  *
  * @param compression Compression type
- * @returns required alignment, in bits
+ * @returns required alignment
  */
-[[nodiscard]] size_t compress_input_alignment_bits(compression_type compression);
-
-/**
- * @brief Gets output alignment requirements for the given compression type.
- *
- * @param compression Compression type
- * @returns required alignment, in bits
- */
-[[nodiscard]] size_t compress_output_alignment_bits(compression_type compression);
+[[nodiscard]] size_t required_alignment(compression_type compression);
 
 /**
  * @brief Maximum size of uncompressed chunks that can be compressed with nvCOMP.

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -532,20 +532,20 @@ auto uncomp_block_alignment(CompressionKind compression_kind)
 {
   if (compression_kind == NONE or
       nvcomp::is_compression_disabled(to_nvcomp_compression_type(compression_kind))) {
-    return 1u;
+    return 1ul;
   }
 
-  return 1u << nvcomp::compress_input_alignment_bits(to_nvcomp_compression_type(compression_kind));
+  return nvcomp::required_alignment(to_nvcomp_compression_type(compression_kind));
 }
 
 auto comp_block_alignment(CompressionKind compression_kind)
 {
   if (compression_kind == NONE or
       nvcomp::is_compression_disabled(to_nvcomp_compression_type(compression_kind))) {
-    return 1u;
+    return 1ul;
   }
 
-  return 1u << nvcomp::compress_output_alignment_bits(to_nvcomp_compression_type(compression_kind));
+  return nvcomp::required_alignment(to_nvcomp_compression_type(compression_kind));
 }
 
 /**

--- a/cpp/src/io/parquet/writer_impl_helpers.cpp
+++ b/cpp/src/io/parquet/writer_impl_helpers.cpp
@@ -62,7 +62,7 @@ uint32_t page_alignment(Compression codec)
     return 1u;
   }
 
-  return 1u << nvcomp::compress_input_alignment_bits(to_nvcomp_compression_type(codec));
+  return nvcomp::required_alignment(to_nvcomp_compression_type(codec));
 }
 
 size_t max_compression_output_size(Compression codec, uint32_t compression_blocksize)

--- a/cpp/tests/io/comp/decomp_test.cpp
+++ b/cpp/tests/io/comp/decomp_test.cpp
@@ -176,23 +176,19 @@ TEST_F(NvcompConfigTest, Compression)
   using cudf::io::nvcomp::compression_type;
   auto const& comp_disabled = cudf::io::nvcomp::is_compression_disabled;
 
-  EXPECT_FALSE(comp_disabled(compression_type::DEFLATE, {2, 5, 0, true, true, 0}));
-  // version 2.5 required
-  EXPECT_TRUE(comp_disabled(compression_type::DEFLATE, {2, 4, 0, true, true, 0}));
+  EXPECT_FALSE(comp_disabled(compression_type::DEFLATE, {true, true}));
   // all integrations enabled required
-  EXPECT_TRUE(comp_disabled(compression_type::DEFLATE, {2, 5, 0, false, true, 0}));
+  EXPECT_TRUE(comp_disabled(compression_type::DEFLATE, {false, true}));
 
-  EXPECT_FALSE(comp_disabled(compression_type::ZSTD, {2, 4, 0, true, true, 0}));
-  EXPECT_FALSE(comp_disabled(compression_type::ZSTD, {2, 4, 0, false, true, 0}));
-  // 2.4 version required
-  EXPECT_TRUE(comp_disabled(compression_type::ZSTD, {2, 3, 1, false, true, 0}));
+  EXPECT_FALSE(comp_disabled(compression_type::ZSTD, {true, true}));
+  EXPECT_FALSE(comp_disabled(compression_type::ZSTD, {false, true}));
   // stable integrations enabled required
-  EXPECT_TRUE(comp_disabled(compression_type::ZSTD, {2, 4, 0, false, false, 0}));
+  EXPECT_TRUE(comp_disabled(compression_type::ZSTD, {false, false}));
 
-  EXPECT_FALSE(comp_disabled(compression_type::SNAPPY, {2, 5, 0, true, true, 0}));
-  EXPECT_FALSE(comp_disabled(compression_type::SNAPPY, {2, 4, 0, false, true, 0}));
+  EXPECT_FALSE(comp_disabled(compression_type::SNAPPY, {true, true}));
+  EXPECT_FALSE(comp_disabled(compression_type::SNAPPY, {false, true}));
   // stable integrations enabled required
-  EXPECT_TRUE(comp_disabled(compression_type::SNAPPY, {2, 3, 0, false, false, 0}));
+  EXPECT_TRUE(comp_disabled(compression_type::SNAPPY, {false, false}));
 }
 
 TEST_F(NvcompConfigTest, Decompression)
@@ -200,27 +196,19 @@ TEST_F(NvcompConfigTest, Decompression)
   using cudf::io::nvcomp::compression_type;
   auto const& decomp_disabled = cudf::io::nvcomp::is_decompression_disabled;
 
-  EXPECT_FALSE(decomp_disabled(compression_type::DEFLATE, {2, 5, 0, true, true, 7}));
-  // version 2.5 required
-  EXPECT_TRUE(decomp_disabled(compression_type::DEFLATE, {2, 4, 0, true, true, 7}));
+  EXPECT_FALSE(decomp_disabled(compression_type::DEFLATE, {true, true}));
   // all integrations enabled required
-  EXPECT_TRUE(decomp_disabled(compression_type::DEFLATE, {2, 5, 0, false, true, 7}));
+  EXPECT_TRUE(decomp_disabled(compression_type::DEFLATE, {false, true}));
 
-  EXPECT_FALSE(decomp_disabled(compression_type::ZSTD, {2, 4, 0, true, true, 7}));
-  EXPECT_FALSE(decomp_disabled(compression_type::ZSTD, {2, 3, 2, false, true, 6}));
-  EXPECT_FALSE(decomp_disabled(compression_type::ZSTD, {2, 3, 0, true, true, 6}));
-  // 2.3.1 and earlier requires all integrations to be enabled
-  EXPECT_TRUE(decomp_disabled(compression_type::ZSTD, {2, 3, 1, false, true, 7}));
-  // 2.3 version required
-  EXPECT_TRUE(decomp_disabled(compression_type::ZSTD, {2, 2, 0, true, true, 7}));
+  EXPECT_FALSE(decomp_disabled(compression_type::ZSTD, {true, true}));
+  EXPECT_FALSE(decomp_disabled(compression_type::ZSTD, {false, true}));
   // stable integrations enabled required
-  EXPECT_TRUE(decomp_disabled(compression_type::ZSTD, {2, 4, 0, false, false, 7}));
+  EXPECT_TRUE(decomp_disabled(compression_type::ZSTD, {false, false}));
 
-  EXPECT_FALSE(decomp_disabled(compression_type::SNAPPY, {2, 4, 0, true, true, 7}));
-  EXPECT_FALSE(decomp_disabled(compression_type::SNAPPY, {2, 3, 0, false, true, 7}));
-  EXPECT_FALSE(decomp_disabled(compression_type::SNAPPY, {2, 2, 0, false, true, 7}));
+  EXPECT_FALSE(decomp_disabled(compression_type::SNAPPY, {true, true}));
+  EXPECT_FALSE(decomp_disabled(compression_type::SNAPPY, {false, true}));
   // stable integrations enabled required
-  EXPECT_TRUE(decomp_disabled(compression_type::SNAPPY, {2, 2, 0, false, false, 7}));
+  EXPECT_TRUE(decomp_disabled(compression_type::SNAPPY, {false, false}));
 }
 
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
## Description
This PR removes the adapter code that allow running with older nvCOMP versions.
Feature status checking has been significantly simplified, and compile-time checks for newer compression types have been removed.
Also removed the fallback to the old version of get_temp_size, since we are now guaranteed to have access to the extended version.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
