### PR TITLE
[NOT READY FOR MERGE] Fix the issue where cmake/ctest finds 0 test despite test binaries having been properly built

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -253,6 +253,7 @@ include(cmake/Modules/JitifyPreprocessKernels.cmake)
 include(cmake/thirdparty/get_cufile.cmake)
 # find KvikIO
 include(cmake/thirdparty/get_kvikio.cmake)
+unset(BUILD_TESTING CACHE)
 # find fmt
 include(cmake/thirdparty/get_fmt.cmake)
 # find spdlog


### PR DESCRIPTION
## Description
The following command shows that cmake/ctest finds 0 test (although all the test binaries have been properly built and can be individually run in the `/home/coder/cudf/cpp/build/latest/gtests` directory).
```
ctest --test-dir /home/coder/cudf/cpp/build/latest -V -N
```
The reason is that the subproject KvikIO sets the cmake cache variable `BUILD_TESTING` to `OFF` and propagates it to cuDF project. This PR provides a fix.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
