### PR TITLE
Support `plc.Scalar.from_py(None)` and `plc.Scalar.from_py(int, float type)`

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -266,8 +266,8 @@ class StringFunction(Expr):
             return Column(
                 plc.strings.slice.slice_strings(
                     column.obj,
-                    plc.interop.from_arrow(pa.scalar(start, type=pa.int32())),
-                    plc.interop.from_arrow(pa.scalar(stop, type=pa.int32())),
+                    plc.Scalar.from_py(start, plc.DataType(plc.TypeId.INT32)),
+                    plc.Scalar.from_py(stop, plc.DataType(plc.TypeId.INT32)),
                 )
             )
         elif self.name in {

--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -219,8 +219,8 @@ class StringFunction(Expr):
             return Column(
                 plc.strings.combine.join_strings(
                     column.obj,
-                    plc.interop.from_arrow(pa.scalar(delimiter, type=pa.string())),
-                    plc.interop.from_arrow(pa.scalar(None, type=pa.string())),
+                    plc.Scalar.from_py(delimiter, plc.DataType(plc.TypeId.STRING)),
+                    plc.Scalar.from_py(None, plc.DataType(plc.TypeId.STRING)),
                 )
             )
         elif self.name is StringFunction.Name.Contains:
@@ -338,8 +338,7 @@ class StringFunction(Expr):
                 not_timestamps = plc.unary.unary_operation(
                     is_timestamps, plc.unary.UnaryOperator.NOT
                 )
-
-                null = plc.interop.from_arrow(pa.scalar(None, type=pa.string()))
+                null = plc.Scalar.from_py(None, plc.DataType(plc.TypeId.STRING))
                 res = plc.copying.boolean_mask_scatter(
                     [null], plc.Table([col.obj]), not_timestamps
                 )

--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 import operator
 from typing import TYPE_CHECKING, Any
 
-import pyarrow as pa
-
 import pylibcudf as plc
 import rmm.mr
 from rmm.pylibrmm.stream import DEFAULT_STREAM
@@ -152,7 +150,7 @@ def _partition_dataframe(
         plc.hashing.murmurhash3_x86_32(
             DataFrame([expr.evaluate(df) for expr in keys]).table
         ),
-        plc.interop.from_arrow(pa.scalar(count, type="uint32")),
+        plc.Scalar.from_py(count, plc.DataType(plc.TypeId.UINT32)),
         plc.binaryop.BinaryOperator.PYMOD,
         plc.types.DataType(plc.types.TypeId.UINT32),
     )

--- a/python/pylibcudf/pylibcudf/libcudf/scalar/scalar_factories.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/scalar/scalar_factories.pxd
@@ -20,3 +20,6 @@ cdef extern from "cudf/scalar/scalar_factories.hpp" namespace "cudf" nogil:
     cdef unique_ptr[scalar] make_empty_scalar_like(
         const column_view &
     ) except +libcudf_exception_handler
+    cdef unique_ptr[scalar] make_default_constructed_scalar(
+        data_type type_
+    ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -21,6 +21,7 @@ from pylibcudf.libcudf.scalar.scalar cimport (
     numeric_scalar,
 )
 from pylibcudf.libcudf.scalar.scalar_factories cimport (
+    make_default_constructed_scalar,
     make_empty_scalar_like,
     make_string_scalar,
     make_numeric_scalar,
@@ -117,7 +118,8 @@ cdef class Scalar:
 
         Parameters
         ----------
-        py_val: bool, int, float, str, datetime.datetime, datetime.timedelta, list, dict
+        py_val: None, bool, int, float, str,
+                datetime.datetime, datetime.timedelta, list, dict
             Value to convert to a pylibcudf.Scalar
         dtype: DataType | None
             The datatype to cast the value to. If None,
@@ -158,6 +160,17 @@ cdef Scalar _new_scalar(unique_ptr[scalar] c_obj, DataType dtype):
 @singledispatch
 def _from_py(py_val, dtype: DataType | None):
     raise TypeError(f"{type(py_val).__name__} cannot be converted to pylibcudf.Scalar")
+
+
+@_from_py.register(type(None))
+def _(py_val, dtype: DataType | None):
+    cdef DataType c_dtype
+    if dtype is None:
+        raise ValueError("Must specify a dtype for a None value.")
+    else:
+        c_dtype = <DataType>dtype
+    cdef unique_ptr[scalar] c_obj = make_default_constructed_scalar(c_dtype.c_obj)
+    return _new_scalar(move(c_obj), dtype)
 
 
 @_from_py.register(dict)

--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -32,6 +32,7 @@ from pylibcudf.libcudf.types cimport type_id
 from rmm.pylibrmm.memory_resource cimport get_current_device_resource
 
 from .column cimport Column
+from .traits cimport is_floating_point
 from .types cimport DataType
 from functools import singledispatch
 
@@ -214,6 +215,8 @@ def _(py_val: int, dtype: DataType | None):
     cdef DataType c_dtype
     if dtype is None:
         c_dtype = DataType(type_id.INT64)
+    elif is_floating_point(dtype):
+        return _from_py(float(py_val), dtype)
     else:
         c_dtype = <DataType>dtype
     tid = c_dtype.id()

--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -119,8 +119,7 @@ cdef class Scalar:
 
         Parameters
         ----------
-        py_val: None, bool, int, float, str,
-                datetime.datetime, datetime.timedelta, list, dict
+        py_val: None, bool, int, float, str, datetime, timedelta, list, dict
             Value to convert to a pylibcudf.Scalar
         dtype: DataType | None
             The datatype to cast the value to. If None,

--- a/python/pylibcudf/pylibcudf/tests/test_scalar.py
+++ b/python/pylibcudf/pylibcudf/tests/test_scalar.py
@@ -33,6 +33,7 @@ def test_from_py(val):
         (1, TypeId.UINT16),
         (1, TypeId.UINT32),
         (1, TypeId.UINT64),
+        (1, TypeId.FLOAT32),
         (1.0, TypeId.FLOAT32),
         (1.5, TypeId.FLOAT64),
         ("str", TypeId.STRING),
@@ -72,18 +73,6 @@ def test_from_py_with_dtype(val, tid):
             TypeId.UINT64,
             ValueError,
             "Cannot assign negative value to UINT64 scalar",
-        ),
-        (
-            1,
-            TypeId.FLOAT32,
-            TypeError,
-            "Cannot convert int to Scalar with dtype FLOAT32",
-        ),
-        (
-            1,
-            TypeId.FLOAT64,
-            TypeError,
-            "Cannot convert int to Scalar with dtype FLOAT64",
         ),
         (
             1,
@@ -147,10 +136,20 @@ def test_from_py_notimplemented(val):
         plc.Scalar.from_py(val)
 
 
-@pytest.mark.parametrize("val", [object, None])
-def test_from_py_typeerror(val):
+def test_from_py_typeerror():
     with pytest.raises(TypeError):
-        plc.Scalar.from_py(val)
+        plc.Scalar.from_py(object)
+
+
+def test_from_py_none_no_type_raises():
+    with pytest.raises(ValueError):
+        plc.Scalar.from_py(None)
+
+
+def test_from_py_none():
+    result = plc.Scalar.from_py(None, plc.DataType(plc.TypeId.STRING))
+    expected = pa.scalar(None, type=pa.string())
+    assert plc.interop.to_arrow(result).equals(expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Contributes to https://github.com/rapidsai/cudf/issues/18534

Should help unblock the failure in https://github.com/rapidsai/cudf/pull/18554

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
