### PR TITLE
Pass dtype objects to Column.astype

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -6,6 +6,7 @@ import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
 
+import numpy as np
 import pandas as pd
 from typing_extensions import Self
 
@@ -2159,7 +2160,7 @@ def _get_result_name(left_name, right_name):
     return left_name if _is_same_name(left_name, right_name) else None
 
 
-def _return_get_indexer_result(result):
+def _return_get_indexer_result(result: cupy.ndarray) -> cupy.ndarray:
     if cudf.get_option("mode.pandas_compatible"):
-        return result.astype("int64")
+        return result.astype(np.dtype(np.int64))
     return result

--- a/python/cudf/cudf/core/_internals/timezones.py
+++ b/python/cudf/cudf/core/_internals/timezones.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 from __future__ import annotations
 
 import datetime
@@ -124,7 +124,9 @@ def _read_tzfile_as_columns(
         from cudf.core.column.column import as_column
 
         # this happens for UTC-like zones
-        min_date = np.int64(np.iinfo("int64").min + 1).astype("M8[s]")
+        min_date = np.int64(np.iinfo("int64").min + 1).astype(
+            np.dtype("M8[s]")
+        )
         return (as_column([min_date]), as_column([np.timedelta64(0, "s")]))  # type: ignore[return-value]
     return tuple(transition_times_and_offsets)  # type: ignore[return-value]
 

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -265,8 +265,8 @@ class DatetimeColumn(column.ColumnBase):
             return False
         elif ts.tzinfo is not None:
             ts = ts.tz_convert(None)
-        return ts.to_numpy().astype("int64") in cast(
-            "cudf.core.column.NumericalColumn", self.astype("int64")
+        return ts.to_numpy().astype(np.dtype(np.int64)) in cast(
+            "cudf.core.column.NumericalColumn", self.astype(np.dtype(np.int64))
         )
 
     @functools.cached_property
@@ -506,7 +506,7 @@ class DatetimeColumn(column.ColumnBase):
 
     def isocalendar(self) -> dict[str, ColumnBase]:
         return {
-            field: self.strftime(format=directive).astype("uint32")
+            field: self.strftime(format=directive).astype(np.dtype(np.uint32))
             for field, directive in zip(
                 ["year", "week", "day"], ["%G", "%V", "%u"]
             )
@@ -559,7 +559,7 @@ class DatetimeColumn(column.ColumnBase):
                 )
 
             if other_time_unit not in {"s", "ms", "ns", "us"}:
-                other = other.astype("timedelta64[s]")
+                other = other.astype(np.dtype("timedelta64[s]"))
 
             return cudf.Scalar(other)
         elif isinstance(other, str):
@@ -656,7 +656,8 @@ class DatetimeColumn(column.ColumnBase):
     def mean(self, skipna=None, min_count: int = 0) -> ScalarLike:
         return pd.Timestamp(
             cast(
-                "cudf.core.column.NumericalColumn", self.astype("int64")
+                "cudf.core.column.NumericalColumn",
+                self.astype(np.dtype(np.int64)),
             ).mean(skipna=skipna, min_count=min_count),
             unit=self.time_unit,
         ).as_unit(self.time_unit)
@@ -668,16 +669,18 @@ class DatetimeColumn(column.ColumnBase):
         ddof: int = 1,
     ) -> pd.Timedelta:
         return pd.Timedelta(
-            cast("cudf.core.column.NumericalColumn", self.astype("int64")).std(
-                skipna=skipna, min_count=min_count, ddof=ddof
-            )
+            cast(
+                "cudf.core.column.NumericalColumn",
+                self.astype(np.dtype(np.int64)),
+            ).std(skipna=skipna, min_count=min_count, ddof=ddof)
             * _unit_to_nanoseconds_conversion[self.time_unit],
         ).as_unit(self.time_unit)
 
     def median(self, skipna: bool | None = None) -> pd.Timestamp:
         return pd.Timestamp(
             cast(
-                "cudf.core.column.NumericalColumn", self.astype("int64")
+                "cudf.core.column.NumericalColumn",
+                self.astype(np.dtype(np.int64)),
             ).median(skipna=skipna),
             unit=self.time_unit,
         ).as_unit(self.time_unit)
@@ -688,8 +691,13 @@ class DatetimeColumn(column.ColumnBase):
                 f"cannot perform cov with types {self.dtype}, {other.dtype}"
             )
         return cast(
-            "cudf.core.column.NumericalColumn", self.astype("int64")
-        ).cov(cast("cudf.core.column.NumericalColumn", other.astype("int64")))
+            "cudf.core.column.NumericalColumn", self.astype(np.dtype(np.int64))
+        ).cov(
+            cast(
+                "cudf.core.column.NumericalColumn",
+                other.astype(np.dtype(np.int64)),
+            )
+        )
 
     def corr(self, other: DatetimeColumn) -> float:
         if not isinstance(other, DatetimeColumn):
@@ -697,8 +705,13 @@ class DatetimeColumn(column.ColumnBase):
                 f"cannot perform corr with types {self.dtype}, {other.dtype}"
             )
         return cast(
-            "cudf.core.column.NumericalColumn", self.astype("int64")
-        ).corr(cast("cudf.core.column.NumericalColumn", other.astype("int64")))
+            "cudf.core.column.NumericalColumn", self.astype(np.dtype(np.int64))
+        ).corr(
+            cast(
+                "cudf.core.column.NumericalColumn",
+                other.astype(np.dtype(np.int64)),
+            )
+        )
 
     def quantile(
         self,
@@ -707,7 +720,7 @@ class DatetimeColumn(column.ColumnBase):
         exact: bool,
         return_scalar: bool,
     ) -> ColumnBase:
-        result = self.astype("int64").quantile(
+        result = self.astype(np.dtype(np.int64)).quantile(
             q=q,
             interpolation=interpolation,
             exact=exact,
@@ -811,13 +824,16 @@ class DatetimeColumn(column.ColumnBase):
         self, value: ScalarLike
     ) -> cudf.core.column.NumericalColumn:
         value = (
-            pd.to_datetime(value).to_numpy().astype(self.dtype).astype("int64")
+            pd.to_datetime(value)
+            .to_numpy()
+            .astype(self.dtype)
+            .astype(np.dtype(np.int64))
         )
-        return self.astype("int64").indices_of(value)
+        return self.astype(np.dtype(np.int64)).indices_of(value)
 
     @property
     def is_unique(self) -> bool:
-        return self.astype("int64").is_unique
+        return self.astype(np.dtype(np.int64)).is_unique
 
     def isin(self, values: Sequence) -> ColumnBase:
         return cudf.core.tools.datetimes._isin_datetimelike(self, values)
@@ -880,7 +896,7 @@ class DatetimeColumn(column.ColumnBase):
         If no transitions occur, the tuple `(False, False)` is returned.
         """
         transition_times, offsets = get_tz_data(zone_name)
-        offsets = offsets.astype(f"timedelta64[{self.time_unit}]")  # type: ignore[assignment]
+        offsets = offsets.astype(np.dtype(f"timedelta64[{self.time_unit}]"))  # type: ignore[assignment]
 
         if len(offsets) == 1:  # no transitions
             return False, False

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -214,7 +214,7 @@ class NumericalColumn(NumericalBaseColumn):
         if op in {"__truediv__", "__rtruediv__"}:
             # Division with integer types results in a suitable float.
             if truediv_type := int_float_dtype_mapping.get(self.dtype.type):
-                return self.astype(truediv_type)._binaryop(other, op)
+                return self.astype(np.dtype(truediv_type))._binaryop(other, op)
         elif op in {
             "__lt__",
             "__gt__",

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -28,6 +28,7 @@ from cudf.core.buffer import acquire_spill_lock
 from cudf.core.column import (
     ColumnBase,
     as_column,
+    column_empty,
     deserialize_columns,
     serialize_columns,
 )
@@ -999,7 +1000,11 @@ class Frame(BinaryOperand, Scannable, Serializable):
                 # of column is 0 (i.e., empty) then we will have an
                 # int8 column in result._data[name] returned by libcudf,
                 # which needs to be type-casted to 'category' dtype.
-                result[name] = result[name].astype("category")
+                result[name] = result[name].astype(
+                    cudf.CategoricalDtype(
+                        categories=column_empty(0, dtype=result[name].dtype)
+                    )
+                )
             elif (
                 pandas_dtypes.get(name) == "empty"
                 and np_dtypes.get(name) == "object"

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -735,7 +735,7 @@ class GroupBy(Serializable, Reducible, Scannable):
 
         if cudf.get_option("mode.pandas_compatible"):
             # pandas always returns floats:
-            return result.astype("float64")
+            return result.astype(np.dtype(np.float64))
 
         return result
 
@@ -1017,7 +1017,7 @@ class GroupBy(Serializable, Reducible, Scannable):
                     col = col._with_type_metadata(cudf.ListDtype(orig_dtype))
 
                 if agg_kind in {"COUNT", "SIZE", "ARGMIN", "ARGMAX"}:
-                    data[key] = col.astype("int64")
+                    data[key] = col.astype(np.dtype(np.int64))
                 elif (
                     self.obj.empty
                     and (
@@ -1966,7 +1966,7 @@ class GroupBy(Serializable, Reducible, Scannable):
             )
         if self.obj.empty:
             if func in {"count", "size", "idxmin", "idxmax"}:
-                res = cudf.Series([], dtype="int64")
+                res = cudf.Series([], dtype=np.dtype(np.int64))
             else:
                 res = self.obj.copy(deep=True)
             res.index = self.grouping.keys
@@ -1975,7 +1975,7 @@ class GroupBy(Serializable, Reducible, Scannable):
                 # will need to result in `int64` type.
                 for name, col in res._column_labels_and_values:
                     if col.dtype.kind == "b":
-                        res._data[name] = col.astype("int")
+                        res._data[name] = col.astype(np.dtype(np.int64))
             return res
 
         if not callable(func):
@@ -3226,7 +3226,7 @@ class DataFrameGroupBy(GroupBy, GetAttrGetItemMixin):
             ]
             .count()
             .sort_index()
-            .astype(np.int64)
+            .astype(np.dtype(np.int64))
         )
 
         if normalize:

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -1453,12 +1453,12 @@ class Index(SingleColumnFrame, BaseIndex, metaclass=IndexMeta):
         if isinstance(preprocess, CategoricalIndex):
             if preprocess.categories.dtype.kind == "f":
                 output = repr(
-                    preprocess.astype("str")
+                    preprocess.astype(CUDF_STRING_DTYPE)
                     .to_pandas()
                     .astype(
                         dtype=pd.CategoricalDtype(
                             categories=preprocess.dtype.categories.astype(
-                                "str"
+                                CUDF_STRING_DTYPE
                             ).to_pandas(),
                             ordered=preprocess.dtype.ordered,
                         )
@@ -2016,7 +2016,7 @@ class DatetimeIndex(Index):
 
     @property
     def asi8(self) -> cupy.ndarray:
-        return self._column.astype("int64").values
+        return self._column.astype(np.dtype(np.int64)).values
 
     @property
     def inferred_freq(self) -> cudf.DateOffset | None:
@@ -2330,7 +2330,8 @@ class DatetimeIndex(Index):
                 # Need to manually promote column to int32 because
                 # pandas-matching binop behaviour requires that this
                 # __mul__ returns an int16 column.
-                self._column.millisecond.astype("int32") * np.int32(1000)
+                self._column.millisecond.astype(np.dtype(np.int32))
+                * np.int32(1000)
             )
             + self._column.microsecond,
             name=self.name,
@@ -2490,7 +2491,9 @@ class DatetimeIndex(Index):
         >>> gIndex.quarter
         Index([2, 4], dtype='int8')
         """
-        return Index._from_column(self._column.quarter.astype("int8"))
+        return Index._from_column(
+            self._column.quarter.astype(np.dtype(np.int8))
+        )
 
     @_performance_tracking
     def day_name(self, locale: str | None = None) -> Index:
@@ -2932,7 +2935,7 @@ class TimedeltaIndex(Index):
 
     @property
     def asi8(self) -> cupy.ndarray:
-        return self._column.astype("int64").values
+        return self._column.astype(np.dtype(np.int64)).values
 
     def sum(self, *, skipna: bool = True, axis: int | None = 0):
         return self._column.sum(skipna=skipna)
@@ -2990,7 +2993,7 @@ class TimedeltaIndex(Index):
         """
         # Need to specifically return `int64` to avoid overflow.
         return Index._from_column(
-            self._column.days.astype("int64"), name=self.name
+            self._column.days.astype(np.dtype(np.int64)), name=self.name
         )
 
     @property  # type: ignore
@@ -3000,7 +3003,7 @@ class TimedeltaIndex(Index):
         Number of seconds (>= 0 and less than 1 day) for each element.
         """
         return Index._from_column(
-            self._column.seconds.astype("int32"), name=self.name
+            self._column.seconds.astype(np.dtype(np.int32)), name=self.name
         )
 
     @property  # type: ignore
@@ -3010,7 +3013,8 @@ class TimedeltaIndex(Index):
         Number of microseconds (>= 0 and less than 1 second) for each element.
         """
         return Index._from_column(
-            self._column.microseconds.astype("int32"), name=self.name
+            self._column.microseconds.astype(np.dtype(np.int32)),
+            name=self.name,
         )
 
     @property  # type: ignore
@@ -3021,7 +3025,7 @@ class TimedeltaIndex(Index):
         element.
         """
         return Index._from_column(
-            self._column.nanoseconds.astype("int32"), name=self.name
+            self._column.nanoseconds.astype(np.dtype(np.int32)), name=self.name
         )
 
     @property  # type: ignore

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -426,7 +426,7 @@ class IndexedFrame(Frame):
             if cast_to_int and result_col.dtype.kind in "uib":
                 # For reductions that accumulate a value (e.g. sum, not max)
                 # pandas returns an int64 dtype for all int or bool dtypes.
-                result_col = result_col.astype(np.int64)
+                result_col = result_col.astype(np.dtype(np.int64))
             results.append(getattr(result_col, op)())
         return self._from_data_like_self(
             self._data._from_columns_like_self(results)
@@ -2010,7 +2010,7 @@ class IndexedFrame(Frame):
                     FutureWarning,
                 )
             if col.nullable:
-                col = col.astype("float64").fillna(np.nan)
+                col = col.astype(np.dtype(np.float64)).fillna(np.nan)
 
             columns.append(
                 cudf.core.algorithms._interpolation(col, index=interp_index)

--- a/python/cudf/cudf/core/join/join.py
+++ b/python/cudf/cudf/core/join/join.py
@@ -293,8 +293,8 @@ class Merge:
                 and isinstance(lcol.dtype, cudf.CategoricalDtype)
                 and isinstance(rcol.dtype, cudf.CategoricalDtype)
             ):
-                lcol_casted = lcol_casted.astype("category")
-                rcol_casted = rcol_casted.astype("category")
+                lcol_casted = lcol_casted.astype(lcol.dtype)
+                rcol_casted = rcol_casted.astype(rcol.dtype)
 
             left_key.set(self.lhs, lcol_casted)
             right_key.set(self.rhs, rcol_casted)

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -169,7 +169,7 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
         for code in codes:
             if not (is_list_like(code) or is_column_like(code)):
                 raise TypeError("Each code must be list-like")
-            new_code = column.as_column(code).astype("int64")
+            new_code = column.as_column(code, dtype=np.dtype(np.int64))
             if copy and new_code is code:
                 new_code = new_code.copy(deep=True)
             new_codes.append(new_code)
@@ -341,7 +341,7 @@ class MultiIndex(Frame, BaseIndex, NotIterable):
             codes = []
             for col in self._data.values():
                 code, cats = factorize(col)
-                codes.append(column.as_column(code.astype(np.int64)))
+                codes.append(column.as_column(code.astype(np.dtype(np.int64))))
                 levels.append(cats)
             self._levels = levels
             self._codes = codes

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -20,7 +20,7 @@ from cudf.core.column_accessor import ColumnAccessor
 from cudf.utils.dtypes import SIZE_TYPE_DTYPE, min_unsigned_type
 
 if TYPE_CHECKING:
-    from cudf._typing import Dtype
+    from cudf._typing import DtypeObj
 
 _AXIS_MAP = {0: 0, 1: 1, "index": 0, "columns": 1}
 
@@ -810,6 +810,8 @@ def get_dummies(
     if sparse:
         raise NotImplementedError("sparse is not supported yet")
 
+    dtype = cudf.dtype(dtype)
+
     if isinstance(data, cudf.DataFrame):
         encode_fallback_dtypes = ["object", "category"]
 
@@ -1316,7 +1318,7 @@ def _one_hot_encode_column(
     categories: ColumnBase,
     prefix: str | None,
     prefix_sep: str | None,
-    dtype: Dtype | None,
+    dtype: DtypeObj,
     drop_first: bool,
 ) -> dict[str, ColumnBase]:
     """Encode a single column with one hot encoding. The return dictionary
@@ -1348,8 +1350,7 @@ def _one_hot_encode_column(
         data.pop(next(iter(data)))
     if prefix is not None and prefix_sep is not None:
         data = {f"{prefix}{prefix_sep}{col}": enc for col, enc in data.items()}
-    if dtype:
-        data = {k: v.astype(dtype) for k, v in data.items()}
+    data = {k: v.astype(dtype) for k, v in data.items()}
     return data
 
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -4181,9 +4181,9 @@ class DatetimeProperties(BaseDatelikeProperties):
         # Need to manually promote column to int32 because
         # pandas-matching binop behaviour requires that this
         # __mul__ returns an int16 column.
-        extra = self.series._column.millisecond.astype("int32") * np.int32(
-            1000
-        )
+        extra = self.series._column.millisecond.astype(
+            np.dtype(np.int32)
+        ) * np.int32(1000)
         return self._return_result_like_self(micro + extra)
 
     @property  # type: ignore
@@ -4443,7 +4443,7 @@ class DatetimeProperties(BaseDatelikeProperties):
         dtype: int8
         """
         return self._return_result_like_self(
-            self.series._column.quarter.astype(np.int8)
+            self.series._column.quarter.astype(np.dtype(np.int8))
         )
 
     @_performance_tracking

--- a/python/cudf/cudf/core/subword_tokenizer.py
+++ b/python/cudf/cudf/core/subword_tokenizer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 
 import cupy as cp
+import numpy as np
 
 import pylibcudf as plc
 
@@ -19,7 +20,7 @@ def _cast_to_appropriate_type(ar, cast_type):
     elif cast_type == "tf":
         from tensorflow.experimental.dlpack import from_dlpack
 
-    return from_dlpack(ar.astype("int32").toDlpack())
+    return from_dlpack(ar.astype(np.dtype(np.int32)).toDlpack())
 
 
 class SubwordTokenizer:

--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -21,6 +21,7 @@ from cudf.core import column
 from cudf.core.buffer import acquire_spill_lock
 from cudf.core.index import ensure_index
 from cudf.core.scalar import pa_scalar_to_plc_scalar
+from cudf.utils.dtypes import CUDF_STRING_DTYPE
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -214,11 +215,11 @@ def to_datetime(
                 )
 
             new_series = (
-                arg[unit_rev["year"]].astype("str")
+                arg[unit_rev["year"]].astype(CUDF_STRING_DTYPE)
                 + "-"
-                + arg[unit_rev["month"]].astype("str").str.zfill(2)
+                + arg[unit_rev["month"]].astype(CUDF_STRING_DTYPE).str.zfill(2)
                 + "-"
-                + arg[unit_rev["day"]].astype("str").str.zfill(2)
+                + arg[unit_rev["day"]].astype(CUDF_STRING_DTYPE).str.zfill(2)
             )
             format = "%Y-%m-%d"
             for u in ["h", "m", "s", "ms", "us", "ns"]:
@@ -255,9 +256,13 @@ def to_datetime(
                     # float dtype we don't want to type-cast
                     if current_col.dtype.kind in ("O"):
                         try:
-                            current_col = current_col.astype(dtype="int64")
+                            current_col = current_col.astype(
+                                np.dtype(np.int64)
+                            )
                         except ValueError:
-                            current_col = current_col.astype(dtype="float64")
+                            current_col = current_col.astype(
+                                np.dtype(np.float64)
+                            )
 
                     factor = (
                         column.datetime._unit_to_nanoseconds_conversion[u]
@@ -269,7 +274,7 @@ def to_datetime(
                     else:
                         times_column = times_column + (current_col * factor)
             if times_column is not None:
-                col = (col.astype(dtype="int64") + times_column).astype(
+                col = (col.astype(np.dtype(np.int64)) + times_column).astype(
                     dtype=col.dtype
                 )
             col = _process_col(
@@ -336,7 +341,7 @@ def _process_col(
             # parsing against `format`.
             col = (
                 col.astype(np.dtype(np.int64))
-                .astype("str")
+                .astype(CUDF_STRING_DTYPE)
                 .strptime(
                     dtype=np.dtype("datetime64[us]")
                     if "%f" in format
@@ -356,7 +361,7 @@ def _process_col(
             col = col * factor
 
         if format is not None:
-            col = col.astype("str").strptime(
+            col = col.astype(CUDF_STRING_DTYPE).strptime(
                 dtype=np.dtype(_unit_dtype_map[unit]), format=format
             )
         else:

--- a/python/cudf/cudf/core/tools/numeric.py
+++ b/python/cudf/cudf/core/tools/numeric.py
@@ -127,8 +127,8 @@ def to_numeric(
     if dtype.kind in "mM":
         col = col.astype(np.dtype(np.int64))
     elif isinstance(dtype, CategoricalDtype):
-        cat_dtype = col.dtype.type
-        if _is_non_decimal_numeric_dtype(cat_dtype):
+        cat_dtype = col.dtype.categories.dtype
+        if cat_dtype.kind in "iufb":
             col = col.astype(cat_dtype)
         else:
             try:
@@ -187,7 +187,7 @@ def to_numeric(
     else:
         if col.has_nulls():
             # To match pandas, always return a floating type filled with nan.
-            col = col.astype(float).fillna(np.nan)
+            col = col.astype(np.dtype(np.float64)).fillna(np.nan)
         return col.values
 
 

--- a/python/cudf/cudf/core/window/ewm.py
+++ b/python/cudf/cudf/core/window/ewm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 from __future__ import annotations
 
 import warnings
@@ -192,7 +192,9 @@ class ExponentialMovingWindow(_RollingBase):
         # pandas does nans in the same positions mathematically.
         # as such we need to convert the nans to nulls before
         # passing them in.
-        to_libcudf_column = source_column.astype("float64").nans_to_nulls()
+        to_libcudf_column = source_column.astype(
+            np.dtype(np.float64)
+        ).nans_to_nulls()
         return to_libcudf_column.scan(
             agg_name, True, com=self.com, adjust=self.adjust
         )

--- a/python/cudf/cudf/core/window/rolling.py
+++ b/python/cudf/cudf/core/window/rolling.py
@@ -19,6 +19,7 @@ from cudf.core.buffer import acquire_spill_lock
 from cudf.core.column.column import as_column
 from cudf.core.mixins import Reducible
 from cudf.utils import cudautils
+from cudf.utils.dtypes import SIZE_TYPE_DTYPE
 from cudf.utils.utils import GetAttrGetItemMixin
 
 if TYPE_CHECKING:
@@ -273,12 +274,16 @@ class Rolling(GetAttrGetItemMixin, _RollingBase, Reducible):
                 closed=None,
                 step=None,
             )
-            start = as_column(start, dtype="int32")
-            end = as_column(end, dtype="int32")
+            start = as_column(start, dtype=SIZE_TYPE_DTYPE)
+            end = as_column(end, dtype=SIZE_TYPE_DTYPE)
 
             idx = as_column(range(len(start)))
-            preceding_window = (idx - start + np.int32(1)).astype("int32")
-            following_window = (end - idx - np.int32(1)).astype("int32")
+            preceding_window = (idx - start + np.int32(1)).astype(
+                SIZE_TYPE_DTYPE
+            )
+            following_window = (end - idx - np.int32(1)).astype(
+                SIZE_TYPE_DTYPE
+            )
             window = None
         else:
             preceding_window = as_column(self.window)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -2603,8 +2603,7 @@ def test_comparison_binops_df_reindexing(request, pdf, gdf, binop, other):
     pdf[pdf == 1.0] = 2
     gdf[gdf == 1.0] = 2
     try:
-        with pytest.warns(FutureWarning):
-            d = binop(pdf, other)
+        d = binop(pdf, other)
     except Exception:
         if isinstance(other, (pd.Series, pd.DataFrame)):
             cudf_other = cudf.from_pandas(other)

--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -1639,11 +1639,7 @@ def test_date_range_raise_overflow():
     periods = 2
     freq = cudf.DateOffset(months=1)
     with pytest.raises(pd.errors.OutOfBoundsDatetime):
-        # Extending beyond the max value will trigger a warning when pandas
-        # does an internal conversion to a Python built-in datetime.datetime
-        # object, which only supports down to microsecond resolution.
-        with pytest.warns(UserWarning):
-            cudf.date_range(start=start, periods=periods, freq=freq)
+        cudf.date_range(start=start, periods=periods, freq=freq)
 
 
 @pytest.mark.parametrize(
@@ -1683,7 +1679,9 @@ def test_date_range_raise_unsupported(freqstr_unsupported):
     if freqstr_unsupported != "3MS":
         freqstr_unsupported = freqstr_unsupported.lower()
         with pytest.raises(ValueError, match="does not yet support"):
-            with expect_warning_if(PANDAS_GE_220):
+            with expect_warning_if(
+                PANDAS_GE_220 and freqstr_unsupported not in {"b", "bh"}
+            ):
                 cudf.date_range(start=s, end=e, freq=freqstr_unsupported)
 
 

--- a/python/cudf/cudf/tests/test_string_udfs.py
+++ b/python/cudf/cudf/tests/test_string_udfs.py
@@ -101,7 +101,7 @@ def run_udf_test(data, func, dtype):
     else:
         result = output
 
-    got = cudf.Series._from_column(result.astype(dtype))
+    got = cudf.Series._from_column(result.astype(cudf.dtype(dtype)))
     assert_eq(expect, got, check_dtype=False)
     with _CUDFNumbaConfig():
         udf_str_kernel.forall(len(data))(str_views, output)
@@ -110,7 +110,7 @@ def run_udf_test(data, func, dtype):
     else:
         result = output
 
-    got = cudf.Series._from_column(result.astype(dtype))
+    got = cudf.Series._from_column(result.astype(cudf.dtype(dtype)))
     assert_eq(expect, got, check_dtype=False)
 
 

--- a/python/cudf/cudf/utils/utils.py
+++ b/python/cudf/cudf/utils/utils.py
@@ -439,12 +439,12 @@ def _datetime_timedelta_find_and_replace(
         if replacement.can_cast_safely(original_column.dtype):
             replacement = replacement.astype(original_column.dtype)
     if isinstance(to_replace, original_col_class):
-        to_replace = to_replace.as_numerical_column(dtype=np.dtype("int64"))
+        to_replace = to_replace.astype(np.dtype(np.int64))
     if isinstance(replacement, original_col_class):
-        replacement = replacement.as_numerical_column(dtype=np.dtype("int64"))
+        replacement = replacement.astype(np.dtype(np.int64))
     try:
         result_col = (
-            original_column.as_numerical_column(dtype=np.dtype("int64"))
+            original_column.astype(np.dtype(np.int64))
             .find_and_replace(to_replace, replacement, all_nan)
             .astype(original_column.dtype)
         )


### PR DESCRIPTION
## Description
Broken off from https://github.com/rapidsai/cudf/pull/17978

This passes more dtype objects to `Column.astype` but does not _ensure_ that a dtype object is passes unlike in https://github.com/rapidsai/cudf/pull/17978

Also it appears we avoid surfacing from warnings from pandas within our tests.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
