### PR TITLE
Exclude librmm.so from auditwheel

### DIFF
--- a/ci/build_wheel_cudf.sh
+++ b/ci/build_wheel_cudf.sh
@@ -26,6 +26,7 @@ python -m auditwheel repair \
     --exclude libnvcomp.so \
     --exclude libkvikio.so \
     --exclude librapids_logger.so \
+    --exclude librmm.so \
     -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     ${package_dir}/dist/*
 

--- a/ci/build_wheel_libcudf.sh
+++ b/ci/build_wheel_libcudf.sh
@@ -39,6 +39,7 @@ python -m auditwheel repair \
     --exclude libnvcomp.so.4 \
     --exclude libkvikio.so \
     --exclude librapids_logger.so \
+    --exclude librmm.so \
     -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     ${package_dir}/dist/*
 

--- a/ci/build_wheel_pylibcudf.sh
+++ b/ci/build_wheel_pylibcudf.sh
@@ -24,6 +24,7 @@ python -m auditwheel repair \
     --exclude libnvcomp.so \
     --exclude libkvikio.so \
     --exclude librapids_logger.so \
+    --exclude librmm.so \
     -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     ${package_dir}/dist/*
 


### PR DESCRIPTION
## Description
librmm will ship a shared library component in 25.06 (xref: https://github.com/rapidsai/rmm/issues/1779). This PR updates `auditwheel` calls to exclude `librmm.so`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
