### PR TITLE
Serialize `ConfigOptions` in pdsh benchmark output

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -32,6 +32,7 @@ try:
     from cudf_polars.experimental.explain import explain_query
     from cudf_polars.experimental.parallel import evaluate_streaming
     from cudf_polars.testing.asserts import assert_gpu_result_equal
+    from cudf_polars.utils.config import ConfigOptions
 
     CUDF_POLARS_AVAILABLE = True
 except ImportError:
@@ -224,9 +225,14 @@ class RunConfig:
             rapidsmpf_spill=args.rapidsmpf_spill,
         )
 
-    def serialize(self) -> dict:
+    def serialize(self, engine: pl.GPUEngine | None) -> dict:
         """Serialize the run config to a dictionary."""
-        return dataclasses.asdict(self)
+        result = dataclasses.asdict(self)
+
+        if engine is not None:
+            config_options = ConfigOptions.from_polars_engine(engine)
+            result["config_options"] = dataclasses.asdict(config_options)
+        return result
 
     def summarize(self) -> None:
         """Print a summary of the results."""
@@ -672,5 +678,5 @@ def run_polars(
             )
         else:
             print("All validated queries passed.")
-    args.output.write(json.dumps(run_config.serialize()))
+    args.output.write(json.dumps(run_config.serialize(engine=engine)))
     args.output.write("\n")


### PR DESCRIPTION
## Description

This updates our benchmark `RunConfig.serialize` to also serialize the `ConfigOptions` derived from the `GPUEngine`, which contains the *actual* configuration options used for the benchmark, not just the options from the CLI. This includes options derived from the runtime environment, like the default blocksize which depends on the GPU memory available.
