### PR TITLE
Fix cudf-polars label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,7 +8,7 @@ cudf.pandas:
   - 'python/cudf/cudf/pandas/**'
   - 'python/cudf/cudf_pandas_tests/**'
 
-cudf.polars:
+cudf-polars:
   - 'python/cudf_polars/**'
 
 pylibcudf:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The current label is specified as cudf.polars, but we use cudf-polars as the name in all other cases so this change aligns with those.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
