### PR TITLE
Clarify that cudf.pandas should be enabled before importing pandas.

### DIFF
--- a/docs/cudf/source/cudf_pandas/usage.md
+++ b/docs/cudf/source/cudf_pandas/usage.md
@@ -1,6 +1,7 @@
 # Usage
 
-There are three ways to enable `cudf.pandas`. Here is a summary:
+To use `cudf.pandas`, enable it *before importing or using pandas* using one of
+these methods:
 
 1. With Jupyter/IPython magics: `%load_ext cudf.pandas`
 2. When executing a Python script from the command line: `python -m cudf.pandas script.py`


### PR DESCRIPTION
## Description
This improves the documentation by clarifying that `cudf.pandas` must be enabled *before importing or using pandas* in order to provide GPU acceleration.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
