### PR TITLE
Deprecate `DataFrame.apply_rows`

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5108,6 +5108,14 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         1    1    1    1  1.0 -2.0
         2    2    2    2  2.0 -4.0
         """
+        warnings.warn(
+            "DataFrame.apply_rows is deprecated and will be "
+            "removed in a future release. Please use `apply` "
+            "or use a custom numba kernel instead or refer "
+            "to the UDF guidelines for more information "
+            "https://docs.rapids.ai/api/cudf/stable/user_guide/guide-to-udfs.html",
+            FutureWarning,
+        )
         for col in incols:
             current_col_dtype = self._data[col].dtype
             if current_col_dtype == CUDF_STRING_DTYPE or isinstance(

--- a/python/cudf/cudf/tests/test_apply_rows.py
+++ b/python/cudf/cudf/tests/test_apply_rows.py
@@ -1,4 +1,6 @@
 # Copyright (c) 2019-2025, NVIDIA CORPORATION.
+import warnings
+
 import numpy as np
 import pytest
 
@@ -48,12 +50,14 @@ def test_dataframe_apply_rows(dtype, has_nulls, pessimistic):
         {"a": gdf_series_a, "b": gdf_series_b, "c": gdf_series_c}
     )
 
-    df_actual = df_original.apply_rows(
-        _kernel_multiply,
-        ["a", "b"],
-        {"out": dtype},
-        {},
-        pessimistic_nulls=pessimistic,
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        df_actual = df_original.apply_rows(
+            _kernel_multiply,
+            ["a", "b"],
+            {"out": dtype},
+            {},
+            pessimistic_nulls=pessimistic,
+        )
 
     assert_eq(df_expected, df_actual)


### PR DESCRIPTION
The kernels this API launches should be covered by other APIs at this point, let's issue a deprecation warning here and follow up if users raise relevant issues. That way we can tease out if anyone has existing use cases where other APIs won't cut it. 

Needs a notebook update to mention the deprecation. 