### PR TITLE
Add ``Sort`` +  ``head/tail`` support to streaming cudf-polars executor

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -9,11 +9,6 @@ import operator
 from functools import reduce
 from typing import TYPE_CHECKING, Any
 
-import cudf_polars.experimental.groupby
-import cudf_polars.experimental.io
-import cudf_polars.experimental.join
-import cudf_polars.experimental.select
-import cudf_polars.experimental.shuffle  # noqa: F401
 from cudf_polars.dsl.ir import (
     IR,
     Cache,
@@ -23,6 +18,7 @@ from cudf_polars.dsl.ir import (
     MapFunction,
     Projection,
     Select,
+    Sort,
     Union,
 )
 from cudf_polars.dsl.traversal import CachingVisitor, traversal
@@ -312,3 +308,4 @@ generate_ir_tasks.register(GroupBy, _generate_ir_tasks_pwise)
 generate_ir_tasks.register(HStack, _generate_ir_tasks_pwise)
 generate_ir_tasks.register(MapFunction, _generate_ir_tasks_pwise)
 generate_ir_tasks.register(Select, _generate_ir_tasks_pwise)
+generate_ir_tasks.register(Sort, _generate_ir_tasks_pwise)

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -9,6 +9,12 @@ import operator
 from functools import reduce
 from typing import TYPE_CHECKING, Any
 
+import cudf_polars.experimental.groupby
+import cudf_polars.experimental.io
+import cudf_polars.experimental.join
+import cudf_polars.experimental.select
+import cudf_polars.experimental.shuffle
+import cudf_polars.experimental.sort  # noqa: F401
 from cudf_polars.dsl.ir import (
     IR,
     Cache,

--- a/python/cudf_polars/cudf_polars/experimental/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/sort.py
@@ -27,6 +27,7 @@ def _(
     # (May be a top- or bottom-k operation)
 
     if ir.zlice is not None and ir.zlice[0] < 1:
+        # TODO: Handle large slices (e.g. 1m+ rows)
         from cudf_polars.experimental.parallel import _lower_ir_pwise
 
         # Sort input partitions
@@ -41,8 +42,4 @@ def _(
         return new_node, partition_info
 
     # Fallback
-    return _lower_ir_fallback(
-        ir,
-        rec,
-        msg="Sort does not support multiple partitions.",
-    )
+    return _lower_ir_fallback(ir, rec, msg="Sort does not support multiple partitions.")

--- a/python/cudf_polars/cudf_polars/experimental/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/sort.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""Sorting Logic."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cudf_polars.dsl.ir import Sort
+from cudf_polars.experimental.base import PartitionInfo
+from cudf_polars.experimental.dispatch import lower_ir_node
+from cudf_polars.experimental.repartition import Repartition
+from cudf_polars.experimental.utils import _lower_ir_fallback
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
+    from cudf_polars.dsl.ir import IR
+    from cudf_polars.experimental.dispatch import LowerIRTransformer
+
+
+@lower_ir_node.register(Sort)
+def _(
+    ir: Sort, rec: LowerIRTransformer
+) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+    # Special handling for slicing
+    # (May be a top- or bottom-k operation)
+
+    if ir.zlice is not None and ir.zlice[0] < 1:
+        from cudf_polars.experimental.parallel import _lower_ir_pwise
+
+        # Sort input partitions
+        new_node, partition_info = _lower_ir_pwise(ir, rec)
+        if partition_info[new_node].count > 1:
+            # Collapse down to single partition
+            inter = Repartition(new_node.schema, new_node)
+            partition_info[inter] = PartitionInfo(count=1)
+            # Sort reduced partition
+            new_node = ir.reconstruct([inter])
+            partition_info[new_node] = PartitionInfo(count=1)
+        return new_node, partition_info
+
+    # Fallback
+    return _lower_ir_fallback(
+        ir,
+        rec,
+        msg="Sort does not support multiple partitions.",
+    )

--- a/python/cudf_polars/tests/experimental/test_sort.py
+++ b/python/cudf_polars/tests/experimental/test_sort.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+
+from cudf_polars.testing.asserts import DEFAULT_SCHEDULER, assert_gpu_result_equal
+
+
+@pytest.fixture(scope="module")
+def engine():
+    return pl.GPUEngine(
+        raise_on_fail=True,
+        executor="streaming",
+        executor_options={
+            "max_rows_per_partition": 3,
+            "scheduler": DEFAULT_SCHEDULER,
+            "shuffle_method": "tasks",
+            "fallback_mode": "raise",
+        },
+    )
+
+
+@pytest.fixture(scope="module")
+def df():
+    return pl.LazyFrame(
+        {
+            "x": [1, 2, 3, 4, 5, 6, 7],
+            "y": [1, 6, 7, 2, 5, 4, 3],
+            "z": ["e", "c", "b", "g", "a", "f", "d"],
+        }
+    )
+
+
+def test_sort(df, engine):
+    q = df.sort(by=["y", "z"])
+    with pytest.raises(
+        pl.exceptions.ComputeError, match="Sort does not support multiple partitions."
+    ):
+        assert_gpu_result_equal(q, engine=engine)
+
+
+def test_sort_head(df, engine):
+    q = df.sort(by=["y", "z"]).head(2)
+    assert_gpu_result_equal(q, engine=engine)
+
+
+def test_sort_tail(df, engine):
+    q = df.sort(by=["y", "z"]).tail(2)
+    assert_gpu_result_equal(q, engine=engine)


### PR DESCRIPTION
## Description
Should cover task "1(A)" of https://github.com/rapidsai/cudf/issues/18527

Adds `Sort` support to the "streaming" cudf-polars executor when the sort is followed by a `head`/`tails` operation. This functionality is needed for several TPCH queries. Shuffle-based sorting can be added in a follow-up.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
