### PR TITLE
Bump librdkafka to 2.8.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -42,7 +42,7 @@ dependencies:
 - libcurand-dev=10.3.0.86
 - libcurand=10.3.0.86
 - libkvikio==25.4.*,>=0.0.0a0
-- librdkafka>=2.5.0,<2.6.0a0
+- librdkafka>=2.8.0,<2.9.0a0
 - librmm==25.4.*,>=0.0.0a0
 - make
 - mmh3
@@ -77,7 +77,7 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - pytest<8
-- python-confluent-kafka>=2.5.0,<2.6.0a0
+- python-confluent-kafka>=2.8.0,<2.9.0a0
 - python-xxhash
 - python>=3.10,<3.13
 - rapids-build-backend>=0.3.0,<0.4.0.dev0

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -41,7 +41,7 @@ dependencies:
 - libcufile-dev
 - libcurand-dev
 - libkvikio==25.4.*,>=0.0.0a0
-- librdkafka>=2.5.0,<2.6.0a0
+- librdkafka>=2.8.0,<2.9.0a0
 - librmm==25.4.*,>=0.0.0a0
 - make
 - mmh3
@@ -75,7 +75,7 @@ dependencies:
 - pytest-cov
 - pytest-xdist
 - pytest<8
-- python-confluent-kafka>=2.5.0,<2.6.0a0
+- python-confluent-kafka>=2.8.0,<2.9.0a0
 - python-xxhash
 - python>=3.10,<3.13
 - pytorch>=2.4.0

--- a/conda/recipes/custreamz/recipe.yaml
+++ b/conda/recipes/custreamz/recipe.yaml
@@ -30,7 +30,7 @@ requirements:
     - pip
     - rapids-build-backend >=0.3.0,<0.4.0.dev0
     - setuptools
-    - python-confluent-kafka >=2.5.0,<2.6.0a0
+    - python-confluent-kafka >=2.8.0,<2.9.0a0
     - cudf_kafka =${{ version }}
     - cuda-version =${{ cuda_version }}
   run:
@@ -39,7 +39,7 @@ requirements:
     - cudf =${{ version }}
     - cudf_kafka =${{ version }}
     - rapids-dask-dependency =${{ minor_version }}
-    - python-confluent-kafka >=2.5.0,<2.6.0a0
+    - python-confluent-kafka >=2.8.0,<2.9.0a0
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
 
 tests:

--- a/conda/recipes/libcudf/conda_build_config.yaml
+++ b/conda/recipes/libcudf/conda_build_config.yaml
@@ -23,7 +23,7 @@ dlpack_version:
   - ">=0.8,<1.0"
 
 librdkafka_version:
-  - ">=2.5.0,<2.6.0a0"
+  - ">=2.8.0,<2.9.0a0"
 
 flatbuffers_version:
   - "=24.3.25"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -458,7 +458,7 @@ dependencies:
       - output_types: conda
         packages:
           - flatbuffers==24.3.25
-          - librdkafka>=2.5.0,<2.6.0a0
+          - librdkafka>=2.8.0,<2.9.0a0
   depends_on_nvcomp:
     common:
       - output_types: conda
@@ -829,13 +829,13 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - python-confluent-kafka>=2.5.0,<2.6.0a0
+          - python-confluent-kafka>=2.8.0,<2.9.0a0
       - output_types: [conda, requirements, pyproject]
         packages:
           - streamz
       - output_types: [requirements, pyproject]
         packages:
-          - confluent-kafka>=2.5.0,<2.6.0a0
+          - confluent-kafka>=2.8.0,<2.9.0a0
   test_cpp:
     common:
       - output_types: conda

--- a/python/custreamz/pyproject.toml
+++ b/python/custreamz/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
-    "confluent-kafka>=2.5.0,<2.6.0a0",
+    "confluent-kafka>=2.8.0,<2.9.0a0",
     "cudf==25.4.*,>=0.0.0a0",
     "cudf_kafka==25.4.*,>=0.0.0a0",
     "streamz",


### PR DESCRIPTION
## Description
There appears to be a conda solve conflict between `cuspatial` & `custreamz`/`libcudf_kafka`.

I think it ultimately stems from `lz4-c` pinnings. `cuspatial`'s dependencies require `lz4-c >=1.10.0,<1.11.0a0`, but `libcudf_kafka`'s `librdkafka >=2.5.0,<2.6.0a0` requires `lz4-c >=1.9.3,<1.10.0a0`.

Bumping `librdkafka` to `>=2.8.0` should resolve this conflict.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
