### PR TITLE
Add alloc_size member function to cudf::column and cudf::table

### DIFF
--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -278,6 +278,17 @@ class column {
    * the column.
    */
   contents release() noexcept;
+
+  /**
+   * @brief Returns the total device allocation size of the column in bytes
+   *
+   * This includes the size of the data buffer, null mask, and any child columns.
+   * It also includes any padding bytes and is not guaranteed to be the same as
+   * the size()*sizeof(T) for the column's logical type.
+   *
+   * @return The total allocation size in bytes
+   */
+  [[nodiscard]] std::size_t alloc_size() const;
 
   /**
    * @brief Creates an immutable, non-owning view of the column's data and

--- a/cpp/include/cudf/table/table.hpp
+++ b/cpp/include/cudf/table/table.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,15 @@ class table {
    * @return  The number of rows
    */
   [[nodiscard]] size_type num_rows() const noexcept { return _num_rows; }
+
+  /**
+   * @brief Returns the total device allocation size of the table's columns in bytes
+   *
+   * @see cudf::column::alloc_size
+   *
+   * @return The total allocation size in bytes
+   */
+  [[nodiscard]] std::size_t alloc_size() const;
 
   /**
    * @brief Returns an immutable, non-owning `table_view` of the contents of

--- a/cpp/src/column/column.cu
+++ b/cpp/src/column/column.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,6 +83,15 @@ column::contents column::release() noexcept
   return column::contents{std::make_unique<rmm::device_buffer>(std::move(_data)),
                           std::make_unique<rmm::device_buffer>(std::move(_null_mask)),
                           std::move(_children)};
+}
+
+std::size_t column::alloc_size() const
+{
+  return _data.size() + _null_mask.size() +
+         std::accumulate(
+           _children.begin(), _children.end(), 0, [](auto const& sum, auto const& child) {
+             return sum + child->alloc_size();
+           });
 }
 
 // Create immutable view

--- a/cpp/src/table/table.cpp
+++ b/cpp/src/table/table.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+
+#include <numeric>
 
 namespace cudf {
 
@@ -59,6 +61,13 @@ table::table(table_view view, rmm::cuda_stream_view stream, rmm::device_async_re
   for (auto const& c : view) {
     _columns.emplace_back(std::make_unique<column>(c, stream, mr));
   }
+}
+
+std::size_t table::alloc_size() const
+{
+  return std::accumulate(_columns.begin(), _columns.end(), 0, [](auto const& sum, auto const& c) {
+    return sum + c->alloc_size();
+  });
 }
 
 // Create immutable view

--- a/cpp/tests/table/table_tests.cpp
+++ b/cpp/tests/table/table_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,6 +146,32 @@ TEST_F(TableTest, CreateFromViewVectorEmptyTables)
   views.emplace_back(std::vector<column_view>{});
   TView final_view{views};
   EXPECT_EQ(final_view.num_columns(), 0);
+}
+
+TEST_F(TableTest, AllocSize)
+{
+  column_wrapper<int32_t> col1{{1, 2, 3, 4}};
+  column_wrapper<int16_t> col2{{1, 2, 3, 4}};
+
+  CVector cols;
+  cols.push_back(col1.release());
+  cols.push_back(col2.release());
+
+  Table t(std::move(cols));
+  EXPECT_EQ(t.alloc_size(), 24);
+}
+
+TEST_F(TableTest, AllocSizeWithNulls)
+{
+  column_wrapper<int32_t> col1{{1, 2, 3, 4}, {1, 0, 1, 0}};
+  column_wrapper<int16_t> col2{{1, 2, 3, 4}, {1, 0, 1, 0}};
+
+  CVector cols;
+  cols.push_back(col1.release());
+  cols.push_back(col2.release());
+
+  Table t(std::move(cols));
+  EXPECT_EQ(t.alloc_size(), 152);  // bitmask has padding
 }
 
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
## Description
Adds a new member function to the `cudf::table` and `cudf::column` classes to report the device memory allocation size of the internal device-buffers of itself and its children.
The value will including padding and may not be computable from the logical column type and the number of elements and null-count.

Closes #18462 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
