### PR TITLE
Fix binop with LHS numpy datetimelike scalar

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -580,8 +580,8 @@ class ColumnBase(Column, Serializable, BinaryOperand, Reducible):
         if cudf.utils.utils.is_na_like(other):
             return cudf.Scalar(other, dtype=self.dtype)
         if isinstance(other, np.ndarray) and other.ndim == 0:
-            # Try and maintain the dtype
-            other = other.dtype.type(other.item())
+            # Return numpy scalar
+            other = other[()]
         return self.normalize_binop_value(other)
 
     def _scatter_by_slice(

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -3433,13 +3433,14 @@ def test_binop_eq_ne_index_series(data1, data2):
     assert_eq(expected, actual)
 
 
-def test_binop_lhs_numpy_datetime_scalar():
-    dt1 = np.datetime64("2024-03-04T18:24:35.67")
-    dt2 = np.datetime64("2024-03-04T18:24:35.670870310")
-    result = dt1 < cudf.Series([dt2])
-    expected = dt1 < pd.Series([dt2])
+@pytest.mark.parametrize("scalar", [np.datetime64, np.timedelta64])
+def test_binop_lhs_numpy_datetimelike_scalar(scalar):
+    slr1 = scalar(1, "ms")
+    slr2 = scalar(1, "ns")
+    result = slr1 < cudf.Series([slr2])
+    expected = slr1 < pd.Series([slr2])
     assert_eq(result, expected)
 
-    result = dt2 < cudf.Series([dt1])
-    expected = dt2 < pd.Series([dt1])
+    result = slr2 < cudf.Series([slr1])
+    expected = slr2 < pd.Series([slr1])
     assert_eq(result, expected)

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -3431,3 +3431,15 @@ def test_binop_eq_ne_index_series(data1, data2):
     expected = gi.to_pandas() != gs.to_pandas()
 
     assert_eq(expected, actual)
+
+
+def test_binop_lhs_numpy_datetime_scalar():
+    dt1 = np.datetime64("2024-03-04T18:24:35.67")
+    dt2 = np.datetime64("2024-03-04T18:24:35.670870310")
+    result = dt1 < cudf.Series([dt2])
+    expected = dt1 < pd.Series([dt2])
+    assert_eq(result, expected)
+
+    result = dt2 < cudf.Series([dt1])
+    expected = dt2 < pd.Series([dt1])
+    assert_eq(result, expected)


### PR DESCRIPTION
## Description
closes #17087

For binops, cudf tries to convert a 0D numpy array to a numpy scalar via `.dtype.type(value)`, but `.dtype.type` requires other parameters if its a `numpy.datetime64` or `numpy.timedelta64`. Indexing via `[()]` will perform this conversion correctly.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
