### PR TITLE
Add .cursorignore to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ DartConfiguration.tcl
 .nfs*
 .clangd
 compile_commands.json
+.cursorignore
 
 ## Python build directories & artifacts
 dask-worker-space/


### PR DESCRIPTION
## Description
As some of us may be using Cursor for development, I've started to leverage `.cursorignore` to specify files not to index for model accuracy and IDE performance https://docs.cursor.com/context/ignore-files

This PR just adds that `.cursorignore` to `.gitignore` so it doesn't get tracked by git (like we have an entry for `.vscode`)

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
