### PR TITLE
allow pandas patch version to float in cudf-pandas unit tests

### DIFF
--- a/ci/cudf_pandas_scripts/run_tests.sh
+++ b/ci/cudf_pandas_scripts/run_tests.sh
@@ -91,7 +91,7 @@ IFS=',' read -r -a versions <<< "$output"
 
 for version in "${versions[@]}"; do
     echo "Installing pandas version: ${version}"
-    python -m pip install "numpy>=1.23,<2.0a0" "pandas==${version}"
+    python -m pip install "numpy>=1.23,<2.0a0" "pandas==${version}.*"
     python -m pytest -p cudf.pandas \
     --ignore=./python/cudf/cudf_pandas_tests/third_party_integration_tests/ \
     --cov-config=./python/cudf/.coveragerc \


### PR DESCRIPTION
## Description

#16745 added support for Python 3.12 in this project.

When that was merged, nightly `unit-tests-cudf-pandas` jobs on Python 3.12 started failing, with errors from compiling `pandas`: ([build link](https://github.com/rapidsai/cudf/actions/runs/10733915866/job/29768130164))

That's only happening because we're running `pip install pandas==2.1` in those jobs, which matches exactly `pandas==2.1.0`, which does not have Python 3.12 wheels on PyPI (https://pypi.org/project/pandas/2.1.0/#files).

```text
Collecting pandas==2.1
  Downloading pandas-2.1.0.tar.gz (4.3 MB)
```

`pandas==2.1.1` DOES have Python 3.12 wheels on PyPI (https://pypi.org/project/pandas/2.1.1/#files).

To fix those jobs, this proposes allowing the patch version of `pandas` installed in those CI jobs to float:

* before: `pip install pandas==2.1`
* after: `pip install pandas==2.1.*`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
