### PR TITLE
Use CCCL::libcudacxx include directories in Jitify preprocessing.

### DIFF
--- a/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
+++ b/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -23,6 +23,7 @@ target_link_libraries(jitify_preprocess PUBLIC ${CMAKE_DL_LIBS})
 function(jit_preprocess_files)
   cmake_parse_arguments(ARG "" "SOURCE_DIRECTORY" "FILES" ${ARGN})
 
+  get_target_property(libcudacxx_raw_includes CCCL::libcudacxx INTERFACE_INCLUDE_DIRECTORIES)
   set(includes)
   foreach(inc IN LISTS libcudacxx_raw_includes CUDAToolkit_INCLUDE_DIRS)
     list(APPEND includes "-I${inc}")


### PR DESCRIPTION
## Description
This fixes our jitify preprocessing commands to use include directories from the libcudacxx (CCCL) target that cuDF is using, rather than falling back to the CUDA Toolkit version.

This was removed earlier in commit 38616feaf04fcc1c410b1f1454c7a97bd0873ca5, perhaps by accident, but went unnoticed because the bundled CUDA Toolkit libcudacxx was sufficient.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
