### PR TITLE
Backport: Fix index of right table in unary operators in AST, in Joins

### DIFF
--- a/cpp/include/cudf/ast/detail/expression_evaluator.cuh
+++ b/cpp/include/cudf/ast/detail/expression_evaluator.cuh
@@ -356,7 +356,7 @@ struct expression_evaluator {
     IntermediateDataType<has_nulls>* thread_intermediate_storage) const
   {
     auto const typed_input =
-      resolve_input<Input>(input, thread_intermediate_storage, input_row_index);
+      resolve_input<Input>(input, thread_intermediate_storage, input_row_index, input_row_index);
     ast_operator_dispatcher(op,
                             unary_expression_output_handler<Input>{},
                             output_object,


### PR DESCRIPTION
## Description
Backport of #18333 to 25.04. This bug fix will be needed for Velox-cuDF to use the stable 25.04 release.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
