### PR TITLE
Avoid unnecessary partition step in streaming join

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/join.py
@@ -315,8 +315,13 @@ def _(
         getit_name = f"getit-{out_name}"
         inter_name = f"inter-{out_name}"
 
+        # Split each large partition if we have
+        # multiple small partitions (unless this
+        # is an inner join)
+        split_large = ir.options[0] != "Inner" and small_size > 1
+
         for part_out in range(out_size):
-            if ir.options[0] != "Inner":
+            if split_large:
                 graph[(split_name, part_out)] = (
                     _partition_dataframe,
                     (large_name, part_out),
@@ -327,7 +332,7 @@ def _(
             _concat_list = []
             for j in range(small_size):
                 left_key: tuple[str, int] | tuple[str, int, int]
-                if ir.options[0] != "Inner":
+                if split_large:
                     left_key = (getit_name, part_out, j)
                     graph[left_key] = (operator.getitem, (split_name, part_out), j)
                 else:


### PR DESCRIPTION
## Description
Minor optimization in cudf-polars streaming engine. The broadcast-join code path currently splits/shuffles each large-table partitions, even when the small table only has one partition. This introduces an unnecessary step to split the partition into one group. This PR skips this step if the small table has only one partition.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
