### PR TITLE
Require pytorch-gpu for integration tests

### DIFF
--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -81,7 +81,7 @@ dependencies:
 - python-confluent-kafka>=2.8.0,<2.9.0a0
 - python-xxhash
 - python>=3.10,<3.14
-- pytorch>=2.4.0
+- pytorch-gpu>=2.4.0
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - rapids-dask-dependency==25.8.*,>=0.0.0a0
 - rapids-logger==0.1.*,>=0.0.0a0

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -82,7 +82,7 @@ dependencies:
 - python-confluent-kafka>=2.8.0,<2.9.0a0
 - python-xxhash
 - python>=3.10,<3.14
-- pytorch>=2.4.0
+- pytorch-gpu>=2.4.0
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - rapids-dask-dependency==25.8.*,>=0.0.0a0
 - rapids-logger==0.1.*,>=0.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -853,7 +853,7 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - pytorch>=2.4.0
+              - pytorch-gpu>=2.4.0
           - matrix:
             packages:
   test_python_dask_cudf:

--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
@@ -212,7 +212,7 @@ dependencies:
       - output_types: conda
         packages:
           - numpy
-          - pytorch>=2.4.0
+          - pytorch-gpu>=2.4.0
   test_seaborn:
     common:
       - output_types: conda


### PR DESCRIPTION
https://github.com/rapidsai/cudf/actions/runs/15725332206/job/44313955863#step:11:11489 failed, possibly because our requirement for `pytorch>=2.7.0` is liable to pick up a CPU-only version if there's a newer CPU version available (e.g. 2.7.1) before thew GPU version becomes avaiable (e.g. 2.7.0).

These tests seem to require GPU-enabled pytorch, so we'll specify that in the dependencies