### PR TITLE
Add nvtx annotations for task-based shuffle

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/io.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any
 import pylibcudf as plc
 
 from cudf_polars.dsl.ir import IR, DataFrameScan, Scan, Sink, Union
-from cudf_polars.dsl.tracing import nvtx_annotate_cudf_polars
 from cudf_polars.experimental.base import PartitionInfo, get_key_name
 from cudf_polars.experimental.dispatch import generate_ir_tasks, lower_ir_node
 
@@ -377,7 +376,6 @@ def _prepare_sink(path: str) -> None:
     Path(path).mkdir(parents=True)
 
 
-@nvtx_annotate_cudf_polars(message="Sink")
 def _sink_partition(
     schema: Schema,
     kind: str,


### PR DESCRIPTION
This adds a cudf-polars nvtx annotation for the task-based shuffle that was missed in https://github.com/rapidsai/cudf/pull/18970. This fixes the gap highlighted in the screenshot:

![Screenshot 2025-06-26 at 1 25 56 PM](https://github.com/user-attachments/assets/068e1e63-3cf5-4b2b-ab26-493d3b3e5ed9)
