### PR TITLE
[DO NOT MERGE] [POC] Metadata caching prototype in Parquet reader

### DIFF
--- a/cpp/examples/parquet_io/CMakeLists.txt
+++ b/cpp/examples/parquet_io/CMakeLists.txt
@@ -3,6 +3,7 @@
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
 include(../set_cuda_architecture.cmake)
+include_directories(../../src)  # due to #include "io/parquet/reader_impl_helpers.hpp"
 
 # initialize cuda architecture
 rapids_cuda_init_architectures(parquet_io)
@@ -30,6 +31,15 @@ target_link_libraries(
 )
 target_compile_features(parquet_io PRIVATE cxx_std_17)
 install(TARGETS parquet_io DESTINATION bin/examples/libcudf)
+
+# Build and install parquet_io_metadata_caching
+add_executable(parquet_io_metadata_caching parquet_io_metadata_caching.cpp)
+target_link_libraries(
+  parquet_io_metadata_caching PRIVATE cudf::cudf $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>
+                     $<TARGET_OBJECTS:parquet_io_utils>
+)
+target_compile_features(parquet_io_metadata_caching PRIVATE cxx_std_17)
+install(TARGETS parquet_io_metadata_caching DESTINATION bin/examples/libcudf)
 
 # Build and install parquet_io_multithreaded
 add_executable(parquet_io_multithreaded parquet_io_multithreaded.cpp)

--- a/cpp/examples/parquet_io/parquet_io_metadata_caching.cpp
+++ b/cpp/examples/parquet_io/parquet_io_metadata_caching.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../utilities/timer.hpp"
+#include "common_utils.hpp"
+#include "io_source.hpp"
+
+#include <cudf/io/parquet.hpp>
+#include <cudf/io/types.hpp>
+#include <cudf/table/table_view.hpp>
+
+#include <string>
+
+/**
+ * @file parquet_io_metadata_caching.cpp
+ * @brief Demonstrates usage of the libcudf APIs to read parquet file format
+ * with and without metadata caching.
+ */
+
+/**
+ * @brief Read parquet input from file
+ *
+ * @param filepath path to input parquet file
+ * @return cudf::io::table_with_metadata
+ */
+cudf::io::table_with_metadata read_parquet(std::string filepath)
+{
+  auto source_info = cudf::io::source_info(filepath);
+  auto builder     = cudf::io::parquet_reader_options::builder(source_info);
+  auto options     = builder.build();
+  return cudf::io::read_parquet(options);
+}
+
+/**
+ * @brief Read parquet input from file iterarting all rowgroups
+ *
+ * @param filepath path to input parquet file
+ * @param num_rowgroups the number of rowgroups
+ */
+void read_parquet_RGs(std::string filepath, cudf::size_type num_rowgroups)
+{
+  for (cudf::size_type rg_id = 0; rg_id < num_rowgroups; rg_id++) {
+    auto source_info = cudf::io::source_info(filepath);
+    auto builder     = cudf::io::parquet_reader_options::builder(source_info);
+    auto options     = builder.build();
+    options.set_row_groups({{rg_id}});
+    cudf::io::read_parquet(options);
+  }
+}
+
+/**
+ * @brief Read parquet input from file with metadata-caching
+ *
+ * @param filepath path to input parquet file
+ * @param aggregate_reader_metadata_ptr the cached metadata pointer
+ * @return cudf::io::table_with_metadata
+ */
+cudf::io::table_with_metadata read_parquet_with_metadata_caching(
+  std::string filepath, std::uintptr_t aggregate_reader_metadata_ptr)
+{
+  auto source_info = cudf::io::source_info(filepath);
+  auto builder     = cudf::io::parquet_reader_options::builder(source_info);
+  auto options     = builder.build();
+  options.set_aggregate_reader_metadata(
+    aggregate_reader_metadata_ptr);  // here to enable metadata caching
+  return cudf::io::read_parquet(options);
+}
+
+/**
+ * @brief Read parquet input from file iterarting all rowgroups
+ *
+ * @param filepath path to input parquet file
+ * @param aggregate_reader_metadata_ptr the cached metadata pointer
+ * @param num_rowgroups the number of rowgroups
+ */
+void read_parquet_RGs_with_metadata_caching(std::string filepath,
+                                            std::uintptr_t aggregate_reader_metadata_ptr,
+                                            cudf::size_type num_rowgroups)
+{
+  for (cudf::size_type rg_id = 0; rg_id < num_rowgroups; rg_id++) {
+    auto source_info = cudf::io::source_info(filepath);
+    auto builder     = cudf::io::parquet_reader_options::builder(source_info);
+    auto options     = builder.build();
+    options.set_row_groups({{rg_id}});
+    options.set_aggregate_reader_metadata(
+      aggregate_reader_metadata_ptr);  // here to enable metadata caching
+    cudf::io::read_parquet(options);
+  }
+}
+
+/**
+ * @brief Function to print example usage and argument information.
+ */
+void print_usage() { std::cout << "\nUsage: parquet_io_metadata_caching <input parquet file>\n"; }
+
+/**
+ * @brief Main for nested_types examples
+ *
+ * Command line parameters:
+ * 1. parquet input file name/path (default: "example.parquet")
+ *
+ */
+int main(int argc, char const** argv)
+{
+  std::string input_filepath = "example.parquet";
+
+  switch (argc) {
+    case 2:  // Check if instead of input_paths, the first argument is `-h` or `--help`
+      if (auto arg = std::string{argv[1]}; arg != "-h" and arg != "--help") {
+        input_filepath = std::move(arg);
+        break;
+      }
+      [[fallthrough]];
+    default: print_usage(); throw std::runtime_error("");
+  }
+
+  // Create and use a memory pool
+  bool is_pool_used = true;
+  auto resource     = create_memory_resource(is_pool_used);
+  cudf::set_current_device_resource(resource.get());
+
+  // Prepare the metadata outside the timer scope
+  auto source_info                   = cudf::io::source_info(input_filepath);
+  auto metadata                      = cudf::io::read_parquet_metadata(source_info);
+  auto aggregate_reader_metadata_ptr = metadata.get_aggregate_reader_metadata_ptr();
+
+  // Bluk Read: read the file in one read call
+  {
+    // Read input parquet file
+    // We do not want to time the initial read time as it may include
+    // time for nvcomp, cufile loading and RMM growth
+    std::cout << "\nReading " << input_filepath << " without metadata-caching...\n";
+    std::cout << "Note: Not timing the initial parquet read as it may include\n"
+                 "times for nvcomp, cufile loading and RMM growth.\n\n";
+
+    cudf::examples::timer timer;
+    auto [first_read_input, first_read_metadata] = read_parquet(input_filepath);
+    timer.print_elapsed_millis();
+
+    // Read the parquet file written with encoding and compression
+    std::cout << "Reading " << input_filepath << " with metadata-caching...\n";
+
+    // Reset the timer
+    timer.reset();
+    auto [second_read_input, second_read_metadata] =
+      read_parquet_with_metadata_caching(input_filepath, aggregate_reader_metadata_ptr);
+    timer.print_elapsed_millis();
+
+    // Check for validity
+    check_tables_equal(first_read_input->view(), second_read_input->view());
+  }
+
+  // Iterating all row-groups one-by-one
+  {
+    const auto num_rowgroups = metadata.num_rowgroups();
+    std::cout << "Number of Parquet row-groups of the inputfile: " << num_rowgroups << std::endl;
+
+    std::cout << "Iterating all rowgroups " << input_filepath << " without metadata-caching...\n";
+    cudf::examples::timer timer;
+    read_parquet_RGs(input_filepath, num_rowgroups);
+    timer.print_elapsed_millis();
+
+    std::cout << "Iterating all rowgroups " << input_filepath << " with metadata-caching...\n";
+    timer.reset();
+    read_parquet_RGs_with_metadata_caching(
+      input_filepath, aggregate_reader_metadata_ptr, num_rowgroups);
+    timer.print_elapsed_millis();
+  }
+  return 0;
+}

--- a/cpp/include/cudf/io/parquet.hpp
+++ b/cpp/include/cudf/io/parquet.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "io/parquet/reader_impl_helpers.hpp"
+
 #include <cudf/ast/expressions.hpp>
 #include <cudf/io/detail/parquet.hpp>
 #include <cudf/io/types.hpp>
@@ -72,6 +74,8 @@ constexpr size_type default_max_page_fragment_size     = 5000;  ///< 5000 rows p
 
 class parquet_reader_options_builder;
 
+using aggregate_reader_metadata = parquet::detail::aggregate_reader_metadata;
+
 /**
  * @brief Settings for `read_parquet()`.
  */
@@ -113,6 +117,8 @@ class parquet_reader_options {
 
   friend parquet_reader_options_builder;
 
+  aggregate_reader_metadata* _aggregate_reader_metadata = nullptr;
+
  public:
   /**
    * @brief Default constructor.
@@ -130,6 +136,16 @@ class parquet_reader_options {
    * @return Builder to build reader options
    */
   static parquet_reader_options_builder builder(source_info src = source_info{});
+
+  /**
+   * @brief Returns the _aggregate_reader_metadata pointer in this option.
+   *
+   * @return _aggregate_reader_metadata pointer. If not cached, then nullptr.
+   */
+  [[nodiscard]] aggregate_reader_metadata* get_aggregate_reader_metadata_ptr() const
+  {
+    return _aggregate_reader_metadata;
+  }
 
   /**
    * @brief Returns source info.
@@ -360,6 +376,16 @@ class parquet_reader_options {
    * @param type The timestamp data_type to which all timestamp columns need to be cast
    */
   void set_timestamp_type(data_type type) { _timestamp_type = type; }
+
+  /**
+   * @brief Sets the cached metadata
+   *
+   * @param meta_ptr the cached metadata pointer
+   */
+  void set_aggregate_reader_metadata(std::uintptr_t meta_ptr)
+  {
+    _aggregate_reader_metadata = reinterpret_cast<aggregate_reader_metadata*>(meta_ptr);
+  }
 };
 
 /**

--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -289,6 +289,8 @@ class aggregate_reader_metadata {
     rmm::cuda_stream_view stream) const;
 
  public:
+  explicit aggregate_reader_metadata() = default;
+
   aggregate_reader_metadata(host_span<std::unique_ptr<datasource> const> sources,
                             bool use_arrow_schema,
                             bool has_cols_from_mismatched_srcs);


### PR DESCRIPTION
## Description

For the issue #18890, this draft PR demonstrates the performance benefits of decoupling metadata parsing from data page reads in the Parquet reader. The goal is to:
1. Decouple metadata reading from `read_parquet`
2. Enable metadata-caching for repeated reads of the same file

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
