### PR TITLE
Remove warning in the stream pool when asking for more streams than available

### DIFF
--- a/cpp/src/io/comp/comp.cpp
+++ b/cpp/src/io/comp/comp.cpp
@@ -330,11 +330,8 @@ void host_compress(compression_type compression,
   });
 
   std::vector<std::future<size_t>> tasks;
-  auto const num_streams =
-    std::min<std::size_t>({num_chunks,
-                           cudf::detail::global_cuda_stream_pool().get_stream_pool_size(),
-                           h_comp_pool().get_thread_count()});
-  auto const streams = cudf::detail::fork_streams(stream, num_streams);
+  auto const num_streams = std::min<std::size_t>(num_chunks, h_comp_pool().get_thread_count());
+  auto const streams     = cudf::detail::fork_streams(stream, num_streams);
   for (size_t i = 0; i < num_chunks; ++i) {
     auto const idx        = task_order[i];
     auto const cur_stream = streams[i % streams.size()];

--- a/cpp/src/io/json/read_json.cu
+++ b/cpp/src/io/json/read_json.cu
@@ -675,9 +675,7 @@ device_span<char> ingest_raw_input(device_span<char> buffer,
   range_offset -= start_source ? prefsum_source_sizes[start_source - 1] : 0;
 
   std::size_t const num_streams =
-    std::min<std::size_t>({sources.size() - start_source + 1,
-                           cudf::detail::global_cuda_stream_pool().get_stream_pool_size(),
-                           pools::tpool().get_thread_count()});
+    std::min<std::size_t>(sources.size() - start_source + 1, pools::tpool().get_thread_count());
   auto stream_pool = cudf::detail::fork_streams(stream, num_streams);
   for (std::size_t i = start_source, cur_stream = 0;
        i < sources.size() && bytes_read < total_bytes_to_read;

--- a/cpp/src/utilities/stream_pool.cpp
+++ b/cpp/src/utilities/stream_pool.cpp
@@ -128,10 +128,6 @@ class rmm_cuda_stream_pool : public cuda_stream_pool {
 
   std::vector<rmm::cuda_stream_view> get_streams(std::size_t count) override
   {
-    if (count > STREAM_POOL_SIZE) {
-      CUDF_LOG_WARN(
-        "get_streams called with count (%zu) > pool size (%zu)", count, STREAM_POOL_SIZE);
-    }
     auto streams = std::vector<rmm::cuda_stream_view>();
     for (uint32_t i = 0; i < count; i++) {
       streams.emplace_back(_pool.get_stream());


### PR DESCRIPTION
## Description
When `get_streams` requests more streams than there are in the pool, the pool returns existing streams in round-robin order. We originally included this warning because the behavior might be surprising to the caller. However, this warning just clutters the logs when we don't add extra logic to make sure we don't ask for more streams than available.

Removing the warning and cleaning up call sites.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
