### PR TITLE
Raise NotImplementedError if `.merge(suffixes=)` introduces duplicate labels

### DIFF
--- a/python/cudf/cudf/core/join/join.py
+++ b/python/cudf/cudf/core/join/join.py
@@ -372,7 +372,14 @@ class Merge:
         for name, col in right_result._column_labels_and_values:
             if name in common_names:
                 if name not in self._key_columns_with_same_name:
-                    data[f"{name}{self.rsuffix}"] = col
+                    r_label = f"{name}{self.rsuffix}"
+                    if r_label in data:
+                        raise NotImplementedError(
+                            f"suffixes={(self.lsuffix, self.rsuffix)} would introduce a "
+                            f"duplicate column label, '{name}{self.rsuffix}', which is "
+                            "not supported."
+                        )
+                    data[r_label] = col
             else:
                 data[name] = col
 

--- a/python/cudf/cudf/core/join/join.py
+++ b/python/cudf/cudf/core/join/join.py
@@ -376,7 +376,7 @@ class Merge:
                     if r_label in data:
                         raise NotImplementedError(
                             f"suffixes={(self.lsuffix, self.rsuffix)} would introduce a "
-                            f"duplicate column label, '{name}{self.rsuffix}', which is "
+                            f"duplicate column label, '{r_label}', which is "
                             "not supported."
                         )
                     data[r_label] = col

--- a/python/cudf/cudf/tests/test_joining.py
+++ b/python/cudf/cudf/tests/test_joining.py
@@ -2290,3 +2290,15 @@ def test_merge_index_on_opposite_how_column_reset_index():
     expected = pd.merge(ser, df, on="a", how="right")
     result = cudf.merge(ser_cudf, df_cudf, on="a", how="right")
     assert_eq(result, expected)
+
+
+def test_merge_suffixes_duplicate_label_raises():
+    data = {"a": [1, 2, 3, 4, 5], "b": [6, 6, 6, 6, 6]}
+    df_cudf = cudf.DataFrame(data)
+    df_pd = pd.DataFrame(data)
+    result = df_cudf.merge(df_cudf, on=["a"], suffixes=("", "_right"))
+    expected = df_pd.merge(df_pd, on=["a"], suffixes=("", "_right"))
+    assert_eq(result, expected)
+
+    with pytest.raises(NotImplementedError):
+        result.merge(df_cudf, on=["a"], suffixes=("", "_right"))


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/17902

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
