### PR TITLE
:construction: Enable `skip_rows` in the chunked parquet reader.

### DIFF
--- a/cpp/src/io/parquet/reader.cpp
+++ b/cpp/src/io/parquet/reader.cpp
@@ -39,11 +39,6 @@ chunked_reader::chunked_reader(std::size_t chunk_read_limit,
                                rmm::cuda_stream_view stream,
                                rmm::device_async_resource_ref mr)
 {
-  // TODO: skip_rows not currently supported in chunked parquet reader until
-  // https://github.com/rapidsai/cudf/issues/16186 is closed
-  CUDF_EXPECTS(options.get_skip_rows() == 0,
-               "skip_rows > 0 is not currently supported in the Chunked Parquet reader.");
-
   _impl = std::make_unique<impl>(
     chunk_read_limit, pass_read_limit, std::move(sources), options, stream, mr);
 }

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -1503,14 +1503,16 @@ void reader::impl::preprocess_subpass_pages(read_mode mode, size_t chunk_read_li
       max_col_row--;
     }
 
-    max_row = min(max_row, max_col_row);
+    max_row = std::min<size_t>(max_row, max_col_row);
 
     page_index += subpass.column_page_count[idx];
   }
   subpass.skip_rows   = pass.skip_rows + pass.processed_rows;
   auto const pass_end = pass.skip_rows + pass.num_rows;
-  max_row             = min(max_row, pass_end);
-  subpass.num_rows    = max_row - subpass.skip_rows;
+  max_row             = std::min<size_t>(max_row, pass_end);
+  // Make sure we don't skip past the max rows.
+  CUDF_EXPECTS(max_row > subpass.skip_rows, "Unexpected subpass row count");
+  subpass.num_rows = max_row - subpass.skip_rows;
 
   // now split up the output into chunks as necessary
   compute_output_chunks_for_subpass();


### PR DESCRIPTION
## Description
:construction: Closes #16186

This PR adds a bug fix essential to re-enable the `skip_rows` option for the Chunked Parquet reader.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
