### PR TITLE
add debug log for HostMemoryBuffer allocation

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/DefaultHostMemoryAllocator.java
+++ b/java/src/main/java/ai/rapids/cudf/DefaultHostMemoryAllocator.java
@@ -46,7 +46,7 @@ public class DefaultHostMemoryAllocator implements HostMemoryAllocator {
         return pinnedBuffer;
       }
     }
-    return new HostMemoryBuffer(UnsafeMemoryAccessor.allocate(bytes), bytes);
+    return HostMemoryBuffer.allocateRaw(bytes);
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR closes #17444 by adding a line of log and call site stacktrace, at each time when HostMemoryBuffer reaches a new watermark.

The logging behavior is guarded by a system property toggle called `ai.rapids.hostmemory.debug`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
