### PR TITLE
Deprecate old nvtext::normalize_characters

### DIFF
--- a/cpp/include/nvtext/normalize.hpp
+++ b/cpp/include/nvtext/normalize.hpp
@@ -60,7 +60,7 @@ std::unique_ptr<cudf::column> normalize_spaces(
 /**
  * @brief Normalizes strings characters for tokenizing.
  *
- * @deprecated in branch-25.04 and to be removed in a future release;
+ * @deprecated in branch-25.06 and to be removed in a future release;
  * Use nvtext::character_normalizer instead
  *
  * This uses the normalizer that is built into the nvtext::subword_tokenize function

--- a/cpp/include/nvtext/normalize.hpp
+++ b/cpp/include/nvtext/normalize.hpp
@@ -60,6 +60,9 @@ std::unique_ptr<cudf::column> normalize_spaces(
 /**
  * @brief Normalizes strings characters for tokenizing.
  *
+ * @deprecated in branch-25.04 and to be removed in a future release;
+ * Use nvtext::character_normalizer instead
+ *
  * This uses the normalizer that is built into the nvtext::subword_tokenize function
  * which includes:
  *
@@ -102,7 +105,7 @@ std::unique_ptr<cudf::column> normalize_spaces(
  * @param mr Memory resource to allocate any returned objects
  * @return Normalized strings column
  */
-std::unique_ptr<cudf::column> normalize_characters(
+[[deprecated]] std::unique_ptr<cudf::column> normalize_characters(
   cudf::strings_column_view const& input,
   bool do_lower_case,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),

--- a/cpp/tests/streams/text/replace_test.cpp
+++ b/cpp/tests/streams/text/replace_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ TEST_F(TextReplaceTest, NormalizeSpaces)
 TEST_F(TextReplaceTest, NormalizeCharacters)
 {
   auto input = cudf::test::strings_column_wrapper({"abc£def", "éè â îô\taeio", "\tĂĆĖÑ  Ü"});
-  nvtext::normalize_characters(
-    cudf::strings_column_view(input), false, cudf::test::get_default_stream());
+  auto sv = cudf::strings_column_view(input);
+  auto cn = nvtext::create_character_normalizer(false, sv, cudf::test::get_default_stream());
+  nvtext::normalize_characters(sv, *cn, cudf::test::get_default_stream());
 }


### PR DESCRIPTION
## Description
Deprecates the old `nvtext::normalize_characters` API which accepts a column and to-lower bool parameter.

```
std::unique_ptr<cudf::column> normalize_characters(
  cudf::strings_column_view const& input,
  bool do_lower_case,
  rmm::cuda_stream_view stream ,
  rmm::device_async_resource_ref mr);
```

This has been replaced with the `nvtext::character_normalizer` APIs:

```
std::unique_ptr<cudf::column> normalize_characters(
  cudf::strings_column_view const& input,
  character_normalizer const& normalizer, // created using nvtext::create_character_normalizer
  rmm::cuda_stream_view stream,
  rmm::device_async_resource_ref mr );
```
Associated gtests have also been removed to prevent warnings as errors.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
