### PR TITLE
Support storing `precision` of decimal types in `Schema` class

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/DType.java
+++ b/java/src/main/java/ai/rapids/cudf/DType.java
@@ -95,13 +95,11 @@ public final class DType {
   }
 
   final DTypeEnum typeId;
-
-  // Variables for Decimal Type
   private final int scale;
-  private final int precision;
 
   private DType(DTypeEnum id) {
-    this(id, 0, 0);
+    typeId = id;
+    scale = 0;
   }
 
   /**
@@ -110,42 +108,8 @@ public final class DType {
    * @param decimalScale Scale of fixed point decimal type
    */
   private DType(DTypeEnum id, int decimalScale) {
-    this(id, decimalScale, 0);
-  }
-
-  /**
-   * Constructor for Decimal Type.
-   * <p>
-   * If precision is less than or equal to 0, it will be set to the maximum precision of
-   * the corresponding decimal type.
-   *
-   * @param id Enum representing data type.
-   * @param decimalScale Scale of fixed point decimal type
-   * @param decimalPrecision Precision of the original decimal type
-   */
-  private DType(DTypeEnum id, int decimalScale, int  decimalPrecision) {
     typeId = id;
     scale = decimalScale;
-
-    if (decimalPrecision <= 0) {
-      if (id == DTypeEnum.DECIMAL32) {
-        precision = DECIMAL32_MAX_PRECISION;
-      } else if (id == DTypeEnum.DECIMAL64) {
-        precision = DECIMAL64_MAX_PRECISION;
-      } else if (id == DTypeEnum.DECIMAL128) {
-        precision = DType.DECIMAL128_MAX_PRECISION;
-      } else {
-        precision = 0; // this is not a decimal type
-      }
-    } else {
-      if ((id == DTypeEnum.DECIMAL32 && decimalPrecision > DECIMAL32_MAX_PRECISION) ||
-          (id == DTypeEnum.DECIMAL64 && decimalPrecision > DECIMAL64_MAX_PRECISION) ||
-          (id == DTypeEnum.DECIMAL128 && decimalPrecision > DECIMAL128_MAX_PRECISION)) {
-        throw new IllegalArgumentException("Precision " + decimalPrecision +
-            " exceeds max precision for " + id);
-      }
-      precision = decimalPrecision;
-    }
   }
 
   public static final DType EMPTY = new DType(DTypeEnum.EMPTY);
@@ -256,12 +220,6 @@ public final class DType {
    *         if scale = 2, decimal value = 123456 * 10^2 = 12345600
    */
   public int getScale() { return scale; }
-
-  /**
-   * Returns precision for Decimal Type.
-   * @return number of digits in the unscaled value
-   */
-  public int getDecimalPrecision() { return precision; }
 
   /**
    * Return enum for this DType

--- a/java/src/main/java/ai/rapids/cudf/DType.java
+++ b/java/src/main/java/ai/rapids/cudf/DType.java
@@ -95,11 +95,13 @@ public final class DType {
   }
 
   final DTypeEnum typeId;
+
+  // Variables for Decimal Type
   private final int scale;
+  private final int precision;
 
   private DType(DTypeEnum id) {
-    typeId = id;
-    scale = 0;
+    this(id, 0, 0);
   }
 
   /**
@@ -108,8 +110,42 @@ public final class DType {
    * @param decimalScale Scale of fixed point decimal type
    */
   private DType(DTypeEnum id, int decimalScale) {
+    this(id, decimalScale, 0);
+  }
+
+  /**
+   * Constructor for Decimal Type.
+   * <p>
+   * If precision is less than or equal to 0, it will be set to the maximum precision of
+   * the corresponding decimal type.
+   *
+   * @param id Enum representing data type.
+   * @param decimalScale Scale of fixed point decimal type
+   * @param decimalPrecision Precision of the original decimal type
+   */
+  private DType(DTypeEnum id, int decimalScale, int  decimalPrecision) {
     typeId = id;
     scale = decimalScale;
+
+    if (decimalPrecision <= 0) {
+      if (id == DTypeEnum.DECIMAL32) {
+        precision = DECIMAL32_MAX_PRECISION;
+      } else if (id == DTypeEnum.DECIMAL64) {
+        precision = DECIMAL64_MAX_PRECISION;
+      } else if (id == DTypeEnum.DECIMAL128) {
+        precision = DType.DECIMAL128_MAX_PRECISION;
+      } else {
+        precision = 0; // this is not a decimal type
+      }
+    } else {
+      if ((id == DTypeEnum.DECIMAL32 && decimalPrecision > DECIMAL32_MAX_PRECISION) ||
+          (id == DTypeEnum.DECIMAL64 && decimalPrecision > DECIMAL64_MAX_PRECISION) ||
+          (id == DTypeEnum.DECIMAL128 && decimalPrecision > DECIMAL128_MAX_PRECISION)) {
+        throw new IllegalArgumentException("Precision " + decimalPrecision +
+            " exceeds max precision for " + id);
+      }
+      precision = decimalPrecision;
+    }
   }
 
   public static final DType EMPTY = new DType(DTypeEnum.EMPTY);
@@ -220,6 +256,12 @@ public final class DType {
    *         if scale = 2, decimal value = 123456 * 10^2 = 12345600
    */
   public int getScale() { return scale; }
+
+  /**
+   * Returns precision for Decimal Type.
+   * @return number of digits in the unscaled value
+   */
+  public int getDecimalPrecision() { return precision; }
 
   /**
    * Return enum for this DType

--- a/java/src/main/java/ai/rapids/cudf/Schema.java
+++ b/java/src/main/java/ai/rapids/cudf/Schema.java
@@ -227,6 +227,23 @@ public class Schema {
   }
 
   /**
+   * Get decimal precisions of the columns' types flattened from all levels in schema by depth-first
+   * traversal.
+   * @return An array containing decimal precision of all columns in schema.
+   */
+  public int[] getFlattenedDecimalPrecisions() {
+    flattenIfNeeded();
+    if (flattenedTypes == null) {
+      return null;
+    }
+    int[] ret = new int[flattenedTypes.length];
+    for (int i = 0; i < flattenedTypes.length; i++) {
+      ret[i] = flattenedTypes[i].getDecimalPrecision();
+    }
+    return ret;
+  }
+
+  /**
    * Get the types of the columns in schema flattened from all levels by depth-first traversal.
    * @return An array containing types of all columns in schema.
    */

--- a/java/src/main/java/ai/rapids/cudf/Schema.java
+++ b/java/src/main/java/ai/rapids/cudf/Schema.java
@@ -38,8 +38,8 @@ public class Schema {
   private boolean flattened = false;
   private String[] flattenedNames;
   private DType[] flattenedTypes;
-  private int[] flattenedCounts;
   private int[] flattenedPrecisions;
+  private int[] flattenedCounts;
 
   private Schema(DType topLevelType,
                  int topLevelPrecision,
@@ -118,18 +118,18 @@ public class Schema {
       if (flatLen == 0) {
         flattenedNames = null;
         flattenedTypes = null;
-        flattenedCounts = null;
         flattenedPrecisions = null;
+        flattenedCounts = null;
       } else {
         String[] names = new String[flatLen];
         DType[] types = new DType[flatLen];
-        int[] counts = new int[flatLen];
         int[] precisions = new int[flatLen];
-        collectFlattened(names, types, counts, precisions, 0);
+        int[] counts = new int[flatLen];
+        collectFlattened(names, types, precisions, counts, 0);
         flattenedNames = names;
         flattenedTypes = types;
-        flattenedCounts = counts;
         flattenedPrecisions = precisions;
+        flattenedCounts = counts;
       }
       flattened = true;
     }
@@ -145,7 +145,7 @@ public class Schema {
     return startingLength;
   }
 
-  private int collectFlattened(String[] names, DType[] types, int[] counts, int[] precisions, int offset) {
+  private int collectFlattened(String[] names, DType[] types, int[] precisions, int[] counts, int offset) {
     if (childSchemas != null) {
       for (int i = 0; i < childSchemas.size(); i++) {
         Schema child = childSchemas.get(i);
@@ -158,7 +158,7 @@ public class Schema {
           counts[offset] = 0;
         }
         offset++;
-        offset = this.childSchemas.get(i).collectFlattened(names, types, counts, precisions, offset);
+        offset = this.childSchemas.get(i).collectFlattened(names, types, precisions, counts, offset);
       }
     }
     return offset;

--- a/java/src/main/java/ai/rapids/cudf/Schema.java
+++ b/java/src/main/java/ai/rapids/cudf/Schema.java
@@ -31,7 +31,7 @@ public class Schema {
   private static final int UNKNOWN_PRECISION = -1;
 
   private final DType topLevelType;
-  private final int precision; // storing precision for decimal types
+  private final int topLevelPrecision; // only applicable if the top level is a decimal type
   private final List<String> childNames;
   private final List<Schema> childSchemas;
   private boolean flattened = false;
@@ -40,14 +40,12 @@ public class Schema {
   private int[] flattenedCounts;
   private int[] flattenedPrecisions;
 
-
-
   private Schema(DType topLevelType,
-                 int precision,
+                 int topLevelPrecision,
                  List<String> childNames,
                  List<Schema> childSchemas) {
     this.topLevelType = topLevelType;
-    this.precision = precision;
+    this.topLevelPrecision = topLevelPrecision;
     this.childNames = childNames;
     this.childSchemas = childSchemas;
   }
@@ -63,7 +61,7 @@ public class Schema {
    */
   private Schema() {
     topLevelType = null;
-    precision = UNKNOWN_PRECISION;
+    topLevelPrecision = UNKNOWN_PRECISION;
     childNames = null;
     childSchemas = null;
   }
@@ -152,7 +150,7 @@ public class Schema {
         Schema child = childSchemas.get(i);
         names[offset] = childNames.get(i);
         types[offset] = child.topLevelType;
-        precisions[offset] = child.precision;
+        precisions[offset] = child.topLevelPrecision;
         if (child.childNames != null) {
           counts[offset] = child.childNames.size();
         } else {
@@ -340,9 +338,9 @@ public class Schema {
     private final List<String> names;
     private final List<Builder> types;
 
-    private Builder(DType topLevelType, int precision) {
+    private Builder(DType topLevelType, int topLevelPrecision) {
       this.topLevelType = topLevelType;
-      this.topLevelPrecision = precision;
+      this.topLevelPrecision = topLevelPrecision;
       if (topLevelType == DType.STRUCT || topLevelType == DType.LIST) {
         // There can be children
         names = new ArrayList<>();

--- a/java/src/main/java/ai/rapids/cudf/Schema.java
+++ b/java/src/main/java/ai/rapids/cudf/Schema.java
@@ -28,11 +28,23 @@ import java.util.stream.Collectors;
 public class Schema {
   public static final Schema INFERRED = new Schema();
 
-  // Default value for precision value, when it is not specified or the column type is not decimal.
+  private final DType topLevelType;
+
+  /**
+   * Default value for precision value, when it is not specified or the column type is not decimal.
+   */
   private static final int UNKNOWN_PRECISION = -1;
 
-  private final DType topLevelType;
-  private final int topLevelPrecision; // only applicable if the top level is a decimal type
+  /**
+  * Store precision for the top level column, only applicable if the column is a decimal type.
+  * <p/>
+  * This variable is not designed to be used by any libcudf's APIs since libcudf does not support
+  * precisions for fixed point numbers.
+  * Instead, it is used only to pass down the precision values from Spark's DecimalType to the
+  * JNI level, where some JNI functions require these values to perform their operations.
+  */
+  private final int topLevelPrecision;
+
   private final List<String> childNames;
   private final List<Schema> childSchemas;
   private boolean flattened = false;
@@ -245,8 +257,14 @@ public class Schema {
   }
 
   /**
-   * Get decimal precisions of the columns' types flattened from all levels in schema by depth-first
-   * traversal.
+   * Get decimal precisions of the columns' types flattened from all levels in schema by
+   * depth-first traversal.
+   * <p/>
+   * This is used to pass down the decimal precisions from Spark to only the JNI layer, where
+   * some JNI functions require precision values to perform their operations.
+   * Decimal precisions should not be consumed by any libcudf's APIs since libcudf does not
+   * support precisions for fixed point numbers.
+   *
    * @return An array containing decimal precision of all columns in schema.
    */
   public int[] getFlattenedDecimalPrecisions() {

--- a/java/src/main/java/ai/rapids/cudf/Schema.java
+++ b/java/src/main/java/ai/rapids/cudf/Schema.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 public class Schema {
   public static final Schema INFERRED = new Schema();
 
+  // Default value for precision value, when it is not specified or the column type is not decimal.
   private static final int UNKNOWN_PRECISION = -1;
 
   private final DType topLevelType;


### PR DESCRIPTION
In Spark, the `DecimalType` has a specific number of digits to represent the numbers. However, when creating a data Schema, only type and name of the column are stored, thus we lose that precision information. As such, it would be difficult to reconstruct the original decimal types from cudf's `Schema` instance.

This PR adds a `precision` member variable to the `Schema` class in cudf Java, allowing it to store the precision number of the original decimal column.

Partially contributes to https://github.com/NVIDIA/spark-rapids/issues/11560.