### PR TITLE
Fix `print()` keyword argument in cudf pandas test

### DIFF
--- a/python/cudf/cudf_pandas_tests/test_main.py
+++ b/python/cudf/cudf_pandas_tests/test_main.py
@@ -82,7 +82,7 @@ def test_cudf_pandas_script_repl():
         "print(pd.Series(range(2)).sum())\n",
         "print(pd.Series(range(5)).sum())\n",
         "import sys\n",
-        "print(pd.Series(list('abcd')), out=sys.stderr)\n",
+        "print(pd.Series(list('abcd')), file=sys.stderr)\n",
     ]
 
     res = get_repl_output(p1, commands)


### PR DESCRIPTION
## Description
Not sure if this test is running in CI, but `print()` doesn't have an `out=` keyword argument:

```shell
$ python
Python 3.10.12 (main, Feb  4 2025, 14:57:36) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> print("hello", out=sys.stderr)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'out' is an invalid keyword argument for print()
>>> print("hello", file=sys.stderr)
hello
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
