### PR TITLE
Refactor JNI error handling

### DIFF
--- a/java/src/main/native/include/error.hpp
+++ b/java/src/main/native/include/error.hpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/detail/error.hpp>
+
+#include <jni.h>
+
+namespace cudf::jni {
+constexpr char const* CUDA_ERROR_CLASS          = "ai/rapids/cudf/CudaException";
+constexpr char const* CUDA_FATAL_ERROR_CLASS    = "ai/rapids/cudf/CudaFatalException";
+constexpr char const* CUDF_ERROR_CLASS          = "ai/rapids/cudf/CudfException";
+constexpr char const* CUDF_OVERFLOW_ERROR_CLASS = "ai/rapids/cudf/CudfColumnSizeOverflowException";
+constexpr char const* CUDF_DTYPE_ERROR_CLASS    = "ai/rapids/cudf/CudfException";
+constexpr char const* INDEX_OOB_CLASS           = "java/lang/ArrayIndexOutOfBoundsException";
+constexpr char const* ILLEGAL_ARG_CLASS         = "java/lang/IllegalArgumentException";
+constexpr char const* NPE_CLASS                 = "java/lang/NullPointerException";
+constexpr char const* OOM_CLASS                 = "java/lang/OutOfMemoryError";
+
+/**
+ * @brief indicates that a JNI error of some kind was thrown and the main
+ * function should return.
+ */
+class jni_exception : public std::runtime_error {
+ public:
+  jni_exception(char const* const message) : std::runtime_error(message) {}
+
+  jni_exception(std::string const& message) : std::runtime_error(message) {}
+};
+
+/**
+ * @brief throw a java exception and a C++ one for flow control.
+ */
+inline void throw_java_exception(JNIEnv* const env, char const* class_name, char const* message)
+{
+  jclass ex_class = env->FindClass(class_name);
+  if (ex_class != NULL) { env->ThrowNew(ex_class, message); }
+  throw jni_exception(message);
+}
+
+/**
+ * @brief check if an java exceptions have been thrown and if so throw a C++
+ * exception so the flow control stop processing.
+ */
+inline void check_java_exception(JNIEnv* const env)
+{
+  if (env->ExceptionCheck()) {
+    // Not going to try to get the message out of the Exception, too complex and
+    // might fail.
+    throw jni_exception("JNI Exception...");
+  }
+}
+
+/**
+ * @brief create a cuda exception from a given cudaError_t
+ */
+inline jthrowable cuda_exception(JNIEnv* const env, cudaError_t status, jthrowable cause = NULL)
+{
+  char const* ex_class_name;
+
+  // Calls cudaGetLastError twice. It is nearly certain that a fatal error occurred if the second
+  // call doesn't return with cudaSuccess.
+  cudaGetLastError();
+  auto const last = cudaGetLastError();
+  // Call cudaDeviceSynchronize to ensure `last` did not result from an asynchronous error.
+  // between two calls.
+  if (status == last && last == cudaDeviceSynchronize()) {
+    ex_class_name = cudf::jni::CUDA_FATAL_ERROR_CLASS;
+  } else {
+    ex_class_name = cudf::jni::CUDA_ERROR_CLASS;
+  }
+
+  jclass ex_class = env->FindClass(ex_class_name);
+  if (ex_class == NULL) { return NULL; }
+  jmethodID ctor_id =
+    env->GetMethodID(ex_class, "<init>", "(Ljava/lang/String;ILjava/lang/Throwable;)V");
+  if (ctor_id == NULL) { return NULL; }
+
+  jstring msg = env->NewStringUTF(cudaGetErrorString(status));
+  if (msg == NULL) { return NULL; }
+
+  jint err_code = static_cast<jint>(status);
+
+  jobject ret = env->NewObject(ex_class, ctor_id, msg, err_code, cause);
+  return (jthrowable)ret;
+}
+
+inline void jni_cuda_check(JNIEnv* const env, cudaError_t cuda_status)
+{
+  if (cudaSuccess != cuda_status) {
+    jthrowable jt = cuda_exception(env, cuda_status);
+    if (jt != NULL) { env->Throw(jt); }
+    throw jni_exception(std::string("CUDA ERROR: code ") +
+                        std::to_string(static_cast<int>(cuda_status)));
+  }
+}
+}  // namespace cudf::jni
+
+#define JNI_EXCEPTION_OCCURRED_CHECK(env, ret_val)    \
+  {                                                   \
+    if (env->ExceptionOccurred()) { return ret_val; } \
+  }
+
+#define JNI_THROW_NEW(env, class_name, message, ret_val) \
+  {                                                      \
+    jclass ex_class = env->FindClass(class_name);        \
+    if (ex_class == NULL) { return ret_val; }            \
+    env->ThrowNew(ex_class, message);                    \
+    return ret_val;                                      \
+  }
+
+// Throw a new exception only if one is not pending then always return with the specified value
+#define JNI_CHECK_THROW_CUDF_EXCEPTION(env, class_name, message, stacktrace, ret_val)           \
+  {                                                                                             \
+    JNI_EXCEPTION_OCCURRED_CHECK(env, ret_val);                                                 \
+    auto const ex_class = env->FindClass(class_name);                                           \
+    if (ex_class == nullptr) { return ret_val; }                                                \
+    auto const ctor_id =                                                                        \
+      env->GetMethodID(ex_class, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");          \
+    if (ctor_id == nullptr) { return ret_val; }                                                 \
+    auto const empty_str = std::string{""};                                                     \
+    auto const jmessage  = env->NewStringUTF(message == nullptr ? empty_str.c_str() : message); \
+    if (jmessage == nullptr) { return ret_val; }                                                \
+    auto const jstacktrace =                                                                    \
+      env->NewStringUTF(stacktrace == nullptr ? empty_str.c_str() : stacktrace);                \
+    if (jstacktrace == nullptr) { return ret_val; }                                             \
+    auto const jobj = env->NewObject(ex_class, ctor_id, jmessage, jstacktrace);                 \
+    if (jobj == nullptr) { return ret_val; }                                                    \
+    env->Throw(reinterpret_cast<jthrowable>(jobj));                                             \
+    return ret_val;                                                                             \
+  }
+
+// Throw a new exception only if one is not pending then always return with the specified value
+#define JNI_CHECK_THROW_CUDA_EXCEPTION(env, class_name, message, stacktrace, error_code, ret_val)   \
+  {                                                                                                 \
+    JNI_EXCEPTION_OCCURRED_CHECK(env, ret_val);                                                     \
+    auto const ex_class = env->FindClass(class_name);                                               \
+    if (ex_class == nullptr) { return ret_val; }                                                    \
+    auto const ctor_id =                                                                            \
+      env->GetMethodID(ex_class, "<init>", "(Ljava/lang/String;Ljava/lang/String;I)V");             \
+    if (ctor_id == nullptr) { return ret_val; }                                                     \
+    auto const empty_str = std::string{""};                                                         \
+    auto const jmessage  = env->NewStringUTF(message == nullptr ? empty_str.c_str() : message);     \
+    if (jmessage == nullptr) { return ret_val; }                                                    \
+    auto const jstacktrace =                                                                        \
+      env->NewStringUTF(stacktrace == nullptr ? empty_str.c_str() : stacktrace);                    \
+    if (jstacktrace == nullptr) { return ret_val; }                                                 \
+    auto const jerror_code = static_cast<jint>(error_code);                                         \
+    auto const jobj        = env->NewObject(ex_class, ctor_id, jmessage, jstacktrace, jerror_code); \
+    if (jobj == nullptr) { return ret_val; }                                                        \
+    env->Throw(reinterpret_cast<jthrowable>(jobj));                                                 \
+    return ret_val;                                                                                 \
+  }
+
+#define JNI_NULL_CHECK(env, obj, error_msg, ret_val)                                  \
+  {                                                                                   \
+    if ((obj) == 0) { JNI_THROW_NEW(env, cudf::jni::NPE_CLASS, error_msg, ret_val); } \
+  }
+
+#define JNI_ARG_CHECK(env, obj, error_msg, ret_val)                                       \
+  {                                                                                       \
+    if (!(obj)) { JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, error_msg, ret_val); } \
+  }
+
+#define CATCH_STD_CLASS(env, class_name, ret_val)                                                 \
+  catch (const rmm::out_of_memory& e)                                                             \
+  {                                                                                               \
+    JNI_EXCEPTION_OCCURRED_CHECK(env, ret_val);                                                   \
+    auto const what =                                                                             \
+      std::string("Could not allocate native memory: ") + (e.what() == nullptr ? "" : e.what());  \
+    JNI_THROW_NEW(env, cudf::jni::OOM_CLASS, what.c_str(), ret_val);                              \
+  }                                                                                               \
+  catch (const cudf::fatal_cuda_error& e)                                                         \
+  {                                                                                               \
+    JNI_CHECK_THROW_CUDA_EXCEPTION(                                                               \
+      env, cudf::jni::CUDA_FATAL_ERROR_CLASS, e.what(), e.stacktrace(), e.error_code(), ret_val); \
+  }                                                                                               \
+  catch (const cudf::cuda_error& e)                                                               \
+  {                                                                                               \
+    JNI_CHECK_THROW_CUDA_EXCEPTION(                                                               \
+      env, cudf::jni::CUDA_ERROR_CLASS, e.what(), e.stacktrace(), e.error_code(), ret_val);       \
+  }                                                                                               \
+  catch (const cudf::data_type_error& e)                                                          \
+  {                                                                                               \
+    JNI_CHECK_THROW_CUDF_EXCEPTION(                                                               \
+      env, cudf::jni::CUDF_DTYPE_ERROR_CLASS, e.what(), e.stacktrace(), ret_val);                 \
+  }                                                                                               \
+  catch (std::overflow_error const& e)                                                            \
+  {                                                                                               \
+    JNI_CHECK_THROW_CUDF_EXCEPTION(env,                                                           \
+                                   cudf::jni::CUDF_OVERFLOW_ERROR_CLASS,                          \
+                                   e.what(),                                                      \
+                                   "No native stacktrace is available.",                          \
+                                   ret_val);                                                      \
+  }                                                                                               \
+  catch (const std::exception& e)                                                                 \
+  {                                                                                               \
+    char const* stacktrace = "No native stacktrace is available.";                                \
+    if (auto const cudf_ex = dynamic_cast<cudf::logic_error const*>(&e); cudf_ex != nullptr) {    \
+      stacktrace = cudf_ex->stacktrace();                                                         \
+    }                                                                                             \
+    /* Double check whether the thrown exception is unrecoverable CUDA error or not. */           \
+    /* Like cudf::detail::throw_cuda_error, it is nearly certain that a fatal error  */           \
+    /* occurred if the second call doesn't return with cudaSuccess. */                            \
+    cudaGetLastError();                                                                           \
+    auto const last = cudaFree(0);                                                                \
+    if (cudaSuccess != last && last == cudaDeviceSynchronize()) {                                 \
+      /* Throw CudaFatalException since the thrown exception is unrecoverable CUDA error */       \
+      JNI_CHECK_THROW_CUDA_EXCEPTION(                                                             \
+        env, cudf::jni::CUDA_FATAL_ERROR_CLASS, e.what(), stacktrace, last, ret_val);             \
+    }                                                                                             \
+    JNI_CHECK_THROW_CUDF_EXCEPTION(env, class_name, e.what(), stacktrace, ret_val);               \
+  }
+
+#define CATCH_STD(env, ret_val) CATCH_STD_CLASS(env, cudf::jni::CUDF_ERROR_CLASS, ret_val)

--- a/java/src/main/native/include/error.hpp
+++ b/java/src/main/native/include/error.hpp
@@ -35,8 +35,12 @@ constexpr char const* CUDF_OVERFLOW_EXCEPTION_CLASS =
 constexpr char const* INDEX_OOB_EXCEPTION_CLASS   = "java/lang/ArrayIndexOutOfBoundsException";
 constexpr char const* ILLEGAL_ARG_EXCEPTION_CLASS = "java/lang/IllegalArgumentException";
 constexpr char const* NPE_EXCEPTION_CLASS         = "java/lang/NullPointerException";
-constexpr char const* OOM_EXCEPTION_CLASS         = "java/lang/OutOfMemoryError";
+constexpr char const* RUNTIME_EXCEPTION_CLASS     = "java/lang/RuntimeException";
 constexpr char const* UNSUPPORTED_EXCEPTION_CLASS = "java/lang/UnsupportedOperationException";
+
+// Java error classes.
+// An error is a serious problem and the applications should not expect to recover from it.
+constexpr char const* OOM_ERROR_CLASS = "java/lang/OutOfMemoryError";
 
 /**
  * @brief indicates that a JNI error of some kind was thrown and the main
@@ -191,7 +195,7 @@ inline void jni_cuda_check(JNIEnv* const env, cudaError_t cuda_status)
     JNI_EXCEPTION_OCCURRED_CHECK(env, ret_val);                                                  \
     auto const what =                                                                            \
       std::string("Could not allocate native memory: ") + (e.what() == nullptr ? "" : e.what()); \
-    JNI_THROW_NEW(env, cudf::jni::OOM_EXCEPTION_CLASS, what.c_str(), ret_val);                   \
+    JNI_THROW_NEW(env, cudf::jni::OOM_ERROR_CLASS, what.c_str(), ret_val);                       \
   }                                                                                              \
   catch (const cudf::fatal_cuda_error& e)                                                        \
   {                                                                                              \

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,65 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
-#include <cudf/utilities/error.hpp>
-
-#include <rmm/detail/error.hpp>
-
-#include <jni.h>
+#include "error.hpp"
 
 #include <algorithm>
 #include <memory>
 #include <vector>
 
-namespace cudf {
-namespace jni {
-
+namespace cudf::jni {
 constexpr jint MINIMUM_JNI_VERSION = JNI_VERSION_1_6;
-
-constexpr char const* CUDA_ERROR_CLASS          = "ai/rapids/cudf/CudaException";
-constexpr char const* CUDA_FATAL_ERROR_CLASS    = "ai/rapids/cudf/CudaFatalException";
-constexpr char const* CUDF_ERROR_CLASS          = "ai/rapids/cudf/CudfException";
-constexpr char const* CUDF_OVERFLOW_ERROR_CLASS = "ai/rapids/cudf/CudfColumnSizeOverflowException";
-constexpr char const* CUDF_DTYPE_ERROR_CLASS    = "ai/rapids/cudf/CudfException";
-constexpr char const* INDEX_OOB_CLASS           = "java/lang/ArrayIndexOutOfBoundsException";
-constexpr char const* ILLEGAL_ARG_CLASS         = "java/lang/IllegalArgumentException";
-constexpr char const* NPE_CLASS                 = "java/lang/NullPointerException";
-constexpr char const* OOM_CLASS                 = "java/lang/OutOfMemoryError";
-
-/**
- * @brief indicates that a JNI error of some kind was thrown and the main
- * function should return.
- */
-class jni_exception : public std::runtime_error {
- public:
-  jni_exception(char const* const message) : std::runtime_error(message) {}
-  jni_exception(std::string const& message) : std::runtime_error(message) {}
-};
-
-/**
- * @brief throw a java exception and a C++ one for flow control.
- */
-inline void throw_java_exception(JNIEnv* const env, char const* class_name, char const* message)
-{
-  jclass ex_class = env->FindClass(class_name);
-  if (ex_class != NULL) { env->ThrowNew(ex_class, message); }
-  throw jni_exception(message);
-}
-
-/**
- * @brief check if an java exceptions have been thrown and if so throw a C++
- * exception so the flow control stop processing.
- */
-inline void check_java_exception(JNIEnv* const env)
-{
-  if (env->ExceptionCheck()) {
-    // Not going to try to get the message out of the Exception, too complex and
-    // might fail.
-    throw jni_exception("JNI Exception...");
-  }
-}
 
 /**
  * @brief Helper to convert a pointer to a jlong.
@@ -782,50 +734,6 @@ class native_jstringArray {
   }
 };
 
-/**
- * @brief create a cuda exception from a given cudaError_t
- */
-inline jthrowable cuda_exception(JNIEnv* const env, cudaError_t status, jthrowable cause = NULL)
-{
-  char const* ex_class_name;
-
-  // Calls cudaGetLastError twice. It is nearly certain that a fatal error occurred if the second
-  // call doesn't return with cudaSuccess.
-  cudaGetLastError();
-  auto const last = cudaGetLastError();
-  // Call cudaDeviceSynchronize to ensure `last` did not result from an asynchronous error.
-  // between two calls.
-  if (status == last && last == cudaDeviceSynchronize()) {
-    ex_class_name = cudf::jni::CUDA_FATAL_ERROR_CLASS;
-  } else {
-    ex_class_name = cudf::jni::CUDA_ERROR_CLASS;
-  }
-
-  jclass ex_class = env->FindClass(ex_class_name);
-  if (ex_class == NULL) { return NULL; }
-  jmethodID ctor_id =
-    env->GetMethodID(ex_class, "<init>", "(Ljava/lang/String;ILjava/lang/Throwable;)V");
-  if (ctor_id == NULL) { return NULL; }
-
-  jstring msg = env->NewStringUTF(cudaGetErrorString(status));
-  if (msg == NULL) { return NULL; }
-
-  jint err_code = static_cast<jint>(status);
-
-  jobject ret = env->NewObject(ex_class, ctor_id, msg, err_code, cause);
-  return (jthrowable)ret;
-}
-
-inline void jni_cuda_check(JNIEnv* const env, cudaError_t cuda_status)
-{
-  if (cudaSuccess != cuda_status) {
-    jthrowable jt = cuda_exception(env, cuda_status);
-    if (jt != NULL) { env->Throw(jt); }
-    throw jni_exception(std::string("CUDA ERROR: code ") +
-                        std::to_string(static_cast<int>(cuda_status)));
-  }
-}
-
 inline auto add_global_ref(JNIEnv* env, jobject jobj)
 {
   auto new_global_ref = env->NewGlobalRef(jobj);
@@ -838,124 +746,4 @@ inline nullptr_t del_global_ref(JNIEnv* env, jobject jobj)
   if (jobj != nullptr) { env->DeleteGlobalRef(jobj); }
   return nullptr;
 }
-
-}  // namespace jni
-}  // namespace cudf
-
-#define JNI_EXCEPTION_OCCURRED_CHECK(env, ret_val)    \
-  {                                                   \
-    if (env->ExceptionOccurred()) { return ret_val; } \
-  }
-
-#define JNI_THROW_NEW(env, class_name, message, ret_val) \
-  {                                                      \
-    jclass ex_class = env->FindClass(class_name);        \
-    if (ex_class == NULL) { return ret_val; }            \
-    env->ThrowNew(ex_class, message);                    \
-    return ret_val;                                      \
-  }
-
-// Throw a new exception only if one is not pending then always return with the specified value
-#define JNI_CHECK_THROW_CUDF_EXCEPTION(env, class_name, message, stacktrace, ret_val)           \
-  {                                                                                             \
-    JNI_EXCEPTION_OCCURRED_CHECK(env, ret_val);                                                 \
-    auto const ex_class = env->FindClass(class_name);                                           \
-    if (ex_class == nullptr) { return ret_val; }                                                \
-    auto const ctor_id =                                                                        \
-      env->GetMethodID(ex_class, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");          \
-    if (ctor_id == nullptr) { return ret_val; }                                                 \
-    auto const empty_str = std::string{""};                                                     \
-    auto const jmessage  = env->NewStringUTF(message == nullptr ? empty_str.c_str() : message); \
-    if (jmessage == nullptr) { return ret_val; }                                                \
-    auto const jstacktrace =                                                                    \
-      env->NewStringUTF(stacktrace == nullptr ? empty_str.c_str() : stacktrace);                \
-    if (jstacktrace == nullptr) { return ret_val; }                                             \
-    auto const jobj = env->NewObject(ex_class, ctor_id, jmessage, jstacktrace);                 \
-    if (jobj == nullptr) { return ret_val; }                                                    \
-    env->Throw(reinterpret_cast<jthrowable>(jobj));                                             \
-    return ret_val;                                                                             \
-  }
-
-// Throw a new exception only if one is not pending then always return with the specified value
-#define JNI_CHECK_THROW_CUDA_EXCEPTION(env, class_name, message, stacktrace, error_code, ret_val)   \
-  {                                                                                                 \
-    JNI_EXCEPTION_OCCURRED_CHECK(env, ret_val);                                                     \
-    auto const ex_class = env->FindClass(class_name);                                               \
-    if (ex_class == nullptr) { return ret_val; }                                                    \
-    auto const ctor_id =                                                                            \
-      env->GetMethodID(ex_class, "<init>", "(Ljava/lang/String;Ljava/lang/String;I)V");             \
-    if (ctor_id == nullptr) { return ret_val; }                                                     \
-    auto const empty_str = std::string{""};                                                         \
-    auto const jmessage  = env->NewStringUTF(message == nullptr ? empty_str.c_str() : message);     \
-    if (jmessage == nullptr) { return ret_val; }                                                    \
-    auto const jstacktrace =                                                                        \
-      env->NewStringUTF(stacktrace == nullptr ? empty_str.c_str() : stacktrace);                    \
-    if (jstacktrace == nullptr) { return ret_val; }                                                 \
-    auto const jerror_code = static_cast<jint>(error_code);                                         \
-    auto const jobj        = env->NewObject(ex_class, ctor_id, jmessage, jstacktrace, jerror_code); \
-    if (jobj == nullptr) { return ret_val; }                                                        \
-    env->Throw(reinterpret_cast<jthrowable>(jobj));                                                 \
-    return ret_val;                                                                                 \
-  }
-
-#define JNI_NULL_CHECK(env, obj, error_msg, ret_val)                                  \
-  {                                                                                   \
-    if ((obj) == 0) { JNI_THROW_NEW(env, cudf::jni::NPE_CLASS, error_msg, ret_val); } \
-  }
-
-#define JNI_ARG_CHECK(env, obj, error_msg, ret_val)                                       \
-  {                                                                                       \
-    if (!(obj)) { JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, error_msg, ret_val); } \
-  }
-
-#define CATCH_STD_CLASS(env, class_name, ret_val)                                                 \
-  catch (const rmm::out_of_memory& e)                                                             \
-  {                                                                                               \
-    JNI_EXCEPTION_OCCURRED_CHECK(env, ret_val);                                                   \
-    auto const what =                                                                             \
-      std::string("Could not allocate native memory: ") + (e.what() == nullptr ? "" : e.what());  \
-    JNI_THROW_NEW(env, cudf::jni::OOM_CLASS, what.c_str(), ret_val);                              \
-  }                                                                                               \
-  catch (const cudf::fatal_cuda_error& e)                                                         \
-  {                                                                                               \
-    JNI_CHECK_THROW_CUDA_EXCEPTION(                                                               \
-      env, cudf::jni::CUDA_FATAL_ERROR_CLASS, e.what(), e.stacktrace(), e.error_code(), ret_val); \
-  }                                                                                               \
-  catch (const cudf::cuda_error& e)                                                               \
-  {                                                                                               \
-    JNI_CHECK_THROW_CUDA_EXCEPTION(                                                               \
-      env, cudf::jni::CUDA_ERROR_CLASS, e.what(), e.stacktrace(), e.error_code(), ret_val);       \
-  }                                                                                               \
-  catch (const cudf::data_type_error& e)                                                          \
-  {                                                                                               \
-    JNI_CHECK_THROW_CUDF_EXCEPTION(                                                               \
-      env, cudf::jni::CUDF_DTYPE_ERROR_CLASS, e.what(), e.stacktrace(), ret_val);                 \
-  }                                                                                               \
-  catch (std::overflow_error const& e)                                                            \
-  {                                                                                               \
-    JNI_CHECK_THROW_CUDF_EXCEPTION(env,                                                           \
-                                   cudf::jni::CUDF_OVERFLOW_ERROR_CLASS,                          \
-                                   e.what(),                                                      \
-                                   "No native stacktrace is available.",                          \
-                                   ret_val);                                                      \
-  }                                                                                               \
-  catch (const std::exception& e)                                                                 \
-  {                                                                                               \
-    char const* stacktrace = "No native stacktrace is available.";                                \
-    if (auto const cudf_ex = dynamic_cast<cudf::logic_error const*>(&e); cudf_ex != nullptr) {    \
-      stacktrace = cudf_ex->stacktrace();                                                         \
-    }                                                                                             \
-    /* Double check whether the thrown exception is unrecoverable CUDA error or not. */           \
-    /* Like cudf::detail::throw_cuda_error, it is nearly certain that a fatal error  */           \
-    /* occurred if the second call doesn't return with cudaSuccess. */                            \
-    cudaGetLastError();                                                                           \
-    auto const last = cudaFree(0);                                                                \
-    if (cudaSuccess != last && last == cudaDeviceSynchronize()) {                                 \
-      /* Throw CudaFatalException since the thrown exception is unrecoverable CUDA error */       \
-      JNI_CHECK_THROW_CUDA_EXCEPTION(                                                             \
-        env, cudf::jni::CUDA_FATAL_ERROR_CLASS, e.what(), stacktrace, last, ret_val);             \
-    }                                                                                             \
-    JNI_CHECK_THROW_CUDF_EXCEPTION(env, class_name, e.what(), stacktrace, ret_val);               \
-  }
-
-#define CATCH_STD(env, ret_val) CATCH_STD_CLASS(env, cudf::jni::CUDF_ERROR_CLASS, ret_val)
+}  // namespace cudf::jni

--- a/java/src/main/native/include/jni_utils.hpp
+++ b/java/src/main/native/include/jni_utils.hpp
@@ -224,15 +224,19 @@ class native_jArray {
 
   N_TYPE operator[](int index) const
   {
-    if (orig == NULL) { throw_java_exception(env, NPE_CLASS, "pointer is NULL"); }
-    if (index < 0 || index >= len) { throw_java_exception(env, INDEX_OOB_CLASS, "NOT IN BOUNDS"); }
+    if (orig == NULL) { throw_java_exception(env, NPE_EXCEPTION_CLASS, "pointer is NULL"); }
+    if (index < 0 || index >= len) {
+      throw_java_exception(env, INDEX_OOB_EXCEPTION_CLASS, "NOT IN BOUNDS");
+    }
     return data()[index];
   }
 
   N_TYPE& operator[](int index)
   {
-    if (orig == NULL) { throw_java_exception(env, NPE_CLASS, "pointer is NULL"); }
-    if (index < 0 || index >= len) { throw_java_exception(env, INDEX_OOB_CLASS, "NOT IN BOUNDS"); }
+    if (orig == NULL) { throw_java_exception(env, NPE_EXCEPTION_CLASS, "pointer is NULL"); }
+    if (index < 0 || index >= len) {
+      throw_java_exception(env, INDEX_OOB_EXCEPTION_CLASS, "NOT IN BOUNDS");
+    }
     return data()[index];
   }
 
@@ -357,18 +361,18 @@ class native_jpointerArray {
 
   T* operator[](int index) const
   {
-    if (data() == NULL) { throw_java_exception(env, NPE_CLASS, "pointer is NULL"); }
+    if (data() == NULL) { throw_java_exception(env, NPE_EXCEPTION_CLASS, "pointer is NULL"); }
     if (index < 0 || index >= wrapped.size()) {
-      throw_java_exception(env, INDEX_OOB_CLASS, "NOT IN BOUNDS");
+      throw_java_exception(env, INDEX_OOB_EXCEPTION_CLASS, "NOT IN BOUNDS");
     }
     return data()[index];
   }
 
   T*& operator[](int index)
   {
-    if (data() == NULL) { throw_java_exception(env, NPE_CLASS, "pointer is NULL"); }
+    if (data() == NULL) { throw_java_exception(env, NPE_EXCEPTION_CLASS, "pointer is NULL"); }
     if (index < 0 || index >= wrapped.size()) {
-      throw_java_exception(env, INDEX_OOB_CLASS, "NOT IN BOUNDS");
+      throw_java_exception(env, INDEX_OOB_EXCEPTION_CLASS, "NOT IN BOUNDS");
     }
     return data()[index];
   }
@@ -385,7 +389,7 @@ class native_jpointerArray {
   void assert_no_nulls() const
   {
     if (std::any_of(data(), data() + size(), [](T* const ptr) { return ptr == nullptr; })) {
-      throw_java_exception(env, NPE_CLASS, "pointer is NULL");
+      throw_java_exception(env, NPE_EXCEPTION_CLASS, "pointer is NULL");
     }
   }
 
@@ -607,7 +611,9 @@ class native_jobjectArray {
 
   T get(int index) const
   {
-    if (orig == NULL) { throw_java_exception(env, NPE_CLASS, "jobjectArray pointer is NULL"); }
+    if (orig == NULL) {
+      throw_java_exception(env, NPE_EXCEPTION_CLASS, "jobjectArray pointer is NULL");
+    }
     T ret = static_cast<T>(env->GetObjectArrayElement(orig, index));
     check_java_exception(env);
     return ret;
@@ -615,7 +621,9 @@ class native_jobjectArray {
 
   void set(int index, T const& val)
   {
-    if (orig == NULL) { throw_java_exception(env, NPE_CLASS, "jobjectArray pointer is NULL"); }
+    if (orig == NULL) {
+      throw_java_exception(env, NPE_EXCEPTION_CLASS, "jobjectArray pointer is NULL");
+    }
     env->SetObjectArrayElement(orig, index, val);
     check_java_exception(env);
   }
@@ -695,7 +703,7 @@ class native_jstringArray {
   native_jstring& get(int index) const
   {
     if (arr.is_null()) {
-      throw_java_exception(env, cudf::jni::NPE_CLASS, "jstringArray pointer is NULL");
+      throw_java_exception(env, cudf::jni::NPE_EXCEPTION_CLASS, "jstringArray pointer is NULL");
     }
     init_cache();
     return cache[index];

--- a/java/src/main/native/src/ChunkedReaderJni.cpp
+++ b/java/src/main/native/src/ChunkedReaderJni.cpp
@@ -21,11 +21,9 @@
 #include <cudf/column/column.hpp>
 #include <cudf/io/orc.hpp>
 #include <cudf/io/parquet.hpp>
-#include <cudf/table/table.hpp>
 
 #include <memory>
 #include <optional>
-#include <vector>
 
 // This file is for the code related to chunked reader (Parquet, ORC, etc.).
 
@@ -55,7 +53,7 @@ Java_ai_rapids_cudf_ParquetChunkedReader_create(JNIEnv* env,
     read_buffer = false;
   } else if (inp_file_path != nullptr) {
     JNI_THROW_NEW(env,
-                  cudf::jni::ILLEGAL_ARG_CLASS,
+                  cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
                   "Cannot pass in both buffers and an inp_file_path",
                   nullptr);
   }
@@ -64,7 +62,8 @@ Java_ai_rapids_cudf_ParquetChunkedReader_create(JNIEnv* env,
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring filename(env, inp_file_path);
     if (!read_buffer && filename.is_empty()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "inp_file_path cannot be empty", nullptr);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "inp_file_path cannot be empty", nullptr);
     }
 
     cudf::jni::native_jstringArray n_filter_col_names(env, filter_col_names);
@@ -217,7 +216,8 @@ jlong create_chunked_orc_reader(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, buffer, "buffer is null", 0);
   if (buffer_length <= 0) {
-    JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "An empty buffer is not supported", 0);
+    JNI_THROW_NEW(
+      env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", 0);
   }
 
   try {

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -210,19 +210,19 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromArrow(JNIEnv* env,
 
     ArrowSchema sch;
     if (!arrow::ExportSchema(*arrow_table->schema(), &sch).ok()) {
-      JNI_THROW_NEW(env, "java/lang/RuntimeException", "Unable to produce an ArrowSchema", 0)
+      JNI_THROW_NEW(env, cudf::jni::RUNTIME_EXCEPTION_CLASS, "Unable to produce an ArrowSchema", 0)
     }
     auto batch = arrow_table->CombineChunksToBatch().ValueOrDie();
     ArrowArray arr;
     if (!arrow::ExportRecordBatch(*batch, &arr).ok()) {
-      JNI_THROW_NEW(env, "java/lang/RuntimeException", "Unable to produce an ArrowArray", 0)
+      JNI_THROW_NEW(env, cudf::jni::RUNTIME_EXCEPTION_CLASS, "Unable to produce an ArrowArray", 0)
     }
     auto retCols = cudf::from_arrow(&sch, &arr)->release();
     arr.release(&arr);
     sch.release(&sch);
 
     if (retCols.size() != 1) {
-      JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Must result in one column", 0);
+      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "Must result in one column", 0);
     }
     return release_as_jlong(retCols[0]);
   }

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -28,11 +28,9 @@
 #include <cudf/lists/combine.hpp>
 #include <cudf/lists/detail/concatenate.hpp>
 #include <cudf/lists/filling.hpp>
-#include <cudf/lists/lists_column_view.hpp>
 #include <cudf/reshape.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/strings/combine.hpp>
-#include <cudf/structs/structs_column_view.hpp>
 #include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
@@ -176,21 +174,25 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromArrow(JNIEnv* env,
     switch (n_type) {
       case cudf::type_id::DECIMAL32:
         JNI_THROW_NEW(
-          env, cudf::jni::ILLEGAL_ARG_CLASS, "Don't support converting DECIMAL32 yet", 0);
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "Don't support converting DECIMAL32 yet", 0);
         break;
       case cudf::type_id::DECIMAL64:
         JNI_THROW_NEW(
-          env, cudf::jni::ILLEGAL_ARG_CLASS, "Don't support converting DECIMAL64 yet", 0);
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "Don't support converting DECIMAL64 yet", 0);
         break;
       case cudf::type_id::STRUCT:
-        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Don't support converting STRUCT yet", 0);
+        JNI_THROW_NEW(
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "Don't support converting STRUCT yet", 0);
         break;
       case cudf::type_id::LIST:
-        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Don't support converting LIST yet", 0);
+        JNI_THROW_NEW(
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "Don't support converting LIST yet", 0);
         break;
       case cudf::type_id::DICTIONARY32:
-        JNI_THROW_NEW(
-          env, cudf::jni::ILLEGAL_ARG_CLASS, "Don't support converting DICTIONARY32 yet", 0);
+        JNI_THROW_NEW(env,
+                      cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                      "Don't support converting DICTIONARY32 yet",
+                      0);
         break;
       case cudf::type_id::STRING:
         arrow_array = std::make_shared<arrow::StringArray>(

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -803,8 +803,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_reverseStringsOrLists(JNI
         return release_as_jlong(cudf::lists::reverse(cudf::lists_column_view{*input}));
       default:
         JNI_THROW_NEW(env,
-                      "java/lang/IllegalArgumentException",
-                      "A column of type string or list is required for reverse()",
+                      cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                      "In of type string or list is required for reverse()",
                       0);
     }
   }
@@ -821,8 +821,10 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringSplit(
     // This is because cudf operates on a different parameter (`max_split`) which is converted from
     // limit. When limit == 0 or limit == 1, max_split will be non-positive and will result in an
     // unlimited split.
-    JNI_THROW_NEW(
-      env, "java/lang/IllegalArgumentException", "limit == 0 and limit == 1 are not supported", 0);
+    JNI_THROW_NEW(env,
+                  cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                  "limit == 0 and limit == 1 are not supported",
+                  0);
   }
 
   try {
@@ -853,8 +855,10 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRe(JNIEnv
     // This is because cudf operates on a different parameter (`max_split`) which is converted from
     // limit. When limit == 0 or limit == 1, max_split will be non-positive and will result in an
     // unlimited split.
-    JNI_THROW_NEW(
-      env, "java/lang/IllegalArgumentException", "limit == 0 and limit == 1 are not supported", 0);
+    JNI_THROW_NEW(env,
+                  cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                  "limit == 0 and limit == 1 are not supported",
+                  0);
   }
 
   try {
@@ -883,8 +887,10 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRecord(
     // This is because cudf operates on a different parameter (`max_split`) which is converted from
     // limit. When limit == 0 or limit == 1, max_split will be non-positive and will result in an
     // unlimited split.
-    JNI_THROW_NEW(
-      env, "java/lang/IllegalArgumentException", "limit == 0 and limit == 1 are not supported", 0);
+    JNI_THROW_NEW(env,
+                  cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                  "limit == 0 and limit == 1 are not supported",
+                  0);
   }
 
   try {
@@ -916,8 +922,10 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRecordRe(JNIEn
     // This is because cudf operates on a different parameter (`max_split`) which is converted from
     // limit. When limit == 0 or limit == 1, max_split will be non-positive and will result in an
     // unlimited split.
-    JNI_THROW_NEW(
-      env, "java/lang/IllegalArgumentException", "limit == 0 and limit == 1 are not supported", 0);
+    JNI_THROW_NEW(env,
+                  cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                  "limit == 0 and limit == 1 are not supported",
+                  0);
   }
 
   try {
@@ -1137,7 +1145,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractDateTimeComponent(
       case 7: comp = cudf::datetime::datetime_component::MILLISECOND; break;
       case 8: comp = cudf::datetime::datetime_component::MICROSECOND; break;
       case 9: comp = cudf::datetime::datetime_component::NANOSECOND; break;
-      default: JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Invalid component", 0);
+      default: JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "Invalid component", 0);
     }
     return release_as_jlong(cudf::datetime::extract_datetime_component(*input, comp));
   }
@@ -1316,7 +1324,7 @@ Java_ai_rapids_cudf_ColumnView_castTo(JNIEnv* env, jclass, jlong handle, jint ty
         case cudf::type_id::DECIMAL64:
         case cudf::type_id::DECIMAL128:
           return release_as_jlong(cudf::strings::from_fixed_point(*column));
-        default: JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Invalid data type", 0);
+        default: JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "Invalid data type", 0);
       }
     } else if (column->type().id() == cudf::type_id::STRING) {
       switch (n_data_type.id()) {
@@ -1340,7 +1348,7 @@ Java_ai_rapids_cudf_ColumnView_castTo(JNIEnv* env, jclass, jlong handle, jint ty
         case cudf::type_id::DECIMAL64:
         case cudf::type_id::DECIMAL128:
           return release_as_jlong(cudf::strings::to_fixed_point(*column, n_data_type));
-        default: JNI_THROW_NEW(env, "java/lang/IllegalArgumentException", "Invalid data type", 0);
+        default: JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "Invalid data type", 0);
       }
     } else if (cudf::is_timestamp(n_data_type) && cudf::is_numeric(column->type())) {
       // This is a temporary workaround to allow Java to cast from integral types into a timestamp
@@ -1349,14 +1357,14 @@ Java_ai_rapids_cudf_ColumnView_castTo(JNIEnv* env, jclass, jlong handle, jint ty
       if (n_data_type.id() == cudf::type_id::TIMESTAMP_DAYS) {
         if (column->type().id() != cudf::type_id::INT32) {
           JNI_THROW_NEW(env,
-                        "java/lang/IllegalArgumentException",
+                        cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
                         "Numeric cast to TIMESTAMP_DAYS requires INT32",
                         0);
         }
       } else {
         if (column->type().id() != cudf::type_id::INT64) {
           JNI_THROW_NEW(env,
-                        "java/lang/IllegalArgumentException",
+                        cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
                         "Numeric cast to non-day timestamp requires INT64",
                         0);
         }

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -26,14 +26,10 @@
 #include <cudf/column/column_factories.hpp>
 #include <cudf/concatenate.hpp>
 #include <cudf/datetime.hpp>
-#include <cudf/detail/null_mask.hpp>
-#include <cudf/filling.hpp>
-#include <cudf/hashing.hpp>
 #include <cudf/json/json.hpp>
 #include <cudf/lists/combine.hpp>
 #include <cudf/lists/contains.hpp>
 #include <cudf/lists/count_elements.hpp>
-#include <cudf/lists/detail/concatenate.hpp>
 #include <cudf/lists/extract.hpp>
 #include <cudf/lists/gather.hpp>
 #include <cudf/lists/lists_column_view.hpp>
@@ -48,7 +44,6 @@
 #include <cudf/reshape.hpp>
 #include <cudf/rolling.hpp>
 #include <cudf/round.hpp>
-#include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/search.hpp>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/strings/attributes.hpp>
@@ -2127,7 +2122,9 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
         copy->set_null_mask(std::move(new_bitmask), null_count);
         break;
       }
-      default: JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "Unsupported merge operation", 0);
+      default:
+        JNI_THROW_NEW(
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "Unsupported merge operation", 0);
     }
     auto const copy_cv = copy->view();
     if (cudf::has_nonempty_nulls(copy_cv)) { copy = cudf::purge_nonempty_nulls(copy_cv); }

--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-#include <cudf/utilities/error.hpp>
+#include "jni_utils.hpp"
 
 #include <rmm/device_buffer.hpp>
 
 #ifdef CUDF_JNI_ENABLE_PROFILING
 #include <cuda_profiler_api.h>
 #endif
-
-#include "jni_utils.hpp"
 
 namespace {
 
@@ -158,7 +156,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_setDevice(JNIEnv* env, jclass, j
   try {
     if (Cudf_device != cudaInvalidDeviceId && dev != Cudf_device) {
       cudf::jni::throw_java_exception(
-        env, cudf::jni::CUDF_ERROR_CLASS, "Cannot change device after RMM init");
+        env, cudf::jni::CUDF_EXCEPTION_CLASS, "Cannot change device after RMM init");
     }
     CUDF_CUDA_TRY(cudaSetDevice(dev));
   }
@@ -407,7 +405,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_profilerStart(JNIEnv* env, jclas
   CATCH_STD(env, );
 #else
   cudf::jni::throw_java_exception(
-    env, cudf::jni::CUDF_ERROR_CLASS, "This library was built without CUDA profiler support.");
+    env, cudf::jni::CUDF_EXCEPTION_CLASS, "This library was built without CUDA profiler support.");
 #endif
 }
 
@@ -420,7 +418,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_profilerStop(JNIEnv* env, jclass
   CATCH_STD(env, );
 #else
   cudf::jni::throw_java_exception(
-    env, cudf::jni::CUDF_ERROR_CLASS, "This library was built without CUDA profiler support.");
+    env, cudf::jni::CUDF_EXCEPTION_CLASS, "This library was built without CUDA profiler support.");
 #endif
 }
 

--- a/java/src/main/native/src/CudfJni.cpp
+++ b/java/src/main/native/src/CudfJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,14 +144,14 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void*)
     ss << "Libcudf is_ptds_enabled=" << cudf::is_ptds_enabled()
        << ", which does not match cudf jni is_ptds_enabled=" << cudf::jni::is_ptds_enabled
        << ". They need to be built with the same per-thread default stream flag.";
-    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), ss.str().c_str());
+    env->ThrowNew(env->FindClass(cudf::jni::RUNTIME_EXCEPTION_CLASS), ss.str().c_str());
     return JNI_ERR;
   }
 
   // cache any class objects and method IDs here
   if (!cudf::jni::cache_contiguous_table_jni(env)) {
     if (!env->ExceptionCheck()) {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"),
+      env->ThrowNew(env->FindClass(cudf::jni::RUNTIME_EXCEPTION_CLASS),
                     "Unable to locate contiguous table methods needed by JNI");
     }
     return JNI_ERR;
@@ -159,7 +159,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void*)
 
   if (!cudf::jni::cache_contig_split_group_by_result_jni(env)) {
     if (!env->ExceptionCheck()) {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"),
+      env->ThrowNew(env->FindClass(cudf::jni::RUNTIME_EXCEPTION_CLASS),
                     "Unable to locate group by table result methods needed by JNI");
     }
     return JNI_ERR;
@@ -167,7 +167,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void*)
 
   if (!cudf::jni::cache_host_memory_buffer_jni(env)) {
     if (!env->ExceptionCheck()) {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"),
+      env->ThrowNew(env->FindClass(cudf::jni::RUNTIME_EXCEPTION_CLASS),
                     "Unable to locate host memory buffer methods needed by JNI");
     }
     return JNI_ERR;
@@ -175,7 +175,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void*)
 
   if (!cudf::jni::cache_data_source_jni(env)) {
     if (!env->ExceptionCheck()) {
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"),
+      env->ThrowNew(env->FindClass(cudf::jni::RUNTIME_EXCEPTION_CLASS),
                     "Unable to locate data source helper methods needed by JNI");
     }
     return JNI_ERR;

--- a/java/src/main/native/src/NvcompJni.cpp
+++ b/java/src/main/native/src/NvcompJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "check_nvcomp_output_sizes.hpp"
 #include "cudf_jni_apis.hpp"
+#include "error.hpp"
 
 #include <rmm/device_uvector.hpp>
 
@@ -26,18 +28,18 @@ namespace {
 
 constexpr char const* NVCOMP_ERROR_CLASS      = "ai/rapids/cudf/nvcomp/NvcompException";
 constexpr char const* NVCOMP_CUDA_ERROR_CLASS = "ai/rapids/cudf/nvcomp/NvcompCudaException";
-constexpr char const* ILLEGAL_ARG_CLASS       = "java/lang/IllegalArgumentException";
-constexpr char const* UNSUPPORTED_CLASS       = "java/lang/UnsupportedOperationException";
 
 void check_nvcomp_status(JNIEnv* env, nvcompStatus_t status)
 {
   switch (status) {
     case nvcompSuccess: break;
     case nvcompErrorInvalidValue:
-      cudf::jni::throw_java_exception(env, ILLEGAL_ARG_CLASS, "nvcomp invalid value");
+      cudf::jni::throw_java_exception(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "nvcomp invalid value");
       break;
     case nvcompErrorNotSupported:
-      cudf::jni::throw_java_exception(env, UNSUPPORTED_CLASS, "nvcomp unsupported");
+      cudf::jni::throw_java_exception(
+        env, cudf::jni::UNSUPPORTED_EXCEPTION_CLASS, "nvcomp unsupported");
       break;
     case nvcompErrorCannotDecompress:
       cudf::jni::throw_java_exception(env, NVCOMP_ERROR_CLASS, "nvcomp cannot decompress");

--- a/java/src/main/native/src/ScalarJni.cpp
+++ b/java/src/main/native/src/ScalarJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,7 +150,7 @@ JNIEXPORT jbyteArray JNICALL Java_ai_rapids_cudf_Scalar_getUTF8(JNIEnv* env,
     std::string val{s->to_string()};
     if (val.size() > 0x7FFFFFFF) {
       cudf::jni::throw_java_exception(
-        env, "java/lang/IllegalArgumentException", "string scalar too large");
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "string scalar too large");
     }
     cudf::jni::native_jbyteArray jbytes{
       env, reinterpret_cast<jbyte const*>(val.data()), static_cast<int>(val.size())};

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -2897,12 +2897,12 @@ Java_ai_rapids_cudf_Table_convertArrowTableToCudf(JNIEnv* env, jclass, jlong arr
 
     ArrowSchema sch;
     if (!arrow::ExportSchema(*handle->get()->schema(), &sch).ok()) {
-      JNI_THROW_NEW(env, "java/lang/RuntimeException", "Unable to produce an ArrowSchema", 0)
+      JNI_THROW_NEW(env, cudf::jni::RUNTIME_EXCEPTION_CLASS, "Unable to produce an ArrowSchema", 0)
     }
     auto batch = handle->get()->CombineChunksToBatch().ValueOrDie();
     ArrowArray arr;
     if (!arrow::ExportRecordBatch(*batch, &arr).ok()) {
-      JNI_THROW_NEW(env, "java/lang/RuntimeException", "Unable to produce an ArrowArray", 0)
+      JNI_THROW_NEW(env, cudf::jni::RUNTIME_EXCEPTION_CLASS, "Unable to produce an ArrowArray", 0)
     }
     auto ret = cudf::from_arrow(&sch, &arr);
     arr.release(&arr);

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "csv_chunked_writer.hpp"
 #include "cudf_jni_apis.hpp"
 #include "dtype_utils.hpp"
@@ -28,7 +29,6 @@
 #include <cudf/copying.hpp>
 #include <cudf/filling.hpp>
 #include <cudf/groupby.hpp>
-#include <cudf/hashing.hpp>
 #include <cudf/interop.hpp>
 #include <cudf/io/avro.hpp>
 #include <cudf/io/csv.hpp>
@@ -55,10 +55,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
-
-#include <thrust/iterator/counting_iterator.h>
 
 #include <arrow/api.h>
 #include <arrow/c/bridge.h>
@@ -1342,12 +1339,14 @@ Java_ai_rapids_cudf_Table_readCSVFromDataSource(JNIEnv* env,
     cudf::jni::native_jintArray n_types(env, j_types);
     cudf::jni::native_jintArray n_scales(env, j_scales);
     if (n_types.is_null() != n_scales.is_null()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and scales must match null", NULL);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and scales must match null", NULL);
     }
     std::vector<cudf::data_type> data_types;
     if (!n_types.is_null()) {
       if (n_types.size() != n_scales.size()) {
-        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and scales must match size", NULL);
+        JNI_THROW_NEW(
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and scales must match size", NULL);
       }
       data_types.reserve(n_types.size());
       std::transform(n_types.begin(),
@@ -1415,10 +1414,13 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(JNIEnv* env,
     JNI_NULL_CHECK(env, inputfilepath, "input file or buffer must be supplied", NULL);
     read_buffer = false;
   } else if (inputfilepath != NULL) {
-    JNI_THROW_NEW(
-      env, cudf::jni::ILLEGAL_ARG_CLASS, "cannot pass in both a buffer and an inputfilepath", NULL);
+    JNI_THROW_NEW(env,
+                  cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                  "cannot pass in both a buffer and an inputfilepath",
+                  NULL);
   } else if (buffer_length <= 0) {
-    JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "An empty buffer is not supported", NULL);
+    JNI_THROW_NEW(
+      env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", NULL);
   }
 
   try {
@@ -1427,12 +1429,14 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(JNIEnv* env,
     cudf::jni::native_jintArray n_types(env, j_types);
     cudf::jni::native_jintArray n_scales(env, j_scales);
     if (n_types.is_null() != n_scales.is_null()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and scales must match null", NULL);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and scales must match null", NULL);
     }
     std::vector<cudf::data_type> data_types;
     if (!n_types.is_null()) {
       if (n_types.size() != n_scales.size()) {
-        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and scales must match size", NULL);
+        JNI_THROW_NEW(
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and scales must match size", NULL);
       }
       data_types.reserve(n_types.size());
       std::transform(n_types.begin(),
@@ -1446,7 +1450,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(JNIEnv* env,
 
     cudf::jni::native_jstring filename(env, inputfilepath);
     if (!read_buffer && filename.is_empty()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "inputfilepath can't be empty", NULL);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "inputfilepath can't be empty", NULL);
     }
 
     cudf::jni::native_jstringArray n_null_values(env, null_values);
@@ -1696,7 +1701,8 @@ Java_ai_rapids_cudf_Table_readAndInferJSON(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, buffer, "buffer cannot be null", 0);
   if (buffer_length <= 0) {
-    JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "An empty buffer is not supported", 0);
+    JNI_THROW_NEW(
+      env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", 0);
   }
 
   try {
@@ -1846,13 +1852,16 @@ Java_ai_rapids_cudf_Table_readJSONFromDataSource(JNIEnv* env,
     cudf::jni::native_jintArray n_scales(env, j_scales);
     cudf::jni::native_jintArray n_children(env, j_num_children);
     if (n_types.is_null() != n_scales.is_null()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and scales must match null", 0);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and scales must match null", 0);
     }
     if (n_types.is_null() != n_col_names.is_null()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and names must match null", 0);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and names must match null", 0);
     }
     if (n_types.is_null() != n_children.is_null()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and num children must match null", 0);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and num children must match null", 0);
     }
 
     auto ds = reinterpret_cast<cudf::io::datasource*>(ds_handle);
@@ -1882,15 +1891,16 @@ Java_ai_rapids_cudf_Table_readJSONFromDataSource(JNIEnv* env,
 
     if (!n_types.is_null()) {
       if (n_types.size() != n_scales.size()) {
-        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and scales must match size", 0);
+        JNI_THROW_NEW(
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and scales must match size", 0);
       }
       if (n_col_names.size() != n_types.size()) {
         JNI_THROW_NEW(
-          env, cudf::jni::ILLEGAL_ARG_CLASS, "types and column names must match size", 0);
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and column names must match size", 0);
       }
       if (n_children.size() != n_types.size()) {
         JNI_THROW_NEW(
-          env, cudf::jni::ILLEGAL_ARG_CLASS, "types and num children must match size", 0);
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and num children must match size", 0);
       }
 
       std::map<std::string, cudf::io::schema_element> data_types;
@@ -1947,10 +1957,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_readJSON(JNIEnv* env,
     JNI_NULL_CHECK(env, inputfilepath, "input file or buffer must be supplied", 0);
     read_buffer = false;
   } else if (inputfilepath != NULL) {
-    JNI_THROW_NEW(
-      env, cudf::jni::ILLEGAL_ARG_CLASS, "cannot pass in both a buffer and an inputfilepath", 0);
+    JNI_THROW_NEW(env,
+                  cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                  "cannot pass in both a buffer and an inputfilepath",
+                  0);
   } else if (buffer_length <= 0) {
-    JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "An empty buffer is not supported", 0);
+    JNI_THROW_NEW(
+      env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", 0);
   }
 
   try {
@@ -1960,18 +1973,21 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_readJSON(JNIEnv* env,
     cudf::jni::native_jintArray n_scales(env, j_scales);
     cudf::jni::native_jintArray n_children(env, j_num_children);
     if (n_types.is_null() != n_scales.is_null()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and scales must match null", 0);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and scales must match null", 0);
     }
     if (n_types.is_null() != n_col_names.is_null()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and names must match null", 0);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and names must match null", 0);
     }
     if (n_types.is_null() != n_children.is_null()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and num children must match null", 0);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and num children must match null", 0);
     }
 
     cudf::jni::native_jstring filename(env, inputfilepath);
     if (!read_buffer && filename.is_empty()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "inputfilepath can't be empty", 0);
+      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "inputfilepath can't be empty", 0);
     }
 
     auto source =
@@ -2004,15 +2020,16 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_readJSON(JNIEnv* env,
 
     if (!n_types.is_null()) {
       if (n_types.size() != n_scales.size()) {
-        JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "types and scales must match size", 0);
+        JNI_THROW_NEW(
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and scales must match size", 0);
       }
       if (n_col_names.size() != n_types.size()) {
         JNI_THROW_NEW(
-          env, cudf::jni::ILLEGAL_ARG_CLASS, "types and column names must match size", 0);
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and column names must match size", 0);
       }
       if (n_children.size() != n_types.size()) {
         JNI_THROW_NEW(
-          env, cudf::jni::ILLEGAL_ARG_CLASS, "types and num children must match size", 0);
+          env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "types and num children must match size", 0);
       }
 
       std::map<std::string, cudf::io::schema_element> data_types;
@@ -2089,15 +2106,18 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readParquet(JNIEnv* env,
     JNI_NULL_CHECK(env, inputfilepath, "input file or buffer must be supplied", NULL);
     read_buffer = false;
   } else if (inputfilepath != NULL) {
-    JNI_THROW_NEW(
-      env, cudf::jni::ILLEGAL_ARG_CLASS, "cannot pass in both a buffer and an inputfilepath", NULL);
+    JNI_THROW_NEW(env,
+                  cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                  "cannot pass in both a buffer and an inputfilepath",
+                  NULL);
   }
 
   try {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring filename(env, inputfilepath);
     if (!read_buffer && filename.is_empty()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "inputfilepath can't be empty", NULL);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "inputfilepath can't be empty", NULL);
     }
 
     cudf::jni::native_jstringArray n_filter_col_names(env, filter_col_names);
@@ -2161,17 +2181,21 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readAvro(JNIEnv* env,
   if (!read_buffer) {
     JNI_NULL_CHECK(env, inputfilepath, "input file or buffer must be supplied", NULL);
   } else if (inputfilepath != NULL) {
-    JNI_THROW_NEW(
-      env, cudf::jni::ILLEGAL_ARG_CLASS, "cannot pass in both a buffer and an inputfilepath", NULL);
+    JNI_THROW_NEW(env,
+                  cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                  "cannot pass in both a buffer and an inputfilepath",
+                  NULL);
   } else if (buffer_length <= 0) {
-    JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "An empty buffer is not supported", NULL);
+    JNI_THROW_NEW(
+      env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", NULL);
   }
 
   try {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring filename(env, inputfilepath);
     if (!read_buffer && filename.is_empty()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "inputfilepath can't be empty", NULL);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "inputfilepath can't be empty", NULL);
     }
 
     cudf::jni::native_jstringArray n_filter_col_names(env, filter_col_names);
@@ -2441,17 +2465,21 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readORC(JNIEnv* env,
     JNI_NULL_CHECK(env, inputfilepath, "input file or buffer must be supplied", NULL);
     read_buffer = false;
   } else if (inputfilepath != NULL) {
-    JNI_THROW_NEW(
-      env, cudf::jni::ILLEGAL_ARG_CLASS, "cannot pass in both a buffer and an inputfilepath", NULL);
+    JNI_THROW_NEW(env,
+                  cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
+                  "cannot pass in both a buffer and an inputfilepath",
+                  NULL);
   } else if (buffer_length <= 0) {
-    JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "An empty buffer is not supported", NULL);
+    JNI_THROW_NEW(
+      env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", NULL);
   }
 
   try {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring filename(env, inputfilepath);
     if (!read_buffer && filename.is_empty()) {
-      JNI_THROW_NEW(env, cudf::jni::ILLEGAL_ARG_CLASS, "inputfilepath can't be empty", NULL);
+      JNI_THROW_NEW(
+        env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "inputfilepath can't be empty", NULL);
     }
 
     cudf::jni::native_jstringArray n_filter_col_names(env, filter_col_names);
@@ -4023,7 +4051,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_dropDuplicates(
         case 3: return cudf::duplicate_keep_option::KEEP_NONE;
         default:
           JNI_THROW_NEW(env,
-                        cudf::jni::ILLEGAL_ARG_CLASS,
+                        cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
                         "Invalid `keep` option",
                         cudf::duplicate_keep_option::KEEP_ANY);
       }
@@ -4249,7 +4277,7 @@ Java_ai_rapids_cudf_Table_rollingWindowAggregate(JNIEnv* env,
 
     if (not valid_window_parameters(values, agg_instances, min_periods, preceding, following)) {
       JNI_THROW_NEW(env,
-                    cudf::jni::ILLEGAL_ARG_CLASS,
+                    cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
                     "Number of aggregation columns must match number of agg ops, and window-specs",
                     nullptr);
     }
@@ -4343,7 +4371,7 @@ Java_ai_rapids_cudf_Table_rangeRollingWindowAggregate(JNIEnv* env,
 
     if (not valid_window_parameters(values, agg_instances, min_periods, preceding, following)) {
       JNI_THROW_NEW(env,
-                    cudf::jni::ILLEGAL_ARG_CLASS,
+                    cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS,
                     "Number of aggregation columns must match number of agg ops, and window-specs",
                     nullptr);
     }

--- a/java/src/main/native/src/cudf_jni_apis.hpp
+++ b/java/src/main/native/src/cudf_jni_apis.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include "jni_utils.hpp"
 
 #include <cudf/contiguous_split.hpp>
-#include <cudf/detail/aggregation/aggregation.hpp>
 
-namespace cudf {
-namespace jni {
+namespace cudf::jni {
 
 /**
  * @brief Detach all columns from the specified table, and pointers to them as an array.
@@ -147,5 +146,4 @@ bool cache_data_source_jni(JNIEnv* env);
 
 void release_data_source_jni(JNIEnv* env);
 
-}  // namespace jni
-}  // namespace cudf
+}  // namespace cudf::jni


### PR DESCRIPTION
This performs some changes to Java JNI, extracting the error-handling code into a separate header along with some simple cleanup. Such modification paves the way for capturing native exception with stacktrace in the follow-up work.

No new feature/implementation is added. Only code moving around.