### PR TITLE
Propagate IR subtypes in `lower_ir_node`

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/dispatch.py
+++ b/python/cudf_polars/cudf_polars/experimental/dispatch.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 """Multi-partition dispatch functions."""
 
@@ -41,6 +41,10 @@ def lower_ir_node(
     new_ir, partition_info
         The rewritten node, and a mapping from unique nodes in
         the full IR graph to associated partitioning information.
+
+        This may or may not be the same subtype of IR as the input
+        ``ir``. While the lowered node must be *some* `IR` subtype,
+        implementations should return the narrowest possible type.
 
     Notes
     -----

--- a/python/cudf_polars/cudf_polars/experimental/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/groupby.py
@@ -130,7 +130,7 @@ def decompose(
 @lower_ir_node.register(GroupBy)
 def _(
     ir: GroupBy, rec: LowerIRTransformer
-) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+) -> tuple[GroupBy | Select, MutableMapping[IR, PartitionInfo]]:
     # Extract child partitioning
     child, partition_info = rec(ir.children[0])
 

--- a/python/cudf_polars/cudf_polars/experimental/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/join.py
@@ -59,7 +59,7 @@ def _make_hash_join(
     partition_info: MutableMapping[IR, PartitionInfo],
     left: IR,
     right: IR,
-) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+) -> tuple[Join, MutableMapping[IR, PartitionInfo]]:
     # Shuffle left and right dataframes (if necessary)
     new_left = _maybe_shuffle_frame(
         left,
@@ -144,7 +144,7 @@ def _make_bcast_join(
     partition_info: MutableMapping[IR, PartitionInfo],
     left: IR,
     right: IR,
-) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+) -> tuple[Join, MutableMapping[IR, PartitionInfo]]:
     if ir.options[0] != "Inner":
         left_count = partition_info[left].count
         right_count = partition_info[right].count
@@ -187,7 +187,7 @@ def _make_bcast_join(
 @lower_ir_node.register(ConditionalJoin)
 def _(
     ir: ConditionalJoin, rec: LowerIRTransformer
-) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+) -> tuple[ConditionalJoin, MutableMapping[IR, PartitionInfo]]:
     if ir.options[2]:  # pragma: no cover
         return _lower_ir_fallback(
             ir,
@@ -225,7 +225,7 @@ def _(
 @lower_ir_node.register(Join)
 def _(
     ir: Join, rec: LowerIRTransformer
-) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+) -> tuple[Join, MutableMapping[IR, PartitionInfo]]:
     # Lower children
     children, _partition_info = zip(*(rec(c) for c in ir.children), strict=True)
     partition_info = reduce(operator.or_, _partition_info)

--- a/python/cudf_polars/cudf_polars/experimental/select.py
+++ b/python/cudf_polars/cudf_polars/experimental/select.py
@@ -26,7 +26,7 @@ def decompose_select(
     input_ir: IR,
     partition_info: MutableMapping[IR, PartitionInfo],
     config_options: ConfigOptions,
-) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+) -> tuple[HConcat | Select, MutableMapping[IR, PartitionInfo]]:
     """
     Decompose a multi-partition Select operation.
 
@@ -80,8 +80,8 @@ def decompose_select(
         partition_info.update(_partition_info)
         selections.append(partial_input_ir)
 
-    # Concatenate partial selections
     new_ir: HConcat | Select
+    # Concatenate partial selections
     if len(selections) > 1:
         new_ir = HConcat(
             select_ir.schema,
@@ -100,7 +100,7 @@ def decompose_select(
 @lower_ir_node.register(Select)
 def _(
     ir: Select, rec: LowerIRTransformer
-) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+) -> tuple[HConcat | Select, MutableMapping[IR, PartitionInfo]]:
     child, partition_info = rec(ir.children[0])
     pi = partition_info[child]
     if pi.count > 1 and not all(

--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -233,6 +233,7 @@ def _(
     new_child, pi = rec(child)
     if pi[new_child].count == 1 or ir.keys == pi[new_child].partitioned_on:
         # Already shuffled
+        # What type is new_child? `rec(child)` is just a generic IR.
         return new_child, pi
     new_node = ir.reconstruct([new_child])
     pi[new_node] = PartitionInfo(

--- a/python/cudf_polars/cudf_polars/experimental/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/sort.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 @lower_ir_node.register(Sort)
 def _(
     ir: Sort, rec: LowerIRTransformer
-) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+) -> tuple[Sort, MutableMapping[IR, PartitionInfo]]:
     # Special handling for slicing
     # (May be a top- or bottom-k operation)
 

--- a/python/cudf_polars/cudf_polars/experimental/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/utils.py
@@ -8,10 +8,10 @@ import operator
 import warnings
 from functools import reduce
 from itertools import chain
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from cudf_polars.dsl.expr import Col
-from cudf_polars.dsl.ir import Union
+from cudf_polars.dsl.ir import IR, Union
 from cudf_polars.experimental.base import PartitionInfo
 
 if TYPE_CHECKING:
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
 
     from cudf_polars.containers import DataFrame
     from cudf_polars.dsl.expr import Expr
-    from cudf_polars.dsl.ir import IR
     from cudf_polars.experimental.dispatch import LowerIRTransformer
     from cudf_polars.utils.config import ConfigOptions
 
@@ -50,12 +49,15 @@ def _fallback_inform(msg: str, config_options: ConfigOptions) -> None:
             )
 
 
+T = TypeVar("T", bound=IR)
+
+
 def _lower_ir_fallback(
-    ir: IR,
+    ir: T,
     rec: LowerIRTransformer,
     *,
     msg: str | None = None,
-) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+) -> tuple[T, MutableMapping[IR, PartitionInfo]]:
     # Catch-all single-partition lowering logic.
     # If any children contain multiple partitions,
     # those children will be collapsed with `Repartition`.


### PR DESCRIPTION
This updates the type signatures for lower_ir_node to narrow the return subtype where possible.

Previously, the return type of `lower_ir_node`'s first element was a generic `IR`. However, the majority of `lower_ir_node` impelmentations return the same subtype as the input. Of those that don't they typically return just one or two subtypes (e.g. Scan returns a `Union` or `Scan` depending on the input).

Only `Shuffle` was unable to be narrowed because of a call to `LowerIRTransformer`.

This ended up not being immediately useful to me, but I was already mostly done updating things so I carried on.