### PR TITLE
[DOC] Fix typo in CONTRIBUTING.md on build type tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ cd $CUDF_HOME
 #### Building for development
 
 To build Python packages for development purposes, add the `--pydevelop` flag.
-To build C++ tests, you can also request that build.sh build the `test` target.
+To build C++ tests, you can also request that build.sh build the `tests` target.
 To build all libraries and tests, with Python packages in development mode, simply run
 
 ```bash


### PR DESCRIPTION
## Description
- No code change
- Only typo fix in `CONTRIBUTING.md`: the build type is `tests` instead of `test`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
