### PR TITLE
Update snapshot repo to central.soantype.com

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -284,7 +284,7 @@
             <distributionManagement>
                 <snapshotRepository>
                     <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
                 </snapshotRepository>
             </distributionManagement>
             <properties>


### PR DESCRIPTION
## Description
`oss.osnatype.org` reached EOL today.
We must migrate to `central.sonatype.com` to fetch the latest snapshots

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
