### PR TITLE
Make constructor of DeviceMemoryBufferView  public

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ContiguousTable.java
+++ b/java/src/main/java/ai/rapids/cudf/ContiguousTable.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/java/src/main/java/ai/rapids/cudf/ContiguousTable.java
+++ b/java/src/main/java/ai/rapids/cudf/ContiguousTable.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/java/src/main/java/ai/rapids/cudf/ContiguousTable.java
+++ b/java/src/main/java/ai/rapids/cudf/ContiguousTable.java
@@ -42,7 +42,7 @@ public final class ContiguousTable implements AutoCloseable {
   }
 
   /** Construct a contiguous table instance given a table and the device buffer backing it. */
-  ContiguousTable(Table table, DeviceMemoryBuffer buffer) {
+  public ContiguousTable(Table table, DeviceMemoryBuffer buffer) {
     this.meta = new PackedColumnMetadata(createPackedMetadata(table.getNativeView(),
             buffer.getAddress(), buffer.getLength()));
     this.table = table;

--- a/java/src/main/java/ai/rapids/cudf/ContiguousTable.java
+++ b/java/src/main/java/ai/rapids/cudf/ContiguousTable.java
@@ -42,7 +42,7 @@ public final class ContiguousTable implements AutoCloseable {
   }
 
   /** Construct a contiguous table instance given a table and the device buffer backing it. */
-  public ContiguousTable(Table table, DeviceMemoryBuffer buffer) {
+  ContiguousTable(Table table, DeviceMemoryBuffer buffer) {
     this.meta = new PackedColumnMetadata(createPackedMetadata(table.getNativeView(),
             buffer.getAddress(), buffer.getLength()));
     this.table = table;

--- a/java/src/main/java/ai/rapids/cudf/DeviceMemoryBufferView.java
+++ b/java/src/main/java/ai/rapids/cudf/DeviceMemoryBufferView.java
@@ -24,7 +24,7 @@ package ai.rapids.cudf;
  * that is backing it.
  */
 public class DeviceMemoryBufferView extends BaseDeviceMemoryBuffer {
-  DeviceMemoryBufferView(long address, long lengthInBytes) {
+  public DeviceMemoryBufferView(long address, long lengthInBytes) {
     // Set the cleaner to null so we don't end up releasing anything
     super(address, lengthInBytes, (MemoryBufferCleaner) null);
   }

--- a/java/src/main/java/ai/rapids/cudf/DeviceMemoryBufferView.java
+++ b/java/src/main/java/ai/rapids/cudf/DeviceMemoryBufferView.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ *  Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Make constructor of DeviceMemoryBufferView and ContiguousTable public. 


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
