### PR TITLE
Use Conda XGBoost

### DIFF
--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
@@ -242,8 +242,7 @@ dependencies:
           - scipy
           - scikit-learn
           - pip
-          - pip:
-            - xgboost>=2.0.1
+          - xgboost>=2.0.1
   test_cuml:
     common:
       - output_types: conda


### PR DESCRIPTION
## Description

Switch to Conda XGBoost in Conda-based test of third-party dependencies.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
