### PR TITLE
Remove static column vectors from window function tests.

### DIFF
--- a/cpp/tests/rolling/offset_row_window_test.cpp
+++ b/cpp/tests/rolling/offset_row_window_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/rolling/offset_row_window_test.cpp
+++ b/cpp/tests/rolling/offset_row_window_test.cpp
@@ -43,7 +43,6 @@ auto constexpr null = int32_t{0};  // NULL representation for int32_t;
 auto no_nulls_list() { return nulls_at({}); }
 
 struct OffsetRowWindowTest : public cudf::test::BaseFixture {
-
   struct rolling_runner {
     cudf::window_bounds _preceding, _following;
     cudf::size_type _min_periods;
@@ -54,7 +53,9 @@ struct OffsetRowWindowTest : public cudf::test::BaseFixture {
     rolling_runner(cudf::window_bounds const& preceding,
                    cudf::window_bounds const& following,
                    cudf::size_type min_periods_ = 1)
-      : _preceding{preceding}, _following{following}, _min_periods{min_periods_},
+      : _preceding{preceding},
+        _following{following},
+        _min_periods{min_periods_},
         _keys{0, 0, 0, 0, 0, 0, 1, 1, 1, 1},
         _values{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
     {

--- a/cpp/tests/rolling/offset_row_window_test.cpp
+++ b/cpp/tests/rolling/offset_row_window_test.cpp
@@ -54,8 +54,8 @@ struct OffsetRowWindowTest : public cudf::test::BaseFixture {
     rolling_runner(cudf::window_bounds const& preceding,
                    cudf::window_bounds const& following,
                    cudf::size_type min_periods_ = 1)
-      : _preceding{preceding}, _following{following}, _min_periods{min_periods_}, 
-        _keys{0, 0, 0, 0, 0, 0, 1, 1, 1, 1}, 
+      : _preceding{preceding}, _following{following}, _min_periods{min_periods_},
+        _keys{0, 0, 0, 0, 0, 0, 1, 1, 1, 1},
         _values{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
     {
     }
@@ -95,7 +95,7 @@ TEST_F(OffsetRowWindowTest, OffsetRowWindow_Grouped_3_to_Minus_1)
 {
   auto const preceding = cudf::window_bounds::get(3);
   auto const following = cudf::window_bounds::get(-1);
-  auto run_rolling     = rolling_runner{preceding, following}; 
+  auto run_rolling     = rolling_runner{preceding, following};
   run_rolling.min_periods(1).grouped(true);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*run_rolling(*AGG_COUNT_NON_NULL),

--- a/cpp/tests/rolling/offset_row_window_test.cpp
+++ b/cpp/tests/rolling/offset_row_window_test.cpp
@@ -43,18 +43,20 @@ auto constexpr null = int32_t{0};  // NULL representation for int32_t;
 auto no_nulls_list() { return nulls_at({}); }
 
 struct OffsetRowWindowTest : public cudf::test::BaseFixture {
-  static ints_column const _keys;    // {0, 0, 0, 0, 0, 0, 1, 1, 1, 1};
-  static ints_column const _values;  // {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   struct rolling_runner {
     cudf::window_bounds _preceding, _following;
     cudf::size_type _min_periods;
     bool _grouped = true;
+    ints_column const _keys;    // {0, 0, 0, 0, 0, 0, 1, 1, 1, 1};
+    ints_column const _values;  // {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
     rolling_runner(cudf::window_bounds const& preceding,
                    cudf::window_bounds const& following,
                    cudf::size_type min_periods_ = 1)
-      : _preceding{preceding}, _following{following}, _min_periods{min_periods_}
+      : _preceding{preceding}, _following{following}, _min_periods{min_periods_}, 
+        _keys{0, 0, 0, 0, 0, 0, 1, 1, 1, 1}, 
+        _values{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
     {
     }
 
@@ -80,9 +82,6 @@ struct OffsetRowWindowTest : public cudf::test::BaseFixture {
   };
 };
 
-ints_column const OffsetRowWindowTest::_keys{0, 0, 0, 0, 0, 0, 1, 1, 1, 1};
-ints_column const OffsetRowWindowTest::_values{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-
 auto const AGG_COUNT_NON_NULL =
   cudf::make_count_aggregation<cudf::rolling_aggregation>(cudf::null_policy::EXCLUDE);
 auto const AGG_COUNT_ALL =
@@ -96,7 +95,8 @@ TEST_F(OffsetRowWindowTest, OffsetRowWindow_Grouped_3_to_Minus_1)
 {
   auto const preceding = cudf::window_bounds::get(3);
   auto const following = cudf::window_bounds::get(-1);
-  auto run_rolling     = rolling_runner{preceding, following}.min_periods(1).grouped(true);
+  auto run_rolling     = rolling_runner{preceding, following}; 
+  run_rolling.min_periods(1).grouped(true);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*run_rolling(*AGG_COUNT_NON_NULL),
                                  ints_column{{0, 1, 2, 2, 2, 2, 0, 1, 2, 2}, nulls_at({0, 6})});
@@ -136,7 +136,8 @@ TEST_F(OffsetRowWindowTest, OffsetRowWindow_Ungrouped_3_to_Minus_1)
 {
   auto const preceding = cudf::window_bounds::get(3);
   auto const following = cudf::window_bounds::get(-1);
-  auto run_rolling     = rolling_runner{preceding, following}.min_periods(1).grouped(false);
+  auto run_rolling     = rolling_runner{preceding, following};
+  run_rolling.min_periods(1).grouped(false);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*run_rolling(*AGG_COUNT_NON_NULL),
                                  ints_column{{0, 1, 2, 2, 2, 2, 2, 2, 2, 2}, nulls_at({0})});
@@ -176,7 +177,8 @@ TEST_F(OffsetRowWindowTest, OffsetRowWindow_Grouped_0_to_2)
 {
   auto const preceding = cudf::window_bounds::get(0);
   auto const following = cudf::window_bounds::get(2);
-  auto run_rolling     = rolling_runner{preceding, following}.min_periods(1).grouped(true);
+  auto run_rolling     = rolling_runner{preceding, following};
+  run_rolling.min_periods(1).grouped(true);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(
     *run_rolling(*AGG_COUNT_NON_NULL),
@@ -219,7 +221,8 @@ TEST_F(OffsetRowWindowTest, OffsetRowWindow_Ungrouped_0_to_2)
 {
   auto const preceding = cudf::window_bounds::get(0);
   auto const following = cudf::window_bounds::get(2);
-  auto run_rolling     = rolling_runner{preceding, following}.min_periods(1).grouped(false);
+  auto run_rolling     = rolling_runner{preceding, following};
+  run_rolling.min_periods(1).grouped(false);
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*run_rolling(*AGG_COUNT_NON_NULL),
                                  ints_column{{2, 2, 2, 2, 2, 2, 2, 2, 1, null}, nulls_at({9})});


### PR DESCRIPTION
Fixes #18079.

This commit fixes the failures reported in #18079, where the use of static column vector objects in the tests causes the use of a CUDA runtime context before it's been initialized, causing the tests to fail with:
```
parallel_for failed: cudaErrorInvalidResourceHandle: invalid resource handle
```

The solution is to switch the static column vectors to runtime, as a member of the test utility class `rolling_runner`.