### PR TITLE
Add APIs to copy data to and from device to `cudf::detail::host_vector`

### DIFF
--- a/cpp/include/cudf/detail/utilities/host_vector.hpp
+++ b/cpp/include/cudf/detail/utilities/host_vector.hpp
@@ -209,7 +209,7 @@ class host_vector : public thrust::host_vector<T, rmm_host_allocator<T>> {
    */
   void to_device_async(T* d_ptr, rmm::cuda_stream_view stream) const
   {
-    auto const is_pinned = this->is_device_accessible();
+    auto const is_pinned = this->get_allocator().is_device_accessible();
     cuda_memcpy_async(d_ptr,
                       this->data(),
                       this->size() * sizeof(T),
@@ -230,7 +230,7 @@ class host_vector : public thrust::host_vector<T, rmm_host_allocator<T>> {
    */
   void from_device_async(T const* d_ptr, rmm::cuda_stream_view stream)
   {
-    auto const is_pinned = this->is_device_accessible();
+    auto const is_pinned = this->get_allocator().is_device_accessible();
     cuda_memcpy_async(this->data(),
                       d_ptr,
                       this->size() * sizeof(T),

--- a/cpp/include/cudf/detail/utilities/host_vector.hpp
+++ b/cpp/include/cudf/detail/utilities/host_vector.hpp
@@ -207,7 +207,7 @@ class host_vector : public thrust::host_vector<T, rmm_host_allocator<T>> {
   /**
    * @brief Copies the contents to the given device address asynchronously
    */
-  void to_device_async(T* d_ptr, rmm::cuda_stream_view stream) const
+  void copy_to_device_async(T* d_ptr, rmm::cuda_stream_view stream) const
   {
     auto const is_pinned = this->get_allocator().is_device_accessible();
     cuda_memcpy_async(d_ptr,
@@ -219,16 +219,16 @@ class host_vector : public thrust::host_vector<T, rmm_host_allocator<T>> {
   /**
    * @brief Copies the contents to the given device address and synchronizes the stream
    */
-  void to_device(T* d_ptr, rmm::cuda_stream_view stream) const
+  void copy_to_device(T* d_ptr, rmm::cuda_stream_view stream) const
   {
-    to_device_async(d_ptr, stream);
+    copy_to_device_async(d_ptr, stream);
     stream.synchronize();
   }
 
   /**
    * @brief Copies the contents from the given device address asynchronously
    */
-  void from_device_async(T const* d_ptr, rmm::cuda_stream_view stream)
+  void copy_from_device_async(T const* d_ptr, rmm::cuda_stream_view stream)
   {
     auto const is_pinned = this->get_allocator().is_device_accessible();
     cuda_memcpy_async(this->data(),
@@ -241,9 +241,9 @@ class host_vector : public thrust::host_vector<T, rmm_host_allocator<T>> {
   /**
    * @brief Copies the contents from the given device address and synchronizes the stream
    */
-  void from_device(T const* d_ptr, rmm::cuda_stream_view stream)
+  void copy_from_device(T const* d_ptr, rmm::cuda_stream_view stream)
   {
-    from_device_async(d_ptr, stream);
+    copy_from_device_async(d_ptr, stream);
     stream.synchronize();
   }
 };

--- a/cpp/src/io/json/host_tree_algorithms.cu
+++ b/cpp/src/io/json/host_tree_algorithms.cu
@@ -201,7 +201,7 @@ NodeIndexT get_row_array_parent_col_id(device_span<NodeIndexT const> col_ids,
 
   auto value                 = cudf::detail::make_host_vector<NodeIndexT>(1, stream);
   auto const list_node_index = is_enabled_lines ? 0 : 1;
-  value.from_device(col_ids.data() + list_node_index, stream);
+  value.copy_from_device(col_ids.data() + list_node_index, stream);
   return value[0];
 }
 /**
@@ -629,7 +629,7 @@ std::pair<cudf::detail::host_vector<bool>, hashmap_of_device_columns> build_tree
           is_mixed_type_column[this_col_id] == 1)
         column_categories[this_col_id] = NC_STR;
     }
-    column_categories.to_device_async(d_column_tree.node_categories.data(), stream);
+    column_categories.copy_to_device_async(d_column_tree.node_categories.data(), stream);
   }
 
   // ignore all children of columns forced as string
@@ -644,7 +644,7 @@ std::pair<cudf::detail::host_vector<bool>, hashmap_of_device_columns> build_tree
         forced_as_string_column[this_col_id])
       column_categories[this_col_id] = NC_STR;
   }
-  column_categories.to_device_async(d_column_tree.node_categories.data(), stream);
+  column_categories.copy_to_device_async(d_column_tree.node_categories.data(), stream);
 
   // restore unique_col_ids order
   std::sort(h_range_col_id_it, h_range_col_id_it + num_columns, [](auto const& a, auto const& b) {
@@ -1378,7 +1378,7 @@ std::pair<cudf::detail::host_vector<bool>, hashmap_of_device_columns> build_tree
                  column_categories.cbegin(),
                  expected_types.begin(),
                  [](auto exp, auto cat) { return exp == NUM_NODE_CLASSES ? cat : exp; });
-  expected_types.to_device_async(d_column_tree.node_categories.data(), stream);
+  expected_types.copy_to_device_async(d_column_tree.node_categories.data(), stream);
 
   return {is_pruned, columns};
 }

--- a/cpp/src/io/json/host_tree_algorithms.cu
+++ b/cpp/src/io/json/host_tree_algorithms.cu
@@ -632,11 +632,7 @@ build_tree(device_json_column& root,
           is_mixed_type_column[this_col_id] == 1)
         column_categories[this_col_id] = NC_STR;
     }
-    cudf::detail::cuda_memcpy_async(d_column_tree.node_categories.begin(),
-                                    column_categories.data(),
-                                    column_categories.size() * sizeof(column_categories[0]),
-                                    cudf::detail::host_memory_kind::PAGEABLE,
-                                    stream);
+    column_categories.to_device_async(d_column_tree.node_categories.data(), stream);
   }
 
   // ignore all children of columns forced as string
@@ -651,11 +647,7 @@ build_tree(device_json_column& root,
         forced_as_string_column[this_col_id])
       column_categories[this_col_id] = NC_STR;
   }
-  cudf::detail::cuda_memcpy_async(d_column_tree.node_categories.begin(),
-                                  column_categories.data(),
-                                  column_categories.size() * sizeof(column_categories[0]),
-                                  cudf::detail::host_memory_kind::PAGEABLE,
-                                  stream);
+  column_categories.to_device_async(d_column_tree.node_categories.data(), stream);
 
   // restore unique_col_ids order
   std::sort(h_range_col_id_it, h_range_col_id_it + num_columns, [](auto const& a, auto const& b) {


### PR DESCRIPTION
## Description
Current utilities for D2H/H2D copying do not cover well the case where data is transferred between an existing `cudf::detail::host_vector` and an existing device memory. To potentially avoid copy engine use, the caller needs to know if the `host_vector` in question actually uses pinned memory. This makes the code very verbose and dependent on `host_vector` implementation details.

This PR adds APIs to copy the content of a `host_vector` to the given device memory location. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
