### PR TITLE
xfail narwhals sqlframe tests

### DIFF
--- a/ci/test_narwhals.sh
+++ b/ci/test_narwhals.sh
@@ -56,7 +56,9 @@ NARWHALS_DEFAULT_CONSTRUCTORS=pandas python -m pytest \
         test_to_arrow_with_nulls or \
         test_sumh_transformations or \
         test_dask_order_dependent_ops or \
-        test_q1 \
+        test_q1 or \
+        test_eager_only_sqlframe or \
+        test_series_only_sqlframe \
     )" \
     --numprocesses=8 \
     --dist=worksteal

--- a/python/cudf/cudf/testing/narwhals_test_plugin.py
+++ b/python/cudf/cudf/testing/narwhals_test_plugin.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
 
 EXPECTED_FAILURES: Mapping[str, str] = {
     "tests/frame/select_test.py::test_select_duplicates[cudf]": "cuDF doesn't support having multiple columns with same names",
+    "tests/translate/from_native_test.py::test_eager_only_sqlframe[False-context0]": "duckdb not installed",
+    "tests/translate/from_native_test.py::test_eager_only_sqlframe[True-context1]": "duckdb not installed",
+    "tests/translate/from_native_test.py::test_series_only_sqlframe": "duckdb not installed",
 }
 
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The narwhals tests are failing due to a new Narwhals release (1.31) and polars release (1.25). The majority of the failures are in the polars pytest run. They will be fixed in #18132 which will update our polars version pinning to 1.25. 

The remaining tests which fail during the cudf and cudf.pandas pytest runs are skipped/xfailed in this PR. They fail because duckdb is not installed as a test dependency in Narwhals. Is it missing somewhere in https://github.com/narwhals-dev/narwhals/blob/main/pyproject.toml?

CC @MarcoGorelli
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
