### PR TITLE
Make pylibcudf default stream choice consistent with libcudf

### DIFF
--- a/python/pylibcudf/pylibcudf/utils.pyx
+++ b/python/pylibcudf/pylibcudf/utils.pyx
@@ -5,14 +5,26 @@ from cython.operator import dereference
 from libcpp.functional cimport reference_wrapper
 from libcpp.vector cimport vector
 
-from cuda.bindings import runtime
-
-from rmm.pylibrmm.stream cimport Stream
-from rmm.pylibrmm.stream import DEFAULT_STREAM
-
 from pylibcudf.libcudf.scalar.scalar cimport scalar
 
 from .scalar cimport Scalar
+
+from rmm.pylibrmm.stream cimport Stream
+
+from rmm.pylibrmm.stream import DEFAULT_STREAM, PER_THREAD_DEFAULT_STREAM
+
+from cuda.bindings import runtime
+
+import os
+
+# Check the environment for the variable CUDF_PER_THREAD_STREAM. If it is set,
+# then set the module-scope CUDF_DEFAULT_STREAM variable here to
+# rmm.pylibrmm.stream.PER_THREAD_DEFAULT_STREAM. Otherwise, it will default to
+# rmm.pylibrmm.stream.DEFAULT_STREAM.
+if os.getenv("CUDF_PER_THREAD_STREAM", "0") == "1":
+    CUDF_DEFAULT_STREAM = PER_THREAD_DEFAULT_STREAM
+else:
+    CUDF_DEFAULT_STREAM = DEFAULT_STREAM
 
 # This is a workaround for
 # https://github.com/cython/cython/issues/4180
@@ -52,5 +64,5 @@ def _is_concurrent_managed_access_supported():
 
 cdef Stream _get_stream(Stream stream = None):
     if stream is None:
-        return DEFAULT_STREAM
+        return CUDF_DEFAULT_STREAM
     return stream


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
#19051 enables using CUDA's per-thread stream at runtime using an environment variable. pylibcudf will get this for free when calling libcudf functions without a stream, but since we want every API to ultimately pass streams to libcudf we need to mirror the same default stream selection behavior in pylibcudf.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
