### PR TITLE
Update NumPy dependency in cudf.pandas-catboost integration test

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -336,7 +336,7 @@ jobs:
       sha: ${{ inputs.sha }}
       node_type: "gpu-l4-latest-1"
       continue-on-error: true
-      container_image: "rapidsai/ci-conda:latest"
+      container_image: "rapidsai/ci-conda:cuda12.9.0-ubuntu24.04-py3.12"
       run_script: |
         ci/cudf_pandas_scripts/third-party-integration/test.sh python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
   pandas-tests:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -135,7 +135,7 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       node_type: "gpu-l4-latest-1"
-      container_image: "rapidsai/ci-conda:latest"
+      container_image: "rapidsai/ci-conda:cuda12.9.0-ubuntu24.04-py3.12"
       run_script: |
         ci/cudf_pandas_scripts/third-party-integration/test.sh python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
   wheel-tests-cudf-polars:

--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
@@ -265,8 +265,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-        # TODO: Remove numpy pinning once https://github.com/catboost/catboost/issues/2671 is resolved
-          - numpy>=1.23,<2.0.0
+          - numpy
           - scipy
           - scikit-learn
           - catboost

--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
@@ -69,6 +69,8 @@ files:
       - py_version
       - test_base
       - test_tensorflow
+    matrix:
+      py: "3.12"
   test_xgboost:
     output: none
     includes:

--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
@@ -70,7 +70,7 @@ files:
       - test_base
       - test_tensorflow
     matrix:
-      py: "3.12"
+      py: ["3.12"]
   test_xgboost:
     output: none
     includes:

--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
@@ -69,8 +69,6 @@ files:
       - py_version
       - test_base
       - test_tensorflow
-    matrix:
-      py: ["3.12"]
   test_xgboost:
     output: none
     includes:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Catboost supports NumPy 2.0 now. This PR also pins the python version to 3.12 because TensorFlow does not support python 3.13 (I was not able to pin python version to 3.12 in just the TensorFlow environment).
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
