### PR TITLE
Adjust cudf Python groupby test for cuCollections update

### DIFF
--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -259,7 +259,7 @@ Examples
 >>> df = cudf.DataFrame({"key": [1, 1, 2], "a": [-1, 0, 1], 1: [10, 11, 12]})
 >>> agg_a = cudf.NamedAgg(column="a", aggfunc="min")
 >>> agg_1 = cudf.NamedAgg(column=1, aggfunc=lambda x: x.mean())
->>> df.groupby("key").agg(result_a=agg_a, result_1=agg_1)
+>>> df.groupby("key", sort=True).agg(result_a=agg_a, result_1=agg_1)
         result_a  result_1
 key
 1          -1      10.5

--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -4096,14 +4096,14 @@ def test_size_as_index_false():
     df = pd.DataFrame({"a": [1, 2, 1], "b": [1, 2, 3]}, columns=["a", "b"])
     expected = df.groupby("a", as_index=False).size()
     result = cudf.from_pandas(df).groupby("a", as_index=False).size()
-    assert_eq(result, expected)
+    assert_groupby_results_equal(result, expected, as_index=False, by="a")
 
 
 def test_size_series_with_name():
     ser = pd.Series(range(3), name="foo")
     expected = ser.groupby(ser).size()
     result = cudf.from_pandas(ser).groupby(ser).size()
-    assert_eq(result, expected)
+    assert_groupby_results_equal(result, expected)
 
 
 @pytest.mark.parametrize("op", ["cumsum", "cumprod", "cummin", "cummax"])
@@ -4131,4 +4131,4 @@ def test_agg_duplicate_aggs_pandas_compat_raises():
         index=cudf.Index([1, 2], name="a"),
         columns=pd.MultiIndex.from_tuples([("b", "mean")]),
     )
-    assert_eq(result, expected)
+    assert_groupby_results_equal(result, expected)


### PR DESCRIPTION
## Description
Broken off from https://github.com/rapidsai/cudf/pull/18541/files, adjusting some groupby test (including a doctest) to be more order agnostic as an expected difference between cudf and pandas and happened to fail with an cuCollections update

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
