### PR TITLE
Update calls to KvikIO's config setter

### DIFF
--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -36,10 +36,10 @@ void set_up_kvikio()
     cudaFree(nullptr);
 
     auto const compat_mode = kvikio::getenv_or("KVIKIO_COMPAT_MODE", kvikio::CompatMode::ON);
-    kvikio::defaults::compat_mode_reset(compat_mode);
+    kvikio::defaults::set_compat_mode(compat_mode);
 
     auto const nthreads = getenv_or<unsigned int>("KVIKIO_NTHREADS", 4u);
-    kvikio::defaults::thread_pool_nthreads_reset(nthreads);
+    kvikio::defaults::set_thread_pool_nthreads(nthreads);
   });
 }
 


### PR DESCRIPTION
## Description
KvikIO has changed the function names of the config setters to improve clarity (https://github.com/rapidsai/kvikio/pull/644). This PR updates the setter calls in cuDF accordingly.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
