### PR TITLE
Pin cmake in test_java to be less than 4.0.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -866,8 +866,8 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - &cmake_ver cmake>=3.30.4,<4.0.0
-          - &ninja ninja
+          - cmake>=3.30.4,<4.0.0
+          - ninja
           - maven
           - openjdk=8.*
           - boost

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -96,7 +96,6 @@ files:
   test_java:
     output: none
     includes:
-      - build_base
       - build_all
       - cuda
       - cuda_version
@@ -867,7 +866,8 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - *cmake_ver
+          - &cmake_ver cmake>=3.30.4,<4.0.0
+          - &ninja ninja
           - maven
           - openjdk=8.*
           - boost


### PR DESCRIPTION
Closes https://github.com/rapidsai/cudf/issues/18391

This PR sets the cmake version range in `test_java` to be [3.30.4, 4.0.0), allowing us to side step the issue linked due to the java native build needing to build thrift.

I am not 100% sure about this change, as I don't think I have a way to test this locally. 