### PR TITLE
Add benchmarks for sorting float and timestamp

### DIFF
--- a/cpp/benchmarks/sort/sort.cpp
+++ b/cpp/benchmarks/sort/sort.cpp
@@ -27,8 +27,8 @@ template <typename DataType>
 static void bench_sort(nvbench::state& state, nvbench::type_list<DataType>)
 {
   auto const stable    = static_cast<bool>(state.get_int64("stable"));
-  auto const n_rows    = static_cast<cudf::size_type>(state.get_int64("num_rows"));
-  auto const n_cols    = static_cast<cudf::size_type>(state.get_int64("num_cols"));
+  auto const num_rows  = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const num_cols  = static_cast<cudf::size_type>(state.get_int64("num_cols"));
   auto const nulls     = state.get_float64("nulls");
   auto const data_type = cudf::type_to_id<DataType>();
 
@@ -36,12 +36,12 @@ static void bench_sort(nvbench::state& state, nvbench::type_list<DataType>)
     data_profile_builder().cardinality(0).null_probability(nulls).distribution(
       data_type, distribution_id::UNIFORM, 100, 10'000);
   auto input_table =
-    create_random_table(cycle_dtypes({data_type}, n_cols), row_count{n_rows}, profile);
+    create_random_table(cycle_dtypes({data_type}, num_cols), row_count{num_rows}, profile);
   cudf::table_view input{*input_table};
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   state.add_global_memory_reads<nvbench::int8_t>(input_table->alloc_size());
-  state.add_global_memory_writes<nvbench::int32_t>(n_rows);
+  state.add_global_memory_writes<nvbench::int32_t>(num_rows);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     if (stable)

--- a/cpp/benchmarks/sort/sort.cpp
+++ b/cpp/benchmarks/sort/sort.cpp
@@ -17,27 +17,30 @@
 #include <benchmarks/common/generate_input.hpp>
 
 #include <cudf/sorting.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
 #include <nvbench/nvbench.cuh>
 
-static void bench_sort(nvbench::state& state)
+template <typename DataType>
+static void bench_sort(nvbench::state& state, nvbench::type_list<DataType>)
 {
-  auto const stable = static_cast<bool>(state.get_int64("stable"));
-  auto const n_rows = static_cast<cudf::size_type>(state.get_int64("n_rows"));
-  auto const n_cols = static_cast<cudf::size_type>(state.get_int64("n_cols"));
-  auto const nulls  = state.get_float64("nulls");
+  auto const stable    = static_cast<bool>(state.get_int64("stable"));
+  auto const n_rows    = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const n_cols    = static_cast<cudf::size_type>(state.get_int64("num_cols"));
+  auto const nulls     = state.get_float64("nulls");
+  auto const data_type = cudf::type_to_id<DataType>();
 
-  // Create table with values in the range [0,100)
   data_profile const profile =
     data_profile_builder().cardinality(0).null_probability(nulls).distribution(
-      cudf::type_id::INT32, distribution_id::UNIFORM, 0, 10);
+      data_type, distribution_id::UNIFORM, 100, 10'000);
   auto input_table =
-    create_random_table(cycle_dtypes({cudf::type_id::INT32}, n_cols), row_count{n_rows}, profile);
+    create_random_table(cycle_dtypes({data_type}, n_cols), row_count{n_rows}, profile);
   cudf::table_view input{*input_table};
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
-  state.add_global_memory_reads<nvbench::int32_t>(n_rows * n_cols);
+  state.add_global_memory_reads<nvbench::int8_t>(input_table->alloc_size());
   state.add_global_memory_writes<nvbench::int32_t>(n_rows);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
@@ -48,9 +51,13 @@ static void bench_sort(nvbench::state& state)
   });
 }
 
-NVBENCH_BENCH(bench_sort)
+NVBENCH_DECLARE_TYPE_STRINGS(cudf::timestamp_ms, "time_ms", "time_ms");
+
+using Types = nvbench::type_list<int32_t, float, cudf::timestamp_ms>;
+
+NVBENCH_BENCH_TYPES(bench_sort, NVBENCH_TYPE_AXES(Types))
   .set_name("sort")
   .add_int64_axis("stable", {0, 1})
   .add_float64_axis("nulls", {0, 0.1})
-  .add_int64_axis("n_rows", {32768, 262144, 2097152, 16777216, 67108864})
-  .add_int64_axis("n_cols", {1, 8});
+  .add_int64_axis("num_rows", {262144, 2097152, 16777216, 67108864})
+  .add_int64_axis("num_cols", {1, 8});


### PR DESCRIPTION
## Description
Adds `float` and `timestamp_ms` to the libcudf sort benchmark.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
