### PR TITLE
Add pylibcudf.Column.from_arrow factory method

### DIFF
--- a/docs/cudf/source/pylibcudf/developer_docs.md
+++ b/docs/cudf/source/pylibcudf/developer_docs.md
@@ -134,7 +134,7 @@ def pa_column(pa_dtype):
 
 @pytest.fixture(scope="module")
 def column(pa_column):
-    return plc.Column(pa_column)
+    return plc.Column.from_arrow(pa_column)
 
 
 def test_foo(pa_column, column):

--- a/python/cudf_polars/tests/containers/test_column.py
+++ b/python/cudf_polars/tests/containers/test_column.py
@@ -68,7 +68,7 @@ def test_shallow_copy():
 def test_mask_nans(typeid):
     dtype = plc.DataType(typeid)
     values = pyarrow.array([0, 0, 0], type=plc.interop.to_arrow(dtype))
-    column = Column(plc.Column(values))
+    column = Column(plc.Column.from_arrow(values))
     masked = column.mask_nans()
     assert column.null_count == masked.null_count
 
@@ -76,7 +76,7 @@ def test_mask_nans(typeid):
 def test_mask_nans_float():
     dtype = plc.DataType(plc.TypeId.FLOAT32)
     values = pyarrow.array([0, 0, float("nan")], type=plc.interop.to_arrow(dtype))
-    column = Column(plc.Column(values))
+    column = Column(plc.Column.from_arrow(values))
     masked = column.mask_nans()
     expect = pyarrow.array([0, 0, None], type=plc.interop.to_arrow(dtype))
     got = pyarrow.array(plc.interop.to_arrow(masked.obj))

--- a/python/pylibcudf/pylibcudf/column.pyi
+++ b/python/pylibcudf/pylibcudf/column.pyi
@@ -5,6 +5,7 @@ from typing import Any, Protocol, TypedDict
 
 from rmm.pylibrmm.device_buffer import DeviceBuffer
 
+from pylibcudf._interop_helpers import ArrowLike
 from pylibcudf.gpumemoryview import gpumemoryview
 from pylibcudf.scalar import Scalar
 from pylibcudf.types import DataType
@@ -64,6 +65,8 @@ class Column:
     def from_rmm_buffer(
         buff: DeviceBuffer, dtype: DataType, size: int, children: list[Column]
     ) -> Column: ...
+    @classmethod
+    def from_arrow(cls, obj: ArrowLike) -> Column: ...
     @classmethod
     def from_cuda_array_interface(
         cls, obj: SupportsCudaArrayInterface

--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -315,26 +315,9 @@ cdef class Column:
     children : list
         The children of this column if it is a compound column type.
     """
-    def __init__(self, obj=None, *args, **kwargs):
-        self._init(obj, *args, **kwargs)
-
     __hash__ = None
 
-    @functools.singledispatchmethod
-    def _init(self, obj, *args, **kwargs):
-        if obj is None:
-            if (data_type := kwargs.get("data_type")) is not None:
-                kwargs.pop("data_type")
-                self._init(data_type, *args, **kwargs)
-                return
-            elif (arrow_like := kwargs.get("arrow_like")) is not None:
-                kwargs.pop("arrow_like")
-                self._init(arrow_like, *args, **kwargs)
-                return
-        raise ValueError(f"Invalid input type {type(obj)}")
-
-    @_init.register(DataType)
-    def _(
+    def __init__(
         self, DataType data_type not None, size_type size, gpumemoryview data,
         gpumemoryview mask, size_type null_count, size_type offset,
         list children
@@ -350,8 +333,41 @@ cdef class Column:
         self._children = children
         self._num_children = len(children)
 
-    @_init.register(ArrowLike)
-    def _(self, arrow_like):
+    @staticmethod
+    def from_arrow(arrow_like: ArrowLike):
+        """
+        Create a Column from an Arrow-like object using the Arrow C Data Interface.
+
+        This method supports host and device Arrow arrays or streams. It detects
+        the type of Arrow object provided and constructs a `pylibcudf.Column`
+        accordingly using the appropriate Arrow C pointer-based interface.
+
+        Parameters
+        ----------
+        arrow_like : ArrowLike
+            An object implementing one of the following:
+            - `__arrow_c_array__` (host Arrow array)
+            - `__arrow_c_device_array__` (device Arrow array)
+            - `__arrow_c_stream__` (host Arrow stream)
+            - `__arrow_c_device_stream__` (not yet supported)
+
+        Returns
+        -------
+        Column
+            A `pylibcudf.Column` representing the Arrow data.
+
+        Raises
+        ------
+        NotImplementedError
+            If the Arrow-like object is a device stream (`__arrow_c_device_stream__`).
+        ValueError
+            If the object does not implement a known Arrow C interface.
+
+        Notes
+        -----
+        - This method supports zero-copy construction for device arrays.
+        - Device stream support (`__arrow_c_device_stream__`) is not supported yet.
+        """
         cdef ArrowSchema* c_schema
         cdef ArrowArray* c_array
         cdef ArrowDeviceArray* c_device_array
@@ -371,16 +387,7 @@ cdef class Column:
                 )
             result.col.swap(c_result)
 
-            tmp = Column.from_column_view_of_arbitrary(result.col.get().view(), result)
-            self._init(
-                tmp.type(),
-                tmp.size(),
-                tmp.data(),
-                tmp.null_mask(),
-                tmp.null_count(),
-                tmp.offset(),
-                tmp.children(),
-            )
+            return Column.from_column_view_of_arbitrary(result.col.get().view(), result)
         elif hasattr(arrow_like, "__arrow_c_array__"):
             schema, h_array = arrow_like.__arrow_c_array__()
             c_schema = <ArrowSchema*>PyCapsule_GetPointer(schema, "arrow_schema")
@@ -393,16 +400,7 @@ cdef class Column:
                 )
             result.col.swap(c_result)
 
-            tmp = Column.from_column_view_of_arbitrary(result.col.get().view(), result)
-            self._init(
-                tmp.type(),
-                tmp.size(),
-                tmp.data(),
-                tmp.null_mask(),
-                tmp.null_count(),
-                tmp.offset(),
-                tmp.children(),
-            )
+            return Column.from_column_view_of_arbitrary(result.col.get().view(), result)
         elif hasattr(arrow_like, "__arrow_c_stream__"):
             stream = arrow_like.__arrow_c_stream__()
             c_stream = (
@@ -416,16 +414,7 @@ cdef class Column:
                 )
             result.col.swap(c_result)
 
-            tmp = Column.from_column_view_of_arbitrary(result.col.get().view(), result)
-            self._init(
-                tmp.type(),
-                tmp.size(),
-                tmp.data(),
-                tmp.null_mask(),
-                tmp.null_count(),
-                tmp.offset(),
-                tmp.children(),
-            )
+            return Column.from_column_view_of_arbitrary(result.col.get().view(), result)
         elif hasattr(arrow_like, "__arrow_c_device_stream__"):
             # TODO: When we add support for this case, it should be moved above
             # the __arrow_c_array__ case since we should prioritize device

--- a/python/pylibcudf/pylibcudf/interop.pyx
+++ b/python/pylibcudf/pylibcudf/interop.pyx
@@ -134,7 +134,7 @@ def _from_arrow_column(pyarrow_object, *, DataType data_type=None):
     if data_type is not None:
         raise ValueError("data_type may not be passed for arrays")
 
-    return Column(pyarrow_object)
+    return Column.from_arrow(pyarrow_object)
 
 
 @singledispatch

--- a/python/pylibcudf/pylibcudf/tests/test_binaryops.py
+++ b/python/pylibcudf/pylibcudf/tests/test_binaryops.py
@@ -66,8 +66,8 @@ def tests(request, nulls):
     ltype, rtype, py_outtype, plc_op, py_op = request.param
     pa_lhs, pa_rhs = make_col(ltype, nulls), make_col(rtype, nulls)
     plc_lhs, plc_rhs = (
-        plc.Column(pa_lhs),
-        plc.Column(pa_rhs),
+        plc.Column.from_arrow(pa_lhs),
+        plc.Column.from_arrow(pa_rhs),
     )
     plc_dtype = plc.interop.from_arrow(
         pa.from_numpy_dtype(np.dtype(py_outtype))

--- a/python/pylibcudf/pylibcudf/tests/test_column_factories.py
+++ b/python/pylibcudf/pylibcudf/tests/test_column_factories.py
@@ -102,7 +102,7 @@ def mask_state(request):
 def test_make_empty_column_dtype(pa_type):
     pa_col = pa.array([], type=pa_type)
 
-    plc_type = plc.Column(pa_col).type()
+    plc_type = plc.Column.from_arrow(pa_col).type()
 
     if isinstance(pa_type, (pa.ListType, pa.StructType)):
         with pytest.raises(TypeError):
@@ -116,7 +116,7 @@ def test_make_empty_column_dtype(pa_type):
 def test_make_empty_column_typeid(pa_type):
     pa_col = pa.array([], type=pa_type)
 
-    tid = plc.Column(pa_col).type().id()
+    tid = plc.Column.from_arrow(pa_col).type().id()
 
     if isinstance(pa_type, (pa.ListType, pa.StructType)):
         with pytest.raises(TypeError):

--- a/python/pylibcudf/pylibcudf/tests/test_column_from_device.py
+++ b/python/pylibcudf/pylibcudf/tests/test_column_from_device.py
@@ -120,7 +120,8 @@ def test_from_rmm_buffer():
 def test_from_rmm_buffer_invalid(dtype, children_data):
     buff = rmm.DeviceBuffer.to_device(b"")
     children = [
-        plc.Column(pa.array(child_data)) for child_data in children_data
+        plc.Column.from_arrow(pa.array(child_data))
+        for child_data in children_data
     ]
     with pytest.raises(ValueError):
         plc.Column.from_rmm_buffer(

--- a/python/pylibcudf/pylibcudf/tests/test_copying.py
+++ b/python/pylibcudf/pylibcudf/tests/test_copying.py
@@ -53,14 +53,14 @@ def input_column(pa_type):
             )
     else:
         raise ValueError("Unsupported type")
-    return pa_array, plc.Column(pa_array)
+    return pa_array, plc.Column.from_arrow(pa_array)
 
 
 @pytest.fixture(scope="module")
 def index_column():
     # Index column for testing gather/scatter, always integral.
     pa_array = pa.array([1, 2, 3])
-    return pa_array, plc.Column(pa_array)
+    return pa_array, plc.Column.from_arrow(pa_array)
 
 
 @pytest.fixture(scope="module")
@@ -107,7 +107,7 @@ def target_column(pa_type):
             )
     else:
         raise ValueError("Unsupported type")
-    return pa_array, plc.Column(pa_array)
+    return pa_array, plc.Column.from_arrow(pa_array)
 
 
 @pytest.fixture
@@ -164,7 +164,7 @@ def source_scalar(pa_type):
 def mask(target_column):
     pa_target_column, _ = target_column
     pa_mask = pa.array([True, False] * (len(pa_target_column) // 2))
-    return pa_mask, plc.Column(pa_mask)
+    return pa_mask, plc.Column.from_arrow(pa_mask)
 
 
 def test_gather(target_table, index_column):
@@ -181,7 +181,7 @@ def test_gather(target_table, index_column):
 
 def test_gather_map_has_nulls(target_table):
     _, plc_target_table = target_table
-    gather_map = plc.Column(pa.array([0, 1, None]))
+    gather_map = plc.Column.from_arrow(pa.array([0, 1, None]))
     with cudf_raises(ValueError):
         plc.copying.gather(
             plc_target_table,
@@ -331,7 +331,9 @@ def test_scatter_table_num_row_mismatch(source_table, target_table):
     with cudf_raises(ValueError):
         plc.copying.scatter(
             plc_source_table,
-            plc.Column(pa.array(range(plc_source_table.num_rows() * 2))),
+            plc.Column.from_arrow(
+                pa.array(range(plc_source_table.num_rows() * 2))
+            ),
             plc_target_table,
         )
 
@@ -342,7 +344,9 @@ def test_scatter_table_map_has_nulls(source_table, target_table):
     with cudf_raises(ValueError):
         plc.copying.scatter(
             plc_source_table,
-            plc.Column(pa.array([None] * plc_source_table.num_rows())),
+            plc.Column.from_arrow(
+                pa.array([None] * plc_source_table.num_rows())
+            ),
             plc_target_table,
         )
 
@@ -412,7 +416,7 @@ def test_scatter_scalars_map_has_nulls(source_scalar, target_table):
     with cudf_raises(ValueError):
         plc.copying.scatter(
             [plc_source_scalar] * plc_target_table.num_columns(),
-            plc.Column(pa.array([None, None])),
+            plc.Column.from_arrow(pa.array([None, None])),
             plc_target_table,
         )
 
@@ -524,9 +528,9 @@ def test_copy_range_in_place_different_types(mutable_target_column):
     if plc.traits.is_integral_not_bool(
         dtype := mutable_target_column.type()
     ) or plc.traits.is_floating_point(dtype):
-        plc_input_column = plc.Column(pa.array(["a", "b", "c"]))
+        plc_input_column = plc.Column.from_arrow(pa.array(["a", "b", "c"]))
     else:
-        plc_input_column = plc.Column(pa.array([1, 2, 3]))
+        plc_input_column = plc.Column.from_arrow(pa.array([1, 2, 3]))
 
     with cudf_raises(TypeError):
         plc.copying.copy_range_in_place(
@@ -549,7 +553,7 @@ def test_copy_range_in_place_null_mismatch(
             pa_input_column,
             pa.scalar(None, type=pa_input_column.type),
         )
-        input_column = plc.Column(pa_input_column)
+        input_column = plc.Column.from_arrow(pa_input_column)
         with cudf_raises(ValueError):
             plc.copying.copy_range_in_place(
                 input_column,
@@ -610,9 +614,9 @@ def test_copy_range_different_types(target_column):
     if plc.traits.is_integral_not_bool(
         dtype := plc_target_column.type()
     ) or plc.traits.is_floating_point(dtype):
-        plc_input_column = plc.Column(pa.array(["a", "b", "c"]))
+        plc_input_column = plc.Column.from_arrow(pa.array(["a", "b", "c"]))
     else:
-        plc_input_column = plc.Column(pa.array([1, 2, 3]))
+        plc_input_column = plc.Column.from_arrow(pa.array([1, 2, 3]))
 
     with cudf_raises(TypeError):
         plc.copying.copy_range(
@@ -731,7 +735,7 @@ def test_copy_if_else_column_column(target_column, mask, source_scalar):
     pa_other_column = pa.concat_arrays(
         [pa.array([pa_source_scalar] * 2), pa_target_column[:-2]]
     )
-    plc_other_column = plc.Column(pa_other_column)
+    plc_other_column = plc.Column.from_arrow(pa_other_column)
 
     result = plc.copying.copy_if_else(
         plc_target_column,
@@ -753,11 +757,13 @@ def test_copy_if_else_wrong_type(target_column, mask):
     if plc.traits.is_integral_not_bool(
         dtype := plc_target_column.type()
     ) or plc.traits.is_floating_point(dtype):
-        plc_input_column = plc.Column(
+        plc_input_column = plc.Column.from_arrow(
             pa.array(["a"] * plc_target_column.size())
         )
     else:
-        plc_input_column = plc.Column(pa.array([1] * plc_target_column.size()))
+        plc_input_column = plc.Column.from_arrow(
+            pa.array([1] * plc_target_column.size())
+        )
 
     with cudf_raises(TypeError):
         plc.copying.copy_if_else(plc_input_column, plc_target_column, plc_mask)
@@ -769,7 +775,9 @@ def test_copy_if_else_wrong_type_mask(target_column):
         plc.copying.copy_if_else(
             plc_target_column,
             plc_target_column,
-            plc.Column(pa.array([1.0, 2.0] * (plc_target_column.size() // 2))),
+            plc.Column.from_arrow(
+                pa.array([1.0, 2.0] * (plc_target_column.size() // 2))
+            ),
         )
 
 
@@ -777,9 +785,9 @@ def test_copy_if_else_wrong_size(target_column):
     _, plc_target_column = target_column
     with cudf_raises(ValueError):
         plc.copying.copy_if_else(
-            plc.Column(pa.array([1])),
+            plc.Column.from_arrow(pa.array([1])),
             plc_target_column,
-            plc.Column(
+            plc.Column.from_arrow(
                 pa.array([True, False] * (plc_target_column.size() // 2))
             ),
         )
@@ -791,7 +799,7 @@ def test_copy_if_else_wrong_size_mask(target_column):
         plc.copying.copy_if_else(
             plc_target_column,
             plc_target_column,
-            plc.Column(pa.array([True])),
+            plc.Column.from_arrow(pa.array([True])),
         )
 
 
@@ -921,7 +929,7 @@ def test_boolean_mask_scatter_from_wrong_num_cols(source_table, target_table):
         plc.copying.boolean_mask_scatter(
             plc.Table(plc_source_table.columns()[:2]),
             plc_target_table,
-            plc.Column(pa.array([True, False] * 3)),
+            plc.Column.from_arrow(pa.array([True, False] * 3)),
         )
 
 
@@ -932,7 +940,7 @@ def test_boolean_mask_scatter_from_wrong_mask_size(source_table, target_table):
         plc.copying.boolean_mask_scatter(
             plc_source_table,
             plc_target_table,
-            plc.Column(pa.array([True, False] * 2)),
+            plc.Column.from_arrow(pa.array([True, False] * 2)),
         )
 
 
@@ -943,7 +951,9 @@ def test_boolean_mask_scatter_from_wrong_num_true(source_table, target_table):
         plc.copying.boolean_mask_scatter(
             plc.Table(plc_source_table.columns()[:2]),
             plc_target_table,
-            plc.Column(pa.array([True, False] * 2 + [False, False])),
+            plc.Column.from_arrow(
+                pa.array([True, False] * 2 + [False, False])
+            ),
         )
 
 
@@ -953,9 +963,9 @@ def test_boolean_mask_scatter_from_wrong_col_type(target_table, mask):
     if plc.traits.is_integral_not_bool(
         dtype := plc_target_table.columns()[0].type()
     ) or plc.traits.is_floating_point(dtype):
-        input_column = plc.Column(pa.array(["a", "b", "c"]))
+        input_column = plc.Column.from_arrow(pa.array(["a", "b", "c"]))
     else:
-        input_column = plc.Column(pa.array([1, 2, 3]))
+        input_column = plc.Column.from_arrow(pa.array([1, 2, 3]))
 
     with cudf_raises(TypeError):
         plc.copying.boolean_mask_scatter(
@@ -970,7 +980,7 @@ def test_boolean_mask_scatter_from_wrong_mask_type(source_table, target_table):
         plc.copying.boolean_mask_scatter(
             plc_source_table,
             plc_target_table,
-            plc.Column(pa.array([1.0, 2.0] * 3)),
+            plc.Column.from_arrow(pa.array([1.0, 2.0] * 3)),
         )
 
 

--- a/python/pylibcudf/pylibcudf/tests/test_datetime.py
+++ b/python/pylibcudf/pylibcudf/tests/test_datetime.py
@@ -23,7 +23,9 @@ def datetime_column(has_nulls, request):
     ]
     if has_nulls:
         values[2] = None
-    return plc.Column(pa.array(values, type=pa.timestamp(request.param)))
+    return plc.Column.from_arrow(
+        pa.array(values, type=pa.timestamp(request.param))
+    )
 
 
 @pytest.fixture(

--- a/python/pylibcudf/pylibcudf/tests/test_filling.py
+++ b/python/pylibcudf/pylibcudf/tests/test_filling.py
@@ -22,7 +22,7 @@ def pa_table():
 
 def test_fill(pa_col):
     result = plc.filling.fill(
-        plc.Column(pa_col),
+        plc.Column.from_arrow(pa_col),
         1,
         3,
         plc.interop.from_arrow(pa.scalar(5)),
@@ -32,7 +32,7 @@ def test_fill(pa_col):
 
 
 def test_fill_in_place(pa_col):
-    result = plc.Column(pa_col)
+    result = plc.Column.from_arrow(pa_col)
     plc.filling.fill_in_place(
         result,
         1,
@@ -66,7 +66,7 @@ def test_repeat_with_count_int(pa_table):
 
 def test_repeat_with_count_column(pa_table):
     input_table = plc.Table(pa_table)
-    count = plc.Column(pa.array([1, 2, 3]))
+    count = plc.Column.from_arrow(pa.array([1, 2, 3]))
     result = plc.filling.repeat(input_table, count)
     expect = pa.table([[1] + [2] * 2 + [3] * 3], names=["a"])
     assert_table_eq(expect, result)

--- a/python/pylibcudf/pylibcudf/tests/test_interop.py
+++ b/python/pylibcudf/pylibcudf/tests/test_interop.py
@@ -45,7 +45,7 @@ def test_struct_dtype_roundtrip():
 
 def test_table_with_nested_dtype_to_arrow():
     pa_array = pa.array([[{"": 1}]])
-    plc_table = plc.Table([plc.Column(pa_array)])
+    plc_table = plc.Table([plc.Column.from_arrow(pa_array)])
     result = plc.interop.to_arrow(plc_table)
     expected_schema = pa.schema(
         [
@@ -125,10 +125,10 @@ def test_from_dlpack_error():
 
 def test_device_interop_column():
     pa_arr = pa.array([{"a": [1, None]}, None, {"b": [None, 4]}])
-    plc_col = plc.Column(pa_arr)
+    plc_col = plc.Column.from_arrow(pa_arr)
 
     na_arr = nanoarrow.device.c_device_array(plc_col)
-    new_col = plc.Column(na_arr)
+    new_col = plc.Column.from_arrow(na_arr)
     assert_column_eq(pa_arr, new_col)
 
 
@@ -179,5 +179,5 @@ def test_device_interop_table():
 )
 def test_column_from_arrow_stream(data):
     pa_arr = pa.chunked_array(data)
-    col = plc.Column(pa_arr)
+    col = plc.Column.from_arrow(pa_arr)
     assert_column_eq(pa_arr, col)

--- a/python/pylibcudf/pylibcudf/tests/test_json.py
+++ b/python/pylibcudf/pylibcudf/tests/test_json.py
@@ -11,7 +11,7 @@ def plc_col():
     arr = pa.array(
         ['{"foo": {"bar": [{"a": 1, "b": 2}, {"a": 3, "b": 4}]', None]
     )
-    return plc.Column(arr)
+    return plc.Column.from_arrow(arr)
 
 
 @pytest.fixture(scope="module")

--- a/python/pylibcudf/pylibcudf/tests/test_labeling.py
+++ b/python/pylibcudf/pylibcudf/tests/test_labeling.py
@@ -13,9 +13,9 @@ import pylibcudf as plc
     "right_inclusive", [plc.labeling.Inclusive.YES, plc.labeling.Inclusive.NO]
 )
 def test_label_bins(left_inclusive, right_inclusive):
-    in_col = plc.Column(pa.array([1, 2, 3]))
-    left_edges = plc.Column(pa.array([0, 5]))
-    right_edges = plc.Column(pa.array([4, 6]))
+    in_col = plc.Column.from_arrow(pa.array([1, 2, 3]))
+    left_edges = plc.Column.from_arrow(pa.array([0, 5]))
+    right_edges = plc.Column.from_arrow(pa.array([4, 6]))
     result = plc.interop.to_arrow(
         plc.labeling.label_bins(
             in_col, left_edges, left_inclusive, right_edges, right_inclusive

--- a/python/pylibcudf/pylibcudf/tests/test_lists.py
+++ b/python/pylibcudf/pylibcudf/tests/test_lists.py
@@ -73,7 +73,7 @@ def test_concatenate_rows(test_data):
 )
 def test_concatenate_list_elements(test_data, dropna, expected):
     got = plc.lists.concatenate_list_elements(
-        plc.Column(pa.array(test_data)), dropna
+        plc.Column.from_arrow(pa.array(test_data)), dropna
     )
 
     expect = pa.array(expected)
@@ -82,7 +82,7 @@ def test_concatenate_list_elements(test_data, dropna, expected):
 
 
 def test_contains_scalar(list_column, scalar):
-    plc_column = plc.Column(pa.array(list_column))
+    plc_column = plc.Column.from_arrow(pa.array(list_column))
     plc_scalar = plc.interop.from_arrow(scalar)
     got = plc.lists.contains(plc_column, plc_scalar)
 
@@ -92,8 +92,8 @@ def test_contains_scalar(list_column, scalar):
 
 
 def test_contains_list_column(list_column, search_key_column):
-    plc_column1 = plc.Column(pa.array(list_column))
-    plc_column2 = plc.Column(pa.array(search_key_column[0]))
+    plc_column1 = plc.Column.from_arrow(pa.array(list_column))
+    plc_column2 = plc.Column.from_arrow(pa.array(search_key_column[0]))
     got = plc.lists.contains(plc_column1, plc_column2)
 
     expect = pa.array([False, True, True, True])
@@ -115,7 +115,7 @@ def test_contains_list_column(list_column, search_key_column):
     ],
 )
 def test_contains_nulls(list_column, expected):
-    plc_column = plc.Column(pa.array(list_column))
+    plc_column = plc.Column.from_arrow(pa.array(list_column))
     got = plc.lists.contains_nulls(plc_column)
 
     expect = pa.array(expected)
@@ -126,7 +126,7 @@ def test_contains_nulls(list_column, expected):
 def test_index_of_scalar(list_column, scalar):
     arr = pa.array(list_column)
 
-    plc_column = plc.Column(arr)
+    plc_column = plc.Column.from_arrow(arr)
     plc_scalar = plc.interop.from_arrow(scalar)
     got = plc.lists.index_of(
         plc_column, plc_scalar, plc.lists.DuplicateFindOption.FIND_FIRST
@@ -138,8 +138,8 @@ def test_index_of_scalar(list_column, scalar):
 
 
 def test_index_of_list_column(list_column, search_key_column):
-    plc_column1 = plc.Column(pa.array(list_column))
-    plc_column2 = plc.Column(search_key_column[0])
+    plc_column1 = plc.Column.from_arrow(pa.array(list_column))
+    plc_column2 = plc.Column.from_arrow(search_key_column[0])
     got = plc.lists.index_of(
         plc_column1, plc_column2, plc.lists.DuplicateFindOption.FIND_FIRST
     )
@@ -150,7 +150,7 @@ def test_index_of_list_column(list_column, search_key_column):
 
 
 def test_reverse(list_column):
-    plc_column = plc.Column(pa.array(list_column))
+    plc_column = plc.Column.from_arrow(pa.array(list_column))
 
     got = plc.lists.reverse(plc_column)
 
@@ -162,8 +162,8 @@ def test_reverse(list_column):
 def test_segmented_gather(test_data):
     list_column1, list_column2 = test_data[0]
 
-    plc_column1 = plc.Column(pa.array(list_column1))
-    plc_column2 = plc.Column(pa.array(list_column2))
+    plc_column1 = plc.Column.from_arrow(pa.array(list_column1))
+    plc_column2 = plc.Column.from_arrow(pa.array(list_column2))
 
     got = plc.lists.segmented_gather(plc_column2, plc_column1)
 
@@ -173,7 +173,7 @@ def test_segmented_gather(test_data):
 
 
 def test_extract_list_element_scalar(list_column):
-    plc_column = plc.Column(pa.array(list_column))
+    plc_column = plc.Column.from_arrow(pa.array(list_column))
 
     got = plc.lists.extract_list_element(plc_column, 0)
     expect = pc.list_element(list_column, 0)
@@ -182,8 +182,8 @@ def test_extract_list_element_scalar(list_column):
 
 
 def test_extract_list_element_column(list_column):
-    plc_column = plc.Column(pa.array(list_column))
-    indices = plc.Column(pa.array([0, 1, -4, -1]))
+    plc_column = plc.Column.from_arrow(pa.array(list_column))
+    indices = plc.Column.from_arrow(pa.array([0, 1, -4, -1]))
 
     got = plc.lists.extract_list_element(plc_column, indices)
     expect = pa.array([0, None, None, 7])
@@ -193,7 +193,7 @@ def test_extract_list_element_column(list_column):
 
 def test_count_elements(test_data):
     arr = pa.array(test_data[0][1])
-    plc_column = plc.Column(arr)
+    plc_column = plc.Column.from_arrow(arr)
     got = plc.lists.count_elements(plc_column)
 
     expect = pa.array([1, 1, 0, 3], type=pa.int32())
@@ -212,9 +212,9 @@ def test_count_elements(test_data):
     ],
 )
 def test_sequences_parametrized(steps, expect):
-    starts = plc.Column(pa.array([0, 1, 2, 3, 4]))
-    sizes = plc.Column(pa.array([0, 2, 2, 1, 3]))
-    steps = plc.Column(steps) if steps is not None else None
+    starts = plc.Column.from_arrow(pa.array([0, 1, 2, 3, 4]))
+    sizes = plc.Column.from_arrow(pa.array([0, 2, 2, 1, 3]))
+    steps = plc.Column.from_arrow(steps) if steps is not None else None
 
     got = (
         plc.lists.sequences(starts, sizes)
@@ -252,7 +252,7 @@ def test_sequences_parametrized(steps, expect):
 )
 @pytest.mark.parametrize("stable", [False, True])
 def test_sort_lists_param(lists_column, order, na_position, expect, stable):
-    plc_column = plc.Column(pa.array(lists_column))
+    plc_column = plc.Column.from_arrow(pa.array(lists_column))
     got = plc.lists.sort_lists(plc_column, order, na_position, stable)
     expect = pa.array(expect)
 
@@ -328,8 +328,8 @@ def test_set_operations(
     lhs, rhs = set_lists_column
 
     got = set_operation(
-        plc.Column(pa.array(lhs)),
-        plc.Column(pa.array(rhs)),
+        plc.Column.from_arrow(pa.array(lhs)),
+        plc.Column.from_arrow(pa.array(rhs)),
         nans_equal,
         nulls_equal,
     )
@@ -372,7 +372,7 @@ def test_set_operations(
     ],
 )
 def test_distinct(list_column, nans_equal, nulls_equal, expected):
-    plc_column = plc.Column(
+    plc_column = plc.Column.from_arrow(
         pa.array(
             [
                 [np.nan, np.nan, 0, 1, 2, 3, 2],

--- a/python/pylibcudf/pylibcudf/tests/test_null_mask.py
+++ b/python/pylibcudf/pylibcudf/tests/test_null_mask.py
@@ -20,7 +20,7 @@ def column(request, nullable):
     typ = {"float32": pa.float32(), "float64": pa.float64()}[request.param]
     if nullable:
         values[2] = None
-    return plc.Column(pa.array(values, type=typ))
+    return plc.Column.from_arrow(pa.array(values, type=typ))
 
 
 def test_copy_bitmask(column, nullable):

--- a/python/pylibcudf/pylibcudf/tests/test_nvtext_deduplicate.py
+++ b/python/pylibcudf/pylibcudf/tests/test_nvtext_deduplicate.py
@@ -16,11 +16,11 @@ def input_col():
 @pytest.mark.parametrize("min_width", [10, 20])
 def test_substring_duplicates(input_col, min_width):
     sa = plc.nvtext.deduplicate.build_suffix_array(
-        plc.Column(input_col),
+        plc.Column.from_arrow(input_col),
         min_width,
     )
     result = plc.nvtext.deduplicate.resolve_duplicates(
-        plc.Column(input_col),
+        plc.Column.from_arrow(input_col),
         sa,
         min_width,
     )

--- a/python/pylibcudf/pylibcudf/tests/test_nvtext_edit_distance.py
+++ b/python/pylibcudf/pylibcudf/tests/test_nvtext_edit_distance.py
@@ -17,8 +17,8 @@ def edit_distance_data():
 def test_edit_distance(edit_distance_data):
     input_col, targets = edit_distance_data
     got = plc.nvtext.edit_distance.edit_distance(
-        plc.Column(input_col),
-        plc.Column(targets),
+        plc.Column.from_arrow(input_col),
+        plc.Column.from_arrow(targets),
     )
     expect = pa.array([1, 7, 0], type=pa.int32())
     assert_column_eq(expect, got)
@@ -26,7 +26,9 @@ def test_edit_distance(edit_distance_data):
 
 def test_edit_distance_matrix(edit_distance_data):
     input_col, _ = edit_distance_data
-    got = plc.nvtext.edit_distance.edit_distance_matrix(plc.Column(input_col))
+    got = plc.nvtext.edit_distance.edit_distance_matrix(
+        plc.Column.from_arrow(input_col)
+    )
     expect = pa.array(
         [[0, 7, 4], [7, 0, 6], [4, 6, 0]], type=pa.list_(pa.int32())
     )

--- a/python/pylibcudf/pylibcudf/tests/test_nvtext_generate_ngrams.py
+++ b/python/pylibcudf/pylibcudf/tests/test_nvtext_generate_ngrams.py
@@ -17,7 +17,7 @@ def input_col():
 @pytest.mark.parametrize("sep", ["_", "**", ","])
 def test_generate_ngrams(input_col, ngram, sep):
     got = plc.nvtext.generate_ngrams.generate_ngrams(
-        plc.Column(input_col),
+        plc.Column.from_arrow(input_col),
         ngram,
         plc.interop.from_arrow(pa.scalar(sep)),
     )
@@ -30,7 +30,7 @@ def test_generate_ngrams(input_col, ngram, sep):
 @pytest.mark.parametrize("ngram", [2, 3])
 def test_generate_character_ngrams(input_col, ngram):
     got = plc.nvtext.generate_ngrams.generate_character_ngrams(
-        plc.Column(input_col),
+        plc.Column.from_arrow(input_col),
         ngram,
     )
     expect = pa.array([["ab"], ["cd", "de"], ["fg", "gh"]])
@@ -43,7 +43,7 @@ def test_generate_character_ngrams(input_col, ngram):
 @pytest.mark.parametrize("seed", [0, 3])
 def test_hash_character_ngrams(input_col, ngram, seed):
     result = plc.nvtext.generate_ngrams.hash_character_ngrams(
-        plc.Column(input_col), ngram, seed
+        plc.Column.from_arrow(input_col), ngram, seed
     )
     pa_result = plc.interop.to_arrow(result)
     assert all(

--- a/python/pylibcudf/pylibcudf/tests/test_nvtext_jaccard.py
+++ b/python/pylibcudf/pylibcudf/tests/test_nvtext_jaccard.py
@@ -26,7 +26,7 @@ def test_jaccard_index(input_data, width):
 
     input1, input2 = input_data
     got = plc.nvtext.jaccard.jaccard_index(
-        plc.Column(input1), plc.Column(input2), width
+        plc.Column.from_arrow(input1), plc.Column.from_arrow(input2), width
     )
     expect = pa.array(
         [

--- a/python/pylibcudf/pylibcudf/tests/test_nvtext_minhash.py
+++ b/python/pylibcudf/pylibcudf/tests/test_nvtext_minhash.py
@@ -22,10 +22,10 @@ def test_minhash(minhash_input_data, width):
         else plc.nvtext.minhash.minhash64
     )
     result = minhash_func(
-        plc.Column(input_arr),
+        plc.Column.from_arrow(input_arr),
         0,
-        plc.Column(seeds),
-        plc.Column(seeds),
+        plc.Column.from_arrow(seeds),
+        plc.Column.from_arrow(seeds),
         width,
     )
     pa_result = plc.interop.to_arrow(result)
@@ -68,11 +68,11 @@ def test_minhash_ngrams(minhash_ngrams_input_data, ngrams):
         else plc.nvtext.minhash.minhash64_ngrams
     )
     result = minhash_func(
-        plc.Column(input_arr),
+        plc.Column.from_arrow(input_arr),
         ngrams,
         0,
-        plc.Column(ab),
-        plc.Column(ab),
+        plc.Column.from_arrow(ab),
+        plc.Column.from_arrow(ab),
     )
     pa_result = plc.interop.to_arrow(result)
     assert all(len(got) == len(ab) for got, s in zip(pa_result, input_arr))

--- a/python/pylibcudf/pylibcudf/tests/test_nvtext_ngrams_tokenize.py
+++ b/python/pylibcudf/pylibcudf/tests/test_nvtext_ngrams_tokenize.py
@@ -27,7 +27,7 @@ def test_ngrams_tokenize(input_col, ngrams, delim, sep):
         return tokens
 
     result = plc.nvtext.ngrams_tokenize.ngrams_tokenize(
-        plc.Column(input_col),
+        plc.Column.from_arrow(input_col),
         ngrams,
         plc.interop.from_arrow(pa.scalar(delim)),
         plc.interop.from_arrow(pa.scalar(sep)),

--- a/python/pylibcudf/pylibcudf/tests/test_nvtext_normalize.py
+++ b/python/pylibcudf/pylibcudf/tests/test_nvtext_normalize.py
@@ -21,7 +21,7 @@ def norm_chars_input_data():
 
 def test_normalize_spaces(norm_spaces_input_data):
     got = plc.nvtext.normalize.normalize_spaces(
-        plc.Column(norm_spaces_input_data)
+        plc.Column.from_arrow(norm_spaces_input_data)
     )
     expect = pa.array(["a b", "c d", "e f"])
     assert_column_eq(expect, got)
@@ -30,7 +30,7 @@ def test_normalize_spaces(norm_spaces_input_data):
 @pytest.mark.parametrize("do_lower", [True, False])
 def test_normalize_characters(norm_chars_input_data, do_lower):
     got = plc.nvtext.normalize.characters_normalize(
-        plc.Column(norm_chars_input_data),
+        plc.Column.from_arrow(norm_chars_input_data),
         do_lower,
     )
     if do_lower:
@@ -61,7 +61,7 @@ def test_normalize_characters(norm_chars_input_data, do_lower):
 @pytest.mark.parametrize("do_lower", [True, False])
 def test_normalizer(norm_chars_input_data, do_lower):
     got = plc.nvtext.normalize.normalize_characters(
-        plc.Column(norm_chars_input_data),
+        plc.Column.from_arrow(norm_chars_input_data),
         plc.nvtext.normalize.CharacterNormalizer(
             do_lower,
             plc.column_factories.make_empty_column(plc.types.TypeId.STRING),
@@ -96,9 +96,9 @@ def test_normalizer(norm_chars_input_data, do_lower):
 def test_normalizer_with_special_tokens(norm_chars_input_data, do_lower):
     special_tokens = pa.array(["[pad]"])
     got = plc.nvtext.normalize.normalize_characters(
-        plc.Column(norm_chars_input_data),
+        plc.Column.from_arrow(norm_chars_input_data),
         plc.nvtext.normalize.CharacterNormalizer(
-            do_lower, plc.Column(special_tokens)
+            do_lower, plc.Column.from_arrow(special_tokens)
         ),
     )
     if do_lower:

--- a/python/pylibcudf/pylibcudf/tests/test_nvtext_replace.py
+++ b/python/pylibcudf/pylibcudf/tests/test_nvtext_replace.py
@@ -23,9 +23,9 @@ def targets():
 def test_replace_tokens(input_col, targets, delim):
     replacements = pa.array(["slow", "cat", "looked", "rat"])
     got = plc.nvtext.replace.replace_tokens(
-        plc.Column(input_col),
-        plc.Column(targets),
-        plc.Column(replacements),
+        plc.Column.from_arrow(input_col),
+        plc.Column.from_arrow(targets),
+        plc.Column.from_arrow(replacements),
         plc.interop.from_arrow(pa.scalar(delim)) if delim else None,
     )
     expect = pa.array(["slow", "cat", "jumps*over the", "rat"])
@@ -41,7 +41,7 @@ def test_replace_tokens(input_col, targets, delim):
 @pytest.mark.parametrize("delim", ["*", None])
 def test_filter_tokens(input_col, min_token_length, replace, delim):
     got = plc.nvtext.replace.filter_tokens(
-        plc.Column(input_col),
+        plc.Column.from_arrow(input_col),
         min_token_length,
         plc.interop.from_arrow(pa.scalar(replace)) if replace else None,
         plc.interop.from_arrow(pa.scalar(delim)) if delim else None,

--- a/python/pylibcudf/pylibcudf/tests/test_nvtext_stemmer.py
+++ b/python/pylibcudf/pylibcudf/tests/test_nvtext_stemmer.py
@@ -21,9 +21,9 @@ def test_is_letter(input_col, check_vowels, indices):
         return (s[i] in vowels) == check
 
     got = plc.nvtext.stemmer.is_letter(
-        plc.Column(input_col),
+        plc.Column.from_arrow(input_col),
         check_vowels,
-        plc.Column(pa.array(indices))
+        plc.Column.from_arrow(pa.array(indices))
         if isinstance(indices, list)
         else indices,
     )
@@ -42,7 +42,7 @@ def test_is_letter(input_col, check_vowels, indices):
 
 def test_porter_stemmer_measure(input_col):
     got = plc.nvtext.stemmer.porter_stemmer_measure(
-        plc.Column(input_col),
+        plc.Column.from_arrow(input_col),
     )
     expect = pa.array([1, 1, 2], type=pa.int32())
     assert_column_eq(expect, got)

--- a/python/pylibcudf/pylibcudf/tests/test_nvtext_subword_tokenize.py
+++ b/python/pylibcudf/pylibcudf/tests/test_nvtext_subword_tokenize.py
@@ -11,7 +11,7 @@ import pylibcudf as plc
 def test_wordpiece_tokenize(max_words):
     vocab_strs = pa.array(["[unk]", "abc", "def", "gh", "##i"])
     vocab = plc.nvtext.wordpiece_tokenize.WordPieceVocabulary(
-        plc.Column(vocab_strs)
+        plc.Column.from_arrow(vocab_strs)
     )
     strings_col = pa.array(
         [
@@ -21,7 +21,7 @@ def test_wordpiece_tokenize(max_words):
         ]
     )
     got = plc.nvtext.wordpiece_tokenize.wordpiece_tokenize(
-        plc.Column(strings_col), vocab, max_words
+        plc.Column.from_arrow(strings_col), vocab, max_words
     )
     expect_type = plc.interop.to_arrow(
         got.type(), value_type=pa.list_(pa.int32()).value_type

--- a/python/pylibcudf/pylibcudf/tests/test_nvtext_tokenize.py
+++ b/python/pylibcudf/pylibcudf/tests/test_nvtext_tokenize.py
@@ -16,7 +16,9 @@ def input_col():
     "delimiter", [None, plc.interop.from_arrow(pa.scalar("."))]
 )
 def test_tokenize_scalar(input_col, delimiter):
-    got = plc.nvtext.tokenize.tokenize_scalar(plc.Column(input_col), delimiter)
+    got = plc.nvtext.tokenize.tokenize_scalar(
+        plc.Column.from_arrow(input_col), delimiter
+    )
     if delimiter is None:
         expect = pa.array(["a", "b", "c", "d.e:f;"])
     else:
@@ -26,7 +28,8 @@ def test_tokenize_scalar(input_col, delimiter):
 
 def test_tokenize_column(input_col):
     got = plc.nvtext.tokenize.tokenize_column(
-        plc.Column(input_col), plc.Column(pa.array([" ", ".", ":", ";"]))
+        plc.Column.from_arrow(input_col),
+        plc.Column.from_arrow(pa.array([" ", ".", ":", ";"])),
     )
     expect = pa.array(["a", "b", "c", "d", "e", "f"])
     assert_column_eq(expect, got)
@@ -37,7 +40,7 @@ def test_tokenize_column(input_col):
 )
 def test_count_tokens_scalar(input_col, delimiter):
     got = plc.nvtext.tokenize.count_tokens_scalar(
-        plc.Column(input_col), delimiter
+        plc.Column.from_arrow(input_col), delimiter
     )
     if delimiter is None:
         expect = pa.array([1, 2, 1], type=pa.int32())
@@ -48,14 +51,17 @@ def test_count_tokens_scalar(input_col, delimiter):
 
 def test_count_tokens_column(input_col):
     got = plc.nvtext.tokenize.count_tokens_column(
-        plc.Column(input_col), plc.Column(pa.array([" ", ".", ":", ";"]))
+        plc.Column.from_arrow(input_col),
+        plc.Column.from_arrow(pa.array([" ", ".", ":", ";"])),
     )
     expect = pa.array([1, 2, 3], type=pa.int32())
     assert_column_eq(expect, got)
 
 
 def test_character_tokenize(input_col):
-    got = plc.nvtext.tokenize.character_tokenize(plc.Column(input_col))
+    got = plc.nvtext.tokenize.character_tokenize(
+        plc.Column.from_arrow(input_col)
+    )
     expect = pa.array(["a", "b", " ", "c", "d", ".", "e", ":", "f", ";"])
     assert_column_eq(expect, got)
 
@@ -66,7 +72,7 @@ def test_character_tokenize(input_col):
 def test_detokenize(input_col, delimiter):
     row_indices = pa.array([0, 0, 1])
     got = plc.nvtext.tokenize.detokenize(
-        plc.Column(input_col), plc.Column(row_indices)
+        plc.Column.from_arrow(input_col), plc.Column.from_arrow(row_indices)
     )
     expect = pa.array(["a b c", "d.e:f;"])
     assert_column_eq(expect, got)
@@ -75,8 +81,10 @@ def test_detokenize(input_col, delimiter):
 @pytest.mark.parametrize("default_id", [-1, 0])
 def test_tokenize_with_vocabulary(input_col, default_id):
     got = plc.nvtext.tokenize.tokenize_with_vocabulary(
-        plc.Column(input_col),
-        plc.nvtext.tokenize.TokenizeVocabulary(plc.Column(input_col)),
+        plc.Column.from_arrow(input_col),
+        plc.nvtext.tokenize.TokenizeVocabulary(
+            plc.Column.from_arrow(input_col)
+        ),
         plc.interop.from_arrow(pa.scalar(" ")),
         default_id,
     )

--- a/python/pylibcudf/pylibcudf/tests/test_partitioning.py
+++ b/python/pylibcudf/pylibcudf/tests/test_partitioning.py
@@ -19,7 +19,7 @@ def test_partition(partitioning_data):
     raw_data, plc_table, pa_table = partitioning_data
     got, offsets = plc.partitioning.partition(
         plc_table,
-        plc.Column(pa.array([0, 0, 0])),
+        plc.Column.from_arrow(pa.array([0, 0, 0])),
         1,
     )
     expect = pa.table(

--- a/python/pylibcudf/pylibcudf/tests/test_quantiles.py
+++ b/python/pylibcudf/pylibcudf/tests/test_quantiles.py
@@ -21,7 +21,7 @@ interp_mapping = {
 @pytest.fixture(scope="module", params=[[1, 2, 3, 4, 5], [5, 4, 3, 2, 1]])
 def col_data(request, numeric_pa_type):
     pa_array = pa.array(request.param, type=numeric_pa_type)
-    return pa_array, plc.Column(pa_array)
+    return pa_array, plc.Column.from_arrow(pa_array)
 
 
 @pytest.fixture(
@@ -58,7 +58,7 @@ def plc_tbl_data(request):
 @pytest.mark.parametrize("exact", [True, False])
 def test_quantile(col_data, interp_opt, q, exact):
     pa_col_data, plc_col_data = col_data
-    ordered_indices = plc.Column(
+    ordered_indices = plc.Column.from_arrow(
         pc.cast(pc.sort_indices(pa_col_data), pa.int32())
     )
     got = plc.quantiles.quantile(
@@ -209,7 +209,7 @@ def test_quantiles_invalid_interp(plc_tbl_data, invalid_interp):
 )
 def test_quantile_q_array_like(col_data, q):
     pa_col_data, plc_col_data = col_data
-    ordered_indices = plc.Column(
+    ordered_indices = plc.Column.from_arrow(
         pc.cast(pc.sort_indices(pa_col_data), pa.int32())
     )
     got = plc.quantiles.quantile(

--- a/python/pylibcudf/pylibcudf/tests/test_rolling.py
+++ b/python/pylibcudf/pylibcudf/tests/test_rolling.py
@@ -205,10 +205,10 @@ def test_rolling_windows(
     if len(groups) == 0:
         keys = plc.Table([])
     else:
-        keys = plc.Table([plc.Column(pa.array(groups))])
+        keys = plc.Table([plc.Column.from_arrow(pa.array(groups))])
 
-    orderby = plc.Column(pa.array(orderby))
-    values = plc.Column(pa.array(values))
+    orderby = plc.Column.from_arrow(pa.array(orderby))
+    values = plc.Column.from_arrow(pa.array(values))
 
     request = plc.rolling.RollingRequest(
         values, 1, plc.aggregation.collect_list()

--- a/python/pylibcudf/pylibcudf/tests/test_round.py
+++ b/python/pylibcudf/pylibcudf/tests/test_round.py
@@ -14,7 +14,7 @@ def column(request, has_nulls):
     typ = {"float32": pa.float32(), "float64": pa.float64()}[request.param]
     if has_nulls:
         values[2] = None
-    return plc.Column(pa.array(values, type=typ))
+    return plc.Column.from_arrow(pa.array(values, type=typ))
 
 
 @pytest.mark.parametrize(

--- a/python/pylibcudf/pylibcudf/tests/test_scalar.py
+++ b/python/pylibcudf/pylibcudf/tests/test_scalar.py
@@ -244,4 +244,4 @@ def test_non_constant_column_to_scalar_raises():
     with pytest.raises(
         ValueError, match="to_scalar only works for columns of size 1"
     ):
-        plc.Column(pa.array([0, 1])).to_scalar()
+        plc.Column.from_arrow(pa.array([0, 1])).to_scalar()

--- a/python/pylibcudf/pylibcudf/tests/test_string_attributes.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_attributes.py
@@ -11,7 +11,7 @@ import pylibcudf as plc
 @pytest.fixture
 def str_data():
     pa_data = pa.array(["A", None])
-    return pa_data, plc.Column(pa_data)
+    return pa_data, plc.Column.from_arrow(pa_data)
 
 
 def test_count_characters(str_data):

--- a/python/pylibcudf/pylibcudf/tests/test_string_capitalize.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_capitalize.py
@@ -29,7 +29,7 @@ def str_data():
             None,
         ]
     )
-    return pa_data, plc.Column(pa_data)
+    return pa_data, plc.Column.from_arrow(pa_data)
 
 
 def test_capitalize(str_data):

--- a/python/pylibcudf/pylibcudf/tests/test_string_case.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_case.py
@@ -16,21 +16,21 @@ def string_col():
 
 
 def test_to_upper(string_col):
-    plc_col = plc.Column(string_col)
+    plc_col = plc.Column.from_arrow(string_col)
     got = plc.strings.case.to_upper(plc_col)
     expect = pc.utf8_upper(string_col)
     assert_column_eq(expect, got)
 
 
 def test_to_lower(string_col):
-    plc_col = plc.Column(string_col)
+    plc_col = plc.Column.from_arrow(string_col)
     got = plc.strings.case.to_lower(plc_col)
     expect = pc.utf8_lower(string_col)
     assert_column_eq(expect, got)
 
 
 def test_swapcase(string_col):
-    plc_col = plc.Column(string_col)
+    plc_col = plc.Column.from_arrow(string_col)
     got = plc.strings.case.swapcase(plc_col)
     expect = pc.utf8_swapcase(string_col)
     assert_column_eq(expect, got)

--- a/python/pylibcudf/pylibcudf/tests/test_string_char_types.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_char_types.py
@@ -10,7 +10,7 @@ import pylibcudf as plc
 def test_all_characters_of_type():
     pa_array = pa.array(["1", "A"])
     got = plc.strings.char_types.all_characters_of_type(
-        plc.Column(pa_array),
+        plc.Column.from_arrow(pa_array),
         plc.strings.char_types.StringCharacterTypes.ALPHA,
         plc.strings.char_types.StringCharacterTypes.ALL_TYPES,
     )
@@ -21,7 +21,7 @@ def test_all_characters_of_type():
 def test_filter_characters_of_type():
     pa_array = pa.array(["=A="])
     got = plc.strings.char_types.filter_characters_of_type(
-        plc.Column(pa_array),
+        plc.Column.from_arrow(pa_array),
         plc.strings.char_types.StringCharacterTypes.ALPHANUM,
         plc.interop.from_arrow(pa.scalar(" ")),
         plc.strings.char_types.StringCharacterTypes.ALL_TYPES,

--- a/python/pylibcudf/pylibcudf/tests/test_string_combine.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_combine.py
@@ -39,7 +39,7 @@ def test_concatenate_column_seperator():
     plc_table = plc.Table(
         pa.table({"a": ["a", None, "c"], "b": ["a", "b", None]})
     )
-    sep = plc.Column(pa.array(["-", "?", ","]))
+    sep = plc.Column.from_arrow(pa.array(["-", "?", ","]))
     got = plc.strings.combine.concatenate(
         plc_table,
         sep,
@@ -49,7 +49,7 @@ def test_concatenate_column_seperator():
 
     got = plc.strings.combine.concatenate(
         plc_table,
-        plc.Column(pa.array([None, "?", ","])),
+        plc.Column.from_arrow(pa.array([None, "?", ","])),
         narep=plc.interop.from_arrow(pa.scalar("1")),
         col_narep=plc.interop.from_arrow(pa.scalar("*")),
     )
@@ -61,7 +61,7 @@ def test_join_strings():
     pa_arr = pa.array(list("abc"))
     sep = pa.scalar("")
     got = plc.strings.combine.join_strings(
-        plc.Column(pa_arr),
+        plc.Column.from_arrow(pa_arr),
         plc.interop.from_arrow(sep),
         plc.interop.from_arrow(pa.scalar("")),
     )
@@ -73,7 +73,7 @@ def test_join_list_elements():
     pa_arr = pa.array([["a", "a"], ["b", "b"]])
     sep = pa.scalar("")
     got = plc.strings.combine.join_list_elements(
-        plc.Column(pa_arr),
+        plc.Column.from_arrow(pa_arr),
         plc.interop.from_arrow(sep),
         plc.interop.from_arrow(pa.scalar("")),
         plc.interop.from_arrow(pa.scalar("")),

--- a/python/pylibcudf/pylibcudf/tests/test_string_contains.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_contains.py
@@ -13,7 +13,7 @@ def target_col():
     pa_array = pa.array(
         ["AbC", "de", "FGHI", "j", "kLm", "nOPq", None, "RsT", None, "uVw"]
     )
-    return pa_array, plc.Column(pa_array)
+    return pa_array, plc.Column.from_arrow(pa_array)
 
 
 @pytest.fixture(
@@ -53,7 +53,7 @@ def test_count_re():
     pattern = "[1-9][a-z]"
     arr = pa.array(["A1a2A3a4", "A1A2A3", None])
     got = plc.strings.contains.count_re(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         plc.strings.regex_program.RegexProgram.create(
             pattern, plc.strings.regex_flags.RegexFlags.DEFAULT
         ),
@@ -66,7 +66,7 @@ def test_match_re():
     pattern = "[1-9][a-z]"
     arr = pa.array(["1a2b", "b1a2", None])
     got = plc.strings.contains.matches_re(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         plc.strings.regex_program.RegexProgram.create(
             pattern, plc.strings.regex_flags.RegexFlags.DEFAULT
         ),
@@ -79,8 +79,8 @@ def test_like():
     pattern = "%a"
     arr = pa.array(["1a2aa3aaa"])
     got = plc.strings.contains.like(
-        plc.Column(arr),
-        plc.Column(pa.array([pattern])),
+        plc.Column.from_arrow(arr),
+        plc.Column.from_arrow(pa.array([pattern])),
     )
     expect = pc.match_like(arr, pattern)
     assert_column_eq(expect, got)

--- a/python/pylibcudf/pylibcudf/tests/test_string_convert.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_convert.py
@@ -27,7 +27,7 @@ def pa_timestamp_col():
 
 @pytest.fixture(scope="module")
 def plc_timestamp_col(pa_timestamp_col):
-    return plc.Column(pa_timestamp_col)
+    return plc.Column.from_arrow(pa_timestamp_col)
 
 
 @pytest.mark.parametrize("format", ["%Y-%m-%d"])

--- a/python/pylibcudf/pylibcudf/tests/test_string_convert_booleans.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_convert_booleans.py
@@ -9,7 +9,7 @@ import pylibcudf as plc
 def test_to_booleans():
     pa_array = pa.array(["true", None, "True"])
     got = plc.strings.convert.convert_booleans.to_booleans(
-        plc.Column(pa_array),
+        plc.Column.from_arrow(pa_array),
         plc.interop.from_arrow(pa.scalar("True")),
     )
     expect = pa.array([False, None, True])
@@ -19,7 +19,7 @@ def test_to_booleans():
 def test_from_booleans():
     pa_array = pa.array([True, None, False])
     got = plc.strings.convert.convert_booleans.from_booleans(
-        plc.Column(pa_array),
+        plc.Column.from_arrow(pa_array),
         plc.interop.from_arrow(pa.scalar("A")),
         plc.interop.from_arrow(pa.scalar("B")),
     )

--- a/python/pylibcudf/pylibcudf/tests/test_string_convert_datetime.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_convert_datetime.py
@@ -17,7 +17,7 @@ def fmt():
 def test_to_timestamp(fmt):
     arr = pa.array(["2020-01-01T01:01:01", None])
     got = plc.strings.convert.convert_datetime.to_timestamps(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         plc.DataType(plc.TypeId.TIMESTAMP_SECONDS),
         fmt,
     )
@@ -28,9 +28,9 @@ def test_to_timestamp(fmt):
 def test_from_timestamp(fmt):
     arr = pa.array([datetime.datetime(2020, 1, 1, 1, 1, 1), None])
     got = plc.strings.convert.convert_datetime.from_timestamps(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         fmt,
-        plc.Column(pa.array([], type=pa.string())),
+        plc.Column.from_arrow(pa.array([], type=pa.string())),
     )
     # pc.strftime will add the extra %f
     expect = pa.array(["2020-01-01T01:01:01", None])
@@ -40,7 +40,7 @@ def test_from_timestamp(fmt):
 def test_is_timestamp(fmt):
     arr = pa.array(["2020-01-01T01:01:01", None, "2020-01-01"])
     got = plc.strings.convert.convert_datetime.is_timestamp(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         fmt,
     )
     expect = pa.array([True, None, False])

--- a/python/pylibcudf/pylibcudf/tests/test_string_convert_durations.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_convert_durations.py
@@ -28,7 +28,7 @@ def pa_duration_col():
 
 @pytest.fixture(scope="module")
 def plc_duration_col(pa_duration_col):
-    return plc.Column(pa_duration_col)
+    return plc.Column.from_arrow(pa_duration_col)
 
 
 def test_to_duration(pa_duration_col, plc_duration_col, duration_type):
@@ -56,7 +56,7 @@ def test_from_durations(format):
         [timedelta(days=1, hours=1, minutes=1, seconds=1), None]
     )
     got = plc.strings.convert.convert_durations.from_durations(
-        plc.Column(pa_array), format
+        plc.Column.from_arrow(pa_array), format
     )
     expect = pa.array(["1 days 01:01:01", None])
     assert_column_eq(expect, got)

--- a/python/pylibcudf/pylibcudf/tests/test_string_convert_fixed_point.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_convert_fixed_point.py
@@ -11,7 +11,7 @@ def test_to_fixed_point():
     typ = pa.decimal128(38, 2)
     arr = pa.array(["123", "1.23", None])
     got = plc.strings.convert.convert_fixed_point.to_fixed_point(
-        plc.Column(arr), plc.interop.from_arrow(typ)
+        plc.Column.from_arrow(arr), plc.interop.from_arrow(typ)
     )
     expect = arr.cast(typ)
     assert_column_eq(expect, got)
@@ -20,7 +20,7 @@ def test_to_fixed_point():
 def test_from_fixed_point():
     arr = pa.array([decimal.Decimal("1.1"), None])
     got = plc.strings.convert.convert_fixed_point.from_fixed_point(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
     )
     expect = pa.array(["1.1", None])
     assert_column_eq(expect, got)
@@ -29,7 +29,7 @@ def test_from_fixed_point():
 def test_is_fixed_point():
     arr = pa.array(["123", "1.23", "1.2.3", "", None])
     got = plc.strings.convert.convert_fixed_point.is_fixed_point(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
     )
     expect = pa.array([True, True, False, False, None])
     assert_column_eq(expect, got)

--- a/python/pylibcudf/pylibcudf/tests/test_string_convert_floats.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_convert_floats.py
@@ -10,7 +10,7 @@ def test_to_floats():
     typ = pa.float32()
     arr = pa.array(["-1.23", "1", None])
     got = plc.strings.convert.convert_floats.to_floats(
-        plc.Column(arr), plc.interop.from_arrow(typ)
+        plc.Column.from_arrow(arr), plc.interop.from_arrow(typ)
     )
     expect = arr.cast(typ)
     assert_column_eq(expect, got)
@@ -19,7 +19,7 @@ def test_to_floats():
 def test_from_floats():
     arr = pa.array([-1.23, 1, None])
     got = plc.strings.convert.convert_floats.from_floats(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
     )
     expect = pa.array(["-1.23", "1.0", None])
     assert_column_eq(expect, got)
@@ -28,7 +28,7 @@ def test_from_floats():
 def test_is_float():
     arr = pa.array(["-1.23", "1", "1.2.3", "A", None])
     got = plc.strings.convert.convert_floats.is_float(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
     )
     expect = pa.array([True, True, False, False, None])
     assert_column_eq(expect, got)

--- a/python/pylibcudf/pylibcudf/tests/test_string_convert_integers.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_convert_integers.py
@@ -9,7 +9,7 @@ def test_to_integers():
     typ = pa.int8()
     arr = pa.array(["1", "-1", None])
     got = plc.strings.convert.convert_integers.to_integers(
-        plc.Column(arr), plc.interop.from_arrow(typ)
+        plc.Column.from_arrow(arr), plc.interop.from_arrow(typ)
     )
     expect = arr.cast(typ)
     assert_column_eq(expect, got)
@@ -17,14 +17,16 @@ def test_to_integers():
 
 def test_from_integers():
     arr = pa.array([1, -1, None])
-    got = plc.strings.convert.convert_integers.from_integers(plc.Column(arr))
+    got = plc.strings.convert.convert_integers.from_integers(
+        plc.Column.from_arrow(arr)
+    )
     expect = pa.array(["1", "-1", None])
     assert_column_eq(expect, got)
 
 
 def test_is_integer():
     arr = pa.array(["1", "-1", "1.2", "A", None])
-    plc_column = plc.Column(arr)
+    plc_column = plc.Column.from_arrow(arr)
     got = plc.strings.convert.convert_integers.is_integer(plc_column)
     expect = pa.array([True, True, False, False, None])
     assert_column_eq(expect, got)
@@ -40,7 +42,7 @@ def test_hex_to_integers():
     typ = pa.int32()
     data = ["0xff", "0x2a", None]
     got = plc.strings.convert.convert_integers.hex_to_integers(
-        plc.Column(pa.array(data)), plc.interop.from_arrow(typ)
+        plc.Column.from_arrow(pa.array(data)), plc.interop.from_arrow(typ)
     )
     expect = pa.array(
         [int(val, 16) if isinstance(val, str) else val for val in data],
@@ -51,7 +53,9 @@ def test_hex_to_integers():
 
 def test_is_hex():
     arr = pa.array(["0xff", "123", "!", None])
-    got = plc.strings.convert.convert_integers.is_hex(plc.Column(arr))
+    got = plc.strings.convert.convert_integers.is_hex(
+        plc.Column.from_arrow(arr)
+    )
     expect = pa.array([True, True, False, None])
     assert_column_eq(expect, got)
 
@@ -59,6 +63,8 @@ def test_is_hex():
 def test_integers_to_hex():
     data = [255, -42, None]
     arr = pa.array(data)
-    got = plc.strings.convert.convert_integers.integers_to_hex(plc.Column(arr))
+    got = plc.strings.convert.convert_integers.integers_to_hex(
+        plc.Column.from_arrow(arr)
+    )
     expect = pa.array(["FF", "FFFFFFFFFFFFFFD6", None])
     assert_column_eq(expect, got)

--- a/python/pylibcudf/pylibcudf/tests/test_string_convert_ipv4.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_convert_ipv4.py
@@ -7,7 +7,7 @@ import pylibcudf as plc
 
 def test_ipv4_to_integers():
     got = plc.strings.convert.convert_ipv4.ipv4_to_integers(
-        plc.Column(pa.array(["123.45.67.890", None]))
+        plc.Column.from_arrow(pa.array(["123.45.67.890", None]))
     )
     expect = pa.array([2066564730, None], type=pa.uint32())
     assert_column_eq(expect, got)
@@ -15,7 +15,7 @@ def test_ipv4_to_integers():
 
 def test_integers_to_ipv4():
     got = plc.strings.convert.convert_ipv4.integers_to_ipv4(
-        plc.Column(pa.array([1, 0, None], type=pa.uint32()))
+        plc.Column.from_arrow(pa.array([1, 0, None], type=pa.uint32()))
     )
     expect = pa.array(["0.0.0.1", "0.0.0.0", None])
     assert_column_eq(expect, got)
@@ -23,7 +23,7 @@ def test_integers_to_ipv4():
 
 def test_is_ipv4():
     got = plc.strings.convert.convert_ipv4.is_ipv4(
-        plc.Column(pa.array(["0.0.0.1", "1.2.34", "A", None]))
+        plc.Column.from_arrow(pa.array(["0.0.0.1", "1.2.34", "A", None]))
     )
     expect = pa.array([True, False, False, None])
     assert_column_eq(expect, got)

--- a/python/pylibcudf/pylibcudf/tests/test_string_convert_lists.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_convert_lists.py
@@ -11,9 +11,11 @@ import pylibcudf as plc
 @pytest.mark.parametrize("separators", [None, pa.array([",", "[", "]"])])
 def test_format_list_column(na_rep, separators):
     got = plc.strings.convert.convert_lists.format_list_column(
-        plc.Column(pa.array([["1", "A"], None])),
+        plc.Column.from_arrow(pa.array([["1", "A"], None])),
         na_rep if na_rep is None else plc.interop.from_arrow(na_rep),
-        separators if separators is None else plc.Column(separators),
+        separators
+        if separators is None
+        else plc.Column.from_arrow(separators),
     )
     expect = pa.array(["[1,A]", ""])
     assert_column_eq(expect, got)

--- a/python/pylibcudf/pylibcudf/tests/test_string_convert_urls.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_convert_urls.py
@@ -10,7 +10,9 @@ import pylibcudf as plc
 def test_url_encode():
     data = ["/home/nfs", None]
     arr = pa.array(data)
-    result = plc.strings.convert.convert_urls.url_encode(plc.Column(arr))
+    result = plc.strings.convert.convert_urls.url_encode(
+        plc.Column.from_arrow(arr)
+    )
     expected = pa.array(
         [
             urllib.parse.quote(url, safe="") if isinstance(url, str) else url
@@ -23,7 +25,9 @@ def test_url_encode():
 def test_url_decode():
     data = ["%2Fhome%2fnfs", None]
     arr = pa.array(data)
-    result = plc.strings.convert.convert_urls.url_decode(plc.Column(arr))
+    result = plc.strings.convert.convert_urls.url_decode(
+        plc.Column.from_arrow(arr)
+    )
     expected = pa.array(
         [
             urllib.parse.unquote(url) if isinstance(url, str) else url

--- a/python/pylibcudf/pylibcudf/tests/test_string_extract.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_extract.py
@@ -11,7 +11,7 @@ def test_extract():
     pa_pattern = "(?P<letter>[ab])(?P<digit>\\d)"
     arr = pa.array(["a1", "b2", "c3"])
     plc_result = plc.strings.extract.extract(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         plc.strings.regex_program.RegexProgram.create(
             pattern, plc.strings.regex_flags.RegexFlags.DEFAULT
         ),
@@ -27,7 +27,7 @@ def test_extract_all_record():
     pattern = "([ab])(\\d)"
     arr = pa.array(["a1", "b2", "c3"])
     plc_result = plc.strings.extract.extract_all_record(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         plc.strings.regex_program.RegexProgram.create(
             pattern, plc.strings.regex_flags.RegexFlags.DEFAULT
         ),

--- a/python/pylibcudf/pylibcudf/tests/test_string_find.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_find.py
@@ -54,7 +54,7 @@ def data_col():
             None,
         ]
     )
-    return pa_array, plc.Column(pa_array)
+    return pa_array, plc.Column.from_arrow(pa_array)
 
 
 @pytest.fixture(scope="module")
@@ -103,7 +103,7 @@ def target_col():
             None,  # ends_with
         ]
     )
-    return pa_array, plc.Column(pa_array)
+    return pa_array, plc.Column.from_arrow(pa_array)
 
 
 @pytest.fixture(params=["a", " ", "A", "Ab", "23"], scope="module")

--- a/python/pylibcudf/pylibcudf/tests/test_string_find_multiple.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_find_multiple.py
@@ -10,8 +10,8 @@ def test_find_multiple():
     arr = pa.array(["abc", "def"])
     targets = pa.array(["a", "c", "e"])
     got = plc.strings.find_multiple.find_multiple(
-        plc.Column(arr),
-        plc.Column(targets),
+        plc.Column.from_arrow(arr),
+        plc.Column.from_arrow(targets),
     )
     expect = pa.array(
         [

--- a/python/pylibcudf/pylibcudf/tests/test_string_findall.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_findall.py
@@ -11,7 +11,7 @@ def test_findall():
     arr = pa.array(["bunny", "rabbit", "hare", "dog"])
     pattern = "[ab]"
     got = plc.strings.findall.findall(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         plc.strings.regex_program.RegexProgram.create(
             pattern, plc.strings.regex_flags.RegexFlags.DEFAULT
         ),
@@ -27,7 +27,7 @@ def test_find_re():
     arr = pa.array(["bunny", "rabbit", "hare", "dog"])
     pattern = "[eb]"
     got = plc.strings.findall.find_re(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         plc.strings.regex_program.RegexProgram.create(
             pattern, plc.strings.regex_flags.RegexFlags.DEFAULT
         ),

--- a/python/pylibcudf/pylibcudf/tests/test_string_padding.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_padding.py
@@ -10,7 +10,7 @@ import pylibcudf as plc
 def test_pad():
     arr = pa.array(["a", "1", None])
     got = plc.strings.padding.pad(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         2,
         plc.strings.side_type.SideType.LEFT,
         "!",
@@ -21,6 +21,6 @@ def test_pad():
 
 def test_zfill():
     arr = pa.array(["a", "1", None])
-    got = plc.strings.padding.zfill(plc.Column(arr), 2)
+    got = plc.strings.padding.zfill(plc.Column.from_arrow(arr), 2)
     expect = pa.array(pc.utf8_lpad(arr, 2, padding="0"))
     assert_column_eq(expect, got)

--- a/python/pylibcudf/pylibcudf/tests/test_string_repeat.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_repeat.py
@@ -12,8 +12,10 @@ import pylibcudf as plc
 def test_repeat_strings(repeats):
     arr = pa.array(["1", None])
     got = plc.strings.repeat.repeat_strings(
-        plc.Column(arr),
-        plc.Column(repeats) if not isinstance(repeats, int) else repeats,
+        plc.Column.from_arrow(arr),
+        plc.Column.from_arrow(repeats)
+        if not isinstance(repeats, int)
+        else repeats,
     )
     expect = pa.array(pc.binary_repeat(arr, repeats))
     assert_column_eq(expect, got)

--- a/python/pylibcudf/pylibcudf/tests/test_string_replace.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_replace.py
@@ -14,7 +14,7 @@ def data_col():
         ["a", "c", "A", "aa", None, "aaaaaaaaa", "AAAA", "ÁÁÁÁ"],
         type=pa.string(),
     )
-    return pa_data_col, plc.Column(pa_data_col)
+    return pa_data_col, plc.Column.from_arrow(pa_data_col)
 
 
 @pytest.fixture(scope="module", params=["a", "c", "A", "Á", "aa", "ÁÁÁ"])
@@ -37,7 +37,7 @@ def scalar_repl(request):
 )
 def col_repl_target(request):
     pa_target = pa.array(request.param, type=pa.string())
-    return (pa_target, plc.Column(pa_target))
+    return (pa_target, plc.Column.from_arrow(pa_target))
 
 
 @pytest.fixture(
@@ -53,7 +53,7 @@ def col_repl_target(request):
 )
 def col_repl(request):
     pa_repl = pa.array(request.param, type=pa.string())
-    return (pa_repl, plc.Column(pa_repl))
+    return (pa_repl, plc.Column.from_arrow(pa_repl))
 
 
 @pytest.mark.parametrize("maxrepl", [-1, 1, 2, 10])

--- a/python/pylibcudf/pylibcudf/tests/test_string_replace_re.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_replace_re.py
@@ -14,7 +14,7 @@ def test_replace_re_regex_program_scalar(max_replace_count):
     pat = "f."
     repl = "ba"
     got = plc.strings.replace_re.replace_re(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         plc.strings.regex_program.RegexProgram.create(
             pat, plc.strings.regex_flags.RegexFlags.DEFAULT
         ),
@@ -44,9 +44,9 @@ def test_replace_re_list_str_columns(flags):
     pats = ["oo", "uz"]
     repls = ["a", "b"]
     got = plc.strings.replace_re.replace_re(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         pats,
-        plc.Column(pa.array(repls)),
+        plc.Column.from_arrow(pa.array(repls)),
         flags=flags,
     )
     expect = arr
@@ -62,7 +62,7 @@ def test_replace_re_list_str_columns(flags):
 def test_replace_with_backrefs():
     arr = pa.array(["Z756", None])
     got = plc.strings.replace_re.replace_with_backrefs(
-        plc.Column(arr),
+        plc.Column.from_arrow(arr),
         plc.strings.regex_program.RegexProgram.create(
             "(\\d)(\\d)", plc.strings.regex_flags.RegexFlags.DEFAULT
         ),

--- a/python/pylibcudf/pylibcudf/tests/test_string_slice.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_slice.py
@@ -14,7 +14,7 @@ def pa_col():
 
 @pytest.fixture(scope="module")
 def plc_col(pa_col):
-    return plc.Column(pa_col)
+    return plc.Column.from_arrow(pa_col)
 
 
 @pytest.fixture(
@@ -37,7 +37,7 @@ def pa_starts_col():
 
 @pytest.fixture(scope="module")
 def plc_starts_col(pa_starts_col):
-    return plc.Column(pa_starts_col)
+    return plc.Column.from_arrow(pa_starts_col)
 
 
 @pytest.fixture(scope="module")
@@ -47,7 +47,7 @@ def pa_stops_col():
 
 @pytest.fixture(scope="module")
 def plc_stops_col(pa_stops_col):
-    return plc.Column(pa_stops_col)
+    return plc.Column.from_arrow(pa_stops_col)
 
 
 def test_slice(pa_col, plc_col, pa_start_stop_step, plc_start_stop_step):

--- a/python/pylibcudf/pylibcudf/tests/test_string_split_partition.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_split_partition.py
@@ -10,7 +10,7 @@ import pylibcudf as plc
 @pytest.fixture
 def data_col():
     pa_arr = pa.array(["ab_cd", "def_g_h", None])
-    plc_column = plc.Column(pa_arr)
+    plc_column = plc.Column.from_arrow(pa_arr)
     return pa_arr, plc_column
 
 

--- a/python/pylibcudf/pylibcudf/tests/test_string_split_split.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_split_split.py
@@ -11,7 +11,7 @@ import pylibcudf as plc
 @pytest.fixture
 def data_col():
     pa_array = pa.array(["a_b_c", "d-e-f", None])
-    plc_column = plc.Column(pa_array)
+    plc_column = plc.Column.from_arrow(pa_array)
     return pa_array, plc_column
 
 

--- a/python/pylibcudf/pylibcudf/tests/test_string_strip.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_strip.py
@@ -54,7 +54,7 @@ def pa_col():
 
 @pytest.fixture
 def plc_col(pa_col):
-    return plc.Column(pa_col)
+    return plc.Column.from_arrow(pa_col)
 
 
 @pytest.fixture(params=strip_chars)

--- a/python/pylibcudf/pylibcudf/tests/test_string_translate.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_translate.py
@@ -13,7 +13,7 @@ def data_col():
         ["aa", "bbb", "cccc", "abcd", None],
         type=pa.string(),
     )
-    return pa_data_col, plc.Column(pa_data_col)
+    return pa_data_col, plc.Column.from_arrow(pa_data_col)
 
 
 @pytest.fixture

--- a/python/pylibcudf/pylibcudf/tests/test_string_wrap.py
+++ b/python/pylibcudf/pylibcudf/tests/test_string_wrap.py
@@ -16,7 +16,7 @@ def test_wrap():
             None,
         ]
     )
-    got = plc.strings.wrap.wrap(plc.Column(pa_array), width)
+    got = plc.strings.wrap.wrap(plc.Column.from_arrow(pa_array), width)
     expect = pa.array(
         [
             textwrap.fill(val, width) if isinstance(val, str) else val

--- a/python/pylibcudf/pylibcudf/tests/test_transform.py
+++ b/python/pylibcudf/pylibcudf/tests/test_transform.py
@@ -23,7 +23,7 @@ def test_nans_to_nulls(has_nans):
     ]
 
     h_input = pa.array(values, type=pa.float32())
-    input = plc.Column(h_input)
+    input = plc.Column.from_arrow(h_input)
     assert input.null_count() == h_input.null_count
     expect = pa.array(replaced, type=pa.float32())
 
@@ -37,7 +37,7 @@ def test_nans_to_nulls(has_nans):
 
 def test_bools_to_mask_roundtrip():
     pa_array = pa.array([True, None, False])
-    plc_input = plc.Column(pa_array)
+    plc_input = plc.Column.from_arrow(pa_array)
     mask, result_null_count = plc.transform.bools_to_mask(plc_input)
 
     assert result_null_count == 2
@@ -70,8 +70,8 @@ def test_encode():
 
 
 def test_one_hot_encode():
-    plc_input = plc.Column(pa.array([1, 2, 3]))
-    plc_categories = plc.Column(pa.array([0, 0, 0]))
+    plc_input = plc.Column.from_arrow(pa.array([1, 2, 3]))
+    plc_categories = plc.Column.from_arrow(pa.array([0, 0, 0]))
     got = plc.transform.one_hot_encode(plc_input, plc_categories)
     expect = pa.table(
         [[False] * 3] * 3,
@@ -99,9 +99,9 @@ def test_transform_udf():
     expect = pa.array([(A + B) * C] * 100)
     got = plc.transform.transform(
         [
-            plc.Column(pa.array([A] * 100)),
-            plc.Column(pa.array([B] * 100)),
-            plc.Column(pa.array([C])),
+            plc.Column.from_arrow(pa.array([A] * 100)),
+            plc.Column.from_arrow(pa.array([B] * 100)),
+            plc.Column.from_arrow(pa.array([C])),
         ],
         transform_udf=ptx,
         output_type=plc.DataType(plc.TypeId.FLOAT64),


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Contributes to https://github.com/rapidsai/cudf/issues/15132. Deletes the dispatched constructor logic so its a breaking change, but I didn't think it was worth deprecating __init__ in this release and removing it in 25.10 because it was just added in 25.06.
Contributes
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
