### PR TITLE
Fix the index type in the indexing operator of the span types

### DIFF
--- a/cpp/include/cudf/utilities/span.hpp
+++ b/cpp/include/cudf/utilities/span.hpp
@@ -278,7 +278,11 @@ struct host_span : public cudf::detail::span_base<T, Extent, host_span<T, Extent
    * @param idx the index of the element to access
    * @return A reference to the idx-th element of the sequence, i.e., `data()[idx]`
    */
-  constexpr typename base::reference operator[](size_type idx) const { return this->_data[idx]; }
+  constexpr typename base::reference operator[](typename base::size_type idx) const
+  {
+    static_assert(sizeof(idx) >= sizeof(size_t), "index type must not be smaller than size_t");
+    return this->_data[idx];
+  }
 
   // not noexcept due to undefined behavior when size = 0
   /**
@@ -402,8 +406,9 @@ struct device_span : public cudf::detail::span_base<T, Extent, device_span<T, Ex
    * @param idx the index of the element to access
    * @return A reference to the idx-th element of the sequence, i.e., `data()[idx]`
    */
-  __device__ constexpr typename base::reference operator[](size_type idx) const
+  __device__ constexpr typename base::reference operator[](typename base::size_type idx) const
   {
+    static_assert(sizeof(idx) >= sizeof(size_t), "index type must not be smaller than size_t");
     return this->_data[idx];
   }
 
@@ -512,7 +517,7 @@ class base_2dspan {
    * @param row the index of the element to access
    * @return A reference to the row-th element of the sequence, i.e., `data()[row]`
    */
-  CUDF_HOST_DEVICE constexpr RowType<T, dynamic_extent> operator[](size_t row) const
+  CUDF_HOST_DEVICE constexpr RowType<T, dynamic_extent> operator[](std::size_t row) const
   {
     return _flat.subspan(row * _size.second, _size.second);
   }


### PR DESCRIPTION
## Description
Closes https://github.com/rapidsai/cudf/issues/17949
Closes https://github.com/rapidsai/cudf/issues/17960

Derived span classes use `size_type` for the index type in their `operator[]` implementations. The intent was to use `base::size_type`, but the type actually resolves to `cudf::size_type`, which is `int32_t`, and does not allow access past `int32_t::max`.

This PR fixes the type used by explicitly using `typename base::size_type`. Also added static_asserts to make sure the type has the right size for element indexing.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
