### PR TITLE
Fix cpp examples cmake to use the rapids_config.cmake

### DIFF
--- a/cpp/examples/set_cuda_architecture.cmake
+++ b/cpp/examples/set_cuda_architecture.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -14,12 +14,11 @@
 
 include(${CMAKE_CURRENT_LIST_DIR}/versions.cmake)
 
-if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/libcudf_cpp_examples_RAPIDS.cmake)
-  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/${CUDF_TAG}/RAPIDS.cmake
-       ${CMAKE_CURRENT_BINARY_DIR}/libcudf_cpp_examples_RAPIDS.cmake
-  )
-endif()
-include(${CMAKE_CURRENT_BINARY_DIR}/libcudf_cpp_examples_RAPIDS.cmake)
+# if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/libcudf_cpp_examples_RAPIDS.cmake) file(DOWNLOAD
+# https://raw.githubusercontent.com/rapidsai/rapids-cmake/${CUDF_TAG}/RAPIDS.cmake
+# ${CMAKE_CURRENT_BINARY_DIR}/libcudf_cpp_examples_RAPIDS.cmake ) endif()
+# include(${CMAKE_CURRENT_BINARY_DIR}/libcudf_cpp_examples_RAPIDS.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/rapids_config.cmake)
 
 include(rapids-cmake)
 include(rapids-cpm)

--- a/cpp/examples/set_cuda_architecture.cmake
+++ b/cpp/examples/set_cuda_architecture.cmake
@@ -14,10 +14,6 @@
 
 include(${CMAKE_CURRENT_LIST_DIR}/versions.cmake)
 
-# if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/libcudf_cpp_examples_RAPIDS.cmake) file(DOWNLOAD
-# https://raw.githubusercontent.com/rapidsai/rapids-cmake/${CUDF_TAG}/RAPIDS.cmake
-# ${CMAKE_CURRENT_BINARY_DIR}/libcudf_cpp_examples_RAPIDS.cmake ) endif()
-# include(${CMAKE_CURRENT_BINARY_DIR}/libcudf_cpp_examples_RAPIDS.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/rapids_config.cmake)
 
 include(rapids-cmake)


### PR DESCRIPTION
## Description
Fixes one of the cpp examples cmake to use the rapids_config.cmake
Reference #18473 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
