### PR TITLE
Reduce more data sizes of Python tests

### DIFF
--- a/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
+++ b/python/cudf/cudf/tests/test_avro_reader_fastavro_integration.py
@@ -237,6 +237,7 @@ def test_avro_decompression(set_decomp_env_vars, rows, codec):
         ],
         rows,
         seed=0,
+        use_threads=False,
     )
     expected_df = cudf.DataFrame.from_arrow(df)
 

--- a/python/cudf/cudf/tests/test_csv.py
+++ b/python/cudf/cudf/tests/test_csv.py
@@ -887,10 +887,10 @@ def test_csv_reader_nrows(tmpdir):
     names = ["int1", "int2"]
     dtypes = ["int32", "int32"]
 
-    rows = 4000000
+    rows = 4000
     read_rows = (rows * 3) // 4
     skip_rows = (rows - read_rows) // 2
-    sample_skip = 1000
+    sample_skip = 100
 
     with open(str(fname), "w") as fp:
         fp.write(",".join(names) + "\n")

--- a/python/cudf/cudf/tests/test_orc.py
+++ b/python/cudf/cudf/tests/test_orc.py
@@ -724,22 +724,20 @@ def test_orc_write_statistics(tmpdir, datadir, nrows, stats_freq):
 
 
 @pytest.mark.parametrize("stats_freq", ["STRIPE", "ROWGROUP"])
-@pytest.mark.parametrize("nrows", [2, 100, 200000])
+@pytest.mark.parametrize("nrows", [2, 100, 1024])
 def test_orc_chunked_write_statistics(tmpdir, datadir, nrows, stats_freq):
     from pyarrow import orc
 
     supported_stat_types = [*supported_numpy_dtypes, "str"]
     # Writing bool columns to multiple row groups is disabled
     # until #6763 is fixed
-    if nrows == 200000:
+    if nrows == 1024:
         supported_stat_types.remove("bool")
 
     gdf_fname = tmpdir.join("chunked_stats.orc")
-    writer = ORCWriter(
-        gdf_fname, statistics=stats_freq, stripe_size_rows=30000
-    )
+    writer = ORCWriter(gdf_fname, statistics=stats_freq, stripe_size_rows=512)
 
-    max_char_length = 100 if nrows < 10000 else 10
+    max_char_length = 100 if nrows < 1000 else 10
 
     # Make a dataframe
     gdf = cudf.DataFrame(

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -431,7 +431,7 @@ def test_parquet_read_filtered(tmpdir):
     dg.generate(
         fname,
         dg.Parameters(
-            num_rows=2048,
+            num_rows=100,
             column_parameters=[
                 dg.ColumnParameters(
                     cardinality=40,
@@ -442,7 +442,7 @@ def test_parquet_read_filtered(tmpdir):
                                 string.ascii_letters, random.randint(4, 8)
                             )
                         )
-                        for _ in range(40)
+                        for _ in range(10)
                     ],
                     is_sorted=False,
                 ),
@@ -450,14 +450,15 @@ def test_parquet_read_filtered(tmpdir):
                     40,
                     0.2,
                     lambda: np.random.default_rng(seed=0).integers(
-                        0, 100, size=40
+                        0, 100, size=10
                     ),
                     True,
                 ),
             ],
             seed=42,
         ),
-        format={"name": "parquet", "row_group_size": 64},
+        format={"name": "parquet", "row_group_size": 10},
+        use_threads=False,
     )
 
     # Get dataframes to compare
@@ -470,7 +471,7 @@ def test_parquet_read_filtered(tmpdir):
     # with PyArrow is with the method we use and intend to test.
     tbl_filtered = pq.read_table(fname, filters=[("1", ">", 60)])
 
-    assert_eq(cudf.io.read_parquet_metadata(fname)[1], 2048 / 64)
+    assert_eq(cudf.io.read_parquet_metadata(fname)[1], 10)
     assert len(df_filtered) < len(df)
     assert len(tbl_filtered) <= len(df_filtered)
 


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/10001

Before
```
============================= slowest 30 durations =============================
25.62s call     cudf/tests/test_no_cuinit.py::test_cudf_import_no_cuinit
25.29s call     cudf/tests/test_no_cuinit.py::test_cudf_create_series_cuinit
4.00s call     cudf/tests/test_parquet.py::test_parquet_reader_basic[gzip-10-columns3-cudf]
3.97s call     cudf/tests/test_replace.py::test_replace_multiple_rows
3.87s call     cudf/tests/test_json.py::test_chunked_json_reader
3.81s call     cudf/tests/test_parquet.py::test_delta_binary[int16-False-2]
3.69s call     cudf/tests/test_orc.py::test_chunked_orc_writer[TestOrcFile.demo-12-zlib.orc-columns1-None]
3.67s call     cudf/tests/test_csv.py::test_csv_reader_numeric_data[5-float64]
3.49s call     cudf/tests/input_output/test_parquet.py::test_parquet_long_list
3.43s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_alltypes_plain_avro
3.16s call     cudf/tests/test_orc.py::test_chunked_orc_writer[TestOrcFile.demo-12-zlib.orc-columns1-snappy]
3.04s call     cudf/tests/test_parquet.py::test_parquet_read_filtered
2.75s call     cudf/tests/test_parquet.py::test_parquet_writer_list_large_mixed
2.62s call     cudf/tests/test_mvc.py::test_numba_mvc
2.51s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars2-deflate-0]
2.45s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars2-deflate-1]
2.38s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars1-null-1]
2.37s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars0-deflate-10]
2.37s call     cudf/tests/test_orc.py::test_orc_writer_lists[data4]
2.37s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars0-deflate-0]
2.35s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars0-snappy-1000]
2.35s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars2-snappy-1]
2.32s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars2-snappy-10]
2.32s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars0-deflate-1]
2.30s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars0-null-1]
2.30s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars1-deflate-0]
2.29s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars1-snappy-0]
2.29s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars0-snappy-1]
2.29s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars2-snappy-1000]
2.29s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_avro_decompression[set_decomp_env_vars2-null-1000]
========= 91200 passed, 2740 skipped, 766 xfailed in 283.10s (0:04:43) =========
```

After
```
============================= slowest 30 durations =============================
25.18s call     cudf/tests/test_no_cuinit.py::test_cudf_import_no_cuinit
23.77s call     cudf/tests/test_no_cuinit.py::test_cudf_create_series_cuinit
5.40s call     cudf/tests/test_csv.py::test_csv_reader_numeric_data[5-float64]
4.53s call     cudf/tests/test_avro_reader_fastavro_integration.py::test_alltypes_plain_avro
4.10s call     cudf/tests/test_replace.py::test_replace_multiple_rows
3.90s call     cudf/tests/test_orc.py::test_reader_empty_stripe[TestOrcFile.Hive.OneEmptyMap.orc]
3.87s call     cudf/tests/test_json.py::test_chunked_json_reader
3.72s call     cudf/tests/test_parquet.py::test_parquet_reader_basic[gzip-10-columns0-cudf]
3.61s call     cudf/tests/input_output/test_parquet.py::test_parquet_long_list
3.57s call     cudf/tests/test_orc.py::test_chunked_orc_writer[TestOrcFile.demo-12-zlib.orc-columns1-None]
3.06s call     cudf/tests/test_orc.py::test_orc_writer_statistics_frequency[ROWGROUP]
2.96s call     cudf/tests/test_orc.py::test_chunked_orc_writer[TestOrcFile.demo-12-zlib.orc-columns1-snappy]
2.65s call     cudf/tests/test_parquet.py::test_parquet_writer_list_large_mixed
2.53s call     cudf/tests/test_mvc.py::test_numba_mvc
2.36s call     cudf/tests/test_dataframe.py::test_dataframe_series_dot
2.23s call     cudf/tests/test_binops.py::test_binops_dot[other0-df0]
2.22s call     cudf/tests/test_orc.py::test_orc_writer_lists[data4]
2.17s call     cudf/tests/test_cuda_array_interface.py::test_cuda_array_interface_pytorch
2.02s call     cudf/tests/test_orc.py::test_orc_writer_statistics_frequency[STRIPE]
2.00s call     cudf/tests/test_orc.py::test_orc_writer_statistics_frequency[NONE]
1.97s call     cudf/tests/test_parquet.py::test_parquet_writer_list_statistics
1.96s call     cudf/tests/test_udf_masked_ops.py::test_masked_udf_scalar_args_binops_multiple[floordiv0-data2]
1.90s call     cudf/tests/series/test_datetimelike.py::test_tz_localize[us-Jamaica]
1.84s call     cudf/tests/test_s3.py::test_no_s3fs_on_cudf_import
1.82s call     cudf/tests/test_groupby.py::test_groupby_apply_jit_unary_reductions[small-idxmax-float64]
1.79s call     cudf/tests/test_reshape.py::test_df_merge_sorted[10-keys1-first-False]
1.78s call     cudf/tests/test_no_device.py::test_cudf_import_no_device
1.65s call     cudf/tests/test_udf_masked_ops.py::test_apply_mixed_dtypes[eq-int8-uint64]
1.58s call     cudf/tests/test_orc.py::test_orc_writer_lists[data0]
1.44s call     cudf/tests/test_reductions.py::test_sum_decimal[10000-dtype1]
========= 91200 passed, 2740 skipped, 766 xfailed in 275.77s (0:04:35) =========
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
