### PR TITLE
Fix possible OOB mem access in Parquet decoder

### DIFF
--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -1167,6 +1167,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
     // For large strings, update the initial string buffer offset to be used during large string
     // column construction. Otherwise, convert string sizes to final offsets.
     if (s->col.is_large_string_col) {
+      // page.chunk_idx are ordered by input_col_idx and row_group_idx respectively.
       auto const chunks_per_rowgroup = initial_str_offsets.size();
       auto const input_col_idx       = pages[page_idx].chunk_idx % chunks_per_rowgroup;
       compute_initial_large_strings_offset(s, initial_str_offsets[input_col_idx], has_lists_t);

--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -1167,8 +1167,9 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
     // For large strings, update the initial string buffer offset to be used during large string
     // column construction. Otherwise, convert string sizes to final offsets.
     if (s->col.is_large_string_col) {
-      compute_initial_large_strings_offset(
-        s, initial_str_offsets[pages[page_idx].chunk_idx], has_lists_t);
+      auto const chunks_per_rowgroup = initial_str_offsets.size();
+      auto const input_col_idx       = pages[page_idx].chunk_idx % chunks_per_rowgroup;
+      compute_initial_large_strings_offset(s, initial_str_offsets[input_col_idx], has_lists_t);
     } else {
       convert_small_string_lengths_to_offsets<decode_block_size_t>(s, has_lists_t);
     }

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -583,8 +583,9 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   // For large strings, update the initial string buffer offset to be used during large string
   // column construction. Otherwise, convert string sizes to final offsets.
   if (s->col.is_large_string_col) {
-    compute_initial_large_strings_offset(
-      s, initial_str_offsets[pages[page_idx].chunk_idx], has_repetition);
+    auto const chunks_per_rowgroup = initial_str_offsets.size();
+    auto const input_col_idx       = pages[page_idx].chunk_idx % chunks_per_rowgroup;
+    compute_initial_large_strings_offset(s, initial_str_offsets[input_col_idx], has_repetition);
   } else {
     convert_small_string_lengths_to_offsets<decode_block_size>(s, has_repetition);
   }
@@ -742,8 +743,9 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   // For large strings, update the initial string buffer offset to be used during large string
   // column construction. Otherwise, convert string sizes to final offsets.
   if (s->col.is_large_string_col) {
-    compute_initial_large_strings_offset(
-      s, initial_str_offsets[pages[page_idx].chunk_idx], has_repetition);
+    auto const chunks_per_rowgroup = initial_str_offsets.size();
+    auto const input_col_idx       = pages[page_idx].chunk_idx % chunks_per_rowgroup;
+    compute_initial_large_strings_offset(s, initial_str_offsets[input_col_idx], has_repetition);
   } else {
     convert_small_string_lengths_to_offsets<decode_block_size>(s, has_repetition);
   }

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -583,6 +583,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   // For large strings, update the initial string buffer offset to be used during large string
   // column construction. Otherwise, convert string sizes to final offsets.
   if (s->col.is_large_string_col) {
+    // page.chunk_idx are ordered by input_col_idx and row_group_idx respectively.
     auto const chunks_per_rowgroup = initial_str_offsets.size();
     auto const input_col_idx       = pages[page_idx].chunk_idx % chunks_per_rowgroup;
     compute_initial_large_strings_offset(s, initial_str_offsets[input_col_idx], has_repetition);
@@ -743,6 +744,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   // For large strings, update the initial string buffer offset to be used during large string
   // column construction. Otherwise, convert string sizes to final offsets.
   if (s->col.is_large_string_col) {
+    // page.chunk_idx are ordered by input_col_idx and row_group_idx respectively.
     auto const chunks_per_rowgroup = initial_str_offsets.size();
     auto const input_col_idx       = pages[page_idx].chunk_idx % chunks_per_rowgroup;
     compute_initial_large_strings_offset(s, initial_str_offsets[input_col_idx], has_repetition);


### PR DESCRIPTION
## Description
Fixes #17838. Related to #17702

This PR fixes a possible OOB in parquet string decoder when writing initial offset for nested large string cols. Existing tests should have been throwing segfaults in decoder kernels but somehow weren't. The decoder was producing correct results even without this change as the initial offsets are written from the first decoded ColumnChunk of each input column.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
