### PR TITLE
Increase timeout for recently added test

### DIFF
--- a/python/cudf/cudf_pandas_tests/test_disable_pandas_accelerator.py
+++ b/python/cudf/cudf_pandas_tests/test_disable_pandas_accelerator.py
@@ -11,7 +11,7 @@ def test_disable_pandas_accelerator_multi_threaded():
     # Create a copy of the current environment variables
     env = os.environ.copy()
 
-    with utils.cudf_timeout(10):
+    with utils.cudf_timeout(20):
         sp_completed = subprocess.run(
             [
                 "python",


### PR DESCRIPTION
## Description
There is a timeout failure in nightly tests: https://github.com/rapidsai/cudf/actions/runs/12983287834/job/36204344253

It looks like CI runs can get very slow at times, hence bumping up the timeout. This test basically guards us to test against a hang, so 20s timeout should be good too.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
