### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -15,7 +15,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "cachetools",

--- a/python/cudf_kafka/pyproject.toml
+++ b/python/cudf_kafka/pyproject.toml
@@ -15,7 +15,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "cudf==25.4.*,>=0.0.0a0",

--- a/python/cudf_polars/pyproject.toml
+++ b/python/cudf_polars/pyproject.toml
@@ -16,7 +16,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "polars>=1.20,<1.22",

--- a/python/custreamz/pyproject.toml
+++ b/python/custreamz/pyproject.toml
@@ -16,7 +16,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "confluent-kafka>=2.5.0,<2.6.0a0",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -16,7 +16,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "cudf==25.4.*,>=0.0.0a0",

--- a/python/libcudf/pyproject.toml
+++ b/python/libcudf/pyproject.toml
@@ -27,7 +27,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 classifiers = [
     "Intended Audience :: Developers",

--- a/python/pylibcudf/pyproject.toml
+++ b/python/pylibcudf/pyproject.toml
@@ -15,7 +15,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "cuda-python>=11.8.5,<12.0a0",


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
