### PR TITLE
Fixed lifetime issue in ast transform tests

### DIFF
--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -360,7 +360,7 @@ TEST_F(TransformTest, DeeplyNestedArithmeticLogicalExpression)
   constexpr int64_t right_depth_level = 75;
 
   auto generate_ast_expr = [](int64_t depth_level,
-                              cudf::ast::column_reference col_ref,
+                              cudf::ast::column_reference const& col_ref,
                               cudf::ast::ast_operator root_operator,
                               cudf::ast::ast_operator arithmetic_operator,
                               bool nested_left_tree) {


### PR DESCRIPTION
The ast operation takes references to the expressions. The expression was being copied to a lambda scope and destroyed at the end, leading to a dangling reference.
New code should use the ast tree for constructing complicated expression trees as it handles lifetime management.

Closes https://github.com/rapidsai/cudf/issues/17274

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
