### PR TITLE
Fix `Dataframe.loc` to not modify the actual dataframe

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -242,7 +242,7 @@ class _DataFrameLocIndexer(_DataFrameIndexer):
             columns_df = self._frame._get_columns_by_label(arg[1])
             columns_df.index = self._frame.index
         else:
-            columns_df = self._frame
+            columns_df = self._frame.copy(deep=False)
 
         # Step 2: Gather rows
         if isinstance(columns_df.index, MultiIndex):
@@ -284,7 +284,7 @@ class _DataFrameLocIndexer(_DataFrameIndexer):
                     )
             else:
                 tmp_arg = arg
-                if is_scalar(arg[0]):
+                if isinstance(arg, tuple) and is_scalar(arg[0]):
                     # If a scalar, there is possibility of having duplicates.
                     # Join would get all the duplicates. So, converting it to
                     # an array kind.
@@ -298,6 +298,8 @@ class _DataFrameLocIndexer(_DataFrameIndexer):
                                 "typecast to common dtype."
                             )
                     tmp_arg = ([tmp_arg[0]], tmp_arg[1])
+                elif all(is_scalar(a) for a in tmp_arg):
+                    tmp_arg = (tmp_arg, slice(None))
                 if len(tmp_arg[0]) == 0:
                     return columns_df._empty_like(keep_index=True)
                 tmp_arg = (

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -242,7 +242,7 @@ class _DataFrameLocIndexer(_DataFrameIndexer):
             columns_df = self._frame._get_columns_by_label(arg[1])
             columns_df.index = self._frame.index
         else:
-            columns_df = self._frame.copy(deep=False)
+            columns_df = self._frame
 
         # Step 2: Gather rows
         if isinstance(columns_df.index, MultiIndex):
@@ -338,6 +338,7 @@ class _DataFrameLocIndexer(_DataFrameIndexer):
                         },
                         index=cudf.Index._from_column(tmp_arg[0]),
                     )
+                    columns_df = columns_df.copy(deep=False)
                     columns_df[cantor_name] = column.as_column(
                         range(len(columns_df))
                     )

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -11293,3 +11293,25 @@ def test_empty_construction_rangeindex_columns(data):
     result = cudf.DataFrame(data=data).columns
     expected = pd.RangeIndex(0)
     pd.testing.assert_index_equal(result, expected, exact=True)
+
+
+def test_dataframe_midx_columns_loc():
+    idx_1 = ["Hi", "Lo"]
+    idx_2 = ["I", "II", "III"]
+    idx = cudf.MultiIndex.from_product([idx_1, idx_2])
+
+    data_rand = (
+        np.random.default_rng(seed=0)
+        .uniform(0, 1, 3 * len(idx))
+        .reshape(3, -1)
+    )
+    df = cudf.DataFrame(data_rand, index=["A", "B", "C"], columns=idx)
+    pdf = df.to_pandas()
+
+    assert_eq(df.shape, pdf.shape)
+
+    expected = pdf.loc[["A", "B"]]
+    actual = df.loc[["A", "B"]]
+
+    assert_eq(expected, actual)
+    assert_eq(df, pdf)


### PR DESCRIPTION
## Description
Fixes: #18242 

This PR fixes two issues in `DataFrame.loc`:
1. Inplace modification of the original dataframe.
2. Returning series instead of dataframe for a specific combination of `loc` inputs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
