### PR TITLE
Specify a version for rapids_logger dependency

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -277,8 +277,7 @@ rapids_cpm_init()
 # Not using rapids-cmake since we never want to find, always download.
 CPMAddPackage(
   NAME rapids_logger GITHUB_REPOSITORY rapidsai/rapids-logger GIT_SHALLOW TRUE GIT_TAG
-  14bb233d2420f7187a690f0bb528ec0420c70d48
-  VERSION 14bb233d2420f7187a690f0bb528ec0420c70d48
+  14bb233d2420f7187a690f0bb528ec0420c70d48 VERSION 14bb233d2420f7187a690f0bb528ec0420c70d48
 )
 rapids_make_logger(cudf EXPORT_SET cudf-exports)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -277,7 +277,7 @@ rapids_cpm_init()
 # Not using rapids-cmake since we never want to find, always download.
 CPMAddPackage(
   NAME rapids_logger GITHUB_REPOSITORY rapidsai/rapids-logger GIT_SHALLOW TRUE GIT_TAG
-  f9b007ae30f924de2dca8c585334f0d55331d0b8 VERSION f9b007ae30f924de2dca8c585334f0d55331d0b8
+  fix/include_dir VERSION f9b007ae30f924de2dca8c585334f0d55331d0b8
 )
 rapids_make_logger(cudf EXPORT_SET cudf-exports)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -276,8 +276,8 @@ rapids_cpm_init()
 
 # Not using rapids-cmake since we never want to find, always download.
 CPMAddPackage(
-  NAME rapids_logger GITHUB_REPOSITORY vyasr/rapids-logger GIT_SHALLOW TRUE GIT_TAG fix/include_dir
-  VERSION f9b007ae30f924de2dca8c585334f0d55331d0b8
+  NAME rapids_logger GITHUB_REPOSITORY rapidsai/rapids-logger GIT_SHALLOW TRUE GIT_TAG
+  c510947ae9d3a67530cfe3e5eaccb5a3b8ea0e55 VERSION c510947ae9d3a67530cfe3e5eaccb5a3b8ea0e55
 )
 rapids_make_logger(cudf EXPORT_SET cudf-exports)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -277,7 +277,7 @@ rapids_cpm_init()
 # Not using rapids-cmake since we never want to find, always download.
 CPMAddPackage(
   NAME rapids_logger GITHUB_REPOSITORY rapidsai/rapids-logger GIT_SHALLOW TRUE GIT_TAG
-  14bb233d2420f7187a690f0bb528ec0420c70d48 VERSION 14bb233d2420f7187a690f0bb528ec0420c70d48
+  f9b007ae30f924de2dca8c585334f0d55331d0b8 VERSION f9b007ae30f924de2dca8c585334f0d55331d0b8
 )
 rapids_make_logger(cudf EXPORT_SET cudf-exports)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -278,6 +278,7 @@ rapids_cpm_init()
 CPMAddPackage(
   NAME rapids_logger GITHUB_REPOSITORY rapidsai/rapids-logger GIT_SHALLOW TRUE GIT_TAG
   14bb233d2420f7187a690f0bb528ec0420c70d48
+  VERSION 14bb233d2420f7187a690f0bb528ec0420c70d48
 )
 rapids_make_logger(cudf EXPORT_SET cudf-exports)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -276,7 +276,7 @@ rapids_cpm_init()
 
 # Not using rapids-cmake since we never want to find, always download.
 CPMAddPackage(
-  NAME rapids_logger GITHUB_REPOSITORY rapidsai/rapids-logger GIT_SHALLOW TRUE GIT_TAG
+  NAME rapids_logger GITHUB_REPOSITORY vyasr/rapids-logger GIT_SHALLOW TRUE GIT_TAG
   fix/include_dir VERSION f9b007ae30f924de2dca8c585334f0d55331d0b8
 )
 rapids_make_logger(cudf EXPORT_SET cudf-exports)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -276,8 +276,8 @@ rapids_cpm_init()
 
 # Not using rapids-cmake since we never want to find, always download.
 CPMAddPackage(
-  NAME rapids_logger GITHUB_REPOSITORY vyasr/rapids-logger GIT_SHALLOW TRUE GIT_TAG
-  fix/include_dir VERSION f9b007ae30f924de2dca8c585334f0d55331d0b8
+  NAME rapids_logger GITHUB_REPOSITORY vyasr/rapids-logger GIT_SHALLOW TRUE GIT_TAG fix/include_dir
+  VERSION f9b007ae30f924de2dca8c585334f0d55331d0b8
 )
 rapids_make_logger(cudf EXPORT_SET cudf-exports)
 


### PR DESCRIPTION
## Description
#17307 broke builds that use the rapids-cmake pinned dependencies feature since no version was specified for the rapids_logger dependency.  This adds a version string equal to the git tag so the dependency has a stated version.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
