### PR TITLE
Disable `arm64` python tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -245,7 +245,7 @@ jobs:
       package-name: cudf
       package-type: python
   wheel-tests-cudf:
-    needs: [changed-files]
+    needs: [wheel-build-cudf, changed-files]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -245,7 +245,7 @@ jobs:
       package-name: cudf
       package-type: python
   wheel-tests-cudf:
-    needs: [wheel-build-cudf, changed-files]
+    # needs: [wheel-build-cudf, changed-files]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -169,6 +169,8 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.06
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
+      # This selects "ARCH=amd64".
+      matrix_filter: map(select(.ARCH == "amd64"))
       build_type: pull-request
       script: "ci/test_python_cudf.sh"
   conda-python-other-tests:
@@ -248,6 +250,8 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
+      # This selects "ARCH=amd64".
+      matrix_filter: map(select(.ARCH == "amd64"))
       build_type: pull-request
       script: ci/test_wheel_cudf.sh
   wheel-build-cudf-polars:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -245,7 +245,7 @@ jobs:
       package-name: cudf
       package-type: python
   wheel-tests-cudf:
-    # needs: [wheel-build-cudf, changed-files]
+    needs: [changed-files]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,8 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.06
     with:
+      # This selects "ARCH=amd64".
+      matrix_filter: map(select(.ARCH == "amd64"))
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
@@ -70,6 +72,8 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-25.06
     with:
+      # This selects "ARCH=amd64".
+      matrix_filter: map(select(.ARCH == "amd64"))
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
@@ -103,6 +107,8 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
     with:
+      # This selects "ARCH=amd64".
+      matrix_filter: map(select(.ARCH == "amd64"))
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
@@ -112,6 +118,8 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
     with:
+      # This selects "ARCH=amd64".
+      matrix_filter: map(select(.ARCH == "amd64"))
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
@@ -121,6 +129,8 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
     with:
+      # This selects "ARCH=amd64".
+      matrix_filter: map(select(.ARCH == "amd64"))
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
@@ -142,6 +152,8 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
     with:
+      # This selects "ARCH=amd64".
+      matrix_filter: map(select(.ARCH == "amd64"))
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
@@ -151,6 +163,8 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
     with:
+      # This selects "ARCH=amd64".
+      matrix_filter: map(select(.ARCH == "amd64"))
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}


### PR DESCRIPTION
## Description
This PR disables `arm64` tests to unblock CI.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
