### PR TITLE
Use protocol for dlpack instead of deprecated function

### DIFF
--- a/python/cudf/cudf/core/df_protocol.py
+++ b/python/cudf/cudf/core/df_protocol.py
@@ -105,7 +105,7 @@ class _CuDFBuffer:
         # DLPack not implemented in NumPy yet, so leave it out here.
         try:
             cuda_array = as_cuda_array(self._buf).view(self._dtype)
-            return cp.asarray(cuda_array).toDlpack()
+            return cp.asarray(cuda_array).__dlpack__()
         except ValueError:
             raise TypeError(f"dtype {self._dtype} unsupported by `dlpack`")
 

--- a/python/cudf/cudf/core/subword_tokenizer.py
+++ b/python/cudf/cudf/core/subword_tokenizer.py
@@ -19,7 +19,7 @@ def _cast_to_appropriate_type(ar, cast_type):
     elif cast_type == "tf":
         from tensorflow.experimental.dlpack import from_dlpack
 
-    return from_dlpack(ar.astype("int32").toDlpack())
+    return from_dlpack(ar.astype("int32").__dlpack__())
 
 
 class SubwordTokenizer:

--- a/python/cudf/cudf/tests/test_dlpack.py
+++ b/python/cudf/cudf/tests/test_dlpack.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 
 import itertools
 from contextlib import ExitStack as does_not_raise
@@ -140,7 +140,7 @@ def test_to_dlpack_cupy_2d(data_2d):
 def test_from_dlpack_cupy_1d(data_1d):
     cupy_array = cupy.array(data_1d)
     cupy_host_array = cupy_array.get()
-    dlt = cupy_array.toDlpack()
+    dlt = cupy_array.__dlpack__()
 
     gs = cudf.from_dlpack(dlt)
     cudf_host_array = gs.to_numpy(na_value=np.nan)
@@ -151,7 +151,7 @@ def test_from_dlpack_cupy_1d(data_1d):
 def test_from_dlpack_cupy_2d(data_2d):
     cupy_array = cupy.array(data_2d, order="F")
     cupy_host_array = cupy_array.get().flatten()
-    dlt = cupy_array.toDlpack()
+    dlt = cupy_array.__dlpack__()
 
     gdf = cudf.from_dlpack(dlt)
     cudf_host_array = np.array(gdf.to_pandas()).flatten()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR adapts cudf's dlpack tests for compatibility with cupy 13.4, which was just released yesterday on PyPI and containers https://github.com/cupy/cupy/pull/8722 that breaks the legacy toDlpack functionality.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
