### PR TITLE
Switch to importing rather than cimporting datetime

### DIFF
--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -1,6 +1,6 @@
 # Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
-from cpython cimport bool as py_bool, datetime
+from cpython cimport bool as py_bool
 from cython cimport no_gc_clear
 from libc.stdint cimport (
     int8_t,
@@ -52,6 +52,8 @@ from .column cimport Column
 from .traits cimport is_floating_point
 from .types cimport DataType
 from functools import singledispatch
+
+import datetime
 
 try:
     import numpy as np


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The Cython implementation of datetime doesn't provide us any meaningful performance improvements with our usage in this module, which is almost entirely for typing or instance-checking purposes (we construct one `datetime.date`), and it is not compatible with the limited API.

Contributes to https://github.com/rapidsai/build-planning/issues/42

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
