### PR TITLE
Refcount-based dropping of cached evaluations in cudf-polars executor

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -35,12 +35,12 @@ from cudf_polars.dsl.to_ast import to_ast, to_parquet_filter
 from cudf_polars.utils import dtypes
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Hashable, Iterable, MutableMapping, Sequence
+    from collections.abc import Callable, Hashable, Iterable, Sequence
     from typing import Literal
 
     from polars.polars import _expr_nodes as pl_expr
 
-    from cudf_polars.typing import Schema, Slice as Zlice
+    from cudf_polars.typing import CSECache, Schema, Slice as Zlice
     from cudf_polars.utils.config import ConfigOptions
     from cudf_polars.utils.timer import Timer
 
@@ -185,9 +185,7 @@ class IR(Node["IR"]):
         translation phase should fail earlier.
     """
 
-    def evaluate(
-        self, *, cache: MutableMapping[int, DataFrame], timer: Timer | None
-    ) -> DataFrame:
+    def evaluate(self, *, cache: CSECache, timer: Timer | None) -> DataFrame:
         """
         Evaluate the node (recursively) and return a dataframe.
 
@@ -669,37 +667,45 @@ class Cache(IR):
     Used for CSE at the plan level.
     """
 
-    __slots__ = ("key",)
-    _non_child = ("schema", "key")
+    __slots__ = ("key", "refcount")
+    _non_child = ("schema", "key", "refcount")
     key: int
     """The cache key."""
 
-    def __init__(self, schema: Schema, key: int, value: IR):
+    def __init__(self, schema: Schema, key: int, refcount: int, value: IR):
         self.schema = schema
         self.key = key
+        self.refcount = refcount
         self.children = (value,)
-        self._non_child_args = (key,)
+        self._non_child_args = (key, refcount)
 
     @classmethod
     def do_evaluate(
-        cls, key: int, df: DataFrame
+        cls, key: int, refcount: int, df: DataFrame
     ) -> DataFrame:  # pragma: no cover; basic evaluation never calls this
         """Evaluate and return a dataframe."""
         # Our value has already been computed for us, so let's just
         # return it.
         return df
 
-    def evaluate(
-        self, *, cache: MutableMapping[int, DataFrame], timer: Timer | None
-    ) -> DataFrame:
+    def evaluate(self, *, cache: CSECache, timer: Timer | None) -> DataFrame:
         """Evaluate and return a dataframe."""
         # We must override the recursion scheme because we don't want
         # to recurse if we're in the cache.
         try:
-            return cache[self.key]
+            (result, hits) = cache[self.key]
         except KeyError:
             (value,) = self.children
-            return cache.setdefault(self.key, value.evaluate(cache=cache, timer=timer))
+            result = value.evaluate(cache=cache, timer=timer)
+            cache[self.key] = (result, 0)
+            return result
+        else:
+            hits += 1
+            if hits == self.refcount:
+                del cache[self.key]
+            else:
+                cache[self.key] = (result, hits)
+            return result
 
 
 class DataFrameScan(IR):

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -252,7 +252,9 @@ def _(
 def _(
     node: pl_ir.Cache, translator: Translator, schema: dict[str, plc.DataType]
 ) -> ir.IR:
-    return ir.Cache(schema, node.id_, translator.translate_ir(n=node.input))
+    return ir.Cache(
+        schema, node.id_, node.cache_hits, translator.translate_ir(n=node.input)
+    )
 
 
 @_translate_ir.register

--- a/python/cudf_polars/cudf_polars/typing/__init__.py
+++ b/python/cudf_polars/cudf_polars/typing/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Hashable, Mapping
+from collections.abc import Hashable, Mapping, MutableMapping
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, TypedDict, Union
 
 from polars.polars import _expr_nodes as pl_expr, _ir_nodes as pl_ir
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
     import polars as pl
 
+    from cudf_polars.containers import DataFrame
     from cudf_polars.dsl import expr, ir, nodebase
 
 __all__: list[str] = [
@@ -69,6 +70,8 @@ PolarsExpr: TypeAlias = Union[
 Schema: TypeAlias = Mapping[str, plc.DataType]
 
 Slice: TypeAlias = tuple[int, int | None]
+
+CSECache: TypeAlias = MutableMapping[int, tuple["DataFrame", int]]
 
 
 class NodeTraverser(Protocol):

--- a/python/cudf_polars/tests/test_cache.py
+++ b/python/cudf_polars/tests/test_cache.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import polars as pl
+
+from cudf_polars import Translator
+from cudf_polars.dsl import ir
+from cudf_polars.dsl.traversal import traversal
+from cudf_polars.testing.asserts import assert_gpu_result_equal
+
+
+def test_cache():
+    df1 = pl.LazyFrame(
+        {
+            "a": [1, 2, 3, 4, 5, 6, 7],
+            "b": [1, 1, 1, 1, 1, 1, 1],
+        }
+    )
+    df2 = pl.LazyFrame({"a": [7, 8], "b": [12, 13]})
+
+    q = pl.concat([df1, df2, df1, df2, df1])
+    assert_gpu_result_equal(q)
+
+    t = Translator(q._ldf.visit(), pl.GPUEngine())
+    qir = t.translate_ir()
+    # There should be two unique cache nodes.
+    cache_df2, cache_df1 = (
+        node for node in traversal([qir]) if isinstance(node, ir.Cache)
+    )
+    assert cache_df1 != cache_df2
+    assert not cache_df1.is_equal(cache_df2)
+    assert cache_df1 == qir.children[0]
+    assert cache_df2 == qir.children[1]
+    assert cache_df1 == qir.children[2]
+    assert cache_df2 == qir.children[3]
+    assert cache_df1 == qir.children[4]
+
+    class HitCounter(dict):
+        def __init__(self, *args, **kwargs):
+            self.hits = 0
+            super().__init__(*args, **kwargs)
+
+        def __getitem__(self, key):
+            result = super().__getitem__(key)
+            self.hits += 1
+            return result
+
+    node_cache = HitCounter()
+    qir.evaluate(cache=node_cache, timer=None)
+    assert len(node_cache) == 0
+    assert node_cache.hits == 3


### PR DESCRIPTION
## Description

Previously we held on to evaluated `Cache` nodes for the lifetime of the query evaluation. This is more memory pressure than necessary. To fix this, track the number of times we see the node and drop the cached value once we see it for the last time.

So that the same thing occurs in the partitioned executor, implement specialised hashing and equality for cache nodes: their key is guaranteed to be unique by polars within a query, so that is sufficient for the hash key.

- Closes #17363 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
