### PR TITLE
Reduce memory use when writing tables with very short columns to ORC

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -153,7 +153,7 @@ jobs:
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@testing/114_nightly
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-25.04
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -153,7 +153,7 @@ jobs:
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-25.04
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@testing/114_nightly
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -2228,7 +2228,6 @@ stripe_dictionaries build_dictionaries(orc_table_view& orc_table,
 
 [[nodiscard]] uint32_t find_largest_stream_size(device_2dspan<stripe_stream const> ss,
                                                 rmm::cuda_stream_view stream)
-
 {
   auto const longest_stream = thrust::max_element(
     rmm::exec_policy(stream),

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -2226,14 +2226,14 @@ stripe_dictionaries build_dictionaries(orc_table_view& orc_table,
           std::move(dict_order_owner)};
 }
 
-size_t find_largest_stream(hostdevice_2dvector<stripe_stream> const& ss,
-                           rmm::cuda_stream_view stream)
+[[nodiscard]] size_t find_largest_stream_size(device_2dspan<stripe_stream const> ss,
+                                              rmm::cuda_stream_view stream)
 
 {
   auto const longest_stream = thrust::max_element(
     rmm::exec_policy(stream),
-    ss.device_view().data(),
-    ss.device_view().data() + ss.count(),
+    ss.data(),
+    ss.data() + ss.count(),
     cuda::proclaim_return_type<bool>([] __device__(auto const& lhs, auto const& rhs) {
       return lhs.stream_size < rhs.stream_size;
     }));
@@ -2341,9 +2341,9 @@ auto convert_table_to_orc_data(table_view const& input,
   size_t compressed_bfr_size   = 0;
   size_t num_compressed_blocks = 0;
 
-  auto const largest_stream = find_largest_stream(strm_descs, stream);
+  auto const largest_stream_size = find_largest_stream_size(strm_descs, stream);
   auto const max_compressed_block_size =
-    max_compressed_size(compression, std::min(largest_stream, compression_blocksize));
+    max_compressed_size(compression, std::min(largest_stream_size, compression_blocksize));
   auto const padded_max_compressed_block_size =
     util::round_up_unsafe<size_t>(max_compressed_block_size, block_align);
   auto const padded_block_header_size =

--- a/cpp/src/utilities/host_memory.cpp
+++ b/cpp/src/utilities/host_memory.cpp
@@ -25,6 +25,7 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
+
 namespace cudf {
 
 namespace {
@@ -48,16 +49,13 @@ class fixed_pinned_pool_memory_resource {
       pool_size_{rmm::align_up(size, rmm::CUDA_ALLOCATION_ALIGNMENT)},
       pool_{new host_pooled_mr(upstream_mr_, pool_size_, pool_size_)}
   {
+    CUDF_LOG_INFO("Pinned pool size = %zu", pool_size_);
+
     // Allocate full size from the pinned pool to figure out the beginning and end address
     pool_begin_ = pool_->allocate_async(pool_size_, stream_);
     pool_end_   = static_cast<void*>(static_cast<uint8_t*>(pool_begin_) + pool_size_);
     pool_->deallocate_async(pool_begin_, pool_size_, stream_);
   }
-
-  fixed_pinned_pool_memory_resource(fixed_pinned_pool_memory_resource const&)            = delete;
-  fixed_pinned_pool_memory_resource(fixed_pinned_pool_memory_resource&&)                 = delete;
-  fixed_pinned_pool_memory_resource& operator=(fixed_pinned_pool_memory_resource const&) = delete;
-  fixed_pinned_pool_memory_resource& operator=(fixed_pinned_pool_memory_resource&&)      = delete;
 
   void* allocate_async(std::size_t bytes, std::size_t alignment, cuda::stream_ref stream)
   {

--- a/cpp/src/utilities/host_memory.cpp
+++ b/cpp/src/utilities/host_memory.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "io/utilities/getenv_or.hpp"
+#include "sys/sysinfo.h"
 
 #include <cudf/detail/utilities/stream_pool.hpp>
 #include <cudf/logger.hpp>
@@ -25,10 +26,18 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
-
 namespace cudf {
 
 namespace {
+
+std::size_t get_free_system_memory()
+{
+  struct sysinfo memInfo;
+
+  sysinfo(&memInfo);
+  return memInfo.freeram;
+}
+
 class fixed_pinned_pool_memory_resource {
   using upstream_mr    = rmm::mr::pinned_host_memory_resource;
   using host_pooled_mr = rmm::mr::pool_memory_resource<upstream_mr>;
@@ -45,20 +54,26 @@ class fixed_pinned_pool_memory_resource {
  public:
   fixed_pinned_pool_memory_resource(size_t size)
     :  // rmm requires the pool size to be a multiple of 256 bytes
-      pool_size_{rmm::align_up(size, rmm::CUDA_ALLOCATION_ALIGNMENT)},
-      pool_{new host_pooled_mr(upstream_mr_, pool_size_, pool_size_)}
+      pool_size_{rmm::align_up(size, rmm::CUDA_ALLOCATION_ALIGNMENT)}
   {
+    try {
+      pool_ = new host_pooled_mr{&upstream_mr_, pool_size_};
+    } catch (...) {
+      CUDF_LOG_WARN("Failed to create pinned pool, pinned allocations will potentially be slower");
+    }
     CUDF_LOG_INFO("Pinned pool size = %zu", pool_size_);
 
-    // Allocate full size from the pinned pool to figure out the beginning and end address
-    pool_begin_ = pool_->allocate_async(pool_size_, stream_);
-    pool_end_   = static_cast<void*>(static_cast<uint8_t*>(pool_begin_) + pool_size_);
-    pool_->deallocate_async(pool_begin_, pool_size_, stream_);
+    if (pool_ != nullptr) {
+      // Allocate full size from the pinned pool to figure out the beginning and end address
+      pool_begin_ = pool_->allocate_async(pool_size_, stream_);
+      pool_end_   = static_cast<void*>(static_cast<uint8_t*>(pool_begin_) + pool_size_);
+      pool_->deallocate_async(pool_begin_, pool_size_, stream_);
+    }
   }
 
   void* allocate_async(std::size_t bytes, std::size_t alignment, cuda::stream_ref stream)
   {
-    if (bytes <= pool_size_) {
+    if (pool_ != nullptr && bytes <= pool_size_) {
       try {
         return pool_->allocate_async(bytes, alignment, stream);
       } catch (...) {
@@ -86,7 +101,7 @@ class fixed_pinned_pool_memory_resource {
                         std::size_t alignment,
                         cuda::stream_ref stream)
   {
-    if (bytes <= pool_size_ && ptr >= pool_begin_ && ptr < pool_end_) {
+    if (pool_ != nullptr && bytes <= pool_size_ && ptr >= pool_begin_ && ptr < pool_end_) {
       pool_->deallocate_async(ptr, bytes, alignment, stream);
     } else {
       upstream_mr_.deallocate_async(ptr, bytes, alignment, stream);
@@ -147,7 +162,7 @@ CUDF_EXPORT rmm::host_device_async_resource_ref& make_default_pinned_mr(
       if (auto const env_val = getenv("LIBCUDF_PINNED_POOL_SIZE"); env_val != nullptr) {
         return std::atol(env_val);
       }
-
+      CUDF_LOG_WARN("Free system memory: %ld", get_free_system_memory());
       if (config_size.has_value()) { return *config_size; }
 
       auto const total = rmm::available_device_memory().second;

--- a/cpp/src/utilities/host_memory.cpp
+++ b/cpp/src/utilities/host_memory.cpp
@@ -57,7 +57,7 @@ class fixed_pinned_pool_memory_resource {
       pool_size_{rmm::align_up(size, rmm::CUDA_ALLOCATION_ALIGNMENT)}
   {
     try {
-      pool_ = new host_pooled_mr{&upstream_mr_, pool_size_};
+      pool_ = new host_pooled_mr{upstream_mr_, pool_size_, pool_size_};
     } catch (...) {
       CUDF_LOG_WARN("Failed to create pinned pool, pinned allocations will potentially be slower");
     }
@@ -70,6 +70,11 @@ class fixed_pinned_pool_memory_resource {
       pool_->deallocate_async(pool_begin_, pool_size_, stream_);
     }
   }
+
+  fixed_pinned_pool_memory_resource(fixed_pinned_pool_memory_resource const&)            = delete;
+  fixed_pinned_pool_memory_resource(fixed_pinned_pool_memory_resource&&)                 = delete;
+  fixed_pinned_pool_memory_resource& operator=(fixed_pinned_pool_memory_resource const&) = delete;
+  fixed_pinned_pool_memory_resource& operator=(fixed_pinned_pool_memory_resource&&)      = delete;
 
   void* allocate_async(std::size_t bytes, std::size_t alignment, cuda::stream_ref stream)
   {

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -309,7 +309,7 @@ ConfigureTest(
 ConfigureTest(
   ORC_TEST io/orc_chunked_reader_test.cu io/orc_test.cpp
   GPUS 1
-  PERCENT 30
+  PERCENT 100
 )
 ConfigureTest(
   PARQUET_TEST
@@ -340,7 +340,7 @@ ConfigureTest(JSON_TREE_CSR io/json/json_tree_csr.cu)
 ConfigureTest(
   DATA_CHUNK_SOURCE_TEST io/text/data_chunk_source_test.cpp
   GPUS 1
-  PERCENT 30
+  PERCENT 100
 )
 target_link_libraries(DATA_CHUNK_SOURCE_TEST PRIVATE ZLIB::ZLIB)
 ConfigureTest(LOGICAL_STACK_TEST io/fst/logical_stack_test.cu)


### PR DESCRIPTION
## Description

Closes #18059

To avoid estimating the maximum compressed size for each actual block in the file, ORC writer uses the estimate for the (uncompressed) block size limit, which defaults to 256KB. However, when we write many small blocks, this compressed block size estimate is much larger than what is needed, leading to high memory use for wide/short tables.

This PR adds logic to take the actual block size into account, and to use the size of the actual largest block in the file, not the largest possible block. This changes the memory usage by orders of magnitude in some tests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
