### PR TITLE
Add fmt to the test/benchmarks env

### DIFF
--- a/conda/recipes/libcudf/recipe.yaml
+++ b/conda/recipes/libcudf/recipe.yaml
@@ -285,6 +285,7 @@ outputs:
         - ${{ pin_subpackage("libcudf", exact=True) }}
         - ${{ pin_subpackage("libcudf_kafka", exact=True) }}
         - cuda-version =${{ cuda_version }}
+        - fmt >=11.0.2,<12
         - if: cuda_major == "11"
           then:
             - libcurand ${{ cuda11_libcurand_run_version }}


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
With the transition to rapids-logger libcudf no longer has a direct dependency on fmt. However, the benchmarks still have a transitive dependency via nvbench. Interestingly, the google benchmarks also seem to have a dependency there and I have not uncovered why yet. With the merge of https://github.com/rapidsai/rapids-cmake/pull/790, builds using rapids-cmake no longer require a patched version of fmt anywhere, which is resulting in benchmark builds picking up fmt from the environment. This results in overlinking issues for the benchmarks binaries, and if the check is disabled the binaries fail at runtime since fmt will not be present in the runtime environment. This PR temporarily patches this issue by adding the dependency until we can figure out how we want to deal with it going forward.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
