### PR TITLE
Make a pylibcudf Column from a device array object with `strides=None`

### DIFF
--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 from cython.operator cimport dereference
 from libcpp.memory cimport make_unique, unique_ptr
@@ -455,6 +455,8 @@ def is_c_contiguous(
         The boolean answer.
     """
 
+    if strides is None:
+        return True
     if any(dim == 0 for dim in shape):
         return True
     cumulative_stride = itemsize

--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -436,7 +436,7 @@ def _datatype_from_dtype_desc(desc):
 
 
 def is_c_contiguous(
-    shape: Sequence[int], strides: Sequence[int], itemsize: int
+    shape: Sequence[int], strides: None | Sequence[int], itemsize: int
 ) -> bool:
     """Determine if shape and strides are C-contiguous
 
@@ -444,8 +444,9 @@ def is_c_contiguous(
     ----------
     shape : Sequence[int]
         Number of elements in each dimension.
-    strides : Sequence[int]
+    strides : None | Sequence[int]
         The stride of each dimension in bytes.
+        If None, the memory layout is C-contiguous.
     itemsize : int
         Size of an element in bytes.
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Follow up to #15615. The cuda array interface [specification](https://numba.readthedocs.io/en/stable/cuda/cuda_array_interface.html) for a device array with `strides=None` is a C-contiguous layout.

Contributes to #15132 
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
