### PR TITLE
Raise NotImplementedError for groupby.agg if duplicate columns would be created

### DIFF
--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -4115,3 +4115,19 @@ def test_scan_int_null_pandas_compatible(op):
     with cudf.option_context("mode.pandas_compatible", True):
         result = getattr(df_cudf.groupby("b")["a"], op)()
     assert_eq(result, expected)
+
+
+def test_agg_duplicate_aggs_pandas_compat_raises():
+    agg = {"b": ["mean", "mean"]}
+    dfgb = cudf.DataFrame({"a": [1, 1, 2], "b": [4, 5, 6]}).groupby(["a"])
+    with cudf.option_context("mode.pandas_compatible", True):
+        with pytest.raises(NotImplementedError):
+            dfgb.agg(agg)
+
+    result = dfgb.agg(agg)
+    expected = cudf.DataFrame(
+        [4.5, 6.0],
+        index=cudf.Index([1, 2], name="a"),
+        columns=pd.MultiIndex.from_tuples([("b", "mean")]),
+    )
+    assert_eq(result, expected)

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -4124,7 +4124,8 @@ def test_agg_duplicate_aggs_pandas_compat_raises():
         with pytest.raises(NotImplementedError):
             dfgb.agg(agg)
 
-    result = dfgb.agg(agg)
+    with pytest.warns(UserWarning):
+        result = dfgb.agg(agg)
     expected = cudf.DataFrame(
         [4.5, 6.0],
         index=cudf.Index([1, 2], name="a"),


### PR DESCRIPTION
## Description
xref https://github.com/rapidsai/cudf/issues/17649

For `cudf.pandas`, we will dispatch to pandas instead of silently dropping the duplicate column

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
