### PR TITLE
Use pyarrow 15 in oldest dependency CI jobs

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -955,7 +955,10 @@ dependencies:
           - matrix: {dependencies: "oldest"}
             packages:
               - numpy==1.23.*
-              - pyarrow==14.*
+              # pyarrow 14 is fine in some circumstances but we require pyarrow
+              # 15 in our CI tests in order to get a lz4-c that is compatible
+              # with cudf_kafka's dependencies.
+              - pyarrow==15.*
           - matrix:
             packages:
       - output_types: conda
@@ -981,7 +984,10 @@ dependencies:
           - matrix: {dependencies: "oldest"}
             packages:
               - numpy==1.24.*
-              - pyarrow==14.*
+              # pyarrow 14 is fine in some circumstances but we require pyarrow
+              # 15 in our CI tests in order to get a lz4-c that is compatible
+              # with cudf_kafka's dependencies.
+              - pyarrow==15.*
           - matrix:
             packages:
   test_python_cudf_polars:


### PR DESCRIPTION
## Description
We observed nightly failures due to a bad conda solve that fetched outdated cudf-related packages. The root cause is that due to https://github.com/rapidsai/cudf/pull/18370, `cudf_kafka`'s dependency tree requires a newer `lz4-c` than what we can get from `pyarrow==14.*`. Therefore, we must bump the "oldest" pinning we test for `pyarrow` to `pyarrow==15.*` in order to have a compatible `lz4-c` library.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
