### PR TITLE
Remove deprecated `cudf::io::host_buffer`

### DIFF
--- a/cpp/include/cudf/io/datasource.hpp
+++ b/cpp/include/cudf/io/datasource.hpp
@@ -105,16 +105,6 @@ class datasource {
   /**
    * @brief Creates a source from a host memory buffer.
    *
-   # @deprecated Since 23.04
-   *
-   * @param[in] buffer Host buffer object
-   * @return Constructed datasource object
-   */
-  static std::unique_ptr<datasource> create(host_buffer const& buffer);
-
-  /**
-   * @brief Creates a source from a host memory buffer.
-   *
    * @param[in] buffer Host buffer object
    * @return Constructed datasource object
    */

--- a/cpp/include/cudf/io/types.hpp
+++ b/cpp/include/cudf/io/types.hpp
@@ -306,27 +306,6 @@ struct table_with_metadata {
 };
 
 /**
- * @brief Non-owning view of a host memory buffer
- *
- * @deprecated Since 23.04
- *
- * Used to describe buffer input in `source_info` objects.
- */
-struct host_buffer {
-  // TODO: to be replaced by `host_span`
-  char const* data = nullptr;  //!< Pointer to the buffer
-  size_t size      = 0;        //!< Size of the buffer
-  host_buffer()    = default;
-  /**
-   * @brief Construct a new host buffer object
-   *
-   * @param data Pointer to the buffer
-   * @param size Size of the buffer
-   */
-  host_buffer(char const* data, size_t size) : data(data), size(size) {}
-};
-
-/**
  * @brief Returns `true` if the type is byte-like, meaning it is reasonable to pass as a pointer to
  * bytes.
  *
@@ -365,40 +344,6 @@ struct source_info {
    */
   explicit source_info(std::string file_path)
     : _type(io_type::FILEPATH), _filepaths({std::move(file_path)})
-  {
-  }
-
-  /**
-   * @brief Construct a new source info object for multiple buffers in host memory
-   *
-   * @deprecated Since 23.04
-   *
-   * @param host_buffers Input buffers in host memory
-   */
-  explicit source_info(std::vector<host_buffer> const& host_buffers) : _type(io_type::HOST_BUFFER)
-  {
-    _host_buffers.reserve(host_buffers.size());
-    std::transform(host_buffers.begin(),
-                   host_buffers.end(),
-                   std::back_inserter(_host_buffers),
-                   [](auto const hb) {
-                     return cudf::host_span<std::byte const>{
-                       reinterpret_cast<std::byte const*>(hb.data), hb.size};
-                   });
-  }
-
-  /**
-   * @brief Construct a new source info object for a single buffer
-   *
-   * @deprecated Since 23.04
-   *
-   * @param host_data Input buffer in host memory
-   * @param size Size of the buffer
-   */
-  explicit source_info(char const* host_data, size_t size)
-    : _type(io_type::HOST_BUFFER),
-      _host_buffers(
-        {cudf::host_span<std::byte const>(reinterpret_cast<std::byte const*>(host_data), size)})
   {
   }
 

--- a/cpp/src/io/utilities/datasource.cpp
+++ b/cpp/src/io/utilities/datasource.cpp
@@ -515,12 +515,6 @@ std::unique_ptr<datasource> datasource::create(std::string const& filepath,
   }
 }
 
-std::unique_ptr<datasource> datasource::create(host_buffer const& buffer)
-{
-  return create(
-    cudf::host_span<std::byte const>{reinterpret_cast<std::byte const*>(buffer.data), buffer.size});
-}
-
 std::unique_ptr<datasource> datasource::create(cudf::host_span<std::byte const> buffer)
 {
   return std::make_unique<host_buffer_source>(buffer);

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -102,7 +102,9 @@ struct CsvFixedPointReaderTest : public CsvReaderTest {
                                         });
 
     cudf::io::csv_reader_options const in_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
         .dtypes({data_type{type_to_id<DecimalType>(), scale}})
         .header(-1);
 
@@ -1103,7 +1105,9 @@ TEST_F(CsvReaderTest, ByteRangeStrings)
 {
   std::string input = "\"a\"\n\"b\"\n\"c\"";
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{input.c_str(), input.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(input.c_str()), input.size()}})
       .names({"A"})
       .dtypes({dtype<cudf::string_view>()})
       .header(-1)
@@ -1216,7 +1220,9 @@ TEST_F(CsvReaderTest, StringInference)
 {
   std::string buffer = "\"-1\"\n";
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
       .header(-1);
   auto const result = cudf::io::read_csv(in_opts);
 
@@ -1228,7 +1234,9 @@ TEST_F(CsvReaderTest, TypeInferenceThousands)
 {
   std::string buffer = "1`400,123,1`234.56\n123`456,123456,12.34";
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
       .header(-1)
       .thousands('`');
   auto const result      = cudf::io::read_csv(in_opts);
@@ -1255,7 +1263,9 @@ TEST_F(CsvReaderTest, TypeInferenceWithDecimal)
   // col#2 => FLOAT64 (column contains digits and decimal point (i.e., ';'))
   std::string buffer = "1`400,1.23,1`234;56\n123`456,123.456,12;34";
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
       .header(-1)
       .thousands('`')
       .decimal(';');
@@ -1280,13 +1290,17 @@ TEST_F(CsvReaderTest, SkipRowsXorSkipFooter)
   std::string buffer = "1,2,3";
 
   cudf::io::csv_reader_options skiprows_options =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
       .header(-1)
       .skiprows(1);
   EXPECT_NO_THROW(cudf::io::read_csv(skiprows_options));
 
   cudf::io::csv_reader_options skipfooter_options =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
       .header(-1)
       .skipfooter(1);
   EXPECT_NO_THROW(cudf::io::read_csv(skipfooter_options));
@@ -1387,111 +1401,126 @@ TEST_F(CsvReaderTest, FailCases)
 {
   std::string buffer = "1,2,3";
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_offset(4)
-        .skiprows(1),
-      std::invalid_argument);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .byte_range_offset(4)
+                   .skiprows(1),
+                 std::invalid_argument);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_offset(4)
-        .skipfooter(1),
-      std::invalid_argument);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .byte_range_offset(4)
+                   .skipfooter(1),
+                 std::invalid_argument);
   }
 
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_offset(4)
-        .nrows(1),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .byte_range_offset(4)
+                   .nrows(1),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_size(4)
-        .skiprows(1),
-      std::invalid_argument);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .byte_range_size(4)
+                   .skiprows(1),
+                 std::invalid_argument);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_size(4)
-        .skipfooter(1),
-      std::invalid_argument);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .byte_range_size(4)
+                   .skipfooter(1),
+                 std::invalid_argument);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .byte_range_size(4)
-        .nrows(1),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .byte_range_size(4)
+                   .nrows(1),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .skiprows(1)
-        .byte_range_offset(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .skiprows(1)
+                   .byte_range_offset(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .skipfooter(1)
-        .byte_range_offset(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .skipfooter(1)
+                   .byte_range_offset(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .nrows(1)
-        .byte_range_offset(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .nrows(1)
+                   .byte_range_offset(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .skiprows(1)
-        .byte_range_size(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .skiprows(1)
+                   .byte_range_size(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .skipfooter(1)
-        .byte_range_size(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .skipfooter(1)
+                   .byte_range_size(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .nrows(1)
-        .byte_range_size(4),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .nrows(1)
+                   .byte_range_size(4),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .nrows(1)
-        .skipfooter(1),
-      std::invalid_argument);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .nrows(1)
+                   .skipfooter(1),
+                 std::invalid_argument);
     ;
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .skipfooter(1)
-        .nrows(1),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .skipfooter(1)
+                   .nrows(1),
+                 cudf::logic_error);
   }
   {
-    EXPECT_THROW(
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
-        .na_filter(false)
-        .na_values({"Null"}),
-      cudf::logic_error);
+    EXPECT_THROW(cudf::io::csv_reader_options::builder(
+                   cudf::io::source_info{cudf::host_span<std::byte const>{
+                     reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
+                   .na_filter(false)
+                   .na_values({"Null"}),
+                 cudf::logic_error);
   }
 }
 
@@ -2229,7 +2258,9 @@ TEST_F(CsvReaderTest, DtypesMap)
   std::string csv_in{"12,9\n34,8\n56,7"};
 
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(csv_in.c_str()), csv_in.size()}})
       .names({"A", "B"})
       .dtypes({{"B", dtype<int16_t>()}, {"A", dtype<int32_t>()}})
       .header(-1);
@@ -2246,7 +2277,8 @@ TEST_F(CsvReaderTest, DtypesMap)
 TEST_F(CsvReaderTest, DtypesMapPartial)
 {
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{nullptr, 0})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{nullptr, 0}})
       .names({"A", "B"})
       .dtypes({{"A", dtype<int16_t>()}});
   {
@@ -2271,7 +2303,8 @@ TEST_F(CsvReaderTest, DtypesMapPartial)
 TEST_F(CsvReaderTest, DtypesArrayInvalid)
 {
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{nullptr, 0})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{nullptr, 0}})
       .names({"A", "B", "C"})
       .dtypes(std::vector<cudf::data_type>{dtype<int16_t>(), dtype<int8_t>()});
 
@@ -2311,19 +2344,25 @@ TEST_F(CsvReaderTest, UseColsValidation)
   const std::string buffer = "1,2,3";
 
   const cudf::io::csv_reader_options idx_cnt_options =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
       .names({"a", "b"})
       .use_cols_indexes({0});
   EXPECT_THROW(cudf::io::read_csv(idx_cnt_options), cudf::logic_error);
 
   cudf::io::csv_reader_options unique_idx_cnt_options =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
       .names({"a", "b"})
       .use_cols_indexes({0, 0});
   EXPECT_THROW(cudf::io::read_csv(unique_idx_cnt_options), cudf::logic_error);
 
   cudf::io::csv_reader_options bad_name_options =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
       .names({"a", "b", "c"})
       .use_cols_names({"nonexistent_name"});
   EXPECT_THROW(cudf::io::read_csv(bad_name_options), cudf::logic_error);
@@ -2334,7 +2373,9 @@ TEST_F(CsvReaderTest, CropColumns)
   const std::string csv_in{"12,9., 10\n34,8., 20\n56,7., 30"};
 
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(csv_in.c_str()), csv_in.size()}})
       .dtypes(std::vector<data_type>{dtype<int32_t>(), dtype<float>()})
       .names({"a", "b"})
       .header(-1);
@@ -2353,7 +2394,9 @@ TEST_F(CsvReaderTest, CropColumnsUseColsNames)
   std::string csv_in{"12,9., 10\n34,8., 20\n56,7., 30"};
 
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(csv_in.c_str()), csv_in.size()}})
       .dtypes(std::vector<data_type>{dtype<int32_t>(), dtype<float>()})
       .names({"a", "b"})
       .use_cols_names({"b"})
@@ -2371,7 +2414,9 @@ TEST_F(CsvReaderTest, ExtraColumns)
   std::string csv_in{"12,9., 10\n34,8., 20\n56,7., 30"};
   {
     cudf::io::csv_reader_options opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(csv_in.c_str()), csv_in.size()}})
         .names({"a", "b", "c", "d"})
         .header(-1);
     auto result = cudf::io::read_csv(opts);
@@ -2383,7 +2428,9 @@ TEST_F(CsvReaderTest, ExtraColumns)
   }
   {
     cudf::io::csv_reader_options with_dtypes_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(csv_in.c_str()), csv_in.size()}})
         .names({"a", "b", "c", "d"})
         .dtypes({dtype<int32_t>(), dtype<int32_t>(), dtype<int32_t>(), dtype<float>()})
         .header(-1);
@@ -2402,7 +2449,9 @@ TEST_F(CsvReaderTest, ExtraColumnsUseCols)
 
   {
     cudf::io::csv_reader_options in_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(csv_in.c_str()), csv_in.size()}})
         .names({"a", "b", "c", "d"})
         .use_cols_names({"b", "d"})
         .header(-1);
@@ -2415,7 +2464,9 @@ TEST_F(CsvReaderTest, ExtraColumnsUseCols)
   }
   {
     cudf::io::csv_reader_options with_dtypes_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(csv_in.c_str()), csv_in.size()}})
         .names({"a", "b", "c", "d"})
         .use_cols_names({"b", "d"})
         .dtypes({dtype<int32_t>(), dtype<int32_t>(), dtype<int32_t>(), dtype<cudf::string_view>()})
@@ -2435,7 +2486,9 @@ TEST_F(CsvReaderTest, EmptyColumns)
   std::string csv_in{",null\n,null"};
 
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(csv_in.c_str()), csv_in.size()}})
       .names({"a", "b", "c", "d"})
       .header(-1);
   // More elements in `names` than in the file; additional columns are filled with nulls
@@ -2456,7 +2509,9 @@ TEST_F(CsvReaderTest, BlankLineAfterFirstRow)
 
   {
     cudf::io::csv_reader_options no_header_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()})
+      cudf::io::csv_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(csv_in.c_str()), csv_in.size()}})
         .header(-1);
     // No header, getting column names/count from first row
     auto result = cudf::io::read_csv(no_header_opts);
@@ -2466,7 +2521,8 @@ TEST_F(CsvReaderTest, BlankLineAfterFirstRow)
   }
   {
     cudf::io::csv_reader_options header_opts =
-      cudf::io::csv_reader_options::builder(cudf::io::source_info{csv_in.c_str(), csv_in.size()});
+      cudf::io::csv_reader_options::builder(cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(csv_in.c_str()), csv_in.size()}});
     // Getting column names/count from header
     auto result = cudf::io::read_csv(header_opts);
 
@@ -2479,7 +2535,9 @@ TEST_F(CsvReaderTest, NullCount)
 {
   std::string buffer = "0,,\n1,1.,\n2,,\n3,,\n4,4.,\n5,5.,\n6,6.,\n7,7.,\n";
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
       .header(-1);
   auto const result      = cudf::io::read_csv(in_opts);
   auto const result_view = result.tbl->view();
@@ -2494,7 +2552,8 @@ TEST_F(CsvReaderTest, UTF8BOM)
 {
   std::string buffer = "\xEF\xBB\xBFMonth,Day,Year\nJune,6,2023\nAugust,25,1990\nMay,1,2000\n";
   cudf::io::csv_reader_options in_opts =
-    cudf::io::csv_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()});
+    cudf::io::csv_reader_options::builder(cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}});
   auto const result      = cudf::io::read_csv(in_opts);
   auto const result_view = result.tbl->view();
   EXPECT_EQ(result_view.num_rows(), 3);

--- a/cpp/tests/io/json/json_chunked_reader.cu
+++ b/cpp/tests/io/json/json_chunked_reader.cu
@@ -71,7 +71,8 @@ TEST_P(JsonReaderTest, ByteRange_SingleSource)
   // Initialize parsing options (reading json lines)
   cudf::io::json_reader_options json_lines_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.c_str(), json_string.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json_string.c_str()), json_string.size()}})
       .compression(cudf::io::compression_type::NONE)
       .lines(true);
   cudf::io::json_reader_options cjson_lines_options =

--- a/cpp/tests/io/json/json_quote_normalization_test.cpp
+++ b/cpp/tests/io/json/json_quote_normalization_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -191,7 +191,8 @@ TEST_F(JsonNormalizationTest, ReadJsonOption)
   std::string const host_input = R"({"a": "1\n2"}h{'a': 12})";
   cudf::io::json_reader_options input_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{host_input.data(), host_input.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(host_input.data()), host_input.size()}})
       .lines(true)
       .delimiter('h')
       .normalize_single_quotes(true);
@@ -203,7 +204,8 @@ TEST_F(JsonNormalizationTest, ReadJsonOption)
   std::string const expected_input = R"({"a": "1\n2"}h{"a": 12})";
   cudf::io::json_reader_options expected_input_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{expected_input.data(), expected_input.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(expected_input.data()), expected_input.size()}})
       .lines(true)
       .delimiter('h');
 
@@ -222,7 +224,8 @@ TEST_F(JsonNormalizationTest, ErrorCheck)
   std::string const host_input = R"({"A":'TEST"'})";
   cudf::io::json_reader_options input_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{host_input.data(), host_input.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(host_input.data()), host_input.size()}})
       .lines(true);
 
   EXPECT_THROW(cudf::io::read_json(input_options, cudf::test::get_default_stream(), rsc.get()),

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -243,7 +243,9 @@ struct JsonValidFixedPointReaderTest : public JsonFixedPointReaderTest<DecimalTy
                         return acc + (acc.empty() ? "" : "\n") + "{\"col0\":" + rhs + "}";
                       });
     cudf::io::json_reader_options const in_opts =
-      cudf::io::json_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+      cudf::io::json_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
         .dtypes(std::vector{data_type{type_to_id<DecimalType>(), scale}})
         .lines(true);
 
@@ -286,7 +288,9 @@ TEST_P(JsonReaderParamTest, BasicJsonLines)
   std::string data = is_row_orient_test(test_opt) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .dtypes(std::vector<data_type>{dtype<int32_t>(), dtype<double>()})
       .lines(true);
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
@@ -352,7 +356,9 @@ TEST_P(JsonReaderParamTest, JsonLinesStrings)
   std::string data          = is_row_orient_test(test_opt) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .dtypes(std::map<std::string, data_type>{
         {"2", dtype<cudf::string_view>()}, {"0", dtype<int32_t>()}, {"1", dtype<double>()}})
       .lines(true);
@@ -607,7 +613,9 @@ TEST_P(JsonReaderParamTest, JsonLinesDtypeInference)
   std::string data          = is_row_orient_test(test_opt) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .lines(true);
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
@@ -891,7 +899,9 @@ TEST_P(JsonReaderRecordTest, JsonLinesObjectsStrings)
 {
   auto test_json_objects = [](std::string const& data) {
     cudf::io::json_reader_options in_options =
-      cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+      cudf::io::json_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(data.data()), data.size()}})
         .lines(true);
 
     cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
@@ -929,7 +939,9 @@ TEST_P(JsonReaderRecordTest, JsonLinesObjectsMissingData)
     "{              \"col2\":1.1, \"col3\":\"aaa\"}\n"
     "{\"col1\":200,               \"col3\":\"bbb\"}\n";
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .lines(true);
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
@@ -964,7 +976,9 @@ TEST_P(JsonReaderRecordTest, JsonLinesObjectsOutOfOrder)
     "{\"col3\":\"bbb\", \"col1\":200, \"col2\":2.2}\n";
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .lines(true);
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
@@ -1074,7 +1088,9 @@ TEST_P(JsonReaderParamTest, StringInference)
   std::string data          = is_row_orient_test(test_opt) ? row_orient : record_orient;
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.c_str(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .lines(true);
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
 
@@ -1390,7 +1406,8 @@ TEST_F(JsonReaderTest, JsonLines)
   // Initialize parsing options (reading json lines)
   cudf::io::json_reader_options json_lines_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.c_str(), json_string.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json_string.c_str()), json_string.size()}})
       .lines(true);
 
   // Read test data via nested JSON reader
@@ -1465,7 +1482,8 @@ TEST_F(JsonReaderTest, JsonLongString)
   // Initialize parsing options (reading json lines)
   cudf::io::json_reader_options json_lines_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{out_buffer.data(), out_buffer.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(out_buffer.data()), out_buffer.size()}})
       .lines(true)
       .dtypes(types);
 
@@ -1493,7 +1511,9 @@ TEST_F(JsonReaderTest, ErrorStrings)
   // Last one is not an error case, but shows that unicode in json is copied string column output.
 
   cudf::io::json_reader_options const in_opts =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
       .dtypes(std::vector{data_type{cudf::type_id::STRING}})
       .lines(true);
 
@@ -1532,7 +1552,8 @@ TEST_F(JsonReaderTest, TokenAllocation)
     // Initialize parsing options (reading json lines)
     cudf::io::json_reader_options json_lines_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.c_str(), json_string.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(json_string.c_str()), json_string.size()}})
         .lines(true);
 
     EXPECT_NO_THROW(cudf::io::read_json(json_lines_options));
@@ -1560,7 +1581,8 @@ TEST_F(JsonReaderTest, LinesNoOmissions)
     // Initialize parsing options (reading json lines)
     cudf::io::json_reader_options json_lines_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.c_str(), json_string.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(json_string.c_str()), json_string.size()}})
         .lines(true);
 
     // Read test data via nested JSON reader
@@ -1588,7 +1610,8 @@ TEST_F(JsonReaderTest, TestColumnOrder)
   // Initialize parsing options (reading json lines)
   cudf::io::json_reader_options json_lines_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.c_str(), json_string.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json_string.c_str()), json_string.size()}})
       .lines(true);
 
   // Read in data using nested JSON reader
@@ -1646,7 +1669,9 @@ TEST_P(JsonReaderParamTest, JsonDtypeSchema)
   std::map<std::string, cudf::io::schema_element> dtype_schema{
     {"2", {dtype<cudf::string_view>()}}, {"0", {dtype<int32_t>()}}, {"1", {dtype<double>()}}};
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .dtypes(dtype_schema)
       .lines(true);
 
@@ -1684,7 +1709,8 @@ TEST_F(JsonReaderTest, JsonNestedDtypeSchema)
 
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.data(), json_string.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json_string.c_str()), json_string.size()}})
       .dtypes(dtype_schema)
       .lines(false);
 
@@ -1842,7 +1868,9 @@ TEST_P(JsonReaderParamTest, JsonDtypeParsing)
   for (size_t col_type = 0; col_type < cols.size(); col_type++) {
     std::map<std::string, cudf::io::schema_element> dtype_schema{{"0", {dtypes[col_type]}}};
     cudf::io::json_reader_options in_options =
-      cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+      cudf::io::json_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(data.data()), data.size()}})
         .dtypes(dtype_schema)
         .lines(true);
 
@@ -1881,7 +1909,9 @@ TYPED_TEST(JsonFixedPointReaderTest, EmptyValues)
   auto const buffer = std::string{R"({"col0":""})"};
 
   cudf::io::json_reader_options const in_opts =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{buffer.c_str(), buffer.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.c_str()), buffer.size()}})
       .dtypes(std::vector{data_type{type_to_id<TypeParam>(), 0}})
       .lines(true);
 
@@ -1897,8 +1927,10 @@ TYPED_TEST(JsonFixedPointReaderTest, EmptyValues)
 TEST_F(JsonReaderTest, UnsupportedMultipleFileInputs)
 {
   std::string const data = "{\"col\":0}";
-  auto const buffer      = cudf::io::host_buffer{data.data(), data.size()};
-  auto const src         = cudf::io::source_info{{buffer, buffer}};
+  auto const span =
+    cudf::host_span<std::byte const>(reinterpret_cast<std::byte const*>(data.data()), data.size());
+  std::vector<cudf::host_span<std::byte const>> spans{span, span};
+  auto const src = cudf::io::source_info(cudf::host_span<cudf::host_span<std::byte const>>(spans));
 
   cudf::io::json_reader_options const not_lines_opts = cudf::io::json_reader_options::builder(src);
   EXPECT_THROW(cudf::io::read_json(not_lines_opts), cudf::logic_error);
@@ -1928,7 +1960,8 @@ TEST_F(JsonReaderTest, TrailingCommas)
     // Initialize parsing options (reading json lines)
     cudf::io::json_reader_options json_parser_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.c_str(), json_string.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(json_string.c_str()), json_string.size()}})
         .lines(true);
     EXPECT_NO_THROW(cudf::io::read_json(json_parser_options)) << "Failed on test case " << i;
   }
@@ -1940,9 +1973,10 @@ TEST_F(JsonReaderTest, TrailingCommas)
     R"([{"a": 1,}, {"a": null, "b": [null,],}])",
   };
   for (size_t i = 0; i < json_valid.size(); i++) {
-    auto const& json_string                           = json_valid[i];
-    cudf::io::json_reader_options json_parser_options = cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.c_str(), json_string.size()});
+    auto const& json_string = json_valid[i];
+    cudf::io::json_reader_options json_parser_options =
+      cudf::io::json_reader_options::builder(cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json_string.c_str()), json_string.size()}});
     EXPECT_NO_THROW(cudf::io::read_json(json_parser_options)) << "Failed on test case " << i;
   }
 
@@ -1957,9 +1991,10 @@ TEST_F(JsonReaderTest, TrailingCommas)
     R"([{,,}])",
   };
   for (size_t i = 0; i < json_invalid.size(); i++) {
-    auto const& json_string                           = json_invalid[i];
-    cudf::io::json_reader_options json_parser_options = cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_string.c_str(), json_string.size()});
+    auto const& json_string = json_invalid[i];
+    cudf::io::json_reader_options json_parser_options =
+      cudf::io::json_reader_options::builder(cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json_string.c_str()), json_string.size()}});
     EXPECT_THROW(cudf::io::read_json(json_parser_options), cudf::logic_error)
       << "Failed on test case " << i;
   }
@@ -2244,7 +2279,9 @@ TEST_F(JsonReaderTest, ValueValidation)
   // na_values,
   {
     cudf::io::json_reader_options in_options =
-      cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+      cudf::io::json_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(data.data()), data.size()}})
         .lines(true)
         .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
         .strict_validation(true);
@@ -2266,7 +2303,9 @@ TEST_F(JsonReaderTest, ValueValidation)
   // leadingZeros not allowed, NaN allowed
   {
     cudf::io::json_reader_options in_options =
-      cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+      cudf::io::json_reader_options::builder(
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(data.data()), data.size()}})
         .lines(true)
         .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
         .strict_validation(true)
@@ -2302,7 +2341,8 @@ TEST_F(JsonReaderTest, MixedTypes)
 
     cudf::io::json_reader_options in_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.data(), json_string.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(json_string.data()), json_string.size()}})
         .mixed_types_as_string(true)
         .lines(true);
 
@@ -2322,7 +2362,8 @@ TEST_F(JsonReaderTest, MixedTypes)
   auto test_fn = [](std::string_view json_string, cudf::column_view expected) {
     cudf::io::json_reader_options in_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.data(), json_string.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(json_string.data()), json_string.size()}})
         .mixed_types_as_string(true)
         .lines(true);
 
@@ -2491,7 +2532,8 @@ TEST_F(JsonReaderTest, MapTypes)
 
     cudf::io::json_reader_options in_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.data(), json_string.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(json_string.data()), json_string.size()}})
         .dtypes(dtype_schema)
         .mixed_types_as_string(true)
         .lines(lines);
@@ -2561,7 +2603,9 @@ TEST_P(JsonDelimiterParamTest, JsonLinesDelimiter)
   }
 
   cudf::io::json_reader_options json_parser_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{input.c_str(), input.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(input.c_str()), input.size()}})
       .lines(true)
       .delimiter(random_delimiter);
 
@@ -2596,7 +2640,9 @@ TEST_F(JsonReaderTest, ViableDelimiter)
   std::string input = R"({"col1":100, "col2":1.1, "col3":"aaa"})";
 
   cudf::io::json_reader_options json_parser_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{input.c_str(), input.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(input.c_str()), input.size()}})
       .lines(true);
 
   json_parser_options.set_delimiter('\f');
@@ -2612,7 +2658,9 @@ TEST_F(JsonReaderTest, ViableDelimiterNewlineWS)
   100})";
 
   cudf::io::json_reader_options json_parser_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{input.c_str(), input.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(input.c_str()), input.size()}})
       .lines(true)
       .delimiter('\0');
 
@@ -2650,7 +2698,8 @@ TEST_F(JsonReaderTest, JsonNestedDtypeFilter)
   for (auto& [json_string, lines] : {std::pair{json_stringl, true}, {json_string, false}}) {
     cudf::io::json_reader_options in_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.data(), json_string.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(json_string.data()), json_string.size()}})
         .prune_columns(true)
         .lines(lines);
 
@@ -2845,7 +2894,8 @@ TEST_F(JsonReaderTest, JSONMixedTypeChildren)
 
     cudf::io::json_reader_options options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_str.c_str(), json_str.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(json_str.c_str()), json_str.size()}})
         .lines(true)
         .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
         .normalize_single_quotes(true)
@@ -2883,7 +2933,8 @@ TEST_F(JsonReaderTest, JSONMixedTypeChildren)
 
     cudf::io::json_reader_options options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_str.c_str(), json_str.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(json_str.c_str()), json_str.size()}})
         .lines(true)
         .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
         .normalize_single_quotes(true)
@@ -2922,7 +2973,9 @@ TEST_F(JsonReaderTest, MixedTypesWithSchema)
     std::pair{"data", cudf::io::schema_element{cudf::data_type{cudf::type_id::LIST}, child_types}});
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .dtypes(data_types)
       .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
       .normalize_single_quotes(true)
@@ -2946,7 +2999,9 @@ TEST_F(JsonReaderTest, UnicodeFieldname)
   {"d\u0061ta": {"a": 4}})";
 
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
       .experimental(true)
       .lines(true);
@@ -2975,7 +3030,9 @@ TEST_F(JsonReaderTest, JsonDtypeSchema)
                                                                {"b", {data_type{type_id::STRING}}},
                                                                {"a", {dtype<double>()}}};
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .dtypes(dtype_schema)
       .prune_columns(true)
       .lines(true);
@@ -3011,12 +3068,13 @@ TEST_F(JsonReaderTest, LastRecordInvalid)
   std::string data = R"({"key": "1"}
     {"key": "})";
   std::map<std::string, cudf::io::schema_element> schema{{"key", {dtype<cudf::string_view>()}}};
-  auto opts =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
-      .dtypes(schema)
-      .lines(true)
-      .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
-      .build();
+  auto opts = cudf::io::json_reader_options::builder(
+                cudf::io::source_info{cudf::host_span<std::byte const>{
+                  reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+                .dtypes(schema)
+                .lines(true)
+                .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+                .build();
   auto const result = cudf::io::read_json(opts);
 
   EXPECT_EQ(result.metadata.schema_info[0].name, "key");
@@ -3042,7 +3100,8 @@ TEST_F(JsonReaderTest, JsonNestedDtypeFilterWithOrder)
   for (auto& [json_string, lines] : {std::pair{json_stringl, true}, {json_string, false}}) {
     cudf::io::json_reader_options in_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_string.data(), json_string.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(json_string.data()), json_string.size()}})
         .prune_columns(true)
         .lines(lines);
 
@@ -3292,7 +3351,8 @@ TEST_F(JsonReaderTest, JsonNestedDtypeFilterWithOrder)
     auto lines               = true;
     cudf::io::json_reader_options in_options =
       cudf::io::json_reader_options::builder(
-        cudf::io::source_info{json_stringl.data(), json_stringl.size()})
+        cudf::io::source_info{cudf::host_span<std::byte const>{
+          reinterpret_cast<std::byte const*>(json_stringl.data()), json_stringl.size()}})
         .prune_columns(true)
         .experimental(true)
         .lines(lines);
@@ -3378,7 +3438,8 @@ TEST_F(JsonReaderTest, NullifyMixedList)
   // child  {null, null}, {null, null}, {1, null}
   cudf::io::json_reader_options in_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{json_stringl.data(), json_stringl.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json_stringl.data()), json_stringl.size()}})
       .prune_columns(true)
       .experimental(true)
       .lines(true);
@@ -3480,11 +3541,12 @@ TEST_P(JsonCompressedIOTest, BasicJsonLines)
 TEST_F(JsonReaderTest, MismatchedBeginEndTokens)
 {
   std::string data = R"({"not_valid": "json)";
-  auto opts =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
-      .lines(true)
-      .recovery_mode(cudf::io::json_recovery_mode_t::FAIL)
-      .build();
+  auto opts        = cudf::io::json_reader_options::builder(
+                cudf::io::source_info{cudf::host_span<std::byte const>{
+                  reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+                .lines(true)
+                .recovery_mode(cudf::io::json_recovery_mode_t::FAIL)
+                .build();
   EXPECT_THROW(cudf::io::read_json(opts), cudf::logic_error);
 }
 
@@ -3516,10 +3578,11 @@ TEST_F(JsonBatchedReaderTest, EmptyLastBatch)
   // The JSON string corresponding to the second batch is
   // '"b"}\n'
   this->set_batch_size(data.size() - size_of_last_batch);
-  auto opts =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
-      .lines(true)
-      .build();
+  auto opts = cudf::io::json_reader_options::builder(
+                cudf::io::source_info{cudf::host_span<std::byte const>{
+                  reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+                .lines(true)
+                .build();
   auto result = cudf::io::read_json(opts);
 
   EXPECT_EQ(result.tbl->num_columns(), 1);

--- a/cpp/tests/io/json/json_whitespace_normalization_test.cu
+++ b/cpp/tests/io/json/json_whitespace_normalization_test.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,8 @@ TEST_F(JsonWSNormalizationTest, ReadJsonOption)
   std::string const host_input = "{ \"a\" : {\"b\" :\t\"c\"}}";
   cudf::io::json_reader_options input_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{host_input.data(), host_input.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(host_input.data()), host_input.size()}})
       .lines(true)
       .mixed_types_as_string(true)
       .normalize_whitespace(true);
@@ -54,7 +55,8 @@ TEST_F(JsonWSNormalizationTest, ReadJsonOption)
   std::string const expected_input = R"({ "a" : {"b":"c"}})";
   cudf::io::json_reader_options expected_input_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{expected_input.data(), expected_input.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(expected_input.data()), expected_input.size()}})
       .lines(true)
       .mixed_types_as_string(true)
       .normalize_whitespace(false);
@@ -79,7 +81,8 @@ TEST_F(JsonWSNormalizationTest, ReadJsonOption_InvalidRows)
   )";
   cudf::io::json_reader_options input_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{host_input.data(), host_input.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(host_input.data()), host_input.size()}})
       .lines(true)
       .mixed_types_as_string(true)
       .normalize_whitespace(true)
@@ -98,7 +101,8 @@ TEST_F(JsonWSNormalizationTest, ReadJsonOption_InvalidRows)
   )";
   cudf::io::json_reader_options expected_input_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{expected_input.data(), expected_input.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(expected_input.data()), expected_input.size()}})
       .lines(true)
       .mixed_types_as_string(true)
       .normalize_whitespace(false)
@@ -128,7 +132,8 @@ TEST_F(JsonWSNormalizationTest, ReadJsonOption_InvalidRows_NoMixedType)
 
   cudf::io::json_reader_options input_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{host_input.data(), host_input.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(host_input.data()), host_input.size()}})
       .dtypes(dtype_schema)
       .lines(true)
       .prune_columns(true)
@@ -149,7 +154,8 @@ TEST_F(JsonWSNormalizationTest, ReadJsonOption_InvalidRows_NoMixedType)
 
   cudf::io::json_reader_options expected_input_options =
     cudf::io::json_reader_options::builder(
-      cudf::io::source_info{expected_input.data(), expected_input.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(expected_input.data()), expected_input.size()}})
       .dtypes(dtype_schema)
       .lines(true)
       .prune_columns(true)

--- a/cpp/tests/io/json/json_writer.cpp
+++ b/cpp/tests/io/json/json_writer.cpp
@@ -197,7 +197,9 @@ TEST_P(JsonCompressedWriterTest, SimpleNested)
 {"a": 1, "b": 2, "c": {        "e": 4}, "f": 5.5,  "g": [2, null]}
 {"a": 6, "b": 7, "c": {        "e": 9}, "f": 10.5, "g": [3, 4, 5]} )";
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .lines(true);
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
@@ -229,7 +231,9 @@ TEST_P(JsonCompressedWriterTest, MixedNested)
 {"a": 1, "b": 2, "c": {        "e": 4}, "f": 5.5,  "g": [{"h": 2}, null]}
 {"a": 6, "b": 7, "c": {        "e": 9}, "f": 10.5, "g": [{"h": 3}, {"h": 4}, {"h": 5}]} )";
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .lines(true);
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
@@ -288,10 +292,12 @@ TEST_F(JsonWriterTest, WriteReadNested)
 
   // Read back the written JSON, and compare with the original table
   // Without type information
-  auto in_options = cudf::io::json_reader_options::builder(
-                      cudf::io::source_info{output_string.data(), output_string.size()})
-                      .lines(true)
-                      .build();
+  auto in_options =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(output_string.data()), output_string.size()}})
+      .lines(true)
+      .build();
 
   auto result             = cudf::io::read_json(in_options);
   auto tbl_out            = result.tbl->view();
@@ -355,7 +361,8 @@ TEST_F(JsonWriterTest, WriteReadNested)
   cudf::io::write_json(out_options, cudf::test::get_default_stream());
 
   in_options = cudf::io::json_reader_options::builder(
-                 cudf::io::source_info{out_buffer.data(), out_buffer.size()})
+                 cudf::io::source_info{cudf::host_span<std::byte const>{
+                   reinterpret_cast<std::byte const*>(out_buffer.data()), out_buffer.size()}})
                  .lines(true)
                  .build();
   result = cudf::io::read_json(in_options);
@@ -377,7 +384,8 @@ TEST_F(JsonWriterTest, WriteReadNested)
   out_buffer.clear();
   cudf::io::write_json(out_options, cudf::test::get_default_stream());
   in_options = cudf::io::json_reader_options::builder(
-                 cudf::io::source_info{out_buffer.data(), out_buffer.size()})
+                 cudf::io::source_info{cudf::host_span<std::byte const>{
+                   reinterpret_cast<std::byte const*>(out_buffer.data()), out_buffer.size()}})
                  .lines(true)
                  .build();
   result = cudf::io::read_json(in_options);
@@ -429,7 +437,9 @@ TEST_P(JsonCompressedWriterTest, NullList)
 {"a": [null, null, 4], "b": [[2, null], null]}
 {"a": [5, null, null], "b": [null, [3, 4, 5]]} )";
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .lines(true);
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);
@@ -467,7 +477,9 @@ TEST_P(JsonCompressedWriterTest, ChunkedNested)
 {"a": 9, "b": -2, "c": {"d": 81}, "e": [{"f": 9}]}
 )";
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .lines(true);
 
   cudf::io::table_with_metadata result = cudf::io::read_json(in_options);

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -737,9 +737,9 @@ TEST_F(ParquetReaderTest, DecimalRead)
       0x62, 0x65, 0x62, 0x64, 0x31, 0x29, 0x19, 0x3c, 0x1c, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x1c,
       0x00, 0x00, 0x00, 0xd3, 0x02, 0x00, 0x00, 0x50, 0x41, 0x52, 0x31};
 
-    cudf::io::parquet_reader_options read_opts =
-      cudf::io::parquet_reader_options::builder(cudf::io::source_info{
-        reinterpret_cast<char const*>(decimals_parquet.data()), decimals_parquet_len});
+    cudf::io::parquet_reader_options read_opts = cudf::io::parquet_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(decimals_parquet.data()), decimals_parquet.size()}});
     auto result = cudf::io::read_parquet(read_opts);
 
     auto validity =
@@ -880,9 +880,9 @@ TEST_F(ParquetReaderTest, DecimalRead)
 
     unsigned int parquet_len = 1226;
 
-    cudf::io::parquet_reader_options read_opts =
-      cudf::io::parquet_reader_options::builder(cudf::io::source_info{
-        reinterpret_cast<char const*>(fixed_len_bytes_decimal_parquet.data()), parquet_len});
+    cudf::io::parquet_reader_options read_opts = cudf::io::parquet_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(fixed_len_bytes_decimal_parquet.data()), parquet_len}});
     auto result = cudf::io::read_parquet(read_opts);
     EXPECT_EQ(result.tbl->view().num_columns(), 3);
 
@@ -1000,7 +1000,8 @@ TEST_F(ParquetReaderTest, EmptyColumnsParam)
 
   cudf::io::parquet_reader_options read_opts =
     cudf::io::parquet_reader_options::builder(
-      cudf::io::source_info{out_buffer.data(), out_buffer.size()})
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(out_buffer.data()), out_buffer.size()}})
       .columns({});
   auto const result = cudf::io::read_parquet(read_opts);
 
@@ -1240,7 +1241,8 @@ TEST_F(ParquetReaderTest, SingleLevelLists)
 
   // read single level list reproducing parquet file
   cudf::io::parquet_reader_options read_opts = cudf::io::parquet_reader_options::builder(
-    cudf::io::source_info{reinterpret_cast<char const*>(list_bytes.data()), list_bytes.size()});
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(list_bytes.data()), list_bytes.size()}});
   auto table = cudf::io::read_parquet(read_opts);
 
   auto const c0 = table.tbl->get_column(0);
@@ -1272,7 +1274,8 @@ TEST_F(ParquetReaderTest, ChunkedSingleLevelLists)
   auto reader = cudf::io::chunked_parquet_reader(
     1L << 31,
     cudf::io::parquet_reader_options::builder(
-      cudf::io::source_info{reinterpret_cast<char const*>(list_bytes.data()), list_bytes.size()}));
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(list_bytes.data()), list_bytes.size()}}));
   int iterations = 0;
   while (reader.has_next() && iterations < 10) {
     auto chunk = reader.read_chunk();
@@ -1997,9 +2000,10 @@ TEST_F(ParquetReaderTest, RepeatedNoAnnotations)
     0x61, 0x38, 0x33, 0x39, 0x31, 0x36, 0x63, 0x36, 0x39, 0x62, 0x35, 0x65, 0x29, 0x00, 0x32, 0x01,
     0x00, 0x00, 0x50, 0x41, 0x52, 0x31};
 
-  auto read_opts = cudf::io::parquet_reader_options::builder(cudf::io::source_info{
-    reinterpret_cast<char const*>(repeated_bytes.data()), repeated_bytes.size()});
-  auto result    = cudf::io::read_parquet(read_opts);
+  auto read_opts = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(repeated_bytes.data()), repeated_bytes.size()}});
+  auto result = cudf::io::read_parquet(read_opts);
 
   EXPECT_EQ(result.tbl->view().column(0).size(), 6);
   EXPECT_EQ(result.tbl->view().num_columns(), 2);
@@ -2139,7 +2143,8 @@ TEST_F(ParquetReaderTest, DeltaSkipRowsWithNulls)
     cudf::io::write_parquet(out_opts2);
 
     cudf::io::parquet_reader_options default_in_opts = cudf::io::parquet_reader_options::builder(
-      cudf::io::source_info{out_buffer.data(), out_buffer.size()});
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(out_buffer.data()), out_buffer.size()}});
     auto const result2 = cudf::io::read_parquet(default_in_opts);
 
     CUDF_TEST_EXPECT_TABLES_EQUAL(result.tbl->view(), result2.tbl->view());
@@ -2852,8 +2857,9 @@ TEST_P(ParquetDecompressionTest, RoundTripBasic)
       .compression(compression_type);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{buffer.data(), buffer.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(buffer.data()), buffer.size()}});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -2912,8 +2918,9 @@ TEST_F(ParquetReaderTest, DISABLED_ListsWideTable)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&buffer}, expected).build();
   cudf::io::write_parquet(out_opts);
 
-  cudf::io::parquet_reader_options default_in_opts =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info(buffer.data(), buffer.size()));
+  cudf::io::parquet_reader_options default_in_opts = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(buffer.data()), buffer.size()}});
   auto const [result, _] = cudf::io::read_parquet(default_in_opts);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result->view());

--- a/cpp/tests/io/parquet_writer_test.cpp
+++ b/cpp/tests/io/parquet_writer_test.cpp
@@ -185,7 +185,8 @@ TEST_F(ParquetWriterTest, BufferSource)
   // host buffer
   {
     cudf::io::parquet_reader_options in_opts = cudf::io::parquet_reader_options::builder(
-      cudf::io::source_info(out_buffer.data(), out_buffer.size()));
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(out_buffer.data()), out_buffer.size()}});
     auto const result = cudf::io::read_parquet(in_opts);
 
     CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
@@ -362,7 +363,8 @@ TEST_F(ParquetWriterTest, CustomDataSink)
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 
   cudf::io::parquet_reader_options buf_args = cudf::io::parquet_reader_options::builder(
-    cudf::io::source_info{buf_sink.data(), buf_sink.size()});
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(buf_sink.data()), buf_sink.size()}});
   auto buf_tbl = cudf::io::read_parquet(buf_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(buf_tbl.tbl->view(), expected->view());
 }
@@ -1357,8 +1359,9 @@ TEST_P(ParquetCompressionTest, CompStats)
   EXPECT_EQ(stats->num_skipped_bytes(), 0);
   EXPECT_FALSE(std::isnan(stats->compression_ratio()));
 
-  cudf::io::parquet_reader_options in_opts =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{buffer.data(), buffer.size()});
+  cudf::io::parquet_reader_options in_opts = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(buffer.data()), buffer.size()}});
   auto result = cudf::io::read_parquet(in_opts);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(*result.tbl, table->view());
@@ -1410,7 +1413,8 @@ TEST_P(ParquetCompressionTest, RoundTripBasic)
   cudf::io::write_parquet(out_opts);
 
   cudf::io::parquet_reader_options in_opts = cudf::io::parquet_reader_options::builder(
-    cudf::io::source_info{out_buffer.data(), out_buffer.size()});
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(out_buffer.data()), out_buffer.size()}});
   auto result = cudf::io::read_parquet(in_opts);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
@@ -2374,8 +2378,9 @@ TEST_F(ParquetWriterStressTest, LargeTableWeakCompression)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size()}});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -2395,8 +2400,9 @@ TEST_F(ParquetWriterStressTest, LargeTableGoodCompression)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size()}});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -2416,8 +2422,9 @@ TEST_F(ParquetWriterStressTest, LargeTableWithValids)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size()}});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -2437,8 +2444,9 @@ TEST_F(ParquetWriterStressTest, DeviceWriteLargeTableWeakCompression)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size()}});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -2458,8 +2466,9 @@ TEST_F(ParquetWriterStressTest, DeviceWriteLargeTableGoodCompression)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size()}});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }
@@ -2479,8 +2488,9 @@ TEST_F(ParquetWriterStressTest, DeviceWriteLargeTableWithValids)
     cudf::io::parquet_writer_options::builder(cudf::io::sink_info{&custom_sink}, *expected);
   cudf::io::write_parquet(args);
 
-  cudf::io::parquet_reader_options custom_args =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{mm_buf.data(), mm_buf.size()});
+  cudf::io::parquet_reader_options custom_args = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(mm_buf.data()), mm_buf.size()}});
   auto custom_tbl = cudf::io::read_parquet(custom_args);
   CUDF_TEST_EXPECT_TABLES_EQUAL(custom_tbl.tbl->view(), expected->view());
 }

--- a/cpp/tests/io/text/data_chunk_source_test.cpp
+++ b/cpp/tests/io/text/data_chunk_source_test.cpp
@@ -96,9 +96,10 @@ void test_source(std::string const& content, cudf::io::text::data_chunk_source c
 TEST_F(DataChunkSourceTest, DataSourceHost)
 {
   std::string const content = "host buffer source";
-  auto const datasource =
-    cudf::io::datasource::create(cudf::io::host_buffer{content.data(), content.size()});
-  auto const source = cudf::io::text::make_source(*datasource);
+  auto const span           = cudf::host_span<std::byte const>(
+    reinterpret_cast<std::byte const*>(content.data()), content.size());
+  auto const datasource = cudf::io::datasource::create(span);
+  auto const source     = cudf::io::text::make_source(*datasource);
 
   test_source(content, *source);
 }

--- a/cpp/tests/large_strings/parquet_tests.cpp
+++ b/cpp/tests/large_strings/parquet_tests.cpp
@@ -115,8 +115,9 @@ TEST_F(ParquetStringsTest, DISABLED_ChunkedReadLargeStrings)
   size_t constexpr pass_read_limit = size_t{8} * 1024 * 1024 * 1024;
 
   // Reader options
-  cudf::io::parquet_reader_options default_in_opts =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info(buffer.data(), buffer.size()));
+  cudf::io::parquet_reader_options default_in_opts = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(buffer.data()), buffer.size()}});
 
   // Chunked parquet reader
   auto reader = cudf::io::chunked_parquet_reader(0, pass_read_limit, default_in_opts);
@@ -213,8 +214,9 @@ TEST_F(ParquetStringsTest, ChunkedReadNestedLargeStrings)
   cudf::io::write_parquet(out_opts);
 
   // Reader options
-  cudf::io::parquet_reader_options in_opts =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info(buffer.data(), buffer.size()));
+  cudf::io::parquet_reader_options in_opts = cudf::io::parquet_reader_options::builder(
+    cudf::io::source_info{cudf::host_span<std::byte const>{
+      reinterpret_cast<std::byte const*>(buffer.data()), buffer.size()}});
 
   auto constexpr chunk_read_limit = size_t{1} * 1024 * 1024;
   auto constexpr pass_read_limit  = 0;

--- a/cpp/tests/streams/io/json_test.cpp
+++ b/cpp/tests/streams/io/json_test.cpp
@@ -33,7 +33,9 @@ TEST_F(JSONTest, JSONreader)
 {
   std::string data = "[1, 1.1]\n[2, 2.2]\n[3, 3.3]\n";
   cudf::io::json_reader_options in_options =
-    cudf::io::json_reader_options::builder(cudf::io::source_info{data.data(), data.size()})
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
       .dtypes(std::vector<cudf::data_type>{cudf::data_type{cudf::type_id::INT32},
                                            cudf::data_type{cudf::type_id::FLOAT64}})
       .lines(true);


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
In #18503, we removed `host_buffer` in favor of `host_span` in pylibcudf. This PR follows it up to remove `host_buffer` from libcudf.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
