### PR TITLE
Handle empty aggregations in multi-partition cudf.polars group_by

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/utils/groupby.py
+++ b/python/cudf_polars/cudf_polars/dsl/utils/groupby.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pylibcudf as plc
+
 from cudf_polars.dsl import ir
 from cudf_polars.dsl.utils.aggregations import apply_pre_evaluation
 from cudf_polars.dsl.utils.naming import unique_names
@@ -14,8 +16,6 @@ from cudf_polars.dsl.utils.naming import unique_names
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any
-
-    import pylibcudf as plc
 
     from cudf_polars.dsl import expr
     from cudf_polars.utils import config
@@ -71,16 +71,15 @@ def rewrite_groupby(
     unsupported.
     """
     if len(aggs) == 0:
-        # TODO: use Distinct when the partitioned executor supports it
-        return ir.GroupBy(
+        return ir.Distinct(
             schema,
-            keys,
-            [],
-            node.maintain_order,
+            plc.stream_compaction.DuplicateKeepOption.KEEP_ANY,
+            None,
             node.options.slice,
-            config_options,
-            inp,
+            node.maintain_order,
+            ir.Select(schema, keys, True, inp),  # noqa: FBT003
         )
+
     inp, aggs, group_schema, apply_post_evaluation = apply_pre_evaluation(
         schema, inp, keys, aggs, unique_names(schema.keys())
     )

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -165,3 +165,8 @@ def test_groupby_agg_duplicate(
     )
     q = df.group_by("y").agg(op, pl.min(column_name))
     assert_gpu_result_equal(q, engine=engine, check_row_order=False)
+
+
+def test_groupby_agg_empty(df: pl.LazyFrame, engine: pl.GPUEngine) -> None:
+    q = df.group_by("y").agg()
+    assert_gpu_result_equal(q, engine=engine, check_row_order=False)


### PR DESCRIPTION
## Description

This fixes a bug where a group_by with no aggregations raised a ValueError.

```python
df.group_by("col").agg()
```

The fix uses `Distinct`, which is equivalent to a groupby with no aggregations. `Distinct` was previously not supported by the multi-partition executor, so that's implemented here as well.

Closes https://github.com/rapidsai/cudf/issues/18276

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
