### PR TITLE
skip most CI on devcontainer-only changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,6 +61,7 @@ jobs:
       files_yaml: |
         test_cpp:
           - '**'
+          - '!.devcontainer/'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/cudf_pandas_scripts/**'
@@ -71,6 +72,7 @@ jobs:
           - '!python/**'
         test_cudf_pandas:
           - '**'
+          - '!.devcontainer/'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!docs/**'
@@ -79,6 +81,7 @@ jobs:
           - '!notebooks/**'
         test_java:
           - '**'
+          - '!.devcontainer/'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/cudf_pandas_scripts/**'
@@ -88,12 +91,14 @@ jobs:
           - '!python/**'
         test_notebooks:
           - '**'
+          - '!.devcontainer/'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/cudf_pandas_scripts/**'
           - '!java/**'
         test_python:
           - '**'
+          - '!.devcontainer/'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/cudf_pandas_scripts/**'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,7 +61,7 @@ jobs:
       files_yaml: |
         test_cpp:
           - '**'
-          - '!.devcontainer/'
+          - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/cudf_pandas_scripts/**'
@@ -72,7 +72,7 @@ jobs:
           - '!python/**'
         test_cudf_pandas:
           - '**'
-          - '!.devcontainer/'
+          - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!docs/**'
@@ -81,7 +81,7 @@ jobs:
           - '!notebooks/**'
         test_java:
           - '**'
-          - '!.devcontainer/'
+          - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/cudf_pandas_scripts/**'
@@ -91,14 +91,14 @@ jobs:
           - '!python/**'
         test_notebooks:
           - '**'
-          - '!.devcontainer/'
+          - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/cudf_pandas_scripts/**'
           - '!java/**'
         test_python:
           - '**'
-          - '!.devcontainer/'
+          - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/cudf_pandas_scripts/**'


### PR DESCRIPTION
## Description

The contents of the `.devcontainer/` directory don't affect any of the artifacts produced from this repo. This proposes skipping most CI on PRs that only make changes in that directory.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.