### PR TITLE
[DOC] Improve code documentation in `vector_factories.hpp`

### DIFF
--- a/cpp/include/cudf/detail/utilities/vector_factories.hpp
+++ b/cpp/include/cudf/detail/utilities/vector_factories.hpp
@@ -492,7 +492,7 @@ host_vector<T> make_empty_host_vector(size_t capacity, rmm::cuda_stream_view str
 }
 
 /**
- * @brief Asynchronously construct a `thrust::host_vector` containing a copy of data from a
+ * @brief Asynchronously construct a `cudf::detail::host_vector` containing a copy of data from a
  * `device_span`
  *
  * @note This function does not synchronize `stream` after the copy. The returned vector may be
@@ -535,7 +535,7 @@ host_vector<typename Container::value_type> make_host_vector_async(Container con
 }
 
 /**
- * @brief Synchronously construct a `thrust::host_vector` containing a copy of data from a
+ * @brief Synchronously construct a `cudf::detail::host_vector` containing a copy of data from a
  * `device_span`
  *
  * @note This function does a synchronize on `stream` after the copy. The returned vector may be
@@ -567,8 +567,8 @@ template <typename T>
 }
 
 /**
- * @brief Synchronously construct a `thrust::host_vector` containing a copy of data from a device
- * container
+ * @brief Synchronously construct a `cudf::detail::host_vector` containing a copy of data from a
+ * device container
  *
  * @note This function synchronizes `stream` after the copy.
  *


### PR DESCRIPTION
## Description

This PR improves the function documentation in `vector_factories.hpp` to use `cudf::detail::host_vector` instead of old `rmm::host_vector`. It should be useful for new developers. No code change.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
