### PR TITLE
Optimize `sequences` by introducing `make_offsets_child_column`

### DIFF
--- a/cpp/src/lists/sequences.cu
+++ b/cpp/src/lists/sequences.cu
@@ -158,19 +158,11 @@ std::unique_ptr<column> sequences(column_view const& starts,
   auto const n_lists = starts.size();
   if (n_lists == 0) { return cudf::make_empty_lists_column(starts.type(), stream, mr); }
 
-  // Generate list offsets for the output.
-  auto list_offsets = make_numeric_column(
-    data_type(type_to_id<size_type>()), n_lists + 1, mask_state::UNALLOCATED, stream, mr);
-  auto const offsets_begin  = list_offsets->mutable_view().template begin<size_type>();
   auto const sizes_input_it = cudf::detail::indexalator_factory::make_input_iterator(sizes);
-  // First copy the sizes since the exclusive_scan tries to read (n_lists+1) values
-  thrust::copy_n(rmm::exec_policy(stream), sizes_input_it, sizes.size(), offsets_begin);
-
-  auto const n_elements = cudf::detail::sizes_to_offsets(
-    offsets_begin, offsets_begin + list_offsets->size(), offsets_begin, 0, stream);
-  CUDF_EXPECTS(n_elements <= std::numeric_limits<size_type>::max(),
-               "Size of output exceeds the column size limit",
-               std::overflow_error);
+  // Generate list offsets for the output.
+  auto [list_offsets, n_elements] = cudf::detail::make_offsets_child_column(
+    sizes_input_it, sizes_input_it + sizes.size(), stream, mr);
+  auto const offsets_begin  = list_offsets->view().template begin<size_type>();
 
   auto child = type_dispatcher(starts.type(),
                                sequences_dispatcher{},

--- a/cpp/src/lists/sequences.cu
+++ b/cpp/src/lists/sequences.cu
@@ -162,7 +162,7 @@ std::unique_ptr<column> sequences(column_view const& starts,
   // Generate list offsets for the output.
   auto [list_offsets, n_elements] = cudf::detail::make_offsets_child_column(
     sizes_input_it, sizes_input_it + sizes.size(), stream, mr);
-  auto const offsets_begin  = list_offsets->view().template begin<size_type>();
+  auto const offsets_begin = list_offsets->view().template begin<size_type>();
 
   auto child = type_dispatcher(starts.type(),
                                sequences_dispatcher{},


### PR DESCRIPTION
## Description
Closes https://github.com/rapidsai/cudf/issues/18100

This PR simplifies the code for `sequences` by introducing `make_offsets_child_column`, which also reduces the runtime of `sequences`.

I generated `starts` and `sizes` for `num_rows`, where all `start` values are 1 and all `size` values are 5.

Here is the result of the benchmark:

![image](https://github.com/user-attachments/assets/d101cb47-cfe0-492a-9a87-e3a453928864)
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
