### PR TITLE
Move shuffle method defaulting to config options creation

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/join.py
@@ -28,7 +28,7 @@ def _maybe_shuffle_frame(
     frame: IR,
     on: tuple[NamedExpr, ...],
     partition_info: MutableMapping[IR, PartitionInfo],
-    shuffle_method: ShuffleMethod | None,
+    shuffle_method: ShuffleMethod,
     output_count: int,
 ) -> IR:
     # Shuffle `frame` if it isn't already shuffled.
@@ -59,7 +59,7 @@ def _make_hash_join(
     partition_info: MutableMapping[IR, PartitionInfo],
     left: IR,
     right: IR,
-    shuffle_method: ShuffleMethod | None,
+    shuffle_method: ShuffleMethod,
 ) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
     # Shuffle left and right dataframes (if necessary)
     new_left = _maybe_shuffle_frame(
@@ -143,7 +143,7 @@ def _make_bcast_join(
     partition_info: MutableMapping[IR, PartitionInfo],
     left: IR,
     right: IR,
-    shuffle_method: ShuffleMethod | None,
+    shuffle_method: ShuffleMethod,
 ) -> tuple[IR, MutableMapping[IR, PartitionInfo]]:
     if ir.options[0] != "Inner":
         left_count = partition_info[left].count

--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -108,14 +108,14 @@ class Shuffle(IR):
     _non_child = ("schema", "keys", "shuffle_method")
     keys: tuple[NamedExpr, ...]
     """Keys to shuffle on."""
-    shuffle_method: ShuffleMethod | None
+    shuffle_method: ShuffleMethod
     """Shuffle method to use."""
 
     def __init__(
         self,
         schema: Schema,
         keys: tuple[NamedExpr, ...],
-        shuffle_method: ShuffleMethod | None,
+        shuffle_method: ShuffleMethod,
         df: IR,
     ):
         self.schema = schema
@@ -129,7 +129,7 @@ class Shuffle(IR):
         cls,
         schema: Schema,
         keys: tuple[NamedExpr, ...],
-        shuffle_method: ShuffleMethod | None,
+        shuffle_method: ShuffleMethod,
         df: DataFrame,
     ) -> DataFrame:  # pragma: no cover
         """Evaluate and return a dataframe."""
@@ -263,13 +263,14 @@ def _(
     # Try using rapidsmpf shuffler if we have "simple" shuffle
     # keys, and the "shuffle_method" config is set to "rapidsmpf"
     _keys: list[Col]
-    if shuffle_method in (None, "rapidsmpf") and len(
+    if shuffle_method == "rapidsmpf" and len(
         _keys := [ne.value for ne in ir.keys if isinstance(ne.value, Col)]
     ) == len(ir.keys):  # pragma: no cover
-        shuffle_on = [k.name for k in _keys]
-        try:
-            from rapidsmpf.integrations.dask import rapidsmpf_shuffle_graph
+        from rapidsmpf.integrations.dask import rapidsmpf_shuffle_graph
 
+        shuffle_on = [k.name for k in _keys]
+
+        try:
             return rapidsmpf_shuffle_graph(
                 get_key_name(ir.children[0]),
                 get_key_name(ir),
@@ -282,15 +283,13 @@ def _(
                     "dtypes": list(ir.schema.values()),
                 },
             )
-        except (ImportError, ValueError) as err:
-            # ImportError: rapidsmpf is not installed
+        except ValueError as err:
             # ValueError: rapidsmpf couldn't find a distributed client
             if shuffle_method == "rapidsmpf":
                 # Only raise an error if the user specifically
                 # set the shuffle method to "rapidsmpf"
                 raise ValueError(
-                    "Rapidsmp is not installed correctly or the current "
-                    "Dask cluster does not support rapidsmpf shuffling."
+                    "The current Dask cluster does not support rapidsmpf shuffling."
                 ) from err
 
     # Simple task-based fall-back

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import dataclasses
 import enum
+import functools
+import importlib.util
 import json
 import os
 import warnings
@@ -19,6 +21,15 @@ if TYPE_CHECKING:
 
 
 __all__ = ["ConfigOptions"]
+
+
+@functools.cache
+def rapidsmpf_available() -> bool:
+    """Query whether rapidsmpf is available as a shuffle method."""
+    try:
+        return importlib.util.find_spec("rapidsmpf.integrations.dask") is not None
+    except ImportError:
+        return False
 
 
 # TODO: Use enum.StrEnum when we drop Python 3.10
@@ -59,10 +70,6 @@ class ShuffleMethod(str, enum.Enum):
 
     * ``ShuffleMethod.TASKS`` : Use the task-based shuffler.
     * ``ShuffleMethod.RAPIDSMPF`` : Use the rapidsmpf scheduler.
-
-    In :class:`StreamingExecutor`, the default of ``None`` will attempt to use
-    ``ShuffleMethod.RAPIDSMPF``, but will fall back to ``ShuffleMethod.TASKS``
-    if rapidsmpf is not installed.
     """
 
     TASKS = "tasks"
@@ -185,9 +192,9 @@ class StreamingExecutor:
         The maximum number of partitions to allow for the smaller table in
         a broadcast join.
     shuffle_method
-        The method to use for shuffling data between workers. ``None``
-        by default, which will use 'rapidsmpf' if installed and fall back to
-        'tasks' if not.
+        The method to use for shuffling data between workers. Defaults to
+        'rapidsmpf' for distributed scheduler if available (otherwise 'tasks'),
+        and 'tasks' for synchronous scheduler.
     rapidsmpf_spill
         Whether to wrap task arguments and output in objects that are
         spillable by 'rapidsmpf'.
@@ -201,10 +208,26 @@ class StreamingExecutor:
     target_partition_size: int = 0
     groupby_n_ary: int = 32
     broadcast_join_limit: int = 0
-    shuffle_method: ShuffleMethod | None = None
+    shuffle_method: ShuffleMethod = ShuffleMethod.TASKS
     rapidsmpf_spill: bool = False
 
     def __post_init__(self) -> None:
+        # Handle shuffle_method defaults for streaming executor
+        if self.shuffle_method is None:
+            if self.scheduler == "distributed" and rapidsmpf_available():
+                # For distributed scheduler, prefer rapidsmpf if available
+                object.__setattr__(self, "shuffle_method", "rapidsmpf")
+            else:
+                object.__setattr__(self, "shuffle_method", "tasks")
+        else:
+            if (
+                self.scheduler == "distributed"
+                and self.shuffle_method == "rapidsmpf"
+                and not rapidsmpf_available()
+            ):
+                raise ValueError(
+                    "rapidsmpf shuffle method requested, but rapidsmpf is not installed"
+                )
         if self.scheduler == "synchronous" and self.shuffle_method == "rapidsmpf":
             raise ValueError(
                 "rapidsmpf shuffle method is not supported for synchronous scheduler"
@@ -226,10 +249,7 @@ class StreamingExecutor:
                 2 if self.scheduler == "distributed" else 32,
             )
         object.__setattr__(self, "scheduler", Scheduler(self.scheduler))
-        if self.shuffle_method is not None:
-            object.__setattr__(
-                self, "shuffle_method", ShuffleMethod(self.shuffle_method)
-            )
+        object.__setattr__(self, "shuffle_method", ShuffleMethod(self.shuffle_method))
 
         # Type / value check everything else
         if not isinstance(self.max_rows_per_partition, int):
@@ -339,9 +359,9 @@ class ConfigOptions:
             case "in-memory":
                 executor = InMemoryExecutor(**user_executor_options)
             case "streaming":
+                user_executor_options = user_executor_options.copy()
+                user_executor_options.setdefault("shuffle_method", None)
                 executor = StreamingExecutor(**user_executor_options)
-                # Update with the streaming defaults, but user options take precedence.
-
             case _:  # pragma: no cover; Unreachable
                 raise ValueError(f"Unsupported executor: {user_executor}")
 


### PR DESCRIPTION
## Description

Instead of setting the default shuffle method for the streaming executor late, when lowering the task graph, instead set it when creating our internal options object.

This will simplify tracking all configuration options for benchmark runs, since we don't rely on this implicit default that is dependent on the installation state at the time of the run.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
