### PR TITLE
Support `is_numeric_not_bool` on data type with `type_id::EMPTY`

### DIFF
--- a/cpp/src/utilities/traits.cpp
+++ b/cpp/src/utilities/traits.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,6 +195,7 @@ struct is_numeric_not_bool_impl {
 
 bool is_numeric_not_bool(data_type type)
 {
+  if (type.id() == type_id::EMPTY) return false;
   return cudf::type_dispatcher(type, is_numeric_not_bool_impl{});
 }
 

--- a/python/pylibcudf/pylibcudf/tests/test_traits.py
+++ b/python/pylibcudf/pylibcudf/tests/test_traits.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 import pylibcudf as plc
 
@@ -23,6 +23,7 @@ def test_is_numeric():
 def test_is_numeric_not_bool():
     assert plc.traits.is_numeric_not_bool(plc.DataType(plc.TypeId.FLOAT64))
     assert not plc.traits.is_numeric_not_bool(plc.DataType(plc.TypeId.BOOL8))
+    assert not plc.traits.is_numeric_not_bool(plc.DataType(plc.TypeId.EMPTY))
 
 
 def test_is_index_type():


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Closes https://github.com/rapidsai/cudf/issues/18110
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
