### PR TITLE
fix(libxml2): pin libxml2<2.14 to work around breaking ABI

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -44,6 +44,7 @@ dependencies:
 - libkvikio==25.4.*,>=0.0.0a0
 - librdkafka>=2.8.0,<2.9.0a0
 - librmm==25.4.*,>=0.0.0a0
+- libxml2<2.14
 - make
 - mmh3
 - moto>=4.0.8

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -43,6 +43,7 @@ dependencies:
 - libkvikio==25.4.*,>=0.0.0a0
 - librdkafka>=2.8.0,<2.9.0a0
 - librmm==25.4.*,>=0.0.0a0
+- libxml2<2.14
 - make
 - mmh3
 - moto>=4.0.8

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -671,6 +671,8 @@ dependencies:
           - breathe>=4.35.0
           - dask-cuda==25.4.*,>=0.0.0a0
           - *doxygen
+          # Temporary fix while conda-forge sorts out breaking ABI in libxml2
+          - libxml2<2.14
           - make
           - myst-nb
           - nbsphinx

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -880,6 +880,10 @@ dependencies:
           - pytest<8
           - pytest-cov
           - pytest-xdist
+        # TODO: remove this temporary fix when conda-forge sorts out breaking ABI in libxml2
+      - output_types: conda
+        packages:
+          - libxml2<2.14
   test_python_cudf_common:
     specific:
       # Define additional constraints for testing with oldest dependencies.
@@ -940,8 +944,6 @@ dependencies:
           - aiobotocore>=2.2.0
           - boto3>=1.21.21
           - botocore>=1.24.21
-          # TODO: remove this temporary fix when conda-forge sorts out breaking ABI in libxml2
-          - libxml2<2.14
           - msgpack-python
           - moto>=4.0.8
           - s3fs>=2022.3.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -671,7 +671,7 @@ dependencies:
           - breathe>=4.35.0
           - dask-cuda==25.4.*,>=0.0.0a0
           - *doxygen
-          # Temporary fix while conda-forge sorts out breaking ABI in libxml2
+          # TODO: remove this temporary fix when conda-forge sorts out breaking ABI in libxml2
           - libxml2<2.14
           - make
           - myst-nb
@@ -940,6 +940,8 @@ dependencies:
           - aiobotocore>=2.2.0
           - boto3>=1.21.21
           - botocore>=1.24.21
+          # TODO: remove this temporary fix when conda-forge sorts out breaking ABI in libxml2
+          - libxml2<2.14
           - msgpack-python
           - moto>=4.0.8
           - s3fs>=2022.3.0


### PR DESCRIPTION
## Description
`libxml2` broke us with the latest release -- pinning it for now to get docs builds passing

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
