### PR TITLE
Fix `to_arrow` to return consistent pandas-metadata

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5701,7 +5701,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         a: [[1,2,3]]
         b: [[4,5,6]]
         """
-        # import pdb;pdb.set_trace()
+
         data = self
         index_descr: Sequence[dict[str, Any]] | Sequence[str] = []
         write_index = preserve_index is not False

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import inspect
 import itertools
+import json
 import numbers
 import os
 import re
@@ -5700,7 +5701,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         a: [[1,2,3]]
         b: [[4,5,6]]
         """
-
+        # import pdb;pdb.set_trace()
         data = self
         index_descr: Sequence[dict[str, Any]] | Sequence[str] = []
         write_index = preserve_index is not False
@@ -5749,8 +5750,11 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
             preserve_index=preserve_index,
             types=out.schema.types,
         )
+        md_dict = json.loads(metadata[b"pandas"])
 
-        return out.replace_schema_metadata(metadata)
+        cudf.utils.ioutils._post_process_dtypes(self, md_dict)
+
+        return out.replace_schema_metadata({b"pandas": json.dumps(md_dict)})
 
     @_performance_tracking
     def to_records(self, index=True, column_dtypes=None, index_dtypes=None):

--- a/python/cudf/cudf/tests/test_list.py
+++ b/python/cudf/cudf/tests/test_list.py
@@ -974,7 +974,6 @@ def test_dataframe_list_round_trip():
             metadata=metadata,
         )
 
-        # Create a dummy table with the defined schema and some data
         data = {"text": ["asd", "pqr"], "list_col": [[1, 2, 3], [4, 5]]}
 
         table = pa.Table.from_pydict(data, schema=schema)

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1623,12 +1623,16 @@ def generate_pandas_metadata(table: cudf.DataFrame, index: bool | None) -> str:
     )
 
     md_dict = json.loads(metadata[b"pandas"])
+    _post_process_dtypes(table, md_dict)
+    return json.dumps(md_dict)
 
+
+def _post_process_dtypes(df, md_dict):
     # correct metadata for list and struct and nullable numeric types
     for col_meta in md_dict["columns"]:
         if (
-            col_meta["name"] in table._column_names
-            and table._data[col_meta["name"]].nullable
+            col_meta["name"] in df._column_names
+            and df._data[col_meta["name"]].nullable
             and col_meta["numpy_type"] in PARQUET_META_TYPE_MAP
             and col_meta["pandas_type"] != "decimal"
         ):
@@ -1637,8 +1641,6 @@ def generate_pandas_metadata(table: cudf.DataFrame, index: bool | None) -> str:
             ]
         if col_meta["numpy_type"] in ("list", "struct"):
             col_meta["numpy_type"] = "object"
-
-    return json.dumps(md_dict)
 
 
 def is_url(url):


### PR DESCRIPTION
## Description
This PR makes change to `to_arrow` API by making the metadata being generated for types like that of `list` type to have uniform type across IO readers and Arrow table. This will help fix the failure occurring in the added pytest in this PR.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
