### PR TITLE
Optimize pandas metadata generation to reduce memory pressure

### DIFF
--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1538,7 +1538,9 @@ def generate_pandas_metadata(table: cudf.DataFrame, index: bool | None) -> str:
     types = []
     index_levels = []
     index_descriptors = []
-    columns_to_convert = list(table._columns)
+    df_meta = table.head(0)
+    columns_to_convert = list(df_meta._columns)
+
     # Columns
     for name, col in table._column_labels_and_values:
         if cudf.get_option("mode.pandas_compatible"):
@@ -1557,13 +1559,12 @@ def generate_pandas_metadata(table: cudf.DataFrame, index: bool | None) -> str:
             types.append(cudf_dtype_to_pa_type(col.dtype))
 
     # Indexes
-    materialize_index = False
     if index is not False:
         for level, name in enumerate(table.index.names):
-            if isinstance(table.index, cudf.MultiIndex):
-                idx = table.index.get_level_values(level)
+            if isinstance(df_meta.index, cudf.MultiIndex):
+                idx = df_meta.index.get_level_values(level)
             else:
-                idx = table.index
+                idx = df_meta.index
 
             if isinstance(idx, cudf.RangeIndex):
                 if index is None:
@@ -1575,23 +1576,23 @@ def generate_pandas_metadata(table: cudf.DataFrame, index: bool | None) -> str:
                         "step": table.index.step,
                     }
                 else:
-                    materialize_index = True
                     # When `index=True`, RangeIndex needs to be materialized.
-                    materialized_idx = idx._as_int_index()
+                    materialized_idx = df_meta.index._as_int_index()
+                    df_meta.index = materialized_idx
                     descr = _index_level_name(
                         index_name=materialized_idx.name,
                         level=level,
                         column_names=col_names,
                     )
                     index_levels.append(materialized_idx)
-                    columns_to_convert.append(materialized_idx._values)
+                    columns_to_convert.append(materialized_idx)
                     col_names.append(descr)
                     types.append(pa.from_numpy_dtype(materialized_idx.dtype))
             else:
                 descr = _index_level_name(
                     index_name=idx.name, level=level, column_names=col_names
                 )
-                columns_to_convert.append(idx._values)
+                columns_to_convert.append(idx)
                 col_names.append(descr)
                 if idx.dtype.kind == "b":
                     # A boolean element takes 8 bits in cudf and 1 bit in
@@ -1605,12 +1606,9 @@ def generate_pandas_metadata(table: cudf.DataFrame, index: bool | None) -> str:
                 index_levels.append(idx)
             index_descriptors.append(descr)
 
-    df_meta = table.head(0)
-    if materialize_index:
-        df_meta.index = df_meta.index._as_int_index()
     metadata = pa.pandas_compat.construct_metadata(
         columns_to_convert=columns_to_convert,
-        # It is OKAY to do `.head(0).to_pandas()` because
+        # It is OKAY to do `.to_pandas()` because
         # this method will extract `.columns` metadata only
         df=df_meta.to_pandas(),
         column_names=col_names,


### PR DESCRIPTION
## Description
This PR reduces memory pressure in pandas metadata generation by materializing a `0` sized index rather than full range-index.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
