### PR TITLE
Part 2: Use CG in PQ decoders and standardize function names

### DIFF
--- a/cpp/src/io/parquet/delta_binary.cuh
+++ b/cpp/src/io/parquet/delta_binary.cuh
@@ -238,7 +238,7 @@ struct delta_binary_decoder {
       // negative indexes
       d_start += (warp_size * mb_bits) / 8;
 
-      // unpack deltas. modified from version in gpuDecodeDictionaryIndices(), but
+      // unpack deltas. modified from version in decode_dictionary_indices(), but
       // that one only unpacks up to bitwidths of 24. simplified some since this
       // will always do batches of 32.
       // NOTE: because this needs to handle up to 64 bits, the branching used in the other

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
@@ -339,7 +339,7 @@ class hybrid_scan_reader_impl {
    * - The total sizes of all output columns at all nesting levels
    * - The starting output buffer offset for each page, for each nesting level
    *
-   * For flat schemas, these values are computed during header decoding (see gpuDecodePageHeaders).
+   * For flat schemas, these values are computed during header decoding (see decode_page_headers).
    *
    * @param chunk_read_limit Limit on total number of bytes to be returned per read,
    *        or `0` if there is no limit

--- a/cpp/src/io/parquet/page_data.cuh
+++ b/cpp/src/io/parquet/page_data.cuh
@@ -57,7 +57,7 @@ inline __device__ void gpuOutputString(page_state_s* s, state_buf* sb, int src_p
  * @param[in] dst Pointer to row output data
  */
 template <typename state_buf>
-inline __device__ void gpuOutputBoolean(state_buf* sb, int src_pos, uint8_t* dst)
+inline __device__ void read_boolean(state_buf* sb, int src_pos, uint8_t* dst)
 {
   *dst = sb->dict_idx[rolling_index<state_buf::dict_buf_size>(src_pos)];
 }
@@ -131,10 +131,10 @@ inline __device__ void gpuStoreOutput(uint2* dst,
  * @param[out] dst Pointer to row output data
  */
 template <typename state_buf>
-inline __device__ void gpuOutputInt96Timestamp(page_state_s* s,
-                                               state_buf* sb,
-                                               int src_pos,
-                                               int64_t* dst)
+inline __device__ void read_int96_timestamp(page_state_s* s,
+                                            state_buf* sb,
+                                            int src_pos,
+                                            int64_t* dst)
 {
   using cuda::std::chrono::duration_cast;
 
@@ -206,10 +206,10 @@ inline __device__ void gpuOutputInt96Timestamp(page_state_s* s,
  * @param[in] dst Pointer to row output data
  */
 template <typename state_buf>
-inline __device__ void gpuOutputInt64Timestamp(page_state_s* s,
-                                               state_buf* sb,
-                                               int src_pos,
-                                               int64_t* dst)
+inline __device__ void read_int64_timestamp(page_state_s* s,
+                                            state_buf* sb,
+                                            int src_pos,
+                                            int64_t* dst)
 {
   uint8_t const* src8;
   uint32_t dict_pos, dict_size = s->dict_size, ofs;
@@ -289,7 +289,10 @@ __device__ void gpuOutputByteArrayAsInt(char const* ptr, int32_t len, T* dst)
  * @param[in] dst Pointer to row output data
  */
 template <typename T, typename state_buf>
-__device__ void gpuOutputFixedLenByteArrayAsInt(page_state_s* s, state_buf* sb, int src_pos, T* dst)
+__device__ void read_fixed_width_byte_array_as_int(page_state_s* s,
+                                                   state_buf* sb,
+                                                   int src_pos,
+                                                   T* dst)
 {
   uint32_t const dtype_len_in = s->dtype_len_in;
   uint8_t const* data         = s->dict_base ? s->dict_base : s->data_start;
@@ -323,7 +326,10 @@ __device__ void gpuOutputFixedLenByteArrayAsInt(page_state_s* s, state_buf* sb, 
  * @param[in] dst Pointer to row output data
  */
 template <typename T, typename state_buf>
-inline __device__ void gpuOutputFast(page_state_s* s, state_buf* sb, int src_pos, T* dst)
+inline __device__ void read_fixed_width_value_fast(page_state_s* s,
+                                                   state_buf* sb,
+                                                   int src_pos,
+                                                   T* dst)
 {
   uint8_t const* dict;
   uint32_t dict_pos, dict_size = s->dict_size;
@@ -352,7 +358,7 @@ inline __device__ void gpuOutputFast(page_state_s* s, state_buf* sb, int src_pos
  * @param[in] len Length of element
  */
 template <typename state_buf>
-inline __device__ void gpuOutputGeneric(
+inline __device__ void read_nbyte_fixed_width_value(
   page_state_s* s, state_buf* sb, int src_pos, uint8_t* dst8, int len)
 {
   uint8_t const* dict;

--- a/cpp/src/io/parquet/page_string_decode.cu
+++ b/cpp/src/io/parquet/page_string_decode.cu
@@ -94,7 +94,7 @@ __device__ thrust::pair<int, int> page_bounds(
   auto const pp   = &s->page;
   auto const col  = &s->col;
 
-  // initialize the stream decoders (requires values computed in setupLocalPageInfo)
+  // initialize the stream decoders (requires values computed in setup_local_page_info)
   auto const def_decode = reinterpret_cast<level_t*>(pp->lvl_decode_buf[level_type::DEFINITION]);
   auto const rep_decode = reinterpret_cast<level_t*>(pp->lvl_decode_buf[level_type::REPETITION]);
   decoders[level_type::DEFINITION].init(s->col.level_bits[level_type::DEFINITION],
@@ -625,13 +625,13 @@ CUDF_KERNEL void __launch_bounds__(preprocess_block_size) gpuComputeStringPageBo
     decoders[level_type::NUM_LEVEL_TYPES] = {{def_runs}, {rep_runs}};
 
   // setup page info
-  if (!setupLocalPageInfo(s,
-                          pp,
-                          chunks,
-                          min_row,
-                          num_rows,
-                          mask_filter{STRINGS_MASK},
-                          page_processing_stage::STRING_BOUNDS)) {
+  if (!setup_local_page_info(s,
+                             pp,
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{STRINGS_MASK},
+                             page_processing_stage::STRING_BOUNDS)) {
     return;
   }
 
@@ -679,13 +679,13 @@ CUDF_KERNEL void __launch_bounds__(delta_preproc_block_size) gpuComputeDeltaPage
   bool const has_repetition = chunks[pp->chunk_idx].max_level[level_type::REPETITION] > 0;
 
   // setup page info
-  if (!setupLocalPageInfo(s,
-                          pp,
-                          chunks,
-                          min_row,
-                          num_rows,
-                          mask_filter{decode_kernel_mask::DELTA_BYTE_ARRAY},
-                          page_processing_stage::STRING_BOUNDS)) {
+  if (!setup_local_page_info(s,
+                             pp,
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{decode_kernel_mask::DELTA_BYTE_ARRAY},
+                             page_processing_stage::STRING_BOUNDS)) {
     return;
   }
 
@@ -764,13 +764,13 @@ CUDF_KERNEL void __launch_bounds__(delta_length_block_size) gpuComputeDeltaLengt
   bool const has_repetition = chunks[pp->chunk_idx].max_level[level_type::REPETITION] > 0;
 
   // setup page info
-  if (!setupLocalPageInfo(s,
-                          pp,
-                          chunks,
-                          min_row,
-                          num_rows,
-                          mask_filter{decode_kernel_mask::DELTA_LENGTH_BA},
-                          page_processing_stage::STRING_BOUNDS)) {
+  if (!setup_local_page_info(s,
+                             pp,
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{decode_kernel_mask::DELTA_LENGTH_BA},
+                             page_processing_stage::STRING_BOUNDS)) {
     return;
   }
 
@@ -862,13 +862,13 @@ CUDF_KERNEL void __launch_bounds__(preprocess_block_size) gpuComputePageStringSi
   bool const has_repetition = chunks[pp->chunk_idx].max_level[level_type::REPETITION] > 0;
 
   // setup page info
-  if (!setupLocalPageInfo(s,
-                          pp,
-                          chunks,
-                          min_row,
-                          num_rows,
-                          mask_filter{STRINGS_MASK_NON_DELTA},
-                          page_processing_stage::STRING_BOUNDS)) {
+  if (!setup_local_page_info(s,
+                             pp,
+                             chunks,
+                             min_row,
+                             num_rows,
+                             mask_filter{STRINGS_MASK_NON_DELTA},
+                             page_processing_stage::STRING_BOUNDS)) {
     return;
   }
 

--- a/cpp/src/io/parquet/page_string_utils.cuh
+++ b/cpp/src/io/parquet/page_string_utils.cuh
@@ -246,7 +246,7 @@ __device__ inline int calc_threads_per_string_log2(int avg_string_length)  // re
  * @param string_output_offset Starting offset into the output column data for writing
  */
 template <int block_size, bool has_lists_t, bool split_decode_t, typename state_buf>
-__device__ size_t gpuDecodeString(
+__device__ size_t decode_strings(
   page_state_s* s, state_buf* const sb, int start, int end, int t, size_t string_output_offset)
 {
   // nesting level that is storing actual leaf values

--- a/cpp/src/io/parquet/parquet_gpu.hpp
+++ b/cpp/src/io/parquet/parquet_gpu.hpp
@@ -78,7 +78,7 @@ CUDF_HOST_DEVICE constexpr int rolling_index(int index)
 constexpr uint8_t REP_LVL_HIST_CUTOFF = 0;
 constexpr uint8_t DEF_LVL_HIST_CUTOFF = 0;
 
-// see setupLocalPageInfo() in page_decode.cuh for supported page encodings
+// see setup_local_page_info() in page_decode.cuh for supported page encodings
 CUDF_HOST_DEVICE constexpr bool is_supported_encoding(Encoding enc)
 {
   switch (enc) {
@@ -697,11 +697,11 @@ __device__ inline bool is_repeated_run(int const run_header) { return !is_litera
  * @param[out] error_code Error code for kernel failures
  * @param[in] stream CUDA stream to use
  */
-void DecodePageHeaders(ColumnChunkDesc* chunks,
-                       chunk_page_info* chunk_pages,
-                       int32_t num_chunks,
-                       kernel_error::pointer error_code,
-                       rmm::cuda_stream_view stream);
+void launch_decode_page_headers(ColumnChunkDesc* chunks,
+                                chunk_page_info* chunk_pages,
+                                int32_t num_chunks,
+                                kernel_error::pointer error_code,
+                                rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for building the dictionary index for the column
@@ -711,9 +711,9 @@ void DecodePageHeaders(ColumnChunkDesc* chunks,
  * @param[in] num_chunks Number of column chunks
  * @param[in] stream CUDA stream to use
  */
-void BuildStringDictionaryIndex(ColumnChunkDesc* chunks,
-                                int32_t num_chunks,
-                                rmm::cuda_stream_view stream);
+void launch_build_string_dictionary_index(ColumnChunkDesc* chunks,
+                                          int32_t num_chunks,
+                                          rmm::cuda_stream_view stream);
 
 /**
  * @brief Get the set of kernels that need to be invoked on these pages as a bitmask.
@@ -802,14 +802,14 @@ void ComputePageStringSizes(cudf::detail::hostdevice_span<PageInfo> pages,
  * @param[out] error_code Error code for kernel failures
  * @param[in] stream CUDA stream to use
  */
-void DecodePageData(cudf::detail::hostdevice_span<PageInfo> pages,
-                    cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
-                    size_t num_rows,
-                    size_t min_row,
-                    int level_type_size,
-                    cudf::device_span<bool const> page_mask,
-                    kernel_error::pointer error_code,
-                    rmm::cuda_stream_view stream);
+void launch_decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
+                             cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+                             size_t num_rows,
+                             size_t min_row,
+                             int level_type_size,
+                             cudf::device_span<bool const> page_mask,
+                             kernel_error::pointer error_code,
+                             rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for reading the BYTE_STREAM_SPLIT column data stored in the pages
@@ -826,14 +826,14 @@ void DecodePageData(cudf::detail::hostdevice_span<PageInfo> pages,
  * @param[out] error_code Error code for kernel failures
  * @param[in] stream CUDA stream to use
  */
-void DecodeSplitPageData(cudf::detail::hostdevice_span<PageInfo> pages,
-                         cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
-                         size_t num_rows,
-                         size_t min_row,
-                         int level_type_size,
-                         cudf::device_span<bool const> page_mask,
-                         kernel_error::pointer error_code,
-                         rmm::cuda_stream_view stream);
+void launch_decode_split_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
+                                   cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+                                   size_t num_rows,
+                                   size_t min_row,
+                                   int level_type_size,
+                                   cudf::device_span<bool const> page_mask,
+                                   kernel_error::pointer error_code,
+                                   rmm::cuda_stream_view stream);
 
 /**
  * @brief Writes the final offsets to the corresponding list and string buffer end addresses in a
@@ -862,14 +862,14 @@ void WriteFinalOffsets(host_span<size_type const> offsets,
  * @param[out] error_code Error code for kernel failures
  * @param[in] stream CUDA stream to use
  */
-void DecodeDeltaBinary(cudf::detail::hostdevice_span<PageInfo> pages,
-                       cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
-                       size_t num_rows,
-                       size_t min_row,
-                       int level_type_size,
-                       cudf::device_span<bool const> page_mask,
-                       kernel_error::pointer error_code,
-                       rmm::cuda_stream_view stream);
+void launch_decode_delta_binary(cudf::detail::hostdevice_span<PageInfo> pages,
+                                cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+                                size_t num_rows,
+                                size_t min_row,
+                                int level_type_size,
+                                cudf::device_span<bool const> page_mask,
+                                kernel_error::pointer error_code,
+                                rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for reading the DELTA_BYTE_ARRAY column data stored in the pages
@@ -887,15 +887,15 @@ void DecodeDeltaBinary(cudf::detail::hostdevice_span<PageInfo> pages,
  * @param[out] error_code Error code for kernel failures
  * @param[in] stream CUDA stream to use
  */
-void DecodeDeltaByteArray(cudf::detail::hostdevice_span<PageInfo> pages,
-                          cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
-                          size_t num_rows,
-                          size_t min_row,
-                          int level_type_size,
-                          cudf::device_span<bool const> page_mask,
-                          cudf::device_span<size_t> initial_str_offsets,
-                          kernel_error::pointer error_code,
-                          rmm::cuda_stream_view stream);
+void launch_decode_delta_byte_array(cudf::detail::hostdevice_span<PageInfo> pages,
+                                    cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+                                    size_t num_rows,
+                                    size_t min_row,
+                                    int level_type_size,
+                                    cudf::device_span<bool const> page_mask,
+                                    cudf::device_span<size_t> initial_str_offsets,
+                                    kernel_error::pointer error_code,
+                                    rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for reading the DELTA_LENGTH_BYTE_ARRAY column data stored in the pages
@@ -913,15 +913,16 @@ void DecodeDeltaByteArray(cudf::detail::hostdevice_span<PageInfo> pages,
  * @param[out] error_code Error code for kernel failures
  * @param[in] stream CUDA stream to use
  */
-void DecodeDeltaLengthByteArray(cudf::detail::hostdevice_span<PageInfo> pages,
-                                cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
-                                size_t num_rows,
-                                size_t min_row,
-                                int level_type_size,
-                                cudf::device_span<bool const> page_mask,
-                                cudf::device_span<size_t> initial_str_offsets,
-                                kernel_error::pointer error_code,
-                                rmm::cuda_stream_view stream);
+void launch_decode_delta_length_byte_array(
+  cudf::detail::hostdevice_span<PageInfo> pages,
+  cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+  size_t num_rows,
+  size_t min_row,
+  int level_type_size,
+  cudf::device_span<bool const> page_mask,
+  cudf::device_span<size_t> initial_str_offsets,
+  kernel_error::pointer error_code,
+  rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for reading non-dictionary fixed width column data stored in the pages
@@ -940,16 +941,16 @@ void DecodeDeltaLengthByteArray(cudf::detail::hostdevice_span<PageInfo> pages,
  * @param[out] error_code Error code for kernel failures
  * @param[in] stream CUDA stream to use
  */
-void DecodePageData(cudf::detail::hostdevice_span<PageInfo> pages,
-                    cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
-                    size_t num_rows,
-                    size_t min_row,
-                    int level_type_size,
-                    decode_kernel_mask kernel_mask,
-                    cudf::device_span<bool const> page_mask,
-                    cudf::device_span<size_t> initial_str_offsets,
-                    kernel_error::pointer error_code,
-                    rmm::cuda_stream_view stream);
+void launch_decode_page_data(cudf::detail::hostdevice_span<PageInfo> pages,
+                             cudf::detail::hostdevice_span<ColumnChunkDesc const> chunks,
+                             size_t num_rows,
+                             size_t min_row,
+                             int level_type_size,
+                             decode_kernel_mask kernel_mask,
+                             cudf::device_span<bool const> page_mask,
+                             cudf::device_span<size_t> initial_str_offsets,
+                             kernel_error::pointer error_code,
+                             rmm::cuda_stream_view stream);
 
 /**
  * @brief Launches kernel for initializing encoder row group fragments

--- a/cpp/src/io/parquet/reader_impl.hpp
+++ b/cpp/src/io/parquet/reader_impl.hpp
@@ -223,7 +223,7 @@ class reader::impl {
    * - The total sizes of all output columns at all nesting levels
    * - The starting output buffer offset for each page, for each nesting level
    *
-   * For flat schemas, these values are computed during header decoding (see gpuDecodePageHeaders).
+   * For flat schemas, these values are computed during header decoding (see decode_page_headers).
    *
    * @param read_mode Value indicating if the data sources are read all at once or chunk by chunk
    * @param chunk_read_limit Limit on total number of bytes to be returned per read,

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -303,7 +303,8 @@ void generate_depth_remappings(
 
   kernel_error error_code(stream);
   chunks.host_to_device_async(stream);
-  DecodePageHeaders(chunks.device_ptr(), nullptr, chunks.size(), error_code.data(), stream);
+  launch_decode_page_headers(
+    chunks.device_ptr(), nullptr, chunks.size(), error_code.data(), stream);
   chunks.device_to_host(stream);
 
   // It's required to ignore unsupported encodings in this function
@@ -582,11 +583,11 @@ void decode_page_headers(pass_intermediate_data& pass,
                    });
 
   kernel_error error_code(stream);
-  DecodePageHeaders(pass.chunks.d_begin(),
-                    d_chunk_page_info.begin(),
-                    pass.chunks.size(),
-                    error_code.data(),
-                    stream);
+  launch_decode_page_headers(pass.chunks.d_begin(),
+                             d_chunk_page_info.begin(),
+                             pass.chunks.size(),
+                             error_code.data(),
+                             stream);
 
   if (auto const error = error_code.value_sync(stream); error != 0) {
     if (BitAnd(error, decode_error::UNSUPPORTED_ENCODING) != 0) {
@@ -784,7 +785,7 @@ void reader::impl::build_string_dict_indices()
     set_str_dict_index_ptr{pass.str_dict_index.data(), str_dict_index_offsets, pass.chunks});
 
   // compute the indices
-  BuildStringDictionaryIndex(pass.chunks.device_ptr(), pass.chunks.size(), _stream);
+  launch_build_string_dictionary_index(pass.chunks.device_ptr(), pass.chunks.size(), _stream);
   pass.chunks.device_to_host(_stream);
 }
 


### PR DESCRIPTION
## Description

This PR is a part of many PRs targeted to improve parquet decoders code. 

Here, the changes include using cooperative groups (CGs) in favor of raw cuda primitives, eliminating magic numbers and hard coded calculations, renaming functions to libcudf standards, and adding docs. 

Note: This PR does and must not include any logical changes 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
