### PR TITLE
Increase wheel size limit.

### DIFF
--- a/python/libcudf/pyproject.toml
+++ b/python/libcudf/pyproject.toml
@@ -55,8 +55,8 @@ select = [
     "distro-too-large-compressed",
 ]
 
-# PyPI limit is 600 MiB, fail CI before we get too close to that
-max_allowed_size_compressed = '575M'
+# PyPI limit is 750 MiB, fail CI before we get too close to that
+max_allowed_size_compressed = '675M'
 
 [tool.scikit-build]
 build-dir = "build/{wheel_tag}"


### PR DESCRIPTION
## Description
I saw libcudf wheel builds fail in https://github.com/rapidsai/cudf/pull/18235 because the wheel was exceeding the size limit. We recently got a size limit increase, which was needed to support more GPU architectures. This bumps the limit up.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
