### PR TITLE
Filter out  pkg_resources UserWarning to make nightly CI pass

### DIFF
--- a/python/custreamz/pyproject.toml
+++ b/python/custreamz/pyproject.toml
@@ -98,7 +98,7 @@ filterwarnings = [
     "ignore:Port .* is already in use.:UserWarning:distributed",
     # Should be fixed in the next streamz release
     # https://github.com/python-streamz/streamz/commit/2812f1f961dfcb3f17e948d8b12a12472975558e
-    "ignore:pkg_resources is deprecated as an API:DeprecationWarning:streamz",
+    "ignore:pkg_resources is deprecated as an API:UserWarning:streamz",
     "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",
     # Ignore numba PEP 456 warning specific to arm machines
     "ignore:FNV hashing is not implemented in Numba.*:UserWarning"


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Nightly CI is [failing](https://github.com/rapidsai/cudf/actions/runs/15385272569/job/43301873960). There errors are
```
=========================== short test summary info ============================
ERROR tests/test_dataframes.py - UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
ERROR tests/test_dataframes.py - UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
ERROR tests/test_dataframes.py - UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
ERROR tests/test_dataframes.py - UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
ERROR tests/test_dataframes.py - UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
ERROR tests/test_dataframes.py - UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
ERROR tests/test_dataframes.py - UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
ERROR tests/test_dataframes.py - UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
==================== 1 passed, 6 skipped, 8 errors in 5.82s ====================

```

The recommendation from `pkg_resources` is to either "Refrain from using this package or pin to Setuptools<81." For now, we can filter for this warning like we've done before. 

FYI: There is an open [issue](https://github.com/python-streamz/streamz/issues/460) to remove `pkg_resources` in the `streamz` package.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
