### PR TITLE
Adding an `Open in DevZero` Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,7 @@ See the [RAPIDS installation guide](https://docs.rapids.ai/install) for more OS 
 See build [instructions](CONTRIBUTING.md#setting-up-your-build-environment).
 
 ## Contributing
+[![Open in DevZero](https://assets.devzero.io/open-in-devzero.svg)](https://www.devzero.io/dashboard/recipes/new?repo-url=https://github.com/rapidsai/cudf)
 
 Please see our [guide for contributing to cuDF](CONTRIBUTING.md).
+


### PR DESCRIPTION
DevZero is a dev environment platform. Using this link, all contributors to this project will be able to use a DevZero environment as the dev workspace. DevZero supports a free plan that individual contributors to OSS projects can utilize to make the contributions and/or to just test out the project.