### PR TITLE
fix(rattler): add `librmm` to host for `libcudf` to fix overlinking error

### DIFF
--- a/conda/recipes/libcudf/recipe.yaml
+++ b/conda/recipes/libcudf/recipe.yaml
@@ -118,6 +118,7 @@ outputs:
       host:
         - cuda-version =${{ cuda_version }}
         - libkvikio =${{ minor_version }}
+        - librmm =${{ minor_version }}
         - nvcomp ${{ nvcomp_version }}
         - rapids-logger =0.1
         - zlib ${{ zlib_version }}


### PR DESCRIPTION
## Description

Now that `rmm` isn't a header-only library, it's triggering `overlinking`
errors in `rattler-build`.  Fix is to add `librmm` to the `host` dependencies
of any output that relies on it.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
