### PR TITLE
Add nvtext::tokenized_to_tensor API

### DIFF
--- a/cpp/include/nvtext/subword_tokenize.hpp
+++ b/cpp/include/nvtext/subword_tokenize.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
+#include <cudf/lists/lists_column_view.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
@@ -159,6 +160,44 @@ tokenizer_result subword_tokenize(
   uint32_t max_sequence_length,
   uint32_t stride,
   bool do_lower_case,
+  bool do_truncate,
+  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+
+/**
+ * @brief Converts the output of the wordpiece tokenizer to tensor data
+ * and metadata format
+ *
+ * For `do_truncate==true`:
+ * ```
+ * size of tensor_token_ids = max_sequence_length * input.size()
+ * size of tensor_attention_mask = max_sequence_length * input.size()
+ * size of tensor_metadata = 3 * input.size()
+ * ```
+ *
+ * For `do_truncate==false` the number of output rows depends on the
+ * number of tokens resolved and the `stride` value which may repeat tokens
+ * in subsequent overflow rows.
+ *
+ * @throw cudf::logic_error if `stride > max_sequence_length`
+ * @throw std::overflow_error if `max_sequence_length * max_rows_tensor`
+ *        exceeds the column size limit
+ *
+ * @param input The input tokens from wordpiece tokenizer or similar algorithm
+ * @param max_sequence_length Limit of the number of token-ids per row in the output
+ * @param stride Each output row will replicate the `max_sequence_length - stride`
+ *        token-ids from the previous row, unless it is the first row.
+ * @param do_truncate If true, the tokenizer will discard all the token-ids after
+ *        `max_sequence_length` for each input string. If false, it will use a new row
+ *        in the output token-ids to continue generating the output.
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Memory resource to allocate any returned objects.
+ * @return token-ids, attention-mask, and metadata
+ */
+tokenizer_result tokenized_to_tensor(
+  cudf::lists_column_view const& input,
+  cudf::size_type max_sequence_length,
+  cudf::size_type stride,
   bool do_truncate,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());

--- a/cpp/src/text/subword/subword_tokenize.cu
+++ b/cpp/src/text/subword/subword_tokenize.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/get_value.cuh>
+#include <cudf/detail/iterator.cuh>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/sequence.hpp>
+#include <cudf/detail/sizes_to_offsets_iterator.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -33,6 +35,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/functional>
 #include <thrust/for_each.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -58,15 +61,16 @@ namespace {
  * @param[out] attn_mask Identifies valid token id entries
  * @param[out] metadata Additional data per row
  */
+template <typename InputType, typename OffsetType>
 CUDF_KERNEL void kernel_compute_tensor_metadata(
   // input
-  uint32_t const* token_ids,
-  int64_t const* offsets,
-  uint32_t const* row2tensor,
-  uint32_t const* row2row_within_tensor,
-  uint32_t max_sequence_length,
-  uint32_t nrows_tensor_token_ids,
-  uint32_t stride,
+  InputType const* token_ids,
+  OffsetType const* offsets,
+  InputType const* row2tensor,
+  InputType const* row2row_within_tensor,
+  InputType max_sequence_length,
+  int64_t nrows_tensor_token_ids,
+  InputType stride,
   bool do_truncate,
   // output
   uint32_t* final_tensor,
@@ -75,18 +79,18 @@ CUDF_KERNEL void kernel_compute_tensor_metadata(
 {
   auto const output_idx = cudf::detail::grid_1d::global_thread_id();
 
-  uint32_t const absolute_row_id = output_idx / max_sequence_length;
+  auto const absolute_row_id = output_idx / max_sequence_length;
   if (absolute_row_id >= nrows_tensor_token_ids) { return; }
-  uint32_t const tensor_id               = row2tensor[absolute_row_id];
-  uint32_t const row_within_tensor       = row2row_within_tensor[absolute_row_id];
-  uint32_t const offset_token_ids_tensor = offsets[tensor_id];
-  uint32_t const n_tokens_tensor         = offsets[tensor_id + 1] - offset_token_ids_tensor;
+  auto const tensor_id               = row2tensor[absolute_row_id];
+  auto const row_within_tensor       = row2row_within_tensor[absolute_row_id];
+  auto const offset_token_ids_tensor = offsets[tensor_id];
+  auto const n_tokens_tensor         = offsets[tensor_id + 1] - offset_token_ids_tensor;
   // check for last row within tensor
   bool const last_row_of_tensor = (absolute_row_id == nrows_tensor_token_ids - 1) ||
                                   (row2tensor[absolute_row_id + 1] != tensor_id);
   // compute input offset to retrieve token ids
-  uint32_t const token_idx = output_idx % max_sequence_length;
-  uint32_t const row_offset_token_ids =
+  auto const token_idx = output_idx % max_sequence_length;
+  auto const row_offset_token_ids =
     offset_token_ids_tensor + token_idx +
     (row_within_tensor ? (max_sequence_length + (stride * (row_within_tensor - 1))) : 0);
 
@@ -101,7 +105,7 @@ CUDF_KERNEL void kernel_compute_tensor_metadata(
       attn_mask[output_idx]    = 0;
     }
   } else {
-    uint32_t const n_replicates = max_sequence_length - stride;
+    auto const n_replicates = max_sequence_length - stride;
     if ((row_offset_token_ids - n_replicates) < (offset_token_ids_tensor + n_tokens_tensor)) {
       // replicate elements from previous row or copy new tokens
       final_tensor[output_idx] = token_ids[row_offset_token_ids - n_replicates];
@@ -119,14 +123,18 @@ CUDF_KERNEL void kernel_compute_tensor_metadata(
     metadata[metadata_idx]     = tensor_id;
     metadata[metadata_idx + 1] = (row_within_tensor == 0) ? 0 : (max_sequence_length - stride) / 2;
     metadata[metadata_idx + 2] = [&] {
-      if (!last_row_of_tensor) return max_sequence_length - (max_sequence_length - stride) / 2 - 1;
-      if (n_tokens_tensor <= max_sequence_length)  // we fit, all good
-        return (n_tokens_tensor > 0) ? (n_tokens_tensor - 1) : 0;
-      if (do_truncate) return (max_sequence_length - 1);
+      if (!last_row_of_tensor) {
+        return static_cast<uint32_t>(max_sequence_length - (max_sequence_length - stride) / 2 - 1);
+      }
+      if (n_tokens_tensor <= max_sequence_length) {
+        // we fit, all good
+        return (n_tokens_tensor > 0) ? static_cast<uint32_t>(n_tokens_tensor - 1) : 0;
+      }
+      if (do_truncate) { return static_cast<uint32_t>(max_sequence_length - 1); }
 
       auto const final_row_value =
         (max_sequence_length - stride) + (n_tokens_tensor - max_sequence_length) % stride;
-      return (final_row_value > 0) ? (final_row_value - 1) : 0;
+      return (final_row_value > 0) ? static_cast<uint32_t>(final_row_value - 1) : 0;
     }();
   }
 }
@@ -280,6 +288,118 @@ tokenizer_result subword_tokenize(cudf::strings_column_view const& strings,
                           std::move(tensor_metadata)};
 }
 
+tokenizer_result tokenized_to_tensor(cudf::lists_column_view const& input,
+                                     cudf::size_type max_sequence_length,
+                                     cudf::size_type stride,
+                                     bool do_truncate,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::device_async_resource_ref mr)
+{
+  CUDF_EXPECTS(stride <= max_sequence_length,
+               "stride must be less than or equal to max_sequence_length",
+               std::invalid_argument);
+  if (input.size() == input.null_count()) {  // empty or all-null returns empty
+    auto empty_col = cudf::make_empty_column(cudf::type_id::UINT32);
+    auto ulen      = static_cast<uint32_t>(max_sequence_length);
+    return tokenizer_result{
+      0, ulen, std::move(empty_col), std::move(empty_col), std::move(empty_col)};
+  }
+  CUDF_EXPECTS(max_sequence_length <= (std::numeric_limits<cudf::size_type>::max() / input.size()),
+               "max_sequence_length times number of input rows exceeds the column size limit",
+               std::overflow_error);
+
+  auto token_ids       = cudf::column_device_view::create(input.child(), stream);
+  auto d_token_ids     = token_ids->data<cudf::size_type>();
+  auto token_offsets   = cudf::column_device_view::create(input.offsets(), stream);
+  auto d_token_offsets = token_offsets->data<cudf::size_type>();
+
+  // compute tensor offsets using existing offsets and accounting for the
+  // stride, max_sequence_length, and do_truncate
+  auto offsets_per_tensor   = rmm::device_uvector<cudf::size_type>(input.size() + 1, stream);
+  auto d_offsets_per_tensor = offsets_per_tensor.data();
+  thrust::transform(
+    rmm::exec_policy_nosync(stream),
+    thrust::counting_iterator<cudf::size_type>(0),
+    thrust::counting_iterator<cudf::size_type>(input.size()),
+    d_offsets_per_tensor,
+    cuda::proclaim_return_type<cudf::size_type>(
+      [d_token_offsets, do_truncate, max_sequence_length, stride] __device__(auto idx) {
+        auto const num_tokens = d_token_offsets[idx + 1] - d_token_offsets[idx];
+        if (do_truncate || num_tokens <= max_sequence_length) return cudf::size_type{1};
+        return 1 + ((num_tokens - max_sequence_length + stride - 1) / stride);
+      }));
+
+  auto nrows_tensor_token_ids = cudf::detail::sizes_to_offsets(
+    offsets_per_tensor.begin(), offsets_per_tensor.end(), offsets_per_tensor.begin(), 0, stream);
+
+  // if there are no tokens at all, build a specific empty result
+  if (nrows_tensor_token_ids == 0) {
+    return build_empty_result(input.size(), max_sequence_length, stream, mr);
+  }
+
+  // label row to tensor and row within tensor row
+  auto row2tensor            = rmm::device_uvector<cudf::size_type>(nrows_tensor_token_ids, stream);
+  auto d_row2tensor          = row2tensor.data();
+  auto row2row_within_tensor = rmm::device_uvector<cudf::size_type>(nrows_tensor_token_ids, stream);
+  auto d_row2row_within_tensor = row2row_within_tensor.data();
+  thrust::for_each_n(
+    rmm::exec_policy(stream),
+    thrust::counting_iterator<cudf::size_type>(0),
+    input.size(),
+    [d_offsets_per_tensor, d_row2tensor, d_row2row_within_tensor] __device__(auto idx) {
+      auto const offset = d_offsets_per_tensor[idx];
+      auto const size   = d_offsets_per_tensor[idx + 1] - offset;
+      for (auto jdx = 0; jdx < size; ++jdx) {
+        d_row2tensor[jdx + offset]            = idx;
+        d_row2row_within_tensor[jdx + offset] = jdx;
+      }
+    });
+
+  // create output data columns
+  auto tensor_token_ids = cudf::make_numeric_column(cudf::data_type{cudf::type_id::UINT32},
+                                                    nrows_tensor_token_ids * max_sequence_length,
+                                                    cudf::mask_state::UNALLOCATED,
+                                                    stream,
+                                                    mr);
+  auto tensor_attention_mask =
+    cudf::make_numeric_column(cudf::data_type{cudf::type_id::UINT32},
+                              nrows_tensor_token_ids * max_sequence_length,
+                              cudf::mask_state::UNALLOCATED,
+                              stream,
+                              mr);
+  auto tensor_metadata = cudf::make_numeric_column(cudf::data_type{cudf::type_id::UINT32},
+                                                   nrows_tensor_token_ids * 3,
+                                                   cudf::mask_state::UNALLOCATED,
+                                                   stream,
+                                                   mr);
+
+  // compute final tensor, mask, and metadata
+  constexpr int block_size = 256;
+  cudf::detail::grid_1d const grid{
+    static_cast<cudf::size_type>(nrows_tensor_token_ids * max_sequence_length), block_size};
+  kernel_compute_tensor_metadata<<<grid.num_blocks,
+                                   grid.num_threads_per_block,
+                                   0,
+                                   stream.value()>>>(
+    d_token_ids,
+    d_token_offsets,
+    d_row2tensor,
+    d_row2row_within_tensor,
+    max_sequence_length,
+    nrows_tensor_token_ids,
+    stride,
+    do_truncate,
+    tensor_token_ids->mutable_view().data<uint32_t>(),
+    tensor_attention_mask->mutable_view().data<uint32_t>(),
+    tensor_metadata->mutable_view().data<uint32_t>());
+
+  return tokenizer_result{static_cast<uint32_t>(nrows_tensor_token_ids),
+                          static_cast<uint32_t>(max_sequence_length),
+                          std::move(tensor_token_ids),
+                          std::move(tensor_attention_mask),
+                          std::move(tensor_metadata)};
+}
+
 }  // namespace detail
 
 tokenizer_result subword_tokenize(cudf::strings_column_view const& strings,
@@ -294,6 +414,17 @@ tokenizer_result subword_tokenize(cudf::strings_column_view const& strings,
   CUDF_FUNC_RANGE();
   return detail::subword_tokenize(
     strings, vocabulary_table, max_sequence_length, stride, do_lower_case, do_truncate, stream, mr);
+}
+
+tokenizer_result tokenized_to_tensor(cudf::lists_column_view const& input,
+                                     cudf::size_type max_sequence_length,
+                                     cudf::size_type stride,
+                                     bool do_truncate,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+  return detail::tokenized_to_tensor(input, max_sequence_length, stride, do_truncate, stream, mr);
 }
 
 }  // namespace nvtext


### PR DESCRIPTION
## Description
Adds new `nvtest::tokenized_to_tensor` API for compatibility of the existing subword tokenizer. The tokenizer is to be replaced with a normalizer, wordpiece tokenizer and this new API to provide the complete functions to match what the subword tokenizer currently produces.

The wordpiece tokenizer created here #17600 will produce tokens for an input strings column as a list column of integers. This list column can be provided to this new API to produce the existing tensor data structure containing token-ids truncated or strided as well as an attention mask and metadata.

```
nvtext::tokenizer_result nvtext::tokenized_to_tensor(
  cudf::lists_column_view const& input,
  cudf::size_type max_sequence_length,
  cudf::size_type stride,
  bool do_truncate,
  rmm::cuda_stream_view stream ,
  rmm::device_async_resource_ref mr);
```

The `nvtext::tokenizer_result` is defined here: https://github.com/rapidsai/cudf/blob/4323ae4084a81efa7fa1d7d9b4a57ce3e92e7290/cpp/include/nvtext/subword_tokenize.hpp#L77


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
