### PR TITLE
Fix upstream dask `loc` test

### DIFF
--- a/python/dask_cudf/dask_cudf/_expr/__init__.py
+++ b/python/dask_cudf/dask_cudf/_expr/__init__.py
@@ -20,6 +20,7 @@ from dask.dataframe.dask_expr._cumulative import (
 )
 from dask.dataframe.dask_expr._expr import (
     Elemwise,
+    EnforceRuntimeDivisions,
     Expr,
     RenameAxis,
     VarColumns,
@@ -70,6 +71,7 @@ __all__ = [
     "DXSeriesGroupBy",
     "DecomposableGroupbyAggregation",
     "Elemwise",
+    "EnforceRuntimeDivisions",
     "Expr",
     "FragmentWrapper",
     "FrameBase",


### PR DESCRIPTION
## Description
The upstream [test_gpu_loc dask test is failing](https://github.com/rapidsai/dask-upstream-testing/actions/runs/13419658348/job/37489003426), and the culprit seems to be https://github.com/dask/dask/pull/11745

I don't see anything "wrong" with the changes in that PR. However, the divisions assertion is now sensitive to the fact that an  element of divisions can end up being a 0-dimensional cupy arrays for GPU-backed data. The `test_gpu_loc` feels like a pretty strange corner case to me. So, this PR proposes a temporary fix in dask-cudf.


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
