### PR TITLE
Fix synchronization issues in host compression and decompression

### DIFF
--- a/cpp/src/io/comp/comp.hpp
+++ b/cpp/src/io/comp/comp.hpp
@@ -31,13 +31,10 @@ namespace io::detail {
  *
  * @param compression Type of compression of the input data
  * @param src         Decompressed host buffer
- * @param stream      CUDA stream used for device memory operations and kernel launches
  *
  * @return Vector containing the Compressed output
  */
-std::vector<uint8_t> compress(compression_type compression,
-                              host_span<uint8_t const> src,
-                              rmm::cuda_stream_view stream);
+std::vector<uint8_t> compress(compression_type compression, host_span<uint8_t const> src);
 
 /**
  * @brief Maximum size of uncompressed chunks that can be compressed.

--- a/cpp/src/io/comp/io_uncomp.hpp
+++ b/cpp/src/io/comp/io_uncomp.hpp
@@ -43,14 +43,12 @@ namespace io::detail {
  * @param compression Type of compression of the input data
  * @param src         Compressed host buffer
  * @param dst         Destination host span to place decompressed buffer
- * @param stream      CUDA stream used for device memory operations and kernel launches
  *
  * @return Size of decompressed output
  */
 size_t decompress(compression_type compression,
                   host_span<uint8_t const> src,
-                  host_span<uint8_t> dst,
-                  rmm::cuda_stream_view stream);
+                  host_span<uint8_t> dst);
 
 /**
  * @brief Decompresses device memory buffers.

--- a/cpp/src/io/json/write_json.cu
+++ b/cpp/src/io/json/write_json.cu
@@ -999,8 +999,7 @@ void write_json(data_sink* out_sink,
     stream.synchronize();
     auto comp_hbuf = cudf::io::detail::compress(
       options.get_compression(),
-      host_span<uint8_t>(reinterpret_cast<uint8_t*>(hbuf.data()), hbuf.size()),
-      stream);
+      host_span<uint8_t>(reinterpret_cast<uint8_t*>(hbuf.data()), hbuf.size()));
     out_sink->host_write(comp_hbuf.data(), comp_hbuf.size());
     return;
   }

--- a/cpp/src/io/orc/aggregate_orc_metadata.cpp
+++ b/cpp/src/io/orc/aggregate_orc_metadata.cpp
@@ -260,7 +260,7 @@ aggregate_orc_metadata::select_stripes(
       auto const buffer =
         per_file_metadata[mapping.source_idx].source->host_read(sf_comp_offset, sf_comp_length);
       auto sf_data = per_file_metadata[mapping.source_idx].decompressor->decompress_blocks(
-        {buffer->data(), buffer->size()}, stream);
+        {buffer->data(), buffer->size()});
       protobuf_reader(sf_data.data(), sf_data.size())
         .read(per_file_metadata[mapping.source_idx].stripefooters[i]);
       mapping.stripe_info[i].stripe_footer =

--- a/cpp/src/io/orc/orc.hpp
+++ b/cpp/src/io/orc/orc.hpp
@@ -542,12 +542,10 @@ class orc_decompressor {
    * @brief ORC block decompression
    *
    * @param src compressed data
-   * @param stream CUDA stream used for device memory operations and kernel launches
    *
    * @return decompressed data
    */
-  host_span<uint8_t const> decompress_blocks(host_span<uint8_t const> src,
-                                             rmm::cuda_stream_view stream);
+  host_span<uint8_t const> decompress_blocks(host_span<uint8_t const> src);
   [[nodiscard]] uint32_t GetLog2MaxCompressionRatio() const { return m_log2MaxRatio; }
   [[nodiscard]] uint64_t GetMaxUncompressedBlockSize(uint32_t block_len) const
   {

--- a/cpp/tests/io/comp/comp_test.cpp
+++ b/cpp/tests/io/comp/comp_test.cpp
@@ -298,9 +298,8 @@ TEST_P(ZstdDecompressTest, HelloWorld)
 {
   std::string const uncompressed{"hello world"};
   std::vector<uint8_t> input = vector_from_string(uncompressed);
-  auto compressed =
-    cudf::io::detail::compress(cudf::io::compression_type::ZSTD, input, cudf::get_default_stream());
-  auto output = Decompress(
+  auto compressed            = cudf::io::detail::compress(cudf::io::compression_type::ZSTD, input);
+  auto output                = Decompress(
     GetParam(), cudf::host_span<uint8_t const>(compressed.data(), compressed.size()), input.size());
   EXPECT_EQ(output, input);
 }

--- a/cpp/tests/io/json/json_chunked_reader.cu
+++ b/cpp/tests/io/json/json_chunked_reader.cu
@@ -62,8 +62,7 @@ TEST_P(JsonReaderTest, ByteRange_SingleSource)
     cdata = cudf::io::detail::compress(
       comptype,
       cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(json_string.data()),
-                                     json_string.size()),
-      cudf::get_default_stream());
+                                     json_string.size()));
   } else
     cdata = std::vector<uint8_t>(
       reinterpret_cast<uint8_t const*>(json_string.data()),
@@ -124,8 +123,7 @@ TEST_P(JsonReaderTest, ReadCompleteFiles)
     cdata = cudf::io::detail::compress(
       comptype,
       cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(json_string.data()),
-                                     json_string.size()),
-      cudf::get_default_stream());
+                                     json_string.size()));
   } else
     cdata = std::vector<uint8_t>(
       reinterpret_cast<uint8_t const*>(json_string.data()),
@@ -184,8 +182,7 @@ TEST_P(JsonReaderTest, ByteRange_MultiSource)
     cdata = cudf::io::detail::compress(
       comptype,
       cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(json_string.data()),
-                                     json_string.size()),
-      cudf::get_default_stream());
+                                     json_string.size()));
   } else
     cdata = std::vector<uint8_t>(
       reinterpret_cast<uint8_t const*>(json_string.data()),

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -3443,8 +3443,7 @@ TEST_P(JsonCompressedIOTest, BasicJsonLines)
   if (comptype != cudf::io::compression_type::NONE) {
     cdata = cudf::io::detail::compress(
       comptype,
-      cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(data.data()), data.size()),
-      cudf::get_default_stream());
+      cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(data.data()), data.size()));
     auto decomp_out_buffer = cudf::io::detail::decompress(
       comptype, cudf::host_span<uint8_t const>(cdata.data(), cdata.size()));
     std::string const expected = R"({"0":1, "1":1.1}

--- a/cpp/tests/large_strings/json_tests.cu
+++ b/cpp/tests/large_strings/json_tests.cu
@@ -74,8 +74,7 @@ TEST_P(JsonLargeReaderTest, MultiBatch)
     cdata = cudf::io::detail::compress(
       comptype,
       cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(json_string.data()),
-                                     json_string.size()),
-      cudf::get_default_stream());
+                                     json_string.size()));
   } else
     cdata = std::vector<uint8_t>(
       reinterpret_cast<uint8_t const*>(json_string.data()),
@@ -174,8 +173,7 @@ TEST_P(JsonLargeReaderTest, MultiBatchWithNulls)
     cdata = cudf::io::detail::compress(
       comptype,
       cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(json_string.data()),
-                                     json_string.size()),
-      cudf::get_default_stream());
+                                     json_string.size()));
   } else
     cdata = std::vector<uint8_t>(
       reinterpret_cast<uint8_t const*>(json_string.data()),
@@ -234,8 +232,7 @@ TEST_P(JsonLargeReaderTest, MultiBatchDoubleBufferInput)
     cdata = cudf::io::detail::compress(
       comptype,
       cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(json_string.data()),
-                                     json_string.size()),
-      cudf::get_default_stream());
+                                     json_string.size()));
   } else {
     cdata = std::vector<uint8_t>(
       reinterpret_cast<uint8_t const*>(json_string.data()),
@@ -305,8 +302,7 @@ TEST_P(JsonLargeReaderTest, OverBatchLimitLine)
     cdata = cudf::io::detail::compress(
       comptype,
       cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(json_string.data()),
-                                     json_string.size()),
-      cudf::get_default_stream());
+                                     json_string.size()));
   } else {
     cdata = std::vector<uint8_t>(
       reinterpret_cast<uint8_t const*>(json_string.data()),


### PR DESCRIPTION
## Description

Host decompression and compression have race conditions mostly because of the incorrect assumption that the pinned buffers are deallocated in stream-ordered way. However, this is only the case of the allocations in the pinned pool. Vectors allocated when the pool is full are deallocated immediately in the destructor, so we can't assume stream ordering at the end of the scope.

Fixed several race conditions in host compression and decompression:

1. Use `cuda_memcpy` instead of `cuda_memcpy_async` at the end of host decompression AND compression because, without synchronization, the host buffer with results can be deallocated before the copy is performed.
2. Use `make_pinned_vector_sync` instead of `make_pinned_vector_async` when creating the decompression output buffer because the buffer is used on the host without any prior synchronization.
3. Use `cuda_memcpy` instead of `cuda_memcpy_async` at the end of the decompression tasks because, without synchronization, the pinned buffer with decompressed data can be deallocated before the copy is performed.

Other changes: removed unused stream parameter from several functions. Clear input buffer in host compression immediately after decompression (before the H2D copy) to reduce the pinned memory use.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
