### PR TITLE
Allow .iloc with cuDF objects as column indexers

### DIFF
--- a/python/cudf/cudf/core/indexing_utils.py
+++ b/python/cudf/cudf/core/indexing_utils.py
@@ -145,7 +145,8 @@ def destructure_dataframe_iloc_indexer(
     rows, cols = destructure_iloc_key(key, frame)
     if cols is Ellipsis:
         cols = slice(None)
-    scalar = is_integer(cols)
+    elif isinstance(cols, (cudf.Series, cudf.Index)):
+        cols = cols.to_pandas()
     try:
         column_names: ColumnLabels = list(
             frame._data.get_labels_by_index(cols)
@@ -154,6 +155,7 @@ def destructure_dataframe_iloc_indexer(
         raise TypeError(
             "Column indices must be integers, slices, or list-like of integers"
         )
+    scalar = is_integer(cols)
     if scalar:
         assert len(column_names) == 1, (
             "Scalar column indexer should not produce more than one column"

--- a/python/cudf/cudf/tests/test_indexing.py
+++ b/python/cudf/cudf/tests/test_indexing.py
@@ -2397,3 +2397,12 @@ def test_slice_empty_columns(indexer, column_slice):
     result = getattr(df_cudf, indexer)[:, column_slice]
     expected = getattr(df_pd, indexer)[:, column_slice]
     assert_eq(result, expected)
+
+
+@pytest.mark.parametrize("obj", [cudf.Series, cudf.Index])
+def test_iloc_columns_with_cudf_object(obj):
+    data = {"a": [1, 2], "c": [0, 2], "d": ["c", "a"]}
+    col_indexer = obj([0, 2])
+    result = cudf.DataFrame(data).iloc[:, col_indexer]
+    expected = pd.DataFrame(data).iloc[:, col_indexer.to_pandas()]
+    assert_eq(result, expected)


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/18556

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
