### PR TITLE
fix(rattler): add `cudatoolkit` ignore run export to `cudf`

### DIFF
--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -111,6 +111,8 @@ requirements:
           - cuda-cudart-dev
           - if: linux and x86_64
             then: libcufile-dev
+        else:
+          - cudatoolkit
     by_name:
       - cuda-version
 


### PR DESCRIPTION
## Description

`cudatoolkit` was version constrained to >=11.8 because of an inherited run
export, causing older versions to be installed on CI runs (see
https://github.com/rapidsai/cudf/actions/runs/13714799167/job/38378393950)

This removes that constraint.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
