### PR TITLE
Use cooperative groups in parquet decoder kernels

### DIFF
--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -1103,7 +1103,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
       if constexpr (has_dict_t) {
         skip_decode<rolling_buf_size>(dict_stream, skipped_leaf_values, t);
       } else if constexpr (has_strings_t) {
-        gpuInitStringDescriptors<true>(
+        gpuInitStringDescriptors<is_calc_sizes_only::YES>(
           s, sb, skipped_leaf_values, cooperative_groups::this_thread_block());
         if (t == 0) { s->dict_pos = processed_count; }
         __syncthreads();
@@ -1162,7 +1162,8 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
       __syncthreads();
     } else if constexpr (has_strings_t) {
       auto const target_pos = next_valid_count + skipped_leaf_values;
-      gpuInitStringDescriptors<false>(s, sb, target_pos, cooperative_groups::this_thread_block());
+      gpuInitStringDescriptors<is_calc_sizes_only::NO>(
+        s, sb, target_pos, cooperative_groups::this_thread_block());
       if (t == 0) { s->dict_pos = target_pos; }
       __syncthreads();
     } else if constexpr (has_bools_t) {

--- a/cpp/src/io/parquet/decode_preprocess.cu
+++ b/cpp/src/io/parquet/decode_preprocess.cu
@@ -166,7 +166,7 @@ __device__ size_type gpuDecodeTotalPageStringSize(page_state_s* s, int t)
       // For V1, the choice is an overestimate (s->dict_size), or an exact number that's
       // expensive to compute. For now we're going with the latter.
       else {
-        str_len = gpuInitStringDescriptors<true, unused_state_buf>(
+        str_len = gpuInitStringDescriptors<is_calc_sizes_only::YES, unused_state_buf>(
           s, nullptr, target_pos, cg::this_thread_block());
       }
       break;

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -68,9 +68,11 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
   page_state_s* const s = &state_g;
   auto* const sb        = &state_buffers;
-  int page_idx          = blockIdx.x;
-  int t                 = threadIdx.x;
-  [[maybe_unused]] null_count_back_copier _{s, t};
+  int const page_idx    = cg::this_grid().block_rank();
+  auto const block      = cg::this_thread_block();
+  auto const warp       = cg::tiled_partition<cudf::detail::warp_size>(block);
+
+  [[maybe_unused]] null_count_back_copier _{s, static_cast<int>(block.thread_rank())};
 
   // Setup local page info
   if (!setupLocalPageInfo(s,
@@ -96,9 +98,8 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     return;
   }
 
-  auto const data_len    = cuda::std::distance(s->data_start, s->data_end);
-  auto const num_values  = data_len / s->dtype_len_in;
-  auto const out_thread0 = warp_size;
+  auto const data_len   = cuda::std::distance(s->data_start, s->data_end);
+  auto const num_values = data_len / s->dtype_len_in;
 
   PageNestingDecodeInfo* nesting_info_base = s->nesting_info;
 
@@ -112,27 +113,27 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     int target_pos;
     int src_pos = s->src_pos;
 
-    if (t < out_thread0) {
-      target_pos = min(src_pos + 2 * (decode_block_size - out_thread0),
-                       s->nz_count + (decode_block_size - out_thread0));
+    if (warp.meta_group_rank() == 0) {
+      target_pos = cuda::std::min(src_pos + 2 * (decode_block_size - warp.size()),
+                                  s->nz_count + (decode_block_size - warp.size()));
     } else {
-      target_pos = min(s->nz_count, src_pos + decode_block_size - out_thread0);
+      target_pos = cuda::std::min<int32_t>(s->nz_count, src_pos + decode_block_size - warp.size());
     }
-    // this needs to be here to prevent warp 1 modifying src_pos before all threads have read it
-    __syncthreads();
+    // This needs to be here to prevent warp 1 modifying src_pos before all threads have read it
+    block.sync();
 
-    if (t < warp_size) {
-      // decode repetition and definition levels.
+    if (warp.meta_group_rank() == 0) {
+      // WARP0: decode repetition and definition levels.
       // - update validity vectors
       // - updates offsets (for nested columns)
       // - produces non-NULL value indices in s->nz_idx for subsequent decoding
-      gpuDecodeLevels<lvl_buf_size, level_t>(s, sb, target_pos, rep, def, t);
+      gpuDecodeLevels<lvl_buf_size, level_t>(s, sb, target_pos, rep, def, warp);
     } else {
       // WARP1..WARP3: Decode values
       Type const dtype = s->col.physical_type;
-      src_pos += t - out_thread0;
+      src_pos += block.thread_rank() - warp.size();
 
-      // the position in the output column/buffer
+      // The position in the output column/buffer
       int dst_pos = sb->nz_idx[rolling_index<rolling_buf_size>(src_pos)];
 
       // for the flat hierarchy case we will be reading from the beginning of the value stream,
@@ -211,12 +212,12 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
           s->set_error_code(decode_error::UNSUPPORTED_ENCODING);
         }
       }
-
-      if (t == out_thread0) { s->src_pos = target_pos; }
+      // Only the first thread in the warp 1 updates src_pos
+      if (warp.meta_group_rank() == 1 and warp.thread_rank() == 0) { s->src_pos = target_pos; }
     }
-    __syncthreads();
+    block.sync();
   }
-  if (t == 0 and s->error != 0) { set_error(s->error, error_code); }
+  if (block.thread_rank() == 0 and s->error != 0) { set_error(s->error, error_code); }
 }
 
 /**
@@ -337,13 +338,13 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     }
     // this needs to be here to prevent warp 3 modifying src_pos before all threads have read it
     __syncthreads();
-    auto const tile_warp = cg::tiled_partition<cudf::detail::warp_size>(cg::this_thread_block());
+    auto const warp = cg::tiled_partition<cudf::detail::warp_size>(cg::this_thread_block());
     if (t < 32) {
       // decode repetition and definition levels.
       // - update validity vectors
       // - updates offsets (for nested columns)
       // - produces non-NULL value indices in s->nz_idx for subsequent decoding
-      gpuDecodeLevels<lvl_buf_size, level_t>(s, sb, target_pos, rep, def, t);
+      gpuDecodeLevels<lvl_buf_size, level_t>(s, sb, target_pos, rep, def, warp);
     } else if (t < out_thread0) {
       // skipped_leaf_values will always be 0 for flat hierarchies.
       uint32_t src_target_pos = target_pos + skipped_leaf_values;
@@ -359,9 +360,9 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
         src_target_pos = gpuDecodeRleBooleans(s, sb, src_target_pos, t & 0x1f);
       } else if (s->col.physical_type == Type::BYTE_ARRAY or
                  s->col.physical_type == Type::FIXED_LEN_BYTE_ARRAY) {
-        gpuInitStringDescriptors<false>(s, sb, src_target_pos, tile_warp);
+        gpuInitStringDescriptors<is_calc_sizes_only::NO>(s, sb, src_target_pos, warp);
       }
-      if (tile_warp.thread_rank() == 0) { s->dict_pos = src_target_pos; }
+      if (warp.thread_rank() == 0) { s->dict_pos = src_target_pos; }
     } else {
       // WARP1..WARP3: Decode values
       Type const dtype = s->col.physical_type;

--- a/cpp/src/io/parquet/page_decode.cuh
+++ b/cpp/src/io/parquet/page_decode.cuh
@@ -27,6 +27,8 @@
 
 namespace cudf::io::parquet::detail {
 
+namespace cg = cooperative_groups;
+
 struct page_state_s {
   CUDF_HOST_DEVICE constexpr page_state_s() noexcept {}
   uint8_t const* data_start{};
@@ -374,9 +376,12 @@ inline __device__ int gpuDecodeRleBooleans(page_state_s* s, state_buf* sb, int t
   // because the only path that does not include a sync will lead to s->dict_pos being overwritten
   // with the same value
 
+  // Create a warp cooperative group
+  auto const warp = cooperative_groups::tiled_partition<cudf::detail::warp_size>(
+    cooperative_groups::this_thread_block());
   while (pos < target_pos) {
     int is_literal, batch_len;
-    if (!t) {
+    if (warp.thread_rank() == 0) {
       uint32_t run       = s->dict_run;
       uint8_t const* cur = s->data_start;
       if (run <= 1) {
@@ -404,10 +409,12 @@ inline __device__ int gpuDecodeRleBooleans(page_state_s* s, state_buf* sb, int t
       is_literal    = run & 1;
       __threadfence_block();
     }
-    __syncwarp();
+
+    warp.sync();
     is_literal = shuffle(is_literal);
     batch_len  = shuffle(batch_len);
-    if (t < batch_len) {
+
+    if (warp.thread_rank() < batch_len) {
       int dict_idx;
       if (is_literal) {
         int32_t ofs      = t - ((batch_len + 7) & ~7);
@@ -424,26 +431,31 @@ inline __device__ int gpuDecodeRleBooleans(page_state_s* s, state_buf* sb, int t
 }
 
 /**
+ * @brief Indicates if the string descriptor initializer kernel is only calculating sizes
+ */
+enum class is_calc_sizes_only : bool { NO = false, YES = true };
+
+/**
  * @brief Parses the length and position of strings and returns total length of all strings
  * processed
  *
  * @param[in,out] s Page state input/output
  * @param[out] sb Page state buffer output
  * @param[in] target_pos Target output position
- * @param[in] g Cooperative group (thread block or tile)
- * @tparam sizes_only True if only sizes are to be calculated
+ * @param[in] group Cooperative group (thread block or tile)
+ * @tparam sizes_only Indicates if only sizes are to be calculated
  * @tparam state_buf Typename of the `state_buf` (usually inferred)
  * @tparam thread_group Typename of the cooperative group (inferred)
  *
  * @return Total length of strings processed
  */
-template <bool sizes_only, typename state_buf, typename thread_group>
+template <is_calc_sizes_only sizes_only, typename state_buf, typename thread_group>
 __device__ size_type gpuInitStringDescriptors(page_state_s* s,
                                               [[maybe_unused]] state_buf* sb,
                                               int target_pos,
-                                              thread_group const& g)
+                                              thread_group const& group)
 {
-  int const t         = g.thread_rank();
+  int const tid       = group.thread_rank();
   int const dict_size = s->dict_size;
   int k               = s->dict_val;
   int pos             = s->dict_pos;
@@ -453,22 +465,22 @@ __device__ size_type gpuInitStringDescriptors(page_state_s* s,
   if (s->col.physical_type == Type::FIXED_LEN_BYTE_ARRAY) {
     int const dtype_len_in = s->dtype_len_in;
     total_len              = min((target_pos - pos) * dtype_len_in, dict_size - s->dict_val);
-    if constexpr (!sizes_only) {
-      for (pos += t, k += t * dtype_len_in; pos < target_pos; pos += g.size()) {
+    if constexpr (sizes_only == is_calc_sizes_only::NO) {
+      for (pos += tid, k += tid * dtype_len_in; pos < target_pos; pos += group.size()) {
         sb->str_len[rolling_index<state_buf::str_buf_size>(pos)] =
           (k < dict_size) ? dtype_len_in : 0;
         // dict_idx is upperbounded by dict_size.
         sb->dict_idx[rolling_index<state_buf::dict_buf_size>(pos)] = k;
         // Increment k if needed.
-        if (k < dict_size) { k = min(k + (g.size() * dtype_len_in), dict_size); }
+        if (k < dict_size) { k = min(k + (group.size() * dtype_len_in), dict_size); }
       }
     }
     // Only thread_rank = 0 updates the s->dict_val
-    if (!t) { s->dict_val += total_len; }
+    if (tid == 0) { s->dict_val += total_len; }
   }
   // This step is purely serial for byte arrays
   else {
-    if (!t) {
+    if (tid == 0) {
       uint8_t const* cur = s->data_start;
 
       for (int len = 0; pos < target_pos; pos++, len = 0) {
@@ -477,7 +489,7 @@ __device__ size_type gpuInitStringDescriptors(page_state_s* s,
           k += 4;
           if (k + len > dict_size) { len = 0; }
         }
-        if constexpr (!sizes_only) {
+        if constexpr (sizes_only == is_calc_sizes_only::NO) {
           sb->dict_idx[rolling_index<state_buf::dict_buf_size>(pos)] = k;
           sb->str_len[rolling_index<state_buf::str_buf_size>(pos)]   = len;
         }
@@ -702,8 +714,6 @@ inline __device__ void get_nesting_bounds(int& start_depth,
 template <int block_size>
 static __device__ void update_list_offsets_for_pruned_pages(page_state_s* state)
 {
-  namespace cg = cooperative_groups;
-
   int const max_depth          = state->col.max_nesting_depth - 1;
   bool const in_nesting_bounds = max_depth >= 0;
   auto const tid               = cg::this_thread_block().thread_rank();
@@ -921,43 +931,46 @@ __device__ void gpuUpdateValidityOffsetsAndRowIndices(int32_t target_input_value
  * @param[in] target_leaf_count Target count of non-null leaf values to generate indices for
  * @param[in] rep Repetition level buffer
  * @param[in] def Definition level buffer
- * @param[in] t Thread index
+ * @param[in] warp Warp cooperative group
  * @tparam rolling_buf_size Size of the cyclic buffer used to store value data
  * @tparam level_t Type used to store decoded repetition and definition levels
  * @tparam state_buf Typename of the `state_buf` (usually inferred)
  */
 template <int rolling_buf_size, typename level_t, typename state_buf>
-__device__ void gpuDecodeLevels(page_state_s* s,
-                                state_buf* sb,
-                                int32_t target_leaf_count,
-                                level_t* const rep,
-                                level_t* const def,
-                                int t)
+__device__ void gpuDecodeLevels(
+  page_state_s* s,
+  state_buf* sb,
+  int32_t target_leaf_count,
+  level_t* const rep,
+  level_t* const def,
+  cg::thread_block_tile<cudf::detail::warp_size, cg::thread_block> const& warp)
 {
-  bool has_repetition = s->col.max_level[level_type::REPETITION] > 0;
+  auto const has_repetition = s->col.max_level[level_type::REPETITION] > 0;
 
-  constexpr int batch_size = cudf::detail::warp_size;
-  int cur_leaf_count       = target_leaf_count;
+  auto cur_leaf_count = target_leaf_count;
   while (s->error == 0 && s->nz_count < target_leaf_count &&
          s->input_value_count < s->num_input_values) {
     if (has_repetition) {
-      gpuDecodeStream<level_t, rolling_buf_size>(rep, s, cur_leaf_count, t, level_type::REPETITION);
+      gpuDecodeStream<level_t, rolling_buf_size>(
+        rep, s, cur_leaf_count, warp.thread_rank(), level_type::REPETITION);
     }
-    gpuDecodeStream<level_t, rolling_buf_size>(def, s, cur_leaf_count, t, level_type::DEFINITION);
-    __syncwarp();
+    gpuDecodeStream<level_t, rolling_buf_size>(
+      def, s, cur_leaf_count, warp.thread_rank(), level_type::DEFINITION);
+    warp.sync();
 
     // because the rep and def streams are encoded separately, we cannot request an exact
     // # of values to be decoded at once. we can only process the lowest # of decoded rep/def
     // levels we get.
-    int actual_leaf_count = has_repetition ? min(s->lvl_count[level_type::REPETITION],
-                                                 s->lvl_count[level_type::DEFINITION])
-                                           : s->lvl_count[level_type::DEFINITION];
+    auto const actual_leaf_count = has_repetition
+                                     ? cuda::std::min<int32_t>(s->lvl_count[level_type::REPETITION],
+                                                               s->lvl_count[level_type::DEFINITION])
+                                     : s->lvl_count[level_type::DEFINITION];
 
     // process what we got back
     gpuUpdateValidityOffsetsAndRowIndices<level_t, state_buf, rolling_buf_size>(
-      actual_leaf_count, s, sb, rep, def, t);
-    cur_leaf_count = actual_leaf_count + batch_size;
-    __syncwarp();
+      actual_leaf_count, s, sb, rep, def, warp.thread_rank());
+    cur_leaf_count = actual_leaf_count + warp.size();
+    warp.sync();
   }
 }
 

--- a/cpp/src/io/parquet/page_string_utils.cuh
+++ b/cpp/src/io/parquet/page_string_utils.cuh
@@ -21,6 +21,7 @@
 #include <cudf/strings/detail/gather.cuh>
 
 #include <cuda/atomic>
+#include <cuda/std/bit>
 
 namespace cudf::io::parquet::detail {
 
@@ -83,17 +84,17 @@ __device__ inline void block_excl_sum(size_type* arr, size_type length, size_typ
 {
   using block_scan = cub::BlockScan<size_type, block_size>;
   __shared__ typename block_scan::TempStorage scan_storage;
-  int const t = threadIdx.x;
 
-  // do a series of block sums, storing results in arr as we go
-  for (int pos = 0; pos < length; pos += block_size) {
-    int const tidx = pos + t;
+  // Do a series of block sums, storing results in arr as we go
+  auto const block = cooperative_groups::this_thread_block();
+  for (int pos = 0; pos < length; pos += block.size()) {
+    int const tidx = pos + block.thread_rank();
     size_type tval = tidx < length ? arr[tidx] : 0;
 
     size_type block_sum;
     size_type new_tval;
     block_scan(scan_storage).ExclusiveSum(tval, new_tval, block_sum);
-    __syncthreads();
+    block.sync();
 
     if (tidx < length) { arr[tidx] = new_tval + initial_value; }
     initial_value += block_sum;
@@ -203,10 +204,11 @@ template <int value>
 inline constexpr int log2_int()
 {
   static_assert((value >= 1) && ((value & (value - 1)) == 0), "Only works for powers of 2!");
-  if constexpr (value == 1)
+  if constexpr (value == 1) {
     return 0;
-  else
-    return 1 + log2_int<value / 2>();
+  } else {
+    return sizeof(uint32_t) - 1 - cuda::std::countl_zero(static_cast<uint32_t>(value));
+  }
 }
 
 template <int block_size>


### PR DESCRIPTION
## Description
This PR is the first of many PRs that will help improve parquet decoders code. The changes will include renaming functions to libcudf standards, eliminate the use of magic numbers, raw warp/block level primitives such as `__syncwarp` and bug prone computations such as `warp_id, lane_id`, and other cleanups.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
