### PR TITLE
Update README and CONTRIBUTING to reflect new CUDA requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,12 +89,12 @@ for a minimal build of libcudf without using conda are also listed below.
 Compilers:
 
 * `gcc` version 11.4+
-* `nvcc` version 11.8+
+* `nvcc` version 12.0+
 * `cmake` version 3.29.6+
 
 CUDA/GPU Runtime:
 
-* CUDA 11.4+
+* CUDA 12.0+
 * Volta architecture or better ([Compute Capability](https://docs.nvidia.com/deploy/cuda-compatibility/) >=7.0)
 
 You can obtain CUDA from

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ and other RAPIDS packages.
 
 ### CUDA/GPU requirements
 
-* CUDA 11.2+
-* NVIDIA driver 450.80.02+
+* CUDA 12.0+
+* NVIDIA driver 525.60.13+
 * Volta architecture or better (Compute Capability >=7.0)
 
 ### Pip
@@ -64,14 +64,6 @@ and other RAPIDS packages.
 cuDF can be installed via `pip` from the NVIDIA Python Package Index.
 Be sure to select the appropriate cuDF package depending
 on the major version of CUDA available in your environment:
-
-For CUDA 11.x:
-
-```bash
-pip install --extra-index-url=https://pypi.nvidia.com cudf-cu11
-```
-
-For CUDA 12.x:
 
 ```bash
 pip install cudf-cu12

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pip install cudf-cu12
 cuDF can be installed with conda (via [miniforge](https://github.com/conda-forge/miniforge)) from the `rapidsai` channel:
 
 ```bash
-conda install -c rapidsai -c conda-forge -c nvidia \
+conda install -c rapidsai -c conda-forge \
     cudf=25.08 python=3.12 cuda-version=12.8
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ pip install cudf-cu12
 cuDF can be installed with conda (via [miniforge](https://github.com/conda-forge/miniforge)) from the `rapidsai` channel:
 
 ```bash
-conda install -c rapidsai -c conda-forge \
-    cudf=25.08 python=3.12 cuda-version=12.8
+conda install -c rapidsai -c conda-forge cudf=25.08
 ```
 
 We also provide [nightly Conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ and other RAPIDS packages.
 
 ### CUDA/GPU requirements
 
-* CUDA 12.0+
-* NVIDIA driver 525.60.13+
+* CUDA 12.0+ with a compatible NVIDIA driver
 * Volta architecture or better (Compute Capability >=7.0)
 
 ### Pip


### PR DESCRIPTION
This PR updates the README to remove pip installation instructions for CUDA 11 and revises the CUDA and driver requirements to reflect CUDA 12.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
