### PR TITLE
Fix integer overflows in pylibcudf `from_column_view_of_arbitrary`

### DIFF
--- a/cpp/include/cudf/strings/strings_column_view.hpp
+++ b/cpp/include/cudf/strings/strings_column_view.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,8 +43,6 @@ class strings_column_view : private column_view {
    * @param strings_column The column view to wrap.
    */
   strings_column_view(column_view strings_column);
-  // So we can use this from cython.
-  strings_column_view()                           = default;
   strings_column_view(strings_column_view&&)      = default;  ///< Move constructor
   strings_column_view(strings_column_view const&) = default;  ///< Copy constructor
   ~strings_column_view() override                 = default;

--- a/cpp/include/cudf/strings/strings_column_view.hpp
+++ b/cpp/include/cudf/strings/strings_column_view.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,8 @@ class strings_column_view : private column_view {
    * @param strings_column The column view to wrap.
    */
   strings_column_view(column_view strings_column);
+  // So we can use this from cython.
+  strings_column_view()                           = default;
   strings_column_view(strings_column_view&&)      = default;  ///< Move constructor
   strings_column_view(strings_column_view const&) = default;  ///< Copy constructor
   ~strings_column_view() override                 = default;

--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -25,6 +25,7 @@ from pylibcudf.libcudf.interop cimport (
     to_arrow_device_raw,
     to_arrow_schema_raw,
 )
+from pylibcudf.libcudf.null_mask cimport bitmask_allocation_size_bytes
 from pylibcudf.libcudf.scalar.scalar cimport scalar
 from pylibcudf.libcudf.strings.strings_column_view cimport strings_column_view
 from pylibcudf.libcudf.types cimport size_type, size_of as cpp_size_of, bitmask_type
@@ -50,7 +51,6 @@ from ._interop_helpers cimport (
     _release_device_array,
     _metadata_to_libcudf,
 )
-from .null_mask cimport bitmask_allocation_size_bytes
 from .utils cimport _get_stream
 
 from .gpumemoryview import _datatype_from_dtype_desc
@@ -90,12 +90,10 @@ cdef class OwnerWithCAI:
         # The default size of 0 will be applied for any type that stores data in the
         # children (such that the parent size is 0).
         size = 0
-        cdef column_view offsets_column
-        cdef unique_ptr[scalar] last_offset
         if cv.type().id() == type_id.EMPTY:
             size = cv.size()
         elif is_fixed_width(cv.type()):
-            # Cast to Python integers before multiplyling to avoid overflow.
+            # Cast to Python integers before multiplying to avoid overflow.
             size = int(cv.size()) * int(cpp_size_of(cv.type()))
         elif cv.type().id() == type_id.STRING:
             # TODO: stream-ordered

--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -1,4 +1,5 @@
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# cython: cpp_locals=True
 
 from cython.operator cimport dereference
 

--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -7,7 +7,7 @@ from cpython.pycapsule cimport (
     PyCapsule_New,
 )
 
-from libc.stdint cimport uintptr_t
+from libc.stdint cimport uintptr_t, int32_t, int64_t
 
 from libcpp.limits cimport numeric_limits
 from libcpp.memory cimport make_unique, unique_ptr
@@ -103,7 +103,12 @@ cdef class OwnerWithCAI:
             if cv.num_children():
                 offsets_column = cv.child(0)
                 last_offset = get_element(offsets_column, offsets_column.size() - 1)
-                size = (<numeric_scalar[size_type] *> last_offset.get()).value()
+                if offsets_column.type().id() == type_id.INT32:
+                    size = (<numeric_scalar[int32_t] *> last_offset.get()).value()
+                elif offsets_column.type().id() == type_id.INT64:
+                    size = (<numeric_scalar[int64_t] *>last_offset.get()).value()
+                else:
+                    raise RuntimeError("Invalid strings column offset dtype")
 
         obj.cai = {
             "shape": (size,),

--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -1,5 +1,4 @@
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
-# cython: cpp_locals=True
 
 from cython.operator cimport dereference
 

--- a/python/pylibcudf/pylibcudf/gpumemoryview.pyx
+++ b/python/pylibcudf/pylibcudf/gpumemoryview.pyx
@@ -1,11 +1,10 @@
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
+from libc.stddef cimport size_t
 import functools
 import operator
 
 from .types cimport DataType, size_of, type_id
-
-from pylibcudf.libcudf.types cimport size_type
 
 
 __all__ = ["gpumemoryview"]
@@ -62,7 +61,7 @@ cdef class gpumemoryview:
         self.ptr = cai["data"][0]
 
         # Compute the buffer size.
-        cdef size_type itemsize = size_of(
+        cdef size_t itemsize = size_of(
             _datatype_from_dtype_desc(
                 cai["typestr"][1:]  # ignore the byteorder (the first char).
             )

--- a/python/pylibcudf/pylibcudf/libcudf/strings/strings_column_view.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/strings_column_view.pxd
@@ -1,0 +1,12 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
+from libc.stdint cimport int64_t
+from pylibcudf.exception_handler cimport libcudf_exception_handler
+from pylibcudf.libcudf.column.column_view cimport column_view
+
+from rmm.librmm.cuda_stream_view cimport cuda_stream_view
+
+cdef extern from "cudf/strings/strings_column_view.hpp" namespace "cudf" nogil:
+    cdef cppclass strings_column_view:
+        strings_column_view(column_view) except +libcudf_exception_handler
+        int64_t chars_size(cuda_stream_view) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/types.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/types.pxd
@@ -1,4 +1,5 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+from libc.stddef cimport size_t
 from libc.stdint cimport int32_t, uint32_t
 from libcpp cimport bool
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -100,4 +101,4 @@ cdef extern from "cudf/types.hpp" namespace "cudf" nogil:
         MIDPOINT
         NEAREST
 
-    cdef size_type size_of(data_type t) except +libcudf_exception_handler
+    cdef size_t size_of(data_type t) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/types.pxd
+++ b/python/pylibcudf/pylibcudf/types.pxd
@@ -1,5 +1,6 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
+from libc.stddef cimport size_t
 from libc.stdint cimport int32_t
 from libcpp cimport bool as cbool
 from pylibcudf.libcudf.types cimport (
@@ -27,4 +28,4 @@ cdef class DataType:
     @staticmethod
     cdef DataType from_libcudf(data_type dt)
 
-cpdef size_type size_of(DataType t)
+cpdef size_t size_of(DataType t)

--- a/python/pylibcudf/pylibcudf/types.pyx
+++ b/python/pylibcudf/pylibcudf/types.pyx
@@ -1,5 +1,6 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
+from libc.stddef cimport size_t
 from libc.stdint cimport int32_t
 from pylibcudf.libcudf.types cimport (
     data_type,
@@ -92,7 +93,7 @@ cdef class DataType:
         ret.c_obj = dt
         return ret
 
-cpdef size_type size_of(DataType t):
+cpdef size_t size_of(DataType t):
     """Returns the size in bytes of elements of the specified data_type.
 
     Only fixed-width types are supported.


### PR DESCRIPTION
## Description

Although the number of _rows_ in a `column_view` cannot exceed `size_type`, the number of _bytes_ surely can. So fix that.

This fixes multi-GPU errors we are seeing in rapidsmpf when communicating buffers.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
