### PR TITLE
Fix nvbench output for sha512

### DIFF
--- a/cpp/benchmarks/hashing/hash.cpp
+++ b/cpp/benchmarks/hashing/hash.cpp
@@ -50,7 +50,7 @@ static void bench_hash(nvbench::state& state)
   state.add_global_memory_reads<nvbench::int64_t>(num_rows);
   // add memory read from bitmaks
   if (!no_nulls) {
-    state.add_global_memory_reads<nvbench::int8_t>(2 *
+    state.add_global_memory_reads<nvbench::int8_t>(2L *
                                                    cudf::bitmask_allocation_size_bytes(num_rows));
   }
   // memory written depends on used hash
@@ -63,37 +63,37 @@ static void bench_hash(nvbench::state& state)
     });
   } else if (hash_name == "md5") {
     // md5 creates a 32-byte string
-    state.add_global_memory_writes<nvbench::int8_t>(32 * num_rows);
+    state.add_global_memory_writes<nvbench::int8_t>(32L * num_rows);
 
     state.exec(nvbench::exec_tag::sync,
                [&](nvbench::launch& launch) { auto result = cudf::hashing::md5(data->view()); });
   } else if (hash_name == "sha1") {
     // sha1 creates a 40-byte string
-    state.add_global_memory_writes<nvbench::int8_t>(40 * num_rows);
+    state.add_global_memory_writes<nvbench::int8_t>(40L * num_rows);
 
     state.exec(nvbench::exec_tag::sync,
                [&](nvbench::launch& launch) { auto result = cudf::hashing::sha1(data->view()); });
   } else if (hash_name == "sha224") {
     // sha224 creates a 56-byte string
-    state.add_global_memory_writes<nvbench::int8_t>(56 * num_rows);
+    state.add_global_memory_writes<nvbench::int8_t>(56L * num_rows);
 
     state.exec(nvbench::exec_tag::sync,
                [&](nvbench::launch& launch) { auto result = cudf::hashing::sha224(data->view()); });
   } else if (hash_name == "sha256") {
     // sha256 creates a 64-byte string
-    state.add_global_memory_writes<nvbench::int8_t>(64 * num_rows);
+    state.add_global_memory_writes<nvbench::int8_t>(64L * num_rows);
 
     state.exec(nvbench::exec_tag::sync,
                [&](nvbench::launch& launch) { auto result = cudf::hashing::sha256(data->view()); });
   } else if (hash_name == "sha384") {
     // sha384 creates a 96-byte string
-    state.add_global_memory_writes<nvbench::int8_t>(96 * num_rows);
+    state.add_global_memory_writes<nvbench::int8_t>(96L * num_rows);
 
     state.exec(nvbench::exec_tag::sync,
                [&](nvbench::launch& launch) { auto result = cudf::hashing::sha384(data->view()); });
   } else if (hash_name == "sha512") {
     // sha512 creates a 128-byte string
-    state.add_global_memory_writes<nvbench::int8_t>(128 * num_rows);
+    state.add_global_memory_writes<nvbench::int8_t>(128L * num_rows);
 
     state.exec(nvbench::exec_tag::sync,
                [&](nvbench::launch& launch) { auto result = cudf::hashing::sha512(data->view()); });


### PR DESCRIPTION
## Description
Fixes the `sha512` output for nvbench for `GlobalMem BW`.
Previously:
```
|    65536 |     0 | sha512 |   1216x | 417.898 us |  1.40% | 412.669 us | 0.61% |     24.139 GB/s |           3.14% |
| 16777216 |     0 | sha512 |     11x |  71.392 ms |  0.03% |  71.387 ms | 0.03% | 258404.649 PB/s | 33642233417.78% |
|    65536 |   0.1 | sha512 |   1184x | 433.031 us |  1.58% | 427.815 us | 1.01% |     22.919 GB/s |           2.98% |
| 16777216 |   0.1 | sha512 |     11x |  73.457 ms |  0.03% |  73.452 ms | 0.03% | 251140.174 PB/s | 32696456458.71% |
```
Fixed integer overflow calculation:
```
|    65536 |     0 | sha512 |   1200x | 423.838 us |  1.42% | 418.561 us | 0.66% |  23.799 GB/s |  3.10% |
| 16777216 |     0 | sha512 |     11x |  72.773 ms |  0.11% |  72.767 ms | 0.11% |  35.041 GB/s |  4.56% |
|    65536 |   0.1 | sha512 |   1168x | 439.078 us |  1.60% | 433.843 us | 1.05% |  22.601 GB/s |  2.94% |
| 16777216 |   0.1 | sha512 |     19x |  75.108 ms |  0.49% |  75.102 ms | 0.49% |  33.412 GB/s |  4.35% |
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
