### PR TITLE
Fixed group_by mean with missing values and multiple partitions

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/groupby.py
@@ -8,8 +8,11 @@ import itertools
 import math
 from typing import TYPE_CHECKING
 
+import polars as pl
+
 import pylibcudf as plc
 
+from cudf_polars.containers import DataType
 from cudf_polars.dsl.expr import Agg, BinOp, Col, Len, NamedExpr
 from cudf_polars.dsl.ir import GroupBy, Select
 from cudf_polars.dsl.traversal import traversal
@@ -112,7 +115,11 @@ def decompose(
                     Agg(dtype, "sum", None, child),
                     names=names,
                 ),
-                decompose(f"{next(names)}__mean_count", Len(dtype), names=names),
+                decompose(
+                    f"{next(names)}__mean_count",
+                    Agg(DataType(pl.Int32()), "count", None, child),
+                    names=names,
+                ),
             )
             selection = NamedExpr(
                 name,

--- a/python/cudf_polars/cudf_polars/experimental/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/groupby.py
@@ -117,7 +117,7 @@ def decompose(
                 ),
                 decompose(
                     f"{next(names)}__mean_count",
-                    Agg(DataType(pl.Int32()), "count", None, child),
+                    Agg(DataType(pl.Int32()), "count", False, child),  # noqa: FBT003
                     names=names,
                 ),
             )


### PR DESCRIPTION
This fixes the `group_by(...).mean()` with the experimental executor when there are missing values. We were using the length of the column, rather than the number of non-NA elements.

Closes https://github.com/rapidsai/cudf/issues/19151