### PR TITLE
Revert "Enable pytest-xdist runs for py-polars tests (#18016)"

### DIFF
--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -48,9 +48,7 @@ python -m pytest \
        --cache-clear \
        -m "" \
        -p cudf_polars.testing.plugin \
-       -n 8 \
-       --dist=worksteal \
-       -vv \
+       -v \
        --tb=native \
        $DESELECTED_TESTS_STR \
        "$@" \


### PR DESCRIPTION
This reverts commit 2b6dcb0faa28a51989e32da6dd78378778b72198. I'm testing if some of polars tests that are [failing](https://github.com/rapidsai/cudf/actions/runs/13558185762/job/37897248644?pr=18097) due to being run in parallel.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
