### PR TITLE
Fix overflow for `MERGE_M2` groupby aggregation

### DIFF
--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -51,7 +51,7 @@ struct merge_fn {
   result_type const* d_means;
   result_type const* d_M2s;
 
-  auto __device__ operator()(size_type const group_idx) noexcept
+  auto __device__ operator()(size_type const group_idx) const
   {
     count_type n{0};
     result_type avg{0};

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -152,7 +152,7 @@ std::unique_ptr<column> group_merge_m2(column_view const& values,
 
   return count_type_id == type_id::INT64
            ? merge_m2<int64_t>(values, group_offsets, num_groups, stream, mr)
-           : merge_m2<double>(values, group_offsets, num_groups, stream, mr);
+           : merge_m2<result_type>(values, group_offsets, num_groups, stream, mr);
 }
 
 }  // namespace detail

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -64,8 +64,9 @@ struct accumulate_fn {
 
     auto const n_ab  = merge_vals.count + partial_vals.count;
     auto const delta = partial_vals.mean - merge_vals.mean;
-    merge_vals.M2 +=
-      partial_vals.M2 + (delta * delta) * merge_vals.count * partial_vals.count / n_ab;
+    merge_vals.M2 += partial_vals.M2 + (delta * delta) *
+                                         static_cast<result_type>(merge_vals.count) *
+                                         static_cast<result_type>(partial_vals.count) / n_ab;
     merge_vals.mean =
       (merge_vals.mean * merge_vals.count + partial_vals.mean * partial_vals.count) / n_ab;
     merge_vals.count = n_ab;

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -14,24 +14,20 @@
  * limitations under the License.
  */
 
-#include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/detail/valid_if.cuh>
-#include <cudf/dictionary/detail/iterator.cuh>
 #include <cudf/structs/structs_column_view.hpp>
-#include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/functional>
 #include <cuda/std/functional>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/reduce.h>
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
 
@@ -39,129 +35,69 @@ namespace cudf {
 namespace groupby {
 namespace detail {
 namespace {
-/**
- * @brief Struct to store partial results for merging.
- */
-template <class result_type>
-struct partial_result {
-  int64_t count;
-  result_type mean;
-  result_type M2;
-};
 
-/**
- * @brief Functor to accumulate (merge) all partial results corresponding to the same key into a
- * final result storing in a member variable. It performs merging for the partial results of
- * `COUNT_VALID`, `MEAN`, and `M2` at the same time.
- */
-template <class result_type>
-struct accumulate_fn {
-  partial_result<result_type> merge_vals;
-
-  void __device__ operator()(partial_result<result_type> const& partial_vals) noexcept
-  {
-    if (partial_vals.count == 0) { return; }
-
-    auto const n_ab  = merge_vals.count + partial_vals.count;
-    auto const delta = partial_vals.mean - merge_vals.mean;
-    merge_vals.M2 += partial_vals.M2 + (delta * delta) *
-                                         static_cast<result_type>(merge_vals.count) *
-                                         static_cast<result_type>(partial_vals.count) / n_ab;
-    merge_vals.mean =
-      (merge_vals.mean * merge_vals.count + partial_vals.mean * partial_vals.count) / n_ab;
-    merge_vals.count = n_ab;
-  }
-};
+using result_type = double;
+static_assert(
+  std::is_same_v<cudf::detail::target_type_t<result_type, aggregation::Kind::M2>, result_type>);
 
 /**
  * @brief Functor to merge partial results of `COUNT_VALID`, `MEAN`, and `M2` aggregations
  * for a given group (key) index.
  */
-template <class result_type>
+template <typename count_type>
 struct merge_fn {
-  size_type const* const d_offsets;
-  int64_t const* const d_counts;
-  result_type const* const d_means;
-  result_type const* const d_M2s;
+  size_type const* d_offsets;
+  count_type const* d_counts;
+  result_type const* d_means;
+  result_type const* d_M2s;
 
   auto __device__ operator()(size_type const group_idx) noexcept
   {
+    count_type n{0};
+    result_type avg{0};
+    result_type m2{0};
+
     auto const start_idx = d_offsets[group_idx], end_idx = d_offsets[group_idx + 1];
-
-    // This case should never happen, because all groups are non-empty as the results of
-    // aggregation. Here we just to make sure we cover this case.
-    if (start_idx == end_idx) {
-      return thrust::make_tuple(int64_t{0}, result_type{0}, result_type{0}, int8_t{0});
+    for (auto idx = start_idx; idx < end_idx; ++idx) {
+      auto const partial_n = d_counts[idx];
+      if (partial_n == 0) { continue; }
+      auto const partial_avg = d_means[idx];
+      auto const partial_m2  = d_M2s[idx];
+      auto const new_n       = n + partial_n;
+      auto const delta       = partial_avg - avg;
+      m2 += partial_m2 + delta * delta * n * partial_n / new_n;
+      avg = (avg * n + partial_avg * partial_n) / new_n;
+      n   = new_n;
     }
-
-    // If `(n = d_counts[idx]) > 0` then `d_means[idx] != null` and `d_M2s[idx] != null`.
-    // Otherwise (`n == 0`), these value (mean and M2) will always be nulls.
-    // In such cases, reading `mean` and `M2` from memory will return garbage values.
-    // By setting these values to zero when `n == 0`, we can safely merge the all-zero tuple without
-    // affecting the final result.
-    auto get_partial_result = [&] __device__(size_type idx) {
-      {
-        auto const n = d_counts[idx];
-        return n > 0 ? partial_result<result_type>{n, d_means[idx], d_M2s[idx]}
-                     : partial_result<result_type>{int64_t{0}, result_type{0}, result_type{0}};
-      };
-    };
-
-    // Firstly, store tuple(count, mean, M2) of the first partial result in an accumulator.
-    auto accumulator = accumulate_fn<result_type>{get_partial_result(start_idx)};
-
-    // Then, accumulate (merge) the remaining partial results into that accumulator.
-    for (auto idx = start_idx + 1; idx < end_idx; ++idx) {
-      accumulator(get_partial_result(idx));
-    }
-
-    // Get the final result after merging.
-    auto const& merge_vals = accumulator.merge_vals;
 
     // If there are all nulls in the partial results (i.e., sum of all valid counts is
     // zero), then the output is a null.
-    auto const is_valid = int8_t{merge_vals.count > 0};
-
-    return thrust::make_tuple(merge_vals.count, merge_vals.mean, merge_vals.M2, is_valid);
+    auto const is_valid = n > 0;
+    return thrust::make_tuple(n, avg, m2, is_valid);
   }
 };
 
-}  // namespace
-
-std::unique_ptr<column> group_merge_m2(column_view const& values,
-                                       cudf::device_span<size_type const> group_offsets,
-                                       size_type num_groups,
-                                       rmm::cuda_stream_view stream,
-                                       rmm::device_async_resource_ref mr)
+template <typename count_type>
+std::unique_ptr<column> merge_m2(column_view const& values,
+                                 cudf::device_span<size_type const> group_offsets,
+                                 size_type num_groups,
+                                 rmm::cuda_stream_view stream,
+                                 rmm::device_async_resource_ref mr)
 {
-  CUDF_EXPECTS(values.type().id() == type_id::STRUCT,
-               "Input to `group_merge_m2` must be a structs column.");
-  CUDF_EXPECTS(values.num_children() == 3,
-               "Input to `group_merge_m2` must be a structs column having 3 children columns.");
-
-  using result_type = id_to_type<type_id::FLOAT64>;
-  static_assert(
-    std::is_same_v<cudf::detail::target_type_t<result_type, aggregation::Kind::M2>, result_type>);
-  CUDF_EXPECTS(values.child(0).type().id() == type_id::INT64 &&
-                 values.child(1).type().id() == type_to_id<result_type>() &&
-                 values.child(2).type().id() == type_to_id<result_type>(),
-               "Input to `group_merge_m2` must be a structs column having children columns "
-               "containing tuples of (M2_value, mean, valid_count).");
-
   auto result_counts = make_numeric_column(
-    data_type(type_to_id<int64_t>()), num_groups, mask_state::UNALLOCATED, stream, mr);
+    data_type(type_to_id<count_type>()), num_groups, mask_state::UNALLOCATED, stream, mr);
   auto result_means = make_numeric_column(
     data_type(type_to_id<result_type>()), num_groups, mask_state::UNALLOCATED, stream, mr);
   auto result_M2s = make_numeric_column(
     data_type(type_to_id<result_type>()), num_groups, mask_state::UNALLOCATED, stream, mr);
-  auto validities = rmm::device_uvector<int8_t>(num_groups, stream);
+  auto validities = rmm::device_uvector<bool>(num_groups, stream);
 
   // Perform merging for all the aggregations. Their output (and their validity data) are written
   // out concurrently through an output zip iterator.
-  using iterator_tuple  = thrust::tuple<int64_t*, result_type*, result_type*, int8_t*>;
+  using iterator_tuple  = thrust::tuple<count_type*, result_type*, result_type*, bool*>;
   using output_iterator = thrust::zip_iterator<iterator_tuple>;
   auto const out_iter =
-    output_iterator{thrust::make_tuple(result_counts->mutable_view().template data<int64_t>(),
+    output_iterator{thrust::make_tuple(result_counts->mutable_view().template data<count_type>(),
                                        result_means->mutable_view().template data<result_type>(),
                                        result_M2s->mutable_view().template data<result_type>(),
                                        validities.begin())};
@@ -171,11 +107,11 @@ std::unique_ptr<column> group_merge_m2(column_view const& values,
   auto const M2_values   = values.child(2);
   auto const iter        = thrust::make_counting_iterator<size_type>(0);
 
-  auto const fn = merge_fn<result_type>{group_offsets.begin(),
-                                        count_valid.template begin<int64_t>(),
-                                        mean_values.template begin<result_type>(),
-                                        M2_values.template begin<result_type>()};
-  thrust::transform(rmm::exec_policy(stream), iter, iter + num_groups, out_iter, fn);
+  auto const fn = merge_fn<count_type>{group_offsets.begin(),
+                                       count_valid.template begin<count_type>(),
+                                       mean_values.template begin<result_type>(),
+                                       M2_values.template begin<result_type>()};
+  thrust::transform(rmm::exec_policy_nosync(stream), iter, iter + num_groups, out_iter, fn);
 
   // Generate bitmask for the output.
   // Only mean and M2 values can be nullable. Count column must be non-nullable.
@@ -191,10 +127,32 @@ std::unique_ptr<column> group_merge_m2(column_view const& values,
   out_columns.emplace_back(std::move(result_counts));
   out_columns.emplace_back(std::move(result_means));
   out_columns.emplace_back(std::move(result_M2s));
-  auto result = cudf::make_structs_column(
+  return cudf::make_structs_column(
     num_groups, std::move(out_columns), 0, rmm::device_buffer{0, stream, mr}, stream, mr);
+}
 
-  return result;
+}  // namespace
+
+std::unique_ptr<column> group_merge_m2(column_view const& values,
+                                       cudf::device_span<size_type const> group_offsets,
+                                       size_type num_groups,
+                                       rmm::cuda_stream_view stream,
+                                       rmm::device_async_resource_ref mr)
+{
+  CUDF_EXPECTS(values.type().id() == type_id::STRUCT,
+               "Input to `group_merge_m2` must be a structs column.");
+  CUDF_EXPECTS(values.num_children() == 3,
+               "Input to `group_merge_m2` must be a structs column having 3 children columns.");
+
+  auto const count_type_id = values.child(0).type().id();
+  CUDF_EXPECTS((count_type_id == type_id::INT64 || count_type_id == type_id::FLOAT64) &&
+                 values.child(1).type().id() == type_to_id<result_type>() &&
+                 values.child(2).type().id() == type_to_id<result_type>(),
+               "Input to `group_merge_m2` has invalid children type.");
+
+  return count_type_id == type_id::INT64
+           ? merge_m2<int64_t>(values, group_offsets, num_groups, stream, mr)
+           : merge_m2<double>(values, group_offsets, num_groups, stream, mr);
 }
 
 }  // namespace detail

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -64,9 +64,8 @@ struct accumulate_fn {
 
     auto const n_ab  = merge_vals.count + partial_vals.count;
     auto const delta = partial_vals.mean - merge_vals.mean;
-    merge_vals.M2 += partial_vals.M2 + (delta * delta) *
-                                         static_cast<result_type>(merge_vals.count) *
-                                         static_cast<result_type>(partial_vals.count) / n_ab;
+    merge_vals.M2 +=
+      partial_vals.M2 + (delta * delta) * merge_vals.count * partial_vals.count / n_ab;
     merge_vals.mean =
       (merge_vals.mean * merge_vals.count + partial_vals.mean * partial_vals.count) / n_ab;
     merge_vals.count = n_ab;

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -24,12 +24,11 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <cuda/functional>
 #include <cuda/std/functional>
-#include <cuda/std/tuple>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
+#include <thrust/tuple.h>
 
 namespace cudf {
 namespace groupby {
@@ -73,7 +72,7 @@ struct merge_fn {
     // If there are all nulls in the partial results (i.e., sum of all valid counts is
     // zero), then the output is a null.
     auto const is_valid = n > 0;
-    return cuda::std::tuple{n, avg, m2, is_valid};
+    return thrust::tuple{n, avg, m2, is_valid};
   }
 };
 

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -44,7 +44,7 @@ namespace {
  */
 template <class result_type>
 struct partial_result {
-  size_type count;
+  result_type count;
   result_type mean;
   result_type M2;
 };
@@ -80,7 +80,7 @@ struct accumulate_fn {
 template <class result_type>
 struct merge_fn {
   size_type const* const d_offsets;
-  size_type const* const d_counts;
+  result_type const* const d_counts;
   result_type const* const d_means;
   result_type const* const d_M2s;
 
@@ -91,7 +91,7 @@ struct merge_fn {
     // This case should never happen, because all groups are non-empty as the results of
     // aggregation. Here we just to make sure we cover this case.
     if (start_idx == end_idx) {
-      return thrust::make_tuple(size_type{0}, result_type{0}, result_type{0}, int8_t{0});
+      return thrust::make_tuple(result_type{0}, result_type{0}, result_type{0}, int8_t{0});
     }
 
     // If `(n = d_counts[idx]) > 0` then `d_means[idx] != null` and `d_M2s[idx] != null`.
@@ -103,7 +103,7 @@ struct merge_fn {
       {
         auto const n = d_counts[idx];
         return n > 0 ? partial_result<result_type>{n, d_means[idx], d_M2s[idx]}
-                     : partial_result<result_type>{size_type{0}, result_type{0}, result_type{0}};
+                     : partial_result<result_type>{result_type{0}, result_type{0}, result_type{0}};
       };
     };
 
@@ -142,14 +142,14 @@ std::unique_ptr<column> group_merge_m2(column_view const& values,
   using result_type = id_to_type<type_id::FLOAT64>;
   static_assert(
     std::is_same_v<cudf::detail::target_type_t<result_type, aggregation::Kind::M2>, result_type>);
-  CUDF_EXPECTS(values.child(0).type().id() == type_id::INT32 &&
+  CUDF_EXPECTS(values.child(0).type().id() == type_to_id<result_type>() &&
                  values.child(1).type().id() == type_to_id<result_type>() &&
                  values.child(2).type().id() == type_to_id<result_type>(),
                "Input to `group_merge_m2` must be a structs column having children columns "
                "containing tuples of (M2_value, mean, valid_count).");
 
   auto result_counts = make_numeric_column(
-    data_type(type_to_id<size_type>()), num_groups, mask_state::UNALLOCATED, stream, mr);
+    data_type(type_to_id<result_type>()), num_groups, mask_state::UNALLOCATED, stream, mr);
   auto result_means = make_numeric_column(
     data_type(type_to_id<result_type>()), num_groups, mask_state::UNALLOCATED, stream, mr);
   auto result_M2s = make_numeric_column(
@@ -158,10 +158,10 @@ std::unique_ptr<column> group_merge_m2(column_view const& values,
 
   // Perform merging for all the aggregations. Their output (and their validity data) are written
   // out concurrently through an output zip iterator.
-  using iterator_tuple  = thrust::tuple<size_type*, result_type*, result_type*, int8_t*>;
+  using iterator_tuple  = thrust::tuple<result_type*, result_type*, result_type*, int8_t*>;
   using output_iterator = thrust::zip_iterator<iterator_tuple>;
   auto const out_iter =
-    output_iterator{thrust::make_tuple(result_counts->mutable_view().template data<size_type>(),
+    output_iterator{thrust::make_tuple(result_counts->mutable_view().template data<result_type>(),
                                        result_means->mutable_view().template data<result_type>(),
                                        result_M2s->mutable_view().template data<result_type>(),
                                        validities.begin())};
@@ -172,7 +172,7 @@ std::unique_ptr<column> group_merge_m2(column_view const& values,
   auto const iter        = thrust::make_counting_iterator<size_type>(0);
 
   auto const fn = merge_fn<result_type>{group_offsets.begin(),
-                                        count_valid.template begin<size_type>(),
+                                        count_valid.template begin<result_type>(),
                                         mean_values.template begin<result_type>(),
                                         M2_values.template begin<result_type>()};
   thrust::transform(rmm::exec_policy(stream), iter, iter + num_groups, out_iter, fn);

--- a/cpp/tests/groupby/merge_m2_tests.cpp
+++ b/cpp/tests/groupby/merge_m2_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 #include <cudf/detail/aggregation/aggregation.hpp>
 #include <cudf/groupby.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/unary.hpp>
 
 using namespace cudf::test::iterators;
 
@@ -66,7 +67,11 @@ auto compute_partial_results(cudf::column_view const& keys, cudf::column_view co
   auto gb_obj                  = cudf::groupby::groupby(cudf::table_view({keys}));
   auto [out_keys, out_results] = gb_obj.aggregate(requests);
 
-  auto const num_output_rows = out_keys->num_rows();
+  // Cast the `COUNT_VALID` column to `INT64` type.
+  out_results[0].results.front() = cudf::cast(out_results[0].results.front()->view(),
+                                              cudf::data_type(cudf::type_id::INT64),
+                                              cudf::get_default_stream());
+  auto const num_output_rows     = out_keys->num_rows();
   return std::pair(std::move(out_keys->release()[0]),
                    cudf::make_structs_column(
                      num_output_rows, std::move(out_results[0].results), 0, rmm::device_buffer{}));
@@ -123,13 +128,15 @@ TYPED_TEST(GroupbyMergeM2TypedTest, InvalidInput)
     EXPECT_THROW(merge_M2({keys}, {vals}), cudf::logic_error);
   }
 
-  // The input column must be a structs column having types (int32_t, double, double).
+  // The input column must be a structs column having types (int64_t/double, double, double).
   {
-    auto vals1      = keys_col<T>{1, 2, 3};
-    auto vals2      = keys_col<T>{1, 2, 3};
-    auto vals3      = keys_col<T>{1, 2, 3};
-    auto const vals = structs_col{vals1, vals2, vals3};
-    EXPECT_THROW(merge_M2({keys}, {vals}), cudf::logic_error);
+    if constexpr (!std::is_same_v<T, double>) {
+      auto vals1      = keys_col<T>{1, 2, 3};
+      auto vals2      = keys_col<T>{1, 2, 3};
+      auto vals3      = keys_col<T>{1, 2, 3};
+      auto const vals = structs_col{vals1, vals2, vals3};
+      EXPECT_THROW(merge_M2({keys}, {vals}), cudf::logic_error);
+    }
   }
 }
 

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -7867,45 +7867,45 @@ public class TableTest extends CudfTestBase {
   @Test
   void testGroupByMergeM2() {
     StructType nestedType = new StructType(false,
-        new BasicType(true, DType.INT32),
+        new BasicType(true, DType.INT64),
         new BasicType(true, DType.FLOAT64),
         new BasicType(true, DType.FLOAT64));
 
     try (Table partialResults1 = new Table.TestBuilder()
              .column(1, 2, 3, 4)
              .column(nestedType,
-                 struct(1, 0.0, 0.0),
-                 struct(1, 1.0, 0.0),
-                 struct(0, null, null),
-                 struct(0, null, null))
+                 struct(1L, 0.0, 0.0),
+                 struct(1L, 1.0, 0.0),
+                 struct(0L, null, null),
+                 struct(0L, null, null))
              .build();
          Table partialResults2 = new Table.TestBuilder()
              .column(1, 2, 3)
              .column(nestedType,
-                 struct(1, 3.0, 0.0),
-                 struct(1, 4.0, 0.0),
-                 struct(1, 2.0, 0.0))
+                 struct(1L, 3.0, 0.0),
+                 struct(1L, 4.0, 0.0),
+                 struct(1L, 2.0, 0.0))
              .build();
          Table partialResults3 = new Table.TestBuilder()
              .column(1, 2)
              .column(nestedType,
-                 struct(1, 6.0, 0.0),
-                 struct(1, Double.NaN, Double.NaN))
+                 struct(1L, 6.0, 0.0),
+                 struct(1L, Double.NaN, Double.NaN))
              .build();
          Table partialResults4 = new Table.TestBuilder()
              .column(2, 3, 4)
              .column(nestedType,
-                 struct(1, 9.0, 0.0),
-                 struct(1, 8.0, 0.0),
-                 struct(2, Double.NaN, Double.NaN))
+                 struct(1L, 9.0, 0.0),
+                 struct(1L, 8.0, 0.0),
+                 struct(2L, Double.NaN, Double.NaN))
              .build();
          Table expected = new Table.TestBuilder()
              .column(1, 2, 3, 4)
              .column(nestedType,
-                 struct(3, 3.0, 18.0),
-                 struct(4, Double.NaN, Double.NaN),
-                 struct(2, 5.0, 18.0),
-                 struct(2, Double.NaN, Double.NaN))
+                 struct(3L, 3.0, 18.0),
+                 struct(4L, Double.NaN, Double.NaN),
+                 struct(2L, 5.0, 18.0),
+                 struct(2L, Double.NaN, Double.NaN))
              .build()) {
       try (Table concatenatedResults = Table.concatenate(
              partialResults1,


### PR DESCRIPTION
This fixes an overflow issue for the `MERGE_M2` groupby aggregation that has been reported in https://github.com/NVIDIA/spark-rapids/issues/12468. In particular, the current implementation of this aggregation requires the `count` input to be a column of type `INT32`, which cannot handle groups with sizes larger than `INT_MAX` (2B rows). To fix that, `count` type is changed to a wider type, which can be either `INT64` or `FLOAT64`.

This is also a breaking change and requires the downstream applications (Spark-Rapids) to change the corresponding data structure.