### PR TITLE
Test nvbench entropy stopping with throttling for the inner join benchmark

### DIFF
--- a/cmake/rapids_config.cmake
+++ b/cmake/rapids_config.cmake
@@ -11,6 +11,10 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
+
+set(rapids-cmake-repo PointKernel/rapids-cmake)
+set(rapids-cmake-branch fetch-nvbench-throttle)
+
 file(READ "${CMAKE_CURRENT_LIST_DIR}/../VERSION" _rapids_version)
 if(_rapids_version MATCHES [[^([0-9][0-9])\.([0-9][0-9])\.([0-9][0-9])]])
   set(RAPIDS_VERSION_MAJOR "${CMAKE_MATCH_1}")

--- a/cpp/benchmarks/join/join.cu
+++ b/cpp/benchmarks/join/join.cu
@@ -27,6 +27,8 @@ void nvbench_inner_join(nvbench::state& state,
                  cudf::null_equality compare_nulls) {
     return cudf::inner_join(left_input, right_input, compare_nulls);
   };
+  state.set_throttle_threshold(0.9);
+  state.set_throttle_recovery_delay(0.05);
   BM_join<Key, Nullable>(state, join);
 }
 
@@ -55,6 +57,7 @@ void nvbench_full_join(nvbench::state& state, nvbench::type_list<Key, nvbench::e
 NVBENCH_BENCH_TYPES(nvbench_inner_join, NVBENCH_TYPE_AXES(JOIN_KEY_TYPE_RANGE, JOIN_NULLABLE_RANGE))
   .set_name("inner_join")
   .set_type_axes_names({"Key", "Nullable"})
+  .set_stopping_criterion("entropy")
   .add_int64_axis("left_size", JOIN_SIZE_RANGE)
   .add_int64_axis("right_size", JOIN_SIZE_RANGE);
 


### PR DESCRIPTION
## Description
This PR evaluates the impact of combining entropy-based stopping with throttling control in the inner join benchmark. Depending on https://github.com/rapidsai/rapids-cmake/pull/830.


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
