### PR TITLE
Pin `ibis` version in the cudf.pandas integration tests <10.0.0

### DIFF
--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
@@ -262,7 +262,7 @@ dependencies:
         packages:
           - pip
           - pip:
-              - ibis-framework[pandas]
+              - ibis-framework[pandas]<10.0.0
   test_hvplot:
     common:
       - output_types: conda

--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_ibis.py
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_ibis.py
@@ -5,15 +5,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from cudf.pandas import is_proxy_object
+ibis.set_backend("pandas")
 
 ibis.options.interactive = False
 
 
 def ibis_assert_equal(expect, got, rtol: float = 1e-7, atol: float = 0.0):
-    assert is_proxy_object(got), (
-        "The result from cudf.pandas must be a proxy object"
-    )
     pd._testing.assert_almost_equal(expect, got, rtol=rtol, atol=atol)
 
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Follows up #17972. This PR is intended to get 25.02 nightly CI passing, which has been failing for few days.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
