### PR TITLE
 Enable using page masks in `decompress_page_data` in Parquet reader

### DIFF
--- a/cpp/src/io/parquet/reader_impl_chunking.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking.cu
@@ -340,8 +340,16 @@ void reader::impl::setup_next_subpass(read_mode mode)
   // decompress the data pages in this subpass; also decompress the dictionary pages in this pass,
   // if this is the first subpass in the pass
   if (pass.has_compressed_data) {
-    auto [pass_data, subpass_data] = decompress_page_data(
-      pass.chunks, is_first_subpass ? pass.pages : host_span<PageInfo>{}, subpass.pages, _stream);
+    // Empty page mask indicates all pages must be decompressed
+    auto const empty_page_mask = cudf::host_span<bool>{};
+    auto [pass_data, subpass_data] =
+      decompress_page_data(pass.chunks,
+                           is_first_subpass ? pass.pages : host_span<PageInfo>{},
+                           empty_page_mask,
+                           subpass.pages,
+                           empty_page_mask,
+                           _stream,
+                           _mr);
 
     if (is_first_subpass) {
       pass.decomp_dict_data = std::move(pass_data);

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cuh
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cuh
@@ -188,8 +188,13 @@ std::vector<row_range> compute_page_splits_by_row(device_span<cumulative_page_in
  *
  * @param chunks List of column chunk descriptors
  * @param pass_pages List of page information for the pass
+ * @param pass_page_mask Boolean page mask indicating which pass pages to decompress. Empty
+ * span indicates all pages should be decompressed
  * @param subpass_pages List of page information for the subpass
+ * @param subpass_page_mask Boolean page mask indicating which subpass pages to decompress. Empty
+ * span indicates all pages should be decompressed
  * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate buffers
  *
  * @return A pair of device buffers containing the decompressed data for dictionary and
  * non-dictionary pages, respectively.
@@ -197,8 +202,11 @@ std::vector<row_range> compute_page_splits_by_row(device_span<cumulative_page_in
 [[nodiscard]] std::pair<rmm::device_buffer, rmm::device_buffer> decompress_page_data(
   host_span<ColumnChunkDesc const> chunks,
   host_span<PageInfo> pass_pages,
+  host_span<bool const> pass_page_mask,
   host_span<PageInfo> subpass_pages,
-  rmm::cuda_stream_view stream);
+  host_span<bool const> subpass_page_mask,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
 
 /**
  * @brief Detect malformed parquet input data
@@ -353,7 +361,8 @@ struct codec_stats {
 
   void add_pages(host_span<ColumnChunkDesc const> chunks,
                  host_span<PageInfo> pages,
-                 page_selection selection);
+                 page_selection selection,
+                 host_span<bool const> page_mask);
 };
 
 /**


### PR DESCRIPTION
## Description
This PR updates the `decompress_page_data` API in Parquet reader utilities to accept two boolean vectors indicating page masks for input pass and subpass pages. This allows us to skip decompression of pages that may have been marked as pruned.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
