### PR TITLE
Fix unspecified behavior involving move semantics and order of evaluation

### DIFF
--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -59,7 +59,8 @@ class kvikio_source : public datasource {
     // Clamp length to available data
     auto const read_size = std::min(size, this->size() - offset);
     std::vector<uint8_t> v(read_size);
-    return {std::move(v), _kvikio_handle.pread(v.data(), read_size, offset)};
+    auto v_data = v.data();
+    return {std::move(v), _kvikio_handle.pread(v_data, read_size, offset)};
   }
 
  public:


### PR DESCRIPTION
## Description

Generally, for a function `g(X x, Y y)` that is called in such a way `g(f(u), h(u))`. The order of evaluation is unspecified on two aspects:
- The order of `f(u)` and `h(u)` is unspecified.
- The order of `x` and `y` initialization is unspecified.

As a result, function call `g(f(v), std::move(v))` has unspecified (not undefined) behaviors: although `std::move(v)` is only a cast to xvalue that does not affect `v` itself, the order of `X x(f(v))` and `Y y(std::move(v))` is still unspecified. If the latter is evaluated first, then a moved-from `v` will be passed to `f(v)` with which to initialize `x`.

This PR fixes a few places where this potential issue exists.

References: https://eel.is/c++draft/expr#call-7

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
