### PR TITLE
xfail Narwhals `over` tests

### DIFF
--- a/python/cudf/cudf/testing/narwhals_test_plugin.py
+++ b/python/cudf/cudf/testing/narwhals_test_plugin.py
@@ -12,6 +12,24 @@ if TYPE_CHECKING:
 
 EXPECTED_FAILURES: Mapping[str, str] = {
     "tests/frame/select_test.py::test_select_duplicates[cudf]": "cuDF doesn't support having multiple columns with same names",
+    "tests/expr_and_series/over_test.py::test_over_cummin[cudf]": "NotImplementedError: Passing kwargs to func is currently not supported",
+    "tests/expr_and_series/over_test.py::test_over_anonymous_cumulative[cudf]": "NotImplementedError: Passing kwargs to func is currently not supported",
+    "tests/expr_and_series/over_test.py::test_over_cummax[cudf]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/over_test.py::test_over_cumprod[cudf]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/over_test.py::test_over_cum_reverse[cudf-cum_max-expected_b0]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/over_test.py::test_over_shift[cudf]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/over_test.py::test_over_cumcount[cudf]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/over_test.py::test_over_cum_reverse[cudf-cum_prod-expected_b4]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/over_test.py::test_over_diff[cudf]": "AttributeError: type object 'Aggregation' has no attribute 'diff'",
+    "tests/expr_and_series/over_test.py::test_over_cum_reverse[cudf-cum_count-expected_b3]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/over_test.py::test_over_cum_reverse[cudf-cum_sum-expected_b2]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/over_test.py::test_over_cum_reverse[cudf-cum_min-expected_b1]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/over_test.py::test_over_cumsum[cudf]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/rank_test.py::test_rank_expr_in_over_context[cudf-ordinal]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/rank_test.py::test_rank_expr_in_over_context[cudf-dense]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/rank_test.py::test_rank_expr_in_over_context[cudf-min]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/rank_test.py::test_rank_expr_in_over_context[cudf-average]": "NotImplementedError: Passing kwargs to func is currently not supported.",
+    "tests/expr_and_series/rank_test.py::test_rank_expr_in_over_context[cudf-max]": "NotImplementedError: Passing kwargs to func is currently not supported.",
 }
 
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
I think https://github.com/narwhals-dev/narwhals/pull/2138 is causing some failures on our side. The kwargs in this [line](https://github.com/narwhals-dev/narwhals/pull/2138/files#diff-0ded7e876f1f6f0aa79abda7252f76be22c1a01b1e97e7b65a5da8fa23e35ffdR71) are ultimately passed to a cudf groupby-apply or transform call which is not supported in cudf. In this PR, I'm xfailing the tests for now until we have a better idea of what change is needed in cudf or narwhals.

CC @MarcoGorelli Do you know of a way we can test on a stable version on Narwhals? 
CC @vyas @mroeschke 
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
