### PR TITLE
Use radix sort for float/double types (experimental)

### DIFF
--- a/cpp/benchmarks/sort/sort.cpp
+++ b/cpp/benchmarks/sort/sort.cpp
@@ -17,28 +17,31 @@
 #include <benchmarks/common/generate_input.hpp>
 
 #include <cudf/sorting.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
 #include <nvbench/nvbench.cuh>
 
-static void bench_sort(nvbench::state& state)
+template <typename DataType>
+static void bench_sort(nvbench::state& state, nvbench::type_list<DataType>)
 {
-  auto const stable = static_cast<bool>(state.get_int64("stable"));
-  auto const n_rows = static_cast<cudf::size_type>(state.get_int64("n_rows"));
-  auto const n_cols = static_cast<cudf::size_type>(state.get_int64("n_cols"));
-  auto const nulls  = state.get_float64("nulls");
+  auto const stable    = static_cast<bool>(state.get_int64("stable"));
+  auto const num_rows  = static_cast<cudf::size_type>(state.get_int64("num_rows"));
+  auto const num_cols  = static_cast<cudf::size_type>(state.get_int64("num_cols"));
+  auto const nulls     = state.get_float64("nulls");
+  auto const data_type = cudf::type_to_id<DataType>();
 
-  // Create table with values in the range [0,100)
   data_profile const profile =
     data_profile_builder().cardinality(0).null_probability(nulls).distribution(
-      cudf::type_id::INT32, distribution_id::UNIFORM, 0, 10);
+      data_type, distribution_id::UNIFORM, 100, 10'000);
   auto input_table =
-    create_random_table(cycle_dtypes({cudf::type_id::INT32}, n_cols), row_count{n_rows}, profile);
+    create_random_table(cycle_dtypes({data_type}, num_cols), row_count{num_rows}, profile);
   cudf::table_view input{*input_table};
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
-  state.add_global_memory_reads<nvbench::int32_t>(n_rows * n_cols);
-  state.add_global_memory_writes<nvbench::int32_t>(n_rows);
+  state.add_global_memory_reads<nvbench::int8_t>(input_table->alloc_size());
+  state.add_global_memory_writes<nvbench::int32_t>(num_rows);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     if (stable)
@@ -48,9 +51,13 @@ static void bench_sort(nvbench::state& state)
   });
 }
 
-NVBENCH_BENCH(bench_sort)
+NVBENCH_DECLARE_TYPE_STRINGS(cudf::timestamp_ms, "time_ms", "time_ms");
+
+using Types = nvbench::type_list<int32_t, float, cudf::timestamp_ms>;
+
+NVBENCH_BENCH_TYPES(bench_sort, NVBENCH_TYPE_AXES(Types))
   .set_name("sort")
   .add_int64_axis("stable", {0, 1})
   .add_float64_axis("nulls", {0, 0.1})
-  .add_int64_axis("n_rows", {32768, 262144, 2097152, 16777216, 67108864})
-  .add_int64_axis("n_cols", {1, 8});
+  .add_int64_axis("num_rows", {262144, 2097152, 16777216, 67108864})
+  .add_int64_axis("num_cols", {1, 8});

--- a/cpp/src/sort/faster_sort_column_impl.cuh
+++ b/cpp/src/sort/faster_sort_column_impl.cuh
@@ -30,6 +30,31 @@
 namespace cudf {
 namespace detail {
 
+template <typename F>
+struct float_pair {
+  size_type bnan;
+  F f;
+};
+
+template <typename F>
+struct float_decomposer {
+  __device__ cuda::std::tuple<size_type&, F&> operator()(float_pair<F>& key) const
+  {
+    return {key.bnan, key.f};
+  }
+};
+
+template <typename F>
+struct float_to_pair_and_seq {
+  F* fs;
+  __device__ cuda::std::pair<float_pair<F>, size_type> operator()(cudf::size_type idx)
+  {
+    auto f = fs[idx];
+    auto s = (isnan(f) * idx);  // makes stable
+    return {float_pair<F>{s, f}, idx};
+  }
+};
+
 /**
  * @brief Sort indices of a single column.
  *
@@ -50,23 +75,7 @@ void faster_sorted_order(column_view const& input,
 template <sort_method method>
 struct faster_sorted_order_fn {
   /**
-   * @brief Compile time check for allowing faster sort.
-   *
-   * Faster sort is defined for fixed-width types where only
-   * the primitive comparators cuda::std::greater or cuda::std::less
-   * are needed.
-   *
-   * Floating point is removed here for special handling of NaNs
-   * which require the row-comparator.
-   */
-  template <typename T>
-  static constexpr bool is_supported()
-  {
-    return cudf::is_fixed_width<T>() && !cudf::is_floating_point<T>();
-  }
-
-  /**
-   * @brief Sorts fixed-width columns using faster thrust sort.
+   * @brief Sorts fixed-width columns using faster thrust sort
    *
    * Should not be called if `input.has_nulls()==true`
    *
@@ -109,7 +118,46 @@ struct faster_sorted_order_fn {
     }
   }
 
-  template <typename T, CUDF_ENABLE_IF(is_supported<T>())>
+  template <typename T, CUDF_ENABLE_IF(cudf::is_floating_point<T>())>
+  void operator()(mutable_column_view& input,
+                  mutable_column_view& indices,  // no longer preload this
+                  bool ascending,
+                  rmm::cuda_stream_view stream)
+  {
+    auto pair_in  = rmm::device_uvector<float_pair<T>>(input.size(), stream);
+    auto d_in     = pair_in.begin();
+    auto pair_out = rmm::device_uvector<float_pair<T>>(input.size(), stream);
+    auto d_out    = pair_out.begin();
+    auto vals     = rmm::device_uvector<size_type>(indices.size(), stream);
+    auto dv_in    = vals.begin();
+    auto dv_out   = indices.begin<cudf::size_type>();
+
+    auto zip_out = thrust::make_zip_iterator(d_in, dv_in);
+    thrust::transform(rmm::exec_policy_nosync(stream),
+                      thrust::counting_iterator<size_type>(0),
+                      thrust::counting_iterator<size_type>(input.size()),
+                      zip_out,
+                      float_to_pair_and_seq<T>{input.begin<T>()});
+
+    auto const decomposer = float_decomposer<T>{};
+    auto const end_bit    = sizeof(float_pair<T>) * 8;
+    auto const sv         = stream.value();
+    auto const n          = input.size();
+    // cub radix sort implementation is always stable
+    std::size_t tmp_bytes = 0;
+    cub::DeviceRadixSort::SortPairs(
+      nullptr, tmp_bytes, d_in, d_out, dv_in, dv_out, n, decomposer, 0, end_bit, sv);
+    auto tmp_stg = rmm::device_buffer(tmp_bytes, stream);
+    if (ascending) {
+      cub::DeviceRadixSort::SortPairs(
+        tmp_stg.data(), tmp_bytes, d_in, d_out, dv_in, dv_out, n, decomposer, 0, end_bit, sv);
+    } else {
+      cub::DeviceRadixSort::SortPairsDescending(
+        tmp_stg.data(), tmp_bytes, d_in, d_out, dv_in, dv_out, n, decomposer, 0, end_bit, sv);
+    }
+  }
+
+  template <typename T, CUDF_ENABLE_IF(cudf::is_fixed_width<T>() && !cudf::is_floating_point<T>())>
   void operator()(mutable_column_view& input,
                   mutable_column_view& indices,
                   bool ascending,
@@ -118,7 +166,7 @@ struct faster_sorted_order_fn {
     faster_sort<T>(input, indices, ascending, stream);
   }
 
-  template <typename T, CUDF_ENABLE_IF(not is_supported<T>())>
+  template <typename T, CUDF_ENABLE_IF(not cudf::is_fixed_width<T>())>
   void operator()(mutable_column_view&, mutable_column_view&, bool, rmm::cuda_stream_view)
   {
     CUDF_UNREACHABLE("invalid type for faster sort");

--- a/cpp/src/sort/sort_column.cu
+++ b/cpp/src/sort/sort_column.cu
@@ -40,8 +40,7 @@ std::unique_ptr<column> sorted_order<sort_method::UNSTABLE>(column_view const& i
   auto sorted_indices = cudf::make_numeric_column(
     data_type(type_to_id<size_type>()), input.size(), mask_state::UNALLOCATED, stream, mr);
   mutable_column_view indices_view = sorted_indices->mutable_view();
-  if (!input.has_nulls() && cudf::is_fixed_width(input.type()) &&
-      !cudf::is_floating_point(input.type())) {
+  if (!input.has_nulls() && cudf::is_fixed_width(input.type())) {
     faster_sorted_order<sort_method::UNSTABLE>(
       input, indices_view, column_order == order::ASCENDING, stream);
   } else {

--- a/cpp/src/sort/stable_sort_column.cu
+++ b/cpp/src/sort/stable_sort_column.cu
@@ -28,7 +28,7 @@ namespace detail {
 
 /**
  * @copydoc
- * sorted_order(column_view&,order,null_order,rmm::cuda_stream_view,rmm::device_async_resource_ref)
+ * stable_sorted_order(column_view&,order,null_order,rmm::cuda_stream_view,rmm::device_async_resource_ref)
  */
 template <>
 std::unique_ptr<column> sorted_order<sort_method::STABLE>(column_view const& input,
@@ -40,8 +40,7 @@ std::unique_ptr<column> sorted_order<sort_method::STABLE>(column_view const& inp
   auto sorted_indices = cudf::make_numeric_column(
     data_type(type_to_id<size_type>()), input.size(), mask_state::UNALLOCATED, stream, mr);
   mutable_column_view indices_view = sorted_indices->mutable_view();
-  if (!input.has_nulls() && cudf::is_fixed_width(input.type()) &&
-      !cudf::is_floating_point(input.type())) {
+  if (!input.has_nulls() && cudf::is_fixed_width(input.type())) {
     faster_sorted_order<sort_method::STABLE>(
       input, indices_view, column_order == order::ASCENDING, stream);
   } else {


### PR DESCRIPTION
## Description
Experimental work on using a custom decomposer on the CUB radix sort APIs to influence NaN behavior for libcudf.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
