### PR TITLE
dask-polars: use splat everywhere.

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/base.py
+++ b/python/cudf_polars/cudf_polars/experimental/base.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from cudf_polars.dsl.ir import Union
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
+    from collections.abc import Iterator
 
     from cudf_polars.containers import DataFrame
     from cudf_polars.dsl.expr import NamedExpr
@@ -44,6 +44,6 @@ def get_key_name(node: Node) -> str:
     return f"{type(node).__name__.lower()}-{hash(node)}"
 
 
-def _concat(dfs: Sequence[DataFrame]) -> DataFrame:
+def _concat(*dfs: DataFrame) -> DataFrame:
     # Concatenate a sequence of DataFrames vertically
     return Union.do_evaluate(None, *dfs)

--- a/python/cudf_polars/cudf_polars/experimental/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/groupby.py
@@ -251,8 +251,8 @@ def _(
     return new_node, partition_info
 
 
-def _tree_node(do_evaluate, batch, *args):
-    return do_evaluate(*args, _concat(batch))
+def _tree_node(do_evaluate, nbatch, *args):
+    return do_evaluate(*args[nbatch:], _concat(*args[:nbatch]))
 
 
 @generate_ir_tasks.register(GroupBy)
@@ -289,7 +289,8 @@ def _(
             graph[(name, j, i)] = (
                 _tree_node,
                 ir.do_evaluate,
-                batch,
+                len(batch),
+                *batch,
                 *ir._non_child_args,
             )
             new_keys.append((name, j, i))
@@ -298,7 +299,8 @@ def _(
     graph[(name, 0)] = (
         _tree_node,
         ir.do_evaluate,
-        keys,
+        len(keys),
+        *keys,
         *ir._non_child_args,
     )
     return graph

--- a/python/cudf_polars/cudf_polars/experimental/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/join.py
@@ -309,6 +309,6 @@ def _(
             if len(_concat_list) == 1:
                 graph[(out_name, part_out)] = graph.pop(_concat_list[0])
             else:
-                graph[(out_name, part_out)] = (_concat, _concat_list)
+                graph[(out_name, part_out)] = (_concat, *_concat_list)
 
         return graph

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -14,15 +14,7 @@ import cudf_polars.experimental.io
 import cudf_polars.experimental.join
 import cudf_polars.experimental.select
 import cudf_polars.experimental.shuffle  # noqa: F401
-from cudf_polars.dsl.ir import (
-    IR,
-    Cache,
-    Filter,
-    HStack,
-    Projection,
-    Select,
-    Union,
-)
+from cudf_polars.dsl.ir import IR, Cache, Filter, HStack, Projection, Select, Union
 from cudf_polars.dsl.traversal import CachingVisitor, traversal
 from cudf_polars.experimental.base import PartitionInfo, _concat, get_key_name
 from cudf_polars.experimental.dispatch import (

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -14,7 +14,15 @@ import cudf_polars.experimental.io
 import cudf_polars.experimental.join
 import cudf_polars.experimental.select
 import cudf_polars.experimental.shuffle  # noqa: F401
-from cudf_polars.dsl.ir import IR, Cache, Filter, HStack, Projection, Select, Union
+from cudf_polars.dsl.ir import (
+    IR,
+    Cache,
+    Filter,
+    HStack,
+    Projection,
+    Select,
+    Union,
+)
 from cudf_polars.dsl.traversal import CachingVisitor, traversal
 from cudf_polars.experimental.base import PartitionInfo, _concat, get_key_name
 from cudf_polars.experimental.dispatch import (
@@ -150,7 +158,7 @@ def task_graph(
     key_name = get_key_name(ir)
     partition_count = partition_info[ir].count
     if partition_count > 1:
-        graph[key_name] = (_concat, list(partition_info[ir].keys(ir)))
+        graph[key_name] = (_concat, *partition_info[ir].keys(ir))
         return graph, key_name
     else:
         return graph, (key_name, 0)

--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -159,7 +159,7 @@ def _simple_shuffle_graph(
                 (split_name, part_in),
                 part_out,
             )
-        graph[(name_out, part_out)] = (_concat, _concat_list)
+        graph[(name_out, part_out)] = (_concat, *_concat_list)
     return graph
 
 


### PR DESCRIPTION
In the dask-graph, use the splat operator instead of list arguments everywhere. The splat operator is used in most places already, only a few functions are missing.
This makes it easier to transform the dask-graph after its creation, which will be useful for prototyping.