### PR TITLE
Allow polars arrow conversion to produce string_view

### DIFF
--- a/python/cudf_polars/cudf_polars/containers/dataframe.py
+++ b/python/cudf_polars/cudf_polars/containers/dataframe.py
@@ -108,7 +108,7 @@ class DataFrame:
         -------
         New dataframe representing the input.
         """
-        table = df.to_arrow(compat_level=pl.CompatLevel.newest())
+        table = df.to_arrow(compat_level=dtypes.TO_ARROW_COMPAT_LEVEL)
         schema = table.schema
         for i, field in enumerate(schema):
             schema = schema.set(

--- a/python/cudf_polars/cudf_polars/containers/dataframe.py
+++ b/python/cudf_polars/cudf_polars/containers/dataframe.py
@@ -108,7 +108,7 @@ class DataFrame:
         -------
         New dataframe representing the input.
         """
-        table = df.to_arrow()
+        table = df.to_arrow(compat_level=pl.CompatLevel.newest())
         schema = table.schema
         for i, field in enumerate(schema):
             schema = schema.set(

--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -157,7 +157,7 @@ class StringFunction(Expr):
             target = self.children[1]
             # Above, we raise NotImplementedError if the target is not a Literal,
             # so we can safely access .value here.
-            if target.value == pa.scalar("", type=pa.string()):  # type: ignore[attr-defined]
+            if target.value == pa.scalar("", type=target.value.type):  # type: ignore[attr-defined]
                 raise NotImplementedError(
                     "libcudf replace does not support empty strings"
                 )
@@ -174,7 +174,7 @@ class StringFunction(Expr):
             target = self.children[1]
             # Above, we raise NotImplementedError if the target is not a Literal,
             # so we can safely access .value here.
-            if pc.any(pc.equal(target.value, "")).as_py():  # type: ignore[attr-defined]
+            if pc.any(pc.equal(target.value.cast(pa.string()), "")).as_py():  # type: ignore[attr-defined]
                 raise NotImplementedError(
                     "libcudf replace_many is implemented differently from polars "
                     "for empty strings"

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -666,7 +666,7 @@ def _(node: pl_expr.Window, translator: Translator, dtype: plc.DataType) -> expr
 def _(node: pl_expr.Literal, translator: Translator, dtype: plc.DataType) -> expr.Expr:
     if isinstance(node.value, plrs.PySeries):
         data = pl.Series._from_pyseries(node.value).to_arrow(
-            compat_level=pl.CompatLevel.newest()
+            compat_level=dtypes.TO_ARROW_COMPAT_LEVEL
         )
         return expr.LiteralColumn(
             dtype, data.cast(dtypes.downcast_arrow_lists(data.type))

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -662,7 +662,9 @@ def _(node: pl_expr.Window, translator: Translator, dtype: plc.DataType) -> expr
 @_translate_expr.register
 def _(node: pl_expr.Literal, translator: Translator, dtype: plc.DataType) -> expr.Expr:
     if isinstance(node.value, plrs.PySeries):
-        data = pl.Series._from_pyseries(node.value).to_arrow()
+        data = pl.Series._from_pyseries(node.value).to_arrow(
+            compat_level=pl.CompatLevel.newest()
+        )
         return expr.LiteralColumn(
             dtype, data.cast(dtypes.downcast_arrow_lists(data.type))
         )

--- a/python/cudf_polars/cudf_polars/utils/dtypes.py
+++ b/python/cudf_polars/cudf_polars/utils/dtypes.py
@@ -12,6 +12,7 @@ from typing_extensions import assert_never
 
 import polars as pl
 
+import pylibcudf as plc
 from pylibcudf.traits import (
     is_floating_point,
     is_integral_not_bool,
@@ -19,12 +20,18 @@ from pylibcudf.traits import (
 )
 
 __all__ = [
+    "TO_ARROW_COMPAT_LEVEL",
     "can_cast",
     "downcast_arrow_lists",
     "from_polars",
     "is_order_preserving_cast",
 ]
-import pylibcudf as plc
+
+TO_ARROW_COMPAT_LEVEL = (
+    pl.CompatLevel.newest()
+    if hasattr(pa.lib, "Type_STRING_VIEW")
+    else pl.CompatLevel.oldest()
+)
 
 
 def downcast_arrow_lists(typ: pa.DataType) -> pa.DataType:


### PR DESCRIPTION
## Description
Now that libcudf can ingest arrow string_view columns, we don't need to convert on the host side.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
