### PR TITLE
Explain why we disable parallelism for profiler tests to avoid pytest-cov issue

### DIFF
--- a/ci/cudf_pandas_scripts/run_tests.sh
+++ b/ci/cudf_pandas_scripts/run_tests.sh
@@ -79,11 +79,11 @@ python -m pytest -p cudf.pandas \
     --cov-report=term \
     ./python/cudf/cudf_pandas_tests/
 
-# pytest-xdist and pytest-cov prevent our profiler's trace function from running,  
-# even with pytest.mark.no_cover. This likely stems from specialized logic in  
-# coveragepy and pytest-cov for distributed testing (pytest-dev/pytest-cov#246).  
-# As a workaround, we run profiler tests separately without parallelism or `--cov`.  
-# More details: https://github.com/rapidsai/cudf/pull/16930#issuecomment-2707873968  
+# pytest-xdist and pytest-cov prevent our profiler's trace function from running,
+# even with pytest.mark.no_cover. This likely stems from specialized logic in
+# coveragepy and pytest-cov for distributed testing (pytest-dev/pytest-cov#246).
+# As a workaround, we run profiler tests separately without parallelism or `--cov`.
+# More details: https://github.com/rapidsai/cudf/pull/16930#issuecomment-2707873968
 python -m pytest -p cudf.pandas \
     --ignore=./python/cudf/cudf_pandas_tests/third_party_integration_tests/ \
     --numprocesses=1 \

--- a/ci/cudf_pandas_scripts/run_tests.sh
+++ b/ci/cudf_pandas_scripts/run_tests.sh
@@ -79,6 +79,11 @@ python -m pytest -p cudf.pandas \
     --cov-report=term \
     ./python/cudf/cudf_pandas_tests/
 
+# pytest-xdist and pytest-cov prevent our profiler's trace function from running,  
+# even with pytest.mark.no_cover. This likely stems from specialized logic in  
+# coveragepy and pytest-cov for distributed testing (pytest-dev/pytest-cov#246).  
+# As a workaround, we run profiler tests separately without parallelism or `--cov`.  
+# More details: https://github.com/rapidsai/cudf/pull/16930#issuecomment-2707873968  
 python -m pytest -p cudf.pandas \
     --ignore=./python/cudf/cudf_pandas_tests/third_party_integration_tests/ \
     --numprocesses=1 \


### PR DESCRIPTION
Follow up of #16930 [comment](https://github.com/rapidsai/cudf/pull/16930#discussion_r1989879989).

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
