### PR TITLE
Add CUDA_ARCHITECTURES setting to cpp-linters script

### DIFF
--- a/ci/cpp_linters.sh
+++ b/ci/cpp_linters.sh
@@ -28,7 +28,7 @@ iwyu_flag=""
 if [[ "${RAPIDS_BUILD_TYPE:-}" == "nightly" ]]; then
   iwyu_flag="-DCUDF_IWYU=ON"
 fi
-cmake -S cpp -B cpp/build -DCMAKE_BUILD_TYPE=Release -DCUDF_CLANG_TIDY=ON ${iwyu_flag} -DBUILD_TESTS=OFF -GNinja
+cmake -S cpp -B cpp/build -DCMAKE_BUILD_TYPE=Release -DCUDF_CLANG_TIDY=ON ${iwyu_flag} -DBUILD_TESTS=OFF -DCMAKE_CUDA_ARCHITECTURES=75 -GNinja
 cmake --build cpp/build 2>&1 | python cpp/scripts/parse_iwyu_output.py
 
 # Remove invalid components of the path for local usage. The path below is


### PR DESCRIPTION
## Description
Fixes errors in the cpp-linters nightly test run by specifying supported CUDA architecture in the cmake command.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
