### PR TITLE
Reduce libcudf memcheck tests output

### DIFF
--- a/ci/run_cudf_memcheck_ctests.sh
+++ b/ci/run_cudf_memcheck_ctests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -uo pipefail
 
@@ -10,6 +10,7 @@ trap "EXITCODE=1" ERR
 cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/gtests/libcudf/";
 
 export GTEST_CUDF_RMM_MODE=cuda
+export GTEST_BRIEF=1
 # compute-sanitizer bug 4553815
 export LIBCUDF_MEMCHECK_ENABLED=1
 for gt in ./*_TEST ; do
@@ -18,6 +19,7 @@ for gt in ./*_TEST ; do
   echo "Running compute-sanitizer on $test_name"
   compute-sanitizer --tool memcheck ${gt} "$@"
 done
+unset GTEST_BRIEF
 unset GTEST_CUDF_RMM_MODE
 unset LIBCUDF_MEMCHECK_ENABLED
 


### PR DESCRIPTION
Uses the `GTEST_BRIEF=1` environment variable to reduce the output of the memcheck script.
This should help find errors more quickly in the nightly memcheck build output.

Example output where 1 test fails in the entire `STRINGS_TEST`
```
$ export GTEST_BRIEF=1
$ gtests/STRINGS_TEST 
/cudf/cpp/tests/utilities/column_utilities.cu:566: Failure
Failed
first difference: lhs[12] = 50089, rhs[12] = 500890
Google Test trace:
/cudf/cpp/tests/strings/attrs_tests.cpp:45:  <--  line of failure

[  FAILED  ] StringsAttributesTest.CodePoints (13 ms)
[==========] 488 tests from 53 test suites ran. (697 ms total)
[  PASSED  ] 487 tests.

```
It reports only on failing tests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
