### PR TITLE
Fix merge(how=left, left_on=, right_index=True, sort=True)

### DIFF
--- a/python/cudf/cudf/tests/test_joining.py
+++ b/python/cudf/cudf/tests/test_joining.py
@@ -2302,3 +2302,24 @@ def test_merge_suffixes_duplicate_label_raises():
 
     with pytest.raises(NotImplementedError):
         result.merge(df_cudf, on=["a"], suffixes=("", "_right"))
+
+
+def test_merge_left_on_right_index_sort():
+    ser = cudf.Series(range(10), name="left_ser")
+    ser2 = cudf.Series(
+        range(10), index=[4, 5, 6, 3, 2, 1, 8, 9, 0, 7], name="right_ser"
+    )
+    ser_pd = ser.to_pandas()
+    ser2_pd = ser2.to_pandas()
+    result = cudf.merge(
+        ser, ser2, how="left", left_on="left_ser", right_index=True, sort=True
+    )
+    expected = pd.merge(
+        ser_pd,
+        ser2_pd,
+        how="left",
+        left_on="left_ser",
+        right_index=True,
+        sort=True,
+    )
+    assert_eq(result, expected)


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/18153

This fix a bit more conservative than what was initially done in https://github.com/rapidsai/cudf/pull/17739. 

Before, we were modifying the `_using_left_index/_using_right_index` attributes which affects other merge operations besides setting the result index. Now, this PR scopes a specific attribute to determine when to set a `RangeIndex` in the result

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
