### PR TITLE
Call the correct `from_pandas` in `hdf` reader

### DIFF
--- a/python/cudf/cudf/io/hdf.py
+++ b/python/cudf/cudf/io/hdf.py
@@ -4,7 +4,7 @@ import warnings
 
 import pandas as pd
 
-from cudf.core.dataframe import DataFrame
+from cudf.core.dataframe import from_pandas
 from cudf.utils import ioutils
 
 
@@ -16,7 +16,7 @@ def read_hdf(path_or_buf, *args, **kwargs):
         "be GPU accelerated in the future"
     )
     pd_value = pd.read_hdf(path_or_buf, *args, **kwargs)
-    return DataFrame.from_pandas(pd_value)
+    return from_pandas(pd_value)
 
 
 @ioutils.doc_to_hdf()


### PR DESCRIPTION
## Description
https://github.com/rapidsai/cudf/pull/18829 made changes to `cudf.from_pandas` call to `DataFrame.from_pandas` and hdf reader can read series objects too. So reverting this change.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
