### PR TITLE
Fix reading of Snappy compressed Avro files

### DIFF
--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -279,7 +279,7 @@ rmm::device_buffer decompress_data(datasource& source,
                      return device_span<uint8_t const>{
                        static_cast<uint8_t const*>(comp_block_data.data()) +
                          (block.offset - meta.block_list[0].offset),
-                       block.size};
+                       block.size - sizeof(uint32_t)};  // exclude the CRC32 checksum
                    });
     compressed_blocks.host_to_device_async(stream);
 


### PR DESCRIPTION
## Description
Based on the specs at https://avro.apache.org/docs/1.11.1/specification/

In Avro files with Snappy compression, blocks contain a CRC32 checksum after the compressed data. The reader did not take this into account when setting up the decompression inputs, leading to errors with HW decompression (other implementations ignore the unused bytes).

This PR adjusts the size of the compressed block to exclude the checksum.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
