### PR TITLE
Allow read_csv(header=None) to return int column labels in `mode.pandas_compatible`

### DIFF
--- a/python/cudf/cudf/_lib/csv.pyx
+++ b/python/cudf/cudf/_lib/csv.pyx
@@ -276,8 +276,10 @@ def read_csv(
                     col_name = df._data.names[index]
                     df._data[col_name] = df._data[col_name].astype(col_dtype)
 
-    if names is not None and len(names) and isinstance(names[0], (int)):
+    if names is not None and len(names) and isinstance(names[0], int):
         df.columns = [int(x) for x in df._data]
+    elif names is None and header == -1 and cudf.get_option("mode.pandas_compatible"):
+        df.columns = [int(x) for x in df._column_names]
 
     # Set index if the index_col parameter is passed
     if index_col is not None and index_col is not False:

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -2269,3 +2269,11 @@ def test_read_compressed_BOM(tmpdir):
         f.write(buffer)
 
     assert_eq(pd.read_csv(fname), cudf.read_csv(fname))
+
+
+def test_read_header_none_pandas_compat_column_type():
+    data = "1\n2\n"
+    with cudf.option_context("mode.pandas_compatible", True):
+        result = cudf.read_csv(StringIO(data), header=None).columns
+    expected = pd.read_csv(StringIO(data), header=None).columns
+    pd.testing.assert_index_equal(result, expected, exact=True)


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/16766

If the cudf `read_csv` behavior of always returning string column labels is long standing behavior, we can match the pandas behavior of returning integer column labels in `mode.pandas_compatible`


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
