### PR TITLE
Switch from printing to logging

### DIFF
--- a/cpp/src/column/column_view.cpp
+++ b/cpp/src/column/column_view.cpp
@@ -17,6 +17,7 @@
 #include <cudf/column/column_view.hpp>
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/hashing/detail/hashing.hpp>
+#include <cudf/logger_macros.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -55,8 +56,7 @@ void prefetch_col_data(ColumnView& col, void const* data_ptr, std::string_view k
         scv.chars_size(cudf::get_default_stream()) * sizeof(char),
         cudf::get_default_stream());
     } else {
-      std::cout << key << ": Unsupported type: " << static_cast<int32_t>(col.type().id())
-                << std::endl;
+      CUDF_LOG_DEBUG("Unsupported type: %d", static_cast<int32_t>(col.type().id()));
     }
   }
 }


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Currently we print a notice when prefetching is enabled and we try to use a type that cannot be safely prefetched (essentially any nested type). We should not be printing unconditionally. Logging is more appropriate.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
