### PR TITLE
Move thrift-derived parquet schema to public headers

### DIFF
--- a/cpp/include/cudf/io/parquet_schema.hpp
+++ b/cpp/include/cudf/io/parquet_schema.hpp
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include "parquet_common.hpp"
-
 #include <cudf/types.hpp>
 
 #include <cuda/std/optional>
@@ -27,9 +25,142 @@
 #include <string>
 #include <vector>
 
-namespace cudf::io::parquet::detail {
+namespace CUDF_EXPORT cudf {
+
+namespace io::parquet {
 
 constexpr uint32_t parquet_magic = (('P' << 0) | ('A' << 8) | ('R' << 16) | ('1' << 24));
+
+/**
+ * @brief Basic data types in Parquet, determines how data is physically stored
+ */
+enum Type : int8_t {
+  UNDEFINED_TYPE       = -1,  // Undefined for non-leaf nodes
+  BOOLEAN              = 0,
+  INT32                = 1,
+  INT64                = 2,
+  INT96                = 3,  // Deprecated
+  FLOAT                = 4,
+  DOUBLE               = 5,
+  BYTE_ARRAY           = 6,
+  FIXED_LEN_BYTE_ARRAY = 7,
+};
+
+/**
+ * @brief High-level data types in Parquet, determines how data is logically interpreted
+ */
+enum ConvertedType {
+  UNKNOWN = -1,  // No type information present
+  UTF8    = 0,   // a BYTE_ARRAY may contain UTF8 encoded chars
+  MAP     = 1,   // a map is converted as an optional field containing a repeated key/value pair
+  MAP_KEY_VALUE = 2,  // a key/value pair is converted into a group of two fields
+  LIST =
+    3,  // a list is converted into an optional field containing a repeated field for its values
+  ENUM    = 4,      // an enum is converted into a binary field
+  DECIMAL = 5,      // A decimal value. 10^(-scale) encoded as 2's complement big endian
+                    // (precision=number of digits, scale=location of decimal point)
+  DATE        = 6,  // A Date, stored as days since Unix epoch, encoded as the INT32 physical type.
+  TIME_MILLIS = 7,  // A time. The total number of milliseconds since midnight.The value is stored
+                    // as an INT32 physical type.
+  TIME_MICROS = 8,  // A time. The total number of microseconds since midnight.  The value is stored
+                    // as an INT64 physical type.
+  TIMESTAMP_MILLIS = 9,   // A date/time combination, recorded as milliseconds since the Unix epoch
+                          // using physical type of INT64.
+  TIMESTAMP_MICROS = 10,  // A date/time combination, microseconds since the Unix epoch as INT64
+  UINT_8           = 11,  // An unsigned integer 8-bit value as INT32
+  UINT_16          = 12,  // An unsigned integer 16-bit value as INT32
+  UINT_32          = 13,  // An unsigned integer 32-bit value as INT32
+  UINT_64          = 14,  // An unsigned integer 64-bit value as INT64
+  INT_8            = 15,  // A signed integer 8-bit value as INT32
+  INT_16           = 16,  // A signed integer 16-bit value as INT32
+  INT_32           = 17,  // A signed integer 32-bit value as INT32
+  INT_64           = 18,  // A signed integer 8-bit value as INT64
+  JSON             = 19,  // A JSON document embedded within a single UTF8 column.
+  BSON             = 20,  // A BSON document embedded within a single BINARY column.
+  INTERVAL = 21,  // This type annotates a time interval stored as a FIXED_LEN_BYTE_ARRAY of length
+                  // 12 for 3 integers {months,days,milliseconds}
+  NA = 25,        // No Type information, For eg, all-nulls.
+};
+
+/**
+ * @brief Encoding types for the actual data stream
+ */
+enum class Encoding : uint8_t {
+  PLAIN                   = 0,
+  GROUP_VAR_INT           = 1,  // Deprecated, never used
+  PLAIN_DICTIONARY        = 2,
+  RLE                     = 3,
+  BIT_PACKED              = 4,  // Deprecated by parquet-format in 2013, superseded by RLE
+  DELTA_BINARY_PACKED     = 5,
+  DELTA_LENGTH_BYTE_ARRAY = 6,
+  DELTA_BYTE_ARRAY        = 7,
+  RLE_DICTIONARY          = 8,
+  BYTE_STREAM_SPLIT       = 9,
+  NUM_ENCODINGS           = 10,
+};
+
+/**
+ * @brief Compression codec used for compressed data pages
+ */
+enum Compression {
+  UNCOMPRESSED = 0,
+  SNAPPY       = 1,
+  GZIP         = 2,
+  LZO          = 3,
+  BROTLI       = 4,  // Added in 2.3.2
+  LZ4          = 5,  // deprecated; based on LZ4, but with an additional undocumented framing scheme
+  ZSTD         = 6,  // Added in 2.3.2
+  LZ4_RAW      = 7,  // "standard" LZ4 block format
+};
+
+/**
+ * @brief Compression codec used for compressed data pages
+ */
+enum FieldRepetitionType {
+  NO_REPETITION_TYPE = -1,
+  REQUIRED = 0,  // This field is required (can not be null) and each record has exactly 1 value.
+  OPTIONAL = 1,  // The field is optional (can be null) and each record has 0 or 1 values.
+  REPEATED = 2,  // The field is repeated and can contain 0 or more values
+};
+
+/**
+ * @brief Types of pages
+ */
+enum class PageType : uint8_t {
+  DATA_PAGE       = 0,
+  INDEX_PAGE      = 1,
+  DICTIONARY_PAGE = 2,
+  DATA_PAGE_V2    = 3,
+};
+
+/**
+ * @brief Enum to annotate whether lists of min/max elements inside ColumnIndex
+ * are ordered and if so, in which direction.
+ */
+enum BoundaryOrder {
+  UNORDERED  = 0,
+  ASCENDING  = 1,
+  DESCENDING = 2,
+};
+
+/**
+ * @brief Thrift compact protocol struct field types
+ */
+enum class FieldType : uint8_t {
+  BOOLEAN_TRUE  = 1,
+  BOOLEAN_FALSE = 2,
+  I8            = 3,
+  I16           = 4,
+  I32           = 5,
+  I64           = 6,
+  DOUBLE        = 7,
+  BINARY        = 8,
+  LIST          = 9,
+  SET           = 10,
+  MAP           = 11,
+  STRUCT        = 12,
+  UUID          = 13,
+};
 
 /**
  * @brief Struct that describes the Parquet file data header
@@ -564,28 +695,5 @@ struct PageHeader {
   DataPageHeaderV2 data_page_header_v2;
 };
 
-// bit space we are reserving in column_buffer::user_data
-constexpr uint32_t PARQUET_COLUMN_BUFFER_SCHEMA_MASK          = (0xff'ffffu);
-constexpr uint32_t PARQUET_COLUMN_BUFFER_FLAG_LIST_TERMINATED = (1 << 24);
-// if this column has a list parent anywhere above it in the hierarchy
-constexpr uint32_t PARQUET_COLUMN_BUFFER_FLAG_HAS_LIST_PARENT = (1 << 25);
-
-/**
- * @brief Count the number of leading zeros in an unsigned integer
- */
-static inline int CountLeadingZeros32(uint32_t value)
-{
-#if defined(__clang__) || defined(__GNUC__)
-  if (value == 0) return 32;
-  return static_cast<int>(__builtin_clz(value));
-#else
-  int bitpos = 0;
-  while (value != 0) {
-    value >>= 1;
-    ++bitpos;
-  }
-  return 32 - bitpos;
-#endif
-}
-
-}  // namespace cudf::io::parquet::detail
+}  // namespace io::parquet
+}  // namespace CUDF_EXPORT cudf

--- a/cpp/src/io/parquet/bloom_filter_reader.cu
+++ b/cpp/src/io/parquet/bloom_filter_reader.cu
@@ -15,7 +15,6 @@
  */
 
 #include "compact_protocol_reader.hpp"
-#include "io/parquet/parquet.hpp"
 #include "reader_impl_helpers.hpp"
 
 #include <cudf/ast/detail/expression_transformer.hpp>
@@ -24,6 +23,7 @@
 #include <cudf/detail/cuco_helpers.hpp>
 #include <cudf/detail/transform.hpp>
 #include <cudf/hashing/detail/xxhash_64.cuh>
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/logger.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>

--- a/cpp/src/io/parquet/compact_protocol_reader.cpp
+++ b/cpp/src/io/parquet/compact_protocol_reader.cpp
@@ -16,9 +16,7 @@
 
 #include "compact_protocol_reader.hpp"
 
-#include "parquet.hpp"
-#include "parquet_common.hpp"
-
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <algorithm>

--- a/cpp/src/io/parquet/compact_protocol_reader.hpp
+++ b/cpp/src/io/parquet/compact_protocol_reader.hpp
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include "parquet.hpp"
+#include "parquet_common.hpp"
 
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/utilities/export.hpp>
 
 #include <algorithm>

--- a/cpp/src/io/parquet/compact_protocol_writer.cpp
+++ b/cpp/src/io/parquet/compact_protocol_writer.cpp
@@ -16,8 +16,7 @@
 
 #include "compact_protocol_writer.hpp"
 
-#include "parquet.hpp"
-
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/utilities/error.hpp>
 
 namespace cudf::io::parquet::detail {

--- a/cpp/src/io/parquet/compact_protocol_writer.hpp
+++ b/cpp/src/io/parquet/compact_protocol_writer.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "parquet.hpp"
+#include <cudf/io/parquet_schema.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/cpp/src/io/parquet/parquet_common.hpp
+++ b/cpp/src/io/parquet/parquet_common.hpp
@@ -36,135 +36,28 @@ std::string const ARROW_SCHEMA_KEY                                   = "ARROW:sc
 // Schema type ipc message has zero length body
 int64_t constexpr SCHEMA_HEADER_TYPE_IPC_MESSAGE_BODYLENGTH = 0;
 
-/**
- * @brief Basic data types in Parquet, determines how data is physically stored
- */
-enum Type : int8_t {
-  UNDEFINED_TYPE       = -1,  // Undefined for non-leaf nodes
-  BOOLEAN              = 0,
-  INT32                = 1,
-  INT64                = 2,
-  INT96                = 3,  // Deprecated
-  FLOAT                = 4,
-  DOUBLE               = 5,
-  BYTE_ARRAY           = 6,
-  FIXED_LEN_BYTE_ARRAY = 7,
-};
+// bit space we are reserving in column_buffer::user_data
+constexpr uint32_t PARQUET_COLUMN_BUFFER_SCHEMA_MASK          = (0xff'ffffu);
+constexpr uint32_t PARQUET_COLUMN_BUFFER_FLAG_LIST_TERMINATED = (1 << 24);
+// if this column has a list parent anywhere above it in the hierarchy
+constexpr uint32_t PARQUET_COLUMN_BUFFER_FLAG_HAS_LIST_PARENT = (1 << 25);
 
 /**
- * @brief High-level data types in Parquet, determines how data is logically interpreted
+ * @brief Count the number of leading zeros in an unsigned integer
  */
-enum ConvertedType {
-  UNKNOWN = -1,  // No type information present
-  UTF8    = 0,   // a BYTE_ARRAY may contain UTF8 encoded chars
-  MAP     = 1,   // a map is converted as an optional field containing a repeated key/value pair
-  MAP_KEY_VALUE = 2,  // a key/value pair is converted into a group of two fields
-  LIST =
-    3,  // a list is converted into an optional field containing a repeated field for its values
-  ENUM    = 4,      // an enum is converted into a binary field
-  DECIMAL = 5,      // A decimal value. 10^(-scale) encoded as 2's complement big endian
-                    // (precision=number of digits, scale=location of decimal point)
-  DATE        = 6,  // A Date, stored as days since Unix epoch, encoded as the INT32 physical type.
-  TIME_MILLIS = 7,  // A time. The total number of milliseconds since midnight.The value is stored
-                    // as an INT32 physical type.
-  TIME_MICROS = 8,  // A time. The total number of microseconds since midnight.  The value is stored
-                    // as an INT64 physical type.
-  TIMESTAMP_MILLIS = 9,   // A date/time combination, recorded as milliseconds since the Unix epoch
-                          // using physical type of INT64.
-  TIMESTAMP_MICROS = 10,  // A date/time combination, microseconds since the Unix epoch as INT64
-  UINT_8           = 11,  // An unsigned integer 8-bit value as INT32
-  UINT_16          = 12,  // An unsigned integer 16-bit value as INT32
-  UINT_32          = 13,  // An unsigned integer 32-bit value as INT32
-  UINT_64          = 14,  // An unsigned integer 64-bit value as INT64
-  INT_8            = 15,  // A signed integer 8-bit value as INT32
-  INT_16           = 16,  // A signed integer 16-bit value as INT32
-  INT_32           = 17,  // A signed integer 32-bit value as INT32
-  INT_64           = 18,  // A signed integer 8-bit value as INT64
-  JSON             = 19,  // A JSON document embedded within a single UTF8 column.
-  BSON             = 20,  // A BSON document embedded within a single BINARY column.
-  INTERVAL = 21,  // This type annotates a time interval stored as a FIXED_LEN_BYTE_ARRAY of length
-                  // 12 for 3 integers {months,days,milliseconds}
-  NA = 25,        // No Type information, For eg, all-nulls.
-};
-
-/**
- * @brief Encoding types for the actual data stream
- */
-enum class Encoding : uint8_t {
-  PLAIN                   = 0,
-  GROUP_VAR_INT           = 1,  // Deprecated, never used
-  PLAIN_DICTIONARY        = 2,
-  RLE                     = 3,
-  BIT_PACKED              = 4,  // Deprecated by parquet-format in 2013, superseded by RLE
-  DELTA_BINARY_PACKED     = 5,
-  DELTA_LENGTH_BYTE_ARRAY = 6,
-  DELTA_BYTE_ARRAY        = 7,
-  RLE_DICTIONARY          = 8,
-  BYTE_STREAM_SPLIT       = 9,
-  NUM_ENCODINGS           = 10,
-};
-
-/**
- * @brief Compression codec used for compressed data pages
- */
-enum Compression {
-  UNCOMPRESSED = 0,
-  SNAPPY       = 1,
-  GZIP         = 2,
-  LZO          = 3,
-  BROTLI       = 4,  // Added in 2.3.2
-  LZ4          = 5,  // deprecated; based on LZ4, but with an additional undocumented framing scheme
-  ZSTD         = 6,  // Added in 2.3.2
-  LZ4_RAW      = 7,  // "standard" LZ4 block format
-};
-
-/**
- * @brief Compression codec used for compressed data pages
- */
-enum FieldRepetitionType {
-  NO_REPETITION_TYPE = -1,
-  REQUIRED = 0,  // This field is required (can not be null) and each record has exactly 1 value.
-  OPTIONAL = 1,  // The field is optional (can be null) and each record has 0 or 1 values.
-  REPEATED = 2,  // The field is repeated and can contain 0 or more values
-};
-
-/**
- * @brief Types of pages
- */
-enum class PageType : uint8_t {
-  DATA_PAGE       = 0,
-  INDEX_PAGE      = 1,
-  DICTIONARY_PAGE = 2,
-  DATA_PAGE_V2    = 3,
-};
-
-/**
- * @brief Enum to annotate whether lists of min/max elements inside ColumnIndex
- * are ordered and if so, in which direction.
- */
-enum BoundaryOrder {
-  UNORDERED  = 0,
-  ASCENDING  = 1,
-  DESCENDING = 2,
-};
-
-/**
- * @brief Thrift compact protocol struct field types
- */
-enum class FieldType : uint8_t {
-  BOOLEAN_TRUE  = 1,
-  BOOLEAN_FALSE = 2,
-  I8            = 3,
-  I16           = 4,
-  I32           = 5,
-  I64           = 6,
-  DOUBLE        = 7,
-  BINARY        = 8,
-  LIST          = 9,
-  SET           = 10,
-  MAP           = 11,
-  STRUCT        = 12,
-  UUID          = 13,
-};
+static inline int CountLeadingZeros32(uint32_t value)
+{
+#if defined(__clang__) || defined(__GNUC__)
+  if (value == 0) return 32;
+  return static_cast<int>(__builtin_clz(value));
+#else
+  int bitpos = 0;
+  while (value != 0) {
+    value >>= 1;
+    ++bitpos;
+  }
+  return 32 - bitpos;
+#endif
+}
 
 }  // namespace cudf::io::parquet::detail

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -18,13 +18,13 @@
 
 #include "error.hpp"
 #include "io/comp/comp.hpp"
-#include "io/parquet/parquet.hpp"
 #include "io/parquet/parquet_common.hpp"
 #include "io/statistics/statistics.cuh"
 #include "io/utilities/column_buffer.hpp"
 
 #include <cudf/detail/device_scalar.hpp>
 #include <cudf/io/datasource.hpp>
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/span.hpp>
 

--- a/cpp/src/io/parquet/reader_impl_helpers.cpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.cpp
@@ -17,13 +17,13 @@
 #include "reader_impl_helpers.hpp"
 
 #include "compact_protocol_reader.hpp"
-#include "io/parquet/parquet.hpp"
 #include "io/utilities/base64_utilities.hpp"
 #include "io/utilities/row_selection.hpp"
 #include "ipc/Message_generated.h"
 #include "ipc/Schema_generated.h"
 
 #include <cudf/detail/utilities/host_worker_pool.hpp>
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/logger.hpp>
 
 #include <thrust/iterator/counting_iterator.h>

--- a/cpp/src/io/parquet/stats_filter_helpers.hpp
+++ b/cpp/src/io/parquet/stats_filter_helpers.hpp
@@ -16,13 +16,12 @@
 
 #pragma once
 
-#include "io/parquet/parquet_common.hpp"
-
 #include <cudf/ast/detail/expression_transformer.hpp>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/memory_resource.hpp>

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -23,7 +23,6 @@
 #include "compact_protocol_reader.hpp"
 #include "compact_protocol_writer.hpp"
 #include "io/comp/comp.hpp"
-#include "io/parquet/parquet.hpp"
 #include "io/parquet/parquet_gpu.hpp"
 #include "io/statistics/column_statistics.cuh"
 #include "io/utilities/column_utils.cuh"
@@ -38,6 +37,7 @@
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/detail/utilities/linked_column.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/lists/detail/dremel.hpp>
 #include <cudf/lists/lists_column_view.hpp>
 #include <cudf/logger.hpp>

--- a/cpp/src/io/parquet/writer_impl.hpp
+++ b/cpp/src/io/parquet/writer_impl.hpp
@@ -21,13 +21,13 @@
 
 #pragma once
 
-#include "parquet.hpp"
 #include "parquet_gpu.hpp"
 
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/io/data_sink.hpp>
 #include <cudf/io/detail/parquet.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/error.hpp>
 

--- a/cpp/tests/io/parquet_chunked_reader_test.cu
+++ b/cpp/tests/io/parquet_chunked_reader_test.cu
@@ -35,6 +35,7 @@
 #include <cudf/io/data_sink.hpp>
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
@@ -47,7 +48,6 @@
 #include <thrust/iterator/counting_iterator.h>
 
 #include <src/io/parquet/compact_protocol_reader.hpp>
-#include <src/io/parquet/parquet.hpp>
 
 #include <fstream>
 #include <type_traits>

--- a/cpp/tests/io/parquet_common.cpp
+++ b/cpp/tests/io/parquet_common.cpp
@@ -213,30 +213,28 @@ template std::vector<uint64_t> random_values<uint64_t>(size_t size);
 // of the file to populate the FileMetaData pointed to by file_meta_data.
 // throws cudf::logic_error if the file or metadata is invalid.
 void read_footer(std::unique_ptr<cudf::io::datasource> const& source,
-                 cudf::io::parquet::detail::FileMetaData* file_meta_data)
+                 cudf::io::parquet::FileMetaData* file_meta_data)
 {
-  constexpr auto header_len = sizeof(cudf::io::parquet::detail::file_header_s);
-  constexpr auto ender_len  = sizeof(cudf::io::parquet::detail::file_ender_s);
+  using namespace cudf::io::parquet;
+  constexpr auto header_len = sizeof(file_header_s);
+  constexpr auto ender_len  = sizeof(file_ender_s);
 
   auto const len           = source->size();
   auto const header_buffer = source->host_read(0, header_len);
-  auto const header =
-    reinterpret_cast<cudf::io::parquet::detail::file_header_s const*>(header_buffer->data());
-  auto const ender_buffer = source->host_read(len - ender_len, ender_len);
-  auto const ender =
-    reinterpret_cast<cudf::io::parquet::detail::file_ender_s const*>(ender_buffer->data());
+  auto const header        = reinterpret_cast<file_header_s const*>(header_buffer->data());
+  auto const ender_buffer  = source->host_read(len - ender_len, ender_len);
+  auto const ender         = reinterpret_cast<file_ender_s const*>(ender_buffer->data());
 
   // checks for valid header, footer, and file length
   ASSERT_GT(len, header_len + ender_len);
-  ASSERT_TRUE(header->magic == cudf::io::parquet::detail::parquet_magic &&
-              ender->magic == cudf::io::parquet::detail::parquet_magic);
+  ASSERT_TRUE(header->magic == parquet_magic && ender->magic == parquet_magic);
   ASSERT_TRUE(ender->footer_len != 0 && ender->footer_len <= (len - header_len - ender_len));
 
   // parquet files end with 4-byte footer_length and 4-byte magic == "PAR1"
   // seek backwards from the end of the file (footer_length + 8 bytes of ender)
   auto const footer_buffer =
     source->host_read(len - ender->footer_len - ender_len, ender->footer_len);
-  cudf::io::parquet::detail::CompactProtocolReader cp(footer_buffer->data(), ender->footer_len);
+  detail::CompactProtocolReader cp(footer_buffer->data(), ender->footer_len);
 
   cp.read(file_meta_data);
 }
@@ -245,14 +243,15 @@ void read_footer(std::unique_ptr<cudf::io::datasource> const& source,
 // this assumes the data is uncompressed.
 // throws cudf::logic_error if the page_loc data is invalid.
 int read_dict_bits(std::unique_ptr<cudf::io::datasource> const& source,
-                   cudf::io::parquet::detail::PageLocation const& page_loc)
+                   cudf::io::parquet::PageLocation const& page_loc)
 {
+  using namespace cudf::io::parquet;
   CUDF_EXPECTS(page_loc.offset > 0, "Cannot find page header");
   CUDF_EXPECTS(page_loc.compressed_page_size > 0, "Invalid page header length");
 
-  cudf::io::parquet::detail::PageHeader page_hdr;
+  PageHeader page_hdr;
   auto const page_buf = source->host_read(page_loc.offset, page_loc.compressed_page_size);
-  cudf::io::parquet::detail::CompactProtocolReader cp(page_buf->data(), page_buf->size());
+  detail::CompactProtocolReader cp(page_buf->data(), page_buf->size());
   cp.read(&page_hdr);
 
   // cp should be pointing at the start of page data now. the first byte
@@ -263,14 +262,13 @@ int read_dict_bits(std::unique_ptr<cudf::io::datasource> const& source,
 // read column index from datasource at location indicated by chunk,
 // parse and return as a ColumnIndex struct.
 // throws cudf::logic_error if the chunk data is invalid.
-cudf::io::parquet::detail::ColumnIndex read_column_index(
-  std::unique_ptr<cudf::io::datasource> const& source,
-  cudf::io::parquet::detail::ColumnChunk const& chunk)
+cudf::io::parquet::ColumnIndex read_column_index(
+  std::unique_ptr<cudf::io::datasource> const& source, cudf::io::parquet::ColumnChunk const& chunk)
 {
   CUDF_EXPECTS(chunk.column_index_offset > 0, "Cannot find column index");
   CUDF_EXPECTS(chunk.column_index_length > 0, "Invalid column index length");
 
-  cudf::io::parquet::detail::ColumnIndex colidx;
+  cudf::io::parquet::ColumnIndex colidx;
   auto const ci_buf = source->host_read(chunk.column_index_offset, chunk.column_index_length);
   cudf::io::parquet::detail::CompactProtocolReader cp(ci_buf->data(), ci_buf->size());
   cp.read(&colidx);
@@ -280,14 +278,13 @@ cudf::io::parquet::detail::ColumnIndex read_column_index(
 // read offset index from datasource at location indicated by chunk,
 // parse and return as an OffsetIndex struct.
 // throws cudf::logic_error if the chunk data is invalid.
-cudf::io::parquet::detail::OffsetIndex read_offset_index(
-  std::unique_ptr<cudf::io::datasource> const& source,
-  cudf::io::parquet::detail::ColumnChunk const& chunk)
+cudf::io::parquet::OffsetIndex read_offset_index(
+  std::unique_ptr<cudf::io::datasource> const& source, cudf::io::parquet::ColumnChunk const& chunk)
 {
   CUDF_EXPECTS(chunk.offset_index_offset > 0, "Cannot find offset index");
   CUDF_EXPECTS(chunk.offset_index_length > 0, "Invalid offset index length");
 
-  cudf::io::parquet::detail::OffsetIndex offidx;
+  cudf::io::parquet::OffsetIndex offidx;
   auto const oi_buf = source->host_read(chunk.offset_index_offset, chunk.offset_index_length);
   cudf::io::parquet::detail::CompactProtocolReader cp(oi_buf->data(), oi_buf->size());
   cp.read(&offidx);
@@ -295,8 +292,7 @@ cudf::io::parquet::detail::OffsetIndex read_offset_index(
 }
 
 // Return as a Statistics from the column chunk
-cudf::io::parquet::detail::Statistics const& get_statistics(
-  cudf::io::parquet::detail::ColumnChunk const& chunk)
+cudf::io::parquet::Statistics const& get_statistics(cudf::io::parquet::ColumnChunk const& chunk)
 {
   return chunk.meta_data.statistics;
 }
@@ -304,14 +300,13 @@ cudf::io::parquet::detail::Statistics const& get_statistics(
 // read page header from datasource at location indicated by page_loc,
 // parse and return as a PageHeader struct.
 // throws cudf::logic_error if the page_loc data is invalid.
-cudf::io::parquet::detail::PageHeader read_page_header(
-  std::unique_ptr<cudf::io::datasource> const& source,
-  cudf::io::parquet::detail::PageLocation const& page_loc)
+cudf::io::parquet::PageHeader read_page_header(std::unique_ptr<cudf::io::datasource> const& source,
+                                               cudf::io::parquet::PageLocation const& page_loc)
 {
   CUDF_EXPECTS(page_loc.offset > 0, "Cannot find page header");
   CUDF_EXPECTS(page_loc.compressed_page_size > 0, "Invalid page header length");
 
-  cudf::io::parquet::detail::PageHeader page_hdr;
+  cudf::io::parquet::PageHeader page_hdr;
   auto const page_buf = source->host_read(page_loc.offset, page_loc.compressed_page_size);
   cudf::io::parquet::detail::CompactProtocolReader cp(page_buf->data(), page_buf->size());
   cp.read(&page_hdr);
@@ -743,16 +738,16 @@ int32_t compare(T& v1, T& v2)
 // 1 if v1 > v2.
 int32_t compare_binary(std::vector<uint8_t> const& v1,
                        std::vector<uint8_t> const& v2,
-                       cudf::io::parquet::detail::Type ptype,
-                       std::optional<cudf::io::parquet::detail::ConvertedType> const& ctype)
+                       cudf::io::parquet::Type ptype,
+                       std::optional<cudf::io::parquet::ConvertedType> const& ctype)
 {
-  auto ctype_val = ctype.value_or(cudf::io::parquet::detail::UNKNOWN);
+  auto ctype_val = ctype.value_or(cudf::io::parquet::UNKNOWN);
   switch (ptype) {
-    case cudf::io::parquet::detail::INT32:
+    case cudf::io::parquet::INT32:
       switch (ctype_val) {
-        case cudf::io::parquet::detail::UINT_8:
-        case cudf::io::parquet::detail::UINT_16:
-        case cudf::io::parquet::detail::UINT_32:
+        case cudf::io::parquet::UINT_8:
+        case cudf::io::parquet::UINT_16:
+        case cudf::io::parquet::UINT_32:
           return compare(*(reinterpret_cast<uint32_t const*>(v1.data())),
                          *(reinterpret_cast<uint32_t const*>(v2.data())));
         default:
@@ -760,23 +755,23 @@ int32_t compare_binary(std::vector<uint8_t> const& v1,
                          *(reinterpret_cast<int32_t const*>(v2.data())));
       }
 
-    case cudf::io::parquet::detail::INT64:
-      if (ctype_val == cudf::io::parquet::detail::UINT_64) {
+    case cudf::io::parquet::INT64:
+      if (ctype_val == cudf::io::parquet::UINT_64) {
         return compare(*(reinterpret_cast<uint64_t const*>(v1.data())),
                        *(reinterpret_cast<uint64_t const*>(v2.data())));
       }
       return compare(*(reinterpret_cast<int64_t const*>(v1.data())),
                      *(reinterpret_cast<int64_t const*>(v2.data())));
 
-    case cudf::io::parquet::detail::FLOAT:
+    case cudf::io::parquet::FLOAT:
       return compare(*(reinterpret_cast<float const*>(v1.data())),
                      *(reinterpret_cast<float const*>(v2.data())));
 
-    case cudf::io::parquet::detail::DOUBLE:
+    case cudf::io::parquet::DOUBLE:
       return compare(*(reinterpret_cast<double const*>(v1.data())),
                      *(reinterpret_cast<double const*>(v2.data())));
 
-    case cudf::io::parquet::detail::BYTE_ARRAY: {
+    case cudf::io::parquet::BYTE_ARRAY: {
       int32_t v1sz = v1.size();
       int32_t v2sz = v2.size();
       int32_t ret  = memcmp(v1.data(), v2.data(), std::min(v1sz, v2sz));

--- a/cpp/tests/io/parquet_common.hpp
+++ b/cpp/tests/io/parquet_common.hpp
@@ -22,11 +22,11 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/io/datasource.hpp>
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 
 #include <src/io/parquet/compact_protocol_reader.hpp>
-#include <src/io/parquet/parquet.hpp>
 
 #include <random>
 #include <type_traits>
@@ -106,38 +106,34 @@ std::unique_ptr<cudf::column> make_parquet_list_list_col(
 // of the file to populate the FileMetaData pointed to by file_meta_data.
 // throws cudf::logic_error if the file or metadata is invalid.
 void read_footer(std::unique_ptr<cudf::io::datasource> const& source,
-                 cudf::io::parquet::detail::FileMetaData* file_meta_data);
+                 cudf::io::parquet::FileMetaData* file_meta_data);
 
 // returns the number of bits used for dictionary encoding data at the given page location.
 // this assumes the data is uncompressed.
 // throws cudf::logic_error if the page_loc data is invalid.
 int read_dict_bits(std::unique_ptr<cudf::io::datasource> const& source,
-                   cudf::io::parquet::detail::PageLocation const& page_loc);
+                   cudf::io::parquet::PageLocation const& page_loc);
 
 // read column index from datasource at location indicated by chunk,
 // parse and return as a ColumnIndex struct.
 // throws cudf::logic_error if the chunk data is invalid.
-cudf::io::parquet::detail::ColumnIndex read_column_index(
-  std::unique_ptr<cudf::io::datasource> const& source,
-  cudf::io::parquet::detail::ColumnChunk const& chunk);
+cudf::io::parquet::ColumnIndex read_column_index(
+  std::unique_ptr<cudf::io::datasource> const& source, cudf::io::parquet::ColumnChunk const& chunk);
 
 // read offset index from datasource at location indicated by chunk,
 // parse and return as an OffsetIndex struct.
 // throws cudf::logic_error if the chunk data is invalid.
-cudf::io::parquet::detail::OffsetIndex read_offset_index(
-  std::unique_ptr<cudf::io::datasource> const& source,
-  cudf::io::parquet::detail::ColumnChunk const& chunk);
+cudf::io::parquet::OffsetIndex read_offset_index(
+  std::unique_ptr<cudf::io::datasource> const& source, cudf::io::parquet::ColumnChunk const& chunk);
 
 // Return as a Statistics from the column chunk
-cudf::io::parquet::detail::Statistics const& get_statistics(
-  cudf::io::parquet::detail::ColumnChunk const& chunk);
+cudf::io::parquet::Statistics const& get_statistics(cudf::io::parquet::ColumnChunk const& chunk);
 
 // read page header from datasource at location indicated by page_loc,
 // parse and return as a PageHeader struct.
 // throws cudf::logic_error if the page_loc data is invalid.
-cudf::io::parquet::detail::PageHeader read_page_header(
-  std::unique_ptr<cudf::io::datasource> const& source,
-  cudf::io::parquet::detail::PageLocation const& page_loc);
+cudf::io::parquet::PageHeader read_page_header(std::unique_ptr<cudf::io::datasource> const& source,
+                                               cudf::io::parquet::PageLocation const& page_loc);
 
 // make a random validity iterator
 inline auto random_validity(std::mt19937& engine)
@@ -169,8 +165,8 @@ std::pair<cudf::table, std::string> create_parquet_typed_with_stats(std::string 
 
 int32_t compare_binary(std::vector<uint8_t> const& v1,
                        std::vector<uint8_t> const& v2,
-                       cudf::io::parquet::detail::Type ptype,
-                       std::optional<cudf::io::parquet::detail::ConvertedType> const& ctype);
+                       cudf::io::parquet::Type ptype,
+                       std::optional<cudf::io::parquet::ConvertedType> const& ctype);
 
 void expect_compression_stats_empty(std::shared_ptr<cudf::io::writer_compression_statistics> stats);
 

--- a/cpp/tests/io/parquet_misc_test.cpp
+++ b/cpp/tests/io/parquet_misc_test.cpp
@@ -166,13 +166,13 @@ TEST_P(ParquetSizedTest, DictionaryTest)
 
   // make sure dictionary was used
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
   auto used_dict = [&fmd]() {
     for (auto enc : fmd.row_groups[0].columns[0].meta_data.encodings) {
-      if (enc == cudf::io::parquet::detail::Encoding::PLAIN_DICTIONARY or
-          enc == cudf::io::parquet::detail::Encoding::RLE_DICTIONARY) {
+      if (enc == cudf::io::parquet::Encoding::PLAIN_DICTIONARY or
+          enc == cudf::io::parquet::Encoding::RLE_DICTIONARY) {
         return true;
       }
     }
@@ -215,7 +215,7 @@ TYPED_TEST(ParquetWriterComparableTypeTest, ThreeColumnSorted)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
   ASSERT_GT(fmd.row_groups.size(), 0);
@@ -225,9 +225,9 @@ TYPED_TEST(ParquetWriterComparableTypeTest, ThreeColumnSorted)
 
   // now check that the boundary order for chunk 1 is ascending,
   // chunk 2 is descending, and chunk 3 is unordered
-  std::array expected_orders{cudf::io::parquet::detail::BoundaryOrder::ASCENDING,
-                             cudf::io::parquet::detail::BoundaryOrder::DESCENDING,
-                             cudf::io::parquet::detail::BoundaryOrder::UNORDERED};
+  std::array expected_orders{cudf::io::parquet::BoundaryOrder::ASCENDING,
+                             cudf::io::parquet::BoundaryOrder::DESCENDING,
+                             cudf::io::parquet::BoundaryOrder::UNORDERED};
 
   for (std::size_t i = 0; i < columns.size(); i++) {
     auto const ci = read_column_index(source, columns[i]);

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -1120,10 +1120,10 @@ TEST_F(ParquetReaderTest, NestedByteArray)
   cudf::io::write_parquet(out_opts);
 
   auto source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
-  EXPECT_EQ(fmd.schema[5].type, cudf::io::parquet::detail::Type::BYTE_ARRAY);
+  EXPECT_EQ(fmd.schema[5].type, cudf::io::parquet::Type::BYTE_ARRAY);
 
   std::vector<cudf::io::reader_column_schema> md{
     {},

--- a/cpp/tests/io/parquet_v2_test.cpp
+++ b/cpp/tests/io/parquet_v2_test.cpp
@@ -688,10 +688,10 @@ TEST_P(ParquetV2Test, PartitionedWriteEmptyColumns)
 
 TEST_P(ParquetV2Test, CheckColumnOffsetIndex)
 {
-  constexpr auto num_rows      = 50000;
-  auto const is_v2             = GetParam();
-  auto const expected_hdr_type = is_v2 ? cudf::io::parquet::detail::PageType::DATA_PAGE_V2
-                                       : cudf::io::parquet::detail::PageType::DATA_PAGE;
+  constexpr auto num_rows = 50000;
+  auto const is_v2        = GetParam();
+  auto const expected_hdr_type =
+    is_v2 ? cudf::io::parquet::PageType::DATA_PAGE_V2 : cudf::io::parquet::PageType::DATA_PAGE;
 
   // fixed length strings
   auto str1_elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
@@ -734,7 +734,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndex)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
@@ -782,10 +782,10 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndex)
 
 TEST_P(ParquetV2Test, CheckColumnOffsetIndexNulls)
 {
-  constexpr auto num_rows      = 100000;
-  auto const is_v2             = GetParam();
-  auto const expected_hdr_type = is_v2 ? cudf::io::parquet::detail::PageType::DATA_PAGE_V2
-                                       : cudf::io::parquet::detail::PageType::DATA_PAGE;
+  constexpr auto num_rows = 100000;
+  auto const is_v2        = GetParam();
+  auto const expected_hdr_type =
+    is_v2 ? cudf::io::parquet::PageType::DATA_PAGE_V2 : cudf::io::parquet::PageType::DATA_PAGE;
 
   // fixed length strings
   auto str1_elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
@@ -838,7 +838,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexNulls)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
@@ -892,10 +892,10 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexNulls)
 
 TEST_P(ParquetV2Test, CheckColumnOffsetIndexNullColumn)
 {
-  constexpr auto num_rows      = 100000;
-  auto const is_v2             = GetParam();
-  auto const expected_hdr_type = is_v2 ? cudf::io::parquet::detail::PageType::DATA_PAGE_V2
-                                       : cudf::io::parquet::detail::PageType::DATA_PAGE;
+  constexpr auto num_rows = 100000;
+  auto const is_v2        = GetParam();
+  auto const expected_hdr_type =
+    is_v2 ? cudf::io::parquet::PageType::DATA_PAGE_V2 : cudf::io::parquet::PageType::DATA_PAGE;
 
   // fixed length strings
   auto str1_elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
@@ -933,7 +933,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexNullColumn)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
@@ -993,9 +993,9 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexNullColumn)
 
 TEST_P(ParquetV2Test, CheckColumnOffsetIndexStruct)
 {
-  auto const is_v2             = GetParam();
-  auto const expected_hdr_type = is_v2 ? cudf::io::parquet::detail::PageType::DATA_PAGE_V2
-                                       : cudf::io::parquet::detail::PageType::DATA_PAGE;
+  auto const is_v2 = GetParam();
+  auto const expected_hdr_type =
+    is_v2 ? cudf::io::parquet::PageType::DATA_PAGE_V2 : cudf::io::parquet::PageType::DATA_PAGE;
 
   auto c0 = testdata::ascending<uint32_t>();
 
@@ -1030,7 +1030,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexStruct)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
@@ -1079,9 +1079,9 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexStruct)
 
 TEST_P(ParquetV2Test, CheckColumnOffsetIndexStructNulls)
 {
-  auto const is_v2             = GetParam();
-  auto const expected_hdr_type = is_v2 ? cudf::io::parquet::detail::PageType::DATA_PAGE_V2
-                                       : cudf::io::parquet::detail::PageType::DATA_PAGE;
+  auto const is_v2 = GetParam();
+  auto const expected_hdr_type =
+    is_v2 ? cudf::io::parquet::PageType::DATA_PAGE_V2 : cudf::io::parquet::PageType::DATA_PAGE;
 
   auto validity2 =
     cudf::detail::make_counting_transform_iterator(0, [](cudf::size_type i) { return i % 2; });
@@ -1123,7 +1123,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexStructNulls)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
@@ -1180,9 +1180,9 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexStructNulls)
 
 TEST_P(ParquetV2Test, CheckColumnIndexListWithNulls)
 {
-  auto const is_v2             = GetParam();
-  auto const expected_hdr_type = is_v2 ? cudf::io::parquet::detail::PageType::DATA_PAGE_V2
-                                       : cudf::io::parquet::detail::PageType::DATA_PAGE;
+  auto const is_v2 = GetParam();
+  auto const expected_hdr_type =
+    is_v2 ? cudf::io::parquet::PageType::DATA_PAGE_V2 : cudf::io::parquet::PageType::DATA_PAGE;
 
   using cudf::test::iterators::null_at;
   using cudf::test::iterators::nulls_at;
@@ -1330,7 +1330,7 @@ TEST_P(ParquetV2Test, CheckColumnIndexListWithNulls)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
@@ -1399,7 +1399,7 @@ TEST_P(ParquetV2Test, CheckColumnIndexListWithNulls)
 
 TEST_P(ParquetV2Test, CheckEncodings)
 {
-  using cudf::io::parquet::detail::Encoding;
+  using cudf::io::parquet::Encoding;
   constexpr auto num_rows = 100'000;
   auto const is_v2        = GetParam();
 
@@ -1432,7 +1432,7 @@ TEST_P(ParquetV2Test, CheckEncodings)
   };
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
   auto const& chunk0_enc = fmd.row_groups[0].columns[0].meta_data.encodings;

--- a/cpp/tests/io/parquet_writer_test.cpp
+++ b/cpp/tests/io/parquet_writer_test.cpp
@@ -24,11 +24,11 @@
 
 #include <cudf/io/data_sink.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/io/types.hpp>
 #include <cudf/unary.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <src/io/parquet/parquet.hpp>
 #include <src/io/parquet/parquet_common.hpp>
 
 #include <array>
@@ -669,7 +669,7 @@ TEST_F(ParquetWriterTest, CheckPageRows)
 
   // check first page header and make sure it has only page_rows values
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
   ASSERT_GT(fmd.row_groups.size(), 0);
@@ -680,7 +680,7 @@ TEST_F(ParquetWriterTest, CheckPageRows)
   // read first data page header.  sizeof(PageHeader) is not exact, but the thrift encoded
   // version should be smaller than size of the struct.
   auto const ph = read_page_header(
-    source, {first_chunk.data_page_offset, sizeof(cudf::io::parquet::detail::PageHeader), 0});
+    source, {first_chunk.data_page_offset, sizeof(cudf::io::parquet::PageHeader), 0});
 
   EXPECT_EQ(ph.data_page_header.num_values, page_rows);
 }
@@ -705,7 +705,7 @@ TEST_F(ParquetWriterTest, CheckPageRowsAdjusted)
 
   // check first page header and make sure it has only page_rows values
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
   ASSERT_GT(fmd.row_groups.size(), 0);
@@ -716,7 +716,7 @@ TEST_F(ParquetWriterTest, CheckPageRowsAdjusted)
   // read first data page header.  sizeof(PageHeader) is not exact, but the thrift encoded
   // version should be smaller than size of the struct.
   auto const ph = read_page_header(
-    source, {first_chunk.data_page_offset, sizeof(cudf::io::parquet::detail::PageHeader), 0});
+    source, {first_chunk.data_page_offset, sizeof(cudf::io::parquet::PageHeader), 0});
 
   EXPECT_LE(ph.data_page_header.num_values, rows_per_page);
 }
@@ -742,7 +742,7 @@ TEST_F(ParquetWriterTest, CheckPageRowsTooSmall)
 
   // check that file is written correctly when rows/page < fragment size
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
   ASSERT_TRUE(fmd.row_groups.size() > 0);
@@ -753,7 +753,7 @@ TEST_F(ParquetWriterTest, CheckPageRowsTooSmall)
   // read first data page header.  sizeof(PageHeader) is not exact, but the thrift encoded
   // version should be smaller than size of the struct.
   auto const ph = read_page_header(
-    source, {first_chunk.data_page_offset, sizeof(cudf::io::parquet::detail::PageHeader), 0});
+    source, {first_chunk.data_page_offset, sizeof(cudf::io::parquet::PageHeader), 0});
 
   // there should be only one page since the fragment size is larger than rows_per_page
   EXPECT_EQ(ph.data_page_header.num_values, num_rows);
@@ -778,7 +778,7 @@ TEST_F(ParquetWriterTest, Decimal32Stats)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
@@ -807,7 +807,7 @@ TEST_F(ParquetWriterTest, Decimal64Stats)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
@@ -839,7 +839,7 @@ TEST_F(ParquetWriterTest, Decimal128Stats)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
@@ -916,7 +916,7 @@ TEST_F(ParquetWriterTest, CheckColumnIndexTruncation)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
@@ -985,7 +985,7 @@ TEST_F(ParquetWriterTest, BinaryColumnIndexTruncation)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
@@ -1044,12 +1044,12 @@ TEST_F(ParquetWriterTest, ByteArrayStats)
   auto result = cudf::io::read_parquet(in_opts);
 
   auto source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
 
-  EXPECT_EQ(fmd.schema[1].type, cudf::io::parquet::detail::Type::BYTE_ARRAY);
-  EXPECT_EQ(fmd.schema[2].type, cudf::io::parquet::detail::Type::BYTE_ARRAY);
+  EXPECT_EQ(fmd.schema[1].type, cudf::io::parquet::Type::BYTE_ARRAY);
+  EXPECT_EQ(fmd.schema[2].type, cudf::io::parquet::Type::BYTE_ARRAY);
 
   auto const stats0 = get_statistics(fmd.row_groups[0].columns[0]);
   auto const stats1 = get_statistics(fmd.row_groups[0].columns[1]);
@@ -1088,13 +1088,13 @@ TEST_F(ParquetWriterTest, SingleValueDictionaryTest)
 
   // make sure dictionary was used
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
   auto used_dict = [&fmd]() {
     for (auto enc : fmd.row_groups[0].columns[0].meta_data.encodings) {
-      if (enc == cudf::io::parquet::detail::Encoding::PLAIN_DICTIONARY or
-          enc == cudf::io::parquet::detail::Encoding::RLE_DICTIONARY) {
+      if (enc == cudf::io::parquet::Encoding::PLAIN_DICTIONARY or
+          enc == cudf::io::parquet::Encoding::RLE_DICTIONARY) {
         return true;
       }
     }
@@ -1134,13 +1134,13 @@ TEST_F(ParquetWriterTest, DictionaryNeverTest)
 
   // make sure dictionary was not used
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
   auto used_dict = [&fmd]() {
     for (auto enc : fmd.row_groups[0].columns[0].meta_data.encodings) {
-      if (enc == cudf::io::parquet::detail::Encoding::PLAIN_DICTIONARY or
-          enc == cudf::io::parquet::detail::Encoding::RLE_DICTIONARY) {
+      if (enc == cudf::io::parquet::Encoding::PLAIN_DICTIONARY or
+          enc == cudf::io::parquet::Encoding::RLE_DICTIONARY) {
         return true;
       }
     }
@@ -1184,13 +1184,13 @@ TEST_F(ParquetWriterTest, DictionaryAdaptiveTest)
   // make sure dictionary was used as expected. col0 should use one,
   // col1 should not.
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
   auto used_dict = [&fmd](int col) {
     for (auto enc : fmd.row_groups[0].columns[col].meta_data.encodings) {
-      if (enc == cudf::io::parquet::detail::Encoding::PLAIN_DICTIONARY or
-          enc == cudf::io::parquet::detail::Encoding::RLE_DICTIONARY) {
+      if (enc == cudf::io::parquet::Encoding::PLAIN_DICTIONARY or
+          enc == cudf::io::parquet::Encoding::RLE_DICTIONARY) {
         return true;
       }
     }
@@ -1234,13 +1234,13 @@ TEST_F(ParquetWriterTest, DictionaryAlwaysTest)
 
   // make sure dictionary was used for both columns
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
   auto used_dict = [&fmd](int col) {
     for (auto enc : fmd.row_groups[0].columns[col].meta_data.encodings) {
-      if (enc == cudf::io::parquet::detail::Encoding::PLAIN_DICTIONARY or
-          enc == cudf::io::parquet::detail::Encoding::RLE_DICTIONARY) {
+      if (enc == cudf::io::parquet::Encoding::PLAIN_DICTIONARY or
+          enc == cudf::io::parquet::Encoding::RLE_DICTIONARY) {
         return true;
       }
     }
@@ -1400,11 +1400,11 @@ TEST_F(ParquetWriterTest, SkipCompression)
 
   // check metadata to make sure column 0 is not compressed and column 1 is
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
   read_footer(source, &fmd);
 
-  EXPECT_EQ(fmd.row_groups[0].columns[0].meta_data.codec, cudf::io::parquet::detail::UNCOMPRESSED);
-  EXPECT_EQ(fmd.row_groups[0].columns[1].meta_data.codec, cudf::io::parquet::detail::ZSTD);
+  EXPECT_EQ(fmd.row_groups[0].columns[0].meta_data.codec, cudf::io::parquet::UNCOMPRESSED);
+  EXPECT_EQ(fmd.row_groups[0].columns[1].meta_data.codec, cudf::io::parquet::ZSTD);
 }
 
 TEST_F(ParquetWriterTest, NoNullsAsNonNullable)
@@ -1525,7 +1525,7 @@ TEST_F(ParquetWriterTest, EmptyMinStringStatistics)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
   read_footer(source, &fmd);
 
   ASSERT_TRUE(fmd.row_groups.size() > 0);
@@ -1563,7 +1563,7 @@ TEST_F(ParquetWriterTest, RowGroupMetadata)
 
   // check row group metadata to make sure total_byte_size is the uncompressed value
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
   read_footer(source, &fmd);
 
   ASSERT_GT(fmd.row_groups.size(), 0);
@@ -1623,18 +1623,18 @@ TEST_F(ParquetWriterTest, UserRequestedDictFallback)
   cudf::io::write_parquet(opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
   read_footer(source, &fmd);
 
   // encoding should have fallen back to PLAIN
   EXPECT_EQ(fmd.row_groups[0].columns[0].meta_data.encodings[0],
-            cudf::io::parquet::detail::Encoding::PLAIN);
+            cudf::io::parquet::Encoding::PLAIN);
 }
 
 TEST_F(ParquetWriterTest, UserRequestedEncodings)
 {
   using cudf::io::column_encoding;
-  using cudf::io::parquet::detail::Encoding;
+  using cudf::io::parquet::Encoding;
   constexpr int num_rows = 500;
   std::mt19937 engine{31337};
 
@@ -1704,12 +1704,12 @@ TEST_F(ParquetWriterTest, UserRequestedEncodings)
 
   // check page headers to make sure each column is encoded with the appropriate encoder
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
   read_footer(source, &fmd);
 
   // no nulls and no repetition, so the only encoding used should be for the data.
   // since we're writing v1, both dict and data pages should use PLAIN_DICTIONARY.
-  auto const expect_enc = [&fmd](int idx, cudf::io::parquet::detail::Encoding enc) {
+  auto const expect_enc = [&fmd](int idx, cudf::io::parquet::Encoding enc) {
     auto const& col_meta = fmd.row_groups[0].columns[idx].meta_data;
     EXPECT_EQ(col_meta.encodings[0], enc);
 
@@ -1717,7 +1717,7 @@ TEST_F(ParquetWriterTest, UserRequestedEncodings)
     ASSERT_TRUE(col_meta.encoding_stats.has_value());
     auto const& enc_stats = col_meta.encoding_stats.value();
     for (auto const& ec : enc_stats) {
-      if (ec.page_type == cudf::io::parquet::detail::PageType::DATA_PAGE) {
+      if (ec.page_type == cudf::io::parquet::PageType::DATA_PAGE) {
         EXPECT_EQ(ec.encoding, enc);
         EXPECT_EQ(ec.count, 1);
       }
@@ -1781,12 +1781,12 @@ TEST_F(ParquetWriterTest, Decimal128DeltaByteArray)
   cudf::io::write_parquet(out_opts);
 
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
   read_footer(source, &fmd);
 
   // make sure DELTA_BYTE_ARRAY was not used
   EXPECT_NE(fmd.row_groups[0].columns[0].meta_data.encodings[0],
-            cudf::io::parquet::detail::Encoding::DELTA_BYTE_ARRAY);
+            cudf::io::parquet::Encoding::DELTA_BYTE_ARRAY);
 }
 
 TEST_F(ParquetWriterTest, DeltaBinaryStartsWithNulls)
@@ -1979,7 +1979,7 @@ TEST_F(ParquetWriterTest, DurationByteStreamSplit)
 TEST_F(ParquetWriterTest, WriteFixedLenByteArray)
 {
   srand(31337);
-  using cudf::io::parquet::detail::Encoding;
+  using cudf::io::parquet::Encoding;
   constexpr int fixed_width          = 16;
   constexpr cudf::size_type num_rows = 200;
   std::vector<uint8_t> data(num_rows * fixed_width);
@@ -2037,17 +2037,17 @@ TEST_F(ParquetWriterTest, WriteFixedLenByteArray)
 
   // check page headers to make sure each column is encoded with the appropriate encoder
   auto const source = cudf::io::datasource::create(filepath);
-  cudf::io::parquet::detail::FileMetaData fmd;
+  cudf::io::parquet::FileMetaData fmd;
   read_footer(source, &fmd);
 
   // check that the schema retains the FIXED_LEN_BYTE_ARRAY type
   for (int i = 1; i <= 4; i++) {
-    EXPECT_EQ(fmd.schema[i].type, cudf::io::parquet::detail::Type::FIXED_LEN_BYTE_ARRAY);
+    EXPECT_EQ(fmd.schema[i].type, cudf::io::parquet::Type::FIXED_LEN_BYTE_ARRAY);
     EXPECT_EQ(fmd.schema[i].type_length, fixed_width);
   }
 
   // no nulls and no repetition, so the only encoding used should be for the data.
-  auto const expect_enc = [&fmd](int idx, cudf::io::parquet::detail::Encoding enc) {
+  auto const expect_enc = [&fmd](int idx, cudf::io::parquet::Encoding enc) {
     EXPECT_EQ(fmd.row_groups[0].columns[idx].meta_data.encodings[0], enc);
   };
 


### PR DESCRIPTION
## Description
This PR moves the Thrift-derived Parquet schema types and structs to a public cudf header allowing direct external access to them.

Part of #17896. Helps #18011

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
