### PR TITLE
Remove deprecated nvtext::minhash_permuted APIs

### DIFF
--- a/cpp/include/nvtext/minhash.hpp
+++ b/cpp/include/nvtext/minhash.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,20 +79,6 @@ std::unique_ptr<cudf::column> minhash(
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
- * @copydoc nvtext::minhash
- *
- * @deprecated Use nvtext::minhash()
- */
-[[deprecated]] std::unique_ptr<cudf::column> minhash_permuted(
-  cudf::strings_column_view const& input,
-  uint32_t seed,
-  cudf::device_span<uint32_t const> parameter_a,
-  cudf::device_span<uint32_t const> parameter_b,
-  cudf::size_type width,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
-
-/**
  * @brief Returns the minhash values for each string
  *
  * This function uses MurmurHash3_x64_128 for the hash algorithm.
@@ -131,20 +117,6 @@ std::unique_ptr<cudf::column> minhash(
  * @return List column of minhash values for each string per seed
  */
 std::unique_ptr<cudf::column> minhash64(
-  cudf::strings_column_view const& input,
-  uint64_t seed,
-  cudf::device_span<uint64_t const> parameter_a,
-  cudf::device_span<uint64_t const> parameter_b,
-  cudf::size_type width,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
-
-/**
- * @copydoc nvtext::minhash64
- *
- * @deprecated Use nvtext::minhash64()
- */
-[[deprecated]] std::unique_ptr<cudf::column> minhash64_permuted(
   cudf::strings_column_view const& input,
   uint64_t seed,
   cudf::device_span<uint64_t const> parameter_a,

--- a/cpp/src/text/minhash.cu
+++ b/cpp/src/text/minhash.cu
@@ -72,7 +72,7 @@ constexpr cudf::size_type blocks_per_string = 64;
  *
  * This kernel computes the hashes for each string using the seed and the specified
  * hash function. The width is used to compute rolling substrings to hash over.
- * The hashes are stored in d_hashes to be used in the minhash_permuted_kernel.
+ * The hashes are stored in d_hashes to be used in the minhash_kernel.
  *
  * This kernel also counts the number of strings above the wide_string_threshold
  * and proactively initializes the output values for those strings.
@@ -454,18 +454,6 @@ std::unique_ptr<cudf::column> minhash(cudf::strings_column_view const& input,
   return detail::minhash(input, seed, parameter_a, parameter_b, width, stream, mr);
 }
 
-std::unique_ptr<cudf::column> minhash_permuted(cudf::strings_column_view const& input,
-                                               uint32_t seed,
-                                               cudf::device_span<uint32_t const> parameter_a,
-                                               cudf::device_span<uint32_t const> parameter_b,
-                                               cudf::size_type width,
-                                               rmm::cuda_stream_view stream,
-                                               rmm::device_async_resource_ref mr)
-{
-  CUDF_FUNC_RANGE();
-  return detail::minhash(input, seed, parameter_a, parameter_b, width, stream, mr);
-}
-
 std::unique_ptr<cudf::column> minhash64(cudf::strings_column_view const& input,
                                         uint64_t seed,
                                         cudf::device_span<uint64_t const> parameter_a,
@@ -473,18 +461,6 @@ std::unique_ptr<cudf::column> minhash64(cudf::strings_column_view const& input,
                                         cudf::size_type width,
                                         rmm::cuda_stream_view stream,
                                         rmm::device_async_resource_ref mr)
-{
-  CUDF_FUNC_RANGE();
-  return detail::minhash64(input, seed, parameter_a, parameter_b, width, stream, mr);
-}
-
-std::unique_ptr<cudf::column> minhash64_permuted(cudf::strings_column_view const& input,
-                                                 uint64_t seed,
-                                                 cudf::device_span<uint64_t const> parameter_a,
-                                                 cudf::device_span<uint64_t const> parameter_b,
-                                                 cudf::size_type width,
-                                                 rmm::cuda_stream_view stream,
-                                                 rmm::device_async_resource_ref mr)
 {
   CUDF_FUNC_RANGE();
   return detail::minhash64(input, seed, parameter_a, parameter_b, width, stream, mr);


### PR DESCRIPTION
## Description
Removes `nvtext::minhash_permuted` and `nvtext::minhash64_permuted` APIs deprecated in the previous release.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
