### PR TITLE
Minor I/O code quality improvements

### DIFF
--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -335,10 +335,10 @@ class datasource {
   template <typename Container>
   class owning_buffer : public buffer {
    public:
-    /**
-     * @brief Disallow callers to pass an lvalue Container.
-     */
-    owning_buffer(Container&) = delete;
+    // Disallow the container argument to be an lvalue (in which case Container = T& is a
+    // reference).
+    static_assert(!std::is_reference_v<Container>,
+                  "The container argument passed to the constructor must be an rvalue.");
 
     /**
      * @brief Moves the input container into the newly created object.
@@ -352,11 +352,6 @@ class datasource {
         _size(_data.size())
     {
     }
-
-    /**
-     * @brief Disallow callers to pass an lvalue Container.
-     */
-    owning_buffer(Container&, uint8_t const*, size_t) = delete;
 
     /**
      * @brief Moves the input container into the newly created object, and exposes a subspan of the

--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -70,16 +70,22 @@ class datasource {
     virtual ~buffer() {}
 
     /**
+     * @brief Disallow callers to pass an lvalue Container.
+     */
+    template <typename Container>
+    static std::unique_ptr<buffer> create(Container&) = delete;
+
+    /**
      * @brief Factory to construct a datasource buffer object from a container.
      *
      * @tparam Container Type of the container to construct the buffer from
-     * @param data_owner The container to construct the buffer from (ownership is transferred)
+     * @param moved_data_owner The container to construct the buffer from (ownership is transferred)
      * @return Constructed buffer object
      */
     template <typename Container>
-    static std::unique_ptr<buffer> create(Container&& data_owner)
+    static std::unique_ptr<buffer> create(Container&& moved_data_owner)
     {
-      return std::make_unique<owning_buffer<Container>>(std::move(data_owner));
+      return std::make_unique<owning_buffer<Container>>(std::forward<Container>(moved_data_owner));
     }
   };
 

--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -350,10 +350,12 @@ class datasource {
      * @brief Moves the input container into the newly created object.
      *
      * @param moved_data_owner The container to construct the buffer from. Callers should explicitly
-     * pass std::move(data_owner_from) to this function to transfer the ownership.
+     * pass std::move(data_owner) to this function to transfer the ownership.
      */
     owning_buffer(Container&& moved_data_owner)
-      : _data(std::move(moved_data_owner)), _data_ptr(_data.data()), _size(_data.size())
+      : _data(std::forward<Container>(moved_data_owner)),
+        _data_ptr(_data.data()),
+        _size(_data.size())
     {
     }
 
@@ -367,12 +369,12 @@ class datasource {
      * buffer.
      *
      * @param moved_data_owner The container to construct the buffer from. Callers should explicitly
-     * pass std::move(data_owner_from) to this function to transfer the ownership.
+     * pass std::move(data_owner) to this function to transfer the ownership.
      * @param data_ptr Pointer to the start of the subspan
      * @param size The size of the subspan
      */
     owning_buffer(Container&& moved_data_owner, uint8_t const* data_ptr, size_t size)
-      : _data(std::move(moved_data_owner)), _data_ptr(data_ptr), _size(size)
+      : _data(std::forward<Container>(moved_data_owner)), _data_ptr(data_ptr), _size(size)
     {
     }
 

--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -70,22 +70,16 @@ class datasource {
     virtual ~buffer() {}
 
     /**
-     * @brief Disallow callers to pass an lvalue Container.
-     */
-    template <typename Container>
-    static std::unique_ptr<buffer> create(Container&) = delete;
-
-    /**
      * @brief Factory to construct a datasource buffer object from a container.
      *
      * @tparam Container Type of the container to construct the buffer from
-     * @param moved_data_owner The container to construct the buffer from (ownership is transferred)
+     * @param data_owner The container to construct the buffer from (ownership is transferred)
      * @return Constructed buffer object
      */
     template <typename Container>
-    static std::unique_ptr<buffer> create(Container&& moved_data_owner)
+    static std::unique_ptr<buffer> create(Container&& data_owner)
     {
-      return std::make_unique<owning_buffer<Container>>(std::forward<Container>(moved_data_owner));
+      return std::make_unique<owning_buffer<Container>>(std::forward<Container>(data_owner));
     }
   };
 

--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -336,25 +336,37 @@ class datasource {
   class owning_buffer : public buffer {
    public:
     /**
+     * @brief Disallow callers to pass an lvalue Container.
+     */
+    owning_buffer(Container&) = delete;
+
+    /**
      * @brief Moves the input container into the newly created object.
      *
-     * @param data_owner The container to construct the buffer from (ownership is transferred)
+     * @param moved_data_owner The container to construct the buffer from. Callers should explicitly
+     * pass std::move(data_owner_from) to this function to transfer the ownership.
      */
-    owning_buffer(Container&& data_owner)
-      : _data(std::move(data_owner)), _data_ptr(_data.data()), _size(_data.size())
+    owning_buffer(Container&& moved_data_owner)
+      : _data(std::move(moved_data_owner)), _data_ptr(_data.data()), _size(_data.size())
     {
     }
+
+    /**
+     * @brief Disallow callers to pass an lvalue Container.
+     */
+    owning_buffer(Container&, uint8_t const*, size_t) = delete;
 
     /**
      * @brief Moves the input container into the newly created object, and exposes a subspan of the
      * buffer.
      *
-     * @param data_owner The container to construct the buffer from (ownership is transferred)
+     * @param moved_data_owner The container to construct the buffer from. Callers should explicitly
+     * pass std::move(data_owner_from) to this function to transfer the ownership.
      * @param data_ptr Pointer to the start of the subspan
      * @param size The size of the subspan
      */
-    owning_buffer(Container&& data_owner, uint8_t const* data_ptr, size_t size)
-      : _data(std::move(data_owner)), _data_ptr(data_ptr), _size(size)
+    owning_buffer(Container&& moved_data_owner, uint8_t const* data_ptr, size_t size)
+      : _data(std::move(moved_data_owner)), _data_ptr(data_ptr), _size(size)
     {
     }
 

--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -347,9 +347,7 @@ class datasource {
      * pass std::move(data_owner) to this function to transfer the ownership.
      */
     owning_buffer(Container&& moved_data_owner)
-      : _data(std::forward<Container>(moved_data_owner)),
-        _data_ptr(_data.data()),
-        _size(_data.size())
+      : _data(std::move(moved_data_owner)), _data_ptr(_data.data()), _size(_data.size())
     {
     }
 
@@ -363,7 +361,7 @@ class datasource {
      * @param size The size of the subspan
      */
     owning_buffer(Container&& moved_data_owner, uint8_t const* data_ptr, size_t size)
-      : _data(std::forward<Container>(moved_data_owner)), _data_ptr(data_ptr), _size(size)
+      : _data(std::move(moved_data_owner)), _data_ptr(data_ptr), _size(size)
     {
     }
 

--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -335,9 +335,9 @@ class datasource {
   template <typename Container>
   class owning_buffer : public buffer {
    public:
-    // Disallow the container argument to be an lvalue (in which case Container = T& is a
+    // Require that the argument passed to the constructor be an rvalue (Container&& being an rvalue
     // reference).
-    static_assert(!std::is_reference_v<Container>,
+    static_assert(std::is_rvalue_reference_v<Container&&>,
                   "The container argument passed to the constructor must be an rvalue.");
 
     /**

--- a/cpp/src/io/utilities/file_io_utilities.cpp
+++ b/cpp/src/io/utilities/file_io_utilities.cpp
@@ -108,9 +108,11 @@ class cufile_shim {
 
   ~cufile_shim()
   {
-    // TODO: revisit the segfault issue presumably caused by cuFile's implicit driver-close function
-    // using CUDA API after the main() returns, which constitutes UB.
+    // Explicit cuFile driver close should not be performed here to avoid segfault. However, in the
+    // absence of driver_close(), cuFile will implicitly do that, which in most cases causes
+    // segfault anyway. TODO: Revisit this conundrum once cuFile is fixed.
     // https://github.com/rapidsai/cudf/issues/17121
+
     if (cf_lib != nullptr) dlclose(cf_lib);
   }
 

--- a/cpp/src/io/utilities/file_io_utilities.cpp
+++ b/cpp/src/io/utilities/file_io_utilities.cpp
@@ -108,7 +108,11 @@ class cufile_shim {
 
   ~cufile_shim()
   {
-    if (driver_close != nullptr) driver_close();
+    // TODO: This destructor is called after the main function returns. The cuFileDriverClose()
+    // internally calls CUDA API, resulting in UB (usually manifested as segfault), and therefore
+    // should not be called here. However, even in the absence of cuFileDriverClose(), cuFile will
+    // implicitly close the driver, during which process some CUDA calls are still made, likely
+    // causing segfault. The best way to clean up the resources needs to be revisited in the future.
     if (cf_lib != nullptr) dlclose(cf_lib);
   }
 

--- a/cpp/src/io/utilities/file_io_utilities.cpp
+++ b/cpp/src/io/utilities/file_io_utilities.cpp
@@ -108,11 +108,9 @@ class cufile_shim {
 
   ~cufile_shim()
   {
-    // TODO: This destructor is called after the main function returns. The cuFileDriverClose()
-    // internally calls CUDA API, resulting in UB (usually manifested as segfault), and therefore
-    // should not be called here. However, even in the absence of cuFileDriverClose(), cuFile will
-    // implicitly close the driver, during which process some CUDA calls are still made, likely
-    // causing segfault. The best way to clean up the resources needs to be revisited in the future.
+    // TODO: revisit the segfault issue presumably caused by cuFile's implicit driver-close function
+    // using CUDA API after the main() returns, which constitutes UB.
+    // https://github.com/rapidsai/cudf/issues/17121
     if (cf_lib != nullptr) dlclose(cf_lib);
   }
 

--- a/cpp/src/io/utilities/file_io_utilities.hpp
+++ b/cpp/src/io/utilities/file_io_utilities.hpp
@@ -104,7 +104,7 @@ class cufile_shim;
 /**
  * @brief Class that provides RAII for cuFile file registration.
  */
-struct cufile_registered_file {
+class cufile_registered_file {
   void register_handle();
 
  public:


### PR DESCRIPTION
## Description
This PR makes small improvements for the I/O code. Specifically,
- Place type constraint on a template class to allow only for rvalue argument. In addition, replace `std::move` with `std::forward` to make the code more *apparently* consistent with the convention, i.e. use `std::move()` on the rvalue references, and `std::forward` on the forwarding references (Effective modern C++ item 25).
- Alleviate (but not completely resolve) an existing cuFile driver close issue by removing the explicit driver close call. See #17121 
- Minor typo fix (`struct` &#8594; `class`).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
