### PR TITLE
Remove need for to_cudf_compatible_scalar

### DIFF
--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -859,6 +859,10 @@ class DatetimeColumn(column.ColumnBase):
     def _cast_setitem_value(self, value: Any) -> plc.Scalar | ColumnBase:
         if isinstance(value, (np.str_, np.datetime64)):
             value = pd.Timestamp(value.item())
+        elif isinstance(value, str):
+            value = pd.Timestamp(value)
+        elif value is cudf.NaT:
+            value = None
         return super()._cast_setitem_value(value)
 
     def indices_of(

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -123,7 +123,7 @@ class ListColumn(ColumnBase):
             return pa_scalar_to_plc_scalar(
                 pa.scalar(value, type=self.dtype.to_arrow())
             )
-        elif value is NA:
+        elif value is NA or value is None:
             return pa_scalar_to_plc_scalar(
                 pa.scalar(None, type=self.dtype.to_arrow())
             )

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -139,12 +139,21 @@ class NumericalColumn(NumericalBaseColumn):
 
     def _cast_setitem_value(self, value: Any) -> plc.Scalar | ColumnBase:
         if is_scalar(value):
-            scalar = pa.scalar(
-                value
-                if not cudf.utils.utils._is_null_host_scalar(value)
-                else None
-            )
-            if pa.types.is_boolean(scalar.type) and self.dtype.kind != "b":
+            if value is cudf.NA or value is None:
+                scalar = pa.scalar(
+                    None, type=cudf_dtype_to_pa_type(self.dtype)
+                )
+            else:
+                try:
+                    scalar = pa.scalar(value)
+                except ValueError as err:
+                    raise TypeError(
+                        f"Cannot set value of type {type(value)} to column of type {self.dtype}"
+                    ) from err
+            is_scalar_bool = pa.types.is_boolean(scalar.type)
+            if (is_scalar_bool and self.dtype.kind != "b") or (
+                not is_scalar_bool and self.dtype.kind == "b"
+            ):
                 raise TypeError(
                     f"Invalid value {value} for dtype {self.dtype}"
                 )

--- a/python/cudf/cudf/core/column/struct.py
+++ b/python/cudf/cudf/core/column/struct.py
@@ -144,12 +144,14 @@ class StructColumn(ColumnBase):
             return pa_scalar_to_plc_scalar(
                 pa.scalar(new_value, type=self.dtype.to_arrow())
             )
-        elif _is_null_host_scalar(value):
+        elif value is None or value is cudf.NA:
             return pa_scalar_to_plc_scalar(
                 pa.scalar(None, type=self.dtype.to_arrow())
             )
         else:
-            raise ValueError("Can not set dict values into StructColumn")
+            raise ValueError(
+                f"Can not set {type(value).__name__} into StructColumn"
+            )
 
     def copy(self, deep: bool = True) -> Self:
         # Since struct columns are immutable, both deep and

--- a/python/cudf/cudf/core/scalar.py
+++ b/python/cudf/cudf/core/scalar.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+import datetime
 import decimal
 import functools
 import operator
@@ -9,7 +10,9 @@ import warnings
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 
+import cupy as cp
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 
 import pylibcudf as plc
@@ -27,9 +30,9 @@ from cudf.core.missing import NA, NaT
 from cudf.core.mixins import BinaryOperand
 from cudf.utils.dtypes import (
     CUDF_STRING_DTYPE,
+    _maybe_convert_to_default_type,
     cudf_dtype_from_pa_type,
     find_common_type,
-    to_cudf_compatible_scalar,
 )
 
 if TYPE_CHECKING:
@@ -143,6 +146,86 @@ _POW_TYPES = [
     "fff",
     "ddd",
 ]
+
+
+def to_cudf_compatible_scalar(val, dtype=None):
+    """
+    Converts the value `val` to a numpy/Pandas scalar,
+    optionally casting to `dtype`.
+
+    If `val` is None, returns None.
+    """
+
+    if cudf.utils.utils._is_null_host_scalar(val) or isinstance(
+        val, cudf.Scalar
+    ):
+        return val
+
+    if not cudf.api.types._is_scalar_or_zero_d_array(val):
+        raise ValueError(
+            f"Cannot convert value of type {type(val).__name__} to cudf scalar"
+        )
+
+    if isinstance(val, decimal.Decimal):
+        return val
+
+    if isinstance(val, (np.ndarray, cp.ndarray)) and val.ndim == 0:
+        val = val.item()
+
+    if (
+        (dtype is None) and isinstance(val, str)
+    ) or cudf.api.types.is_string_dtype(dtype):
+        dtype = "str"
+
+        if isinstance(val, str) and val.endswith("\x00"):
+            # Numpy string dtypes are fixed width and use NULL to
+            # indicate the end of the string, so they cannot
+            # distinguish between "abc\x00" and "abc".
+            # https://github.com/numpy/numpy/issues/20118
+            # In this case, don't try going through numpy and just use
+            # the string value directly (cudf.DeviceScalar will DTRT)
+            return val
+
+    tz_error_msg = (
+        "Cannot covert a timezone-aware timestamp to timezone-naive scalar."
+    )
+    if isinstance(val, pd.Timestamp):
+        if val.tz is not None:
+            raise NotImplementedError(tz_error_msg)
+
+        val = val.to_datetime64()
+    elif isinstance(val, pd.Timedelta):
+        val = val.to_timedelta64()
+    elif isinstance(val, datetime.datetime):
+        if val.tzinfo is not None:
+            raise NotImplementedError(tz_error_msg)
+        val = np.datetime64(val)
+    elif isinstance(val, datetime.timedelta):
+        val = np.timedelta64(val)
+
+    if dtype is not None:
+        dtype = np.dtype(dtype)
+        if isinstance(val, str) and dtype.kind == "M":
+            # pd.Timestamp can handle str, but not np.str_
+            val = pd.Timestamp(str(val)).to_datetime64().astype(dtype)
+        else:
+            # At least datetimes cannot be converted to scalar via dtype.type:
+            val = np.array(val, dtype)[()]
+    else:
+        val = _maybe_convert_to_default_type(
+            cudf.api.types.pandas_dtype(type(val))
+        ).type(val)
+
+    if val.dtype.type is np.datetime64:
+        time_unit, _ = np.datetime_data(val.dtype)
+        if time_unit in ("D", "W", "M", "Y"):
+            val = val.astype("datetime64[s]")
+    elif val.dtype.type is np.timedelta64:
+        time_unit, _ = np.datetime_data(val.dtype)
+        if time_unit in ("D", "W", "M", "Y"):
+            val = val.astype("timedelta64[ns]")
+
+    return val
 
 
 def get_allowed_combinations_for_operator(

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -57,7 +57,6 @@ from cudf.core.indexed_frame import (
 from cudf.core.resample import SeriesResampler
 from cudf.core.single_column_frame import SingleColumnFrame
 from cudf.core.udf.scalar_function import _get_scalar_kernel
-from cudf.errors import MixedTypeError
 from cudf.utils import docutils
 from cudf.utils.docutils import copy_docstring
 from cudf.utils.dtypes import (
@@ -66,7 +65,6 @@ from cudf.utils.dtypes import (
     find_common_type,
     is_dtype_obj_numeric,
     is_mixed_with_object_dtype,
-    to_cudf_compatible_scalar,
 )
 from cudf.utils.performance_tracking import _performance_tracking
 
@@ -197,78 +195,44 @@ class _SeriesIlocIndexer(_FrameIndexer):
         if isinstance(key, tuple):
             key = list(key)
 
-        # coerce value into a scalar or column
-        if is_scalar(value):
-            value = to_cudf_compatible_scalar(value)
-            if (
-                self._frame.dtype.kind not in "mM"
-                and cudf.utils.utils._isnat(value)
-                and not (
-                    self._frame.dtype == "object" and isinstance(value, str)
-                )
-            ):
-                raise MixedTypeError(
-                    f"Cannot assign {value=} to non-datetime/non-timedelta "
-                    "columns"
-                )
-            elif (
-                not (
-                    self._frame.dtype.kind == "f"
-                    or (
-                        isinstance(self._frame.dtype, cudf.CategoricalDtype)
-                        and self._frame.dtype.categories.dtype.kind == "f"
-                    )
-                )
-                and isinstance(value, np.floating)
-                and np.isnan(value)
-            ):
-                raise MixedTypeError(
-                    f"Cannot assign {value=} to "
-                    f"non-float dtype={self._frame.dtype}"
-                )
-            elif self._frame.dtype.kind == "b" and not (
-                value in {None, cudf.NA}
-                or isinstance(value, (np.bool_, bool))
-                or (isinstance(value, cudf.Scalar) and value.dtype.kind == "b")
-            ):
-                raise MixedTypeError(
-                    f"Cannot assign {value=} to bool dtype={self._frame.dtype}"
-                )
-        elif not (
-            isinstance(value, (list, dict))
-            and isinstance(
-                self._frame.dtype, (cudf.ListDtype, cudf.StructDtype)
-            )
-        ):
-            value = as_column(value)
-
         if (
-            (self._frame.dtype.kind in "uifb" or self._frame.dtype == "object")
-            and hasattr(value, "dtype")
-            and value.dtype.kind in "uifb"
+            self._frame.dtype.kind in "uifb"
+            or self._frame.dtype == CUDF_STRING_DTYPE
         ):
             # normalize types if necessary:
             # In contrast to Column.__setitem__ (which downcasts the value to
             # the dtype of the column) here we upcast the series to the
             # larger data type mimicking pandas
-            to_dtype = find_common_type((value.dtype, self._frame.dtype))
-            value = value.astype(to_dtype)
-            if to_dtype != self._frame.dtype:
-                # Do not remove until pandas-3.0 support is added.
-                assert PANDAS_LT_300, (
-                    "Need to drop after pandas-3.0 support is added."
-                )
-                warnings.warn(
-                    f"Setting an item of incompatible dtype is deprecated "
-                    "and will raise in a future error of pandas. "
-                    f"Value '{value}' has dtype incompatible with "
-                    f"{self._frame.dtype}, "
-                    "please explicitly cast to a compatible dtype first.",
-                    FutureWarning,
-                )
-                self._frame._column._mimic_inplace(
-                    self._frame._column.astype(to_dtype), inplace=True
-                )
+            if not (value is None or value is cudf.NA or value is np.nan):
+                tmp_value = as_column(value)
+                if tmp_value.dtype.kind in "uifb" and not (
+                    self._frame.dtype.kind == "b"
+                    and tmp_value.dtype.kind != "b"
+                    or self._frame.dtype.kind != "b"
+                    and tmp_value.dtype.kind == "b"
+                ):
+                    to_dtype = find_common_type(
+                        (tmp_value.dtype, self._frame.dtype)
+                    )
+                    tmp_value = tmp_value.astype(to_dtype)
+                    if to_dtype != self._frame.dtype:
+                        # Do not remove until pandas-3.0 support is added.
+                        assert PANDAS_LT_300, (
+                            "Need to drop after pandas-3.0 support is added."
+                        )
+                        warnings.warn(
+                            f"Setting an item of incompatible dtype is deprecated "
+                            "and will raise in a future error of pandas. "
+                            f"Value '{value}' has dtype incompatible with "
+                            f"{self._frame.dtype}, "
+                            "please explicitly cast to a compatible dtype first.",
+                            FutureWarning,
+                        )
+                        self._frame._column._mimic_inplace(
+                            self._frame._column.astype(to_dtype), inplace=True
+                        )
+                    if is_scalar(value):
+                        value = tmp_value.element_indexing(0)
 
         self._frame._column[key] = value
 
@@ -1257,7 +1221,7 @@ class Series(SingleColumnFrame, IndexedFrame):
 
             # 0D array (scalar)
             if out.ndim == 0:
-                return to_cudf_compatible_scalar(out)
+                return out.item()
             # 1D array
             elif (
                 # Only allow 1D arrays

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -999,10 +999,7 @@ def test_series_setitem_iloc(key, value, nulls):
 @pytest.mark.parametrize(
     "key, value",
     [
-        pytest.param(
-            0,
-            0.5,
-        ),
+        (0, 0.5),
         ([0, 1], 0.5),
         ([0, 1], [0.5, 2.5]),
         (slice(0, 2), [0.5, 0.25]),
@@ -1016,9 +1013,9 @@ def test_series_setitem_dtype(key, value):
     psr = pd.Series([1, 2, 3], dtype="int32")
     gsr = cudf.from_pandas(psr)
 
-    with expect_warning_if(isinstance(value, (float, list))):
+    with pytest.warns(FutureWarning):
         psr[key] = value
-    with expect_warning_if(isinstance(value, (float, list))):
+    with pytest.warns(FutureWarning):
         gsr[key] = value
 
     assert_eq(psr, gsr)

--- a/python/cudf/cudf/tests/test_scalar.py
+++ b/python/cudf/cudf/tests/test_scalar.py
@@ -1,21 +1,9 @@
 # Copyright (c) 2021-2025, NVIDIA CORPORATION.
 
-import datetime
 
-import pandas as pd
 import pytest
 
 import cudf
-
-
-def test_construct_timezone_scalar_error():
-    pd_scalar = pd.Timestamp("1970-01-01 00:00:00.000000001", tz="utc")
-    with pytest.raises(NotImplementedError):
-        cudf.utils.dtypes.to_cudf_compatible_scalar(pd_scalar)
-
-    date_scalar = datetime.datetime.now(datetime.timezone.utc)
-    with pytest.raises(NotImplementedError):
-        cudf.utils.dtypes.to_cudf_compatible_scalar(date_scalar)
 
 
 def test_scalar_deprecation():

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -1,11 +1,8 @@
 # Copyright (c) 2020-2025, NVIDIA CORPORATION.
 from __future__ import annotations
 
-import datetime
-from decimal import Decimal
 from typing import TYPE_CHECKING
 
-import cupy as cp
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -136,86 +133,6 @@ def cudf_dtype_from_pa_type(typ: pa.DataType) -> DtypeObj:
         return CUDF_STRING_DTYPE
     else:
         return cudf.api.types.pandas_dtype(typ.to_pandas_dtype())
-
-
-def to_cudf_compatible_scalar(val, dtype=None):
-    """
-    Converts the value `val` to a numpy/Pandas scalar,
-    optionally casting to `dtype`.
-
-    If `val` is None, returns None.
-    """
-
-    if cudf.utils.utils._is_null_host_scalar(val) or isinstance(
-        val, cudf.Scalar
-    ):
-        return val
-
-    if not cudf.api.types._is_scalar_or_zero_d_array(val):
-        raise ValueError(
-            f"Cannot convert value of type {type(val).__name__} to cudf scalar"
-        )
-
-    if isinstance(val, Decimal):
-        return val
-
-    if isinstance(val, (np.ndarray, cp.ndarray)) and val.ndim == 0:
-        val = val.item()
-
-    if (
-        (dtype is None) and isinstance(val, str)
-    ) or cudf.api.types.is_string_dtype(dtype):
-        dtype = "str"
-
-        if isinstance(val, str) and val.endswith("\x00"):
-            # Numpy string dtypes are fixed width and use NULL to
-            # indicate the end of the string, so they cannot
-            # distinguish between "abc\x00" and "abc".
-            # https://github.com/numpy/numpy/issues/20118
-            # In this case, don't try going through numpy and just use
-            # the string value directly (cudf.DeviceScalar will DTRT)
-            return val
-
-    tz_error_msg = (
-        "Cannot covert a timezone-aware timestamp to timezone-naive scalar."
-    )
-    if isinstance(val, pd.Timestamp):
-        if val.tz is not None:
-            raise NotImplementedError(tz_error_msg)
-
-        val = val.to_datetime64()
-    elif isinstance(val, pd.Timedelta):
-        val = val.to_timedelta64()
-    elif isinstance(val, datetime.datetime):
-        if val.tzinfo is not None:
-            raise NotImplementedError(tz_error_msg)
-        val = np.datetime64(val)
-    elif isinstance(val, datetime.timedelta):
-        val = np.timedelta64(val)
-
-    if dtype is not None:
-        dtype = np.dtype(dtype)
-        if isinstance(val, str) and dtype.kind == "M":
-            # pd.Timestamp can handle str, but not np.str_
-            val = pd.Timestamp(str(val)).to_datetime64().astype(dtype)
-        else:
-            # At least datetimes cannot be converted to scalar via dtype.type:
-            val = np.array(val, dtype)[()]
-    else:
-        val = _maybe_convert_to_default_type(
-            cudf.api.types.pandas_dtype(type(val))
-        ).type(val)
-
-    if val.dtype.type is np.datetime64:
-        time_unit, _ = np.datetime_data(val.dtype)
-        if time_unit in ("D", "W", "M", "Y"):
-            val = val.astype("datetime64[s]")
-    elif val.dtype.type is np.timedelta64:
-        time_unit, _ = np.datetime_data(val.dtype)
-        if time_unit in ("D", "W", "M", "Y"):
-            val = val.astype("timedelta64[ns]")
-
-    return val
 
 
 def is_column_like(obj):


### PR DESCRIPTION
## Description
`to_cudf_compatible_scalar` was largely used as a utility function for `cudf.Scalar` and `Series.__setitem__`.

The use for the function in `Series.__setitem__` is largely unneeded in as logic can be pushed to `Column._cast_setitem_value`. Therefore, `to_cudf_compatible_scalar` can be moved along side `cudf.Scalar`, which is now deprecated, and both can be removed once the deprecation is enforced. 



## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
