### PR TITLE
Fix `datetime64` vs `datetime` binops max resolution

### DIFF
--- a/python/cudf/cudf/tests/test_datetime.py
+++ b/python/cudf/cudf/tests/test_datetime.py
@@ -930,6 +930,8 @@ def test_str_to_datetime_error():
         [None] * 7,
         [10, 20, 30, None, 100, 200, None],
         [3223.234, 342.2332, 23423.23, 3343.23324, 23432.2323, 242.23, 233],
+        datetime.datetime(1993, 6, 22, 13, 30),
+        datetime.datetime(2005, 1, 22, 10, 00),
         np.datetime64("2005-02"),
         np.datetime64("2005-02-25"),
         np.datetime64("2005-02-25T03:30"),


### PR DESCRIPTION
## Description
Fixes: #17740 
This PR fixes max time resolution of datetime binops with `datetime` scalars.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
