### PR TITLE
Skip cuml third-party integration tests that may segfault

### DIFF
--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_cuml.py
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_cuml.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 import cupy as cp
 import numpy as np
 import pandas as pd

--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_cuml.py
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_cuml.py
@@ -54,6 +54,7 @@ def binary_classification_data():
     return df
 
 
+@pytest.mark.skip(reason="Disabled due to potential segfaults")
 def test_linear_regression():
     lr = LinearRegression(fit_intercept=True, normalize=False, algorithm="eig")
     X = pd.DataFrame()
@@ -69,6 +70,7 @@ def test_linear_regression():
     return preds.values
 
 
+@pytest.mark.skip(reason="Disabled due to potential segfaults")
 def test_logistic_regression(binary_classification_data):
     X = binary_classification_data[["feature1", "feature2"]]
     y = binary_classification_data["target"]
@@ -86,6 +88,7 @@ def test_logistic_regression(binary_classification_data):
     return accuracy
 
 
+@pytest.mark.skip(reason="Disabled due to potential segfaults")
 def test_random_forest(binary_classification_data):
     X = binary_classification_data[["feature1", "feature2"]]
     y = binary_classification_data["target"]
@@ -99,6 +102,7 @@ def test_random_forest(binary_classification_data):
     return preds.values
 
 
+@pytest.mark.skip(reason="Disabled due to potential segfaults")
 def test_clustering():
     rng = np.random.default_rng(42)
     nsamps = 300
@@ -118,6 +122,7 @@ def test_data_scaling():
     return scaled_data
 
 
+@pytest.mark.skip(reason="Disabled due to potential segfaults")
 def test_pipeline(binary_classification_data):
     X = binary_classification_data[["feature1", "feature2"]]
     y = binary_classification_data["target"]


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Skips cuml integration tests that may fail (eg. https://github.com/rapidsai/cudf/actions/runs/14607488227/job/40980050789?pr=18554) during execution. We will let a cuml developer follow-up and potentially unskip these tests or move them to cuml.
CC @csadorf, @vyasr 
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
