### PR TITLE
Link to `nvtx3::nvtx3-cpp` instead of `nvToolsExt`

### DIFF
--- a/cpp/examples/billion_rows/CMakeLists.txt
+++ b/cpp/examples/billion_rows/CMakeLists.txt
@@ -24,13 +24,22 @@ add_library(groupby_results OBJECT groupby_results.cpp)
 target_link_libraries(groupby_results PRIVATE cudf::cudf)
 
 add_executable(brc brc.cpp)
-target_link_libraries(brc PRIVATE cudf::cudf nvToolsExt $<TARGET_OBJECTS:groupby_results>)
+target_link_libraries(
+  brc PRIVATE cudf::cudf $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>
+              $<TARGET_OBJECTS:groupby_results>
+)
 install(TARGETS brc DESTINATION bin/examples/libcudf)
 
 add_executable(brc_chunks brc_chunks.cpp)
-target_link_libraries(brc_chunks PRIVATE cudf::cudf nvToolsExt $<TARGET_OBJECTS:groupby_results>)
+target_link_libraries(
+  brc_chunks PRIVATE cudf::cudf $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>
+                     $<TARGET_OBJECTS:groupby_results>
+)
 install(TARGETS brc_chunks DESTINATION bin/examples/libcudf)
 
 add_executable(brc_pipeline brc_pipeline.cpp)
-target_link_libraries(brc_pipeline PRIVATE cudf::cudf nvToolsExt $<TARGET_OBJECTS:groupby_results>)
+target_link_libraries(
+  brc_pipeline PRIVATE cudf::cudf $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>
+                       $<TARGET_OBJECTS:groupby_results>
+)
 install(TARGETS brc_pipeline DESTINATION bin/examples/libcudf)

--- a/cpp/examples/parquet_io/CMakeLists.txt
+++ b/cpp/examples/parquet_io/CMakeLists.txt
@@ -24,14 +24,18 @@ target_link_libraries(parquet_io_utils PRIVATE cudf::cudf)
 
 # Build and install parquet_io
 add_executable(parquet_io parquet_io.cpp)
-target_link_libraries(parquet_io PRIVATE cudf::cudf nvToolsExt $<TARGET_OBJECTS:parquet_io_utils>)
+target_link_libraries(
+  parquet_io PRIVATE cudf::cudf $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>
+                     $<TARGET_OBJECTS:parquet_io_utils>
+)
 target_compile_features(parquet_io PRIVATE cxx_std_17)
 install(TARGETS parquet_io DESTINATION bin/examples/libcudf)
 
 # Build and install parquet_io_multithreaded
 add_executable(parquet_io_multithreaded parquet_io_multithreaded.cpp)
 target_link_libraries(
-  parquet_io_multithreaded PRIVATE cudf::cudf nvToolsExt $<TARGET_OBJECTS:parquet_io_utils>
+  parquet_io_multithreaded PRIVATE cudf::cudf $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>
+                                   $<TARGET_OBJECTS:parquet_io_utils>
 )
 target_compile_features(parquet_io_multithreaded PRIVATE cxx_std_17)
 install(TARGETS parquet_io_multithreaded DESTINATION bin/examples/libcudf)

--- a/cpp/examples/strings/CMakeLists.txt
+++ b/cpp/examples/strings/CMakeLists.txt
@@ -22,25 +22,27 @@ list(APPEND CUDF_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr)
 
 add_executable(libcudf_apis libcudf_apis.cpp)
 target_compile_features(libcudf_apis PRIVATE cxx_std_17)
-target_link_libraries(libcudf_apis PRIVATE cudf::cudf nvToolsExt)
+target_link_libraries(libcudf_apis PRIVATE cudf::cudf $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>)
 install(TARGETS libcudf_apis DESTINATION bin/examples/libcudf)
 
 add_executable(custom_with_malloc custom_with_malloc.cu)
 target_compile_features(custom_with_malloc PRIVATE cxx_std_17)
 target_compile_options(custom_with_malloc PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_FLAGS}>")
-target_link_libraries(custom_with_malloc PRIVATE cudf::cudf nvToolsExt)
+target_link_libraries(
+  custom_with_malloc PRIVATE cudf::cudf $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>
+)
 install(TARGETS custom_with_malloc DESTINATION bin/examples/libcudf)
 
 add_executable(custom_prealloc custom_prealloc.cu)
 target_compile_features(custom_prealloc PRIVATE cxx_std_17)
 target_compile_options(custom_prealloc PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_FLAGS}>")
-target_link_libraries(custom_prealloc PRIVATE cudf::cudf nvToolsExt)
+target_link_libraries(custom_prealloc PRIVATE cudf::cudf $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>)
 install(TARGETS custom_prealloc DESTINATION bin/examples/libcudf)
 
 add_executable(custom_optimized custom_optimized.cu)
 target_compile_features(custom_optimized PRIVATE cxx_std_17)
 target_compile_options(custom_optimized PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:${CUDF_CUDA_FLAGS}>")
-target_link_libraries(custom_optimized PRIVATE cudf::cudf nvToolsExt)
+target_link_libraries(custom_optimized PRIVATE cudf::cudf $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>)
 install(TARGETS custom_optimized DESTINATION bin/examples/libcudf)
 
 install(FILES ${CMAKE_CURRENT_LIST_DIR}/names.csv DESTINATION bin/examples/libcudf)


### PR DESCRIPTION
## Description

Cherry-picking and squashing Bradley's commits: https://github.com/rapidsai/cudf/commit/35b78d8832be98ab2756cac4f8a223706116828d & https://github.com/rapidsai/cudf/commit/c5741194ba5d23c5965612e2a399aadae0ddf497

As part of CUDA 12.9 bringup, we found that cuDF is linking to the legacy `nvToolsExt` library, which is dropped in that CUDA release. However cuDF no longer uses the legacy `nvToolsExt` library since upgrading to NVTX 3.

In the rest of the code, we use the `nvtx3::nvtx3-cpp` target. So this replaces the few `nvToolsExt` usages with the new/preferred target.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
