### PR TITLE
Fix `DataFrame.memory_usage` output order

### DIFF
--- a/python/cudf/cudf/core/_base_index.py
+++ b/python/cudf/cudf/core/_base_index.py
@@ -117,7 +117,7 @@ class BaseIndex(Serializable):
         """Return if the index has unique values."""
         raise NotImplementedError
 
-    def memory_usage(self, deep=False):
+    def memory_usage(self, deep: bool = False) -> int:
         """Return the memory usage of an object.
 
         Parameters

--- a/python/cudf/cudf/core/column/lists.py
+++ b/python/cudf/cudf/core/column/lists.py
@@ -80,7 +80,7 @@ class ListColumn(ColumnBase):
         return self
 
     @cached_property
-    def memory_usage(self):
+    def memory_usage(self) -> int:
         n = super().memory_usage
         child0_size = (self.size + 1) * self.base_children[0].dtype.itemsize
         current_base_child = self.base_children[1]

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1618,15 +1618,15 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         self._drop_column(name)
 
     @_performance_tracking
-    def memory_usage(self, index=True, deep=False) -> cudf.Series:
+    def memory_usage(self, index: bool = True, deep: bool = False) -> cudf.Series:
         mem_usage = [col.memory_usage for col in self._columns]
-        names = [str(name) for name in self._column_names]
+        result_index = self._data.to_pandas_index
         if index:
-            mem_usage.append(self.index.memory_usage())
-            names.append("Index")
+            mem_usage = [self.index.memory_usage()] + mem_usage
+            result_index = pd.Index(["Index"]).append(result_index.astype(str))
         return Series._from_column(
             as_column(mem_usage),
-            index=cudf.Index(names),
+            index=cudf.Index(result_index),
         )
 
     @_performance_tracking

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1618,14 +1618,18 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         self._drop_column(name)
 
     @_performance_tracking
-    def memory_usage(self, index: bool = True, deep: bool = False) -> cudf.Series:
-        mem_usage = [col.memory_usage for col in self._columns]
+    def memory_usage(
+        self, index: bool = True, deep: bool = False
+    ) -> cudf.Series:
+        mem_usage: abc.Iterable[int] = (
+            col.memory_usage for col in self._columns
+        )
         result_index = self._data.to_pandas_index
         if index:
-            mem_usage = [self.index.memory_usage()] + mem_usage
+            mem_usage = itertools.chain([self.index.memory_usage()], mem_usage)
             result_index = pd.Index(["Index"]).append(result_index.astype(str))
         return Series._from_column(
-            as_column(mem_usage),
+            as_column(list(mem_usage)),
             index=cudf.Index(result_index),
         )
 

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -297,7 +297,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
         """
         return self._num_columns * self._num_rows
 
-    def memory_usage(self, deep=False):
+    def memory_usage(self, deep: bool = False) -> int:
         """Return the memory usage of an object.
 
         Parameters

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2753,7 +2753,7 @@ class IndexedFrame(Frame):
 
         return self._mimic_inplace(out, inplace=inplace)
 
-    def memory_usage(self, index=True, deep=False):
+    def memory_usage(self, index: bool = True, deep: bool = False) -> int:
         """Return the memory usage of an object.
 
         Parameters

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2753,7 +2753,7 @@ class IndexedFrame(Frame):
 
         return self._mimic_inplace(out, inplace=inplace)
 
-    def memory_usage(self, index: bool = True, deep: bool = False) -> int:
+    def memory_usage(self, index: bool = True, deep: bool = False) -> int:  # type: ignore[override]
         """Return the memory usage of an object.
 
         Parameters

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -1174,7 +1174,7 @@ class Series(SingleColumnFrame, IndexedFrame):
         return self._to_frame(name=name, index=self.index)
 
     @_performance_tracking
-    def memory_usage(self, index=True, deep=False):
+    def memory_usage(self, index: bool = True, deep: bool = False) -> int:
         return self._column.memory_usage + (
             self.index.memory_usage() if index else 0
         )

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -5952,6 +5952,15 @@ def test_memory_usage_multi(rows):
     assert expect == gdf.index.memory_usage(deep=True)
 
 
+@pytest.mark.parametrize("index", [False, True])
+def test_memory_usage_index_preserve_types(index):
+    data = [[1, 2, 3]]
+    columns = pd.Index(np.array([1, 2, 3], dtype=np.int8), name="a")
+    result = cudf.DataFrame(data, columns=columns).memory_usage(index=index).index
+    expected = pd.DataFrame(data, columns=columns).memory_usage(index=index).index
+    assert_eq(result, expected)
+
+
 @pytest.mark.parametrize(
     "list_input",
     [

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -5956,8 +5956,15 @@ def test_memory_usage_multi(rows):
 def test_memory_usage_index_preserve_types(index):
     data = [[1, 2, 3]]
     columns = pd.Index(np.array([1, 2, 3], dtype=np.int8), name="a")
-    result = cudf.DataFrame(data, columns=columns).memory_usage(index=index).index
-    expected = pd.DataFrame(data, columns=columns).memory_usage(index=index).index
+    result = (
+        cudf.DataFrame(data, columns=columns).memory_usage(index=index).index
+    )
+    expected = (
+        pd.DataFrame(data, columns=columns).memory_usage(index=index).index
+    )
+    if index:
+        # pandas returns an Index[object] with int and string elements
+        expected = expected.astype(str)
     assert_eq(result, expected)
 
 


### PR DESCRIPTION
## Description
Namely when `index=True`, the index memory usage should be the first element not the last.

Also adds more type annotations to `memory_usage` signatures

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
