### PR TITLE
[POC] Print the physical cudf-polars plan in ``pdsh.py``

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
@@ -29,6 +29,7 @@ import pynvml
 
 import polars as pl
 
+from cudf_polars.dsl.ir import Union
 from cudf_polars.dsl.translate import Translator
 from cudf_polars.experimental.parallel import evaluate_streaming, lower_ir_graph
 from cudf_polars.utils.config import ConfigOptions
@@ -221,9 +222,13 @@ def _explain(
     """Print the physical plan for an IR node."""
     val = offset
     count = partition_info[ir].count
-    val += f"{type(ir).__name__.upper()} ({count})\n"
-    for child in ir.children:
-        val += _explain(child, partition_info, offset=offset + "  ")
+    if isinstance(ir, Union):
+        child_type = type(ir.children[0]).__name__.upper()
+        val += f"UNION ({count} x {child_type})\n"
+    else:
+        val += f"{type(ir).__name__.upper()} ({count})\n"
+        for child in ir.children:
+            val += _explain(child, partition_info, offset=offset + "  ")
     return val
 
 
@@ -1211,7 +1216,7 @@ def run(args: argparse.Namespace) -> None:
             if args.print_results:
                 print(result)
             if args.explain:
-                print(f"Query {q_id} physical plan:")
+                print(f"Query {q_id} - Physical plan")
                 print(explain_query(q, engine))
             print(f"Ran query={q_id} in {record.duration:0.4f}s", flush=True)
             records[q_id].append(record)

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
@@ -1071,7 +1071,7 @@ parser.add_argument(
 parser.add_argument(
     "-e",
     "--executor",
-    default="dask",
+    default="streaming",
     type=str,
     choices=["in-memory", "streaming", "cpu"],
     help="Executor.",

--- a/python/cudf_polars/cudf_polars/experimental/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/utils.py
@@ -20,6 +20,15 @@ if TYPE_CHECKING:
     from cudf_polars.experimental.dispatch import LowerIRTransformer
 
 
+def _print_tree(ir: IR, _offset: str = "") -> str:
+    """Print the tree representation of ``ir``."""
+    val = _offset
+    val += f"{type(ir).__name__.upper()}\n"
+    for child in ir.children:
+        val += _print_tree(child, _offset + "  ")
+    return val
+
+
 def _concat(*dfs: DataFrame) -> DataFrame:
     # Concatenate a sequence of DataFrames vertically
     return Union.do_evaluate(None, *dfs)


### PR DESCRIPTION
## Description
Proposes a simple utility to print the physical plan for each query in `experimental/benchmarks/pdsh.py`. For example,

Add the `--explain` flag when calling `pdsh.py`:
```
$ python pdsh.py 13 --path $DATSET_PATH --explain

...

Query 13 - Physical plan

SORT ('custdist', 'c_count') [1]
  SELECT ('c_count', 'custdist') [1]
    SELECT ('c_count', 'len') [1]
      SELECT ('c_count', '_______0') [1]
        GROUPBY ('c_count',) [1]
          REPARTITION [1]
            GROUPBY ('c_count',) [4]
              SELECT ('c_custkey', 'c_count') [4]
                SELECT ('c_custkey', '_________0') [4]
                  GROUPBY ('c_custkey',) [4]
                    SHUFFLE [4]
                      GROUPBY ('c_custkey',) [91]
                        PROJECTION ('c_custkey', 'o_orderkey') [91]
                          JOIN Left ('c_custkey',) ('o_custkey',) [91]
                            SHUFFLE [91]
                              UNION [1 x SCAN ('c_custkey',) customer/customer_00164338-2a8d-4392-9bab-d5259dd47133.parquet ...]
                            SHUFFLE [91]
                              UNION [91 x SCAN ('o_custkey', 'o_orderkey', 'o_comment') orders/orders_00426f3f-530b-4cdd-ae6c-8c9cb046b522.parquet ...]
                              
 ...
```

We may want a **proper** utility like this outside of `pdsh.py`, but it also seems fine to keep it in the benchmarking file for now.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
