### PR TITLE
Add jaccard_index to generated cuDF docs

### DIFF
--- a/docs/cudf/source/user_guide/api_docs/string_handling.rst
+++ b/docs/cudf/source/user_guide/api_docs/string_handling.rst
@@ -60,6 +60,7 @@ strings and apply several methods to it. These can be accessed like
    isupper
    istimestamp
    istitle
+   jaccard_index
    join
    len
    like
@@ -67,6 +68,7 @@ strings and apply several methods to it. These can be accessed like
    lower
    lstrip
    match
+   minhash
    ngrams
    ngrams_tokenize
    normalize_characters


### PR DESCRIPTION
## Description
Adds the `jaccard_index` API to the generated docs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
