### PR TITLE
Disable the Parquet reader's wide lists tables GTest by default

### DIFF
--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -2725,7 +2725,9 @@ TYPED_TEST(ParquetReaderPredicatePushdownTest, FilterTyped)
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected->view(), result_table);
 }
 
-TEST_F(ParquetReaderTest, ListsWideTable)
+// The test below requires several minutes to complete with memcheck, thus it is disabled by
+// default.
+TEST_F(ParquetReaderTest, DISABLED_ListsWideTable)
 {
   auto constexpr num_rows = 2;
   auto constexpr num_cols = 26'755;  // for slightly over 2B keys


### PR DESCRIPTION
## Description
This PR disables Parquet reader's wide lists table gtest by default as it takes several minutes to complete with memcheck. See the discussion on PR #17059 (this [comment](https://github.com/rapidsai/cudf/pull/17059#discussion_r1805342332)) for more context.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
