### PR TITLE
Add optional dtype argument to `Scalar.from_any`

### DIFF
--- a/python/pylibcudf/pylibcudf/scalar.pyi
+++ b/python/pylibcudf/pylibcudf/scalar.pyi
@@ -1,10 +1,19 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
+from typing import Any
+
 from pylibcudf.column import Column
 from pylibcudf.types import DataType
 
+NpDtype = type[Any]
+
 class Scalar:
+    def __init__(self): ...
     def type(self) -> DataType: ...
     def is_valid(self) -> bool: ...
     @staticmethod
     def empty_like(column: Column) -> Scalar: ...
+    @classmethod
+    def from_py(cls, py_val: Any, dtype: DataType | None = None) -> Scalar: ...
+    @classmethod
+    def from_numpy(cls, np_val: NpDtype) -> Scalar: ...

--- a/python/pylibcudf/pylibcudf/scalar.pyi
+++ b/python/pylibcudf/pylibcudf/scalar.pyi
@@ -5,7 +5,7 @@ from typing import Any
 from pylibcudf.column import Column
 from pylibcudf.types import DataType
 
-NpDtype = type[Any]
+NpGeneric = type[Any]
 
 class Scalar:
     def __init__(self): ...
@@ -16,4 +16,4 @@ class Scalar:
     @classmethod
     def from_py(cls, py_val: Any, dtype: DataType | None = None) -> Scalar: ...
     @classmethod
-    def from_numpy(cls, np_val: NpDtype) -> Scalar: ...
+    def from_numpy(cls, np_val: NpGeneric) -> Scalar: ...

--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -110,7 +110,7 @@ cdef class Scalar:
         return s
 
     @classmethod
-    def from_py(cls, py_val, dtype: DataType = None):
+    def from_py(cls, py_val, dtype: DataType | None = None):
         """
         Convert a Python standard library object to a Scalar.
 
@@ -118,8 +118,11 @@ cdef class Scalar:
         ----------
         py_val: bool, int, float, str, datetime.datetime, datetime.timedelta, list, dict
             Value to convert to a pylibcudf.Scalar
+        dtype: DataType | None
+            The datatype to cast the value to. If None,
+            the type is inferred from `py_val`.
 
-        Returns
+        Return
         -------
         Scalar
             New pylibcudf.Scalar

--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -280,7 +280,9 @@ def _(py_val: py_bool, dtype: DataType | None):
     if dtype is None:
         dtype = DataType(type_id.BOOL8)
     elif dtype.id() != type_id.BOOL8:
-        raise TypeError(f"Cannot convert bool to Scalar with dtype {dtype.id().name}")
+        raise TypeError(
+            f"Cannot convert bool to Scalar with dtype {(<DataType>dtype).id().name}"
+        )
 
     cdef unique_ptr[scalar] c_obj = make_numeric_scalar((<DataType>dtype).c_obj)
     (<numeric_scalar[cbool]*>c_obj.get()).set_value(py_val)
@@ -292,7 +294,9 @@ def _(py_val: str, dtype: DataType | None):
     if dtype is None:
         dtype = DataType(type_id.STRING)
     elif dtype.id() != type_id.STRING:
-        raise TypeError(f"Cannot convert str to Scalar with dtype {dtype.id().name}")
+        raise TypeError(
+            f"Cannot convert str to Scalar with dtype {(<DataType>dtype).id().name}"
+        )
 
     cdef unique_ptr[scalar] c_obj = make_string_scalar(py_val.encode())
     return _new_scalar(move(c_obj), dtype)

--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -280,8 +280,9 @@ def _(py_val: py_bool, dtype: DataType | None):
     if dtype is None:
         dtype = DataType(type_id.BOOL8)
     elif dtype.id() != type_id.BOOL8:
+        tid = (<DataType>dtype).id()
         raise TypeError(
-            f"Cannot convert bool to Scalar with dtype {(<DataType>dtype).id().name}"
+            f"Cannot convert bool to Scalar with dtype {tid.name}"
         )
 
     cdef unique_ptr[scalar] c_obj = make_numeric_scalar((<DataType>dtype).c_obj)
@@ -294,10 +295,10 @@ def _(py_val: str, dtype: DataType | None):
     if dtype is None:
         dtype = DataType(type_id.STRING)
     elif dtype.id() != type_id.STRING:
+        tid = (<DataType>dtype).id()
         raise TypeError(
-            f"Cannot convert str to Scalar with dtype {(<DataType>dtype).id().name}"
+            f"Cannot convert str to Scalar with dtype {tid.name}"
         )
-
     cdef unique_ptr[scalar] c_obj = make_string_scalar(py_val.encode())
     return _new_scalar(move(c_obj), dtype)
 

--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -206,25 +206,33 @@ def _(py_val: int, dtype: DataType | None):
     tid = c_dtype.id()
 
     if tid == type_id.INT8:
-        if abs(py_val) > numeric_limits[int8_t].max():
+        if not (
+            numeric_limits[int8_t].min() <= py_val <= numeric_limits[int8_t].max()
+        ):
             raise OverflowError(f"{py_val} out of range for INT8 scalar")
         c_obj = make_numeric_scalar(c_dtype.c_obj)
         (<numeric_scalar[int8_t]*>c_obj.get()).set_value(py_val)
 
     elif tid == type_id.INT16:
-        if abs(py_val) > numeric_limits[int16_t].max():
+        if not (
+            numeric_limits[int16_t].min() <= py_val <= numeric_limits[int16_t].max()
+        ):
             raise OverflowError(f"{py_val} out of range for INT16 scalar")
         c_obj = make_numeric_scalar(c_dtype.c_obj)
         (<numeric_scalar[int16_t]*>c_obj.get()).set_value(py_val)
 
     elif tid == type_id.INT32:
-        if abs(py_val) > numeric_limits[int32_t].max():
+        if not (
+            numeric_limits[int32_t].min() <= py_val <= numeric_limits[int32_t].max()
+        ):
             raise OverflowError(f"{py_val} out of range for INT32 scalar")
         c_obj = make_numeric_scalar(c_dtype.c_obj)
         (<numeric_scalar[int32_t]*>c_obj.get()).set_value(py_val)
 
     elif tid == type_id.INT64:
-        if abs(py_val) > numeric_limits[int64_t].max():
+        if not (
+            numeric_limits[int64_t].min() <= py_val <= numeric_limits[int64_t].max()
+        ):
             raise OverflowError(f"{py_val} out of range for INT64 scalar")
         c_obj = make_numeric_scalar(c_dtype.c_obj)
         (<numeric_scalar[int64_t]*>c_obj.get()).set_value(py_val)

--- a/python/pylibcudf/pylibcudf/tests/test_scalar.py
+++ b/python/pylibcudf/pylibcudf/tests/test_scalar.py
@@ -5,6 +5,7 @@ import pyarrow as pa
 import pytest
 
 import pylibcudf as plc
+from pylibcudf.types import DataType, TypeId
 
 
 @pytest.fixture(scope="module")
@@ -19,6 +20,101 @@ def test_from_py(val):
     result = plc.Scalar.from_py(val)
     expected = pa.scalar(val)
     assert plc.interop.to_arrow(result).equals(expected)
+
+
+@pytest.mark.parametrize(
+    "val,tid",
+    [
+        (1, TypeId.INT8),
+        (1, TypeId.INT16),
+        (1, TypeId.INT32),
+        (1, TypeId.INT64),
+        (1, TypeId.UINT8),
+        (1, TypeId.UINT16),
+        (1, TypeId.UINT32),
+        (1, TypeId.UINT64),
+        (1.0, TypeId.FLOAT32),
+        (1.5, TypeId.FLOAT64),
+        ("str", TypeId.STRING),
+        (True, TypeId.BOOL8),
+    ],
+)
+def test_from_py_with_dtype(val, tid):
+    dtype = DataType(tid)
+    result = plc.Scalar.from_py(val, dtype)
+    expected = pa.scalar(val).cast(plc.interop.to_arrow(dtype))
+    assert plc.interop.to_arrow(result).equals(expected)
+
+
+@pytest.mark.parametrize(
+    "val,tid,error,msg",
+    [
+        (
+            -1,
+            TypeId.UINT8,
+            ValueError,
+            "Cannot assign negative value to UINT8 scalar",
+        ),
+        (
+            -1,
+            TypeId.UINT16,
+            ValueError,
+            "Cannot assign negative value to UINT16 scalar",
+        ),
+        (
+            -1,
+            TypeId.UINT32,
+            ValueError,
+            "Cannot assign negative value to UINT32 scalar",
+        ),
+        (
+            -1,
+            TypeId.UINT64,
+            ValueError,
+            "Cannot assign negative value to UINT64 scalar",
+        ),
+        (
+            1,
+            TypeId.FLOAT32,
+            TypeError,
+            "Cannot convert int to Scalar with dtype FLOAT32",
+        ),
+        (
+            1,
+            TypeId.FLOAT64,
+            TypeError,
+            "Cannot convert int to Scalar with dtype FLOAT64",
+        ),
+        (
+            1,
+            TypeId.BOOL8,
+            TypeError,
+            "Cannot convert int to Scalar with dtype BOOL8",
+        ),
+        (
+            "str",
+            TypeId.INT32,
+            TypeError,
+            "Cannot convert str to Scalar with dtype INT32",
+        ),
+        (
+            True,
+            TypeId.INT32,
+            TypeError,
+            "Cannot convert bool to Scalar with dtype INT32",
+        ),
+        (
+            1.5,
+            TypeId.INT32,
+            TypeError,
+            "Cannot convert float to Scalar with dtype INT32",
+        ),
+    ],
+)
+def test_from_py_with_dtype_errors(val, tid, error, msg):
+    dtype = DataType(tid)
+    with pytest.raises(error, match=msg):
+        plc.Scalar.from_py(val, dtype)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Adds an optional dtype argument to `Scalar.from_any`.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
