### PR TITLE
Avoid undefined behaviour in rolling_store_output_functor

### DIFF
--- a/cpp/src/rolling/detail/rolling.cuh
+++ b/cpp/src/rolling/detail/rolling.cuh
@@ -126,9 +126,17 @@ struct DeviceRolling {
 
     bool output_is_valid = (count >= min_periods);
 
-    // store the output value, one per thread
-    cudf::detail::rolling_store_output_functor<OutputType, op == aggregation::MEAN>{}(
-      output.element<OutputType>(current_index), val, count);
+    if (output_is_valid) {
+      // store the output value, one per thread, but only if the
+      // output is valid. min_periods is required to be >= 1, and so
+      // here, count must be nonzero. We need to avoid storing if
+      // count is zero because for mean aggregations this could
+      // perform integer division by zero (undefined behaviour), which
+      // could cause the compiler to deduce nonsense about the loop
+      // that increments count.
+      cudf::detail::rolling_store_output_functor<OutputType, op == aggregation::MEAN>{}(
+        output.element<OutputType>(current_index), val, count);
+    }
 
     return output_is_valid;
   }

--- a/cpp/src/rolling/detail/rolling.cuh
+++ b/cpp/src/rolling/detail/rolling.cuh
@@ -130,7 +130,7 @@ struct DeviceRolling {
       // store the output value, one per thread, but only if the
       // output is valid. min_periods is required to be >= 1, and so
       // here, count must be nonzero. We need to avoid storing if
-      // count is zero since this could could UB in some aggregations,
+      // count is zero since this could cause UB in some aggregations,
       // which may cause the compiler to deduce nonsense about the loop
       // that increments count.
       cudf::detail::rolling_store_output_functor<OutputType, op == aggregation::MEAN>{}(

--- a/cpp/src/rolling/detail/rolling.cuh
+++ b/cpp/src/rolling/detail/rolling.cuh
@@ -130,9 +130,8 @@ struct DeviceRolling {
       // store the output value, one per thread, but only if the
       // output is valid. min_periods is required to be >= 1, and so
       // here, count must be nonzero. We need to avoid storing if
-      // count is zero because for mean aggregations this could
-      // perform integer division by zero (undefined behaviour), which
-      // could cause the compiler to deduce nonsense about the loop
+      // count is zero since this could could UB in some aggregations,
+      // which may cause the compiler to deduce nonsense about the loop
       // that increments count.
       cudf::detail::rolling_store_output_functor<OutputType, op == aggregation::MEAN>{}(
         output.element<OutputType>(current_index), val, count);

--- a/cpp/src/rolling/detail/rolling.hpp
+++ b/cpp/src/rolling/detail/rolling.hpp
@@ -45,18 +45,14 @@ struct rolling_store_output_functor<_T, true> {
             std::enable_if_t<!(cudf::is_boolean<T>() || cudf::is_timestamp<T>())>* = nullptr>
   CUDF_HOST_DEVICE inline void operator()(T& out, T& val, size_type count)
   {
-    if (count > 0) {
-      out = val / count;
-    }
+    if (count > 0) { out = val / count; }
   }
 
   // SFINAE for timestamp types
   template <typename T = _T, std::enable_if_t<cudf::is_timestamp<T>()>* = nullptr>
   CUDF_HOST_DEVICE inline void operator()(T& out, T& val, size_type count)
   {
-    if (count > 0) {
-      out = static_cast<T>(val.time_since_epoch() / count);
-    }
+    if (count > 0) { out = static_cast<T>(val.time_since_epoch() / count); }
   }
 };
 

--- a/cpp/src/rolling/detail/rolling.hpp
+++ b/cpp/src/rolling/detail/rolling.hpp
@@ -35,10 +35,9 @@ struct rolling_store_output_functor {
 // Specialization for MEAN
 template <typename _T>
 struct rolling_store_output_functor<_T, true> {
-  // We need to avoid storing if count is zero because for mean aggregations
-  // this could perform integer division by zero (undefined behaviour), which
-  // could cause the compiler to deduce nonsense about the loop that increments
-  // count.
+  // Don't store the output if count is zero since integral division by zero is
+  // undefined behaviour. The caller must ensure that the relevant row is
+  // marked as invalid with a null.
 
   // SFINAE for non-bool, non-timestamp types
   template <typename T                                                             = _T,


### PR DESCRIPTION
## Description

For rolling mean, the aggregation is computed by summing valid values in the window and then dividing by the count in the store operation.

For duration types, the output type is also a duration (i.e. has an integer representation), and so the division of the sum of the window by the count is an integer division. Integer division by zero is undefined behaviour so we must avoid it. If the compiler just emits the division as is we might get a runtime trap, however, a sufficiently smart compiler might deduce that, since count is initialized to zero and then only incremented in the loop over the window bounds, and division by zero is undefined, that the loop between start_index and end_index must execute at least once (with a valid input value).

To avoid this, only store the output (also saving some memory traffic) if the output is determined to be valid.

This might leave some uninitialized values in the output but by contract you're not allowed to look at them because they are masked by a null.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
