### PR TITLE
[DOC] Document environment variable for failing on fallback in `cudf.pandas`

### DIFF
--- a/docs/cudf/source/developer_guide/cudf_pandas.md
+++ b/docs/cudf/source/developer_guide/cudf_pandas.md
@@ -136,3 +136,21 @@ Arrays are not almost equal to 7 decimals
  ACTUAL: 1.0
  DESIRED: 2.0.
 ```
+
+Setting the environment variable `CUDF_PANDAS_FAIL_ON_FALLBACK` causes `cudf.pandas` to fail when falling back from cuDF to Pandas.
+For example,
+```python
+import cudf.pandas
+cudf.pandas.install()
+import pandas as pd
+import numpy as np
+
+df = pd.DataFrame({
+    'complex_col': [1 + 2j, 3 + 4j, 5 + 6j]
+})
+
+print(df)
+```
+```
+ProxyFallbackError: The operation failed with cuDF, the reason was <class 'NotImplementedError'>: Series with Complex128DType is not supported.
+```

--- a/python/cudf/cudf/pandas/fast_slow_proxy.py
+++ b/python/cudf/cudf/pandas/fast_slow_proxy.py
@@ -965,7 +965,7 @@ def _fast_slow_function_call(
     except Exception as err:
         if _env_get_bool("CUDF_PANDAS_FAIL_ON_FALLBACK", False):
             raise ProxyFallbackError(
-                f"The operation failed with cuDF, the reason was {type(err)}: {err}."
+                f"The operation failed with cuDF, the reason was {type(err)}: {err}"
             ) from err
         with nvtx.annotate(
             "EXECUTE_SLOW",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR documents the environment variable `CUDF_PANDAS_FAIL_ON_FALLBACK` which causes `cudf.pandas` to raise an error when fallback occurs.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
