### PR TITLE
Workaround for ARM compiler issue with single space literal string

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -153,7 +153,7 @@ jobs:
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@disable-arm-pr-ci
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@test-more-configs
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -153,7 +153,7 @@ jobs:
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@test-more-configs
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@disable-arm-pr-ci
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request

--- a/cpp/src/text/bpe/load_merge_pairs.cu
+++ b/cpp/src/text/bpe/load_merge_pairs.cu
@@ -107,8 +107,9 @@ std::unique_ptr<bpe_merge_pairs::bpe_merge_pairs_impl> create_bpe_merge_pairs_im
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
+  auto space = std::string(" ");  // workaround to ARM issue
   auto pairs =
-    cudf::strings::split_record(input, cudf::string_scalar(" ", true, stream, mr), 1, stream, mr);
+    cudf::strings::split_record(input, cudf::string_scalar(space, true, stream, mr), 1, stream, mr);
   auto content = pairs->release();
   return create_bpe_merge_pairs_impl(std::move(content.children.back()), stream);
 }

--- a/cpp/src/text/bpe/load_merge_pairs.cu
+++ b/cpp/src/text/bpe/load_merge_pairs.cu
@@ -107,7 +107,7 @@ std::unique_ptr<bpe_merge_pairs::bpe_merge_pairs_impl> create_bpe_merge_pairs_im
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  auto space = std::string(" ");  // workaround to ARM issue
+  auto const space = std::string(" ");  // workaround to ARM issue
   auto pairs =
     cudf::strings::split_record(input, cudf::string_scalar(space, true, stream, mr), 1, stream, mr);
   auto content = pairs->release();

--- a/cpp/src/text/subword/load_hash_file.cu
+++ b/cpp/src/text/subword/load_hash_file.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,7 +205,7 @@ std::unique_ptr<hashed_vocabulary> load_vocabulary_file(
 
   for (int i = 0; i < result.num_bins; ++i) {
     std::getline(hash_file, line);
-    size_t loc_of_space = line.find(" ");
+    size_t loc_of_space = line.find(' ');
     CUDF_EXPECTS(loc_of_space != line.npos, "invalid hash file format");
 
     std::string first_num  = line.substr(0, loc_of_space);


### PR DESCRIPTION
## Description
This works around CI failures on ARM build machines where single space literal character array is not working properly.

Minimal example of failures found
```
auto input = std::string("string with spaces");
auto space = std::string(" ");
auto sview = std::string_view(" ");
auto schar = " ";

input.find(' ') works
input.find(" ") fails
input.find(space) works
input.find(sview) fails
input.find(schar) fails
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
