### PR TITLE
Fix `cudf_kafka` run export for `cudatoolkit`

### DIFF
--- a/conda/recipes/cudf_kafka/recipe.yaml
+++ b/conda/recipes/cudf_kafka/recipe.yaml
@@ -72,6 +72,7 @@ requirements:
         then: cuda-cudart-dev
     by_name:
       - cuda-version
+      - cudatoolkit
 
 tests:
   - python:


### PR DESCRIPTION
## Description

I missed this `ignore_run_export` in the previous round of fixes, but it is still constraining cuda 11.x environments:
https://github.com/rapidsai/cudf/actions/runs/13804299839/job/38612724166#step:9:5077

Maybe this is the last one of these.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
