### PR TITLE
Update spark-rapids-jni CI image version to cuda12.8.0

### DIFF
--- a/.github/workflows/spark-rapids-jni.yaml
+++ b/.github/workflows/spark-rapids-jni.yaml
@@ -7,7 +7,7 @@ jobs:
   spark-rapids-jni-build:
     runs-on: linux-amd64-cpu8
     container:
-      image: rapidsai/ci-spark-rapids-jni:rockylinux8-cuda12.2.0
+      image: rapidsai/ci-spark-rapids-jni:rockylinux8-cuda12.8.0
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description
spark-rapids-jni is going to drop support for the 12.2.0 CI image, 
this change is to switch image version to cuda12.8.0 one https://hub.docker.com/r/rapidsai/ci-spark-rapids-jni/tags

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
