### PR TITLE
Remove numpy requirement when converting 2d cuda array interface objects to pylibcudf Columns

### DIFF
--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -368,8 +368,6 @@ cdef class Column:
         ------
         ValueError
             If the object is not 1D or 2D, or is not C-contiguous.
-        ImportError
-            If the data is 2D and NumPy is not installed.
         """
         try:
             iface = obj.__cuda_array_interface__
@@ -391,20 +389,12 @@ cdef class Column:
             size = shape[0]
             return cls(data_type, size, data, None, 0, 0, [])
         elif len(shape) == 2:
-            try:
-                import numpy as np
-            except ImportError:
-                raise ImportError(
-                    "NumPy must be installed to use this method on 2D data"
-                )
             num_rows, num_cols = shape
             if num_rows < numeric_limits[size_type].max():
-                # TODO: Add a new Scalar.from_py(value, dtype) API so
-                # we can specify the dtype (size_type in this case) too.
                 offsets_col = sequence(
                     num_rows + 1,
-                    Scalar.from_numpy(np.int32(0)),
-                    Scalar.from_numpy(np.int32(num_cols))
+                    Scalar.from_py(0, DataType(type_id.INT32)),
+                    Scalar.from_py(num_cols, DataType(type_id.INT32)),
                 )
             else:
                 raise ValueError(

--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -366,8 +366,13 @@ cdef class Column:
 
         Raises
         ------
+        TypeError
+            If the object does not support __cuda_array_interface__.
         ValueError
             If the object is not 1D or 2D, or is not C-contiguous.
+            If the number of rows exceeds size_type limit.
+        NotImplementedError
+            If the object has a mask.
         """
         try:
             iface = obj.__cuda_array_interface__
@@ -375,7 +380,7 @@ cdef class Column:
             raise TypeError("Object does not implement __cuda_array_interface__")
 
         if iface.get("mask") is not None:
-            raise ValueError("mask not yet supported")
+            raise NotImplementedError("mask not yet supported")
 
         typestr = iface["typestr"][1:]
         data_type = _datatype_from_dtype_desc(typestr)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Contributes to #15132. Follow up to #18311.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
