### PR TITLE
Remove `MultiIndex._poplevel` inplace implementation.

### DIFF
--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1548,8 +1548,7 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
         """
         if is_scalar(level):
             level = (level,)
-
-        if len(level) == 0:
+        elif len(level) == 0:
             return self
 
         new_names = list(self.names)

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -12,6 +12,7 @@ import cudf
 from cudf._lib.transform import one_hot_encode
 from cudf._lib.types import size_type_dtype
 from cudf.api.extensions import no_default
+from cudf.api.types import is_scalar
 from cudf.core._compat import PANDAS_LT_300
 from cudf.core.column import ColumnBase, as_column, column_empty_like
 from cudf.core.column_accessor import ColumnAccessor
@@ -1227,9 +1228,11 @@ def unstack(df, level, fill_value=None, sort: bool = True):
         )
         return res
     else:
-        df = df.copy(deep=False)
-        columns = df.index._poplevels(level)
-        index = df.index
+        columns = df.index.droplevel(level)
+        if is_scalar(level):
+            index = df.index.get_level_values(level)
+        else:
+            pass
     result = _pivot(df, index, columns)
     if result.index.nlevels == 1:
         result.index = result.index.get_level_values(result.index.names[0])

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -1228,11 +1228,20 @@ def unstack(df, level, fill_value=None, sort: bool = True):
         )
         return res
     else:
-        columns = df.index.droplevel(level)
+        index = df.index.droplevel(level)
         if is_scalar(level):
-            index = df.index.get_level_values(level)
+            columns = df.index.get_level_values(level)
         else:
-            pass
+            new_names = []
+            ca_data = {}
+            for lev in level:
+                ca_level, level_idx = df.index._level_to_ca_label(lev)
+                new_names.append(df.index.names[level_idx])
+                ca_data[ca_level] = df.index._data[ca_level]
+            columns = type(df.index)._from_data(
+                ColumnAccessor(ca_data, verify=False)
+            )
+            columns.names = new_names
     result = _pivot(df, index, columns)
     if result.index.nlevels == 1:
         result.index = result.index.get_level_values(result.index.names[0])

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -1242,10 +1242,10 @@ def unstack(df, level, fill_value=None, sort: bool = True):
                 ColumnAccessor(ca_data, verify=False)
             )
             columns.names = new_names
-    result = _pivot(df, index, columns)
-    if result.index.nlevels == 1:
-        result.index = result.index.get_level_values(result.index.names[0])
-    return result
+        result = _pivot(df, index, columns)
+        if result.index.nlevels == 1:
+            result.index = result.index.get_level_values(result.index.names[0])
+        return result
 
 
 def _get_unique(column: ColumnBase, dummy_na: bool) -> ColumnBase:


### PR DESCRIPTION
## Description
`MultiIndex._poplevel`, which backs `MultiIndex.droplevel`, operates by dropping a given level inplace. There 2 places where `._poplevel` is called, and both usages makes a shallow copy of the data first, presumably to work around side effects of this inplace behavior.

This PR remove the `MultiIndex._poplevel` implementation and just implements dropping level like behavior by just returning a new object.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
