### PR TITLE
Fix alpha versions of cudf package.

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -12,6 +12,7 @@ export CMAKE_GENERATOR=Ninja
 rapids-print-env
 
 rapids-generate-version > ./VERSION
+rapids-generate-version > ./python/cudf/cudf/VERSION
 
 rapids-logger "Begin py build"
 

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -10,6 +10,7 @@ source rapids-configure-sccache
 source rapids-date-string
 
 rapids-generate-version > ./VERSION
+rapids-generate-version > ./python/cudf/cudf/VERSION
 
 cd "${package_dir}"
 


### PR DESCRIPTION
## Description
In PR #18198, we created a standalone file `python/cudf/cudf/VERSION` that is not a symlink to `VERSION`. This was meant to fix issues with editable installations. However, because of this, we also need to write out the alpha version information to `python/cudf/cudf/VERSION` at build time. This PR fixes that.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
