### PR TITLE
Clean up misc, unneeded pylibcudf.libcudf in cudf._lib

### DIFF
--- a/python/cudf/cudf/_lib/copying.pyx
+++ b/python/cudf/cudf/_lib/copying.pyx
@@ -30,13 +30,9 @@ from libcpp.memory cimport make_unique
 cimport pylibcudf.libcudf.contiguous_split as cpp_contiguous_split
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
-from pylibcudf.libcudf.scalar.scalar cimport scalar
 from pylibcudf.libcudf.types cimport size_type
 
 from cudf._lib.utils cimport columns_from_pylibcudf_table, data_from_table_view
-
-# workaround for https://github.com/cython/cython/issues/3885
-ctypedef const scalar constscalar
 
 
 def _gather_map_is_valid(

--- a/python/cudf/cudf/_lib/groupby.pyx
+++ b/python/cudf/cudf/_lib/groupby.pyx
@@ -18,8 +18,6 @@ from cudf._lib.utils cimport columns_from_pylibcudf_table
 
 from cudf._lib.scalar import as_device_scalar
 
-from pylibcudf.libcudf.scalar.scalar cimport scalar
-
 import pylibcudf
 
 from cudf._lib.aggregation import make_aggregation
@@ -53,8 +51,6 @@ _DECIMAL_AGGS = {
     "NUNIQUE",
     "SUM",
 }
-# workaround for https://github.com/cython/cython/issues/3885
-ctypedef const scalar constscalar
 
 
 @singledispatch

--- a/python/cudf/cudf/_lib/lists.pyx
+++ b/python/cudf/cudf/_lib/lists.pyx
@@ -4,9 +4,7 @@ from cudf.core.buffer import acquire_spill_lock
 
 from libcpp cimport bool
 
-from pylibcudf.libcudf.types cimport (
-    nan_equality, null_equality, null_order, order, size_type
-)
+from pylibcudf.libcudf.types cimport size_type
 
 from cudf._lib.column cimport Column
 from cudf._lib.utils cimport columns_from_pylibcudf_table
@@ -39,8 +37,16 @@ def distinct(Column col, bool nulls_equal, bool nans_all_equal):
     return Column.from_pylibcudf(
         plc.lists.distinct(
             col.to_pylibcudf(mode="read"),
-            null_equality.EQUAL if nulls_equal else null_equality.UNEQUAL,
-            nan_equality.ALL_EQUAL if nans_all_equal else nan_equality.UNEQUAL,
+            (
+                plc.types.NullEquality.EQUAL
+                if nulls_equal
+                else plc.types.NullEquality.UNEQUAL
+            ),
+            (
+                plc.types.NanEquality.ALL_EQUAL
+                if nans_all_equal
+                else plc.types.NanEquality.UNEQUAL
+            ),
         )
     )
 
@@ -50,8 +56,12 @@ def sort_lists(Column col, bool ascending, str na_position):
     return Column.from_pylibcudf(
         plc.lists.sort_lists(
             col.to_pylibcudf(mode="read"),
-            order.ASCENDING if ascending else order.DESCENDING,
-            null_order.BEFORE if na_position == "first" else null_order.AFTER,
+            plc.types.Order.ASCENDING if ascending else plc.types.Order.DESCENDING,
+            (
+                plc.types.NullOrder.BEFORE
+                if na_position == "first"
+                else plc.types.NullOrder.AFTER
+            ),
             False,
         )
     )

--- a/python/cudf/cudf/_lib/lists.pyx
+++ b/python/cudf/cudf/_lib/lists.pyx
@@ -11,8 +11,6 @@ from cudf._lib.utils cimport columns_from_pylibcudf_table
 
 import pylibcudf as plc
 
-from pylibcudf cimport Scalar
-
 
 @acquire_spill_lock()
 def count_elements(Column col):
@@ -92,7 +90,7 @@ def contains_scalar(Column col, py_search_key):
     return Column.from_pylibcudf(
         plc.lists.contains(
             col.to_pylibcudf(mode="read"),
-            <Scalar> py_search_key.device_value.c_value,
+            py_search_key.device_value.c_value,
         )
     )
 
@@ -102,7 +100,7 @@ def index_of_scalar(Column col, object py_search_key):
     return Column.from_pylibcudf(
         plc.lists.index_of(
             col.to_pylibcudf(mode="read"),
-            <Scalar> py_search_key.device_value.c_value,
+            py_search_key.device_value.c_value,
             plc.lists.DuplicateFindOption.FIND_FIRST,
         )
     )

--- a/python/pylibcudf/pylibcudf/io/types.pyx
+++ b/python/pylibcudf/pylibcudf/io/types.pyx
@@ -182,6 +182,8 @@ cdef class SourceInfo:
                     raise FileNotFoundError(
                         errno.ENOENT, os.strerror(errno.ENOENT), src
                     )
+                # TODO: Keep the sources alive (self.byte_sources = sources)
+                # for str data (e.g. read_json)?
                 c_files.push_back(<string> str(src).encode())
 
             self.c_obj = move(source_info(c_files))


### PR DESCRIPTION
## Description
* Removed `ctypedef const scalar constscalar` usage
* Use `dtype_to_pylibcudf_type` where appropriate
* Use pylibcudf enums instead of `pylibcudf.libcudf` types

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
