### PR TITLE
Exclude nanoarrow and flatbuffers from installation

### DIFF
--- a/cpp/cmake/thirdparty/get_flatbuffers.cmake
+++ b/cpp/cmake/thirdparty/get_flatbuffers.cmake
@@ -22,6 +22,7 @@ function(find_and_configure_flatbuffers VERSION)
     GIT_REPOSITORY https://github.com/google/flatbuffers.git
     GIT_TAG v${VERSION}
     GIT_SHALLOW TRUE
+    EXCLUDE_FROM_ALL TRUE
   )
 
   rapids_export_find_package_root(

--- a/cpp/cmake/thirdparty/get_nanoarrow.cmake
+++ b/cpp/cmake/thirdparty/get_nanoarrow.cmake
@@ -26,6 +26,7 @@ function(find_and_configure_nanoarrow)
     GLOBAL_TARGETS nanoarrow
     CPM_ARGS
     OPTIONS "BUILD_SHARED_LIBS OFF" "NANOARROW_NAMESPACE cudf"
+    EXCLUDE_FROM_ALL TRUE
   )
   set_target_properties(nanoarrow PROPERTIES POSITION_INDEPENDENT_CODE ON)
   rapids_export_find_package_root(BUILD nanoarrow "${nanoarrow_BINARY_DIR}" EXPORT_SET cudf-exports)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This change helps shrink RAPIDS wheels. It should not affect Spark builds since those use the build directory of cudf and statically link in those components to its final binary.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
