### PR TITLE
Get rid of the deprecated `thrust::identity`

### DIFF
--- a/cpp/benchmarks/common/generate_input.cu
+++ b/cpp/benchmarks/common/generate_input.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
-#include <thrust/functional.h>
 #include <thrust/gather.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
@@ -511,7 +510,7 @@ std::unique_ptr<cudf::column> create_random_column(data_profile const& profile,
   auto [result_bitmask, null_count] =
     cudf::detail::valid_if(null_mask.begin(),
                            null_mask.end(),
-                           thrust::identity<bool>{},
+                           cuda::std::identity{},
                            cudf::get_default_stream(),
                            cudf::get_current_device_resource_ref());
 
@@ -600,7 +599,7 @@ std::unique_ptr<cudf::column> create_random_utf8_string_column(data_profile cons
   auto [result_bitmask, null_count] =
     profile.get_null_probability().has_value()
       ? cudf::detail::valid_if(
-          null_mask.begin(), null_mask.end() - 1, thrust::identity<bool>{}, stream, mr)
+          null_mask.begin(), null_mask.end() - 1, cuda::std::identity{}, stream, mr)
       : std::pair{rmm::device_buffer{}, 0};
 
   return cudf::make_strings_column(
@@ -693,7 +692,7 @@ std::unique_ptr<cudf::column> create_random_column<cudf::struct_view>(data_profi
           auto valids = valid_dist(engine, num_rows);
           return cudf::detail::valid_if(valids.begin(),
                                         valids.end(),
-                                        thrust::identity<bool>{},
+                                        cuda::std::identity{},
                                         cudf::get_default_stream(),
                                         cudf::get_current_device_resource_ref());
         }
@@ -787,7 +786,7 @@ std::unique_ptr<cudf::column> create_random_column<cudf::list_view>(data_profile
 
     auto [null_mask, null_count] = cudf::detail::valid_if(valids.begin(),
                                                           valids.end(),
-                                                          thrust::identity<bool>{},
+                                                          cuda::std::identity{},
                                                           cudf::get_default_stream(),
                                                           cudf::get_current_device_resource_ref());
     list_column                  = cudf::make_lists_column(

--- a/cpp/benchmarks/groupby/group_max_multithreaded.cpp
+++ b/cpp/benchmarks/groupby/group_max_multithreaded.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ void bench_groupby_max_multithreaded(nvbench::state& state, nvbench::type_list<T
       thread_requests.emplace_back();
       thread_requests.back().values = vals->view();
       thread_requests.back().aggregations.push_back(
-        cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+        cudf::make_max_aggregation<cudf::groupby_aggregation>());
     }
   }
 
@@ -90,9 +90,9 @@ void bench_groupby_max_multithreaded(nvbench::state& state, nvbench::type_list<T
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }
 
-NVBENCH_BENCH_TYPES(bench_groupby_sum_multithreaded,
+NVBENCH_BENCH_TYPES(bench_groupby_max_multithreaded,
                     NVBENCH_TYPE_AXES(nvbench::type_list<int32_t, int64_t, float, double>))
-  .set_name("groupby_sum_multithreaded")
+  .set_name("groupby_max_multithreaded")
   .add_int64_axis("cardinality", {0})
   .add_int64_power_of_two_axis("num_rows", {12, 18})
   .add_float64_axis("null_probability", {0, 0.1, 0.9})

--- a/cpp/benchmarks/groupby/group_max_multithreaded.cpp
+++ b/cpp/benchmarks/groupby/group_max_multithreaded.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ void bench_groupby_max_multithreaded(nvbench::state& state, nvbench::type_list<T
       thread_requests.emplace_back();
       thread_requests.back().values = vals->view();
       thread_requests.back().aggregations.push_back(
-        cudf::make_max_aggregation<cudf::groupby_aggregation>());
+        cudf::make_sum_aggregation<cudf::groupby_aggregation>());
     }
   }
 
@@ -90,9 +90,9 @@ void bench_groupby_max_multithreaded(nvbench::state& state, nvbench::type_list<T
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }
 
-NVBENCH_BENCH_TYPES(bench_groupby_max_multithreaded,
+NVBENCH_BENCH_TYPES(bench_groupby_sum_multithreaded,
                     NVBENCH_TYPE_AXES(nvbench::type_list<int32_t, int64_t, float, double>))
-  .set_name("groupby_max_multithreaded")
+  .set_name("groupby_sum_multithreaded")
   .add_int64_axis("cardinality", {0})
   .add_int64_power_of_two_axis("num_rows", {12, 18})
   .add_float64_axis("null_probability", {0, 0.1, 0.9})

--- a/cpp/benchmarks/join/join_common.hpp
+++ b/cpp/benchmarks/join/join_common.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <thrust/functional.h>
+#include <cuda/std/functional>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/random/linear_congruential_engine.h>
@@ -85,7 +85,7 @@ void BM_join(state_type& state, Join JoinFunc)
       thrust::make_transform_iterator(thrust::make_counting_iterator(0), null75_generator{});
     return cudf::detail::valid_if(validity,
                                   validity + size,
-                                  thrust::identity<bool>{},
+                                  cuda::std::identity{},
                                   cudf::get_default_stream(),
                                   cudf::get_current_device_resource_ref());
   };

--- a/cpp/include/cudf/detail/utilities/cast_functor.cuh
+++ b/cpp/include/cudf/detail/utilities/cast_functor.cuh
@@ -41,7 +41,7 @@ struct cast_fn {
   {
     return T{cuda::std::forward<U>(val)};
   }
-  
+
   CUDF_HOST_DEVICE constexpr T&& operator()(T&& val) const noexcept
   {
     return cuda::std::forward<T>(val);

--- a/cpp/include/cudf/detail/utilities/cast_functor.cuh
+++ b/cpp/include/cudf/detail/utilities/cast_functor.cuh
@@ -39,7 +39,7 @@ struct cast_fn {
   template <typename U>
   CUDF_HOST_DEVICE constexpr T operator()(U&& val) const
   {
-    return T{static_cast<T>(cuda::std::forward<U>(val))};
+    return static_cast<T>(cuda::std::forward<U>(val));
   }
 
   CUDF_HOST_DEVICE constexpr T&& operator()(T&& val) const noexcept

--- a/cpp/include/cudf/detail/utilities/cast_functor.cuh
+++ b/cpp/include/cudf/detail/utilities/cast_functor.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,18 @@
 
 namespace cudf {
 namespace detail {
+
+/**
+ * @brief Functor that casts a primitive input value to a specified type
+ */
+template <typename T>
+struct cast_fn {
+  template <typename U>
+  CUDF_HOST_DEVICE constexpr T operator()(U val) const
+  {
+    return static_cast<T>(val);
+  }
+};
 
 /**
  * @brief Functor that casts another functor's result to a specified type.

--- a/cpp/include/cudf/detail/utilities/cast_functor.cuh
+++ b/cpp/include/cudf/detail/utilities/cast_functor.cuh
@@ -37,9 +37,14 @@ namespace detail {
 template <typename T>
 struct cast_fn {
   template <typename U>
-  CUDF_HOST_DEVICE constexpr T operator()(U val) const
+  CUDF_HOST_DEVICE constexpr T operator()(U&& val) const
   {
-    return static_cast<T>(val);
+    return T{cuda::std::forward<U>(val)};
+  }
+  
+  CUDF_HOST_DEVICE constexpr T&& operator()(T&& val) const noexcept
+  {
+    return cuda::std::forward<T>(val);
   }
 };
 

--- a/cpp/include/cudf/detail/utilities/cast_functor.cuh
+++ b/cpp/include/cudf/detail/utilities/cast_functor.cuh
@@ -39,7 +39,7 @@ struct cast_fn {
   template <typename U>
   CUDF_HOST_DEVICE constexpr T operator()(U&& val) const
   {
-    return T{cuda::std::forward<U>(val)};
+    return T{static_cast<T>(cuda::std::forward<U>(val))};
   }
 
   CUDF_HOST_DEVICE constexpr T&& operator()(T&& val) const noexcept

--- a/cpp/include/cudf/reduction/detail/reduction_operators.cuh
+++ b/cpp/include/cudf/reduction/detail/reduction_operators.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,10 @@
 #pragma once
 
 #include <cudf/detail/iterator.cuh>
+#include <cudf/detail/utilities/cast_functor.cuh>
 #include <cudf/detail/utilities/device_operators.cuh>
 #include <cudf/detail/utilities/transform_unary_functions.cuh>
 #include <cudf/types.hpp>  //for CUDF_HOST_DEVICE
-
-#include <thrust/functional.h>
 
 #include <cmath>
 
@@ -156,7 +155,7 @@ struct sum : public simple_op<sum> {
   using op = cudf::DeviceSum;
 
   template <typename ResultType>
-  using transformer = thrust::identity<ResultType>;
+  using transformer = cudf::detail::cast_fn<ResultType>;
 };
 
 // operator for `product`
@@ -164,7 +163,7 @@ struct product : public simple_op<product> {
   using op = cudf::DeviceProduct;
 
   template <typename ResultType>
-  using transformer = thrust::identity<ResultType>;
+  using transformer = cudf::detail::cast_fn<ResultType>;
 };
 
 // operator for `sum_of_squares`
@@ -180,7 +179,7 @@ struct min : public simple_op<min> {
   using op = cudf::DeviceMin;
 
   template <typename ResultType>
-  using transformer = thrust::identity<ResultType>;
+  using transformer = cudf::detail::cast_fn<ResultType>;
 };
 
 // operator for `max`
@@ -188,7 +187,7 @@ struct max : public simple_op<max> {
   using op = cudf::DeviceMax;
 
   template <typename ResultType>
-  using transformer = thrust::identity<ResultType>;
+  using transformer = cudf::detail::cast_fn<ResultType>;
 };
 
 /**
@@ -246,7 +245,7 @@ struct mean : public compound_op<mean> {
   using op = cudf::DeviceSum;
 
   template <typename ResultType>
-  using transformer = thrust::identity<ResultType>;
+  using transformer = cudf::detail::cast_fn<ResultType>;
 
   template <typename ResultType>
   struct intermediate {

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,8 @@
 
 #include <rmm/device_buffer.hpp>
 
+#include <cuda/std/functional>
 #include <thrust/copy.h>
-#include <thrust/functional.h>
 #include <thrust/host_vector.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -1645,8 +1645,11 @@ class lists_column_wrapper : public detail::column_wrapper {
 
     // concatenate them together, skipping children that are null.
     std::vector<column_view> children;
-    thrust::copy_if(
-      std::cbegin(cols), std::cend(cols), valids, std::back_inserter(children), thrust::identity{});
+    thrust::copy_if(std::cbegin(cols),
+                    std::cend(cols),
+                    valids,
+                    std::back_inserter(children),
+                    cuda::std::identity{});
 
     auto data = children.empty() ? cudf::empty_like(expected_hierarchy)
                                  : cudf::concatenate(children,

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <thrust/functional.h>
+#include <cuda/std/functional>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
@@ -180,7 +180,7 @@ std::unique_ptr<column> group_merge_m2(column_view const& values,
   // Generate bitmask for the output.
   // Only mean and M2 values can be nullable. Count column must be non-nullable.
   auto [null_mask, null_count] =
-    cudf::detail::valid_if(validities.begin(), validities.end(), thrust::identity{}, stream, mr);
+    cudf::detail::valid_if(validities.begin(), validities.end(), cuda::std::identity{}, stream, mr);
   if (null_count > 0) {
     result_means->set_null_mask(null_mask, null_count, stream);   // copy null_mask
     result_M2s->set_null_mask(std::move(null_mask), null_count);  // take over null_mask

--- a/cpp/src/groupby/sort/group_scan_util.cuh
+++ b/cpp/src/groupby/sort/group_scan_util.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/structs/utilities.hpp>
+#include <cudf/detail/utilities/cast_functor.cuh>
 #include <cudf/table/table_device_view.cuh>
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
@@ -36,7 +37,6 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
@@ -129,12 +129,12 @@ struct group_scan_functor<K, T, std::enable_if_t<is_group_scan_supported<K, T>()
     if (values.has_nulls()) {
       auto input = thrust::make_transform_iterator(
         make_null_replacement_iterator(*values_view, OpType::template identity<DeviceType>()),
-        thrust::identity<ResultDeviceType>{});
+        cudf::detail::cast_fn<ResultDeviceType>{});
       do_scan(input, result_view->begin<ResultDeviceType>(), OpType{});
       result->set_null_mask(cudf::detail::copy_bitmask(values, stream, mr), values.null_count());
     } else {
       auto input = thrust::make_transform_iterator(values_view->begin<DeviceType>(),
-                                                   thrust::identity<ResultDeviceType>{});
+                                                   cudf::detail::cast_fn<ResultDeviceType>{});
       do_scan(input, result_view->begin<ResultDeviceType>(), OpType{});
     }
     return result;

--- a/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
+++ b/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <thrust/functional.h>
+#include <cuda/std/functional>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/reduce.h>
@@ -204,7 +204,7 @@ struct group_reduction_functor<
                    thrust::logical_or{});
 
       auto [null_mask, null_count] =
-        cudf::detail::valid_if(validity.begin(), validity.end(), thrust::identity{}, stream, mr);
+        cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
       result->set_null_mask(std::move(null_mask), null_count);
     }
     return result;
@@ -257,7 +257,7 @@ struct group_reduction_functor<
                    thrust::logical_or{});
 
       auto [null_mask, null_count] =
-        cudf::detail::valid_if(validity.begin(), validity.end(), thrust::identity{}, stream, mr);
+        cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);
       result->set_null_mask(std::move(null_mask), null_count);
     }
 

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,7 +165,7 @@ sort_groupby_helper::index_vector const& sort_groupby_helper::group_offsets(
                                  itr + size,
                                  result.begin(),
                                  group_offsets->begin(),
-                                 thrust::identity<bool>{});
+                                 cuda::std::identity{});
   } else {
     auto const d_key_equal = comparator.equal_to<false>(
       cudf::nullate::DYNAMIC{cudf::has_nested_nulls(_keys)}, null_equality::EQUAL);

--- a/cpp/src/io/json/json_normalization.cu
+++ b/cpp/src/io/json/json_normalization.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@
 
 #include <cub/device/device_copy.cuh>
 #include <cuda/atomic>
+#include <cuda/std/functional>
 #include <thrust/binary_search.h>
 #include <thrust/distance.h>
 #include <thrust/gather.h>
@@ -442,7 +443,7 @@ std::
                     inbuf.begin(),
                     inbuf.end(),
                     stencil.begin(),
-                    thrust::identity<int>());
+                    cuda::std::identity{});
   inbuf.resize(inbuf_size - num_deletions, stream);
 
   thrust::exclusive_scan(rmm::exec_policy_nosync(stream),

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/functional>
 #include <thrust/count.h>
-#include <thrust/functional.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
@@ -357,7 +357,7 @@ std::size_t get_full_join_size(
     left_join_complement_size = thrust::count_if(rmm::exec_policy(stream),
                                                  invalid_index_map->begin(),
                                                  invalid_index_map->end(),
-                                                 thrust::identity());
+                                                 cuda::std::identity());
   }
   return join_size + left_join_complement_size;
 }

--- a/cpp/src/join/join_utils.cu
+++ b/cpp/src/join/join_utils.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/functional>
 #include <thrust/copy.h>
-#include <thrust/functional.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/scatter.h>
@@ -141,7 +141,7 @@ get_left_join_indices_complement(std::unique_ptr<rmm::device_uvector<size_type>>
                                               thrust::make_counting_iterator(end_counter),
                                               invalid_index_map->begin(),
                                               right_indices_complement->begin(),
-                                              thrust::identity{}) -
+                                              cuda::std::identity{}) -
                               right_indices_complement->begin();
     right_indices_complement->resize(indices_count, stream);
   }

--- a/cpp/src/lists/combine/concatenate_list_elements.cu
+++ b/cpp/src/lists/combine/concatenate_list_elements.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@
 #include <cuda/functional>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
-#include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/logical.h>
 #include <thrust/scan.h>
@@ -227,7 +226,7 @@ std::unique_ptr<column> concatenate_lists_nullifying_rows(column_view const& inp
   auto list_entries =
     gather_list_entries(input, offsets_view, num_rows, num_output_entries, stream, mr);
   auto [null_mask, null_count] = cudf::detail::valid_if(
-    list_validities.begin(), list_validities.end(), thrust::identity{}, stream, mr);
+    list_validities.begin(), list_validities.end(), cuda::std::identity{}, stream, mr);
 
   return make_lists_column(num_rows,
                            std::move(list_offsets),

--- a/cpp/src/lists/interleave_columns.cu
+++ b/cpp/src/lists/interleave_columns.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@
 #include <thrust/copy.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
-#include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
@@ -282,7 +281,7 @@ struct interleave_list_entries_impl<T, std::enable_if_t<cudf::is_fixed_width<T>(
 
     if (data_has_null_mask) {
       auto [null_mask, null_count] = cudf::detail::valid_if(
-        validities.begin(), validities.end(), thrust::identity{}, stream, mr);
+        validities.begin(), validities.end(), cuda::std::identity{}, stream, mr);
       if (null_count > 0) { output->set_null_mask(std::move(null_mask), null_count); }
     }
 
@@ -381,7 +380,7 @@ std::unique_ptr<column> interleave_columns(table_view const& input,
   }
 
   auto [null_mask, null_count] = cudf::detail::valid_if(
-    list_validities.begin(), list_validities.end(), thrust::identity{}, stream, mr);
+    list_validities.begin(), list_validities.end(), cuda::std::identity{}, stream, mr);
   return make_lists_column(num_output_lists,
                            std::move(list_offsets),
                            std::move(list_entries),

--- a/cpp/src/reductions/scan/scan_inclusive.cu
+++ b/cpp/src/reductions/scan/scan_inclusive.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,8 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/functional>
 #include <thrust/find.h>
-#include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/scan.h>
 
@@ -57,7 +57,7 @@ std::pair<rmm::device_buffer, size_type> mask_scan(column_view const& input_view
   auto first_null_position = [&] {
     size_type const first_null =
       thrust::find_if_not(
-        rmm::exec_policy(stream), valid_itr, valid_itr + input_view.size(), thrust::identity{}) -
+        rmm::exec_policy(stream), valid_itr, valid_itr + input_view.size(), cuda::std::identity{}) -
       valid_itr;
     size_type const exclusive_offset = (inclusive == scan_type::EXCLUSIVE) ? 1 : 0;
     return std::min(input_view.size(), first_null + exclusive_offset);

--- a/cpp/src/sort/rank.cu
+++ b/cpp/src/sort/rank.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@
 
 #include <cuda/functional>
 #include <cuda/std/type_traits>
-#include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/permutation_iterator.h>
@@ -204,7 +203,7 @@ void rank_min(cudf::device_span<size_type const> group_keys,
                                        sorted_order_view,
                                        rank_mutable_view.begin<outputType>(),
                                        thrust::minimum{},
-                                       thrust::identity{},
+                                       cuda::std::identity{},
                                        stream);
 }
 
@@ -222,7 +221,7 @@ void rank_max(cudf::device_span<size_type const> group_keys,
                                        sorted_order_view,
                                        rank_mutable_view.begin<outputType>(),
                                        thrust::maximum{},
-                                       thrust::identity{},
+                                       cuda::std::identity{},
                                        stream);
 }
 

--- a/cpp/src/stream_compaction/unique.cu
+++ b/cpp/src/stream_compaction/unique.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/functional>
 #include <thrust/copy.h>
 #include <thrust/distance.h>
 #include <thrust/execution_policy.h>
@@ -87,7 +88,7 @@ std::unique_ptr<table> unique(table_view const& input,
                                         itr + num_rows,
                                         d_results.begin(),
                                         mutable_view->begin<size_type>(),
-                                        thrust::identity<bool>{});
+                                        cuda::std::identity{});
       return static_cast<size_type>(thrust::distance(mutable_view->begin<size_type>(), result_end));
     } else {
       // Using thrust::unique_copy with the comparator directly will compile more slowly but

--- a/cpp/src/strings/search/contains_multiple.cu
+++ b/cpp/src/strings/search/contains_multiple.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -180,7 +180,7 @@ CUDF_KERNEL void multi_contains_kernel(column_device_view const d_strings,
     for (auto target_idx = lane_idx; target_idx < num_targets; target_idx += tile_size) {
       auto const begin = bools + (target_idx * tile_size);
       d_results[target_idx][str_idx] =
-        thrust::any_of(thrust::seq, begin, begin + tile_size, thrust::identity<bool>{});
+        thrust::any_of(thrust::seq, begin, begin + tile_size, cuda::std::identity{});
       // cooperative_group any() implementation was almost 3x slower than this parallel reduce
     }
   }

--- a/cpp/tests/iterator/iterator_tests.cuh
+++ b/cpp/tests/iterator/iterator_tests.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,10 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_reduce.cuh>
+#include <cuda/std/functional>
 #include <thrust/distance.h>
 #include <thrust/equal.h>
 #include <thrust/execution_policy.h>
-#include <thrust/functional.h>
 #include <thrust/host_vector.h>
 #include <thrust/logical.h>
 #include <thrust/transform.h>
@@ -102,7 +102,7 @@ struct IteratorTest : public cudf::test::BaseFixture {
     auto result = thrust::all_of(rmm::exec_policy(cudf::get_default_stream()),
                                  dev_results.begin(),
                                  dev_results.end(),
-                                 thrust::identity<bool>{});
+                                 cuda::std::identity{});
     EXPECT_TRUE(result) << "thrust test";
   }
 

--- a/cpp/tests/iterator/value_iterator_test_transform.cu
+++ b/cpp/tests/iterator/value_iterator_test_transform.cu
@@ -16,11 +16,20 @@
 
 #include <cudf_test/random.hpp>
 
-#include <cuda/std/functional>
+#include <cuda/functional>
 #include <thrust/host_vector.h>
 #include <thrust/iterator/transform_iterator.h>
 
 struct TransformedIteratorTest : public IteratorTest<int8_t> {};
+
+template <typename T>
+struct cast_fn {
+  template <typename U>
+  __device__ T operator()(U const& val) const
+  {
+    return static_cast<T>(val);
+  }
+};
 
 // Tests up cast reduction with null iterator.
 // The up cast iterator will be created by transform_iterator and
@@ -57,7 +66,7 @@ TEST_F(TransformedIteratorTest, null_iterator_upcast)
 
   // GPU test
   auto it_dev        = cudf::detail::make_null_replacement_iterator(*d_col, T{0});
-  auto it_dev_upcast = thrust::make_transform_iterator(it_dev, cuda::std::identity{});
+  auto it_dev_upcast = thrust::make_transform_iterator(it_dev, cast_fn<T_upcast>{});
   this->iterator_test_thrust(replaced_array, it_dev_upcast, d_col->size());
   this->iterator_test_cub(expected_value, it_dev, d_col->size());
 }
@@ -100,7 +109,7 @@ TEST_F(TransformedIteratorTest, null_iterator_square)
 
   // GPU test
   auto it_dev         = cudf::detail::make_null_replacement_iterator(*d_col, T{0});
-  auto it_dev_upcast  = thrust::make_transform_iterator(it_dev, cuda::std::identity{});
+  auto it_dev_upcast  = thrust::make_transform_iterator(it_dev, cast_fn<T_upcast>{});
   auto it_dev_squared = thrust::make_transform_iterator(it_dev_upcast, transformer);
   this->iterator_test_thrust(replaced_array, it_dev_squared, d_col->size());
   this->iterator_test_cub(expected_value, it_dev_squared, d_col->size());

--- a/cpp/tests/iterator/value_iterator_test_transform.cu
+++ b/cpp/tests/iterator/value_iterator_test_transform.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 #include <cudf_test/random.hpp>
 
-#include <thrust/functional.h>
+#include <cuda/std/functional>
 #include <thrust/host_vector.h>
 #include <thrust/iterator/transform_iterator.h>
 
@@ -57,7 +57,7 @@ TEST_F(TransformedIteratorTest, null_iterator_upcast)
 
   // GPU test
   auto it_dev        = cudf::detail::make_null_replacement_iterator(*d_col, T{0});
-  auto it_dev_upcast = thrust::make_transform_iterator(it_dev, thrust::identity<T_upcast>());
+  auto it_dev_upcast = thrust::make_transform_iterator(it_dev, cuda::std::identity{});
   this->iterator_test_thrust(replaced_array, it_dev_upcast, d_col->size());
   this->iterator_test_cub(expected_value, it_dev, d_col->size());
 }
@@ -100,7 +100,7 @@ TEST_F(TransformedIteratorTest, null_iterator_square)
 
   // GPU test
   auto it_dev         = cudf::detail::make_null_replacement_iterator(*d_col, T{0});
-  auto it_dev_upcast  = thrust::make_transform_iterator(it_dev, thrust::identity<T_upcast>());
+  auto it_dev_upcast  = thrust::make_transform_iterator(it_dev, cuda::std::identity{});
   auto it_dev_squared = thrust::make_transform_iterator(it_dev_upcast, transformer);
   this->iterator_test_thrust(replaced_array, it_dev_squared, d_col->size());
   this->iterator_test_cub(expected_value, it_dev_squared, d_col->size());

--- a/cpp/tests/rolling/collect_ops_test.cpp
+++ b/cpp/tests/rolling/collect_ops_test.cpp
@@ -27,7 +27,7 @@
 #include <cudf/rolling/range_window_bounds.hpp>
 #include <cudf/table/table_view.hpp>
 
-#include <thrust/functional.h>
+#include <cuda/std/functional>
 
 #include <vector>
 
@@ -455,8 +455,7 @@ TEST_F(CollectListTest, RollingWindowHonoursMinPeriodsWithDecimal)
 {
   // Test that when the number of observations is fewer than min_periods,
   // the result is null.
-  auto const input_iter =
-    cudf::detail::make_counting_transform_iterator(0, thrust::identity<int32_t>{});
+  auto const input_iter = cudf::detail::make_counting_transform_iterator(0, cuda::std::identity{});
   auto const input_column = cudf::test::fixed_point_column_wrapper<int32_t>{
     input_iter, input_iter + 6, numeric::scale_type{0}};
 

--- a/cpp/tests/rolling/collect_ops_test.cpp
+++ b/cpp/tests/rolling/collect_ops_test.cpp
@@ -455,7 +455,7 @@ TEST_F(CollectListTest, RollingWindowHonoursMinPeriodsWithDecimal)
 {
   // Test that when the number of observations is fewer than min_periods,
   // the result is null.
-  auto const input_iter = cudf::detail::make_counting_transform_iterator(0, cuda::std::identity{});
+  auto const input_iter   = thrust::counting_iterator{0};
   auto const input_column = cudf::test::fixed_point_column_wrapper<int32_t>{
     input_iter, input_iter + 6, numeric::scale_type{0}};
 

--- a/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
+++ b/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-#include <thrust/functional.h>
+#include <cuda/std/functional>
 
 struct ApplyBooleanMask : public cudf::test::BaseFixture {};
 
@@ -208,13 +208,13 @@ TEST_F(ApplyBooleanMask, FixedPointLargeColumnTest)
                   dec32_data.cend(),
                   mask_data.cbegin(),
                   std::back_inserter(expect_dec32_data),
-                  thrust::identity{});
+                  cuda::std::identity{});
   thrust::copy_if(thrust::seq,
                   dec64_data.cbegin(),
                   dec64_data.cend(),
                   mask_data.cbegin(),
                   std::back_inserter(expect_dec64_data),
-                  thrust::identity{});
+                  cuda::std::identity{});
 
   decimal32_wrapper expect_col32(
     expect_dec32_data.begin(), expect_dec32_data.end(), numeric::scale_type{-3});

--- a/cpp/tests/transform/row_bit_count_test.cu
+++ b/cpp/tests/transform/row_bit_count_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/std/functional>
 #include <thrust/fill.h>
-#include <thrust/functional.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/tabulate.h>
 #include <thrust/transform.h>
@@ -348,7 +348,7 @@ TEST_F(RowBitCount, StructsWithLists_RowsExceedingASingleBlock)
   thrust::tabulate(rmm::exec_policy(cudf::get_default_stream()),
                    ints_view.begin<int32_t>(),
                    ints_view.end<int32_t>(),
-                   thrust::identity{});
+                   cuda::std::identity{});
 
   // List offsets = {0, 2, 4, 6, 8, ..., num_rows*2};
   auto list_offsets =

--- a/cpp/tests/utilities/column_utilities.cu
+++ b/cpp/tests/utilities/column_utilities.cu
@@ -554,7 +554,7 @@ struct column_comparator_impl {
                                      input_iter + lhs_row_indices.size(),
                                      diff_map.begin(),
                                      differences.begin(),
-                                     thrust::identity<bool>{});
+                                     cuda::std::identity{});
 
     differences.resize(thrust::distance(differences.begin(), diff_iter),
                        cudf::test::get_default_stream());  // shrink back down


### PR DESCRIPTION
## Description
This PR removes the usage of the deprecated `thrust::identity` and replaces it with `cuda::std::identity` where applicable. In cases where `thrust::identity` was used as a type conversion callable and `cuda::std::identity` is not suitable, it uses a new utility called `cast_fn` in the `detail` namespace.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
