### PR TITLE
Update Dask-cuDF documentation to fix all warnings and errors

### DIFF
--- a/docs/dask_cudf/Makefile
+++ b/docs/dask_cudf/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -n -v
+SPHINXOPTS    ?= -n -v -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SPHINXPROJ    = dask_cudf
 SOURCEDIR     = source

--- a/docs/dask_cudf/source/api.rst
+++ b/docs/dask_cudf/source/api.rst
@@ -2,74 +2,34 @@
  API reference
 ===============
 
-This page provides a list of all publicly accessible modules, methods,
-and classes in the ``dask_cudf`` namespace.
+As recommended in the introduction, we recommend that you use ``dask_cudf``
+through the `Dask DataFrame`_ API with the backend set to cudf.
 
+.. code-block:: python
+
+   >>> import dask
+   >>> dask.config.set({"dataframe.backend": "cudf"})
+
+With this configuration, ``dask_cudf`` will behave as documented in the Dask
+DataFrame API, but with ``cudf`` objects used in place of ``pandas`` objects.
+
+The rest of this page documents the API you might use from ``dask_cudf``
+explicitly.
 
 Creating and storing DataFrames
 ===============================
 
 :doc:`Like Dask <dask:dataframe-create>`, Dask-cuDF supports creation
-of DataFrames from a variety of storage formats. For on-disk data that
-are not supported directly in Dask-cuDF, we recommend using Dask's
-data reading facilities, followed by calling
-:meth:`*.to_backend("cudf")` to obtain a Dask-cuDF object.
+of DataFrames from a variety of storage formats. In addition to the methods
+documented there, Dask-cuDF provides some cuDF-specific methods:
 
 .. automodule:: dask_cudf
    :members:
       from_cudf,
-      from_delayed,
-      read_csv,
-      read_json,
-      read_orc,
-      to_orc,
-      read_text,
-      read_parquet
 
-Grouping
-========
+For on-disk data that are not supported directly in Dask or Dask-cuDF, we
+recommend using Dask's data reading facilities, followed by calling
+:meth:`dask.dataframe.DataFrame.to_backend` with ``"cudf"`` to obtain a
+Dask-cuDF object.
 
-As discussed in the :doc:`Dask documentation for groupby
-<dask:dataframe-groupby>`, ``groupby``, ``join``, and ``merge``, and
-similar operations that require matching up rows of a DataFrame become
-significantly more challenging in a parallel setting than they are in
-serial. Dask-cuDF has the same challenges, however for certain groupby
-operations, we can take advantage of functionality in cuDF that allows
-us to compute multiple aggregations at once. There are therefore two
-interfaces to grouping in Dask-cuDF, the general
-:meth:`DataFrame.groupby` which returns a
-:class:`.CudfDataFrameGroupBy` object, and a specialized
-:func:`.groupby_agg`. Generally speaking, you should not need to call
-:func:`.groupby_agg` directly, since Dask-cuDF will arrange to call it
-if possible.
-
-.. autoclass:: dask_cudf.groupby.CudfDataFrameGroupBy
-   :members:
-   :inherited-members:
-   :show-inheritance:
-
-.. autofunction:: dask_cudf.groupby_agg
-
-
-DataFrames and Series
-=====================
-
-The core distributed objects provided by Dask-cuDF are the
-:class:`.DataFrame` and :class:`.Series`. These inherit respectively
-from :class:`dask.dataframe.DataFrame` and
-:class:`dask.dataframe.Series`, and so the API is essentially
-identical. The full API is provided below.
-
-.. autoclass:: dask_cudf.DataFrame
-   :members:
-   :inherited-members:
-   :show-inheritance:
-
-.. autoclass:: dask_cudf.Series
-   :members:
-   :inherited-members:
-   :show-inheritance:
-
-.. automodule:: dask_cudf
-   :members:
-      concat
+.. _Dask DataFrame: https://docs.dask.org/en/stable/dataframe.html

--- a/docs/dask_cudf/source/conf.py
+++ b/docs/dask_cudf/source/conf.py
@@ -83,6 +83,8 @@ numpydoc_show_inherited_class_members = True
 numpydoc_class_members_toctree = False
 numpydoc_attributes_as_param_list = False
 
+nitpicky = True
+
 
 def setup(app):
     app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")

--- a/docs/dask_cudf/source/index.rst
+++ b/docs/dask_cudf/source/index.rst
@@ -56,12 +56,13 @@ Once this is done, the public Dask DataFrame API will leverage
 from an on-disk format using any of the following ``dask.dataframe``
 functions:
 
-* :func:`read_parquet`
-* :func:`read_json`
-* :func:`read_csv`
-* :func:`read_orc`
-* :func:`read_hdf`
-* :func:`from_dict`
+* :py:func:`dask.dataframe.read_parquet`
+* :py:func:`dask.dataframe.read_json`
+* :py:func:`dask.dataframe.read_csv`
+* :py:func:`dask.dataframe.read_orc`
+* :py:func:`dask.dataframe.read_hdf`
+* :py:meth:`dask.dataframe.DataFrame.from_dict`
+
 
 For example::
 
@@ -77,8 +78,8 @@ For example::
   df = dd.read_parquet("data.parquet", ...)
 
 When other functions are used to create a new collection
-(e.g. :func:`from_map`, :func:`from_pandas`, :func:`from_delayed`,
-and :func:`from_array`), the backend of the new collection will
+(e.g. :func:`dask.dataframe.from_map`, :func:`dask.dataframe.from_pandas`, :func:`dask.dataframe.from_delayed`,
+and :func:`dask.dataframe.from_array`), the backend of the new collection will
 depend on the inputs to those functions. For example::
 
   import pandas as pd
@@ -91,7 +92,7 @@ depend on the inputs to those functions. For example::
   dd.from_pandas(cudf.DataFrame({"a": range(10)}))
 
 An existing collection can always be moved to a specific backend
-using the :func:`dask.dataframe.DataFrame.to_backend` API::
+using the :meth:`dask.dataframe.DataFrame.to_backend` API::
 
   # This ensures that we have a cuDF-backed dataframe
   df = df.to_backend("cudf")
@@ -144,10 +145,9 @@ Simplified expression graph (``df.simplify().pprint()``)::
 
 .. note::
   Dask will automatically simplify the expression graph (within
-  :func:`optimize`) when the result is converted to a task graph
-  (via :func:`compute` or :func:`persist`). You do not need to call
-  :func:`simplify` yourself.
-
+  :func:`dask.optimize`) when the result is converted to a task graph
+  (via :func:`dask.compute` or :func:`dask.persist`). You do not need
+  to optimize or simplify the graph yourself.
 
 Using Multiple GPUs and Multiple Nodes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -184,8 +184,8 @@ to define a client object. For example::
     agg.compute()  # This will use the cluster defined above
 
 .. note::
-  This example uses :func:`compute` to materialize a concrete
-  ``cudf.DataFrame`` object in local memory. Never call :func:`compute`
+  This example uses :func:`dask.compute` to materialize a concrete
+  ``cudf.DataFrame`` object in local memory. Never call :func:`dask.compute`
   on a large collection that cannot fit comfortably in the memory of a
   single GPU! See Dask's `documentation on managing computation
   <https://distributed.dask.org/en/stable/manage-computation.html>`__
@@ -214,6 +214,7 @@ differences and all functionality that Dask cuDF supports.
 .. toctree::
    :maxdepth: 2
 
+   best_practices
    api
 
 

--- a/python/dask_cudf/dask_cudf/core.py
+++ b/python/dask_cudf/dask_cudf/core.py
@@ -36,14 +36,18 @@ def from_cudf(data, npartitions=None, chunksize=None, sort=True, name=None):
 
 from_cudf.__doc__ = textwrap.dedent(
     """
-        Create a :class:`.DataFrame` from a :class:`cudf.DataFrame`.
+        Create a :class:`dask.dataframe.DataFrame` from a :class:`cudf.DataFrame`.
 
         This function is a thin wrapper around
         :func:`dask.dataframe.from_pandas`, accepting the same
         arguments (described below) excepting that it operates on cuDF
         rather than pandas objects.\n
         """
-) + textwrap.dedent(dd.from_pandas.__doc__)
+) + (
+    textwrap.dedent(dd.from_pandas.__doc__)
+    .replace("from_array", "dask.dataframe.from_array")
+    .replace("read_csv", "dask.dataframe.read_csv")
+)
 
 
 def _deprecated_api(old_api, new_api=None, rec=None):


### PR DESCRIPTION
This updates the dask-cudf docs to fix a few things

1. Removes the majority of the API reference, which is mostly inherited from dask.dataframe.
2. Updates all references that previously pointed to our API docs to dasks (e.g. ``:meth:\`dataframe.read_parquet\`` is now `:meth:\`dask.dataframe.read_parquet`` )
3. Links to best-practices (which was previously orphaned) from index.rst
4. fixes all remaining warnings

More context on the first change: our documentation recommends using the ``dask.dataframe`` API with the cudf backend set. This is functionally equivalent to using APIs from ``dask_cudf`` directly. I think the API refererence should match what we document, and because we are inheriting all the docstrings there isn't really any value in having them in both places (dask and dask-cudf).


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
