### PR TITLE
Add `build_type` input to workflow inputs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,9 @@ on:
       sha:
         required: true
         type: string
+      build_type:
+        type: string
+        default: nightly
 
 jobs:
   conda-cpp-checks:


### PR DESCRIPTION
xref: rapidsai/build-planning#147
xref: rapidsai/shared-workflows#275

## Description

This adds `build_input` as an input option so we can (as needed) manually run `*test` workflows against a particular branch.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
