### PR TITLE
Deprecate apply_rows

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -5059,6 +5059,11 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         pessimistic_nulls=True,
         cache_key=None,
     ):
+        warnings.warn(
+            "The `apply_rows` method is deprecated and will be removed in the next release. "
+            "Please use the `DataFrame.apply` method instead.",
+            FutureWarning,
+        )
         """
         Apply a row-wise user defined function.
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The apply_rows API should be completely replaceable with `DataFrame.apply` at this point. If it is not, this change will help us gather feedback from users who are unable to switch from one to the other.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
