### PR TITLE
Pin deltalake to <1.0.0

### DIFF
--- a/ci/test_cudf_polars_polars_tests.sh
+++ b/ci/test_cudf_polars_polars_tests.sh
@@ -26,8 +26,11 @@ git clone https://github.com/pola-rs/polars.git --branch "${TAG}" --depth 1
 
 # Install requirements for running polars tests
 rapids-logger "Install polars test requirements"
-# TODO: Remove sed command when polars-cloud supports 1.23
+# We don't need to pick up dependencies from polars-cloud, so we remove it.
 sed -i '/^polars-cloud$/d' polars/py-polars/requirements-dev.txt
+# Deltalake release 1.0.0 broke something Polars. So we're adding an upper pinning temporarily
+# until things get resolved.
+sed -i 's/^deltalake>=0.15.0.*/deltalake>=0.15.0,<1.0.0/' polars/py-polars/requirements-dev.txt
 rapids-pip-retry install -r polars/py-polars/requirements-dev.txt -r polars/py-polars/requirements-ci.txt
 
 # shellcheck disable=SC2317

--- a/ci/test_cudf_polars_polars_tests.sh
+++ b/ci/test_cudf_polars_polars_tests.sh
@@ -28,8 +28,8 @@ git clone https://github.com/pola-rs/polars.git --branch "${TAG}" --depth 1
 rapids-logger "Install polars test requirements"
 # We don't need to pick up dependencies from polars-cloud, so we remove it.
 sed -i '/^polars-cloud$/d' polars/py-polars/requirements-dev.txt
-# Deltalake release 1.0.0 broke something Polars. So we're adding an upper pinning temporarily
-# until things get resolved.
+# Deltalake release 1.0.0 contains breaking changes for Polars. So we're adding an upper pinning temporarily
+# until things get resolved. Tracking Issue: https://github.com/pola-rs/polars/issues/22999
 sed -i 's/^deltalake>=0.15.0.*/deltalake>=0.15.0,<1.0.0/' polars/py-polars/requirements-dev.txt
 rapids-pip-retry install -r polars/py-polars/requirements-dev.txt -r polars/py-polars/requirements-ci.txt
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The latest release of deltalake (>=1.0.0) introduces changes that are incompatible with the current version of polars supported by cudf. So this PR updates Polars' requirements-dev.txt to pin deltalake to <1.0.0.

Example of the failures we are seeing: https://github.com/rapidsai/cudf/actions/runs/15308055134/job/43067933487?pr=18916
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
