### PR TITLE
Prune more redundant subclass methods

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -1303,29 +1303,6 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
             "_constructor_expanddim not supported for DataFrames!"
         )
 
-    def serialize(self):
-        header, frames = super().serialize()
-
-        header["index"], index_frames = self.index.device_serialize()
-        header["index_frame_count"] = len(index_frames)
-        # For backwards compatibility with older versions of cuDF, index
-        # columns are placed before data columns.
-        frames = index_frames + frames
-
-        return header, frames
-
-    @classmethod
-    def deserialize(cls, header, frames):
-        index_nframes = header["index_frame_count"]
-        obj = super().deserialize(
-            header, frames[header["index_frame_count"] :]
-        )
-
-        index = cls.device_deserialize(header["index"], frames[:index_nframes])
-        obj.index = index
-
-        return obj
-
     @property
     @_performance_tracking
     def shape(self) -> tuple[int, int]:

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -93,7 +93,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
 
     @property
     def ndim(self) -> int:
-        raise NotImplementedError()
+        raise NotImplementedError
 
     @_performance_tracking
     def serialize(self):

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -34,11 +34,11 @@ from cudf.core.column import (
 from cudf.core.column.categorical import CategoricalColumn, as_unsigned_codes
 from cudf.core.column_accessor import ColumnAccessor
 from cudf.core.mixins import BinaryOperand, Scannable
-from cudf.utils import ioutils
 from cudf.utils.dtypes import (
     CUDF_STRING_DTYPE,
     cudf_dtype_from_pa_type,
     find_common_type,
+    is_dtype_obj_numeric,
 )
 from cudf.utils.performance_tracking import _performance_tracking
 from cudf.utils.utils import _array_ufunc, _warn_no_dask_cudf
@@ -602,6 +602,42 @@ class Frame(BinaryOperand, Scannable, Serializable):
         Instead, it should be called on subclasses like DataFrame/Series.
         """
         raise NotImplementedError(f"{type(self)} must implement to_pylibcudf")
+
+    @_performance_tracking
+    def to_pandas(self, *, nullable: bool = False, arrow_type: bool = False):
+        raise NotImplementedError(f"{type(self)} must implement to_pandas")
+
+    @_performance_tracking
+    def to_dlpack(self):
+        """
+        Converts a cuDF object to a DLPack tensor.
+        DLPack is an open-source memory tensor structure:
+        `dmlc/dlpack <https://github.com/dmlc/dlpack>`_.
+
+        Returns
+        -------
+        PyCapsule
+            A DLPack tensor pointer which is encapsulated in a PyCapsule object.
+
+        Notes
+        -----
+        The result is in column-major (Fortran order) format. If the
+        output tensor needs to be row major, transpose the output of this function.
+        """
+        dtypes = []
+        for _, dtype in self._dtypes:
+            if not is_dtype_obj_numeric(dtype, include_decimal=False):
+                raise NotImplementedError(
+                    "non-numeric data is not yet supported"
+                )
+            dtypes.append(dtype)
+        dtype = find_common_type(dtypes)
+        casted = self.astype(dtype)
+        return plc.interop.to_dlpack(
+            plc.Table(
+                [col.to_pylibcudf(mode="read") for col in casted._columns]
+            )
+        )
 
     @_performance_tracking
     def to_cupy(
@@ -1964,13 +2000,6 @@ class Frame(BinaryOperand, Scannable, Serializable):
             skipna=skipna,
             **kwargs,
         )
-
-    @_performance_tracking
-    @ioutils.doc_to_dlpack()
-    def to_dlpack(self):
-        """{docstring}"""
-
-        return cudf.io.dlpack.to_dlpack(self)
 
     @_performance_tracking
     def __str__(self) -> str:

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2250,7 +2250,7 @@ class Index(SingleColumnFrame):  # type: ignore[misc]
         )
 
     def repeat(self, repeats, axis=None) -> Self:
-        result = super()._repeat([self._column], repeats, axis)[0]
+        result = self._repeat([self._column], repeats, axis)[0]
         result = result._with_type_metadata(self.dtype)
         return type(self)._from_column(result, name=self.name)
 

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -4959,7 +4959,7 @@ class IndexedFrame(Frame):
         dtype: int64
         """
         res = self._from_columns_like_self(
-            Frame._repeat(
+            self._repeat(
                 [*self.index._columns, *self._columns], repeats, axis
             ),
             self._column_names,

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -2220,7 +2220,7 @@ class MultiIndex(Index):
     def repeat(self, repeats, axis=None) -> Self:
         return self._from_data(
             self._data._from_columns_like_self(
-                super()._repeat(self._columns, repeats, axis)
+                self._repeat(self._columns, repeats, axis)
             )
         )
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -751,31 +751,6 @@ class Series(SingleColumnFrame, IndexedFrame):
         return self._column.has_nulls(include_nan=True)
 
     @_performance_tracking
-    def serialize(self):
-        header, frames = super().serialize()
-
-        header["index"], index_frames = self.index.device_serialize()
-        header["index_frame_count"] = len(index_frames)
-        # For backwards compatibility with older versions of cuDF, index
-        # columns are placed before data columns.
-        frames = index_frames + frames
-
-        return header, frames
-
-    @classmethod
-    @_performance_tracking
-    def deserialize(cls, header, frames):
-        index_nframes = header["index_frame_count"]
-        obj = super().deserialize(
-            header, frames[header["index_frame_count"] :]
-        )
-
-        index = cls.device_deserialize(header["index"], frames[:index_nframes])
-        obj.index = index
-
-        return obj
-
-    @_performance_tracking
     def drop(
         self,
         labels=None,

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -1087,28 +1087,6 @@ cudf.read_feather
 """
 doc_to_feather = docfmt_partial(docstring=_docstring_to_feather)
 
-_docstring_to_dlpack = """
-Converts a cuDF object into a DLPack tensor.
-
-DLPack is an open-source memory tensor structure:
-`dmlc/dlpack <https://github.com/dmlc/dlpack>`_.
-
-This function takes a cuDF object and converts it to a PyCapsule object
-which contains a pointer to a DLPack tensor. This function deep copies the
-data into the DLPack tensor from the cuDF object.
-
-Parameters
-----------
-cudf_obj : DataFrame, Series, Index, or Column
-
-Returns
--------
-pycapsule_obj : PyCapsule
-    Output DLPack tensor pointer which is encapsulated in a PyCapsule
-    object.
-"""
-doc_to_dlpack = docfmt_partial(docstring=_docstring_to_dlpack)
-
 _docstring_read_csv = """
 Load a comma-separated-values (CSV) dataset into a DataFrame
 


### PR DESCRIPTION
## Description
Broken off from https://github.com/rapidsai/cudf/pull/18942

* Implement `to_dlpack` directly on `Frame`
* Call `self._repeat` instead of `super()._repeat`
* Move `DataFrame/Series.(de)serialize` to `IndexedFrame`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
