### PR TITLE
Silence warning by setting BUILD_SHARED_LIBS

### DIFF
--- a/cpp/cmake/thirdparty/get_zstd.cmake
+++ b/cpp/cmake/thirdparty/get_zstd.cmake
@@ -24,7 +24,7 @@ function(find_and_configure_zstd)
     GIT_TAG v1.5.7
     GIT_SHALLOW FALSE SOURCE_SUBDIR build/cmake
     OPTIONS "ZSTD_BUILD_STATIC ON" "ZSTD_BUILD_SHARED OFF" "ZSTD_BUILD_TESTS OFF"
-            "ZSTD_BUILD_PROGRAMS OFF"
+            "ZSTD_BUILD_PROGRAMS OFF" "BUILD_SHARED_LIBS OFF"
   )
 
   if(zstd_ADDED)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
zstd [warns](https://github.com/facebook/zstd/blob/0c3345d6ec207c5207cb2b9bd50a32a0c709228b/build/cmake/lib/CMakeLists.txt#L156) (but behaves as expected) if `BUILD_SHARED_LIBS` conflicts with the zstd-specific CMake options. This change silences that warning.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
