### PR TITLE
Ignore numba warning specific to ARM runners

### DIFF
--- a/python/cudf/cudf/tests/pytest.ini
+++ b/python/cudf/cudf/tests/pytest.ini
@@ -14,4 +14,6 @@ filterwarnings =
     ignore:Passing a BlockManager to DataFrame is deprecated:DeprecationWarning
     # PerformanceWarning from cupy warming up the JIT cache
     ignore:Jitify is performing a one-time only warm-up to populate the persistent cache:cupy._util.PerformanceWarning
+    # Ignore numba PEP 456 warning specific to arm machines
+    ignore:FNV hashing is not implemented in Numba.*:UserWarning
 addopts = --tb=native


### PR DESCRIPTION
## Description
This PR ignores numba warnings that are showing up in arm runners: https://github.com/numba/numba/issues/6589#issuecomment-748595076

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
