### PR TITLE
Optimize  `to_cupy` and `.values`

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -8,6 +8,7 @@ from collections import abc
 from typing import TYPE_CHECKING, Any, Literal
 
 import cupy
+import cupy as cp
 import numpy
 import numpy as np
 import pyarrow as pa
@@ -548,6 +549,10 @@ class Frame(BinaryOperand, Scannable, Serializable):
         -------
         cupy.ndarray
         """
+        if self.ndim == 1 and not copy and dtype is None and na_value is None:
+            col = self._columns[0]
+            if not col.has_nulls():
+                return cp.asarray(col)
         return self._to_array(
             lambda col: col.values,
             cupy,

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import cupy as cp
 from typing_extensions import Self
 
 import cudf
@@ -106,7 +107,7 @@ class SingleColumnFrame(Frame, NotIterable):
     @property  # type: ignore
     @_performance_tracking
     def values(self) -> cupy.ndarray:
-        return self._column.values
+        return cp.asarray(self)
 
     @property  # type: ignore
     @_performance_tracking


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
- Closes #11648 
```
Series<int8>:
  series.values      : 186.90 µs
  series.to_cupy()   : 45.56 µs
  cp.asarray(series) : 35.20 µs

Series<int16>:
  series.values      : 93.56 µs
  series.to_cupy()   : 32.74 µs
  cp.asarray(series) : 34.47 µs

Series<int32>:
  series.values      : 108.63 µs
  series.to_cupy()   : 32.48 µs
  cp.asarray(series) : 31.05 µs

Series<int64>:
  series.values      : 124.96 µs
  series.to_cupy()   : 36.73 µs
  cp.asarray(series) : 30.73 µs

Series<uint8>:
  series.values      : 79.11 µs
  series.to_cupy()   : 30.24 µs
  cp.asarray(series) : 29.50 µs

Series<uint16>:
  series.values      : 90.13 µs
  series.to_cupy()   : 30.77 µs
  cp.asarray(series) : 30.70 µs

Series<uint32>:
  series.values      : 118.15 µs
  series.to_cupy()   : 33.36 µs
  cp.asarray(series) : 30.76 µs

Series<uint64>:
  series.values      : 118.12 µs
  series.to_cupy()   : 32.72 µs
  cp.asarray(series) : 38.75 µs

Series<float32>:
  series.values      : 109.73 µs
  series.to_cupy()   : 32.61 µs
  cp.asarray(series) : 28.21 µs

Series<float64>:
  series.values      : 112.43 µs
  series.to_cupy()   : 30.65 µs
  cp.asarray(series) : 29.91 µs

Series<bool>:
  series.values      : 92.39 µs
  series.to_cupy()   : 29.27 µs
  cp.asarray(series) : 29.29 µs
```
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
