### PR TITLE
Expose Scalar's constructor and `Scalar#getScalarHandle()` to public

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Scalar.java
+++ b/java/src/main/java/ai/rapids/cudf/Scalar.java
@@ -521,11 +521,26 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
   private static native long makeStructScalar(long[] viewHandles, boolean isValid);
   private static native long repeatString(long scalarHandle, int repeatTimes);
 
-  Scalar(DType type, long scalarHandle) {
+  /**
+   * Constructor to create a scalar from a native handle and a type.
+   *
+   * @param type The type of the scalar
+   * @param scalarHandle The native handle (pointer address) to the scalar data
+   */
+  public Scalar(DType type, long scalarHandle) {
     this.type = type;
     this.offHeap = new OffHeapState(scalarHandle);
     MemoryCleaner.register(this, offHeap);
     incRefCount();
+  }
+
+  /**
+   * Get the native handle (native pointer address) for the scalar.
+   *
+   * @return The native handle
+   */
+  public long getScalarHandle() {
+    return offHeap.scalarHandle;
   }
 
   /**
@@ -540,10 +555,6 @@ public final class Scalar implements AutoCloseable, BinaryOperable {
     offHeap.addRef();
     ++refCount;
     return this;
-  }
-
-  long getScalarHandle() {
-    return offHeap.scalarHandle;
   }
 
   /**


### PR DESCRIPTION
This exposes the constructor and `getScalarHandle()` method in `Scalar.java` to the public, allowing them to be called from the outside. Without access to these methods, it was very inconvenient. Workaround has been implemented ([spark-rapids-jni/CudfAccessor.java](https://github.com/NVIDIA/spark-rapids-jni/blob/5231d4d82603d488b95ea259874a26f9f4354005/src/main/java/ai/rapids/cudf/CudfAccessor.java#L21)) to overcome this but it is better to have the issue addressed from the root.

Partially contributes to https://github.com/NVIDIA/spark-rapids-jni/issues/1307.