### PR TITLE
Remove unnecessary synchronization (miss-sync) during Parquet reading

### DIFF
--- a/cpp/include/cudf/detail/sizes_to_offsets_iterator.cuh
+++ b/cpp/include/cudf/detail/sizes_to_offsets_iterator.cuh
@@ -280,9 +280,13 @@ auto sizes_to_offsets(SizesIterator begin,
 
   // Copy the scalar from device to host pinned memory
   auto host_scalar = make_pinned_vector_async<LastType>(1, stream);  // as host pinned memory
-  cudaMemcpyAsync(host_scalar.data(), last_element.data(), sizeof(LastType), cudaMemcpyDeviceToHost, stream.value());
+  cudaMemcpyAsync(host_scalar.data(),
+                  last_element.data(),
+                  sizeof(LastType),
+                  cudaMemcpyDeviceToHost,
+                  stream.value());  // host pinned <- device
   stream.synchronize();
-  return host_scalar.front(); 
+  return host_scalar.front();
   // Note: the rmm::device_scalar::value(stream) returns a copy to a
   // host-pageable stack variable in T
 }

--- a/cpp/include/cudf/detail/utilities/batched_memset.hpp
+++ b/cpp/include/cudf/detail/utilities/batched_memset.hpp
@@ -61,7 +61,7 @@ void batched_memset(std::vector<cudf::device_span<T>> const& bufs,
 
   // copy bufs into device memory and then get sizes
   auto gpu_bufs = cudf::detail::make_device_uvector_async(
-    host_pinned_bufs, stream, cudf::get_current_device_resource_ref());
+    host_pinned_bufs, stream, cudf::get_current_device_resource_ref());  // host pinned -> device
 
   // get a vector with the sizes of all buffers
   auto sizes = thrust::make_transform_iterator(

--- a/cpp/include/cudf/detail/utilities/batched_memset.hpp
+++ b/cpp/include/cudf/detail/utilities/batched_memset.hpp
@@ -50,7 +50,7 @@ void batched_memset(std::vector<cudf::device_span<T>> const& bufs,
   // define task and bytes parameters
   auto const num_bufs = bufs.size();
 
-  // duplicate std::vector to host-pinned memory for efficient device memory transfer
+  // duplicate std::vector to host pinned memory for efficient device memory transfer
   auto host_pinned_bufs =
     cudf::detail::make_pinned_vector_async<cudf::device_span<T>>(num_bufs, stream);
   CUDF_CUDA_TRY(cudaMemcpyAsync(host_pinned_bufs.data(),

--- a/cpp/include/cudf/reduction/detail/reduction.cuh
+++ b/cpp/include/cudf/reduction/detail/reduction.cuh
@@ -272,13 +272,13 @@ template <typename Op,
           typename OutputType = cuda::std::iter_value_t<KeysInputIteratorT>,
           std::enable_if_t<is_fixed_width<OutputType>() &&
                            not cudf::is_fixed_point<OutputType>()>* = nullptr>
-void reduce_by_key(KeysInputIteratorT d_keys_in,                // input keys
-                   UniqueOutputIteratorT d_unique_out,          // output keys
-                   ValuesInputIteratorT d_values_in,            // input values
-                   AggregatesOutputIteratorT d_aggregates_out,  // output values
-                   cudf::size_type* d_num_runs_out,             // output size  cudf::size_type
+void reduce_by_key(KeysInputIteratorT d_keys_in,
+                   UniqueOutputIteratorT d_unique_out,
+                   ValuesInputIteratorT d_values_in,
+                   AggregatesOutputIteratorT d_aggregates_out,
+                   cudf::size_type* d_num_runs_out,
                    op::simple_op<Op> op,
-                   cudf::size_type num_items,  // input
+                   cudf::size_type num_items,
                    rmm::cuda_stream_view stream,
                    rmm::device_async_resource_ref mr)
 {

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -474,7 +474,7 @@ uint32_t GetAggregatedDecodeKernelMask(cudf::detail::hostdevice_span<PageInfo co
   // reduce mask_iter with bit_or to compute the return-value after stream-sync
   std::unique_ptr<scalar> device_reduce_result =
     cudf::reduction::detail::reduce(mask_iter,
-                                    pages.size(),  // static_cast<cudf::size_type>(pages.size()),
+                                    pages.size(),
                                     cudf::reduction::detail::op::bit_or{},
                                     std::optional<uint32_t /**ResultType*/>(std::nullopt),
                                     stream,

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -476,7 +476,7 @@ uint32_t GetAggregatedDecodeKernelMask(cudf::detail::hostdevice_span<PageInfo co
     cudf::reduction::detail::reduce(mask_iter,
                                     pages.size(),  // static_cast<cudf::size_type>(pages.size()),
                                     cudf::reduction::detail::op::bit_or{},
-                                    std::optional<uint32_t /**ResultType*/>(0),
+                                    std::optional<uint32_t /**ResultType*/>(std::nullopt),
                                     stream,
                                     cudf::get_current_device_resource_ref());
   auto host_scalar = cudf::detail::make_pinned_vector_async<uint32_t>(1, stream);

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -1780,13 +1780,12 @@ cudf::detail::host_vector<size_t> reader::impl::calculate_page_string_offsets()
                                 page_offset_output_iter{subpass.pages.device_ptr()});
 
   // now sum up page sizes
-  rmm::device_uvector<int> reduce_keys(
-    d_col_sizes.size(), _stream);  // TODO: Jigao: could be a thrust::make_discard_iterator()
+
   // reduce_by_key on page_keys [input keys] and val_iter [input values] resulting in
-  // reduce_keys [output keys] and d_col_sizes [output values]
+  // d_col_sizes [output values]
   auto d_num_runs_out = cudf::detail::make_pinned_vector_async<cudf::size_type>(1, _stream);
   cudf::reduction::detail::reduce_by_key(page_keys,
-                                         reduce_keys.begin(),
+                                         thrust::make_discard_iterator(),
                                          val_iter,
                                          d_col_sizes.begin(),
                                          d_num_runs_out.data(),

--- a/cpp/src/io/utilities/hostdevice_vector.hpp
+++ b/cpp/src/io/utilities/hostdevice_vector.hpp
@@ -114,9 +114,8 @@ class hostdevice_vector {
    */
   [[nodiscard]] T element(std::size_t element_index, rmm::cuda_stream_view stream) const
   {
-    auto const host_scalar =
-      make_pinned_vector_async<T>(1, stream);  // as host pinned memory if host_allocator allows
-    CUDF_CUDA_TRY(cudaMemcpyAsync(const_cast<T*>(host_scalar.data()),
+    auto host_scalar = make_pinned_vector_async<T>(1, stream);  // as host pinned memory
+    CUDF_CUDA_TRY(cudaMemcpyAsync(host_scalar.data(),
                                   d_data.element_ptr(element_index),
                                   sizeof(T),
                                   cudaMemcpyDeviceToHost,

--- a/cpp/src/io/utilities/hostdevice_vector.hpp
+++ b/cpp/src/io/utilities/hostdevice_vector.hpp
@@ -115,13 +115,11 @@ class hostdevice_vector {
   [[nodiscard]] T element(std::size_t element_index, rmm::cuda_stream_view stream) const
   {
     auto host_scalar = make_pinned_vector_async<T>(1, stream);  // as host pinned memory
-    CUDF_CUDA_TRY(
-      cudaMemcpyAsync(host_scalar.data(),  // TODO(jigao): BITMASK null_mask_partition_bulk sometime
-                                           // fails...not deterministic
-                      d_data.element_ptr(element_index),
-                      sizeof(T),
-                      cudaMemcpyDeviceToHost,
-                      stream.value()));  // host pinned <- device
+    CUDF_CUDA_TRY(cudaMemcpyAsync(host_scalar.data(),
+                                  d_data.element_ptr(element_index),
+                                  sizeof(T),
+                                  cudaMemcpyDeviceToHost,
+                                  stream.value()));  // host pinned <- device
     stream.synchronize();
     return host_scalar.front();
     // Note: the rmm::device_uvector::element(element_index, stream) returns a copy to a

--- a/cpp/src/io/utilities/hostdevice_vector.hpp
+++ b/cpp/src/io/utilities/hostdevice_vector.hpp
@@ -119,7 +119,7 @@ class hostdevice_vector {
                                   d_data.element_ptr(element_index),
                                   sizeof(T),
                                   cudaMemcpyDeviceToHost,
-                                  stream.value()));
+                                  stream.value()));  // host pinned <- device
     stream.synchronize();
     return host_scalar.front();
     // Note: the rmm::device_uvector::element(element_index, stream) returns a copy to a

--- a/cpp/src/io/utilities/hostdevice_vector.hpp
+++ b/cpp/src/io/utilities/hostdevice_vector.hpp
@@ -115,11 +115,13 @@ class hostdevice_vector {
   [[nodiscard]] T element(std::size_t element_index, rmm::cuda_stream_view stream) const
   {
     auto host_scalar = make_pinned_vector_async<T>(1, stream);  // as host pinned memory
-    CUDF_CUDA_TRY(cudaMemcpyAsync(host_scalar.data(),
-                                  d_data.element_ptr(element_index),
-                                  sizeof(T),
-                                  cudaMemcpyDeviceToHost,
-                                  stream.value()));  // host pinned <- device
+    CUDF_CUDA_TRY(
+      cudaMemcpyAsync(host_scalar.data(),  // TODO(jigao): BITMASK null_mask_partition_bulk sometime
+                                           // fails...not deterministic
+                      d_data.element_ptr(element_index),
+                      sizeof(T),
+                      cudaMemcpyDeviceToHost,
+                      stream.value()));  // host pinned <- device
     stream.synchronize();
     return host_scalar.front();
     // Note: the rmm::device_uvector::element(element_index, stream) returns a copy to a


### PR DESCRIPTION
## Description

This is a PR Draft aimed at removing all unnecessary synchronization points (termed "miss-sync") in the Parquet reader.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
