### PR TITLE
Add missing standard includes

### DIFF
--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@
 #include <thrust/pair.h>
 
 #include <algorithm>
+#include <functional>
 #include <type_traits>
 
 /**

--- a/cpp/src/copying/pack.cpp
+++ b/cpp/src/copying/pack.cpp
@@ -20,6 +20,12 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
 namespace cudf {
 namespace detail {
 


### PR DESCRIPTION
With the upcoming CCCL release we moved some includes around and it seems that we relied on transitively including `<functional>` in some files.

Fix that and include all the headers used in at least those two files