### PR TITLE
Disable conda prefix patching to avoid mangling binaries

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -156,7 +156,7 @@ jobs:
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@disable-arm-pr-ci
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@test-more-configs
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
@@ -169,7 +169,7 @@ jobs:
   conda-python-cudf-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@disable-arm-pr-ci
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@test-more-configs
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       build_type: pull-request
@@ -178,7 +178,7 @@ jobs:
     # Tests for dask_cudf, custreamz, cudf_kafka are separated for CI parallelism
     needs: [conda-python-build, changed-files]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.04
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@test-more-configs
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       build_type: pull-request

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -156,7 +156,7 @@ jobs:
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@test-more-configs
+    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@disable-arm-pr-ci
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
@@ -169,7 +169,7 @@ jobs:
   conda-python-cudf-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@test-more-configs
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@disable-arm-pr-ci
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       build_type: pull-request
@@ -178,7 +178,7 @@ jobs:
     # Tests for dask_cudf, custreamz, cudf_kafka are separated for CI parallelism
     needs: [conda-python-build, changed-files]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@test-more-configs
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.04
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       build_type: pull-request

--- a/conda/recipes/libcudf/recipe.yaml
+++ b/conda/recipes/libcudf/recipe.yaml
@@ -106,14 +106,7 @@ outputs:
         overlinking_behavior: "error"
       prefix_detection:
         ignore:
-          # Due to the present of __FILE__ in cudf and rmm's error macros,
-          # rattler's prefix replacement will modify the binary directly to use
-          # paths that point into the install prefix. This causes problems for
-          # C++ strings where a null terminator is not required and conda's
-          # replacement logic is therefore incorrect, breaking rodata constants
-          # that other parts of the code rely on. Since the paths only exist in
-          # error messages, removing the prefix replacement is an acceptable
-          # alternative for now.
+          # See https://github.com/rapidsai/build-planning/issues/160
           - lib/libcudf.so
     requirements:
       build:

--- a/conda/recipes/libcudf/recipe.yaml
+++ b/conda/recipes/libcudf/recipe.yaml
@@ -104,6 +104,17 @@ outputs:
       string: cuda${{ cuda_major }}_${{ date_string }}_${{ head_rev }}
       dynamic_linking:
         overlinking_behavior: "error"
+      prefix_detection:
+        ignore:
+          # Due to the present of __FILE__ in cudf and rmm's error macros,
+          # rattler's prefix replacement will modify the binary directly to use
+          # paths that point into the install prefix. This causes problems for
+          # C++ strings where a null terminator is not required and conda's
+          # replacement logic is therefore incorrect, breaking rodata constants
+          # that other parts of the code rely on. Since the paths only exist in
+          # error messages, removing the prefix replacement is an acceptable
+          # alternative for now.
+          - lib/libcudf.so
     requirements:
       build:
         - cmake ${{ cmake_version }}


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR disables part of rattler-build's process for making packages relocatable ([see the conda-build docs](https://docs.conda.io/projects/conda-build/en/latest/resources/make-relocatable.html)) because it was resulting in an unsafe modification to libcudf binaries. A much longer writeup is in #18251.

Fixes #18251 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
