### PR TITLE
Skip flaky multi GPU test

### DIFF
--- a/ci/run_cudf_polars_pytests.sh
+++ b/ci/run_cudf_polars_pytests.sh
@@ -17,5 +17,5 @@ python -m pytest --cache-clear "$@" tests --executor dask-experimental
 # Test the "dask-experimental" executor with Distributed cluster
 # Not all tests pass yet, deselecting by name those that are failing.
 python -m pytest --cache-clear "$@" tests --executor dask-experimental --dask-cluster \
-    -k "not test_groupby_maintain_order_random and not test_scan_csv_multi and not test_select_literal_series and not test_can_convert_lists and not test_executor_basics and not test_replace_literal and not test_hconcat_different_heights and not test_join and not test_dataframescan and not test_strip_chars" \
+    -k "not test_groupby_maintain_order_random and not test_scan_csv_multi and not test_select_literal_series and not test_can_convert_lists and not test_executor_basics and not test_replace_literal and not test_hconcat_different_heights and not test_join and not test_dataframescan and not test_strip_chars and not test_agg" \
     --cov-fail-under=80  # Override coverage, Distributed cluster coverage not yet 100%


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR skips a flaky test for the experimental dask engine for polars. An example failure is https://github.com/rapidsai/cudf/actions/runs/13705493794/job/38331727822?pr=18175
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
