### PR TITLE
Replace thrust functors with libcu++ ones

### DIFF
--- a/cpp/doxygen/developer_guide/DEVELOPER_GUIDE.md
+++ b/cpp/doxygen/developer_guide/DEVELOPER_GUIDE.md
@@ -879,7 +879,7 @@ thrust::lower_bound(rmm::exec_policy(stream),
                     values->begin<Element>(),
                     values->end<Element>(),
                     result_itr,
-                    thrust::less<Element>());
+                    cuda::std::less<Element>());
 ```
 
 ### Offset-normalizing iterators

--- a/cpp/include/cudf/detail/indexalator.cuh
+++ b/cpp/include/cudf/detail/indexalator.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ struct input_indexalator : base_normalator<input_indexalator, cudf::size_type> {
  *                      values->begin<Element>(),
  *                      values->end<Element>(),
  *                      result_itr,
- *                      thrust::less<Element>());
+ *                      cuda::std::less<Element>());
  * @endcode
  */
 struct output_indexalator : base_normalator<output_indexalator, cudf::size_type> {

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -93,7 +93,7 @@ auto create_device_views(host_span<column_view const> views, rmm::cuda_stream_vi
     device_views.cend(),
     std::next(offsets.begin()),
     [](auto const& col) { return col.size(); },
-    thrust::plus{});
+    cuda::std::plus{});
   auto d_offsets =
     make_device_uvector_async(offsets, stream, cudf::get_current_device_resource_ref());
   auto const output_size = offsets.back();

--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -179,7 +179,7 @@ struct dispatch_compute_indices {
                         all_itr,
                         all_itr + all_indices.size(),
                         result_itr,
-                        thrust::less<Element>());
+                        cuda::std::less<Element>());
 #else
     // There is a problem with thrust::lower_bound and the output_indexalator.
     // https://github.com/NVIDIA/thrust/issues/1452; thrust team created nvbug 3322776

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -90,7 +90,7 @@ struct dispatch_compute_indices {
                         dictionary_itr,
                         dictionary_itr + input.size(),
                         result_itr,
-                        thrust::less<Element>());
+                        cuda::std::less<Element>());
 #else
     // There is a problem with thrust::lower_bound and the output_indexalator
     // https://github.com/NVIDIA/thrust/issues/1452; thrust team created nvbug 3322776

--- a/cpp/src/io/comp/comp.cu
+++ b/cpp/src/io/comp/comp.cu
@@ -37,7 +37,7 @@ writer_compression_statistics collect_compression_statistics(
       return res.status == compression_status::SUCCESS ? res.bytes_written : 0;
     }),
     0ul,
-    thrust::plus<size_t>());
+    cuda::std::plus<size_t>());
 
   auto input_size_with_status = [inputs, results, stream](compression_status status) {
     auto const zipped_begin =
@@ -52,7 +52,7 @@ writer_compression_statistics collect_compression_statistics(
         return thrust::get<1>(tup).status == status ? thrust::get<0>(tup).size() : 0;
       }),
       0ul,
-      thrust::plus<size_t>());
+      cuda::std::plus<size_t>());
   };
 
   return writer_compression_statistics{input_size_with_status(compression_status::SUCCESS),

--- a/cpp/src/io/json/column_tree_construction.cu
+++ b/cpp/src/io/json/column_tree_construction.cu
@@ -228,7 +228,7 @@ std::tuple<compressed_sparse_row, column_tree_properties> reduce_to_column_tree(
           auto idx = thrust::get<1>(a);
           return n == 1 ? idx : idx + 1;
         }),
-        thrust::plus<NodeIndexT>{});
+        cuda::std::plus<NodeIndexT>{});
     } else {
       auto single_node = 1;
       row_idx.set_element_async(1, single_node, stream);

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -1713,7 +1713,7 @@ pushdown_null_masks init_pushdown_null_masks(orc_table_view& orc_table,
                           null_mask + pd_masks.back().size(),
                           parent_pd_mask,
                           pd_masks.back().data(),
-                          thrust::bit_and<bitmask_type>());
+                          cuda::std::bit_and<bitmask_type>());
       }
     }
     if (col.orc_kind() == LIST or col.orc_kind() == MAP) {
@@ -1893,7 +1893,8 @@ hostdevice_2dvector<rowgroup_rows> calculate_rowgroup_bounds(orc_table_view cons
           // Root column
           if (!col.parent_index.has_value()) {
             size_type const rows_begin = rg_idx * rowgroup_size;
-            auto const rows_end = thrust::min<size_type>((rg_idx + 1) * rowgroup_size, col.size());
+            auto const rows_end =
+              cuda::std::min<size_type>((rg_idx + 1) * rowgroup_size, col.size());
             return rowgroup_rows{rows_begin, rows_end};
           } else {
             // Child column

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -470,8 +470,11 @@ uint32_t GetAggregatedDecodeKernelMask(cudf::detail::hostdevice_span<PageInfo co
 {
   // determine which kernels to invoke
   auto mask_iter = thrust::make_transform_iterator(pages.device_begin(), mask_tform{});
-  return thrust::reduce(
-    rmm::exec_policy(stream), mask_iter, mask_iter + pages.size(), 0U, thrust::bit_or<uint32_t>{});
+  return thrust::reduce(rmm::exec_policy(stream),
+                        mask_iter,
+                        mask_iter + pages.size(),
+                        0U,
+                        cuda::std::bit_or<uint32_t>{});
 }
 
 /**

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -3430,8 +3430,11 @@ void EncodePages(device_span<EncPage> pages,
 
   // determine which kernels to invoke
   auto mask_iter       = thrust::make_transform_iterator(pages.begin(), mask_tform{});
-  uint32_t kernel_mask = thrust::reduce(
-    rmm::exec_policy(stream), mask_iter, mask_iter + pages.size(), 0U, thrust::bit_or<uint32_t>{});
+  uint32_t kernel_mask = thrust::reduce(rmm::exec_policy(stream),
+                                        mask_iter,
+                                        mask_iter + pages.size(),
+                                        0U,
+                                        cuda::std::bit_or<uint32_t>{});
 
   // get the number of streams we need from the pool
   int nkernels = std::bitset<32>(kernel_mask).count();

--- a/cpp/src/io/parquet/page_string_decode.cu
+++ b/cpp/src/io/parquet/page_string_decode.cu
@@ -1012,7 +1012,7 @@ void ComputePageStringSizes(cudf::detail::hostdevice_span<PageInfo> pages,
                                                      pages.device_end(),
                                                      page_sizes,
                                                      0L,
-                                                     thrust::plus<int64_t>{});
+                                                     cuda::std::plus<int64_t>{});
 
     // now do an exclusive scan over the temp_string_sizes to get offsets for each
     // page's chunk of the temp buffer
@@ -1023,7 +1023,7 @@ void ComputePageStringSizes(cudf::detail::hostdevice_span<PageInfo> pages,
                                      page_string_offsets.begin(),
                                      page_sizes,
                                      0L,
-                                     thrust::plus<int64_t>{});
+                                     cuda::std::plus<int64_t>{});
 
     // allocate the temp space
     temp_string_buf.resize(total_size, stream);

--- a/cpp/src/io/parquet/reader_impl_chunking.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking.cu
@@ -1399,7 +1399,7 @@ void reader::impl::setup_next_subpass(read_mode mode)
                                      dst_offsets.begin(),
                                      get_span_size_by_index{page_indices},
                                      0,
-                                     thrust::plus<size_t>{});
+                                     cuda::std::plus<size_t>{});
     thrust::for_each(
       rmm::exec_policy_nosync(_stream),
       iter,

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -469,8 +469,12 @@ std::string encoding_to_string(Encoding encoding)
   auto const to_mask = cuda::proclaim_return_type<uint32_t>([] __device__(auto const& page) {
     return is_supported_encoding(page.encoding) ? 0U : encoding_to_mask(page.encoding);
   });
-  uint32_t const unsupported = thrust::transform_reduce(
-    rmm::exec_policy(stream), pages.begin(), pages.end(), to_mask, 0U, thrust::bit_or<uint32_t>());
+  uint32_t const unsupported = thrust::transform_reduce(rmm::exec_policy(stream),
+                                                        pages.begin(),
+                                                        pages.end(),
+                                                        to_mask,
+                                                        0U,
+                                                        cuda::std::bit_or<uint32_t>());
   return encoding_bitmask_to_str(unsupported);
 }
 
@@ -527,7 +531,7 @@ cudf::detail::hostdevice_vector<PageInfo> sort_pages(device_span<PageInfo const>
                              page_keys.begin(),
                              page_keys.end(),
                              sort_indices.begin(),
-                             thrust::less<int>());
+                             cuda::std::less<int>());
   auto pass_pages =
     cudf::detail::hostdevice_vector<PageInfo>(unsorted_pages.size(), unsorted_pages.size(), stream);
   thrust::transform(
@@ -566,7 +570,7 @@ void decode_page_headers(pass_intermediate_data& pass,
           i >= num_chunks ? 0 : chunks[i].num_data_pages + chunks[i].num_dict_pages);
       }),
     size_t{0},
-    thrust::plus<size_t>{});
+    cuda::std::plus<size_t>{});
   rmm::device_uvector<chunk_page_info> d_chunk_page_info(pass.chunks.size(), stream);
   thrust::for_each(rmm::exec_policy_nosync(stream),
                    iter,

--- a/cpp/src/labeling/label_bins.cu
+++ b/cpp/src/labeling/label_bins.cu
@@ -181,16 +181,16 @@ struct bin_type_dispatcher {
     rmm::device_async_resource_ref mr)
   {
     if ((left_inclusive == inclusive::YES) && (right_inclusive == inclusive::YES))
-      return label_bins<T, thrust::less_equal<T>, thrust::less_equal<T>>(
+      return label_bins<T, cuda::std::less_equal<T>, cuda::std::less_equal<T>>(
         input, left_edges, right_edges, stream, mr);
     if ((left_inclusive == inclusive::YES) && (right_inclusive == inclusive::NO))
-      return label_bins<T, thrust::less_equal<T>, thrust::less<T>>(
+      return label_bins<T, cuda::std::less_equal<T>, cuda::std::less<T>>(
         input, left_edges, right_edges, stream, mr);
     if ((left_inclusive == inclusive::NO) && (right_inclusive == inclusive::YES))
-      return label_bins<T, thrust::less<T>, thrust::less_equal<T>>(
+      return label_bins<T, cuda::std::less<T>, cuda::std::less_equal<T>>(
         input, left_edges, right_edges, stream, mr);
     if ((left_inclusive == inclusive::NO) && (right_inclusive == inclusive::NO))
-      return label_bins<T, thrust::less<T>, thrust::less<T>>(
+      return label_bins<T, cuda::std::less<T>, cuda::std::less<T>>(
         input, left_edges, right_edges, stream, mr);
 
     CUDF_FAIL("Undefined inclusive setting.");

--- a/cpp/src/sort/common_sort_impl.cuh
+++ b/cpp/src/sort/common_sort_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,9 +84,9 @@ struct inplace_column_sort_fn {
       }
     };
     if (order == order::ASCENDING) {
-      do_sort(thrust::less<T>());
+      do_sort(cuda::std::less<T>());
     } else {
-      do_sort(thrust::greater<T>());
+      do_sort(cuda::std::greater<T>());
     }
   }
 

--- a/cpp/src/sort/sort_column_impl.cuh
+++ b/cpp/src/sort/sort_column_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ struct column_sorted_order_fn {
    * @brief Compile time check for allowing faster sort.
    *
    * Faster sort is defined for fixed-width types where only
-   * the primitive comparators thrust::greater or thrust::less
+   * the primitive comparators cuda::std::greater or cuda::std::less
    * are needed.
    *
    * Floating point is removed here for special handling of NaNs
@@ -140,9 +140,9 @@ struct column_sorted_order_fn {
     };
 
     if (ascending) {
-      do_sort(thrust::less<T>{});
+      do_sort(cuda::std::less<T>{});
     } else {
-      do_sort(thrust::greater<T>{});
+      do_sort(cuda::std::greater<T>{});
     }
   }
 

--- a/cpp/src/strings/attributes.cu
+++ b/cpp/src/strings/attributes.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,7 +237,7 @@ std::unique_ptr<column> code_points(strings_column_view const& input,
       if (!d_column.is_null(idx)) length = d_column.element<string_view>(idx).length();
       return length;
     }),
-    thrust::plus<size_type>());
+    cuda::std::plus<size_type>());
 
   offsets.set_element_to_zero_async(0, stream);
 

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -360,7 +360,7 @@ struct from_durations_fn {
         return (item.length != -1) ? item.length : format_length(item.value, &timeparts);
       },
       size_type{0},
-      thrust::plus<size_type>());
+      cuda::std::plus<size_type>());
   }
 
   __device__ void set_chars(size_type idx)

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -101,7 +101,7 @@ auto create_strings_device_views(host_span<column_view const> views, rmm::cuda_s
                                    device_views_ptr + views.size(),
                                    std::next(d_partition_offsets.begin()),
                                    chars_size_transform{},
-                                   thrust::plus{});
+                                   cuda::std::plus{});
   auto const output_chars_size = d_partition_offsets.back_element(stream);
   stream.synchronize();  // ensure copy of output_chars_size is complete before returning
 

--- a/cpp/src/strings/search/contains_multiple.cu
+++ b/cpp/src/strings/search/contains_multiple.cu
@@ -213,7 +213,7 @@ std::unique_ptr<table> contains_multiple(strings_column_view const& input,
     auto keys_out  = first_bytes.begin();
     auto vals_out  = indices.begin();
     auto num_items = targets.size();
-    auto cmp_op    = thrust::less();
+    auto cmp_op    = cuda::std::less();
     auto sv        = stream.value();
 
     std::size_t tmp_bytes = 0;

--- a/cpp/src/text/edit_distance.cu
+++ b/cpp/src/text/edit_distance.cu
@@ -283,7 +283,7 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
     offsets_column->mutable_view().data<cudf::size_type>(),
     [strings_count] __device__(auto idx) { return strings_count; },
     cudf::size_type{0},
-    thrust::plus<cudf::size_type>());
+    cuda::std::plus<cudf::size_type>());
   return cudf::make_lists_column(strings_count,
                                  std::move(offsets_column),
                                  std::move(results),

--- a/cpp/src/text/normalize.cu
+++ b/cpp/src/text/normalize.cu
@@ -142,7 +142,7 @@ struct codepoint_to_utf8_fn {
       str_cps + count,
       [](auto cp) { return 1 + (cp >= UTF8_1BYTE) + (cp >= UTF8_2BYTE) + (cp >= UTF8_3BYTE); },
       0,
-      thrust::plus());
+      cuda::std::plus());
   }
 
   __device__ void operator()(cudf::size_type idx)
@@ -473,7 +473,7 @@ rmm::device_uvector<cudf::size_type> compute_sizes(cudf::device_span<uint32_t co
       };
       auto const begin = d_data + idx;
       auto const end   = begin + MAX_NEW_CHARS;
-      return thrust::transform_reduce(thrust::seq, begin, end, tfn, 0, thrust::plus{});
+      return thrust::transform_reduce(thrust::seq, begin, end, tfn, 0, cuda::std::plus{});
     }));
 
   // DeviceSegmentedReduce is used to compute the size of each output row

--- a/cpp/src/text/subword/subword_tokenize.cu
+++ b/cpp/src/text/subword/subword_tokenize.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -209,7 +209,7 @@ tokenizer_result subword_tokenize(cudf::strings_column_view const& strings,
       return 1 + ((num_tokens - max_sequence_length + stride - 1) / stride);
     },
     uint32_t{0},
-    thrust::plus<uint32_t>());
+    cuda::std::plus<uint32_t>());
   // last element is the total number of output rows
   uint32_t const nrows_tensor_token_ids = offsets_per_tensor.element(strings_count, stream);
   // if there are no tokens at all, build a specific empty result

--- a/cpp/src/text/subword/wordpiece_tokenizer.cu
+++ b/cpp/src/text/subword/wordpiece_tokenizer.cu
@@ -548,7 +548,7 @@ void wordpiece_tokenizer::tokenize(uvector_pair& cps_and_offsets, rmm::cuda_stre
                                    device_tokens_per_word.data() + num_code_points,
                                    token_id_counts,
                                    tranform_fn{},
-                                   thrust::plus<uint32_t>());
+                                   cuda::std::plus<uint32_t>());
 
   // Update the device_strings_offsets using the token_id_counts
   thrust::for_each_n(rmm::exec_policy(stream),

--- a/cpp/tests/reductions/host_udf_example_tests.cu
+++ b/cpp/tests/reductions/host_udf_example_tests.cu
@@ -114,7 +114,7 @@ struct host_udf_reduction_example : cudf::reduce_host_udf {
                                                    thrust::make_counting_iterator(input.size()),
                                                    transform_fn{*input_dv_ptr},
                                                    static_cast<OutputType>(init_value),
-                                                   thrust::plus<>{});
+                                                   cuda::std::plus<>{});
 
       auto output = cudf::make_numeric_scalar(output_dtype, stream, mr);
       static_cast<cudf::scalar_type_t<OutputType>*>(output.get())->set_value(result, stream);


### PR DESCRIPTION
They are aliases to the libcu++ ones and we want to get rid of them