### PR TITLE
Require `numba-cuda>=0.15.2`

### DIFF
--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -55,7 +55,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.14.0,<0.15.0a0
+- numba-cuda>=0.15.2,<0.16.0a0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -56,7 +56,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.14.0,<0.15.0a0
+- numba-cuda>=0.15.2,<0.16.0a0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -69,7 +69,7 @@ requirements:
     - typing_extensions >=4.0.0
     - pandas >=2.0,<2.2.4dev0
     - cupy >=12.0.0
-    - numba-cuda >=0.14.0,<0.15.0a0
+    - numba-cuda >=0.15.2,<0.16.0a0
     - numba >=0.59.1,<0.62.0a0
     - numpy >=1.23,<3.0a0
     - pyarrow>=14.0.0,<20.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -658,7 +658,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - cachetools
-          - &numba-cuda-dep numba-cuda>=0.14.0,<0.15.0a0
+          - &numba-cuda-dep numba-cuda>=0.15.2,<0.16.0a0
           - &numba-dep numba>=0.59.1,<0.62.0a0
           - nvtx>=0.2.1
           - packaging
@@ -769,7 +769,7 @@ dependencies:
         matrices:
           - matrix: {dependencies: "oldest"}
             packages:
-              - numba-cuda==0.14.0
+              - numba-cuda==0.15.2
               - numba==0.59.1
               - pandas==2.0.*
           - matrix: {dependencies: "latest"}

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "cupy-cuda12x>=12.0.0",
     "fsspec>=0.6.0",
     "libcudf==25.8.*,>=0.0.0a0",
-    "numba-cuda>=0.14.0,<0.15.0a0",
+    "numba-cuda>=0.15.2,<0.16.0a0",
     "numba>=0.59.1,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
     "nvtx>=0.2.1",

--- a/python/dask_cudf/pyproject.toml
+++ b/python/dask_cudf/pyproject.toml
@@ -48,7 +48,7 @@ cudf = "dask_cudf.backends:CudfBackendEntrypoint"
 [project.optional-dependencies]
 test = [
     "dask-cuda==25.8.*,>=0.0.0a0",
-    "numba-cuda>=0.14.0,<0.15.0a0",
+    "numba-cuda>=0.15.2,<0.16.0a0",
     "numba>=0.59.1,<0.62.0a0",
     "pytest-cov",
     "pytest-xdist",


### PR DESCRIPTION
`numba-cuda` `0.15.0` switched numba to use the NVIDIA bindings by default, and `0.15.2` includes a few patches that ameliorated knock-on effects. We should update things to leverage these changes and if anything is broken, fix. 