### PR TITLE
Ensure __eq__/__ne__ between Columns in public objects don't return bool

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1153,6 +1153,29 @@ class ColumnBase(Serializable, BinaryOperand, Reducible):
             return pa.scalar(None, type=cudf_dtype_to_pa_type(self.dtype))
         return NotImplemented
 
+    def _all_bools_with_nulls(
+        self, other: ColumnBase, bool_fill_value: bool
+    ) -> ColumnBase:
+        # Might be able to remove if we share more of
+        # DatetimeColumn._binaryop & TimedeltaColumn._binaryop
+        if self.has_nulls() and other.has_nulls():
+            result_mask = (
+                self._get_mask_as_column() & other._get_mask_as_column()
+            )
+        elif self.has_nulls():
+            result_mask = self._get_mask_as_column()
+        elif other.has_nulls():
+            result_mask = other._get_mask_as_column()
+        else:
+            result_mask = None
+
+        result_col = as_column(
+            bool_fill_value, dtype=np.dtype(np.bool_), length=len(self)
+        )
+        if result_mask is not None:
+            result_col = result_col.set_mask(result_mask.as_mask())
+        return result_col
+
     def _scatter_by_slice(
         self,
         key: builtins.slice,

--- a/python/cudf/cudf/core/column/temporal_base.py
+++ b/python/cudf/cudf/core/column/temporal_base.py
@@ -126,29 +126,6 @@ class TemporalBaseColumn(ColumnBase):
             rhs = rhs.astype(lhs.dtype)
         return lhs, rhs
 
-    def _all_bools_with_nulls(
-        self, other: ColumnBase, bool_fill_value: bool
-    ) -> ColumnBase:
-        # Might be able to remove if we share more of
-        # DatetimeColumn._binaryop & TimedeltaColumn._binaryop
-        if self.has_nulls() and other.has_nulls():
-            result_mask = (
-                self._get_mask_as_column() & other._get_mask_as_column()
-            )
-        elif self.has_nulls():
-            result_mask = self._get_mask_as_column()
-        elif other.has_nulls():
-            result_mask = other._get_mask_as_column()
-        else:
-            result_mask = None
-
-        result_col = as_column(
-            bool_fill_value, dtype=np.dtype(np.bool_), length=len(self)
-        )
-        if result_mask is not None:
-            result_col = result_col.set_mask(result_mask.as_mask())
-        return result_col
-
     def _normalize_binop_operand(self, other: Any) -> pa.Scalar | ColumnBase:
         if isinstance(other, ColumnBase):
             return other

--- a/python/cudf/cudf/tests/test_binops.py
+++ b/python/cudf/cudf/tests/test_binops.py
@@ -2644,3 +2644,26 @@ def test_cat_non_cat_compare_ops(comp_op, data_left, data_right, ordered):
         expected = comp_op(pd_non_cat, pd_cat)
         result = comp_op(cudf_non_cat, cudf_cat)
         assert_eq(result, expected)
+
+
+@pytest.mark.parametrize(
+    "left_data, right_data",
+    [[["a", "b"], [1, 2]], [[[1, 2, 3], [4, 5]], [{"a": 1}, {"a": 2}]]],
+)
+@pytest.mark.parametrize(
+    "op, expected_data",
+    [[operator.eq, [False, False]], [operator.ne, [True, True]]],
+)
+@pytest.mark.parametrize("with_na", [True, False])
+def test_eq_ne_non_comparable_types(
+    left_data, right_data, op, expected_data, with_na
+):
+    if with_na:
+        left_data[0] = None
+    left = cudf.Series(left_data)
+    right = cudf.Series(right_data)
+    result = op(left, right)
+    if with_na:
+        expected_data[0] = None
+    expected = cudf.Series(expected_data)
+    assert_eq(result, expected)


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/18860

This was returning `bool` because `ColumnBase._binaryop` might have returned `NotImplemented` for both operands and therefore `is/is not` was being used for equality.

My fix ensures this returns a broadcasted result when this was done in a public cuDF object, but a more rigorous solution would be to change `_binaryop` to ensure all subclasses returned this broadcasted result.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
