### PR TITLE
Fix arrow perf regression

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -68,7 +68,7 @@ dependencies:
 - polars>=1.8,<1.9
 - pre-commit
 - ptxcompiler
-- pyarrow>=14.0.0,<18.0.0a0
+- pyarrow==16.1.0
 - pydata-sphinx-theme!=0.14.2
 - pytest-benchmark
 - pytest-cases>=3.8.2

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -65,7 +65,7 @@ dependencies:
 - pandoc
 - polars>=1.8,<1.9
 - pre-commit
-- pyarrow>=14.0.0,<18.0.0a0
+- pyarrow==16.1.0
 - pydata-sphinx-theme!=0.14.2
 - pynvjitlink>=0.0.0a0
 - pytest-benchmark

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -206,6 +206,7 @@ include(cmake/thirdparty/get_fmt.cmake)
 include(cmake/thirdparty/get_spdlog.cmake)
 # find nanoarrow
 include(cmake/thirdparty/get_nanoarrow.cmake)
+set(CUDF_USE_ARROW_STATIC OFF)
 include(cmake/thirdparty/get_arrow.cmake)
 # find thread_pool
 include(cmake/thirdparty/get_thread_pool.cmake)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -206,6 +206,7 @@ include(cmake/thirdparty/get_fmt.cmake)
 include(cmake/thirdparty/get_spdlog.cmake)
 # find nanoarrow
 include(cmake/thirdparty/get_nanoarrow.cmake)
+include(cmake/thirdparty/get_arrow.cmake)
 # find thread_pool
 include(cmake/thirdparty/get_thread_pool.cmake)
 
@@ -806,7 +807,7 @@ target_link_libraries(
   cudf
   PUBLIC CCCL::CCCL rmm::rmm $<BUILD_LOCAL_INTERFACE:BS::thread_pool> spdlog::spdlog_header_only
   PRIVATE $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp> cuco::cuco ZLIB::ZLIB nvcomp::nvcomp
-          kvikio::kvikio $<TARGET_NAME_IF_EXISTS:cuFile_interface> nanoarrow
+          kvikio::kvikio $<TARGET_NAME_IF_EXISTS:cuFile_interface> nanoarrow ${ARROW_LIBRARIES}
 )
 
 # Add Conda library, and include paths if specified

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -354,14 +354,17 @@ add_library(
   src/hash/sha512_hash.cu
   src/hash/xxhash_64.cu
   src/interop/dlpack.cpp
+  src/interop/from_arrow.cu
   src/interop/arrow_utilities.cpp
   src/interop/decimal_conversion_utilities.cu
+  src/interop/to_arrow.cu
   src/interop/to_arrow_device.cu
   src/interop/to_arrow_host.cu
   src/interop/from_arrow_device.cu
   src/interop/from_arrow_host.cu
   src/interop/from_arrow_stream.cu
   src/interop/to_arrow_schema.cpp
+  src/interop/detail/arrow_allocator.cpp
   src/io/avro/avro.cpp
   src/io/avro/avro_gpu.cu
   src/io/avro/reader_impl.cu

--- a/cpp/include/cudf/detail/interop.hpp
+++ b/cpp/include/cudf/detail/interop.hpp
@@ -16,6 +16,21 @@
 
 #pragma once
 
+// We disable warning 611 because the `arrow::TableBatchReader` only partially
+// override the `ReadNext` method of `arrow::RecordBatchReader::ReadNext`
+// triggering warning 611-D from nvcc.
+#ifdef __CUDACC__
+#pragma nv_diag_suppress 611
+#pragma nv_diag_suppress 2810
+#endif
+#include <rmm/resource_ref.hpp>
+
+#include <arrow/api.h>
+#ifdef __CUDACC__
+#pragma nv_diag_default 611
+#pragma nv_diag_default 2810
+#endif
+
 #include <cudf/interop.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
@@ -44,6 +59,89 @@ std::unique_ptr<table> from_dlpack(DLManagedTensor const* managed_tensor,
 DLManagedTensor* to_dlpack(table_view const& input,
                            rmm::cuda_stream_view stream,
                            rmm::device_async_resource_ref mr);
+
+// Creating arrow as per given type_id and buffer arguments
+template <typename... Ts>
+std::shared_ptr<arrow::Array> to_arrow_array(cudf::type_id id, Ts&&... args)
+{
+  switch (id) {
+    case type_id::BOOL8: return std::make_shared<arrow::BooleanArray>(std::forward<Ts>(args)...);
+    case type_id::INT8: return std::make_shared<arrow::Int8Array>(std::forward<Ts>(args)...);
+    case type_id::INT16: return std::make_shared<arrow::Int16Array>(std::forward<Ts>(args)...);
+    case type_id::INT32: return std::make_shared<arrow::Int32Array>(std::forward<Ts>(args)...);
+    case type_id::INT64: return std::make_shared<arrow::Int64Array>(std::forward<Ts>(args)...);
+    case type_id::UINT8: return std::make_shared<arrow::UInt8Array>(std::forward<Ts>(args)...);
+    case type_id::UINT16: return std::make_shared<arrow::UInt16Array>(std::forward<Ts>(args)...);
+    case type_id::UINT32: return std::make_shared<arrow::UInt32Array>(std::forward<Ts>(args)...);
+    case type_id::UINT64: return std::make_shared<arrow::UInt64Array>(std::forward<Ts>(args)...);
+    case type_id::FLOAT32: return std::make_shared<arrow::FloatArray>(std::forward<Ts>(args)...);
+    case type_id::FLOAT64: return std::make_shared<arrow::DoubleArray>(std::forward<Ts>(args)...);
+    case type_id::TIMESTAMP_DAYS:
+      return std::make_shared<arrow::Date32Array>(std::make_shared<arrow::Date32Type>(),
+                                                  std::forward<Ts>(args)...);
+    case type_id::TIMESTAMP_SECONDS:
+      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::SECOND),
+                                                     std::forward<Ts>(args)...);
+    case type_id::TIMESTAMP_MILLISECONDS:
+      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::MILLI),
+                                                     std::forward<Ts>(args)...);
+    case type_id::TIMESTAMP_MICROSECONDS:
+      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::MICRO),
+                                                     std::forward<Ts>(args)...);
+    case type_id::TIMESTAMP_NANOSECONDS:
+      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::NANO),
+                                                     std::forward<Ts>(args)...);
+    case type_id::DURATION_SECONDS:
+      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::SECOND),
+                                                    std::forward<Ts>(args)...);
+    case type_id::DURATION_MILLISECONDS:
+      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::MILLI),
+                                                    std::forward<Ts>(args)...);
+    case type_id::DURATION_MICROSECONDS:
+      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::MICRO),
+                                                    std::forward<Ts>(args)...);
+    case type_id::DURATION_NANOSECONDS:
+      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::NANO),
+                                                    std::forward<Ts>(args)...);
+    default: CUDF_FAIL("Unsupported type_id conversion to arrow");
+  }
+}
+
+// Converting arrow type to cudf type
+data_type arrow_to_cudf_type(arrow::DataType const& arrow_type);
+
+/**
+ * @copydoc cudf::to_arrow(table_view input, std::vector<column_metadata> const& metadata,
+ * rmm::cuda_stream_view stream, arrow::MemoryPool* ar_mr)
+ */
+std::shared_ptr<arrow::Table> to_arrow(table_view input,
+                                       std::vector<column_metadata> const& metadata,
+                                       rmm::cuda_stream_view stream,
+                                       arrow::MemoryPool* ar_mr);
+
+/**
+ * @copydoc cudf::to_arrow(cudf::scalar const& input, column_metadata const& metadata,
+ * rmm::cuda_stream_view stream, arrow::MemoryPool* ar_mr)
+ */
+std::shared_ptr<arrow::Scalar> to_arrow(cudf::scalar const& input,
+                                        column_metadata const& metadata,
+                                        rmm::cuda_stream_view stream,
+                                        arrow::MemoryPool* ar_mr);
+/**
+ * @copydoc cudf::from_arrow(arrow::Table const& input_table, rmm::cuda_stream_view stream,
+ * rmm::device_async_resource_ref mr)
+ */
+std::unique_ptr<table> from_arrow(arrow::Table const& input_table,
+                                  rmm::cuda_stream_view stream,
+                                  rmm::device_async_resource_ref mr);
+
+/**
+ * @copydoc cudf::from_arrow(arrow::Scalar const& input, rmm::cuda_stream_view stream,
+ * rmm::device_async_resource_ref mr)
+ */
+std::unique_ptr<cudf::scalar> from_arrow(arrow::Scalar const& input,
+                                         rmm::cuda_stream_view stream,
+                                         rmm::device_async_resource_ref mr);
 
 /**
  * @brief Return a maximum precision for a given type.

--- a/cpp/include/cudf/interop.hpp
+++ b/cpp/include/cudf/interop.hpp
@@ -16,6 +16,21 @@
 
 #pragma once
 
+// We disable warning 611 because the `arrow::TableBatchReader` only partially
+// override the `ReadNext` method of `arrow::RecordBatchReader::ReadNext`
+// triggering warning 611-D from nvcc.
+#ifdef __CUDACC__
+#pragma nv_diag_suppress 611
+#pragma nv_diag_suppress 2810
+#endif
+#include <rmm/resource_ref.hpp>
+
+#include <arrow/api.h>
+#ifdef __CUDACC__
+#pragma nv_diag_default 611
+#pragma nv_diag_default 2810
+#endif
+
 #include <cudf/column/column.hpp>
 #include <cudf/detail/transform.hpp>
 #include <cudf/table/table.hpp>
@@ -113,6 +128,59 @@ struct column_metadata {
   column_metadata(std::string _name) : name(std::move(_name)) {}
   column_metadata() = default;
 };
+
+/**
+ * @brief Create `arrow::Table` from cudf table `input`
+ *
+ * Converts the `cudf::table_view` to `arrow::Table` with the provided
+ * metadata `column_names`.
+ *
+ * @deprecated Since 24.08. Use cudf::to_arrow_host instead.
+ *
+ * @throws cudf::logic_error if `column_names` size doesn't match with number of columns.
+ *
+ * @param input table_view that needs to be converted to arrow Table
+ * @param metadata Contains hierarchy of names of columns and children
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param ar_mr arrow memory pool to allocate memory for arrow Table
+ * @return arrow Table generated from `input`
+ *
+ * @note For decimals, since the precision is not stored for them in libcudf,
+ * it will be converted to an Arrow decimal128 that has the widest-precision the cudf decimal type
+ * supports. For example, numeric::decimal32 will be converted to Arrow decimal128 of the precision
+ * 9 which is the maximum precision for 32-bit types. Similarly, numeric::decimal128 will be
+ * converted to Arrow decimal128 of the precision 38.
+ */
+[[deprecated("Use cudf::to_arrow_host")]] std::shared_ptr<arrow::Table> to_arrow(
+  table_view input,
+  std::vector<column_metadata> const& metadata = {},
+  rmm::cuda_stream_view stream                 = cudf::get_default_stream(),
+  arrow::MemoryPool* ar_mr                     = arrow::default_memory_pool());
+
+/**
+ * @brief Create `arrow::Scalar` from cudf scalar `input`
+ *
+ * Converts the `cudf::scalar` to `arrow::Scalar`.
+ *
+ * @deprecated Since 24.08.
+ *
+ * @param input scalar that needs to be converted to arrow Scalar
+ * @param metadata Contains hierarchy of names of columns and children
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param ar_mr arrow memory pool to allocate memory for arrow Scalar
+ * @return arrow Scalar generated from `input`
+ *
+ * @note For decimals, since the precision is not stored for them in libcudf,
+ * it will be converted to an Arrow decimal128 that has the widest-precision the cudf decimal type
+ * supports. For example, numeric::decimal32 will be converted to Arrow decimal128 of the precision
+ * 9 which is the maximum precision for 32-bit types. Similarly, numeric::decimal128 will be
+ * converted to Arrow decimal128 of the precision 38.
+ */
+[[deprecated("Use cudf::to_arrow_host")]] std::shared_ptr<arrow::Scalar> to_arrow(
+  cudf::scalar const& input,
+  column_metadata const& metadata = {},
+  rmm::cuda_stream_view stream    = cudf::get_default_stream(),
+  arrow::MemoryPool* ar_mr        = arrow::default_memory_pool());
 
 /**
  * @brief typedef for a unique_ptr to an ArrowSchema with custom deleter
@@ -315,6 +383,39 @@ unique_device_array_t to_arrow_host(
   cudf::column_view const& col,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
+ * @brief Create `cudf::table` from given arrow Table input
+ *
+ * @deprecated Since 24.08. Use cudf::from_arrow_host instead.
+ *
+ * @param input arrow:Table that needs to be converted to `cudf::table`
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr    Device memory resource used to allocate `cudf::table`
+ * @return cudf table generated from given arrow Table
+ */
+[[deprecated("Use cudf::from_arrow_host")]] std::unique_ptr<table> from_arrow(
+  arrow::Table const& input,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
+
+/**
+ * @brief Create `cudf::scalar` from given arrow Scalar input
+ *
+ * @deprecated Since 24.08. Use arrow's `MakeArrayFromScalar` on the
+ * input, followed by `ExportArray` to obtain something that can be
+ * consumed by `from_arrow_host`. Then use `cudf::get_element` to
+ * extract a device scalar from the column.
+ *
+ * @param input `arrow::Scalar` that needs to be converted to `cudf::scalar`
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr    Device memory resource used to allocate `cudf::scalar`
+ * @return cudf scalar generated from given arrow Scalar
+ */
+[[deprecated("See docstring for migration strategies")]] std::unique_ptr<cudf::scalar> from_arrow(
+  arrow::Scalar const& input,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource());
 
 /**
  * @brief Create `cudf::table` from given ArrowArray and ArrowSchema input

--- a/cpp/src/interop/arrow_utilities.cpp
+++ b/cpp/src/interop/arrow_utilities.cpp
@@ -97,7 +97,6 @@ ArrowType id_to_arrow_type(cudf::type_id id)
 ArrowType id_to_arrow_storage_type(cudf::type_id id)
 {
   switch (id) {
-    case cudf::type_id::TIMESTAMP_DAYS: return NANOARROW_TYPE_INT32;
     case cudf::type_id::TIMESTAMP_SECONDS:
     case cudf::type_id::TIMESTAMP_MILLISECONDS:
     case cudf::type_id::TIMESTAMP_MICROSECONDS:

--- a/cpp/src/interop/detail/arrow_allocator.cpp
+++ b/cpp/src/interop/detail/arrow_allocator.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/detail/interop.hpp>
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <memory>
+
+namespace cudf {
+namespace detail {
+
+/*
+  Enable Transparent Huge Pages (THP) for large (>4MB) allocations.
+  `buf` is returned untouched.
+  Enabling THP can improve performance of device-host memory transfers
+  significantly, see <https://github.com/rapidsai/cudf/pull/13914>.
+*/
+template <typename T>
+T enable_hugepage(T&& buf)
+{
+  if (buf->size() < (1u << 22u)) {  // Smaller than 4 MB
+    return std::move(buf);
+  }
+
+#ifdef MADV_HUGEPAGE
+  auto const pagesize = sysconf(_SC_PAGESIZE);
+  void* addr          = const_cast<uint8_t*>(buf->data());
+  if (addr == nullptr) { return std::move(buf); }
+  auto length{static_cast<std::size_t>(buf->size())};
+  if (std::align(pagesize, pagesize, addr, length)) {
+    // Intentionally not checking for errors that may be returned by older kernel versions;
+    // optimistically tries enabling huge pages.
+    madvise(addr, length, MADV_HUGEPAGE);
+  }
+#endif
+  return std::move(buf);
+}
+
+std::unique_ptr<arrow::Buffer> allocate_arrow_buffer(int64_t const size, arrow::MemoryPool* ar_mr)
+{
+  /*
+  nvcc 11.0 generates Internal Compiler Error during codegen when arrow::AllocateBuffer
+  and `ValueOrDie` are used inside a CUDA compilation unit.
+
+  To work around this issue we compile an allocation shim in C++ and use
+  that from our cuda sources
+  */
+  arrow::Result<std::unique_ptr<arrow::Buffer>> result = arrow::AllocateBuffer(size, ar_mr);
+  CUDF_EXPECTS(result.ok(), "Failed to allocate Arrow buffer");
+  return enable_hugepage(std::move(result).ValueOrDie());
+}
+
+std::shared_ptr<arrow::Buffer> allocate_arrow_bitmap(int64_t const size, arrow::MemoryPool* ar_mr)
+{
+  /*
+  nvcc 11.0 generates Internal Compiler Error during codegen when arrow::AllocateBuffer
+  and `ValueOrDie` are used inside a CUDA compilation unit.
+
+  To work around this issue we compile an allocation shim in C++ and use
+  that from our cuda sources
+  */
+  arrow::Result<std::shared_ptr<arrow::Buffer>> result = arrow::AllocateBitmap(size, ar_mr);
+  CUDF_EXPECTS(result.ok(), "Failed to allocate Arrow bitmap");
+  return enable_hugepage(std::move(result).ValueOrDie());
+}
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/src/interop/detail/arrow_allocator.hpp
+++ b/cpp/src/interop/detail/arrow_allocator.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/detail/interop.hpp>
+
+namespace cudf {
+namespace detail {
+
+// unique_ptr because that is what AllocateBuffer returns
+std::unique_ptr<arrow::Buffer> allocate_arrow_buffer(int64_t const size, arrow::MemoryPool* ar_mr);
+
+// shared_ptr because that is what AllocateBitmap returns
+std::shared_ptr<arrow::Buffer> allocate_arrow_bitmap(int64_t const size, arrow::MemoryPool* ar_mr);
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/src/interop/from_arrow.cu
+++ b/cpp/src/interop/from_arrow.cu
@@ -1,0 +1,524 @@
+/*
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/detail/concatenate.hpp>
+#include <cudf/detail/copy.hpp>
+#include <cudf/detail/interop.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/detail/transform.hpp>
+#include <cudf/detail/unary.hpp>
+#include <cudf/dictionary/dictionary_factories.hpp>
+#include <cudf/interop.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/traits.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <thrust/gather.h>
+
+namespace cudf {
+
+namespace detail {
+data_type arrow_to_cudf_type(arrow::DataType const& arrow_type)
+{
+  switch (arrow_type.id()) {
+    case arrow::Type::NA: return data_type(type_id::EMPTY);
+    case arrow::Type::BOOL: return data_type(type_id::BOOL8);
+    case arrow::Type::INT8: return data_type(type_id::INT8);
+    case arrow::Type::INT16: return data_type(type_id::INT16);
+    case arrow::Type::INT32: return data_type(type_id::INT32);
+    case arrow::Type::INT64: return data_type(type_id::INT64);
+    case arrow::Type::UINT8: return data_type(type_id::UINT8);
+    case arrow::Type::UINT16: return data_type(type_id::UINT16);
+    case arrow::Type::UINT32: return data_type(type_id::UINT32);
+    case arrow::Type::UINT64: return data_type(type_id::UINT64);
+    case arrow::Type::FLOAT: return data_type(type_id::FLOAT32);
+    case arrow::Type::DOUBLE: return data_type(type_id::FLOAT64);
+    case arrow::Type::DATE32: return data_type(type_id::TIMESTAMP_DAYS);
+    case arrow::Type::TIMESTAMP: {
+      auto type = static_cast<arrow::TimestampType const*>(&arrow_type);
+      switch (type->unit()) {
+        case arrow::TimeUnit::type::SECOND: return data_type(type_id::TIMESTAMP_SECONDS);
+        case arrow::TimeUnit::type::MILLI: return data_type(type_id::TIMESTAMP_MILLISECONDS);
+        case arrow::TimeUnit::type::MICRO: return data_type(type_id::TIMESTAMP_MICROSECONDS);
+        case arrow::TimeUnit::type::NANO: return data_type(type_id::TIMESTAMP_NANOSECONDS);
+        default: CUDF_FAIL("Unsupported timestamp unit in arrow");
+      }
+    }
+    case arrow::Type::DURATION: {
+      auto type = static_cast<arrow::DurationType const*>(&arrow_type);
+      switch (type->unit()) {
+        case arrow::TimeUnit::type::SECOND: return data_type(type_id::DURATION_SECONDS);
+        case arrow::TimeUnit::type::MILLI: return data_type(type_id::DURATION_MILLISECONDS);
+        case arrow::TimeUnit::type::MICRO: return data_type(type_id::DURATION_MICROSECONDS);
+        case arrow::TimeUnit::type::NANO: return data_type(type_id::DURATION_NANOSECONDS);
+        default: CUDF_FAIL("Unsupported duration unit in arrow");
+      }
+    }
+    case arrow::Type::STRING: return data_type(type_id::STRING);
+    case arrow::Type::LARGE_STRING: return data_type(type_id::STRING);
+    case arrow::Type::DICTIONARY: return data_type(type_id::DICTIONARY32);
+    case arrow::Type::LIST: return data_type(type_id::LIST);
+    case arrow::Type::DECIMAL: {
+      auto const type = static_cast<arrow::Decimal128Type const*>(&arrow_type);
+      return data_type{type_id::DECIMAL128, -type->scale()};
+    }
+    case arrow::Type::STRUCT: return data_type(type_id::STRUCT);
+    default: CUDF_FAIL("Unsupported type_id conversion to cudf");
+  }
+}
+
+namespace {
+/**
+ * @brief Functor to return column for a corresponding arrow array. column
+ * is formed from buffer underneath the arrow array along with any offset and
+ * change in length that array has.
+ */
+struct dispatch_to_cudf_column {
+  /**
+   * @brief Returns mask from an array without any offsets.
+   */
+  std::unique_ptr<rmm::device_buffer> get_mask_buffer(arrow::Array const& array,
+                                                      rmm::cuda_stream_view stream,
+                                                      rmm::device_async_resource_ref mr)
+  {
+    if (array.null_bitmap_data() == nullptr) {
+      return std::make_unique<rmm::device_buffer>(0, stream, mr);
+    }
+    auto const null_bitmap_size = array.null_bitmap()->size();
+    auto const allocation_size =
+      bitmask_allocation_size_bytes(static_cast<size_type>(null_bitmap_size * CHAR_BIT));
+    auto mask        = std::make_unique<rmm::device_buffer>(allocation_size, stream, mr);
+    auto mask_buffer = array.null_bitmap();
+    CUDF_CUDA_TRY(cudaMemcpyAsync(mask->data(),
+                                  reinterpret_cast<uint8_t const*>(mask_buffer->address()),
+                                  null_bitmap_size,
+                                  cudaMemcpyDefault,
+                                  stream.value()));
+    // Zero-initialize trailing padding bytes
+    auto const num_trailing_bytes = allocation_size - null_bitmap_size;
+    if (num_trailing_bytes > 0) {
+      auto trailing_bytes = static_cast<uint8_t*>(mask->data()) + null_bitmap_size;
+      CUDF_CUDA_TRY(cudaMemsetAsync(trailing_bytes, 0, num_trailing_bytes, stream.value()));
+    }
+    return mask;
+  }
+
+  template <typename T, CUDF_ENABLE_IF(not is_rep_layout_compatible<T>())>
+  std::unique_ptr<column> operator()(
+    arrow::Array const&, data_type, bool, rmm::cuda_stream_view, rmm::device_async_resource_ref)
+  {
+    CUDF_FAIL("Unsupported type in from_arrow.");
+  }
+
+  template <typename T, CUDF_ENABLE_IF(is_rep_layout_compatible<T>())>
+  std::unique_ptr<column> operator()(arrow::Array const& array,
+                                     data_type type,
+                                     bool skip_mask,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::device_async_resource_ref mr)
+  {
+    auto data_buffer         = array.data()->buffers[1];
+    size_type const num_rows = array.length();
+    auto const has_nulls     = skip_mask ? false : array.null_bitmap_data() != nullptr;
+    auto col = make_fixed_width_column(type, num_rows, mask_state::UNALLOCATED, stream, mr);
+    auto mutable_column_view = col->mutable_view();
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+      mutable_column_view.data<T>(),
+      reinterpret_cast<uint8_t const*>(data_buffer->address()) + array.offset() * sizeof(T),
+      sizeof(T) * num_rows,
+      cudaMemcpyDefault,
+      stream.value()));
+    if (has_nulls) {
+      auto tmp_mask = get_mask_buffer(array, stream, mr);
+
+      // If array is sliced, we have to copy whole mask and then take copy.
+      auto out_mask = (num_rows == static_cast<size_type>(data_buffer->size() / sizeof(T)))
+                        ? std::move(*tmp_mask)
+                        : cudf::detail::copy_bitmask(static_cast<bitmask_type*>(tmp_mask->data()),
+                                                     array.offset(),
+                                                     array.offset() + num_rows,
+                                                     stream,
+                                                     mr);
+
+      col->set_null_mask(std::move(out_mask), array.null_count());
+    }
+
+    return col;
+  }
+};
+
+std::unique_ptr<column> get_empty_type_column(size_type size)
+{
+  // this abomination is required by cuDF Python, which needs to handle
+  // [PyArrow null arrays](https://arrow.apache.org/docs/python/generated/pyarrow.NullArray.html)
+  // of finite length
+  return std::make_unique<column>(
+    data_type(type_id::EMPTY), size, rmm::device_buffer{}, rmm::device_buffer{}, size);
+}
+
+/**
+ * @brief Returns cudf column formed from given arrow array
+ * This has been introduced to take care of compiler error "error: explicit specialization of
+ * function must precede its first use"
+ */
+std::unique_ptr<column> get_column(arrow::Array const& array,
+                                   data_type type,
+                                   bool skip_mask,
+                                   rmm::cuda_stream_view stream,
+                                   rmm::device_async_resource_ref mr);
+
+template <>
+std::unique_ptr<column> dispatch_to_cudf_column::operator()<numeric::decimal128>(
+  arrow::Array const& array,
+  data_type type,
+  bool skip_mask,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  using DeviceType = __int128_t;
+
+  auto data_buffer    = array.data()->buffers[1];
+  auto const num_rows = static_cast<size_type>(array.length());
+  auto col = make_fixed_width_column(type, num_rows, mask_state::UNALLOCATED, stream, mr);
+  auto mutable_column_view = col->mutable_view();
+
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+    mutable_column_view.data<DeviceType>(),
+    reinterpret_cast<uint8_t const*>(data_buffer->address()) + array.offset() * sizeof(DeviceType),
+    sizeof(DeviceType) * num_rows,
+    cudaMemcpyDefault,
+    stream.value()));
+
+  auto null_mask = [&] {
+    if (not skip_mask and array.null_bitmap_data()) {
+      auto temp_mask = get_mask_buffer(array, stream, mr);
+      // If array is sliced, we have to copy whole mask and then take copy.
+      return (num_rows == static_cast<size_type>(data_buffer->size() / sizeof(DeviceType)))
+               ? std::move(*temp_mask.release())
+               : cudf::detail::copy_bitmask(static_cast<bitmask_type*>(temp_mask->data()),
+                                            array.offset(),
+                                            array.offset() + num_rows,
+                                            stream,
+                                            mr);
+    }
+    return rmm::device_buffer{};
+  }();
+
+  col->set_null_mask(std::move(null_mask), array.null_count());
+  return col;
+}
+
+template <>
+std::unique_ptr<column> dispatch_to_cudf_column::operator()<bool>(arrow::Array const& array,
+                                                                  data_type,
+                                                                  bool skip_mask,
+                                                                  rmm::cuda_stream_view stream,
+                                                                  rmm::device_async_resource_ref mr)
+{
+  auto data_buffer = array.data()->buffers[1];
+  // mask-to-bools expects the mask to be bitmask_type aligned/padded
+  auto data = rmm::device_buffer(
+    cudf::bitmask_allocation_size_bytes(data_buffer->size() * CHAR_BIT), stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(data.data(),
+                                reinterpret_cast<uint8_t const*>(data_buffer->address()),
+                                data_buffer->size(),
+                                cudaMemcpyDefault,
+                                stream.value()));
+  auto out_col = mask_to_bools(static_cast<bitmask_type*>(data.data()),
+                               array.offset(),
+                               array.offset() + array.length(),
+                               stream,
+                               mr);
+
+  auto const has_nulls = skip_mask ? false : array.null_bitmap_data() != nullptr;
+  if (has_nulls) {
+    auto out_mask =
+      detail::copy_bitmask(static_cast<bitmask_type*>(get_mask_buffer(array, stream, mr)->data()),
+                           array.offset(),
+                           array.offset() + array.length(),
+                           stream,
+                           mr);
+
+    out_col->set_null_mask(std::move(out_mask), array.null_count());
+  }
+
+  return out_col;
+}
+
+template <>
+std::unique_ptr<column> dispatch_to_cudf_column::operator()<cudf::string_view>(
+  arrow::Array const& array,
+  data_type,
+  bool,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  if (array.length() == 0) { return make_empty_column(type_id::STRING); }
+
+  std::unique_ptr<column> offsets_column;
+  std::unique_ptr<arrow::Array> char_array;
+
+  if (array.type_id() == arrow::Type::LARGE_STRING) {
+    auto str_array    = static_cast<arrow::LargeStringArray const*>(&array);
+    auto offset_array = std::make_unique<arrow::Int64Array>(
+      str_array->value_offsets()->size() / sizeof(int64_t), str_array->value_offsets(), nullptr);
+    offsets_column = dispatch_to_cudf_column{}.operator()<int64_t>(
+      *offset_array, data_type(type_id::INT64), true, stream, mr);
+    char_array = std::make_unique<arrow::Int8Array>(
+      str_array->value_data()->size(), str_array->value_data(), nullptr);
+  } else if (array.type_id() == arrow::Type::STRING) {
+    auto str_array    = static_cast<arrow::StringArray const*>(&array);
+    auto offset_array = std::make_unique<arrow::Int32Array>(
+      str_array->value_offsets()->size() / sizeof(int32_t), str_array->value_offsets(), nullptr);
+    offsets_column = dispatch_to_cudf_column{}.operator()<int32_t>(
+      *offset_array, data_type(type_id::INT32), true, stream, mr);
+    char_array = std::make_unique<arrow::Int8Array>(
+      str_array->value_data()->size(), str_array->value_data(), nullptr);
+  } else {
+    throw std::runtime_error("Unsupported array type");
+  }
+
+  rmm::device_buffer chars(char_array->length(), stream, mr);
+  auto data_buffer = char_array->data()->buffers[1];
+  CUDF_CUDA_TRY(cudaMemcpyAsync(chars.data(),
+                                reinterpret_cast<uint8_t const*>(data_buffer->address()),
+                                chars.size(),
+                                cudaMemcpyDefault,
+                                stream.value()));
+
+  auto const num_rows = offsets_column->size() - 1;
+  auto out_col        = make_strings_column(num_rows,
+                                     std::move(offsets_column),
+                                     std::move(chars),
+                                     array.null_count(),
+                                     std::move(*get_mask_buffer(array, stream, mr)));
+
+  return num_rows == array.length()
+           ? std::move(out_col)
+           : std::make_unique<column>(
+               cudf::detail::slice(out_col->view(),
+                                   static_cast<size_type>(array.offset()),
+                                   static_cast<size_type>(array.offset() + array.length()),
+                                   stream),
+               stream,
+               mr);
+}
+
+template <>
+std::unique_ptr<column> dispatch_to_cudf_column::operator()<cudf::dictionary32>(
+  arrow::Array const& array,
+  data_type,
+  bool,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto dict_array  = static_cast<arrow::DictionaryArray const*>(&array);
+  auto dict_type   = arrow_to_cudf_type(*(dict_array->dictionary()->type()));
+  auto keys_column = get_column(*(dict_array->dictionary()), dict_type, true, stream, mr);
+  auto ind_type    = arrow_to_cudf_type(*(dict_array->indices()->type()));
+
+  auto indices_column = get_column(*(dict_array->indices()), ind_type, false, stream, mr);
+  // If index type is not of type uint32_t, then cast it to uint32_t
+  auto const dict_indices_type = data_type{type_id::UINT32};
+  if (indices_column->type().id() != dict_indices_type.id())
+    indices_column = cudf::detail::cast(indices_column->view(), dict_indices_type, stream, mr);
+
+  // Child columns shouldn't have masks and we need the mask in main column
+  auto column_contents = indices_column->release();
+  indices_column       = std::make_unique<column>(dict_indices_type,
+                                            static_cast<size_type>(array.length()),
+                                            std::move(*(column_contents.data)),
+                                            rmm::device_buffer{},
+                                            0);
+
+  return make_dictionary_column(std::move(keys_column),
+                                std::move(indices_column),
+                                std::move(*(column_contents.null_mask)),
+                                array.null_count());
+}
+
+template <>
+std::unique_ptr<column> dispatch_to_cudf_column::operator()<cudf::struct_view>(
+  arrow::Array const& array,
+  data_type,
+  bool,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto struct_array = static_cast<arrow::StructArray const*>(&array);
+  std::vector<std::unique_ptr<column>> child_columns;
+  // Offsets have already been applied to child
+  arrow::ArrayVector array_children = struct_array->fields();
+  std::transform(array_children.cbegin(),
+                 array_children.cend(),
+                 std::back_inserter(child_columns),
+                 [&mr, &stream](auto const& child_array) {
+                   auto type = arrow_to_cudf_type(*(child_array->type()));
+                   return get_column(*child_array, type, false, stream, mr);
+                 });
+
+  auto out_mask = std::move(*(get_mask_buffer(array, stream, mr)));
+  if (struct_array->null_bitmap_data() != nullptr) {
+    out_mask = detail::copy_bitmask(static_cast<bitmask_type*>(out_mask.data()),
+                                    array.offset(),
+                                    array.offset() + array.length(),
+                                    stream,
+                                    mr);
+  }
+
+  return make_structs_column(
+    array.length(), move(child_columns), array.null_count(), std::move(out_mask), stream, mr);
+}
+
+template <>
+std::unique_ptr<column> dispatch_to_cudf_column::operator()<cudf::list_view>(
+  arrow::Array const& array,
+  data_type,
+  bool,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto list_array   = static_cast<arrow::ListArray const*>(&array);
+  auto offset_array = std::make_unique<arrow::Int32Array>(
+    list_array->value_offsets()->size() / sizeof(int32_t), list_array->value_offsets(), nullptr);
+  auto offsets_column = dispatch_to_cudf_column{}.operator()<int32_t>(
+    *offset_array, data_type(type_id::INT32), true, stream, mr);
+
+  auto child_type   = arrow_to_cudf_type(*(list_array->values()->type()));
+  auto child_column = get_column(*(list_array->values()), child_type, false, stream, mr);
+
+  auto const num_rows = offsets_column->size() - 1;
+  auto out_col        = make_lists_column(num_rows,
+                                   std::move(offsets_column),
+                                   std::move(child_column),
+                                   array.null_count(),
+                                   std::move(*get_mask_buffer(array, stream, mr)),
+                                   stream,
+                                   mr);
+
+  return num_rows == array.length()
+           ? std::move(out_col)
+           : std::make_unique<column>(
+               cudf::detail::slice(out_col->view(),
+                                   static_cast<size_type>(array.offset()),
+                                   static_cast<size_type>(array.offset() + array.length()),
+                                   stream),
+               stream,
+               mr);
+}
+
+std::unique_ptr<column> get_column(arrow::Array const& array,
+                                   data_type type,
+                                   bool skip_mask,
+                                   rmm::cuda_stream_view stream,
+                                   rmm::device_async_resource_ref mr)
+{
+  return type.id() != type_id::EMPTY
+           ? type_dispatcher(type, dispatch_to_cudf_column{}, array, type, skip_mask, stream, mr)
+           : get_empty_type_column(array.length());
+}
+
+}  // namespace
+
+std::unique_ptr<table> from_arrow(arrow::Table const& input_table,
+                                  rmm::cuda_stream_view stream,
+                                  rmm::device_async_resource_ref mr)
+{
+  if (input_table.num_columns() == 0) { return std::make_unique<table>(); }
+  std::vector<std::unique_ptr<column>> columns;
+  auto chunked_arrays = input_table.columns();
+  std::transform(chunked_arrays.begin(),
+                 chunked_arrays.end(),
+                 std::back_inserter(columns),
+                 [&mr, &stream](auto const& chunked_array) {
+                   std::vector<std::unique_ptr<column>> concat_columns;
+                   auto cudf_type    = arrow_to_cudf_type(*(chunked_array->type()));
+                   auto array_chunks = chunked_array->chunks();
+                   if (cudf_type.id() == type_id::EMPTY) {
+                     return get_empty_type_column(chunked_array->length());
+                   }
+                   std::transform(array_chunks.begin(),
+                                  array_chunks.end(),
+                                  std::back_inserter(concat_columns),
+                                  [&cudf_type, &mr, &stream](auto const& array_chunk) {
+                                    return get_column(*array_chunk, cudf_type, false, stream, mr);
+                                  });
+                   if (concat_columns.empty()) {
+                     return std::make_unique<column>(
+                       cudf_type, 0, rmm::device_buffer{}, rmm::device_buffer{}, 0);
+                   } else if (concat_columns.size() == 1) {
+                     return std::move(concat_columns[0]);
+                   }
+
+                   std::vector<cudf::column_view> column_views;
+                   std::transform(concat_columns.begin(),
+                                  concat_columns.end(),
+                                  std::back_inserter(column_views),
+                                  [](auto const& col) { return col->view(); });
+                   return cudf::detail::concatenate(column_views, stream, mr);
+                 });
+
+  return std::make_unique<table>(std::move(columns));
+}
+
+std::unique_ptr<cudf::scalar> from_arrow(arrow::Scalar const& input,
+                                         rmm::cuda_stream_view stream,
+                                         rmm::device_async_resource_ref mr)
+{
+  auto maybe_array = arrow::MakeArrayFromScalar(input, 1);
+  if (!maybe_array.ok()) { CUDF_FAIL("Failed to create array"); }
+  auto array = *maybe_array;
+
+  auto field = arrow::field("", input.type);
+
+  auto table = arrow::Table::Make(arrow::schema({field}), {array});
+
+  auto cudf_table = detail::from_arrow(*table, stream, mr);
+
+  auto cv = cudf_table->view().column(0);
+  return get_element(cv, 0, stream);
+}
+
+}  // namespace detail
+
+std::unique_ptr<table> from_arrow(arrow::Table const& input_table,
+                                  rmm::cuda_stream_view stream,
+                                  rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+
+  return detail::from_arrow(input_table, stream, mr);
+}
+
+std::unique_ptr<cudf::scalar> from_arrow(arrow::Scalar const& input,
+                                         rmm::cuda_stream_view stream,
+                                         rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+
+  return detail::from_arrow(input, stream, mr);
+}
+}  // namespace cudf

--- a/cpp/src/interop/to_arrow.cu
+++ b/cpp/src/interop/to_arrow.cu
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "arrow_utilities.hpp"
+#include "decimal_conversion_utilities.cuh"
+#include "detail/arrow_allocator.hpp"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/interop.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/detail/null_mask.hpp>
+#include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/detail/unary.hpp>
+#include <cudf/dictionary/dictionary_column_view.hpp>
+#include <cudf/interop.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
+#include <cudf/utilities/traits.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+
+#include <thrust/copy.h>
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
+
+namespace cudf {
+namespace detail {
+namespace {
+
+/**
+ * @brief Create arrow data buffer from given cudf column
+ */
+template <typename T>
+std::shared_ptr<arrow::Buffer> fetch_data_buffer(device_span<T const> input,
+                                                 arrow::MemoryPool* ar_mr,
+                                                 rmm::cuda_stream_view stream)
+{
+  int64_t const data_size_in_bytes = sizeof(T) * input.size();
+
+  auto data_buffer = allocate_arrow_buffer(data_size_in_bytes, ar_mr);
+
+  CUDF_CUDA_TRY(cudaMemcpyAsync(data_buffer->mutable_data(),
+                                input.data(),
+                                data_size_in_bytes,
+                                cudaMemcpyDefault,
+                                stream.value()));
+
+  return std::move(data_buffer);
+}
+
+/**
+ * @brief Create arrow buffer of mask from given cudf column
+ */
+std::shared_ptr<arrow::Buffer> fetch_mask_buffer(column_view input_view,
+                                                 arrow::MemoryPool* ar_mr,
+                                                 rmm::cuda_stream_view stream)
+{
+  int64_t const mask_size_in_bytes = cudf::bitmask_allocation_size_bytes(input_view.size());
+
+  if (input_view.has_nulls()) {
+    auto mask_buffer = allocate_arrow_bitmap(static_cast<int64_t>(input_view.size()), ar_mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+      mask_buffer->mutable_data(),
+      (input_view.offset() > 0)
+        ? cudf::detail::copy_bitmask(input_view, stream, rmm::mr::get_current_device_resource())
+            .data()
+        : input_view.null_mask(),
+      mask_size_in_bytes,
+      cudaMemcpyDefault,
+      stream.value()));
+
+    // Resets all padded bits to 0
+    mask_buffer->ZeroPadding();
+
+    return mask_buffer;
+  }
+
+  return nullptr;
+}
+
+/**
+ * @brief Functor to convert cudf column to arrow array
+ */
+struct dispatch_to_arrow {
+  /**
+   * @brief Creates vector Arrays from given cudf column children
+   */
+  std::vector<std::shared_ptr<arrow::Array>> fetch_child_array(
+    column_view input_view,
+    std::vector<column_metadata> const& metadata,
+    arrow::MemoryPool* ar_mr,
+    rmm::cuda_stream_view stream)
+  {
+    std::vector<std::shared_ptr<arrow::Array>> child_arrays;
+    std::transform(
+      input_view.child_begin(),
+      input_view.child_end(),
+      metadata.begin(),
+      std::back_inserter(child_arrays),
+      [&ar_mr, &stream](auto const& child, auto const& meta) {
+        return type_dispatcher(
+          child.type(), dispatch_to_arrow{}, child, child.type().id(), meta, ar_mr, stream);
+      });
+    return child_arrays;
+  }
+
+  template <typename T, CUDF_ENABLE_IF(not is_rep_layout_compatible<T>())>
+  std::shared_ptr<arrow::Array> operator()(
+    column_view, cudf::type_id, column_metadata const&, arrow::MemoryPool*, rmm::cuda_stream_view)
+  {
+    CUDF_FAIL("Unsupported type for to_arrow.");
+  }
+
+  template <typename T, CUDF_ENABLE_IF(is_rep_layout_compatible<T>())>
+  std::shared_ptr<arrow::Array> operator()(column_view input_view,
+                                           cudf::type_id id,
+                                           column_metadata const&,
+                                           arrow::MemoryPool* ar_mr,
+                                           rmm::cuda_stream_view stream)
+  {
+    return to_arrow_array(
+      id,
+      static_cast<int64_t>(input_view.size()),
+      fetch_data_buffer<T>(
+        device_span<T const>(input_view.data<T>(), input_view.size()), ar_mr, stream),
+      fetch_mask_buffer(input_view, ar_mr, stream),
+      static_cast<int64_t>(input_view.null_count()));
+  }
+};
+
+// Convert decimal types from libcudf to arrow where those types are not
+// directly supported by Arrow. These types must be fit into 128 bits, the
+// smallest decimal resolution supported by Arrow.
+template <typename DeviceType>
+std::shared_ptr<arrow::Array> unsupported_decimals_to_arrow(column_view input,
+                                                            int32_t precision,
+                                                            arrow::MemoryPool* ar_mr,
+                                                            rmm::cuda_stream_view stream)
+{
+  auto buf = detail::convert_decimals_to_decimal128<DeviceType>(
+    input, stream, rmm::mr::get_current_device_resource());
+
+  // Synchronize stream here to ensure the decimal128 buffer is ready.
+  stream.synchronize();
+
+  auto const buf_size_in_bytes = buf->size();
+  auto data_buffer             = allocate_arrow_buffer(buf_size_in_bytes, ar_mr);
+
+  CUDF_CUDA_TRY(cudaMemcpyAsync(data_buffer->mutable_data(),
+                                buf->data(),
+                                buf_size_in_bytes,
+                                cudaMemcpyDefault,
+                                stream.value()));
+
+  auto type    = arrow::decimal(precision, -input.type().scale());
+  auto mask    = fetch_mask_buffer(input, ar_mr, stream);
+  auto buffers = std::vector<std::shared_ptr<arrow::Buffer>>{mask, std::move(data_buffer)};
+  auto data    = std::make_shared<arrow::ArrayData>(type, input.size(), buffers);
+
+  return std::make_shared<arrow::Decimal128Array>(data);
+}
+
+template <>
+std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<numeric::decimal32>(
+  column_view input,
+  cudf::type_id,
+  column_metadata const&,
+  arrow::MemoryPool* ar_mr,
+  rmm::cuda_stream_view stream)
+{
+  using DeviceType = int32_t;
+  return unsupported_decimals_to_arrow<DeviceType>(
+    input, cudf::detail::max_precision<DeviceType>(), ar_mr, stream);
+}
+
+template <>
+std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<numeric::decimal64>(
+  column_view input,
+  cudf::type_id,
+  column_metadata const&,
+  arrow::MemoryPool* ar_mr,
+  rmm::cuda_stream_view stream)
+{
+  using DeviceType = int64_t;
+  return unsupported_decimals_to_arrow<DeviceType>(
+    input, cudf::detail::max_precision<DeviceType>(), ar_mr, stream);
+}
+
+template <>
+std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<numeric::decimal128>(
+  column_view input,
+  cudf::type_id,
+  column_metadata const&,
+  arrow::MemoryPool* ar_mr,
+  rmm::cuda_stream_view stream)
+{
+  using DeviceType         = __int128_t;
+  auto const max_precision = cudf::detail::max_precision<DeviceType>();
+
+  rmm::device_uvector<DeviceType> buf(input.size(), stream);
+
+  thrust::copy(rmm::exec_policy(stream),  //
+               input.begin<DeviceType>(),
+               input.end<DeviceType>(),
+               buf.begin());
+
+  auto const buf_size_in_bytes = buf.size() * sizeof(DeviceType);
+  auto data_buffer             = allocate_arrow_buffer(buf_size_in_bytes, ar_mr);
+
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+    data_buffer->mutable_data(), buf.data(), buf_size_in_bytes, cudaMemcpyDefault, stream.value()));
+
+  auto type    = arrow::decimal(max_precision, -input.type().scale());
+  auto mask    = fetch_mask_buffer(input, ar_mr, stream);
+  auto buffers = std::vector<std::shared_ptr<arrow::Buffer>>{mask, std::move(data_buffer)};
+  auto data    = std::make_shared<arrow::ArrayData>(type, input.size(), buffers);
+
+  return std::make_shared<arrow::Decimal128Array>(data);
+}
+
+template <>
+std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<bool>(column_view input,
+                                                                  cudf::type_id id,
+                                                                  column_metadata const&,
+                                                                  arrow::MemoryPool* ar_mr,
+                                                                  rmm::cuda_stream_view stream)
+{
+  auto bitmask = detail::bools_to_mask(input, stream, rmm::mr::get_current_device_resource());
+
+  auto data_buffer = allocate_arrow_buffer(static_cast<int64_t>(bitmask.first->size()), ar_mr);
+
+  CUDF_CUDA_TRY(cudaMemcpyAsync(data_buffer->mutable_data(),
+                                bitmask.first->data(),
+                                bitmask.first->size(),
+                                cudaMemcpyDefault,
+                                stream.value()));
+  return to_arrow_array(id,
+                        static_cast<int64_t>(input.size()),
+                        std::move(data_buffer),
+                        fetch_mask_buffer(input, ar_mr, stream),
+                        static_cast<int64_t>(input.null_count()));
+}
+
+template <>
+std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<cudf::string_view>(
+  column_view input,
+  cudf::type_id,
+  column_metadata const&,
+  arrow::MemoryPool* ar_mr,
+  rmm::cuda_stream_view stream)
+{
+  std::unique_ptr<column> tmp_column =
+    ((input.offset() != 0) or
+     ((input.num_children() == 1) and (input.child(0).size() - 1 != input.size())))
+      ? std::make_unique<cudf::column>(input, stream)
+      : nullptr;
+
+  column_view input_view = (tmp_column != nullptr) ? tmp_column->view() : input;
+  auto child_arrays      = fetch_child_array(input_view, {{}, {}}, ar_mr, stream);
+  if (child_arrays.empty()) {
+    // Empty string will have only one value in offset of 4 bytes
+    auto tmp_offset_buffer = allocate_arrow_buffer(sizeof(int32_t), ar_mr);
+    auto tmp_data_buffer   = allocate_arrow_buffer(0, ar_mr);
+    memset(tmp_offset_buffer->mutable_data(), 0, sizeof(int32_t));
+
+    return std::make_shared<arrow::StringArray>(
+      0, std::move(tmp_offset_buffer), std::move(tmp_data_buffer));
+  }
+  auto offset_buffer = child_arrays[strings_column_view::offsets_column_index]->data()->buffers[1];
+  auto const sview   = strings_column_view{input_view};
+  auto data_buffer   = fetch_data_buffer<char>(
+    device_span<char const>{sview.chars_begin(stream),
+                              static_cast<std::size_t>(sview.chars_size(stream))},
+    ar_mr,
+    stream);
+  if (sview.offsets().type().id() == cudf::type_id::INT64) {
+    return std::make_shared<arrow::LargeStringArray>(static_cast<int64_t>(input_view.size()),
+                                                     offset_buffer,
+                                                     data_buffer,
+                                                     fetch_mask_buffer(input_view, ar_mr, stream),
+                                                     static_cast<int64_t>(input_view.null_count()));
+  } else {
+    return std::make_shared<arrow::StringArray>(static_cast<int64_t>(input_view.size()),
+                                                offset_buffer,
+                                                data_buffer,
+                                                fetch_mask_buffer(input_view, ar_mr, stream),
+                                                static_cast<int64_t>(input_view.null_count()));
+  }
+}
+
+template <>
+std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<cudf::struct_view>(
+  column_view input,
+  cudf::type_id,
+  column_metadata const& metadata,
+  arrow::MemoryPool* ar_mr,
+  rmm::cuda_stream_view stream)
+{
+  CUDF_EXPECTS(metadata.children_meta.size() == static_cast<std::size_t>(input.num_children()),
+               "Number of field names and number of children doesn't match\n");
+  std::unique_ptr<column> tmp_column = nullptr;
+
+  if (input.offset() != 0) { tmp_column = std::make_unique<cudf::column>(input, stream); }
+
+  column_view input_view = (tmp_column != nullptr) ? tmp_column->view() : input;
+  auto child_arrays      = fetch_child_array(input_view, metadata.children_meta, ar_mr, stream);
+  auto mask              = fetch_mask_buffer(input_view, ar_mr, stream);
+
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  std::transform(child_arrays.cbegin(),
+                 child_arrays.cend(),
+                 metadata.children_meta.cbegin(),
+                 std::back_inserter(fields),
+                 [](auto const array, auto const meta) {
+                   return std::make_shared<arrow::Field>(
+                     meta.name, array->type(), array->null_count() > 0);
+                 });
+  auto dtype = std::make_shared<arrow::StructType>(fields);
+
+  return std::make_shared<arrow::StructArray>(dtype,
+                                              static_cast<int64_t>(input_view.size()),
+                                              child_arrays,
+                                              mask,
+                                              static_cast<int64_t>(input_view.null_count()));
+}
+
+template <>
+std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<cudf::list_view>(
+  column_view input,
+  cudf::type_id,
+  column_metadata const& metadata,
+  arrow::MemoryPool* ar_mr,
+  rmm::cuda_stream_view stream)
+{
+  CUDF_EXPECTS(metadata.children_meta.empty() ||
+                 metadata.children_meta.size() == static_cast<std::size_t>(input.num_children()),
+               "Number of field names and number of children do not match\n");
+  std::unique_ptr<column> tmp_column = nullptr;
+  if ((input.offset() != 0) or
+      ((input.num_children() == 2) and (input.child(0).size() - 1 != input.size()))) {
+    tmp_column = std::make_unique<cudf::column>(input, stream);
+  }
+
+  column_view input_view = (tmp_column != nullptr) ? tmp_column->view() : input;
+  auto children_meta =
+    metadata.children_meta.empty() ? std::vector<column_metadata>{{}, {}} : metadata.children_meta;
+  auto child_arrays = fetch_child_array(input_view, children_meta, ar_mr, stream);
+  if (child_arrays.empty() || child_arrays[0]->data()->length == 0) {
+    auto element_type = child_arrays.empty() ? arrow::null() : child_arrays[1]->type();
+    auto result       = arrow::MakeEmptyArray(arrow::list(element_type), ar_mr);
+    CUDF_EXPECTS(result.ok(), "Failed to construct empty arrow list array\n");
+    return result.ValueUnsafe();
+  }
+
+  auto offset_buffer = child_arrays[0]->data()->buffers[1];
+  auto data          = child_arrays[1];
+  return std::make_shared<arrow::ListArray>(arrow::list(data->type()),
+                                            static_cast<int64_t>(input_view.size()),
+                                            offset_buffer,
+                                            data,
+                                            fetch_mask_buffer(input_view, ar_mr, stream),
+                                            static_cast<int64_t>(input_view.null_count()));
+}
+
+template <>
+std::shared_ptr<arrow::Array> dispatch_to_arrow::operator()<cudf::dictionary32>(
+  column_view input,
+  cudf::type_id,
+  column_metadata const& metadata,
+  arrow::MemoryPool* ar_mr,
+  rmm::cuda_stream_view stream)
+{
+  // Arrow dictionary requires indices to be signed integer
+  std::unique_ptr<column> dict_indices =
+    detail::cast(cudf::dictionary_column_view(input).get_indices_annotated(),
+                 cudf::data_type{type_id::INT32},
+                 stream,
+                 rmm::mr::get_current_device_resource());
+  auto indices = dispatch_to_arrow{}.operator()<int32_t>(
+    dict_indices->view(), dict_indices->type().id(), {}, ar_mr, stream);
+  auto dict_keys = cudf::dictionary_column_view(input).keys();
+  auto dictionary =
+    type_dispatcher(dict_keys.type(),
+                    dispatch_to_arrow{},
+                    dict_keys,
+                    dict_keys.type().id(),
+                    metadata.children_meta.empty() ? column_metadata{} : metadata.children_meta[0],
+                    ar_mr,
+                    stream);
+
+  return std::make_shared<arrow::DictionaryArray>(
+    arrow::dictionary(indices->type(), dictionary->type()), indices, dictionary);
+}
+}  // namespace
+
+std::shared_ptr<arrow::Table> to_arrow(table_view input,
+                                       std::vector<column_metadata> const& metadata,
+                                       rmm::cuda_stream_view stream,
+                                       arrow::MemoryPool* ar_mr)
+{
+  CUDF_EXPECTS((metadata.size() == static_cast<std::size_t>(input.num_columns())),
+               "columns' metadata should be equal to number of columns in table");
+
+  std::vector<std::shared_ptr<arrow::Array>> arrays;
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+
+  std::transform(
+    input.begin(),
+    input.end(),
+    metadata.begin(),
+    std::back_inserter(arrays),
+    [&](auto const& c, auto const& meta) {
+      return c.type().id() != type_id::EMPTY
+               ? type_dispatcher(
+                   c.type(), detail::dispatch_to_arrow{}, c, c.type().id(), meta, ar_mr, stream)
+               : std::make_shared<arrow::NullArray>(c.size());
+    });
+
+  std::transform(
+    arrays.begin(),
+    arrays.end(),
+    metadata.begin(),
+    std::back_inserter(fields),
+    [](auto const& array, auto const& meta) { return arrow::field(meta.name, array->type()); });
+
+  auto result = arrow::Table::Make(arrow::schema(fields), arrays);
+
+  // synchronize the stream because after the return the data may be accessed from the host before
+  // the above `cudaMemcpyAsync` calls have completed their copies (especially if pinned host
+  // memory is used).
+  stream.synchronize();
+
+  return result;
+}
+
+std::shared_ptr<arrow::Scalar> to_arrow(cudf::scalar const& input,
+                                        column_metadata const& metadata,
+                                        rmm::cuda_stream_view stream,
+                                        arrow::MemoryPool* ar_mr)
+{
+  auto const column = cudf::make_column_from_scalar(input, 1, stream);
+  cudf::table_view const tv{{column->view()}};
+  auto const arrow_table  = detail::to_arrow(tv, {metadata}, stream, ar_mr);
+  auto const ac           = arrow_table->column(0);
+  auto const maybe_scalar = ac->GetScalar(0);
+  if (!maybe_scalar.ok()) { CUDF_FAIL("Failed to produce a scalar"); }
+  return maybe_scalar.ValueOrDie();
+}
+}  // namespace detail
+
+std::shared_ptr<arrow::Table> to_arrow(table_view input,
+                                       std::vector<column_metadata> const& metadata,
+                                       rmm::cuda_stream_view stream,
+                                       arrow::MemoryPool* ar_mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::to_arrow(input, metadata, stream, ar_mr);
+}
+
+std::shared_ptr<arrow::Scalar> to_arrow(cudf::scalar const& input,
+                                        column_metadata const& metadata,
+                                        rmm::cuda_stream_view stream,
+                                        arrow::MemoryPool* ar_mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::to_arrow(input, metadata, stream, ar_mr);
+}
+}  // namespace cudf

--- a/cpp/src/interop/to_arrow_schema.cpp
+++ b/cpp/src/interop/to_arrow_schema.cpp
@@ -170,9 +170,8 @@ int dispatch_to_arrow_type::operator()<cudf::list_view>(column_view input,
   NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(out, NANOARROW_TYPE_LIST));
   auto child = input.child(cudf::lists_column_view::child_column_index);
   ArrowSchemaInit(out->children[0]);
-  auto child_meta = metadata.children_meta.empty()
-                      ? column_metadata{"element"}
-                      : metadata.children_meta[cudf::lists_column_view::child_column_index];
+  auto child_meta =
+    metadata.children_meta.empty() ? column_metadata{"element"} : metadata.children_meta[0];
 
   out->flags = input.has_nulls() ? ARROW_FLAG_NULLABLE : 0;
   NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(out->children[0], child_meta.name.c_str()));

--- a/cpp/src/io/parquet/ipc/Message_generated.h
+++ b/cpp/src/io/parquet/ipc/Message_generated.h
@@ -5,11 +5,11 @@
 
 #include <flatbuffers/flatbuffers.h>
 
-// Ensure the included flatbuffers.h is the same version as when this file was
-// generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 24 && FLATBUFFERS_VERSION_MINOR == 3 &&
-                FLATBUFFERS_VERSION_REVISION == 25,
-              "Non-compatible flatbuffers version included");
+//// Ensure the included flatbuffers.h is the same version as when this file was
+//// generated, otherwise it may not be compatible.
+//static_assert(FLATBUFFERS_VERSION_MAJOR == 24 && FLATBUFFERS_VERSION_MINOR == 3 &&
+//                FLATBUFFERS_VERSION_REVISION == 25,
+//              "Non-compatible flatbuffers version included");
 
 #include "Schema_generated.h"
 

--- a/cpp/src/io/parquet/ipc/Schema_generated.h
+++ b/cpp/src/io/parquet/ipc/Schema_generated.h
@@ -5,11 +5,11 @@
 
 #include <flatbuffers/flatbuffers.h>
 
-// Ensure the included flatbuffers.h is the same version as when this file was
-// generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 24 && FLATBUFFERS_VERSION_MINOR == 3 &&
-                FLATBUFFERS_VERSION_REVISION == 25,
-              "Non-compatible flatbuffers version included");
+//// Ensure the included flatbuffers.h is the same version as when this file was
+//// generated, otherwise it may not be compatible.
+//static_assert(FLATBUFFERS_VERSION_MAJOR == 24 && FLATBUFFERS_VERSION_MINOR == 3 &&
+//                FLATBUFFERS_VERSION_REVISION == 25,
+//              "Non-compatible flatbuffers version included");
 
 namespace cudf {
 namespace io {

--- a/cpp/tests/interop/arrow_utils.hpp
+++ b/cpp/tests/interop/arrow_utils.hpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#pragma once
-
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
@@ -32,65 +30,11 @@
 #include <cudf/transform.hpp>
 #include <cudf/types.hpp>
 
-#include <arrow/api.h>
 #include <arrow/util/bitmap_builders.h>
 
-// Creating arrow as per given type_id and buffer arguments
-template <typename... Ts>
-std::shared_ptr<arrow::Array> to_arrow_array(cudf::type_id id, Ts&&... args)
-{
-  switch (id) {
-    case cudf::type_id::BOOL8:
-      return std::make_shared<arrow::BooleanArray>(std::forward<Ts>(args)...);
-    case cudf::type_id::INT8: return std::make_shared<arrow::Int8Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::INT16:
-      return std::make_shared<arrow::Int16Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::INT32:
-      return std::make_shared<arrow::Int32Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::INT64:
-      return std::make_shared<arrow::Int64Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::UINT8:
-      return std::make_shared<arrow::UInt8Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::UINT16:
-      return std::make_shared<arrow::UInt16Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::UINT32:
-      return std::make_shared<arrow::UInt32Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::UINT64:
-      return std::make_shared<arrow::UInt64Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::FLOAT32:
-      return std::make_shared<arrow::FloatArray>(std::forward<Ts>(args)...);
-    case cudf::type_id::FLOAT64:
-      return std::make_shared<arrow::DoubleArray>(std::forward<Ts>(args)...);
-    case cudf::type_id::TIMESTAMP_DAYS:
-      return std::make_shared<arrow::Date32Array>(std::make_shared<arrow::Date32Type>(),
-                                                  std::forward<Ts>(args)...);
-    case cudf::type_id::TIMESTAMP_SECONDS:
-      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::SECOND),
-                                                     std::forward<Ts>(args)...);
-    case cudf::type_id::TIMESTAMP_MILLISECONDS:
-      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::MILLI),
-                                                     std::forward<Ts>(args)...);
-    case cudf::type_id::TIMESTAMP_MICROSECONDS:
-      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::MICRO),
-                                                     std::forward<Ts>(args)...);
-    case cudf::type_id::TIMESTAMP_NANOSECONDS:
-      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::NANO),
-                                                     std::forward<Ts>(args)...);
-    case cudf::type_id::DURATION_SECONDS:
-      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::SECOND),
-                                                    std::forward<Ts>(args)...);
-    case cudf::type_id::DURATION_MILLISECONDS:
-      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::MILLI),
-                                                    std::forward<Ts>(args)...);
-    case cudf::type_id::DURATION_MICROSECONDS:
-      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::MICRO),
-                                                    std::forward<Ts>(args)...);
-    case cudf::type_id::DURATION_NANOSECONDS:
-      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::NANO),
-                                                    std::forward<Ts>(args)...);
-    default: CUDF_FAIL("Unsupported type_id conversion to arrow");
-  }
-}
+#include <algorithm>
+
+#pragma once
 
 template <typename T>
 std::enable_if_t<cudf::is_fixed_width<T>() and !std::is_same_v<T, bool>,
@@ -106,7 +50,7 @@ get_arrow_array(std::vector<T> const& data, std::vector<uint8_t> const& mask = {
   std::shared_ptr<arrow::Buffer> mask_buffer =
     mask.empty() ? nullptr : arrow::internal::BytesToBits(mask).ValueOrDie();
 
-  return to_arrow_array(cudf::type_to_id<T>(), data.size(), data_buffer, mask_buffer);
+  return cudf::detail::to_arrow_array(cudf::type_to_id<T>(), data.size(), data_buffer, mask_buffer);
 }
 
 template <typename T>

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -423,7 +423,7 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - pyarrow>=14.0.0,<18.0.0a0
+          - pyarrow==16.1.0
       - output_types: [requirements, pyproject]
         packages:
           # pyarrow 17.0.0 wheels have a subtle issue around threading that

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -37,69 +37,11 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <arrow/api.h>
-#include <arrow/c/bridge.h>
 
 #include <algorithm>
 
 using cudf::jni::ptr_as_jlong;
 using cudf::jni::release_as_jlong;
-
-// Creating arrow as per given type_id and buffer arguments
-template <typename... Ts>
-std::shared_ptr<arrow::Array> to_arrow_array(cudf::type_id id, Ts&&... args)
-{
-  switch (id) {
-    case cudf::type_id::BOOL8:
-      return std::make_shared<arrow::BooleanArray>(std::forward<Ts>(args)...);
-    case cudf::type_id::INT8: return std::make_shared<arrow::Int8Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::INT16:
-      return std::make_shared<arrow::Int16Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::INT32:
-      return std::make_shared<arrow::Int32Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::INT64:
-      return std::make_shared<arrow::Int64Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::UINT8:
-      return std::make_shared<arrow::UInt8Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::UINT16:
-      return std::make_shared<arrow::UInt16Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::UINT32:
-      return std::make_shared<arrow::UInt32Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::UINT64:
-      return std::make_shared<arrow::UInt64Array>(std::forward<Ts>(args)...);
-    case cudf::type_id::FLOAT32:
-      return std::make_shared<arrow::FloatArray>(std::forward<Ts>(args)...);
-    case cudf::type_id::FLOAT64:
-      return std::make_shared<arrow::DoubleArray>(std::forward<Ts>(args)...);
-    case cudf::type_id::TIMESTAMP_DAYS:
-      return std::make_shared<arrow::Date32Array>(std::make_shared<arrow::Date32Type>(),
-                                                  std::forward<Ts>(args)...);
-    case cudf::type_id::TIMESTAMP_SECONDS:
-      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::SECOND),
-                                                     std::forward<Ts>(args)...);
-    case cudf::type_id::TIMESTAMP_MILLISECONDS:
-      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::MILLI),
-                                                     std::forward<Ts>(args)...);
-    case cudf::type_id::TIMESTAMP_MICROSECONDS:
-      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::MICRO),
-                                                     std::forward<Ts>(args)...);
-    case cudf::type_id::TIMESTAMP_NANOSECONDS:
-      return std::make_shared<arrow::TimestampArray>(arrow::timestamp(arrow::TimeUnit::NANO),
-                                                     std::forward<Ts>(args)...);
-    case cudf::type_id::DURATION_SECONDS:
-      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::SECOND),
-                                                    std::forward<Ts>(args)...);
-    case cudf::type_id::DURATION_MILLISECONDS:
-      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::MILLI),
-                                                    std::forward<Ts>(args)...);
-    case cudf::type_id::DURATION_MICROSECONDS:
-      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::MICRO),
-                                                    std::forward<Ts>(args)...);
-    case cudf::type_id::DURATION_NANOSECONDS:
-      return std::make_shared<arrow::DurationArray>(arrow::duration(arrow::TimeUnit::NANO),
-                                                    std::forward<Ts>(args)...);
-    default: CUDF_FAIL("Unsupported type_id conversion to arrow");
-  }
-}
 
 extern "C" {
 
@@ -198,27 +140,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromArrow(JNIEnv* env,
         break;
       default:
         // this handles the primitive types
-        arrow_array = to_arrow_array(n_type, j_col_length, data_buffer, null_buffer, j_null_count);
+        arrow_array = cudf::detail::to_arrow_array(
+          n_type, j_col_length, data_buffer, null_buffer, j_null_count);
     }
     auto name_and_type                                = arrow::field("col", arrow_array->type());
     std::vector<std::shared_ptr<arrow::Field>> fields = {name_and_type};
     std::shared_ptr<arrow::Schema> schema             = std::make_shared<arrow::Schema>(fields);
     auto arrow_table =
       arrow::Table::Make(schema, std::vector<std::shared_ptr<arrow::Array>>{arrow_array});
-
-    ArrowSchema sch;
-    if (!arrow::ExportSchema(*arrow_table->schema(), &sch).ok()) {
-      JNI_THROW_NEW(env, "java/lang/RuntimeException", "Unable to produce an ArrowSchema", 0)
-    }
-    auto batch = arrow_table->CombineChunksToBatch().ValueOrDie();
-    ArrowArray arr;
-    if (!arrow::ExportRecordBatch(*batch, &arr).ok()) {
-      JNI_THROW_NEW(env, "java/lang/RuntimeException", "Unable to produce an ArrowArray", 0)
-    }
-    auto retCols = cudf::from_arrow(&sch, &arr)->release();
-    arr.release(&arr);
-    sch.release(&sch);
-
+    auto retCols = cudf::from_arrow(*(arrow_table))->release();
     if (retCols.size() != 1) {
       JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Must result in one column", 0);
     }

--- a/python/LinkPyarrowHeaders.cmake
+++ b/python/LinkPyarrowHeaders.cmake
@@ -1,0 +1,40 @@
+# =============================================================================
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+include_guard(GLOBAL)
+
+find_package(Python REQUIRED COMPONENTS Development NumPy)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -c "import pyarrow; print(pyarrow.get_include())"
+  OUTPUT_VARIABLE PYARROW_INCLUDE_DIR
+  ERROR_VARIABLE PYARROW_ERROR
+  RESULT_VARIABLE PYARROW_RESULT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(${PYARROW_RESULT})
+  message(FATAL_ERROR "Error while trying to obtain pyarrow include directory:\n${PYARROW_ERROR}")
+endif()
+
+# Due to cudf's scalar.pyx needing to cimport pylibcudf's scalar.pyx (because there are parts of
+# cudf Cython that need to directly access the c_obj underlying the pylibcudf Scalar) the
+# requirement for arrow headers infects all of cudf. These requirements will go away once all
+# scalar-related Cython code is removed from cudf.
+function(link_to_pyarrow_headers targets)
+  foreach(target IN LISTS targets)
+    # PyArrow headers require numpy headers.
+    target_include_directories(${target} PRIVATE "${Python_NumPy_INCLUDE_DIRS}")
+    target_include_directories(${target} PRIVATE "${PYARROW_INCLUDE_DIR}")
+  endforeach()
+endfunction()

--- a/python/cudf/CMakeLists.txt
+++ b/python/cudf/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(cudf "${RAPIDS_VERSION}" REQUIRED)
 include(rapids-cpm)
 rapids_cpm_init()
 include(../../cpp/cmake/thirdparty/get_dlpack.cmake)
+include(../LinkPyarrowHeaders.cmake)
 
 include(rapids-cython-core)
 rapids_cython_init()

--- a/python/cudf/cudf/_lib/CMakeLists.txt
+++ b/python/cudf/cudf/_lib/CMakeLists.txt
@@ -69,6 +69,9 @@ include(${rapids-cmake-dir}/export/find_package_root.cmake)
 include(../../../../cpp/cmake/thirdparty/get_nanoarrow.cmake)
 target_link_libraries(interop PUBLIC nanoarrow)
 
+set(targets_using_arrow_headers interop avro csv orc json parquet)
+link_to_pyarrow_headers("${targets_using_arrow_headers}")
+
 add_subdirectory(io)
 add_subdirectory(nvtext)
 add_subdirectory(strings)

--- a/python/pylibcudf/CMakeLists.txt
+++ b/python/pylibcudf/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(cudf "${RAPIDS_VERSION}" REQUIRED)
 include(rapids-cpm)
 rapids_cpm_init()
 include(../../cpp/cmake/thirdparty/get_dlpack.cmake)
+include(../LinkPyarrowHeaders.cmake)
 
 include(rapids-cython-core)
 

--- a/python/pylibcudf/pylibcudf/CMakeLists.txt
+++ b/python/pylibcudf/pylibcudf/CMakeLists.txt
@@ -65,6 +65,8 @@ include(${rapids-cmake-dir}/export/find_package_root.cmake)
 include(../../../cpp/cmake/thirdparty/get_nanoarrow.cmake)
 target_link_libraries(pylibcudf_interop PUBLIC nanoarrow)
 
+link_to_pyarrow_headers(pylibcudf_interop)
+
 add_subdirectory(libcudf)
 add_subdirectory(strings)
 add_subdirectory(io)

--- a/python/pylibcudf/pylibcudf/interop.pyx
+++ b/python/pylibcudf/pylibcudf/interop.pyx
@@ -43,7 +43,7 @@ from .types cimport DataType, type_id
 
 import os
 
-USE_LEGACY_INTEROP = bool(os.environ.get("USE_LEGACY_INTEROP", 0))
+USE_LEGACY_INTEROP = bool(int(os.environ.get("USE_LEGACY_INTEROP", 0)))
 
 
 ARROW_TO_PYLIBCUDF_TYPES = {

--- a/python/pylibcudf/pylibcudf/interop.pyx
+++ b/python/pylibcudf/pylibcudf/interop.pyx
@@ -13,6 +13,12 @@ from functools import singledispatch
 from pyarrow import lib as pa
 
 from pylibcudf.libcudf.column.column cimport column
+from pylibcudf.libcudf.fixed_point.fixed_point cimport (
+    decimal32,
+    decimal64,
+    decimal128,
+    scale_type,
+)
 from pylibcudf.libcudf.interop cimport (
     ArrowArray,
     ArrowArrayStream,
@@ -23,19 +29,8 @@ from pylibcudf.libcudf.interop cimport (
     from_arrow_stream as cpp_from_arrow_stream,
     to_arrow as cpp_to_arrow,
 )
+from pylibcudf.libcudf.scalar.scalar cimport fixed_point_scalar, scalar
 from pylibcudf.libcudf.table.table cimport table
-
-from cudf._lib.pylibcudf.libcudf.scalar.scalar cimport (
-    fixed_point_scalar,
-    scalar,
-)
-from cudf._lib.pylibcudf.libcudf.table.table cimport table
-from cudf._lib.pylibcudf.libcudf.wrappers.decimals cimport (
-    decimal32,
-    decimal64,
-    decimal128,
-    scale_type,
-)
 
 from .column cimport Column
 from .scalar cimport Scalar

--- a/python/pylibcudf/pylibcudf/interop.pyx
+++ b/python/pylibcudf/pylibcudf/interop.pyx
@@ -1,10 +1,11 @@
 # Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
-from cpython.pycapsule cimport PyCapsule_GetPointer, PyCapsule_New
-from libc.stdlib cimport free
-from libcpp.memory cimport unique_ptr
+from cpython cimport pycapsule
+from cython.operator cimport dereference
+from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.utility cimport move
 from libcpp.vector cimport vector
+from pyarrow cimport lib as pa
 
 from dataclasses import dataclass, field
 from functools import singledispatch
@@ -17,14 +18,25 @@ from pylibcudf.libcudf.interop cimport (
     ArrowArrayStream,
     ArrowSchema,
     column_metadata,
+    from_arrow as cpp_from_arrow,
     from_arrow_column as cpp_from_arrow_column,
     from_arrow_stream as cpp_from_arrow_stream,
-    to_arrow_host_raw,
-    to_arrow_schema_raw,
+    to_arrow as cpp_to_arrow,
 )
 from pylibcudf.libcudf.table.table cimport table
 
-from . cimport copying
+from cudf._lib.pylibcudf.libcudf.scalar.scalar cimport (
+    fixed_point_scalar,
+    scalar,
+)
+from cudf._lib.pylibcudf.libcudf.table.table cimport table
+from cudf._lib.pylibcudf.libcudf.wrappers.decimals cimport (
+    decimal32,
+    decimal64,
+    decimal128,
+    scale_type,
+)
+
 from .column cimport Column
 from .scalar cimport Scalar
 from .table cimport Table
@@ -99,9 +111,7 @@ def from_arrow(pyarrow_object, *, DataType data_type=None):
     Union[Table, Scalar]
         The converted object of type corresponding to the input type in cudf.
     """
-    raise TypeError(
-        f"Unsupported type {type(pyarrow_object)} for conversion from arrow"
-    )
+    raise TypeError("from_arrow only accepts Table and Scalar objects")
 
 
 @from_arrow.register(pa.DataType)
@@ -125,7 +135,7 @@ def _from_arrow_table(pyarrow_object, *, DataType data_type=None):
         raise ValueError("data_type may not be passed for tables")
     stream = pyarrow_object.__arrow_c_stream__()
     cdef ArrowArrayStream* c_stream = (
-        <ArrowArrayStream*>PyCapsule_GetPointer(stream, "arrow_array_stream")
+        <ArrowArrayStream*>pycapsule.PyCapsule_GetPointer(stream, "arrow_array_stream")
     )
 
     cdef unique_ptr[table] c_result
@@ -138,17 +148,54 @@ def _from_arrow_table(pyarrow_object, *, DataType data_type=None):
 
 @from_arrow.register(pa.Scalar)
 def _from_arrow_scalar(pyarrow_object, *, DataType data_type=None):
-    if isinstance(pyarrow_object.type, pa.ListType) and pyarrow_object.as_py() is None:
-        # pyarrow doesn't correctly handle None values for list types, so
-        # we have to create this one manually.
-        # https://github.com/apache/arrow/issues/40319
-        pa_array = pa.array([None], type=pyarrow_object.type)
-    else:
-        pa_array = pa.array([pyarrow_object])
-    return copying.get_element(
-        from_arrow(pa_array, data_type=data_type),
-        0,
-    )
+    cdef shared_ptr[pa.CScalar] arrow_scalar = pa.pyarrow_unwrap_scalar(pyarrow_object)
+
+    cdef unique_ptr[scalar] c_result
+    with nogil:
+        c_result = move(cpp_from_arrow(dereference(arrow_scalar)))
+
+    cdef Scalar result = Scalar.from_libcudf(move(c_result))
+
+    if result.type().id() != type_id.DECIMAL128:
+        if data_type is not None:
+            raise ValueError(
+                "dtype may not be passed for non-decimal types"
+            )
+        return result
+
+    if data_type is None:
+        raise ValueError(
+            "Decimal scalars must be constructed with a dtype"
+        )
+
+    cdef type_id tid = data_type.id()
+
+    if tid == type_id.DECIMAL32:
+        result.c_obj.reset(
+            new fixed_point_scalar[decimal32](
+                (
+                    <fixed_point_scalar[decimal128]*> result.c_obj.get()
+                ).value(),
+                scale_type(-pyarrow_object.type.scale),
+                result.c_obj.get().is_valid()
+            )
+        )
+    elif tid == type_id.DECIMAL64:
+        result.c_obj.reset(
+            new fixed_point_scalar[decimal64](
+                (
+                    <fixed_point_scalar[decimal128]*> result.c_obj.get()
+                ).value(),
+                scale_type(-pyarrow_object.type.scale),
+                result.c_obj.get().is_valid()
+            )
+        )
+    elif tid != type_id.DECIMAL128:
+        raise ValueError(
+            "Decimal scalars may only be cast to decimals"
+        )
+
+    return result
 
 
 @from_arrow.register(pa.Array)
@@ -158,10 +205,10 @@ def _from_arrow_column(pyarrow_object, *, DataType data_type=None):
 
     schema, array = pyarrow_object.__arrow_c_array__()
     cdef ArrowSchema* c_schema = (
-        <ArrowSchema*>PyCapsule_GetPointer(schema, "arrow_schema")
+        <ArrowSchema*>pycapsule.PyCapsule_GetPointer(schema, "arrow_schema")
     )
     cdef ArrowArray* c_array = (
-        <ArrowArray*>PyCapsule_GetPointer(array, "arrow_array")
+        <ArrowArray*>pycapsule.PyCapsule_GetPointer(array, "arrow_array")
     )
 
     cdef unique_ptr[column] c_result
@@ -192,7 +239,7 @@ def to_arrow(cudf_object, metadata=None):
     Union[pyarrow.Array, pyarrow.Table, pyarrow.Scalar]
         The converted object of type corresponding to the input type in PyArrow.
     """
-    raise TypeError(f"Unsupported type {type(cudf_object)} for conversion to arrow")
+    raise TypeError("to_arrow only accepts Table and Scalar objects")
 
 
 @to_arrow.register(DataType)
@@ -235,83 +282,46 @@ def _to_arrow_datatype(cudf_object, **kwargs):
             )
 
 
-cdef void _release_schema(object schema_capsule) noexcept:
-    """Release the ArrowSchema object stored in a PyCapsule."""
-    cdef ArrowSchema* schema = <ArrowSchema*>PyCapsule_GetPointer(
-        schema_capsule, 'arrow_schema'
-    )
-    if schema.release != NULL:
-        schema.release(schema)
-
-    free(schema)
-
-
-cdef void _release_array(object array_capsule) noexcept:
-    """Release the ArrowArray object stored in a PyCapsule."""
-    cdef ArrowArray* array = <ArrowArray*>PyCapsule_GetPointer(
-        array_capsule, 'arrow_array'
-    )
-    if array.release != NULL:
-        array.release(array)
-
-    free(array)
-
-
-def _table_to_schema(Table tbl, metadata):
-    if metadata is None:
-        metadata = [ColumnMetadata() for _ in range(len(tbl.columns()))]
-    metadata = [ColumnMetadata(m) if isinstance(m, str) else m for m in metadata]
-
-    cdef vector[column_metadata] c_metadata
-    c_metadata.reserve(len(metadata))
-    for meta in metadata:
-        c_metadata.push_back(_metadata_to_libcudf(meta))
-
-    cdef ArrowSchema* raw_schema_ptr
-    with nogil:
-        raw_schema_ptr = to_arrow_schema_raw(tbl.view(), c_metadata)
-
-    return PyCapsule_New(<void*>raw_schema_ptr, 'arrow_schema', _release_schema)
-
-
-def _table_to_host_array(Table tbl):
-    cdef ArrowArray* raw_host_array_ptr
-    with nogil:
-        raw_host_array_ptr = to_arrow_host_raw(tbl.view())
-
-    return PyCapsule_New(<void*>raw_host_array_ptr, "arrow_array", _release_array)
-
-
-class _TableWithArrowMetadata:
-    def __init__(self, tbl, metadata=None):
-        self.tbl = tbl
-        self.metadata = metadata
-
-    def __arrow_c_array__(self, requested_schema=None):
-        return _table_to_schema(self.tbl, self.metadata), _table_to_host_array(self.tbl)
-
-
-# TODO: In the long run we should get rid of the `to_arrow` functions in favor of using
-# the protocols directly via `pa.table(cudf_object, schema=...)` directly. We can do the
-# same for columns. We cannot do this for scalars since there is no corresponding
-# protocol. Since this will require broader changes throughout the codebase, the current
-# approach is to leverage the protocol internally but to continue exposing `to_arrow`.
 @to_arrow.register(Table)
 def _to_arrow_table(cudf_object, metadata=None):
-    test_table = _TableWithArrowMetadata(cudf_object, metadata)
-    return pa.table(test_table)
+    if metadata is None:
+        metadata = [ColumnMetadata() for _ in range(len(cudf_object.columns()))]
+    metadata = [ColumnMetadata(m) if isinstance(m, str) else m for m in metadata]
+    cdef vector[column_metadata] c_table_metadata
+    cdef shared_ptr[pa.CTable] c_table_result
+    for meta in metadata:
+        c_table_metadata.push_back(_metadata_to_libcudf(meta))
+    with nogil:
+        c_table_result = move(
+            cpp_to_arrow((<Table> cudf_object).view(), c_table_metadata)
+        )
 
-
-@to_arrow.register(Column)
-def _to_arrow_array(cudf_object, metadata=None):
-    """Create a PyArrow array from a pylibcudf column."""
-    if metadata is not None:
-        metadata = [metadata]
-    return to_arrow(Table([cudf_object]), metadata)[0]
+    return pa.pyarrow_wrap_table(c_table_result)
 
 
 @to_arrow.register(Scalar)
 def _to_arrow_scalar(cudf_object, metadata=None):
     # Note that metadata for scalars is primarily important for preserving
     # information on nested types since names are otherwise irrelevant.
-    return to_arrow(Column.from_scalar(cudf_object, 1), metadata=metadata)[0]
+    if metadata is None:
+        metadata = ColumnMetadata()
+    metadata = ColumnMetadata(metadata) if isinstance(metadata, str) else metadata
+    cdef column_metadata c_scalar_metadata = _metadata_to_libcudf(metadata)
+    cdef shared_ptr[pa.CScalar] c_scalar_result
+    with nogil:
+        c_scalar_result = move(
+            cpp_to_arrow(
+                dereference((<Scalar> cudf_object).c_obj), c_scalar_metadata
+            )
+        )
+
+    return pa.pyarrow_wrap_scalar(c_scalar_result)
+
+
+@to_arrow.register(Column)
+def _to_arrow_array(cudf_object, metadata=None):
+    """Create a PyArrow array from a pylibcudf column."""
+    if metadata is None:
+        metadata = ColumnMetadata()
+    metadata = ColumnMetadata(metadata) if isinstance(metadata, str) else metadata
+    return to_arrow(Table([cudf_object]), [metadata])[0]

--- a/python/pylibcudf/pylibcudf/interop.pyx
+++ b/python/pylibcudf/pylibcudf/interop.pyx
@@ -1,7 +1,8 @@
 # Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
-from cpython cimport pycapsule
+from cpython.pycapsule cimport PyCapsule_GetPointer, PyCapsule_New
 from cython.operator cimport dereference
+from libc.stdlib cimport free
 from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.utility cimport move
 from libcpp.vector cimport vector
@@ -28,14 +29,22 @@ from pylibcudf.libcudf.interop cimport (
     from_arrow_column as cpp_from_arrow_column,
     from_arrow_stream as cpp_from_arrow_stream,
     to_arrow as cpp_to_arrow,
+    to_arrow_host_raw,
+    to_arrow_schema_raw,
 )
 from pylibcudf.libcudf.scalar.scalar cimport fixed_point_scalar, scalar
 from pylibcudf.libcudf.table.table cimport table
 
+from . cimport copying
 from .column cimport Column
 from .scalar cimport Scalar
 from .table cimport Table
 from .types cimport DataType, type_id
+
+import os
+
+USE_LEGACY_INTEROP = bool(os.environ.get("USE_LEGACY_INTEROP", 0))
+
 
 ARROW_TO_PYLIBCUDF_TYPES = {
     pa.int8(): type_id.INT8,
@@ -106,7 +115,9 @@ def from_arrow(pyarrow_object, *, DataType data_type=None):
     Union[Table, Scalar]
         The converted object of type corresponding to the input type in cudf.
     """
-    raise TypeError("from_arrow only accepts Table and Scalar objects")
+    raise TypeError(
+        f"Unsupported type {type(pyarrow_object)} for conversion from arrow"
+    )
 
 
 @from_arrow.register(pa.DataType)
@@ -130,7 +141,7 @@ def _from_arrow_table(pyarrow_object, *, DataType data_type=None):
         raise ValueError("data_type may not be passed for tables")
     stream = pyarrow_object.__arrow_c_stream__()
     cdef ArrowArrayStream* c_stream = (
-        <ArrowArrayStream*>pycapsule.PyCapsule_GetPointer(stream, "arrow_array_stream")
+        <ArrowArrayStream*>PyCapsule_GetPointer(stream, "arrow_array_stream")
     )
 
     cdef unique_ptr[table] c_result
@@ -144,53 +155,69 @@ def _from_arrow_table(pyarrow_object, *, DataType data_type=None):
 @from_arrow.register(pa.Scalar)
 def _from_arrow_scalar(pyarrow_object, *, DataType data_type=None):
     cdef shared_ptr[pa.CScalar] arrow_scalar = pa.pyarrow_unwrap_scalar(pyarrow_object)
-
     cdef unique_ptr[scalar] c_result
-    with nogil:
-        c_result = move(cpp_from_arrow(dereference(arrow_scalar)))
+    cdef Scalar result
+    cdef type_id tid
 
-    cdef Scalar result = Scalar.from_libcudf(move(c_result))
+    if USE_LEGACY_INTEROP:
+        with nogil:
+            c_result = move(cpp_from_arrow(dereference(arrow_scalar)))
 
-    if result.type().id() != type_id.DECIMAL128:
-        if data_type is not None:
+        result = Scalar.from_libcudf(move(c_result))
+
+        if result.type().id() != type_id.DECIMAL128:
+            if data_type is not None:
+                raise ValueError(
+                    "dtype may not be passed for non-decimal types"
+                )
+            return result
+
+        if data_type is None:
             raise ValueError(
-                "dtype may not be passed for non-decimal types"
+                "Decimal scalars must be constructed with a dtype"
             )
+
+        tid = data_type.id()
+
+        if tid == type_id.DECIMAL32:
+            result.c_obj.reset(
+                new fixed_point_scalar[decimal32](
+                    (
+                        <fixed_point_scalar[decimal128]*> result.c_obj.get()
+                    ).value(),
+                    scale_type(-pyarrow_object.type.scale),
+                    result.c_obj.get().is_valid()
+                )
+            )
+        elif tid == type_id.DECIMAL64:
+            result.c_obj.reset(
+                new fixed_point_scalar[decimal64](
+                    (
+                        <fixed_point_scalar[decimal128]*> result.c_obj.get()
+                    ).value(),
+                    scale_type(-pyarrow_object.type.scale),
+                    result.c_obj.get().is_valid()
+                )
+            )
+        elif tid != type_id.DECIMAL128:
+            raise ValueError(
+                "Decimal scalars may only be cast to decimals"
+            )
+
         return result
-
-    if data_type is None:
-        raise ValueError(
-            "Decimal scalars must be constructed with a dtype"
+    else:
+        if isinstance(pyarrow_object.type, pa.ListType) \
+                and pyarrow_object.as_py() is None:
+            # pyarrow doesn't correctly handle None values for list types, so
+            # we have to create this one manually.
+            # https://github.com/apache/arrow/issues/40319
+            pa_array = pa.array([None], type=pyarrow_object.type)
+        else:
+            pa_array = pa.array([pyarrow_object])
+        return copying.get_element(
+            from_arrow(pa_array, data_type=data_type),
+            0,
         )
-
-    cdef type_id tid = data_type.id()
-
-    if tid == type_id.DECIMAL32:
-        result.c_obj.reset(
-            new fixed_point_scalar[decimal32](
-                (
-                    <fixed_point_scalar[decimal128]*> result.c_obj.get()
-                ).value(),
-                scale_type(-pyarrow_object.type.scale),
-                result.c_obj.get().is_valid()
-            )
-        )
-    elif tid == type_id.DECIMAL64:
-        result.c_obj.reset(
-            new fixed_point_scalar[decimal64](
-                (
-                    <fixed_point_scalar[decimal128]*> result.c_obj.get()
-                ).value(),
-                scale_type(-pyarrow_object.type.scale),
-                result.c_obj.get().is_valid()
-            )
-        )
-    elif tid != type_id.DECIMAL128:
-        raise ValueError(
-            "Decimal scalars may only be cast to decimals"
-        )
-
-    return result
 
 
 @from_arrow.register(pa.Array)
@@ -200,10 +227,10 @@ def _from_arrow_column(pyarrow_object, *, DataType data_type=None):
 
     schema, array = pyarrow_object.__arrow_c_array__()
     cdef ArrowSchema* c_schema = (
-        <ArrowSchema*>pycapsule.PyCapsule_GetPointer(schema, "arrow_schema")
+        <ArrowSchema*>PyCapsule_GetPointer(schema, "arrow_schema")
     )
     cdef ArrowArray* c_array = (
-        <ArrowArray*>pycapsule.PyCapsule_GetPointer(array, "arrow_array")
+        <ArrowArray*>PyCapsule_GetPointer(array, "arrow_array")
     )
 
     cdef unique_ptr[column] c_result
@@ -277,46 +304,115 @@ def _to_arrow_datatype(cudf_object, **kwargs):
             )
 
 
+cdef void _release_schema(object schema_capsule) noexcept:
+    """Release the ArrowSchema object stored in a PyCapsule."""
+    cdef ArrowSchema* schema = <ArrowSchema*>PyCapsule_GetPointer(
+        schema_capsule, 'arrow_schema'
+    )
+    if schema.release != NULL:
+        schema.release(schema)
+
+    free(schema)
+
+
+cdef void _release_array(object array_capsule) noexcept:
+    """Release the ArrowArray object stored in a PyCapsule."""
+    cdef ArrowArray* array = <ArrowArray*>PyCapsule_GetPointer(
+        array_capsule, 'arrow_array'
+    )
+    if array.release != NULL:
+        array.release(array)
+
+    free(array)
+
+
+def _table_to_schema(Table tbl, metadata):
+    if metadata is None:
+        metadata = [ColumnMetadata() for _ in range(len(tbl.columns()))]
+    metadata = [ColumnMetadata(m) if isinstance(m, str) else m for m in metadata]
+
+    cdef vector[column_metadata] c_metadata
+    c_metadata.reserve(len(metadata))
+    for meta in metadata:
+        c_metadata.push_back(_metadata_to_libcudf(meta))
+
+    cdef ArrowSchema* raw_schema_ptr
+    with nogil:
+        raw_schema_ptr = to_arrow_schema_raw(tbl.view(), c_metadata)
+
+    return PyCapsule_New(<void*>raw_schema_ptr, 'arrow_schema', _release_schema)
+
+
+def _table_to_host_array(Table tbl):
+    cdef ArrowArray* raw_host_array_ptr
+    with nogil:
+        raw_host_array_ptr = to_arrow_host_raw(tbl.view())
+
+    return PyCapsule_New(<void*>raw_host_array_ptr, "arrow_array", _release_array)
+
+
+class _TableWithArrowMetadata:
+    def __init__(self, tbl, metadata=None):
+        self.tbl = tbl
+        self.metadata = metadata
+
+    def __arrow_c_array__(self, requested_schema=None):
+        return _table_to_schema(self.tbl, self.metadata), _table_to_host_array(self.tbl)
+
+
 @to_arrow.register(Table)
 def _to_arrow_table(cudf_object, metadata=None):
-    if metadata is None:
-        metadata = [ColumnMetadata() for _ in range(len(cudf_object.columns()))]
-    metadata = [ColumnMetadata(m) if isinstance(m, str) else m for m in metadata]
     cdef vector[column_metadata] c_table_metadata
     cdef shared_ptr[pa.CTable] c_table_result
-    for meta in metadata:
-        c_table_metadata.push_back(_metadata_to_libcudf(meta))
-    with nogil:
-        c_table_result = move(
-            cpp_to_arrow((<Table> cudf_object).view(), c_table_metadata)
-        )
+    if USE_LEGACY_INTEROP:
+        if metadata is None:
+            metadata = [ColumnMetadata() for _ in range(len(cudf_object.columns()))]
+        metadata = [ColumnMetadata(m) if isinstance(m, str) else m for m in metadata]
+        for meta in metadata:
+            c_table_metadata.push_back(_metadata_to_libcudf(meta))
+        with nogil:
+            c_table_result = move(
+                cpp_to_arrow((<Table> cudf_object).view(), c_table_metadata)
+            )
 
-    return pa.pyarrow_wrap_table(c_table_result)
+        return pa.pyarrow_wrap_table(c_table_result)
+    else:
+        test_table = _TableWithArrowMetadata(cudf_object, metadata)
+        return pa.table(test_table)
 
 
 @to_arrow.register(Scalar)
 def _to_arrow_scalar(cudf_object, metadata=None):
-    # Note that metadata for scalars is primarily important for preserving
-    # information on nested types since names are otherwise irrelevant.
-    if metadata is None:
-        metadata = ColumnMetadata()
-    metadata = ColumnMetadata(metadata) if isinstance(metadata, str) else metadata
-    cdef column_metadata c_scalar_metadata = _metadata_to_libcudf(metadata)
+    cdef column_metadata c_scalar_metadata
     cdef shared_ptr[pa.CScalar] c_scalar_result
-    with nogil:
-        c_scalar_result = move(
-            cpp_to_arrow(
-                dereference((<Scalar> cudf_object).c_obj), c_scalar_metadata
+    if USE_LEGACY_INTEROP:
+        # Note that metadata for scalars is primarily important for preserving
+        # information on nested types since names are otherwise irrelevant.
+        if metadata is None:
+            metadata = ColumnMetadata()
+        metadata = ColumnMetadata(metadata) if isinstance(metadata, str) else metadata
+        c_scalar_metadata = _metadata_to_libcudf(metadata)
+        with nogil:
+            c_scalar_result = move(
+                cpp_to_arrow(
+                    dereference((<Scalar> cudf_object).c_obj), c_scalar_metadata
+                )
             )
-        )
 
-    return pa.pyarrow_wrap_scalar(c_scalar_result)
+        return pa.pyarrow_wrap_scalar(c_scalar_result)
+    else:
+        return to_arrow(Column.from_scalar(cudf_object, 1), metadata=metadata)[0]
 
 
 @to_arrow.register(Column)
 def _to_arrow_array(cudf_object, metadata=None):
     """Create a PyArrow array from a pylibcudf column."""
-    if metadata is None:
-        metadata = ColumnMetadata()
-    metadata = ColumnMetadata(metadata) if isinstance(metadata, str) else metadata
-    return to_arrow(Table([cudf_object]), [metadata])[0]
+    if USE_LEGACY_INTEROP:
+        if metadata is None:
+            metadata = ColumnMetadata()
+        metadata = ColumnMetadata(metadata) if isinstance(metadata, str) else metadata
+        return to_arrow(Table([cudf_object]), [metadata])[0]
+    else:
+        if metadata is not None:
+            metadata = [metadata]
+        return to_arrow(Table([cudf_object]), metadata)[0]

--- a/python/pylibcudf/pylibcudf/libcudf/fixed_point/fixed_point.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/fixed_point/fixed_point.pxd
@@ -1,8 +1,16 @@
 # Copyright (c) 2021-2024, NVIDIA CORPORATION.
 
-from libc.stdint cimport int32_t
+from libc.stdint cimport int32_t, int64_t
+from pylibcudf.libcudf.types cimport int128
 
 
 cdef extern from "cudf/fixed_point/fixed_point.hpp" namespace "numeric" nogil:
+    # cython type stub to help resolve to numeric::decimal64
+    ctypedef int64_t decimal64
+    # cython type stub to help resolve to numeric::decimal32
+    ctypedef int64_t decimal32
+    # cython type stub to help resolve to numeric::decimal128
+    ctypedef int128 decimal128
+
     cdef cppclass scale_type:
         scale_type(int32_t)

--- a/python/pylibcudf/pylibcudf/libcudf/interop.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/interop.pxd
@@ -3,11 +3,19 @@
 from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.string cimport string
 from libcpp.vector cimport vector
+from pyarrow.lib cimport CScalar, CTable
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport scalar
 from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.table.table_view cimport table_view
+
+from cudf._lib.types import cudf_to_np_types, np_to_cudf_types
+
+from cudf._lib.pylibcudf.libcudf.column.column cimport column
+from cudf._lib.pylibcudf.libcudf.scalar.scalar cimport scalar
+from cudf._lib.pylibcudf.libcudf.table.table cimport table
+from cudf._lib.pylibcudf.libcudf.table.table_view cimport table_view
 
 
 cdef extern from "dlpack/dlpack.h" nogil:
@@ -26,9 +34,6 @@ cdef extern from "cudf/interop.hpp" nogil:
     cdef struct ArrowArrayStream:
         void (*release)(ArrowArrayStream*) noexcept nogil
 
-    cdef struct ArrowDeviceArray:
-        ArrowArray array
-
 
 cdef extern from "cudf/interop.hpp" namespace "cudf" \
         nogil:
@@ -38,11 +43,24 @@ cdef extern from "cudf/interop.hpp" namespace "cudf" \
     DLManagedTensor* to_dlpack(table_view input_table
                                ) except +
 
+    cdef unique_ptr[table] from_arrow(CTable input) except +
+    cdef unique_ptr[scalar] from_arrow(CScalar input) except +
+
     cdef cppclass column_metadata:
         column_metadata() except +
         column_metadata(string name_) except +
         string name
         vector[column_metadata] children_meta
+
+    cdef shared_ptr[CTable] to_arrow(
+        table_view input,
+        vector[column_metadata] metadata,
+    ) except +
+
+    cdef shared_ptr[CScalar] to_arrow(
+        const scalar& input,
+        column_metadata metadata,
+    ) except +
 
     cdef unique_ptr[table] from_arrow_stream(ArrowArrayStream* input) except +
     cdef unique_ptr[column] from_arrow_column(

--- a/python/pylibcudf/pylibcudf/libcudf/interop.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/interop.pxd
@@ -12,11 +12,6 @@ from pylibcudf.libcudf.table.table_view cimport table_view
 
 from cudf._lib.types import cudf_to_np_types, np_to_cudf_types
 
-from cudf._lib.pylibcudf.libcudf.column.column cimport column
-from cudf._lib.pylibcudf.libcudf.scalar.scalar cimport scalar
-from cudf._lib.pylibcudf.libcudf.table.table cimport table
-from cudf._lib.pylibcudf.libcudf.table.table_view cimport table_view
-
 
 cdef extern from "dlpack/dlpack.h" nogil:
     ctypedef struct DLManagedTensor:

--- a/python/pylibcudf/pylibcudf/tests/common/utils.py
+++ b/python/pylibcudf/pylibcudf/tests/common/utils.py
@@ -45,7 +45,7 @@ def metadata_from_arrow_type(
 def assert_column_eq(
     lhs: pa.Array | plc.Column,
     rhs: pa.Array | plc.Column,
-    check_field_nullability=False,
+    check_field_nullability=True,
 ) -> None:
     """Verify that a pylibcudf array and PyArrow array are equal.
 
@@ -60,9 +60,7 @@ def assert_column_eq(
         on child fields are equal.
 
         Useful for checking roundtripping of lossy formats like JSON that may not
-        preserve this information. Also, our Arrow interop functions make different
-        choices by default than pyarrow field constructors since the interop functions
-        may make data-dependent choices.
+        preserve this information.
     """
     # Nested types require children metadata to be passed to the conversion function.
     if isinstance(lhs, (pa.Array, pa.ChunkedArray)) and isinstance(


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The intent of this PR is to fix #17075, but it provides no fixes as of yet. Due to the large changes that we have made around both arrow and pylibcudf since 24.08, getting back to a state where we can benchmark and profile cudf's legacy arrow interop against the current C data interface implementations is challenging. This PR makes the necessary changes to enable side-by-side benchmarking and profiling. The code will switch between the old and new implementation using the `USE_LEGACY_INTEROP` flag, like so:
```
(rapids) coder ➜ ~/cudf/arrow_slowdown $ ipython test.ipy 
to_arrow() time:
1.54 s ± 1.37 ms per loop (mean ± std. dev. of 2 runs, 2 loops each)
from_arrow() time:
587 ms ± 120 ms per loop (mean ± std. dev. of 2 runs, 2 loops each)
GPU -> CPU -> GPU Arrow roundtrip time:
2.03 s ± 8.61 ms per loop (mean ± std. dev. of 2 runs, 2 loops each)
to_pandas() time:
2.12 s ± 614 μs per loop (mean ± std. dev. of 2 runs, 2 loops each)
GPU -> CPU -> GPU Pandas roundtrip time:
3.26 s ± 47.6 ms per loop (mean ± std. dev. of 2 runs, 2 loops each)
(rapids) coder ➜ 
(rapids) coder ➜ ~/cudf/arrow_slowdown $ USE_LEGACY_INTEROP=1 ipython test.ipy 
to_arrow() time:
728 ms ± 1.23 ms per loop (mean ± std. dev. of 2 runs, 2 loops each)
from_arrow() time:
454 ms ± 7.49 ms per loop (mean ± std. dev. of 2 runs, 2 loops each)
GPU -> CPU -> GPU Arrow roundtrip time:
1.15 s ± 443 μs per loop (mean ± std. dev. of 2 runs, 2 loops each)
to_pandas() time:
2.11 s ± 395 μs per loop (mean ± std. dev. of 2 runs, 2 loops each)
GPU -> CPU -> GPU Pandas roundtrip time:
3.25 s ± 45.8 ms per loop (mean ± std. dev. of 2 runs, 2 loops each)
```

I'll move on to profiling from here, but this should also make it easier for someone else to pick up this benchmarking if necessary.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
