### PR TITLE
Ensure hash-based ARGMIN/ARGMAX grouped reductions are deterministic

### DIFF
--- a/cpp/include/cudf/detail/aggregation/device_aggregators.cuh
+++ b/cpp/include/cudf/detail/aggregation/device_aggregators.cuh
@@ -325,7 +325,9 @@ struct update_target_element<
     auto old     = cudf::detail::atomic_cas(
       &target.element<Target>(target_index), ARGMAX_SENTINEL, source_index);
     if (old != ARGMAX_SENTINEL) {
-      while (source.element<Source>(source_index) > source.element<Source>(old)) {
+      while (source.element<Source>(source_index) > source.element<Source>(old) ||
+             (source.element<Source>(source_index) == source.element<Source>(old) &&
+              source_index < old)) {
         old = cudf::detail::atomic_cas(&target.element<Target>(target_index), old, source_index);
       }
     }
@@ -349,7 +351,9 @@ struct update_target_element<
     auto old     = cudf::detail::atomic_cas(
       &target.element<Target>(target_index), ARGMIN_SENTINEL, source_index);
     if (old != ARGMIN_SENTINEL) {
-      while (source.element<Source>(source_index) < source.element<Source>(old)) {
+      while (source.element<Source>(source_index) < source.element<Source>(old) ||
+             (source.element<Source>(source_index) == source.element<Source>(old) &&
+              source_index < old)) {
         old = cudf::detail::atomic_cas(&target.element<Target>(target_index), old, source_index);
       }
     }

--- a/cpp/src/groupby/hash/global_memory_aggregator.cuh
+++ b/cpp/src/groupby/hash/global_memory_aggregator.cuh
@@ -206,8 +206,10 @@ struct update_target_element_gmem<
     auto old                 = cudf::detail::atomic_cas(
       &target.element<Target>(target_index), cudf::detail::ARGMAX_SENTINEL, source_argmax_index);
     if (old != cudf::detail::ARGMAX_SENTINEL) {
-      while (source_column.element<Source>(source_argmax_index) >
-             source_column.element<Source>(old)) {
+      while (
+        source_column.element<Source>(source_argmax_index) > source_column.element<Source>(old) ||
+        (source_column.element<Source>(source_argmax_index) == source_column.element<Source>(old) &&
+         source_argmax_index < old)) {
         old =
           cudf::detail::atomic_cas(&target.element<Target>(target_index), old, source_argmax_index);
       }
@@ -234,8 +236,10 @@ struct update_target_element_gmem<
     auto old                 = cudf::detail::atomic_cas(
       &target.element<Target>(target_index), cudf::detail::ARGMIN_SENTINEL, source_argmin_index);
     if (old != cudf::detail::ARGMIN_SENTINEL) {
-      while (source_column.element<Source>(source_argmin_index) <
-             source_column.element<Source>(old)) {
+      while (
+        source_column.element<Source>(source_argmin_index) < source_column.element<Source>(old) ||
+        (source_column.element<Source>(source_argmin_index) == source_column.element<Source>(old) &&
+         source_argmin_index < old)) {
         old =
           cudf::detail::atomic_cas(&target.element<Target>(target_index), old, source_argmin_index);
       }

--- a/cpp/src/groupby/hash/shared_memory_aggregator.cuh
+++ b/cpp/src/groupby/hash/shared_memory_aggregator.cuh
@@ -197,7 +197,9 @@ struct update_target_element_shmem<
     auto old              = cudf::detail::atomic_cas(
       &target_casted[target_index], cudf::detail::ARGMAX_SENTINEL, source_index);
     if (old != cudf::detail::ARGMAX_SENTINEL) {
-      while (source.element<Source>(source_index) > source.element<Source>(old)) {
+      while (source.element<Source>(source_index) > source.element<Source>(old) ||
+             (source.element<Source>(source_index) == source.element<Source>(old) &&
+              source_index < old)) {
         old = cudf::detail::atomic_cas(&target_casted[target_index], old, source_index);
       }
     }
@@ -223,7 +225,9 @@ struct update_target_element_shmem<
     auto old              = cudf::detail::atomic_cas(
       &target_casted[target_index], cudf::detail::ARGMIN_SENTINEL, source_index);
     if (old != cudf::detail::ARGMIN_SENTINEL) {
-      while (source.element<Source>(source_index) < source.element<Source>(old)) {
+      while (source.element<Source>(source_index) < source.element<Source>(old) ||
+             (source.element<Source>(source_index) == source.element<Source>(old) &&
+              source_index < old)) {
         old = cudf::detail::atomic_cas(&target_casted[target_index], old, source_index);
       }
     }


### PR DESCRIPTION
## Description
We should always choose the lower row index if the rows compare the same.

- Closes #17479

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
