### PR TITLE
Remove unused `group_range_rolling_window` API

### DIFF
--- a/cpp/include/cudf/rolling.hpp
+++ b/cpp/include/cudf/rolling.hpp
@@ -549,33 +549,6 @@ std::unique_ptr<column> grouped_range_rolling_window(
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
- * @brief Apply a grouping-aware range-based rolling window function to a sequence of columns.
- *
- * @param group_keys Possibly empty table of sorted keys defining groups.
- * @param orderby Column defining window ranges. Must be sorted. If `group_keys` is non-empty, must
- * be sorted groupwise.
- * @param order Sort order of the `orderby` column.
- * @param null_order Null sort order in the sorted `orderby` column.
- * @param preceding Type of the preceding window.
- * @param following Type of the following window.
- * @param min_periods Minimum number of observations in the window required to have a value.
- * @param requests Vector of pairs of columns and aggregation requests.
- * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned column's device memory
- * @return A table of results, one column per input request.
- */
-std::unique_ptr<table> grouped_range_rolling_window(
-  table_view const& group_keys,
-  column_view const& orderby,
-  order order,
-  null_order null_order,
-  range_window_type preceding,
-  range_window_type following,
-  size_type min_periods,
-  std::vector<std::pair<column_view const&, rolling_aggregation const&>> requests,
-  rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
-/**
  * @brief  Applies a variable-size rolling window function to the values in a column.
  *
  * This function aggregates values in a window around each element i of the input column, and

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -485,30 +485,4 @@ std::unique_ptr<column> grouped_range_rolling_window(table_view const& group_key
                                               mr);
 }
 
-std::unique_ptr<table> grouped_range_rolling_window(
-  table_view const& group_keys,
-  column_view const& orderby,
-  order order,
-  null_order null_order,
-  range_window_type preceding,
-  range_window_type following,
-  size_type min_periods,
-  std::vector<std::pair<column_view const&, rolling_aggregation const&>> requests,
-  rmm::cuda_stream_view stream,
-  rmm::device_async_resource_ref mr)
-{
-  CUDF_FUNC_RANGE();
-  CUDF_EXPECTS(min_periods > 0, "min_periods must be positive");
-  return detail::grouped_range_rolling_window(group_keys,
-                                              orderby,
-                                              order,
-                                              null_order,
-                                              preceding,
-                                              following,
-                                              min_periods,
-                                              requests,
-                                              stream,
-                                              mr);
-}
-
 }  // namespace cudf


### PR DESCRIPTION
## Description

The new API for aggregating multiple columns in a single `grouped_range_rolling_window` call has some issues when trying to use it from cython.

To avoid rewriting a public API between 25.04 and 25.06, let's just remove it, leaving only the detail API for now.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
