### PR TITLE
Replace workaround of JNI build with CUDF_KVIKIO_REMOTE_IO=OFF

### DIFF
--- a/java/ci/build-in-docker.sh
+++ b/java/ci/build-in-docker.sh
@@ -65,7 +65,7 @@ cmake .. -G"${CMAKE_GENERATOR}" \
          -DCUDF_USE_PER_THREAD_DEFAULT_STREAM=$ENABLE_PTDS \
          -DRMM_LOGGING_LEVEL=$RMM_LOGGING_LEVEL \
          -DBUILD_SHARED_LIBS=OFF \
-         -DKvikIO_REMOTE_SUPPORT=OFF
+         -DCUDF_KVIKIO_REMOTE_IO=OFF
 
 if [[ -z "${PARALLEL_LEVEL}" ]]; then
     cmake --build .


### PR DESCRIPTION
## Description
JNI build does not require kvikIO, to unblock the build use `CUDF_KVIKIO_REMOTE_IO=OFF` in cpp build phase.

this should be merged after https://github.com/rapidsai/cudf/pull/17291

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
