### PR TITLE
Java Parquet reads via multiple host buffers

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ParquetChunkedReader.java
+++ b/java/src/main/java/ai/rapids/cudf/ParquetChunkedReader.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ *  Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -62,12 +62,13 @@ public class ParquetChunkedReader implements AutoCloseable {
    * @param filePath Full path of the input Parquet file to read.
    */
   public ParquetChunkedReader(long chunkSizeByteLimit, long passReadLimit, ParquetOptions opts, File filePath) {
-    handle = create(chunkSizeByteLimit, passReadLimit, opts.getIncludeColumnNames(), opts.getReadBinaryAsString(),
-        filePath.getAbsolutePath(), 0, 0, opts.timeUnit().typeId.getNativeId());
-
+    long[] handles = create(chunkSizeByteLimit, passReadLimit, opts.getIncludeColumnNames(), opts.getReadBinaryAsString(),
+        filePath.getAbsolutePath(), null, opts.timeUnit().typeId.getNativeId());
+    handle = handles[0];
     if (handle == 0) {
       throw new IllegalStateException("Cannot create native chunked Parquet reader object.");
     }
+    multiHostBufferSourceHandle = handles[1];
   }
 
   /**
@@ -100,12 +101,41 @@ public class ParquetChunkedReader implements AutoCloseable {
   public ParquetChunkedReader(long chunkSizeByteLimit, long passReadLimit,
                               ParquetOptions opts, HostMemoryBuffer buffer,
                               long offset, long len) {
-    handle = create(chunkSizeByteLimit,passReadLimit,  opts.getIncludeColumnNames(), opts.getReadBinaryAsString(), null,
-        buffer.getAddress() + offset, len, opts.timeUnit().typeId.getNativeId());
-
+    long[] addrsSizes = new long[]{ buffer.getAddress() + offset, len };
+    long[] handles = create(chunkSizeByteLimit,passReadLimit,  opts.getIncludeColumnNames(), opts.getReadBinaryAsString(), null,
+        addrsSizes, opts.timeUnit().typeId.getNativeId());
+    handle = handles[0];
     if (handle == 0) {
       throw new IllegalStateException("Cannot create native chunked Parquet reader object.");
     }
+    multiHostBufferSourceHandle = handles[1];
+  }
+
+  /**
+   * Construct the reader instance from a read limit and data in host memory buffers.
+   *
+   * @param chunkSizeByteLimit Limit on total number of bytes to be returned per read,
+   *                           or 0 if there is no limit.
+   * @param passReadLimit Limit on the amount of memory used for reading and decompressing data or
+   *                      0 if there is no limit
+   * @param opts The options for Parquet reading.
+   * @param buffers Array of buffers containing the file data. The buffers are logically
+   *                concatenated to construct the file being read.
+   */
+  public ParquetChunkedReader(long chunkSizeByteLimit, long passReadLimit,
+                              ParquetOptions opts, HostMemoryBuffer... buffers) {
+    long[] addrsSizes = new long[buffers.length * 2];
+    for (int i = 0; i < buffers.length; i++) {
+      addrsSizes[i * 2] = buffers[i].getAddress();
+      addrsSizes[(i * 2) + 1] = buffers[i].getLength();
+    }
+    long[] handles = create(chunkSizeByteLimit,passReadLimit,  opts.getIncludeColumnNames(), opts.getReadBinaryAsString(), null,
+        addrsSizes, opts.timeUnit().typeId.getNativeId());
+    handle = handles[0];
+    if (handle == 0) {
+      throw new IllegalStateException("Cannot create native chunked Parquet reader object.");
+    }
+    multiHostBufferSourceHandle = handles[1];
   }
 
   /**
@@ -181,6 +211,10 @@ public class ParquetChunkedReader implements AutoCloseable {
       DataSourceHelper.destroyWrapperDataSource(dataSourceHandle);
       dataSourceHandle = 0;
     }
+    if (multiHostBufferSourceHandle != 0) {
+      destroyMultiHostBufferSource(multiHostBufferSourceHandle);
+      multiHostBufferSourceHandle = 0;
+    }
   }
 
 
@@ -196,6 +230,8 @@ public class ParquetChunkedReader implements AutoCloseable {
 
   private long dataSourceHandle = 0;
 
+  private long multiHostBufferSourceHandle = 0;
+
   /**
    * Create a native chunked Parquet reader object on heap and return its memory address.
    *
@@ -206,13 +242,12 @@ public class ParquetChunkedReader implements AutoCloseable {
    * @param filterColumnNames Name of the columns to read, or an empty array if we want to read all.
    * @param binaryToString Whether to convert the corresponding column to String if it is binary.
    * @param filePath Full path of the file to read, or given as null if reading from a buffer.
-   * @param bufferAddrs The address of a buffer to read from, or 0 if we are not using that buffer.
-   * @param length The length of the buffer to read from.
+   * @param bufferAddrsSizes The address and size pairs of buffers to read from, or null if we are not using buffers.
    * @param timeUnit Return type of time unit for timestamps.
    */
-  private static native long create(long chunkSizeByteLimit, long passReadLimit,
-                                    String[] filterColumnNames, boolean[] binaryToString,
-                                    String filePath, long bufferAddrs, long length, int timeUnit);
+  private static native long[] create(long chunkSizeByteLimit, long passReadLimit,
+                                      String[] filterColumnNames, boolean[] binaryToString,
+                                      String filePath, long[] bufferAddrsSizes, int timeUnit);
 
   private static native long createWithDataSource(long chunkedSizeByteLimit,
       String[] filterColumnNames, boolean[] binaryToString, int timeUnit, long dataSourceHandle);
@@ -222,4 +257,6 @@ public class ParquetChunkedReader implements AutoCloseable {
   private static native long[] readChunk(long handle);
 
   private static native void close(long handle);
+
+  private static native void destroyMultiHostBufferSource(long handle);
 }

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -156,8 +156,9 @@ add_library(
   src/ScalarJni.cpp
   src/TableJni.cpp
   src/aggregation128_utils.cu
-  src/maps_column_view.cu
   src/check_nvcomp_output_sizes.cu
+  src/maps_column_view.cu
+  src/multi_host_buffer_source.cpp
 )
 
 # Disable NVTX if necessary

--- a/java/src/main/native/include/multi_host_buffer_source.hpp
+++ b/java/src/main/native/include/multi_host_buffer_source.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "jni_utils.hpp"
+
+#include <cudf/io/datasource.hpp>
+
+#include <vector>
+
+namespace cudf {
+namespace jni {
+
+/**
+ * @brief A custom datasource providing data from an array of host memory buffers.
+ */
+class multi_host_buffer_source : public cudf::io::datasource {
+  std::vector<uint8_t const*> addrs_;
+  std::vector<size_t> offsets_;
+
+  size_t locate_offset_index(size_t offset);
+
+ public:
+  explicit multi_host_buffer_source(native_jlongArray const& addrs_sizes);
+  std::unique_ptr<buffer> host_read(size_t offset, size_t size) override;
+  size_t host_read(size_t offset, size_t size, uint8_t* dst) override;
+  bool supports_device_read() const override { return true; }
+  bool is_device_read_preferred(size_t size) const override { return true; }
+  std::unique_ptr<buffer> device_read(size_t offset,
+                                      size_t size,
+                                      rmm::cuda_stream_view stream) override;
+  size_t device_read(size_t offset,
+                     size_t size,
+                     uint8_t* dst,
+                     rmm::cuda_stream_view stream) override;
+  std::future<size_t> device_read_async(size_t offset,
+                                        size_t size,
+                                        uint8_t* dst,
+                                        rmm::cuda_stream_view stream) override;
+  size_t size() const override { return offsets_.back(); }
+};
+
+}  // namespace jni
+}  // namespace cudf

--- a/java/src/main/native/src/multi_host_buffer_source.cpp
+++ b/java/src/main/native/src/multi_host_buffer_source.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "multi_host_buffer_source.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+namespace cudf {
+namespace jni {
+
+multi_host_buffer_source::multi_host_buffer_source(native_jlongArray const& addrs_sizes)
+{
+  if (addrs_sizes.size() % 2 != 0) {
+    throw std::logic_error("addrs_sizes length not a multiple of 2");
+  }
+  auto count = addrs_sizes.size() / 2;
+  addrs_.reserve(count);
+  offsets_.reserve(count + 1);
+  size_t total_size = 0;
+  for (int i = 0; i < addrs_sizes.size(); i += 2) {
+    addrs_.push_back(reinterpret_cast<uint8_t const*>(addrs_sizes[i]));
+    offsets_.push_back(total_size);
+    total_size += addrs_sizes[i + 1];
+  }
+  offsets_.push_back(total_size);
+}
+
+size_t multi_host_buffer_source::locate_offset_index(size_t offset)
+{
+  if (offset < 0 || offset >= offsets_.back()) { throw std::runtime_error("bad offset"); }
+  auto start = offsets_.begin();
+  auto it    = std::upper_bound(start, offsets_.end(), offset);
+  return (it - start) - 1;
+}
+
+std::unique_ptr<cudf::io::datasource::buffer> multi_host_buffer_source::host_read(size_t offset,
+                                                                                  size_t size)
+{
+  if (size == 0) { return 0; }
+  if (offset < 0 || offset >= offsets_.back()) { throw std::runtime_error("bad offset"); }
+  auto const end_offset = offset + size;
+  if (end_offset > offsets_.back()) { throw std::runtime_error("read past end of file"); }
+  auto buffer_index = locate_offset_index(offset);
+  auto next_offset  = offsets_[buffer_index + 1];
+  if (end_offset <= next_offset) {
+    auto src = addrs_[buffer_index] + offset - offsets_[buffer_index];
+    return std::make_unique<non_owning_buffer>(src, size);
+  }
+  auto buf        = std::vector<uint8_t>(size);
+  uint8_t* dst    = buf.data();
+  auto bytes_left = size;
+  while (bytes_left > 0) {
+    auto next_offset = offsets_[buffer_index + 1];
+    auto buffer_size = next_offset = offsets_[buffer_index];
+    auto buffer_left               = next_offset - offset;
+    auto src                       = addrs_[buffer_index] + buffer_size - buffer_left;
+    auto copy_size                 = std::min(buffer_left, bytes_left);
+    std::memcpy(dst, src, copy_size);
+    offset += copy_size;
+    dst += copy_size;
+    bytes_left -= copy_size;
+    ++buffer_index;
+  }
+  return std::make_unique<owning_buffer<std::vector<uint8_t>>>(std::move(buf));
+}
+
+size_t multi_host_buffer_source::host_read(size_t offset, size_t size, uint8_t* dst)
+{
+  if (size == 0) { return 0; }
+  if (offset < 0 || offset >= offsets_.back()) { throw std::runtime_error("bad offset"); }
+  if (offset + size > offsets_.back()) { throw std::runtime_error("read past end of file"); }
+  auto buffer_index = locate_offset_index(offset);
+  auto bytes_left   = size;
+  while (bytes_left > 0) {
+    auto next_offset = offsets_[buffer_index + 1];
+    auto buffer_size = next_offset = offsets_[buffer_index];
+    auto buffer_left               = next_offset - offset;
+    auto src                       = addrs_[buffer_index] + buffer_size - buffer_left;
+    auto copy_size                 = std::min(buffer_left, bytes_left);
+    std::memcpy(dst, src, copy_size);
+    offset += copy_size;
+    dst += copy_size;
+    bytes_left -= copy_size;
+    ++buffer_index;
+  }
+  return size;
+}
+
+std::unique_ptr<cudf::io::datasource::buffer> multi_host_buffer_source::device_read(
+  size_t offset, size_t size, rmm::cuda_stream_view stream)
+{
+  if (size == 0) { return 0; }
+  if (offset < 0 || offset >= offsets_.back()) { throw std::runtime_error("bad offset"); }
+  if (offset + size > offsets_.back()) { throw std::runtime_error("read past end of file"); }
+  rmm::device_buffer buf(size, stream);
+  auto dst          = static_cast<uint8_t*>(buf.data());
+  auto buffer_index = locate_offset_index(offset);
+  auto bytes_left   = size;
+  while (bytes_left > 0) {
+    auto next_offset = offsets_[buffer_index + 1];
+    auto buffer_size = next_offset = offsets_[buffer_index];
+    auto buffer_left               = next_offset - offset;
+    auto src                       = addrs_[buffer_index] + buffer_size - buffer_left;
+    auto copy_size                 = std::min(buffer_left, bytes_left);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(dst, src, copy_size, cudaMemcpyHostToDevice, stream.value()));
+    offset += copy_size;
+    dst += copy_size;
+    bytes_left -= copy_size;
+    ++buffer_index;
+  }
+  return std::make_unique<owning_buffer<rmm::device_buffer>>(std::move(buf));
+}
+
+size_t multi_host_buffer_source::device_read(size_t offset,
+                                             size_t size,
+                                             uint8_t* dst,
+                                             rmm::cuda_stream_view stream)
+{
+  if (size == 0) { return 0; }
+  if (offset < 0 || offset >= offsets_.back()) { throw std::runtime_error("bad offset"); }
+  if (offset + size > offsets_.back()) { throw std::runtime_error("read past end of file"); }
+  auto buffer_index = locate_offset_index(offset);
+  auto bytes_left   = size;
+  while (bytes_left > 0) {
+    auto next_offset   = offsets_[buffer_index + 1];
+    auto buffer_left   = next_offset - offset;
+    auto buffer_offset = offset - offsets_[buffer_index];
+    auto src           = addrs_[buffer_index] + buffer_offset;
+    auto copy_size     = std::min(buffer_left, bytes_left);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(dst, src, copy_size, cudaMemcpyHostToDevice, stream.value()));
+    offset += copy_size;
+    dst += copy_size;
+    bytes_left -= copy_size;
+    ++buffer_index;
+  }
+  return size;
+}
+
+std::future<size_t> multi_host_buffer_source::device_read_async(size_t offset,
+                                                                size_t size,
+                                                                uint8_t* dst,
+                                                                rmm::cuda_stream_view stream)
+{
+  std::promise<size_t> p;
+  p.set_value(device_read(offset, size, dst, stream));
+  return p.get_future();
+}
+
+}  // namespace jni
+}  // namespace cudf


### PR DESCRIPTION
## Description
Adds a custom cuio datasource that can provide file data via multiple host memory buffers.  This allows data that arrives from multiple threads in multiple buffers to be read directly rather than requiring the buffers to be concatenated into a single host memory buffer before reading.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
