### PR TITLE
Rework strings split_helper utility for better reuse

### DIFF
--- a/cpp/src/strings/split/split.cu
+++ b/cpp/src/strings/split/split.cu
@@ -105,14 +105,19 @@ namespace {
  *      6    ''    aa  b__ccc__
  * ```
  *
- * @tparam Tokenizer provides unique functions for split/rsplit.
- * @param strings_column The strings to split
+ * @tparam Tokenizer provides unique functions for split/rsplit
+ * @tparam DelimiterFn Functor for locating delimiters
+ * @param input The strings to split
  * @param tokenizer Tokenizer for counting and producing tokens
+ * @param delimiter_fn Functor called on each byte to check for delimiters
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned objects' device memory
  * @return table of columns for the output of the split
  */
-template <typename Tokenizer>
+template <typename Tokenizer, typename DelimiterFn>
 std::unique_ptr<table> split_fn(strings_column_view const& input,
                                 Tokenizer tokenizer,
+                                DelimiterFn delimiter_fn,
                                 rmm::cuda_stream_view stream,
                                 rmm::device_async_resource_ref mr)
 {
@@ -123,7 +128,7 @@ std::unique_ptr<table> split_fn(strings_column_view const& input,
   }
 
   // builds the offsets and the vector of all tokens
-  auto [offsets, tokens] = split_helper(input, tokenizer, stream, mr);
+  auto [offsets, tokens] = split_helper(input, tokenizer, delimiter_fn, stream, mr);
   auto const d_offsets   = cudf::detail::offsetalator_factory::make_input_iterator(offsets->view());
   auto const d_tokens    = tokens.data();
 
@@ -386,7 +391,7 @@ std::unique_ptr<table> whitespace_split_fn(size_type strings_count,
 
 }  // namespace
 
-std::unique_ptr<table> split(strings_column_view const& strings_column,
+std::unique_ptr<table> split(strings_column_view const& input,
                              string_scalar const& delimiter,
                              size_type maxsplit,
                              rmm::cuda_stream_view stream,
@@ -396,20 +401,18 @@ std::unique_ptr<table> split(strings_column_view const& strings_column,
 
   size_type max_tokens = maxsplit > 0 ? maxsplit + 1 : std::numeric_limits<size_type>::max();
 
-  auto strings_device_view = column_device_view::create(strings_column.parent(), stream);
+  auto d_strings = column_device_view::create(input.parent(), stream);
   if (delimiter.size() == 0) {
-    return whitespace_split_fn(strings_column.size(),
-                               whitespace_split_tokenizer_fn{*strings_device_view, max_tokens},
-                               stream,
-                               mr);
+    return whitespace_split_fn(
+      input.size(), whitespace_split_tokenizer_fn{*d_strings, max_tokens}, stream, mr);
   }
 
-  string_view d_delimiter(delimiter.data(), delimiter.size());
-  return split_fn(
-    strings_column, split_tokenizer_fn{*strings_device_view, d_delimiter, max_tokens}, stream, mr);
+  auto tokenizer    = split_tokenizer_fn{*d_strings, delimiter.size(), max_tokens};
+  auto delimiter_fn = string_delimiter_fn{delimiter.value(stream)};
+  return split_fn(input, tokenizer, delimiter_fn, stream, mr);
 }
 
-std::unique_ptr<table> rsplit(strings_column_view const& strings_column,
+std::unique_ptr<table> rsplit(strings_column_view const& input,
                               string_scalar const& delimiter,
                               size_type maxsplit,
                               rmm::cuda_stream_view stream,
@@ -419,17 +422,15 @@ std::unique_ptr<table> rsplit(strings_column_view const& strings_column,
 
   size_type max_tokens = maxsplit > 0 ? maxsplit + 1 : std::numeric_limits<size_type>::max();
 
-  auto strings_device_view = column_device_view::create(strings_column.parent(), stream);
+  auto d_strings = column_device_view::create(input.parent(), stream);
   if (delimiter.size() == 0) {
-    return whitespace_split_fn(strings_column.size(),
-                               whitespace_rsplit_tokenizer_fn{*strings_device_view, max_tokens},
-                               stream,
-                               mr);
+    return whitespace_split_fn(
+      input.size(), whitespace_rsplit_tokenizer_fn{*d_strings, max_tokens}, stream, mr);
   }
 
-  string_view d_delimiter(delimiter.data(), delimiter.size());
-  return split_fn(
-    strings_column, rsplit_tokenizer_fn{*strings_device_view, d_delimiter, max_tokens}, stream, mr);
+  auto tokenizer    = rsplit_tokenizer_fn{*d_strings, delimiter.size(), max_tokens};
+  auto delimiter_fn = string_delimiter_fn{delimiter.value(stream)};
+  return split_fn(input, tokenizer, delimiter_fn, stream, mr);
 }
 
 }  // namespace detail

--- a/cpp/src/strings/split/split.cuh
+++ b/cpp/src/strings/split/split.cuh
@@ -43,6 +43,35 @@
 namespace cudf::strings::detail {
 
 /**
+ * @brief Returns `true` if the byte at `idx` is the start of the delimiter
+ */
+struct string_delimiter_fn {
+  __device__ bool operator()(int64_t idx) const
+  {
+    if (idx + d_delimiter.size_bytes() > chars_bytes) { return false; }
+    return d_delimiter.compare(d_chars + idx, d_delimiter.size_bytes()) == 0;
+  }
+  cudf::string_view d_delimiter;
+  int64_t chars_bytes{};
+  char const* d_chars{};
+};
+
+/**
+ * @brief Get the offsets for a string in the strings column
+ *
+ * @param d_strings The strings column
+ * @param idx The index of the string to retrieve
+ * @return The start and end offsets for the string
+ */
+__device__ __inline__ auto get_string_offsets(column_device_view const& d_strings, size_type idx)
+{
+  auto const offsets = d_strings.child(d_strings.offsets_column_index);
+  auto const itr     = cudf::detail::input_offsetalator(offsets.head(), offsets.type());
+  auto const index   = d_strings.offset() + idx;
+  return cuda::std::make_pair(itr[index], itr[index + 1]);
+}
+
+/**
  * @brief Base class for delimiter-based tokenizers
  *
  * These are common methods used by both split and rsplit tokenizer functors.
@@ -51,32 +80,6 @@ namespace cudf::strings::detail {
  */
 template <typename Derived>
 struct base_split_tokenizer {
-  __device__ char const* get_base_ptr() const { return d_strings.head<char>(); }
-
-  __device__ string_view const get_string(size_type idx) const
-  {
-    return d_strings.element<string_view>(idx);
-  }
-
-  __device__ bool is_valid(size_type idx) const { return d_strings.is_valid(idx); }
-
-  /**
-   * @brief Returns `true` if the byte at `idx` is the start of the delimiter
-   *
-   * @param idx Index of a byte in the chars column
-   * @param d_offsets Offsets values to locate the chars ranges
-   * @param chars_bytes Total number of characters to process
-   * @return true if delimiter is found starting at position `idx`
-   */
-  __device__ bool is_delimiter(int64_t idx,
-                               cudf::detail::input_offsetalator const d_offsets,
-                               int64_t chars_bytes) const
-  {
-    auto const d_chars = get_base_ptr() + d_offsets[0];
-    if (idx + d_delimiter.size_bytes() > chars_bytes) { return false; }
-    return d_delimiter.compare(d_chars + idx, d_delimiter.size_bytes()) == 0;
-  }
-
   /**
    * @brief This counts the tokens for strings that contain delimiters
    *
@@ -92,22 +95,19 @@ struct base_split_tokenizer {
                                     int64_t const* d_positions,
                                     cudf::detail::input_offsetalator d_delimiter_offsets) const
   {
-    if (!is_valid(idx)) { return 0; }
+    if (d_strings.is_null(idx)) { return 0; }
 
-    auto const delim_size = d_delimiter.size_bytes();
-    auto const d_str      = get_string(idx);
-    auto const d_str_end  = d_str.data() + d_str.size_bytes();
-    auto const base_ptr   = get_base_ptr() + delim_size - 1;
-
+    auto const d_str_offsets = get_string_offsets(d_strings, idx);
     auto const delimiters =
       cudf::device_span<int64_t const>(d_positions + d_delimiter_offsets[idx],
                                        d_delimiter_offsets[idx + 1] - d_delimiter_offsets[idx]);
 
     size_type token_count = 1;  // all strings will have at least one token
-    auto last_pos         = !delimiters.empty() ? (delimiters[0] - delim_size) : 0L;
+    auto last_pos         = d_str_offsets.first - delimiter_size;
     for (auto d_pos : delimiters) {
-      // delimiter must fit in string && overlapping delimiters are ignored
-      if (((base_ptr + d_pos) < d_str_end) && ((d_pos - last_pos) >= delim_size)) {
+      // delimiter must fit within the string and overlapping delimiters are ignored
+      if (((d_pos + delimiter_size) <= d_str_offsets.second) &&
+          ((d_pos - last_pos) >= delimiter_size)) {
         ++token_count;
         last_pos = d_pos;
       }
@@ -137,38 +137,32 @@ struct base_split_tokenizer {
                              cudf::detail::input_offsetalator d_delimiter_offsets,
                              string_index_pair* d_all_tokens) const
   {
+    if (d_strings.is_null(idx)) { return; }
+
     auto const d_tokens =  // this string's tokens output
       cudf::device_span<string_index_pair>(d_all_tokens + d_tokens_offsets[idx],
                                            d_tokens_offsets[idx + 1] - d_tokens_offsets[idx]);
 
-    if (!is_valid(idx)) { return; }
-
-    auto const d_str = get_string(idx);
-
-    // max_tokens already included in token counts
-    if (d_tokens.size() == 1) {
-      d_tokens[0] = string_index_pair{(d_str.empty() ? "" : d_str.data()), d_str.size_bytes()};
-      return;
-    }
+    auto const d_str_offsets = get_string_offsets(d_strings, idx);
 
     auto const delimiters =
       cudf::device_span<int64_t const>(d_positions + d_delimiter_offsets[idx],
                                        d_delimiter_offsets[idx + 1] - d_delimiter_offsets[idx]);
 
     auto& derived = static_cast<Derived const&>(*this);
-    derived.process_tokens(d_str, delimiters, d_tokens);
+    derived.process_tokens(d_str_offsets.first, d_str_offsets.second, delimiters, d_tokens);
   }
 
   base_split_tokenizer(column_device_view const& d_strings,
-                       string_view const& d_delimiter,
+                       size_type delimiter_size,
                        size_type max_tokens)
-    : d_strings(d_strings), d_delimiter(d_delimiter), max_tokens(max_tokens)
+    : d_strings(d_strings), delimiter_size(delimiter_size), max_tokens(max_tokens)
   {
   }
 
  protected:
   column_device_view const d_strings;  // strings to split
-  string_view const d_delimiter;       // delimiter for split
+  size_type delimiter_size;            // size of the delimiter
   size_type max_tokens;                // maximum number of tokens to identify
 };
 
@@ -186,41 +180,42 @@ struct split_tokenizer_fn : base_split_tokenizer<split_tokenizer_fn> {
    * @param d_delimiters Positions of delimiters for this string
    * @param d_tokens Output vector to store tokens for this string
    */
-  __device__ void process_tokens(string_view const d_str,
+  __device__ void process_tokens(int64_t pos_begin,
+                                 int64_t pos_end,
                                  device_span<int64_t const> d_delimiters,
                                  device_span<string_index_pair> d_tokens) const
   {
-    auto const base_ptr    = get_base_ptr();  // d_positions values based on this
-    auto str_ptr           = d_str.data();
-    auto const str_end     = str_ptr + d_str.size_bytes();  // end of the string
+    auto const base_ptr = d_strings.head<char>();  // d_delimiters, pos_begin/end based on this ptr
     auto const token_count = static_cast<size_type>(d_tokens.size());
-    auto const delim_size  = d_delimiter.size_bytes();
 
     // build the index-pair of each token for this string
     size_type token_idx = 0;
+    auto last_pos       = pos_begin - delimiter_size;
     for (auto d_pos : d_delimiters) {
-      auto const next_delim = base_ptr + d_pos;
-      if (next_delim < str_ptr || ((next_delim + delim_size) > str_end)) { continue; }
-      auto const end_ptr = (token_idx + 1 < token_count) ? next_delim : str_end;
+      if (((d_pos + delimiter_size) > pos_end) || ((d_pos - last_pos) < delimiter_size)) {
+        continue;
+      }
+      auto const end_pos = (token_idx + 1 < token_count) ? d_pos : pos_end;
 
       // store the token into the output vector
-      d_tokens[token_idx++] =
-        string_index_pair{str_ptr, static_cast<size_type>(cuda::std::distance(str_ptr, end_ptr))};
+      last_pos += delimiter_size;
+      d_tokens[token_idx++] = string_index_pair{base_ptr + last_pos, end_pos - last_pos};
 
-      // setup for next token
-      str_ptr = end_ptr + delim_size;
+      last_pos = d_pos;
+      if (token_idx >= token_count) { break; }
     }
     // include anything leftover
     if (token_idx < token_count) {
-      d_tokens[token_idx] =
-        string_index_pair{str_ptr, static_cast<size_type>(cuda::std::distance(str_ptr, str_end))};
+      last_pos += delimiter_size;
+      d_tokens[token_idx] = base_ptr ? string_index_pair{base_ptr + last_pos, pos_end - last_pos}
+                                     : string_index_pair{"", 0};
     }
   }
 
   split_tokenizer_fn(column_device_view const& d_strings,
-                     string_view const& d_delimiter,
+                     size_type delimiter_size,
                      size_type max_tokens)
-    : base_split_tokenizer(d_strings, d_delimiter, max_tokens)
+    : base_split_tokenizer(d_strings, delimiter_size, max_tokens)
   {
   }
 };
@@ -241,43 +236,43 @@ struct rsplit_tokenizer_fn : base_split_tokenizer<rsplit_tokenizer_fn> {
    * @param d_delimiters Positions of delimiters for this string
    * @param d_tokens Output vector to store tokens for this string
    */
-  __device__ void process_tokens(string_view const d_str,
+  __device__ void process_tokens(int64_t pos_begin,
+                                 int64_t pos_end,
                                  device_span<int64_t const> d_delimiters,
                                  device_span<string_index_pair> d_tokens) const
   {
-    auto const base_ptr    = get_base_ptr();  // d_positions values are based on this ptr
-    auto const str_begin   = d_str.data();    // beginning of the string
+    auto const base_ptr = d_strings.head<char>();  // d_delimiters, pos_begin/end based on this ptr
     auto const token_count = static_cast<size_type>(d_tokens.size());
     auto const delim_count = static_cast<size_type>(d_delimiters.size());
-    auto const delim_size  = d_delimiter.size_bytes();
 
     // build the index-pair of each token for this string
-    auto str_ptr        = str_begin + d_str.size_bytes();
+    auto last_pos       = pos_end;
     size_type token_idx = 0;
-    for (auto d = delim_count - 1; d >= 0; --d) {  // read right-to-left
-      auto const prev_delim = base_ptr + d_delimiters[d] + delim_size;
-      if (prev_delim > str_ptr || ((prev_delim - delim_size) < str_begin)) { continue; }
-      auto const start_ptr = (token_idx + 1 < token_count) ? prev_delim : str_begin;
+    for (auto d = delim_count - 1; d >= 0 && token_idx < token_count; --d) {  // read right-to-left
+      auto const d_pos = d_delimiters[d];
+      if (((d_pos + delimiter_size) > pos_end) || ((last_pos - d_pos) < delimiter_size)) {
+        continue;
+      }
+      auto const start_pos = (token_idx + 1 < token_count) ? d_pos + delimiter_size : pos_begin;
 
       // store the token into the output vector right-to-left
-      d_tokens[token_count - token_idx - 1] = string_index_pair{
-        start_ptr, static_cast<size_type>(cuda::std::distance(start_ptr, str_ptr))};
+      d_tokens[token_count - token_idx - 1] =
+        string_index_pair{base_ptr + start_pos, last_pos - start_pos};
 
-      // setup for next token
-      str_ptr = start_ptr - delim_size;
+      last_pos = d_pos;
       ++token_idx;
     }
     // include anything leftover (rightover?)
     if (token_idx < token_count) {
-      d_tokens[0] = string_index_pair{
-        str_begin, static_cast<size_type>(cuda::std::distance(str_begin, str_ptr))};
+      d_tokens[0] = base_ptr ? string_index_pair{base_ptr + pos_begin, last_pos - pos_begin}
+                             : string_index_pair{"", 0};
     }
   }
 
   rsplit_tokenizer_fn(column_device_view const& d_strings,
-                      string_view const& d_delimiter,
+                      size_type delimiter_size,
                       size_type max_tokens)
-    : base_split_tokenizer(d_strings, d_delimiter, max_tokens)
+    : base_split_tokenizer(d_strings, delimiter_size, max_tokens)
   {
   }
 };
@@ -285,18 +280,16 @@ struct rsplit_tokenizer_fn : base_split_tokenizer<rsplit_tokenizer_fn> {
 /**
  * @brief Count the number of delimiters in a strings column
  *
- * @tparam Tokenizer Functor containing `is_delimiter` function
+ * @tparam DelimiterFn Functor for locating delimiters
  * @tparam block_size Number of threads per block
  * @tparam bytes_per_thread Number of bytes processed per thread
  *
- * @param tokenizer For checking delimiters
- * @param d_offsets Offsets for the strings column
+ * @param delimiter_fn Functor called on each byte to check for delimiters
  * @param chars_bytes Number of bytes in the strings column
  * @param d_output Result of the count
  */
-template <typename Tokenizer, int64_t block_size, size_type bytes_per_thread>
-CUDF_KERNEL void count_delimiters_kernel(Tokenizer tokenizer,
-                                         cudf::detail::input_offsetalator d_offsets,
+template <typename DelimiterFn, int64_t block_size, size_type bytes_per_thread>
+CUDF_KERNEL void count_delimiters_kernel(DelimiterFn delimiter_fn,
                                          int64_t chars_bytes,
                                          int64_t* d_output)
 {
@@ -310,7 +303,7 @@ CUDF_KERNEL void count_delimiters_kernel(Tokenizer tokenizer,
   int64_t count = 0;
   // each thread processes multiple bytes
   for (auto i = byte_idx; (i < (byte_idx + bytes_per_thread)) && (i < chars_bytes); ++i) {
-    count += tokenizer.is_delimiter(i, d_offsets, chars_bytes);
+    count += delimiter_fn(i);
   }
   auto const total = block_reduce(temp_storage).Reduce(count, cuda::std::plus());
 
@@ -327,26 +320,27 @@ CUDF_KERNEL void count_delimiters_kernel(Tokenizer tokenizer,
  * the given tokenizer. It also returns the offsets for each set of tokens identified per string.
  *
  * @tparam Tokenizer Type of the tokenizer object
+ * @tparam DelimiterFn Functor for locating delimiters
  *
  * @param input The input column of strings to split
  * @param tokenizer Object used for counting and identifying delimiters and tokens
+ * @param delimiter_fn Functor called on each byte to check for delimiters
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate the returned objects' device memory
  * @return Token offsets and a vector of string indices
  */
-template <typename Tokenizer>
+template <typename Tokenizer, typename DelimiterFn>
 std::pair<std::unique_ptr<column>, rmm::device_uvector<string_index_pair>> split_helper(
   strings_column_view const& input,
   Tokenizer tokenizer,
+  DelimiterFn delimiter_fn,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  auto const strings_count = input.size();
-  auto const chars_bytes =
-    get_offset_value(input.offsets(), input.offset() + strings_count, stream) -
-    get_offset_value(input.offsets(), input.offset(), stream);
-  auto const d_offsets =
-    cudf::detail::offsetalator_factory::make_input_iterator(input.offsets(), input.offset());
+  auto [first_offset, last_offset] = get_first_and_last_offset(input, stream);
+  auto const chars_bytes           = last_offset - first_offset;
+  delimiter_fn.d_chars             = input.chars_begin(stream) + first_offset;
+  delimiter_fn.chars_bytes         = chars_bytes;
 
   // count the number of delimiters in the entire column
   cudf::detail::device_scalar<int64_t> d_count(0, stream);
@@ -355,24 +349,19 @@ std::pair<std::unique_ptr<column>, rmm::device_uvector<string_index_pair>> split
     constexpr size_type bytes_per_thread = 4;
     auto const num_blocks                = util::div_rounding_up_safe(
       util::div_rounding_up_safe(chars_bytes, static_cast<int64_t>(bytes_per_thread)), block_size);
-    count_delimiters_kernel<Tokenizer, block_size, bytes_per_thread>
-      <<<num_blocks, block_size, 0, stream.value()>>>(
-        tokenizer, d_offsets, chars_bytes, d_count.data());
+    count_delimiters_kernel<DelimiterFn, block_size, bytes_per_thread>
+      <<<num_blocks, block_size, 0, stream.value()>>>(delimiter_fn, chars_bytes, d_count.data());
   }
 
   // Create a vector of every delimiter position in the chars column.
   // These may include overlapping or otherwise out-of-bounds delimiters which
   // will be resolved during token processing.
   auto delimiter_positions = rmm::device_uvector<int64_t>(d_count.value(stream), stream);
-  auto d_positions         = delimiter_positions.data();
-  cudf::detail::copy_if_safe(
-    thrust::counting_iterator<int64_t>(0),
-    thrust::counting_iterator<int64_t>(chars_bytes),
-    delimiter_positions.begin(),
-    [tokenizer, d_offsets, chars_bytes] __device__(int64_t idx) {
-      return tokenizer.is_delimiter(idx, d_offsets, chars_bytes);
-    },
-    stream);
+  cudf::detail::copy_if_safe(thrust::counting_iterator<int64_t>(0),
+                             thrust::counting_iterator<int64_t>(chars_bytes),
+                             delimiter_positions.begin(),
+                             delimiter_fn,
+                             stream);
 
   // create a vector of offsets to each string's delimiter set within delimiter_positions
   auto const delimiter_offsets =
@@ -381,11 +370,13 @@ std::pair<std::unique_ptr<column>, rmm::device_uvector<string_index_pair>> split
     cudf::detail::offsetalator_factory::make_input_iterator(delimiter_offsets->view());
 
   // compute the number of tokens per string
-  auto token_counts = rmm::device_uvector<size_type>(strings_count, stream);
+  auto token_counts    = rmm::device_uvector<size_type>(input.size(), stream);
+  auto d_positions     = delimiter_positions.data();
+  auto const zero_iter = thrust::make_counting_iterator<size_type>(0);
   thrust::transform(
     rmm::exec_policy_nosync(stream),
-    thrust::make_counting_iterator<size_type>(0),
-    thrust::make_counting_iterator<size_type>(strings_count),
+    zero_iter,
+    zero_iter + input.size(),
     token_counts.begin(),
     [tokenizer, d_positions, d_delimiter_offsets] __device__(size_type idx) -> size_type {
       return tokenizer.count_tokens(idx, d_positions, d_delimiter_offsets);
@@ -400,14 +391,12 @@ std::pair<std::unique_ptr<column>, rmm::device_uvector<string_index_pair>> split
   // build a vector of all the token positions for all the strings
   auto tokens   = rmm::device_uvector<string_index_pair>(total_tokens, stream);
   auto d_tokens = tokens.data();
-  thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
-    thrust::make_counting_iterator<size_type>(0),
-    strings_count,
+  auto get_tokens_fn =
     [tokenizer, d_tokens_offsets, d_positions, d_delimiter_offsets, d_tokens] __device__(
       size_type idx) {
       tokenizer.get_tokens(idx, d_tokens_offsets, d_positions, d_delimiter_offsets, d_tokens);
-    });
+    };
+  thrust::for_each_n(rmm::exec_policy_nosync(stream), zero_iter, input.size(), get_tokens_fn);
 
   return std::make_pair(std::move(offsets), std::move(tokens));
 }


### PR DESCRIPTION
## Description
Part of the strings split refactor work. This change reworks the `split_helper` internal utility for better reuse with split-on-whitespace and tokenizers (follow on work).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
