### PR TITLE
Use delete not free to release data allocated with new

### DIFF
--- a/python/pylibcudf/pylibcudf/interop.pyx
+++ b/python/pylibcudf/pylibcudf/interop.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 from cpython.pycapsule cimport (
     PyCapsule_GetPointer,
@@ -6,7 +6,6 @@ from cpython.pycapsule cimport (
     PyCapsule_New,
     PyCapsule_SetName,
 )
-from libc.stdlib cimport free
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 from libcpp.vector cimport vector
@@ -26,6 +25,8 @@ from pylibcudf.libcudf.interop cimport (
     from_arrow_column as cpp_from_arrow_column,
     from_arrow_stream as cpp_from_arrow_stream,
     from_dlpack as cpp_from_dlpack,
+    release_arrow_array_raw,
+    release_arrow_schema_raw,
     to_arrow_host_raw,
     to_arrow_schema_raw,
     to_dlpack as cpp_to_dlpack,
@@ -256,10 +257,7 @@ cdef void _release_schema(object schema_capsule) noexcept:
     cdef ArrowSchema* schema = <ArrowSchema*>PyCapsule_GetPointer(
         schema_capsule, 'arrow_schema'
     )
-    if schema.release != NULL:
-        schema.release(schema)
-
-    free(schema)
+    release_arrow_schema_raw(schema)
 
 
 cdef void _release_array(object array_capsule) noexcept:
@@ -267,10 +265,7 @@ cdef void _release_array(object array_capsule) noexcept:
     cdef ArrowArray* array = <ArrowArray*>PyCapsule_GetPointer(
         array_capsule, 'arrow_array'
     )
-    if array.release != NULL:
-        array.release(array)
-
-    free(array)
+    release_arrow_array_raw(array)
 
 
 def _maybe_create_nested_column_metadata(Column col):

--- a/python/pylibcudf/pylibcudf/libcudf/interop.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/interop.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -72,6 +72,13 @@ cdef extern from *:
       return to_arrow_schema(input, metadata).release();
     }
 
+    void release_arrow_schema_raw(ArrowSchema *schema) {
+      if (schema->release != nullptr) {
+          schema->release(schema);
+      }
+      delete schema;
+    }
+
     ArrowArray* to_arrow_host_raw(
       cudf::table_view const& tbl,
       rmm::cuda_stream_view stream       = cudf::get_default_stream(),
@@ -82,11 +89,24 @@ cdef extern from *:
       ArrowArrayMove(&device_arr->array, arr);
       return arr;
     }
+
+    void release_arrow_array_raw(ArrowArray *array) {
+      if (array->release != nullptr) {
+        array->release(array);
+      }
+      delete array;
+    }
     """
     cdef ArrowSchema *to_arrow_schema_raw(
         const table_view& tbl,
         const vector[column_metadata]& metadata,
     ) except +libcudf_exception_handler nogil
+    cdef void release_arrow_schema_raw(
+        ArrowSchema *
+    ) except +libcudf_exception_handler nogil
     cdef ArrowArray* to_arrow_host_raw(
         const table_view& tbl
+    ) except +libcudf_exception_handler nogil
+    cdef void release_arrow_array_raw(
+        ArrowArray *
     ) except +libcudf_exception_handler nogil


### PR DESCRIPTION
## Description

When releasing nanoarrow schemas and arrays in pylibcudf interop we allocate the space for the struct with new, but previously deallocated it with free. This is technically incorrect: data allocated with new should be deallocated with delete. To fix this, introduce a few more inlined C++ functions that take the place of the calls to free.



## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
