### PR TITLE
Update CI jobs to include Polars in nightlies and improve IWYU

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,7 +14,6 @@ jobs:
     needs:
       - changed-files
       - checks
-      - cpp-linters
       - conda-cpp-build
       - conda-cpp-checks
       - conda-cpp-tests
@@ -95,13 +94,6 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.12
     with:
       enable_check_generated_files: false
-  cpp-linters:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.12
-    with:
-      build_type: pull-request
-      run_script: "ci/cpp_linters.sh"
-      file_to_upload: iwyu_results.txt
   conda-cpp-build:
     needs: checks
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -228,8 +228,6 @@ jobs:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
       build_type: pull-request
-      # This always runs, but only fails if this PR touches code in
-      # pylibcudf or cudf_polars
       script: "ci/test_wheel_cudf_polars.sh"
   cudf-polars-polars-tests:
     needs: wheel-build-cudf-polars
@@ -239,8 +237,6 @@ jobs:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
       build_type: pull-request
-      # This always runs, but only fails if this PR touches code in
-      # pylibcudf or cudf_polars
       script: "ci/test_cudf_polars_polars_tests.sh"
   wheel-build-dask-cudf:
     needs: wheel-build-cudf

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,7 @@ jobs:
     needs:
       - changed-files
       - checks
+      - cpp-linters
       - conda-cpp-build
       - conda-cpp-checks
       - conda-cpp-tests
@@ -94,6 +95,13 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.12
     with:
       enable_check_generated_files: false
+  cpp-linters:
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.12
+    with:
+      build_type: pull-request
+      run_script: "ci/cpp_linters.sh"
+      file_to_upload: iwyu_results.txt
   conda-cpp-build:
     needs: checks
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
       # primary static consumers (Spark) are not in conda anyway.
       container_image: "rapidsai/ci-wheel:latest"
       run_script: "ci/configure_cpp_static.sh"
-  clang-tidy:
+  cpp-linters:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-24.12
     with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -149,3 +149,25 @@ jobs:
       container_image: "rapidsai/ci-conda:latest"
       run_script: |
         ci/cudf_pandas_scripts/third-party-integration/test.sh python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+  wheel-tests-cudf-polars:
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.12
+    with:
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      build_type: nightly
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      script: "ci/test_wheel_cudf_polars.sh"
+  cudf-polars-polars-tests:
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.12
+    with:
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      build_type: nightly
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+      script: "ci/test_cudf_polars_polars_tests.sh"

--- a/ci/cpp_linters.sh
+++ b/ci/cpp_linters.sh
@@ -24,19 +24,6 @@ RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
 
 source rapids-configure-sccache
 
-# TODO: For testing purposes, clone and build IWYU. We can switch to a release
-# once a clang 19-compatible version is available, which should be soon
-# (https://github.com/include-what-you-use/include-what-you-use/issues/1641).
-git clone --depth 1 https://github.com/include-what-you-use/include-what-you-use.git
-pushd include-what-you-use
-# IWYU's CMake build uses some Python scripts that assume that the cwd is
-# importable, so support that legacy behavior.
-export PYTHONPATH=${PWD}:${PYTHONPATH:-}
-cmake -S . -B build -GNinja --install-prefix=${CONDA_PREFIX}
-cmake --build build
-cmake --install build
-popd
-
 # Run the build via CMake, which will run clang-tidy when CUDF_STATIC_LINTERS is enabled.
 cmake -S cpp -B cpp/build -DCMAKE_BUILD_TYPE=Release -DCUDF_STATIC_LINTERS=ON -GNinja
 cmake --build cpp/build 2>&1 | python cpp/scripts/parse_iwyu_output.py

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -215,9 +215,9 @@ function(enable_static_checkers target)
       # than the global CUDF_CXX_FLAGS, but this solution is good enough for now since we never run
       # the linters on real builds.
       foreach(_flag -Wno-missing-braces -Wno-absolute-value -Wunneeded-internal-declaration)
-        list(FIND CUDF_CXX_FLAGS "${flag}" _flag_index)
+        list(FIND CUDF_CXX_FLAGS "${_flag}" _flag_index)
         if(_flag_index EQUAL -1)
-          list(APPEND CUDF_CXX_FLAGS ${flag})
+          list(APPEND CUDF_CXX_FLAGS ${_flag})
         endif()
       endforeach()
       set(CUDF_CXX_FLAGS

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -214,7 +214,7 @@ function(enable_static_checkers target)
       # compile flags. To do this completely cleanly we should modify the flags on the target rather
       # than the global CUDF_CXX_FLAGS, but this solution is good enough for now since we never run
       # the linters on real builds.
-      foreach(_flag -Wno-missing-braces -Wno-absolute-value -Wno-unneeded-internal-declaration)
+      foreach(_flag -Wno-missing-braces -Wno-unneeded-internal-declaration)
         list(FIND CUDF_CXX_FLAGS "${_flag}" _flag_index)
         if(_flag_index EQUAL -1)
           list(APPEND CUDF_CXX_FLAGS ${_flag})

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -214,7 +214,7 @@ function(enable_static_checkers target)
       # compile flags. To do this completely cleanly we should modify the flags on the target rather
       # than the global CUDF_CXX_FLAGS, but this solution is good enough for now since we never run
       # the linters on real builds.
-      foreach(_flag -Wno-missing-braces -Wno-absolute-value -Wunneeded-internal-declaration)
+      foreach(_flag -Wno-missing-braces -Wno-absolute-value -Wno-unneeded-internal-declaration)
         list(FIND CUDF_CXX_FLAGS "${_flag}" _flag_index)
         if(_flag_index EQUAL -1)
           list(APPEND CUDF_CXX_FLAGS ${_flag})

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -587,12 +587,7 @@ dependencies:
         packages:
           - clang==19.1.0
           - clang-tools==19.1.0
-          # TODO: These are build requirements for IWYU and can be replaced
-          # with IWYU itself once a conda package of IWYU supporting clang 19
-          # is available.
-          - clangdev==19.1.0
-          - llvm==19.1.0
-          - llvmdev==19.1.0
+          - include-what-you-use==0.23.0
   docs:
     common:
       - output_types: [conda]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -585,8 +585,8 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - clang==19.1.0
-          - clang-tools==19.1.0
+          - clang==19.1.3
+          - clang-tools==19.1.3
           - include-what-you-use==0.23.0
   docs:
     common:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR adds Polars tests to our nightly runs now that [we no longer only fail conditional on certain files changing in PRs](https://github.com/rapidsai/cudf/pull/17299). This PR also updates the IWYU jobs to use [the version released three days ago, which supports clang 19 like we need](https://github.com/include-what-you-use/include-what-you-use/releases/tag/0.23). It also fixes a couple of errors in the CMake for how we were setting compile flags for IWYU.

Closes #16383

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
