### PR TITLE
Do not exclude nanoarrow and flatbuffers from installation if statically linked

### DIFF
--- a/cpp/cmake/thirdparty/get_flatbuffers.cmake
+++ b/cpp/cmake/thirdparty/get_flatbuffers.cmake
@@ -16,9 +16,9 @@
 function(find_and_configure_flatbuffers VERSION)
 
   if(NOT BUILD_SHARED_LIBS)
-    set(_exclude_from_all "EXCLUDE_FROM_ALL FALSE")
+    set(_exclude_from_all EXCLUDE_FROM_ALL FALSE)
   else()
-    set(_exclude_from_all "EXCLUDE_FROM_ALL TRUE")
+    set(_exclude_from_all EXCLUDE_FROM_ALL TRUE)
   endif()
 
   rapids_cpm_find(

--- a/cpp/cmake/thirdparty/get_flatbuffers.cmake
+++ b/cpp/cmake/thirdparty/get_flatbuffers.cmake
@@ -16,9 +16,9 @@
 function(find_and_configure_flatbuffers VERSION)
 
   if (NOT BUILD_SHARED_LIBS)
-  set(_exclude_from_all "EXCLUDE_FROM_ALL OFF")
+    set(_exclude_from_all "EXCLUDE_FROM_ALL OFF")
   else()
-  set(_exclude_from_all "EXCLUDE_FROM_ALL ON")
+    set(_exclude_from_all "EXCLUDE_FROM_ALL ON")
   endif()
 
   rapids_cpm_find(

--- a/cpp/cmake/thirdparty/get_flatbuffers.cmake
+++ b/cpp/cmake/thirdparty/get_flatbuffers.cmake
@@ -15,7 +15,7 @@
 # Use CPM to find or clone flatbuffers
 function(find_and_configure_flatbuffers VERSION)
 
-  if (NOT BUILD_SHARED_LIBS)
+  if(NOT BUILD_SHARED_LIBS)
     set(_exclude_from_all "EXCLUDE_FROM_ALL FALSE")
   else()
     set(_exclude_from_all "EXCLUDE_FROM_ALL TRUE")
@@ -27,8 +27,7 @@ function(find_and_configure_flatbuffers VERSION)
     CPM_ARGS
     GIT_REPOSITORY https://github.com/google/flatbuffers.git
     GIT_TAG v${VERSION}
-    GIT_SHALLOW TRUE
-    ${_exclude_from_all}
+    GIT_SHALLOW TRUE ${_exclude_from_all}
   )
 
   rapids_export_find_package_root(

--- a/cpp/cmake/thirdparty/get_flatbuffers.cmake
+++ b/cpp/cmake/thirdparty/get_flatbuffers.cmake
@@ -15,6 +15,12 @@
 # Use CPM to find or clone flatbuffers
 function(find_and_configure_flatbuffers VERSION)
 
+  if (NOT BUILD_SHARED_LIBS)
+  set(_exclude_from_all "EXCLUDE_FROM_ALL OFF")
+  else()
+  set(_exclude_from_all "EXCLUDE_FROM_ALL ON")
+  endif()
+
   rapids_cpm_find(
     flatbuffers ${VERSION}
     GLOBAL_TARGETS flatbuffers
@@ -22,7 +28,7 @@ function(find_and_configure_flatbuffers VERSION)
     GIT_REPOSITORY https://github.com/google/flatbuffers.git
     GIT_TAG v${VERSION}
     GIT_SHALLOW TRUE
-    EXCLUDE_FROM_ALL TRUE
+    ${_exclude_from_all}
   )
 
   rapids_export_find_package_root(

--- a/cpp/cmake/thirdparty/get_flatbuffers.cmake
+++ b/cpp/cmake/thirdparty/get_flatbuffers.cmake
@@ -16,9 +16,9 @@
 function(find_and_configure_flatbuffers VERSION)
 
   if (NOT BUILD_SHARED_LIBS)
-    set(_exclude_from_all "EXCLUDE_FROM_ALL OFF")
+    set(_exclude_from_all "EXCLUDE_FROM_ALL FALSE")
   else()
-    set(_exclude_from_all "EXCLUDE_FROM_ALL ON")
+    set(_exclude_from_all "EXCLUDE_FROM_ALL TRUE")
   endif()
 
   rapids_cpm_find(

--- a/cpp/cmake/thirdparty/get_nanoarrow.cmake
+++ b/cpp/cmake/thirdparty/get_nanoarrow.cmake
@@ -19,6 +19,12 @@ function(find_and_configure_nanoarrow)
   set(cudf_patch_dir "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/patches")
   rapids_cpm_package_override("${cudf_patch_dir}/nanoarrow_override.json")
 
+  if (NOT BUILD_SHARED_LIBS)
+    set(_exclude_from_all "EXCLUDE_FROM_ALL OFF")
+  else()
+    set(_exclude_from_all "EXCLUDE_FROM_ALL ON")
+  endif()
+
   # Currently we need to always build nanoarrow so we don't pickup a previous installed version
   set(CPM_DOWNLOAD_nanoarrow ON)
   rapids_cpm_find(
@@ -26,7 +32,7 @@ function(find_and_configure_nanoarrow)
     GLOBAL_TARGETS nanoarrow
     CPM_ARGS
     OPTIONS "BUILD_SHARED_LIBS OFF" "NANOARROW_NAMESPACE cudf"
-    EXCLUDE_FROM_ALL TRUE
+    ${_exclude_from_all}
   )
   set_target_properties(nanoarrow PROPERTIES POSITION_INDEPENDENT_CODE ON)
   rapids_export_find_package_root(BUILD nanoarrow "${nanoarrow_BINARY_DIR}" EXPORT_SET cudf-exports)

--- a/cpp/cmake/thirdparty/get_nanoarrow.cmake
+++ b/cpp/cmake/thirdparty/get_nanoarrow.cmake
@@ -20,9 +20,9 @@ function(find_and_configure_nanoarrow)
   rapids_cpm_package_override("${cudf_patch_dir}/nanoarrow_override.json")
 
   if (NOT BUILD_SHARED_LIBS)
-    set(_exclude_from_all "EXCLUDE_FROM_ALL OFF")
+    set(_exclude_from_all "EXCLUDE_FROM_ALL FALSE")
   else()
-    set(_exclude_from_all "EXCLUDE_FROM_ALL ON")
+    set(_exclude_from_all "EXCLUDE_FROM_ALL TRUE")
   endif()
 
   # Currently we need to always build nanoarrow so we don't pickup a previous installed version

--- a/cpp/cmake/thirdparty/get_nanoarrow.cmake
+++ b/cpp/cmake/thirdparty/get_nanoarrow.cmake
@@ -20,9 +20,9 @@ function(find_and_configure_nanoarrow)
   rapids_cpm_package_override("${cudf_patch_dir}/nanoarrow_override.json")
 
   if(NOT BUILD_SHARED_LIBS)
-    set(_exclude_from_all "EXCLUDE_FROM_ALL FALSE")
+    set(_exclude_from_all EXCLUDE_FROM_ALL FALSE)
   else()
-    set(_exclude_from_all "EXCLUDE_FROM_ALL TRUE")
+    set(_exclude_from_all EXCLUDE_FROM_ALL TRUE)
   endif()
 
   # Currently we need to always build nanoarrow so we don't pickup a previous installed version

--- a/cpp/cmake/thirdparty/get_nanoarrow.cmake
+++ b/cpp/cmake/thirdparty/get_nanoarrow.cmake
@@ -19,7 +19,7 @@ function(find_and_configure_nanoarrow)
   set(cudf_patch_dir "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/patches")
   rapids_cpm_package_override("${cudf_patch_dir}/nanoarrow_override.json")
 
-  if (NOT BUILD_SHARED_LIBS)
+  if(NOT BUILD_SHARED_LIBS)
     set(_exclude_from_all "EXCLUDE_FROM_ALL FALSE")
   else()
     set(_exclude_from_all "EXCLUDE_FROM_ALL TRUE")
@@ -31,8 +31,7 @@ function(find_and_configure_nanoarrow)
     nanoarrow 0.6.0.dev
     GLOBAL_TARGETS nanoarrow
     CPM_ARGS
-    OPTIONS "BUILD_SHARED_LIBS OFF" "NANOARROW_NAMESPACE cudf"
-    ${_exclude_from_all}
+    OPTIONS "BUILD_SHARED_LIBS OFF" "NANOARROW_NAMESPACE cudf" ${_exclude_from_all}
   )
   set_target_properties(nanoarrow PROPERTIES POSITION_INDEPENDENT_CODE ON)
   rapids_export_find_package_root(BUILD nanoarrow "${nanoarrow_BINARY_DIR}" EXPORT_SET cudf-exports)


### PR DESCRIPTION
## Description
Had an issue crop up in spark-rapids-jni where we statically link arrow and the build started to fail due to change #17308. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
