### PR TITLE
Use cupy 12.2.0 as oldest dependency pinning on CUDA 12 ARM

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -710,7 +710,7 @@ dependencies:
               - numpy==1.23.*
               - pandas==2.0.*
               - pyarrow==14.0.0
-              - cupy==12.0.0  # ignored as pip constraint
+              - cupy==12.2.0  # ignored as pip constraint. cupy 12.2.0 is the earliest with CUDA 12 ARM packages.
           - matrix:
             packages:
       - output_types: requirements

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -710,7 +710,16 @@ dependencies:
               - numpy==1.23.*
               - pandas==2.0.*
               - pyarrow==14.0.0
-              - cupy==12.2.0  # ignored as pip constraint. cupy 12.2.0 is the earliest with CUDA 12 ARM packages.
+          - matrix:
+            packages:
+      - output_types: conda
+        matrices:
+          - matrix: {dependencies: "oldest", arch: "aarch64", cuda: "12.*"}
+            packages:
+              - cupy==12.2.0  # cupy 12.2.0 is the earliest with CUDA 12 ARM packages.
+          - matrix: {dependencies: "oldest"}
+            packages:
+              - cupy==12.0.0
           - matrix:
             packages:
       - output_types: requirements


### PR DESCRIPTION
## Description
Uses cupy 12.2.0 as oldest dependency pinning on ARM to ensure CUDA 12 support.

This will fix nightly CI failures that look like:

```
LibMambaUnsatisfiableError: Encountered problems while solving:
  - package cupy-12.0.0-py311h308989c_2 requires python_abi 3.11.* *_cp311, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ cuda-version 12.2**  is installable and it requires
│  └─ cudatoolkit 12.2|12.2.* , which can be installed;
├─ cupy 12.0.0  is installable with the potential options
│  ├─ cupy 12.0.0 would require
│  │  └─ cudatoolkit >=11.2,<12 , which conflicts with any installable versions previously reported;
...
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
