### PR TITLE
[DOC] Add wordpiece tokenizer to cudf documentation

### DIFF
--- a/docs/cudf/source/user_guide/api_docs/index.rst
+++ b/docs/cudf/source/user_guide/api_docs/index.rst
@@ -19,9 +19,10 @@ This page provides a list of all publicly accessible modules, methods and classe
     general_utilities
     window
     io
-    character_normalizer
-    tokenize_vocabulary
     string_handling
+    character_normalizer
+    wordpiece_tokenizer
+    tokenize_vocabulary
     list_handling
     struct_handling
     options

--- a/docs/cudf/source/user_guide/api_docs/wordpiece_tokenizer.rst
+++ b/docs/cudf/source/user_guide/api_docs/wordpiece_tokenizer.rst
@@ -1,7 +1,7 @@
 ===================
 WordPieceTokenizer
 ===================
-.. currentmodule:: cudf.core.wordpiece_tokenizer
+.. currentmodule:: cudf.core.wordpiece_tokenize
 
 Constructor
 ~~~~~~~~~~~

--- a/docs/cudf/source/user_guide/api_docs/wordpiece_tokenizer.rst
+++ b/docs/cudf/source/user_guide/api_docs/wordpiece_tokenizer.rst
@@ -1,0 +1,12 @@
+===================
+WordPieceTokenizer
+===================
+.. currentmodule:: cudf.core.wordpiece_tokenizer
+
+Constructor
+~~~~~~~~~~~
+.. autosummary::
+   :toctree: api/
+
+   WordPieceVocabulary
+   WordPieceVocabulary.tokenize


### PR DESCRIPTION
## Description
Add `WordPieceVocabulary` and `tokenize` to the cudf docs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
