### PR TITLE
Make `_Series_dtype` method a property

### DIFF
--- a/python/cudf/cudf/pandas/_wrappers/pandas.py
+++ b/python/cudf/cudf/pandas/_wrappers/pandas.py
@@ -293,7 +293,7 @@ Series = make_final_proxy_type(
         "_constructor": _FastSlowAttribute("_constructor"),
         "_constructor_expanddim": _FastSlowAttribute("_constructor_expanddim"),
         "_accessors": set(),
-        "dtype": _Series_dtype,
+        "dtype": property(_Series_dtype),
     },
 )
 

--- a/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
+++ b/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
@@ -1926,4 +1926,4 @@ def test_series_dtype_property():
     xs = xpd.Series([1, 2, 3])
     expected = np.dtype(s)
     actual = np.dtype(xs)
-    assert expected.dtype == actual.dtype
+    assert expected == actual

--- a/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
+++ b/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
@@ -1919,3 +1919,11 @@ def test_is_cudf_pandas():
 
         assert not isinstance_cudf_pandas(obj._fsproxy_slow, np.ndarray)
         assert not isinstance_cudf_pandas(obj._fsproxy_fast, np.ndarray)
+
+
+def test_series_dtype_property():
+    s = pd.Series([1, 2, 3])
+    xs = xpd.Series([1, 2, 3])
+    expected = np.dtype(s)
+    actual = np.dtype(xs)
+    assert expected.dtype == actual.dtype


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Follow up #17629 to make `_Series_dtype` a property. Should fix the nightly integration tests https://github.com/rapidsai/cudf/actions/runs/13026631397/job/36336775867#step:10:28786
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
