### PR TITLE
Fix libcudf compile error when logging is disabled

### DIFF
--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -70,7 +70,7 @@ auto batched_decompress_async(compression_type compression, Args&&... args)
   }
 }
 
-std::string compression_type_name(compression_type compression)
+[[maybe_unused]] std::string compression_type_name(compression_type compression)
 {
   switch (compression) {
     case compression_type::SNAPPY: return "Snappy";


### PR DESCRIPTION
## Description
Adds `[[maybe_unused]]` to the `compression_type_name` function to prevent the warning/error.
Error/warning introduced in #17431
Closes #17510 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
