### PR TITLE
Remove pandas backend from `cudf.pandas` - ibis integration tests

### DIFF
--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_ibis.py
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_ibis.py
@@ -1,15 +1,19 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 import ibis
 import numpy as np
 import pandas as pd
 import pytest
 
-ibis.set_backend("pandas")
+from cudf.pandas import is_proxy_object
+
 ibis.options.interactive = False
 
 
 def ibis_assert_equal(expect, got, rtol: float = 1e-7, atol: float = 0.0):
+    assert is_proxy_object(got), (
+        "The result from cudf.pandas must be a proxy object"
+    )
     pd._testing.assert_almost_equal(expect, got, rtol=rtol, atol=atol)
 
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
ibis has removed their pandas backend in version 10.0.0. In their release notes,

> pandas: The pandas backend is removed. Note that pandas DataFrames are STILL VALID INPUTS AND OUTPUTS and will remain so for the foreseeable future. Please use one of the other local backends like DuckDB, Polars, or DataFusion to perform operations directly on pandas DataFrames.

This PR removes the pandas backend from the integration tests. And asserts that the inputs and outputs to ibis APIs are proxy objects.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
