### PR TITLE
Rename cudf-polars executors

### DIFF
--- a/ci/run_cudf_polars_pytests.sh
+++ b/ci/run_cudf_polars_pytests.sh
@@ -8,14 +8,14 @@ set -euo pipefail
 # Support invoking run_cudf_polars_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cudf_polars/
 
-# Test the default "cudf" executor
+# Test the default "in-memory" executor
 python -m pytest --cache-clear "$@" tests
 
-# Test the "dask-experimental" executor
-python -m pytest --cache-clear "$@" tests --executor dask-experimental
+# Test the "streaming" executor
+python -m pytest --cache-clear "$@" tests --executor streaming
 
 # Run experimental tests with Distributed cluster
 python -m pytest --cache-clear "$@" "tests/experimental" \
-    --executor dask-experimental \
-    --dask-cluster \
+    --executor streaming \
+    --scheduler distributed \
     --cov-fail-under=0  # No code-coverage requirement for these tests.

--- a/python/cudf_polars/cudf_polars/callback.py
+++ b/python/cudf_polars/cudf_polars/callback.py
@@ -187,7 +187,7 @@ def _callback(
     *,
     device: int | None,
     memory_resource: int | None,
-    executor: Literal["pylibcudf", "dask-experimental"] | None,
+    executor: Literal["in-memory", "streaming"] | None,
     config_options: ConfigOptions,
     timer: Timer | None,
 ) -> pl.DataFrame: ...
@@ -203,7 +203,7 @@ def _callback(
     *,
     device: int | None,
     memory_resource: int | None,
-    executor: Literal["pylibcudf", "dask-experimental"] | None,
+    executor: Literal["in-memory", "streaming"] | None,
     config_options: ConfigOptions,
     timer: Timer | None,
 ) -> tuple[pl.DataFrame, list[tuple[int, int, str]]]: ...
@@ -218,7 +218,7 @@ def _callback(
     *,
     device: int | None,
     memory_resource: int | None,
-    executor: Literal["pylibcudf", "dask-experimental"] | None,
+    executor: Literal["in-memory", "streaming"] | None,
     config_options: ConfigOptions,
     timer: Timer | None,
 ) -> pl.DataFrame | tuple[pl.DataFrame, list[tuple[int, int, str]]]:
@@ -233,16 +233,16 @@ def _callback(
         set_device(device),
         set_memory_resource(memory_resource),
     ):
-        if executor is None or executor == "pylibcudf":
+        if executor is None or executor == "in-memory":
             df = ir.evaluate(cache={}, timer=timer).to_polars()
             if timer is None:
                 return df
             else:
                 return df, timer.timings
-        elif executor == "dask-experimental":
-            from cudf_polars.experimental.parallel import evaluate_dask
+        elif executor == "streaming":
+            from cudf_polars.experimental.parallel import evaluate_streaming
 
-            return evaluate_dask(ir, config_options).to_polars()
+            return evaluate_streaming(ir, config_options).to_polars()
         else:
             raise ValueError(f"Unknown executor '{executor}'")
 

--- a/python/cudf_polars/cudf_polars/experimental/dask_serialize.py
+++ b/python/cudf_polars/cudf_polars/experimental/dask_serialize.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 __all__ = ["SerializerManager", "register"]
 
 
-class SerializerManager:
+class SerializerManager:  # pragma: no cover; Only used with Distributed scheduler
     """Manager to ensure ensure serializer is only registered once."""
 
     _serializer_registered: bool = False
@@ -42,9 +42,7 @@ class SerializerManager:
     @classmethod
     def run_on_cluster(cls, client: Client) -> None:
         """Run serializer registration on the workers and scheduler."""
-        if (
-            client.id not in cls._client_run_executed
-        ):  # pragma: no cover; Only executes with Distributed scheduler
+        if client.id not in cls._client_run_executed:
             client.run(cls.register_serialize)
             client.run_on_scheduler(cls.register_serialize)
             cls._client_run_executed.add(client.id)

--- a/python/cudf_polars/cudf_polars/experimental/dask_serialize.py
+++ b/python/cudf_polars/cudf_polars/experimental/dask_serialize.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, ClassVar, overload
 
 from distributed.protocol import dask_deserialize, dask_serialize
 from distributed.protocol.cuda import cuda_deserialize, cuda_serialize
@@ -17,9 +17,37 @@ import rmm
 from cudf_polars.containers import Column, DataFrame
 
 if TYPE_CHECKING:
+    from distributed import Client
+
     from cudf_polars.typing import ColumnHeader, DataFrameHeader
 
-__all__ = ["register"]
+__all__ = ["SerializerManager", "register"]
+
+
+class SerializerManager:
+    """Manager to ensure ensure serializer is only registered once."""
+
+    _serializer_registered: bool = False
+    _client_run_executed: ClassVar[set[str]] = set()
+
+    @classmethod
+    def register_serialize(cls) -> None:
+        """Register Dask/cudf-polars serializers in calling process."""
+        if not cls._serializer_registered:
+            from cudf_polars.experimental.dask_serialize import register
+
+            register()
+            cls._serializer_registered = True
+
+    @classmethod
+    def run_on_cluster(cls, client: Client) -> None:
+        """Run serializer registration on the workers and scheduler."""
+        if (
+            client.id not in cls._client_run_executed
+        ):  # pragma: no cover; Only executes with Distributed scheduler
+            client.run(cls.register_serialize)
+            client.run_on_scheduler(cls.register_serialize)
+            cls._client_run_executed.add(client.id)
 
 
 def register() -> None:

--- a/python/cudf_polars/cudf_polars/experimental/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/groupby.py
@@ -213,9 +213,7 @@ def _(
     groupby_key_columns = [ne.name for ne in ir.keys]
     cardinality_factor = {
         c: min(f, 1.0)
-        for c, f in ir.config_options.get(
-            "executor_options.cardinality_factor", default={}
-        ).items()
+        for c, f in ir.config_options.get("executor_options.cardinality_factor").items()
         if c in groupby_key_columns
     }
     if cardinality_factor:
@@ -333,7 +331,7 @@ def _(
 
     # Simple N-ary tree reduction
     j = 0
-    n_ary = ir.config_options.get("executor_options.groupby_n_ary", default=32)
+    n_ary = ir.config_options.get("executor_options.groupby_n_ary")
     graph: MutableMapping[Any, Any] = {}
     name = get_key_name(ir)
     keys: list[Any] = [(child_name, i) for i in range(child_count)]

--- a/python/cudf_polars/cudf_polars/experimental/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/io.py
@@ -36,8 +36,7 @@ def _(
     ir: DataFrameScan, rec: LowerIRTransformer
 ) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
     rows_per_partition = ir.config_options.get(
-        "executor_options.max_rows_per_partition",
-        default=1_000_000,
+        "executor_options.max_rows_per_partition"
     )
 
     nrows = max(ir.df.shape()[0], 1)
@@ -99,10 +98,7 @@ class ScanPartitionPlan:
         """Extract the partitioning plan of a Scan operation."""
         if ir.typ == "parquet":
             # TODO: Use system info to set default blocksize
-            blocksize: int = ir.config_options.get(
-                "executor_options.parquet_blocksize",
-                default=1024**3,
-            )
+            blocksize: int = ir.config_options.get("executor_options.parquet_blocksize")
             # _sample_pq_statistics is generic over the bit-width of the array
             # We don't care about that here, so we ignore it.
             stats = _sample_pq_statistics(ir)  # type: ignore[var-annotated]

--- a/python/cudf_polars/cudf_polars/experimental/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/join.py
@@ -127,8 +127,7 @@ def _should_bcast_join(
         and small_count
         <= ir.config_options.get(
             # Maximum number of "small"-table partitions to bcast
-            "executor_options.broadcast_join_limit",
-            default=16,
+            "executor_options.broadcast_join_limit"
         )
         and (
             ir.options[0] == "Inner"

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -130,9 +130,6 @@ def task_graph(
 def get_scheduler(config_options: ConfigOptions) -> Any:
     """Get appropriate task scheduler."""
     scheduler = config_options.get("executor_options.scheduler", default="synchronous")
-    scheduler_options = config_options.get(
-        "executor_options.scheduler_options", default={}
-    )
     if (
         scheduler == "distributed"
     ):  # pragma: no cover; block depends on executor type and Distributed cluster
@@ -140,18 +137,12 @@ def get_scheduler(config_options: ConfigOptions) -> Any:
 
         from cudf_polars.experimental.dask_serialize import SerializerManager
 
-        if scheduler_options:  # pragma: no cover
-            raise ValueError(f"scheduler_options not supported: {scheduler_options}")
-
         client = get_client()
         SerializerManager.register_serialize()
         SerializerManager.run_on_cluster(client)
         return client.get
     elif scheduler == "synchronous":
         from dask import get
-
-        if scheduler_options:  # pragma: no cover
-            raise ValueError(f"scheduler_options not supported: {scheduler_options}")
 
         return get
     else:  # pragma: no cover

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
-"""Multi-partition Dask execution."""
+"""Multi-partition evaluation."""
 
 from __future__ import annotations
 
@@ -168,8 +168,7 @@ def evaluate_streaming(ir: IR, config_options: ConfigOptions) -> DataFrame:
 
     graph, key = task_graph(ir, partition_info)
 
-    get = get_scheduler(config_options)
-    return get(graph, key)
+    return get_scheduler(config_options)(graph, key)
 
 
 @generate_ir_tasks.register(IR)

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import itertools
 import operator
-from functools import reduce
-from typing import TYPE_CHECKING, Any, ClassVar
+from functools import partial, reduce
+from typing import TYPE_CHECKING, Any
 
 import cudf_polars.experimental.groupby
 import cudf_polars.experimental.io
@@ -28,36 +28,8 @@ if TYPE_CHECKING:
     from collections.abc import MutableMapping
     from typing import Any
 
-    from distributed import Client
-
     from cudf_polars.containers import DataFrame
     from cudf_polars.experimental.dispatch import LowerIRTransformer
-
-
-class SerializerManager:
-    """Manager to ensure ensure serializer is only registered once."""
-
-    _serializer_registered: bool = False
-    _client_run_executed: ClassVar[set[str]] = set()
-
-    @classmethod
-    def register_serialize(cls) -> None:
-        """Register Dask/cudf-polars serializers in calling process."""
-        if not cls._serializer_registered:
-            from cudf_polars.experimental.dask_serialize import register
-
-            register()
-            cls._serializer_registered = True
-
-    @classmethod
-    def run_on_cluster(cls, client: Client) -> None:
-        """Run serializer registration on the workers and scheduler."""
-        if (
-            client.id not in cls._client_run_executed
-        ):  # pragma: no cover; Only executes with Distributed scheduler
-            client.run(cls.register_serialize)
-            client.run_on_scheduler(cls.register_serialize)
-            cls._client_run_executed.add(client.id)
 
 
 @lower_ir_node.register(IR)
@@ -152,34 +124,64 @@ def task_graph(
         return graph, (key_name, 0)
 
 
-# The true type signature for get_client() needs an overload. Not worth it.
+# The true type signature for get_scheduler() needs an overload. Not worth it.
 
 
-def get_client() -> Any:
-    """Get appropriate Dask client or scheduler."""
-    SerializerManager.register_serialize()
-
-    try:  # pragma: no cover; block depends on executor type and Distributed cluster
+def get_scheduler(config_options: ConfigOptions) -> Any:
+    """Get appropriate task scheduler."""
+    scheduler = config_options.get("executor_options.scheduler", default="synchronous")
+    scheduler_options = config_options.get(
+        "executor_options.scheduler_options", default={}
+    )
+    if (
+        scheduler == "distributed"
+    ):  # pragma: no cover; block depends on executor type and Distributed cluster
         from distributed import get_client
 
+        from cudf_polars.experimental.dask_serialize import SerializerManager
+
+        if scheduler_options:  # pragma: no cover
+            raise ValueError(f"scheduler_options not supported: {scheduler_options}")
+
         client = get_client()
+        SerializerManager.register_serialize()
         SerializerManager.run_on_cluster(client)
-    except (
-        ImportError,
-        ValueError,
-    ):  # pragma: no cover; block depends on Dask local scheduler
+        return client.get
+    elif scheduler == "threads":  # pragma: no cover; threaded scheduler not tested yet
+        from dask.threaded import get
+
+        kwargs = {"num_workers": 2}
+        kwargs.update(scheduler_options)
+        return partial(get, **kwargs)
+    elif scheduler == "synchronous":
         from dask import get
 
+        if scheduler_options:  # pragma: no cover
+            raise ValueError(f"scheduler_options not supported: {scheduler_options}")
+
         return get
-    else:  # pragma: no cover; block depends on executor type and Distributed cluster
-        return client.get
+    else:  # pragma: no cover
+        raise ValueError(f"{scheduler} not a supported scheduler option.")
 
 
-def evaluate_dask(ir: IR, config_options: ConfigOptions | None = None) -> DataFrame:
-    """Evaluate an IR graph with partitioning."""
+def evaluate_streaming(ir: IR, config_options: ConfigOptions) -> DataFrame:
+    """
+    Evaluate an IR graph with partitioning.
+
+    Parameters
+    ----------
+    ir
+        Logical plan to evaluate.
+    config_options
+        GPUEngine configuration options.
+
+    Returns
+    -------
+    A cudf-polars DataFrame object.
+    """
+    get = get_scheduler(config_options)
+
     ir, partition_info = lower_ir_graph(ir, config_options)
-
-    get = get_client()
 
     graph, key = task_graph(ir, partition_info)
     return get(graph, key)

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -173,11 +173,11 @@ def evaluate_streaming(ir: IR, config_options: ConfigOptions) -> DataFrame:
     -------
     A cudf-polars DataFrame object.
     """
-    get = get_scheduler(config_options)
-
     ir, partition_info = lower_ir_graph(ir, config_options)
 
     graph, key = task_graph(ir, partition_info)
+
+    get = get_scheduler(config_options)
     return get(graph, key)
 
 

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -22,7 +22,6 @@ from cudf_polars.experimental.dispatch import (
     lower_ir_node,
 )
 from cudf_polars.experimental.utils import _concat, _lower_ir_fallback
-from cudf_polars.utils.config import ConfigOptions
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
@@ -30,6 +29,7 @@ if TYPE_CHECKING:
 
     from cudf_polars.containers import DataFrame
     from cudf_polars.experimental.dispatch import LowerIRTransformer
+    from cudf_polars.utils.config import ConfigOptions
 
 
 @lower_ir_node.register(IR)
@@ -48,7 +48,7 @@ def _(ir: IR, rec: LowerIRTransformer) -> tuple[IR, MutableMapping[IR, Partition
 
 
 def lower_ir_graph(
-    ir: IR, config_options: ConfigOptions | None = None
+    ir: IR, config_options: ConfigOptions
 ) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
     """
     Rewrite an IR graph and extract partitioning information.
@@ -75,7 +75,6 @@ def lower_ir_graph(
     --------
     lower_ir_node
     """
-    config_options = config_options or ConfigOptions({})
     mapper = CachingVisitor(lower_ir_node, state={"config_options": config_options})
     return mapper(ir)
 

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import itertools
 import operator
-from functools import partial, reduce
+from functools import reduce
 from typing import TYPE_CHECKING, Any
 
 import cudf_polars.experimental.groupby
@@ -147,12 +147,6 @@ def get_scheduler(config_options: ConfigOptions) -> Any:
         SerializerManager.register_serialize()
         SerializerManager.run_on_cluster(client)
         return client.get
-    elif scheduler == "threads":  # pragma: no cover; threaded scheduler not tested yet
-        from dask.threaded import get
-
-        kwargs = {"num_workers": 2}
-        kwargs.update(scheduler_options)
-        return partial(get, **kwargs)
     elif scheduler == "synchronous":
         from dask import get
 

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -128,7 +128,7 @@ def task_graph(
 
 def get_scheduler(config_options: ConfigOptions) -> Any:
     """Get appropriate task scheduler."""
-    scheduler = config_options.get("executor_options.scheduler", default="synchronous")
+    scheduler = config_options.get("executor_options.scheduler")
     if (
         scheduler == "distributed"
     ):  # pragma: no cover; block depends on executor type and Distributed cluster

--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -107,26 +107,6 @@ class Shuffle(IR):
         self._non_child_args = (schema, keys, config_options)
         self.children = (df,)
 
-        # Check shuffle-method configuration
-        scheduler = config_options.get(
-            "executor_options.scheduler", default="synchronous"
-        )
-        shuffle_method = config_options.get(
-            "executor_options.shuffle_method", default=None
-        )
-        if scheduler != "distributed" and shuffle_method != "tasks":
-            if shuffle_method is None:
-                config_options.set("executor_options.shuffle_method", "tasks")
-            else:
-                raise ValueError(
-                    f"{shuffle_method} shuffle requires scheduler='distributed'."
-                )
-        if shuffle_method not in (*_SHUFFLE_METHODS, None):  # pragma: no cover
-            raise ValueError(
-                f"{shuffle_method} is not a supported shuffle method. "
-                f"Expected one of: {_SHUFFLE_METHODS}."
-            )
-
     @classmethod
     def do_evaluate(
         cls,
@@ -255,8 +235,12 @@ def _(
     ir: Shuffle, partition_info: MutableMapping[IR, PartitionInfo]
 ) -> MutableMapping[Any, Any]:
     # Extract "shuffle_method" configuration
+    scheduler = ir.config_options.get(
+        "executor_options.scheduler", default="synchronous"
+    )
     shuffle_method = ir.config_options.get(
-        "executor_options.shuffle_method", default=None
+        "executor_options.shuffle_method",
+        default=None if scheduler == "distributed" else "tasks",
     )
 
     # Try using rapidsmpf shuffler if we have "simple" shuffle

--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -235,13 +235,7 @@ def _(
     ir: Shuffle, partition_info: MutableMapping[IR, PartitionInfo]
 ) -> MutableMapping[Any, Any]:
     # Extract "shuffle_method" configuration
-    scheduler = ir.config_options.get(
-        "executor_options.scheduler", default="synchronous"
-    )
-    shuffle_method = ir.config_options.get(
-        "executor_options.shuffle_method",
-        default=None if scheduler == "distributed" else "tasks",
-    )
+    shuffle_method = ir.config_options.get("executor_options.shuffle_method")
 
     # Try using rapidsmpf shuffler if we have "simple" shuffle
     # keys, and the "shuffle_method" config is set to "rapidsmpf"

--- a/python/cudf_polars/cudf_polars/experimental/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/utils.py
@@ -56,7 +56,7 @@ def _lower_ir_fallback(
         # Warn/raise the user if any children were collapsed
         # and the "fallback_mode" configuration is not "silent"
         match fallback_mode := rec.state["config_options"].get(
-            "executor_options.fallback_mode", default="warn"
+            "executor_options.fallback_mode"
         ):
             case "warn":
                 warnings.warn(msg, stacklevel=2)

--- a/python/cudf_polars/cudf_polars/experimental/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/utils.py
@@ -64,7 +64,7 @@ def _lower_ir_fallback(
                 raise NotImplementedError(msg)
             case "silent":
                 pass
-            case _:
+            case _:  # pragma: no cover; Should never get here.
                 raise ValueError(
                     f"{fallback_mode} is not a supported 'fallback_mode' "
                     "option. Please use 'warn', 'raise', or 'silent'."

--- a/python/cudf_polars/cudf_polars/testing/asserts.py
+++ b/python/cudf_polars/cudf_polars/testing/asserts.py
@@ -21,9 +21,9 @@ __all__: list[str] = ["assert_gpu_result_equal", "assert_ir_translation_raises"]
 
 
 # Will be overriden by `conftest.py` with the value from the `--executor`
-# and `--scheduler` command-line argument
-Executor = None
-Scheduler = "synchronous"
+# and `--scheduler` command-line arguments
+DEFAULT_EXECUTOR = "in-memory"
+DEFAULT_SCHEDULER = "synchronous"
 
 
 def assert_gpu_result_equal(
@@ -90,12 +90,12 @@ def assert_gpu_result_equal(
         If GPU collection failed in some way.
     """
     if engine is None:
-        executor = executor or Executor
+        executor = executor or DEFAULT_EXECUTOR
         engine = GPUEngine(
             raise_on_fail=True,
             executor=executor,
             executor_options=(
-                {"scheduler": Scheduler} if executor == "streaming" else {}
+                {"scheduler": DEFAULT_SCHEDULER} if executor == "streaming" else {}
             ),
         )
 

--- a/python/cudf_polars/cudf_polars/testing/asserts.py
+++ b/python/cudf_polars/cudf_polars/testing/asserts.py
@@ -21,8 +21,9 @@ __all__: list[str] = ["assert_gpu_result_equal", "assert_ir_translation_raises"]
 
 
 # Will be overriden by `conftest.py` with the value from the `--executor`
-# command-line argument
+# and `--scheduler` command-line argument
 Executor = None
+Scheduler = "synchronous"
 
 
 def assert_gpu_result_equal(
@@ -89,7 +90,14 @@ def assert_gpu_result_equal(
         If GPU collection failed in some way.
     """
     if engine is None:
-        engine = GPUEngine(raise_on_fail=True, executor=executor or Executor)
+        executor = executor or Executor
+        engine = GPUEngine(
+            raise_on_fail=True,
+            executor=executor,
+            executor_options=(
+                {"scheduler": Scheduler} if executor == "streaming" else {}
+            ),
+        )
 
     final_polars_collect_kwargs, final_cudf_collect_kwargs = _process_kwargs(
         collect_kwargs, polars_collect_kwargs, cudf_collect_kwargs

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -155,7 +155,7 @@ def _valid_option(
     if astype is not None:
         value = astype(value)
     if choices is not None and value not in choices:
-        raise ValueError(f"Unsupported {key} option: {value}")
+        raise ValueError(f"Unsupported {key} option: {value}. Choices are: {choices}")
     options[key] = value
     return options
 
@@ -205,7 +205,7 @@ def _valid_streaming_options(
                 if options["scheduler"] != "distributed":
                     default = "tasks"
                     choices = (None, "tasks")
-                else:
+                else:  # pragma: no cover; Requires distributed testing.
                     default = None
                     choices = (None, "tasks", "rapidsmpf")
                 options = _valid_option(options, key, default=default, choices=choices)

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -121,9 +121,11 @@ class ConfigOptions:
         )
 
         # Validate executor_options
-        executor = config.get("executor", "pylibcudf")
-        if executor == "dask-experimental":
+        executor = config.get("executor", "in-memory")
+        if executor == "streaming":
             unsupported = config.get("executor_options", {}).keys() - {
+                "scheduler",
+                "scheduler_options",
                 "fallback_mode",
                 "max_rows_per_partition",
                 "parquet_blocksize",

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -125,7 +125,6 @@ class ConfigOptions:
         if executor == "streaming":
             unsupported = config.get("executor_options", {}).keys() - {
                 "scheduler",
-                "scheduler_options",
                 "fallback_mode",
                 "max_rows_per_partition",
                 "parquet_blocksize",

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -18,15 +18,17 @@ def pytest_addoption(parser):
     parser.addoption(
         "--executor",
         action="store",
-        default="pylibcudf",
-        choices=("pylibcudf", "dask-experimental"),
+        default="in-memory",
+        choices=("in-memory", "streaming"),
         help="Executor to use for GPUEngine.",
     )
 
     parser.addoption(
-        "--dask-cluster",
-        action="store_true",
-        help="Executor to use for GPUEngine.",
+        "--scheduler",
+        action="store",
+        default="synchronous",
+        choices=("synchronous", "distributed"),
+        help="Scheduler to use for 'streaming' executor.",
     )
 
 
@@ -34,20 +36,19 @@ def pytest_configure(config):
     import cudf_polars.testing.asserts
 
     if (
-        config.getoption("--dask-cluster")
-        and config.getoption("--executor") != "dask-experimental"
+        config.getoption("--scheduler") == "distributed"
+        and config.getoption("--executor") != "streaming"
     ):
-        raise pytest.UsageError(
-            "--dask-cluster requires --executor='dask-experimental'"
-        )
+        raise pytest.UsageError("Distributed scheduler requires --executor='streaming'")
 
     cudf_polars.testing.asserts.Executor = config.getoption("--executor")
+    cudf_polars.testing.asserts.Scheduler = config.getoption("--scheduler")
 
 
 def pytest_sessionstart(session):
     if (
-        session.config.getoption("--dask-cluster")
-        and session.config.getoption("--executor") == "dask-experimental"
+        session.config.getoption("--scheduler") == "distributed"
+        and session.config.getoption("--executor") == "streaming"
     ):
         from dask import config
         from dask.distributed import Client

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -41,8 +41,8 @@ def pytest_configure(config):
     ):
         raise pytest.UsageError("Distributed scheduler requires --executor='streaming'")
 
-    cudf_polars.testing.asserts.Executor = config.getoption("--executor")
-    cudf_polars.testing.asserts.Scheduler = config.getoption("--scheduler")
+    cudf_polars.testing.asserts.DEFAULT_EXECUTOR = config.getoption("--executor")
+    cudf_polars.testing.asserts.DEFAULT_SCHEDULER = config.getoption("--scheduler")
 
 
 def pytest_sessionstart(session):

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -10,6 +10,7 @@ import polars as pl
 from cudf_polars import Translator
 from cudf_polars.experimental.parallel import lower_ir_graph
 from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
+from cudf_polars.utils.config import ConfigOptions
 
 
 @pytest.fixture(scope="module")
@@ -38,7 +39,7 @@ def test_parallel_dataframescan(df, max_rows_per_partition):
 
     # Check partitioning
     qir = Translator(df._ldf.visit(), engine).translate_ir()
-    ir, info = lower_ir_graph(qir)
+    ir, info = lower_ir_graph(qir, ConfigOptions(engine.config))
     count = info[ir].count
     if max_rows_per_partition < total_row_count:
         assert count > 1

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -9,7 +9,7 @@ import polars as pl
 
 from cudf_polars import Translator
 from cudf_polars.experimental.parallel import lower_ir_graph
-from cudf_polars.testing.asserts import assert_gpu_result_equal
+from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
 
 
 @pytest.fixture(scope="module")
@@ -28,8 +28,11 @@ def test_parallel_dataframescan(df, max_rows_per_partition):
     total_row_count = len(df.collect())
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
-        executor_options={"max_rows_per_partition": max_rows_per_partition},
+        executor="streaming",
+        executor_options={
+            "max_rows_per_partition": max_rows_per_partition,
+            "scheduler": Scheduler,
+        },
     )
     assert_gpu_result_equal(df, engine=engine)
 
@@ -46,8 +49,8 @@ def test_parallel_dataframescan(df, max_rows_per_partition):
 def test_dataframescan_concat(df):
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
-        executor_options={"max_rows_per_partition": 1_000},
+        executor="streaming",
+        executor_options={"max_rows_per_partition": 1_000, "scheduler": Scheduler},
     )
     df2 = pl.concat([df, df])
     assert_gpu_result_equal(df2, engine=engine)

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -9,7 +9,7 @@ import polars as pl
 
 from cudf_polars import Translator
 from cudf_polars.experimental.parallel import lower_ir_graph
-from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
+from cudf_polars.testing.asserts import DEFAULT_SCHEDULER, assert_gpu_result_equal
 from cudf_polars.utils.config import ConfigOptions
 
 
@@ -32,7 +32,7 @@ def test_parallel_dataframescan(df, max_rows_per_partition):
         executor="streaming",
         executor_options={
             "max_rows_per_partition": max_rows_per_partition,
-            "scheduler": Scheduler,
+            "scheduler": DEFAULT_SCHEDULER,
         },
     )
     assert_gpu_result_equal(df, engine=engine)
@@ -51,7 +51,10 @@ def test_dataframescan_concat(df):
     engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
-        executor_options={"max_rows_per_partition": 1_000, "scheduler": Scheduler},
+        executor_options={
+            "max_rows_per_partition": 1_000,
+            "scheduler": DEFAULT_SCHEDULER,
+        },
     )
     df2 = pl.concat([df, df])
     assert_gpu_result_equal(df2, engine=engine)

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -9,7 +9,7 @@ import pytest
 
 import polars as pl
 
-from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
+from cudf_polars.testing.asserts import DEFAULT_SCHEDULER, assert_gpu_result_equal
 
 
 @pytest.fixture(scope="module")
@@ -19,7 +19,7 @@ def engine():
         executor="streaming",
         executor_options={
             "max_rows_per_partition": 4,
-            "scheduler": Scheduler,
+            "scheduler": DEFAULT_SCHEDULER,
         },
     )
 
@@ -53,7 +53,7 @@ def test_groupby_single_partitions(df, op, keys):
             executor="streaming",
             executor_options={
                 "max_rows_per_partition": 1e9,
-                "scheduler": Scheduler,
+                "scheduler": DEFAULT_SCHEDULER,
             },
         ),
         check_row_order=False,
@@ -79,7 +79,7 @@ def test_groupby_agg_config_options(df, op, keys):
             "cardinality_factor": {"z": 0.5},
             # Check that we can change the n-ary factor
             "groupby_n_ary": 8,
-            "scheduler": Scheduler,
+            "scheduler": DEFAULT_SCHEDULER,
             "shuffle_method": "tasks",
         },
     )
@@ -98,7 +98,7 @@ def test_groupby_fallback(df, engine, fallback_mode):
         executor_options={
             "fallback_mode": fallback_mode,
             "max_rows_per_partition": 4,
-            "scheduler": Scheduler,
+            "scheduler": DEFAULT_SCHEDULER,
         },
     )
     match = "Failed to decompose groupby aggs"
@@ -111,7 +111,7 @@ def test_groupby_fallback(df, engine, fallback_mode):
         ctx = pytest.raises(pl.exceptions.ComputeError, match=match)
     elif fallback_mode == "foo":
         ctx = pytest.raises(
-            pl.exceptions.ComputeError, match="not a supported 'fallback_mode' option"
+            pl.exceptions.ComputeError, match="Unsupported fallback_mode option"
         )
     else:
         ctx = pytest.warns(UserWarning, match=match)

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -9,15 +9,18 @@ import pytest
 
 import polars as pl
 
-from cudf_polars.testing.asserts import assert_gpu_result_equal
+from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
 
 
 @pytest.fixture(scope="module")
 def engine():
     return pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
-        executor_options={"max_rows_per_partition": 4},
+        executor="streaming",
+        executor_options={
+            "max_rows_per_partition": 4,
+            "scheduler": Scheduler,
+        },
     )
 
 
@@ -47,8 +50,11 @@ def test_groupby_single_partitions(df, op, keys):
         q,
         engine=pl.GPUEngine(
             raise_on_fail=True,
-            executor="dask-experimental",
-            executor_options={"max_rows_per_partition": 1e9},
+            executor="streaming",
+            executor_options={
+                "max_rows_per_partition": 1e9,
+                "scheduler": Scheduler,
+            },
         ),
         check_row_order=False,
     )
@@ -66,13 +72,15 @@ def test_groupby_agg(df, engine, op, keys):
 def test_groupby_agg_config_options(df, op, keys):
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="streaming",
         executor_options={
             "max_rows_per_partition": 4,
             # Trigger shuffle-based groupby
             "cardinality_factor": {"z": 0.5},
             # Check that we can change the n-ary factor
             "groupby_n_ary": 8,
+            "scheduler": Scheduler,
+            "shuffle_method": "tasks",
         },
     )
     agg = getattr(pl.col("x"), op)()
@@ -86,10 +94,11 @@ def test_groupby_agg_config_options(df, op, keys):
 def test_groupby_fallback(df, engine, fallback_mode):
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="streaming",
         executor_options={
             "fallback_mode": fallback_mode,
             "max_rows_per_partition": 4,
+            "scheduler": Scheduler,
         },
     )
     match = "Failed to decompose groupby aggs"

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -10,7 +10,7 @@ import polars as pl
 from cudf_polars import Translator
 from cudf_polars.experimental.parallel import lower_ir_graph
 from cudf_polars.experimental.shuffle import Shuffle
-from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
+from cudf_polars.testing.asserts import DEFAULT_SCHEDULER, assert_gpu_result_equal
 from cudf_polars.utils.config import ConfigOptions
 
 
@@ -23,7 +23,7 @@ def test_join(how, reverse, max_rows_per_partition, broadcast_join_limit):
         raise_on_fail=True,
         executor="streaming",
         executor_options={
-            "scheduler": Scheduler,
+            "scheduler": DEFAULT_SCHEDULER,
             "max_rows_per_partition": max_rows_per_partition,
             "broadcast_join_limit": broadcast_join_limit,
             "shuffle_method": "tasks",
@@ -72,7 +72,7 @@ def test_broadcast_join_limit(broadcast_join_limit):
         executor_options={
             "max_rows_per_partition": 3,
             "broadcast_join_limit": broadcast_join_limit,
-            "scheduler": Scheduler,
+            "scheduler": DEFAULT_SCHEDULER,
             "shuffle_method": "tasks",
         },
     )

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -11,6 +11,7 @@ from cudf_polars import Translator
 from cudf_polars.experimental.parallel import lower_ir_graph
 from cudf_polars.experimental.shuffle import Shuffle
 from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
+from cudf_polars.utils.config import ConfigOptions
 
 
 @pytest.mark.parametrize("how", ["inner", "left", "right", "full", "semi", "anti"])
@@ -93,7 +94,10 @@ def test_broadcast_join_limit(broadcast_join_limit):
     q = left.join(right, on="y", how="inner")
     shuffle_nodes = [
         type(node)
-        for node in lower_ir_graph(Translator(q._ldf.visit(), engine).translate_ir())[1]
+        for node in lower_ir_graph(
+            Translator(q._ldf.visit(), engine).translate_ir(),
+            ConfigOptions(engine.config),
+        )[1]
         if isinstance(node, Shuffle)
     ]
 

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -10,7 +10,7 @@ import polars as pl
 from cudf_polars import Translator
 from cudf_polars.experimental.parallel import lower_ir_graph
 from cudf_polars.experimental.shuffle import Shuffle
-from cudf_polars.testing.asserts import assert_gpu_result_equal
+from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
 
 
 @pytest.mark.parametrize("how", ["inner", "left", "right", "full", "semi", "anti"])
@@ -20,10 +20,12 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 def test_join(how, reverse, max_rows_per_partition, broadcast_join_limit):
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="streaming",
         executor_options={
+            "scheduler": Scheduler,
             "max_rows_per_partition": max_rows_per_partition,
             "broadcast_join_limit": broadcast_join_limit,
+            "shuffle_method": "tasks",
         },
     )
     left = pl.LazyFrame(
@@ -65,10 +67,12 @@ def test_join(how, reverse, max_rows_per_partition, broadcast_join_limit):
 def test_broadcast_join_limit(broadcast_join_limit):
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="streaming",
         executor_options={
             "max_rows_per_partition": 3,
             "broadcast_join_limit": broadcast_join_limit,
+            "scheduler": Scheduler,
+            "shuffle_method": "tasks",
         },
     )
     left = pl.LazyFrame(

--- a/python/cudf_polars/tests/experimental/test_parallel.py
+++ b/python/cudf_polars/tests/experimental/test_parallel.py
@@ -13,19 +13,24 @@ from polars.testing import assert_frame_equal
 
 from cudf_polars import Translator
 from cudf_polars.dsl.traversal import traversal
+from cudf_polars.testing.asserts import Scheduler
 
 
-def test_evaluate_dask():
+def test_evaluate_streaming():
     df = pl.LazyFrame({"a": [1, 2, 3], "b": [3, 4, 5], "c": [5, 6, 7], "d": [7, 9, 8]})
     q = df.select(pl.col("a") - (pl.col("b") + pl.col("c") * 2), pl.col("d")).sort("d")
 
     expected = q.collect(engine="cpu")
     got_gpu = q.collect(engine=GPUEngine(raise_on_fail=True))
-    got_dask = q.collect(
-        engine=GPUEngine(raise_on_fail=True, executor="dask-experimental")
+    got_streaming = q.collect(
+        engine=GPUEngine(
+            raise_on_fail=True,
+            executor="streaming",
+            executor_options={"scheduler": Scheduler},
+        )
     )
     assert_frame_equal(expected, got_gpu)
-    assert_frame_equal(expected, got_dask)
+    assert_frame_equal(expected, got_streaming)
 
 
 @pytest.mark.parametrize(

--- a/python/cudf_polars/tests/experimental/test_parallel.py
+++ b/python/cudf_polars/tests/experimental/test_parallel.py
@@ -13,7 +13,7 @@ from polars.testing import assert_frame_equal
 
 from cudf_polars import Translator
 from cudf_polars.dsl.traversal import traversal
-from cudf_polars.testing.asserts import Scheduler
+from cudf_polars.testing.asserts import DEFAULT_SCHEDULER
 
 
 def test_evaluate_streaming():
@@ -26,7 +26,7 @@ def test_evaluate_streaming():
         engine=GPUEngine(
             raise_on_fail=True,
             executor="streaming",
-            executor_options={"scheduler": Scheduler},
+            executor_options={"scheduler": DEFAULT_SCHEDULER},
         )
     )
     assert_frame_equal(expected, got_gpu)

--- a/python/cudf_polars/tests/experimental/test_rapidsmpf.py
+++ b/python/cudf_polars/tests/experimental/test_rapidsmpf.py
@@ -14,7 +14,7 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 def test_join_rapidsmpf(max_rows_per_partition: int) -> None:
     # Check that we have a distributed cluster running.
     # This tests must be run with:
-    # --executor='dask-experimental' --dask-cluster
+    # --executor='streaming' --scheduler='distributed'
     distributed = pytest.importorskip("distributed")
     try:
         client = distributed.get_client()
@@ -37,11 +37,12 @@ def test_join_rapidsmpf(max_rows_per_partition: int) -> None:
     # Setup the GPUEngine config
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="streaming",
         executor_options={
             "max_rows_per_partition": max_rows_per_partition,
             "broadcast_join_limit": 2,
             "shuffle_method": "rapidsmpf",
+            "scheduler": "distributed",
         },
     )
 

--- a/python/cudf_polars/tests/experimental/test_scan.py
+++ b/python/cudf_polars/tests/experimental/test_scan.py
@@ -9,7 +9,7 @@ import polars as pl
 
 from cudf_polars import Translator
 from cudf_polars.experimental.parallel import lower_ir_graph
-from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
+from cudf_polars.testing.asserts import DEFAULT_SCHEDULER, assert_gpu_result_equal
 from cudf_polars.utils.config import ConfigOptions
 
 
@@ -55,7 +55,7 @@ def test_parallel_scan(tmp_path, df, fmt, scan_fn):
     engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
-        executor_options={"scheduler": Scheduler},
+        executor_options={"scheduler": DEFAULT_SCHEDULER},
     )
     assert_gpu_result_equal(q, engine=engine)
 
@@ -68,7 +68,10 @@ def test_parquet_blocksize(tmp_path, df, blocksize, n_files):
     engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
-        executor_options={"parquet_blocksize": blocksize, "scheduler": Scheduler},
+        executor_options={
+            "parquet_blocksize": blocksize,
+            "scheduler": DEFAULT_SCHEDULER,
+        },
     )
     assert_gpu_result_equal(q, engine=engine)
 

--- a/python/cudf_polars/tests/experimental/test_scan.py
+++ b/python/cudf_polars/tests/experimental/test_scan.py
@@ -9,7 +9,7 @@ import polars as pl
 
 from cudf_polars import Translator
 from cudf_polars.experimental.parallel import lower_ir_graph
-from cudf_polars.testing.asserts import assert_gpu_result_equal
+from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
 
 
 @pytest.fixture(scope="module")
@@ -53,7 +53,8 @@ def test_parallel_scan(tmp_path, df, fmt, scan_fn):
     q = scan_fn(tmp_path)
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="streaming",
+        executor_options={"scheduler": Scheduler},
     )
     assert_gpu_result_equal(q, engine=engine)
 
@@ -65,8 +66,8 @@ def test_parquet_blocksize(tmp_path, df, blocksize, n_files):
     q = pl.scan_parquet(tmp_path)
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
-        executor_options={"parquet_blocksize": blocksize},
+        executor="streaming",
+        executor_options={"parquet_blocksize": blocksize, "scheduler": Scheduler},
     )
     assert_gpu_result_equal(q, engine=engine)
 

--- a/python/cudf_polars/tests/experimental/test_scan.py
+++ b/python/cudf_polars/tests/experimental/test_scan.py
@@ -10,6 +10,7 @@ import polars as pl
 from cudf_polars import Translator
 from cudf_polars.experimental.parallel import lower_ir_graph
 from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
+from cudf_polars.utils.config import ConfigOptions
 
 
 @pytest.fixture(scope="module")
@@ -73,7 +74,7 @@ def test_parquet_blocksize(tmp_path, df, blocksize, n_files):
 
     # Check partitioning
     qir = Translator(q._ldf.visit(), engine).translate_ir()
-    ir, info = lower_ir_graph(qir)
+    ir, info = lower_ir_graph(qir, ConfigOptions(engine.config))
     count = info[ir].count
     if blocksize <= 12_000:
         assert count > n_files

--- a/python/cudf_polars/tests/experimental/test_select.py
+++ b/python/cudf_polars/tests/experimental/test_select.py
@@ -9,15 +9,15 @@ import pytest
 
 import polars as pl
 
-from cudf_polars.testing.asserts import assert_gpu_result_equal
+from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
 
 
 @pytest.fixture(scope="module")
 def engine():
     return pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
-        executor_options={"max_rows_per_partition": 3},
+        executor="streaming",
+        executor_options={"max_rows_per_partition": 3, "scheduler": Scheduler},
     )
 
 
@@ -42,10 +42,11 @@ def test_select(df, engine):
 def test_select_reduce_fallback(df, fallback_mode):
     engine = pl.GPUEngine(
         raise_on_fail=True,
-        executor="dask-experimental",
+        executor="streaming",
         executor_options={
             "fallback_mode": fallback_mode,
             "max_rows_per_partition": 3,
+            "scheduler": Scheduler,
         },
     )
     match = "This selection not support for multiple partitions."

--- a/python/cudf_polars/tests/experimental/test_select.py
+++ b/python/cudf_polars/tests/experimental/test_select.py
@@ -9,7 +9,7 @@ import pytest
 
 import polars as pl
 
-from cudf_polars.testing.asserts import Scheduler, assert_gpu_result_equal
+from cudf_polars.testing.asserts import DEFAULT_SCHEDULER, assert_gpu_result_equal
 
 
 @pytest.fixture(scope="module")
@@ -17,7 +17,7 @@ def engine():
     return pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
-        executor_options={"max_rows_per_partition": 3, "scheduler": Scheduler},
+        executor_options={"max_rows_per_partition": 3, "scheduler": DEFAULT_SCHEDULER},
     )
 
 
@@ -46,7 +46,7 @@ def test_select_reduce_fallback(df, fallback_mode):
         executor_options={
             "fallback_mode": fallback_mode,
             "max_rows_per_partition": 3,
-            "scheduler": Scheduler,
+            "scheduler": DEFAULT_SCHEDULER,
         },
     )
     match = "This selection not support for multiple partitions."
@@ -62,7 +62,7 @@ def test_select_reduce_fallback(df, fallback_mode):
         ctx = pytest.raises(pl.exceptions.ComputeError, match=match)
     elif fallback_mode == "foo":
         ctx = pytest.raises(
-            pl.exceptions.ComputeError, match="not a supported 'fallback_mode' option"
+            pl.exceptions.ComputeError, match="Unsupported fallback_mode option"
         )
     else:
         ctx = pytest.warns(UserWarning, match=match)

--- a/python/cudf_polars/tests/experimental/test_shuffle.py
+++ b/python/cudf_polars/tests/experimental/test_shuffle.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import copy
-
 import pytest
 
 import polars as pl
@@ -48,7 +46,7 @@ def test_hash_shuffle(df, engine):
 
     # Add first Shuffle node
     keys = (NamedExpr("x", Col(qir.schema["x"], "x")),)
-    options = ConfigOptions(copy.deepcopy(engine.config))
+    options = ConfigOptions(engine.config)
     qir1 = Shuffle(qir.schema, keys, options, qir)
 
     # Add second Shuffle node (on the same keys)
@@ -56,7 +54,7 @@ def test_hash_shuffle(df, engine):
 
     # Check that sequential shuffles on the same keys
     # are replaced with a single shuffle node
-    partition_info = lower_ir_graph(qir2)[1]
+    partition_info = lower_ir_graph(qir2, options)[1]
     assert len([node for node in partition_info if isinstance(node, Shuffle)]) == 1
 
     # Add second Shuffle node (on different keys)
@@ -65,7 +63,7 @@ def test_hash_shuffle(df, engine):
 
     # Check that we have an additional shuffle
     # node after shuffling on different keys
-    partition_info = lower_ir_graph(qir3)[1]
+    partition_info = lower_ir_graph(qir3, options)[1]
     assert len([node for node in partition_info if isinstance(node, Shuffle)]) == 2
 
     # Check that streaming evaluation works

--- a/python/cudf_polars/tests/experimental/test_shuffle.py
+++ b/python/cudf_polars/tests/experimental/test_shuffle.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import copy
+
 import pytest
 
 import polars as pl
@@ -46,7 +48,7 @@ def test_hash_shuffle(df, engine):
 
     # Add first Shuffle node
     keys = (NamedExpr("x", Col(qir.schema["x"], "x")),)
-    options = ConfigOptions(engine.config)
+    options = ConfigOptions(copy.deepcopy(engine.config))
     qir1 = Shuffle(qir.schema, keys, options, qir)
 
     # Add second Shuffle node (on the same keys)

--- a/python/cudf_polars/tests/experimental/test_shuffle.py
+++ b/python/cudf_polars/tests/experimental/test_shuffle.py
@@ -12,7 +12,7 @@ from cudf_polars import Translator
 from cudf_polars.dsl.expr import Col, NamedExpr
 from cudf_polars.experimental.parallel import evaluate_streaming, lower_ir_graph
 from cudf_polars.experimental.shuffle import Shuffle
-from cudf_polars.testing.asserts import Scheduler
+from cudf_polars.testing.asserts import DEFAULT_SCHEDULER
 from cudf_polars.utils.config import ConfigOptions
 
 
@@ -23,7 +23,7 @@ def engine(request):
         executor="streaming",
         executor_options={
             "max_rows_per_partition": 4,
-            "scheduler": Scheduler,
+            "scheduler": DEFAULT_SCHEDULER,
             "shuffle_method": request.param,
         },
     )

--- a/python/cudf_polars/tests/test_executors.py
+++ b/python/cudf_polars/tests/test_executors.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -10,9 +10,9 @@ import polars as pl
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
-@pytest.mark.parametrize("executor", [None, "pylibcudf", "dask-experimental"])
+@pytest.mark.parametrize("executor", [None, "in-memory", "streaming"])
 def test_executor_basics(executor):
-    if executor == "dask-experimental":
+    if executor == "streaming":
         pytest.importorskip("dask")
 
     df = pl.LazyFrame(
@@ -42,7 +42,7 @@ def test_cudf_cache_evaluate():
     ).lazy()
     ldf2 = ldf.select((pl.col("a") + pl.col("b")).alias("c"), pl.col("a"))
     query = pl.concat([ldf, ldf2], how="diagonal")
-    assert_gpu_result_equal(query, executor="pylibcudf")
+    assert_gpu_result_equal(query, executor="in-memory")
 
 
 def test_dask_experimental_map_function_get_hashable():
@@ -55,7 +55,7 @@ def test_dask_experimental_map_function_get_hashable():
         }
     )
     q = df.unpivot(index="d")
-    assert_gpu_result_equal(q, executor="dask-experimental")
+    assert_gpu_result_equal(q, executor="streaming")
 
 
 def test_unknown_executor():
@@ -68,7 +68,7 @@ def test_unknown_executor():
         assert_gpu_result_equal(df, executor="unknown-executor")
 
 
-@pytest.mark.parametrize("executor", [None, "pylibcudf", "dask-experimental"])
+@pytest.mark.parametrize("executor", [None, "in-memory", "streaming"])
 def test_unknown_executor_options(executor):
     df = pl.LazyFrame({})
 


### PR DESCRIPTION
## Description
Closes https://github.com/rapidsai/cudf/issues/18348

- Renames the cudf-polars executors (currently `"pylibcudf"` and `"dask-experimental"`) to `"in-memory"` and `"streaming"`.
  - The new terms are consistent with the engine options available for cpu-polars.
- Adds a `"scheduler"` configuration option to enable distributed execution when the `"streaming"` executor is active.
  - The new options are `"synchronous"` and `"distributed"`, for now. It will be easy to add a `"threads"` option in a follow-up PR (to take advantage of both UVM and PTDS on a single GPU)
  - We no longer import dask/distributed and look for a distributed client unless the `"distributed"` option is configured.

## Usage

```python
import polars as pl

# Use the lazy Polars API to construct a query 
import polars as pl
q = pl.scan_parquet("/parquet/directory").group_by("y").sum()

# Configure Polars to use the "streaming"  GPUEngine executor
engine = pl.GPUEngine(executor="streaming")
q.collect(engine=engine)
```
By default, cudf-polars will use a synchronous Dask scheduler when the `"streaming"` executor is active.

If you have a distributed client available, you can also set the `"scheduler"` option to `"distributed"`:
```python
client = ...

engine = pl.GPUEngine(
    executor="streaming",
    executor_options={"scheduler": "distributed"},
)
q.collect(engine=engine)
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
