### PR TITLE
Remove unecessary _Ravelled class

### DIFF
--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -146,15 +146,6 @@ cdef class OwnerMaskWithCAI:
         return self.cai
 
 
-class _Ravelled:
-    def __init__(self, obj):
-        self.obj = obj
-        cai = obj.__cuda_array_interface__.copy()
-        shape = cai["shape"]
-        cai["shape"] = (shape[0]*shape[1],)
-        self.__cuda_array_interface__ = cai
-
-
 def _prepare_array_metadata(
     iface: dict,
 ) -> tuple[int, int, tuple[int, ...], tuple[int, ...] | None, DataType]:
@@ -787,9 +778,6 @@ cdef class Column:
             raise TypeError("Object does not implement __cuda_array_interface__")
 
         _, _, shape, _, dtype = _prepare_array_metadata(iface)
-
-        if len(shape) == 2:
-            obj = _Ravelled(obj)
 
         return Column._from_gpumemoryview(gpumemoryview(obj), shape, dtype)
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The `_Ravelled` object was orginally added in https://github.com/rapidsai/cudf/pull/18311 to avoid cupy dependence (ie `cp.asarray(obj).ravel()`). But we dont need to ravel the object because it must be C-contiguous already. Addresses https://github.com/rapidsai/cudf/pull/18744#issuecomment-2873769554
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
