### PR TITLE
Setup and implement row group pruning in the experimental Parquet reader

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -487,6 +487,7 @@ add_library(
   src/io/csv/durations.cu
   src/io/csv/reader_impl.cu
   src/io/csv/writer_impl.cu
+  src/io/experimental/functions.cpp
   src/io/functions.cpp
   src/io/json/host_tree_algorithms.cu
   src/io/json/json_column.cu
@@ -516,6 +517,10 @@ add_library(
   src/io/parquet/compact_protocol_reader.cpp
   src/io/parquet/compact_protocol_writer.cpp
   src/io/parquet/decode_preprocess.cu
+  src/io/parquet/experimental/dictionary_page_filter.cu
+  src/io/parquet/experimental/hybrid_scan.cpp
+  src/io/parquet/experimental/hybrid_scan_impl.cpp
+  src/io/parquet/experimental/hybrid_scan_helpers.cpp
   src/io/parquet/page_data.cu
   src/io/parquet/chunk_dict.cu
   src/io/parquet/page_enc.cu

--- a/cpp/include/cudf/io/detail/experimental/hybrid_scan.hpp
+++ b/cpp/include/cudf/io/detail/experimental/hybrid_scan.hpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file parquet.hpp
+ */
+
+#pragma once
+
+#include <cudf/io/parquet.hpp>
+#include <cudf/io/text/byte_range_info.hpp>
+#include <cudf/io/types.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/export.hpp>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace CUDF_EXPORT cudf {
+
+namespace experimental::io::parquet {
+
+namespace detail {
+/**
+ * @brief Internal experimental Parquet reader optimized for hybrid scan
+ */
+class impl;
+
+}  // namespace detail
+
+/**
+ * @brief The experimental parquet reader class to optimize reading parquet files subject to
+ *        highly selective filters (Hybrid Scan operation).
+ *
+ * This class is designed to address the gap between the available and exploited optimization
+ * techniques to speed up reading Parquet files subject to highly selective filters (Hybrid scan
+ * operation). This class reads file contents in two passes, where the first pass optimizes reading
+ * only the filter columns and the second pass optimizes reading the predicate columns.
+ */
+class hybrid_scan_reader {
+ public:
+  hybrid_scan_reader();
+
+  hybrid_scan_reader(cudf::host_span<uint8_t const> footer_bytes,
+                     cudf::host_span<uint8_t const> page_index_bytes,
+                     cudf::io::parquet_reader_options const& options);
+
+  ~hybrid_scan_reader();
+
+  [[nodiscard]] std::vector<size_type> get_valid_row_groups(
+    cudf::io::parquet_reader_options const& options) const;
+
+  [[nodiscard]] std::vector<std::vector<size_type>> filter_row_groups_with_stats(
+    cudf::host_span<std::vector<size_type> const> row_group_indices,
+    cudf::io::parquet_reader_options const& options,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const;
+
+  [[nodiscard]] std::pair<std::vector<cudf::io::text::byte_range_info>,
+                          std::vector<cudf::io::text::byte_range_info>>
+  get_secondary_filters(cudf::host_span<std::vector<size_type> const> row_group_indices,
+                        cudf::io::parquet_reader_options const& options) const;
+
+  [[nodiscard]] std::vector<std::vector<size_type>> filter_row_groups_with_dictionary_pages(
+    std::vector<rmm::device_buffer>& dictionary_page_data,
+    cudf::host_span<std::vector<size_type> const> row_group_indices,
+    cudf::io::parquet_reader_options const& options,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const;
+
+  [[nodiscard]] std::vector<std::vector<size_type>> filter_row_groups_with_bloom_filters(
+    std::vector<rmm::device_buffer>& bloom_filter_data,
+    cudf::host_span<std::vector<size_type> const> row_group_indices,
+    cudf::io::parquet_reader_options const& options,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const;
+
+ private:
+  std::unique_ptr<detail::impl> _impl;
+};
+
+}  // namespace experimental::io::parquet
+}  // namespace CUDF_EXPORT cudf

--- a/cpp/include/cudf/io/experimental/hybrid_scan.hpp
+++ b/cpp/include/cudf/io/experimental/hybrid_scan.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file parquet.hpp
+ */
+
+#pragma once
+
+#include <cudf/io/parquet.hpp>
+#include <cudf/io/text/byte_range_info.hpp>
+#include <cudf/io/types.hpp>
+#include <cudf/types.hpp>
+#include <cudf/utilities/export.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace cudf {
+namespace experimental::io {
+
+namespace parquet {
+// Forward declaration
+struct hybrid_scan_reader;
+}  // namespace parquet
+
+// To be defined
+struct hybrid_scan_metadata;
+
+// API # 1
+[[nodiscard]] std::unique_ptr<parquet::hybrid_scan_reader> make_hybrid_scan_reader(
+  cudf::host_span<uint8_t const> footer_bytes,
+  cudf::host_span<uint8_t const> page_index_bytes,
+  cudf::io::parquet_reader_options const& options);
+
+// API # 2
+[[nodiscard]] std::vector<size_type> get_valid_row_groups(
+  cudf::io::parquet_reader_options const& options);
+
+// API # 3
+[[nodiscard]] std::vector<size_type> filter_row_groups_with_stats(
+  std::unique_ptr<parquet::hybrid_scan_reader> reader,
+  cudf::host_span<size_type const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream);
+
+// API # 4
+[[nodiscard]] std::pair<std::vector<cudf::io::text::byte_range_info>,
+                        std::vector<cudf::io::text::byte_range_info>>
+get_secondary_filters(std::unique_ptr<parquet::hybrid_scan_reader> reader,
+                      cudf::host_span<size_type const> row_group_indices,
+                      cudf::io::parquet_reader_options const& options);
+
+// API # 5
+[[nodiscard]] std::vector<size_type> filter_row_groups_with_dictionary_pages(
+  std::unique_ptr<parquet::hybrid_scan_reader> reader,
+  std::vector<rmm::device_buffer>& dictionary_page_data,
+  cudf::host_span<size_type const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream);
+
+// API # 6
+[[nodiscard]] std::vector<size_type> filter_row_groups_with_bloom_filters(
+  std::unique_ptr<parquet::hybrid_scan_reader> reader,
+  std::vector<rmm::device_buffer>& bloom_filter_data,
+  cudf::host_span<size_type const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream);
+
+// API # 7
+[[nodiscard]] std::vector<size_type> filter_data_pages_with_stats(
+  std::unique_ptr<parquet::hybrid_scan_reader> reader,
+  cudf::host_span<size_type const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream);
+
+}  // namespace experimental::io
+}  // namespace cudf

--- a/cpp/src/io/experimental/functions.cpp
+++ b/cpp/src/io/experimental/functions.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cudf/utilities/error.hpp"
+#include "io/parquet/experimental/hybrid_scan_impl.hpp"
+
+#include <cudf/io/experimental/hybrid_scan.hpp>
+
+namespace cudf::experimental::io::parquet {
+
+// API # 1
+std::unique_ptr<hybrid_scan_reader> make_hybrid_scan_reader(
+  cudf::host_span<uint8_t const> footer_bytes,
+  cudf::host_span<uint8_t const> page_index_bytes,
+  cudf::io::parquet_reader_options const& options)
+{
+  return std::make_unique<hybrid_scan_reader>(footer_bytes, page_index_bytes, options);
+}
+
+// API # 2
+std::vector<size_type> get_valid_row_groups(std::unique_ptr<hybrid_scan_reader> reader,
+                                            cudf::io::parquet_reader_options const& options)
+{
+  return reader->get_valid_row_groups(options);
+}
+
+// API # 3
+std::vector<size_type> filter_row_groups_with_stats(
+  std::unique_ptr<hybrid_scan_reader> reader,
+  cudf::host_span<size_type const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const input_row_group_indices =
+    std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
+  return reader->filter_row_groups_with_stats(input_row_group_indices, options, stream, mr)[0];
+}
+
+// API # 4
+[[nodiscard]] std::pair<std::vector<cudf::io::text::byte_range_info>,
+                        std::vector<cudf::io::text::byte_range_info>>
+get_secondary_filters(std::unique_ptr<hybrid_scan_reader> reader,
+                      cudf::host_span<size_type const> row_group_indices,
+                      cudf::io::parquet_reader_options const& options)
+{
+  auto const input_row_group_indices =
+    std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
+  return reader->get_secondary_filters(input_row_group_indices, options);
+}
+
+// API # 5
+std::vector<size_type> filter_row_groups_with_dictionary_pages(
+  std::unique_ptr<hybrid_scan_reader> reader,
+  std::vector<rmm::device_buffer>& dictionary_page_data,
+  cudf::host_span<size_type const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const input_row_group_indices =
+    std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
+  return reader->filter_row_groups_with_dictionary_pages(
+    dictionary_page_data, input_row_group_indices, options, stream, mr)[0];
+}
+
+// API # 6
+std::vector<size_type> filter_row_groups_with_bloom_filters(
+  std::unique_ptr<hybrid_scan_reader> reader,
+  std::vector<rmm::device_buffer>& bloom_filter_data,
+  cudf::host_span<size_type const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const input_row_group_indices =
+    std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
+  return reader->filter_row_groups_with_bloom_filters(
+    bloom_filter_data, input_row_group_indices, options, stream, mr)[0];
+}
+
+}  // namespace cudf::experimental::io::parquet

--- a/cpp/src/io/parquet/experimental/dictionary_page_filter.cu
+++ b/cpp/src/io/parquet/experimental/dictionary_page_filter.cu
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hybrid_scan_helpers.hpp"
+#include "io/parquet/parquet.hpp"
+
+#include <cudf/ast/detail/expression_transformer.hpp>
+#include <cudf/ast/detail/operators.hpp>
+#include <cudf/ast/expressions.hpp>
+#include <cudf/detail/cuco_helpers.hpp>
+#include <cudf/detail/transform.hpp>
+#include <cudf/hashing/detail/xxhash_64.cuh>
+#include <cudf/logger.hpp>
+#include <cudf/utilities/span.hpp>
+#include <cudf/utilities/traits.hpp>
+#include <cudf/utilities/type_checks.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/tabulate.h>
+
+#include <future>
+#include <numeric>
+#include <optional>
+
+namespace cudf::experimental::io::parquet::detail {
+
+dictionary_literals_and_operators_collector::dictionary_literals_and_operators_collector() =
+  default;
+
+dictionary_literals_and_operators_collector::dictionary_literals_and_operators_collector(
+  ast::expression const& expr, cudf::size_type num_input_columns)
+{
+  _num_input_columns = num_input_columns;
+  _literals.resize(num_input_columns);
+  _operators.resize(num_input_columns);
+  expr.accept(*this);
+}
+
+std::reference_wrapper<ast::expression const> dictionary_literals_and_operators_collector::visit(
+  ast::column_reference const& expr)
+{
+  CUDF_EXPECTS(expr.get_table_source() == ast::table_reference::LEFT,
+               "DictionaryAST supports only left table");
+  CUDF_EXPECTS(expr.get_column_index() < _num_input_columns,
+               "Column index cannot be more than number of columns in the table");
+  return expr;
+}
+
+std::reference_wrapper<ast::expression const> dictionary_literals_and_operators_collector::visit(
+  ast::column_name_reference const& expr)
+{
+  CUDF_FAIL("Column name reference is not supported in DictionaryAST");
+}
+
+std::reference_wrapper<ast::expression const> dictionary_literals_and_operators_collector::visit(
+  ast::operation const& expr)
+{
+  using cudf::ast::ast_operator;
+  auto const operands = expr.get_operands();
+  auto const op       = expr.get_operator();
+
+  if (auto* v = dynamic_cast<ast::column_reference const*>(&operands[0].get())) {
+    // First operand should be column reference, second should be literal.
+    CUDF_EXPECTS(cudf::ast::detail::ast_operator_arity(op) == 2,
+                 "Only binary operations are supported on column reference");
+    auto const literal_ptr = dynamic_cast<ast::literal const*>(&operands[1].get());
+    CUDF_EXPECTS(literal_ptr != nullptr,
+                 "Second operand of binary operation with column reference must be a literal");
+    v->accept(*this);
+
+    // Push to the corresponding column's literals and operators list iff EQUAL or NOT_EQUAL
+    // operator is seen
+    if (op == ast_operator::EQUAL or op == ast::ast_operator::NOT_EQUAL) {
+      auto const col_idx = v->get_column_index();
+      _literals[col_idx].emplace_back(const_cast<ast::literal*>(literal_ptr));
+      _operators[col_idx].emplace_back(op);
+    }
+  } else {
+    // Just visit the operands and ignore any output
+    std::ignore = visit_operands(operands);
+  }
+
+  return expr;
+}
+
+std::pair<std::vector<std::vector<ast::literal*>>, std::vector<std::vector<ast::ast_operator>>>
+dictionary_literals_and_operators_collector::get_literals_and_operators() &&
+{
+  return {std::move(_literals), std::move(_operators)};
+}
+
+}  // namespace cudf::experimental::io::parquet::detail

--- a/cpp/src/io/parquet/experimental/hybrid_scan.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cudf/utilities/error.hpp"
+#include "hybrid_scan_impl.hpp"
+
+#include <cudf/io/experimental/hybrid_scan.hpp>
+
+namespace cudf::experimental::io::parquet {
+
+hybrid_scan_reader::hybrid_scan_reader() = default;
+
+hybrid_scan_reader::hybrid_scan_reader(cudf::host_span<uint8_t const> footer_bytes,
+                                       cudf::host_span<uint8_t const> page_index_bytes,
+                                       cudf::io::parquet_reader_options const& options)
+  : _impl{std::make_unique<detail::impl>(footer_bytes, page_index_bytes, options)}
+{
+}
+
+hybrid_scan_reader::~hybrid_scan_reader() = default;
+
+std::vector<std::vector<size_type>> hybrid_scan_reader::filter_row_groups_with_stats(
+  cudf::host_span<std::vector<size_type> const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
+  // Prefer user provided row group indices, else use the ones in options.
+  auto const input_row_group_indices =
+    row_group_indices.size() ? row_group_indices : options.get_row_groups();
+
+  return _impl->filter_row_groups_with_stats(input_row_group_indices, options, stream, mr);
+}
+
+std::vector<size_type> hybrid_scan_reader::get_valid_row_groups(
+  cudf::io::parquet_reader_options const& options) const
+{
+  CUDF_EXPECTS(options.get_row_groups().size() == 0 or options.get_row_groups().size() == 1, "");
+  if (options.get_row_groups().size()) { return options.get_row_groups()[0]; }
+
+  return _impl->get_valid_row_groups(options);
+}
+
+std::pair<std::vector<cudf::io::text::byte_range_info>,
+          std::vector<cudf::io::text::byte_range_info>>
+hybrid_scan_reader::get_secondary_filters(
+  cudf::host_span<std::vector<size_type> const> row_group_indices,
+  cudf::io::parquet_reader_options const& options) const
+{
+  return _impl->get_secondary_filters(row_group_indices, options);
+}
+
+std::vector<std::vector<size_type>> hybrid_scan_reader::filter_row_groups_with_dictionary_pages(
+  std::vector<rmm::device_buffer>& dictionary_page_data,
+  cudf::host_span<std::vector<size_type> const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
+  CUDF_EXPECTS(row_group_indices.size() == 1 and row_group_indices[0].size(), "");
+  CUDF_EXPECTS(row_group_indices[0].size() == dictionary_page_data.size(), "");
+  return _impl->filter_row_groups_with_dictionary_pages(
+    dictionary_page_data, row_group_indices, options, stream, mr);
+}
+
+std::vector<std::vector<size_type>> hybrid_scan_reader::filter_row_groups_with_bloom_filters(
+  std::vector<rmm::device_buffer>& bloom_filter_data,
+  cudf::host_span<std::vector<size_type> const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
+  CUDF_EXPECTS(row_group_indices.size() == 1 and row_group_indices[0].size(), "");
+  CUDF_EXPECTS(row_group_indices[0].size() == bloom_filter_data.size(), "");
+  return _impl->filter_row_groups_with_bloom_filters(
+    bloom_filter_data, row_group_indices, options, stream, mr);
+}
+
+}  // namespace cudf::experimental::io::parquet

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -1,0 +1,456 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hybrid_scan_helpers.hpp"
+
+#include "io/parquet/compact_protocol_reader.hpp"
+#include "io/parquet/reader_impl_helpers.hpp"
+
+#include <cudf/logger.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+
+#include <cstdint>
+#include <functional>
+#include <numeric>
+#include <optional>
+
+namespace cudf::experimental::io::parquet::detail {
+
+metadata::metadata(cudf::host_span<uint8_t const> footer_bytes,
+                   cudf::host_span<uint8_t const> page_index_bytes)
+{
+  cudf::io::parquet::detail::CompactProtocolReader cp(footer_bytes.data(), footer_bytes.size());
+  cp.read(this);
+  CUDF_EXPECTS(cp.InitSchema(this), "Cannot initialize schema");
+
+  // column index and offset index are encoded back to back.
+  // the first column of the first row group will have the first column index, the last
+  // column of the last row group will have the final offset index.
+
+  // Check if we have page_index buffer, and non-zoro row groups and columnchunks
+  if (page_index_bytes.size() and row_groups.size() and row_groups.front().columns.size()) {
+    // Set the first ColumnChunk's offset of ColumnIndex as the adjusted zero offset
+    int64_t const min_offset = row_groups.front().columns.front().column_index_offset;
+    // now loop over row groups
+    for (auto& rg : row_groups) {
+      for (auto& col : rg.columns) {
+        // Read the ColumnIndex for this ColumnChunk
+        if (col.column_index_length > 0 && col.column_index_offset > 0) {
+          int64_t const offset = col.column_index_offset - min_offset;
+          cp.init(page_index_bytes.data() + offset, col.column_index_length);
+          cudf::io::parquet::detail::ColumnIndex ci;
+          cp.read(&ci);
+          col.column_index = std::move(ci);
+        }
+        // Read the OffsetIndex for this ColumnChunk
+        if (col.offset_index_length > 0 && col.offset_index_offset > 0) {
+          int64_t const offset = col.offset_index_offset - min_offset;
+          cp.init(page_index_bytes.data() + offset, col.offset_index_length);
+          cudf::io::parquet::detail::OffsetIndex oi;
+          cp.read(&oi);
+          col.offset_index = std::move(oi);
+        }
+      }
+    }
+  }
+
+  sanitize_schema();
+}
+
+aggregate_reader_metadata::aggregate_reader_metadata(
+  cudf::host_span<uint8_t const> footer_bytes,
+  cudf::host_span<uint8_t const> page_index_bytes,
+  bool use_arrow_schema,
+  bool has_cols_from_mismatched_srcs)
+  : cudf::io::parquet::detail::aggregate_reader_metadata({}, false, false)
+{
+  // Re-initialize internal variables here as base class was initialized without a source
+  per_file_metadata = std::vector<cudf::io::parquet::detail::metadata>{
+    metadata{footer_bytes, page_index_bytes}.get_file_metadata()};
+  keyval_maps     = collect_keyval_metadata();
+  schema_idx_maps = init_schema_idx_maps(has_cols_from_mismatched_srcs);
+  num_rows        = calc_num_rows();
+  num_row_groups  = calc_num_row_groups();
+
+  // Collect and apply arrow:schema from Parquet's key value metadata section
+  if (use_arrow_schema) {
+    apply_arrow_schema();
+
+    // Erase ARROW_SCHEMA_KEY from the output pfm if exists
+    std::for_each(keyval_maps.begin(), keyval_maps.end(), [](auto& pfm) {
+      pfm.erase(cudf::io::parquet::detail::ARROW_SCHEMA_KEY);
+    });
+  }
+}
+
+std::tuple<std::vector<cudf::io::parquet::detail::input_column_info>,
+           std::vector<cudf::io::detail::inline_column_buffer>,
+           std::vector<size_type>>
+aggregate_reader_metadata::select_filter_columns(
+  std::optional<std::vector<std::string>> const& filter_columns_names,
+  bool include_index,
+  bool strings_to_categorical,
+  type_id timestamp_type_id)
+{
+  // Only extract filter columns
+  return select_columns(
+    filter_columns_names, std::nullopt, include_index, strings_to_categorical, timestamp_type_id);
+}
+
+std::vector<std::vector<size_type>> aggregate_reader_metadata::filter_row_groups_with_stats(
+  host_span<std::vector<size_type> const> row_group_indices,
+  host_span<data_type const> output_dtypes,
+  host_span<int const> output_column_schemas,
+  std::optional<std::reference_wrapper<ast::expression const>> filter,
+  rmm::cuda_stream_view stream) const
+{
+  std::vector<std::vector<size_type>> all_row_group_indices;
+  std::transform(per_file_metadata.cbegin(),
+                 per_file_metadata.cend(),
+                 std::back_inserter(all_row_group_indices),
+                 [](auto const& file_meta) {
+                   std::vector<size_type> rg_idx(file_meta.row_groups.size());
+                   std::iota(rg_idx.begin(), rg_idx.end(), 0);
+                   return rg_idx;
+                 });
+
+  if (not filter.has_value()) { return all_row_group_indices; }
+
+  // Compute total number of input row groups
+  size_type total_row_groups = [&]() {
+    if (not row_group_indices.empty()) {
+      size_t const total_row_groups =
+        std::accumulate(row_group_indices.begin(),
+                        row_group_indices.end(),
+                        size_t{0},
+                        [](size_t& sum, auto const& pfm) { return sum + pfm.size(); });
+
+      // Check if we have less than 2B total row groups.
+      CUDF_EXPECTS(total_row_groups <= std::numeric_limits<cudf::size_type>::max(),
+                   "Total number of row groups exceed the size_type's limit");
+      return static_cast<size_type>(total_row_groups);
+    } else {
+      return num_row_groups;
+    }
+  }();
+
+  // Span of input row group indices for predicate pushdown
+  host_span<std::vector<size_type> const> input_row_group_indices;
+  if (row_group_indices.empty()) {
+    std::transform(per_file_metadata.cbegin(),
+                   per_file_metadata.cend(),
+                   std::back_inserter(all_row_group_indices),
+                   [](auto const& file_meta) {
+                     std::vector<size_type> rg_idx(file_meta.row_groups.size());
+                     std::iota(rg_idx.begin(), rg_idx.end(), 0);
+                     return rg_idx;
+                   });
+    input_row_group_indices = host_span<std::vector<size_type> const>(all_row_group_indices);
+  } else {
+    input_row_group_indices = row_group_indices;
+  }
+
+  // Filter stats table with StatsAST expression and collect filtered row group indices
+  auto const stats_filtered_row_group_indices = apply_stats_filters(input_row_group_indices,
+                                                                    total_row_groups,
+                                                                    output_dtypes,
+                                                                    output_column_schemas,
+                                                                    filter.value(),
+                                                                    stream);
+
+  return stats_filtered_row_group_indices.value_or(all_row_group_indices);
+}
+
+std::vector<cudf::io::text::byte_range_info> aggregate_reader_metadata::get_bloom_filter_bytes(
+  cudf::host_span<std::vector<size_type> const> row_group_indices,
+  host_span<data_type const> output_dtypes,
+  host_span<int const> output_column_schemas,
+  std::optional<std::reference_wrapper<ast::expression const>> filter)
+{
+  // Number of surviving row groups after applying stats filter
+  auto const total_row_groups = std::accumulate(
+    row_group_indices.begin(),
+    row_group_indices.end(),
+    size_type{0},
+    [](auto& sum, auto const& per_file_row_groups) { return sum + per_file_row_groups.size(); });
+
+  // Collect equality literals for each input table column
+  auto const equality_literals =
+    cudf::io::parquet::detail::equality_literals_collector{
+      filter.value().get(), static_cast<cudf::size_type>(output_dtypes.size())}
+      .get_literals();
+
+  // Collect schema indices of columns with equality predicate(s)
+  std::vector<cudf::size_type> equality_col_schemas;
+  thrust::copy_if(thrust::host,
+                  output_column_schemas.begin(),
+                  output_column_schemas.end(),
+                  equality_literals.begin(),
+                  std::back_inserter(equality_col_schemas),
+                  [](auto& eq_literals) { return not eq_literals.empty(); });
+
+  // Descriptors for all the chunks that make up the selected columns
+  auto const num_equality_columns = equality_col_schemas.size();
+  auto const num_chunks           = total_row_groups * num_equality_columns;
+
+  std::vector<cudf::io::text::byte_range_info> bloom_filter_bytes;
+  bloom_filter_bytes.reserve(num_chunks);
+
+  // Flag to check if we have at least one valid bloom filter offset
+  auto have_bloom_filters = false;
+
+  // For all sources
+  std::for_each(
+    thrust::counting_iterator<size_t>(0),
+    thrust::counting_iterator(row_group_indices.size()),
+    [&](auto const src_index) {
+      // Get all row group indices in the data source
+      auto const& rg_indices = row_group_indices[src_index];
+      // For all row groups
+      std::for_each(rg_indices.cbegin(), rg_indices.cend(), [&](auto const rg_index) {
+        // For all column chunks
+        std::for_each(
+          equality_col_schemas.begin(), equality_col_schemas.end(), [&](auto const schema_idx) {
+            auto& col_meta = get_column_metadata(rg_index, src_index, schema_idx);
+            // Get bloom filter offsets and sizes
+            bloom_filter_bytes.emplace_back(col_meta.bloom_filter_offset.value_or(0),
+                                            col_meta.bloom_filter_length.value_or(0));
+
+            // Set `have_bloom_filters` if `bloom_filter_offset` is valid
+            if (col_meta.bloom_filter_offset.has_value()) { have_bloom_filters = true; }
+          });
+      });
+    });
+
+  // Clear vectors if found nothing
+  if (not have_bloom_filters) { bloom_filter_bytes.clear(); }
+
+  return bloom_filter_bytes;
+}
+
+std::vector<cudf::io::text::byte_range_info> aggregate_reader_metadata::get_dictionary_page_bytes(
+  cudf::host_span<std::vector<size_type> const> row_group_indices,
+  host_span<data_type const> output_dtypes,
+  host_span<int const> output_column_schemas,
+  std::optional<std::reference_wrapper<ast::expression const>> filter)
+{
+  // Number of surviving row groups after applying stats filter
+  auto const total_row_groups = std::accumulate(
+    row_group_indices.begin(),
+    row_group_indices.end(),
+    size_type{0},
+    [](auto& sum, auto const& per_file_row_groups) { return sum + per_file_row_groups.size(); });
+
+  // Collect equality literals for each input table column
+  auto const [literals, _] =
+    dictionary_literals_and_operators_collector{filter.value().get(),
+                                                static_cast<cudf::size_type>(output_dtypes.size())}
+      .get_literals_and_operators();
+
+  // Collect schema indices of columns with equality predicate(s)
+  std::vector<cudf::size_type> dictionary_col_schemas;
+  thrust::copy_if(thrust::host,
+                  output_column_schemas.begin(),
+                  output_column_schemas.end(),
+                  literals.begin(),
+                  std::back_inserter(dictionary_col_schemas),
+                  [](auto& dict_literals) { return not dict_literals.empty(); });
+
+  // Descriptors for all the chunks that make up the selected columns
+  auto const num_equality_columns = dictionary_col_schemas.size();
+  auto const num_chunks           = total_row_groups * num_equality_columns;
+
+  std::vector<cudf::io::text::byte_range_info> dictionary_page_bytes;
+  dictionary_page_bytes.reserve(num_chunks);
+
+  // Flag to check if we have at least one valid dictionary page
+  auto have_dictionary_pages = false;
+
+  // For all sources
+  std::for_each(
+    thrust::counting_iterator<size_t>(0),
+    thrust::counting_iterator(row_group_indices.size()),
+    [&](auto const src_index) {
+      // Get all row group indices in the data source
+      auto const& rg_indices = row_group_indices[src_index];
+      // For all row groups
+      std::for_each(rg_indices.cbegin(), rg_indices.cend(), [&](auto const rg_index) {
+        auto const& rg = per_file_metadata[0].row_groups[rg_index];
+        // For all column chunks
+        std::for_each(
+          dictionary_col_schemas.begin(), dictionary_col_schemas.end(), [&](auto const schema_idx) {
+            auto& col_meta        = get_column_metadata(rg_index, src_index, schema_idx);
+            auto const& col_chunk = rg.columns[schema_idx];
+
+            auto dictionary_offset = int64_t{0};
+            auto dictionary_size   = int64_t{0};
+
+            // If any columns lack the page indexes then just return without modifying the
+            // row_group_info.
+            if (col_chunk.offset_index.has_value() and col_chunk.column_index.has_value()) {
+              auto const& offset_index = col_chunk.offset_index.value();
+              auto const num_pages     = offset_index.page_locations.size();
+
+              // There is a bug in older versions of parquet-mr where the first data page offset
+              // really points to the dictionary page. The first possible offset in a file is 4
+              // (after the "PAR1" header), so check to see if the dictionary_page_offset is > 0. If
+              // it is, then we haven't encountered the bug.
+              if (col_meta.dictionary_page_offset > 0) {
+                dictionary_offset     = col_meta.dictionary_page_offset;
+                dictionary_size       = col_meta.data_page_offset - dictionary_offset;
+                have_dictionary_pages = true;
+              } else {
+                // dictionary_page_offset is 0, so check to see if the data_page_offset does not
+                // match the first offset in the offset index.  If they don't match, then
+                // data_page_offset points to the dictionary page.
+                if (num_pages > 0 &&
+                    col_meta.data_page_offset < offset_index.page_locations[0].offset) {
+                  dictionary_offset = col_meta.data_page_offset;
+                  dictionary_size =
+                    offset_index.page_locations[0].offset - col_meta.data_page_offset;
+                  have_dictionary_pages = true;
+                }
+              }
+            }
+
+            dictionary_page_bytes.emplace_back(dictionary_offset, dictionary_size);
+          });
+      });
+    });
+
+  // Clear vectors if found nothing
+  if (not have_dictionary_pages) { dictionary_page_bytes.clear(); }
+
+  return dictionary_page_bytes;
+}
+
+std::vector<std::vector<size_type>>
+aggregate_reader_metadata::filter_row_groups_with_dictionary_pages(
+  std::vector<rmm::device_buffer>& dictionary_page_data,
+  host_span<std::vector<size_type> const> row_group_indices,
+  host_span<data_type const> output_dtypes,
+  host_span<int const> output_column_schemas,
+  std::optional<std::reference_wrapper<ast::expression const>> filter,
+  rmm::cuda_stream_view stream) const
+{
+  std::vector<std::vector<size_type>> all_row_group_indices;
+  std::transform(row_group_indices.begin(),
+                 row_group_indices.end(),
+                 std::back_inserter(all_row_group_indices),
+                 [](auto const& row_group) {
+                   std::vector<size_type> rg_idx(row_group.size());
+                   std::iota(rg_idx.begin(), rg_idx.end(), 0);
+                   return rg_idx;
+                 });
+
+  // Number of surviving row groups after applying stats filter
+  // auto const total_row_groups = std::accumulate(
+  //   row_group_indices.begin(),
+  //   row_group_indices.end(),
+  //   size_type{0},
+  //   [](auto& sum, auto const& per_file_row_groups) { return sum + per_file_row_groups.size(); });
+
+  // Collect literals and operators for dictionary page filtering for each input table column
+  auto const [literals, operators] =
+    dictionary_literals_and_operators_collector{filter.value().get(),
+                                                static_cast<cudf::size_type>(output_dtypes.size())}
+      .get_literals_and_operators();
+
+  // Collect schema indices of columns with equality predicate(s)
+  std::vector<cudf::size_type> dictionary_col_schemas;
+  thrust::copy_if(thrust::host,
+                  output_column_schemas.begin(),
+                  output_column_schemas.end(),
+                  literals.begin(),
+                  std::back_inserter(dictionary_col_schemas),
+                  [](auto& dict_literals) { return not dict_literals.empty(); });
+
+  // Return early if no column with equality predicate(s)
+  if (dictionary_col_schemas.empty()) { return all_row_group_indices; }
+
+  // TODO: Decode dictionary pages and filter row groups based on dictionary pages
+  // auto const dictionary_filtered_row_groups = apply_dictionary_filter(dictionary_page_data,
+  //                                                                     row_group_indices,
+  //                                                                     literals,
+  //                                                                     operators,
+  //                                                                     total_row_groups,
+  //                                                                     output_dtypes,
+  //                                                                     dictionary_col_schemas,
+  //                                                                     filter.value(),
+  //                                                                     stream);
+
+  // return dictionary_filtered_row_groups.value_or(all_row_group_indices);
+  return all_row_group_indices;
+}
+
+std::vector<std::vector<size_type>> aggregate_reader_metadata::filter_row_groups_with_bloom_filters(
+  std::vector<rmm::device_buffer>& bloom_filter_data,
+  host_span<std::vector<size_type> const> row_group_indices,
+  host_span<data_type const> output_dtypes,
+  host_span<int const> output_column_schemas,
+  std::optional<std::reference_wrapper<ast::expression const>> filter,
+  rmm::cuda_stream_view stream) const
+{
+  std::vector<std::vector<size_type>> all_row_group_indices;
+  std::transform(row_group_indices.begin(),
+                 row_group_indices.end(),
+                 std::back_inserter(all_row_group_indices),
+                 [](auto const& row_group) {
+                   std::vector<size_type> rg_idx(row_group.size());
+                   std::iota(rg_idx.begin(), rg_idx.end(), 0);
+                   return rg_idx;
+                 });
+
+  // Number of surviving row groups after applying stats filter
+  auto const total_row_groups = std::accumulate(
+    row_group_indices.begin(),
+    row_group_indices.end(),
+    size_type{0},
+    [](auto& sum, auto const& per_file_row_groups) { return sum + per_file_row_groups.size(); });
+
+  // Collect equality literals for each input table column
+  auto const equality_literals =
+    cudf::io::parquet::detail::equality_literals_collector{
+      filter.value().get(), static_cast<cudf::size_type>(output_dtypes.size())}
+      .get_literals();
+
+  // Collect schema indices of columns with equality predicate(s)
+  std::vector<cudf::size_type> equality_col_schemas;
+  thrust::copy_if(thrust::host,
+                  output_column_schemas.begin(),
+                  output_column_schemas.end(),
+                  equality_literals.begin(),
+                  std::back_inserter(equality_col_schemas),
+                  [](auto& eq_literals) { return not eq_literals.empty(); });
+
+  // Return early if no column with equality predicate(s)
+  if (equality_col_schemas.empty()) { return all_row_group_indices; }
+
+  auto const bloom_filtered_row_groups = apply_bloom_filters(bloom_filter_data,
+                                                             row_group_indices,
+                                                             equality_literals,
+                                                             total_row_groups,
+                                                             output_dtypes,
+                                                             equality_col_schemas,
+                                                             filter.value(),
+                                                             stream);
+
+  return bloom_filtered_row_groups.value_or(all_row_group_indices);
+}
+
+}  // namespace cudf::experimental::io::parquet::detail

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.hpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "io/parquet/parquet_gpu.hpp"
+#include "io/parquet/reader_impl_chunking.hpp"
+#include "io/parquet/reader_impl_helpers.hpp"
+
+#include <cudf/io/detail/experimental/hybrid_scan.hpp>
+#include <cudf/io/detail/utils.hpp>
+#include <cudf/io/experimental/hybrid_scan.hpp>
+#include <cudf/io/types.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace cudf::experimental::io::parquet::detail {
+
+/**
+ * @brief Class for parsing dataset metadata
+ */
+struct metadata : private cudf::io::parquet::detail::metadata {
+  explicit metadata(cudf::host_span<uint8_t const> footer_bytes,
+                    cudf::host_span<uint8_t const> page_index_bytes);
+
+  cudf::io::parquet::detail::metadata get_file_metadata() { return *this; }
+};
+
+class aggregate_reader_metadata : public cudf::io::parquet::detail::aggregate_reader_metadata {
+ private:
+  /**
+   * @brief Filters the row groups using dictionary pages
+   *
+   * @param dictionary_page_data Dictionary page data device buffers for each input row group
+   * @param input_row_group_indices Lists of input row groups, one per source
+   * @param literals Lists of literals, one per input column
+   * @param operators Lists of operators, one per input column
+   * @param dictionary_operators
+   * @param total_row_groups Total number of row groups in `input_row_group_indices`
+   * @param output_dtypes Datatypes of output columns
+   * @param dictionary_col_schemas schema indices of dictionary columns only
+   * @param filter AST expression to filter row groups based on bloom filter membership
+   * @param stream CUDA stream used for device memory operations and kernel launches
+   *
+   * @return A pair of filtered row group indices if any is filtered.
+   */
+  [[nodiscard]] std::optional<std::vector<std::vector<size_type>>> apply_dictionary_filter(
+    std::vector<rmm::device_buffer>& dictionary_page_data,
+    host_span<std::vector<size_type> const> input_row_group_indices,
+    host_span<std::vector<ast::literal*> const> literals,
+    host_span<std::vector<ast::ast_operator> const> operators,
+    size_type total_row_groups,
+    host_span<data_type const> output_dtypes,
+    host_span<int const> dictionary_col_schemas,
+    std::reference_wrapper<ast::expression const> filter,
+    rmm::cuda_stream_view stream) const;
+
+ public:
+  aggregate_reader_metadata(cudf::host_span<uint8_t const> footer_bytes,
+                            cudf::host_span<uint8_t const> page_index_bytes,
+                            bool use_arrow_schema,
+                            bool has_cols_from_mismatched_srcs);
+  /**
+   * @brief Filters and reduces down to a selection of filter columns
+   *
+   * @param filter_columns_names List of paths of column names that are present only in filter
+   * @param include_index Whether to always include the PANDAS index column(s)
+   * @param strings_to_categorical Type conversion parameter
+   * @param timestamp_type_id Type conversion parameter
+   *
+   * @return input column information, output column information, list of output column schema
+   * indices
+   */
+  [[nodiscard]] std::tuple<std::vector<cudf::io::parquet::detail::input_column_info>,
+                           std::vector<cudf::io::detail::inline_column_buffer>,
+                           std::vector<size_type>>
+  select_filter_columns(std::optional<std::vector<std::string>> const& filter_columns_names,
+                        bool include_index,
+                        bool strings_to_categorical,
+                        type_id timestamp_type_id);
+
+  [[nodiscard]] std::vector<std::vector<size_type>> filter_row_groups_with_stats(
+    host_span<std::vector<size_type> const> row_group_indices,
+    host_span<data_type const> output_dtypes,
+    host_span<int const> output_column_schemas,
+    std::optional<std::reference_wrapper<ast::expression const>> filter,
+    rmm::cuda_stream_view stream) const;
+
+  [[nodiscard]] std::vector<cudf::io::text::byte_range_info> get_bloom_filter_bytes(
+    cudf::host_span<std::vector<size_type> const> row_group_indices,
+    host_span<data_type const> output_dtypes,
+    host_span<int const> output_column_schemas,
+    std::optional<std::reference_wrapper<ast::expression const>> filter);
+
+  [[nodiscard]] std::vector<cudf::io::text::byte_range_info> get_dictionary_page_bytes(
+    cudf::host_span<std::vector<size_type> const> row_group_indices,
+    host_span<data_type const> output_dtypes,
+    host_span<int const> output_column_schemas,
+    std::optional<std::reference_wrapper<ast::expression const>> filter);
+
+  [[nodiscard]] std::vector<std::vector<size_type>> filter_row_groups_with_dictionary_pages(
+    std::vector<rmm::device_buffer>& dictionary_page_data,
+    host_span<std::vector<size_type> const> row_group_indices,
+    host_span<data_type const> output_dtypes,
+    host_span<int const> output_column_schemas,
+    std::optional<std::reference_wrapper<ast::expression const>> filter,
+    rmm::cuda_stream_view stream) const;
+
+  [[nodiscard]] std::vector<std::vector<size_type>> filter_row_groups_with_bloom_filters(
+    std::vector<rmm::device_buffer>& bloom_filter_data,
+    host_span<std::vector<size_type> const> row_group_indices,
+    host_span<data_type const> output_dtypes,
+    host_span<int const> output_column_schemas,
+    std::optional<std::reference_wrapper<ast::expression const>> filter,
+    rmm::cuda_stream_view stream) const;
+};
+
+/**
+ * @brief Collects lists of equal and not-equal predicate literals in the AST expression, one list
+ * per input table column. This is used in row group filtering based on dictionary pages.
+ */
+class dictionary_literals_and_operators_collector
+  : public cudf::io::parquet::detail::equality_literals_collector {
+ public:
+  dictionary_literals_and_operators_collector();
+
+  dictionary_literals_and_operators_collector(ast::expression const& expr,
+                                              cudf::size_type num_input_columns);
+
+  using equality_literals_collector::visit;
+
+  /**
+   * @copydoc ast::detail::expression_transformer::visit(ast::column_reference const& )
+   */
+  std::reference_wrapper<ast::expression const> visit(ast::column_reference const& expr) override;
+
+  /**
+   * @copydoc ast::detail::expression_transformer::visit(ast::column_name_reference const& )
+   */
+  std::reference_wrapper<ast::expression const> visit(
+    ast::column_name_reference const& expr) override;
+
+  /**
+   * @copydoc ast::detail::expression_transformer::visit(ast::operation const& )
+   */
+  std::reference_wrapper<ast::expression const> visit(ast::operation const& expr) override;
+
+  /**
+   * @brief Returns the vectors of dictionary page filter literals in the AST expression, one per
+   * input table column
+   */
+  [[nodiscard]] std::vector<std::vector<ast::literal*>> get_literals() = delete;
+
+  /**
+   * @brief Returns a pair of two vectors containing dictionary filter literals and operators
+   * in the AST expression respectively, one per input table column
+   */
+  [[nodiscard]] std::pair<std::vector<std::vector<ast::literal*>>,
+                          std::vector<std::vector<ast::ast_operator>>>
+  get_literals_and_operators() &&;
+
+ private:
+  std::vector<std::vector<ast::ast_operator>> _operators;
+};
+
+}  // namespace cudf::experimental::io::parquet::detail

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hybrid_scan_impl.hpp"
+
+#include "cudf/utilities/error.hpp"
+#include "hybrid_scan_helpers.hpp"
+
+// #include "error.hpp"
+
+#include <cudf/detail/stream_compaction.hpp>
+#include <cudf/detail/transform.hpp>
+#include <cudf/detail/utilities/stream_pool.hpp>
+#include <cudf/strings/detail/utilities.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+
+#include <bitset>
+#include <iterator>
+#include <limits>
+#include <numeric>
+
+namespace cudf::experimental::io::parquet::detail {
+
+impl::impl(cudf::host_span<uint8_t const> footer_bytes,
+           cudf::host_span<uint8_t const> page_index_bytes,
+           cudf::io::parquet_reader_options const& options)
+{
+  // Open and parse the source dataset metadata
+  _metadata = std::make_unique<aggregate_reader_metadata>(
+    footer_bytes,
+    page_index_bytes,
+    options.is_enabled_use_arrow_schema(),
+    options.get_columns().has_value() and options.is_enabled_allow_mismatched_pq_schemas());
+
+  // Strings may be returned as either string or categorical columns
+  auto const strings_to_categorical = options.is_enabled_convert_strings_to_categories();
+
+  // Select only columns required by the filter
+  std::optional<std::vector<std::string>> filter_columns_names;
+  if (options.get_filter().has_value() and options.get_columns().has_value()) {
+    // list, struct, dictionary are not supported by AST filter yet.
+    // extract columns not present in get_columns() & keep count to remove at end.
+    filter_columns_names = cudf::io::parquet::detail::get_column_names_in_expression(
+      options.get_filter(), *(options.get_columns()));
+    _num_filter_only_columns = filter_columns_names->size();
+  }
+
+  // Only need to select columns if filter is available
+  if (filter_columns_names.has_value()) {
+    std::tie(_input_columns, _output_buffers, _output_column_schemas) =
+      _metadata->select_filter_columns(filter_columns_names,
+                                       options.is_enabled_use_pandas_metadata(),
+                                       strings_to_categorical,
+                                       options.get_timestamp_type().id());
+
+    // Save the states of the output buffers for reuse.
+    for (auto const& buff : _output_buffers) {
+      _output_buffers_template.emplace_back(
+        cudf::io::detail::inline_column_buffer::empty_like(buff));
+    }
+  }
+}
+
+std::vector<size_type> impl::get_valid_row_groups(
+  cudf::io::parquet_reader_options const& options) const
+{
+  auto const num_row_groups = _metadata->get_num_row_groups();
+  auto row_groups_indices   = std::vector<size_type>(num_row_groups);
+  std::iota(row_groups_indices.begin(), row_groups_indices.end(), size_type{0});
+  return row_groups_indices;
+}
+
+std::vector<std::vector<size_type>> impl::filter_row_groups_with_stats(
+  cudf::host_span<std::vector<size_type> const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
+  // Save the name to reference converter to extract output filter AST in
+  // `preprocess_file()` and `finalize_output()`
+  table_metadata metadata;
+  populate_metadata(metadata);
+  auto expr_conv = named_to_reference_converter(options.get_filter(), metadata);
+
+  std::vector<data_type> output_dtypes;
+  if (expr_conv.get_converted_expr().has_value()) {
+    std::transform(_output_buffers_template.cbegin(),
+                   _output_buffers_template.cend(),
+                   std::back_inserter(output_dtypes),
+                   [](auto const& col) { return col.type; });
+  }
+
+  return _metadata->filter_row_groups_with_stats(row_group_indices,
+                                                 output_dtypes,
+                                                 _output_column_schemas,
+                                                 expr_conv.get_converted_expr(),
+                                                 stream);
+}
+
+std::pair<std::vector<cudf::io::text::byte_range_info>,
+          std::vector<cudf::io::text::byte_range_info>>
+impl::get_secondary_filters(cudf::host_span<std::vector<size_type> const> row_group_indices,
+                            cudf::io::parquet_reader_options const& options) const
+{
+  // Save the name to reference converter to extract output filter AST in
+  // `preprocess_file()` and `finalize_output()`
+  table_metadata metadata;
+  populate_metadata(metadata);
+  auto expr_conv = named_to_reference_converter(options.get_filter(), metadata);
+
+  std::vector<data_type> output_dtypes;
+  if (expr_conv.get_converted_expr().has_value()) {
+    std::transform(_output_buffers_template.cbegin(),
+                   _output_buffers_template.cend(),
+                   std::back_inserter(output_dtypes),
+                   [](auto const& col) { return col.type; });
+  }
+
+  auto const bloom_filter_bytes = _metadata->get_bloom_filter_bytes(
+    row_group_indices, output_dtypes, _output_column_schemas, expr_conv.get_converted_expr());
+  auto const dictionary_page_bytes = _metadata->get_dictionary_page_bytes(
+    row_group_indices, output_dtypes, _output_column_schemas, expr_conv.get_converted_expr());
+
+  return {bloom_filter_bytes, dictionary_page_bytes};
+}
+
+std::vector<std::vector<size_type>> impl::filter_row_groups_with_dictionary_pages(
+  std::vector<rmm::device_buffer>& dictionary_page_data,
+  cudf::host_span<std::vector<size_type> const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
+  // Save the name to reference converter to extract output filter AST in
+  // `preprocess_file()` and `finalize_output()`
+  table_metadata metadata;
+  populate_metadata(metadata);
+  auto expr_conv = named_to_reference_converter(options.get_filter(), metadata);
+
+  std::vector<data_type> output_dtypes;
+  if (expr_conv.get_converted_expr().has_value()) {
+    std::transform(_output_buffers_template.cbegin(),
+                   _output_buffers_template.cend(),
+                   std::back_inserter(output_dtypes),
+                   [](auto const& col) { return col.type; });
+  }
+
+  return _metadata->filter_row_groups_with_dictionary_pages(dictionary_page_data,
+                                                            row_group_indices,
+                                                            output_dtypes,
+                                                            _output_column_schemas,
+                                                            expr_conv.get_converted_expr(),
+                                                            stream);
+}
+
+std::vector<std::vector<size_type>> impl::filter_row_groups_with_bloom_filters(
+  std::vector<rmm::device_buffer>& bloom_filter_data,
+  cudf::host_span<std::vector<size_type> const> row_group_indices,
+  cudf::io::parquet_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
+  // Save the name to reference converter to extract output filter AST in
+  // `preprocess_file()` and `finalize_output()`
+  table_metadata metadata;
+  populate_metadata(metadata);
+  auto expr_conv = named_to_reference_converter(options.get_filter(), metadata);
+
+  std::vector<data_type> output_dtypes;
+  if (expr_conv.get_converted_expr().has_value()) {
+    std::transform(_output_buffers_template.cbegin(),
+                   _output_buffers_template.cend(),
+                   std::back_inserter(output_dtypes),
+                   [](auto const& col) { return col.type; });
+  }
+
+  return _metadata->filter_row_groups_with_bloom_filters(bloom_filter_data,
+                                                         row_group_indices,
+                                                         output_dtypes,
+                                                         _output_column_schemas,
+                                                         expr_conv.get_converted_expr(),
+                                                         stream);
+}
+
+void impl::populate_metadata(table_metadata& out_metadata) const
+{
+  // Return column names
+  out_metadata.schema_info.resize(_output_buffers.size());
+  for (size_t i = 0; i < _output_column_schemas.size(); i++) {
+    auto const& schema               = _metadata->get_schema(_output_column_schemas[i]);
+    out_metadata.schema_info[i].name = schema.name;
+    out_metadata.schema_info[i].is_nullable =
+      schema.repetition_type != cudf::io::parquet::detail::REQUIRED;
+  }
+
+  // Return user metadata
+  out_metadata.per_file_user_data = _metadata->get_key_value_metadata();
+  out_metadata.user_data          = {out_metadata.per_file_user_data[0].begin(),
+                                     out_metadata.per_file_user_data[0].end()};
+}
+
+}  // namespace cudf::experimental::io::parquet::detail

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file reader_impl.hpp
+ * @brief cuDF-IO Parquet reader class implementation header
+ */
+
+#pragma once
+
+#include "hybrid_scan_helpers.hpp"
+#include "io/parquet/parquet_gpu.hpp"
+// #include "io/parquet/reader_impl_chunking.hpp"
+
+#include <cudf/io/detail/experimental/hybrid_scan.hpp>
+#include <cudf/io/detail/utils.hpp>
+#include <cudf/io/experimental/hybrid_scan.hpp>
+#include <cudf/io/types.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace cudf::experimental::io::parquet::detail {
+
+/**
+ * @brief Implementation for Parquet reader
+ */
+class impl {
+ public:
+  /**
+   * @brief Constructor from an array of dataset sources with reader options.
+   *
+   * By using this constructor, each call to `read()` or `read_chunk()` will perform reading the
+   * entire given file.
+   *
+   * @param sources Dataset sources
+   * @param options Settings for controlling reading behavior
+   */
+  explicit impl(cudf::host_span<uint8_t const> footer_bytes,
+                cudf::host_span<uint8_t const> page_index_bytes,
+                cudf::io::parquet_reader_options const& options);
+
+  [[nodiscard]] std::vector<size_type> get_valid_row_groups(
+    cudf::io::parquet_reader_options const& options) const;
+
+  [[nodiscard]] std::vector<std::vector<size_type>> filter_row_groups_with_stats(
+    cudf::host_span<std::vector<size_type> const> row_group_indices,
+    cudf::io::parquet_reader_options const& options,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const;
+
+  [[nodiscard]] std::pair<std::vector<cudf::io::text::byte_range_info>,
+                          std::vector<cudf::io::text::byte_range_info>>
+  get_secondary_filters(cudf::host_span<std::vector<size_type> const> row_group_indices,
+                        cudf::io::parquet_reader_options const& options) const;
+
+  [[nodiscard]] std::vector<std::vector<size_type>> filter_row_groups_with_dictionary_pages(
+    std::vector<rmm::device_buffer>& dictionary_page_data,
+    cudf::host_span<std::vector<size_type> const> row_group_indices,
+    cudf::io::parquet_reader_options const& options,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const;
+
+  [[nodiscard]] std::vector<std::vector<size_type>> filter_row_groups_with_bloom_filters(
+    std::vector<rmm::device_buffer>& bloom_filter_data,
+    cudf::host_span<std::vector<size_type> const> row_group_indices,
+    cudf::io::parquet_reader_options const& options,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const;
+
+ private:
+  using table_metadata = cudf::io::table_metadata;
+
+  /**
+   * @brief Populate the output table metadata from the parquet file metadata.
+   *
+   * @param out_metadata The output table metadata to add to
+   */
+  void populate_metadata(table_metadata& out_metadata) const;
+
+ private:
+  using named_to_reference_converter = cudf::io::parquet::detail::named_to_reference_converter;
+  using input_column_info            = cudf::io::parquet::detail::input_column_info;
+  using inline_column_buffer         = cudf::io::detail::inline_column_buffer;
+
+  std::unique_ptr<aggregate_reader_metadata> _metadata;
+
+  // name to reference converter to extract AST output filter
+  // named_to_reference_converter _expr_conv{std::nullopt, cudf::io::table_metadata{}};
+
+  // input columns to be processed
+  std::vector<input_column_info> _input_columns;
+  // Buffers for generating output columns
+  std::vector<inline_column_buffer> _output_buffers;
+  // Buffers copied from `_output_buffers` after construction for reuse
+  std::vector<inline_column_buffer> _output_buffers_template;
+  // _output_buffers associated schema indices
+  std::vector<int> _output_column_schemas;
+
+  // _output_buffers associated metadata
+  std::unique_ptr<table_metadata> _output_metadata;
+
+  // number of extra filter columns
+  std::size_t _num_filter_only_columns{0};
+
+  cudf::io::parquet::detail::file_intermediate_data _file_itm_data;
+};
+
+}  // namespace cudf::experimental::io::parquet::detail

--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -113,6 +113,7 @@ struct row_group_info {
  * @brief Class for parsing dataset metadata
  */
 struct metadata : public FileMetaData {
+  metadata() = default;
   explicit metadata(datasource* source);
   void sanitize_schema();
 };
@@ -134,6 +135,7 @@ struct surviving_row_group_metrics {
 };
 
 class aggregate_reader_metadata {
+ protected:
   std::vector<metadata> per_file_metadata;
   std::vector<std::unordered_map<std::string, std::string>> keyval_maps;
   std::vector<std::unordered_map<int32_t, int32_t>> schema_idx_maps;
@@ -582,8 +584,6 @@ class equality_literals_collector : public ast::detail::expression_transformer {
     cudf::host_span<std::reference_wrapper<ast::expression const> const> operands);
 
   size_type _num_input_columns;
-
- private:
   std::vector<std::vector<ast::literal*>> _literals;
 };
 


### PR DESCRIPTION
## Description
This PR setups up vital classes and structs for the experimental Parquet reader for hybrid scan and implements APIs for row group pruning. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
