### PR TITLE
Fix Dataframe `getitem` when `MultiIndex` columns exist

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1493,13 +1493,13 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
                 or (
                     out._data.multiindex is False
                     and self._data.multiindex is True
-                    and len(out._data.names)
+                    and out._num_columns
                     and all(n == "" for n in out._column_names)
                 )
                 or (
                     out._data.multiindex is True
                     and self._data.multiindex is True
-                    and len(out._data.names)
+                    and out._num_columns
                     and all(n == "" for n in out._column_names[0])
                 )
             ):

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1494,7 +1494,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
                     out._data.multiindex is False
                     and self._data.multiindex is True
                     and len(out._data.names)
-                    and all(n == "" for n in out._data.names)
+                    and all(n == "" for n in out._column_names)
                 )
                 or (
                     out._data.multiindex is True

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1500,7 +1500,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
                     out._data.multiindex is True
                     and self._data.multiindex is True
                     and len(out._data.names)
-                    and all(n == "" for n in out._data.names[0])
+                    and all(n == "" for n in out._column_names[0])
                 )
             ):
                 out = self._constructor_sliced._from_data(out._data)

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -11169,3 +11169,29 @@ def test_setitem_reset_label_dtype():
     result["a"] = [2]
     expected["a"] = [2]
     assert_eq(result, expected)
+
+
+def test_dataframe_midx_cols_getitem():
+    df = cudf.DataFrame(
+        {
+            "a": ["a", "b", "c"],
+            "b": ["b", "", ""],
+            "c": [10, 11, 12],
+        }
+    )
+    df.columns = df.set_index(["a", "b"]).index
+    pdf = df.to_pandas()
+
+    expected = df["c"]
+    actual = pdf["c"]
+    assert_eq(expected, actual)
+    df = cudf.DataFrame(
+        [[1, 0], [0, 1]],
+        columns=[
+            ["foo", "foo"],
+            ["location", "location"],
+            ["x", "y"],
+        ],
+    )
+    df = df.assign(bools=cudf.Series([True, False], dtype="bool"))
+    assert_eq(df["bools"], df.to_pandas()["bools"])


### PR DESCRIPTION
## Description
Forks off of: https://github.com/rapidsai/cudf/pull/18832/

xref: https://github.com/rapidsai/cudf/pull/18832#discussion_r2096186843


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
