### PR TITLE
Improve WordPieceVocabulary.tokenize documentation

### DIFF
--- a/python/cudf/cudf/core/wordpiece_tokenize.py
+++ b/python/cudf/cudf/core/wordpiece_tokenize.py
@@ -24,12 +24,14 @@ class WordPieceVocabulary:
 
     def tokenize(self, text, max_words_per_row: int = 0) -> Series:
         """
+        Produces tokens for the input strings.
+        The input is expected to be the output of NormalizeCharacters or a
+        similar normalizer.
+
         Parameters
         ----------
         text : cudf.Series
-            The strings to be tokenized.
-            This input is expected to be the output of NormalizeCharacters
-            or similar.
+            Normalized strings to be tokenized.
         max_words_per_row : int
             Maximum number of words to tokenize per row.
             Default 0 tokenizes all words.

--- a/python/pylibcudf/pylibcudf/nvtext/wordpiece_tokenize.pyx
+++ b/python/pylibcudf/pylibcudf/nvtext/wordpiece_tokenize.pyx
@@ -37,13 +37,14 @@ cpdef Column wordpiece_tokenize(
     """
     Returns the token ids for the input string by looking
     up each delimited token in the given vocabulary.
+    The input is expected to be normalized.
 
     For details, see cpp:func:`cudf::nvtext::wordpiece_tokenize`
 
     Parameters
     ----------
     input : Column
-        Strings column to tokenize
+        Normalized strings column to tokenize
     vocabulary : WordPieceVocabulary
         Used to lookup tokens within ``input``
     max_words_per_row : size_type


### PR DESCRIPTION
## Description
Improves the `WordPieceVocabulary.tokenizer` docstrings to make it clear the input is expected to be normalized first.
Hoping this will help with migration from the subword-tokenizer.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
