### PR TITLE
Revise `DaskIntegration` protocol to align with `rapidsmpf`

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import operator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import pylibcudf as plc
 import rmm.mr
@@ -32,6 +32,13 @@ if TYPE_CHECKING:
 _SHUFFLE_METHODS = ("rapidsmpf", "tasks")
 
 
+class ShuffleOptions(TypedDict):
+    """RapidsMPF shuffling options."""
+
+    on: Sequence[str]
+    column_names: Sequence[str]
+
+
 # Experimental rapidsmpf shuffler integration
 class RMPFIntegration:  # pragma: no cover
     """cuDF-Polars protocol for rapidsmpf shuffler."""
@@ -42,13 +49,13 @@ class RMPFIntegration:  # pragma: no cover
         partition_id: int,  # Not currently used
         partition_count: int,
         shuffler: Any,
-        options: dict[str, Any],
+        options: ShuffleOptions,
         *other: Any,
     ) -> None:
         """Add cudf-polars DataFrame chunks to an RMP shuffler."""
         from rapidsmpf.shuffler import partition_and_pack
 
-        on: Sequence[str] = options["on"]
+        on = options["on"]
         assert not other, f"Unexpected arguments: {other}"
         columns_to_hash = tuple(df.column_names.index(val) for val in on)
         packed_inputs = partition_and_pack(
@@ -64,13 +71,13 @@ class RMPFIntegration:  # pragma: no cover
     def extract_partition(
         partition_id: int,
         shuffler: Any,
-        options: dict[str, Any],
+        options: ShuffleOptions,
     ) -> DataFrame:
         """Extract a finished partition from the RMP shuffler."""
         from rapidsmpf.shuffler import unpack_and_concat
 
         shuffler.wait_on(partition_id)
-        column_names: list[str] = options["column_names"]
+        column_names = options["column_names"]
         return DataFrame.from_table(
             unpack_and_concat(
                 shuffler.extract(partition_id),

--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -39,6 +39,7 @@ class RMPFIntegration:  # pragma: no cover
     @staticmethod
     def insert_partition(
         df: DataFrame,
+        partition_id: int,  # Not currently used
         partition_count: int,
         shuffler: Any,
         options: dict[str, Any],

--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -49,7 +49,7 @@ class RMPFIntegration:  # pragma: no cover
         from rapidsmpf.shuffler import partition_and_pack
 
         on: Sequence[str] = options["on"]
-        assert not other, "Unexpected arguments: {other}"
+        assert not other, f"Unexpected arguments: {other}"
         columns_to_hash = tuple(df.column_names.index(val) for val in on)
         packed_inputs = partition_and_pack(
             df.table,

--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -39,13 +39,16 @@ class RMPFIntegration:  # pragma: no cover
     @staticmethod
     def insert_partition(
         df: DataFrame,
-        on: Sequence[str],
         partition_count: int,
         shuffler: Any,
+        options: dict[str, Any],
+        *other: Any,
     ) -> None:
         """Add cudf-polars DataFrame chunks to an RMP shuffler."""
         from rapidsmpf.shuffler import partition_and_pack
 
+        on: Sequence[str] = options["on"]
+        assert not other, "Unexpected arguments: {other}"
         columns_to_hash = tuple(df.column_names.index(val) for val in on)
         packed_inputs = partition_and_pack(
             df.table,
@@ -59,13 +62,14 @@ class RMPFIntegration:  # pragma: no cover
     @staticmethod
     def extract_partition(
         partition_id: int,
-        column_names: list[str],
         shuffler: Any,
+        options: dict[str, Any],
     ) -> DataFrame:
         """Extract a finished partition from the RMP shuffler."""
         from rapidsmpf.shuffler import unpack_and_concat
 
         shuffler.wait_on(partition_id)
+        column_names: list[str] = options["column_names"]
         return DataFrame.from_table(
             unpack_and_concat(
                 shuffler.extract(partition_id),
@@ -256,11 +260,10 @@ def _(
             return rapidsmpf_shuffle_graph(
                 get_key_name(ir.children[0]),
                 get_key_name(ir),
-                list(ir.schema.keys()),
-                shuffle_on,
                 partition_info[ir.children[0]].count,
                 partition_info[ir].count,
                 RMPFIntegration,
+                {"on": shuffle_on, "column_names": list(ir.schema.keys())},
             )
         except (ImportError, ValueError) as err:
             # ImportError: rapidsmpf is not installed


### PR DESCRIPTION
## Description
Teeing up this "fix" for the proposed change in https://github.com/rapidsai/rapidsmpf/pull/256

Once that PR is merged, we will want to get this in asap to keep `rapidsmpf` shuffling from breaking. We can update `Sort` in a follow-up PR.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
