### PR TITLE
Store polars Series instead of pyarrow Array in cudf_polars LiterColumn expr

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/literal.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/literal.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
     import pyarrow as pa
 
+    import polars as pl
+
     from cudf_polars.containers import DataFrame
 
 __all__ = ["Literal", "LiteralColumn"]
@@ -54,9 +56,9 @@ class Literal(Expr):
 class LiteralColumn(Expr):
     __slots__ = ("value",)
     _non_child = ("dtype", "value")
-    value: pa.Array[Any]
+    value: pl.PySeries
 
-    def __init__(self, dtype: plc.DataType, value: pa.Array) -> None:
+    def __init__(self, dtype: plc.DataType, value: pl.Series) -> None:
         self.dtype = dtype
         self.value = value
         self.children = ()
@@ -77,8 +79,7 @@ class LiteralColumn(Expr):
         mapping: Mapping[Expr, Column] | None = None,
     ) -> Column:
         """Evaluate this expression given a dataframe for context."""
-        # datatype of pyarrow array is correct by construction.
-        return Column(plc.interop.from_arrow(self.value))
+        return Column(self.value)
 
     def collect_agg(self, *, depth: int) -> AggInfo:
         """Collect information about aggregations in groupbys."""

--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -10,7 +10,6 @@ from enum import IntEnum, auto
 from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
-import pyarrow.compute as pc
 
 from polars.exceptions import InvalidOperationError
 
@@ -174,7 +173,9 @@ class StringFunction(Expr):
             target = self.children[1]
             # Above, we raise NotImplementedError if the target is not a Literal,
             # so we can safely access .value here.
-            if pc.any(pc.equal(target.value.cast(pa.string()), "")).as_py():  # type: ignore[attr-defined]
+            if (isinstance(target, Literal) and target.value == "") or (
+                isinstance(target, LiteralColumn) and (target.value == "").any()
+            ):
                 raise NotImplementedError(
                     "libcudf replace_many is implemented differently from polars "
                     "for empty strings"

--- a/python/cudf_polars/cudf_polars/dsl/to_ast.py
+++ b/python/cudf_polars/cudf_polars/dsl/to_ast.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """Conversion of expression nodes to libcudf AST nodes."""
@@ -188,9 +188,7 @@ def _(node: expr.BooleanFunction, self: Transformer) -> plc_expr.Expression:
         if isinstance(haystack, expr.LiteralColumn) and len(haystack.value) < 16:
             # 16 is an arbitrary limit
             needle_ref = self(needles)
-            values = [
-                plc_expr.Literal(plc.interop.from_arrow(v)) for v in haystack.value
-            ]
+            values = [plc_expr.Literal(haystack.dtype, val) for val in haystack.value]
             return reduce(
                 partial(plc_expr.Operation, plc_expr.ASTOperator.LOGICAL_OR),
                 (

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -667,12 +667,7 @@ def _(node: pl_expr.Window, translator: Translator, dtype: plc.DataType) -> expr
 @_translate_expr.register
 def _(node: pl_expr.Literal, translator: Translator, dtype: plc.DataType) -> expr.Expr:
     if isinstance(node.value, plrs.PySeries):
-        data = pl.Series._from_pyseries(node.value).to_arrow(
-            compat_level=dtypes.TO_ARROW_COMPAT_LEVEL
-        )
-        return expr.LiteralColumn(
-            dtype, data.cast(dtypes.downcast_arrow_lists(data.type))
-        )
+        return expr.LiteralColumn(dtype, pl.Series._from_pyseries(node.value))
     value = pa.scalar(node.value, type=plc.interop.to_arrow(dtype))
     return expr.Literal(dtype, value)
 


### PR DESCRIPTION
## Description
Contributes to https://github.com/rapidsai/cudf/issues/18534

Depends on:

- [ ] https://github.com/rapidsai/cudf/pull/18562
- [ ] `pylibcudf.Column` accepting objects with `__arrow_c_stream__`
- [ ] https://github.com/rapidsai/cudf/pull/18563


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
