### PR TITLE
Fix race check failures in shared memory groupby

### DIFF
--- a/cpp/src/groupby/hash/compute_aggregations.cuh
+++ b/cpp/src/groupby/hash/compute_aggregations.cuh
@@ -76,7 +76,7 @@ rmm::device_uvector<cudf::size_type> compute_aggregations(
       // for shared memory aggregations
       auto const size = cudf::type_dispatcher<cudf::dispatch_storage_type>(request.values.type(),
                                                                            size_of_functor{});
-      return static_cast<size_type>(data_buffer_size) >= (size * GROUPBY_CARDINALITY_THRESHOLD);
+      return data_buffer_size >= (size * GROUPBY_CARDINALITY_THRESHOLD);
     });
 
   // Performs naive global memory aggregations when the workload is not compatible with shared

--- a/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
+++ b/cpp/src/groupby/hash/compute_shared_memory_aggs.cu
@@ -99,7 +99,6 @@ __device__ void initialize_shmem_aggregations(cooperative_groups::thread_block c
                                                   idx);
     }
   }
-  block.sync();
 }
 
 __device__ void compute_pre_aggregrations(cudf::size_type col_start,
@@ -174,7 +173,6 @@ __device__ void compute_final_aggregations(cooperative_groups::thread_block cons
                                                   idx);
     }
   }
-  block.sync();
 }
 
 /* Takes the local_mapping_index and global_mapping_index to compute
@@ -213,6 +211,7 @@ CUDF_KERNEL void single_pass_shmem_aggs_kernel(cudf::size_type num_rows,
   block.sync();
 
   while (col_end < num_cols) {
+    block.sync();
     if (block.thread_rank() == 0) {
       calculate_columns_to_aggregate(col_start,
                                      col_end,
@@ -234,6 +233,7 @@ CUDF_KERNEL void single_pass_shmem_aggs_kernel(cudf::size_type num_rows,
                                   shmem_agg_mask_offsets,
                                   cardinality,
                                   d_agg_kinds);
+    block.sync();
 
     compute_pre_aggregrations(col_start,
                               col_end,
@@ -263,7 +263,7 @@ CUDF_KERNEL void single_pass_shmem_aggs_kernel(cudf::size_type num_rows,
 }
 }  // namespace
 
-std::size_t get_available_shared_memory_size(cudf::size_type grid_size)
+size_type get_available_shared_memory_size(cudf::size_type grid_size)
 {
   auto const active_blocks_per_sm =
     cudf::util::div_rounding_up_safe(grid_size, cudf::detail::num_multiprocessors());
@@ -276,7 +276,7 @@ std::size_t get_available_shared_memory_size(cudf::size_type grid_size)
 }
 
 void compute_shared_memory_aggs(cudf::size_type grid_size,
-                                std::size_t available_shmem_size,
+                                size_type available_shmem_size,
                                 cudf::size_type num_input_rows,
                                 bitmask_type const* row_bitmask,
                                 bool skip_rows_with_nulls,

--- a/cpp/src/groupby/hash/compute_shared_memory_aggs.hpp
+++ b/cpp/src/groupby/hash/compute_shared_memory_aggs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,15 +22,15 @@
 #include <rmm/cuda_stream_view.hpp>
 
 namespace cudf::groupby::detail::hash {
-std::size_t get_available_shared_memory_size(cudf::size_type grid_size);
+size_type get_available_shared_memory_size(cudf::size_type grid_size);
 
-std::size_t constexpr compute_shmem_offsets_size(cudf::size_type num_cols)
+size_type constexpr compute_shmem_offsets_size(cudf::size_type num_cols)
 {
-  return sizeof(cudf::size_type) * num_cols;
+  return static_cast<size_type>(sizeof(cudf::size_type) * num_cols);
 }
 
 void compute_shared_memory_aggs(cudf::size_type grid_size,
-                                std::size_t available_shmem_size,
+                                cudf::size_type available_shmem_size,
                                 cudf::size_type num_input_rows,
                                 bitmask_type const* row_bitmask,
                                 bool skip_rows_with_nulls,


### PR DESCRIPTION
## Description

Replace https://github.com/rapidsai/cudf/pull/17976

This fixes the race check failures in shared memory groupby and resolves https://github.com/NVIDIA/spark-rapids/issues/11835.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
