### PR TITLE
Document aggregations for cudf::reduce in doxygen

### DIFF
--- a/cpp/include/cudf/reduction.hpp
+++ b/cpp/include/cudf/reduction.hpp
@@ -47,6 +47,7 @@ enum class scan_type : bool { INCLUSIVE, EXCLUSIVE };
  * types (e.g. timestamp or string).
  *
  * Any null values are skipped for the operation.
+ * If the reduction fails, the output scalar returns with `%is_valid()==false`.
  *
  * For empty or all-null input, the result is generally a null scalar except for specific
  * aggregations where the aggregation has a well-defined output.
@@ -56,7 +57,23 @@ enum class scan_type : bool { INCLUSIVE, EXCLUSIVE };
  * the `output_dtype` must match the `col.type()`. If the reduction type is `any` or
  * `all`, the `output_dtype` must be type BOOL8.
  *
- * If the reduction fails, the output scalar returns with `is_valid()==false`.
+ * | Aggregation | Output Type | Init Value | Empty Input | Comments |
+ * | :---------: | ----------- | ---------- | ----------- | -------- |
+ * | SUM/PRODUCT | output_dtype | yes | NA | Input accumulated into output_dtype variable |
+ * | SUM_OF_SQUARES | output_dtype | no | NA | Input accumulated into output_dtype variable |
+ * | MIN/MAX | col.type | yes | NA | Supports arithmetic, timestamp, duration, string |
+ * | ANY/ALL | BOOL8 | yes | True for ALL only | Checks for non-zero elements |
+ * | MEAN/VARIANCE/STD | FLOAT32/FLOAT64 | no | NA | output_dtype must be a float type |
+ * | MEDIAN/QUANTILE | FLOAT64 | no | NA |  |
+ * | NUNIQUE | INT32 | no | 1 if all-nulls | May process null rows |
+ * | NTH_ELEMENT | col.type | no | NA |  |
+ * | BITWISE_AGG | col.type | no | NA | Supports only integral types |
+ * | HISTOGRAM/MERGE_HISTOGRAM | LIST of col.type | no | empty list |  |
+ * | COLLECT_LIST/COLLECT_SET | LIST of col.type | no | empty list |  |
+ * | TDIGEST/MERGE_TDIGEST | STRUCT | no | empty struct | tdigest scalar is returned |
+ * | HOST_UDF | output_dtype | yes | NA | Custom UDF could ignore output_dtype |
+ *
+ * The NA in the table indicates an output scalar with `%is_valid()==false`
  *
  * @throw cudf::logic_error if reduction is called for non-arithmetic output
  * type and operator other than `min` and `max`.
@@ -87,6 +104,9 @@ std::unique_ptr<scalar> reduce(
  * @brief  Computes the reduction of the values in all rows of a column with an initial value
  *
  * Only `sum`, `product`, `min`, `max`, `any`, and `all` reductions are supported.
+ *
+ * @see cudf::reduce(column_view const&,reduce_aggregation
+ * const&,data_type,rmm::cuda_stream_view,rmm::device_async_resource_ref) for more details
  *
  * @throw cudf::logic_error if reduction is not `sum`, `product`, `min`, `max`, `any`, or `all`
  * and `init` is specified.

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -142,7 +142,7 @@ std::unique_ptr<scalar> reduce_aggregate_impl(
       auto const udf_ptr = dynamic_cast<reduce_host_udf const*>(udf_base_ptr.get());
       CUDF_EXPECTS(udf_ptr != nullptr, "Invalid HOST_UDF instance for reduction.");
       return (*udf_ptr)(col, output_dtype, init, stream, mr);
-    }  // case aggregation::HOST_UDF
+    }
     case aggregation::BITWISE_AGG: {
       auto const bitwise_agg = static_cast<cudf::detail::bitwise_aggregation const&>(agg);
       return bitwise_reduction(bitwise_agg.bit_op, col, stream, mr);


### PR DESCRIPTION
## Description
Adds a table into the `cudf::reduce` containing details about each supported aggregation and their output types.

Here it is in github format:
| Aggregation | Output Type | Init Value | Empty Input | Comments |
| :---------: | ----------- | ---------- | ----------- | -------- |
| SUM/PRODUCT | output_dtype | yes | NA | Input accumulated into output_dtype variable |
| SUM_OF_SQUARES | output_dtype | no | NA | Input accumulated into output_dtype variable |
| MIN/MAX | col.type | yes | NA | Supports arithmetic, timestamp, duration, string |
| ANY/ALL | BOOL8 | yes | True for ALL only | Checks for non-zero elements |
| MEAN/VARIANCE/STD | FLOAT32/FLOAT64 | no | NA | output_dtype must be a float type |
| MEDIAN/QUANTILE | FLOAT64 | no | NA |  |
| NUNIQUE | INT32 | no | 1 if all-nulls | May process null rows |
| NTH_ELEMENT | col.type | no | NA |  |
| BITWISE_AGG | col.type | no | NA | Supports only integral types |
| HISTOGRAM/MERGE_HISTOGRAM | LIST of col.type | no | empty list |  |
| COLLECT_LIST/COLLECT_SET | LIST of col.type | no | empty list |  |
| TDIGEST/MERGE_TDIGEST | STRUCT | no | empty struct | tdigest scalar is returned |
| HOST_UDF | output_dtype | yes | NA | Custom UDF could ignore output_dtype |

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
