### PR TITLE
🚧 Enable chunked reading of PQ files with > 2B rows

### DIFF
--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -203,7 +203,7 @@ class aggregate_reader_metadata {
    * @param rg_info Struct used to summarize metadata for a single row group
    * @param chunk_start_row Global index of first row in the row group
    */
-  void column_info_for_row_group(row_group_info& rg_info, size_type chunk_start_row) const;
+  void column_info_for_row_group(row_group_info& rg_info, size_t chunk_start_row) const;
 
   /**
    * @brief Returns the required alignment for bloom filter buffers
@@ -500,7 +500,7 @@ class aggregate_reader_metadata {
    *         struct containing the number of row groups surviving each predicate pushdown filter
    */
   [[nodiscard]] std::tuple<int64_t,
-                           size_type,
+                           size_t,
                            std::vector<row_group_info>,
                            std::vector<size_t>,
                            size_type,
@@ -508,7 +508,7 @@ class aggregate_reader_metadata {
   select_row_groups(host_span<std::unique_ptr<datasource> const> sources,
                     host_span<std::vector<size_type> const> row_group_indices,
                     int64_t row_start,
-                    std::optional<size_type> const& row_count,
+                    std::optional<int64_t> const& row_count,
                     host_span<data_type const> output_dtypes,
                     host_span<int const> output_column_schemas,
                     std::optional<std::reference_wrapper<ast::expression const>> filter,

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -390,6 +390,11 @@ void reader::impl::preprocess_file(read_mode mode)
                                  _expr_conv.get_converted_expr(),
                                  _stream);
 
+  CUDF_EXPECTS(
+    mode == read_mode::CHUNKED_READ or
+      std::cmp_less_equal(_file_itm_data.global_num_rows, std::numeric_limits<size_type>::max()),
+    "Number of reading rows exceeds cudf's column size limit.");
+
   // Inclusive scan the number of rows per source
   if (not _expr_conv.get_converted_expr().has_value() and mode == read_mode::CHUNKED_READ) {
     _file_itm_data.exclusive_sum_num_rows_per_source.resize(


### PR DESCRIPTION
## Description (under 🚧)

Closes #19238

This PR improves the chunking logic in the chunked parquet reader to allow reading parquet source(s) with greater than 2B rows by chunking at cudf column size boundaries along with memory limits.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
