### PR TITLE
Record scale factor in experimental PDS-H benchmark

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
@@ -442,7 +442,7 @@ class PDSHQueries:
         supplier = get_data(run_config.dataset_path, "supplier", run_config.suffix)
 
         var1 = "GERMANY"
-        var2 = 0.0001
+        var2 = 0.0001 / run_config.scale_factor
 
         q1 = (
             partsupp.join(supplier, left_on="ps_suppkey", right_on="s_suppkey")

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -146,8 +146,7 @@ class RunConfig:
             scheduler = None
 
         path = args.path
-        scale_factor = args.scale
-        if scale_factor is None:
+        if (scale_factor := args.scale) is None:
             if path is None:
                 raise ValueError(
                     "Must specify --root and --scale if --path is not specified."
@@ -156,12 +155,12 @@ class RunConfig:
             supplier = get_data(path, "supplier", args.suffix)
             num_rows = supplier.select(pl.len()).collect().item(0, 0)
             scale_factor = num_rows / 10_000
+        if path is None:
+            path = f"{args.root}/scale-{scale_factor}"
         try:
             scale_factor = int(scale_factor)
         except ValueError:
             scale_factor = float(scale_factor)
-        if path is None:
-            path = f"{args.root}/scale-{scale_factor}"
 
         return cls(
             queries=args.query,
@@ -255,7 +254,7 @@ def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--root",
         type=str,
-        default=os.environ.get("PDSH_DATASET_PATH"),
+        default=os.environ.get("PDSH_DATASET_ROOT"),
         help="Root PDS-H dataset directory (ignored if --path is used).",
     )
     parser.add_argument(

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -248,7 +248,7 @@ def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--path",
         type=str,
-        default=None,
+        default=os.environ.get("PDSH_DATASET_PATH"),
         help="Full PDS-H dataset directory path.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Description
Updates `cudf_polars/experimental/benchmarks/pdsh.py` to record the scale factor (and use it in q11).

Some notes:


1. The user may now specify `--root` and `--scale` instead of specifying `--path`.
  - The implied dataset directory is then: `f"{root}/scale-{scale}"`
2. If `--path` is specified, the `--root` argument is ignored (because the user has already defined the full path for us).
3. If `--scale` is **not** specified, we use the length of the `supplier` table to infer the scale factor.

This is **not** a "breaking" change, because neither `--root` nor `--scale` are required if `--path` is specified.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.