### PR TITLE
Require `numba-cuda>=0.11.0`

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -54,7 +54,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.11.0
+- numba-cuda>=0.11.0,<0.12.0a0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -54,7 +54,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.10.1,<0.11.0a0
+- numba-cuda>=0.11.0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -56,7 +56,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.11.0
+- numba-cuda>=0.11.0,<0.12.0a0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -56,7 +56,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.10.1,<0.11.0a0
+- numba-cuda>=0.11.0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -54,7 +54,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.11.0
+- numba-cuda>=0.11.0,<0.12.0a0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -54,7 +54,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.10.1,<0.11.0a0
+- numba-cuda>=0.11.0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -55,7 +55,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.11.0
+- numba-cuda>=0.11.0,<0.12.0a0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -55,7 +55,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.10.1,<0.11.0a0
+- numba-cuda>=0.11.0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -73,7 +73,7 @@ requirements:
     - typing_extensions >=4.0.0
     - pandas >=2.0,<2.2.4dev0
     - cupy >=12.0.0
-    - numba-cuda >=0.11.0
+    - numba-cuda >=0.11.0,<0.12.0a0
     - numba >=0.59.1,<0.62.0a0
     - numpy >=1.23,<3.0a0
     - pyarrow>=14.0.0,<20.0.0a0

--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -73,7 +73,7 @@ requirements:
     - typing_extensions >=4.0.0
     - pandas >=2.0,<2.2.4dev0
     - cupy >=12.0.0
-    - numba-cuda >=0.10.1,<0.11.0a0
+    - numba-cuda >=0.11.0
     - numba >=0.59.1,<0.62.0a0
     - numpy >=1.23,<3.0a0
     - pyarrow>=14.0.0,<20.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -771,7 +771,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - cachetools
-          - &numba-cuda-dep numba-cuda>=0.11.0
+          - &numba-cuda-dep numba-cuda>=0.11.0,<0.12.0a0
           - &numba-dep numba>=0.59.1,<0.62.0a0
           - nvtx>=0.2.1
           - packaging
@@ -906,7 +906,7 @@ dependencies:
         matrices:
           - matrix: {dependencies: "oldest"}
             packages:
-              - numba-cuda>=0.11.0
+              - numba-cuda==0.11.0
               - numba==0.59.1
               - pandas==2.0.*
           - matrix: {dependencies: "latest"}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -771,7 +771,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - cachetools
-          - &numba-cuda-dep numba-cuda>=0.10.1,<0.11.0a0
+          - &numba-cuda-dep numba-cuda>=0.11.0
           - &numba-dep numba>=0.59.1,<0.62.0a0
           - nvtx>=0.2.1
           - packaging

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -906,7 +906,7 @@ dependencies:
         matrices:
           - matrix: {dependencies: "oldest"}
             packages:
-              - numba-cuda==0.10.1
+              - numba-cuda>=0.11.0
               - numba==0.59.1
               - pandas==2.0.*
           - matrix: {dependencies: "latest"}

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "cupy-cuda11x>=12.0.0",
     "fsspec>=0.6.0",
     "libcudf==25.6.*,>=0.0.0a0",
-    "numba-cuda>=0.11.0",
+    "numba-cuda>=0.11.0,<0.12.0a0",
     "numba>=0.59.1,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
     "nvtx>=0.2.1",

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "cupy-cuda11x>=12.0.0",
     "fsspec>=0.6.0",
     "libcudf==25.6.*,>=0.0.0a0",
-    "numba-cuda>=0.10.1,<0.11.0a0",
+    "numba-cuda>=0.11.0",
     "numba>=0.59.1,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
     "nvtx>=0.2.1",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -48,7 +48,7 @@ cudf = "dask_cudf.backends:CudfBackendEntrypoint"
 [project.optional-dependencies]
 test = [
     "dask-cuda==25.6.*,>=0.0.0a0",
-    "numba-cuda>=0.10.1,<0.11.0a0",
+    "numba-cuda>=0.11.0",
     "numba>=0.59.1,<0.62.0a0",
     "pytest-cov",
     "pytest-xdist",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -48,7 +48,7 @@ cudf = "dask_cudf.backends:CudfBackendEntrypoint"
 [project.optional-dependencies]
 test = [
     "dask-cuda==25.6.*,>=0.0.0a0",
-    "numba-cuda>=0.11.0",
+    "numba-cuda>=0.11.0,<0.12.0a0",
     "numba>=0.59.1,<0.62.0a0",
     "pytest-cov",
     "pytest-xdist",


### PR DESCRIPTION
This PR updates the lower bound for `numba-cuda` to `0.11.0`. 