### PR TITLE
Rename rapidsmp to rapidsmpf

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -35,7 +35,7 @@ _SHUFFLE_METHODS = ("rapidsmpf", "tasks")
 
 
 # Experimental rapidsmpf shuffler integration
-class RMPIntegration:  # pragma: no cover
+class RMPFIntegration:  # pragma: no cover
     """cuDF-Polars protocol for rapidsmpf shuffler."""
 
     @staticmethod
@@ -263,7 +263,7 @@ def _(
                 shuffle_on,
                 partition_info[ir.children[0]].count,
                 partition_info[ir].count,
-                RMPIntegration,
+                RMPFIntegration,
             )
         except (ImportError, ValueError) as err:
             # ImportError: rapidsmpf is not installed

--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -31,12 +31,12 @@ if TYPE_CHECKING:
 
 
 # Supported shuffle methods
-_SHUFFLE_METHODS = ("rapidsmp", "tasks")
+_SHUFFLE_METHODS = ("rapidsmpf", "tasks")
 
 
-# Experimental rapidsmp shuffler integration
+# Experimental rapidsmpf shuffler integration
 class RMPIntegration:  # pragma: no cover
-    """cuDF-Polars protocol for rapidsmp shuffler."""
+    """cuDF-Polars protocol for rapidsmpf shuffler."""
 
     @staticmethod
     def insert_partition(
@@ -46,7 +46,7 @@ class RMPIntegration:  # pragma: no cover
         shuffler: Any,
     ) -> None:
         """Add cudf-polars DataFrame chunks to an RMP shuffler."""
-        from rapidsmp.shuffler import partition_and_pack
+        from rapidsmpf.shuffler import partition_and_pack
 
         columns_to_hash = tuple(df.column_names.index(val) for val in on)
         packed_inputs = partition_and_pack(
@@ -65,7 +65,7 @@ class RMPIntegration:  # pragma: no cover
         shuffler: Any,
     ) -> DataFrame:
         """Extract a finished partition from the RMP shuffler."""
-        from rapidsmp.shuffler import unpack_and_concat
+        from rapidsmpf.shuffler import unpack_and_concat
 
         shuffler.wait_on(partition_id)
         return DataFrame.from_table(
@@ -246,17 +246,17 @@ def _(
             f"Expected one of: {_SHUFFLE_METHODS}."
         )
 
-    # Try using rapidsmp shuffler if we have "simple" shuffle
-    # keys, and the "shuffle_method" config is set to "rapidsmp"
+    # Try using rapidsmpf shuffler if we have "simple" shuffle
+    # keys, and the "shuffle_method" config is set to "rapidsmpf"
     _keys: list[Col]
-    if shuffle_method in (None, "rapidsmp") and len(
+    if shuffle_method in (None, "rapidsmpf") and len(
         _keys := [ne.value for ne in ir.keys if isinstance(ne.value, Col)]
     ) == len(ir.keys):  # pragma: no cover
         shuffle_on = [k.name for k in _keys]
         try:
-            from rapidsmp.integrations.dask import rapidsmp_shuffle_graph
+            from rapidsmpf.integrations.dask import rapidsmpf_shuffle_graph
 
-            return rapidsmp_shuffle_graph(
+            return rapidsmpf_shuffle_graph(
                 get_key_name(ir.children[0]),
                 get_key_name(ir),
                 list(ir.schema.keys()),
@@ -266,14 +266,14 @@ def _(
                 RMPIntegration,
             )
         except (ImportError, ValueError) as err:
-            # ImportError: rapidsmp is not installed
-            # ValueError: rapidsmp couldn't find a distributed client
-            if shuffle_method == "rapidsmp":
+            # ImportError: rapidsmpf is not installed
+            # ValueError: rapidsmpf couldn't find a distributed client
+            if shuffle_method == "rapidsmpf":
                 # Only raise an error if the user specifically
-                # set the shuffle method to "rapidsmp"
+                # set the shuffle method to "rapidsmpf"
                 raise ValueError(
                     "Rapidsmp is not installed correctly or the current "
-                    "Dask cluster does not support rapidsmp shuffling."
+                    "Dask cluster does not support rapidsmpf shuffling."
                 ) from err
 
     # Simple task-based fall-back

--- a/python/cudf_polars/tests/experimental/test_rapidsmpf.py
+++ b/python/cudf_polars/tests/experimental/test_rapidsmpf.py
@@ -11,28 +11,28 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
 @pytest.mark.parametrize("max_rows_per_partition", [1, 5])
-def test_join_rapidsmp(max_rows_per_partition: int) -> None:
+def test_join_rapidsmpf(max_rows_per_partition: int) -> None:
     # Check that we have a distributed cluster running.
     # This tests must be run with:
-    # --executor='dask-experimental' --dask-cluster --rapidsmp
+    # --executor='dask-experimental' --dask-cluster
     distributed = pytest.importorskip("distributed")
     try:
         client = distributed.get_client()
     except ValueError:
         pytest.skip(reason="Requires distributed execution.")
 
-    # check that we have a rapidsmp cluster running
-    pytest.importorskip("rapidsmp")
+    # check that we have a rapidsmpf cluster running
+    pytest.importorskip("rapidsmpf")
     try:
         # This will result in a ValueError if the
-        # scheduler isn't compatible with rapidsmp.
+        # scheduler isn't compatible with rapidsmpf.
         # Otherwise, it's a no-op if the cluster
         # was already bootstrapped.
-        from rapidsmp.integrations.dask import bootstrap_dask_cluster
+        from rapidsmpf.integrations.dask import bootstrap_dask_cluster
 
         bootstrap_dask_cluster(client)
     except ValueError:
-        pytest.skip(reason="Requires rapidsmp cluster.")
+        pytest.skip(reason="Requires a rapidsmpf-bootstrapped cluster.")
 
     # Setup the GPUEngine config
     engine = pl.GPUEngine(
@@ -41,7 +41,7 @@ def test_join_rapidsmp(max_rows_per_partition: int) -> None:
         executor_options={
             "max_rows_per_partition": max_rows_per_partition,
             "broadcast_join_limit": 2,
-            "shuffle_method": "rapidsmp",
+            "shuffle_method": "rapidsmpf",
         },
     )
 


### PR DESCRIPTION
## Description
The experimental `rapidsmp` module has been renamed to `rapidsmpf`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
