### PR TITLE
Update compression formats supported in JSON reader

### DIFF
--- a/python/cudf/cudf/io/json.py
+++ b/python/cudf/cudf/io/json.py
@@ -53,7 +53,20 @@ def _get_cudf_schema_element_from_dtype(
 
 
 def _to_plc_compression(
-    compression: Literal["infer", "snappy", "gzip", "bz2", "brotli", "zip", "xz", "zlib", "lz4", "lzo", "zstd", None],
+    compression: Literal[
+        "infer",
+        "snappy",
+        "gzip",
+        "bz2",
+        "brotli",
+        "zip",
+        "xz",
+        "zlib",
+        "lz4",
+        "lzo",
+        "zstd",
+        None,
+    ],
 ) -> plc.io.types.CompressionType:
     if compression is not None:
         if compression == "snappy":
@@ -297,7 +310,20 @@ def _plc_write_json(
     table: cudf.Series | cudf.DataFrame,
     colnames: list[tuple[abc.Hashable, Any]],
     path_or_buf,
-    compression: Literal["infer", "snappy", "gzip", "bz2", "brotli", "zip", "xz", "zlib", "lz4", "lzo", "zstd", None] = None,
+    compression: Literal[
+        "infer",
+        "snappy",
+        "gzip",
+        "bz2",
+        "brotli",
+        "zip",
+        "xz",
+        "zlib",
+        "lz4",
+        "lzo",
+        "zstd",
+        None,
+    ] = None,
     na_rep: str = "null",
     include_nulls: bool = True,
     lines: bool = False,
@@ -335,7 +361,20 @@ def _plc_write_json(
 def to_json(
     cudf_val: cudf.DataFrame | cudf.Series,
     path_or_buf=None,
-    compression: Literal["infer", "snappy", "gzip", "bz2", "brotli", "zip", "xz", "zlib", "lz4", "lzo", "zstd", None] = None,
+    compression: Literal[
+        "infer",
+        "snappy",
+        "gzip",
+        "bz2",
+        "brotli",
+        "zip",
+        "xz",
+        "zlib",
+        "lz4",
+        "lzo",
+        "zstd",
+        None,
+    ] = None,
     engine: Literal["auto", "pandas", "cudf"] = "auto",
     orient=None,
     storage_options=None,
@@ -374,10 +413,17 @@ def to_json(
             with path_or_buf as file_obj:
                 file_obj = ioutils.get_IOBase_writer(file_obj)
                 _plc_write_json(
-                    cudf_val, colnames, path_or_buf, compression, *args, **kwargs
+                    cudf_val,
+                    colnames,
+                    path_or_buf,
+                    compression,
+                    *args,
+                    **kwargs,
                 )
         else:
-            _plc_write_json(cudf_val, colnames, path_or_buf, compression, *args, **kwargs)
+            _plc_write_json(
+                cudf_val, colnames, path_or_buf, compression, *args, **kwargs
+            )
 
         if return_as_string:
             path_or_buf.seek(0)

--- a/python/cudf/cudf/io/json.py
+++ b/python/cudf/cudf/io/json.py
@@ -53,15 +53,29 @@ def _get_cudf_schema_element_from_dtype(
 
 
 def _to_plc_compression(
-    compression: Literal["infer", "gzip", "bz2", "zip", "xz", None],
+    compression: Literal["infer", "snappy", "gzip", "bz2", "brotli", "zip", "xz", "zlib", "lz4", "lzo", "zstd", None],
 ) -> plc.io.types.CompressionType:
     if compression is not None:
-        if compression == "gzip":
+        if compression == "snappy":
+            return plc.io.types.CompressionType.SNAPPY
+        elif compression == "gzip":
             return plc.io.types.CompressionType.GZIP
         elif compression == "bz2":
             return plc.io.types.CompressionType.BZIP2
+        elif compression == "brotli":
+            return plc.io.types.CompressionType.BROTLI
         elif compression == "zip":
             return plc.io.types.CompressionType.ZIP
+        elif compression == "xz":
+            return plc.io.types.CompressionType.XZ
+        elif compression == "zlib":
+            return plc.io.types.CompressionType.ZLIB
+        elif compression == "lz4":
+            return plc.io.types.CompressionType.LZ4
+        elif compression == "lzo":
+            return plc.io.types.CompressionType.LZO
+        elif compression == "zstd":
+            return plc.io.types.CompressionType.ZSTD
         else:
             return plc.io.types.CompressionType.AUTO
     else:
@@ -283,11 +297,11 @@ def _plc_write_json(
     table: cudf.Series | cudf.DataFrame,
     colnames: list[tuple[abc.Hashable, Any]],
     path_or_buf,
+    compression: Literal["infer", "snappy", "gzip", "bz2", "brotli", "zip", "xz", "zlib", "lz4", "lzo", "zstd", None] = None,
     na_rep: str = "null",
     include_nulls: bool = True,
     lines: bool = False,
     rows_per_chunk: int = 1024 * 64,  # 64K rows
-    compression: Literal["infer", "gzip", "bz2", "zip", "xz", None] = None,
 ) -> None:
     try:
         tbl_w_meta = plc.io.TableWithMetadata(
@@ -321,6 +335,7 @@ def _plc_write_json(
 def to_json(
     cudf_val: cudf.DataFrame | cudf.Series,
     path_or_buf=None,
+    compression: Literal["infer", "snappy", "gzip", "bz2", "brotli", "zip", "xz", "zlib", "lz4", "lzo", "zstd", None] = None,
     engine: Literal["auto", "pandas", "cudf"] = "auto",
     orient=None,
     storage_options=None,
@@ -359,10 +374,10 @@ def to_json(
             with path_or_buf as file_obj:
                 file_obj = ioutils.get_IOBase_writer(file_obj)
                 _plc_write_json(
-                    cudf_val, colnames, path_or_buf, *args, **kwargs
+                    cudf_val, colnames, path_or_buf, compression, *args, **kwargs
                 )
         else:
-            _plc_write_json(cudf_val, colnames, path_or_buf, *args, **kwargs)
+            _plc_write_json(cudf_val, colnames, path_or_buf, compression, *args, **kwargs)
 
         if return_as_string:
             path_or_buf.seek(0)

--- a/python/cudf/cudf/tests/test_json.py
+++ b/python/cudf/cudf/tests/test_json.py
@@ -84,7 +84,8 @@ def gdf_writer_types(request):
 
 
 index_params = [True, False]
-compression_params = ["gzip", "bz2", "zip", "xz", None]
+# tests limited to compressions formats supported by pandas: zip, gzip, bz2, zstd, xz
+compression_params = ["gzip", "bz2", "zip", "xz", "zstd", None]
 orient_params = ["columns", "records", "table", "split"]
 params = itertools.product(index_params, compression_params, orient_params)
 
@@ -1453,7 +1454,7 @@ def test_chunked_json_reader():
     assert_eq(df, gdf)
 
 
-@pytest.mark.parametrize("compression", ["gzip", None])
+@pytest.mark.parametrize("compression", ["gzip", "snappy", "zstd"])
 def test_roundtrip_compression(compression, tmp_path):
     expected = cudf.DataFrame({"a": [1], "b": ["2"]})
     fle = BytesIO()


### PR DESCRIPTION
## Description
1. Updates compression types accepted in cuDF JSON reader.
2. Introduces compression type to the JSON writer.
3. Updates tests to include more compression types.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
