### PR TITLE
Update Numpy <2.1 unpinning xfail condition

### DIFF
--- a/python/cudf/cudf/tests/test_array_ufunc.py
+++ b/python/cudf/cudf/tests/test_array_ufunc.py
@@ -91,7 +91,8 @@ def test_ufunc_index(request, ufunc):
     request.applymarker(
         pytest.mark.xfail(
             condition=fname in {"ceil", "floor", "trunc"}
-            and parse(np.__version__) >= parse("2.1"),
+            and parse(np.__version__) >= parse("2.1")
+            and parse(cp.__version__) < parse("14"),
             reason="https://github.com/cupy/cupy/issues/9018",
         )
     )
@@ -401,7 +402,8 @@ def test_ufunc_dataframe(request, ufunc, has_nulls, indexed):
         pytest.mark.xfail(
             condition=fname in {"ceil", "floor", "trunc"}
             and not has_nulls
-            and parse(np.__version__) >= parse("2.1"),
+            and parse(np.__version__) >= parse("2.1")
+            and parse(cp.__version__) < parse("14"),
             reason="https://github.com/cupy/cupy/issues/9018",
         )
     )

--- a/python/cudf/cudf/tests/test_unaops.py
+++ b/python/cudf/cudf/tests/test_unaops.py
@@ -5,6 +5,7 @@ import operator
 import re
 from decimal import Decimal
 
+import cupy as cp
 import numpy as np
 import pandas as pd
 import pytest
@@ -89,7 +90,8 @@ def test_scalar_unary_operations(slr, dtype, op, request):
         pytest.mark.xfail(
             condition=op in {np.ceil, np.floor}
             and not isinstance(slr, float)
-            and parse(np.__version__) >= parse("2.1"),
+            and parse(np.__version__) >= parse("2.1")
+            and parse(cp.__version__) < parse("14.0"),
             reason="https://github.com/cupy/cupy/issues/9018",
         )
     )


### PR DESCRIPTION
## Description
Updating the xfail condition in https://github.com/rapidsai/cudf/pull/18128 to capture that this behavior will be fixed in cupy 14 (https://github.com/cupy/cupy/issues/9018#issuecomment-2705550983) so we can avoid failures here when cupy 14 is released

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
