### PR TITLE
Fix noexcept annotations on strings_column_view

### DIFF
--- a/cpp/include/cudf/strings/strings_column_view.hpp
+++ b/cpp/include/cudf/strings/strings_column_view.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ class strings_column_view : private column_view {
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @return Number of bytes in the chars child column
    */
-  [[nodiscard]] int64_t chars_size(rmm::cuda_stream_view stream) const noexcept;
+  [[nodiscard]] int64_t chars_size(rmm::cuda_stream_view stream) const;
 
   /**
    * @brief Return an iterator for the chars child column.
@@ -108,7 +108,7 @@ class strings_column_view : private column_view {
    *
    * @return Iterator pointing to the first char byte.
    */
-  [[nodiscard]] chars_iterator chars_begin(rmm::cuda_stream_view) const;
+  [[nodiscard]] chars_iterator chars_begin(rmm::cuda_stream_view) const noexcept;
 
   /**
    * @brief Return an end iterator for the offsets child column.

--- a/cpp/src/strings/strings_column_view.cpp
+++ b/cpp/src/strings/strings_column_view.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,13 +35,14 @@ column_view strings_column_view::offsets() const
   return child(offsets_column_index);
 }
 
-int64_t strings_column_view::chars_size(rmm::cuda_stream_view stream) const noexcept
+int64_t strings_column_view::chars_size(rmm::cuda_stream_view stream) const
 {
   if (size() == 0) { return 0L; }
   return cudf::strings::detail::get_offset_value(offsets(), offsets().size() - 1, stream);
 }
 
-strings_column_view::chars_iterator strings_column_view::chars_begin(rmm::cuda_stream_view) const
+strings_column_view::chars_iterator strings_column_view::chars_begin(
+  rmm::cuda_stream_view) const noexcept
 {
   return head<char>();
 }


### PR DESCRIPTION
## Description
`chars_size` can throw (since `get_offset_value` might throw), conversely `chars_begin` doesn't throw.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
