### PR TITLE
Replace deprecated host_buffer in favor of host_span in SourceInfo

### DIFF
--- a/python/pylibcudf/pylibcudf/io/types.pxd
+++ b/python/pylibcudf/pylibcudf/io/types.pxd
@@ -6,6 +6,7 @@ from libcpp.vector cimport vector
 from libcpp cimport bool
 from pylibcudf.libcudf.io.data_sink cimport data_sink
 from pylibcudf.libcudf.io.types cimport (
+    const_byte,
     column_encoding,
     column_in_metadata,
     column_name_info,
@@ -22,6 +23,8 @@ from pylibcudf.libcudf.io.types cimport (
     table_with_metadata,
 )
 from pylibcudf.libcudf.types cimport size_type
+from pylibcudf.libcudf.utilities.span cimport host_span
+
 from pylibcudf.table cimport Table
 from pylibcudf.libcudf.types cimport size_type
 from rmm.pylibrmm.stream cimport Stream
@@ -86,6 +89,7 @@ cdef class SourceInfo:
     # Keep the bytes converted from stringio alive
     # (otherwise we end up with a use after free when they get gc'ed)
     cdef list byte_sources
+    cdef vector[host_span[const_byte]] _hspans
 
 cdef class SinkInfo:
     # This vector just exists to keep the unique_ptrs to the sinks alive

--- a/python/pylibcudf/pylibcudf/io/types.pyx
+++ b/python/pylibcudf/pylibcudf/io/types.pyx
@@ -10,10 +10,10 @@ from pylibcudf.io.datasource cimport Datasource
 from pylibcudf.libcudf.io.data_sink cimport data_sink
 from pylibcudf.libcudf.io.datasource cimport datasource
 from pylibcudf.libcudf.io.types cimport (
+    const_byte,
     column_encoding,
     column_in_metadata,
     column_name_info,
-    host_buffer,
     partition_info,
     source_info,
     table_input_metadata,
@@ -22,6 +22,7 @@ from pylibcudf.libcudf.io.types cimport (
     table_input_metadata,
 )
 from pylibcudf.libcudf.types cimport size_type
+from pylibcudf.libcudf.utilities.span cimport host_span
 
 import codecs
 import errno
@@ -474,8 +475,9 @@ cdef class SourceInfo:
                     raise FileNotFoundError(
                         errno.ENOENT, os.strerror(errno.ENOENT), src
                     )
-                # TODO: Keep the sources alive (self.byte_sources = sources)
-                # for str data (e.g. read_json)?
+                # No need to keep sources alive. The file path strings are copied
+                # into C++, so there's no risk of use-after-free if the original
+                # Python objects are garbage-collected.
                 c_files.push_back(<string> str(src).encode())
 
             self.c_obj = move(source_info(c_files))
@@ -488,44 +490,51 @@ cdef class SourceInfo:
             self.c_obj = move(source_info(c_datasources))
             return
 
-        # TODO: host_buffer is deprecated API, use host_span instead
-        cdef vector[host_buffer] c_host_buffers
-        cdef const unsigned char[::1] c_buffer
-        cdef bint empty_buffer = False
         cdef list new_sources = []
+        cdef vector[host_span[const_byte]] hspans
+        self._hspans = hspans
 
         if isinstance(sources[0], io.StringIO):
             for buffer in sources:
                 if not isinstance(buffer, io.StringIO):
                     raise ValueError("All sources must be of the same type!")
+
                 new_sources.append(buffer.read().encode())
             sources = new_sources
             self.byte_sources = sources
         if isinstance(sources[0], bytes):
-            empty_buffer = True
-            for buffer in sources:
-                if not isinstance(buffer, bytes):
-                    raise ValueError("All sources must be of the same type!")
-                if (len(buffer) > 0):
-                    c_buffer = buffer
-                    c_host_buffers.push_back(host_buffer(<char*>&c_buffer[0],
-                                                         c_buffer.shape[0]))
-                    empty_buffer = False
+            self._init_byte_like_sources(sources, bytes)
         elif isinstance(sources[0], io.BytesIO):
-            for bio in sources:
-                if not isinstance(bio, io.BytesIO):
-                    raise ValueError("All sources must be of the same type!")
-                c_buffer = bio.getbuffer()  # check if empty?
-                c_host_buffers.push_back(host_buffer(<char*>&c_buffer[0],
-                                                     c_buffer.shape[0]))
+            self._init_byte_like_sources(sources, io.BytesIO)
         else:
             raise ValueError("Sources must be a list of str/paths, "
                              "bytes, io.BytesIO, io.StringIO, or a Datasource")
 
-        if empty_buffer is True:
-            c_host_buffers.push_back(host_buffer(<char*>NULL, 0))
+        self.c_obj = source_info(host_span[host_span[const_byte]](self._hspans))
 
-        self.c_obj = source_info(c_host_buffers)
+    def _init_byte_like_sources(self, list sources, type expected_type):
+        cdef const unsigned char[::1] c_buffer
+        cdef bint empty_buffer = True
+
+        for src in sources:
+            if not isinstance(src, expected_type):
+                raise ValueError("All sources must be of the same type!")
+
+            if expected_type is bytes:
+                c_buffer = src
+            else:
+                c_buffer = src.getbuffer()
+
+            if c_buffer.shape[0] > 0:
+                self._hspans.push_back(
+                    host_span[const_byte](<const_byte*>&c_buffer[0], c_buffer.shape[0])
+                )
+                empty_buffer = False
+
+        if empty_buffer:
+            # Not necessary, but future-proofs against libcudf code
+            # that might reject an empty host_span.
+            self._hspans.push_back(host_span[const_byte](<const_byte*>NULL, 0))
 
     __hash__ = None
 

--- a/python/pylibcudf/pylibcudf/libcudf/io/types.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/types.pxd
@@ -13,7 +13,13 @@ from libcpp.optional cimport optional
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.types cimport size_type
+from pylibcudf.libcudf.utilities.span cimport host_span
 
+cdef extern from "<cstddef>" namespace "std":
+    cdef cppclass byte:
+        pass
+
+ctypedef const byte const_byte
 
 cdef extern from "cudf/io/types.hpp" \
         namespace "cudf::io" nogil:
@@ -118,13 +124,6 @@ cdef extern from "cudf/io/types.hpp" \
             size_type start_row, size_type num_rows
         ) except +libcudf_exception_handler
 
-    cdef cppclass host_buffer:
-        const char* data
-        size_t size
-
-        host_buffer()
-        host_buffer(const char* data, size_t size)
-
     cdef cppclass source_info:
         const vector[string]& filepaths() except +libcudf_exception_handler
 
@@ -133,13 +132,17 @@ cdef extern from "cudf/io/types.hpp" \
             const vector[string] &filepaths
         ) except +libcudf_exception_handler
         source_info(
-            const vector[host_buffer] &host_buffers
-        ) except +libcudf_exception_handler
-        source_info(
             cudf_io_datasource.datasource *source
         ) except +libcudf_exception_handler
         source_info(
             const vector[cudf_io_datasource.datasource*] &datasources
+        ) except +libcudf_exception_handler
+        source_info(
+            const host_span[const_byte]& hspan
+        ) except +libcudf_exception_handler
+
+        source_info(
+            const host_span[host_span[const_byte]]& hspans
         ) except +libcudf_exception_handler
 
     cdef cppclass sink_info:

--- a/python/pylibcudf/pylibcudf/libcudf/utilities/span.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/utilities/span.pxd
@@ -8,6 +8,7 @@ cdef extern from "cudf/utilities/span.hpp" namespace "cudf" nogil:
     cdef cppclass host_span[T]:
         host_span() except +libcudf_exception_handler
         host_span(vector[T]) except +libcudf_exception_handler
+        host_span(T* data, size_type size) noexcept
 
     cdef cppclass device_span[T]:
         device_span() noexcept

--- a/python/pylibcudf/pylibcudf/tests/io/test_types.py
+++ b/python/pylibcudf/pylibcudf/tests/io/test_types.py
@@ -1,12 +1,25 @@
 # Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 import gc
+import io
 import weakref
 
 import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
+from utils import assert_table_and_meta_eq
 
 import pylibcudf as plc
+
+
+@pytest.fixture
+def pa_table():
+    return pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+
+
+@pytest.fixture
+def expected(pa_table):
+    return plc.interop.from_arrow(pa_table)
 
 
 @pytest.fixture
@@ -23,6 +36,16 @@ def parquet_data(tmp_path):
     return [path1, path2]
 
 
+@pytest.fixture
+def parquet_files(tmp_path, pa_table):
+    paths = []
+    for i in range(2):
+        path = tmp_path / f"file_{i}.parquet"
+        pq.write_table(pa_table, path)
+        paths.append(path)
+    return paths
+
+
 def test_gc_with_table_and_column_input_metadata():
     class Foo(plc.io.types.TableInputMetadata):
         def __del__(self):
@@ -34,6 +57,7 @@ def test_gc_with_table_and_column_input_metadata():
     plc_table = plc.interop.from_arrow(pa_table)
 
     tbl_meta = Foo(plc_table)
+
     weak_tbl_meta = weakref.ref(tbl_meta)
 
     del tbl_meta
@@ -53,6 +77,49 @@ def test_num_input_row_groups(parquet_data):
     source = plc.io.SourceInfo(parquet_data)
     options = plc.io.parquet.ParquetReaderOptions.builder(source).build()
     assert plc.io.parquet.read_parquet(options).num_input_row_groups == 2
+
+
+def test_sourceinfo_from_paths(parquet_files, pa_table):
+    source = plc.io.SourceInfo(parquet_files)
+    opts = plc.io.parquet.ParquetReaderOptions.builder(source).build()
+    res = plc.io.parquet.read_parquet(opts)
+    expected = pa.concat_tables([pa_table] * len(parquet_files))
+    assert_table_and_meta_eq(expected, res)
+
+
+def test_sourceinfo_from_bytes(pa_table):
+    buf = io.BytesIO()
+    pq.write_table(pa_table, buf)
+    source = plc.io.SourceInfo([buf.getvalue()])
+    opts = plc.io.parquet.ParquetReaderOptions.builder(source).build()
+    res = plc.io.parquet.read_parquet(opts)
+    expected = pa_table
+    assert_table_and_meta_eq(expected, res)
+
+
+def test_sourceinfo_from_bytesio(pa_table):
+    buf = io.BytesIO()
+    pq.write_table(pa_table, buf)
+    source = plc.io.SourceInfo([buf])
+    opts = plc.io.parquet.ParquetReaderOptions.builder(source).build()
+    res = plc.io.parquet.read_parquet(opts)
+    expected = pa_table
+    assert_table_and_meta_eq(expected, res)
+
+
+def test_sourceinfo_with_empty_bytesio():
+    # Test passing empty source
+    plc.io.SourceInfo([io.BytesIO(), io.BytesIO()])
+
+
+def test_sourceinfo_from_stringio(pa_table):
+    expected = pa_table
+    csv_data = "a,b\n1,x\n2,y\n3,z\n"
+
+    source = plc.io.SourceInfo([io.StringIO(csv_data)])
+    opts = plc.io.csv.CsvReaderOptions.builder(source).build()
+    res = plc.io.csv.read_csv(opts)
+    assert_table_and_meta_eq(expected, res)
 
 
 # TODO: Test more IO types


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Replaces uses of deprecated libcudf API `cudf::io::host_buffer` in pylibcudf. Also adds more tests for `SourceInfo`. We maybe able to remove it from libcudf in a follow-up PR.

Also added some related pieces in 18496. Will address merge conflicts depending on which one gets in first.
- https://github.com/rapidsai/cudf/pull/18496
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
