### PR TITLE
Require to implement `AutoCloseable` for the classes derived from `HostUDFWrapper`

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/HostUDFWrapper.java
+++ b/java/src/main/java/ai/rapids/cudf/HostUDFWrapper.java
@@ -25,7 +25,7 @@ package ai.rapids.cudf;
  * A new host UDF aggregation implementation must extend this class and override the
  * {@code hashCode} and {@code equals} methods for such purposes.
  * In addition, since this class implements {@code AutoCloseable}, the {@code close} method must
- * also be overridden to automatically delete the native UDF instance.
+ * also be overridden to automatically delete the native UDF instance upon class destruction.
  */
 public abstract class HostUDFWrapper implements AutoCloseable {
   public final long udfNativeHandle;

--- a/java/src/main/java/ai/rapids/cudf/HostUDFWrapper.java
+++ b/java/src/main/java/ai/rapids/cudf/HostUDFWrapper.java
@@ -24,8 +24,10 @@ package ai.rapids.cudf;
  * <p>
  * A new host UDF aggregation implementation must extend this class and override the
  * {@code hashCode} and {@code equals} methods for such purposes.
+ * In addition, since this class implements {@code AutoCloseable}, the {@code close} method must
+ * also be overridden to automatically delete the native UDF instance.
  */
-public abstract class HostUDFWrapper {
+public abstract class HostUDFWrapper implements AutoCloseable {
   public final long udfNativeHandle;
 
   public HostUDFWrapper(long udfNativeHandle) {


### PR DESCRIPTION
This adds the requirement to implement `AutoCloseable`  to the classes derived from `HostUDFWrapper`, forcing them to delete the native UDF instance upon class destruction. Doing so will fix the memory leak issue when the native UDF instance never being destroyed.