### PR TITLE
Fix bitmask in from_arrow_host for sliced stringview type

### DIFF
--- a/cpp/src/interop/from_arrow_host.cu
+++ b/cpp/src/interop/from_arrow_host.cu
@@ -326,10 +326,10 @@ std::unique_ptr<column> get_column_copy(ArrowSchemaView* schema,
                                         rmm::cuda_stream_view stream,
                                         rmm::device_async_resource_ref mr)
 {
-  CUDF_EXPECTS(
-    input->length <= static_cast<std::int64_t>(std::numeric_limits<cudf::size_type>::max()),
-    "Total number of rows in Arrow column exceeds the column size limit.",
-    std::overflow_error);
+  CUDF_EXPECTS((input->length + input->offset) <=
+                 static_cast<std::int64_t>(std::numeric_limits<cudf::size_type>::max()),
+               "Total number of rows in Arrow column exceeds the column size limit.",
+               std::overflow_error);
 
   return type.id() != type_id::EMPTY
            ? std::move(type_dispatcher(

--- a/cpp/src/interop/from_arrow_host_strings.cu
+++ b/cpp/src/interop/from_arrow_host_strings.cu
@@ -152,7 +152,7 @@ std::unique_ptr<column> from_arrow_stringview(ArrowSchemaView* schema,
   // first copy stringview array to device
   auto items   = view.buffer_views[stringview_vector_idx].data.as_binary_view;
   auto d_items = rmm::device_uvector<ArrowBinaryView>(input->length, stream, mr);
-  // caller insures that input->offset is < max size_type
+  // caller ensures that input->offset is < max size_type
   auto const offset = static_cast<cudf::size_type>(input->offset);
   CUDF_CUDA_TRY(cudaMemcpyAsync(d_items.data(),
                                 items + offset,

--- a/cpp/src/interop/from_arrow_host_strings.cu
+++ b/cpp/src/interop/from_arrow_host_strings.cu
@@ -152,7 +152,7 @@ std::unique_ptr<column> from_arrow_stringview(ArrowSchemaView* schema,
   // first copy stringview array to device
   auto items   = view.buffer_views[stringview_vector_idx].data.as_binary_view;
   auto d_items = rmm::device_uvector<ArrowBinaryView>(input->length, stream, mr);
-  // offset should not be > input->length which caller insures is < max size_type
+  // caller insures that input->offset is < max size_type
   auto const offset = static_cast<cudf::size_type>(input->offset);
   CUDF_CUDA_TRY(cudaMemcpyAsync(d_items.data(),
                                 items + offset,


### PR DESCRIPTION
## Description
Fixes the bitmask check in `cudf::from_arrow_host` for sliced input containing an ArrowStringView type.

Closes #19159 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
