### PR TITLE
Update strings benchmarks to use alloc_size column/table function

### DIFF
--- a/cpp/benchmarks/string/char_types.cpp
+++ b/cpp/benchmarks/string/char_types.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,12 +38,12 @@ static void bench_char_types(nvbench::state& state)
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   // gather some throughput statistics as well
-  auto chars_size = input.chars_size(cudf::get_default_stream());
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);  // all bytes are read;
+  auto data_size = table->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);  // all bytes are read;
   if (api_type == "all") {
     state.add_global_memory_writes<nvbench::int8_t>(num_rows);  // output is a bool8 per row
   } else {
-    state.add_global_memory_writes<nvbench::int8_t>(chars_size);
+    state.add_global_memory_writes<nvbench::int8_t>(data_size);
   }
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {

--- a/cpp/benchmarks/string/combine.cpp
+++ b/cpp/benchmarks/string/combine.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,9 @@ static void bench_combine(nvbench::state& state)
 
   auto stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
-  auto chars_size =
-    input1.chars_size(stream) + input2.chars_size(stream) + (num_rows * separator.size());
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);  // all bytes are read;
-  state.add_global_memory_writes<nvbench::int8_t>(chars_size);
+  auto const data_size = table->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);  // all bytes are read;
+  state.add_global_memory_writes<nvbench::int8_t>(data_size + (num_rows * separator.size()));
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto result = cudf::strings::concatenate(table->view(), separator);

--- a/cpp/benchmarks/string/contains.cpp
+++ b/cpp/benchmarks/string/contains.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,9 +40,7 @@ static void bench_contains(nvbench::state& state)
   auto pattern = patterns[pattern_index];
   auto program = cudf::strings::regex_program::create(pattern);
 
-  auto chars_size = input.chars_size(cudf::get_default_stream());
-  state.add_element_count(chars_size, "chars_size");
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);
+  state.add_global_memory_reads<nvbench::int8_t>(col->alloc_size());
   state.add_global_memory_writes<nvbench::int32_t>(input.size());
 
   state.exec(nvbench::exec_tag::sync,

--- a/cpp/benchmarks/string/convert_datetime.cpp
+++ b/cpp/benchmarks/string/convert_datetime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,12 +54,12 @@ void bench_convert_datetime(nvbench::state& state, nvbench::type_list<DataType>)
 
   if (from_ts) {
     state.add_global_memory_reads<DataType>(num_rows);
-    state.add_global_memory_writes<int8_t>(sv.chars_size(stream));
+    state.add_global_memory_writes<int8_t>(s_col->alloc_size());
     state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       cudf::strings::from_timestamps(ts_col->view(), format);
     });
   } else {
-    state.add_global_memory_reads<int8_t>(sv.chars_size(stream));
+    state.add_global_memory_reads<int8_t>(s_col->alloc_size());
     state.add_global_memory_writes<DataType>(num_rows);
     state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       cudf::strings::to_timestamps(sv, data_type, format);

--- a/cpp/benchmarks/string/convert_durations.cpp
+++ b/cpp/benchmarks/string/convert_durations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ void bench_convert_duration(nvbench::state& state, nvbench::type_list<DataType>)
   } else {
     auto source = cudf::strings::from_durations(input, format);
     auto view   = cudf::strings_column_view(source->view());
-    state.add_global_memory_reads<int8_t>(view.chars_size(stream));
+    state.add_global_memory_reads<int8_t>(source->alloc_size());
     state.add_global_memory_writes<DataType>(num_rows);
     state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       cudf::strings::to_durations(view, data_type, format);

--- a/cpp/benchmarks/string/convert_fixed_point.cpp
+++ b/cpp/benchmarks/string/convert_fixed_point.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,11 +45,11 @@ void bench_convert_fixed_point(nvbench::state& state, nvbench::type_list<DataTyp
 
   if (from_num) {
     state.add_global_memory_reads<int8_t>(num_rows * cudf::size_of(data_type));
-    state.add_global_memory_writes<int8_t>(sv.chars_size(stream));
+    state.add_global_memory_writes<int8_t>(strings_col->alloc_size());
     state.exec(nvbench::exec_tag::sync,
                [&](nvbench::launch& launch) { cudf::strings::to_fixed_point(sv, data_type); });
   } else {
-    state.add_global_memory_reads<int8_t>(sv.chars_size(stream));
+    state.add_global_memory_reads<int8_t>(strings_col->alloc_size());
     state.add_global_memory_writes<int8_t>(num_rows * cudf::size_of(data_type));
     state.exec(nvbench::exec_tag::sync,
                [&](nvbench::launch& launch) { cudf::strings::from_fixed_point(fp_col->view()); });

--- a/cpp/benchmarks/string/convert_numerics.cpp
+++ b/cpp/benchmarks/string/convert_numerics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ void bench_convert_number(nvbench::state& state, nvbench::type_list<NumericType>
 
   if (from_num) {
     state.add_global_memory_reads<NumericType>(num_rows);
-    state.add_global_memory_writes<int8_t>(sv.chars_size(stream));
+    state.add_global_memory_writes<int8_t>(strings_col->alloc_size());
     state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       if constexpr (std::is_floating_point_v<NumericType>) {
         cudf::strings::to_floats(sv, data_type);
@@ -64,7 +64,7 @@ void bench_convert_number(nvbench::state& state, nvbench::type_list<NumericType>
       }
     });
   } else {
-    state.add_global_memory_reads<int8_t>(sv.chars_size(stream));
+    state.add_global_memory_reads<int8_t>(strings_col->alloc_size());
     state.add_global_memory_writes<NumericType>(num_rows);
     state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       if constexpr (std::is_floating_point_v<NumericType>)

--- a/cpp/benchmarks/string/copy.cpp
+++ b/cpp/benchmarks/string/copy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,21 +46,21 @@ static void bench_copy(nvbench::state& state)
   if (api == "gather") {
     auto result =
       cudf::gather(source->view(), map_view, cudf::out_of_bounds_policy::NULLIFY, stream);
-    auto chars_size = cudf::strings_column_view(result->view().column(0)).chars_size(stream);
-    state.add_global_memory_reads<nvbench::int8_t>(chars_size +
+    auto data_size = result->alloc_size();
+    state.add_global_memory_reads<nvbench::int8_t>(data_size +
                                                    (map_view.size() * sizeof(cudf::size_type)));
-    state.add_global_memory_writes<nvbench::int8_t>(chars_size);
+    state.add_global_memory_writes<nvbench::int8_t>(data_size);
     state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       cudf::gather(source->view(), map_view, cudf::out_of_bounds_policy::NULLIFY, stream);
     });
   } else if (api == "scatter") {
     auto const target =
       create_random_table({cudf::type_id::STRING}, row_count{num_rows}, table_profile);
-    auto result     = cudf::scatter(source->view(), map_view, target->view(), stream);
-    auto chars_size = cudf::strings_column_view(result->view().column(0)).chars_size(stream);
-    state.add_global_memory_reads<nvbench::int8_t>(chars_size +
+    auto result    = cudf::scatter(source->view(), map_view, target->view(), stream);
+    auto data_size = result->alloc_size();
+    state.add_global_memory_reads<nvbench::int8_t>(data_size +
                                                    (map_view.size() * sizeof(cudf::size_type)));
-    state.add_global_memory_writes<nvbench::int8_t>(chars_size);
+    state.add_global_memory_writes<nvbench::int8_t>(data_size);
     state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
       cudf::scatter(source->view(), map_view, target->view(), stream);
     });

--- a/cpp/benchmarks/string/copy_if_else.cpp
+++ b/cpp/benchmarks/string/copy_if_else.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,9 +43,9 @@ static void bench_copy(nvbench::state& state)
   auto const left_right = booleans->view().column(0);
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
-  auto chars_size = cudf::strings_column_view(target).chars_size(cudf::get_default_stream());
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);   // all bytes are read;
-  state.add_global_memory_writes<nvbench::int8_t>(chars_size);  // both columns are similar size
+  auto data_size = target_table->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;
+  state.add_global_memory_writes<nvbench::int8_t>(data_size);  // both columns are similar size
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     [[maybe_unused]] auto result = cudf::copy_if_else(source, target, left_right);

--- a/cpp/benchmarks/string/copy_range.cpp
+++ b/cpp/benchmarks/string/copy_range.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,9 @@ static void bench_copy_range(nvbench::state& state)
   auto const target = source_tables->view().column(1);
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
-  auto chars_size = cudf::strings_column_view(target).chars_size(cudf::get_default_stream());
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);   // all bytes are read;
-  state.add_global_memory_writes<nvbench::int8_t>(chars_size);  // both columns are similar size
+  auto data_size = source_tables->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;
+  state.add_global_memory_writes<nvbench::int8_t>(data_size);  // both columns are similar size
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     [[maybe_unused]] auto result = cudf::copy_range(source, target, start, end, start / 2);

--- a/cpp/benchmarks/string/count.cpp
+++ b/cpp/benchmarks/string/count.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,9 +46,8 @@ static void bench_count(nvbench::state& state)
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   // gather some throughput statistics as well
-  auto chars_size = input.chars_size(cudf::get_default_stream());
-  state.add_element_count(chars_size, "chars_size");
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);
+  auto data_size = table->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);
   state.add_global_memory_writes<nvbench::int32_t>(input.size());
 
   state.exec(nvbench::exec_tag::sync,

--- a/cpp/benchmarks/string/extract.cpp
+++ b/cpp/benchmarks/string/extract.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,10 +62,9 @@ static void bench_extract(nvbench::state& state)
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   // gather some throughput statistics as well
-  auto chars_size = strings_view.chars_size(cudf::get_default_stream());
-  state.add_element_count(chars_size, "chars_size");            // number of bytes;
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);   // all bytes are read;
-  state.add_global_memory_writes<nvbench::int8_t>(chars_size);  // all bytes are written
+  auto data_size = input->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;
+  state.add_global_memory_writes<nvbench::int8_t>(data_size);  // all bytes are written
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto result = cudf::strings::extract(strings_view, *prog);

--- a/cpp/benchmarks/string/factory.cpp
+++ b/cpp/benchmarks/string/factory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,9 +44,9 @@ static void bench_factory(nvbench::state& state)
   auto d_strings = cudf::strings::detail::create_string_vector_from_column(sv, stream, mr);
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
-  auto chars_size = sv.chars_size(stream);
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);
-  state.add_global_memory_writes<nvbench::int8_t>(chars_size);
+  auto const data_size = column->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);
+  state.add_global_memory_writes<nvbench::int8_t>(data_size);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     cudf::make_strings_column(d_strings, cudf::string_view{nullptr, 0});

--- a/cpp/benchmarks/string/find.cpp
+++ b/cpp/benchmarks/string/find.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,9 +43,8 @@ static void bench_find_string(nvbench::state& state)
   auto const targets = cudf::strings_column_view(targets_col->view());
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
-  auto const chars_size = input.chars_size(stream);
-  state.add_element_count(chars_size, "chars_size");
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);
+  auto const data_size = col->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);
   if (api == "find") {
     state.add_global_memory_writes<nvbench::int32_t>(input.size());
   } else {

--- a/cpp/benchmarks/string/find_multiple.cpp
+++ b/cpp/benchmarks/string/find_multiple.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,8 @@ static void bench_find_string(nvbench::state& state)
   cudf::test::strings_column_wrapper targets(h_targets.begin(), h_targets.end());
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
-  auto const chars_size = input.chars_size(stream);
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);
+  auto const data_size = col->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);
   if (api == "find") {
     state.add_global_memory_writes<nvbench::int32_t>(input.size());
   } else {

--- a/cpp/benchmarks/string/lengths.cpp
+++ b/cpp/benchmarks/string/lengths.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,8 +36,8 @@ static void bench_lengths(nvbench::state& state)
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   // gather some throughput statistics as well
-  auto chars_size = input.chars_size(cudf::get_default_stream());
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);  // all bytes are read;
+  auto data_size = table->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;
   state.add_global_memory_writes<nvbench::int32_t>(num_rows);  // output is an integer per row
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {

--- a/cpp/benchmarks/string/like.cpp
+++ b/cpp/benchmarks/string/like.cpp
@@ -38,10 +38,9 @@ static void bench_like(nvbench::state& state)
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   // gather some throughput statistics as well
-  auto chars_size = input.chars_size(cudf::get_default_stream());
-  state.add_element_count(chars_size, "chars_size");           // number of bytes;
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);  // all bytes are read;
-  state.add_global_memory_writes<nvbench::int8_t>(n_rows);     // writes are BOOL8
+  auto const data_size = col->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);  // all bytes are read;
+  state.add_global_memory_writes<nvbench::int8_t>(n_rows);    // writes are BOOL8
 
   state.exec(nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) { auto result = cudf::strings::like(input, pattern); });

--- a/cpp/benchmarks/string/repeat_strings.cpp
+++ b/cpp/benchmarks/string/repeat_strings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,19 +42,18 @@ static void bench_repeat(nvbench::state& state)
 
   auto stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
-  auto chars_size = input.chars_size(stream);
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);
+  auto const data_size = table->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);
 
   if (api == "scalar") {
-    state.add_global_memory_writes<nvbench::int8_t>(chars_size * max_repeat);
+    state.add_global_memory_writes<nvbench::int8_t>(data_size * max_repeat);
     state.exec(nvbench::exec_tag::sync,
                [&](nvbench::launch& launch) { cudf::strings::repeat_strings(input, max_repeat); });
   } else if (api == "column") {
     auto repeats = table->view().column(1);
     {
       auto result = cudf::strings::repeat_strings(input, repeats);
-      auto output = cudf::strings_column_view(result->view());
-      state.add_global_memory_writes<nvbench::int8_t>(output.chars_size(stream));
+      state.add_global_memory_writes<nvbench::int8_t>(result->alloc_size());
     }
     state.exec(nvbench::exec_tag::sync,
                [&](nvbench::launch& launch) { cudf::strings::repeat_strings(input, repeats); });

--- a/cpp/benchmarks/string/replace.cpp
+++ b/cpp/benchmarks/string/replace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,9 +43,9 @@ static void bench_replace(nvbench::state& state)
 
   auto stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
-  auto const chars_size = input.chars_size(stream);
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);
-  state.add_global_memory_writes<nvbench::int8_t>(chars_size);
+  auto const data_size = column->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);
+  state.add_global_memory_writes<nvbench::int8_t>(data_size);
 
   if (api == "scalar") {
     cudf::string_scalar target("+");

--- a/cpp/benchmarks/string/replace_re.cpp
+++ b/cpp/benchmarks/string/replace_re.cpp
@@ -38,10 +38,9 @@ static void bench_replace(nvbench::state& state)
 
   auto program = cudf::strings::regex_program::create("(\\d+)");
 
-  auto chars_size = input.chars_size(cudf::get_default_stream());
-  state.add_element_count(chars_size, "chars_size");
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);
-  state.add_global_memory_writes<nvbench::int8_t>(chars_size);
+  auto const data_size = column->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);
+  state.add_global_memory_writes<nvbench::int8_t>(data_size);
 
   if (rtype == "backref") {
     auto replacement = std::string("#\\1X");

--- a/cpp/benchmarks/string/reverse.cpp
+++ b/cpp/benchmarks/string/reverse.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,10 +36,9 @@ static void bench_reverse(nvbench::state& state)
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   // gather some throughput statistics as well
-  auto chars_size = input.chars_size(cudf::get_default_stream());
-  state.add_element_count(chars_size, "chars_size");            // number of bytes;
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);   // all bytes are read;
-  state.add_global_memory_writes<nvbench::int8_t>(chars_size);  // all bytes are written
+  auto const data_size = table->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;
+  state.add_global_memory_writes<nvbench::int8_t>(data_size);  // all bytes are written
 
   state.exec(nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) { auto result = cudf::strings::reverse(input); });

--- a/cpp/benchmarks/string/slice.cpp
+++ b/cpp/benchmarks/string/slice.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,9 +50,8 @@ static void bench_slice(nvbench::state& state)
   auto stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
   // gather some throughput statistics as well
-  auto chars_size = input.chars_size(stream);
-  state.add_element_count(chars_size, "chars_size");           // number of bytes
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);  // all bytes are read
+  auto const data_size = column->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);  // all bytes are read
   auto output_size = (row_width / 3 - row_width / 4) * num_rows;
   state.add_global_memory_writes<nvbench::int8_t>(output_size);
 

--- a/cpp/benchmarks/string/split.cpp
+++ b/cpp/benchmarks/string/split.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,10 +40,9 @@ static void bench_split(nvbench::state& state)
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   // gather some throughput statistics as well
-  auto chars_size = input.chars_size(cudf::get_default_stream());
-  state.add_element_count(chars_size, "chars_size");            // number of bytes;
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);   // all bytes are read;
-  state.add_global_memory_writes<nvbench::int8_t>(chars_size);  // all bytes are written
+  auto const data_size = column->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;
+  state.add_global_memory_writes<nvbench::int8_t>(data_size);  // all bytes are written
 
   if (stype == "split") {
     state.exec(nvbench::exec_tag::sync,

--- a/cpp/benchmarks/string/split_re.cpp
+++ b/cpp/benchmarks/string/split_re.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,10 +40,9 @@ static void bench_split(nvbench::state& state)
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   // gather some throughput statistics as well
-  auto chars_size = input.chars_size(cudf::get_default_stream());
-  state.add_element_count(chars_size, "chars_size");            // number of bytes;
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);   // all bytes are read;
-  state.add_global_memory_writes<nvbench::int8_t>(chars_size);  // all bytes are written
+  auto const data_size = column->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);   // all bytes are read;
+  state.add_global_memory_writes<nvbench::int8_t>(data_size);  // all bytes are written
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto result = cudf::strings::split_record_re(input, *prog);

--- a/cpp/benchmarks/string/translate.cpp
+++ b/cpp/benchmarks/string/translate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,9 +51,9 @@ static void bench_translate(nvbench::state& state)
 
   auto stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
-  auto chars_size = input.chars_size(stream);
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);
-  state.add_global_memory_writes<nvbench::int8_t>(chars_size);
+  auto const data_size = column->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);
+  state.add_global_memory_writes<nvbench::int8_t>(data_size);
 
   state.exec(nvbench::exec_tag::sync,
              [&](nvbench::launch& launch) { cudf::strings::translate(input, entries); });

--- a/cpp/benchmarks/string/url_decode.cu
+++ b/cpp/benchmarks/string/url_decode.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,8 +79,8 @@ static void bench_url_decode(nvbench::state& state)
 
   auto stream = cudf::get_default_stream();
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
-  auto chars_size = input.chars_size(stream);
-  state.add_global_memory_reads<nvbench::int8_t>(chars_size);
+  auto const data_size = column->alloc_size();
+  state.add_global_memory_reads<nvbench::int8_t>(data_size);
 
   {
     auto result = cudf::strings::url_decode(input);


### PR DESCRIPTION
## Description
Fixes the strings benchmarks to use `alloc_size()` member function instead of `chars_size()` which did not account for reading the offsets or the bitmask.

Reference #13735 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
