### PR TITLE
Cross-link cudf.pandas profiler documentation.

### DIFF
--- a/docs/cudf/source/cudf_pandas/faq.md
+++ b/docs/cudf/source/cudf_pandas/faq.md
@@ -63,11 +63,11 @@ keyword arguments, cuDF is not able to provide GPU acceleration and
 `cudf.pandas` will fall back to the CPU.
 
 The most accurate way to assess which functions run on the GPU is to try
-running the code while using the `cudf.pandas` profiling features. The
-profiler will indicate which functions ran on GPU / CPU. To improve
-performance, try to use only functionality that can run entirely on GPU.
-This helps reduce the number of memory transfers needed to fallback to
-CPU.
+running the code while using the `cudf.pandas` [profiling
+features](cudf-pandas-profiling). The profiler will indicate which functions
+ran on GPU / CPU. To improve performance, try to use only functionality that
+can run entirely on GPU.  This helps reduce the number of memory transfers
+needed to fallback to CPU.
 
 ## How can I improve performance of my workflow with `cudf.pandas`?
 

--- a/docs/cudf/source/cudf_pandas/usage.md
+++ b/docs/cudf/source/cudf_pandas/usage.md
@@ -75,6 +75,7 @@ with Pool(4) as pool:
     ...
 ```
 
+(cudf-pandas-profiling)=
 ## Profiling `cudf.pandas`
 
 `cudf.pandas` will attempt to use the GPU whenever possible and fall


### PR DESCRIPTION
## Description
Adds a cross-link to the cudf.pandas profiler docs. This cross-linking would have helped answer a user question about how to profile.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
