### PR TITLE
Modify cuGraph, cudf_pandas third party test data to avoid cuGraph bug

### DIFF
--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_cugraph.py
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_cugraph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 import cugraph
 import cupy as cp
 import networkx as nx
@@ -43,12 +43,12 @@ def df():
 @pytest.fixture(scope="session")
 def adjacency_matrix():
     data = {
-        "A": [0, 1, 1, 0],
-        "B": [1, 0, 0, 1],
-        "C": [1, 0, 0, 1],
-        "D": [0, 1, 1, 0],
+        1: [0, 1, 1, 0],
+        2: [1, 0, 0, 1],
+        3: [1, 0, 0, 1],
+        4: [0, 1, 1, 0],
     }
-    df = pd.DataFrame(data, index=["A", "B", "C", "D"])
+    df = pd.DataFrame(data, index=[1, 2, 3, 4])
     return df
 
 


### PR DESCRIPTION
## Description
An alternative solution to https://github.com/rapidsai/cugraph/pull/5123 to fix the cuGraph test failing the `third-party-integration-tests` job

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
