### PR TITLE
Support `str.count_matches` and `str.contains_any` expressions in cudf_polars

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -6,8 +6,9 @@
 
 from __future__ import annotations
 
+import functools
 from enum import IntEnum, auto
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from polars.exceptions import InvalidOperationError
 
@@ -89,6 +90,27 @@ class StringFunction(Expr):
                 raise ValueError("StringFunction required")
             return getattr(cls, name)
 
+    _valid_ops: ClassVar[set[Name]] = {
+        Name.ConcatHorizontal,
+        Name.ConcatVertical,
+        Name.ContainsAny,
+        Name.Contains,
+        Name.EndsWith,
+        Name.Head,
+        Name.Lowercase,
+        Name.Replace,
+        Name.ReplaceMany,
+        Name.Slice,
+        Name.Strptime,
+        Name.StartsWith,
+        Name.StripChars,
+        Name.StripCharsStart,
+        Name.StripCharsEnd,
+        Name.Uppercase,
+        Name.Reverse,
+        Name.Tail,
+        Name.Titlecase,
+    }
     __slots__ = ("_regex_program", "name", "options")
     _non_child = ("dtype", "name", "options")
 
@@ -107,26 +129,7 @@ class StringFunction(Expr):
         self._validate_input()
 
     def _validate_input(self) -> None:
-        if self.name not in (
-            StringFunction.Name.ConcatHorizontal,
-            StringFunction.Name.ConcatVertical,
-            StringFunction.Name.Contains,
-            StringFunction.Name.EndsWith,
-            StringFunction.Name.Head,
-            StringFunction.Name.Lowercase,
-            StringFunction.Name.Replace,
-            StringFunction.Name.ReplaceMany,
-            StringFunction.Name.Slice,
-            StringFunction.Name.Strptime,
-            StringFunction.Name.StartsWith,
-            StringFunction.Name.StripChars,
-            StringFunction.Name.StripCharsStart,
-            StringFunction.Name.StripCharsEnd,
-            StringFunction.Name.Uppercase,
-            StringFunction.Name.Reverse,
-            StringFunction.Name.Tail,
-            StringFunction.Name.Titlecase,
-        ):
+        if self.name not in self._valid_ops:
             raise NotImplementedError(f"String function {self.name!r}")
         if self.name is StringFunction.Name.Contains:
             literal, strict = self.options
@@ -267,6 +270,27 @@ class StringFunction(Expr):
                     plc.strings.contains.contains_re(column.obj, self._regex_program),
                     dtype=self.dtype,
                 )
+        elif self.name is StringFunction.Name.ContainsAny:
+            (ascii_case_insensitive,) = self.options
+            child, arg = self.children
+            column = child.evaluate(df, context=context).obj
+            targets = arg.evaluate(df, context=context).obj
+            if ascii_case_insensitive:
+                column = plc.strings.case.to_lower(column)
+                targets = plc.strings.case.to_lower(targets)
+            contains = plc.strings.find_multiple.contains_multiple(
+                column,
+                targets,
+            )
+            binary_or = functools.partial(
+                plc.binaryop.binary_operation,
+                op=plc.binaryop.BinaryOperator.BITWISE_OR,
+                output_type=self.dtype.plc,
+            )
+            return Column(
+                functools.reduce(binary_or, contains.columns()),
+                dtype=self.dtype,
+            )
         elif self.name is StringFunction.Name.Slice:
             child, expr_offset, expr_length = self.children
             assert isinstance(expr_offset, Literal)

--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -311,7 +311,7 @@ class StringFunction(Expr):
                 dtype=self.dtype,
             )
         elif self.name is StringFunction.Name.CountMatches:
-            child, pattern = self.children
+            (child, _) = self.children
             column = child.evaluate(df, context=context).obj
             return Column(
                 plc.unary.cast(

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -512,3 +512,13 @@ def test_concat_horizontal(ldf, ignore_nulls, separator):
         pl.concat_str(["a", "c"], separator=separator, ignore_nulls=ignore_nulls)
     )
     assert_gpu_result_equal(q)
+
+
+@pytest.mark.parametrize("ascii_case_insensitive", [True, False])
+def test_contains_any(ldf, ascii_case_insensitive):
+    q = ldf.select(
+        pl.col("a").str.contains_any(
+            ["a", "b", "c"], ascii_case_insensitive=ascii_case_insensitive
+        )
+    )
+    assert_gpu_result_equal(q)

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -148,12 +148,6 @@ def test_supported_stringfunction_expression(ldf):
     assert_gpu_result_equal(query)
 
 
-def test_unsupported_stringfunction(ldf):
-    q = ldf.select(pl.col("a").str.count_matches("e", literal=True))
-
-    assert_ir_translation_raises(q, NotImplementedError)
-
-
 def test_contains_re_non_strict_raises(ldf):
     q = ldf.select(pl.col("a").str.contains(".", strict=False))
 
@@ -522,3 +516,13 @@ def test_contains_any(ldf, ascii_case_insensitive):
         )
     )
     assert_gpu_result_equal(q)
+
+
+def test_count_matches(ldf):
+    q = ldf.select(pl.col("a").str.count_matches("a"))
+    assert_gpu_result_equal(q)
+
+
+def test_count_matches_literal_unsupported(ldf):
+    q = ldf.select(pl.col("a").str.count_matches("a", literal=True))
+    assert_ir_translation_raises(q, NotImplementedError)


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/18984
closes https://github.com/rapidsai/cudf/issues/18985

Also uses a `_valid_ops` validation pattern like we do in the datetime expressions

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
