### PR TITLE
Add `numba` pinning to `cudf` repo

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -56,6 +56,7 @@ dependencies:
 - ninja
 - notebook
 - numba-cuda>=0.2.0,<0.3.0
+- numba>=0.59.1,<0.61.0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - nvcc_linux-64=11.8

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -56,7 +56,7 @@ dependencies:
 - ninja
 - notebook
 - numba-cuda>=0.2.0,<0.3.0
-- numba>=0.59.1,<0.61.0
+- numba>=0.59.1,<0.61.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - nvcc_linux-64=11.8

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -55,7 +55,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.2.0,<0.3.0
+- numba-cuda>=0.2.0,<0.3.0a0
 - numba>=0.59.1,<0.61.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -54,7 +54,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.2.0,<0.3.0
+- numba-cuda>=0.2.0,<0.3.0a0
 - numba>=0.59.1,<0.61.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -55,6 +55,7 @@ dependencies:
 - ninja
 - notebook
 - numba-cuda>=0.2.0,<0.3.0
+- numba>=0.59.1,<0.61.0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - nvcomp==4.1.0.6

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -55,7 +55,7 @@ dependencies:
 - ninja
 - notebook
 - numba-cuda>=0.2.0,<0.3.0
-- numba>=0.59.1,<0.61.0
+- numba>=0.59.1,<0.61.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - nvcomp==4.1.0.6

--- a/conda/recipes/cudf/meta.yaml
+++ b/conda/recipes/cudf/meta.yaml
@@ -78,7 +78,8 @@ requirements:
     - typing_extensions >=4.0.0
     - pandas >=2.0,<2.2.4dev0
     - cupy >=12.0.0
-    - numba-cuda >=0.2.0,<0.3.0
+    - numba-cuda >=0.2.0,<0.3.0a0
+    - numba >=0.59.1,<0.61.0a0
     - numpy >=1.23,<3.0a0
     - pyarrow>=14.0.0,<18.0.0a0
     - libcudf ={{ version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -709,7 +709,7 @@ dependencies:
         packages:
           - cachetools
           - &numba-cuda-dep numba-cuda>=0.2.0,<0.3.0
-          - &numba-dep numba>=0.59.1,<0.61.0
+          - &numba-dep numba>=0.59.1,<0.61.0a0
           - nvtx>=0.2.1
           - packaging
           - rich

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -708,7 +708,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - cachetools
-          - &numba-cuda-dep numba-cuda>=0.2.0,<0.3.0
+          - &numba-cuda-dep numba-cuda>=0.2.0,<0.3.0a0
           - &numba-dep numba>=0.59.1,<0.61.0a0
           - nvtx>=0.2.1
           - packaging

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -709,6 +709,7 @@ dependencies:
         packages:
           - cachetools
           - &numba-cuda-dep numba-cuda>=0.2.0,<0.3.0
+          - &numba-dep numba>=0.59.1,<0.61.0
           - nvtx>=0.2.1
           - packaging
           - rich
@@ -835,6 +836,7 @@ dependencies:
           - matrix: {dependencies: "latest"}
             packages:
               - *numba-cuda-dep
+              - *numba-dep
               - pandas==2.2.3
           - matrix:
             packages:
@@ -917,6 +919,7 @@ dependencies:
         packages:
           - dask-cuda==25.2.*,>=0.0.0a0
           - *numba-cuda-dep
+          - *numba-dep
     specific:
       - output_types: [conda, requirements]
         matrices:

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "fsspec>=0.6.0",
     "libcudf==25.2.*,>=0.0.0a0",
     "numba-cuda>=0.2.0,<0.3.0",
-    "numba>=0.59.1,<0.61.0",
+    "numba>=0.59.1,<0.61.0a0",
     "numpy>=1.23,<3.0a0",
     "nvtx>=0.2.1",
     "packaging",

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "fsspec>=0.6.0",
     "libcudf==25.2.*,>=0.0.0a0",
     "numba-cuda>=0.2.0,<0.3.0",
+    "numba>=0.59.1,<0.61.0",
     "numpy>=1.23,<3.0a0",
     "nvtx>=0.2.1",
     "packaging",

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "cupy-cuda11x>=12.0.0",
     "fsspec>=0.6.0",
     "libcudf==25.2.*,>=0.0.0a0",
-    "numba-cuda>=0.2.0,<0.3.0",
+    "numba-cuda>=0.2.0,<0.3.0a0",
     "numba>=0.59.1,<0.61.0a0",
     "numpy>=1.23,<3.0a0",
     "nvtx>=0.2.1",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -48,6 +48,7 @@ cudf = "dask_cudf.backends:CudfBackendEntrypoint"
 test = [
     "dask-cuda==25.2.*,>=0.0.0a0",
     "numba-cuda>=0.2.0,<0.3.0",
+    "numba>=0.59.1,<0.61.0",
     "pytest-cov",
     "pytest-xdist",
     "pytest<8",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -48,7 +48,7 @@ cudf = "dask_cudf.backends:CudfBackendEntrypoint"
 test = [
     "dask-cuda==25.2.*,>=0.0.0a0",
     "numba-cuda>=0.2.0,<0.3.0",
-    "numba>=0.59.1,<0.61.0",
+    "numba>=0.59.1,<0.61.0a0",
     "pytest-cov",
     "pytest-xdist",
     "pytest<8",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -47,7 +47,7 @@ cudf = "dask_cudf.backends:CudfBackendEntrypoint"
 [project.optional-dependencies]
 test = [
     "dask-cuda==25.2.*,>=0.0.0a0",
-    "numba-cuda>=0.2.0,<0.3.0",
+    "numba-cuda>=0.2.0,<0.3.0a0",
     "numba>=0.59.1,<0.61.0a0",
     "pytest-cov",
     "pytest-xdist",


### PR DESCRIPTION
## Description
This PR unblock `cudf` CI from recent failures: https://github.com/rapidsai/cudf/actions/runs/12881355939/job/35911797186 introduced by latest release of `numba-0.61.0`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
