### PR TITLE
Use more pylibcudf.io.types enums in cudf._libs

### DIFF
--- a/python/cudf/cudf/_lib/csv.pyx
+++ b/python/cudf/cudf/_lib/csv.pyx
@@ -28,7 +28,7 @@ from pylibcudf.libcudf.io.csv cimport (
     write_csv as cpp_write_csv,
 )
 from pylibcudf.libcudf.io.data_sink cimport data_sink
-from pylibcudf.libcudf.io.types cimport compression_type, sink_info
+from pylibcudf.libcudf.io.types cimport sink_info
 from pylibcudf.libcudf.table.table_view cimport table_view
 
 from cudf._lib.io.utils cimport make_sink_info
@@ -148,13 +148,13 @@ def read_csv(
         byte_range = (0, 0)
 
     if compression is None:
-        c_compression = compression_type.NONE
+        c_compression = plc.io.types.CompressionType.NONE
     else:
         compression_map = {
-            "infer": compression_type.AUTO,
-            "gzip": compression_type.GZIP,
-            "bz2": compression_type.BZIP2,
-            "zip": compression_type.ZIP,
+            "infer": plc.io.types.CompressionType.AUTO,
+            "gzip": plc.io.types.CompressionType.GZIP,
+            "bz2": plc.io.types.CompressionType.BZIP2,
+            "zip": plc.io.types.CompressionType.ZIP,
         }
         c_compression = compression_map[compression]
 

--- a/python/cudf/cudf/_lib/json.pyx
+++ b/python/cudf/cudf/_lib/json.pyx
@@ -9,10 +9,6 @@ from cudf.core.buffer import acquire_spill_lock
 
 from libcpp cimport bool
 
-cimport pylibcudf.libcudf.io.types as cudf_io_types
-from pylibcudf.io.types cimport compression_type
-from pylibcudf.libcudf.io.json cimport json_recovery_mode_t
-from pylibcudf.libcudf.io.types cimport compression_type
 from pylibcudf.libcudf.types cimport data_type, type_id
 from pylibcudf.types cimport DataType
 
@@ -24,15 +20,6 @@ from cudf._lib.utils cimport _data_from_columns, data_from_pylibcudf_io
 import pylibcudf as plc
 
 
-cdef json_recovery_mode_t _get_json_recovery_mode(object on_bad_lines):
-    if on_bad_lines.lower() == "error":
-        return json_recovery_mode_t.FAIL
-    elif on_bad_lines.lower() == "recover":
-        return json_recovery_mode_t.RECOVER_WITH_NULL
-    else:
-        raise TypeError(f"Invalid parameter for {on_bad_lines=}")
-
-
 cpdef read_json(object filepaths_or_buffers,
                 object dtype,
                 bool lines,
@@ -41,7 +28,7 @@ cpdef read_json(object filepaths_or_buffers,
                 bool keep_quotes,
                 bool mixed_types_as_string,
                 bool prune_columns,
-                object on_bad_lines):
+                str on_bad_lines):
     """
     Cython function to call into libcudf API, see `read_json`.
 
@@ -64,19 +51,24 @@ cpdef read_json(object filepaths_or_buffers,
             filepaths_or_buffers[idx] = filepaths_or_buffers[idx].encode()
 
     # Setup arguments
-    cdef cudf_io_types.compression_type c_compression
-
     if compression is not None:
         if compression == 'gzip':
-            c_compression = cudf_io_types.compression_type.GZIP
+            c_compression = plc.io.types.CompressionType.GZIP
         elif compression == 'bz2':
-            c_compression = cudf_io_types.compression_type.BZIP2
+            c_compression = plc.io.types.CompressionType.BZIP2
         elif compression == 'zip':
-            c_compression = cudf_io_types.compression_type.ZIP
+            c_compression = plc.io.types.CompressionType.ZIP
         else:
-            c_compression = cudf_io_types.compression_type.AUTO
+            c_compression = plc.io.types.CompressionType.AUTO
     else:
-        c_compression = cudf_io_types.compression_type.NONE
+        c_compression = plc.io.types.CompressionType.NONE
+
+    if on_bad_lines.lower() == "error":
+        c_on_bad_lines = plc.io.types.JSONRecoveryMode.FAIL
+    elif on_bad_lines.lower() == "recover":
+        c_on_bad_lines = plc.io.types.JSONRecoveryMode.RECOVER_WITH_NULL
+    else:
+        raise TypeError(f"Invalid parameter for {on_bad_lines=}")
 
     processed_dtypes = None
 
@@ -108,7 +100,7 @@ cpdef read_json(object filepaths_or_buffers,
             keep_quotes = keep_quotes,
             mixed_types_as_string = mixed_types_as_string,
             prune_columns = prune_columns,
-            recovery_mode = _get_json_recovery_mode(on_bad_lines)
+            recovery_mode = c_on_bad_lines
         )
         df = cudf.DataFrame._from_data(
             *_data_from_columns(
@@ -130,7 +122,7 @@ cpdef read_json(object filepaths_or_buffers,
             keep_quotes = keep_quotes,
             mixed_types_as_string = mixed_types_as_string,
             prune_columns = prune_columns,
-            recovery_mode = _get_json_recovery_mode(on_bad_lines)
+            recovery_mode = c_on_bad_lines
         )
 
         df = cudf.DataFrame._from_data(

--- a/python/cudf/cudf/_lib/parquet.pyx
+++ b/python/cudf/cudf/_lib/parquet.pyx
@@ -531,10 +531,10 @@ def write_parquet(
             "Valid values are '1.0' and '2.0'"
         )
 
-    cdef cudf_io_types.dictionary_policy dict_policy = (
-        cudf_io_types.dictionary_policy.ADAPTIVE
+    dict_policy = (
+        plc.io.types.DictionaryPolicy.ADAPTIVE
         if use_dictionary
-        else cudf_io_types.dictionary_policy.NEVER
+        else plc.io.types.DictionaryPolicy.NEVER
     )
 
     cdef cudf_io_types.compression_type comp_type = _get_comp_type(compression)

--- a/python/pylibcudf/pylibcudf/io/types.pyx
+++ b/python/pylibcudf/pylibcudf/io/types.pyx
@@ -23,8 +23,10 @@ import os
 
 from pylibcudf.libcudf.io.json import \
     json_recovery_mode_t as JSONRecoveryMode  # no-cython-lint
-from pylibcudf.libcudf.io.types import \
-    compression_type as CompressionType  # no-cython-lint
+from pylibcudf.libcudf.io.types import (
+    compression_type as CompressionType,  # no-cython-lint
+    dictionary_policy as DictionaryPolicy,  # no-cython-lint
+)
 
 
 cdef class TableWithMetadata:

--- a/python/pylibcudf/pylibcudf/io/types.pyx
+++ b/python/pylibcudf/pylibcudf/io/types.pyx
@@ -25,7 +25,9 @@ from pylibcudf.libcudf.io.json import \
     json_recovery_mode_t as JSONRecoveryMode  # no-cython-lint
 from pylibcudf.libcudf.io.types import (
     compression_type as CompressionType,  # no-cython-lint
+    column_encoding as ColumnEncoding,  # no-cython-lint
     dictionary_policy as DictionaryPolicy,  # no-cython-lint
+    statistics_freq as StatisticsFreq, # no-cython-lint
 )
 
 


### PR DESCRIPTION
## Description
If we consider the `pylibcudf.libcudf` namespace to eventually be more "private", this PR replaces that usage, specifically when accessing enums, with their public counterparts 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
