### PR TITLE
Move execution context into the Expr nodes

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 # TODO: remove need for this
 # ruff: noqa: D101
@@ -13,16 +13,21 @@ from cudf_polars.dsl.expressions.base import Expr
 if TYPE_CHECKING:
     import pylibcudf as plc
 
+    from cudf_polars.dsl.expressions.base import ExecutionContext
+
 __all__ = ["GroupedRollingWindow", "RollingWindow"]
 
 
 class RollingWindow(Expr):
     __slots__ = ("options",)
-    _non_child = ("dtype", "options")
+    _non_child = ("dtype", "context", "options")
 
-    def __init__(self, dtype: plc.DataType, options: Any, agg: Expr) -> None:
+    def __init__(
+        self, dtype: plc.DataType, context: ExecutionContext, options: Any, agg: Expr
+    ) -> None:
         self.dtype = dtype
         self.options = options
+        self.context = context
         self.children = (agg,)
         self.is_pointwise = False
         raise NotImplementedError("Rolling window not implemented")
@@ -30,11 +35,19 @@ class RollingWindow(Expr):
 
 class GroupedRollingWindow(Expr):
     __slots__ = ("options",)
-    _non_child = ("dtype", "options")
+    _non_child = ("dtype", "context", "options")
 
-    def __init__(self, dtype: plc.DataType, options: Any, agg: Expr, *by: Expr) -> None:
+    def __init__(
+        self,
+        dtype: plc.DataType,
+        context: ExecutionContext,
+        options: Any,
+        agg: Expr,
+        *by: Expr,
+    ) -> None:
         self.dtype = dtype
         self.options = options
+        self.context = context
         self.children = (agg, *by)
         self.is_pointwise = False
         raise NotImplementedError("Grouped rolling window not implemented")

--- a/python/cudf_polars/cudf_polars/dsl/expressions/slicing.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/slicing.py
@@ -8,10 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from cudf_polars.dsl.expressions.base import (
-    ExecutionContext,
-    Expr,
-)
+from cudf_polars.dsl.expressions.base import Expr
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -19,6 +16,7 @@ if TYPE_CHECKING:
     import pylibcudf as plc
 
     from cudf_polars.containers import Column, DataFrame
+    from cudf_polars.dsl.expressions.base import ExecutionContext
 
 
 __all__ = ["Slice"]
@@ -26,16 +24,18 @@ __all__ = ["Slice"]
 
 class Slice(Expr):
     __slots__ = ("length", "offset")
-    _non_child = ("dtype", "offset", "length")
+    _non_child = ("dtype", "context", "offset", "length")
 
     def __init__(
         self,
         dtype: plc.DataType,
+        context: ExecutionContext,
         offset: int,
         length: int,
         column: Expr,
     ) -> None:
         self.dtype = dtype
+        self.context = context
         self.offset = offset
         self.length = length
         self.children = (column,)
@@ -44,7 +44,6 @@ class Slice(Expr):
         self,
         df: DataFrame,
         *,
-        context: ExecutionContext = ExecutionContext.FRAME,
         mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""

--- a/python/cudf_polars/cudf_polars/dsl/to_ast.py
+++ b/python/cudf_polars/cudf_polars/dsl/to_ast.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """Conversion of expression nodes to libcudf AST nodes."""
@@ -275,6 +275,7 @@ def _insert_colrefs(node: expr.Expr, rec: ExprTransformer) -> expr.Expr:
     if isinstance(node, expr.Col):
         return expr.ColRef(
             node.dtype,
+            node.context,
             rec.state["name_to_index"][node.name],
             rec.state["table_ref"],
             node,


### PR DESCRIPTION
## Description
This way the context becomes part of the hash key. This is necessary to notice the difference between an Expr that appears inside a groupby and one that appears outside.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
