### PR TITLE
Rename PascalCase functions and types to to snake_case to improve consistency

### DIFF
--- a/cpp/include/cudf/io/orc_metadata.hpp
+++ b/cpp/include/cudf/io/orc_metadata.hpp
@@ -172,9 +172,9 @@ using statistics_type = std::variant<no_statistics,
 
 //! Orc I/O interfaces
 namespace orc::detail {
-// forward declare the type that ProtobufReader uses. The `cudf::io::column_statistics` objects,
+// forward declare the type that protobuf_reader uses. The `cudf::io::column_statistics` objects,
 // returned from `read_parsed_orc_statistics`, are constructed from
-// `cudf::io::orc::detail::column_statistics` objects that `ProtobufReader` initializes.
+// `cudf::io::orc::detail::column_statistics` objects that `protobuf_reader` initializes.
 struct column_statistics;
 }  // namespace orc::detail
 

--- a/cpp/src/io/functions.cpp
+++ b/cpp/src/io/functions.cpp
@@ -351,8 +351,8 @@ parsed_orc_statistics read_parsed_orc_statistics(source_info const& src_info,
 
   auto parse_column_statistics = [](auto const& raw_col_stats) {
     orc::detail::column_statistics stats_internal;
-    orc::detail::ProtobufReader(reinterpret_cast<uint8_t const*>(raw_col_stats.c_str()),
-                                raw_col_stats.size())
+    orc::detail::protobuf_reader(reinterpret_cast<uint8_t const*>(raw_col_stats.c_str()),
+                                 raw_col_stats.size())
       .read(stats_internal);
     return column_statistics(std::move(stats_internal));
   };

--- a/cpp/src/io/orc/aggregate_orc_metadata.cpp
+++ b/cpp/src/io/orc/aggregate_orc_metadata.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/io/orc/aggregate_orc_metadata.cpp
+++ b/cpp/src/io/orc/aggregate_orc_metadata.cpp
@@ -260,7 +260,7 @@ aggregate_orc_metadata::select_stripes(
         per_file_metadata[mapping.source_idx].source->host_read(sf_comp_offset, sf_comp_length);
       auto sf_data = per_file_metadata[mapping.source_idx].decompressor->decompress_blocks(
         {buffer->data(), buffer->size()}, stream);
-      ProtobufReader(sf_data.data(), sf_data.size())
+      protobuf_reader(sf_data.data(), sf_data.size())
         .read(per_file_metadata[mapping.source_idx].stripefooters[i]);
       mapping.stripe_info[i].stripe_footer =
         &per_file_metadata[mapping.source_idx].stripefooters[i];

--- a/cpp/src/io/orc/orc.cpp
+++ b/cpp/src/io/orc/orc.cpp
@@ -40,14 +40,14 @@ namespace {
 }
 }  // namespace
 
-uint32_t ProtobufReader::read_field_size(uint8_t const* end)
+uint32_t protobuf_reader::read_field_size(uint8_t const* end)
 {
   auto const size = get<uint32_t>();
   CUDF_EXPECTS(size <= static_cast<uint32_t>(end - m_cur), "Protobuf parsing out of bounds");
   return size;
 }
 
-void ProtobufReader::skip_struct_field(int t)
+void protobuf_reader::skip_struct_field(int t)
 {
   switch (t) {
     case ProtofType::VARINT: get<uint32_t>(); break;
@@ -58,7 +58,7 @@ void ProtobufReader::skip_struct_field(int t)
   }
 }
 
-void ProtobufReader::read(PostScript& s, size_t maxlen)
+void protobuf_reader::read(PostScript& s, size_t maxlen)
 {
   auto op = std::tuple(field_reader(1, s.footerLength),
                        field_reader(2, s.compression),
@@ -70,7 +70,7 @@ void ProtobufReader::read(PostScript& s, size_t maxlen)
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(Footer& s, size_t maxlen)
+void protobuf_reader::read(Footer& s, size_t maxlen)
 {
   auto op = std::tuple(field_reader(1, s.headerLength),
                        field_reader(2, s.contentLength),
@@ -84,7 +84,7 @@ void ProtobufReader::read(Footer& s, size_t maxlen)
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(StripeInformation& s, size_t maxlen)
+void protobuf_reader::read(StripeInformation& s, size_t maxlen)
 {
   auto op = std::tuple(field_reader(1, s.offset),
                        field_reader(2, s.indexLength),
@@ -94,7 +94,7 @@ void ProtobufReader::read(StripeInformation& s, size_t maxlen)
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(SchemaType& s, size_t maxlen)
+void protobuf_reader::read(SchemaType& s, size_t maxlen)
 {
   auto op = std::tuple(field_reader(1, s.kind),
                        packed_field_reader(2, s.subtypes),
@@ -105,79 +105,79 @@ void ProtobufReader::read(SchemaType& s, size_t maxlen)
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(UserMetadataItem& s, size_t maxlen)
+void protobuf_reader::read(UserMetadataItem& s, size_t maxlen)
 {
   auto op = std::tuple(field_reader(1, s.name), field_reader(2, s.value));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(StripeFooter& s, size_t maxlen)
+void protobuf_reader::read(StripeFooter& s, size_t maxlen)
 {
   auto op = std::tuple(
     field_reader(1, s.streams), field_reader(2, s.columns), field_reader(3, s.writerTimezone));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(Stream& s, size_t maxlen)
+void protobuf_reader::read(Stream& s, size_t maxlen)
 {
   auto op =
     std::tuple(field_reader(1, s.kind), field_reader(2, s.column_id), field_reader(3, s.length));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(ColumnEncoding& s, size_t maxlen)
+void protobuf_reader::read(ColumnEncoding& s, size_t maxlen)
 {
   auto op = std::tuple(field_reader(1, s.kind), field_reader(2, s.dictionarySize));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(integer_statistics& s, size_t maxlen)
+void protobuf_reader::read(integer_statistics& s, size_t maxlen)
 {
   auto op =
     std::tuple(field_reader(1, s.minimum), field_reader(2, s.maximum), field_reader(3, s.sum));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(double_statistics& s, size_t maxlen)
+void protobuf_reader::read(double_statistics& s, size_t maxlen)
 {
   auto op =
     std::tuple(field_reader(1, s.minimum), field_reader(2, s.maximum), field_reader(3, s.sum));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(string_statistics& s, size_t maxlen)
+void protobuf_reader::read(string_statistics& s, size_t maxlen)
 {
   auto op =
     std::tuple(field_reader(1, s.minimum), field_reader(2, s.maximum), field_reader(3, s.sum));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(bucket_statistics& s, size_t maxlen)
+void protobuf_reader::read(bucket_statistics& s, size_t maxlen)
 {
   auto op = std::tuple(packed_field_reader(1, s.count));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(decimal_statistics& s, size_t maxlen)
+void protobuf_reader::read(decimal_statistics& s, size_t maxlen)
 {
   auto op =
     std::tuple(field_reader(1, s.minimum), field_reader(2, s.maximum), field_reader(3, s.sum));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(date_statistics& s, size_t maxlen)
+void protobuf_reader::read(date_statistics& s, size_t maxlen)
 {
   auto op = std::tuple(field_reader(1, s.minimum), field_reader(2, s.maximum));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(binary_statistics& s, size_t maxlen)
+void protobuf_reader::read(binary_statistics& s, size_t maxlen)
 {
   auto op = std::tuple(field_reader(1, s.sum));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(timestamp_statistics& s, size_t maxlen)
+void protobuf_reader::read(timestamp_statistics& s, size_t maxlen)
 {
   auto op = std::tuple(field_reader(1, s.minimum),
                        field_reader(2, s.maximum),
@@ -201,7 +201,7 @@ void ProtobufReader::read(timestamp_statistics& s, size_t maxlen)
   }
 }
 
-void ProtobufReader::read(column_statistics& s, size_t maxlen)
+void protobuf_reader::read(column_statistics& s, size_t maxlen)
 {
   auto op = std::tuple(field_reader(1, s.number_of_values),
                        field_reader(2, s.int_stats),
@@ -216,13 +216,13 @@ void ProtobufReader::read(column_statistics& s, size_t maxlen)
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(StripeStatistics& s, size_t maxlen)
+void protobuf_reader::read(StripeStatistics& s, size_t maxlen)
 {
   auto op = std::tuple(raw_field_reader(1, s.colStats));
   function_builder(s, maxlen, op);
 }
 
-void ProtobufReader::read(Metadata& s, size_t maxlen)
+void protobuf_reader::read(Metadata& s, size_t maxlen)
 {
   auto op = std::tuple(field_reader(1, s.stripeStats));
   function_builder(s, maxlen, op);
@@ -231,16 +231,16 @@ void ProtobufReader::read(Metadata& s, size_t maxlen)
 /**
  * @brief Add a single rowIndexEntry, negative input values treated as not present
  */
-void ProtobufWriter::put_row_index_entry(int32_t present_blk,
-                                         int32_t present_ofs,
-                                         int32_t data_blk,
-                                         int32_t data_ofs,
-                                         int32_t data2_blk,
-                                         int32_t data2_ofs,
-                                         TypeKind kind,
-                                         ColStatsBlob const* stats)
+void protobuf_writer::put_row_index_entry(int32_t present_blk,
+                                          int32_t present_ofs,
+                                          int32_t data_blk,
+                                          int32_t data_ofs,
+                                          int32_t data2_blk,
+                                          int32_t data2_ofs,
+                                          TypeKind kind,
+                                          col_stats_blob const* stats)
 {
-  ProtobufWriter position_writer;
+  protobuf_writer position_writer;
   auto const positions_size_offset = position_writer.put_uint(
     encode_field_number(1, ProtofType::FIXEDLEN));  // 1:positions[packed=true]
   position_writer.put_byte(0xcd);                   // positions size placeholder
@@ -291,13 +291,13 @@ void ProtobufWriter::put_row_index_entry(int32_t present_blk,
     put_uint(encode_field_number<decltype(*stats)>(2));  // 2: statistics
     // Statistics field contains its length as varint and dtype specific data (encoded on the GPU)
     put_uint(stats->size());
-    put_bytes<typename ColStatsBlob::value_type>(*stats);
+    put_bytes<typename col_stats_blob::value_type>(*stats);
   }
 }
 
-size_t ProtobufWriter::write(PostScript const& s)
+size_t protobuf_writer::write(PostScript const& s)
 {
-  ProtobufFieldWriter w(this);
+  protobuf_field_writer w(this);
   w.field_uint(1, s.footerLength);
   w.field_uint(2, s.compression);
   if (s.compression != NONE) { w.field_uint(3, s.compressionBlockSize); }
@@ -308,9 +308,9 @@ size_t ProtobufWriter::write(PostScript const& s)
   return w.value();
 }
 
-size_t ProtobufWriter::write(Footer const& s)
+size_t protobuf_writer::write(Footer const& s)
 {
-  ProtobufFieldWriter w(this);
+  protobuf_field_writer w(this);
   w.field_uint(1, s.headerLength);
   w.field_uint(2, s.contentLength);
   w.field_repeated_struct(3, s.stripes);
@@ -323,9 +323,9 @@ size_t ProtobufWriter::write(Footer const& s)
   return w.value();
 }
 
-size_t ProtobufWriter::write(StripeInformation const& s)
+size_t protobuf_writer::write(StripeInformation const& s)
 {
-  ProtobufFieldWriter w(this);
+  protobuf_field_writer w(this);
   w.field_uint(1, s.offset);
   w.field_uint(2, s.indexLength);
   w.field_uint(3, s.dataLength);
@@ -334,9 +334,9 @@ size_t ProtobufWriter::write(StripeInformation const& s)
   return w.value();
 }
 
-size_t ProtobufWriter::write(SchemaType const& s)
+size_t protobuf_writer::write(SchemaType const& s)
 {
-  ProtobufFieldWriter w(this);
+  protobuf_field_writer w(this);
   w.field_uint(1, s.kind);
   w.field_packed_uint(2, s.subtypes);
   w.field_repeated_string(3, s.fieldNames);
@@ -346,55 +346,55 @@ size_t ProtobufWriter::write(SchemaType const& s)
   return w.value();
 }
 
-size_t ProtobufWriter::write(UserMetadataItem const& s)
+size_t protobuf_writer::write(UserMetadataItem const& s)
 {
-  ProtobufFieldWriter w(this);
+  protobuf_field_writer w(this);
   w.field_blob(1, s.name);
   w.field_blob(2, s.value);
   return w.value();
 }
 
-size_t ProtobufWriter::write(StripeFooter const& s)
+size_t protobuf_writer::write(StripeFooter const& s)
 {
-  ProtobufFieldWriter w(this);
+  protobuf_field_writer w(this);
   w.field_repeated_struct(1, s.streams);
   w.field_repeated_struct(2, s.columns);
   if (s.writerTimezone != "") { w.field_blob(3, s.writerTimezone); }
   return w.value();
 }
 
-size_t ProtobufWriter::write(Stream const& s)
+size_t protobuf_writer::write(Stream const& s)
 {
-  ProtobufFieldWriter w(this);
+  protobuf_field_writer w(this);
   w.field_uint(1, s.kind);
   if (s.column_id) w.field_uint(2, *s.column_id);
   w.field_uint(3, s.length);
   return w.value();
 }
 
-size_t ProtobufWriter::write(ColumnEncoding const& s)
+size_t protobuf_writer::write(ColumnEncoding const& s)
 {
-  ProtobufFieldWriter w(this);
+  protobuf_field_writer w(this);
   w.field_uint(1, s.kind);
   if (s.kind == DICTIONARY || s.kind == DICTIONARY_V2) { w.field_uint(2, s.dictionarySize); }
   return w.value();
 }
 
-size_t ProtobufWriter::write(StripeStatistics const& s)
+size_t protobuf_writer::write(StripeStatistics const& s)
 {
-  ProtobufFieldWriter w(this);
+  protobuf_field_writer w(this);
   w.field_repeated_struct_blob(1, s.colStats);
   return w.value();
 }
 
-size_t ProtobufWriter::write(Metadata const& s)
+size_t protobuf_writer::write(Metadata const& s)
 {
-  ProtobufFieldWriter w(this);
+  protobuf_field_writer w(this);
   w.field_repeated_struct(1, s.stripeStats);
   return w.value();
 }
 
-OrcDecompressor::OrcDecompressor(CompressionKind kind, uint64_t block_size)
+orc_decompressor::orc_decompressor(CompressionKind kind, uint64_t block_size)
   : m_blockSize(block_size)
 {
   switch (kind) {
@@ -420,8 +420,8 @@ OrcDecompressor::OrcDecompressor(CompressionKind kind, uint64_t block_size)
   }
 }
 
-host_span<uint8_t const> OrcDecompressor::decompress_blocks(host_span<uint8_t const> src,
-                                                            rmm::cuda_stream_view stream)
+host_span<uint8_t const> orc_decompressor::decompress_blocks(host_span<uint8_t const> src,
+                                                             rmm::cuda_stream_view stream)
 {
   // If uncompressed, just pass-through the input
   if (src.empty() or _compression == compression_type::NONE) { return src; }
@@ -480,24 +480,24 @@ metadata::metadata(datasource* const src, rmm::cuda_stream_view stream) : source
   auto buffer            = source->host_read(len - max_ps_size, max_ps_size);
   size_t const ps_length = buffer->data()[max_ps_size - 1];
   uint8_t const* ps_data = &buffer->data()[max_ps_size - ps_length - 1];
-  ProtobufReader(ps_data, ps_length).read(ps);
+  protobuf_reader(ps_data, ps_length).read(ps);
   CUDF_EXPECTS(ps.footerLength + ps_length < len, "Invalid footer length");
 
   // If compression is used, the rest of the metadata is compressed
   // If no compressed is used, the decompressor is simply a pass-through
-  decompressor = std::make_unique<OrcDecompressor>(ps.compression, ps.compressionBlockSize);
+  decompressor = std::make_unique<orc_decompressor>(ps.compression, ps.compressionBlockSize);
 
   // Read compressed filefooter section
   buffer             = source->host_read(len - ps_length - 1 - ps.footerLength, ps.footerLength);
   auto const ff_data = decompressor->decompress_blocks({buffer->data(), buffer->size()}, stream);
-  ProtobufReader(ff_data.data(), ff_data.size()).read(ff);
+  protobuf_reader(ff_data.data(), ff_data.size()).read(ff);
   CUDF_EXPECTS(get_num_columns() > 0, "No columns found");
 
   // Read compressed metadata section
   buffer =
     source->host_read(len - ps_length - 1 - ps.footerLength - ps.metadataLength, ps.metadataLength);
   auto const md_data = decompressor->decompress_blocks({buffer->data(), buffer->size()}, stream);
-  ProtobufReader(md_data.data(), md_data.size()).read(md);
+  protobuf_reader(md_data.data(), md_data.size()).read(md);
 
   init_parent_descriptors();
   init_column_names();

--- a/cpp/src/io/orc/orc_field_writer.hpp
+++ b/cpp/src/io/orc/orc_field_writer.hpp
@@ -23,16 +23,16 @@
 /**
  * @file orc_field_writer.hpp
  * @brief Struct to encapsulate common functionality required to implement
- * `ProtobufWriter::write(...)` functions
+ * `protobuf_writer::write(...)` functions
  */
 
 namespace cudf::io::orc::detail {
 
-struct ProtobufWriter::ProtobufFieldWriter {
+struct protobuf_writer::protobuf_field_writer {
   int struct_size{0};
-  ProtobufWriter* p;
+  protobuf_writer* p;
 
-  ProtobufFieldWriter(ProtobufWriter* pbw) : p(pbw) {}
+  protobuf_field_writer(protobuf_writer* pbw) : p(pbw) {}
 
   /**
    * @brief Function to write a unsigned integer to the internal buffer

--- a/cpp/src/io/orc/orc_gpu.hpp
+++ b/cpp/src/io/orc/orc_gpu.hpp
@@ -58,9 +58,10 @@ using slot_type        = cuco::pair<key_type, mapped_type>;
 auto constexpr KEY_SENTINEL   = size_type{-1};
 auto constexpr VALUE_SENTINEL = size_type{-1};
 
-struct CompressedStreamInfo {
-  CompressedStreamInfo() = default;
-  explicit constexpr CompressedStreamInfo(uint8_t const* compressed_data_, size_t compressed_size_)
+struct compressed_stream_info {
+  compressed_stream_info() = default;
+  explicit constexpr compressed_stream_info(uint8_t const* compressed_data_,
+                                            size_t compressed_size_)
     : compressed_data(compressed_data_), compressed_data_size(compressed_size_)
   {
   }
@@ -81,7 +82,7 @@ struct CompressedStreamInfo {
   uint32_t max_uncompressed_block_size{};  // [out] maximum uncompressed size of any block in stream
 };
 
-enum StreamIndexType {
+enum stream_index_type {
   CI_DATA = 0,    // Primary data stream
   CI_DATA2,       // Secondary/Length stream
   CI_PRESENT,     // Present stream
@@ -93,7 +94,7 @@ enum StreamIndexType {
 /**
  * @brief Struct to describe a single entry in the global dictionary
  */
-struct DictionaryEntry {
+struct dictionary_entry {
   uint32_t pos;  // Position in data stream
   uint32_t len;  // Length in data stream
 };
@@ -101,7 +102,7 @@ struct DictionaryEntry {
 /**
  * @brief Struct to describe per stripe's column information
  */
-struct ColumnDesc {
+struct column_desc {
   uint8_t const* streams[CI_NUM_STREAMS];  // ptr to data stream index
   uint32_t strm_id[CI_NUM_STREAMS];        // stream ids
   int64_t strm_len[CI_NUM_STREAMS];        // stream length
@@ -130,7 +131,7 @@ struct ColumnDesc {
 /**
  * @brief Struct to describe a groups of row belonging to a column stripe
  */
-struct RowGroup {
+struct row_group {
   uint32_t chunk_id;        // Column chunk this entry belongs to
   int64_t strm_offset[2];   // Index offset for CI_DATA and CI_DATA2 streams
   uint16_t run_pos[2];      // Run position for CI_DATA and CI_DATA2
@@ -142,7 +143,7 @@ struct RowGroup {
 /**
  * @brief Struct to describe an encoder data chunk
  */
-struct EncChunk {
+struct encoder_chunk {
   int64_t start_row;                 // start row of this chunk
   uint32_t num_rows;                 // number of rows in this chunk
   int64_t null_mask_start_row;       // adjusted to multiple of 8
@@ -159,7 +160,7 @@ struct EncChunk {
 };
 
 /**
- * @brief Struct to describe the streams that correspond to a single `EncChunk`.
+ * @brief Struct to describe the streams that correspond to a single `encoder_chunk`.
  */
 struct encoder_chunk_streams {
   uint8_t* data_ptrs[CI_NUM_STREAMS];  // encoded output
@@ -170,7 +171,7 @@ struct encoder_chunk_streams {
 /**
  * @brief Struct to describe a column stream within a stripe
  */
-struct StripeStream {
+struct stripe_stream {
   uint8_t* data_ptr;        // encoded and gathered output
   size_t bfr_offset;        // Offset of this stream in compressed buffer
   uint32_t stream_size;     // Size of stream in bytes
@@ -254,11 +255,11 @@ constexpr uint32_t encode_block_size = 512;
  * compressed size)
  * @param[in] stream CUDA stream used for device memory operations and kernel launches
  */
-void ParseCompressedStripeData(CompressedStreamInfo* strm_info,
-                               int32_t num_streams,
-                               uint64_t compression_block_size,
-                               uint32_t log2maxcr,
-                               rmm::cuda_stream_view stream);
+void parse_compressed_stripe_data(compressed_stream_info* strm_info,
+                                  int32_t num_streams,
+                                  uint64_t compression_block_size,
+                                  uint32_t log2maxcr,
+                                  rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for re-assembling decompressed blocks into a single contiguous block
@@ -267,16 +268,16 @@ void ParseCompressedStripeData(CompressedStreamInfo* strm_info,
  * @param[in] num_streams Number of compressed streams
  * @param[in] stream CUDA stream used for device memory operations and kernel launches
  */
-void PostDecompressionReassemble(CompressedStreamInfo* strm_info,
-                                 int32_t num_streams,
-                                 rmm::cuda_stream_view stream);
+void post_decompression_reassemble(compressed_stream_info* strm_info,
+                                   int32_t num_streams,
+                                   rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for constructing rowgroup from index streams
  *
- * @param[out] row_groups RowGroup device array [rowgroup][column]
+ * @param[out] row_groups row_group device array [rowgroup][column]
  * @param[in] strm_info List of compressed streams (or NULL if uncompressed)
- * @param[in] chunks ColumnDesc device array [stripe][column]
+ * @param[in] chunks column_desc device array [stripe][column]
  * @param[in] num_columns Number of columns
  * @param[in] num_stripes Number of stripes
  * @param[in] rowidx_stride Row index stride
@@ -284,36 +285,36 @@ void PostDecompressionReassemble(CompressedStreamInfo* strm_info,
  * value
  * @param[in] stream CUDA stream used for device memory operations and kernel launches
  */
-void ParseRowGroupIndex(RowGroup* row_groups,
-                        CompressedStreamInfo* strm_info,
-                        ColumnDesc* chunks,
-                        size_type num_columns,
-                        size_type num_stripes,
-                        size_type rowidx_stride,
-                        bool use_base_stride,
-                        rmm::cuda_stream_view stream);
+void parse_row_group_index(row_group* row_groups,
+                           compressed_stream_info* strm_info,
+                           column_desc* chunks,
+                           size_type num_columns,
+                           size_type num_stripes,
+                           size_type rowidx_stride,
+                           bool use_base_stride,
+                           rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for decoding NULLs and building string dictionary index tables
  *
- * @param[in] chunks ColumnDesc device array [stripe][column]
+ * @param[in] chunks column_desc device array [stripe][column]
  * @param[in] global_dictionary Global dictionary device array
  * @param[in] num_columns Number of columns
  * @param[in] num_stripes Number of stripes
  * @param[in] first_row Crop all rows below first_row
  * @param[in] stream CUDA stream used for device memory operations and kernel launches
  */
-void DecodeNullsAndStringDictionaries(ColumnDesc* chunks,
-                                      DictionaryEntry* global_dictionary,
-                                      size_type num_columns,
-                                      size_type num_stripes,
-                                      int64_t first_row,
-                                      rmm::cuda_stream_view stream);
+void decode_nulls_and_string_dictionaries(column_desc* chunks,
+                                          dictionary_entry* global_dictionary,
+                                          size_type num_columns,
+                                          size_type num_stripes,
+                                          int64_t first_row,
+                                          rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for decoding column data
  *
- * @param[in] chunks ColumnDesc device array [stripe][column]
+ * @param[in] chunks column_desc device array [stripe][column]
  * @param[in] global_dictionary Global dictionary device array
  * @param[in] num_columns Number of columns
  * @param[in] num_stripes Number of stripes
@@ -327,18 +328,18 @@ void DecodeNullsAndStringDictionaries(ColumnDesc* chunks,
  * @param[out] error_count Number of errors during decode
  * @param[in] stream CUDA stream used for device memory operations and kernel launches
  */
-void DecodeOrcColumnData(ColumnDesc* chunks,
-                         DictionaryEntry* global_dictionary,
-                         device_2dspan<RowGroup> row_groups,
-                         size_type num_columns,
-                         size_type num_stripes,
-                         int64_t first_row,
-                         table_device_view tz_table,
-                         int64_t num_rowgroups,
-                         size_type rowidx_stride,
-                         size_t level,
-                         size_type* error_count,
-                         rmm::cuda_stream_view stream);
+void decode_column_data(column_desc* chunks,
+                        dictionary_entry* global_dictionary,
+                        device_2dspan<row_group> row_groups,
+                        size_type num_columns,
+                        size_type num_stripes,
+                        int64_t first_row,
+                        table_device_view tz_table,
+                        int64_t num_rowgroups,
+                        size_type rowidx_stride,
+                        size_t level,
+                        size_type* error_count,
+                        rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for encoding column data
@@ -347,9 +348,9 @@ void DecodeOrcColumnData(ColumnDesc* chunks,
  * @param[in, out] streams chunk streams device array [column][rowgroup]
  * @param[in] stream CUDA stream used for device memory operations and kernel launches
  */
-void EncodeOrcColumnData(device_2dspan<EncChunk const> chunks,
-                         device_2dspan<encoder_chunk_streams> streams,
-                         rmm::cuda_stream_view stream);
+void encode_orc_column_data(device_2dspan<encoder_chunk const> chunks,
+                            device_2dspan<encoder_chunk_streams> streams,
+                            rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for encoding column dictionaries
@@ -362,24 +363,24 @@ void EncodeOrcColumnData(device_2dspan<EncChunk const> chunks,
  * @param[in,out] enc_streams chunk streams device array [column][rowgroup]
  * @param[in] stream CUDA stream used for device memory operations and kernel launches
  */
-void EncodeStripeDictionaries(stripe_dictionary const* stripes,
-                              device_span<orc_column_device_view const> columns,
-                              device_2dspan<EncChunk const> chunks,
-                              size_type num_string_columns,
-                              size_type num_stripes,
-                              device_2dspan<encoder_chunk_streams> enc_streams,
-                              rmm::cuda_stream_view stream);
+void encode_stripe_dictionaries(stripe_dictionary const* stripes,
+                                device_span<orc_column_device_view const> columns,
+                                device_2dspan<encoder_chunk const> chunks,
+                                size_type num_string_columns,
+                                size_type num_stripes,
+                                device_2dspan<encoder_chunk_streams> enc_streams,
+                                rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for compacting chunked column data prior to compression
  *
- * @param[in,out] strm_desc StripeStream device array [stripe][stream]
+ * @param[in,out] strm_desc stripe_stream device array [stripe][stream]
  * @param[in,out] enc_streams chunk streams device array [column][rowgroup]
  * @param[in] stream CUDA stream used for device memory operations and kernel launches
  */
-void CompactOrcDataStreams(device_2dspan<StripeStream> strm_desc,
-                           device_2dspan<encoder_chunk_streams> enc_streams,
-                           rmm::cuda_stream_view stream);
+void compact_orc_data_streams(device_2dspan<stripe_stream> strm_desc,
+                              device_2dspan<encoder_chunk_streams> enc_streams,
+                              rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel(s) for compressing data streams
@@ -391,14 +392,14 @@ void CompactOrcDataStreams(device_2dspan<StripeStream> strm_desc,
  * @param[in] max_comp_blk_size Max size of any block after compression
  * @param[in] comp_block_align Required alignment for compressed blocks
  * @param[in] collect_statistics Whether to collect compression statistics
- * @param[in,out] strm_desc StripeStream device array [stripe][stream]
+ * @param[in,out] strm_desc stripe_stream device array [stripe][stream]
  * @param[in,out] enc_streams chunk streams device array [column][rowgroup]
  * @param[out] comp_res Per-block compression status
  * @param[in] stream CUDA stream used for device memory operations and kernel launches
  *
  * @return Compression statistics (if requested)
  */
-std::optional<writer_compression_statistics> CompressOrcDataStreams(
+std::optional<writer_compression_statistics> compress_orc_data_streams(
   device_span<uint8_t> compressed_data,
   uint32_t num_compressed_blocks,
   compression_type compression,
@@ -406,7 +407,7 @@ std::optional<writer_compression_statistics> CompressOrcDataStreams(
   uint32_t max_comp_blk_size,
   uint32_t comp_block_align,
   bool collect_statistics,
-  device_2dspan<StripeStream> strm_desc,
+  device_2dspan<stripe_stream> strm_desc,
   device_2dspan<encoder_chunk_streams> enc_streams,
   device_span<cudf::io::detail::compression_result> comp_res,
   rmm::cuda_stream_view stream);

--- a/cpp/src/io/orc/reader_impl_chunking.hpp
+++ b/cpp/src/io/orc/reader_impl_chunking.hpp
@@ -316,6 +316,6 @@ std::size_t gather_stream_info_and_column_desc(
   int64_t* num_dictionary_entries,
   std::size_t* local_stream_order,
   std::vector<orc_stream_info>* stream_info,
-  cudf::detail::hostdevice_2dvector<ColumnDesc>* chunks);
+  cudf::detail::hostdevice_2dvector<column_desc>* chunks);
 
 }  // namespace cudf::io::orc::detail

--- a/cpp/src/io/orc/writer_impl.hpp
+++ b/cpp/src/io/orc/writer_impl.hpp
@@ -168,7 +168,7 @@ struct intermediate_statistics {
 
   intermediate_statistics(orc_table_view const& table, rmm::cuda_stream_view stream);
 
-  intermediate_statistics(std::vector<ColStatsBlob> rb,
+  intermediate_statistics(std::vector<col_stats_blob> rb,
                           rmm::device_uvector<statistics_chunk> sc,
                           cudf::detail::hostdevice_vector<statistics_merge_group> smg,
                           std::vector<statistics_dtype> sdt,
@@ -182,7 +182,7 @@ struct intermediate_statistics {
   }
 
   // blobs for the rowgroups. Not persisted
-  std::vector<ColStatsBlob> rowgroup_blobs;
+  std::vector<col_stats_blob> rowgroup_blobs;
 
   rmm::device_uvector<statistics_chunk> stripe_stat_chunks;
   cudf::detail::hostdevice_vector<statistics_merge_group> stripe_stat_merge;
@@ -223,8 +223,8 @@ struct persisted_statistics {
  *
  */
 struct encoded_footer_statistics {
-  std::vector<ColStatsBlob> stripe_level;
-  std::vector<ColStatsBlob> file_level;
+  std::vector<col_stats_blob> stripe_level;
+  std::vector<col_stats_blob> file_level;
 };
 
 enum class writer_state {
@@ -309,8 +309,8 @@ class writer::impl {
                               orc_table_view const& orc_table,
                               device_span<uint8_t const> compressed_data,
                               host_span<compression_result const> comp_results,
-                              host_2dspan<StripeStream const> strm_descs,
-                              host_span<ColStatsBlob const> rg_stats,
+                              host_2dspan<stripe_stream const> strm_descs,
+                              host_span<col_stats_blob const> rg_stats,
                               orc_streams& streams,
                               host_span<StripeInformation> stripes,
                               host_span<uint8_t> bounce_buffer);


### PR DESCRIPTION
Some older code in the ORC reader/writer uses PascalCase, which is not used in the rest of libcudf. This PR renames such functions and types to align the style with the rest of the code base.

The types that are based on the ORC specs are kept as PascalCase to make it easy to identify such types.