### PR TITLE
More minor fixes for CCCL

### DIFF
--- a/cpp/include/cudf/ast/detail/operators.hpp
+++ b/cpp/include/cudf/ast/detail/operators.hpp
@@ -21,8 +21,8 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
+#include <cuda/std/optional>
 #include <cuda/std/type_traits>
-#include <thrust/optional.h>
 
 #include <cmath>
 #include <type_traits>
@@ -35,14 +35,14 @@ namespace ast {
 
 namespace detail {
 
-// Type trait for wrapping nullable types in a thrust::optional. Non-nullable
+// Type trait for wrapping nullable types in a cuda::std::optional. Non-nullable
 // types are returned as is.
 template <typename T, bool has_nulls>
 struct possibly_null_value;
 
 template <typename T>
 struct possibly_null_value<T, true> {
-  using type = thrust::optional<T>;
+  using type = cuda::std::optional<T>;
 };
 
 template <typename T>

--- a/cpp/include/cudf/ast/detail/operators.hpp
+++ b/cpp/include/cudf/ast/detail/operators.hpp
@@ -834,7 +834,7 @@ struct operator_functor<ast_operator::IS_NULL, true> {
   static constexpr auto arity = NonNullOperator::arity;
 
   template <typename LHS>
-  __device__ inline auto operator()(LHS const lhs) -> decltype(!lhs.has_value())
+  __device__ inline auto operator()(LHS const lhs) -> bool
   {
     return !lhs.has_value();
   }


### PR DESCRIPTION
This drops the final use of `thrust::optional` in cuDF