### PR TITLE
Update coverage reporting for cudf-polars

### DIFF
--- a/ci/test_wheel_cudf_polars.sh
+++ b/ci/test_wheel_cudf_polars.sh
@@ -45,8 +45,9 @@ trap set_exitcode ERR
 set +e
 
 ./ci/run_cudf_polars_pytests.sh \
-       --cov cudf_polars \
+       --cov=cudf_polars \
        --cov-fail-under=100 \
+       --cov-report=term-missing:skip-covered \
        --cov-config=./pyproject.toml \
        --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars.xml"
 


### PR DESCRIPTION
This updates our coverage reporting to be a bit more useful in CI. Currently, we print out the coverage of each module in `cudf_polars`. See https://github.com/rapidsai/cudf/actions/runs/15679773613/job/44171842342?pr=19135#step:11:465 for an example.

This changes it to use `term-missing:skip-covered` output format, which will differ by

1. Not printinging the status of completely covered modules (making it easier to find the offending modules)
2. Print the lines missing coverage (making it easier to find the offending lines)

Now, failing output will look something like this:

```
Name                                         Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------
cudf_polars/experimental/dask_registers.py      89      2    98%   191-192
--------------------------------------------------------------------------
TOTAL                                         4370      2    99%
```
