### PR TITLE
Update cudf.pandas colab link in docs

### DIFF
--- a/docs/cudf/source/cudf_pandas/index.rst
+++ b/docs/cudf/source/cudf_pandas/index.rst
@@ -20,7 +20,7 @@ automatically **falling back to pandas** for other operations.
 
 .. figure:: ../_static/colab.png
     :width: 200px
-    :target: https://nvda.ws/rapids-cudf
+    :target: https://nvda.ws/3BnjYjN
 
     Try it on Google Colab!
 


### PR DESCRIPTION
## Description
I changed the link to the cudf-pandas notebook in the docs from the secured link to the new public one

Closes #17845 

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
