### PR TITLE
Expose stream-ordering in replace API

### DIFF
--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -244,7 +244,7 @@ std::unique_ptr<column> normalize_nans_and_zeros(column_view const& input,
 void normalize_nans_and_zeros(mutable_column_view& in_out, rmm::cuda_stream_view stream)
 {
   CUDF_FUNC_RANGE();
-  detail::normalize_nans_and_zeros(in_out, cudf::get_default_stream());
+  detail::normalize_nans_and_zeros(in_out, stream);
 }
 
 }  // namespace cudf

--- a/cpp/tests/streams/replace_test.cpp
+++ b/cpp/tests/streams/replace_test.cpp
@@ -107,6 +107,6 @@ TEST_F(ReplaceTest, NormalizeNansAndZerosMutable)
   auto nan          = std::numeric_limits<double>::quiet_NaN();
   auto input_column = cudf::test::make_type_param_vector<double>({-0.0, 0.0, -nan, nan, nan});
   cudf::test::fixed_width_column_wrapper<double> input(input_column.begin(), input_column.end());
-  cudf::normalize_nans_and_zeros(static_cast<cudf::mutable_column_view>(input),
-                                 cudf::test::get_default_stream());
+  cudf::mutable_column_view mutable_view = cudf::column(input, cudf::test::get_default_stream());
+  cudf::normalize_nans_and_zeros(mutable_view, cudf::test::get_default_stream());
 }


### PR DESCRIPTION
## Description
Adds stream parameter to
```
cudf::normalize_nans_and_zeros
```
Reference: https://github.com/rapidsai/cudf/issues/13744

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
