### PR TITLE
fix(rattler): ignore `libzlib` run dependency to avoid `pandoc` collision

### DIFF
--- a/conda/recipes/libcudf/recipe.yaml
+++ b/conda/recipes/libcudf/recipe.yaml
@@ -152,6 +152,7 @@ outputs:
           - libcurand
           - libkvikio
           - librdkafka
+          - libzlib
           - librmm
           - nvcomp
           - if: cuda_major == "11"
@@ -193,9 +194,11 @@ outputs:
           - flatbuffers
           - libcufile
           - libcurand
+          - libcudf
           - libkvikio
           - librdkafka
           - librmm
+          - libzlib
           - nvcomp
           - if: cuda_major == "11"
             then:
@@ -276,6 +279,7 @@ outputs:
           - libkvikio
           - librdkafka
           - librmm
+          - libzlib
           - nvcomp
           - if: cuda_major == "11"
             then:
@@ -332,11 +336,13 @@ outputs:
           - cuda-nvtx
           - cuda-version
           - flatbuffers
+          - libcudf
           - libcufile
           - libcurand
           - libkvikio
           - librdkafka
           - librmm
+          - libzlib
           - nvcomp
           - if: cuda_major == "11"
             then:


### PR DESCRIPTION
## Description

The `libzlib` run export that snuck through doesn't really cause problems in
`cudf` itself, but it does collide downstream in docs builds for `cuxfilter`
which also requires `pandoc<=2.0.0` (which itself requires an earlier version
of `zlib`).

See
https://github.com/rapidsai/cuxfilter/actions/runs/14053349860/job/39347725537
for representative failure (note the version pulled is the last `cudf` version
before the initial `rattler-build` PR was merged :smile:)

I've also removed some redundant `libcudf` run exports that are handled by
explicit `pin_subpackage` calls.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
