### PR TITLE
Fix Series construction from numpy array with non-native byte order

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2719,8 +2719,16 @@ def as_column(
             return as_column(arbitrary, dtype=dtype, nan_as_null=nan_as_null)
         elif arbitrary.dtype.kind in "biuf":
             from_pandas = nan_as_null is None or nan_as_null
+            try:
+                pa_array = pa.array(arbitrary, from_pandas=from_pandas)
+            except pa.ArrowNotImplementedError:
+                # Byte-swapped arrays not supported
+                pa_array = pa.array(
+                    arbitrary.astype(arbitrary.dtype.newbyteorder()),
+                    from_pandas=from_pandas,
+                )
             return as_column(
-                pa.array(arbitrary, from_pandas=from_pandas),
+                pa_array,
                 dtype=dtype,
                 nan_as_null=nan_as_null,
             )

--- a/python/cudf/cudf/tests/test_series.py
+++ b/python/cudf/cudf/tests/test_series.py
@@ -3040,3 +3040,13 @@ def test_series_dataframe_count_float():
             gs.to_frame().count(),
             gs.to_frame().to_pandas(nullable=True).count(),
         )
+
+
+def test_construct_bigendian_np_array():
+    data = [1, 2, 3.5, 4]
+    dtype = np.dtype("f4")
+    np_array = np.array(data, dtype=dtype)
+    np_bigendian = np.array(data, dtype=dtype.newbyteorder())
+    result = cudf.Series(np_bigendian)
+    expected = cudf.Series(np_array)
+    assert_eq(result, expected)


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/18149

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
