### PR TITLE
Support melt(ignore_index=False)

### DIFF
--- a/python/cudf/cudf/tests/test_reshape.py
+++ b/python/cudf/cudf/tests/test_reshape.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 
 import re
 from itertools import chain
@@ -40,7 +40,10 @@ if get_global_manager() is not None:
 @pytest.mark.parametrize("num_rows", [1, 2, 100])
 @pytest.mark.parametrize("dtype", NUMERIC_TYPES + DATETIME_TYPES)
 @pytest.mark.parametrize("nulls", ["none", "some", "all"])
-def test_melt(nulls, num_id_vars, num_value_vars, num_rows, dtype):
+@pytest.mark.parametrize("ignore_index", [True, False])
+def test_melt(
+    nulls, num_id_vars, num_value_vars, num_rows, dtype, ignore_index
+):
     if dtype not in ["float32", "float64"] and nulls in ["some", "all"]:
         pytest.skip(reason="nulls not supported in dtype: " + dtype)
 
@@ -72,10 +75,22 @@ def test_melt(nulls, num_id_vars, num_value_vars, num_rows, dtype):
 
     gdf = cudf.from_pandas(pdf)
 
-    got = cudf.melt(frame=gdf, id_vars=id_vars, value_vars=value_vars)
-    got_from_melt_method = gdf.melt(id_vars=id_vars, value_vars=value_vars)
+    got = cudf.melt(
+        frame=gdf,
+        id_vars=id_vars,
+        value_vars=value_vars,
+        ignore_index=ignore_index,
+    )
+    got_from_melt_method = gdf.melt(
+        id_vars=id_vars, value_vars=value_vars, ignore_index=ignore_index
+    )
 
-    expect = pd.melt(frame=pdf, id_vars=id_vars, value_vars=value_vars)
+    expect = pd.melt(
+        frame=pdf,
+        id_vars=id_vars,
+        value_vars=value_vars,
+        ignore_index=ignore_index,
+    )
 
     assert_eq(expect, got)
 


### PR DESCRIPTION
## Description
Additionally, refactors `melt` to avoid Series/DataFrame constructors by operating on columns and passing the result to `_from_data`

```python
In [1]: import numpy as np, cudf

In [2]: df = cudf.DataFrame(np.ones((1000, 1000)))

In [3]: %timeit df.melt(id_vars=range(50, 300))   # this PR
1.35 s ± 12.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [3]: %timeit df.melt(id_vars=range(50, 300))  # branch-25.04

24.8 s ± 47 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
