### PR TITLE
`cudf-polars` string/numeric casting

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/unary.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/unary.py
@@ -33,7 +33,19 @@ class Cast(Expr):
     def __init__(self, dtype: plc.DataType, value: Expr) -> None:
         super().__init__(dtype)
         self.children = (value,)
-        if not dtypes.can_cast(value.dtype, self.dtype):
+        if (
+            self.dtype.id() == plc.TypeId.STRING
+            or value.dtype.id() == plc.TypeId.STRING
+        ):
+            if not (
+                self.dtype.id() == plc.TypeId.STRING
+                and value.dtype.id() in {plc.TypeId.FLOAT32, plc.TypeId.FLOAT64}
+            ) or (
+                self.dtype.id() in {plc.TypeId.FLOAT32, plc.TypeId.FLOAT64}
+                and value.dtype.id() == plc.TypeId.STRING
+            ):
+                raise NotImplementedError("Only string to float cast is supported")
+        elif not dtypes.can_cast(value.dtype, self.dtype):
             raise NotImplementedError(
                 f"Can't cast {self.dtype.id().name} to {value.dtype.id().name}"
             )

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -62,6 +62,72 @@ def str_to_float_data(with_nulls):
     return pl.LazyFrame({"a": a})
 
 
+@pytest.fixture
+def str_to_integer_data(with_nulls):
+    a = [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+    ]
+    if with_nulls:
+        a[4] = None
+        a[-3] = None
+    return pl.LazyFrame({"a": a})
+
+
+@pytest.fixture
+def str_from_float_data(with_nulls):
+    a = [
+        1.1,
+        2.2,
+        3.3,
+        4.4,
+        5.5,
+        6.6,
+        7.7,
+        8.8,
+        9.9,
+        10.10,
+        11.11,
+        12.12,
+    ]
+    if with_nulls:
+        a[4] = None
+        a[-3] = None
+    return pl.LazyFrame({"a": a})
+
+
+@pytest.fixture
+def str_from_integer_data(with_nulls):
+    a = [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+    ]
+    if with_nulls:
+        a[4] = None
+        a[-3] = None
+    return pl.LazyFrame({"a": a})
+
+
 slice_cases = [
     (1, 3),
     (0, 3),
@@ -361,6 +427,23 @@ def test_unsupported_regex_raises(pattern):
     assert_ir_translation_raises(q, NotImplementedError)
 
 
-def test_string_to_float(str_to_float_data):
-    query = str_to_float_data.select(pl.col("a").cast(pl.Float64))
+@pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64])
+def test_string_to_float(str_to_float_data, dtype):
+    query = str_to_float_data.select(pl.col("a").cast(dtype))
+    assert_gpu_result_equal(query)
+
+
+@pytest.mark.parametrize("dtype", [pl.Int8, pl.Int16, pl.Int32, pl.Int64])
+def test_string_to_integer(str_to_integer_data, dtype):
+    query = str_to_integer_data.select(pl.col("a").cast(dtype))
+    assert_gpu_result_equal(query)
+
+
+def test_string_from_float(str_from_float_data):
+    query = str_from_float_data.select(pl.col("a").cast(pl.String))
+    assert_gpu_result_equal(query)
+
+
+def test_string_from_integer(str_from_integer_data):
+    query = str_from_integer_data.select(pl.col("a").cast(pl.String))
     assert_gpu_result_equal(query)

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -40,6 +40,28 @@ def ldf(with_nulls):
     )
 
 
+@pytest.fixture
+def str_to_float_data(with_nulls):
+    a = [
+        "1.1",
+        "2.2",
+        "3.3",
+        "4.4",
+        "5.5",
+        "6.6",
+        "7.7",
+        "8.8",
+        "9.9",
+        "10.10",
+        "11.11",
+        "12.12",
+    ]
+    if with_nulls:
+        a[4] = None
+        a[-3] = None
+    return pl.LazyFrame({"a": a})
+
+
 slice_cases = [
     (1, 3),
     (0, 3),
@@ -337,3 +359,8 @@ def test_unsupported_regex_raises(pattern):
 
     q = df.select(pl.col("a").str.contains(pattern, strict=True))
     assert_ir_translation_raises(q, NotImplementedError)
+
+
+def test_string_to_float(str_to_float_data):
+    query = str_to_float_data.select(pl.col("a").cast(pl.Float64))
+    assert_gpu_result_equal(query)


### PR DESCRIPTION
Depends on https://github.com/rapidsai/cudf/pull/16991
Part of https://github.com/rapidsai/cudf/issues/17060

Implements cross casting from string <-> numeric types in `cudf-polars`

