### PR TITLE
Fix the build error due to KvikIO update

### DIFF
--- a/cpp/src/io/utilities/data_sink.cpp
+++ b/cpp/src/io/utilities/data_sink.cpp
@@ -37,7 +37,7 @@ class file_sink : public data_sink {
     _kvikio_file = kvikio::FileHandle(filepath, "w");
     CUDF_EXPECTS(!_kvikio_file.closed(), "KvikIO did not open the file successfully.");
     CUDF_LOG_INFO("Writing a file using kvikIO, with compatibility mode %s.",
-                  _kvikio_file.is_compat_mode_preferred() ? "on" : "off");
+                  _kvikio_file.get_compat_mode_manager().is_compat_mode_preferred() ? "on" : "off");
   }
 
   // Marked as NOLINT because we are calling a virtual method in the destructor

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -54,7 +54,7 @@ class file_source : public datasource {
     _kvikio_file = kvikio::FileHandle(filepath, "r");
     CUDF_EXPECTS(!_kvikio_file.closed(), "KvikIO did not open the file successfully.");
     CUDF_LOG_INFO("Reading a file using kvikIO, with compatibility mode %s.",
-                  _kvikio_file.is_compat_mode_preferred() ? "on" : "off");
+                  _kvikio_file.get_compat_mode_manager().is_compat_mode_preferred() ? "on" : "off");
   }
 
   std::unique_ptr<buffer> host_read(size_t offset, size_t size) override


### PR DESCRIPTION
## Description

KvikIO has just introduced a breaking change (https://github.com/rapidsai/kvikio/pull/608) where the compatibility mode handling is delegated to `CompatModeManager`. This PR updates the way cuDF queries the compatibility mode to avoid build errors.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
