### PR TITLE
Ensure gc fixture is used in custreamz test

### DIFF
--- a/python/custreamz/custreamz/tests/test_dataframes.py
+++ b/python/custreamz/custreamz/tests/test_dataframes.py
@@ -35,6 +35,9 @@ def disable_distributed_gc_diagnosis():
     distributed.gc.enable_gc_diagnosis()
 
 
+pytestmark = pytest.mark.usefixtures("disable_distributed_gc_diagnosis")
+
+
 @pytest.fixture(scope="module")
 def client():
     client = Client(processes=False, asynchronous=False)


### PR DESCRIPTION
## Description

This fixes the issue @mroeschke spotted in https://github.com/rapidsai/cudf/pull/18887#discussion_r2098349135, where this fixture wasn't actually being used.