### PR TITLE
WIP: type-erase offsets buffer type in contiguous_split

### DIFF
--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -181,7 +181,7 @@ __device__ void copy_buffer(uint8_t* __restrict__ dst,
                             std::size_t element_size,
                             std::size_t src_element_index,
                             uint32_t stride,
-                            int value_shift,
+                            cuda::std::int64_t value_shift,
                             int bit_shift,
                             std::size_t num_rows,
                             size_type* valid_count)


### PR DESCRIPTION
## Description
Large strings have an int64 offset buffer, so we must handle that.

- Closes #18228

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
