### PR TITLE
Split Narwhals cudf.pandas tests failures into to fix and to skip

### DIFF
--- a/ci/test_narwhals.sh
+++ b/ci/test_narwhals.sh
@@ -40,25 +40,40 @@ NARWHALS_POLARS_GPU=1 python -m pytest \
     --constructors=polars[lazy]
 
 rapids-logger "Run narwhals tests for cuDF Pandas"
-# TODO: Investigate which of the tests we can avoid skipping
-# Tracking Issue: https://github.com/rapidsai/cudf/issues/18248
+
+# test_is_finite_expr & test_is_finite_series: https://github.com/rapidsai/cudf/issues/18257
+# test_sumh_transformations: Fixed by https://github.com/rapidsai/cudf/pull/18259
+# test_maybe_convert_dtypes_pandas: https://github.com/rapidsai/cudf/issues/14149
+# test_q1 & test_dask_order_dependent_ops: https://github.com/rapidsai/cudf/issues/18253
+# test_cross_join_suffix & test_cross_join: Fixed by https://github.com/rapidsai/cudf/pull/18256
+TESTS_THAT_NEED_CUDF_FIX="
+test_is_finite_expr or \
+test_is_finite_series or \
+test_sumh_transformations or \
+test_maybe_convert_dtypes_pandas or \
+test_q1 or \
+test_dask_order_dependent_ops or \
+test_cross_join_suffix or \
+test_cross_join
+"
+
+# test_array_dunder_with_copy: https://github.com/rapidsai/cudf/issues/18248#issuecomment-2719234741
+# test_to_arrow & test_to_arrow_with_nulls: https://github.com/rapidsai/cudf/issues/18248#issuecomment-2719254791
+# test_pandas_object_series: https://github.com/rapidsai/cudf/issues/18248#issuecomment-2719180627
+TESTS_TO_ALWAYS_SKIP="
+test_array_dunder_with_copy or \
+test_to_arrow or \
+test_to_arrow_with_nulls or \
+test_pandas_object_series
+"
+
 NARWHALS_DEFAULT_CONSTRUCTORS=pandas python -m pytest \
     -p cudf.pandas \
     --cache-clear \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-pandas-narwhals.xml" \
     -k "not ( \
-        test_pandas_object_series or \
-        test_is_finite_expr or \
-        test_is_finite_series or \
-        test_array_dunder_with_copy or \
-        test_maybe_convert_dtypes_pandas or \
-        test_to_arrow or \
-        test_to_arrow_with_nulls or \
-        test_sumh_transformations or \
-        test_dask_order_dependent_ops or \
-        test_q1 or \
-        test_cross_join_suffix or \
-        test_cross_join \
+        ${TESTS_THAT_NEED_CUDF_FIX} or \
+        ${TESTS_TO_ALWAYS_SKIP} \
     )" \
     --numprocesses=8 \
     --dist=worksteal

--- a/ci/test_narwhals.sh
+++ b/ci/test_narwhals.sh
@@ -51,7 +51,7 @@ test_is_finite_series or \
 test_sumh_transformations or \
 test_maybe_convert_dtypes_pandas or \
 test_q1 or \
-test_dask_order_dependent_ops
+test_dask_order_dependent_ops \
 "
 
 # test_array_dunder_with_copy: https://github.com/rapidsai/cudf/issues/18248#issuecomment-2719234741
@@ -61,7 +61,7 @@ TESTS_TO_ALWAYS_SKIP="
 test_array_dunder_with_copy or \
 test_to_arrow or \
 test_to_arrow_with_nulls or \
-test_pandas_object_series
+test_pandas_object_series \
 "
 
 NARWHALS_DEFAULT_CONSTRUCTORS=pandas python -m pytest \

--- a/ci/test_narwhals.sh
+++ b/ci/test_narwhals.sh
@@ -45,7 +45,7 @@ rapids-logger "Run narwhals tests for cuDF Pandas"
 # test_sumh_transformations: Fixed by https://github.com/rapidsai/cudf/pull/18259
 # test_maybe_convert_dtypes_pandas: https://github.com/rapidsai/cudf/issues/14149
 # test_q1 & test_dask_order_dependent_ops: https://github.com/rapidsai/cudf/issues/18253
-TESTS_THAT_NEED_CUDF_FIX="
+TESTS_THAT_NEED_CUDF_FIX=" \
 test_is_finite_expr or \
 test_is_finite_series or \
 test_sumh_transformations or \
@@ -57,7 +57,7 @@ test_dask_order_dependent_ops \
 # test_array_dunder_with_copy: https://github.com/rapidsai/cudf/issues/18248#issuecomment-2719234741
 # test_to_arrow & test_to_arrow_with_nulls: https://github.com/rapidsai/cudf/issues/18248#issuecomment-2719254791
 # test_pandas_object_series: https://github.com/rapidsai/cudf/issues/18248#issuecomment-2719180627
-TESTS_TO_ALWAYS_SKIP="
+TESTS_TO_ALWAYS_SKIP=" \
 test_array_dunder_with_copy or \
 test_to_arrow or \
 test_to_arrow_with_nulls or \


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/18248

With each test skipped, linked to an issue or comment that describes the rational. 

I think we can close out the parent issue as the follow ups have individual issues to track.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
