### PR TITLE
Add labeling pylibcudf doc pages

### DIFF
--- a/docs/cudf/source/user_guide/api_docs/pylibcudf/index.rst
+++ b/docs/cudf/source/user_guide/api_docs/pylibcudf/index.rst
@@ -21,6 +21,7 @@ This page provides API documentation for pylibcudf.
     groupby
     interop
     join
+    labeling
     lists
     merge
     null_mask

--- a/docs/cudf/source/user_guide/api_docs/pylibcudf/labeling.rst
+++ b/docs/cudf/source/user_guide/api_docs/pylibcudf/labeling.rst
@@ -1,0 +1,6 @@
+========
+labeling
+========
+
+.. automodule:: pylibcudf.labeling
+   :members:


### PR DESCRIPTION
## Description
Follow up to https://github.com/rapidsai/cudf/pull/16761, I forgot to add the doc pages for the labeling pylibcudf APIs

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
