### PR TITLE
Change cudf::sort googlebench benchmarks to nvbench

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -219,10 +219,9 @@ ConfigureNVBench(SEARCH_NVBENCH search/contains_scalar.cpp search/contains_table
 
 # ##################################################################################################
 # * sort benchmark --------------------------------------------------------------------------------
-ConfigureBench(SORT_BENCH sort/rank.cpp sort/sort.cpp sort/sort_strings.cpp)
 ConfigureNVBench(
-  SORT_NVBENCH sort/rank_lists.cpp sort/rank_structs.cpp sort/segmented_sort.cpp
-  sort/sort_lists.cpp sort/sort_structs.cpp
+  SORT_NVBENCH sort/rank.cpp sort/rank_lists.cpp sort/rank_structs.cpp sort/segmented_sort.cpp
+  sort/sort.cpp sort/sort_lists.cpp sort/sort_strings.cpp sort/sort_structs.cpp
 )
 
 # ##################################################################################################

--- a/cpp/benchmarks/sort/rank.cpp
+++ b/cpp/benchmarks/sort/rank.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,46 +15,41 @@
  */
 
 #include <benchmarks/common/generate_input.hpp>
-#include <benchmarks/fixture/benchmark_fixture.hpp>
-#include <benchmarks/synchronization/synchronization.hpp>
 
 #include <cudf/column/column_view.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-class Rank : public cudf::benchmark {};
+#include <nvbench/nvbench.cuh>
 
-static void BM_rank(benchmark::State& state, bool nulls)
+static void bench_rank(nvbench::state& state)
 {
-  using Type = int;
-  cudf::size_type const n_rows{(cudf::size_type)state.range(0)};
+  auto const n_rows = static_cast<cudf::size_type>(state.get_int64("n_rows"));
+  auto const nulls  = state.get_float64("nulls");
 
   // Create columns with values in the range [0,100)
-  data_profile profile = data_profile_builder().cardinality(0).distribution(
-    cudf::type_to_id<Type>(), distribution_id::UNIFORM, 0, 100);
-  profile.set_null_probability(nulls ? std::optional{0.2} : std::nullopt);
-  auto keys = create_random_column(cudf::type_to_id<Type>(), row_count{n_rows}, profile);
+  data_profile const profile =
+    data_profile_builder().cardinality(0).null_probability(nulls).distribution(
+      cudf::type_id::INT32, distribution_id::UNIFORM, 0, 10);
 
-  for (auto _ : state) {
-    cuda_event_timer raii(state, true, cudf::get_default_stream());
+  auto input = create_random_column(cudf::type_id::INT32, row_count{n_rows}, profile);
 
-    auto result = cudf::rank(keys->view(),
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.add_element_count(n_rows, "n_rows");
+  state.add_global_memory_reads<nvbench::int32_t>(n_rows);
+  state.add_global_memory_writes<nvbench::int32_t>(n_rows);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+    auto result = cudf::rank(input->view(),
                              cudf::rank_method::FIRST,
                              cudf::order::ASCENDING,
                              nulls ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE,
                              cudf::null_order::AFTER,
                              false);
-  }
+  });
 }
 
-#define RANK_BENCHMARK_DEFINE(name, nulls)          \
-  BENCHMARK_DEFINE_F(Rank, name)                    \
-  (::benchmark::State & st) { BM_rank(st, nulls); } \
-  BENCHMARK_REGISTER_F(Rank, name)                  \
-    ->RangeMultiplier(8)                            \
-    ->Ranges({{1 << 10, 1 << 26}})                  \
-    ->UseManualTime()                               \
-    ->Unit(benchmark::kMillisecond);
-
-RANK_BENCHMARK_DEFINE(no_nulls, false)
-RANK_BENCHMARK_DEFINE(nulls, true)
+NVBENCH_BENCH(bench_rank)
+  .set_name("rank")
+  .add_float64_axis("nulls", {0, 0.1})
+  .add_int64_axis("n_rows", {32768, 262144, 2097152, 16777216, 67108864});

--- a/cpp/benchmarks/sort/sort.cpp
+++ b/cpp/benchmarks/sort/sort.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,48 +15,42 @@
  */
 
 #include <benchmarks/common/generate_input.hpp>
-#include <benchmarks/fixture/benchmark_fixture.hpp>
-#include <benchmarks/synchronization/synchronization.hpp>
 
 #include <cudf/sorting.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
-template <bool stable>
-class Sort : public cudf::benchmark {};
+#include <nvbench/nvbench.cuh>
 
-template <bool stable>
-static void BM_sort(benchmark::State& state, bool nulls)
+static void bench_sort(nvbench::state& state)
 {
-  using Type       = int;
-  auto const dtype = cudf::type_to_id<Type>();
-  cudf::size_type const n_rows{(cudf::size_type)state.range(0)};
-  cudf::size_type const n_cols{(cudf::size_type)state.range(1)};
+  auto const stable = static_cast<bool>(state.get_int64("stable"));
+  auto const n_rows = static_cast<cudf::size_type>(state.get_int64("n_rows"));
+  auto const n_cols = static_cast<cudf::size_type>(state.get_int64("n_cols"));
+  auto const nulls  = state.get_float64("nulls");
 
   // Create table with values in the range [0,100)
-  data_profile const profile = data_profile_builder()
-                                 .cardinality(0)
-                                 .null_probability(nulls ? std::optional{0.01} : std::nullopt)
-                                 .distribution(dtype, distribution_id::UNIFORM, 0, 100);
-  auto input_table = create_random_table(cycle_dtypes({dtype}, n_cols), row_count{n_rows}, profile);
+  data_profile const profile =
+    data_profile_builder().cardinality(0).null_probability(nulls).distribution(
+      cudf::type_id::INT32, distribution_id::UNIFORM, 0, 10);
+  auto input_table =
+    create_random_table(cycle_dtypes({cudf::type_id::INT32}, n_cols), row_count{n_rows}, profile);
   cudf::table_view input{*input_table};
 
-  for (auto _ : state) {
-    cuda_event_timer raii(state, true, cudf::get_default_stream());
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.add_global_memory_reads<nvbench::int32_t>(n_rows * n_cols);
+  state.add_global_memory_writes<nvbench::int32_t>(n_rows);
 
-    auto result = (stable) ? cudf::stable_sorted_order(input) : cudf::sorted_order(input);
-  }
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+    if (stable)
+      cudf::stable_sorted_order(input);
+    else
+      cudf::sorted_order(input);
+  });
 }
 
-#define SORT_BENCHMARK_DEFINE(name, stable, nulls)          \
-  BENCHMARK_TEMPLATE_DEFINE_F(Sort, name, stable)           \
-  (::benchmark::State & st) { BM_sort<stable>(st, nulls); } \
-  BENCHMARK_REGISTER_F(Sort, name)                          \
-    ->RangeMultiplier(8)                                    \
-    ->Ranges({{1 << 10, 1 << 26}, {1, 8}})                  \
-    ->UseManualTime()                                       \
-    ->Unit(benchmark::kMillisecond);
-
-SORT_BENCHMARK_DEFINE(unstable_no_nulls, false, false)
-SORT_BENCHMARK_DEFINE(stable_no_nulls, true, false)
-SORT_BENCHMARK_DEFINE(unstable, false, true)
-SORT_BENCHMARK_DEFINE(stable, true, true)
+NVBENCH_BENCH(bench_sort)
+  .set_name("sort")
+  .add_int64_axis("stable", {0, 1})
+  .add_float64_axis("nulls", {0, 0.1})
+  .add_int64_axis("n_rows", {32768, 262144, 2097152, 16777216, 67108864})
+  .add_int64_axis("n_cols", {1, 8});


### PR DESCRIPTION
## Description
Changing the sort benchmarks to use nvbench to better check performance impact of future code changes to libcudf sort APIs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
