### PR TITLE
Change default KvikIO parameters in cuDF: set the thread pool size to 4, and compatibility mode to ON

### DIFF
--- a/cpp/include/cudf/io/config_utils.hpp
+++ b/cpp/include/cudf/io/config_utils.hpp
@@ -37,10 +37,13 @@ bool is_gds_enabled();
 bool is_kvikio_enabled();
 
 /**
- * @brief Set kvikIO thread pool size according to the environment variable KVIKIO_NTHREADS. If
- * KVIKIO_NTHREADS is not set, use 8 threads by default.
+ * @brief Set kvikIO parameters, including:
+ * - Thread pool size, according to the environment variable KVIKIO_NTHREADS. If KVIKIO_NTHREADS is
+ *   not set, use 4 threads by default.
+ * - Compatibility mode, according to the environment variable KVIKIO_COMPAT_MODE. If
+ *   KVIKIO_COMPAT_MODE is not set, set it to ON by default.
  */
-void set_thread_pool_nthreads_from_env();
+void set_up_kvikio();
 
 }  // namespace cufile_integration
 

--- a/cpp/include/cudf/io/config_utils.hpp
+++ b/cpp/include/cudf/io/config_utils.hpp
@@ -37,11 +37,11 @@ bool is_gds_enabled();
 bool is_kvikio_enabled();
 
 /**
- * @brief Set kvikIO parameters, including:
+ * @brief Set KvikIO parameters, including:
+ * - Compatibility mode, according to the environment variable KVIKIO_COMPAT_MODE. If
+ *   KVIKIO_COMPAT_MODE is not set, enable it by default, which enforces the use of POSIX I/O.
  * - Thread pool size, according to the environment variable KVIKIO_NTHREADS. If KVIKIO_NTHREADS is
  *   not set, use 4 threads by default.
- * - Compatibility mode, according to the environment variable KVIKIO_COMPAT_MODE. If
- *   KVIKIO_COMPAT_MODE is not set, set it to ON by default.
  */
 void set_up_kvikio();
 

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -56,10 +56,10 @@ void set_up_kvikio()
 {
   static std::once_flag flag{};
   std::call_once(flag, [] {
-    auto compat_mode = kvikio::detail::getenv_or<bool>("KVIKIO_COMPAT_MODE", true);
+    auto const compat_mode = kvikio::detail::getenv_or<bool>("KVIKIO_COMPAT_MODE", true);
     kvikio::defaults::compat_mode_reset(compat_mode);
 
-    auto nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 4U);
+    auto const nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 4u);
     kvikio::defaults::thread_pool_nthreads_reset(nthreads);
   });
 }

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -56,7 +56,7 @@ void set_thread_pool_nthreads_from_env()
 {
   static std::once_flag flag{};
   std::call_once(flag, [] {
-    auto nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 8U);
+    auto nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 4U);
     kvikio::defaults::thread_pool_nthreads_reset(nthreads);
   });
 }

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -52,12 +52,15 @@ bool is_gds_enabled() { return is_always_enabled() or get_env_policy() == usage_
 
 bool is_kvikio_enabled() { return get_env_policy() == usage_policy::KVIKIO; }
 
-void set_thread_pool_nthreads_from_env()
+void set_up_kvikio()
 {
   static std::once_flag flag{};
   std::call_once(flag, [] {
     auto nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 4U);
     kvikio::defaults::thread_pool_nthreads_reset(nthreads);
+
+    auto compat_mode = getenv_or<bool>("KVIKIO_COMPAT_MODE", true);
+    kvikio::defaults::compat_mode_reset(compat_mode);
   });
 }
 }  // namespace cufile_integration

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -56,11 +56,11 @@ void set_up_kvikio()
 {
   static std::once_flag flag{};
   std::call_once(flag, [] {
+    auto compat_mode = kvikio::detail::getenv_or<bool>("KVIKIO_COMPAT_MODE", true);
+    kvikio::defaults::compat_mode_reset(compat_mode);
+
     auto nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 4U);
     kvikio::defaults::thread_pool_nthreads_reset(nthreads);
-
-    auto compat_mode = getenv_or<bool>("KVIKIO_COMPAT_MODE", true);
-    kvikio::defaults::compat_mode_reset(compat_mode);
   });
 }
 }  // namespace cufile_integration

--- a/cpp/src/io/utilities/data_sink.cpp
+++ b/cpp/src/io/utilities/data_sink.cpp
@@ -42,7 +42,7 @@ class file_sink : public data_sink {
     if (!_output_stream.is_open()) { detail::throw_on_file_open_failure(filepath, true); }
 
     if (cufile_integration::is_kvikio_enabled()) {
-      cufile_integration::set_thread_pool_nthreads_from_env();
+      cufile_integration::set_up_kvikio();
       _kvikio_file = kvikio::FileHandle(filepath, "w");
       CUDF_LOG_INFO("Writing a file using kvikIO, with compatibility mode {}.",
                     _kvikio_file.is_compat_mode_on() ? "on" : "off");

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -48,7 +48,7 @@ class file_source : public datasource {
   {
     detail::force_init_cuda_context();
     if (cufile_integration::is_kvikio_enabled()) {
-      cufile_integration::set_thread_pool_nthreads_from_env();
+      cufile_integration::set_up_kvikio();
       _kvikio_file = kvikio::FileHandle(filepath);
       CUDF_LOG_INFO("Reading a file using kvikIO, with compatibility mode {}.",
                     _kvikio_file.is_compat_mode_on() ? "on" : "off");

--- a/docs/cudf/source/user_guide/io/io.md
+++ b/docs/cudf/source/user_guide/io/io.md
@@ -112,7 +112,7 @@ control that may alter the effect of "KVIKIO" option in cuDF:
     configuration check, and will error out if GDS requirements are not met. The
     only exceptional case is that if the system does not support files being
     opened with the `O_DIRECT` flag, the GDS compatibility mode will be used.
-- "OFF": Completely disable GDS use.
+- "OFF": Completely disable GDS and kvikIO use.
 
 If no value is set, behavior will be the same as the "KVIKIO" option.
 

--- a/docs/cudf/source/user_guide/io/io.md
+++ b/docs/cudf/source/user_guide/io/io.md
@@ -101,15 +101,14 @@ There are four valid values for the environment variable:
 fall back to the GDS compatibility mode.
 - "ALWAYS": Enable GDS use. If the cuFile library cannot be properly loaded,
 throw an exception.
-- "KVIKIO": Enable GDS through [KvikIO](https://github.com/rapidsai/kvikio).
-Note that KvikIO provides an environment variable `KVIKIO_COMPAT_MODE` to
-control GDS use:
-  - By default, `KVIKIO_COMPAT_MODE` is unset. In this case, KvikIO checks the
-    system configuration, and if GDS requirements are not met, the I/O will fall
-    back to the GDS compatibility mode.
-  - If `KVIKIO_NTHREADS` is set to `ON`, the GDS compatibility mode is always used,
-    and the system configuration check is never performed.
-  - If `KVIKIO_NTHREADS` is set to `OFF`, KvikIO enforces GDS I/O without system
+- "KVIKIO": Enable GDS compatibility mode through [KvikIO](https://github.com/rapidsai/kvikio).
+Note that KvikIO also provides the environment variable `KVIKIO_COMPAT_MODE` for GDS
+control that may alter the effect of "KVIKIO" option in cuDF:
+  - By default, `KVIKIO_COMPAT_MODE` is unset. In this case, cuDF enforces
+    the GDS compatibility mode, and the system configuration check for GDS I/O
+    is never performed.
+  - If `KVIKIO_COMPAT_MODE=ON`, this is the same with the above case.
+  - If `KVIKIO_COMPAT_MODE=OFF`, KvikIO enforces GDS I/O without system
     configuration check, and will error out if GDS requirements are not met. The
     only exceptional case is that if the system does not support files being
     opened with the `O_DIRECT` flag, the GDS compatibility mode will be used.

--- a/docs/cudf/source/user_guide/io/io.md
+++ b/docs/cudf/source/user_guide/io/io.md
@@ -91,8 +91,8 @@ SDK is available for download
 [here](https://developer.nvidia.com/gpudirect-storage). GDS is also
 included in CUDA Toolkit 11.4 and higher.
 
-Use of GPUDirect Storage in cuDF is enabled by default, but can be
-disabled through the environment variable `LIBCUDF_CUFILE_POLICY`.
+Use of GPUDirect Storage in cuDF is disabled by default, but can be
+enabled through the environment variable `LIBCUDF_CUFILE_POLICY`.
 This variable also controls the GDS compatibility mode.
 
 There are four valid values for the environment variable:

--- a/docs/cudf/source/user_guide/io/io.md
+++ b/docs/cudf/source/user_guide/io/io.md
@@ -101,10 +101,9 @@ There are four valid values for the environment variable:
 fall back to the GDS compatibility mode.
 - "ALWAYS": Enable GDS use. If the cuFile library cannot be properly loaded,
 throw an exception.
-- "KVIKIO": Enable GDS through [KvikIO](https://github.com/rapidsai/kvikio). Note
-that if the environment variable `KVIKIO_COMPAT_MODE` is `ON`, or if KvikIO detects
-that the system is not properly configured for GDS, the I/O will fall back to the
-GDS compatibility mode.
+- "KVIKIO": Enable GDS through [KvikIO](https://github.com/rapidsai/kvikio). If
+KvikIO detects that the system is not properly configured for GDS, the I/O will
+fall back to the GDS compatibility mode.
 - "OFF": Completely disable GDS use.
 
 If no value is set, behavior will be the same as the "KVIKIO" option.

--- a/docs/cudf/source/user_guide/io/io.md
+++ b/docs/cudf/source/user_guide/io/io.md
@@ -97,9 +97,14 @@ This variable also controls the GDS compatibility mode.
 
 There are four valid values for the environment variable:
 
-- "GDS": Enable GDS use; GDS compatibility mode is *off*.
-- "ALWAYS": Enable GDS use; GDS compatibility mode is *on*.
-- "KVIKIO": Enable GDS through [KvikIO](https://github.com/rapidsai/kvikio).
+- "GDS": Enable GDS use. If the cuFile library cannot be properly loaded,
+fall back to the GDS compatibility mode.
+- "ALWAYS": Enable GDS use. If the cuFile library cannot be properly loaded,
+throw an exception.
+- "KVIKIO": Enable GDS through [KvikIO](https://github.com/rapidsai/kvikio). Note
+that if the environment variable `KVIKIO_COMPAT_MODE` is `ON`, or if KvikIO detects
+that the system is not properly configured for GDS, the I/O will fall back to the
+GDS compatibility mode.
 - "OFF": Completely disable GDS use.
 
 If no value is set, behavior will be the same as the "KVIKIO" option.

--- a/docs/cudf/source/user_guide/io/io.md
+++ b/docs/cudf/source/user_guide/io/io.md
@@ -101,9 +101,18 @@ There are four valid values for the environment variable:
 fall back to the GDS compatibility mode.
 - "ALWAYS": Enable GDS use. If the cuFile library cannot be properly loaded,
 throw an exception.
-- "KVIKIO": Enable GDS through [KvikIO](https://github.com/rapidsai/kvikio). If
-KvikIO detects that the system is not properly configured for GDS, the I/O will
-fall back to the GDS compatibility mode.
+- "KVIKIO": Enable GDS through [KvikIO](https://github.com/rapidsai/kvikio).
+Note that KvikIO provides an environment variable `KVIKIO_COMPAT_MODE` to
+control GDS use:
+  - By default, `KVIKIO_COMPAT_MODE` is unset. In this case, KvikIO checks the
+    system configuration, and if GDS requirements are not met, the I/O will fall
+    back to the GDS compatibility mode.
+  - If `KVIKIO_NTHREADS` is set to `ON`, the GDS compatibility mode is always used,
+    and the system configuration check is never performed.
+  - If `KVIKIO_NTHREADS` is set to `OFF`, KvikIO enforces GDS I/O without system
+    configuration check, and will error out if GDS requirements are not met. The
+    only exceptional case is that if the system does not support files being
+    opened with the `O_DIRECT` flag, the GDS compatibility mode will be used.
 - "OFF": Completely disable GDS use.
 
 If no value is set, behavior will be the same as the "KVIKIO" option.


### PR DESCRIPTION
## Description

This PR adjusts the default KvikIO parameters in light of recent discussions.
- Set KvikIO compatibility mode to ON (previously unspecified). This is to avoid the overhead of KvikIO validating the cuFile library when most of the time clients are not using cuFile/GDS.
- Set KvikIO thread pool size to 4 (previous 8). See the reason below.

In addition, this PR updates the documentation on `LIBCUDF_CUFILE_POLICY`.

---
It is reported that Dask-cuDF on a 8-GPU node with Lustre file system has major performance regression when the KvikIO thread pool size is 8.

|KVIKIO_NTHREADS| 8 | 4 | 2 | 1 |
|----------------------------|---|----|---|----------|
|Dask-cuDF time [s]| 16 | 3.9 | 4.0 | 4.3 |
|cuDF time [s]| 3.4 | 3.4 | 3.8 | 4.9 |

Additional benchmark on Grace Hopper ([Parquet](https://docs.google.com/spreadsheets/d/1ZxuFTcu67kMVpESHwT0Cr-CAeAP7YmLDrcHxNTt22aU), [CSV](https://docs.google.com/spreadsheets/d/1yFLO-cdxG6jjPwHMtoUbPGMXilRaglush2U6KdrEAvA)) indicates no performance regression by switching the thread pool size from 8 to 4. For the time being, we choose 4 as an empirical sweet spot.

Closes #16512 

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
