### PR TITLE
Remove cudf module name from docs-build summary items

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -277,7 +277,7 @@ rapids_cpm_init()
 # Not using rapids-cmake since we never want to find, always download.
 CPMAddPackage(
   NAME rapids_logger GITHUB_REPOSITORY rapidsai/rapids-logger GIT_SHALLOW FALSE GIT_TAG
-  c510947ae9d3a67530cfe3e5eaccb5a3b8ea0e55 VERSION c510947ae9d3a67530cfe3e5eaccb5a3b8ea0e55
+  1043e0f3989d75ad52f5212544b8154777e86fc9 VERSION 1043e0f3989d75ad52f5212544b8154777e86fc9
 )
 rapids_make_logger(cudf EXPORT_SET cudf-exports)
 

--- a/docs/cudf/source/user_guide/api_docs/general_functions.rst
+++ b/docs/cudf/source/user_guide/api_docs/general_functions.rst
@@ -9,26 +9,26 @@ Data manipulations
 .. autosummary::
    :toctree: api/
 
-   cudf.concat
-   cudf.crosstab
-   cudf.cut
-   cudf.factorize
-   cudf.get_dummies
-   cudf.melt
-   cudf.merge
-   cudf.pivot
-   cudf.pivot_table
-   cudf.unstack
+   concat
+   crosstab
+   cut
+   factorize
+   get_dummies
+   melt
+   merge
+   pivot
+   pivot_table
+   unstack
 
 Top-level conversions
 ---------------------
 .. autosummary::
    :toctree: api/
 
-    cudf.to_numeric
-    cudf.from_dataframe
-    cudf.from_dlpack
-    cudf.from_pandas
+   to_numeric
+   from_dataframe
+   from_dlpack
+   from_pandas
 
 Top-level dealing with datetimelike data
 ----------------------------------------
@@ -36,8 +36,8 @@ Top-level dealing with datetimelike data
 .. autosummary::
    :toctree: api/
 
-    cudf.to_datetime
-    cudf.date_range
+   to_datetime
+   date_range
 
 Top-level dealing with Interval data
 ------------------------------------
@@ -45,4 +45,4 @@ Top-level dealing with Interval data
 .. autosummary::
    :toctree: api/
 
-    cudf.interval_range
+   interval_range

--- a/docs/cudf/source/user_guide/api_docs/io.rst
+++ b/docs/cudf/source/user_guide/api_docs/io.rst
@@ -35,10 +35,10 @@ Parquet
 
    read_parquet
    DataFrame.to_parquet
-   cudf.io.parquet.read_parquet_metadata
-   cudf.io.parquet.ParquetDatasetWriter
-   cudf.io.parquet.ParquetDatasetWriter.close
-   cudf.io.parquet.ParquetDatasetWriter.write_table
+   io.parquet.read_parquet_metadata
+   io.parquet.ParquetDatasetWriter
+   io.parquet.ParquetDatasetWriter.close
+   io.parquet.ParquetDatasetWriter.write_table
 
 
 ORC


### PR DESCRIPTION
## Description
Fixes warnings in the docs-build that indicate `Summarised items should not include the current module`.
Should fix the nightly CI builds for cudf.
Reference: https://github.com/rapidsai/cudf/actions/runs/12577935126/job/35056917571#step:10:3394

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
