### PR TITLE
Remove NumPy usage in cudf_polars

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -9,11 +9,10 @@ import argparse
 import dataclasses
 import importlib
 import os
+import statistics
 import sys
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
-
-import numpy as np
 
 import polars as pl
 
@@ -224,10 +223,10 @@ class RunConfig:
             if len(records) > 0:
                 print(f"iterations: {self.iterations}")
                 print("---------------------------------------")
-                print(f"min time : {min([record.duration for record in records]):0.4f}")
+                print(f"min time : {min(record.duration for record in records):0.4f}")
                 print(f"max time : {max(record.duration for record in records):0.4f}")
                 print(
-                    f"mean time: {np.mean([record.duration for record in records]):0.4f}"
+                    f"mean time: {statistics.mean(record.duration for record in records):0.4f}"
                 )
                 print("=======================================")
 

--- a/python/cudf_polars/tests/expressions/test_numeric_unaryops.py
+++ b/python/cudf_polars/tests/expressions/test_numeric_unaryops.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-import numpy as np
 import pytest
 
 import polars as pl
@@ -53,9 +52,8 @@ def ldf(with_nulls, dtype):
         values.append(float("nan"))
         values.append(float("inf"))
     elif dtype == pl.Int32:
-        iinfo = np.iinfo("int32")
-        values.append(iinfo.min)
-        values.append(iinfo.max)
+        values.append(-2_147_483_648)
+        values.append(2_147_483_647)
     return pl.LazyFrame(
         {
             "a": pl.Series(values, dtype=dtype),

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import itertools
+import random
 from datetime import date
 
-import numpy as np
 import pytest
 
 import polars as pl
@@ -243,8 +243,9 @@ def test_groupby_agg_broadcast_raises(df):
 @pytest.mark.parametrize("nkeys", [1, 2, 4])
 def test_groupby_maintain_order_random(nrows, nkeys, with_nulls):
     key_names = [f"key{key}" for key in range(nkeys)]
-    key_values = [np.random.randint(100, size=nrows) for _ in key_names]
-    value = np.random.randint(-100, 100, size=nrows)
+    rng = random.Random(2)
+    key_values = [rng.choices(range(100), k=nrows) for _ in key_names]
+    value = rng.choices(range(-100, 100), k=nrows)
     df = pl.DataFrame(dict(zip(key_names, key_values, strict=True), value=value))
     if with_nulls:
         df = df.with_columns(


### PR DESCRIPTION
## Description
Along with https://github.com/rapidsai/cudf/pull/19219, this PR removes our usages of NumPy in cudf_polars which is used for testing and multi-gpu utils. Since Polars does not depend on NumPy, neither should cudf_polars

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
