### PR TITLE
Pass more dtype objects to `astype` calls

### DIFF
--- a/python/cudf/cudf/core/column/categorical.py
+++ b/python/cudf/cudf/core/column/categorical.py
@@ -811,21 +811,15 @@ class CategoricalColumn(column.ColumnBase):
 
     def to_arrow(self) -> pa.Array:
         """Convert to PyArrow Array."""
-        # arrow doesn't support unsigned codes
+        # pyarrow.Table doesn't support unsigned codes
         signed_type = (
             min_signed_type(self.codes.max())
             if self.codes.size > 0
-            else np.int8
+            else np.dtype(np.int8)
         )
-        codes = self.codes.astype(signed_type)
-        categories = self.categories
-
-        out_indices = codes.to_arrow()
-        out_dictionary = categories.to_arrow()
-
         return pa.DictionaryArray.from_arrays(
-            out_indices,
-            out_dictionary,
+            self.codes.astype(signed_type).to_arrow(),
+            self.categories.to_arrow(),
             ordered=self.ordered,
         )
 

--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1629,7 +1629,7 @@ class ColumnBase(Serializable, BinaryOperand, Reducible):
             elif isinstance(dtype, IntervalDtype):
                 result = self.as_interval_column(dtype)
             elif isinstance(dtype, (ListDtype, StructDtype)):
-                if not self.dtype == dtype:
+                if self.dtype != dtype:
                     raise NotImplementedError(
                         f"Casting {self.dtype} columns not currently supported"
                     )

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -262,7 +262,7 @@ class CategoricalDtype(_BaseDtype):
             getattr(categories, "dtype", None),
             (cudf.IntervalDtype, pd.IntervalDtype),
         ):
-            dtype = "object"  # type: Any
+            dtype = CUDF_STRING_DTYPE
         else:
             dtype = None
 

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -3135,7 +3135,7 @@ class CategoricalIndex(Index):
             data = column.as_column(data)
         else:
             data = column.as_column(
-                data, dtype="category" if dtype is None else dtype
+                data, dtype=cudf.CategoricalDtype() if dtype is None else dtype
             )
             # dtype has already been taken care
             dtype = None

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -6517,7 +6517,7 @@ class IndexedFrame(Frame):
             for col in self._columns:
                 if col.dtype.kind == "f":
                     col = col.fillna(0)
-                    as_int = col.astype("int64")
+                    as_int = col.astype(np.dtype(np.int64))
                     if cp.allclose(col, as_int):
                         cols.append(as_int)
                         continue

--- a/python/cudf/cudf/core/join/_join_helpers.py
+++ b/python/cudf/cudf/core/join/_join_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 
 from __future__ import annotations
 
@@ -114,7 +114,8 @@ def _match_join_keys(
 
     if how == "left" and rcol.fillna(0).can_cast_safely(ltype):
         return lcol, rcol.astype(ltype)
-
+    elif common_type is None:
+        common_type = np.dtype(np.float64)
     return lcol.astype(common_type), rcol.astype(common_type)
 
 

--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -369,9 +369,9 @@ def _process_col(
     elif col.dtype.kind == "O":
         if unit not in (None, "ns") or col.null_count == len(col):
             try:
-                col = col.astype(dtype="int64")
+                col = col.astype(np.dtype(np.int64))
             except ValueError:
-                col = col.astype(dtype="float64")
+                col = col.astype(np.dtype(np.float64))
             return _process_col(
                 col=col,
                 unit=unit,

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -4343,21 +4343,27 @@ def test_as_column_types():
 
     assert_eq(pds, gds)
 
-    col = column.as_column(cudf.Series([], dtype="float64"), dtype="float32")
+    col = column.as_column(
+        cudf.Series([], dtype="float64"), dtype=np.dtype(np.float32)
+    )
     assert_eq(col.dtype, np.dtype("float32"))
     gds = cudf.Series._from_column(col)
     pds = pd.Series(pd.Series([], dtype="float32"))
 
     assert_eq(pds, gds)
 
-    col = column.as_column(cudf.Series([], dtype="float64"), dtype="str")
+    col = column.as_column(
+        cudf.Series([], dtype="float64"), dtype=cudf.dtype("str")
+    )
     assert_eq(col.dtype, np.dtype("object"))
     gds = cudf.Series._from_column(col)
     pds = pd.Series(pd.Series([], dtype="str"))
 
     assert_eq(pds, gds)
 
-    col = column.as_column(cudf.Series([], dtype="float64"), dtype="object")
+    col = column.as_column(
+        cudf.Series([], dtype="float64"), dtype=cudf.dtype("str")
+    )
     assert_eq(col.dtype, np.dtype("object"))
     gds = cudf.Series._from_column(col)
     pds = pd.Series(pd.Series([], dtype="object"))
@@ -4366,7 +4372,7 @@ def test_as_column_types():
 
     pds = pd.Series(np.array([1, 2, 3]), dtype="float32")
     gds = cudf.Series._from_column(
-        column.as_column(np.array([1, 2, 3]), dtype="float32")
+        column.as_column(np.array([1, 2, 3]), dtype=np.dtype(np.float32))
     )
 
     assert_eq(pds, gds)
@@ -4389,14 +4395,18 @@ def test_as_column_types():
 
     pds = pd.Series([1.2, 18.0, 9.0], dtype="float32")
     gds = cudf.Series._from_column(
-        column.as_column(cudf.Series([1.2, 18.0, 9.0]), dtype="float32")
+        column.as_column(
+            cudf.Series([1.2, 18.0, 9.0]), dtype=np.dtype(np.float32)
+        )
     )
 
     assert_eq(pds, gds)
 
     pds = pd.Series([1.2, 18.0, 9.0], dtype="str")
     gds = cudf.Series._from_column(
-        column.as_column(cudf.Series([1.2, 18.0, 9.0]), dtype="str")
+        column.as_column(
+            cudf.Series([1.2, 18.0, 9.0]), dtype=cudf.dtype("str")
+        )
     )
 
     assert_eq(pds, gds)
@@ -5228,7 +5238,7 @@ def test_empty_df_astype(dtype):
 )
 def test_series_astype_error_handling(errors):
     sr = cudf.Series(["random", "words"])
-    got = sr.astype("datetime64", errors=errors)
+    got = sr.astype("datetime64[ns]", errors=errors)
     assert_eq(sr, got)
 
 


### PR DESCRIPTION
## Description
Broken off from https://github.com/rapidsai/cudf/pull/17978

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
