### PR TITLE
Move detail header floating_conversion.hpp to detail subdirectory

### DIFF
--- a/cpp/include/cudf/fixed_point/detail/floating_conversion.hpp
+++ b/cpp/include/cudf/fixed_point/detail/floating_conversion.hpp
@@ -26,14 +26,6 @@
 #include <cstring>
 
 namespace CUDF_EXPORT numeric {
-
-/**
- * @addtogroup floating_conversion
- * @{
- * @file
- * @brief fixed_point <--> floating-point conversion functions.
- */
-
 namespace detail {
 
 /**
@@ -1141,6 +1133,4 @@ CUDF_HOST_DEVICE inline FloatingType convert_integral_to_floating(Rep const& val
 }
 
 }  // namespace detail
-
-/** @} */  // end of group
 }  // namespace CUDF_EXPORT numeric

--- a/cpp/include/cudf/unary.hpp
+++ b/cpp/include/cudf/unary.hpp
@@ -16,8 +16,8 @@
 
 #pragma once
 
+#include <cudf/fixed_point/detail/floating_conversion.hpp>
 #include <cudf/fixed_point/fixed_point.hpp>
-#include <cudf/fixed_point/floating_conversion.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/export.hpp>

--- a/cpp/include/doxygen_groups.h
+++ b/cpp/include/doxygen_groups.h
@@ -48,9 +48,6 @@
  *      @defgroup scalar_factories Factories
  *   @}
  *   @defgroup fixed_point_classes Fixed Point
- *   @{
- *      @defgroup floating_conversion Float Conversion
- *   @}
  * @}
  * @defgroup column_apis Column and Table
  * @{

--- a/cpp/include/doxygen_groups.h
+++ b/cpp/include/doxygen_groups.h
@@ -48,6 +48,9 @@
  *      @defgroup scalar_factories Factories
  *   @}
  *   @defgroup fixed_point_classes Fixed Point
+ *   @{
+ *      @defgroup floating_conversion Float Conversion
+ *   @}
  * @}
  * @defgroup column_apis Column and Table
  * @{


### PR DESCRIPTION
## Description
Moves the 'cudf/fixed_point/floating_conversion.hpp' to `cudf/fixed_point/detail/` subdirectory since it only contains declarations and definition in the `detail` namespace.
It had previously been its own module. https://docs.rapids.ai/api/libcudf/stable/modules.html

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
