### PR TITLE
Ensure RAPIDS_ARTIFACTS_DIR is set for build metrics reports.

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -20,6 +20,9 @@ sccache --zero-stats
 RAPIDS_PACKAGE_VERSION=$(rapids-generate-version)
 export RAPIDS_PACKAGE_VERSION
 
+RAPIDS_ARTIFACTS_DIR=${RAPIDS_ARTIFACTS_DIR:-"${PWD}/artifacts"}
+mkdir -p "${RAPIDS_ARTIFACTS_DIR}"
+
 source rapids-rattler-channel-string
 
 # --no-build-id allows for caching with `sccache`


### PR DESCRIPTION
## Description
This fixes an issue where local reproductions of CI fail with the following error:

```
 ╭─ Finding outputs from recipe
 │ Loading variant config file: "/cudf/conda/recipes/libcudf/conda_build_config.yaml"
 │
 ╰─────────────────── (took 0 seconds)
Error:   × Failed to parse recipe

Error:
  × failed to render Jinja expression: invalid operation: Environment variable RAPIDS_ARTIFACTS_DIR not found (in <string>:1)
    ╭─[conda/recipes/libcudf/recipe.yaml:45:31]
 44 │         PARALLEL_LEVEL: ${{ env.get("PARALLEL_LEVEL") }}
 45 │         RAPIDS_ARTIFACTS_DIR: ${{ env.get("RAPIDS_ARTIFACTS_DIR") }}
    ·                               ───────────────────┬──────────────────
    ·                                                  ╰── invalid operation: Environment variable RAPIDS_ARTIFACTS_DIR not found
 46 │         SCCACHE_BUCKET: ${{ env.get("SCCACHE_BUCKET") }}
    ╰────
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
