### PR TITLE
Ensure DataFrame column label operations reset label_dtype

### DIFF
--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -372,9 +372,8 @@ class ColumnAccessor(abc.MutableMapping):
             new_values = self.columns[:loc] + (value,) + self.columns[loc:]
             self._data = dict(zip(new_keys, new_values))
         self._clear_cache(old_ncols, old_ncols + 1)
-        if old_ncols == 0:
-            # The type(name) may no longer match the prior label_dtype
-            self.label_dtype = None
+        # The type(name) may no longer match the prior label_dtype
+        self.label_dtype = None
 
     def copy(self, deep: bool = False) -> Self:
         """
@@ -733,7 +732,6 @@ class ColumnAccessor(abc.MutableMapping):
             data=data,
             level_names=self.level_names,
             multiindex=self.multiindex,
-            label_dtype=self.label_dtype,
             verify=False,
         )
 

--- a/python/cudf/cudf/core/column_accessor.py
+++ b/python/cudf/cudf/core/column_accessor.py
@@ -727,11 +727,18 @@ class ColumnAccessor(abc.MutableMapping):
             if len(new_col_names) != len(set(new_col_names)):
                 raise ValueError("Duplicate column names are not allowed")
 
+        label_dtype = self.label_dtype
+        if len(self) > 0 and label_dtype is not None:
+            old_type = type(next(iter(self.keys())))
+            if not all(isinstance(label, old_type) for label in new_col_names):
+                label_dtype = None
+
         data = dict(zip(new_col_names, self.values()))
         return type(self)(
             data=data,
             level_names=self.level_names,
             multiindex=self.multiindex,
+            label_dtype=label_dtype,
             verify=False,
         )
 

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -11338,3 +11338,27 @@ def test_construct_dict_scalar_values_raises():
         pd.DataFrame(data)
     with pytest.raises(ValueError):
         cudf.DataFrame(data)
+
+
+def test_rename_reset_label_dtype():
+    data = {1: [2]}
+    col_mapping = {1: "a"}
+    result = cudf.DataFrame(data).rename(columns=col_mapping)
+    expected = pd.DataFrame(data).rename(columns=col_mapping)
+    assert_eq(result, expected)
+
+
+def test_insert_reset_label_dtype():
+    result = cudf.DataFrame({1: [2]})
+    expected = pd.DataFrame({1: [2]})
+    result.insert(1, "a", [2])
+    expected.insert(1, "a", [2])
+    assert_eq(result, expected)
+
+
+def test_setitem_reset_label_dtype():
+    result = cudf.DataFrame({1: [2]})
+    expected = pd.DataFrame({1: [2]})
+    result["a"] = [2]
+    expected["a"] = [2]
+    assert_eq(result, expected)


### PR DESCRIPTION
## Description
After https://github.com/rapidsai/cudf/pull/18306, we are maintaining a non-`None` `ColumnAccessor.label_dtype` (i.e. `DataFrame.columns.dtype`) attribute more often; however, now we need to be more careful to set this attribute to `None` if we add a new column label that isn't the same type.

cuml is experiencing some test failures because of this. 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
