### PR TITLE
Disable kvikio remote I/O to avoid openssl dependencies in JNI build

### DIFF
--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -64,7 +64,8 @@ cmake .. -G"${CMAKE_GENERATOR}" \
          -DBUILD_TESTS=$BUILD_CPP_TESTS \
          -DCUDF_USE_PER_THREAD_DEFAULT_STREAM=$ENABLE_PTDS \
          -DRMM_LOGGING_LEVEL=$RMM_LOGGING_LEVEL \
-         -DBUILD_SHARED_LIBS=OFF
+         -DBUILD_SHARED_LIBS=OFF \
+         -DKvikIO_REMOTE_SUPPORT=OFF
 
 if [[ -z "${PARALLEL_LEVEL}" ]]; then
     cmake --build .


### PR DESCRIPTION
## Description
the same issue as https://github.com/NVIDIA/spark-rapids-jni/issues/2475 due to https://github.com/rapidsai/kvikio/pull/464

Port the fix from https://github.com/NVIDIA/spark-rapids-jni/pull/2476, verified locally

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
