### PR TITLE
Share Index.values with base implementaiton

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2257,10 +2257,6 @@ class Index(SingleColumnFrame):  # type: ignore[misc]
         result = result._with_type_metadata(self.dtype)
         return type(self)._from_column(result, name=self.name)
 
-    @property
-    def values(self) -> cupy.ndarray:
-        return self._column.values
-
     def __contains__(self, item) -> bool:
         hash(item)
         return item in self._column

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1245,7 +1245,7 @@ class MultiIndex(Index):
         # TODO: Could implement as Index of ListDtype?
         raise NotImplementedError("to_flat_index is not currently supported.")
 
-    @property  # type: ignore
+    @property
     @_performance_tracking
     def values_host(self) -> np.ndarray:
         """
@@ -1273,7 +1273,7 @@ class MultiIndex(Index):
         """
         return self.to_pandas().values
 
-    @property  # type: ignore
+    @property
     @_performance_tracking
     def values(self) -> cp.ndarray:
         """
@@ -1307,7 +1307,7 @@ class MultiIndex(Index):
             raise NotImplementedError(
                 "Unable to create a cupy array with tuples."
             )
-        return self.to_frame(index=False).values
+        return Frame.to_cupy(self)
 
     @classmethod
     @_performance_tracking


### PR DESCRIPTION
## Description
Broken off https://github.com/rapidsai/cudf/pull/18942

Namely, allows `MultiIndex` to potentially leverage the faster `pylibcudf.reshape.table_to_array` conversion for a `MultiIndex` with more than 1 level

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
