### PR TITLE
Fix bug in ``group_by().n_unique()`` in streaming cudf-polars

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/groupby.py
@@ -33,8 +33,8 @@ _GB_AGG_SUPPORTED = ("sum", "count", "mean", "min", "max", "n_unique")
 
 
 def combine(
-    *decompositions: tuple[NamedExpr, list[NamedExpr], list[NamedExpr]],
-) -> tuple[list[NamedExpr], list[NamedExpr], list[NamedExpr]]:
+    *decompositions: tuple[NamedExpr, list[NamedExpr], list[NamedExpr], bool],
+) -> tuple[list[NamedExpr], list[NamedExpr], list[NamedExpr], bool]:
     """
     Combine multiple groupby-aggregation decompositions.
 
@@ -48,19 +48,22 @@ def combine(
     Unified groupby-aggregation decomposition.
     """
     if len(decompositions) == 0:
-        return [], [], []
-    selections, aggregations, reductions = zip(*decompositions, strict=True)
+        return [], [], [], False
+    selections, aggregations, reductions, need_preshuffles = zip(
+        *decompositions, strict=True
+    )
     assert all(isinstance(ne, NamedExpr) for ne in selections)
     return (
         list(selections),
         list(itertools.chain.from_iterable(aggregations)),
         list(itertools.chain.from_iterable(reductions)),
+        any(need_preshuffles),
     )
 
 
 def decompose(
     name: str, expr: Expr, *, names: Generator[str, None, None]
-) -> tuple[NamedExpr, list[NamedExpr], list[NamedExpr]]:
+) -> tuple[NamedExpr, list[NamedExpr], list[NamedExpr], bool]:
     """
     Decompose a groupby-aggregation expression.
 
@@ -81,6 +84,8 @@ def decompose(
         The initial aggregation expressions.
     list[NamedExpr]
         The reduction expressions.
+    bool
+        Whether we need to pre-shuffle on the group_by keys.
     """
     dtype = expr.dtype
 
@@ -88,7 +93,7 @@ def decompose(
         selection = NamedExpr(name, Col(dtype, name))
         aggregation = [NamedExpr(name, expr)]
         reduction = [NamedExpr(name, Agg(dtype, "sum", None, Col(dtype, name)))]
-        return selection, aggregation, reduction
+        return selection, aggregation, reduction, False
     if isinstance(expr, Agg):
         if expr.name in ("sum", "count", "min", "max", "n_unique"):
             if expr.name in ("sum", "count", "n_unique"):
@@ -98,10 +103,10 @@ def decompose(
             selection = NamedExpr(name, Col(dtype, name))
             aggregation = [NamedExpr(name, expr)]
             reduction = [NamedExpr(name, Agg(dtype, aggfunc, None, Col(dtype, name)))]
-            return selection, aggregation, reduction
+            return selection, aggregation, reduction, expr.name == "n_unique"
         elif expr.name == "mean":
             (child,) = expr.children
-            (sum, count), aggregations, reductions = combine(
+            (sum, count), aggregations, reductions, need_preshuffle = combine(
                 decompose(
                     f"{next(names)}__mean_sum",
                     Agg(dtype, "sum", None, child),
@@ -113,7 +118,7 @@ def decompose(
                 name,
                 BinOp(dtype, plc.binaryop.BinaryOperator.DIV, sum.value, count.value),
             )
-            return selection, aggregations, reductions
+            return selection, aggregations, reductions, need_preshuffle
         else:
             raise NotImplementedError(
                 "group_by does not support multiple partitions "
@@ -159,6 +164,7 @@ def _(
         "'in-memory' executor not supported in 'generate_ir_tasks'"
     )
 
+    child_count = partition_info[child].count
     cardinality_factor = {
         c: min(f, 1.0)
         for c, f in ir.config_options.executor.cardinality_factor.items()
@@ -170,7 +176,6 @@ def _(
         # cardinality "factors". Each factor estimates the
         # fractional number of unique values in the column.
         # Each value should be in the range (0, 1].
-        child_count = partition_info[child].count
         post_aggregation_count = max(
             int(max(cardinality_factor.values()) * child_count),
             1,
@@ -180,7 +185,7 @@ def _(
     name_generator = unique_names(ir.schema.keys())
     # Decompose the aggregation requests into three distinct phases
     try:
-        selection_exprs, piecewise_exprs, reduction_exprs = combine(
+        selection_exprs, piecewise_exprs, reduction_exprs, need_preshuffle = combine(
             *(
                 decompose(agg.name, agg.value, names=name_generator)
                 for agg in ir.agg_requests
@@ -196,6 +201,20 @@ def _(
         return _lower_ir_fallback(
             ir, rec, msg="Failed to decompose groupby aggs for multiple partitions."
         )
+
+    # Preshuffle ir.child if needed
+    if need_preshuffle:
+        child = Shuffle(
+            child.schema,
+            ir.keys,
+            ir.config_options,
+            child,
+        )
+        partition_info[child] = PartitionInfo(
+            count=child_count,
+            partitioned_on=ir.keys,
+        )
+        shuffled = True
 
     # Partition-wise groupby operation
     pwise_schema = {k.name: k.value.dtype for k in ir.keys} | {

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -30,6 +30,7 @@ def df():
     return pl.LazyFrame(
         {
             "x": range(150),
+            "xx": list(range(75)) * 2,
             "y": [1, 2, 3] * 50,
             "z": [1.0, 2.0, 3.0, 4.0, 5.0] * 30,
         }
@@ -70,6 +71,12 @@ def test_groupby_agg(df, engine, op, keys):
     if op == "n_unique":
         agg = agg.cast(pl.Int64)
     q = df.group_by(*keys).agg(agg)
+    assert_gpu_result_equal(q, engine=engine, check_row_order=False)
+
+
+@pytest.mark.parametrize("keys", [("y",), ("y", "z")])
+def test_groupby_n_unique(df, engine, keys):
+    q = df.group_by(*keys).agg(pl.col("xx").n_unique().cast(pl.Int64))
     assert_gpu_result_equal(q, engine=engine, check_row_order=False)
 
 


### PR DESCRIPTION
## Description
The streaming cudf-polars engine is missing the pre-shuffling step needed to guarantee correct results for `group_by(...).n_unique()`. This PR fixes the problem and adds test coverage.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
