### PR TITLE
[NO MRG] Test XGBoost 2.1.4 with CUDA 12.8 support

### DIFF
--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
@@ -241,9 +241,7 @@ dependencies:
           - numpy
           - scipy
           - scikit-learn
-          - pip
-          - pip:
-            - xgboost>=2.0.1
+          - xgboost==2.1.4
   test_cuml:
     common:
       - output_types: conda

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -1,5 +1,6 @@
 # Copyright (c) 2021-2025, NVIDIA CORPORATION.
 
+
 [build-system]
 build-backend = "rapids_build_backend.build"
 requires = [


### PR DESCRIPTION
Testing the recently produced packages of XGBoost 2.1.4 with CUDA 12.8 support.

xref: https://github.com/rapidsai/xgboost-feedstock/issues/79