### PR TITLE
Set the default number of threads in KvikIO thread pool to 8

### DIFF
--- a/cpp/include/cudf/io/config_utils.hpp
+++ b/cpp/include/cudf/io/config_utils.hpp
@@ -18,7 +18,8 @@
 #include <cudf/utilities/export.hpp>
 
 namespace CUDF_EXPORT cudf {
-namespace io::cufile_integration {
+namespace io {
+namespace cufile_integration {
 
 /**
  * @brief Returns true if cuFile and its compatibility mode are enabled.
@@ -35,9 +36,9 @@ bool is_gds_enabled();
  */
 bool is_kvikio_enabled();
 
-}  // namespace io::cufile_integration
+}  // namespace cufile_integration
 
-namespace io::nvcomp_integration {
+namespace nvcomp_integration {
 
 /**
  * @brief Returns true if all nvCOMP uses are enabled.
@@ -49,5 +50,19 @@ bool is_all_enabled();
  */
 bool is_stable_enabled();
 
-}  // namespace io::nvcomp_integration
+}  // namespace nvcomp_integration
+
+namespace kvikio_setting {
+
+/**
+ * @brief Set kvikIO thread pool size.
+ *
+ * @param nthreads The number of threads used for kvikIO thread pool. If not set, the environment
+ * variable KVIKIO_NTHREADS will be used. If KVIKIO_NTHREADS is unset either, use 8 threads by
+ * default. Priority: nthreads parameter > KVIKIO_NTHREADS > default 8 threads.
+ */
+void set_thread_pool_nthreads(unsigned int nthreads = 0U);
+
+}  // namespace kvikio_setting
+}  // namespace io
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/include/cudf/io/config_utils.hpp
+++ b/cpp/include/cudf/io/config_utils.hpp
@@ -55,13 +55,10 @@ bool is_stable_enabled();
 namespace kvikio_setting {
 
 /**
- * @brief Set kvikIO thread pool size.
- *
- * @param nthreads The number of threads used for kvikIO thread pool. If not set, the environment
- * variable KVIKIO_NTHREADS will be used. If KVIKIO_NTHREADS is unset either, use 8 threads by
- * default. Priority: nthreads parameter > KVIKIO_NTHREADS > default 8 threads.
+ * @brief Set kvikIO thread pool size according to the environment variable KVIKIO_NTHREADS. If
+ * KVIKIO_NTHREADS is not set, use 8 threads by default.
  */
-void set_thread_pool_nthreads(unsigned int nthreads = 0U);
+void set_thread_pool_nthreads_from_env();
 
 }  // namespace kvikio_setting
 }  // namespace io

--- a/cpp/include/cudf/io/config_utils.hpp
+++ b/cpp/include/cudf/io/config_utils.hpp
@@ -36,6 +36,12 @@ bool is_gds_enabled();
  */
 bool is_kvikio_enabled();
 
+/**
+ * @brief Set kvikIO thread pool size according to the environment variable KVIKIO_NTHREADS. If
+ * KVIKIO_NTHREADS is not set, use 8 threads by default.
+ */
+void set_thread_pool_nthreads_from_env();
+
 }  // namespace cufile_integration
 
 namespace nvcomp_integration {
@@ -51,15 +57,5 @@ bool is_all_enabled();
 bool is_stable_enabled();
 
 }  // namespace nvcomp_integration
-
-namespace kvikio_setting {
-
-/**
- * @brief Set kvikIO thread pool size according to the environment variable KVIKIO_NTHREADS. If
- * KVIKIO_NTHREADS is not set, use 8 threads by default.
- */
-void set_thread_pool_nthreads_from_env();
-
-}  // namespace kvikio_setting
 }  // namespace io
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -19,6 +19,8 @@
 #include <cudf/detail/utilities/logger.hpp>
 #include <cudf/utilities/error.hpp>
 
+#include <kvikio/defaults.hpp>
+
 #include <cstdlib>
 #include <sstream>
 #include <string>
@@ -81,5 +83,13 @@ bool is_all_enabled() { return get_env_policy() == usage_policy::ALWAYS; }
 bool is_stable_enabled() { return is_all_enabled() or get_env_policy() == usage_policy::STABLE; }
 
 }  // namespace nvcomp_integration
+
+namespace kvikio_setting {
+void set_thread_pool_nthreads(unsigned int nthreads)
+{
+  if (nthreads == 0U) { nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 8U); }
+  kvikio::defaults::thread_pool_nthreads_reset(nthreads);
+}
+}  // namespace kvikio_setting
 
 }  // namespace cudf::io

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -85,9 +85,9 @@ bool is_stable_enabled() { return is_all_enabled() or get_env_policy() == usage_
 }  // namespace nvcomp_integration
 
 namespace kvikio_setting {
-void set_thread_pool_nthreads(unsigned int nthreads)
+void set_thread_pool_nthreads_from_env()
 {
-  if (nthreads == 0U) { nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 8U); }
+  auto nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 8U);
   kvikio::defaults::thread_pool_nthreads_reset(nthreads);
 }
 }  // namespace kvikio_setting

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -22,6 +22,7 @@
 #include <kvikio/defaults.hpp>
 
 #include <cstdlib>
+#include <mutex>
 #include <sstream>
 #include <string>
 
@@ -55,6 +56,14 @@ bool is_gds_enabled() { return is_always_enabled() or get_env_policy() == usage_
 
 bool is_kvikio_enabled() { return get_env_policy() == usage_policy::KVIKIO; }
 
+void set_thread_pool_nthreads_from_env()
+{
+  static std::once_flag flag{};
+  std::call_once(flag, [] {
+    auto nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 8U);
+    kvikio::defaults::thread_pool_nthreads_reset(nthreads);
+  });
+}
 }  // namespace cufile_integration
 
 namespace nvcomp_integration {
@@ -83,13 +92,4 @@ bool is_all_enabled() { return get_env_policy() == usage_policy::ALWAYS; }
 bool is_stable_enabled() { return is_all_enabled() or get_env_policy() == usage_policy::STABLE; }
 
 }  // namespace nvcomp_integration
-
-namespace kvikio_setting {
-void set_thread_pool_nthreads_from_env()
-{
-  auto nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 8U);
-  kvikio::defaults::thread_pool_nthreads_reset(nthreads);
-}
-}  // namespace kvikio_setting
-
 }  // namespace cudf::io

--- a/cpp/src/io/utilities/data_sink.cpp
+++ b/cpp/src/io/utilities/data_sink.cpp
@@ -42,6 +42,7 @@ class file_sink : public data_sink {
     if (!_output_stream.is_open()) { detail::throw_on_file_open_failure(filepath, true); }
 
     if (cufile_integration::is_kvikio_enabled()) {
+      kvikio_setting::set_thread_pool_nthreads();
       _kvikio_file = kvikio::FileHandle(filepath, "w");
       CUDF_LOG_INFO("Writing a file using kvikIO, with compatibility mode {}.",
                     _kvikio_file.is_compat_mode_on() ? "on" : "off");

--- a/cpp/src/io/utilities/data_sink.cpp
+++ b/cpp/src/io/utilities/data_sink.cpp
@@ -42,7 +42,7 @@ class file_sink : public data_sink {
     if (!_output_stream.is_open()) { detail::throw_on_file_open_failure(filepath, true); }
 
     if (cufile_integration::is_kvikio_enabled()) {
-      kvikio_setting::set_thread_pool_nthreads();
+      kvikio_setting::set_thread_pool_nthreads_from_env();
       _kvikio_file = kvikio::FileHandle(filepath, "w");
       CUDF_LOG_INFO("Writing a file using kvikIO, with compatibility mode {}.",
                     _kvikio_file.is_compat_mode_on() ? "on" : "off");

--- a/cpp/src/io/utilities/data_sink.cpp
+++ b/cpp/src/io/utilities/data_sink.cpp
@@ -42,7 +42,7 @@ class file_sink : public data_sink {
     if (!_output_stream.is_open()) { detail::throw_on_file_open_failure(filepath, true); }
 
     if (cufile_integration::is_kvikio_enabled()) {
-      kvikio_setting::set_thread_pool_nthreads_from_env();
+      cufile_integration::set_thread_pool_nthreads_from_env();
       _kvikio_file = kvikio::FileHandle(filepath, "w");
       CUDF_LOG_INFO("Writing a file using kvikIO, with compatibility mode {}.",
                     _kvikio_file.is_compat_mode_on() ? "on" : "off");

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -48,7 +48,7 @@ class file_source : public datasource {
   {
     detail::force_init_cuda_context();
     if (cufile_integration::is_kvikio_enabled()) {
-      kvikio_setting::set_thread_pool_nthreads();
+      kvikio_setting::set_thread_pool_nthreads_from_env();
       _kvikio_file = kvikio::FileHandle(filepath);
       CUDF_LOG_INFO("Reading a file using kvikIO, with compatibility mode {}.",
                     _kvikio_file.is_compat_mode_on() ? "on" : "off");

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -48,6 +48,7 @@ class file_source : public datasource {
   {
     detail::force_init_cuda_context();
     if (cufile_integration::is_kvikio_enabled()) {
+      kvikio_setting::set_thread_pool_nthreads();
       _kvikio_file = kvikio::FileHandle(filepath);
       CUDF_LOG_INFO("Reading a file using kvikIO, with compatibility mode {}.",
                     _kvikio_file.is_compat_mode_on() ? "on" : "off");

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -48,7 +48,7 @@ class file_source : public datasource {
   {
     detail::force_init_cuda_context();
     if (cufile_integration::is_kvikio_enabled()) {
-      kvikio_setting::set_thread_pool_nthreads_from_env();
+      cufile_integration::set_thread_pool_nthreads_from_env();
       _kvikio_file = kvikio::FileHandle(filepath);
       CUDF_LOG_INFO("Reading a file using kvikIO, with compatibility mode {}.",
                     _kvikio_file.is_compat_mode_on() ? "on" : "off");


### PR DESCRIPTION
## Description

Recent benchmarks have shown that setting the environment variable `KVIKIO_NTHREADS=8` in cuDF usually leads to optimal I/O performance. This PR internally sets the default KvikIO thread pool size to 8. The env `KVIKIO_NTHREADS` will still be honored if users explicitly set it.

Fixes #16718 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
