### PR TITLE
[WIP] Preserve partitioning after ``Filter`` and ``Projection`` in cudf-polars

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import itertools
 import operator
-from functools import reduce
+from functools import partial, reduce
 from typing import TYPE_CHECKING, Any
 
 import cudf_polars.experimental.groupby
@@ -251,7 +251,7 @@ def _(
 
 
 def _lower_ir_pwise(
-    ir: IR, rec: LowerIRTransformer
+    ir: IR, rec: LowerIRTransformer, *, preserve_partitioning: bool = False
 ) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
     # Lower a partition-wise (i.e. embarrassingly-parallel) IR node
 
@@ -268,15 +268,21 @@ def _lower_ir_pwise(
             msg=f"Class {type(ir)} does not support children with mismatched partition counts.",
         )
 
+    # Preserve child partition_info if possible
+    if preserve_partitioning and len(children) == 1:
+        partition = partition_info[children[0]]
+    else:
+        partition = PartitionInfo(count=max(counts))
+
     # Return reconstructed node and partition-info dict
-    partition = PartitionInfo(count=max(counts))
     new_node = ir.reconstruct(children)
     partition_info[new_node] = partition
     return new_node, partition_info
 
 
-lower_ir_node.register(Projection, _lower_ir_pwise)
+_lower_ir_pwise_preserve = partial(_lower_ir_pwise, preserve_partitioning=True)
+lower_ir_node.register(Projection, _lower_ir_pwise_preserve)
+lower_ir_node.register(Filter, _lower_ir_pwise_preserve)
 lower_ir_node.register(Cache, _lower_ir_pwise)
-lower_ir_node.register(Filter, _lower_ir_pwise)
 lower_ir_node.register(HStack, _lower_ir_pwise)
 lower_ir_node.register(HConcat, _lower_ir_pwise)


### PR DESCRIPTION
## Description
`Filter` and `Projection` nodes currently "refresh" partitioning information. This isn't necessary, and may result in unnecessary `Shuffle` operations.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
