### PR TITLE
[WIP] Track table statistics in cudf-polars streaming engine

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/base.py
+++ b/python/cudf_polars/cudf_polars/experimental/base.py
@@ -28,6 +28,8 @@ class ColumnStats:
     """Column data type."""
     cardinality: float
     """Known or estimated column cardinality."""
+    file_size: int | None
+    """Estimated file size for this column."""
     estimated: bool
     """Whether statistics are estimated."""
 

--- a/python/cudf_polars/cudf_polars/experimental/base.py
+++ b/python/cudf_polars/cudf_polars/experimental/base.py
@@ -4,36 +4,124 @@
 
 from __future__ import annotations
 
+import dataclasses
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, MutableMapping
+
+    from typing_extensions import Self
+
+    import pylibcudf as plc
 
     from cudf_polars.dsl.expr import NamedExpr
+    from cudf_polars.dsl.ir import IR
     from cudf_polars.dsl.nodebase import Node
+    from cudf_polars.typing import Schema
+
+
+@dataclasses.dataclass(frozen=True)
+class ColumnStats:
+    """Known or estimated column statistics."""
+
+    dtype: plc.DataType
+    """Column data type."""
+    cardinality: float
+    """Known or estimated column cardinality."""
+    estimated: bool
+    """Whether statistics are estimated."""
+
+
+@dataclasses.dataclass(frozen=True)
+class TableStats:
+    """Known or estimated table statistics."""
+
+    column_stats: dict[str, ColumnStats]
+    """Known or estimated column statistics."""
+    num_rows: int | None
+    """Known or estimated row count."""
+    estimated: bool
+    """Whether the row count is estimated."""
+
+    @classmethod
+    def merge(cls, schema: Schema, *tables: TableStats) -> Self:
+        """Merge multiple TableStats objects."""
+        num_rows = 0
+        estimated = False
+        column_stats: dict[str, ColumnStats] = {}
+        for table_stats in tables:
+            column_stats.update(
+                {k: v for k, v in table_stats.column_stats.items() if k in schema}
+            )
+            if isinstance(table_stats.num_rows, int):
+                num_rows = max(num_rows, table_stats.num_rows)
+            estimated = estimated or table_stats.estimated
+        return cls(column_stats, num_rows or None, estimated)
 
 
 class PartitionInfo:
     """Partitioning information."""
 
-    __slots__ = ("count", "partitioned_on")
+    __slots__ = ("count", "partitioned_on", "table_stats")
     count: int
     """Partition count."""
     partitioned_on: tuple[NamedExpr, ...]
     """Columns the data is hash-partitioned on."""
+    table_stats: TableStats | None
+    """Table statistics."""
 
     def __init__(
         self,
         count: int,
         partitioned_on: tuple[NamedExpr, ...] = (),
+        table_stats: TableStats | None = None,
     ):
         self.count = count
         self.partitioned_on = partitioned_on
+        self.table_stats = table_stats
 
     def keys(self, node: Node) -> Iterator[tuple[str, int]]:
         """Return the partitioned keys for a given node."""
         name = get_key_name(node)
         yield from ((name, i) for i in range(self.count))
+
+    @classmethod
+    def new(
+        cls,
+        ir: IR,
+        partition_info: MutableMapping[IR, PartitionInfo],
+        *,
+        count: int | None = None,
+        partitioned_on: tuple[NamedExpr, ...] | None = None,
+        inherit_partitioned_on: bool = False,
+        table_stats: TableStats | None = None,
+        inherit_table_stats: bool = True,
+    ) -> Self:
+        """Create a new PartitionInfo object."""
+        children = ir.children
+        count = count or (
+            max(partition_info[child].count for child in children) if children else 1
+        )
+        if partitioned_on is None and inherit_partitioned_on:
+            # Inherit partitioned_on
+            partitionining = {
+                partition_info[child].partitioned_on
+                for child in children
+                if partition_info[child].partitioned_on
+            }
+            partitioned_on = partitionining.pop() if len(partitionining) == 1 else ()
+
+        if table_stats is None and inherit_table_stats:
+            # Inherit table statistics
+            child_table_stats: list[TableStats] = []
+            for child in children:
+                stats = partition_info[child].table_stats
+                if stats is not None:
+                    child_table_stats.append(stats)
+            if child_table_stats:
+                table_stats = TableStats.merge(ir.schema, *child_table_stats)
+
+        return cls(count, partitioned_on or (), table_stats)
 
 
 def get_key_name(node: Node) -> str:

--- a/python/cudf_polars/cudf_polars/experimental/base.py
+++ b/python/cudf_polars/cudf_polars/experimental/base.py
@@ -28,6 +28,8 @@ class ColumnStats:
     """Column data type."""
     cardinality: float
     """Known or estimated column cardinality."""
+    row_size: int | None
+    """Estimated row size for this column."""
     file_size: int | None
     """Estimated file size for this column."""
     estimated: bool
@@ -55,10 +57,12 @@ class TableStats:
             column_stats.update(
                 {k: v for k, v in table_stats.column_stats.items() if k in schema}
             )
-            if isinstance(table_stats.num_rows, int):
+            if table_stats.num_rows is not None:
                 num_rows = max(num_rows, table_stats.num_rows)
             estimated = estimated or table_stats.estimated
-        return cls(column_stats, num_rows or None, estimated)
+        if num_rows is not None:
+            num_rows = int(num_rows)
+        return cls(column_stats, num_rows, estimated)
 
 
 class PartitionInfo:

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
@@ -1164,12 +1164,12 @@ def run(args: argparse.Namespace) -> None:
         executor_options: dict[str, Any] = {}
         if run_config.executor == "streaming":
             executor_options = {
-                "cardinality_factor": {
-                    "c_custkey": 0.05,  # Q10
-                    "l_orderkey": 1.0,  # Q18
-                    "l_partkey": 0.1,  # Q20
-                    "o_custkey": 0.25,  # Q22
-                },
+                # "cardinality_factor": {
+                #     "c_custkey": 0.05,  # Q10
+                #     "l_orderkey": 1.0,  # Q18
+                #     "l_partkey": 0.1,  # Q20
+                #     "o_custkey": 0.25,  # Q22
+                # },
             }
             if run_config.blocksize:
                 executor_options["target_partition_size"] = run_config.blocksize

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -257,7 +257,7 @@ def _(
 
     # Return reconstructed node and partition-info dict
     new_node = ir.reconstruct(children)
-    partition_info[new_node] = PartitionInfo(count=count)
+    partition_info[new_node] = PartitionInfo.new(new_node, partition_info, count=count)
     return new_node, partition_info
 
 
@@ -306,15 +306,13 @@ def _lower_ir_pwise(
             msg=f"Class {type(ir)} does not support children with mismatched partition counts.",
         )
 
-    # Preserve child partition_info if possible
-    if preserve_partitioning and len(children) == 1:
-        partition = partition_info[children[0]]
-    else:
-        partition = PartitionInfo(count=max(counts))
-
     # Return reconstructed node and partition-info dict
     new_node = ir.reconstruct(children)
-    partition_info[new_node] = partition
+    partition_info[new_node] = PartitionInfo.new(
+        new_node,
+        partition_info,
+        inherit_partitioned_on=preserve_partitioning,
+    )
     return new_node, partition_info
 
 

--- a/python/cudf_polars/cudf_polars/experimental/select.py
+++ b/python/cudf_polars/cudf_polars/experimental/select.py
@@ -88,9 +88,7 @@ def decompose_select(
             True,  # noqa: FBT003
             *selections,
         )
-        partition_info[new_ir] = PartitionInfo(
-            count=max(partition_info[c].count for c in selections)
-        )
+        partition_info[new_ir] = PartitionInfo.new(new_ir, partition_info)
     else:
         new_ir = selections[0]
 

--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -235,9 +235,9 @@ def _(
         # Already shuffled
         return new_child, pi
     new_node = ir.reconstruct([new_child])
-    pi[new_node] = PartitionInfo(
-        # Default shuffle preserves partition count
-        count=pi[new_child].count,
+    pi[new_node] = PartitionInfo.new(
+        new_node,
+        pi,
         # Add partitioned_on info
         partitioned_on=ir.keys,
     )

--- a/python/cudf_polars/cudf_polars/experimental/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/sort.py
@@ -35,10 +35,10 @@ def _(
         if partition_info[new_node].count > 1:
             # Collapse down to single partition
             inter = Repartition(new_node.schema, new_node)
-            partition_info[inter] = PartitionInfo(count=1)
+            partition_info[inter] = PartitionInfo.new(inter, partition_info, count=1)
             # Sort reduced partition
             new_node = ir.reconstruct([inter])
-            partition_info[new_node] = PartitionInfo(count=1)
+            partition_info[new_node] = PartitionInfo.new(new_node, partition_info)
         return new_node, partition_info
 
     # Fallback

--- a/python/cudf_polars/cudf_polars/experimental/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/utils.py
@@ -74,7 +74,7 @@ def _lower_ir_fallback(
             # Fall-back logic
             fallback = True
             child = Repartition(child.schema, child)
-            partition_info[child] = PartitionInfo(count=1)
+            partition_info[child] = PartitionInfo.new(child, partition_info, count=1)
         children.append(child)
 
     if fallback and msg:
@@ -84,7 +84,7 @@ def _lower_ir_fallback(
 
     # Reconstruct and return
     new_node = ir.reconstruct(children)
-    partition_info[new_node] = PartitionInfo(count=1)
+    partition_info[new_node] = PartitionInfo.new(new_node, partition_info)
     return new_node, partition_info
 
 


### PR DESCRIPTION
## Description

- Updates `PartitionInfo` to include a new `table_stats: TableStats` attribute. 
- Updates `_sample_pq_statistics` to populate/return a `TableStats` object (with caching)
  - When `distinct_count` are unavailable (the norm) we read a single row-group from the dataset to approximate the cardinality of each column.
- Adds `PartitoinInfo.new` to make it easier to propagate the `TableStats` information as `partition_info` is constructed.

With this PR, I am able to remove the `"cardinality_factor"` configurations from `pdsh.py` for sf1k. However, the performance may be a bit worse until we **use**/**update** the `table_stats` more intelligently (e.g. after a Join or GroupBy).

To illustrate `PartitionInfo.table_stats` a bit more, this is what I see when I place a breakpoint in `_make_bcast_join`:

```
(Pdb) pp partition_info[right].table_stats
TableStats(column_stats={'l_commitdate': ColumnStats(dtype=<pylibcudf.types.DataType object at 0x7f42d4202f10>,
                                                     cardinality=np.float64(0.019731365266393443),
                                                     row_size=168,
                                                     file_size=20549518,
                                                     estimated=True),
                         'l_orderkey': ColumnStats(dtype=<pylibcudf.types.DataType object at 0x7f42d40d2230>,
                                                   cardinality=np.float64(0.2500480276639344),
                                                   row_size=84,
                                                   file_size=10275084,
                                                   estimated=True),
                         'l_receiptdate': ColumnStats(dtype=<pylibcudf.types.DataType object at 0x7f42d4202f10>,
                                                      cardinality=np.float64(0.020315701844262294),
                                                      row_size=168,
                                                      file_size=20549518,
                                                      estimated=True),
                         'l_suppkey': ColumnStats(dtype=<pylibcudf.types.DataType object at 0x7f42d40d2230>,
                                                  cardinality=np.float64(0.9928038550204918),
                                                  row_size=84,
                                                  file_size=10275084,
                                                  estimated=True)},
           num_rows=7705824000,
           estimated=True)
```

Notice that we keep track of:
- Estimated cardinality (float between 0 and 1)
- Estimated row-size (not doing anything smart here for simple dtypes - just dividing the sampled size by the sampled row-count when `Scan` is lowered)
- Estimated file size (this is only used for choosing the initial partition count for Scan).

It seems like we should be able to update the estimated row-size and cardinality size for certain `IR` nodes and inject `Repartition` operations when the estimated row-size X row-count calls for a significant change in `PartitionInfo.count`.


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
