### PR TITLE
Add restart kernel note in cudf pandas docs

### DIFF
--- a/docs/cudf/source/cudf_pandas/usage.md
+++ b/docs/cudf/source/cudf_pandas/usage.md
@@ -27,7 +27,9 @@ df.apply(list, axis=1)                # uses the CPU (fallback)
 ```
 
 ```{note}
-If you have already imported or used pandas in your current kernel session, you will need to restart your kernel and run `%load_ext cudf.pandas` as the first command before any pandas imports or usage.
+If you have already imported or used pandas in your current kernel session,
+you will need to restart your kernel and run `%load_ext cudf.pandas` as the
+first command before any pandas imports or usage.
 ```
 
 ## Command Line Usage

--- a/docs/cudf/source/cudf_pandas/usage.md
+++ b/docs/cudf/source/cudf_pandas/usage.md
@@ -26,6 +26,10 @@ df.groupby("size").total_bill.mean()  # uses the GPU
 df.apply(list, axis=1)                # uses the CPU (fallback)
 ```
 
+```{note}
+If you have already imported or used pandas in your current kernel session, you will need to restart your kernel and run `%load_ext cudf.pandas` as the first command before any pandas imports or usage.
+```
+
 ## Command Line Usage
 
 From the command line, run your Python scripts with `-m cudf.pandas`:


### PR DESCRIPTION
## Description
Adding a note about restarting the kernel when needed in the cudf pandas usage docs
xref: https://github.com/rapidsai/rapids.ai/pull/437#issuecomment-2744449620

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
