### PR TITLE
Change calls to thrust::swap to cuda::std::swap

### DIFF
--- a/cpp/src/sort/sort_column_impl.cuh
+++ b/cpp/src/sort/sort_column_impl.cuh
@@ -68,7 +68,7 @@ struct simple_comparator {
       bool lhs_null{d_column.is_null(lhs)};
       bool rhs_null{d_column.is_null(rhs)};
       if (lhs_null || rhs_null) {
-        if (!ascending) thrust::swap(lhs_null, rhs_null);
+        if (!ascending) { cuda::std::swap(lhs_null, rhs_null); }
         return (null_precedence == cudf::null_order::BEFORE ? !rhs_null : !lhs_null);
       }
     }

--- a/cpp/src/text/edit_distance.cu
+++ b/cpp/src/text/edit_distance.cu
@@ -84,7 +84,7 @@ __device__ cudf::size_type compute_distance(cudf::string_view const& d_str,
       auto ins_cost = v1[j] + 1;
       v1[j + 1]     = cuda::std::min(cuda::std::min(sub_cost, del_cost), ins_cost);
     }
-    thrust::swap(v0, v1);
+    cuda::std::swap(v0, v1);
   }
   return v0[n];
 }


### PR DESCRIPTION
## Description
Using the `cuda::std` functions instead of `thrust` whenever possible.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
