### PR TITLE
Switch the ptr type in gpumemoryview from Py_ssize_t to uintptr_t

### DIFF
--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -1,6 +1,7 @@
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 from cython.operator cimport dereference
+from libc.stdint cimport uintptr_t
 from libcpp.memory cimport make_unique, unique_ptr
 from libcpp.utility cimport move
 from rmm.pylibrmm.stream cimport Stream
@@ -256,10 +257,10 @@ cdef class Column:
                 )
 
         cdef gpumemoryview owning_data = gpumemoryview.from_pointer(
-            <Py_ssize_t> cv.head[char](), owner
+            <uintptr_t> cv.head[char](), owner
         )
         cdef gpumemoryview owning_mask = gpumemoryview.from_pointer(
-            <Py_ssize_t> cv.null_mask(), owner
+            <uintptr_t> cv.null_mask(), owner
         )
 
         return Column(

--- a/python/pylibcudf/pylibcudf/gpumemoryview.pxd
+++ b/python/pylibcudf/pylibcudf/gpumemoryview.pxd
@@ -1,11 +1,11 @@
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
-
+from libc.stdint cimport uintptr_t
 
 cdef class gpumemoryview:
     # TODO: Eventually probably want to make this opaque, but for now it's fine
     # to treat this object as something like a POD struct
-    cdef readonly Py_ssize_t ptr
+    cdef readonly uintptr_t ptr
     cdef readonly object obj
 
     @staticmethod
-    cdef gpumemoryview from_pointer(Py_ssize_t ptr, object owner)
+    cdef gpumemoryview from_pointer(uintptr_t ptr, object owner)

--- a/python/pylibcudf/pylibcudf/gpumemoryview.pyx
+++ b/python/pylibcudf/pylibcudf/gpumemoryview.pyx
@@ -2,6 +2,7 @@
 
 import functools
 import operator
+from libc.stdint cimport uintptr_t
 
 __all__ = ["gpumemoryview"]
 
@@ -27,12 +28,12 @@ cdef class gpumemoryview:
         self.ptr = cai["data"][0]
 
     @staticmethod
-    cdef gpumemoryview from_pointer(Py_ssize_t ptr, object owner):
+    cdef gpumemoryview from_pointer(uintptr_t ptr, object owner):
         """Create a gpumemoryview from a pointer and an owning object.
 
         Parameters
         ----------
-        ptr : Py_ssize_t
+        ptr : uintptr_t
             The pointer to the memory.
         owner : object
             The object that owns the data the pointer points to.


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Closes #18324. `Py_ssize_t` is signed and typically used for indexing based on this [stack overflow dicussion](https://stackoverflow.com/questions/20987390/cython-why-when-is-it-preferable-to-use-py-ssize-t-for-indexing). I think we simplify the ptr type by switching it to `uintptr_t` instead.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
