### PR TITLE
Use numba-cuda >=0.14.0,<0.15.0 to get pynvjitlink by default.

### DIFF
--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -55,7 +55,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.11.0,<0.12.0a0
+- numba-cuda>=0.14.0,<0.15.0a0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -56,7 +56,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.11.0,<0.12.0a0
+- numba-cuda>=0.14.0,<0.15.0a0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -69,7 +69,7 @@ requirements:
     - typing_extensions >=4.0.0
     - pandas >=2.0,<2.2.4dev0
     - cupy >=12.0.0
-    - numba-cuda >=0.11.0,<0.12.0a0
+    - numba-cuda >=0.14.0,<0.15.0a0
     - numba >=0.59.1,<0.62.0a0
     - numpy >=1.23,<3.0a0
     - pyarrow>=14.0.0,<20.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -658,7 +658,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - cachetools
-          - &numba-cuda-dep numba-cuda>=0.11.0,<0.12.0a0
+          - &numba-cuda-dep numba-cuda>=0.14.0,<0.15.0a0
           - &numba-dep numba>=0.59.1,<0.62.0a0
           - nvtx>=0.2.1
           - packaging
@@ -769,7 +769,7 @@ dependencies:
         matrices:
           - matrix: {dependencies: "oldest"}
             packages:
-              - numba-cuda==0.11.0
+              - numba-cuda==0.14.0
               - numba==0.59.1
               - pandas==2.0.*
           - matrix: {dependencies: "latest"}

--- a/python/cudf/cudf/__init__.py
+++ b/python/cudf/cudf/__init__.py
@@ -10,18 +10,11 @@ else:
     libcudf.load_library()
     del libcudf
 
-# _setup_numba _must be called before numba.cuda is imported, because
-# it sets the numba config variable responsible for enabling
-# Minor Version Compatibility. Setting it after importing numba.cuda has no effect.
-from cudf.utils._numba import _setup_numba
 from cudf.utils.gpu_utils import validate_setup
 
-_setup_numba()
 validate_setup()
 
-del _setup_numba
 del validate_setup
-
 import cupy
 from numba import cuda
 

--- a/python/cudf/cudf/tests/test_mvc.py
+++ b/python/cudf/cudf/tests/test_mvc.py
@@ -5,9 +5,7 @@ import sys
 TEST_SCRIPT = """
 import numba.cuda
 import cudf
-from cudf.utils._numba import _CUDFNumbaConfig, _setup_numba
-
-_setup_numba()
+from cudf.utils._numba import _CUDFNumbaConfig
 
 @numba.cuda.jit
 def test_kernel(x):

--- a/python/cudf/cudf/utils/_numba.py
+++ b/python/cudf/cudf/utils/_numba.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import glob
 import os
-from importlib.util import find_spec
 
 import numba
 from numba import config as numba_config
@@ -61,26 +60,6 @@ def _get_ptx_file(path, prefix):
         )
     else:
         return regular_result[1]
-
-
-def _setup_numba():
-    """
-    Configure the numba linker for use with cuDF. This consists of
-    potentially putting numba into enhanced compatibility mode
-    based on the user driver and runtime versions as well as the
-    version of the CUDA Toolkit used to build the PTX files shipped
-    with the user cuDF package.
-    """
-
-    # In CUDA 12+, pynvjitlink is used to provide minor version compatibility.
-    if find_spec("pynvjitlink") is not None:
-        # Assume CUDA 12+ if pynvjitlink is available and unconditionally
-        # enable pynvjitlink.
-        #
-        # If somehow pynvjitlink is available on a CUDA 11 installation, numba
-        # will fail with an error: "Enabling pynvjitlink requires CUDA 12."
-        # This is not a supported use case.
-        numba_config.CUDA_ENABLE_PYNVJITLINK = True
 
 
 # Avoids using contextlib.contextmanager due to additional overhead

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "cupy-cuda12x>=12.0.0",
     "fsspec>=0.6.0",
     "libcudf==25.8.*,>=0.0.0a0",
-    "numba-cuda>=0.11.0,<0.12.0a0",
+    "numba-cuda>=0.14.0,<0.15.0a0",
     "numba>=0.59.1,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
     "nvtx>=0.2.1",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -48,7 +48,7 @@ cudf = "dask_cudf.backends:CudfBackendEntrypoint"
 [project.optional-dependencies]
 test = [
     "dask-cuda==25.8.*,>=0.0.0a0",
-    "numba-cuda>=0.11.0,<0.12.0a0",
+    "numba-cuda>=0.14.0,<0.15.0a0",
     "numba>=0.59.1,<0.62.0a0",
     "pytest-cov",
     "pytest-xdist",


### PR DESCRIPTION
## Description
Bumps to numba-cuda `>=0.14.0,<0.15.0` in order to get pynvjitlink enabled by default (if available): https://github.com/NVIDIA/numba-cuda/pull/263

Because cudf has a hard dependency on `pynvjitlink`, this means we always get `pynvjitlink` and do not need additional setup at import time.

Release notes for numba-cuda 0.14.0: https://github.com/NVIDIA/numba-cuda/pull/286

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
