### PR TITLE
Export cudf compiler flags and definitions

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -832,11 +832,11 @@ set_target_properties(
              LINK_FLAGS "-Wl,--exclude-libs,libzstd.a"
 )
 
-# Export the compiler flags and definitions so the downstream applications
-# can optionally retrieve and use them.
+# Export the compiler flags and definitions so the downstream applications can optionally retrieve
+# and use them.
 set_target_properties(
   cudf
-  PROPERTIES EXPORT_PROPERTIES 
+  PROPERTIES EXPORT_PROPERTIES
              "CUDF_CXX_FLAGS;CUDF_CUDA_FLAGS;CUDF_CXX_DEFINITIONS;CUDF_CUDA_DEFINITIONS"
              CUDF_CXX_FLAGS "${CUDF_CXX_FLAGS}"
              CUDF_CUDA_FLAGS "${CUDF_CUDA_FLAGS}"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -832,6 +832,18 @@ set_target_properties(
              LINK_FLAGS "-Wl,--exclude-libs,libzstd.a"
 )
 
+# Export the compiler flags and definitions so the downstream applications
+# can optionally retrieve and use them.
+set_target_properties(
+  cudf
+  PROPERTIES EXPORT_PROPERTIES 
+             "CUDF_CXX_FLAGS;CUDF_CUDA_FLAGS;CUDF_CXX_DEFINITIONS;CUDF_CUDA_DEFINITIONS"
+             CUDF_CXX_FLAGS "${CUDF_CXX_FLAGS}"
+             CUDF_CUDA_FLAGS "${CUDF_CUDA_FLAGS}"
+             CUDF_CXX_DEFINITIONS "${CUDF_CXX_DEFINITIONS}"
+             CUDF_CUDA_DEFINITIONS "${CUDF_CUDA_DEFINITIONS}"
+)
+
 # Note: This must come before the target_compile_options below so that the function can modify the
 # flags if necessary.
 if(CUDF_CLANG_TIDY OR CUDF_IWYU)

--- a/java/src/main/native/CMakeLists.txt
+++ b/java/src/main/native/CMakeLists.txt
@@ -71,13 +71,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/"
 # ##################################################################################################
 # * compiler options ------------------------------------------------------------------------------
 
-set(CUDF_CXX_FLAGS "")
-set(CUDF_CUDA_FLAGS "")
-set(CUDF_CXX_DEFINITIONS "")
-set(CUDF_CUDA_DEFINITIONS "")
-
 rapids_find_package(CUDAToolkit REQUIRED)
-include(ConfigureCUDA) # set other CUDA compilation flags
 
 if(CUDF_USE_PER_THREAD_DEFAULT_STREAM)
   message(STATUS "Using per-thread default stream")
@@ -94,6 +88,11 @@ rapids_cmake_build_type("Release")
 
 set(cudf_ROOT "${CUDF_CPP_BUILD_DIR}")
 rapids_find_package(cudf REQUIRED)
+
+get_target_property(CUDF_CXX_FLAGS cudf::cudf CUDF_CXX_FLAGS)
+get_target_property(CUDF_CUDA_FLAGS cudf::cudf CUDF_CUDA_FLAGS)
+get_target_property(CUDF_CXX_DEFINITIONS cudf::cudf CUDF_CXX_DEFINITIONS)
+get_target_property(CUDF_CUDA_DEFINITIONS cudf::cudf CUDF_CUDA_DEFINITIONS)
 
 # ##################################################################################################
 # * nvtx3-------------------------------------------------------------------------------------------


### PR DESCRIPTION
This exports the compiler flags and definitions that are configured by libcudf, so the downstream applications can retrieve and use them directly. 

This is useful for the applications that heavily depend on libcudf and try to maintain a similar CMake build system as libcudf, such as `spark-rapids-jni`. They typically have to generate the same set of flags/definitions similar to what libcudf uses and have to periodically update their flags/definitions to sync with libcudf.