### PR TITLE
Prune methods from Frame that are specific to subclasses

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
     from cudf._typing import Dtype, DtypeObj, ScalarLike
 
 
-# TODO: It looks like Frame is missing a declaration of `copy`, need to add
 class Frame(BinaryOperand, Scannable, Serializable):
     """A collection of Column objects.
 
@@ -833,55 +832,6 @@ class Frame(BinaryOperand, Scannable, Serializable):
             self._data._from_columns_like_self(columns, verify=False)
         )
 
-    @_performance_tracking
-    def _drop_column(
-        self, name: abc.Hashable, errors: Literal["ignore", "raise"] = "raise"
-    ) -> None:
-        """Drop a column by *name* inplace."""
-        try:
-            del self._data[name]
-        except KeyError as err:
-            if errors != "ignore":
-                raise KeyError(f"column '{name}' does not exist") from err
-
-    @_performance_tracking
-    def _quantile_table(
-        self,
-        q: float,
-        interpolation: Literal[
-            "LINEAR", "LOWER", "HIGHER", "MIDPOINT", "NEAREST"
-        ] = "LINEAR",
-        is_sorted: bool = False,
-        column_order=(),
-        null_precedence=(),
-    ):
-        interpolation = plc.types.Interpolation[interpolation]
-
-        is_sorted = plc.types.Sorted["YES" if is_sorted else "NO"]
-
-        column_order = [plc.types.Order[key] for key in column_order]
-
-        null_precedence = [plc.types.NullOrder[key] for key in null_precedence]
-
-        with acquire_spill_lock():
-            plc_table = plc.quantiles.quantiles(
-                plc.Table(
-                    [c.to_pylibcudf(mode="read") for c in self._columns]
-                ),
-                q,
-                interpolation,
-                is_sorted,
-                column_order,
-                null_precedence,
-            )
-            columns = [
-                ColumnBase.from_pylibcudf(col) for col in plc_table.columns()
-            ]
-        return self._from_columns_like_self(
-            columns,
-            column_names=self._column_names,
-        )
-
     @classmethod
     @_performance_tracking
     def from_arrow(cls, data: pa.Table) -> Self:
@@ -1094,7 +1044,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
         return self
 
     @_performance_tracking
-    def isna(self):
+    def isna(self) -> Self:
         """
         Identify missing values.
 
@@ -1175,7 +1125,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
     isnull = isna
 
     @_performance_tracking
-    def notna(self):
+    def notna(self) -> Self:
         """
         Identify non-missing values.
 
@@ -1509,7 +1459,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
         ]
 
     @_performance_tracking
-    def _encode(self):
+    def _encode(self) -> tuple[Self, ColumnBase]:
         plc_table, plc_column = plc.transform.encode(
             plc.Table([col.to_pylibcudf(mode="read") for col in self._columns])
         )
@@ -1521,7 +1471,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
         return keys, indices
 
     @_performance_tracking
-    def _unaryop(self, op):
+    def _unaryop(self, op: str) -> Self:
         data_columns = (col.unary_operator(op) for col in self._columns)
         return self._from_data_like_self(
             self._data._from_columns_like_self(data_columns)
@@ -1654,7 +1604,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
 
     # Unary logical operators
     @_performance_tracking
-    def __neg__(self):
+    def __neg__(self) -> Self:
         """Negate for integral dtypes, logical NOT for bools."""
         return self._from_data_like_self(
             self._data._from_columns_like_self(
@@ -1668,27 +1618,18 @@ class Frame(BinaryOperand, Scannable, Serializable):
         )
 
     @_performance_tracking
-    def __pos__(self):
+    def __pos__(self) -> Self:
         return self.copy(deep=True)
 
     @_performance_tracking
-    def __abs__(self):
+    def __abs__(self) -> Self:
         return self._unaryop("abs")
 
-    def __bool__(self):
+    def __bool__(self) -> None:
         raise ValueError(
             f"The truth value of a {type(self).__name__} is ambiguous. Use "
             "a.empty, a.bool(), a.item(), a.any() or a.all()."
         )
-
-    # Reductions
-    @classmethod
-    @_performance_tracking
-    def _get_axis_from_axis_arg(cls, axis):
-        try:
-            return cls._SUPPORT_AXIS_LOOKUP[axis]
-        except KeyError:
-            raise ValueError(f"No axis named {axis} for object type {cls}")
 
     @_performance_tracking
     def _reduce(self, *args, **kwargs):
@@ -1909,19 +1850,22 @@ class Frame(BinaryOperand, Scannable, Serializable):
         return cudf.io.dlpack.to_dlpack(self)
 
     @_performance_tracking
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self)
 
     @_performance_tracking
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo) -> Self:
         return self.copy(deep=True)
 
     @_performance_tracking
-    def __copy__(self):
+    def __copy__(self) -> Self:
         return self.copy(deep=False)
 
+    def copy(self, deep: bool = True) -> Self:
+        raise NotImplementedError
+
     @_performance_tracking
-    def __invert__(self):
+    def __invert__(self) -> Self:
         """Bitwise invert (~) for integral dtypes, logical NOT for bools."""
         return self._from_data_like_self(
             self._data._from_columns_like_self((~col for col in self._columns))

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -2026,6 +2026,16 @@ class IndexedFrame(Frame):
             )
         )
 
+    _SUPPORT_AXIS_LOOKUP = {0: 0, "index": 0}
+
+    @classmethod
+    @_performance_tracking
+    def _get_axis_from_axis_arg(cls, axis: int | str) -> int:
+        try:
+            return cls._SUPPORT_AXIS_LOOKUP[axis]
+        except KeyError:
+            raise ValueError(f"No axis named {axis} for object type {cls}")
+
     @_performance_tracking
     def shift(
         self,
@@ -5149,6 +5159,17 @@ class IndexedFrame(Frame):
             if errors == "raise":
                 raise e
             return self
+
+    @_performance_tracking
+    def _drop_column(
+        self, name: abc.Hashable, errors: Literal["ignore", "raise"] = "raise"
+    ) -> None:
+        """Drop a column by *name* inplace."""
+        try:
+            del self._data[name]
+        except KeyError as err:
+            if errors != "ignore":
+                raise KeyError(f"column '{name}' does not exist") from err
 
     @_performance_tracking
     def drop(

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -37,11 +37,6 @@ class SingleColumnFrame(Frame, NotIterable):
     share certain logic that is encoded in this class.
     """
 
-    _SUPPORT_AXIS_LOOKUP = {
-        0: 0,
-        "index": 0,
-    }
-
     @_performance_tracking
     def _reduce(
         self,


### PR DESCRIPTION
## Description
Additionally adds some type annotations to methods of `Frame`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
