### PR TITLE
Experimental PQ reader utility to calculate the total rows in input row groups

### DIFF
--- a/cpp/include/cudf/io/experimental/hybrid_scan.hpp
+++ b/cpp/include/cudf/io/experimental/hybrid_scan.hpp
@@ -203,11 +203,11 @@ namespace io::parquet::experimental {
  * filter columns and also updates the row mask column to only the valid rows that satisfy the
  * filter expression. If no row group pruning is needed, pass a span of all row group indices from
  * `all_row_groups()` function as the current list of row groups. Similarly, if no page pruning is
- * needed, pass an empty span as data page mask and a mutable view of a BOOL8 column of size equal
- * to total number of rows in the current list of row groups containing all `true` values as row
- * mask. Further, the byte ranges for the required column chunk data may be obtained using the
- * `filter_column_chunks_byte_ranges()` function and read into a corresponding vector of vectors of
- * device buffers.
+ * desired, pass an empty span as data page mask and a mutable view of a BOOL8 column of size equal
+ * to total number of rows in the current row groups list (computed by `total_rows_in_row_groups()`)
+ * containing all `true` values as row mask. Further, the byte ranges for the required column chunk
+ * data may be obtained using the `filter_column_chunks_byte_ranges()` function and read into a
+ * corresponding vector of vectors of device buffers.
  * @code{.cpp}
  * // Get byte ranges of column chunk byte ranges from the reader
  * auto const filter_column_chunk_byte_ranges =
@@ -231,11 +231,12 @@ namespace io::parquet::experimental {
  * materialize the payload columns into another table (second reader pass). This is done using the
  * `materialize_payload_columns()` function. This function requires a vector of device buffers
  * containing column chunk data for the current list of row groups, and the updated row mask from
- * the `materialize_filter_columns()`. The function uses the row mask to internally prune payload
- * column data pages and mask the materialized payload columns to the desired rows. Similar to the
- * first reader pass, the byte ranges for the required column chunk data may be obtained using the
- * `payload_column_chunks_byte_ranges()` function, read into a vector of device buffers and read
- * into a corresponding vector of vectors of device buffers.
+ * the `materialize_filter_columns()`. The function uses the row mask - may be a BOOL8 column of
+ * size equal to total number of rows in the current row groups list containing all `true` values if
+ * no pruning is desired - to internally prune payload column data pages and mask the materialized
+ * payload columns to the desired rows. Similar to the first reader pass, the byte ranges for the
+ * required column chunk data may be obtained using the `payload_column_chunks_byte_ranges()`
+ * function and read into a corresponding vector of vectors of device buffers.
  * @code{.cpp}
  * // Get column chunk byte ranges from the reader
  * auto const payload_column_chunk_byte_ranges =
@@ -314,6 +315,15 @@ class hybrid_scan_reader {
    * @return Vector of row group indices
    */
   [[nodiscard]] std::vector<size_type> all_row_groups(parquet_reader_options const& options) const;
+
+  /**
+   * @brief Get the total number of rows in the row groups
+   *
+   * @param row_group_indices Input row groups indices
+   * @return Total number of rows in the row groups
+   */
+  [[nodiscard]] size_type total_rows_in_row_groups(
+    cudf::host_span<size_type const> row_group_indices) const;
 
   /**
    * @brief Filter the input row groups using column chunk statistics

--- a/cpp/src/io/parquet/experimental/hybrid_scan.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan.cpp
@@ -58,6 +58,14 @@ std::vector<cudf::size_type> hybrid_scan_reader::all_row_groups(
   return _impl->all_row_groups(options);
 }
 
+size_type hybrid_scan_reader::total_rows_in_row_groups(
+  cudf::host_span<size_type const> row_group_indices) const
+{
+  auto const input_row_group_indices =
+    std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
+  return _impl->total_rows_in_row_groups(input_row_group_indices);
+}
+
 std::vector<cudf::size_type> hybrid_scan_reader::filter_row_groups_with_stats(
   cudf::host_span<size_type const> row_group_indices,
   parquet_reader_options const& options,

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -150,6 +150,28 @@ void aggregate_reader_metadata::setup_page_index(cudf::host_span<uint8_t const> 
   }
 }
 
+size_type aggregate_reader_metadata::total_rows_in_row_groups(
+  cudf::host_span<std::vector<size_type> const> row_group_indices) const
+{
+  size_t total_rows = 0;
+
+  std::for_each(thrust::counting_iterator<size_t>(0),
+                thrust::counting_iterator(row_group_indices.size()),
+                [&](auto const src_idx) {
+                  auto const& pfm = per_file_metadata[src_idx];
+                  for (auto const row_group_idx : row_group_indices[src_idx]) {
+                    CUDF_EXPECTS(
+                      row_group_idx < static_cast<cudf::size_type>(pfm.row_groups.size()),
+                      "Row group index out of bounds");
+                    total_rows += pfm.row_groups[row_group_idx].num_rows;
+                  }
+                });
+  CUDF_EXPECTS(total_rows <= static_cast<size_t>(std::numeric_limits<size_type>::max()),
+               "Total number of rows exceeds cudf::size_type's limit");
+
+  return static_cast<size_type>(total_rows);
+}
+
 std::tuple<std::vector<input_column_info>,
            std::vector<inline_column_buffer>,
            std::vector<cudf::size_type>>

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.hpp
@@ -127,6 +127,15 @@ class aggregate_reader_metadata : public aggregate_reader_metadata_base {
   void setup_page_index(cudf::host_span<uint8_t const> page_index_bytes);
 
   /**
+   * @brief Get the total number of rows in the row groups
+   *
+   * @param row_group_indices Input row groups indices
+   * @return Total number of rows in the row groups
+   */
+  [[nodiscard]] size_type total_rows_in_row_groups(
+    cudf::host_span<std::vector<size_type> const> row_group_indices) const;
+
+  /**
    * @brief Filters and reduces down to the selection of payload columns
    *
    * @param payload_column_names List of paths of select payload column names, if any

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
@@ -152,6 +152,12 @@ std::vector<size_type> hybrid_scan_reader_impl::all_row_groups(
   return row_groups_indices;
 }
 
+size_type hybrid_scan_reader_impl::total_rows_in_row_groups(
+  cudf::host_span<size_type const> row_group_indices) const
+{
+  return _metadata->total_rows_in_row_groups(row_group_indices);
+}
+
 std::vector<std::vector<size_type>> hybrid_scan_reader_impl::filter_row_groups_with_stats(
   cudf::host_span<std::vector<size_type> const> row_group_indices,
   parquet_reader_options const& options,

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
@@ -79,6 +79,12 @@ class hybrid_scan_reader_impl {
   [[nodiscard]] std::vector<size_type> all_row_groups(parquet_reader_options const& options) const;
 
   /**
+   * @copydoc cudf::io::experimental::hybrid_scan::total_rows_in_row_groups
+   */
+  [[nodiscard]] size_type total_rows_in_row_groups(
+    cudf::host_span<size_type const> row_group_indices) const;
+
+  /**
    * @copydoc cudf::io::experimental::hybrid_scan::filter_row_groups_with_stats
    */
   [[nodiscard]] std::vector<std::vector<size_type>> filter_row_groups_with_stats(


### PR DESCRIPTION
## Description
This PR adds a utility function to the experimental Parquet reader to calculate the total number of rows in the input list of parquet row groups.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.