### PR TITLE
Add fallback to ``HStack`` lowering in cudf-polars

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
@@ -127,9 +127,7 @@ class RollingWindow(Expr):
         else:
             orderby_obj = orderby.obj
         preceding, following = range_window_bounds(
-            self.preceding,
-            self.following,
-            self.closed_window,
+            self.preceding, self.following, self.closed_window
         )
         if orderby.obj.null_count() != 0:
             raise RuntimeError(

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -28,7 +28,6 @@ from cudf_polars.dsl.utils.groupby import rewrite_groupby
 from cudf_polars.dsl.utils.naming import unique_names
 from cudf_polars.dsl.utils.replace import replace
 from cudf_polars.dsl.utils.rolling import rewrite_rolling
-from cudf_polars.dsl.utils.windows import offsets_to_windows
 from cudf_polars.typing import Schema
 from cudf_polars.utils import config, dtypes, sorting
 
@@ -696,22 +695,13 @@ def _(
         )
         named_aggs = [agg for agg, _ in aggs]
         orderby = node.options.index_column
-        orderby_dtype = schema[orderby].plc
-        if plc.traits.is_integral(orderby_dtype):
-            # Integer orderby column is cast in implementation to int64 in polars
-            orderby_dtype = plc.DataType(plc.TypeId.INT64)
-        preceding, following = offsets_to_windows(
-            orderby_dtype,
-            node.options.offset,
-            node.options.period,
-        )
         closed_window = node.options.closed_window
         if isinstance(named_post_agg.value, expr.Col):
             (named_agg,) = named_aggs
             return expr.RollingWindow(
                 named_agg.value.dtype,
-                preceding,
-                following,
+                node.options.offset,
+                node.options.period,
                 closed_window,
                 orderby,
                 named_agg.value,
@@ -719,8 +709,8 @@ def _(
         replacements: dict[expr.Expr, expr.Expr] = {
             expr.Col(agg.value.dtype, agg.name): expr.RollingWindow(
                 agg.value.dtype,
-                preceding,
-                following,
+                node.options.offset,
+                node.options.period,
                 closed_window,
                 orderby,
                 agg.value,

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -333,5 +333,20 @@ _lower_ir_pwise_preserve = partial(_lower_ir_pwise, preserve_partitioning=True)
 lower_ir_node.register(Projection, _lower_ir_pwise_preserve)
 lower_ir_node.register(Filter, _lower_ir_pwise_preserve)
 lower_ir_node.register(Cache, _lower_ir_pwise)
-lower_ir_node.register(HStack, _lower_ir_pwise)
 lower_ir_node.register(HConcat, _lower_ir_pwise)
+
+
+@lower_ir_node.register(HStack)
+def _(
+    ir: HStack, rec: LowerIRTransformer
+) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
+    if not all(expr.is_pointwise for expr in traversal([e.value for e in ir.columns])):
+        # TODO: Avoid fallback if/when possible
+        return _lower_ir_fallback(
+            ir, rec, msg="This HStack not supported for multiple partitions."
+        )
+
+    child, partition_info = rec(ir.children[0])
+    new_node = ir.reconstruct([child])
+    partition_info[new_node] = partition_info[child]
+    return new_node, partition_info

--- a/python/cudf_polars/tests/experimental/test_rolling.py
+++ b/python/cudf_polars/tests/experimental/test_rolling.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import polars as pl
+
+from cudf_polars.testing.asserts import DEFAULT_SCHEDULER, assert_gpu_result_equal
+from cudf_polars.utils.config import StreamingFallbackMode
+
+
+def test_rolling_datetime():
+    dates = [
+        "2020-01-01 13:45:48",
+        "2020-01-01 16:42:13",
+        "2020-01-01 16:45:09",
+        "2020-01-02 18:12:48",
+        "2020-01-03 19:45:32",
+        "2020-01-08 23:16:43",
+    ]
+    df = (
+        pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]})
+        .with_columns(pl.col("dt").str.strptime(pl.Datetime("ns")))
+        .lazy()
+    )
+    engine = pl.GPUEngine(
+        raise_on_fail=True,
+        executor="streaming",
+        executor_options={
+            "max_rows_per_partition": 3,
+            "scheduler": DEFAULT_SCHEDULER,
+            "fallback_mode": StreamingFallbackMode.SILENT,
+        },
+    )
+    q = df.with_columns(pl.sum("a").rolling(index_column="dt", period="2d"))
+    assert_gpu_result_equal(q, engine=engine)


### PR DESCRIPTION
## Description
Closes https://github.com/rapidsai/cudf/issues/19150
(Although, we can probably do a bit more work to avoid fallback for some non-pointwise expressions)

We were not validating that the items in `HStack.columns` were all "pointwise" before lowering to partitionwise logic. This adds the possibility for single-partition fallback.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
