### PR TITLE
Add and revise experimental cudf-polars config options

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -1140,8 +1140,8 @@ class ConditionalJoin(IR):
 class Join(IR):
     """A join of two dataframes."""
 
-    __slots__ = ("left_on", "options", "right_on")
-    _non_child = ("schema", "left_on", "right_on", "options")
+    __slots__ = ("config_options", "left_on", "options", "right_on")
+    _non_child = ("schema", "left_on", "right_on", "options", "config_options")
     left_on: tuple[expr.NamedExpr, ...]
     """List of expressions used as keys in the left frame."""
     right_on: tuple[expr.NamedExpr, ...]
@@ -1163,6 +1163,8 @@ class Join(IR):
     - coalesce: should key columns be coalesced (only makes sense for outer joins)
     - maintain_order: which DataFrame row order to preserve, if any
     """
+    config_options: ConfigOptions
+    """GPU-specific configuration options"""
 
     def __init__(
         self,
@@ -1170,6 +1172,7 @@ class Join(IR):
         left_on: Sequence[expr.NamedExpr],
         right_on: Sequence[expr.NamedExpr],
         options: Any,
+        config_options: ConfigOptions,
         left: IR,
         right: IR,
     ):
@@ -1177,6 +1180,7 @@ class Join(IR):
         self.left_on = tuple(left_on)
         self.right_on = tuple(right_on)
         self.options = options
+        self.config_options = config_options
         self.children = (left, right)
         self._non_child_args = (self.left_on, self.right_on, self.options)
         # TODO: Implement maintain_order

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -343,7 +343,15 @@ def _(
         "Semi",
         "Anti",
     }:
-        return ir.Join(schema, left_on, right_on, node.options, inp_left, inp_right)
+        return ir.Join(
+            schema,
+            left_on,
+            right_on,
+            node.options,
+            translator.config_options,
+            inp_left,
+            inp_right,
+        )
     else:
         how, op1, op2 = node.options[0]
         if how != "IEJoin":

--- a/python/cudf_polars/cudf_polars/experimental/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/groupby.py
@@ -253,11 +253,10 @@ def _(
                 "maintain_order not supported for multiple output partitions."
             )
 
-        shuffle_options: dict[str, Any] = {}
         gb_inter = Shuffle(
             pwise_schema,
             ir.keys,
-            shuffle_options,
+            ir.config_options,
             gb_pwise,
         )
         partition_info[gb_inter] = PartitionInfo(count=post_aggregation_count)

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -128,6 +128,7 @@ class ConfigOptions:
                 "parquet_blocksize",
                 "cardinality_factor",
                 "groupby_n_ary",
+                "broadcast_join_limit",
             }
         else:
             unsupported = config.get("executor_options", {}).keys()

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -7,17 +7,24 @@ import pytest
 
 import polars as pl
 
+from cudf_polars import Translator
+from cudf_polars.experimental.parallel import lower_ir_graph
+from cudf_polars.experimental.shuffle import Shuffle
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
 @pytest.mark.parametrize("how", ["inner", "left", "right", "full", "semi", "anti"])
 @pytest.mark.parametrize("reverse", [True, False])
 @pytest.mark.parametrize("max_rows_per_partition", [1, 5, 10, 15])
-def test_join(how, reverse, max_rows_per_partition):
+@pytest.mark.parametrize("broadcast_join_limit", [1, 16])
+def test_join(how, reverse, max_rows_per_partition, broadcast_join_limit):
     engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="dask-experimental",
-        executor_options={"max_rows_per_partition": max_rows_per_partition},
+        executor_options={
+            "max_rows_per_partition": max_rows_per_partition,
+            "broadcast_join_limit": broadcast_join_limit,
+        },
     )
     left = pl.LazyFrame(
         {
@@ -52,3 +59,46 @@ def test_join(how, reverse, max_rows_per_partition):
         )
         q2 = q.join(right2, left_on="y", right_on="yyy", how=how)
         assert_gpu_result_equal(q2, engine=engine, check_row_order=False)
+
+
+@pytest.mark.parametrize("broadcast_join_limit", [1, 2, 3, 4])
+def test_broadcast_join_limit(broadcast_join_limit):
+    engine = pl.GPUEngine(
+        raise_on_fail=True,
+        executor="dask-experimental",
+        executor_options={
+            "max_rows_per_partition": 3,
+            "broadcast_join_limit": broadcast_join_limit,
+        },
+    )
+    left = pl.LazyFrame(
+        {
+            "x": range(15),
+            "y": [1, 2, 3] * 5,
+            "z": [1.0, 2.0, 3.0, 4.0, 5.0] * 3,
+        }
+    )
+    right = pl.LazyFrame(
+        {
+            "xx": range(9),
+            "y": [2, 4, 3] * 3,
+            "zz": [1, 2, 3] * 3,
+        }
+    )
+
+    q = left.join(right, on="y", how="inner")
+    shuffle_nodes = [
+        type(node)
+        for node in lower_ir_graph(Translator(q._ldf.visit(), engine).translate_ir())[1]
+        if isinstance(node, Shuffle)
+    ]
+
+    # NOTE: Expect small table to have 3 partitions (9 / 3).
+    # Therefore, we will get a shuffle-based join if our
+    # "broadcast_join_limit" config is less than 3.
+    if broadcast_join_limit < 3:
+        # Expect shuffle-based join
+        assert len(shuffle_nodes) == 2
+    else:
+        # Expect broadcast join
+        assert len(shuffle_nodes) == 0

--- a/python/cudf_polars/tests/experimental/test_shuffle.py
+++ b/python/cudf_polars/tests/experimental/test_shuffle.py
@@ -12,6 +12,7 @@ from cudf_polars import Translator
 from cudf_polars.dsl.expr import Col, NamedExpr
 from cudf_polars.experimental.parallel import evaluate_dask, lower_ir_graph
 from cudf_polars.experimental.shuffle import Shuffle
+from cudf_polars.utils.config import ConfigOptions
 
 
 @pytest.fixture(scope="module")
@@ -40,7 +41,7 @@ def test_hash_shuffle(df, engine):
 
     # Add first Shuffle node
     keys = (NamedExpr("x", Col(qir.schema["x"], "x")),)
-    options = {}
+    options = ConfigOptions({})
     qir1 = Shuffle(qir.schema, keys, options, qir)
 
     # Add second Shuffle node (on the same keys)


### PR DESCRIPTION
## Description
**NOTE**: This is intended to be the precursor for #18231
this PR adds the `"broadcast_join_limit"` config option, and revises configuration handling in `Join`, `GroupBy`, and `Shuffle`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
