### PR TITLE
Support BinOp, min, and max Aggregations in cudf-polars parallel groupby

### DIFF
--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -52,7 +52,7 @@ def test_groupby_single_partitions(df, op, keys):
     )
 
 
-@pytest.mark.parametrize("op", ["sum", "mean", "len", "count"])
+@pytest.mark.parametrize("op", ["sum", "mean", "len", "count", "min", "max"])
 @pytest.mark.parametrize("keys", [("y",), ("y", "z")])
 def test_groupby_agg(df, engine, op, keys):
     q = df.group_by(*keys).agg(getattr(pl.col("x"), op)())

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -87,3 +87,18 @@ def test_groupby_raises(df, engine):
         match="NotImplementedError",
     ):
         assert_gpu_result_equal(q, engine=engine, check_row_order=False)
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        pl.max("x") - pl.min("x"),
+        pl.mean("x") * pl.sum("x"),
+        pl.max("x") + pl.max("z"),
+    ],
+)
+def test_groupby_nested_expression(
+    df: pl.LazyFrame, engine: pl.GPUEngine, op: pl.Expr
+) -> None:
+    q = df.group_by("y").agg(op)
+    assert_gpu_result_equal(q, engine=engine, check_row_order=False)


### PR DESCRIPTION
This expands our supported types in the parallel groupby used by cudf-polars. In particular, 1debb44 adds support for new aggregations:

```
df.groupby("key").agg(pl.min("value"))  # and max
```

and b1c8df291567b9cc713703d34923d0585c24b32d adds support for binops of those supported aggregations:

```
df.groupby("key").agg(pl.max("value") - pl.min("value"))
```

Closes https://github.com/rapidsai/cudf/issues/18263