### PR TITLE
Skip failing Narwhals rolling groupy tests

### DIFF
--- a/ci/test_narwhals.sh
+++ b/ci/test_narwhals.sh
@@ -38,12 +38,22 @@ test_eager_only_sqlframe or \
 test_series_only_sqlframe \
 "
 
+# Temporarily skipping these tests in 25.04 and will unskip them in 25.06, which will support Polars 1.26.
+# Will also prioritize https://github.com/rapidsai/cudf/issues/18191, which will switch us to testing against
+# Narwhals tags instead of the "stable" branch for 25.06. That change will allow us to require all
+# Narwhals tests to pass consistently for supported versions.
+TEMPORARILY_SKIP=" \
+test_rolling_std_expr_lazy_ungrouped or \
+test_rolling_var_expr_lazy_ungrouped \
+"
+
 rapids-logger "Run narwhals tests for cuDF Polars"
 NARWHALS_POLARS_GPU=1 python -m pytest \
     --cache-clear \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars-narwhals.xml" \
     -k "not ( \
-        ${TEST_THAT_NEED_NARWHALS_FIX} \
+        ${TEST_THAT_NEED_NARWHALS_FIX} or \
+        ${TEMPORARILY_SKIP} \
     )" \
     --numprocesses=8 \
     --dist=worksteal \


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
In cuDF, we test Narwhals in CI using three separate test calls:
1. cudf-classic
2. cudf-polars (the Polars GPU executor)
3. cudf.pandas

We test against a "stable" branch of Narwhals, which is only updated when Narwhals makes a new release.
However, because Narwhals releases more frequently than cuDF, this branch isn't truly stable and often 
causes our CI to fail after a new Narwhals release.

The tests below [fail](https://github.com/rapidsai/cudf/actions/runs/14190187843/job/39752908239) during the cudf-polars pytest run when using cuDF release 25.04, which supports Polars 
versions 1.24 to 1.25 (inclusive). The failures occur with Polars 1.24 and Narwhals 1.33, but they pass with 
Polars 1.24 + Narwhals 1.32 and also with Polars 1.26 + Narwhals 1.33. 

I'm temporarily skipping these tests in 25.04 and will unskip them in 25.06, which will support Polars 1.26.
I'm also prioritizing https://github.com/rapidsai/cudf/issues/18191, which will switch us to testing against
Narwhals tags instead of the "stable" branch for 25.06. That change will allow us to require all
Narwhals tests to pass consistently for supported versions.

CC @vyasr and @MarcoGorelli (for visibility)
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
