### PR TITLE
Fix build metrics report format with long placehold filenames

### DIFF
--- a/cpp/scripts/sort_ninja_log.py
+++ b/cpp/scripts/sort_ninja_log.py
@@ -3,6 +3,7 @@
 #
 import argparse
 import os
+import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -144,9 +145,14 @@ def format_file_size(input_size):
     return file_size_str
 
 
+def replace_placeholder_patterns(input_string: str) -> str:
+    pattern = r'(_h_env_placehold)[_placehold]+'
+    return re.sub(pattern, r'\1...', input_string)
+
+
 # adjust name for display
-def format_file_name(name):
-    return name.replace("placehold_placehold", "ph")
+def format_file_name(name: str) -> str:
+    return replace_placeholder_patterns(name)
 
 
 # Output chart results in HTML format

--- a/cpp/scripts/sort_ninja_log.py
+++ b/cpp/scripts/sort_ninja_log.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 import argparse
 import os
@@ -144,6 +144,11 @@ def format_file_size(input_size):
     return file_size_str
 
 
+# adjust name for display
+def format_file_name(name):
+    return name.replace("placehold_placehold", "ph")
+
+
 # Output chart results in HTML format
 # Builds a standalone html file with no javascript or styles
 def output_html(entries, sorted_list, cmp_entries, args):
@@ -223,7 +228,8 @@ def output_html(entries, sorted_list, cmp_entries, args):
             print("<td height='20px' width='", size, "px' ", sep="", end="")
             # title text is shown as hover-text by most browsers
             print(color, "title='", end="")
-            print(name, "\n", build_time_str, "' ", sep="", end="")
+            display_name = format_file_name(name)
+            print(display_name, "\n", build_time_str, "' ", sep="", end="")
             # centers the name if it fits in the box
             print("align='center' nowrap>", end="")
             # use a slightly smaller, fixed-width font
@@ -265,7 +271,8 @@ def output_html(entries, sorted_list, cmp_entries, args):
         file_size_str = format_file_size(file_size)
 
         # output entry row
-        print("<tr ", color, "><td>", name, "</td>", sep="", end="")
+        display_name = format_file_name(name)
+        print("<tr ", color, "><td>", display_name, "</td>", sep="", end="")
         print("<td align='right'>", build_time_str, "</td>", sep="", end="")
         print("<td align='right'>", file_size_str, "</td>", sep="", end="")
         # output diff column


### PR DESCRIPTION
## Description
Truncates filenames that appear as multiple `placehold_placedhold_...` in the Build Metrics Report.
Example show here: https://downloads.rapids.ai/ci/cudf/pull-request/17669/0710ad6/cuda12_x86_64.ninja_log.html (requires VPN).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
