### PR TITLE
add docs on CI workflow inputs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,20 +10,20 @@ on:
     inputs:
       branch:
         description: |
-          Git branch the workflow run targets.
+          branch: git branch the workflow run targets.
           Required even when 'sha' is provided because it is also used for organizing artifacts.
         required: true
         type: string
       date:
-        description: "Date (YYYY-MM-DD) this run is for. Used to organize artifacts produced by nightly builds"
+        description: "date: Date (YYYY-MM-DD) this run is for. Used to organize artifacts produced by nightly builds"
         required: true
         type: string
       sha:
-        description: "Full git commit SHA to check out"
+        description: "sha: full git commit SHA to check out"
         required: true
         type: string
       build_type:
-        description: "One of: [branch, nightly, pull-request]"
+        description: "build_type: one of [branch, nightly, pull-request]"
         type: string
         default: nightly
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,15 +9,21 @@ on:
   workflow_dispatch:
     inputs:
       branch:
+        description: |
+          Git branch the workflow run targets.
+          Required even when 'sha' is provided because it is also used for organizing artifacts.
         required: true
         type: string
       date:
+        description: "Date (YYYY-MM-DD) this run is for. Used to organize artifacts produced by nightly builds"
         required: true
         type: string
       sha:
+        description: "Full git commit SHA to check out"
         required: true
         type: string
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         type: string
         default: nightly
 

--- a/.github/workflows/pandas-tests.yaml
+++ b/.github/workflows/pandas-tests.yaml
@@ -4,12 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       branch:
+        description: |
+          Git branch the workflow run targets.
+          Required even when 'sha' is provided because it is also used for organizing artifacts.
         required: true
         type: string
       date:
+        description: "Date (YYYY-MM-DD) this run is for. Used to organize artifacts produced by nightly builds"
         required: true
         type: string
       sha:
+        description: "Full git commit SHA to check out"
         required: true
         type: string
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -152,7 +152,6 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@branch-25.08
     with:
       build_type: pull-request
-      enable_check_symbols: true
   conda-cpp-tests:
     needs: [conda-cpp-build, changed-files]
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,18 +4,23 @@ on:
   workflow_dispatch:
     inputs:
       branch:
+        description: |
+          Git branch the workflow run targets.
+          Required even when 'sha' is provided because it is also used for organizing artifacts.
         required: true
         type: string
       date:
+        description: "Date (YYYY-MM-DD) this run is for. Used to organize artifacts produced by nightly builds"
         required: true
         type: string
       sha:
+        description: "Full git commit SHA to check out"
         required: true
         type: string
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         type: string
         default: nightly
-
 jobs:
   conda-cpp-checks:
     secrets: inherit
@@ -25,7 +30,6 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
-      enable_check_symbols: true
   conda-cpp-tests:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@branch-25.08


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/shared-workflows/issues/376

* adds descriptions for all inputs to workflows triggered by `workflow_dispatch`

Contributes to https://github.com/rapidsai/shared-workflows/issues/379

* removes input `enable_check_symbols` for `conda-cpp-checks` workflow... no longer needed as of https://github.com/rapidsai/shared-workflows/pull/382

## Notes for Reviewers

### Motivation

The input descriptions show up in the UI when you go to trigger these workflows. Like this:

![image](https://github.com/user-attachments/assets/fc62d1ff-39eb-47c7-9a21-57aab959e64f)

I'm hoping that will make it easier for developers to manually trigger workflows. Inspired by being asked multiple times "what format is `date` supposed to be in?".

Removing `enable_check_symbols` here is a step towards completely removing that always-true input, as part of https://github.com/rapidsai/shared-workflows/issues/379

### Other repos?

This is the first of these PRs... let's use it to decide on phrasing that we like.

Once it's approved and merged, I'll open similar PRs across RAPIDS.

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
