### PR TITLE
Annotate and simplify `from_arrow`

### DIFF
--- a/cpp/tests/strings/split_tests.cpp
+++ b/cpp/tests/strings/split_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,48 +86,41 @@ TEST_F(StringsSplitTest, SplitWithMax)
 
 TEST_F(StringsSplitTest, SplitWhitespace)
 {
-  std::vector<char const*> h_strings{
-    "Héllo thesé", nullptr, "are\tsome", "tést\nString", "  ", " a  b ", ""};
-  cudf::test::strings_column_wrapper strings(
-    h_strings.begin(),
-    h_strings.end(),
-    thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; }));
-  cudf::strings_column_view strings_view(strings);
+  auto const input = cudf::test::strings_column_wrapper(
+    {"Héllo thesé", "", "are\tsome", "tést\nString", "  ", " a  b ", "", " 123 "},
+    {1, 0, 1, 1, 1, 1, 1, 1});
+  auto const sv = cudf::strings_column_view(input);
 
-  std::vector<char const*> h_expected1{"Héllo", nullptr, "are", "tést", nullptr, "a", nullptr};
-  cudf::test::strings_column_wrapper expected1(
-    h_expected1.begin(),
-    h_expected1.end(),
-    thrust::make_transform_iterator(h_expected1.begin(), [](auto str) { return str != nullptr; }));
-  std::vector<char const*> h_expected2{"thesé", nullptr, "some", "String", nullptr, "b", nullptr};
-  cudf::test::strings_column_wrapper expected2(
-    h_expected2.begin(),
-    h_expected2.end(),
-    thrust::make_transform_iterator(h_expected2.begin(), [](auto str) { return str != nullptr; }));
+  auto expected1 = cudf::test::strings_column_wrapper(
+    {"Héllo", "", "are", "tést", "", "a", "", "123"}, {1, 0, 1, 1, 0, 1, 0, 1});
+  auto expected2 = cudf::test::strings_column_wrapper(
+    {"thesé", "", "some", "String", "", "b", "", ""}, {1, 0, 1, 1, 0, 1, 0, 0});
   std::vector<std::unique_ptr<cudf::column>> expected_columns;
   expected_columns.push_back(expected1.release());
   expected_columns.push_back(expected2.release());
   auto expected = std::make_unique<cudf::table>(std::move(expected_columns));
 
-  auto results = cudf::strings::split(strings_view);
+  auto const results = cudf::strings::split(sv);
   EXPECT_TRUE(results->num_columns() == 2);
   CUDF_TEST_EXPECT_TABLES_EQUAL(*results, *expected);
 }
 
 TEST_F(StringsSplitTest, SplitWhitespaceWithMax)
 {
-  cudf::test::strings_column_wrapper strings(
-    {"a bc d", "a  bc  d", " ab cd e", "ab cd e ", " ab cd e "});
-  cudf::strings_column_view strings_view(strings);
+  auto const input = cudf::test::strings_column_wrapper(
+    {"a bc d", "a  bc  d", " ab cd e", "ab cd e ", " ab cd e ", " abc ", "", " "});
+  auto const sv = cudf::strings_column_view(input);
 
-  cudf::test::strings_column_wrapper expected1({"a", "a", "ab", "ab", "ab"});
-  cudf::test::strings_column_wrapper expected2({"bc d", "bc  d", "cd e", "cd e ", "cd e "});
+  auto expected1 = cudf::test::strings_column_wrapper({"a", "a", "ab", "ab", "ab", "abc", "", ""},
+                                                      {1, 1, 1, 1, 1, 1, 0, 0});
+  auto expected2 = cudf::test::strings_column_wrapper(
+    {"bc d", "bc  d", "cd e", "cd e ", "cd e ", "", "", ""}, {1, 1, 1, 1, 1, 0, 0, 0});
   std::vector<std::unique_ptr<cudf::column>> expected_columns;
   expected_columns.push_back(expected1.release());
   expected_columns.push_back(expected2.release());
   auto expected = std::make_unique<cudf::table>(std::move(expected_columns));
 
-  auto results = cudf::strings::split(strings_view, cudf::string_scalar(""), 1);
+  auto const results = cudf::strings::split(sv, cudf::string_scalar(""), 1);
   EXPECT_TRUE(results->num_columns() == 2);
   CUDF_TEST_EXPECT_TABLES_EQUAL(*results, *expected);
 }
@@ -227,82 +220,100 @@ TEST_F(StringsSplitTest, RSplitWhitespace)
 
 TEST_F(StringsSplitTest, RSplitWhitespaceWithMax)
 {
-  cudf::test::strings_column_wrapper strings(
-    {"a bc d", "a  bc  d", " ab cd e", "ab cd e ", " ab cd e "});
-  cudf::strings_column_view strings_view(strings);
+  auto const input = cudf::test::strings_column_wrapper(
+    {"a bc d", "a  bc  d", " ab cd e", "ab cd e ", " ab cd e ", " abc ", "", " "});
+  auto const sv = cudf::strings_column_view(input);
 
-  cudf::test::strings_column_wrapper expected1({"a bc", "a  bc", " ab cd", "ab cd", " ab cd"});
-  cudf::test::strings_column_wrapper expected2({"d", "d", "e", "e", "e"});
+  auto expected1 = cudf::test::strings_column_wrapper(
+    {"a bc", "a  bc", " ab cd", "ab cd", " ab cd", "abc", "", ""}, {1, 1, 1, 1, 1, 1, 0, 0});
+  auto expected2 = cudf::test::strings_column_wrapper({"d", "d", "e", "e", "e", "", "", ""},
+                                                      {1, 1, 1, 1, 1, 0, 0, 0});
   std::vector<std::unique_ptr<cudf::column>> expected_columns;
   expected_columns.push_back(expected1.release());
   expected_columns.push_back(expected2.release());
   auto expected = std::make_unique<cudf::table>(std::move(expected_columns));
 
-  auto results = cudf::strings::rsplit(strings_view, cudf::string_scalar(""), 1);
+  auto const results = cudf::strings::rsplit(sv, cudf::string_scalar(""), 1);
   EXPECT_TRUE(results->num_columns() == 2);
   CUDF_TEST_EXPECT_TABLES_EQUAL(*results, *expected);
 }
 
 TEST_F(StringsSplitTest, SplitRecord)
 {
-  std::vector<char const*> h_strings{" Héllo thesé", nullptr, "are some  ", "tést String", ""};
-  auto validity =
-    thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; });
-  cudf::test::strings_column_wrapper strings(h_strings.begin(), h_strings.end(), validity);
+  auto const validity = cudf::test::iterators::null_at(1);
+  auto const input    = cudf::test::strings_column_wrapper(
+    {" Héllo thesé", "", "are some  ", "tést String", "", " 123 "}, validity);
+  auto const sv = cudf::strings_column_view(input);
 
-  auto result =
-    cudf::strings::split_record(cudf::strings_column_view(strings), cudf::string_scalar(" "));
-  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
-  LCW expected(
-    {LCW{"", "Héllo", "thesé"}, LCW{}, LCW{"are", "some", "", ""}, LCW{"tést", "String"}, LCW{""}},
-    validity);
+  auto const result = cudf::strings::split_record(sv, cudf::string_scalar(" "));
+  using LCW         = cudf::test::lists_column_wrapper<cudf::string_view>;
+  LCW expected({LCW{"", "Héllo", "thesé"},
+                LCW{},
+                LCW{"are", "some", "", ""},
+                LCW{"tést", "String"},
+                LCW{""},
+                LCW{"", "123", ""}},
+               validity);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
 }
 
 TEST_F(StringsSplitTest, SplitRecordWithMaxSplit)
 {
-  std::vector<char const*> h_strings{" Héllo thesé", nullptr, "are some  ", "tést String", ""};
-  auto validity =
-    thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; });
-  cudf::test::strings_column_wrapper strings(h_strings.begin(), h_strings.end(), validity);
+  auto const validity = cudf::test::iterators::null_at(1);
+  auto const input    = cudf::test::strings_column_wrapper(
+    {" Héllo thesé", "", "are some  ", "tést String", "", " 123 "}, validity);
+  auto const sv = cudf::strings_column_view(input);
 
-  auto result =
-    cudf::strings::split_record(cudf::strings_column_view(strings), cudf::string_scalar(" "), 1);
+  auto const result = cudf::strings::split_record(sv, cudf::string_scalar(" "), 1);
 
   using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
-  LCW expected(
-    {LCW{"", "Héllo thesé"}, LCW{}, LCW{"are", "some  "}, LCW{"tést", "String"}, LCW{""}},
-    validity);
+  LCW expected({LCW{"", "Héllo thesé"},
+                LCW{},
+                LCW{"are", "some  "},
+                LCW{"tést", "String"},
+                LCW{""},
+                LCW{"", "123 "}},
+               validity);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
 }
 
 TEST_F(StringsSplitTest, SplitRecordWhitespace)
 {
-  std::vector<char const*> h_strings{
-    "   Héllo thesé", nullptr, "are\tsome  ", "tést\nString", "  "};
-  auto validity =
-    thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; });
-  cudf::test::strings_column_wrapper strings(h_strings.begin(), h_strings.end(), validity);
+  auto const validity = cudf::test::iterators::null_at(1);
+  auto const input    = cudf::test::strings_column_wrapper(
+    {"   Héllo thesé", "", "are\tsome  ", "tést\nString", "  ", "", " 123 "}, validity);
+  auto const sv = cudf::strings_column_view(input);
 
-  auto result = cudf::strings::split_record(cudf::strings_column_view(strings));
-  using LCW   = cudf::test::lists_column_wrapper<cudf::string_view>;
-  LCW expected({LCW{"Héllo", "thesé"}, LCW{}, LCW{"are", "some"}, LCW{"tést", "String"}, LCW{}},
+  auto result = cudf::strings::split_record(sv);
+
+  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+  LCW expected({LCW{"Héllo", "thesé"},
+                LCW{},
+                LCW{"are", "some"},
+                LCW{"tést", "String"},
+                LCW{},
+                LCW{},
+                LCW{"123"}},
                validity);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
 }
 
 TEST_F(StringsSplitTest, SplitRecordWhitespaceWithMaxSplit)
 {
-  std::vector<char const*> h_strings{
-    "   Héllo thesé  ", nullptr, "are\tsome  ", "tést\nString", "  "};
-  auto validity =
-    thrust::make_transform_iterator(h_strings.begin(), [](auto str) { return str != nullptr; });
-  cudf::test::strings_column_wrapper strings(h_strings.begin(), h_strings.end(), validity);
+  auto const validity = cudf::test::iterators::null_at(1);
+  auto const input    = cudf::test::strings_column_wrapper(
+    {"   Héllo thesé  ", "", "are\tsome  ", "tést\nString", "  ", "", " 123 "}, validity);
+  auto const sv = cudf::strings_column_view(input);
 
-  auto result =
-    cudf::strings::split_record(cudf::strings_column_view(strings), cudf::string_scalar(""), 1);
-  using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
-  LCW expected({LCW{"Héllo", "thesé  "}, LCW{}, LCW{"are", "some  "}, LCW{"tést", "String"}, LCW{}},
+  auto const result = cudf::strings::split_record(sv, cudf::string_scalar(""), 1);
+  using LCW         = cudf::test::lists_column_wrapper<cudf::string_view>;
+  LCW expected({LCW{"Héllo", "thesé  "},
+                LCW{},
+                LCW{"are", "some  "},
+                LCW{"tést", "String"},
+                LCW{},
+                LCW{},
+                LCW{"123"}},
                validity);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result->view(), expected);
 }

--- a/docs/cudf/source/conf.py
+++ b/docs/cudf/source/conf.py
@@ -596,6 +596,7 @@ nitpick_ignore = [
     ("py:class", "pd.DataFrame"),
     ("py:class", "pandas.core.indexes.frozen.FrozenList"),
     ("py:class", "pa.Array"),
+    ("py:class", "pa.ListType"),
     ("py:class", "pa.Decimal128Type"),
     ("py:class", "ScalarLike"),
     ("py:class", "ParentType"),

--- a/python/cudf/cudf/core/column/decimal.py
+++ b/python/cudf/cudf/core/column/decimal.py
@@ -33,6 +33,8 @@ from cudf.utils.dtypes import (
 from cudf.utils.utils import pa_mask_buffer_to_mask
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from cudf._typing import ColumnBinaryOperand, ColumnLike, Dtype, ScalarLike
     from cudf.core.buffer import Buffer
 
@@ -284,7 +286,7 @@ class Decimal32Column(DecimalBaseColumn):
         )
 
     @classmethod
-    def from_arrow(cls, data: pa.Array):
+    def from_arrow(cls, data: pa.Array) -> Self:
         dtype = Decimal32Dtype.from_arrow(data.type)
         mask_buf = data.buffers()[0]
         mask = (
@@ -365,7 +367,7 @@ class Decimal128Column(DecimalBaseColumn):
         )
 
     @classmethod
-    def from_arrow(cls, data: pa.Array):
+    def from_arrow(cls, data: pa.Array) -> Self:
         result = cast(Decimal128Dtype, super().from_arrow(data))
         result.dtype.precision = data.type.precision
         return result
@@ -406,7 +408,7 @@ class Decimal64Column(DecimalBaseColumn):
         )
 
     @classmethod
-    def from_arrow(cls, data: pa.Array):
+    def from_arrow(cls, data: pa.Array) -> Self:
         dtype = Decimal64Dtype.from_arrow(data.type)
         mask_buf = data.buffers()[0]
         mask = (

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5685,14 +5685,14 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
 
     @classmethod
     @_performance_tracking
-    def from_arrow(cls, table):
+    def from_arrow(cls, table: pa.Table) -> Self:
         """
         Convert from PyArrow Table to DataFrame.
 
         Parameters
         ----------
-        table : PyArrow Table Object
-            PyArrow Table Object which has to be converted to cudf DataFrame.
+        table : pyarrow.Table
+            PyArrow Table to convert to a cudf DataFrame.
 
         Raises
         ------
@@ -5720,59 +5720,49 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
             how :meth:`pyarrow.Table.to_pandas` works for PyArrow Tables i.e.
             it does not support automatically setting index column(s).
         """
-        index_col = None
-        col_index_names = None
-        physical_column_md = []
-        if isinstance(table, pa.Table) and isinstance(
-            table.schema.pandas_metadata, dict
-        ):
-            physical_column_md = table.schema.pandas_metadata["columns"]
-            index_col = table.schema.pandas_metadata["index_columns"]
-            if "column_indexes" in table.schema.pandas_metadata:
-                col_index_names = []
-                for col_meta in table.schema.pandas_metadata["column_indexes"]:
-                    col_index_names.append(col_meta["name"])
-
         out = super().from_arrow(table)
-        if col_index_names is not None:
-            out._data._level_names = col_index_names
-        if index_col:
-            if isinstance(index_col[0], dict):
-                range_meta = index_col[0]
-                idx = cudf.RangeIndex(
-                    start=range_meta["start"],
-                    stop=range_meta["stop"],
-                    step=range_meta["step"],
-                    name=range_meta["name"],
-                )
-                if len(idx) == len(out):
-                    # `idx` is generated from arrow `pandas_metadata`
-                    # which can get out of date with many of the
-                    # arrow operations. Hence verifying if the
-                    # lengths match, or else don't need to set
-                    # an index at all i.e., Default RangeIndex
-                    # will be set.
-                    # See more about the discussion here:
-                    # https://github.com/apache/arrow/issues/15178
-                    out = out.set_index(idx)
-            else:
-                out = out.set_index(index_col)
-
-        if (
-            "__index_level_0__" in out.index.names
-            and len(out.index.names) == 1
-        ):
-            real_index_name = None
-            for md in physical_column_md:
-                if md["field_name"] == "__index_level_0__":
-                    real_index_name = md["name"]
-                    break
-            out.index.name = real_index_name
-
+        if isinstance(table.schema.pandas_metadata, dict):
+            # Maybe set .index or .columns attributes
+            pd_meta = table.schema.pandas_metadata
+            if "column_indexes" in pd_meta:
+                out._data._level_names = [
+                    col_meta["name"] for col_meta in pd_meta["column_indexes"]
+                ]
+            if index_col := pd_meta["index_columns"]:
+                if isinstance(index_col[0], dict):
+                    range_meta = index_col[0]
+                    idx = cudf.RangeIndex(
+                        start=range_meta["start"],
+                        stop=range_meta["stop"],
+                        step=range_meta["step"],
+                        name=range_meta["name"],
+                    )
+                    if len(idx) == len(out):
+                        # `idx` is generated from arrow `pandas_metadata`
+                        # which can get out of date with many of the
+                        # arrow operations. Hence verifying if the
+                        # lengths match, or else don't need to set
+                        # an index at all i.e., Default RangeIndex
+                        # will be set.
+                        # See more about the discussion here:
+                        # https://github.com/apache/arrow/issues/15178
+                        out = out.set_index(idx)
+                else:
+                    out = out.set_index(index_col)
+            if (
+                len(out.index.names) == 1
+                and out.index.names[0] == "__index_level_0__"
+            ):
+                for col_meta in pd_meta["columns"]:
+                    if col_meta["field_name"] == "__index_level_0__":
+                        out.index.name = col_meta["name"]
+                        break
+                else:
+                    out.index.name = None
         return out
 
     @_performance_tracking
-    def to_arrow(self, preserve_index=None) -> pa.Table:
+    def to_arrow(self, preserve_index: bool | None = None) -> pa.Table:
         """
         Convert to a PyArrow Table.
 

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -374,20 +374,13 @@ class ListDtype(_BaseDtype):
     ListDtype(ListDtype(int32))
     """
 
-    _typ: pa.ListType
     name: str = "list"
 
-    def __init__(self, element_type: Any) -> None:
-        if isinstance(element_type, ListDtype):
-            self._typ = pa.list_(element_type._typ)
-        else:
-            element_type = cudf.utils.dtypes.cudf_dtype_to_pa_type(
-                cudf.dtype(element_type)
-            )
-            self._typ = pa.list_(element_type)
+    def __init__(self, element_type: Dtype) -> None:
+        self._element_type = cudf.dtype(element_type)
 
     @cached_property
-    def element_type(self) -> Dtype:
+    def element_type(self) -> DtypeObj:
         """
         Returns the element type of the ``ListDtype``.
 
@@ -408,15 +401,10 @@ class ListDtype(_BaseDtype):
         >>> deep_nested_type.element_type.element_type.element_type
         'float32'
         """
-        if isinstance(self._typ.value_type, pa.ListType):
-            return ListDtype.from_arrow(self._typ.value_type)
-        elif isinstance(self._typ.value_type, pa.StructType):
-            return StructDtype.from_arrow(self._typ.value_type)
-        else:
-            return cudf_dtype_from_pa_type(self._typ.value_type)
+        return self._element_type
 
     @cached_property
-    def leaf_type(self):
+    def leaf_type(self) -> DtypeObj:
         """
         Returns the type of the leaf values.
 
@@ -441,7 +429,7 @@ class ListDtype(_BaseDtype):
         return pa.array
 
     @classmethod
-    def from_arrow(cls, typ):
+    def from_arrow(cls, typ: pa.ListType) -> Self:
         """
         Creates a ``ListDtype`` from ``pyarrow.ListType``.
 
@@ -466,11 +454,9 @@ class ListDtype(_BaseDtype):
         >>> list_dtype
         ListDtype(int64)
         """
-        obj = object.__new__(cls)
-        obj._typ = typ
-        return obj
+        return cls(cudf_dtype_from_pa_type(typ.value_type))
 
-    def to_arrow(self):
+    def to_arrow(self) -> pa.ListType:
         """
         Convert to a ``pyarrow.ListType``
 
@@ -483,23 +469,23 @@ class ListDtype(_BaseDtype):
         >>> list_dtype.to_arrow()
         ListType(list<item: list<item: float>>)
         """
-        return self._typ
+        return pa.list_(cudf_dtype_to_pa_type(self.element_type))
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if isinstance(other, str):
             return other == self.name
         if not isinstance(other, ListDtype):
             return False
-        return self._typ.equals(other._typ)
+        return self.element_type == other.element_type
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if isinstance(self.element_type, (ListDtype, StructDtype)):
             return f"{type(self).__name__}({self.element_type!r})"
         else:
             return f"{type(self).__name__}({self.element_type})"
 
-    def __hash__(self):
-        return hash(self._typ)
+    def __hash__(self) -> int:
+        return hash(self.to_arrow())
 
     def serialize(self) -> tuple[dict, list]:
         header: dict[str, Dtype] = {}
@@ -518,7 +504,7 @@ class ListDtype(_BaseDtype):
         return header, frames
 
     @classmethod
-    def deserialize(cls, header: dict, frames: list):
+    def deserialize(cls, header: dict, frames: list) -> Self:
         _check_type(cls, header, frames)
         if isinstance(header["element-type"], dict):
             element_type = Serializable.device_deserialize(
@@ -529,7 +515,7 @@ class ListDtype(_BaseDtype):
         return cls(element_type=element_type)
 
     @cached_property
-    def itemsize(self):
+    def itemsize(self) -> int:
         return self.element_type.itemsize
 
     def _recursively_replace_fields(self, result: list) -> list:

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -906,28 +906,19 @@ class Frame(BinaryOperand, Scannable, Serializable):
         1  2  5
         2  3  6
         """
-
-        if not isinstance(data, (pa.Table)):
+        if not isinstance(data, pa.Table):
             raise TypeError(
-                "To create a multicolumn cudf data, "
-                "the data should be an arrow Table"
+                f"data must be a pyarrow.Table, not {type(data).__name__}"
             )
 
         column_names = data.column_names
         pandas_dtypes = {}
         np_dtypes = {}
         if isinstance(data.schema.pandas_metadata, dict):
-            metadata = data.schema.pandas_metadata
-            pandas_dtypes = {
-                col["field_name"]: col["pandas_type"]
-                for col in metadata["columns"]
-                if "field_name" in col
-            }
-            np_dtypes = {
-                col["field_name"]: col["numpy_type"]
-                for col in metadata["columns"]
-                if "field_name" in col
-            }
+            for col in data.schema.pandas_metadata:
+                if "field_name" in col:
+                    pandas_dtypes[col["field_name"]] = col["pandas_type"]
+                    np_dtypes[col["field_name"]] = col["numpy_type"]
 
         # Currently we don't have support for
         # pyarrow.DictionaryArray -> cudf Categorical column,
@@ -1049,7 +1040,11 @@ class Frame(BinaryOperand, Scannable, Serializable):
                     cudf.utils.dtypes.cudf_dtype_from_pa_type(data[name].type)
                 )
 
-        return cls._from_data({name: result[name] for name in column_names})
+        return cls._from_data(
+            ColumnAccessor(
+                {name: result[name] for name in column_names}, verify=False
+            )
+        )
 
     @_performance_tracking
     def to_arrow(self) -> pa.Table:

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -1148,7 +1148,7 @@ class Index(SingleColumnFrame, BaseIndex, metaclass=IndexMeta):
 
     @classmethod
     @_performance_tracking
-    def from_arrow(cls, obj) -> Index | cudf.MultiIndex:
+    def from_arrow(cls, obj: pa.Array) -> Index | cudf.MultiIndex:
         """Create from PyArrow Array/ChunkedArray.
 
         Parameters

--- a/python/cudf/cudf/core/single_column_frame.py
+++ b/python/cudf/cudf/core/single_column_frame.py
@@ -124,7 +124,7 @@ class SingleColumnFrame(Frame, NotIterable):
 
     @classmethod
     @_performance_tracking
-    def from_arrow(cls, array) -> Self:
+    def from_arrow(cls, array: pa.Array) -> Self:
         raise NotImplementedError
 
     @_performance_tracking


### PR DESCRIPTION
## Description
Additionally simplifies `ListDtype` to "privately" hold a dtype object instead of a pyarrow object

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
