### PR TITLE
[WIP] Cap default partition size in cudf-polars streaming engine

### DIFF
--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -141,7 +141,8 @@ def default_blocksize(scheduler: str) -> int:
         # support a much larger blocksize.
         blocksize = int(device_size * 0.0625)
 
-    return max(blocksize, 256_000_000)
+    # Cap the default between 256MB and 4GB
+    return min(max(blocksize, 256_000_000), 4_000_000_000)
 
 
 @dataclasses.dataclass(frozen=True, eq=True)


### PR DESCRIPTION
## Description
The default partition size in cudf-polars is proportional to the device size (e.g. B200). For large devices, the default can be extremely large (>10GB). This PR proposes that we cap the default at 4GB. The user can always configure a larger partition size, but the default should probably be more conservative. For example, a 10GB+ partition could potentially run into fundamental column-size limits.
