### PR TITLE
Expose stream-ordering to groupby APIs

### DIFF
--- a/cpp/include/cudf/groupby.hpp
+++ b/cpp/include/cudf/groupby.hpp
@@ -178,6 +178,7 @@ class groupby {
    *
    * @param requests The set of columns to aggregate and the aggregations to
    * perform
+   * @param stream CUDA stream used for device memory operations and kernel launches.
    * @param mr Device memory resource used to allocate the returned table and columns' device memory
    * @return Pair containing the table with each group's unique key and
    * a vector of aggregation_results for each request in the same order as
@@ -185,16 +186,7 @@ class groupby {
    */
   std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> aggregate(
     host_span<aggregation_request const> requests,
-    rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
-
-  /**
-   * @copydoc aggregate(host_span<aggregation_request const>, rmm::device_async_resource_ref)
-   *
-   * @param stream CUDA stream used for device memory operations and kernel launches.
-   */
-  std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> aggregate(
-    host_span<aggregation_request const> requests,
-    rmm::cuda_stream_view stream,
+    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
   /**
    * @brief Performs grouped scans on the specified values.
@@ -242,6 +234,7 @@ class groupby {
    * ```
    *
    * @param requests The set of columns to scan and the scans to perform
+   * @param stream CUDA stream used for device memory operations and kernel launches.
    * @param mr Device memory resource used to allocate the returned table and columns' device memory
    * @return Pair containing the table with each group's key and
    * a vector of aggregation_results for each request in the same order as
@@ -249,6 +242,7 @@ class groupby {
    */
   std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> scan(
     host_span<scan_request const> requests,
+    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -295,6 +289,7 @@ class groupby {
    * @param values Table whose columns to be shifted
    * @param offsets The offsets by which to shift the input
    * @param fill_values Fill values for indeterminable outputs
+   * @param stream CUDA stream used for device memory operations and kernel launches.
    * @param mr Device memory resource used to allocate the returned table and columns' device memory
    * @return Pair containing the tables with each group's key and the columns shifted
    *
@@ -305,6 +300,7 @@ class groupby {
     table_view const& values,
     host_span<size_type const> offsets,
     std::vector<std::reference_wrapper<scalar const>> const& fill_values,
+    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -329,11 +325,13 @@ class groupby {
    * and the `values` of the `groups` object will be `nullptr`.
    *
    * @param values Table representing values on which a groupby operation is to be performed
+   * @param stream CUDA stream used for device memory operations and kernel launches.
    * @param mr Device memory resource used to allocate the returned tables's device memory in the
    * returned groups
    * @return A `groups` object representing grouped keys and values
    */
   groups get_groups(cudf::table_view values           = {},
+                    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
                     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
   /**
@@ -367,6 +365,7 @@ class groupby {
    * @param[in] values A table whose column null values will be replaced
    * @param[in] replace_policies Specify the position of replacement values relative to null values,
    * one for each column
+   * @param[in] stream CUDA stream used for device memory operations and kernel launches.
    * @param[in] mr Device memory resource used to allocate device memory of the returned column
    *
    * @return Pair that contains a table with the sorted keys and the result column
@@ -374,6 +373,7 @@ class groupby {
   std::pair<std::unique_ptr<table>, std::unique_ptr<table>> replace_nulls(
     table_view const& values,
     host_span<cudf::replace_policy const> replace_policies,
+    rmm::cuda_stream_view stream      = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
  private:

--- a/cpp/src/groupby/groupby.cu
+++ b/cpp/src/groupby/groupby.cu
@@ -193,13 +193,6 @@ void verify_valid_requests(host_span<RequestType const> requests)
 
 // Compute aggregation requests
 std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::aggregate(
-  host_span<aggregation_request const> requests, rmm::device_async_resource_ref mr)
-{
-  return aggregate(requests, cudf::get_default_stream(), mr);
-}
-
-// Compute aggregation requests
-std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::aggregate(
   host_span<aggregation_request const> requests,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
@@ -220,7 +213,9 @@ std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::aggr
 
 // Compute scan requests
 std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::scan(
-  host_span<scan_request const> requests, rmm::device_async_resource_ref mr)
+  host_span<scan_request const> requests,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
   CUDF_EXPECTS(
@@ -233,13 +228,14 @@ std::pair<std::unique_ptr<table>, std::vector<aggregation_result>> groupby::scan
 
   if (_keys.num_rows() == 0) { return std::pair(empty_like(_keys), empty_results(requests)); }
 
-  return sort_scan(requests, cudf::get_default_stream(), mr);
+  return sort_scan(requests, stream, mr);
 }
 
-groupby::groups groupby::get_groups(table_view values, rmm::device_async_resource_ref mr)
+groupby::groups groupby::get_groups(table_view values,
+                                    rmm::cuda_stream_view stream,
+                                    rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
-  auto const stream = cudf::get_default_stream();
   auto grouped_keys = helper().sorted_keys(stream, mr);
 
   auto const& group_offsets       = helper().group_offsets(stream);
@@ -262,6 +258,7 @@ groupby::groups groupby::get_groups(table_view values, rmm::device_async_resourc
 std::pair<std::unique_ptr<table>, std::unique_ptr<table>> groupby::replace_nulls(
   table_view const& values,
   host_span<cudf::replace_policy const> replace_policies,
+  rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -271,7 +268,6 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<table>> groupby::replace_nulls
                "Size mismatch between num_columns and replace_policies.");
 
   if (values.is_empty()) { return std::pair(empty_like(_keys), empty_like(values)); }
-  auto const stream = cudf::get_default_stream();
 
   auto const& group_labels = helper().group_labels(stream);
   std::vector<std::unique_ptr<column>> results;
@@ -306,6 +302,7 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<table>> groupby::shift(
   table_view const& values,
   host_span<size_type const> offsets,
   std::vector<std::reference_wrapper<scalar const>> const& fill_values,
+  rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
@@ -320,7 +317,6 @@ std::pair<std::unique_ptr<table>, std::unique_ptr<table>> groupby::shift(
                           }),
                "values and fill_value should have the same type.",
                cudf::data_type_error);
-  auto stream = cudf::get_default_stream();
   std::vector<std::unique_ptr<column>> results;
   auto const& group_offsets = helper().group_offsets(stream);
   std::transform(

--- a/cpp/tests/streams/groupby_test.cpp
+++ b/cpp/tests/streams/groupby_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/groupby.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
 
 using K = int32_t;  // Key type.
 
@@ -64,4 +66,56 @@ TYPED_TEST(groupby_stream_test, test_count)
   this->test_groupby(make_count_agg());
   this->test_groupby(make_count_agg(), force_use_sort_impl::YES);
   this->test_groupby(make_count_agg(cudf::null_policy::INCLUDE));
+}
+
+struct GroupbyTest : public cudf::test::BaseFixture {};
+
+TEST_F(GroupbyTest, Scan)
+{
+  using key_wrapper   = cudf::test::fixed_width_column_wrapper<int32_t>;
+  using value_wrapper = cudf::test::fixed_width_column_wrapper<int32_t>;
+
+  key_wrapper keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
+  value_wrapper vals({5, 6, 7, 8, 9, 0, 1, 2, 3, 4});
+
+  auto agg = cudf::make_min_aggregation<cudf::groupby_scan_aggregation>();
+  std::vector<cudf::groupby::scan_request> requests;
+  requests.emplace_back();
+  requests[0].values = vals;
+  requests[0].aggregations.push_back(std::move(agg));
+
+  cudf::groupby::groupby gb_obj(cudf::table_view({keys}));
+  // cudf::groupby scan uses sort implementation
+  auto result = gb_obj.scan(requests, cudf::test::get_default_stream());
+}
+
+TEST_F(GroupbyTest, Shift)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> key{1, 2, 1, 2, 2, 1, 1};
+  cudf::test::fixed_width_column_wrapper<int32_t> val{3, 4, 5, 6, 7, 8, 9};
+  cudf::size_type offset = 2;
+  auto slr               = cudf::make_default_constructed_scalar(cudf::column_view(val).type());
+
+  cudf::groupby::groupby gb_obj(cudf::table_view({key}));
+  std::vector<cudf::size_type> offsets{offset};
+  auto got =
+    gb_obj.shift(cudf::table_view{{val}}, offsets, {*slr}, cudf::test::get_default_stream());
+}
+
+TEST_F(GroupbyTest, GetGroups)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> keys{1, 1, 2, 1, 2, 3};
+  cudf::test::fixed_width_column_wrapper<int32_t> values({0, 0, 1, 1, 2, 2});
+  cudf::groupby::groupby gb(cudf::table_view({keys}));
+  auto gb_groups = gb.get_groups(cudf::table_view({values}), cudf::test::get_default_stream());
+}
+
+TEST_F(GroupbyTest, ReplaceNullsTest)
+{
+  cudf::test::fixed_width_column_wrapper<int32_t> key{0, 1, 0, 1, 0, 1};
+  cudf::test::fixed_width_column_wrapper<int32_t> val({42, 7, 24, 10, 1, 1000}, {1, 1, 1, 0, 0, 0});
+  cudf::groupby::groupby gb_obj(cudf::table_view({key}));
+  std::vector<cudf::replace_policy> policies{cudf::replace_policy::PRECEDING};
+  auto p =
+    gb_obj.replace_nulls(cudf::table_view({val}), policies, cudf::test::get_default_stream());
 }


### PR DESCRIPTION
## Description
Adds stream parameter to
```
cudf::groupby::scan
cudf::groupby::aggregate
cudf::groupby::shift
cudf::groupby::get_groups
cudf::groupby::replace_nulls
```

Added stream gtests to verify correct stream forwarding.

Reference: https://github.com/rapidsai/cudf/issues/13744

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
