### PR TITLE
Fix hash collision in Union([MapFunction])

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -2260,6 +2260,7 @@ class MapFunction(IR):
             self.name,
             json.dumps(self.options),
             tuple(self.schema.items()),
+            self._ctor_arguments(self.children)[1:],
         )
 
     @classmethod

--- a/python/cudf_polars/tests/experimental/test_parallel.py
+++ b/python/cudf_polars/tests/experimental/test_parallel.py
@@ -209,3 +209,14 @@ def test_task_graph_is_pickle_serializable(engine):
     graph, _ = task_graph(ir, partition_info, config_options)
 
     pickle.loads(pickle.dumps(graph))  # no exception
+
+
+def test_rename_concat(engine: pl.GPUEngine) -> None:
+    # https://github.com/rapidsai/cudf/pull/19121#issuecomment-2959305678
+    q = pl.concat(
+        [
+            pl.DataFrame({"a": [1, 2, 3]}).lazy().rename({"a": "A"}),
+            pl.DataFrame({"a": [4, 5, 6]}).lazy().rename({"a": "A"}),
+        ]
+    )
+    assert_gpu_result_equal(q, engine=engine)

--- a/python/cudf_polars/tests/experimental/test_parallel.py
+++ b/python/cudf_polars/tests/experimental/test_parallel.py
@@ -215,8 +215,8 @@ def test_rename_concat(engine: pl.GPUEngine) -> None:
     # https://github.com/rapidsai/cudf/pull/19121#issuecomment-2959305678
     q = pl.concat(
         [
-            pl.DataFrame({"a": [1, 2, 3]}).lazy().rename({"a": "A"}),
-            pl.DataFrame({"a": [4, 5, 6]}).lazy().rename({"a": "A"}),
+            pl.LazyFrame({"a": [1, 2, 3]}).rename({"a": "A"}),
+            pl.LazyFrame({"a": [4, 5, 6]}).rename({"a": "A"}),
         ]
     )
     assert_gpu_result_equal(q, engine=engine)

--- a/python/cudf_polars/tests/test_mapfunction.py
+++ b/python/cudf_polars/tests/test_mapfunction.py
@@ -99,8 +99,8 @@ def test_with_row_index_defaults():
 
 def test_unique_hash():
     # https://github.com/rapidsai/cudf/pull/19121#issuecomment-2959305678
-    a = pl.DataFrame({"a": [1, 2, 3]}).lazy().rename({"a": "A"})
-    b = pl.DataFrame({"a": [4, 5, 6]}).lazy().rename({"a": "A"})
+    a = pl.LazyFrame({"a": [1, 2, 3]}).rename({"a": "A"})
+    b = pl.LazyFrame({"a": [4, 5, 6]}).rename({"a": "A"})
     ir_a = Translator(a._ldf.visit(), pl.GPUEngine()).translate_ir()
     ir_b = Translator(b._ldf.visit(), pl.GPUEngine()).translate_ir()
 


### PR DESCRIPTION
This fixes a hash collision causing the failures noted in https://github.com/rapidsai/cudf/pull/19121#issuecomment-2956914193 with the streaming executor.

`MapFunction.get_hashable` should include the hash of its children in its hash, otherwise two inputs to, say, `Union` with the same schema and function look identical and an intermediate is (incorrectly) reused.
