### PR TITLE
Remove deprecated groupby.collect

### DIFF
--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -220,15 +220,6 @@ def _is_all_scan_aggregate(all_aggs: list[list[str]]) -> bool:
     return all_scan and any_scan
 
 
-def _deprecate_collect():
-    warnings.warn(
-        "Groupby.collect is deprecated and "
-        "will be removed in a future version. "
-        "Use `.agg(list)` instead.",
-        FutureWarning,
-    )
-
-
 # The three functions below return the quantiles [25%, 50%, 75%]
 # respectively, which are called in the describe() method to output
 # the summary stats of a GroupBy object
@@ -2691,12 +2682,6 @@ class GroupBy(Serializable, Reducible, Scannable):
             return getattr(x, "quantile")(q=q, interpolation=interpolation)
 
         return self.agg(func)
-
-    @_performance_tracking
-    def collect(self):
-        """Get a list of all the values for each column in each group."""
-        _deprecate_collect()
-        return self.agg(list)
 
     @_performance_tracking
     def unique(self):

--- a/python/dask_cudf/dask_cudf/_expr/groupby.py
+++ b/python/dask_cudf/dask_cudf/_expr/groupby.py
@@ -7,7 +7,6 @@ import pandas as pd
 from dask.dataframe.core import _concat
 from dask.dataframe.groupby import Aggregation
 
-from cudf.core.groupby.groupby import _deprecate_collect
 from cudf.utils.performance_tracking import _dask_cudf_performance_tracking
 
 from dask_cudf._expr import (
@@ -548,10 +547,6 @@ class GroupBy(DXGroupBy):
         )
         return g
 
-    def collect(self, **kwargs):
-        _deprecate_collect()
-        return self._single_agg(ListAgg, **kwargs)
-
     def aggregate(self, arg, fused=True, **kwargs):
         if (
             fused
@@ -567,10 +562,6 @@ class SeriesGroupBy(DXSeriesGroupBy):
     def __init__(self, *args, observed=None, **kwargs):
         observed = observed if observed is not None else True
         super().__init__(*args, observed=observed, **kwargs)
-
-    def collect(self, **kwargs):
-        _deprecate_collect()
-        return self._single_agg(ListAgg, **kwargs)
 
     def aggregate(self, arg, **kwargs):
         return super().aggregate(_translate_arg(arg), **kwargs)

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -10,7 +10,6 @@ from dask.utils_test import hlg_layer
 
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
-from cudf.testing._utils import expect_warning_if
 
 import dask_cudf
 from dask_cudf._expr.groupby import OPTIMIZED_AGGS, _aggs_optimized
@@ -53,7 +52,7 @@ def pdf(request):
 # deprecation check for "collect".
 @pytest.mark.parametrize(
     "aggregation",
-    sorted((*tuple(set(OPTIMIZED_AGGS) - {list}), "collect")),
+    sorted(set(OPTIMIZED_AGGS) - {list}),
 )
 @pytest.mark.parametrize("series", [False, True])
 def test_groupby_basic(series, aggregation, pdf):
@@ -69,9 +68,8 @@ def test_groupby_basic(series, aggregation, pdf):
 
     check_dtype = aggregation != "count"
 
-    with expect_warning_if(aggregation == "collect"):
-        expect = getattr(gdf_grouped, aggregation)()
-        actual = getattr(ddf_grouped, aggregation)()
+    expect = getattr(gdf_grouped, aggregation)()
+    actual = getattr(ddf_grouped, aggregation)()
 
     dd.assert_eq(expect, actual, check_dtype=check_dtype)
 


### PR DESCRIPTION
## Description
Deprecated in 24.06: https://github.com/rapidsai/cudf/pull/15808

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
