### PR TITLE
Update Dask array-conversion handling

### DIFF
--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -859,6 +859,16 @@ def test_implicit_array_conversion_cupy():
     dd.assert_eq(result.to_dask_dataframe(), s, check_index=False)
 
 
+def test_array_conversion_cupy_chunks():
+    pdf = pd.DataFrame({"x": range(10), "y": range(10)})
+    df = dd.from_pandas(pdf, npartitions=2)
+    arr = df.to_dask_array()
+    garr = df.to_backend("cudf").to_dask_array()
+    arr.compute_chunk_sizes()
+    garr.compute_chunk_sizes()
+    assert arr.chunks == garr.chunks
+
+
 def test_implicit_array_conversion_cupy_sparse():
     cupyx = pytest.importorskip("cupyx")
 


### PR DESCRIPTION
## Description
Aligns with recent task-spec changes in Dask. The ideal fix is probably in [create_array_collection](https://github.com/dask/dask/blob/4399aef0bfcba1a57d15cce458d6464fb7c0af2b/dask/array/_array_expr/_backends.py#L23), where the output `Array` object is **not** created with `meta` (needed for cupy-backed arrays).

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
