### PR TITLE
Disable intended disabled ORC tests

### DIFF
--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -2198,7 +2198,7 @@ TEST_F(OrcChunkedWriterTest, NoDataInSinkWhenNoWrite)
 
 // Tests whether Y dimension of grid sizes depends on the number of row groups
 // Disabled because of the high execution time (especially compared to the likelihood of regression)
-TEST_F(OrcReaderTest, DISABLE_Over65kRowGroups)
+TEST_F(OrcReaderTest, DISABLED_Over65kRowGroups)
 {
   auto constexpr row_group_size = 512;
   constexpr auto num_rows       = (1 << 16) * row_group_size + 1;
@@ -2222,7 +2222,7 @@ TEST_F(OrcReaderTest, DISABLE_Over65kRowGroups)
 
 // Tests whether Y dimension of grid sizes depends on the number of stripes
 // Disabled because of the high execution time (especially compared to the likelihood of regression)
-TEST_F(OrcReaderTest, DISABLE_Over65kStripes)
+TEST_F(OrcReaderTest, DISABLED_Over65kStripes)
 {
   auto constexpr stripe_size = 512;
   constexpr auto num_rows    = (1 << 16) * stripe_size + 1;
@@ -2247,7 +2247,7 @@ TEST_F(OrcReaderTest, DISABLE_Over65kStripes)
 
 // Tests whether Y dimension of grid sizes depends on the number of columns
 // Disabled because of the high execution time (especially compared to the likelihood of regression)
-TEST_F(OrcWriterTest, DISABLE_Over65kColumns)
+TEST_F(OrcWriterTest, DISABLED_Over65kColumns)
 {
   auto vals_col = random_values<int32_t>(8);
   dec64_col col{vals_col.begin(), vals_col.end(), numeric::scale_type{2}};


### PR DESCRIPTION
The following ORC_TEST tests were intended to be disabed:
```
OrcWriterTest.DISABLE_Over65kColumns
OrcReaderTest.DISABLE_Over65kStripes
OrcReaderTest.DISABLE_Over65kRowGroups
```
Unfortunately they are missing the end `D` and so were not actually disabled. This caused the memcheck nightly build to fail.
Changing `DISABLE_` to `DISABLED_` properly disables the tests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
