### PR TITLE
Ignore `cudatoolkit` run exports by name, not package

### DIFF
--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -111,10 +111,10 @@ requirements:
           - cuda-cudart-dev
           - if: linux and x86_64
             then: libcufile-dev
-        else:
-          - cudatoolkit
     by_name:
       - cuda-version
+      - if: cuda_major == "11"
+        then: cudatoolkit
 
 tests:
   - python:

--- a/conda/recipes/pylibcudf/recipe.yaml
+++ b/conda/recipes/pylibcudf/recipe.yaml
@@ -91,10 +91,10 @@ requirements:
           - if: linux and x86_64
             then:
               - libcufile-dev
-        else:
-          - cudatoolkit
     by_name:
       - cuda-version
+      - if: cuda_major == "11"
+        then: cudatoolkit
 
 tests:
   - python:


### PR DESCRIPTION

## Description

The `cudatoolkit` export is inherited from the cuda compilers
metapackage, so ignoring `from_package` won't catch it.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
