### PR TITLE
Rewrite Java JNI to use `JNI_TRY`/`JNI_CATCH`

### DIFF
--- a/java/src/main/native/include/error.hpp
+++ b/java/src/main/native/include/error.hpp
@@ -80,7 +80,7 @@ inline void check_java_exception(JNIEnv* const env)
 }
 
 /**
- * @brief Create a cuda exception from a given cudaError_t.
+ * @brief Create CudaException or CudaFatalException from a given cudaError_t code.
  */
 inline jthrowable cuda_exception(JNIEnv* const env, cudaError_t status, jthrowable cause = nullptr)
 {
@@ -256,6 +256,6 @@ inline void jni_cuda_check(JNIEnv* const env, cudaError_t cuda_status)
 
 // Separate special exceptions handling from std::exception to allow catching more special
 // exceptions in some situations by inserting additional catch blocks in between.
-#define CATCH_STD(env, ret_val)         \
+#define JNI_CATCH(env, ret_val)         \
   CATCH_SPECIAL_EXCEPTION(env, ret_val) \
   CATCH_STD_EXCEPTION(env, ret_val)

--- a/java/src/main/native/src/Aggregation128UtilsJni.cpp
+++ b/java/src/main/native/src/Aggregation128UtilsJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,26 +24,28 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation128Utils_extractInt32Chun
   JNIEnv* env, jclass, jlong j_column_view, jint j_out_dtype, jint j_chunk_idx)
 {
   JNI_NULL_CHECK(env, j_column_view, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto cview = reinterpret_cast<cudf::column_view const*>(j_column_view);
     auto dtype = cudf::jni::make_data_type(j_out_dtype, 0);
     return cudf::jni::release_as_jlong(cudf::jni::extract_chunk32(*cview, dtype, j_chunk_idx));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Aggregation128Utils_combineInt64SumChunks(
   JNIEnv* env, jclass, jlong j_table_view, jint j_dtype, jint j_scale)
 {
   JNI_NULL_CHECK(env, j_table_view, "table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto tview = reinterpret_cast<cudf::table_view const*>(j_table_view);
     std::unique_ptr<cudf::table> result =
       cudf::jni::assemble128_from_sum(*tview, cudf::jni::make_data_type(j_dtype, j_scale));
     return cudf::jni::convert_table_for_return(env, result);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }

--- a/java/src/main/native/src/AggregationJni.cpp
+++ b/java/src/main/native/src/AggregationJni.cpp
@@ -25,19 +25,21 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Aggregation_close(JNIEnv* env,
                                                              jclass class_object,
                                                              jlong ptr)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto to_del = reinterpret_cast<cudf::aggregation*>(ptr);
     delete to_del;
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createNoParamAgg(JNIEnv* env,
                                                                          jclass class_object,
                                                                          jint kind)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto ret = [&] {
       // These numbers come from Aggregation.java and must stay in sync
@@ -112,7 +114,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createNoParamAgg(JNIEnv*
 
     return reinterpret_cast<jlong>(ret.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createNthAgg(JNIEnv* env,
@@ -120,14 +122,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createNthAgg(JNIEnv* env
                                                                      jint offset,
                                                                      jboolean include_nulls)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     std::unique_ptr<cudf::aggregation> ret = cudf::make_nth_element_aggregation(
       offset, include_nulls ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
     return reinterpret_cast<jlong>(ret.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createDdofAgg(JNIEnv* env,
@@ -135,7 +138,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createDdofAgg(JNIEnv* en
                                                                       jint kind,
                                                                       jint ddof)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     std::unique_ptr<cudf::aggregation> ret;
@@ -151,7 +155,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createDdofAgg(JNIEnv* en
     }
     return reinterpret_cast<jlong>(ret.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createTDigestAgg(JNIEnv* env,
@@ -159,7 +163,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createTDigestAgg(JNIEnv*
                                                                          jint kind,
                                                                          jint delta)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     std::unique_ptr<cudf::aggregation> ret;
@@ -175,7 +180,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createTDigestAgg(JNIEnv*
     }
     return reinterpret_cast<jlong>(ret.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCountLikeAgg(JNIEnv* env,
@@ -183,7 +188,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCountLikeAgg(JNIEn
                                                                            jint kind,
                                                                            jboolean include_nulls)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::null_policy policy =
@@ -201,7 +207,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCountLikeAgg(JNIEn
     }
     return reinterpret_cast<jlong>(ret.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createQuantAgg(JNIEnv* env,
@@ -210,7 +216,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createQuantAgg(JNIEnv* e
                                                                        jdoubleArray j_quantiles)
 {
   JNI_NULL_CHECK(env, j_quantiles, "quantiles are null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     const cudf::jni::native_jdoubleArray quantiles(env, j_quantiles);
@@ -221,7 +228,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createQuantAgg(JNIEnv* e
     std::unique_ptr<cudf::aggregation> ret = cudf::make_quantile_aggregation(quants, interp);
     return reinterpret_cast<jlong>(ret.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createLeadLagAgg(JNIEnv* env,
@@ -229,7 +236,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createLeadLagAgg(JNIEnv*
                                                                          jint kind,
                                                                          jint offset)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     std::unique_ptr<cudf::aggregation> ret;
@@ -245,21 +253,22 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createLeadLagAgg(JNIEnv*
     }
     return reinterpret_cast<jlong>(ret.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCollectListAgg(JNIEnv* env,
                                                                              jclass class_object,
                                                                              jboolean include_nulls)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::null_policy policy =
       include_nulls ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE;
     std::unique_ptr<cudf::aggregation> ret = cudf::make_collect_list_aggregation(policy);
     return reinterpret_cast<jlong>(ret.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCollectSetAgg(JNIEnv* env,
@@ -268,7 +277,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCollectSetAgg(JNIE
                                                                             jboolean nulls_equal,
                                                                             jboolean nans_equal)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::null_policy null_policy =
       include_nulls ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE;
@@ -280,7 +290,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createCollectSetAgg(JNIE
       cudf::make_collect_set_aggregation(null_policy, null_equality, nan_equality);
     return reinterpret_cast<jlong>(ret.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createMergeSetsAgg(JNIEnv* env,
@@ -288,7 +298,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createMergeSetsAgg(JNIEn
                                                                            jboolean nulls_equal,
                                                                            jboolean nans_equal)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::null_equality null_equality =
       nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
@@ -298,7 +309,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createMergeSetsAgg(JNIEn
       cudf::make_merge_sets_aggregation(null_equality, nan_equality);
     return reinterpret_cast<jlong>(ret.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createHostUDFAgg(JNIEnv* env,
@@ -306,46 +317,50 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createHostUDFAgg(JNIEnv*
                                                                          jlong udf_native_handle)
 {
   JNI_NULL_CHECK(env, udf_native_handle, "udf_native_handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const udf_ptr = reinterpret_cast<cudf::host_udf_base const*>(udf_native_handle);
     auto output        = cudf::make_host_udf_aggregation(udf_ptr->clone());
     return reinterpret_cast<jlong>(output.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createBitAndAgg(JNIEnv* env,
                                                                         jclass class_object)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto output = cudf::make_bitwise_aggregation<cudf::aggregation>(cudf::bitwise_op::AND);
     return reinterpret_cast<jlong>(output.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createBitOrAgg(JNIEnv* env,
                                                                        jclass class_object)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto output = cudf::make_bitwise_aggregation<cudf::aggregation>(cudf::bitwise_op::OR);
     return reinterpret_cast<jlong>(output.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Aggregation_createBitXorAgg(JNIEnv* env,
                                                                         jclass class_object)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto output = cudf::make_bitwise_aggregation<cudf::aggregation>(cudf::bitwise_op::XOR);
     return reinterpret_cast<jlong>(output.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/ChunkedPackJni.cpp
+++ b/java/src/main/native/src/ChunkedPackJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,61 +21,66 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_ChunkedPack_chunkedPackDelete(JNIEnv*
                                                                          jclass,
                                                                          jlong chunked_pack)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto cs = reinterpret_cast<cudf::chunked_pack*>(chunked_pack);
     delete cs;
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ChunkedPack_chunkedPackGetTotalContiguousSize(
   JNIEnv* env, jclass, jlong chunked_pack)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto cs = reinterpret_cast<cudf::chunked_pack*>(chunked_pack);
     return cs->get_total_contiguous_size();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_ChunkedPack_chunkedPackHasNext(JNIEnv* env,
                                                                               jclass,
                                                                               jlong chunked_pack)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto cs = reinterpret_cast<cudf::chunked_pack*>(chunked_pack);
     return cs->has_next();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ChunkedPack_chunkedPackNext(
   JNIEnv* env, jclass, jlong chunked_pack, jlong user_ptr, jlong user_ptr_size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto cs               = reinterpret_cast<cudf::chunked_pack*>(chunked_pack);
     auto user_buffer_span = cudf::device_span<uint8_t>(reinterpret_cast<uint8_t*>(user_ptr),
                                                        static_cast<std::size_t>(user_ptr_size));
     return cs->next(user_buffer_span);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ChunkedPack_chunkedPackBuildMetadata(JNIEnv* env,
                                                                                  jclass,
                                                                                  jlong chunked_pack)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto cs = reinterpret_cast<cudf::chunked_pack*>(chunked_pack);
     std::unique_ptr<std::vector<uint8_t>> result = cs->build_metadata();
     return reinterpret_cast<jlong>(result.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/ChunkedReaderJni.cpp
+++ b/java/src/main/native/src/ChunkedReaderJni.cpp
@@ -58,7 +58,8 @@ Java_ai_rapids_cudf_ParquetChunkedReader_create(JNIEnv* env,
                   nullptr);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring filename(env, inp_file_path);
     if (!read_buffer && filename.is_empty()) {
@@ -102,7 +103,7 @@ Java_ai_rapids_cudf_ParquetChunkedReader_create(JNIEnv* env,
     result[1] = cudf::jni::release_as_jlong(multi_buffer_source);
     return result.get_jArray();
   }
-  CATCH_STD(env, nullptr);
+  JNI_CATCH(env, nullptr);
 }
 
 JNIEXPORT jlong JNICALL
@@ -117,7 +118,8 @@ Java_ai_rapids_cudf_ParquetChunkedReader_createWithDataSource(JNIEnv* env,
   JNI_NULL_CHECK(env, j_col_binary_read, "Null col_binary_read", 0);
   JNI_NULL_CHECK(env, ds_handle, "Null DataSouurce", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::jni::native_jstringArray n_filter_col_names(env, filter_col_names);
@@ -142,7 +144,7 @@ Java_ai_rapids_cudf_ParquetChunkedReader_createWithDataSource(JNIEnv* env,
     return reinterpret_cast<jlong>(
       new cudf::io::chunked_parquet_reader(static_cast<std::size_t>(chunk_read_limit), read_opts));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_ParquetChunkedReader_hasNext(JNIEnv* env,
@@ -151,12 +153,13 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_ParquetChunkedReader_hasNext(JNIE
 {
   JNI_NULL_CHECK(env, handle, "handle is null", false);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const reader_ptr = reinterpret_cast<cudf::io::chunked_parquet_reader* const>(handle);
     return reader_ptr->has_next();
   }
-  CATCH_STD(env, false);
+  JNI_CATCH(env, false);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ParquetChunkedReader_readChunk(JNIEnv* env,
@@ -165,13 +168,14 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ParquetChunkedReader_readChunk(
 {
   JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const reader_ptr = reinterpret_cast<cudf::io::chunked_parquet_reader* const>(handle);
     auto chunk            = reader_ptr->read_chunk();
     return chunk.tbl ? cudf::jni::convert_table_for_return(env, chunk.tbl) : nullptr;
   }
-  CATCH_STD(env, nullptr);
+  JNI_CATCH(env, nullptr);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_ParquetChunkedReader_close(JNIEnv* env,
@@ -180,11 +184,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_ParquetChunkedReader_close(JNIEnv* en
 {
   JNI_NULL_CHECK(env, handle, "handle is null", );
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     delete reinterpret_cast<cudf::io::chunked_parquet_reader*>(handle);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_ParquetChunkedReader_destroyMultiHostBufferSource(
@@ -192,10 +197,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_ParquetChunkedReader_destroyMultiHost
 {
   JNI_NULL_CHECK(env, handle, "handle is null", );
 
-  try {
-    delete reinterpret_cast<cudf::jni::multi_host_buffer_source*>(handle);
-  }
-  CATCH_STD(env, );
+  JNI_TRY { delete reinterpret_cast<cudf::jni::multi_host_buffer_source*>(handle); }
+  JNI_CATCH(env, );
 }
 
 //
@@ -220,7 +223,8 @@ jlong create_chunked_orc_reader(JNIEnv* env,
       env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", 0);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstringArray n_filter_col_names(env, filter_col_names);
     cudf::jni::native_jstringArray n_dec128_col_names(env, dec128_col_names);
@@ -248,7 +252,7 @@ jlong create_chunked_orc_reader(JNIEnv* env,
                                        static_cast<std::size_t>(pass_read_limit),
                                        read_opts));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }  // namespace
 
@@ -311,12 +315,13 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_ORCChunkedReader_hasNext(JNIEnv* 
 {
   JNI_NULL_CHECK(env, handle, "handle is null", false);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const reader_ptr = reinterpret_cast<cudf::io::chunked_orc_reader* const>(handle);
     return reader_ptr->has_next();
   }
-  CATCH_STD(env, false);
+  JNI_CATCH(env, false);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ORCChunkedReader_readChunk(JNIEnv* env,
@@ -325,24 +330,26 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ORCChunkedReader_readChunk(JNIE
 {
   JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const reader_ptr = reinterpret_cast<cudf::io::chunked_orc_reader* const>(handle);
     auto chunk            = reader_ptr->read_chunk();
     return chunk.tbl ? cudf::jni::convert_table_for_return(env, chunk.tbl) : nullptr;
   }
-  CATCH_STD(env, nullptr);
+  JNI_CATCH(env, nullptr);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_ORCChunkedReader_close(JNIEnv* env, jclass, jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "handle is null", );
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     delete reinterpret_cast<cudf::io::chunked_orc_reader*>(handle);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/ColumnVectorJni.cpp
+++ b/java/src/main/native/src/ColumnVectorJni.cpp
@@ -105,14 +105,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_sequence(
   JNIEnv* env, jclass, jlong j_initial_val, jlong j_step, jint row_count)
 {
   JNI_NULL_CHECK(env, j_initial_val, "scalar is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto initial_val = reinterpret_cast<cudf::scalar const*>(j_initial_val);
     auto step        = reinterpret_cast<cudf::scalar const*>(j_step);
     return release_as_jlong(step ? cudf::sequence(row_count, *initial_val, *step)
                                  : cudf::sequence(row_count, *initial_val));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_sequences(
@@ -120,7 +121,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_sequences(
 {
   JNI_NULL_CHECK(env, j_start_handle, "start is null", 0);
   JNI_NULL_CHECK(env, j_size_handle, "size is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto start = reinterpret_cast<cudf::column_view const*>(j_start_handle);
     auto size  = reinterpret_cast<cudf::column_view const*>(j_size_handle);
@@ -129,7 +131,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_sequences(
       step ? cudf::lists::sequences(*start, *step, *size) : cudf::lists::sequences(*start, *size);
     return release_as_jlong(ret);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromArrow(JNIEnv* env,
@@ -141,7 +143,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromArrow(JNIEnv* env,
                                                                    jobject j_validity_obj,
                                                                    jobject j_offsets_obj)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::type_id n_type = static_cast<cudf::type_id>(j_type);
     // not all the buffers are used for all types
@@ -226,7 +229,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromArrow(JNIEnv* env,
     }
     return release_as_jlong(retCols[0]);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -240,7 +243,8 @@ Java_ai_rapids_cudf_ColumnVector_stringConcatenation(JNIEnv* env,
   JNI_NULL_CHECK(env, column_handles, "array of column handles is null", 0);
   JNI_NULL_CHECK(env, separator, "separator string scalar object is null", 0);
   JNI_NULL_CHECK(env, narep, "narep string scalar object is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const& separator_scalar = *reinterpret_cast<cudf::string_scalar*>(separator);
     auto const& narep_scalar     = *reinterpret_cast<cudf::string_scalar*>(narep);
@@ -252,7 +256,7 @@ Java_ai_rapids_cudf_ColumnVector_stringConcatenation(JNIEnv* env,
     return release_as_jlong(cudf::strings::concatenate(
       cudf::table_view(column_views), separator_scalar, narep_scalar, null_policy));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -268,7 +272,8 @@ Java_ai_rapids_cudf_ColumnVector_stringConcatenationSepCol(JNIEnv* env,
   JNI_NULL_CHECK(env, sep_handle, "separator column handle is null", 0);
   JNI_NULL_CHECK(env, separator_narep, "separator narep string scalar object is null", 0);
   JNI_NULL_CHECK(env, col_narep, "column narep string scalar object is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const& separator_narep_scalar = *reinterpret_cast<cudf::string_scalar*>(separator_narep);
     auto const& col_narep_scalar       = *reinterpret_cast<cudf::string_scalar*>(col_narep);
@@ -285,7 +290,7 @@ Java_ai_rapids_cudf_ColumnVector_stringConcatenationSepCol(JNIEnv* env,
                                                        col_narep_scalar,
                                                        null_policy));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_concatListByRow(JNIEnv* env,
@@ -294,7 +299,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_concatListByRow(JNIEnv*
                                                                          jboolean ignore_null)
 {
   JNI_NULL_CHECK(env, column_handles, "array of column handles is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto null_policy = ignore_null ? cudf::lists::concatenate_null_policy::IGNORE
                                    : cudf::lists::concatenate_null_policy::NULLIFY_OUTPUT_ROW;
@@ -304,7 +310,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_concatListByRow(JNIEnv*
     return release_as_jlong(
       cudf::lists::concatenate_rows(cudf::table_view(column_views), null_policy));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeList(
@@ -312,7 +318,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeList(
 {
   using ScalarType = cudf::scalar_type_t<cudf::size_type>;
   JNI_NULL_CHECK(env, handles, "native view handles are null", 0)
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto children        = cudf::jni::native_jpointerArray<cudf::column_view>(env, handles);
     auto children_vector = children.get_dereferenced();
@@ -338,7 +345,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeList(
         row_count, std::move(offsets), std::move(data_col), 0, rmm::device_buffer()));
     }
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeListFromOffsets(
@@ -346,7 +353,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeListFromOffsets(
 {
   JNI_NULL_CHECK(env, child_handle, "child_handle is null", 0)
   JNI_NULL_CHECK(env, offsets_handle, "offsets_handle is null", 0)
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const child_cv   = reinterpret_cast<cudf::column_view const*>(child_handle);
     auto const offsets_cv = reinterpret_cast<cudf::column_view const*>(offsets_handle);
@@ -359,7 +367,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeListFromOffsets(
                                                     0,
                                                     {}));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromScalar(JNIEnv* env,
@@ -368,7 +376,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromScalar(JNIEnv* env,
                                                                     jint row_count)
 {
   JNI_NULL_CHECK(env, j_scalar, "scalar is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto scalar_val = reinterpret_cast<cudf::scalar const*>(j_scalar);
     if (scalar_val->type().id() == cudf::type_id::STRUCT && row_count == 0) {
@@ -382,7 +391,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_fromScalar(JNIEnv* env,
       return release_as_jlong(cudf::make_column_from_scalar(*scalar_val, row_count));
     }
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_concatenate(JNIEnv* env,
@@ -392,7 +401,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_concatenate(JNIEnv* env
   JNI_NULL_CHECK(env, column_handles, "input columns are null", 0);
   using cudf::column;
   using cudf::column_view;
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto columns =
       cudf::jni::native_jpointerArray<column_view>{env, column_handles}.get_dereferenced();
@@ -403,7 +413,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_concatenate(JNIEnv* env
             columns, cudf::get_default_stream(), cudf::get_current_device_resource_ref())
         : cudf::concatenate(columns));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_md5(JNIEnv* env,
@@ -412,12 +422,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_md5(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, column_handles, "array of column handles is null", 0);
 
-  try {
+  JNI_TRY
+  {
     auto column_views =
       cudf::jni::native_jpointerArray<cudf::column_view>{env, column_handles}.get_dereferenced();
     return release_as_jlong(cudf::hashing::md5(cudf::table_view{column_views}));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_sha1(JNIEnv* env,
@@ -426,12 +437,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_sha1(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, column_handles, "array of column handles is null", 0);
 
-  try {
+  JNI_TRY
+  {
     auto column_views =
       cudf::jni::native_jpointerArray<cudf::column_view>{env, column_handles}.get_dereferenced();
     return release_as_jlong(cudf::hashing::sha1(cudf::table_view{column_views}));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 ////////
@@ -445,11 +457,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_ColumnVector_deleteCudfColumn(JNIEnv*
                                                                          jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "column handle is null", );
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     delete reinterpret_cast<cudf::column*>(handle);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, )
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_ColumnVector_setNativeNullCountColumn(JNIEnv* env,
@@ -458,12 +471,13 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_ColumnVector_setNativeNullCountColumn
                                                                                  jint null_count)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", );
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column* column = reinterpret_cast<cudf::column*>(handle);
     column->set_null_count(null_count);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeColumnView(JNIEnv* env,
@@ -471,12 +485,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeColumnView(JNI
                                                                              jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column* column = reinterpret_cast<cudf::column*>(handle);
     return ptr_as_jlong(new cudf::column_view{*column});
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeEmptyCudfColumn(JNIEnv* env,
@@ -484,12 +499,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnVector_makeEmptyCudfColumn(JNI
                                                                              jint j_type,
                                                                              jint scale)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::data_type n_data_type = cudf::jni::make_data_type(j_type, scale);
     return release_as_jlong(cudf::make_empty_column(n_data_type));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeNullCountColumn(JNIEnv* env,
@@ -497,11 +513,12 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnVector_getNativeNullCountColumn
                                                                                  jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column* column = reinterpret_cast<cudf::column*>(handle);
     return static_cast<jint>(column->null_count());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }  // extern "C"

--- a/java/src/main/native/src/ColumnViewJni.cpp
+++ b/java/src/main/native/src/ColumnViewJni.cpp
@@ -147,13 +147,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_upperStrings(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, handle, "column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     cudf::strings_column_view strings_column(*column);
     return release_as_jlong(cudf::strings::to_upper(strings_column));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_lowerStrings(JNIEnv* env,
@@ -162,13 +163,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_lowerStrings(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, handle, "column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     cudf::strings_column_view strings_column(*column);
     return release_as_jlong(cudf::strings::to_lower(strings_column));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceNullsScalar(JNIEnv* env,
@@ -178,13 +180,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceNullsScalar(JNIEnv
 {
   JNI_NULL_CHECK(env, j_col, "column is null", 0);
   JNI_NULL_CHECK(env, j_scalar, "scalar is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view col = *reinterpret_cast<cudf::column_view*>(j_col);
     auto val              = reinterpret_cast<cudf::scalar*>(j_scalar);
     return release_as_jlong(cudf::replace_nulls(col, *val));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceNullsColumn(JNIEnv* env,
@@ -194,13 +197,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceNullsColumn(JNIEnv
 {
   JNI_NULL_CHECK(env, j_col, "column is null", 0);
   JNI_NULL_CHECK(env, j_replace_col, "replacement column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto col          = reinterpret_cast<cudf::column_view*>(j_col);
     auto replacements = reinterpret_cast<cudf::column_view*>(j_replace_col);
     return release_as_jlong(cudf::replace_nulls(*col, *replacements));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceNullsPolicy(JNIEnv* env,
@@ -209,13 +213,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceNullsPolicy(JNIEnv
                                                                           jboolean is_preceding)
 {
   JNI_NULL_CHECK(env, j_col, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view col = *reinterpret_cast<cudf::column_view*>(j_col);
     return release_as_jlong(cudf::replace_nulls(
       col, is_preceding ? cudf::replace_policy::PRECEDING : cudf::replace_policy::FOLLOWING));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_distinctCount(JNIEnv* env,
@@ -224,7 +229,8 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_distinctCount(JNIEnv* env,
                                                                     jboolean nulls_included)
 {
   JNI_NULL_CHECK(env, j_col, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view col = *reinterpret_cast<cudf::column_view*>(j_col);
 
@@ -233,7 +239,7 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_distinctCount(JNIEnv* env,
       nulls_included ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE,
       cudf::nan_policy::NAN_IS_VALID);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_ifElseVV(
@@ -242,14 +248,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_ifElseVV(
   JNI_NULL_CHECK(env, j_pred_vec, "predicate column is null", 0);
   JNI_NULL_CHECK(env, j_true_vec, "true column is null", 0);
   JNI_NULL_CHECK(env, j_false_vec, "false column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto pred_vec  = reinterpret_cast<cudf::column_view*>(j_pred_vec);
     auto true_vec  = reinterpret_cast<cudf::column_view*>(j_true_vec);
     auto false_vec = reinterpret_cast<cudf::column_view*>(j_false_vec);
     return release_as_jlong(cudf::copy_if_else(*true_vec, *false_vec, *pred_vec));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_ifElseVS(
@@ -258,14 +265,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_ifElseVS(
   JNI_NULL_CHECK(env, j_pred_vec, "predicate column is null", 0);
   JNI_NULL_CHECK(env, j_true_vec, "true column is null", 0);
   JNI_NULL_CHECK(env, j_false_scalar, "false scalar is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto pred_vec     = reinterpret_cast<cudf::column_view*>(j_pred_vec);
     auto true_vec     = reinterpret_cast<cudf::column_view*>(j_true_vec);
     auto false_scalar = reinterpret_cast<cudf::scalar*>(j_false_scalar);
     return release_as_jlong(cudf::copy_if_else(*true_vec, *false_scalar, *pred_vec));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_ifElseSV(
@@ -274,14 +282,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_ifElseSV(
   JNI_NULL_CHECK(env, j_pred_vec, "predicate column is null", 0);
   JNI_NULL_CHECK(env, j_true_scalar, "true scalar is null", 0);
   JNI_NULL_CHECK(env, j_false_vec, "false column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto pred_vec    = reinterpret_cast<cudf::column_view*>(j_pred_vec);
     auto true_scalar = reinterpret_cast<cudf::scalar*>(j_true_scalar);
     auto false_vec   = reinterpret_cast<cudf::column_view*>(j_false_vec);
     return release_as_jlong(cudf::copy_if_else(*true_scalar, *false_vec, *pred_vec));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_ifElseSS(
@@ -290,14 +299,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_ifElseSS(
   JNI_NULL_CHECK(env, j_pred_vec, "predicate column is null", 0);
   JNI_NULL_CHECK(env, j_true_scalar, "true scalar is null", 0);
   JNI_NULL_CHECK(env, j_false_scalar, "false scalar is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto pred_vec     = reinterpret_cast<cudf::column_view*>(j_pred_vec);
     auto true_scalar  = reinterpret_cast<cudf::scalar*>(j_true_scalar);
     auto false_scalar = reinterpret_cast<cudf::scalar*>(j_false_scalar);
     return release_as_jlong(cudf::copy_if_else(*true_scalar, *false_scalar, *pred_vec));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getElement(JNIEnv* env,
@@ -306,12 +316,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getElement(JNIEnv* env,
                                                                   jint index)
 {
   JNI_NULL_CHECK(env, from, "from column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto from_vec = reinterpret_cast<cudf::column_view*>(from);
     return release_as_jlong(cudf::get_element(*from_vec, index));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_reduce(
@@ -319,7 +330,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_reduce(
 {
   JNI_NULL_CHECK(env, j_col_view, "column view is null", 0);
   JNI_NULL_CHECK(env, j_agg, "aggregation is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto col                  = reinterpret_cast<cudf::column_view*>(j_col_view);
     auto agg                  = reinterpret_cast<cudf::aggregation*>(j_agg);
@@ -327,7 +339,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_reduce(
     return release_as_jlong(
       cudf::reduce(*col, *dynamic_cast<cudf::reduce_aggregation*>(agg), out_dtype));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_segmentedReduce(JNIEnv* env,
@@ -342,7 +354,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_segmentedReduce(JNIEnv* e
   JNI_NULL_CHECK(env, j_data_view, "data column view is null", 0);
   JNI_NULL_CHECK(env, j_offsets_view, "offsets column view is null", 0);
   JNI_NULL_CHECK(env, j_agg, "aggregation is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto data    = reinterpret_cast<cudf::column_view*>(j_data_view);
     auto offsets = reinterpret_cast<cudf::column_view*>(j_offsets_view);
@@ -354,7 +367,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_segmentedReduce(JNIEnv* e
     return release_as_jlong(
       cudf::segmented_reduce(*data, *offsets, *s_agg, out_dtype, null_policy));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_segmentedGather(
@@ -362,7 +375,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_segmentedGather(
 {
   JNI_NULL_CHECK(env, source_column, "source column view is null", 0);
   JNI_NULL_CHECK(env, gather_map_list, "gather map is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const& src_col =
       cudf::lists_column_view(*reinterpret_cast<cudf::column_view*>(source_column));
@@ -372,7 +386,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_segmentedGather(
                                                 : cudf::out_of_bounds_policy::DONT_CHECK;
     return release_as_jlong(cudf::lists::segmented_gather(src_col, gather_map, out_bounds_policy));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_scan(
@@ -380,7 +394,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_scan(
 {
   JNI_NULL_CHECK(env, j_col_view, "column view is null", 0);
   JNI_NULL_CHECK(env, j_agg, "aggregation is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto col         = reinterpret_cast<cudf::column_view*>(j_col_view);
     auto agg         = reinterpret_cast<cudf::aggregation*>(j_agg);
@@ -389,7 +404,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_scan(
     return release_as_jlong(
       cudf::scan(*col, *dynamic_cast<cudf::scan_aggregation*>(agg), scan_type, null_policy));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_approxPercentile(JNIEnv* env,
@@ -399,7 +414,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_approxPercentile(JNIEnv* 
 {
   JNI_NULL_CHECK(env, input_column, "input_column native handle is null", 0);
   JNI_NULL_CHECK(env, percentiles_column, "percentiles_column native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     using namespace cudf;
     using tdigest_column_view = cudf::tdigest::tdigest_column_view;
     jni::auto_set_device(env);
@@ -408,14 +424,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_approxPercentile(JNIEnv* 
     auto const p_percentiles = reinterpret_cast<column_view*>(percentiles_column);
     return release_as_jlong(percentile_approx(tdigest_view, *p_percentiles));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_quantile(
   JNIEnv* env, jclass clazz, jlong input_column, jint quantile_method, jdoubleArray jquantiles)
 {
   JNI_NULL_CHECK(env, input_column, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jdoubleArray native_quantiles(env, jquantiles);
     std::vector<double> quantiles(native_quantiles.data(),
@@ -424,7 +441,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_quantile(
     cudf::interpolation n_quantile_method = static_cast<cudf::interpolation>(quantile_method);
     return release_as_jlong(cudf::quantile(*n_input_column, quantiles, n_quantile_method));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_rollingWindow(JNIEnv* env,
@@ -440,7 +457,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_rollingWindow(JNIEnv* env
 {
   JNI_NULL_CHECK(env, input_col, "native handle is null", 0);
   JNI_NULL_CHECK(env, agg_ptr, "aggregation handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* n_input_col = reinterpret_cast<cudf::column_view*>(input_col);
     cudf::column_view* n_default_output_col =
@@ -474,7 +492,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_rollingWindow(JNIEnv* env
     }
     return release_as_jlong(ret);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_slice(JNIEnv* env,
@@ -485,7 +503,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_slice(JNIEnv* env,
   JNI_NULL_CHECK(env, input_column, "native handle is null", 0);
   JNI_NULL_CHECK(env, slice_indices, "slice indices are null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* n_column = reinterpret_cast<cudf::column_view*>(input_column);
     cudf::jni::native_jintArray n_slice_indices(env, slice_indices);
@@ -501,7 +520,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_slice(JNIEnv* env,
 
     return n_result.get_jArray();
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractListElement(JNIEnv* env,
@@ -510,13 +529,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractListElement(JNIEnv
                                                                           jint index)
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::lists_column_view lcv(*cv);
     return release_as_jlong(cudf::lists::extract_list_element(lcv, index));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractListElementV(JNIEnv* env,
@@ -526,14 +546,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractListElementV(JNIEn
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   JNI_NULL_CHECK(env, indices_view, "indices is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* indices = reinterpret_cast<cudf::column_view*>(indices_view);
     cudf::column_view* cv      = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::lists_column_view lcv(*cv);
     return release_as_jlong(cudf::lists::extract_list_element(lcv, *indices));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dropListDuplicates(JNIEnv* env,
@@ -542,7 +563,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dropListDuplicates(JNIEnv
                                                                           jint keep_option)
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_cv = reinterpret_cast<cudf::column_view const*>(column_view);
     return release_as_jlong(
@@ -553,14 +575,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dropListDuplicates(JNIEnv
                             cudf::get_default_stream(),
                             cudf::get_current_device_resource_ref()));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dropListDuplicatesWithKeysValues(
   JNIEnv* env, jclass, jlong keys_vals_handle)
 {
   JNI_NULL_CHECK(env, keys_vals_handle, "keys_vals_handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_cv = reinterpret_cast<cudf::column_view const*>(keys_vals_handle);
     JNI_ARG_CHECK(
@@ -580,7 +603,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dropListDuplicatesWithKey
     return release_as_jlong(
       cudf::jni::lists_distinct_by_key(lists_keys_vals, cudf::get_default_stream()));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_flattenLists(JNIEnv* env,
@@ -589,14 +612,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_flattenLists(JNIEnv* env,
                                                                     jboolean ignore_null)
 {
   JNI_NULL_CHECK(env, input_handle, "input_handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const null_policy = ignore_null ? cudf::lists::concatenate_null_policy::IGNORE
                                          : cudf::lists::concatenate_null_policy::NULLIFY_OUTPUT_ROW;
     auto const input_cv    = reinterpret_cast<cudf::column_view const*>(input_handle);
     return release_as_jlong(cudf::lists::concatenate_list_elements(*input_cv, null_policy));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listContains(JNIEnv* env,
@@ -606,14 +630,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listContains(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   JNI_NULL_CHECK(env, lookup_key, "lookup scalar is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::lists_column_view lcv(*cv);
     cudf::scalar* lookup_scalar = reinterpret_cast<cudf::scalar*>(lookup_key);
     return release_as_jlong(cudf::lists::contains(lcv, *lookup_scalar));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listContainsNulls(JNIEnv* env,
@@ -621,13 +646,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listContainsNulls(JNIEnv*
                                                                          jlong column_view)
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto cv  = reinterpret_cast<cudf::column_view*>(column_view);
     auto lcv = cudf::lists_column_view{*cv};
     return release_as_jlong(cudf::lists::contains_nulls(lcv));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listContainsColumn(JNIEnv* env,
@@ -637,14 +663,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listContainsColumn(JNIEnv
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   JNI_NULL_CHECK(env, lookup_key_cv, "lookup column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::lists_column_view lcv(*cv);
     cudf::column_view* lookup_cv = reinterpret_cast<cudf::column_view*>(lookup_key_cv);
     return release_as_jlong(cudf::lists::contains(lcv, *lookup_cv));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listIndexOfScalar(
@@ -652,7 +679,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listIndexOfScalar(
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   JNI_NULL_CHECK(env, lookup_key, "lookup scalar is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const cv                = reinterpret_cast<cudf::column_view const*>(column_view);
     auto const lcv               = cudf::lists_column_view{*cv};
@@ -661,7 +689,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listIndexOfScalar(
                                                  : cudf::lists::duplicate_find_option::FIND_LAST;
     return release_as_jlong(cudf::lists::index_of(lcv, *lookup_key_scalar, find_option));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listIndexOfColumn(
@@ -669,7 +697,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listIndexOfColumn(
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   JNI_NULL_CHECK(env, lookup_keys, "lookup key column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const cv                = reinterpret_cast<cudf::column_view const*>(column_view);
     auto const lcv               = cudf::lists_column_view{*cv};
@@ -678,14 +707,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listIndexOfColumn(
                                                  : cudf::lists::duplicate_find_option::FIND_LAST;
     return release_as_jlong(cudf::lists::index_of(lcv, *lookup_key_column, find_option));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listSortRows(
   JNIEnv* env, jclass, jlong column_view, jboolean is_descending, jboolean is_null_smallest)
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto sort_order = is_descending ? cudf::order::DESCENDING : cudf::order::ASCENDING;
     auto null_order = is_null_smallest ? cudf::null_order::BEFORE : cudf::null_order::AFTER;
@@ -693,7 +723,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listSortRows(
     return release_as_jlong(
       cudf::lists::sort_lists(cudf::lists_column_view(*cv), sort_order, null_order));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_generateListOffsets(JNIEnv* env,
@@ -701,12 +731,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_generateListOffsets(JNIEn
                                                                            jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "handle is null", 0)
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const cv = reinterpret_cast<cudf::column_view const*>(handle);
     return release_as_jlong(cudf::jni::generate_list_offsets(*cv));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsHaveOverlap(JNIEnv* env,
@@ -716,7 +747,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsHaveOverlap(JNIEnv* 
 {
   JNI_NULL_CHECK(env, lhs_handle, "lhs_handle is null", 0)
   JNI_NULL_CHECK(env, rhs_handle, "rhs_handle is null", 0)
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const lhs      = reinterpret_cast<cudf::column_view const*>(lhs_handle);
     auto const rhs      = reinterpret_cast<cudf::column_view const*>(rhs_handle);
@@ -727,7 +759,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsHaveOverlap(JNIEnv* 
     cudf::jni::post_process_list_overlap(*lhs, *rhs, overlap_result);
     return release_as_jlong(overlap_result);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsIntersectDistinct(JNIEnv* env,
@@ -737,7 +769,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsIntersectDistinct(JN
 {
   JNI_NULL_CHECK(env, lhs_handle, "lhs_handle is null", 0)
   JNI_NULL_CHECK(env, rhs_handle, "rhs_handle is null", 0)
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const lhs = reinterpret_cast<cudf::column_view const*>(lhs_handle);
     auto const rhs = reinterpret_cast<cudf::column_view const*>(rhs_handle);
@@ -746,7 +779,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsIntersectDistinct(JN
                                                             cudf::null_equality::EQUAL,
                                                             cudf::nan_equality::ALL_EQUAL));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsUnionDistinct(JNIEnv* env,
@@ -756,7 +789,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsUnionDistinct(JNIEnv
 {
   JNI_NULL_CHECK(env, lhs_handle, "lhs_handle is null", 0)
   JNI_NULL_CHECK(env, rhs_handle, "rhs_handle is null", 0)
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const lhs = reinterpret_cast<cudf::column_view const*>(lhs_handle);
     auto const rhs = reinterpret_cast<cudf::column_view const*>(rhs_handle);
@@ -765,7 +799,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsUnionDistinct(JNIEnv
                                                         cudf::null_equality::EQUAL,
                                                         cudf::nan_equality::ALL_EQUAL));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsDifferenceDistinct(JNIEnv* env,
@@ -775,7 +809,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsDifferenceDistinct(J
 {
   JNI_NULL_CHECK(env, lhs_handle, "lhs_handle is null", 0)
   JNI_NULL_CHECK(env, rhs_handle, "rhs_handle is null", 0)
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const lhs = reinterpret_cast<cudf::column_view const*>(lhs_handle);
     auto const rhs = reinterpret_cast<cudf::column_view const*>(rhs_handle);
@@ -784,7 +819,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_listsDifferenceDistinct(J
                                                              cudf::null_equality::EQUAL,
                                                              cudf::nan_equality::ALL_EQUAL));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_reverseStringsOrLists(JNIEnv* env,
@@ -792,7 +827,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_reverseStringsOrLists(JNI
                                                                              jlong input_handle)
 {
   JNI_NULL_CHECK(env, input_handle, "input_handle is null", 0)
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const input = reinterpret_cast<cudf::column_view const*>(input_handle);
@@ -808,7 +844,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_reverseStringsOrLists(JNI
                       0);
     }
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringSplit(
@@ -827,7 +863,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringSplit(
                   0);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input          = reinterpret_cast<cudf::column_view const*>(input_handle);
     auto const strings_column = cudf::strings_column_view{*input};
@@ -837,7 +874,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringSplit(
     auto result = cudf::strings::split(strings_column, cudf::string_scalar{delimiter}, max_split);
     return cudf::jni::convert_table_for_return(env, std::move(result));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRe(JNIEnv* env,
@@ -861,7 +898,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRe(JNIEnv
                   0);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input          = reinterpret_cast<cudf::column_view const*>(input_handle);
     auto const strings_column = cudf::strings_column_view{*input};
@@ -874,7 +912,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRe(JNIEnv
     auto result               = cudf::strings::split_re(strings_column, *regex_prog, max_split);
     return cudf::jni::convert_table_for_return(env, std::move(result));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRecord(
@@ -893,7 +931,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRecord(
                   0);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input          = reinterpret_cast<cudf::column_view const*>(input_handle);
     auto const strings_column = cudf::strings_column_view{*input};
@@ -904,7 +943,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRecord(
       cudf::strings::split_record(strings_column, cudf::string_scalar{delimiter}, max_split);
     return release_as_jlong(result);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRecordRe(JNIEnv* env,
@@ -928,7 +967,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRecordRe(JNIEn
                   0);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input          = reinterpret_cast<cudf::column_view const*>(input_handle);
     auto const strings_column = cudf::strings_column_view{*input};
@@ -941,7 +981,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringSplitRecordRe(JNIEn
     auto result = cudf::strings::split_record_re(strings_column, *regex_prog, max_split);
     return release_as_jlong(result);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_split(JNIEnv* env,
@@ -952,7 +992,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_split(JNIEnv* env,
   JNI_NULL_CHECK(env, input_column, "native handle is null", 0);
   JNI_NULL_CHECK(env, split_indices, "split indices are null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* n_column = reinterpret_cast<cudf::column_view*>(input_column);
     cudf::jni::native_jintArray n_split_indices(env, split_indices);
@@ -968,7 +1009,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_split(JNIEnv* env,
 
     return n_result.get_jArray();
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_countElements(JNIEnv* env,
@@ -976,12 +1017,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_countElements(JNIEnv* env
                                                                      jlong view_handle)
 {
   JNI_NULL_CHECK(env, view_handle, "input column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* n_column = reinterpret_cast<cudf::column_view*>(view_handle);
     return release_as_jlong(cudf::lists::count_elements(cudf::lists_column_view(*n_column)));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_charLengths(JNIEnv* env,
@@ -989,12 +1031,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_charLengths(JNIEnv* env,
                                                                    jlong view_handle)
 {
   JNI_NULL_CHECK(env, view_handle, "input column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* n_column = reinterpret_cast<cudf::column_view*>(view_handle);
     return release_as_jlong(cudf::strings::count_characters(cudf::strings_column_view(*n_column)));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_byteCount(JNIEnv* env,
@@ -1002,12 +1045,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_byteCount(JNIEnv* env,
                                                                  jlong view_handle)
 {
   JNI_NULL_CHECK(env, view_handle, "input column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* n_column = reinterpret_cast<cudf::column_view*>(view_handle);
     return release_as_jlong(cudf::strings::count_bytes(cudf::strings_column_view(*n_column)));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_codePoints(JNIEnv* env,
@@ -1015,12 +1059,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_codePoints(JNIEnv* env,
                                                                   jlong view_handle)
 {
   JNI_NULL_CHECK(env, view_handle, "input column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::column_view const*>(view_handle);
     return release_as_jlong(cudf::strings::code_points(cudf::strings_column_view{*input}));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_findAndReplaceAll(
@@ -1033,7 +1078,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_findAndReplaceAll(
   using cudf::column;
   using cudf::column_view;
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     column_view* input_column      = reinterpret_cast<column_view*>(input_handle);
     column_view* old_values_column = reinterpret_cast<column_view*>(old_values_handle);
@@ -1041,7 +1087,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_findAndReplaceAll(
     return release_as_jlong(
       cudf::find_and_replace_all(*input_column, *old_values_column, *new_values_column));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isNullNative(JNIEnv* env,
@@ -1049,12 +1095,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isNullNative(JNIEnv* env,
                                                                     jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "input column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input = reinterpret_cast<cudf::column_view*>(handle);
     return release_as_jlong(cudf::is_null(*input));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isNotNullNative(JNIEnv* env,
@@ -1062,12 +1109,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isNotNullNative(JNIEnv* e
                                                                        jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "input column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input = reinterpret_cast<cudf::column_view*>(handle);
     return release_as_jlong(cudf::is_valid(*input));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isNanNative(JNIEnv* env,
@@ -1075,12 +1123,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isNanNative(JNIEnv* env,
                                                                    jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "input column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input = reinterpret_cast<cudf::column_view*>(handle);
     return release_as_jlong(cudf::is_nan(*input));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isNotNanNative(JNIEnv* env,
@@ -1088,12 +1137,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isNotNanNative(JNIEnv* en
                                                                       jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "input column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input = reinterpret_cast<cudf::column_view*>(handle);
     return release_as_jlong(cudf::is_not_nan(*input));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_unaryOperation(JNIEnv* env,
@@ -1102,26 +1152,28 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_unaryOperation(JNIEnv* en
                                                                       jint int_op)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* input = reinterpret_cast<cudf::column_view*>(input_ptr);
     cudf::unary_operator op  = static_cast<cudf::unary_operator>(int_op);
     return release_as_jlong(cudf::unary_operation(*input, op));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_round(
   JNIEnv* env, jclass, jlong input_ptr, jint decimal_places, jint rounding_method)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* input     = reinterpret_cast<cudf::column_view*>(input_ptr);
     cudf::rounding_method method = static_cast<cudf::rounding_method>(rounding_method);
     return release_as_jlong(cudf::round(*input, decimal_places, method));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractDateTimeComponent(JNIEnv* env,
@@ -1130,7 +1182,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractDateTimeComponent(
                                                                                 jint component)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input = reinterpret_cast<cudf::column_view*>(input_ptr);
     cudf::datetime::datetime_component comp;
@@ -1149,7 +1202,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractDateTimeComponent(
     }
     return release_as_jlong(cudf::datetime::extract_datetime_component(*input, comp));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_lastDayOfMonth(JNIEnv* env,
@@ -1157,12 +1210,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_lastDayOfMonth(JNIEnv* en
                                                                       jlong input_ptr)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input = reinterpret_cast<cudf::column_view*>(input_ptr);
     return release_as_jlong(cudf::datetime::last_day_of_month(*input));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dayOfYear(JNIEnv* env,
@@ -1170,12 +1224,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dayOfYear(JNIEnv* env,
                                                                  jlong input_ptr)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input = reinterpret_cast<cudf::column_view*>(input_ptr);
     return release_as_jlong(cudf::datetime::day_of_year(*input));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_quarterOfYear(JNIEnv* env,
@@ -1183,12 +1238,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_quarterOfYear(JNIEnv* env
                                                                      jlong input_ptr)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input = reinterpret_cast<cudf::column_view*>(input_ptr);
     return release_as_jlong(cudf::datetime::extract_quarter(*input));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_addCalendricalMonths(JNIEnv* env,
@@ -1198,13 +1254,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_addCalendricalMonths(JNIE
 {
   JNI_NULL_CHECK(env, ts_ptr, "ts is null", 0);
   JNI_NULL_CHECK(env, months_ptr, "months is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* ts     = reinterpret_cast<cudf::column_view*>(ts_ptr);
     cudf::column_view const* months = reinterpret_cast<cudf::column_view*>(months_ptr);
     return release_as_jlong(cudf::datetime::add_calendrical_months(*ts, *months));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_addScalarCalendricalMonths(JNIEnv* env,
@@ -1214,13 +1271,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_addScalarCalendricalMonth
 {
   JNI_NULL_CHECK(env, ts_ptr, "ts is null", 0);
   JNI_NULL_CHECK(env, months_ptr, "months is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* ts = reinterpret_cast<cudf::column_view*>(ts_ptr);
     cudf::scalar const* months  = reinterpret_cast<cudf::scalar*>(months_ptr);
     return release_as_jlong(cudf::datetime::add_calendrical_months(*ts, *months));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isLeapYear(JNIEnv* env,
@@ -1228,12 +1286,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isLeapYear(JNIEnv* env,
                                                                   jlong input_ptr)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input = reinterpret_cast<cudf::column_view*>(input_ptr);
     return release_as_jlong(cudf::datetime::is_leap_year(*input));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_daysInMonth(JNIEnv* env,
@@ -1241,12 +1300,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_daysInMonth(JNIEnv* env,
                                                                    jlong input_ptr)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input = reinterpret_cast<cudf::column_view*>(input_ptr);
     return release_as_jlong(cudf::datetime::days_in_month(*input));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dateTimeCeil(JNIEnv* env,
@@ -1255,13 +1315,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dateTimeCeil(JNIEnv* env,
                                                                     jint freq)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input            = reinterpret_cast<cudf::column_view*>(input_ptr);
     cudf::datetime::rounding_frequency n_freq = as_rounding_freq(freq);
     return release_as_jlong(cudf::datetime::ceil_datetimes(*input, n_freq));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dateTimeFloor(JNIEnv* env,
@@ -1270,13 +1331,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dateTimeFloor(JNIEnv* env
                                                                      jint freq)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input            = reinterpret_cast<cudf::column_view*>(input_ptr);
     cudf::datetime::rounding_frequency n_freq = as_rounding_freq(freq);
     return release_as_jlong(cudf::datetime::floor_datetimes(*input, n_freq));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dateTimeRound(JNIEnv* env,
@@ -1285,20 +1347,22 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_dateTimeRound(JNIEnv* env
                                                                      jint freq)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input            = reinterpret_cast<cudf::column_view*>(input_ptr);
     cudf::datetime::rounding_frequency n_freq = as_rounding_freq(freq);
     return release_as_jlong(cudf::datetime::round_datetimes(*input, n_freq));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
 Java_ai_rapids_cudf_ColumnView_castTo(JNIEnv* env, jclass, jlong handle, jint type, jint scale)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column   = reinterpret_cast<cudf::column_view*>(handle);
     cudf::data_type n_data_type = cudf::jni::make_data_type(type, scale);
@@ -1385,20 +1449,21 @@ Java_ai_rapids_cudf_ColumnView_castTo(JNIEnv* env, jclass, jlong handle, jint ty
       return release_as_jlong(cudf::cast(*column, n_data_type));
     }
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
 Java_ai_rapids_cudf_ColumnView_bitCastTo(JNIEnv* env, jclass, jlong handle, jint type, jint scale)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column   = reinterpret_cast<cudf::column_view*>(handle);
     cudf::data_type n_data_type = cudf::jni::make_data_type(type, scale);
     return ptr_as_jlong(new cudf::column_view{cudf::bit_cast(*column, n_data_type)});
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_byteListCast(JNIEnv* env,
@@ -1407,13 +1472,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_byteListCast(JNIEnv* env,
                                                                     jboolean endianness_config)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     cudf::flip_endianness config(static_cast<cudf::flip_endianness>(endianness_config));
     return release_as_jlong(byte_cast(*column, config));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringTimestampToTimestamp(
@@ -1422,7 +1488,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringTimestampToTimestam
   JNI_NULL_CHECK(env, handle, "column is null", 0);
   JNI_NULL_CHECK(env, formatObj, "format is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring format(env, formatObj);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
@@ -1431,7 +1498,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringTimestampToTimestam
     return release_as_jlong(cudf::strings::to_timestamps(
       strings_column, cudf::data_type(static_cast<cudf::type_id>(time_unit)), format.get()));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isTimestamp(JNIEnv* env,
@@ -1442,14 +1509,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isTimestamp(JNIEnv* env,
   JNI_NULL_CHECK(env, handle, "column is null", 0);
   JNI_NULL_CHECK(env, formatObj, "format is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring format(env, formatObj);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     cudf::strings_column_view strings_column(*column);
     return release_as_jlong(cudf::strings::is_timestamp(strings_column, format.get()));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_timestampToStringTimestamp(JNIEnv* env,
@@ -1460,13 +1528,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_timestampToStringTimestam
   JNI_NULL_CHECK(env, handle, "column is null", 0);
   JNI_NULL_CHECK(env, j_format, "format is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring format(env, j_format);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     return release_as_jlong(cudf::strings::from_timestamps(*column, format.get()));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_ColumnView_containsScalar(JNIEnv* env,
@@ -1476,14 +1545,15 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_ColumnView_containsScalar(JNIEnv*
 {
   JNI_NULL_CHECK(env, j_view_handle, "haystack vector is null", false);
   JNI_NULL_CHECK(env, j_scalar_handle, "scalar needle is null", false);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column_view = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::scalar* scalar           = reinterpret_cast<cudf::scalar*>(j_scalar_handle);
 
     return cudf::contains(*column_view, *scalar);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_containsVector(JNIEnv* env,
@@ -1493,7 +1563,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_containsVector(JNIEnv* en
 {
   JNI_NULL_CHECK(env, j_values_handle, "values vector is null", false);
   JNI_NULL_CHECK(env, j_search_space_handle, "search_space vector is null", false);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const search_space_ptr = reinterpret_cast<cudf::column_view const*>(j_search_space_handle);
     auto const values_ptr       = reinterpret_cast<cudf::column_view const*>(j_values_handle);
@@ -1501,13 +1572,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_containsVector(JNIEnv* en
     // The C++ API `cudf::contains` requires that the search space is the first parameter.
     return release_as_jlong(cudf::contains(*search_space_ptr, *values_ptr));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_transform(
   JNIEnv* env, jobject j_object, jlong handle, jstring j_udf, jboolean j_is_ptx)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     cudf::jni::native_jstring n_j_udf(env, j_udf);
@@ -1515,7 +1587,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_transform(
     return release_as_jlong(
       cudf::transform({*column}, n_udf, cudf::data_type(cudf::type_id::INT32), j_is_ptx));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringStartWith(JNIEnv* env,
@@ -1526,14 +1598,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringStartWith(JNIEnv* e
   JNI_NULL_CHECK(env, j_view_handle, "column is null", false);
   JNI_NULL_CHECK(env, comp_string, "comparison string scalar is null", false);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column_view = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::strings_column_view strings_column(*column_view);
     cudf::string_scalar* comp_scalar = reinterpret_cast<cudf::string_scalar*>(comp_string);
     return release_as_jlong(cudf::strings::starts_with(strings_column, *comp_scalar));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringEndWith(JNIEnv* env,
@@ -1544,14 +1617,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringEndWith(JNIEnv* env
   JNI_NULL_CHECK(env, j_view_handle, "column is null", false);
   JNI_NULL_CHECK(env, comp_string, "comparison string scalar is null", false);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column_view = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::strings_column_view strings_column(*column_view);
     cudf::string_scalar* comp_scalar = reinterpret_cast<cudf::string_scalar*>(comp_string);
     return release_as_jlong(cudf::strings::ends_with(strings_column, *comp_scalar));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringContains(JNIEnv* env,
@@ -1562,14 +1636,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringContains(JNIEnv* en
   JNI_NULL_CHECK(env, j_view_handle, "column is null", false);
   JNI_NULL_CHECK(env, comp_string, "comparison string scalar is null", false);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column_view = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::strings_column_view strings_column(*column_view);
     cudf::string_scalar* comp_scalar = reinterpret_cast<cudf::string_scalar*>(comp_string);
     return release_as_jlong(cudf::strings::contains(strings_column, *comp_scalar));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_matchesRe(JNIEnv* env,
@@ -1582,7 +1657,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_matchesRe(JNIEnv* env,
   JNI_NULL_CHECK(env, j_view_handle, "column is null", false);
   JNI_NULL_CHECK(env, pattern_obj, "pattern is null", false);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const column_view    = reinterpret_cast<cudf::column_view const*>(j_view_handle);
     auto const strings_column = cudf::strings_column_view{*column_view};
@@ -1592,7 +1668,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_matchesRe(JNIEnv* env,
     auto const regex_prog     = cudf::strings::regex_program::create(pattern.get(), flags, groups);
     return release_as_jlong(cudf::strings::matches_re(strings_column, *regex_prog));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_containsRe(JNIEnv* env,
@@ -1605,7 +1681,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_containsRe(JNIEnv* env,
   JNI_NULL_CHECK(env, j_view_handle, "column is null", false);
   JNI_NULL_CHECK(env, pattern_obj, "pattern is null", false);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const column_view    = reinterpret_cast<cudf::column_view const*>(j_view_handle);
     auto const strings_column = cudf::strings_column_view{*column_view};
@@ -1615,7 +1692,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_containsRe(JNIEnv* env,
     auto const regex_prog     = cudf::strings::regex_program::create(pattern.get(), flags, capture);
     return release_as_jlong(cudf::strings::contains_re(strings_column, *regex_prog));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_like(
@@ -1625,7 +1702,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_like(
   JNI_NULL_CHECK(env, pattern, "pattern is null", false);
   JNI_NULL_CHECK(env, escapeChar, "escape character is null", false);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const column_view    = reinterpret_cast<cudf::column_view const*>(j_view_handle);
     auto const strings_column = cudf::strings_column_view{*column_view};
@@ -1633,7 +1711,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_like(
     auto const escape_scalar  = reinterpret_cast<cudf::string_scalar const*>(escapeChar);
     return release_as_jlong(cudf::strings::like(strings_column, *pattern_scalar, *escape_scalar));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_binaryOpVV(
@@ -1641,7 +1719,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_binaryOpVV(
 {
   JNI_NULL_CHECK(env, lhs_view, "lhs is null", 0);
   JNI_NULL_CHECK(env, rhs_view, "rhs is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto lhs                    = reinterpret_cast<cudf::column_view*>(lhs_view);
     auto rhs                    = reinterpret_cast<cudf::column_view*>(rhs_view);
@@ -1666,18 +1745,19 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_binaryOpVV(
 
     return release_as_jlong(cudf::binary_operation(*lhs, *rhs, op, n_data_type));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_fixedPointOutputScale(
   JNIEnv* env, jclass, jint int_op, jint lhs_scale, jint rhs_scale)
 {
-  try {
+  JNI_TRY
+  {
     // we just return the scale as the types will be the same as the lhs input
     return cudf::binary_operation_fixed_point_scale(
       static_cast<cudf::binary_operator>(int_op), lhs_scale, rhs_scale);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_binaryOpVS(
@@ -1685,7 +1765,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_binaryOpVS(
 {
   JNI_NULL_CHECK(env, lhs_view, "lhs is null", 0);
   JNI_NULL_CHECK(env, rhs_ptr, "rhs is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto lhs                    = reinterpret_cast<cudf::column_view*>(lhs_view);
     cudf::scalar* rhs           = reinterpret_cast<cudf::scalar*>(rhs_ptr);
@@ -1711,7 +1792,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_binaryOpVS(
 
     return release_as_jlong(cudf::binary_operation(*lhs, *rhs, op, n_data_type));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substringS(JNIEnv* env,
@@ -1720,26 +1801,28 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substringS(JNIEnv* env,
                                                                   jint start)
 {
   JNI_NULL_CHECK(env, cv_handle, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const cv  = reinterpret_cast<cudf::column_view const*>(cv_handle);
     auto const scv = cudf::strings_column_view{*cv};
     return release_as_jlong(cudf::strings::slice_strings(scv, start));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substring(
   JNIEnv* env, jclass, jlong column_view, jint start, jint end)
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::strings_column_view scv(*cv);
     return release_as_jlong(cudf::strings::slice_strings(scv, start, end));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substringColumn(
@@ -1748,7 +1831,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substringColumn(
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   JNI_NULL_CHECK(env, start_column, "column is null", 0);
   JNI_NULL_CHECK(env, end_column, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::strings_column_view scv(*cv);
@@ -1756,7 +1840,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substringColumn(
     cudf::column_view* ec = reinterpret_cast<cudf::column_view*>(end_column);
     return release_as_jlong(cudf::strings::slice_strings(scv, *sc, *ec));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substringLocate(
@@ -1764,14 +1848,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_substringLocate(
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   JNI_NULL_CHECK(env, substring, "target string scalar is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::strings_column_view scv(*cv);
     cudf::string_scalar* ss_scalar = reinterpret_cast<cudf::string_scalar*>(substring);
     return release_as_jlong(cudf::strings::find(scv, *ss_scalar, start, end));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplace(
@@ -1780,7 +1865,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplace(
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   JNI_NULL_CHECK(env, target, "target string scalar is null", 0);
   JNI_NULL_CHECK(env, replace, "replace string scalar is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::strings_column_view scv(*cv);
@@ -1788,7 +1874,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplace(
     cudf::string_scalar* ss_replace = reinterpret_cast<cudf::string_scalar*>(replace);
     return release_as_jlong(cudf::strings::replace(scv, *ss_target, *ss_replace));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplaceMulti(
@@ -1797,7 +1883,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplaceMulti(
   JNI_NULL_CHECK(env, inputs_cv, "column is null", 0);
   JNI_NULL_CHECK(env, targets_cv, "targets string column view is null", 0);
   JNI_NULL_CHECK(env, repls_cv, "repls string column view is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(inputs_cv);
     cudf::strings_column_view scv(*cv);
@@ -1807,7 +1894,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringReplaceMulti(
     cudf::strings_column_view scvrepls(*cvrepls);
     return release_as_jlong(cudf::strings::replace_multiple(scv, scvtargets, scvrepls));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapLookupForKeys(JNIEnv* env,
@@ -1817,14 +1904,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapLookupForKeys(JNIEnv* 
 {
   JNI_NULL_CHECK(env, map_column_view, "column is null", 0);
   JNI_NULL_CHECK(env, lookup_keys, "lookup key is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const* cv          = reinterpret_cast<cudf::column_view*>(map_column_view);
     auto const* column_keys = reinterpret_cast<cudf::column_view*>(lookup_keys);
     auto const maps_view    = cudf::jni::maps_column_view{*cv};
     return release_as_jlong(maps_view.get_values_for(*column_keys));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapLookup(JNIEnv* env,
@@ -1834,14 +1922,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapLookup(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, map_column_view, "column is null", 0);
   JNI_NULL_CHECK(env, lookup_key, "lookup key is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const* cv         = reinterpret_cast<cudf::column_view*>(map_column_view);
     auto const* scalar_key = reinterpret_cast<cudf::scalar*>(lookup_key);
     auto const maps_view   = cudf::jni::maps_column_view{*cv};
     return release_as_jlong(maps_view.get_values_for(*scalar_key));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapContainsKeys(JNIEnv* env,
@@ -1851,14 +1940,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapContainsKeys(JNIEnv* e
 {
   JNI_NULL_CHECK(env, map_column_view, "column is null", 0);
   JNI_NULL_CHECK(env, lookup_keys, "lookup key is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const* cv         = reinterpret_cast<cudf::column_view*>(map_column_view);
     auto const* column_key = reinterpret_cast<cudf::column_view*>(lookup_keys);
     auto const maps_view   = cudf::jni::maps_column_view{*cv};
     return release_as_jlong(maps_view.contains(*column_key));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapContains(JNIEnv* env,
@@ -1868,14 +1958,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_mapContains(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, map_column_view, "column is null", 0);
   JNI_NULL_CHECK(env, lookup_key, "lookup key is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const* cv         = reinterpret_cast<cudf::column_view*>(map_column_view);
     auto const* scalar_key = reinterpret_cast<cudf::scalar*>(lookup_key);
     auto const maps_view   = cudf::jni::maps_column_view{*cv};
     return release_as_jlong(maps_view.contains(*scalar_key));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceRegex(JNIEnv* env,
@@ -1890,7 +1981,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceRegex(JNIEnv* env,
   JNI_NULL_CHECK(env, j_column_view, "column is null", 0);
   JNI_NULL_CHECK(env, j_pattern, "pattern string is null", 0);
   JNI_NULL_CHECK(env, j_repl, "replace scalar is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const cv             = reinterpret_cast<cudf::column_view const*>(j_column_view);
     auto const strings_column = cudf::strings_column_view{*cv};
@@ -1902,7 +1994,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceRegex(JNIEnv* env,
     return release_as_jlong(
       cudf::strings::replace_re(strings_column, *regex_prog, *repl, j_maxrepl));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceMultiRegex(
@@ -1911,7 +2003,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceMultiRegex(
   JNI_NULL_CHECK(env, j_column_view, "column is null", 0);
   JNI_NULL_CHECK(env, j_patterns, "patterns is null", 0);
   JNI_NULL_CHECK(env, j_repls, "repls is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto cv = reinterpret_cast<cudf::column_view const*>(j_column_view);
     cudf::strings_column_view scv(*cv);
@@ -1920,7 +2013,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_replaceMultiRegex(
     cudf::strings_column_view repl_scv(*repl_cv);
     return release_as_jlong(cudf::strings::replace_re(scv, patterns.as_cpp_vector(), repl_scv));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -1935,7 +2028,8 @@ Java_ai_rapids_cudf_ColumnView_stringReplaceWithBackrefs(JNIEnv* env,
   JNI_NULL_CHECK(env, j_column_view, "column is null", 0);
   JNI_NULL_CHECK(env, pattern_obj, "pattern string is null", 0);
   JNI_NULL_CHECK(env, replace_obj, "replace string is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const cv             = reinterpret_cast<cudf::column_view const*>(j_column_view);
     auto const strings_column = cudf::strings_column_view{*cv};
@@ -1947,7 +2041,7 @@ Java_ai_rapids_cudf_ColumnView_stringReplaceWithBackrefs(JNIEnv* env,
     return release_as_jlong(
       cudf::strings::replace_with_backrefs(strings_column, *regex_prog, ss_replace.get()));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_zfill(JNIEnv* env,
@@ -1956,14 +2050,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_zfill(JNIEnv* env,
                                                              jint j_width)
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::strings_column_view scv(*cv);
     cudf::size_type width = reinterpret_cast<cudf::size_type>(j_width);
     return release_as_jlong(cudf::strings::zfill(scv, width));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_pad(
@@ -1971,7 +2066,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_pad(
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   JNI_NULL_CHECK(env, fill_char, "fill_char is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::strings_column_view scv(*cv);
@@ -1980,7 +2076,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_pad(
     cudf::jni::native_jstring ss_fill(env, fill_char);
     return release_as_jlong(cudf::strings::pad(scv, width, side, ss_fill.get()));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringStrip(
@@ -1988,7 +2084,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringStrip(
 {
   JNI_NULL_CHECK(env, column_view, "column is null", 0);
   JNI_NULL_CHECK(env, to_strip, "to_strip scalar is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* cv = reinterpret_cast<cudf::column_view*>(column_view);
     cudf::strings_column_view scv(*cv);
@@ -1996,7 +2093,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringStrip(
     cudf::string_scalar* ss_tostrip      = reinterpret_cast<cudf::string_scalar*>(to_strip);
     return release_as_jlong(cudf::strings::strip(scv, s_striptype, *ss_tostrip));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_extractRe(JNIEnv* env,
@@ -2009,7 +2106,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_extractRe(JNIEnv* en
   JNI_NULL_CHECK(env, j_view_handle, "column is null", nullptr);
   JNI_NULL_CHECK(env, pattern_obj, "pattern is null", nullptr);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const column_view    = reinterpret_cast<cudf::column_view const*>(j_view_handle);
     auto const strings_column = cudf::strings_column_view{*column_view};
@@ -2020,7 +2118,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_extractRe(JNIEnv* en
     return cudf::jni::convert_table_for_return(env,
                                                cudf::strings::extract(strings_column, *regex_prog));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractAllRecord(JNIEnv* env,
@@ -2034,7 +2132,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractAllRecord(JNIEnv* 
   JNI_NULL_CHECK(env, j_view_handle, "column is null", 0);
   JNI_NULL_CHECK(env, pattern_obj, "pattern is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const column_view    = reinterpret_cast<cudf::column_view const*>(j_view_handle);
     auto const strings_column = cudf::strings_column_view{*column_view};
@@ -2046,7 +2145,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_extractAllRecord(JNIEnv* 
                                            : cudf::strings::extract_all_record(strings_column, *regex_prog);
     return release_as_jlong(result);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_urlDecode(JNIEnv* env,
@@ -2055,13 +2154,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_urlDecode(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, j_view_handle, "column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto view_ptr = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::strings_column_view strings_view(*view_ptr);
     return release_as_jlong(cudf::strings::url_decode(strings_view));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_urlEncode(JNIEnv* env,
@@ -2070,13 +2170,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_urlEncode(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, j_view_handle, "column is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto view_ptr = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::strings_column_view strings_view(*view_ptr);
     return release_as_jlong(cudf::strings::url_encode(strings_view));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_normalizeNANsAndZeros(JNIEnv* env,
@@ -2086,12 +2187,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_normalizeNANsAndZeros(JNI
   using cudf::column_view;
 
   JNI_NULL_CHECK(env, input_column, "Input column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     return release_as_jlong(
       cudf::normalize_nans_and_zeros(*reinterpret_cast<column_view*>(input_column)));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidity(
@@ -2099,7 +2201,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
 {
   JNI_NULL_CHECK(env, base_column, "base column native handle is null", 0);
   JNI_NULL_CHECK(env, column_handles, "array of column handles is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* original_column = reinterpret_cast<cudf::column_view*>(base_column);
     std::unique_ptr<cudf::column> copy(new cudf::column(*original_column));
@@ -2139,7 +2242,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_bitwiseMergeAndSetValidit
 
     return release_as_jlong(copy);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 ////////
@@ -2159,7 +2262,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_makeCudfColumnView(JNIEnv
                                                                           jint size,
                                                                           jlongArray j_children)
 {
-  try {
+  JNI_TRY
+  {
     using cudf::column_view;
     cudf::jni::auto_set_device(env);
     cudf::type_id n_type        = static_cast<cudf::type_id>(j_type);
@@ -2226,7 +2330,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_makeCudfColumnView(JNIEnv
       return ptr_as_jlong(new cudf::column_view(n_data_type, size, data, valid, j_null_count));
     }
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_getNativeTypeId(JNIEnv* env,
@@ -2234,12 +2338,13 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_getNativeTypeId(JNIEnv* en
                                                                       jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     return static_cast<jint>(column->type().id());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_getNativeTypeScale(JNIEnv* env,
@@ -2247,12 +2352,13 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_getNativeTypeScale(JNIEnv*
                                                                          jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     return column->type().scale();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_getNativeRowCount(JNIEnv* env,
@@ -2260,12 +2366,13 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_getNativeRowCount(JNIEnv* 
                                                                         jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     return static_cast<jint>(column->size());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_getNativeNullCount(JNIEnv* env,
@@ -2273,24 +2380,26 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_getNativeNullCount(JNIEnv*
                                                                          jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     return static_cast<jint>(column->null_count());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_ColumnView_deleteColumnView(JNIEnv* env,
                                                                        jobject j_object,
                                                                        jlong handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* view = reinterpret_cast<cudf::column_view*>(handle);
     delete view;
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeDataAddress(JNIEnv* env,
@@ -2298,7 +2407,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeDataAddress(JNIE
                                                                             jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     jlong result              = 0;
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
@@ -2313,7 +2423,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeDataAddress(JNIE
     }
     return result;
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeDataLength(JNIEnv* env,
@@ -2321,7 +2431,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeDataLength(JNIEn
                                                                            jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     jlong result              = 0;
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
@@ -2336,7 +2447,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeDataLength(JNIEn
     }
     return result;
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_getNativeNumChildren(JNIEnv* env,
@@ -2344,7 +2455,8 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_getNativeNumChildren(JNIEn
                                                                            jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     // Strings has children(offsets and chars) but not a nested child() we care about here.
@@ -2359,7 +2471,7 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_ColumnView_getNativeNumChildren(JNIEn
       return 0;
     }
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getChildCvPointer(JNIEnv* env,
@@ -2368,14 +2480,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getChildCvPointer(JNIEnv*
                                                                          jint child_index)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     auto const is_list        = column->type().id() == cudf::type_id::LIST;
     auto const child          = column->child(child_index + (is_list ? 1 : 0));
     return ptr_as_jlong(new cudf::column_view(child));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getListOffsetCvPointer(JNIEnv* env,
@@ -2383,14 +2496,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getListOffsetCvPointer(JN
                                                                               jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column      = reinterpret_cast<cudf::column_view*>(handle);
     cudf::lists_column_view view   = cudf::lists_column_view(*column);
     cudf::column_view offsets_view = view.offsets();
     return ptr_as_jlong(new cudf::column_view(offsets_view));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeOffsetsAddress(JNIEnv* env,
@@ -2398,7 +2512,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeOffsetsAddress(J
                                                                                jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     jlong result              = 0;
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
@@ -2417,7 +2532,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeOffsetsAddress(J
     }
     return result;
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeOffsetsLength(JNIEnv* env,
@@ -2425,7 +2540,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeOffsetsLength(JN
                                                                               jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     jlong result              = 0;
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
@@ -2444,7 +2560,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeOffsetsLength(JN
     }
     return result;
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeValidityAddress(JNIEnv* env,
@@ -2452,12 +2568,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeValidityAddress(
                                                                                 jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     return ptr_as_jlong(column->null_mask());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeValidityLength(JNIEnv* env,
@@ -2465,7 +2582,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeValidityLength(J
                                                                                jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column = reinterpret_cast<cudf::column_view*>(handle);
     jlong result              = 0;
@@ -2474,7 +2592,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getNativeValidityLength(J
     }
     return result;
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getDeviceMemorySize(JNIEnv* env,
@@ -2483,12 +2601,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_getDeviceMemorySize(JNIEn
                                                                            jboolean pad_for_cpu)
 {
   JNI_NULL_CHECK(env, handle, "native handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto view = reinterpret_cast<cudf::column_view const*>(handle);
     return calc_device_memory_size(*view, pad_for_cpu);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_hostPaddingSizeInBytes(JNIEnv* env, jclass)
@@ -2510,7 +2629,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_clamper(JNIEnv* env,
   JNI_NULL_CHECK(env, j_hi_scalar, "lo scalar is null", 0)
   JNI_NULL_CHECK(env, j_hi_replace_scalar, "lo scalar replace value is null", 0)
   using cudf::clamp;
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* column_view  = reinterpret_cast<cudf::column_view*>(handle);
     cudf::scalar* lo_scalar         = reinterpret_cast<cudf::scalar*>(j_lo_scalar);
@@ -2521,7 +2641,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_clamper(JNIEnv* env,
     return release_as_jlong(
       clamp(*column_view, *lo_scalar, *lo_replace_scalar, *hi_scalar, *hi_replace_scalar));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_title(JNIEnv* env,
@@ -2530,12 +2650,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_title(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, handle, "native view handle is null", 0)
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* view = reinterpret_cast<cudf::column_view*>(handle);
     return release_as_jlong(cudf::strings::title(*view));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_capitalize(JNIEnv* env,
@@ -2546,13 +2667,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_capitalize(JNIEnv* env,
   JNI_NULL_CHECK(env, strs_handle, "native view handle is null", 0)
   JNI_NULL_CHECK(env, delimiters_handle, "delimiters scalar handle is null", 0)
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* view   = reinterpret_cast<cudf::column_view*>(strs_handle);
     cudf::string_scalar* deli = reinterpret_cast<cudf::string_scalar*>(delimiters_handle);
     return release_as_jlong(cudf::strings::capitalize(*view, *deli));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_joinStrings(
@@ -2562,14 +2684,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_joinStrings(
   JNI_NULL_CHECK(env, separator_handle, "separator scalar handle is null", 0)
   JNI_NULL_CHECK(env, narep_handle, "narep scalar handle is null", 0)
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* view    = reinterpret_cast<cudf::column_view*>(strs_handle);
     cudf::string_scalar* sep   = reinterpret_cast<cudf::string_scalar*>(separator_handle);
     cudf::string_scalar* narep = reinterpret_cast<cudf::string_scalar*>(narep_handle);
     return release_as_jlong(cudf::strings::join_strings(*view, *sep, *narep));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_makeStructView(JNIEnv* env,
@@ -2578,113 +2701,102 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_makeStructView(JNIEnv* en
                                                                       jlong row_count)
 {
   JNI_NULL_CHECK(env, handles, "native view handles are null", 0)
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto children        = cudf::jni::native_jpointerArray<cudf::column_view>{env, handles};
     auto children_vector = children.get_dereferenced();
     return ptr_as_jlong(new cudf::column_view(
       cudf::data_type{cudf::type_id::STRUCT}, row_count, nullptr, nullptr, 0, 0, children_vector));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_nansToNulls(JNIEnv* env,
                                                                    jobject j_object,
-                                                                   jlong handle)
-{
+                                                                   jlong handle){
   JNI_NULL_CHECK(env, handle, "native view handle is null", 0)
 
-  try {
-    cudf::jni::auto_set_device(env);
-    auto const input = *reinterpret_cast<cudf::column_view*>(handle);
-    // get a new null mask by setting all the nans to null
-    auto [new_nullmask, new_null_count] = cudf::nans_to_nulls(input);
-    // create a column_view which is a no-copy wrapper around the original column without the null
-    // mask
-    auto const input_without_nullmask =
-      cudf::column_view(input.type(),
-                        input.size(),
-                        input.head<void>(),
-                        nullptr,
-                        0,
-                        input.offset(),
-                        std::vector<cudf::column_view>{input.child_begin(), input.child_end()});
-    // create a column by deep copying `input_without_nullmask`.
-    auto deep_copy = std::make_unique<cudf::column>(input_without_nullmask);
-    deep_copy->set_null_mask(std::move(*new_nullmask), new_null_count);
-    return release_as_jlong(deep_copy);
-  }
-  CATCH_STD(env, 0)
+    JNI_TRY{cudf::jni::auto_set_device(env);
+auto const input = *reinterpret_cast<cudf::column_view*>(handle);
+// get a new null mask by setting all the nans to null
+auto [new_nullmask, new_null_count] = cudf::nans_to_nulls(input);
+// create a column_view which is a no-copy wrapper around the original column without the null
+// mask
+auto const input_without_nullmask =
+  cudf::column_view(input.type(),
+                    input.size(),
+                    input.head<void>(),
+                    nullptr,
+                    0,
+                    input.offset(),
+                    std::vector<cudf::column_view>{input.child_begin(), input.child_end()});
+// create a column by deep copying `input_without_nullmask`.
+auto deep_copy = std::make_unique<cudf::column>(input_without_nullmask);
+deep_copy->set_null_mask(std::move(*new_nullmask), new_null_count);
+return release_as_jlong(deep_copy);
+}
+JNI_CATCH(env, 0)
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isFloat(JNIEnv* env,
                                                                jobject j_object,
-                                                               jlong handle)
-{
+                                                               jlong handle){
   JNI_NULL_CHECK(env, handle, "native view handle is null", 0)
 
-  try {
-    cudf::jni::auto_set_device(env);
-    cudf::column_view* view = reinterpret_cast<cudf::column_view*>(handle);
-    return release_as_jlong(cudf::strings::is_float(*view));
-  }
-  CATCH_STD(env, 0)
+    JNI_TRY{cudf::jni::auto_set_device(env);
+cudf::column_view* view = reinterpret_cast<cudf::column_view*>(handle);
+return release_as_jlong(cudf::strings::is_float(*view));
+}
+JNI_CATCH(env, 0)
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isInteger(JNIEnv* env,
                                                                  jobject j_object,
-                                                                 jlong handle)
-{
+                                                                 jlong handle){
   JNI_NULL_CHECK(env, handle, "native view handle is null", 0)
 
-  try {
-    cudf::jni::auto_set_device(env);
-    cudf::column_view* view = reinterpret_cast<cudf::column_view*>(handle);
-    return release_as_jlong(cudf::strings::is_integer(*view));
-  }
-  CATCH_STD(env, 0)
+    JNI_TRY{cudf::jni::auto_set_device(env);
+cudf::column_view* view = reinterpret_cast<cudf::column_view*>(handle);
+return release_as_jlong(cudf::strings::is_integer(*view));
+}
+JNI_CATCH(env, 0)
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isFixedPoint(
-  JNIEnv* env, jobject, jlong handle, jint j_dtype, jint scale)
-{
+  JNIEnv* env, jobject, jlong handle, jint j_dtype, jint scale){
   JNI_NULL_CHECK(env, handle, "native view handle is null", 0)
 
-  try {
-    cudf::jni::auto_set_device(env);
-    cudf::column_view* view  = reinterpret_cast<cudf::column_view*>(handle);
-    cudf::data_type fp_dtype = cudf::jni::make_data_type(j_dtype, scale);
-    return release_as_jlong(cudf::strings::is_fixed_point(*view, fp_dtype));
-  }
-  CATCH_STD(env, 0)
+    JNI_TRY{cudf::jni::auto_set_device(env);
+cudf::column_view* view  = reinterpret_cast<cudf::column_view*>(handle);
+cudf::data_type fp_dtype = cudf::jni::make_data_type(j_dtype, scale);
+return release_as_jlong(cudf::strings::is_fixed_point(*view, fp_dtype));
+}
+JNI_CATCH(env, 0)
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_isIntegerWithType(
-  JNIEnv* env, jobject, jlong handle, jint j_dtype, jint scale)
-{
+  JNIEnv* env, jobject, jlong handle, jint j_dtype, jint scale){
   JNI_NULL_CHECK(env, handle, "native view handle is null", 0)
 
-  try {
-    cudf::jni::auto_set_device(env);
-    cudf::column_view* view   = reinterpret_cast<cudf::column_view*>(handle);
-    cudf::data_type int_dtype = cudf::jni::make_data_type(j_dtype, scale);
-    return release_as_jlong(cudf::strings::is_integer(*view, int_dtype));
-  }
-  CATCH_STD(env, 0)
+    JNI_TRY{cudf::jni::auto_set_device(env);
+cudf::column_view* view   = reinterpret_cast<cudf::column_view*>(handle);
+cudf::data_type int_dtype = cudf::jni::make_data_type(j_dtype, scale);
+return release_as_jlong(cudf::strings::is_integer(*view, int_dtype));
+}
+JNI_CATCH(env, 0)
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_copyColumnViewToCV(JNIEnv* env,
                                                                           jobject j_object,
-                                                                          jlong handle)
-{
+                                                                          jlong handle){
   JNI_NULL_CHECK(env, handle, "native view handle is null", 0)
 
-  try {
-    cudf::jni::auto_set_device(env);
-    cudf::column_view* view = reinterpret_cast<cudf::column_view*>(handle);
-    return ptr_as_jlong(new cudf::column(*view));
-  }
-  CATCH_STD(env, 0)
+    JNI_TRY{cudf::jni::auto_set_device(env);
+cudf::column_view* view = reinterpret_cast<cudf::column_view*>(handle);
+return ptr_as_jlong(new cudf::column(*view));
+}
+JNI_CATCH(env, 0)
 }
 
 JNIEXPORT jlong JNICALL
@@ -2699,7 +2811,8 @@ Java_ai_rapids_cudf_ColumnView_getJSONObject(JNIEnv* env,
   JNI_NULL_CHECK(env, j_view_handle, "view cannot be null", 0);
   JNI_NULL_CHECK(env, j_scalar_handle, "path cannot be null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view* n_column_view = reinterpret_cast<cudf::column_view*>(j_view_handle);
     cudf::strings_column_view n_strings_col_view(*n_column_view);
@@ -2709,18 +2822,17 @@ Java_ai_rapids_cudf_ColumnView_getJSONObject(JNIEnv* env,
     options.set_strip_quotes_from_single_strings(strip_quotes_from_single_strings);
     options.set_missing_fields_as_nulls(missing_fields_as_nulls);
     auto result_col_ptr = [&]() {
-      try {
-        return cudf::get_json_object(n_strings_col_view, *n_scalar_path, options);
-      } catch (std::invalid_argument const& err) {
+      JNI_TRY { return cudf::get_json_object(n_strings_col_view, *n_scalar_path, options); }
+      catch (std::invalid_argument const& err)
+      {
         auto const null_scalar = cudf::string_scalar(std::string(""), false);
         return cudf::make_column_from_scalar(null_scalar, n_strings_col_view.size());
-      } catch (...) {
-        throw;
       }
+      catch (...) { throw; }
     }();
     return release_as_jlong(result_col_ptr);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringConcatenationListElementsSepCol(
@@ -2737,7 +2849,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringConcatenationListEl
   JNI_NULL_CHECK(env, sep_handle, "separator column handle is null", 0);
   JNI_NULL_CHECK(env, separator_narep, "separator narep string scalar object is null", 0);
   JNI_NULL_CHECK(env, col_narep, "column narep string scalar object is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const& separator_narep_scalar = *reinterpret_cast<cudf::string_scalar*>(separator_narep);
     auto const& col_narep_scalar       = *reinterpret_cast<cudf::string_scalar*>(col_narep);
@@ -2758,7 +2871,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringConcatenationListEl
                                                               null_policy,
                                                               empty_list_output));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringConcatenationListElements(
@@ -2773,7 +2886,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringConcatenationListEl
   JNI_NULL_CHECK(env, column_handle, "column handle is null", 0);
   JNI_NULL_CHECK(env, separator, "separator string scalar object is null", 0);
   JNI_NULL_CHECK(env, narep, "separator narep string scalar object is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const& separator_scalar = *reinterpret_cast<cudf::string_scalar*>(separator);
     auto const& narep_scalar     = *reinterpret_cast<cudf::string_scalar*>(narep);
@@ -2788,7 +2902,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_stringConcatenationListEl
     return release_as_jlong(cudf::strings::join_list_elements(
       lcv, separator_scalar, narep_scalar, null_policy, empty_list_output));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_repeatStrings(JNIEnv* env,
@@ -2797,13 +2911,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_repeatStrings(JNIEnv* env
                                                                      jint repeat_times)
 {
   JNI_NULL_CHECK(env, strings_handle, "strings_handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const cv       = *reinterpret_cast<cudf::column_view*>(strings_handle);
     auto const strs_col = cudf::strings_column_view(cv);
     return release_as_jlong(cudf::strings::repeat_strings(strs_col, repeat_times));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_repeatStringsWithColumnRepeatTimes(
@@ -2811,14 +2926,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_repeatStringsWithColumnRe
 {
   JNI_NULL_CHECK(env, strings_handle, "strings_handle is null", 0);
   JNI_NULL_CHECK(env, repeat_times_handle, "repeat_times_handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const strings_cv      = *reinterpret_cast<cudf::column_view*>(strings_handle);
     auto const strs_col        = cudf::strings_column_view(strings_cv);
     auto const repeat_times_cv = *reinterpret_cast<cudf::column_view*>(repeat_times_handle);
     return release_as_jlong(cudf::strings::repeat_strings(strs_col, repeat_times_cv));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_applyBooleanMask(
@@ -2826,7 +2942,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_applyBooleanMask(
 {
   JNI_NULL_CHECK(env, list_column_handle, "list handle is null", 0);
   JNI_NULL_CHECK(env, boolean_mask_list_column_handle, "boolean mask handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::column_view const* list_column =
@@ -2840,7 +2957,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_applyBooleanMask(
 
     return release_as_jlong(cudf::lists::apply_boolean_mask(list_view, boolean_mask_list_view));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_ColumnView_hasNonEmptyNulls(JNIEnv* env,
@@ -2848,12 +2965,13 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_ColumnView_hasNonEmptyNulls(JNIEn
                                                                            jlong column_view_handle)
 {
   JNI_NULL_CHECK(env, column_view_handle, "column_view handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const* cv = reinterpret_cast<cudf::column_view const*>(column_view_handle);
     return cudf::has_nonempty_nulls(*cv);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_purgeNonEmptyNulls(JNIEnv* env,
@@ -2861,23 +2979,25 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_purgeNonEmptyNulls(JNIEnv
                                                                           jlong column_view_handle)
 {
   JNI_NULL_CHECK(env, column_view_handle, "column_view handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const* cv = reinterpret_cast<cudf::column_view const*>(column_view_handle);
     return release_as_jlong(cudf::purge_nonempty_nulls(*cv));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ColumnView_toHex(JNIEnv* env, jclass, jlong input_ptr)
 {
   JNI_NULL_CHECK(env, input_ptr, "input is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::column_view const* input = reinterpret_cast<cudf::column_view*>(input_ptr);
     return release_as_jlong(cudf::strings::integers_to_hex(*input));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringContainsMulti(
@@ -2886,7 +3006,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringContainsMulti(
   JNI_NULL_CHECK(env, j_view_handle, "column is null", 0);
   JNI_NULL_CHECK(env, j_target_view_handle, "targets is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto* column_view         = reinterpret_cast<cudf::column_view*>(j_view_handle);
     auto* targets_view        = reinterpret_cast<cudf::column_view*>(j_target_view_handle);
@@ -2895,7 +3016,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_ColumnView_stringContainsMulti(
     auto contains_results     = cudf::strings::contains_multiple(strings_column, targets_column);
     return cudf::jni::convert_table_for_return(env, std::move(contains_results));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/CompiledExpression.cpp
+++ b/java/src/main/native/src/CompiledExpression.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -399,7 +399,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ast_CompiledExpression_compile(JNIEn
                                                                            jbyteArray jni_data)
 {
   JNI_NULL_CHECK(env, jni_data, "Serialized AST data is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jbyteArray jbytes(env, jni_data);
     jni_serialized_ast jni_ast(jbytes);
@@ -407,7 +408,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ast_CompiledExpression_compile(JNIEn
     jbytes.cancel();
     return reinterpret_cast<jlong>(compiled_expr_ptr.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ast_CompiledExpression_computeColumn(JNIEnv* env,
@@ -417,7 +418,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ast_CompiledExpression_computeColumn
 {
   JNI_NULL_CHECK(env, j_ast, "Compiled AST pointer is null", 0);
   JNI_NULL_CHECK(env, j_table, "Table view pointer is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto compiled_expr_ptr = reinterpret_cast<cudf::jni::ast::compiled_expr const*>(j_ast);
     auto tview_ptr         = reinterpret_cast<cudf::table_view const*>(j_table);
@@ -425,19 +427,20 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ast_CompiledExpression_computeColumn
       cudf::compute_column(*tview_ptr, compiled_expr_ptr->get_top_expression());
     return reinterpret_cast<jlong>(result.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_ast_CompiledExpression_destroy(JNIEnv* env,
                                                                           jclass,
                                                                           jlong jni_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto ptr = reinterpret_cast<cudf::jni::ast::compiled_expr*>(jni_handle);
     delete ptr;
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/ContiguousTableJni.cpp
+++ b/java/src/main/native/src/ContiguousTableJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ContiguousTable_createPackedMetadata
   JNIEnv* env, jclass, jlong j_table, jlong j_buffer_addr, jlong j_buffer_length)
 {
   JNI_NULL_CHECK(env, j_table, "input table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto table        = reinterpret_cast<cudf::table_view const*>(j_table);
     auto data_addr    = reinterpret_cast<uint8_t const*>(j_buffer_addr);
@@ -140,7 +141,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_ContiguousTable_createPackedMetadata
     auto metadata_ptr = new std::vector<uint8_t>(cudf::pack_metadata(*table, data_addr, data_size));
     return reinterpret_cast<jlong>(metadata_ptr);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/CuFileJni.cpp
+++ b/java/src/main/native/src/CuFileJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -291,11 +291,12 @@ extern "C" {
  */
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_CuFileDriver_create(JNIEnv* env, jclass)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     return reinterpret_cast<jlong>(new cufile_driver());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 /**
@@ -306,11 +307,12 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_CuFileDriver_create(JNIEnv* env, jcl
  */
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_CuFileDriver_destroy(JNIEnv* env, jclass, jlong pointer)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     delete reinterpret_cast<cufile_driver*>(pointer);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 /**
@@ -325,13 +327,14 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_CuFileDriver_destroy(JNIEnv* env, jcl
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_CuFileBuffer_create(
   JNIEnv* env, jclass, jlong device_pointer, jlong size, jboolean register_buffer)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto* buffer =
       new cufile_buffer(reinterpret_cast<void*>(device_pointer), size, register_buffer);
     return reinterpret_cast<jlong>(buffer);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 /**
@@ -342,11 +345,12 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_CuFileBuffer_create(
  */
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_CuFileBuffer_destroy(JNIEnv* env, jclass, jlong pointer)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     delete reinterpret_cast<cufile_buffer*>(pointer);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 /**
@@ -360,12 +364,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_CuFileReadHandle_create(JNIEnv* env,
                                                                     jclass,
                                                                     jstring path)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto file = cufile_file::make_reader(env->GetStringUTFChars(path, nullptr));
     return reinterpret_cast<jlong>(file.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 /**
@@ -379,13 +384,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_CuFileReadHandle_create(JNIEnv* env,
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_CuFileReadHandle_readIntoBuffer(
   JNIEnv* env, jclass, jlong file, jlong file_offset, jlong buffer)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto* file_ptr   = reinterpret_cast<cufile_file*>(file);
     auto* buffer_ptr = reinterpret_cast<cufile_buffer*>(buffer);
     file_ptr->read(*buffer_ptr, file_offset);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 /**
@@ -399,12 +405,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_CuFileWriteHandle_create(JNIEnv* env
                                                                      jclass,
                                                                      jstring path)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto file = cufile_file::make_writer(env->GetStringUTFChars(path, nullptr));
     return reinterpret_cast<jlong>(file.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 /**
@@ -419,13 +426,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_CuFileWriteHandle_create(JNIEnv* env
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_CuFileWriteHandle_writeFromBuffer(
   JNIEnv* env, jclass, jlong file, jlong file_offset, jlong buffer, jlong size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto* file_ptr   = reinterpret_cast<cufile_file*>(file);
     auto* buffer_ptr = reinterpret_cast<cufile_buffer*>(buffer);
     file_ptr->write(*buffer_ptr, size, file_offset);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 /**
@@ -440,13 +448,14 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_CuFileWriteHandle_writeFromBuffer(
 JNIEXPORT long JNICALL Java_ai_rapids_cudf_CuFileWriteHandle_appendFromBuffer(
   JNIEnv* env, jclass, jlong file, jlong buffer, jlong size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto* file_ptr   = reinterpret_cast<cufile_file*>(file);
     auto* buffer_ptr = reinterpret_cast<cufile_buffer*>(buffer);
     return file_ptr->append(*buffer_ptr, size);
   }
-  CATCH_STD(env, -1);
+  JNI_CATCH(env, -1);
 }
 
 /**
@@ -457,11 +466,12 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_CuFileWriteHandle_appendFromBuffer(
  */
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_CuFileHandle_destroy(JNIEnv* env, jclass, jlong pointer)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     delete reinterpret_cast<cufile_file*>(pointer);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 /**
@@ -476,13 +486,14 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_CuFileHandle_destroy(JNIEnv* env, jcl
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_CuFile_writeToFile(
   JNIEnv* env, jclass, jstring path, jlong file_offset, jlong device_pointer, jlong size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cufile_buffer buffer{reinterpret_cast<void*>(device_pointer), static_cast<std::size_t>(size)};
     auto writer = cufile_file::make_writer(env->GetStringUTFChars(path, nullptr));
     writer->write(buffer, size, file_offset);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 /**
@@ -497,13 +508,14 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_CuFile_writeToFile(
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_CuFile_appendToFile(
   JNIEnv* env, jclass, jstring path, jlong device_pointer, jlong size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cufile_buffer buffer{reinterpret_cast<void*>(device_pointer), static_cast<std::size_t>(size)};
     auto writer = cufile_file::make_writer(env->GetStringUTFChars(path, nullptr));
     return writer->append(buffer, size);
   }
-  CATCH_STD(env, -1);
+  JNI_CATCH(env, -1);
 }
 
 /**
@@ -518,13 +530,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_CuFile_appendToFile(
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_CuFile_readFromFile(
   JNIEnv* env, jclass, jlong device_pointer, jlong size, jstring path, jlong file_offset)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cufile_buffer buffer{reinterpret_cast<void*>(device_pointer), static_cast<std::size_t>(size)};
     auto const reader = cufile_file::make_reader(env->GetStringUTFChars(path, nullptr));
     reader->read(buffer, file_offset);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -52,13 +52,6 @@ void auto_set_device(JNIEnv* env)
   }
 }
 
-/** Fills all the bytes in the buffer 'buf' with 'value'. */
-void device_memset_async(JNIEnv* env, rmm::device_buffer& buf, char value)
-{
-  cudaError_t cuda_status = cudaMemsetAsync((void*)buf.data(), value, buf.size());
-  jni_cuda_check(env, cuda_status);
-}
-
 }  // namespace jni
 }  // namespace cudf
 
@@ -66,7 +59,8 @@ extern "C" {
 
 JNIEXPORT jobject JNICALL Java_ai_rapids_cudf_Cuda_memGetInfo(JNIEnv* env, jclass clazz)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     size_t free, total;
@@ -83,119 +77,127 @@ JNIEXPORT jobject JNICALL Java_ai_rapids_cudf_Cuda_memGetInfo(JNIEnv* env, jclas
     // to the JVM which will handle throwing any exceptions that happened in the constructor.
     return info_obj;
   }
-  CATCH_STD(env, nullptr);
+  JNI_CATCH(env, nullptr);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Cuda_hostAllocPinned(JNIEnv* env, jclass, jlong size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     void* ret = nullptr;
     CUDF_CUDA_TRY(cudaMallocHost(&ret, size));
     return reinterpret_cast<jlong>(ret);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_freePinned(JNIEnv* env, jclass, jlong ptr)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     CUDF_CUDA_TRY(cudaFreeHost(reinterpret_cast<void*>(ptr)));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL
 Java_ai_rapids_cudf_Cuda_memset(JNIEnv* env, jclass, jlong dst, jbyte value, jlong count, jint kind)
 {
   JNI_NULL_CHECK(env, dst, "dst memory pointer is null", );
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     CUDF_CUDA_TRY(cudaMemsetAsync((void*)dst, value, count));
     CUDF_CUDA_TRY(cudaStreamSynchronize(0));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_asyncMemset(
   JNIEnv* env, jclass, jlong dst, jbyte value, jlong count, jint kind)
 {
   JNI_NULL_CHECK(env, dst, "dst memory pointer is null", );
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     CUDF_CUDA_TRY(cudaMemsetAsync((void*)dst, value, count));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getDevice(JNIEnv* env, jclass)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     jint dev;
     CUDF_CUDA_TRY(cudaGetDevice(&dev));
     return dev;
   }
-  CATCH_STD(env, -2);
+  JNI_CATCH(env, -2);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getDeviceCount(JNIEnv* env, jclass)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     jint count;
     CUDF_CUDA_TRY(cudaGetDeviceCount(&count));
     return count;
   }
-  CATCH_STD(env, -2);
+  JNI_CATCH(env, -2);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_setDevice(JNIEnv* env, jclass, jint dev)
 {
-  try {
+  JNI_TRY
+  {
     if (Cudf_device != cudaInvalidDeviceId && dev != Cudf_device) {
       cudf::jni::throw_java_exception(
         env, cudf::jni::CUDF_EXCEPTION_CLASS, "Cannot change device after RMM init");
     }
     CUDF_CUDA_TRY(cudaSetDevice(dev));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_autoSetDevice(JNIEnv* env, jclass, jint dev)
 {
-  try {
-    cudf::jni::auto_set_device(env);
-  }
-  CATCH_STD(env, );
+  JNI_TRY { cudf::jni::auto_set_device(env); }
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getDriverVersion(JNIEnv* env, jclass)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     jint driver_version;
     CUDF_CUDA_TRY(cudaDriverGetVersion(&driver_version));
     return driver_version;
   }
-  CATCH_STD(env, -2);
+  JNI_CATCH(env, -2);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getRuntimeVersion(JNIEnv* env, jclass)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     jint runtime_version;
     CUDF_CUDA_TRY(cudaRuntimeGetVersion(&runtime_version));
     return runtime_version;
   }
-  CATCH_STD(env, -2);
+  JNI_CATCH(env, -2);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getNativeComputeMode(JNIEnv* env, jclass)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     int device;
     CUDF_CUDA_TRY(cudaGetDevice(&device));
@@ -203,12 +205,13 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getNativeComputeMode(JNIEnv* env
     CUDF_CUDA_TRY(cudaGetDeviceProperties(&device_prop, device));
     return device_prop.computeMode;
   }
-  CATCH_STD(env, -2);
+  JNI_CATCH(env, -2);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getComputeCapabilityMajor(JNIEnv* env, jclass)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     int device;
     CUDF_CUDA_TRY(::cudaGetDevice(&device));
@@ -217,12 +220,13 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getComputeCapabilityMajor(JNIEnv
       ::cudaDeviceGetAttribute(&attribute_value, ::cudaDevAttrComputeCapabilityMajor, device));
     return attribute_value;
   }
-  CATCH_STD(env, -2);
+  JNI_CATCH(env, -2);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getComputeCapabilityMinor(JNIEnv* env, jclass)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     int device;
     CUDF_CUDA_TRY(::cudaGetDevice(&device));
@@ -231,40 +235,43 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getComputeCapabilityMinor(JNIEnv
       ::cudaDeviceGetAttribute(&attribute_value, ::cudaDevAttrComputeCapabilityMinor, device));
     return attribute_value;
   }
-  CATCH_STD(env, -2);
+  JNI_CATCH(env, -2);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_freeZero(JNIEnv* env, jclass)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     CUDF_CUDA_TRY(cudaFree(0));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Cuda_createStream(JNIEnv* env,
                                                               jclass,
                                                               jboolean isNonBlocking)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudaStream_t stream = nullptr;
     auto flags          = isNonBlocking ? cudaStreamNonBlocking : cudaStreamDefault;
     CUDF_CUDA_TRY(cudaStreamCreateWithFlags(&stream, flags));
     return reinterpret_cast<jlong>(stream);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_destroyStream(JNIEnv* env, jclass, jlong jstream)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto stream = reinterpret_cast<cudaStream_t>(jstream);
     CUDF_CUDA_TRY(cudaStreamDestroy(stream));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_streamWaitEvent(JNIEnv* env,
@@ -272,25 +279,27 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_streamWaitEvent(JNIEnv* env,
                                                                 jlong jstream,
                                                                 jlong jevent)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto stream = reinterpret_cast<cudaStream_t>(jstream);
     auto event  = reinterpret_cast<cudaEvent_t>(jevent);
     CUDF_CUDA_TRY(cudaStreamWaitEvent(stream, event, 0));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_streamSynchronize(JNIEnv* env,
                                                                   jclass,
                                                                   jlong jstream)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto stream = reinterpret_cast<cudaStream_t>(jstream);
     CUDF_CUDA_TRY(cudaStreamSynchronize(stream));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Cuda_createEvent(JNIEnv* env,
@@ -298,7 +307,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Cuda_createEvent(JNIEnv* env,
                                                              jboolean enableTiming,
                                                              jboolean blockingSync)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudaEvent_t event  = nullptr;
     unsigned int flags = 0;
@@ -307,22 +317,24 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Cuda_createEvent(JNIEnv* env,
     CUDF_CUDA_TRY(cudaEventCreateWithFlags(&event, flags));
     return reinterpret_cast<jlong>(event);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_destroyEvent(JNIEnv* env, jclass, jlong jevent)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto event = reinterpret_cast<cudaEvent_t>(jevent);
     CUDF_CUDA_TRY(cudaEventDestroy(event));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Cuda_eventQuery(JNIEnv* env, jclass, jlong jevent)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto event  = reinterpret_cast<cudaEvent_t>(jevent);
     auto result = cudaEventQuery(event);
@@ -333,7 +345,7 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Cuda_eventQuery(JNIEnv* env, jcla
     }  // else
     CUDF_CUDA_TRY(result);
   }
-  CATCH_STD(env, false);
+  JNI_CATCH(env, false);
   return false;
 }
 
@@ -342,23 +354,25 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_eventRecord(JNIEnv* env,
                                                             jlong jevent,
                                                             jlong jstream)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto event  = reinterpret_cast<cudaEvent_t>(jevent);
     auto stream = reinterpret_cast<cudaStream_t>(jstream);
     CUDF_CUDA_TRY(cudaEventRecord(event, stream));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_eventSynchronize(JNIEnv* env, jclass, jlong jevent)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto event = reinterpret_cast<cudaEvent_t>(jevent);
     CUDF_CUDA_TRY(cudaEventSynchronize(event));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_memcpyOnStream(
@@ -367,7 +381,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_memcpyOnStream(
   if (count == 0) { return; }
   JNI_ARG_CHECK(env, jdst != 0, "dst memory pointer is null", );
   JNI_ARG_CHECK(env, jsrc != 0, "src memory pointer is null", );
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto dst    = reinterpret_cast<void*>(jdst);
     auto src    = reinterpret_cast<void*>(jsrc);
@@ -376,7 +391,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_memcpyOnStream(
     CUDF_CUDA_TRY(cudaMemcpyAsync(dst, src, count, kind, stream));
     CUDF_CUDA_TRY(cudaStreamSynchronize(stream));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_asyncMemcpyOnStream(
@@ -385,7 +400,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_asyncMemcpyOnStream(
   if (count == 0) { return; }
   JNI_ARG_CHECK(env, jdst != 0, "dst memory pointer is null", );
   JNI_ARG_CHECK(env, jsrc != 0, "src memory pointer is null", );
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto dst    = reinterpret_cast<void*>(jdst);
     auto src    = reinterpret_cast<void*>(jsrc);
@@ -393,16 +409,14 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_asyncMemcpyOnStream(
     auto stream = reinterpret_cast<cudaStream_t>(jstream);
     CUDF_CUDA_TRY(cudaMemcpyAsync(dst, src, count, kind, stream));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_profilerStart(JNIEnv* env, jclass clazz)
 {
 #ifdef CUDF_JNI_ENABLE_PROFILING
-  try {
-    cudaProfilerStart();
-  }
-  CATCH_STD(env, );
+  JNI_TRY { cudaProfilerStart(); }
+  JNI_CATCH(env, );
 #else
   cudf::jni::throw_java_exception(
     env, cudf::jni::CUDF_EXCEPTION_CLASS, "This library was built without CUDA profiler support.");
@@ -412,10 +426,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_profilerStart(JNIEnv* env, jclas
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_profilerStop(JNIEnv* env, jclass clazz)
 {
 #ifdef CUDF_JNI_ENABLE_PROFILING
-  try {
-    cudaProfilerStop();
-  }
-  CATCH_STD(env, );
+  JNI_TRY { cudaProfilerStop(); }
+  JNI_CATCH(env, );
 #else
   cudf::jni::throw_java_exception(
     env, cudf::jni::CUDF_EXCEPTION_CLASS, "This library was built without CUDA profiler support.");
@@ -424,11 +436,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_profilerStop(JNIEnv* env, jclass
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cuda_deviceSynchronize(JNIEnv* env, jclass clazz)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     CUDF_CUDA_TRY(cudaDeviceSynchronize());
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/CudfJni.cpp
+++ b/java/src/main/native/src/CudfJni.cpp
@@ -202,28 +202,25 @@ JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Cuda_isPtdsEnabled(JNIEnv* env, j
   return cudf::jni::is_ptds_enabled;
 }
 
-JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cudf_setKernelPinnedCopyThreshold(JNIEnv* env,
-                                                                             jclass clazz,
-                                                                             jlong jthreshold)
-{
-  try {
-    cudf::jni::auto_set_device(env);
-    auto threshold = static_cast<std::size_t>(jthreshold);
-    cudf::set_kernel_pinned_copy_threshold(threshold);
-  }
-  CATCH_STD(env, )
+JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cudf_setKernelPinnedCopyThreshold(
+  JNIEnv* env, jclass clazz, jlong jthreshold){JNI_TRY{cudf::jni::auto_set_device(env);
+auto threshold = static_cast<std::size_t>(jthreshold);
+cudf::set_kernel_pinned_copy_threshold(threshold);
+}
+JNI_CATCH(env, )
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Cudf_setPinnedAllocationThreshold(JNIEnv* env,
                                                                              jclass clazz,
                                                                              jlong jthreshold)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto threshold = static_cast<std::size_t>(jthreshold);
     cudf::set_allocate_host_as_pinned_threshold(threshold);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, )
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/DataSourceHelperJni.cpp
+++ b/java/src/main/native/src/DataSourceHelperJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,27 +218,29 @@ Java_ai_rapids_cudf_DataSourceHelper_createWrapperDataSource(JNIEnv* env,
                                                              jlong device_read_cutoff)
 {
   JNI_NULL_CHECK(env, ds, "Null data source", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto source =
       new cudf::jni::jni_datasource(env, ds, ds_size, device_read_supported, device_read_cutoff);
     return reinterpret_cast<jlong>(source);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_DataSourceHelper_destroyWrapperDataSource(JNIEnv* env,
                                                                                      jclass,
                                                                                      jlong handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     if (handle != 0) {
       auto source = reinterpret_cast<cudf::jni::jni_datasource*>(handle);
       delete (source);
     }
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/HashJoinJni.cpp
+++ b/java/src/main/native/src/HashJoinJni.cpp
@@ -26,7 +26,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_HashJoin_create(JNIEnv* env,
                                                             jboolean j_nulls_equal)
 {
   JNI_NULL_CHECK(env, j_table, "table handle is null", 0);
-  try {
+  JNI_TRY
+  {
     auto const load_factor = 0.5;
     cudf::jni::auto_set_device(env);
     auto tview         = reinterpret_cast<cudf::table_view const*>(j_table);
@@ -34,17 +35,18 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_HashJoin_create(JNIEnv* env,
     auto hash_join_ptr = new cudf::hash_join(*tview, cudf::nullable_join::YES, nulleq, load_factor);
     return reinterpret_cast<jlong>(hash_join_ptr);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_HashJoin_destroy(JNIEnv* env, jclass, jlong j_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto hash_join_ptr = reinterpret_cast<cudf::hash_join*>(j_handle);
     delete hash_join_ptr;
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/HostMemoryBufferNativeUtilsJni.cpp
+++ b/java/src/main/native/src/HostMemoryBufferNativeUtilsJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_HostMemoryBufferNativeUtils_mmap(
 {
   JNI_NULL_CHECK(env, jpath, "path is null", 0);
   JNI_ARG_CHECK(env, (mode == 0 || mode == 1), "bad mode value", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::native_jstring path(env, jpath);
 
     int fd = open(path.get(), (mode == 0) ? O_RDONLY : O_RDWR);
@@ -54,7 +55,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_HostMemoryBufferNativeUtils_mmap(
     close(fd);
     return reinterpret_cast<jlong>(address);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_HostMemoryBufferNativeUtils_munmap(JNIEnv* env,
@@ -63,11 +64,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_HostMemoryBufferNativeUtils_munmap(JN
                                                                               jlong length)
 {
   JNI_NULL_CHECK(env, address, "address is NULL", );
-  try {
+  JNI_TRY
+  {
     int rc = munmap(reinterpret_cast<void*>(address), length);
     if (rc == -1) { cudf::jni::throw_java_exception(env, "java/io/IOException", strerror(errno)); }
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/HostUDFWrapperJni.cpp
+++ b/java/src/main/native/src/HostUDFWrapperJni.cpp
@@ -24,11 +24,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_HostUDFWrapper_close(JNIEnv* env,
                                                                 jclass class_object,
                                                                 jlong ptr)
 {
-  try {
+  JNI_TRY
+  {
     auto to_del = reinterpret_cast<cudf::host_udf_base*>(ptr);
     delete to_del;
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/NvcompJni.cpp
+++ b/java/src/main/native/src/NvcompJni.cpp
@@ -65,7 +65,8 @@ extern "C" {
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4CompressGetTempSize(
   JNIEnv* env, jclass, jlong j_batch_size, jlong j_max_chunk_size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto batch_size       = static_cast<std::size_t>(j_batch_size);
     auto max_chunk_size   = static_cast<std::size_t>(j_max_chunk_size);
@@ -75,7 +76,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4CompressG
     check_nvcomp_status(env, status);
     return static_cast<jlong>(temp_size);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -83,7 +84,8 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4CompressGetMaxOutputChunkSize(JNI
                                                                              jclass,
                                                                              jlong j_max_chunk_size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto max_chunk_size         = static_cast<std::size_t>(j_max_chunk_size);
     std::size_t max_output_size = 0;
@@ -92,7 +94,7 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4CompressGetMaxOutputChunkSize(JNI
     check_nvcomp_status(env, status);
     return static_cast<jlong>(max_output_size);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL
@@ -108,7 +110,8 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4CompressAsync(JNIEnv* env,
                                                              jlong j_compressed_sizes_out_ptr,
                                                              jlong j_stream)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto in_ptrs              = reinterpret_cast<void const* const*>(j_in_ptrs);
     auto in_sizes             = reinterpret_cast<std::size_t const*>(j_in_sizes);
@@ -131,13 +134,14 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4CompressAsync(JNIEnv* env,
                                                 stream);
     check_nvcomp_status(env, status);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4DecompressGetTempSize(
   JNIEnv* env, jclass, jlong j_batch_size, jlong j_chunk_size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto batch_size       = static_cast<std::size_t>(j_batch_size);
     auto chunk_size       = static_cast<std::size_t>(j_chunk_size);
@@ -146,7 +150,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4Decompres
     check_nvcomp_status(env, status);
     return static_cast<jlong>(temp_size);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL
@@ -161,7 +165,8 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4DecompressAsync(JNIEnv* env,
                                                                jlong j_out_ptrs,
                                                                jlong j_stream)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto compressed_ptrs           = reinterpret_cast<void const* const*>(j_in_ptrs);
     auto compressed_sizes          = reinterpret_cast<std::size_t const*>(j_in_sizes);
@@ -190,7 +195,7 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4DecompressAsync(JNIEnv* env,
         env, cudf::jni::NVCOMP_EXCEPTION_CLASS, "nvcomp decompress output size mismatch");
     }
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL
@@ -202,7 +207,8 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4GetDecompressSizeAsync(JNIEnv* en
                                                                       jlong j_batch_size,
                                                                       jlong j_stream)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto compressed_ptrs    = reinterpret_cast<void const* const*>(j_in_ptrs);
     auto compressed_sizes   = reinterpret_cast<std::size_t const*>(j_in_sizes);
@@ -213,14 +219,15 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedLZ4GetDecompressSizeAsync(JNIEnv* en
       compressed_ptrs, compressed_sizes, uncompressed_sizes, batch_size, stream);
     check_nvcomp_status(env, status);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 // methods for zstd
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdCompressGetTempSize(
   JNIEnv* env, jclass, jlong j_batch_size, jlong j_max_chunk_size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto batch_size       = static_cast<std::size_t>(j_batch_size);
     auto max_chunk_size   = static_cast<std::size_t>(j_max_chunk_size);
@@ -230,14 +237,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdCompress
     check_nvcomp_status(env, status);
     return static_cast<jlong>(temp_size);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
 Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdCompressGetMaxOutputChunkSize(
   JNIEnv* env, jclass, jlong j_max_chunk_size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto max_chunk_size         = static_cast<std::size_t>(j_max_chunk_size);
     std::size_t max_output_size = 0;
@@ -246,7 +254,7 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdCompressGetMaxOutputChunkSize(
     check_nvcomp_status(env, status);
     return static_cast<jlong>(max_output_size);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL
@@ -262,7 +270,8 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdCompressAsync(JNIEnv* env,
                                                               jlong j_compressed_sizes_out_ptr,
                                                               jlong j_stream)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto in_ptrs              = reinterpret_cast<void const* const*>(j_in_ptrs);
     auto in_sizes             = reinterpret_cast<std::size_t const*>(j_in_sizes);
@@ -285,13 +294,14 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdCompressAsync(JNIEnv* env,
                                                  stream);
     check_nvcomp_status(env, status);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdDecompressGetTempSize(
   JNIEnv* env, jclass, jlong j_batch_size, jlong j_chunk_size)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto batch_size       = static_cast<std::size_t>(j_batch_size);
     auto chunk_size       = static_cast<std::size_t>(j_chunk_size);
@@ -300,7 +310,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdDecompre
     check_nvcomp_status(env, status);
     return static_cast<jlong>(temp_size);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL
@@ -315,7 +325,8 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdDecompressAsync(JNIEnv* env,
                                                                 jlong j_out_ptrs,
                                                                 jlong j_stream)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto compressed_ptrs           = reinterpret_cast<void const* const*>(j_in_ptrs);
     auto compressed_sizes          = reinterpret_cast<std::size_t const*>(j_in_sizes);
@@ -344,7 +355,7 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdDecompressAsync(JNIEnv* env,
         env, cudf::jni::NVCOMP_EXCEPTION_CLASS, "nvcomp decompress output size mismatch");
     }
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL
@@ -356,7 +367,8 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdGetDecompressSizeAsync(JNIEnv* e
                                                                        jlong j_batch_size,
                                                                        jlong j_stream)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto compressed_ptrs    = reinterpret_cast<void const* const*>(j_in_ptrs);
     auto compressed_sizes   = reinterpret_cast<std::size_t const*>(j_in_sizes);
@@ -367,7 +379,7 @@ Java_ai_rapids_cudf_nvcomp_NvcompJni_batchedZstdGetDecompressSizeAsync(JNIEnv* e
       compressed_ptrs, compressed_sizes, uncompressed_sizes, batch_size, stream);
     check_nvcomp_status(env, status);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/NvtxRangeJni.cpp
+++ b/java/src/main/native/src/NvtxRangeJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,21 +26,20 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_NvtxRange_push(JNIEnv* env,
                                                           jstring name,
                                                           jint color_bits)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::native_jstring range_name(env, name);
     nvtx3::color range_color(static_cast<nvtx3::color::value_type>(color_bits));
     nvtx3::event_attributes attr{range_color, range_name.get()};
     nvtxDomainRangePushEx(nvtx3::domain::get<cudf::jni::java_domain>(), attr.get());
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_NvtxRange_pop(JNIEnv* env, jclass clazz)
 {
-  try {
-    nvtxDomainRangePop(nvtx3::domain::get<cudf::jni::java_domain>());
-  }
-  CATCH_STD(env, );
+  JNI_TRY { nvtxDomainRangePop(nvtx3::domain::get<cudf::jni::java_domain>()); }
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/NvtxUniqueRangeJni.cpp
+++ b/java/src/main/native/src/NvtxUniqueRangeJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_NvtxUniqueRange_start(JNIEnv* env,
                                                                   jstring name,
                                                                   jint color_bits)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::native_jstring range_name(env, name);
     nvtx3::color range_color(static_cast<nvtx3::color::value_type>(color_bits));
     nvtx3::event_attributes attr{range_color, range_name.get()};
@@ -34,18 +35,19 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_NvtxUniqueRange_start(JNIEnv* env,
       nvtxDomainRangeStartEx(nvtx3::domain::get<cudf::jni::java_domain>(), attr.get());
     return static_cast<jlong>(nvtxRangeId);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_NvtxUniqueRange_end(JNIEnv* env,
                                                                jclass clazz,
                                                                jlong nvtxRangeId)
 {
-  try {
+  JNI_TRY
+  {
     nvtxDomainRangeEnd(nvtx3::domain::get<cudf::jni::java_domain>(),
                        static_cast<nvtxRangeId_t>(nvtxRangeId));
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/PackedColumnMetadataJni.cpp
+++ b/java/src/main/native/src/PackedColumnMetadataJni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,12 @@ JNIEXPORT jobject JNICALL Java_ai_rapids_cudf_PackedColumnMetadata_createMetadat
   JNIEnv* env, jclass, jlong j_metadata_ptr)
 {
   JNI_NULL_CHECK(env, j_metadata_ptr, "metadata is null", nullptr);
-  try {
+  JNI_TRY
+  {
     auto metadata = reinterpret_cast<std::vector<uint8_t>*>(j_metadata_ptr);
     return env->NewDirectByteBuffer(const_cast<uint8_t*>(metadata->data()), metadata->size());
   }
-  CATCH_STD(env, nullptr);
+  JNI_CATCH(env, nullptr);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_PackedColumnMetadata_closeMetadata(JNIEnv* env,
@@ -34,11 +35,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_PackedColumnMetadata_closeMetadata(JN
                                                                               jlong j_metadata_ptr)
 {
   JNI_NULL_CHECK(env, j_metadata_ptr, "metadata is null", );
-  try {
+  JNI_TRY
+  {
     auto metadata = reinterpret_cast<std::vector<uint8_t>*>(j_metadata_ptr);
     delete metadata;
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/ScalarJni.cpp
+++ b/java/src/main/native/src/ScalarJni.cpp
@@ -32,103 +32,112 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Scalar_closeScalar(JNIEnv* env,
                                                               jclass,
                                                               jlong scalar_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::scalar* s = reinterpret_cast<cudf::scalar*>(scalar_handle);
     delete s;
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jboolean JNICALL Java_ai_rapids_cudf_Scalar_isScalarValid(JNIEnv* env,
                                                                     jclass,
                                                                     jlong scalar_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::scalar* s = reinterpret_cast<cudf::scalar*>(scalar_handle);
     return static_cast<jboolean>(s->is_valid());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jbyte JNICALL Java_ai_rapids_cudf_Scalar_getByte(JNIEnv* env, jclass, jlong scalar_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     using ScalarType = cudf::scalar_type_t<int8_t>;
     auto s           = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jbyte>(s->value());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jshort JNICALL Java_ai_rapids_cudf_Scalar_getShort(JNIEnv* env,
                                                              jclass,
                                                              jlong scalar_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     using ScalarType = cudf::scalar_type_t<int16_t>;
     auto s           = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jshort>(s->value());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Scalar_getInt(JNIEnv* env, jclass, jlong scalar_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     using ScalarType = cudf::scalar_type_t<int32_t>;
     auto s           = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jint>(s->value());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_getLong(JNIEnv* env, jclass, jlong scalar_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     using ScalarType = cudf::scalar_type_t<int64_t>;
     auto s           = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jlong>(s->value());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jfloat JNICALL Java_ai_rapids_cudf_Scalar_getFloat(JNIEnv* env,
                                                              jclass,
                                                              jlong scalar_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     using ScalarType = cudf::scalar_type_t<float>;
     auto s           = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jfloat>(s->value());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jdouble JNICALL Java_ai_rapids_cudf_Scalar_getDouble(JNIEnv* env,
                                                                jclass,
                                                                jlong scalar_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     using ScalarType = cudf::scalar_type_t<double>;
     auto s           = reinterpret_cast<ScalarType*>(scalar_handle);
     return static_cast<jdouble>(s->value());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jbyteArray JNICALL Java_ai_rapids_cudf_Scalar_getBigIntegerBytes(JNIEnv* env,
                                                                            jclass,
                                                                            jlong scalar_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     using ScalarType = cudf::scalar_type_t<__int128_t>;
     auto s           = reinterpret_cast<ScalarType*>(scalar_handle);
@@ -137,14 +146,15 @@ JNIEXPORT jbyteArray JNICALL Java_ai_rapids_cudf_Scalar_getBigIntegerBytes(JNIEn
     cudf::jni::native_jbyteArray jbytes{env, ptr, sizeof(__int128_t)};
     return jbytes.get_jArray();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jbyteArray JNICALL Java_ai_rapids_cudf_Scalar_getUTF8(JNIEnv* env,
                                                                 jclass,
                                                                 jlong scalar_handle)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto s = reinterpret_cast<cudf::string_scalar*>(scalar_handle);
     std::string val{s->to_string()};
@@ -156,7 +166,7 @@ JNIEXPORT jbyteArray JNICALL Java_ai_rapids_cudf_Scalar_getUTF8(JNIEnv* env,
       env, reinterpret_cast<jbyte const*>(val.data()), static_cast<int>(val.size())};
     return jbytes.get_jArray();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_getListAsColumnView(JNIEnv* env,
@@ -164,21 +174,23 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_getListAsColumnView(JNIEnv* e
                                                                        jlong scalar_handle)
 {
   JNI_NULL_CHECK(env, scalar_handle, "scalar handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto s = reinterpret_cast<cudf::list_scalar*>(scalar_handle);
     // Creates a column view in heap with the stack one, to let JVM take care of its
     // life cycle.
     return reinterpret_cast<jlong>(new cudf::column_view(s->view()));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL
 Java_ai_rapids_cudf_Scalar_getChildrenFromStructScalar(JNIEnv* env, jclass, jlong scalar_handle)
 {
   JNI_NULL_CHECK(env, scalar_handle, "scalar handle is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const s                  = reinterpret_cast<cudf::struct_scalar*>(scalar_handle);
     cudf::table_view const& table = s->view();
@@ -188,7 +200,7 @@ Java_ai_rapids_cudf_Scalar_getChildrenFromStructScalar(JNIEnv* env, jclass, jlon
     }
     return column_handles.get_jArray();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeBool8Scalar(JNIEnv* env,
@@ -196,7 +208,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeBool8Scalar(JNIEnv* env,
                                                                    jboolean value,
                                                                    jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_numeric_scalar(cudf::data_type(cudf::type_id::BOOL8));
@@ -208,7 +221,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeBool8Scalar(JNIEnv* env,
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt8Scalar(JNIEnv* env,
@@ -216,7 +229,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt8Scalar(JNIEnv* env,
                                                                   jbyte value,
                                                                   jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_numeric_scalar(cudf::data_type(cudf::type_id::INT8));
@@ -227,7 +241,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt8Scalar(JNIEnv* env,
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint8Scalar(JNIEnv* env,
@@ -235,7 +249,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint8Scalar(JNIEnv* env,
                                                                    jbyte value,
                                                                    jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_numeric_scalar(cudf::data_type(cudf::type_id::UINT8));
@@ -246,7 +261,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint8Scalar(JNIEnv* env,
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt16Scalar(JNIEnv* env,
@@ -254,7 +269,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt16Scalar(JNIEnv* env,
                                                                    jshort value,
                                                                    jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_numeric_scalar(cudf::data_type(cudf::type_id::INT16));
@@ -265,7 +281,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt16Scalar(JNIEnv* env,
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint16Scalar(JNIEnv* env,
@@ -273,7 +289,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint16Scalar(JNIEnv* env,
                                                                     jshort value,
                                                                     jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_numeric_scalar(cudf::data_type(cudf::type_id::UINT16));
@@ -284,7 +301,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint16Scalar(JNIEnv* env,
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeDurationDaysScalar(JNIEnv* env,
@@ -292,7 +309,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeDurationDaysScalar(JNIEnv
                                                                           jint value,
                                                                           jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_duration_scalar(cudf::data_type(cudf::type_id::DURATION_DAYS));
@@ -303,7 +321,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeDurationDaysScalar(JNIEnv
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt32Scalar(JNIEnv* env,
@@ -311,7 +329,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt32Scalar(JNIEnv* env,
                                                                    jint value,
                                                                    jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_numeric_scalar(cudf::data_type(cudf::type_id::INT32));
@@ -322,7 +341,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt32Scalar(JNIEnv* env,
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint32Scalar(JNIEnv* env,
@@ -330,7 +349,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint32Scalar(JNIEnv* env,
                                                                     jint value,
                                                                     jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_numeric_scalar(cudf::data_type(cudf::type_id::UINT32));
@@ -341,7 +361,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint32Scalar(JNIEnv* env,
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt64Scalar(JNIEnv* env,
@@ -349,7 +369,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt64Scalar(JNIEnv* env,
                                                                    jlong value,
                                                                    jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_numeric_scalar(cudf::data_type(cudf::type_id::INT64));
@@ -360,7 +381,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeInt64Scalar(JNIEnv* env,
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint64Scalar(JNIEnv* env,
@@ -368,7 +389,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint64Scalar(JNIEnv* env,
                                                                     jlong value,
                                                                     jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_numeric_scalar(cudf::data_type(cudf::type_id::UINT64));
@@ -379,7 +401,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeUint64Scalar(JNIEnv* env,
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeFloat32Scalar(JNIEnv* env,
@@ -387,7 +409,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeFloat32Scalar(JNIEnv* env
                                                                      jfloat value,
                                                                      jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_numeric_scalar(cudf::data_type(cudf::type_id::FLOAT32));
@@ -398,7 +421,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeFloat32Scalar(JNIEnv* env
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeFloat64Scalar(JNIEnv* env,
@@ -406,7 +429,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeFloat64Scalar(JNIEnv* env
                                                                      jdouble value,
                                                                      jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_numeric_scalar(cudf::data_type(cudf::type_id::FLOAT64));
@@ -417,7 +441,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeFloat64Scalar(JNIEnv* env
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeStringScalar(JNIEnv* env,
@@ -425,7 +449,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeStringScalar(JNIEnv* env,
                                                                     jbyteArray value,
                                                                     jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::string strval;
     if (is_valid) {
@@ -436,7 +461,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeStringScalar(JNIEnv* env,
     auto s = new cudf::string_scalar{strval, static_cast<bool>(is_valid)};
     return reinterpret_cast<jlong>(s);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeTimestampDaysScalar(JNIEnv* env,
@@ -444,7 +469,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeTimestampDaysScalar(JNIEn
                                                                            jint value,
                                                                            jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::scalar> s =
       cudf::make_timestamp_scalar(cudf::data_type(cudf::type_id::TIMESTAMP_DAYS));
@@ -455,13 +481,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeTimestampDaysScalar(JNIEn
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeDurationTimeScalar(
   JNIEnv* env, jclass, jint jdtype_id, jlong value, jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto dtype_id                   = static_cast<cudf::type_id>(jdtype_id);
     std::unique_ptr<cudf::scalar> s = cudf::make_duration_scalar(cudf::data_type(dtype_id));
@@ -472,13 +499,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeDurationTimeScalar(
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeTimestampTimeScalar(
   JNIEnv* env, jclass, jint jdtype_id, jlong value, jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto dtype_id                   = static_cast<cudf::type_id>(jdtype_id);
     std::unique_ptr<cudf::scalar> s = cudf::make_timestamp_scalar(cudf::data_type(dtype_id));
@@ -489,13 +517,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeTimestampTimeScalar(
     }
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeDecimal32Scalar(
   JNIEnv* env, jclass, jint value, jint scale, jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const value_ = static_cast<int32_t>(value);
     auto const scale_ = numeric::scale_type{static_cast<int32_t>(scale)};
@@ -504,13 +533,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeDecimal32Scalar(
     s->set_valid_async(is_valid);
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeDecimal64Scalar(
   JNIEnv* env, jclass, jlong value, jint scale, jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const value_ = static_cast<int64_t>(value);
     auto const scale_ = numeric::scale_type{static_cast<int32_t>(scale)};
@@ -519,13 +549,14 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeDecimal64Scalar(
     s->set_valid_async(is_valid);
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeDecimal128Scalar(
   JNIEnv* env, jclass, jbyteArray value, jint scale, jboolean is_valid)
 {
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const scale_ = numeric::scale_type{static_cast<int32_t>(scale)};
     cudf::jni::native_jbyteArray jbytes{env, value};
@@ -535,7 +566,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeDecimal128Scalar(
     s->set_valid_async(is_valid);
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_binaryOpSV(
@@ -543,7 +574,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_binaryOpSV(
 {
   JNI_NULL_CHECK(env, lhs_ptr, "lhs is null", 0);
   JNI_NULL_CHECK(env, rhs_view, "rhs is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::scalar* lhs           = reinterpret_cast<cudf::scalar*>(lhs_ptr);
     auto rhs                    = reinterpret_cast<cudf::column_view*>(rhs_view);
@@ -569,7 +601,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_binaryOpSV(
 
     return release_as_jlong(cudf::binary_operation(*lhs, *rhs, op, n_data_type));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeListScalar(JNIEnv* env,
@@ -578,7 +610,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeListScalar(JNIEnv* env,
                                                                   jboolean is_valid)
 {
   JNI_NULL_CHECK(env, view_handle, "Column view should NOT be null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto col_view = reinterpret_cast<cudf::column_view*>(view_handle);
 
@@ -590,7 +623,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeListScalar(JNIEnv* env,
     s->set_valid_async(is_valid);
     return reinterpret_cast<jlong>(s);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeStructScalar(JNIEnv* env,
@@ -599,7 +632,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeStructScalar(JNIEnv* env,
                                                                     jboolean is_valid)
 {
   JNI_NULL_CHECK(env, handles, "native view handles are null", 0)
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::unique_ptr<cudf::column_view> ret;
     cudf::jni::native_jpointerArray<cudf::column_view> column_pointers(env, handles);
@@ -613,7 +647,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_makeStructScalar(JNIEnv* env,
       cudf::host_span<cudf::column_view const>{columns}, is_valid);
     return reinterpret_cast<jlong>(s.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_repeatString(JNIEnv* env,
@@ -622,12 +656,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Scalar_repeatString(JNIEnv* env,
                                                                 jint repeat_times)
 {
   JNI_NULL_CHECK(env, handle, "scalar handle is null", 0)
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const str = *reinterpret_cast<cudf::string_scalar*>(handle);
     return reinterpret_cast<jlong>(cudf::strings::repeat_string(str, repeat_times).release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 }  // extern "C"

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -772,7 +772,7 @@ jlongArray join_gather_maps(
     auto nulleq = compare_nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
     return gather_maps_to_java(env, join_func(*left_keys, *right_keys, nulleq));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 // Generate gather maps needed to manifest the result of an equi-join between a left table and
@@ -791,7 +791,7 @@ jlongArray hash_join_gather_maps(JNIEnv* env,
     auto hash_join = reinterpret_cast<cudf::hash_join const*>(j_right_hash_join);
     return gather_maps_to_java(env, join_func(*left_keys, *hash_join));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 // Generate gather maps needed to manifest the result of a conditional join between two tables.
@@ -810,7 +810,7 @@ jlongArray cond_join_gather_maps(
     return gather_maps_to_java(
       env, join_func(*left_table, *right_table, condition->get_top_expression()));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 // Generate a gather map needed to manifest the result of a semi/anti join between two tables.
@@ -827,7 +827,7 @@ jlongArray join_gather_single_map(
     auto nulleq = compare_nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL;
     return gather_map_to_java(env, join_func(*left_keys, *right_keys, nulleq));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 // Generate a gather map needed to manifest the result of a conditional semi/anti join
@@ -847,7 +847,7 @@ jlongArray cond_join_gather_single_map(
     return gather_map_to_java(
       env, join_func(*left_table, *right_table, condition->get_top_expression()));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 template <typename T>
@@ -894,7 +894,7 @@ jlongArray mixed_join_size(JNIEnv* env,
                                               0});
     return result.get_jArray();
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 template <typename T>
@@ -929,7 +929,7 @@ jlongArray mixed_join_gather_maps(JNIEnv* env,
                                          condition->get_top_expression(),
                                          nulls_equal));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 template <typename T>
@@ -964,7 +964,7 @@ jlongArray mixed_join_gather_single_map(JNIEnv* env,
                                         condition->get_top_expression(),
                                         nulls_equal));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 std::pair<std::size_t, cudf::device_span<cudf::size_type const>> get_mixed_size_info(
@@ -1112,7 +1112,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_removeNullMasksIfNeeded(J
       cols.begin(), cols.end(), results.begin(), [](auto& col) { return release_as_jlong(col); });
     return results.get_jArray();
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_createCudfTableView(JNIEnv* env,
@@ -1128,7 +1128,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_createCudfTableView(JNIEnv* en
     std::vector<cudf::column_view> column_views = n_cudf_columns.get_dereferenced();
     return ptr_as_jlong(new cudf::table_view(column_views));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_deleteCudfTable(JNIEnv* env,
@@ -1140,7 +1140,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_deleteCudfTable(JNIEnv* env,
     cudf::jni::auto_set_device(env);
     delete reinterpret_cast<cudf::table_view*>(j_cudf_table_view);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_columnViewsFromPacked(JNIEnv* env,
@@ -1173,7 +1173,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_columnViewsFromPacked(JNI
 
     return views.get_jArray();
   }
-  CATCH_STD(env, nullptr);
+  JNI_CATCH(env, nullptr);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_sortOrder(JNIEnv* env,
@@ -1189,7 +1189,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_sortOrder(JNIEnv* env,
   JNI_NULL_CHECK(env, j_is_descending, "sort order array is null", 0);
   JNI_NULL_CHECK(env, j_are_nulls_smallest, "null order array is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<cudf::column_view> n_sort_keys_columns(env,
                                                                            j_sort_keys_columns);
@@ -1216,7 +1217,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_sortOrder(JNIEnv* env,
     std::vector<cudf::column_view> sort_keys = n_sort_keys_columns.get_dereferenced();
     return release_as_jlong(cudf::sorted_order(cudf::table_view{sort_keys}, order, null_order));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_orderBy(JNIEnv* env,
@@ -1232,7 +1233,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_orderBy(JNIEnv* env,
   JNI_NULL_CHECK(env, j_is_descending, "sort order array is null", NULL);
   JNI_NULL_CHECK(env, j_are_nulls_smallest, "null order array is null", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<cudf::column_view> n_sort_keys_columns(env,
                                                                            j_sort_keys_columns);
@@ -1263,7 +1265,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_orderBy(JNIEnv* env,
     auto const input_table = reinterpret_cast<cudf::table_view const*>(j_input_table);
     return convert_table_for_return(env, cudf::gather(*input_table, sorted_col->view()));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_merge(JNIEnv* env,
@@ -1279,7 +1281,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_merge(JNIEnv* env,
   JNI_NULL_CHECK(env, j_is_descending, "sort order array is null", NULL);
   JNI_NULL_CHECK(env, j_are_nulls_smallest, "null order array is null", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<cudf::table_view> n_table_handles(env, j_table_handles);
 
@@ -1310,7 +1313,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_merge(JNIEnv* env,
 
     return convert_table_for_return(env, cudf::merge(tables, indexes, order, null_order));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -1333,7 +1336,8 @@ Java_ai_rapids_cudf_Table_readCSVFromDataSource(JNIEnv* env,
   JNI_NULL_CHECK(env, null_values, "null_values must be supplied, even if it is empty", NULL);
   JNI_NULL_CHECK(env, ds_handle, "no data source handle given", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstringArray n_col_names(env, col_names);
     cudf::jni::native_jintArray n_types(env, j_types);
@@ -1386,7 +1390,7 @@ Java_ai_rapids_cudf_Table_readCSVFromDataSource(JNIEnv* env,
 
     return convert_table_for_return(env, cudf::io::read_csv(opts).tbl);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(JNIEnv* env,
@@ -1423,7 +1427,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(JNIEnv* env,
       env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", NULL);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstringArray n_col_names(env, col_names);
     cudf::jni::native_jintArray n_types(env, j_types);
@@ -1484,7 +1489,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readCSV(JNIEnv* env,
 
     return convert_table_for_return(env, cudf::io::read_csv(opts).tbl);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(JNIEnv* env,
@@ -1509,7 +1514,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(JNIEnv* env,
   JNI_NULL_CHECK(env, j_false_value, "representation string for `false` cannot be null", );
   JNI_NULL_CHECK(env, j_output_path, "output path cannot be null", );
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto const native_output_path = cudf::jni::native_jstring{env, j_output_path};
@@ -1537,7 +1543,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVToFile(JNIEnv* env,
 
     cudf::io::write_csv(options.build());
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlong JNICALL
@@ -1560,7 +1566,8 @@ Java_ai_rapids_cudf_Table_startWriteCSVToBuffer(JNIEnv* env,
   JNI_NULL_CHECK(env, j_null_value, "null representation string cannot be itself null", 0);
   JNI_NULL_CHECK(env, j_buffer, "output buffer cannot be null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto data_sink =
@@ -1589,7 +1596,7 @@ Java_ai_rapids_cudf_Table_startWriteCSVToBuffer(JNIEnv* env,
 
     return ptr_as_jlong(new cudf::jni::io::csv_chunked_writer{options, data_sink});
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVChunkToBuffer(JNIEnv* env,
@@ -1603,11 +1610,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeCSVChunkToBuffer(JNIEnv* e
   auto const table = reinterpret_cast<cudf::table_view*>(j_table_handle);
   auto writer      = reinterpret_cast<cudf::jni::io::csv_chunked_writer*>(j_writer_handle);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     writer->write(*table);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_endWriteCSVToBuffer(JNIEnv* env,
@@ -1620,11 +1628,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_endWriteCSVToBuffer(JNIEnv* env
   auto writer =
     std::unique_ptr<csv_chunked_writer>{reinterpret_cast<csv_chunked_writer*>(j_writer_handle)};
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     writer->close();
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jlong JNICALL
@@ -1647,7 +1656,8 @@ Java_ai_rapids_cudf_Table_readAndInferJSONFromDataSource(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, ds_handle, "no data source handle given", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto ds = reinterpret_cast<cudf::io::datasource*>(ds_handle);
     cudf::io::source_info source{ds};
@@ -1677,7 +1687,7 @@ Java_ai_rapids_cudf_Table_readAndInferJSONFromDataSource(JNIEnv* env,
 
     return reinterpret_cast<jlong>(result.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL
@@ -1705,7 +1715,8 @@ Java_ai_rapids_cudf_Table_readAndInferJSON(JNIEnv* env,
       env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", 0);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     auto source = cudf::io::source_info{cudf::host_span<std::byte const>(
@@ -1737,18 +1748,19 @@ Java_ai_rapids_cudf_Table_readAndInferJSON(JNIEnv* env,
 
     return reinterpret_cast<jlong>(result.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_TableWithMeta_close(JNIEnv* env, jclass, jlong handle)
 {
   JNI_NULL_CHECK(env, handle, "handle is null", );
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     delete reinterpret_cast<cudf::io::table_with_metadata*>(handle);
   }
-  CATCH_STD(env, );
+  JNI_CATCH(env, );
 }
 
 JNIEXPORT jintArray JNICALL Java_ai_rapids_cudf_TableWithMeta_getFlattenedChildCounts(JNIEnv* env,
@@ -1757,7 +1769,8 @@ JNIEXPORT jintArray JNICALL Java_ai_rapids_cudf_TableWithMeta_getFlattenedChildC
 {
   JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto ptr = reinterpret_cast<cudf::io::table_with_metadata*>(handle);
     std::vector<int> counts;
@@ -1774,7 +1787,7 @@ JNIEXPORT jintArray JNICALL Java_ai_rapids_cudf_TableWithMeta_getFlattenedChildC
     ret.commit();
     return ret.get_jArray();
   }
-  CATCH_STD(env, nullptr);
+  JNI_CATCH(env, nullptr);
 }
 
 JNIEXPORT jobjectArray JNICALL
@@ -1782,7 +1795,8 @@ Java_ai_rapids_cudf_TableWithMeta_getFlattenedColumnNames(JNIEnv* env, jclass, j
 {
   JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto ptr = reinterpret_cast<cudf::io::table_with_metadata*>(handle);
     std::vector<std::string> names;
@@ -1800,7 +1814,7 @@ Java_ai_rapids_cudf_TableWithMeta_getFlattenedColumnNames(JNIEnv* env, jclass, j
 
     return ret;
   }
-  CATCH_STD(env, nullptr);
+  JNI_CATCH(env, nullptr);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_TableWithMeta_releaseTable(JNIEnv* env,
@@ -1809,7 +1823,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_TableWithMeta_releaseTable(JNIE
 {
   JNI_NULL_CHECK(env, handle, "handle is null", nullptr);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto ptr = reinterpret_cast<cudf::io::table_with_metadata*>(handle);
     if (ptr->tbl) {
@@ -1818,7 +1833,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_TableWithMeta_releaseTable(JNIE
       return nullptr;
     }
   }
-  CATCH_STD(env, nullptr);
+  JNI_CATCH(env, nullptr);
 }
 
 JNIEXPORT jlong JNICALL
@@ -1845,7 +1860,8 @@ Java_ai_rapids_cudf_Table_readJSONFromDataSource(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, ds_handle, "no data source handle given", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstringArray n_col_names(env, col_names);
     cudf::jni::native_jintArray n_types(env, j_types);
@@ -1926,7 +1942,7 @@ Java_ai_rapids_cudf_Table_readJSONFromDataSource(JNIEnv* env,
 
     return reinterpret_cast<jlong>(result.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_readJSON(JNIEnv* env,
@@ -1966,7 +1982,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_readJSON(JNIEnv* env,
       env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", 0);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstringArray n_col_names(env, col_names);
     cudf::jni::native_jintArray n_types(env, j_types);
@@ -2055,7 +2072,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_readJSON(JNIEnv* env,
 
     return reinterpret_cast<jlong>(result.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -2069,7 +2086,8 @@ Java_ai_rapids_cudf_Table_readParquetFromDataSource(JNIEnv* env,
   JNI_NULL_CHECK(env, ds_handle, "no data source handle given", 0);
   JNI_NULL_CHECK(env, j_col_binary_read, "null col_binary_read", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::jni::native_jstringArray n_filter_col_names(env, filter_col_names);
@@ -2089,7 +2107,7 @@ Java_ai_rapids_cudf_Table_readParquetFromDataSource(JNIEnv* env,
         .build();
     return convert_table_for_return(env, cudf::io::read_parquet(opts).tbl);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readParquet(JNIEnv* env,
@@ -2112,7 +2130,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readParquet(JNIEnv* env,
                   NULL);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring filename(env, inputfilepath);
     if (!read_buffer && filename.is_empty()) {
@@ -2146,7 +2165,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readParquet(JNIEnv* env,
     n_addrs_sizes.cancel();
     return convert_table_for_return(env, tbl);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readAvroFromDataSource(
@@ -2154,7 +2173,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readAvroFromDataSource(
 {
   JNI_NULL_CHECK(env, ds_handle, "no data source handle given", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::jni::native_jstringArray n_filter_col_names(env, filter_col_names);
@@ -2167,7 +2187,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readAvroFromDataSource(
                                            .build();
     return convert_table_for_return(env, cudf::io::read_avro(opts).tbl);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readAvro(JNIEnv* env,
@@ -2190,7 +2210,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readAvro(JNIEnv* env,
       env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", NULL);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring filename(env, inputfilepath);
     if (!read_buffer && filename.is_empty()) {
@@ -2211,7 +2232,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readAvro(JNIEnv* env,
                                            .build();
     return convert_table_for_return(env, cudf::io::read_avro(opts).tbl);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT long JNICALL
@@ -2241,7 +2262,8 @@ Java_ai_rapids_cudf_Table_writeParquetBufferBegin(JNIEnv* env,
   JNI_NULL_CHECK(env, j_metadata_keys, "null metadata keys", 0);
   JNI_NULL_CHECK(env, j_metadata_values, "null metadata values", 0);
   JNI_NULL_CHECK(env, consumer, "null consumer", 0);
-  try {
+  JNI_TRY
+  {
     std::unique_ptr<cudf::jni::jni_writer_data_sink> data_sink(
       new cudf::jni::jni_writer_data_sink(env, consumer, host_memory_allocator));
 
@@ -2292,7 +2314,7 @@ Java_ai_rapids_cudf_Table_writeParquetBufferBegin(JNIEnv* env,
       std::move(writer_ptr), std::move(data_sink), std::move(stats));
     return ptr_as_jlong(ret);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT long JNICALL
@@ -2321,7 +2343,8 @@ Java_ai_rapids_cudf_Table_writeParquetFileBegin(JNIEnv* env,
   JNI_NULL_CHECK(env, j_metadata_keys, "null metadata keys", 0);
   JNI_NULL_CHECK(env, j_metadata_values, "null metadata values", 0);
   JNI_NULL_CHECK(env, j_output_path, "null output path", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::native_jstring output_path(env, j_output_path);
 
     using namespace cudf::io;
@@ -2372,7 +2395,7 @@ Java_ai_rapids_cudf_Table_writeParquetFileBegin(JNIEnv* env,
       new cudf::jni::native_parquet_writer_handle(std::move(writer_ptr), nullptr, std::move(stats));
     return ptr_as_jlong(ret);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeParquetChunk(
@@ -2391,11 +2414,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeParquetChunk(
     long alloc_size = std::max(cudf::jni::MINIMUM_WRITE_BUFFER_SIZE, mem_size / 2);
     state->sink->set_alloc_size(alloc_size);
   }
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     state->writer->write(tview);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, )
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeParquetEnd(JNIEnv* env, jclass, jlong j_state)
@@ -2406,11 +2430,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeParquetEnd(JNIEnv* env, jc
   cudf::jni::native_parquet_writer_handle* state =
     reinterpret_cast<cudf::jni::native_parquet_writer_handle*>(j_state);
   std::unique_ptr<cudf::jni::native_parquet_writer_handle> make_sure_we_delete(state);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     state->writer->close();
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, )
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -2424,7 +2449,8 @@ Java_ai_rapids_cudf_Table_readORCFromDataSource(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, ds_handle, "no data source handle given", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     cudf::jni::native_jstringArray n_filter_col_names(env, filter_col_names);
@@ -2447,7 +2473,7 @@ Java_ai_rapids_cudf_Table_readORCFromDataSource(JNIEnv* env,
         .build();
     return convert_table_for_return(env, cudf::io::read_orc(opts).tbl);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readORC(JNIEnv* env,
@@ -2474,7 +2500,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readORC(JNIEnv* env,
       env, cudf::jni::ILLEGAL_ARG_EXCEPTION_CLASS, "An empty buffer is not supported", NULL);
   }
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring filename(env, inputfilepath);
     if (!read_buffer && filename.is_empty()) {
@@ -2503,7 +2530,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_readORC(JNIEnv* env,
         .build();
     return convert_table_for_return(env, cudf::io::read_orc(opts).tbl);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT long JNICALL
@@ -2527,7 +2554,8 @@ Java_ai_rapids_cudf_Table_writeORCBufferBegin(JNIEnv* env,
   JNI_NULL_CHECK(env, j_metadata_keys, "null metadata keys", 0);
   JNI_NULL_CHECK(env, j_metadata_values, "null metadata values", 0);
   JNI_NULL_CHECK(env, consumer, "null consumer", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     using namespace cudf::io;
     using namespace cudf::jni;
@@ -2581,7 +2609,7 @@ Java_ai_rapids_cudf_Table_writeORCBufferBegin(JNIEnv* env,
       std::move(writer_ptr), std::move(data_sink), std::move(stats));
     return ptr_as_jlong(ret);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeORCFileBegin(JNIEnv* env,
@@ -2603,7 +2631,8 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeORCFileBegin(JNIEnv* env,
   JNI_NULL_CHECK(env, j_metadata_keys, "null metadata keys", 0);
   JNI_NULL_CHECK(env, j_metadata_values, "null metadata values", 0);
   JNI_NULL_CHECK(env, j_output_path, "null output path", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     using namespace cudf::io;
     using namespace cudf::jni;
@@ -2654,7 +2683,7 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeORCFileBegin(JNIEnv* env,
       new cudf::jni::native_orc_writer_handle(std::move(writer_ptr), nullptr, std::move(stats));
     return ptr_as_jlong(ret);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeORCChunk(
@@ -2673,11 +2702,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeORCChunk(
     long alloc_size = std::max(cudf::jni::MINIMUM_WRITE_BUFFER_SIZE, mem_size / 2);
     state->sink->set_alloc_size(alloc_size);
   }
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     state->writer->write(tview);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, )
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeORCEnd(JNIEnv* env, jclass, jlong j_state)
@@ -2688,11 +2718,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeORCEnd(JNIEnv* env, jclass
   cudf::jni::native_orc_writer_handle* state =
     reinterpret_cast<cudf::jni::native_orc_writer_handle*>(j_state);
   std::unique_ptr<cudf::jni::native_orc_writer_handle> make_sure_we_delete(state);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     state->writer->close();
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, )
 }
 
 JNIEXPORT jdoubleArray JNICALL Java_ai_rapids_cudf_TableWriter_getWriteStatistics(JNIEnv* env,
@@ -2703,7 +2734,8 @@ JNIEXPORT jdoubleArray JNICALL Java_ai_rapids_cudf_TableWriter_getWriteStatistic
 
   using namespace cudf::io;
   auto const state = reinterpret_cast<cudf::jni::jni_table_writer_handle_base const*>(j_state);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     if (!state->stats) { return nullptr; }
 
@@ -2716,7 +2748,7 @@ JNIEXPORT jdoubleArray JNICALL Java_ai_rapids_cudf_TableWriter_getWriteStatistic
 
     return output.get_jArray();
   }
-  CATCH_STD(env, nullptr)
+  JNI_CATCH(env, nullptr)
 }
 
 JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeArrowIPCBufferBegin(
@@ -2724,7 +2756,8 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeArrowIPCBufferBegin(
 {
   JNI_NULL_CHECK(env, j_col_names, "null columns", 0);
   JNI_NULL_CHECK(env, consumer, "null consumer", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstringArray col_names(env, j_col_names);
 
@@ -2735,7 +2768,7 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeArrowIPCBufferBegin(
       new cudf::jni::native_arrow_ipc_writer_handle(col_names.as_cpp_vector(), data_sink);
     return ptr_as_jlong(ret);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeArrowIPCFileBegin(JNIEnv* env,
@@ -2745,7 +2778,8 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeArrowIPCFileBegin(JNIEnv* 
 {
   JNI_NULL_CHECK(env, j_col_names, "null columns", 0);
   JNI_NULL_CHECK(env, j_output_path, "null output path", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstringArray col_names(env, j_col_names);
     cudf::jni::native_jstring output_path(env, j_output_path);
@@ -2754,7 +2788,7 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_writeArrowIPCFileBegin(JNIEnv* 
       new cudf::jni::native_arrow_ipc_writer_handle(col_names.as_cpp_vector(), output_path.get());
     return ptr_as_jlong(ret);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_convertCudfToArrowTable(JNIEnv* env,
@@ -2769,7 +2803,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_convertCudfToArrowTable(JNIEnv
   cudf::jni::native_arrow_ipc_writer_handle* state =
     reinterpret_cast<cudf::jni::native_arrow_ipc_writer_handle*>(j_state);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     // The semantics of this function are confusing:
     // The return value is a pointer to a heap-allocated shared_ptr<arrow::Table>.
@@ -2786,7 +2821,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_convertCudfToArrowTable(JNIEnv
 
     return ptr_as_jlong(new result_t{result});
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeArrowIPCArrowChunk(
@@ -2800,11 +2835,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeArrowIPCArrowChunk(
   cudf::jni::native_arrow_ipc_writer_handle* state =
     reinterpret_cast<cudf::jni::native_arrow_ipc_writer_handle*>(j_state);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     state->write(*handle, max_chunk);
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, )
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeArrowIPCEnd(JNIEnv* env,
@@ -2816,11 +2852,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_writeArrowIPCEnd(JNIEnv* env,
   cudf::jni::native_arrow_ipc_writer_handle* state =
     reinterpret_cast<cudf::jni::native_arrow_ipc_writer_handle*>(j_state);
   std::unique_ptr<cudf::jni::native_arrow_ipc_writer_handle> make_sure_we_delete(state);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     state->close();
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, )
 }
 
 JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_readArrowIPCFileBegin(JNIEnv* env,
@@ -2828,12 +2865,13 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_readArrowIPCFileBegin(JNIEnv* e
                                                                        jstring j_input_path)
 {
   JNI_NULL_CHECK(env, j_input_path, "null input path", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jstring input_path(env, j_input_path);
     return ptr_as_jlong(new cudf::jni::native_arrow_ipc_reader_handle(input_path.get()));
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_readArrowIPCBufferBegin(JNIEnv* env,
@@ -2841,13 +2879,14 @@ JNIEXPORT long JNICALL Java_ai_rapids_cudf_Table_readArrowIPCBufferBegin(JNIEnv*
                                                                          jobject provider)
 {
   JNI_NULL_CHECK(env, provider, "null provider", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     std::shared_ptr<cudf::jni::jni_arrow_input_stream> data_source(
       new cudf::jni::jni_arrow_input_stream(env, provider));
     return ptr_as_jlong(new cudf::jni::native_arrow_ipc_reader_handle(data_source));
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_readArrowIPCChunkToArrowTable(JNIEnv* env,
@@ -2860,14 +2899,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_readArrowIPCChunkToArrowTable(
   cudf::jni::native_arrow_ipc_reader_handle* state =
     reinterpret_cast<cudf::jni::native_arrow_ipc_reader_handle*>(j_state);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     // This is a little odd because we have to return a pointer
     // and arrow wants to deal with shared pointers for everything.
     auto result = state->next(row_target);
     return result ? ptr_as_jlong(new std::shared_ptr<arrow::Table>{result}) : 0;
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_closeArrowTable(JNIEnv* env,
@@ -2877,11 +2917,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_closeArrowTable(JNIEnv* env,
   std::shared_ptr<arrow::Table>* handle =
     reinterpret_cast<std::shared_ptr<arrow::Table>*>(arrow_table_handle);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     delete handle;
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, )
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -2892,7 +2933,8 @@ Java_ai_rapids_cudf_Table_convertArrowTableToCudf(JNIEnv* env, jclass, jlong arr
   std::shared_ptr<arrow::Table>* handle =
     reinterpret_cast<std::shared_ptr<arrow::Table>*>(arrow_table_handle);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     ArrowSchema sch;
@@ -2910,7 +2952,7 @@ Java_ai_rapids_cudf_Table_convertArrowTableToCudf(JNIEnv* env, jclass, jlong arr
 
     return convert_table_for_return(env, ret);
   }
-  CATCH_STD(env, 0)
+  JNI_CATCH(env, 0)
 }
 
 JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_readArrowIPCEnd(JNIEnv* env, jclass, jlong j_state)
@@ -2920,11 +2962,12 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Table_readArrowIPCEnd(JNIEnv* env, jc
   cudf::jni::native_arrow_ipc_reader_handle* state =
     reinterpret_cast<cudf::jni::native_arrow_ipc_reader_handle*>(j_state);
   std::unique_ptr<cudf::jni::native_arrow_ipc_reader_handle> make_sure_we_delete(state);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     state->close();
   }
-  CATCH_STD(env, )
+  JNI_CATCH(env, )
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftJoinGatherMaps(
@@ -2963,14 +3006,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_leftJoinRowCount(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, j_left_table, "left table is null", 0);
   JNI_NULL_CHECK(env, j_right_hash_join, "right hash join is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto left_table = reinterpret_cast<cudf::table_view const*>(j_left_table);
     auto hash_join  = reinterpret_cast<cudf::hash_join const*>(j_right_hash_join);
     auto row_count  = hash_join->left_join_size(*left_table);
     return static_cast<jlong>(row_count);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_leftHashJoinGatherMaps(
@@ -3002,7 +3046,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_conditionalLeftJoinRowCount(
   JNI_NULL_CHECK(env, j_left_table, "left_table is null", 0);
   JNI_NULL_CHECK(env, j_right_table, "right_table is null", 0);
   JNI_NULL_CHECK(env, j_condition, "condition is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto left_table  = reinterpret_cast<cudf::table_view const*>(j_left_table);
     auto right_table = reinterpret_cast<cudf::table_view const*>(j_right_table);
@@ -3011,7 +3056,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_conditionalLeftJoinRowCount(
       cudf::conditional_left_join_size(*left_table, *right_table, condition->get_top_expression());
     return static_cast<jlong>(row_count);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_conditionalLeftJoinGatherMaps(
@@ -3175,14 +3220,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_innerJoinRowCount(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, j_left_table, "left table is null", 0);
   JNI_NULL_CHECK(env, j_right_hash_join, "right hash join is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto left_table = reinterpret_cast<cudf::table_view const*>(j_left_table);
     auto hash_join  = reinterpret_cast<cudf::hash_join const*>(j_right_hash_join);
     auto row_count  = hash_join->inner_join_size(*left_table);
     return static_cast<jlong>(row_count);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_innerHashJoinGatherMaps(
@@ -3216,7 +3262,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_conditionalInnerJoinRowCount(
   JNI_NULL_CHECK(env, j_left_table, "left_table is null", 0);
   JNI_NULL_CHECK(env, j_right_table, "right_table is null", 0);
   JNI_NULL_CHECK(env, j_condition, "condition is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto left_table  = reinterpret_cast<cudf::table_view const*>(j_left_table);
     auto right_table = reinterpret_cast<cudf::table_view const*>(j_right_table);
@@ -3225,7 +3272,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_conditionalInnerJoinRowCount(
       cudf::conditional_inner_join_size(*left_table, *right_table, condition->get_top_expression());
     return static_cast<jlong>(row_count);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_conditionalInnerJoinGatherMaps(
@@ -3373,14 +3420,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_fullJoinRowCount(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, j_left_table, "left table is null", 0);
   JNI_NULL_CHECK(env, j_right_hash_join, "right hash join is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto left_table = reinterpret_cast<cudf::table_view const*>(j_left_table);
     auto hash_join  = reinterpret_cast<cudf::hash_join const*>(j_right_hash_join);
     auto row_count  = hash_join->full_join_size(*left_table);
     return static_cast<jlong>(row_count);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_fullHashJoinGatherMaps(
@@ -3469,7 +3517,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_conditionalLeftSemiJoinRowCoun
   JNI_NULL_CHECK(env, j_left_table, "left_table is null", 0);
   JNI_NULL_CHECK(env, j_right_table, "right_table is null", 0);
   JNI_NULL_CHECK(env, j_condition, "condition is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto left_table  = reinterpret_cast<cudf::table_view const*>(j_left_table);
     auto right_table = reinterpret_cast<cudf::table_view const*>(j_right_table);
@@ -3478,7 +3527,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_conditionalLeftSemiJoinRowCoun
       *left_table, *right_table, condition->get_top_expression());
     return static_cast<jlong>(row_count);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_conditionalLeftSemiJoinGatherMap(
@@ -3565,7 +3614,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_conditionalLeftAntiJoinRowCoun
   JNI_NULL_CHECK(env, j_left_table, "left_table is null", 0);
   JNI_NULL_CHECK(env, j_right_table, "right_table is null", 0);
   JNI_NULL_CHECK(env, j_condition, "condition is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto left_table  = reinterpret_cast<cudf::table_view const*>(j_left_table);
     auto right_table = reinterpret_cast<cudf::table_view const*>(j_right_table);
@@ -3574,7 +3624,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_conditionalLeftAntiJoinRowCoun
       *left_table, *right_table, condition->get_top_expression());
     return static_cast<jlong>(row_count);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_conditionalLeftAntiJoinGatherMap(
@@ -3650,13 +3700,14 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_crossJoin(JNIEnv* env,
   JNI_NULL_CHECK(env, left_table, "left_table is null", NULL);
   JNI_NULL_CHECK(env, right_table, "right_table is null", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const left  = reinterpret_cast<cudf::table_view const*>(left_table);
     auto const right = reinterpret_cast<cudf::table_view const*>(right_table);
     return convert_table_for_return(env, cudf::cross_join(*left, *right));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_interleaveColumns(JNIEnv* env,
@@ -3664,12 +3715,13 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_interleaveColumns(JNIEnv* env,
                                                                     jlongArray j_cudf_table_view)
 {
   JNI_NULL_CHECK(env, j_cudf_table_view, "table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::table_view* table_view = reinterpret_cast<cudf::table_view*>(j_cudf_table_view);
     return release_as_jlong(cudf::interleave_columns(*table_view));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_concatenate(JNIEnv* env,
@@ -3677,13 +3729,14 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_concatenate(JNIEnv* env,
                                                                    jlongArray table_handles)
 {
   JNI_NULL_CHECK(env, table_handles, "input tables are null", NULL);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jpointerArray<cudf::table_view> tables(env, table_handles);
     std::vector<cudf::table_view> const to_concat = tables.get_dereferenced();
     return convert_table_for_return(env, cudf::concatenate(to_concat));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_partition(JNIEnv* env,
@@ -3698,7 +3751,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_partition(JNIEnv* env,
   JNI_NULL_CHECK(env, output_offsets, "output_offsets is null", NULL);
   JNI_ARG_CHECK(env, number_of_partitions > 0, "number_of_partitions is zero", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const n_input_table = reinterpret_cast<cudf::table_view const*>(input_table);
     auto const n_part_column = reinterpret_cast<cudf::column_view const*>(partition_column);
@@ -3714,7 +3768,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_partition(JNIEnv* env,
 
     return convert_table_for_return(env, partitioned_table);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_hashPartition(JNIEnv* env,
@@ -3731,7 +3785,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_hashPartition(JNIEnv* env
   JNI_NULL_CHECK(env, output_offsets, "output_offsets is null", NULL);
   JNI_ARG_CHECK(env, number_of_partitions > 0, "number_of_partitions is zero", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const hash_func     = static_cast<cudf::hash_id>(hash_function);
     auto const hash_seed     = static_cast<uint32_t>(seed);
@@ -3750,7 +3805,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_hashPartition(JNIEnv* env
 
     return convert_table_for_return(env, partitioned_table);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_roundRobinPartition(JNIEnv* env,
@@ -3765,7 +3820,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_roundRobinPartition(JNIEn
   JNI_ARG_CHECK(env, num_partitions > 0, "num_partitions <= 0", NULL);
   JNI_ARG_CHECK(env, start_partition >= 0, "start_partition is negative", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto n_input_table = reinterpret_cast<cudf::table_view*>(input_table);
 
@@ -3777,7 +3833,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_roundRobinPartition(JNIEn
 
     return convert_table_for_return(env, partitioned_table);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -3797,7 +3853,8 @@ Java_ai_rapids_cudf_Table_groupByAggregate(JNIEnv* env,
   JNI_NULL_CHECK(env, aggregate_column_indices, "input aggregate_column_indices are null", NULL);
   JNI_NULL_CHECK(env, agg_instances, "agg_instances are null", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::table_view* n_input_table = reinterpret_cast<cudf::table_view*>(input_table);
     cudf::jni::native_jintArray n_keys(env, keys);
@@ -3857,7 +3914,7 @@ Java_ai_rapids_cudf_Table_groupByAggregate(JNIEnv* env,
     }
     return convert_table_for_return(env, result.first, std::move(result_columns));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -3877,7 +3934,8 @@ Java_ai_rapids_cudf_Table_groupByScan(JNIEnv* env,
   JNI_NULL_CHECK(env, aggregate_column_indices, "input aggregate_column_indices are null", NULL);
   JNI_NULL_CHECK(env, agg_instances, "agg_instances are null", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::table_view* n_input_table = reinterpret_cast<cudf::table_view*>(input_table);
     cudf::jni::native_jintArray n_keys(env, keys);
@@ -3938,7 +3996,7 @@ Java_ai_rapids_cudf_Table_groupByScan(JNIEnv* env,
     }
     return convert_table_for_return(env, result.first, std::move(result_columns));
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -3958,7 +4016,8 @@ Java_ai_rapids_cudf_Table_groupByReplaceNulls(JNIEnv* env,
   JNI_NULL_CHECK(env, replace_column_indices, "input replace_column_indices are null", NULL);
   JNI_NULL_CHECK(env, is_preceding, "is_preceding are null", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::table_view* n_input_table = reinterpret_cast<cudf::table_view*>(input_table);
     cudf::jni::native_jintArray n_keys(env, keys);
@@ -3995,7 +4054,7 @@ Java_ai_rapids_cudf_Table_groupByReplaceNulls(JNIEnv* env,
     auto [keys, results] = grouper.replace_nulls(n_replace_table, policies);
     return convert_table_for_return(env, keys, results);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_filter(JNIEnv* env,
@@ -4005,13 +4064,14 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_filter(JNIEnv* env,
 {
   JNI_NULL_CHECK(env, input_jtable, "input table is null", 0);
   JNI_NULL_CHECK(env, mask_jcol, "mask column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::table_view const*>(input_jtable);
     auto const mask  = reinterpret_cast<cudf::column_view const*>(mask_jcol);
     return convert_table_for_return(env, cudf::apply_boolean_mask(*input, *mask));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Table_distinctCount(JNIEnv* env,
@@ -4020,14 +4080,15 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Table_distinctCount(JNIEnv* env,
                                                                jboolean nulls_equal)
 {
   JNI_NULL_CHECK(env, input_jtable, "input table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::table_view const*>(input_jtable);
 
     return cudf::distinct_count(
       *input, nulls_equal ? cudf::null_equality::EQUAL : cudf::null_equality::UNEQUAL);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_dropDuplicates(
@@ -4035,7 +4096,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_dropDuplicates(
 {
   JNI_NULL_CHECK(env, input_jtable, "input table is null", 0);
   JNI_NULL_CHECK(env, key_columns, "input key_columns is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::table_view const*>(input_jtable);
 
@@ -4067,7 +4129,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_dropDuplicates(
                      cudf::get_current_device_resource_ref());
     return convert_table_for_return(env, result);
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_gather(
@@ -4075,7 +4137,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_gather(
 {
   JNI_NULL_CHECK(env, j_input, "input table is null", 0);
   JNI_NULL_CHECK(env, j_map, "map column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::table_view const*>(j_input);
     auto const map   = reinterpret_cast<cudf::column_view const*>(j_map);
@@ -4083,7 +4146,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_gather(
       check_bounds ? cudf::out_of_bounds_policy::NULLIFY : cudf::out_of_bounds_policy::DONT_CHECK;
     return convert_table_for_return(env, cudf::gather(*input, *map, bounds_policy));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_scatterTable(
@@ -4092,14 +4155,15 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_scatterTable(
   JNI_NULL_CHECK(env, j_input, "input table is null", 0);
   JNI_NULL_CHECK(env, j_map, "map column is null", 0);
   JNI_NULL_CHECK(env, j_target, "target table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input  = reinterpret_cast<cudf::table_view const*>(j_input);
     auto const map    = reinterpret_cast<cudf::column_view const*>(j_map);
     auto const target = reinterpret_cast<cudf::table_view const*>(j_target);
     return convert_table_for_return(env, cudf::scatter(*input, *map, *target));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_scatterScalars(
@@ -4108,7 +4172,8 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_scatterScalars(
   JNI_NULL_CHECK(env, j_input, "input scalars array is null", 0);
   JNI_NULL_CHECK(env, j_map, "map column is null", 0);
   JNI_NULL_CHECK(env, j_target, "target table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const scalars_array = cudf::jni::native_jpointerArray<cudf::scalar>(env, j_input);
     std::vector<std::reference_wrapper<cudf::scalar const>> input;
@@ -4120,7 +4185,7 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_scatterScalars(
     auto const target = reinterpret_cast<cudf::table_view const*>(j_target);
     return convert_table_for_return(env, cudf::scatter(input, *map, *target));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_repeatStaticCount(JNIEnv* env,
@@ -4129,12 +4194,13 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_repeatStaticCount(JNIEnv*
                                                                          jint count)
 {
   JNI_NULL_CHECK(env, input_jtable, "input table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::table_view const*>(input_jtable);
     return convert_table_for_return(env, cudf::repeat(*input, count));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_repeatColumnCount(JNIEnv* env,
@@ -4144,13 +4210,14 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_repeatColumnCount(JNIEnv*
 {
   JNI_NULL_CHECK(env, input_jtable, "input table is null", 0);
   JNI_NULL_CHECK(env, count_jcol, "count column is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::table_view const*>(input_jtable);
     auto const count = reinterpret_cast<cudf::column_view const*>(count_jcol);
     return convert_table_for_return(env, cudf::repeat(*input, *count));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_bound(JNIEnv* env,
@@ -4165,7 +4232,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_bound(JNIEnv* env,
   JNI_NULL_CHECK(env, values_jtable, "values table is null", 0);
   using cudf::column;
   using cudf::table_view;
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     table_view* input  = reinterpret_cast<table_view*>(input_jtable);
     table_view* values = reinterpret_cast<table_view*>(values_jtable);
@@ -4186,7 +4254,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_bound(JNIEnv* env,
       is_upper_bound ? cudf::upper_bound(*input, *values, column_desc_flags, column_null_orders)
                      : cudf::lower_bound(*input, *values, column_desc_flags, column_null_orders));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_Table_contiguousSplit(JNIEnv* env,
@@ -4197,7 +4265,8 @@ JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_Table_contiguousSplit(JNIEnv*
   JNI_NULL_CHECK(env, input_table, "native handle is null", 0);
   JNI_NULL_CHECK(env, split_indices, "split indices are null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::table_view* n_table = reinterpret_cast<cudf::table_view*>(input_table);
     cudf::jni::native_jintArray n_split_indices(env, split_indices);
@@ -4214,7 +4283,7 @@ JNIEXPORT jobjectArray JNICALL Java_ai_rapids_cudf_Table_contiguousSplit(JNIEnv*
     }
     return n_result.wrapped();
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_makeChunkedPack(
@@ -4222,7 +4291,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_makeChunkedPack(
 {
   JNI_NULL_CHECK(env, input_table, "native handle is null", 0);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::table_view* n_table = reinterpret_cast<cudf::table_view*>(input_table);
     // `temp_mr` is the memory resource that `cudf::chunked_pack` will use to create temporary
@@ -4234,7 +4304,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_makeChunkedPack(
       cudf::chunked_pack::create(*n_table, bounce_buffer_size, cudf::get_default_stream(), temp_mr);
     return reinterpret_cast<jlong>(chunked_pack.release());
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -4258,7 +4328,8 @@ Java_ai_rapids_cudf_Table_rollingWindowAggregate(JNIEnv* env,
   JNI_NULL_CHECK(env, j_agg_instances, "agg_instances are null", NULL);
   JNI_NULL_CHECK(env, j_default_output, "default_outputs are null", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     using cudf::jni::valid_window_parameters;
@@ -4323,7 +4394,7 @@ Java_ai_rapids_cudf_Table_rollingWindowAggregate(JNIEnv* env,
     auto result_table = std::make_unique<cudf::table>(std::move(result_columns));
     return convert_table_for_return(env, result_table);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL
@@ -4351,7 +4422,8 @@ Java_ai_rapids_cudf_Table_rangeRollingWindowAggregate(JNIEnv* env,
   JNI_NULL_CHECK(env, j_preceding, "preceding are null", NULL);
   JNI_NULL_CHECK(env, j_following, "following are null", NULL);
 
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
 
     using cudf::jni::valid_window_parameters;
@@ -4444,7 +4516,7 @@ Java_ai_rapids_cudf_Table_rangeRollingWindowAggregate(JNIEnv* env,
     auto result_table = std::make_unique<cudf::table>(std::move(result_columns));
     return convert_table_for_return(env, result_table);
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_explode(JNIEnv* env,
@@ -4453,13 +4525,14 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_explode(JNIEnv* env,
                                                                jint column_index)
 {
   JNI_NULL_CHECK(env, input_jtable, "explode: input table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_table = reinterpret_cast<cudf::table_view const*>(input_jtable);
     auto const col_index   = static_cast<cudf::size_type>(column_index);
     return convert_table_for_return(env, cudf::explode(*input_table, col_index));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_explodePosition(JNIEnv* env,
@@ -4468,13 +4541,14 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_explodePosition(JNIEnv* e
                                                                        jint column_index)
 {
   JNI_NULL_CHECK(env, input_jtable, "explode: input table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_table = reinterpret_cast<cudf::table_view const*>(input_jtable);
     auto const col_index   = static_cast<cudf::size_type>(column_index);
     return convert_table_for_return(env, cudf::explode_position(*input_table, col_index));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_explodeOuter(JNIEnv* env,
@@ -4483,13 +4557,14 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_explodeOuter(JNIEnv* env,
                                                                     jint column_index)
 {
   JNI_NULL_CHECK(env, input_jtable, "explode: input table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_table = reinterpret_cast<cudf::table_view const*>(input_jtable);
     auto const col_index   = static_cast<cudf::size_type>(column_index);
     return convert_table_for_return(env, cudf::explode_outer(*input_table, col_index));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_explodeOuterPosition(JNIEnv* env,
@@ -4498,24 +4573,26 @@ JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_explodeOuterPosition(JNIE
                                                                             jint column_index)
 {
   JNI_NULL_CHECK(env, input_jtable, "explode: input table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_table = reinterpret_cast<cudf::table_view const*>(input_jtable);
     auto const col_index   = static_cast<cudf::size_type>(column_index);
     return convert_table_for_return(env, cudf::explode_outer_position(*input_table, col_index));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_rowBitCount(JNIEnv* env, jclass, jlong j_table)
 {
   JNI_NULL_CHECK(env, j_table, "table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input_table = reinterpret_cast<cudf::table_view const*>(j_table);
     return release_as_jlong(cudf::row_bit_count(*input_table));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 
 JNIEXPORT jobject JNICALL
@@ -4536,7 +4613,8 @@ Java_ai_rapids_cudf_Table_contiguousSplitGroups(JNIEnv* env,
   //       the grouped table.
   //    2) Calls `cudf::contiguous_split` to execute the split over the grouped table
   //       according to the group offsets.
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     cudf::jni::native_jintArray n_key_indices(env, jkey_indices);
     auto const input_table = reinterpret_cast<cudf::table_view const*>(jinput_table);
@@ -4650,20 +4728,21 @@ Java_ai_rapids_cudf_Table_contiguousSplitGroups(JNIEnv* env,
       return cudf::jni::contig_split_group_by_result_from(env, groups_array);
     }
   }
-  CATCH_STD(env, NULL);
+  JNI_CATCH(env, NULL);
 }
 
 JNIEXPORT jlongArray JNICALL Java_ai_rapids_cudf_Table_sample(
   JNIEnv* env, jclass, jlong j_input, jlong n, jboolean replacement, jlong seed)
 {
   JNI_NULL_CHECK(env, j_input, "input table is null", 0);
-  try {
+  JNI_TRY
+  {
     cudf::jni::auto_set_device(env);
     auto const input = reinterpret_cast<cudf::table_view const*>(j_input);
     auto sample_with_replacement =
       replacement ? cudf::sample_with_replacement::TRUE : cudf::sample_with_replacement::FALSE;
     return convert_table_for_return(env, cudf::sample(*input, n, sample_with_replacement, seed));
   }
-  CATCH_STD(env, 0);
+  JNI_CATCH(env, 0);
 }
 }  // extern "C"

--- a/java/src/main/native/src/cudf_jni_apis.hpp
+++ b/java/src/main/native/src/cudf_jni_apis.hpp
@@ -131,13 +131,6 @@ void set_cudf_device(int device);
  */
 void auto_set_device(JNIEnv* env);
 
-/**
- * Fills all the bytes in the buffer 'buf' with 'value'.
- * The operation has not necessarily completed when this returns, but it could overlap with
- * operations occurring on other streams.
- */
-void device_memset_async(JNIEnv* env, rmm::device_buffer& buf, char value);
-
 //
 // DataSource APIs
 //


### PR DESCRIPTION
This rewrites all JNI functions, replacing `try`/`CATCH_STD` with `JNI_TRY`/`JNI_CATCH` macros which are just aliases of `try`/`catch`. By doing so, when needed then we can uniformly and easily replace these aliases with anything else.

This is part of [[Epic] Capture native stacktrace when throwing exception using cpptrace #3398](https://github.com/NVIDIA/spark-rapids-jni/issues/3398).