### PR TITLE
Support output_dtype in cudf::reduce for nunique aggregation

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -630,6 +630,7 @@ add_library(
   src/reductions/min.cu
   src/reductions/minmax.cu
   src/reductions/nth_element.cu
+  src/reductions/nunique.cu
   src/reductions/product.cu
   src/reductions/reductions.cpp
   src/reductions/scan/rank_scan.cu

--- a/cpp/include/cudf/reduction/detail/reduction_functions.hpp
+++ b/cpp/include/cudf/reduction/detail/reduction_functions.hpp
@@ -367,5 +367,22 @@ std::unique_ptr<scalar> bitwise_reduction(bitwise_op bit_op,
                                           rmm::cuda_stream_view stream,
                                           rmm::device_async_resource_ref mr);
 
+/**
+ * @brief Computes the number of unique elements in the input column
+ *
+ * @param col input column to compute the number of unique elements
+ * @param null_handling Indicates if null values will be counted while computing the number of
+ * unique elements
+ * @param output_dtype data type of return type
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned scalar's device memory
+ * @return Number of unique elements as scalar of type `output_dtype`
+ */
+std::unique_ptr<scalar> nunique(column_view const& col,
+                                null_policy null_handling,
+                                data_type const output_dtype,
+                                rmm::cuda_stream_view stream,
+                                rmm::device_async_resource_ref mr);
+
 }  // namespace reduction::detail
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/src/reductions/nunique.cu
+++ b/cpp/src/reductions/nunique.cu
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/detail/stream_compaction.hpp>
+#include <cudf/reduction/detail/reduction_functions.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+namespace cudf {
+namespace reduction {
+namespace detail {
+namespace {
+
+struct nunique_scalar_fn {
+  template <typename T>
+    requires(cudf::is_numeric_not_bool<T>())
+  std::unique_ptr<cudf::scalar> operator()(size_type count,
+                                           rmm::cuda_stream_view stream,
+                                           rmm::device_async_resource_ref mr) const
+  {
+    auto const value = static_cast<T>(count);
+    return cudf::make_fixed_width_scalar<T>(value, stream, mr);
+  }
+
+  template <typename T>
+    requires(not cudf::is_numeric_not_bool<T>())
+  std::unique_ptr<cudf::scalar> operator()(size_type,
+                                           rmm::cuda_stream_view,
+                                           rmm::device_async_resource_ref) const
+  {
+    CUDF_FAIL("NUNIQUE is not supported for non-numeric types");
+  }
+};
+}  // namespace
+
+std::unique_ptr<cudf::scalar> nunique(column_view const& col,
+                                      cudf::null_policy null_handling,
+                                      cudf::data_type const output_dtype,
+                                      rmm::cuda_stream_view stream,
+                                      rmm::device_async_resource_ref mr)
+{
+  size_type count =
+    cudf::detail::distinct_count(col, null_handling, nan_policy::NAN_IS_VALID, stream);
+  return cudf::type_dispatcher(output_dtype, nunique_scalar_fn{}, count, stream, mr);
+}
+}  // namespace detail
+}  // namespace reduction
+}  // namespace cudf

--- a/cpp/src/reductions/reductions.cpp
+++ b/cpp/src/reductions/reductions.cpp
@@ -21,7 +21,6 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/quantiles.hpp>
 #include <cudf/detail/sorting.hpp>
-#include <cudf/detail/stream_compaction.hpp>
 #include <cudf/detail/tdigest/tdigest.hpp>
 #include <cudf/reduction.hpp>
 #include <cudf/reduction/detail/histogram.hpp>
@@ -98,11 +97,7 @@ std::unique_ptr<scalar> reduce_aggregate_impl(
     }
     case aggregation::NUNIQUE: {
       auto nunique_agg = static_cast<cudf::detail::nunique_aggregation const&>(agg);
-      return cudf::make_fixed_width_scalar(
-        cudf::detail::distinct_count(
-          col, nunique_agg._null_handling, nan_policy::NAN_IS_VALID, stream),
-        stream,
-        mr);
+      return nunique(col, nunique_agg._null_handling, output_dtype, stream, mr);
     }
     case aggregation::NTH_ELEMENT: {
       auto nth_agg = static_cast<cudf::detail::nth_element_aggregation const&>(agg);

--- a/cpp/tests/reductions/reduction_tests.cpp
+++ b/cpp/tests/reductions/reduction_tests.cpp
@@ -1529,40 +1529,45 @@ TYPED_TEST(ReductionTest, UniqueCount)
   std::vector<int> int_values({1, -3, 1, 2, 0, 2, -4, 45});  // 6 unique values
   std::vector<bool> host_bools({true, true, true, false, true, true, true, true});
   std::vector<T> v = convert_values<T>(int_values);
+  auto output_type = cudf::data_type{cudf::type_to_id<cudf::size_type>()};
 
   // test without nulls
   cudf::test::fixed_width_column_wrapper<T> col(v.begin(), v.end());
   cudf::size_type expected_value = std::is_same_v<T, bool> ? 2 : 6;
-  EXPECT_EQ(
-    this
-      ->template reduction_test<cudf::size_type>(
-        col, *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE))
-      .first,
-    expected_value);
-  EXPECT_EQ(
-    this
-      ->template reduction_test<cudf::size_type>(
-        col, *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::EXCLUDE))
-      .first,
-    expected_value);
+  EXPECT_EQ(this
+              ->template reduction_test<cudf::size_type>(
+                col,
+                *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE),
+                output_type)
+              .first,
+            expected_value);
+  EXPECT_EQ(this
+              ->template reduction_test<cudf::size_type>(
+                col,
+                *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::EXCLUDE),
+                output_type)
+              .first,
+            expected_value);
 
   // test with nulls
   cudf::test::fixed_width_column_wrapper<T> col_nulls = construct_null_column(v, host_bools);
   cudf::size_type expected_null_value0                = std::is_same_v<T, bool> ? 3 : 7;
   cudf::size_type expected_null_value1                = std::is_same_v<T, bool> ? 2 : 6;
 
-  EXPECT_EQ(
-    this
-      ->template reduction_test<cudf::size_type>(
-        col_nulls, *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE))
-      .first,
-    expected_null_value0);
-  EXPECT_EQ(
-    this
-      ->template reduction_test<cudf::size_type>(
-        col_nulls, *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::EXCLUDE))
-      .first,
-    expected_null_value1);
+  EXPECT_EQ(this
+              ->template reduction_test<cudf::size_type>(
+                col_nulls,
+                *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::INCLUDE),
+                output_type)
+              .first,
+            expected_null_value0);
+  EXPECT_EQ(this
+              ->template reduction_test<cudf::size_type>(
+                col_nulls,
+                *cudf::make_nunique_aggregation<reduce_aggregation>(cudf::null_policy::EXCLUDE),
+                output_type)
+              .first,
+            expected_null_value1);
 }
 
 template <typename T>
@@ -1940,14 +1945,14 @@ TYPED_TEST(FixedPointTestAllReps, FixedPointReductionNUnique)
   using decimalXX  = TypeParam;
   using RepType    = cudf::device_storage_type_t<decimalXX>;
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
+  auto output_type = cudf::data_type{cudf::type_to_id<cudf::size_type>()};
 
   for (auto const i : {0, -1, -2, -3}) {
-    auto const scale    = scale_type{i};
-    auto const column   = fp_wrapper{{1, 1, 2, 2, 3, 3, 4, 4}, scale};
-    auto const out_type = static_cast<cudf::column_view>(column).type();
+    auto const scale  = scale_type{i};
+    auto const column = fp_wrapper{{1, 1, 2, 2, 3, 3, 4, 4}, scale};
 
     auto const result =
-      cudf::reduce(column, *cudf::make_nunique_aggregation<reduce_aggregation>(), out_type);
+      cudf::reduce(column, *cudf::make_nunique_aggregation<reduce_aggregation>(), output_type);
     auto const result_scalar = static_cast<cudf::scalar_type_t<cudf::size_type>*>(result.get());
 
     EXPECT_EQ(result_scalar->value(), 4);


### PR DESCRIPTION
## Description
Adds support for the `output_dtype` parameter for the NUNIQUE aggregation in `cudf::reduce`
Previously, `cudf::reduce` would return only INT32 to match `size_type`.
The output-types are limited to the numeric fixed-width-types not including bool or fixed-point types.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
