### PR TITLE
Fix `cross` join with extra columns

### DIFF
--- a/ci/test_narwhals.sh
+++ b/ci/test_narwhals.sh
@@ -56,9 +56,7 @@ NARWHALS_DEFAULT_CONSTRUCTORS=pandas python -m pytest \
         test_to_arrow_with_nulls or \
         test_sumh_transformations or \
         test_dask_order_dependent_ops or \
-        test_q1 or \
-        test_cross_join_suffix or \
-        test_cross_join \
+        test_q1 \
     )" \
     --numprocesses=8 \
     --dist=worksteal

--- a/python/cudf/cudf/core/join/join.py
+++ b/python/cudf/cudf/core/join/join.py
@@ -410,7 +410,12 @@ class Merge:
         common_names = set(left_result._column_names) & set(
             right_result._column_names
         )
-        cols_to_suffix = common_names - self._key_columns_with_same_name
+
+        cols_to_suffix = (
+            common_names
+            if self.how == "cross"
+            else common_names - self._key_columns_with_same_name
+        )
         data = {
             (f"{name}{self.lsuffix}" if name in cols_to_suffix else name): col
             for name, col in left_result._column_labels_and_values
@@ -420,7 +425,10 @@ class Merge:
         # key columns from the right table are removed.
         for name, col in right_result._column_labels_and_values:
             if name in common_names:
-                if name not in self._key_columns_with_same_name:
+                if (
+                    self.how == "cross"
+                    or name not in self._key_columns_with_same_name
+                ):
                     r_label = f"{name}{self.rsuffix}"
                     if r_label in data:
                         raise NotImplementedError(

--- a/python/cudf/cudf/tests/test_joining.py
+++ b/python/cudf/cudf/tests/test_joining.py
@@ -2339,6 +2339,11 @@ def test_merge_left_on_right_index_sort():
     [
         {"lkey": ["foo", "bar", "baz", "foo"], "value": [1, 2, 3, 5]},
         {"lkey": ["foo", "bar", "baz", "foo"], "value": [5, 3, 2, 1]},
+        {
+            "lkey": ["foo", "bar", "baz", "foo"],
+            "value": [5, 3, 2, 1],
+            "extra_left": [1, 2, 3, 4],
+        },
     ],
 )
 @pytest.mark.parametrize(
@@ -2346,6 +2351,11 @@ def test_merge_left_on_right_index_sort():
     [
         {"rkey": ["foo", "bar", "baz", "foo"], "value": [5, 6, 7, 8]},
         {"rkey": ["foo", "bar", "baz", "foo"], "value": [8, 7, 6, 5]},
+        {
+            "rkey": ["foo", "bar", "baz", "foo"],
+            "value": [8, 7, 6, 5],
+            "extra_right": [10, 2, 30, 4],
+        },
     ],
 )
 @pytest.mark.parametrize("sort", [True, False])
@@ -2359,4 +2369,24 @@ def test_cross_join_overlapping(left_data, right_data, sort):
         pdf2, how="cross", lsuffix="_x", rsuffix="_y", sort=sort
     )
     result = df1.join(df2, how="cross", lsuffix="_x", rsuffix="_y", sort=sort)
+    assert_eq(result, expected)
+
+
+@pytest.mark.parametrize(
+    "suffixes",
+    [
+        ("_left", "_right"),
+        ("", "_right"),
+        ("_left", ""),
+    ],
+)
+def test_cross_merge(suffixes):
+    df1 = cudf.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    pdf1 = df1.to_pandas()
+
+    df2 = cudf.DataFrame({"a": [11, 12, 13], "d": [40, 50, 60]})
+    pdf2 = df2.to_pandas()
+
+    expected = pdf1.merge(pdf2, how="cross", suffixes=suffixes)
+    result = df1.merge(df2, how="cross", suffixes=suffixes)
     assert_eq(result, expected)


### PR DESCRIPTION
## Description
Contributes to #18248. This PR fixes failures in narwhals pytest suite by fixing `cross` join in `cudf` to properly suffix columns and factor in extra columns.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
