### PR TITLE
Added pylibcudf.contiguous_split to API docs

### DIFF
--- a/docs/cudf/source/pylibcudf/api_docs/contiguous_split.rst
+++ b/docs/cudf/source/pylibcudf/api_docs/contiguous_split.rst
@@ -1,0 +1,6 @@
+================
+contiguous_split
+================
+
+.. automodule:: pylibcudf.contiguous_split
+   :members:

--- a/docs/cudf/source/pylibcudf/api_docs/index.rst
+++ b/docs/cudf/source/pylibcudf/api_docs/index.rst
@@ -13,6 +13,7 @@ This page provides API documentation for pylibcudf.
     column
     column_factories
     concatenate
+    contiguous_split
     copying
     datetime
     expressions


### PR DESCRIPTION
This module was missing from the API docs.
