### PR TITLE
Throw a descriptive exception in Parquet reader when trying to read files with more than two billion rows

### DIFF
--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -1697,16 +1697,16 @@ void reader::impl::allocate_columns(read_mode mode, size_t skip_rows, size_t num
         // for struct columns, higher levels of the output columns are shared between input
         // columns. so don't compute any given level more than once.
         if ((out_buf.user_data & PARQUET_COLUMN_BUFFER_FLAG_HAS_LIST_PARENT) && out_buf.size == 0) {
-          auto size = static_cast<size_t>(sizes[(idx * max_depth) + l_idx]);
-
+          auto buffer_size = sizes[(idx * max_depth) + l_idx];
           // if this is a list column add 1 for non-leaf levels for the terminating offset
-          if (out_buf.type.id() == type_id::LIST && l_idx < max_depth) { size++; }
-          CUDF_EXPECTS(size <= std::numeric_limits<cudf::size_type>::max(),
+          if (out_buf.type.id() == type_id::LIST && l_idx < max_depth) { buffer_size++; }
+          CUDF_EXPECTS(buffer_size <= std::numeric_limits<cudf::size_type>::max(),
                        "Number of list column rows exceeds cudf's column size limit",
                        std::overflow_error);
           // allocate
           // we're going to start null mask as all valid and then turn bits off if necessary
-          out_buf.create_with_mask(size, cudf::mask_state::UNINITIALIZED, false, _stream, _mr);
+          out_buf.create_with_mask(
+            buffer_size, cudf::mask_state::UNINITIALIZED, false, _stream, _mr);
           memset_bufs.push_back(cudf::device_span<std::byte>(
             static_cast<std::byte*>(out_buf.data()), out_buf.data_size()));
           nullmask_bufs.push_back(cudf::device_span<cudf::bitmask_type>(

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -1526,7 +1526,8 @@ void reader::impl::preprocess_subpass_pages(read_mode mode, size_t chunk_read_li
   subpass.skip_rows   = pass.skip_rows + pass.processed_rows;
   auto const pass_end = pass.skip_rows + pass.num_rows;
   max_row             = min(max_row, pass_end);
-  subpass.num_rows    = max_row - subpass.skip_rows;
+  CUDF_EXPECTS(max_row >= subpass.skip_rows, "Unexpected short subpass");
+  subpass.num_rows = max_row - subpass.skip_rows;
 
   // now split up the output into chunks as necessary
   compute_output_chunks_for_subpass();
@@ -1583,12 +1584,12 @@ void reader::impl::allocate_columns(read_mode mode, size_t skip_rows, size_t num
       else if (out_buf.size == 0) {
         // add 1 for the offset if this is a list column
         // we're going to start null mask as all valid and then turn bits off if necessary
+        auto const out_buf_size =
+          out_buf.type.id() == type_id::LIST && l_idx < max_depth ? num_rows + 1 : num_rows;
+        CUDF_EXPECTS(out_buf_size <= std::numeric_limits<cudf::size_type>::max(),
+                     "Number of rows exceeds cudf's column size limit");
         out_buf.create_with_mask(
-          out_buf.type.id() == type_id::LIST && l_idx < max_depth ? num_rows + 1 : num_rows,
-          cudf::mask_state::UNINITIALIZED,
-          false,
-          _stream,
-          _mr);
+          out_buf_size, cudf::mask_state::UNINITIALIZED, false, _stream, _mr);
         memset_bufs.push_back(cudf::device_span<std::byte>(static_cast<std::byte*>(out_buf.data()),
                                                            out_buf.data_size()));
         nullmask_bufs.push_back(cudf::device_span<cudf::bitmask_type>(
@@ -1695,11 +1696,12 @@ void reader::impl::allocate_columns(read_mode mode, size_t skip_rows, size_t num
         // for struct columns, higher levels of the output columns are shared between input
         // columns. so don't compute any given level more than once.
         if ((out_buf.user_data & PARQUET_COLUMN_BUFFER_FLAG_HAS_LIST_PARENT) && out_buf.size == 0) {
-          auto size = sizes[(idx * max_depth) + l_idx];
+          auto size = static_cast<size_t>(sizes[(idx * max_depth) + l_idx]);
 
           // if this is a list column add 1 for non-leaf levels for the terminating offset
           if (out_buf.type.id() == type_id::LIST && l_idx < max_depth) { size++; }
-
+          CUDF_EXPECTS(size <= std::numeric_limits<cudf::size_type>::max(),
+                       "Number of list column rows exceeds cudf's column size limit");
           // allocate
           // we're going to start null mask as all valid and then turn bits off if necessary
           out_buf.create_with_mask(size, cudf::mask_state::UNINITIALIZED, false, _stream, _mr);

--- a/cpp/src/io/utilities/column_buffer.cpp
+++ b/cpp/src/io/utilities/column_buffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/src/io/utilities/column_buffer.cpp
+++ b/cpp/src/io/utilities/column_buffer.cpp
@@ -98,6 +98,9 @@ void column_buffer_base<string_policy>::create_with_mask(size_type _size,
                                                          rmm::cuda_stream_view stream,
                                                          rmm::device_async_resource_ref mr)
 {
+  CUDF_EXPECTS(_size >= 0 and _size <= std::numeric_limits<cudf::size_type>::max(),
+               "Unexpected column buffer allocation size requested",
+               std::overflow_error);
   size = _size;
   _mr  = mr;
 

--- a/cpp/tests/io/parquet_chunked_reader_test.cu
+++ b/cpp/tests/io/parquet_chunked_reader_test.cu
@@ -1926,12 +1926,15 @@ TEST_F(ParquetReaderTest, ManyLargeLists)
   // Write the table to parquet
   cudf::io::write_parquet(out_opts);
 
-  // Concat filepath 150x for num rows to overflow cudf column size limits
-  constexpr cudf::size_type reads_to_overflow = 150;
+  // Times to concat filepath to overflow cudf column size limits
+  constexpr cudf::size_type reads_to_overflow =
+    (std::numeric_limits<cudf::size_type>::max() / (num_rows * bools_per_row)) + 1;
+
   auto const in_opts =
     cudf::io::parquet_reader_options::builder(
       cudf::io::source_info{std::vector<std::string>(reads_to_overflow, filepath)})
       .build();
+
   // Expect an overflow error when reading the files
   EXPECT_THROW(cudf::io::read_parquet(in_opts), std::overflow_error);
 }

--- a/cpp/tests/io/parquet_chunked_reader_test.cu
+++ b/cpp/tests/io/parquet_chunked_reader_test.cu
@@ -1204,6 +1204,11 @@ template <typename T>
 struct value_gen {
   __device__ T operator()(int i) { return i % 1024; }
 };
+
+struct bool_gen {
+  __device__ bool operator()(int i) { return i % 2 == 0; }
+};
+
 }  // namespace
 
 TEST_F(ParquetChunkedReaderInputLimitTest, List)
@@ -1884,6 +1889,51 @@ TEST_F(ParquetChunkedReaderTest, TestNumRowsPerSourceEmptyTable)
   EXPECT_EQ(num_rows_per_source.size(), nsources);
   EXPECT_TRUE(
     std::equal(expected_counts.cbegin(), expected_counts.cend(), num_rows_per_source.cbegin()));
+}
+
+TEST_F(ParquetReaderTest, ManyLargeLists)
+{
+  auto const stream = cudf::get_default_stream();
+
+  // Generate a list<bool> column with 10M outer rows and 2 bools per row
+  constexpr cudf::size_type num_rows      = 10'000'000;
+  constexpr cudf::size_type bools_per_row = 2;
+  auto offsets_iter = cudf::detail::make_counting_transform_iterator(0, offset_gen{bools_per_row});
+  auto offsets_col  = cudf::make_fixed_width_column(
+    cudf::data_type{cudf::type_id::INT32}, num_rows + 1, cudf::mask_state::UNALLOCATED);
+  thrust::copy(rmm::exec_policy_nosync(stream),
+               offsets_iter,
+               offsets_iter + num_rows + 1,
+               offsets_col->mutable_view().begin<int>());
+
+  auto bools_iter = cudf::detail::make_counting_transform_iterator(0, bool_gen{});
+  auto bools_col  = cudf::make_fixed_width_column(
+    cudf::data_type{cudf::type_id::BOOL8}, num_rows * bools_per_row, cudf::mask_state::UNALLOCATED);
+  thrust::copy(rmm::exec_policy_nosync(stream),
+               bools_iter,
+               bools_iter + (num_rows * bools_per_row),
+               bools_col->mutable_view().begin<bool>());
+
+  stream.synchronize();
+
+  auto list_col = cudf::make_lists_column(
+    num_rows, std::move(offsets_col), std::move(bools_col), 0, rmm::device_buffer{});
+
+  auto const table    = cudf::table_view({*list_col});
+  auto const filepath = temp_env->get_temp_filepath("ManyLargeLists.parquet");
+  auto const out_opts =
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, table).build();
+  // Write the table to parquet
+  cudf::io::write_parquet(out_opts);
+
+  // Concat filepath 150x for num rows to overflow cudf column size limits
+  constexpr cudf::size_type reads_to_overflow = 150;
+  auto const in_opts =
+    cudf::io::parquet_reader_options::builder(
+      cudf::io::source_info{std::vector<std::string>(reads_to_overflow, filepath)})
+      .build();
+  // Expect an overflow error when reading the files
+  EXPECT_THROW(cudf::io::read_parquet(in_opts), std::overflow_error);
 }
 
 TEST_P(ParquetChunkedDecompressionTest, RoundTripBasic)

--- a/cpp/tests/io/parquet_chunked_reader_test.cu
+++ b/cpp/tests/io/parquet_chunked_reader_test.cu
@@ -1895,7 +1895,7 @@ TEST_F(ParquetReaderTest, ManyLargeLists)
 {
   auto const stream = cudf::get_default_stream();
 
-  // Generate a list<bool> column with 10M outer rows and 2 bools per row
+  // Generate a large list<bool> column
   constexpr cudf::size_type num_rows      = 10'000'000;
   constexpr cudf::size_type bools_per_row = 2;
   auto offsets_iter = cudf::detail::make_counting_transform_iterator(0, offset_gen{bools_per_row});

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -4477,17 +4477,3 @@ def test_parquet_decompression(set_decomp_env_vars, my_pdf, compression):
     got = cudf.read_parquet(buffer)
 
     assert_eq(expect, got)
-
-
-def test_parquet_reader_many_large_lists():
-    NROWS = 10_000_000
-    MIN_NTIMES = 150
-    df = cudf.DataFrame({"a": [[True, False]] * NROWS})
-    buffer = BytesIO()
-    df.to_parquet(buffer)
-    buffers = [buffer] * MIN_NTIMES
-    with pytest.raises(
-        OverflowError,
-        match="Number of list column rows exceeds cudf's column size limit",
-    ):
-        cudf.read_parquet(buffers)

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -4477,3 +4477,17 @@ def test_parquet_decompression(set_decomp_env_vars, my_pdf, compression):
     got = cudf.read_parquet(buffer)
 
     assert_eq(expect, got)
+
+
+def test_parquet_reader_many_large_lists():
+    NROWS = 10_000_000
+    MIN_NTIMES = 150
+    df = cudf.DataFrame({"a": [[1.0, 2.0]] * NROWS})
+    buffer = BytesIO()
+    df.to_parquet(buffer)
+    buffers = [buffer] * MIN_NTIMES
+    with pytest.raises(
+        OverflowError,
+        match="Number of list column rows exceeds cudf's column size limit",
+    ):
+        cudf.read_parquet(buffers)

--- a/python/cudf/cudf/tests/test_parquet.py
+++ b/python/cudf/cudf/tests/test_parquet.py
@@ -4482,7 +4482,7 @@ def test_parquet_decompression(set_decomp_env_vars, my_pdf, compression):
 def test_parquet_reader_many_large_lists():
     NROWS = 10_000_000
     MIN_NTIMES = 150
-    df = cudf.DataFrame({"a": [[1.0, 2.0]] * NROWS})
+    df = cudf.DataFrame({"a": [[True, False]] * NROWS})
     buffer = BytesIO()
     df.to_parquet(buffer)
     buffers = [buffer] * MIN_NTIMES


### PR DESCRIPTION
## Description
This PR handles a potential `int32_t` overflow error when Parquet reader attempts to read more than 2 billion rows in one subpass.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
