### PR TITLE
Improve performance of strings split-record on whitespace

### DIFF
--- a/cpp/src/strings/split/split_record.cu
+++ b/cpp/src/strings/split/split_record.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,12 +146,15 @@ std::unique_ptr<column> whitespace_split_record_fn(strings_column_view const& in
                                                    rmm::device_async_resource_ref mr)
 {
   // create offsets column by counting the number of tokens per string
-  auto sizes_itr = cudf::detail::make_counting_transform_iterator(
-    0, cuda::proclaim_return_type<size_type>([reader] __device__(auto idx) {
-      return reader.count_tokens(idx);
-    }));
+  auto token_counts = rmm::device_uvector<size_type>(input.size(), stream);
+  thrust::transform(rmm::exec_policy_nosync(stream),
+                    thrust::make_counting_iterator<size_type>(0),
+                    thrust::make_counting_iterator<size_type>(input.size()),
+                    token_counts.begin(),
+                    cuda::proclaim_return_type<size_type>(
+                      [reader] __device__(auto idx) { return reader.count_tokens(idx); }));
   auto [offsets, total_tokens] =
-    cudf::detail::make_offsets_child_column(sizes_itr, sizes_itr + input.size(), stream, mr);
+    cudf::detail::make_offsets_child_column(token_counts.begin(), token_counts.end(), stream, mr);
   auto d_offsets = offsets->view().template data<cudf::size_type>();
 
   // split each string into an array of index-pair values


### PR DESCRIPTION
## Description
Improves the performance of `cudf::strings::split_record()` when specifying whitespace-split delimiter.
The change includes computing token counts into an intermediate buffer before computing offsets.
Result is up to a 2x performance improvement especially for longer strings.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
