### PR TITLE
Remove the extra index URL for CUDA 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pip install --extra-index-url=https://pypi.nvidia.com cudf-cu11
 For CUDA 12.x:
 
 ```bash
-pip install --extra-index-url=https://pypi.nvidia.com cudf-cu12
+pip install cudf-cu12
 ```
 
 ### Conda


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
We no longer need the extra index for CUDA 12 installation, only CUDA 11.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
