### PR TITLE
Docs for streaming executor options

### DIFF
--- a/docs/cudf/source/cudf_polars/engine_options.md
+++ b/docs/cudf/source/cudf_polars/engine_options.md
@@ -40,7 +40,7 @@ engine = GPUEngine(
 result = query.collect(engine=engine)
 ```
 
-Note: distributed execution requires Dask / Dask-CUDA as a dependency
+Note: Distributed execution requires [Dask](https://www.dask.org/) and [Dask-CUDA](https://docs.rapids.ai/api/dask-cuda/nightly/) to be installed.
 
 ## Disabling CUDA Managed Memory
 

--- a/docs/cudf/source/cudf_polars/engine_options.md
+++ b/docs/cudf/source/cudf_polars/engine_options.md
@@ -34,7 +34,7 @@ executor_options["scheduler"] = "synchronous" # "distributed" for multi-gpu exec
 executor = "streaming":
 
 engine = GPUEngine(
-    executor=run_config.executor,
+    executor=executor,
     executor_options=executor_options,
 )
 result = query.collect(engine=engine)

--- a/docs/cudf/source/cudf_polars/engine_options.md
+++ b/docs/cudf/source/cudf_polars/engine_options.md
@@ -40,7 +40,7 @@ engine = GPUEngine(
 result = query.collect(engine=engine)
 ```
 
-Note: distbritubed execution requires Dask / Dask-CUDA as a dependency
+Note: distributed execution requires Dask / Dask-CUDA as a dependency
 
 ## Disabling CUDA Managed Memory
 

--- a/docs/cudf/source/cudf_polars/engine_options.md
+++ b/docs/cudf/source/cudf_polars/engine_options.md
@@ -31,7 +31,7 @@ we need to specify `streaming` as the `executor` and choose between `synchronous
 
 ```python
 executor_options["scheduler"] = "synchronous" # "distributed" for multi-gpu execution
-executor = "streaming":
+executor = "streaming"
 
 engine = GPUEngine(
     executor=executor,

--- a/docs/cudf/source/cudf_polars/engine_options.md
+++ b/docs/cudf/source/cudf_polars/engine_options.md
@@ -24,6 +24,24 @@ result = query.collect(engine=engine)
 ```
 Note that passing `chunked: False` disables chunked reading entirely, and thus `chunk_read_limit` and `pass_read_limit` will have no effect.
 
+## Experimental Streaming and Multi-GPU Options
+The new experimental streaming executor can be configured for single-gpu (`synchronous`) or multi-gpu (`distributed`) execution.  For both,
+we need to specify `streaming` as the `executor` and choose between `synchronous` or `distributed` as the `executor_options["scheduler"]` when calling collect:
+
+
+```python
+executor_options["scheduler"] = "synchronous" # "distributed" for multi-gpu execution
+executor = "streaming":
+
+engine = GPUEngine(
+    executor=run_config.executor,
+    executor_options=executor_options,
+)
+result = query.collect(engine=engine)
+```
+
+Note: distbritubed execution requires Dask / Dask-CUDA as a dependency
+
 ## Disabling CUDA Managed Memory
 
 By default `cudf_polars` will default to [CUDA managed memory](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#unified-memory-introduction) with RMM's pool allocator. On systems that don't support managed memory, a non-managed asynchronous pool

--- a/docs/cudf/source/cudf_polars/engine_options.md
+++ b/docs/cudf/source/cudf_polars/engine_options.md
@@ -30,7 +30,7 @@ we need to specify `streaming` as the `executor` and choose between `synchronous
 
 
 ```python
-executor_options = {"scheduler": "synchronous"}  # "distributed" for multi-gpu execution
+executor_options = {"scheduler": "synchronous"}  # Use "distributed" for multi-GPU execution
 executor = "streaming"
 
 engine = GPUEngine(

--- a/docs/cudf/source/cudf_polars/engine_options.md
+++ b/docs/cudf/source/cudf_polars/engine_options.md
@@ -30,7 +30,7 @@ we need to specify `streaming` as the `executor` and choose between `synchronous
 
 
 ```python
-executor_options["scheduler"] = "synchronous" # "distributed" for multi-gpu execution
+executor_options = {"scheduler": "synchronous"}  # "distributed" for multi-gpu execution
 executor = "streaming"
 
 engine = GPUEngine(

--- a/docs/cudf/source/cudf_polars/engine_options.md
+++ b/docs/cudf/source/cudf_polars/engine_options.md
@@ -25,7 +25,7 @@ result = query.collect(engine=engine)
 Note that passing `chunked: False` disables chunked reading entirely, and thus `chunk_read_limit` and `pass_read_limit` will have no effect.
 
 ## Experimental Streaming and Multi-GPU Options
-The new experimental streaming executor can be configured for single-gpu (`synchronous`) or multi-gpu (`distributed`) execution.  For both,
+The new experimental streaming executor supports both single-GPU (`synchronous`) and multi-GPU (`distributed`) execution.  To use either mode,
 we need to specify `streaming` as the `executor` and choose between `synchronous` or `distributed` as the `executor_options["scheduler"]` when calling collect:
 
 

--- a/docs/cudf/source/cudf_polars/engine_options.md
+++ b/docs/cudf/source/cudf_polars/engine_options.md
@@ -26,7 +26,7 @@ Note that passing `chunked: False` disables chunked reading entirely, and thus `
 
 ## Experimental Streaming and Multi-GPU Options
 The new experimental streaming executor supports both single-GPU (`synchronous`) and multi-GPU (`distributed`) execution.  To use either mode,
-we need to specify `streaming` as the `executor` and choose between `synchronous` or `distributed` as the `executor_options["scheduler"]` when calling collect:
+set the executor to `streaming` and specify the desired scheduler mode in `executor_options["scheduler"]` when calling collect:
 
 
 ```python


### PR DESCRIPTION
PR to add basic usage of streaming / distributed options for cudf-polars:

xref:  [StreamingExecutor](https://github.com/rapidsai/cudf/blob/branch-25.06/python/cudf_polars/cudf_polars/utils/config.py#L148) / [usage in pdsh](https://github.com/rapidsai/cudf/blob/96b0f94549cf8ac94d8681d789c3491126f08e40/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py#L1205-L1208)