### PR TITLE
Improve cold cache dropping

### DIFF
--- a/cpp/benchmarks/io/cuio_common.cpp
+++ b/cpp/benchmarks/io/cuio_common.cpp
@@ -216,6 +216,13 @@ void try_drop_l3_cache()
     return;
   }
 
+  // When data are written to a file, Linux first places them in dirty pages, and then uses a
+  // writeback mechanism to move them to the file system. sysctl vm.drop_caches=3 is only capable of
+  // dropping the clean cache. The dirty pages may still affect the performance of cold cache
+  // benchmark. A call to sync() triggers the writeback process and makes dirty pages clean, ready
+  // to be dropped. This function never fails and does not require sudo.
+  sync();
+
   std::array drop_cache_cmds{"/sbin/sysctl vm.drop_caches=3", "sudo /sbin/sysctl vm.drop_caches=3"};
   CUDF_EXPECTS(std::any_of(drop_cache_cmds.cbegin(),
                            drop_cache_cmds.cend(),


### PR DESCRIPTION
## Description

This PR makes cuDF cold cache benchmark more rigorous by eliminating the impact of dirty pages before page cache dropping.


<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
