### PR TITLE
Support `ConditianalJoin` via broadcasting in cudf-polars streaming engine

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/join.py
@@ -190,7 +190,9 @@ def _(
 ) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
     if ir.options[2]:  # pragma: no cover
         return _lower_ir_fallback(
-            ir, rec, msg="Slice not yet supported in ConditionalJoin."
+            ir,
+            rec,
+            msg="Slice not supported in ConditionalJoin for multiple partitions."
         )
 
     # Lower children

--- a/python/cudf_polars/cudf_polars/experimental/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/join.py
@@ -188,6 +188,11 @@ def _make_bcast_join(
 def _(
     ir: ConditionalJoin, rec: LowerIRTransformer
 ) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+    if ir.options[2]:  # pragma: no cover
+        return _lower_ir_fallback(
+            ir, rec, msg="Slice not yet supported in ConditionalJoin."
+        )
+
     # Lower children
     left, right = ir.children
     left, pi_left = rec(left)

--- a/python/cudf_polars/cudf_polars/experimental/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/join.py
@@ -192,7 +192,7 @@ def _(
         return _lower_ir_fallback(
             ir,
             rec,
-            msg="Slice not supported in ConditionalJoin for multiple partitions."
+            msg="Slice not supported in ConditionalJoin for multiple partitions.",
         )
 
     # Lower children

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -140,13 +140,14 @@ def test_join_then_shuffle(left, right):
     assert_gpu_result_equal(q, engine=engine, check_row_order=False)
 
 
+@pytest.mark.parametrize("max_rows_per_partition", [3, 9])
 @pytest.mark.parametrize("reverse", [True, False])
-def test_join_conditional(reverse):
+def test_join_conditional(reverse, max_rows_per_partition):
     engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
         executor_options={
-            "max_rows_per_partition": 3,
+            "max_rows_per_partition": max_rows_per_partition,
             "scheduler": DEFAULT_SCHEDULER,
             "fallback_mode": "silent",
         },

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -138,3 +138,20 @@ def test_join_then_shuffle(left, right):
     )
 
     assert_gpu_result_equal(q, engine=engine, check_row_order=False)
+
+
+def test_join_conditional(left, right):
+    engine = pl.GPUEngine(
+        raise_on_fail=True,
+        executor="streaming",
+        executor_options={
+            "max_rows_per_partition": 3,
+            "broadcast_join_limit": 2,
+            "scheduler": DEFAULT_SCHEDULER,
+            "shuffle_method": "tasks",
+            "fallback_mode": "silent",
+        },
+    )
+
+    q = left.join_where(right, pl.col("y") < pl.col("xx"))
+    assert_gpu_result_equal(q, engine=engine, check_row_order=False)

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -148,7 +148,6 @@ def test_join_conditional(reverse):
         executor_options={
             "max_rows_per_partition": 3,
             "scheduler": DEFAULT_SCHEDULER,
-            "shuffle_method": "tasks",
             "fallback_mode": "silent",
         },
     )

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -140,7 +140,8 @@ def test_join_then_shuffle(left, right):
     assert_gpu_result_equal(q, engine=engine, check_row_order=False)
 
 
-def test_join_conditional(left, right):
+@pytest.mark.parametrize("reverse", [True, False])
+def test_join_conditional(reverse):
     engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
@@ -152,6 +153,9 @@ def test_join_conditional(left, right):
             "fallback_mode": "silent",
         },
     )
-
-    q = left.join_where(right, pl.col("y") < pl.col("xx"))
+    left = pl.LazyFrame({"x": range(15), "y": [1, 2, 3] * 5})
+    right = pl.LazyFrame({"xx": range(9), "yy": [2, 4, 3] * 3})
+    if reverse:
+        left, right = right, left
+    q = left.join_where(right, pl.col("y") < pl.col("yy"))
     assert_gpu_result_equal(q, engine=engine, check_row_order=False)

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -147,7 +147,6 @@ def test_join_conditional(reverse):
         executor="streaming",
         executor_options={
             "max_rows_per_partition": 3,
-            "broadcast_join_limit": 2,
             "scheduler": DEFAULT_SCHEDULER,
             "shuffle_method": "tasks",
             "fallback_mode": "silent",


### PR DESCRIPTION
## Description
Adds very basic `ConditianalJoin` support. Simple reduces the smaller table to 1 partition in all cases. Further variations can be added in follow-up work.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
