### PR TITLE
Move `test_large_unique_categories_repr` to benchmarks

### DIFF
--- a/python/cudf/benchmarks/API/bench_index.py
+++ b/python/cudf/benchmarks/API/bench_index.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 """Benchmarks of Index methods."""
 
@@ -15,3 +15,8 @@ def bench_construction(benchmark, N):
 @benchmark_with_object(cls="index", dtype="int", nulls=False)
 def bench_sort_values(benchmark, index):
     benchmark(index.sort_values)
+
+
+def bench_large_unique_categories_repr(benchmark):
+    pi = cudf.CategoricalIndex(range(100_000_000))
+    benchmark(repr, pi)

--- a/python/cudf/cudf/tests/test_repr.py
+++ b/python/cudf/cudf/tests/test_repr.py
@@ -1487,16 +1487,11 @@ def test_interval_index_repr():
     assert repr(pi) == repr(gi)
 
 
-@pytest.mark.skip(reason="This test is unstable in CI")
-@pytest.mark.flaky(reruns=3, reruns_delay=5)
-def test_large_unique_categories_repr():
-    # Unfortunately, this is a long running test (takes about 1 minute)
-    # and there is no way we can reduce the time
-    pi = pd.CategoricalIndex(range(100_000_000))
-    gi = cudf.CategoricalIndex(range(100_000_000))
+def test_unique_categories_repr():
+    pi = pd.CategoricalIndex(range(10_000))
+    gi = cudf.CategoricalIndex(range(10_000))
     expected_repr = repr(pi)
-    with utils.cudf_timeout(6):
-        actual_repr = repr(gi)
+    actual_repr = repr(gi)
     assert expected_repr == actual_repr
 
 


### PR DESCRIPTION
## Description
This PR fully resolves #18665 by moving the test to benchmarks and only verifying the correctness result on a smaller subset of values in the regular pytest suites.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
