### PR TITLE
Use the right version macro `CCCL_MAJOR_VERSION`

### DIFF
--- a/cpp/src/io/fst/dispatch_dfa.cuh
+++ b/cpp/src/io/fst/dispatch_dfa.cuh
@@ -391,7 +391,7 @@ struct DispatchFSM : DeviceFSMPolicy {
     // Alias the temporary allocations from the single storage blob (or compute the necessary size
     // of the blob)
     // TODO (@miscco): remove this once rapids moves to CCCL 2.8
-#if CCCL_VERSION_MAJOR >= 3
+#if CCCL_MAJOR_VERSION >= 3
     error = cub::detail::AliasTemporaries(
 #else   // ^^^ CCCL 3.x ^^^ / vvv CCCL 2.x vvv
     error = cub::AliasTemporaries(


### PR DESCRIPTION
I accidentally used `CCCL_VERSION_MAJOR`, which is used in our cmake scripts
