### PR TITLE
WIP: Support decimal dtypes

### DIFF
--- a/python/cudf_polars/cudf_polars/utils/dtypes.py
+++ b/python/cudf_polars/cudf_polars/utils/dtypes.py
@@ -141,5 +141,8 @@ def from_polars(dtype: pl.DataType) -> plc.DataType:
         # Recurse to catch unsupported inner types
         _ = from_polars(dtype.inner)
         return plc.DataType(plc.TypeId.LIST)
+    elif isinstance(dtype, pl.Decimal):
+        # TODO: Loses precision and just goes to max precision of 38
+        return plc.DataType(plc.TypeId.DECIMAL128, scale=-dtype.scale)
     else:
         raise NotImplementedError(f"{dtype=} conversion not supported")


### PR DESCRIPTION
## Description
Polars only has 128 bit decimals. This currently loses the precision for round trips.

I can run a groupby and it seems to work.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
