### PR TITLE
Fix device compression when writing Parquet files without using nvCOMP

### DIFF
--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -798,6 +798,7 @@ CUDF_KERNEL void __launch_bounds__(128)
           page_g.page_data    = ck_g.uncompressed_bfr + page_offset;
           if (not comp_page_sizes.empty()) {
             page_g.compressed_data = ck_g.compressed_bfr + comp_page_offset;
+            page_g.comp_data_size  = comp_page_sizes[ck_g.first_page + num_pages];
           }
           page_g.start_row          = cur_row;
           page_g.num_rows           = rows_in_page;
@@ -1600,7 +1601,7 @@ __device__ void finish_page_encode(state_buf* s,
       auto const bytes_to_compress = static_cast<uint32_t>(end_ptr - c_base);
       comp_in[blockIdx.x]          = {c_base, bytes_to_compress};
       comp_out[blockIdx.x] = {s->page.compressed_data + s->page.max_hdr_size + s->page.max_lvl_size,
-                              0};  // size is unused
+                              s->page.comp_data_size};
     }
     pages[blockIdx.x] = s->page;
     if (not comp_results.empty()) {

--- a/cpp/src/io/utilities/config_utils.cpp
+++ b/cpp/src/io/utilities/config_utils.cpp
@@ -58,7 +58,7 @@ enum class usage_policy : uint8_t { OFF, STABLE, ALWAYS };
  */
 usage_policy get_env_policy()
 {
-  static auto const env_val = getenv_or<std::string>("LIBCUDF_NVCOMP_POLICY", "STABLE");
+  auto const env_val = getenv_or<std::string>("LIBCUDF_NVCOMP_POLICY", "STABLE");
   if (env_val == "OFF") return usage_policy::OFF;
   if (env_val == "STABLE") return usage_policy::STABLE;
   if (env_val == "ALWAYS") return usage_policy::ALWAYS;


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
