### PR TITLE
Export RAPIDS_ARTIFACTS_DIR.

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -22,6 +22,7 @@ export RAPIDS_PACKAGE_VERSION
 
 RAPIDS_ARTIFACTS_DIR=${RAPIDS_ARTIFACTS_DIR:-"${PWD}/artifacts"}
 mkdir -p "${RAPIDS_ARTIFACTS_DIR}"
+export RAPIDS_ARTIFACTS_DIR
 
 source rapids-rattler-channel-string
 


### PR DESCRIPTION
## Description
Fix for #18192. The environment variables `RAPIDS_ARTIFACTS_DIR` is now exported, so that `rattler-build` can see it.

I verified this works for local reproductions of CI builds.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
