### PR TITLE
[Proposal][WIP] Rename cudf-polars executors and reduce dependence on dask

### DIFF
--- a/ci/run_cudf_polars_pytests.sh
+++ b/ci/run_cudf_polars_pytests.sh
@@ -11,11 +11,11 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cudf_polars/
 # Test the default "cudf" executor
 python -m pytest --cache-clear "$@" tests
 
-# Test the "partitioned-experimental" executor
-python -m pytest --cache-clear "$@" tests --executor partitioned-experimental
+# Test the "multi-experimental" executor
+python -m pytest --cache-clear "$@" tests --executor multi-experimental
 
 # Run experimental tests with Distributed cluster
 python -m pytest --cache-clear "$@" "tests/experimental" \
-    --executor dask-experimental \
+    --executor multi-experimental \
     --dask-cluster \
     --cov-fail-under=0  # No code-coverage requirement for these tests.

--- a/ci/run_cudf_polars_pytests.sh
+++ b/ci/run_cudf_polars_pytests.sh
@@ -11,8 +11,8 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cudf_polars/
 # Test the default "cudf" executor
 python -m pytest --cache-clear "$@" tests
 
-# Test the "dask-experimental" executor
-python -m pytest --cache-clear "$@" tests --executor dask-experimental
+# Test the "partitioned-experimental" executor
+python -m pytest --cache-clear "$@" tests --executor partitioned-experimental
 
 # Run experimental tests with Distributed cluster
 python -m pytest --cache-clear "$@" "tests/experimental" \

--- a/python/cudf_polars/cudf_polars/callback.py
+++ b/python/cudf_polars/cudf_polars/callback.py
@@ -181,7 +181,8 @@ def _callback(
     *,
     device: int | None,
     memory_resource: int | None,
-    executor: Literal["pylibcudf", "dask-experimental"] | None,
+    executor: Literal["in-memory", "partitioned-experimental", "dask-experimental"]
+    | None,
 ) -> pl.DataFrame:
     assert with_columns is None
     assert pyarrow_predicate is None
@@ -192,8 +193,12 @@ def _callback(
         set_device(device),
         set_memory_resource(memory_resource),
     ):
-        if executor is None or executor == "pylibcudf":
+        if executor is None or executor == "in-memory":
             return ir.evaluate(cache={}).to_polars()
+        elif executor == "partitioned-experimental":
+            from cudf_polars.experimental.parallel import evaluate_partitioned
+
+            return evaluate_partitioned(ir).to_polars()
         elif executor == "dask-experimental":
             from cudf_polars.experimental.parallel import evaluate_dask
 

--- a/python/cudf_polars/cudf_polars/callback.py
+++ b/python/cudf_polars/cudf_polars/callback.py
@@ -181,7 +181,7 @@ def _callback(
     *,
     device: int | None,
     memory_resource: int | None,
-    executor: Literal["single", "partitioned-experimental", "dask-experimental"] | None,
+    executor: Literal["single", "multi-experimental"] | None,
 ) -> pl.DataFrame:
     assert with_columns is None
     assert pyarrow_predicate is None
@@ -195,21 +195,11 @@ def _callback(
         if executor is None or executor == "single":
             # Default single-partition executor
             return ir.evaluate(cache={}).to_polars()
-        elif executor == "partitioned-experimental":
-            # Experimental multi-partition executor.
-            # This executor will schedule tasks on a
-            # single python thread (on a single GPU)
-            from cudf_polars.experimental.parallel import evaluate_partitioned
+        elif executor == "multi-experimental":
+            # Experimental multi-partition executor
+            from cudf_polars.experimental.parallel import evaluate_multi
 
-            return evaluate_partitioned(ir).to_polars()
-        elif executor == "dask-experimental":
-            # Experimental multi-partition Dask executor.
-            # This executor will use Dask to schedule tasks.
-            # If a distributed client is detected, tasks
-            # will run on the corresponding Dask cluster.
-            from cudf_polars.experimental.parallel import evaluate_dask
-
-            return evaluate_dask(ir).to_polars()
+            return evaluate_multi(ir).to_polars()
         else:
             raise ValueError(f"Unknown executor '{executor}'")
 

--- a/python/cudf_polars/cudf_polars/callback.py
+++ b/python/cudf_polars/cudf_polars/callback.py
@@ -181,8 +181,7 @@ def _callback(
     *,
     device: int | None,
     memory_resource: int | None,
-    executor: Literal["in-memory", "partitioned-experimental", "dask-experimental"]
-    | None,
+    executor: Literal["single", "partitioned-experimental", "dask-experimental"] | None,
 ) -> pl.DataFrame:
     assert with_columns is None
     assert pyarrow_predicate is None
@@ -193,7 +192,7 @@ def _callback(
         set_device(device),
         set_memory_resource(memory_resource),
     ):
-        if executor is None or executor == "in-memory":
+        if executor is None or executor == "single":
             return ir.evaluate(cache={}).to_polars()
         elif executor == "partitioned-experimental":
             from cudf_polars.experimental.parallel import evaluate_partitioned

--- a/python/cudf_polars/cudf_polars/callback.py
+++ b/python/cudf_polars/cudf_polars/callback.py
@@ -193,12 +193,20 @@ def _callback(
         set_memory_resource(memory_resource),
     ):
         if executor is None or executor == "single":
+            # Default single-partition executor
             return ir.evaluate(cache={}).to_polars()
         elif executor == "partitioned-experimental":
+            # Experimental multi-partition executor.
+            # This executor will schedule tasks on a
+            # single python thread (on a single GPU)
             from cudf_polars.experimental.parallel import evaluate_partitioned
 
             return evaluate_partitioned(ir).to_polars()
         elif executor == "dask-experimental":
+            # Experimental multi-partition Dask executor.
+            # This executor will use Dask to schedule tasks.
+            # If a distributed client is detected, tasks
+            # will run on the corresponding Dask cluster.
             from cudf_polars.experimental.parallel import evaluate_dask
 
             return evaluate_dask(ir).to_polars()

--- a/python/cudf_polars/cudf_polars/experimental/scheduler.py
+++ b/python/cudf_polars/cudf_polars/experimental/scheduler.py
@@ -6,56 +6,22 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import MutableMapping
-from enum import Enum
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Mapping
     from typing import TypeAlias
 
 
-Key: TypeAlias = str | bytes | int | float | tuple["Key", ...]
+Key: TypeAlias = str | int | tuple["Key", ...]
 Graph: TypeAlias = MutableMapping[Key, Any]
 
 
 # NOTE: This is the single-threaded scheduler from `dask.core`.
 
 
-class _NoDefault(Enum):
-    """
-    Unspecified key-word argument.
-
-    Notes
-    -----
-    Typing-aware constant to detect when the user omits a parameter and you can't use
-    None. Copied from pandas._libs.lib._NoDefault.
-    """
-
-    no_default = "NO_DEFAULT"
-
-    def __repr__(self) -> str:
-        return "<no_default>"
-
-
-no_default = _NoDefault.no_default
-NoDefault = Literal[_NoDefault.no_default]
-
-
 def ishashable(x):
-    """
-    Check if x is hashable.
-
-    Examples
-    --------
-    >>> ishashable(1)
-    True
-    >>> ishashable([1])
-    False
-
-    See Also
-    --------
-    iskey
-    """
+    """Check if x is hashable."""
     try:
         hash(x)
     except TypeError:
@@ -65,93 +31,12 @@ def ishashable(x):
 
 
 def istask(x):
-    """
-    Check if x is a runnable task.
-
-    A task is a tuple with a callable first argument.
-
-    Examples
-    --------
-    >>> inc = lambda x: x + 1
-    >>> istask((inc, 1))
-    True
-    >>> istask(1)
-    False
-    """
+    """Check if x is a runnable task."""
     return type(x) is tuple and x and callable(x[0])
 
 
-def has_tasks(dsk, x):
-    """
-    Whether ``x`` has anything to compute.
-
-    Returns True if:
-    - ``x`` is a task
-    - ``x`` is a key in ``dsk``
-    - ``x`` is a list that contains any tasks or keys
-    """
-    if istask(x):
-        return True
-    try:
-        if x in dsk:
-            return True
-    except Exception:
-        pass
-    if isinstance(x, list):
-        for i in x:
-            if has_tasks(dsk, i):
-                return True
-    return False
-
-
-def preorder_traversal(task):
-    """A generator to preorder-traverse a task."""
-    for item in task:
-        if istask(item):
-            yield from preorder_traversal(item)
-        elif isinstance(item, list):
-            yield list
-            yield from preorder_traversal(item)
-        else:
-            yield item
-
-
-def _lists_to_tuples(res, keys):
-    if isinstance(keys, list):
-        return tuple(_lists_to_tuples(r, k) for r, k in zip(res, keys, strict=False))
-    return res
-
-
-def _execute_task(arg, cache, dsk=None):
-    """
-    Do the actual work of collecting data and executing a function.
-
-    Examples
-    --------
-    >>> inc = lambda x: x + 1
-    >>> add = lambda x, y: x + y
-    >>> cache = {"x": 1, "y": 2}
-
-    Compute tasks against a cache
-    >>> _execute_task((add, "x", 1), cache)  # Compute task in naive manner
-    2
-    >>> _execute_task((add, (inc, "x"), 1), cache)  # Support nested computation
-    3
-
-    Also grab data from cache
-    >>> _execute_task("x", cache)
-    1
-
-    Support nested lists
-    >>> list(_execute_task(["x", "y"], cache))
-    [1, 2]
-
-    >>> list(map(list, _execute_task([["x", "y"], ["y", "x"]], cache)))
-    [[1, 2], [2, 1]]
-
-    >>> _execute_task("foo", cache)  # Passes through on non-keys
-    'foo'
-    """
+def _execute_task(arg, cache: MutableMapping):
+    """Collecting data and execute a function."""
     if isinstance(arg, list):
         return [_execute_task(a, cache) for a in arg]
     elif istask(arg):
@@ -168,58 +53,21 @@ def _execute_task(arg, cache, dsk=None):
         return arg
 
 
-def get(dsk, out, cache=None):
-    """
-    Get value from Dask.
-
-    Examples
-    --------
-    >>> inc = lambda x: x + 1
-    >>> d = {"x": 1, "y": (inc, "x")}
-
-    >>> get(d, "x")
-    1
-    >>> get(d, "y")
-    2
-    """
-    for k in flatten(out) if isinstance(out, list) else [out]:
-        if k not in dsk:
-            raise KeyError(f"{k} is not a key in the graph")
+def get(graph: Graph, key: Key, cache: MutableMapping | None = None):
+    """Execute the task graph for a given key."""
+    if key not in graph:
+        raise KeyError(f"{key} is not a key in the graph")
     if cache is None:
         cache = {}
-    for key in toposort(dsk):
-        task = dsk[key]
+    for key in toposort(graph):
+        task = graph[key]
         result = _execute_task(task, cache)
         cache[key] = result
-    result = _execute_task(out, cache)
-    if isinstance(out, list):
-        result = _lists_to_tuples(result, out)
-    return result
+    return _execute_task(key, cache)
 
 
-def keys_in_tasks(
-    keys: Collection[Key],
-    tasks: Iterable[Any],
-    as_list: bool = False,  # noqa: FBT001, FBT002
-):
-    """
-    Returns the keys in `keys` that are also in `tasks`.
-
-    Examples
-    --------
-    >>> inc = lambda x: x + 1
-    >>> add = lambda x, y: x + y
-    >>> dsk = {
-    ...     "x": 1,
-    ...     "y": (inc, "x"),
-    ...     "z": (add, "x", "y"),
-    ...     "w": (inc, "z"),
-    ...     "a": (add, (inc, "x"), 1),
-    ... }
-
-    >>> keys_in_tasks(dsk, ["x", "y", "j"])  # doctest: +SKIP
-    {'x', 'y'}
-    """
+def keys_in_tasks(keys: Collection[Key], tasks: Iterable[Any]):
+    """Returns the keys in `keys` that are also in `tasks`."""
     ret = []
     while tasks:
         work = []
@@ -238,146 +86,7 @@ def keys_in_tasks(
                 except TypeError:  # not hashable
                     pass
         tasks = work
-    return ret if as_list else set(ret)
-
-
-def iskey(key: object) -> bool:
-    """
-    Return True if the given object is a potential dask key; False otherwise.
-
-    The definition of a key in a Dask graph is any str, bytes, int, float, or tuple
-    thereof.
-
-    See Also
-    --------
-    ishashable
-    validate_key
-    dask.typing.Key
-    """
-    typ = type(key)
-    if typ is tuple:
-        return all(iskey(i) for i in cast(tuple, key))
-    return typ in {bytes, int, float, str}
-
-
-def validate_key(key: object) -> None:
-    """
-    Validate the format of a dask key.
-
-    See Also
-    --------
-    iskey
-    """
-    if iskey(key):
-        return
-    typ = type(key)
-
-    if typ is tuple:
-        index = None
-        try:
-            for index, part in enumerate(cast(tuple, key)):  # noqa: B007
-                validate_key(part)
-        except TypeError as e:
-            raise TypeError(
-                f"Composite key contains unexpected key type at {index=} ({key=!r})"
-            ) from e
-    raise TypeError(f"Unexpected key type {typ} ({key=!r})")
-
-
-@overload
-def get_dependencies(
-    dsk: Graph,
-    key: Key | None = ...,
-    task: Key | NoDefault = ...,
-    as_list: Literal[False] = ...,
-) -> set[Key]: ...
-
-
-@overload
-def get_dependencies(
-    dsk: Graph,
-    key: Key | None,
-    task: Key | NoDefault,
-    as_list: Literal[True],
-) -> list[Key]: ...
-
-
-def get_dependencies(
-    dsk: Graph,
-    key: Key | None = None,
-    task: Key | NoDefault = no_default,
-    as_list: bool = False,  # noqa: FBT001, FBT002
-) -> set[Key] | list[Key]:
-    """
-    Get the immediate tasks on which this task depends.
-
-    Examples
-    --------
-    >>> inc = lambda x: x + 1
-    >>> add = lambda x, y: x + y
-    >>> dsk = {
-    ...     "x": 1,
-    ...     "y": (inc, "x"),
-    ...     "z": (add, "x", "y"),
-    ...     "w": (inc, "z"),
-    ...     "a": (add, (inc, "x"), 1),
-    ... }
-
-    >>> get_dependencies(dsk, "x")
-    set()
-
-    >>> get_dependencies(dsk, "y")
-    {'x'}
-
-    >>> get_dependencies(dsk, "z")  # doctest: +SKIP
-    {'x', 'y'}
-
-    >>> get_dependencies(dsk, "w")  # Only direct dependencies
-    {'z'}
-
-    >>> get_dependencies(dsk, "a")  # Ignore non-keys
-    {'x'}
-
-    >>> get_dependencies(dsk, task=(inc, "x"))  # provide tasks directly
-    {'x'}
-    """
-    if key is not None:
-        arg = dsk[key]
-    elif task is not no_default:
-        arg = task
-    else:
-        raise ValueError("Provide either key or task")
-
-    return keys_in_tasks(dsk, [arg], as_list=as_list)
-
-
-def flatten(seq, container=list):
-    """
-    Flatten an arbitrary sequence.
-
-    >>> list(flatten([1]))
-    [1]
-
-    >>> list(flatten([[1, 2], [1, 2]]))
-    [1, 2, 1, 2]
-
-    >>> list(flatten([[[1], [2]], [[1], [2]]]))
-    [1, 2, 1, 2]
-
-    >>> list(flatten(((1, 2), (1, 2))))  # Don't flatten tuples
-    [(1, 2), (1, 2)]
-
-    >>> list(flatten((1, 2, [3, 4])))  # support heterogeneous
-    [1, 2, 3, 4]
-    """
-    if isinstance(seq, str):
-        yield seq
-    else:
-        for item in seq:
-            if isinstance(item, container):
-                yield from flatten(item, container=container)
-            else:
-                yield item
+    return ret
 
 
 T_ = TypeVar("T_")
@@ -393,15 +102,12 @@ def _reverse_dict(d: Mapping[T_, Iterable[T_]]) -> dict[T_, set[T_]]:
     return dict(result)
 
 
-def _toposort(dsk, *, keys=None, returncycle=False, dependencies=None):
+def toposort(graph):
+    """Return a list of task keys sorted in topological order."""
     # Stack-based depth-first search traversal.  This is based on Tarjan's
     # method for topological sorting (see wikipedia for pseudocode)
-    if keys is None:
-        keys = dsk
-    elif not isinstance(keys, list):
-        keys = [keys]
-    if not returncycle:
-        ordered = []
+    keys = graph
+    ordered = []
 
     # Nodes whose descendents have been completely explored.
     # These nodes are guaranteed to not be part of a cycle.
@@ -414,9 +120,7 @@ def _toposort(dsk, *, keys=None, returncycle=False, dependencies=None):
     # that has already been added to `completed`.
     seen = set()
 
-    if dependencies is None:
-        dependencies = {k: get_dependencies(dsk, k) for k in dsk}
-
+    dependencies = {k: keys_in_tasks(graph, [graph[k]]) for k in graph}
     for key in keys:
         if key in completed:
             continue
@@ -462,28 +166,17 @@ def _toposort(dsk, *, keys=None, returncycle=False, dependencies=None):
                             prev = min(deps, key=priorities.__getitem__)
                             cycle.append(prev)
                         cycle.reverse()
-
-                        if returncycle:
-                            return cycle
-                        else:
-                            cycle = "->".join(str(x) for x in cycle)
-                            raise RuntimeError(f"Cycle detected in Dask: {cycle}")
+                        cycle = "->".join(str(x) for x in cycle)
+                        raise RuntimeError(f"Cycle detected in the graph: {cycle}")
                     next_nodes.append(nxt)
 
             if next_nodes:
                 nodes.extend(next_nodes)
             else:
                 # cur has no more descendants to explore, so we're done with it
-                if not returncycle:
-                    ordered.append(cur)
+                ordered.append(cur)
                 completed.add(cur)
                 seen.remove(cur)
                 nodes.pop()
-    if returncycle:
-        return []
+
     return ordered
-
-
-def toposort(dsk, dependencies=None):
-    """Return a list of keys of dask sorted in topological order."""
-    return _toposort(dsk, dependencies=dependencies)

--- a/python/cudf_polars/cudf_polars/experimental/scheduler.py
+++ b/python/cudf_polars/cudf_polars/experimental/scheduler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 """Synchronous task scheduler."""
 
@@ -17,7 +17,8 @@ Key: TypeAlias = str | int | tuple["Key", ...]
 Graph: TypeAlias = MutableMapping[Key, Any]
 
 
-# NOTE: This is the single-threaded scheduler from `dask.core`.
+# NOTE: This is a slimmed-down version of the single-threaded
+# (synchronous) scheduler in `dask.core`.
 
 
 def ishashable(x):

--- a/python/cudf_polars/cudf_polars/experimental/scheduler.py
+++ b/python/cudf_polars/cudf_polars/experimental/scheduler.py
@@ -1,0 +1,489 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""Synchronous task scheduler."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import MutableMapping
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable, Mapping
+    from typing import TypeAlias
+
+
+Key: TypeAlias = str | bytes | int | float | tuple["Key", ...]
+Graph: TypeAlias = MutableMapping[Key, Any]
+
+
+# NOTE: This is the single-threaded scheduler from `dask.core`.
+
+
+class _NoDefault(Enum):
+    """
+    Unspecified key-word argument.
+
+    Notes
+    -----
+    Typing-aware constant to detect when the user omits a parameter and you can't use
+    None. Copied from pandas._libs.lib._NoDefault.
+    """
+
+    no_default = "NO_DEFAULT"
+
+    def __repr__(self) -> str:
+        return "<no_default>"
+
+
+no_default = _NoDefault.no_default
+NoDefault = Literal[_NoDefault.no_default]
+
+
+def ishashable(x):
+    """
+    Check if x is hashable.
+
+    Examples
+    --------
+    >>> ishashable(1)
+    True
+    >>> ishashable([1])
+    False
+
+    See Also
+    --------
+    iskey
+    """
+    try:
+        hash(x)
+    except TypeError:
+        return False
+    else:
+        return True
+
+
+def istask(x):
+    """
+    Check if x is a runnable task.
+
+    A task is a tuple with a callable first argument.
+
+    Examples
+    --------
+    >>> inc = lambda x: x + 1
+    >>> istask((inc, 1))
+    True
+    >>> istask(1)
+    False
+    """
+    return type(x) is tuple and x and callable(x[0])
+
+
+def has_tasks(dsk, x):
+    """
+    Whether ``x`` has anything to compute.
+
+    Returns True if:
+    - ``x`` is a task
+    - ``x`` is a key in ``dsk``
+    - ``x`` is a list that contains any tasks or keys
+    """
+    if istask(x):
+        return True
+    try:
+        if x in dsk:
+            return True
+    except Exception:
+        pass
+    if isinstance(x, list):
+        for i in x:
+            if has_tasks(dsk, i):
+                return True
+    return False
+
+
+def preorder_traversal(task):
+    """A generator to preorder-traverse a task."""
+    for item in task:
+        if istask(item):
+            yield from preorder_traversal(item)
+        elif isinstance(item, list):
+            yield list
+            yield from preorder_traversal(item)
+        else:
+            yield item
+
+
+def _lists_to_tuples(res, keys):
+    if isinstance(keys, list):
+        return tuple(_lists_to_tuples(r, k) for r, k in zip(res, keys, strict=False))
+    return res
+
+
+def _execute_task(arg, cache, dsk=None):
+    """
+    Do the actual work of collecting data and executing a function.
+
+    Examples
+    --------
+    >>> inc = lambda x: x + 1
+    >>> add = lambda x, y: x + y
+    >>> cache = {"x": 1, "y": 2}
+
+    Compute tasks against a cache
+    >>> _execute_task((add, "x", 1), cache)  # Compute task in naive manner
+    2
+    >>> _execute_task((add, (inc, "x"), 1), cache)  # Support nested computation
+    3
+
+    Also grab data from cache
+    >>> _execute_task("x", cache)
+    1
+
+    Support nested lists
+    >>> list(_execute_task(["x", "y"], cache))
+    [1, 2]
+
+    >>> list(map(list, _execute_task([["x", "y"], ["y", "x"]], cache)))
+    [[1, 2], [2, 1]]
+
+    >>> _execute_task("foo", cache)  # Passes through on non-keys
+    'foo'
+    """
+    if isinstance(arg, list):
+        return [_execute_task(a, cache) for a in arg]
+    elif istask(arg):
+        func, args = arg[0], arg[1:]
+        # Note: Don't assign the subtask results to a variable. numpy detects
+        # temporaries by their reference count and can execute certain
+        # operations in-place.
+        return func(*(_execute_task(a, cache) for a in args))
+    elif not ishashable(arg):
+        return arg
+    elif arg in cache:
+        return cache[arg]
+    else:
+        return arg
+
+
+def get(dsk, out, cache=None):
+    """
+    Get value from Dask.
+
+    Examples
+    --------
+    >>> inc = lambda x: x + 1
+    >>> d = {"x": 1, "y": (inc, "x")}
+
+    >>> get(d, "x")
+    1
+    >>> get(d, "y")
+    2
+    """
+    for k in flatten(out) if isinstance(out, list) else [out]:
+        if k not in dsk:
+            raise KeyError(f"{k} is not a key in the graph")
+    if cache is None:
+        cache = {}
+    for key in toposort(dsk):
+        task = dsk[key]
+        result = _execute_task(task, cache)
+        cache[key] = result
+    result = _execute_task(out, cache)
+    if isinstance(out, list):
+        result = _lists_to_tuples(result, out)
+    return result
+
+
+def keys_in_tasks(
+    keys: Collection[Key],
+    tasks: Iterable[Any],
+    as_list: bool = False,  # noqa: FBT001, FBT002
+):
+    """
+    Returns the keys in `keys` that are also in `tasks`.
+
+    Examples
+    --------
+    >>> inc = lambda x: x + 1
+    >>> add = lambda x, y: x + y
+    >>> dsk = {
+    ...     "x": 1,
+    ...     "y": (inc, "x"),
+    ...     "z": (add, "x", "y"),
+    ...     "w": (inc, "z"),
+    ...     "a": (add, (inc, "x"), 1),
+    ... }
+
+    >>> keys_in_tasks(dsk, ["x", "y", "j"])  # doctest: +SKIP
+    {'x', 'y'}
+    """
+    ret = []
+    while tasks:
+        work = []
+        for w in tasks:
+            typ = type(w)
+            if typ is tuple and w and callable(w[0]):  # istask(w)
+                work.extend(w[1:])
+            elif typ is list:
+                work.extend(w)
+            elif typ is dict:
+                work.extend(w.values())
+            else:
+                try:
+                    if w in keys:
+                        ret.append(w)
+                except TypeError:  # not hashable
+                    pass
+        tasks = work
+    return ret if as_list else set(ret)
+
+
+def iskey(key: object) -> bool:
+    """
+    Return True if the given object is a potential dask key; False otherwise.
+
+    The definition of a key in a Dask graph is any str, bytes, int, float, or tuple
+    thereof.
+
+    See Also
+    --------
+    ishashable
+    validate_key
+    dask.typing.Key
+    """
+    typ = type(key)
+    if typ is tuple:
+        return all(iskey(i) for i in cast(tuple, key))
+    return typ in {bytes, int, float, str}
+
+
+def validate_key(key: object) -> None:
+    """
+    Validate the format of a dask key.
+
+    See Also
+    --------
+    iskey
+    """
+    if iskey(key):
+        return
+    typ = type(key)
+
+    if typ is tuple:
+        index = None
+        try:
+            for index, part in enumerate(cast(tuple, key)):  # noqa: B007
+                validate_key(part)
+        except TypeError as e:
+            raise TypeError(
+                f"Composite key contains unexpected key type at {index=} ({key=!r})"
+            ) from e
+    raise TypeError(f"Unexpected key type {typ} ({key=!r})")
+
+
+@overload
+def get_dependencies(
+    dsk: Graph,
+    key: Key | None = ...,
+    task: Key | NoDefault = ...,
+    as_list: Literal[False] = ...,
+) -> set[Key]: ...
+
+
+@overload
+def get_dependencies(
+    dsk: Graph,
+    key: Key | None,
+    task: Key | NoDefault,
+    as_list: Literal[True],
+) -> list[Key]: ...
+
+
+def get_dependencies(
+    dsk: Graph,
+    key: Key | None = None,
+    task: Key | NoDefault = no_default,
+    as_list: bool = False,  # noqa: FBT001, FBT002
+) -> set[Key] | list[Key]:
+    """
+    Get the immediate tasks on which this task depends.
+
+    Examples
+    --------
+    >>> inc = lambda x: x + 1
+    >>> add = lambda x, y: x + y
+    >>> dsk = {
+    ...     "x": 1,
+    ...     "y": (inc, "x"),
+    ...     "z": (add, "x", "y"),
+    ...     "w": (inc, "z"),
+    ...     "a": (add, (inc, "x"), 1),
+    ... }
+
+    >>> get_dependencies(dsk, "x")
+    set()
+
+    >>> get_dependencies(dsk, "y")
+    {'x'}
+
+    >>> get_dependencies(dsk, "z")  # doctest: +SKIP
+    {'x', 'y'}
+
+    >>> get_dependencies(dsk, "w")  # Only direct dependencies
+    {'z'}
+
+    >>> get_dependencies(dsk, "a")  # Ignore non-keys
+    {'x'}
+
+    >>> get_dependencies(dsk, task=(inc, "x"))  # provide tasks directly
+    {'x'}
+    """
+    if key is not None:
+        arg = dsk[key]
+    elif task is not no_default:
+        arg = task
+    else:
+        raise ValueError("Provide either key or task")
+
+    return keys_in_tasks(dsk, [arg], as_list=as_list)
+
+
+def flatten(seq, container=list):
+    """
+    Flatten an arbitrary sequence.
+
+    >>> list(flatten([1]))
+    [1]
+
+    >>> list(flatten([[1, 2], [1, 2]]))
+    [1, 2, 1, 2]
+
+    >>> list(flatten([[[1], [2]], [[1], [2]]]))
+    [1, 2, 1, 2]
+
+    >>> list(flatten(((1, 2), (1, 2))))  # Don't flatten tuples
+    [(1, 2), (1, 2)]
+
+    >>> list(flatten((1, 2, [3, 4])))  # support heterogeneous
+    [1, 2, 3, 4]
+    """
+    if isinstance(seq, str):
+        yield seq
+    else:
+        for item in seq:
+            if isinstance(item, container):
+                yield from flatten(item, container=container)
+            else:
+                yield item
+
+
+T_ = TypeVar("T_")
+
+
+def _reverse_dict(d: Mapping[T_, Iterable[T_]]) -> dict[T_, set[T_]]:
+    result: defaultdict[T_, set[T_]] = defaultdict(set)
+    _add = set.add
+    for k, vals in d.items():
+        result[k]
+        for val in vals:
+            _add(result[val], k)
+    return dict(result)
+
+
+def _toposort(dsk, *, keys=None, returncycle=False, dependencies=None):
+    # Stack-based depth-first search traversal.  This is based on Tarjan's
+    # method for topological sorting (see wikipedia for pseudocode)
+    if keys is None:
+        keys = dsk
+    elif not isinstance(keys, list):
+        keys = [keys]
+    if not returncycle:
+        ordered = []
+
+    # Nodes whose descendents have been completely explored.
+    # These nodes are guaranteed to not be part of a cycle.
+    completed = set()
+
+    # All nodes that have been visited in the current traversal.  Because
+    # we are doing depth-first search, going "deeper" should never result
+    # in visiting a node that has already been seen.  The `seen` and
+    # `completed` sets are mutually exclusive; it is okay to visit a node
+    # that has already been added to `completed`.
+    seen = set()
+
+    if dependencies is None:
+        dependencies = {k: get_dependencies(dsk, k) for k in dsk}
+
+    for key in keys:
+        if key in completed:
+            continue
+        nodes = [key]
+        while nodes:
+            # Keep current node on the stack until all descendants are visited
+            cur = nodes[-1]
+            if cur in completed:
+                # Already fully traversed descendants of cur
+                nodes.pop()
+                continue
+            seen.add(cur)
+
+            # Add direct descendants of cur to nodes stack
+            next_nodes = []
+            for nxt in dependencies[cur]:
+                if nxt not in completed:
+                    if nxt in seen:
+                        # Cycle detected!
+                        # Let's report only the nodes that directly participate in the cycle.
+                        # We use `priorities` below to greedily construct a short cycle.
+                        # Shorter cycles may exist.
+                        priorities = {}
+                        prev = nodes[-1]
+                        # Give priority to nodes that were seen earlier.
+                        while nodes[-1] != nxt:
+                            priorities[nodes.pop()] = -len(priorities)
+                        priorities[nxt] = -len(priorities)
+                        # We're going to get the cycle by walking backwards along dependents,
+                        # so calculate dependents only for the nodes in play.
+                        inplay = set(priorities)
+                        dependents = _reverse_dict(
+                            {k: inplay.intersection(dependencies[k]) for k in inplay}
+                        )
+                        # Begin with the node that was seen twice and the node `prev` from
+                        # which we detected the cycle.
+                        cycle = [nodes.pop()]
+                        cycle.append(prev)
+                        while prev != cycle[0]:
+                            # Greedily take a step that takes us closest to completing the cycle.
+                            # This may not give us the shortest cycle, but we get *a* short cycle.
+                            deps = dependents[cycle[-1]]
+                            prev = min(deps, key=priorities.__getitem__)
+                            cycle.append(prev)
+                        cycle.reverse()
+
+                        if returncycle:
+                            return cycle
+                        else:
+                            cycle = "->".join(str(x) for x in cycle)
+                            raise RuntimeError(f"Cycle detected in Dask: {cycle}")
+                    next_nodes.append(nxt)
+
+            if next_nodes:
+                nodes.extend(next_nodes)
+            else:
+                # cur has no more descendants to explore, so we're done with it
+                if not returncycle:
+                    ordered.append(cur)
+                completed.add(cur)
+                seen.remove(cur)
+                nodes.pop()
+    if returncycle:
+        return []
+    return ordered
+
+
+def toposort(dsk, dependencies=None):
+    """Return a list of keys of dask sorted in topological order."""
+    return _toposort(dsk, dependencies=dependencies)

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -122,7 +122,7 @@ class ConfigOptions:
 
         # Validate executor_options
         executor = config.get("executor", "single")
-        if executor in ("partitioned-experimental", "dask-experimental"):
+        if executor == "multi-experimental":
             unsupported = config.get("executor_options", {}).keys() - {
                 "max_rows_per_partition",
                 "parquet_blocksize",

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -121,8 +121,8 @@ class ConfigOptions:
         )
 
         # Validate executor_options
-        executor = config.get("executor", "pylibcudf")
-        if executor == "dask-experimental":
+        executor = config.get("executor", "in-memory")
+        if executor in ("partitioned-experimental", "dask-experimental"):
             unsupported = config.get("executor_options", {}).keys() - {
                 "max_rows_per_partition",
                 "parquet_blocksize",

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -121,7 +121,7 @@ class ConfigOptions:
         )
 
         # Validate executor_options
-        executor = config.get("executor", "in-memory")
+        executor = config.get("executor", "single")
         if executor in ("partitioned-experimental", "dask-experimental"):
             unsupported = config.get("executor_options", {}).keys() - {
                 "max_rows_per_partition",

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -16,8 +16,8 @@ def pytest_addoption(parser):
     parser.addoption(
         "--executor",
         action="store",
-        default="pylibcudf",
-        choices=("pylibcudf", "dask-experimental"),
+        default="in-memory",
+        choices=("in-memory", "partitioned-experimental", "dask-experimental"),
         help="Executor to use for GPUEngine.",
     )
 

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -17,7 +17,7 @@ def pytest_addoption(parser):
         "--executor",
         action="store",
         default="single",
-        choices=("single", "partitioned-experimental", "dask-experimental"),
+        choices=("single", "multi-experimental"),
         help="Executor to use for GPUEngine.",
     )
 
@@ -33,10 +33,10 @@ def pytest_configure(config):
 
     if (
         config.getoption("--dask-cluster")
-        and config.getoption("--executor") != "dask-experimental"
+        and config.getoption("--executor") != "multi-experimental"
     ):
         raise pytest.UsageError(
-            "--dask-cluster requires --executor='dask-experimental'"
+            "--dask-cluster requires --executor='multi-experimental'"
         )
 
     cudf_polars.testing.asserts.Executor = config.getoption("--executor")
@@ -45,7 +45,7 @@ def pytest_configure(config):
 def pytest_sessionstart(session):
     if (
         session.config.getoption("--dask-cluster")
-        and session.config.getoption("--executor") == "dask-experimental"
+        and session.config.getoption("--executor") == "multi-experimental"
     ):
         from dask import config
         from dask.distributed import Client, LocalCluster

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -16,8 +16,8 @@ def pytest_addoption(parser):
     parser.addoption(
         "--executor",
         action="store",
-        default="in-memory",
-        choices=("in-memory", "partitioned-experimental", "dask-experimental"),
+        default="single",
+        choices=("single", "partitioned-experimental", "dask-experimental"),
         help="Executor to use for GPUEngine.",
     )
 

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -28,7 +28,7 @@ def test_parallel_dataframescan(df, max_rows_per_partition):
     total_row_count = len(df.collect())
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="multi-experimental",
         executor_options={"max_rows_per_partition": max_rows_per_partition},
     )
     assert_gpu_result_equal(df, engine=engine)
@@ -46,7 +46,7 @@ def test_parallel_dataframescan(df, max_rows_per_partition):
 def test_dataframescan_concat(df):
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="multi-experimental",
         executor_options={"max_rows_per_partition": 1_000},
     )
     df2 = pl.concat([df, df])

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -14,7 +14,7 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 def engine():
     return pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="multi-experimental",
         executor_options={"max_rows_per_partition": 4},
     )
 
@@ -45,7 +45,7 @@ def test_groupby_single_partitions(df, op, keys):
         q,
         engine=pl.GPUEngine(
             raise_on_fail=True,
-            executor="dask-experimental",
+            executor="multi-experimental",
             executor_options={"max_rows_per_partition": 1e9},
         ),
         check_row_order=False,
@@ -64,7 +64,7 @@ def test_groupby_agg(df, engine, op, keys):
 def test_groupby_agg_config_options(df, op, keys):
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="multi-experimental",
         executor_options={
             "max_rows_per_partition": 4,
             # Trigger shuffle-based groupby

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -16,7 +16,7 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 def test_join(how, reverse, max_rows_per_partition):
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="multi-experimental",
         executor_options={"max_rows_per_partition": max_rows_per_partition},
     )
     left = pl.LazyFrame(

--- a/python/cudf_polars/tests/experimental/test_parallel.py
+++ b/python/cudf_polars/tests/experimental/test_parallel.py
@@ -15,17 +15,17 @@ from cudf_polars import Translator
 from cudf_polars.dsl.traversal import traversal
 
 
-def test_evaluate_dask():
+def test_evaluate_multi():
     df = pl.LazyFrame({"a": [1, 2, 3], "b": [3, 4, 5], "c": [5, 6, 7], "d": [7, 9, 8]})
     q = df.select(pl.col("a") - (pl.col("b") + pl.col("c") * 2), pl.col("d")).sort("d")
 
     expected = q.collect(engine="cpu")
     got_gpu = q.collect(engine=GPUEngine(raise_on_fail=True))
-    got_dask = q.collect(
-        engine=GPUEngine(raise_on_fail=True, executor="dask-experimental")
+    got_multi = q.collect(
+        engine=GPUEngine(raise_on_fail=True, executor="multi-experimental")
     )
     assert_frame_equal(expected, got_gpu)
-    assert_frame_equal(expected, got_dask)
+    assert_frame_equal(expected, got_multi)
 
 
 @pytest.mark.parametrize(

--- a/python/cudf_polars/tests/experimental/test_scan.py
+++ b/python/cudf_polars/tests/experimental/test_scan.py
@@ -53,7 +53,7 @@ def test_parallel_scan(tmp_path, df, fmt, scan_fn):
     q = scan_fn(tmp_path)
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="multi-experimental",
     )
     assert_gpu_result_equal(q, engine=engine)
 
@@ -65,7 +65,7 @@ def test_parquet_blocksize(tmp_path, df, blocksize, n_files):
     q = pl.scan_parquet(tmp_path)
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="multi-experimental",
         executor_options={"parquet_blocksize": blocksize},
     )
     assert_gpu_result_equal(q, engine=engine)

--- a/python/cudf_polars/tests/experimental/test_select.py
+++ b/python/cudf_polars/tests/experimental/test_select.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -14,7 +14,7 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 def engine():
     return pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="multi-experimental",
         executor_options={"max_rows_per_partition": 3},
     )
 

--- a/python/cudf_polars/tests/experimental/test_shuffle.py
+++ b/python/cudf_polars/tests/experimental/test_shuffle.py
@@ -10,7 +10,7 @@ from polars.testing import assert_frame_equal
 
 from cudf_polars import Translator
 from cudf_polars.dsl.expr import Col, NamedExpr
-from cudf_polars.experimental.parallel import evaluate_dask, lower_ir_graph
+from cudf_polars.experimental.parallel import evaluate_multi, lower_ir_graph
 from cudf_polars.experimental.shuffle import Shuffle
 
 
@@ -18,7 +18,7 @@ from cudf_polars.experimental.shuffle import Shuffle
 def engine():
     return pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="multi-experimental",
         executor_options={"max_rows_per_partition": 4},
     )
 
@@ -60,7 +60,7 @@ def test_hash_shuffle(df, engine):
     partition_info = lower_ir_graph(qir3)[1]
     assert len([node for node in partition_info if isinstance(node, Shuffle)]) == 2
 
-    # Check that Dask evaluation works
-    result = evaluate_dask(qir3).to_polars()
+    # Check that multi-partition evaluation works
+    result = evaluate_multi(qir3).to_polars()
     expect = df.collect(engine="cpu")
     assert_frame_equal(result, expect, check_row_order=False)

--- a/python/cudf_polars/tests/test_executors.py
+++ b/python/cudf_polars/tests/test_executors.py
@@ -11,7 +11,7 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
 @pytest.mark.parametrize(
-    "executor", [None, "in-memory", "partitioned-experimental", "dask-experimental"]
+    "executor", [None, "single", "partitioned-experimental", "dask-experimental"]
 )
 def test_executor_basics(executor):
     if executor == "dask-experimental":
@@ -44,7 +44,7 @@ def test_cudf_cache_evaluate():
     ).lazy()
     ldf2 = ldf.select((pl.col("a") + pl.col("b")).alias("c"), pl.col("a"))
     query = pl.concat([ldf, ldf2], how="diagonal")
-    assert_gpu_result_equal(query, executor="in-memory")
+    assert_gpu_result_equal(query, executor="single")
 
 
 @pytest.mark.parametrize("executor", ["partitioned-experimental", "dask-experimental"])
@@ -71,7 +71,7 @@ def test_unknown_executor():
         assert_gpu_result_equal(df, executor="unknown-executor")
 
 
-@pytest.mark.parametrize("executor", [None, "in-memory", "partitioned-experimental"])
+@pytest.mark.parametrize("executor", [None, "single", "partitioned-experimental"])
 def test_unknown_executor_options(executor):
     df = pl.LazyFrame({})
 

--- a/python/cudf_polars/tests/test_executors.py
+++ b/python/cudf_polars/tests/test_executors.py
@@ -49,6 +49,9 @@ def test_cudf_cache_evaluate():
 
 @pytest.mark.parametrize("executor", ["partitioned-experimental", "dask-experimental"])
 def test_dask_experimental_map_function_get_hashable(executor):
+    if executor == "dask-experimental":
+        pytest.importorskip("dask")
+
     df = pl.LazyFrame(
         {
             "a": pl.Series([11, 12, 13], dtype=pl.UInt16),

--- a/python/cudf_polars/tests/test_executors.py
+++ b/python/cudf_polars/tests/test_executors.py
@@ -10,13 +10,8 @@ import polars as pl
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
-@pytest.mark.parametrize(
-    "executor", [None, "single", "partitioned-experimental", "dask-experimental"]
-)
+@pytest.mark.parametrize("executor", [None, "single", "multi-experimental"])
 def test_executor_basics(executor):
-    if executor == "dask-experimental":
-        pytest.importorskip("dask")
-
     df = pl.LazyFrame(
         {
             "a": pl.Series([[1, 2], [3]], dtype=pl.List(pl.Int8())),
@@ -47,11 +42,7 @@ def test_cudf_cache_evaluate():
     assert_gpu_result_equal(query, executor="single")
 
 
-@pytest.mark.parametrize("executor", ["partitioned-experimental", "dask-experimental"])
-def test_dask_experimental_map_function_get_hashable(executor):
-    if executor == "dask-experimental":
-        pytest.importorskip("dask")
-
+def test_dask_experimental_map_function_get_hashable():
     df = pl.LazyFrame(
         {
             "a": pl.Series([11, 12, 13], dtype=pl.UInt16),
@@ -61,7 +52,7 @@ def test_dask_experimental_map_function_get_hashable(executor):
         }
     )
     q = df.unpivot(index="d")
-    assert_gpu_result_equal(q, executor=executor)
+    assert_gpu_result_equal(q, executor="multi-experimental")
 
 
 def test_unknown_executor():
@@ -74,7 +65,7 @@ def test_unknown_executor():
         assert_gpu_result_equal(df, executor="unknown-executor")
 
 
-@pytest.mark.parametrize("executor", [None, "single", "partitioned-experimental"])
+@pytest.mark.parametrize("executor", [None, "single", "multi-experimental"])
 def test_unknown_executor_options(executor):
     df = pl.LazyFrame({})
 

--- a/python/cudf_polars/tests/test_executors.py
+++ b/python/cudf_polars/tests/test_executors.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -10,7 +10,9 @@ import polars as pl
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
-@pytest.mark.parametrize("executor", [None, "pylibcudf", "dask-experimental"])
+@pytest.mark.parametrize(
+    "executor", [None, "in-memory", "partitioned-experimental", "dask-experimental"]
+)
 def test_executor_basics(executor):
     if executor == "dask-experimental":
         pytest.importorskip("dask")
@@ -42,10 +44,11 @@ def test_cudf_cache_evaluate():
     ).lazy()
     ldf2 = ldf.select((pl.col("a") + pl.col("b")).alias("c"), pl.col("a"))
     query = pl.concat([ldf, ldf2], how="diagonal")
-    assert_gpu_result_equal(query, executor="pylibcudf")
+    assert_gpu_result_equal(query, executor="in-memory")
 
 
-def test_dask_experimental_map_function_get_hashable():
+@pytest.mark.parametrize("executor", ["partitioned-experimental", "dask-experimental"])
+def test_dask_experimental_map_function_get_hashable(executor):
     df = pl.LazyFrame(
         {
             "a": pl.Series([11, 12, 13], dtype=pl.UInt16),
@@ -55,7 +58,7 @@ def test_dask_experimental_map_function_get_hashable():
         }
     )
     q = df.unpivot(index="d")
-    assert_gpu_result_equal(q, executor="dask-experimental")
+    assert_gpu_result_equal(q, executor=executor)
 
 
 def test_unknown_executor():
@@ -68,7 +71,7 @@ def test_unknown_executor():
         assert_gpu_result_equal(df, executor="unknown-executor")
 
 
-@pytest.mark.parametrize("executor", [None, "pylibcudf", "dask-experimental"])
+@pytest.mark.parametrize("executor", [None, "in-memory", "partitioned-experimental"])
 def test_unknown_executor_options(executor):
     df = pl.LazyFrame({})
 


### PR DESCRIPTION
## Description

I propose that we replace the `"pylibcudf"` and `"dask-experimental"` executor options in cudf-polars with the following:

- `"single"` (default): All data is treated as single partition, and the logical plan is directly executed on a single GPU.
  - This is how cudf-polars behaves now, by default.
- `"multi-experimental"`: Data is split into multiple partitions (as necessary), and the logical plan is converted into a (dask-compatible) task graph.
  - If a Dask client is detected, we schedule the tasks with `client.get`. Otherwise, we use a native single-threaded scheduler to execute the tasks on a single GPU.
  - **NOTE**: We can make the scheduler configurable in the future (rather than checking for a Dask client every time).
  - **IMPORTANT**: Since this PR adds a native single-threaded scheduler, **we no longer need to depend on Dask for single-GPU/multi-partition execution.**

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
