### PR TITLE
Mark pandas unit test test_eval_no_support_column_name as xpassing

### DIFF
--- a/python/cudf/cudf/pandas/scripts/conftest-patch.py
+++ b/python/cudf/cudf/pandas/scripts/conftest-patch.py
@@ -2114,6 +2114,8 @@ NODEIDS_THAT_XPASS_WITH_CUDF_PANDAS = {
     "tests/window/moments/test_moments_consistency_rolling.py::test_rolling_apply_consistency_sum[all_data16-rolling_consistency_cases0-True-sum]",
     "tests/window/moments/test_moments_consistency_rolling.py::test_rolling_apply_consistency_sum[all_data16-rolling_consistency_cases0-False-sum]",
     "tests/plotting/test_datetimelike.py::TestTSPlot::test_add_matplotlib_datetime64",
+    "tests/computation/test_eval.py::test_eval_no_support_column_name[inf]",
+    "tests/computation/test_eval.py::test_eval_no_support_column_name[Inf]",
 }
 
 


### PR DESCRIPTION
## Description
This possibly got fixed when https://github.com/rapidsai/cudf/pull/18979 was merged, but these tests were not marked as xpassing in that PR

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
