### PR TITLE
Add Keep Option Parameter to Distinct

### DIFF
--- a/cpp/include/cudf/lists/detail/stream_compaction.hpp
+++ b/cpp/include/cudf/lists/detail/stream_compaction.hpp
@@ -19,6 +19,7 @@
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
+#include <cudf/stream_compaction.hpp>
 
 #include <rmm/mr/device/device_memory_resource.hpp>
 
@@ -40,7 +41,8 @@ std::unique_ptr<column> distinct(lists_column_view const& input,
                                  null_equality nulls_equal,
                                  nan_equality nans_equal,
                                  rmm::cuda_stream_view stream,
-                                 rmm::device_async_resource_ref mr);
+                                 rmm::device_async_resource_ref mr,
+                                 duplicate_keep_option keep_option=duplicate_keep_option::KEEP_ANY);
 
 }  // namespace lists::detail
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/include/cudf/lists/stream_compaction.hpp
+++ b/cpp/include/cudf/lists/stream_compaction.hpp
@@ -19,6 +19,7 @@
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
+#include <cudf/stream_compaction.hpp>
 
 #include <rmm/mr/device/device_memory_resource.hpp>
 
@@ -84,6 +85,7 @@ std::unique_ptr<column> apply_boolean_mask(
  * @param nans_equal Flag to specify whether floating-point NaNs should be considered as equal
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate the returned object
+ * @param keep_option Flag to specify which element to keep (first, last, any)
  * @return The resulting lists column containing lists without duplicates
  */
 std::unique_ptr<column> distinct(
@@ -91,7 +93,8 @@ std::unique_ptr<column> distinct(
   null_equality nulls_equal         = null_equality::EQUAL,
   nan_equality nans_equal           = nan_equality::ALL_EQUAL,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref(),
+  duplicate_keep_option keep_option = duplicate_keep_option::KEEP_ANY);
 
 /** @} */  // end of group
 

--- a/cpp/src/lists/stream_compaction/distinct.cu
+++ b/cpp/src/lists/stream_compaction/distinct.cu
@@ -39,7 +39,8 @@ std::unique_ptr<column> distinct(lists_column_view const& input,
                                  null_equality nulls_equal,
                                  nan_equality nans_equal,
                                  rmm::cuda_stream_view stream,
-                                 rmm::device_async_resource_ref mr)
+                                 rmm::device_async_resource_ref mr,
+                                 duplicate_keep_option keep_option)
 {
   // Algorithm:
   // - Generate labels for the child elements.
@@ -55,7 +56,7 @@ std::unique_ptr<column> distinct(lists_column_view const& input,
   auto const distinct_table =
     cudf::detail::stable_distinct(table_view{{labels->view(), child}},  // input table
                                   std::vector<size_type>{0, 1},         // keys
-                                  duplicate_keep_option::KEEP_ANY,
+                                  keep_option,
                                   nulls_equal,
                                   nans_equal,
                                   stream,
@@ -79,10 +80,11 @@ std::unique_ptr<column> distinct(lists_column_view const& input,
                                  null_equality nulls_equal,
                                  nan_equality nans_equal,
                                  rmm::cuda_stream_view stream,
-                                 rmm::device_async_resource_ref mr)
+                                 rmm::device_async_resource_ref mr,
+                                 duplicate_keep_option keep_option)
 {
   CUDF_FUNC_RANGE();
-  return detail::distinct(input, nulls_equal, nans_equal, stream, mr);
+  return detail::distinct(input, nulls_equal, nans_equal, stream, mr, keep_option);
 }
 
 }  // namespace cudf::lists

--- a/java/src/main/java/ai/rapids/cudf/ColumnView.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnView.java
@@ -341,6 +341,16 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
     StripType(int nativeId) { this.nativeId = nativeId; }
   }
 
+  public enum DuplicateKeepOption {
+    KEEP_ANY(0),
+    KEEP_FIRST(1),
+    KEEP_LAST(2),
+    KEEP_NONE(3);
+    final int nativeId;
+
+    DuplicateKeepOption(int nativeId) { this.nativeId = nativeId; }
+  }
+
   /**
    * Returns a new ColumnVector with NaNs converted to nulls, preserving the existing null values.
    */
@@ -2538,13 +2548,25 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
    * Create a new LIST column by copying elements from the current LIST column ignoring duplicate,
    * producing a LIST column in which each list contain only unique elements.
    *
-   * Order of the output elements within each list are not guaranteed to be preserved as in the
-   * input.
+   * Order of the output elements within each list will be preserved as in the input
    *
    * @return A new LIST column having unique list elements.
    */
   public final ColumnVector dropListDuplicates() {
-    return new ColumnVector(dropListDuplicates(getNativeView()));
+    return new ColumnVector(dropListDuplicates(getNativeView(), DuplicateKeepOption.KEEP_ANY.nativeId));
+  }
+
+  /**
+   * Create a new LIST column by copying elements from the current LIST column ignoring duplicate,
+   * producing a LIST column in which each list contain only unique elements.
+   *
+   * Order of the output elements within each list will be preserved as in the input
+   *
+   * @param keepOption
+   * @return A new LIST column having unique list elements.
+   */
+  public final ColumnVector dropListDuplicates(DuplicateKeepOption keepOption) {
+    return new ColumnVector(dropListDuplicates(getNativeView(), keepOption.nativeId));
   }
 
   /**
@@ -4614,7 +4636,7 @@ public class ColumnView implements AutoCloseable, BinaryOperable {
 
   private static native long extractListElementV(long nativeView, long indicesView);
 
-  private static native long dropListDuplicates(long nativeView);
+  private static native long dropListDuplicates(long nativeView, int keep_option);
 
   private static native long dropListDuplicatesWithKeysValues(long nativeHandle);
 

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -543,13 +543,16 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractListElementV(JNIEn
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dropListDuplicates(JNIEnv* env,
                                                                           jclass,
-                                                                          jlong column_view)
+                                                                          jlong column_view,
+                                                                          jint keep_option)
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   try {
     cudf::jni::auto_set_device(env);
     auto const input_cv = reinterpret_cast<cudf::column_view const*>(column_view);
-    return release_as_jlong(cudf::lists::distinct(cudf::lists_column_view{*input_cv}));
+    return release_as_jlong(cudf::lists::distinct(cudf::lists_column_view{*input_cv},
+      cudf::null_equality::EQUAL, cudf::nan_equality::ALL_EQUAL, cudf::get_default_stream(),
+      cudf::get_current_device_resource_ref(), static_cast<cudf::duplicate_keep_option>(keep_option)));
   }
   CATCH_STD(env, 0);
 }

--- a/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ColumnVectorTest.java
@@ -18,6 +18,7 @@
 
 package ai.rapids.cudf;
 
+import ai.rapids.cudf.ColumnView.DuplicateKeepOption;
 import ai.rapids.cudf.ColumnView.FindOptions;
 import ai.rapids.cudf.HostColumnVector.*;
 import com.google.common.collect.Lists;
@@ -4356,20 +4357,35 @@ void testExtractReWithMultiLineDelimiters() {
     List<Integer> list1 = Arrays.asList(1, 2);
     List<Integer> list2 = Arrays.asList(3, 4, 5);
     List<Integer> list3 = Arrays.asList(null, 0, 6, 6, 0);
-    List<Integer> dedupeList3 = Arrays.asList(0, 6, null);
+    List<Integer> keepAnyDedupeList3 = Arrays.asList(0, 6, null);
+    List<Integer> keepFirstDedupeList3 = Arrays.asList(null, 0, 6);
+    List<Integer> keepLastDedupeList3 = Arrays.asList(null, 6, 0);
+    List<Integer> keepNoneDedupeList3 = Collections.singletonList(null);
     List<Integer> list4 = Arrays.asList(null, 6, 7, null, 7);
-    List<Integer> dedupeList4 = Arrays.asList(6, 7, null);
+    List<Integer> keepAnyDedupeList4 = Arrays.asList(6, 7, null);
+    List<Integer> keepFirstDedupeList4 = Arrays.asList(null, 6, 7);
+    List<Integer> keepLastDedupeList4 = Arrays.asList(6, null, 7);
+    List<Integer> keepNoneDedupeList4 = Collections.singletonList(6);
     List<Integer> list5 = null;
 
     HostColumnVector.DataType listType = new HostColumnVector.ListType(true,
         new HostColumnVector.BasicType(true, DType.INT32));
     try (ColumnVector v = ColumnVector.fromLists(listType, list1, list2, list3, list4, list5);
-         ColumnVector expected = ColumnVector.fromLists(listType, list1, list2, dedupeList3, dedupeList4, list5);
-         ColumnVector tmp = v.dropListDuplicates();
-         // Note dropping duplicates does not have any ordering guarantee, so sort to make it all
+         ColumnVector keepAnyExpected = ColumnVector.fromLists(listType, list1, list2, keepAnyDedupeList3, keepAnyDedupeList4, list5);
+         ColumnVector keepFirstExpected = ColumnVector.fromLists(listType, list1, list2, keepFirstDedupeList3, keepFirstDedupeList4, list5);
+         ColumnVector keepLastExpected = ColumnVector.fromLists(listType, list1, list2, keepLastDedupeList3, keepLastDedupeList4, list5);
+         ColumnVector keepNoneExpected = ColumnVector.fromLists(listType, list1, list2, keepNoneDedupeList3, keepNoneDedupeList4, list5);
+         ColumnVector tmp = v.dropListDuplicates(DuplicateKeepOption.KEEP_ANY);
+         // Note dropping duplicates w/ KEEP_ANY does not have any ordering guarantee, so sort to make it all
          // consistent
-         ColumnVector result = tmp.listSortRows(false, false)) {
-      assertColumnsAreEqual(expected, result);
+         ColumnVector keepAnyResult = tmp.listSortRows(false, false);
+         ColumnVector keepFirstResult = v.dropListDuplicates(DuplicateKeepOption.KEEP_FIRST);
+         ColumnVector keepLastResult = v.dropListDuplicates(DuplicateKeepOption.KEEP_LAST);
+         ColumnVector keepNoneResult = v.dropListDuplicates(DuplicateKeepOption.KEEP_NONE)) {
+      assertColumnsAreEqual(keepAnyExpected, keepAnyResult);
+      assertColumnsAreEqual(keepFirstExpected, keepFirstResult);
+      assertColumnsAreEqual(keepLastExpected, keepLastResult);
+      assertColumnsAreEqual(keepNoneExpected, keepNoneResult);
     }
   }
 


### PR DESCRIPTION
## Description
Distinct currently uses KEEP_ANY. I would like to expose this duplicate keep option as a parameter, so that I can use another keep option. This is helpful for https://github.com/NVIDIA/spark-rapids/issues/5221, as implementing array_distinct correctly would use KEEP_FIRST. This can also be helpful in the future.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
