### PR TITLE
Fix groupby scans with int and NA data in mode.pandas_compatible

### DIFF
--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -473,6 +473,8 @@ class GroupBy(Serializable, Reducible, Scannable):
         dropna : bool, optional
             If True (default), do not include the "null" group.
         """
+        if cudf.get_option("mode.pandas_compatible"):
+            obj = obj.nans_to_nulls()
         self.obj = obj
         self._as_index = as_index
         self._by = by.copy(deep=True) if isinstance(by, _Grouping) else by

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -4111,7 +4111,7 @@ def test_scan_int_null_pandas_compatible(op):
     data = {"a": [1, 2, None, 3], "b": ["x"] * 4}
     df_pd = pd.DataFrame(data)
     df_cudf = cudf.DataFrame(data)
-    result = getattr(df_pd.groupby("b")["a"], op)()
+    expected = getattr(df_pd.groupby("b")["a"], op)()
     with cudf.option_context("mode.pandas_compatible", True):
-        expected = getattr(df_cudf.groupby("b")["a"], op)()
+        result = getattr(df_cudf.groupby("b")["a"], op)()
     assert_eq(result, expected)

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 
 import collections
 import datetime
@@ -4103,4 +4103,15 @@ def test_size_series_with_name():
     ser = pd.Series(range(3), name="foo")
     expected = ser.groupby(ser).size()
     result = cudf.from_pandas(ser).groupby(ser).size()
+    assert_eq(result, expected)
+
+
+@pytest.mark.parametrize("op", ["cumsum", "cumprod", "cummin", "cummax"])
+def test_scan_int_null_pandas_compatible(op):
+    data = {"a": [1, 2, None, 3], "b": ["x"] * 4}
+    df_pd = pd.DataFrame(data)
+    df_cudf = cudf.DataFrame(data)
+    result = getattr(df_pd.groupby("b")["a"], op)()
+    with cudf.option_context("mode.pandas_compatible", True):
+        expected = getattr(df_cudf.groupby("b")["a"], op)()
     assert_eq(result, expected)


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/17880

Needed similar handing as the `rolling` case in https://github.com/rapidsai/cudf/pull/17822

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
