### PR TITLE
Quick fixes of `modernize-use-constraints` rule

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ include(${rapids-cmake-dir}/cuda/set_runtime.cmake)
 include(rapids-export)
 include(rapids-find)
 
+set (CMAKE_CUDA_ARCHITECTURES "NATIVE")
 rapids_cuda_init_architectures(CUDF)
 
 project(


### PR DESCRIPTION
## Description
Applied all quick fixes of the modernize-use-constraints rule, which suggests use of the requires clause instead of SFINAE.

This covers around half of the SFINAE use, so follow up PR will be needed.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
