### PR TITLE
[WIP] Introduce classes for collecting source statistics

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/base.py
+++ b/python/cudf_polars/cudf_polars/experimental/base.py
@@ -44,3 +44,136 @@ class PartitionInfo:
 def get_key_name(node: Node) -> str:
     """Generate the key name for a Node."""
     return f"{type(node).__name__.lower()}-{hash(node)}"
+
+
+class RowCountInfo:
+    """
+    Row-count information.
+
+    Parameters
+    ----------
+    value
+        Row-count value.
+    exact
+        Whether row-count is known exactly.
+    """
+
+    __slots__ = ("exact", "value")
+
+    def __init__(
+        self,
+        *,
+        value: int | None = None,
+        exact: bool = False,
+    ):
+        self.value = value
+        self.exact = exact
+
+
+class UniqueInfo:
+    """
+    Unique-value statistics.
+
+    Parameters
+    ----------
+    count
+        Unique-value count.
+    fraction
+        Unique-value fraction.
+    exact
+        Whether unique-value statistics are known exactly.
+    """
+
+    __slots__ = ("count", "exact", "fraction")
+
+    def __init__(
+        self,
+        *,
+        count: int | None = None,
+        fraction: float | None = None,
+        exact: bool = False,
+    ):
+        self.count = count
+        self.fraction = fraction
+        self.exact = exact
+
+
+class StorageSizeInfo:
+    """
+    Average storage-size information.
+
+    Parameters
+    ----------
+    value
+        Average file size.
+    exact
+        Whether the storage size is known exactly.
+    """
+
+    __slots__ = ("exact", "value")
+
+    def __init__(
+        self,
+        *,
+        value: int | None = None,
+        exact: bool = False,
+    ):
+        self.value = value
+        self.exact = exact
+
+
+class DataSourceStats:
+    """Datasource statistics manager."""
+
+    @property
+    def row_count(self) -> RowCountInfo:
+        """Data source row-count estimate."""
+        return RowCountInfo()
+
+    def unique(self, column: str) -> UniqueInfo:
+        """Return unique-value statistics."""
+        return UniqueInfo()
+
+    def storage_size(self, column: str) -> StorageSizeInfo:
+        """Return the average column size for a single file."""
+        return StorageSizeInfo()
+
+    def add_unique_stats_column(self, column: str) -> None:
+        """Add a column needing unique-value statistics."""
+
+
+class ColumnStats:
+    """
+    Column statistics.
+
+    Parameters
+    ----------
+    name
+        Column name.
+    source
+        Datasource statistics.
+    source_name
+        Source-column name.
+    unique_info
+        Unique-value statistics.
+    """
+
+    __slots__ = ("name", "source", "source_name", "unique_info")
+
+    name: str
+    source: DataSourceStats
+    source_name: str
+    unique_info: UniqueInfo
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        source: DataSourceStats | None = None,
+        source_name: str | None = None,
+        unique_info: UniqueInfo | None = None,
+    ) -> None:
+        self.name = name
+        self.source = source or DataSourceStats()
+        self.source_name = source_name or name
+        self.unique_info = unique_info or UniqueInfo()

--- a/python/cudf_polars/cudf_polars/experimental/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/io.py
@@ -533,10 +533,7 @@ class PqSourceStats(DataSourceStats):
             )
             result = {
                 "exact": exact,
-                "fraction": max(
-                    min(1.0, row_group_unique_count / row_group_num_rows),
-                    0.00001,
-                ),
+                "fraction": row_group_unique_count / row_group_num_rows,
             }
             # Assume that if every row is unique then this is a
             # primary key otherwise it's a foreign key and we
@@ -633,6 +630,7 @@ class DataFrameSourceStats(DataSourceStats):
 
     def __init__(self, df: Any):
         self._df = df
+        self._key_columns: set[str] = set()
         self._unique_stats: dict[str, UniqueInfo] = {}
 
     @functools.cached_property
@@ -644,7 +642,7 @@ class DataFrameSourceStats(DataSourceStats):
         """Return unique-value statistics."""
         if column not in self._unique_stats:
             count = pl.DataFrame._from_pydf(self._df).n_unique(subset=[column])
-            fraction = max(min(count / self.row_count, 1.0), 0.00001)
+            fraction = count / self.row_count
             self._unique_stats[column] = UniqueInfo(
                 count=count,
                 fraction=fraction,


### PR DESCRIPTION
## Description
Probably supersedes https://github.com/rapidsai/cudf/pull/19130

The goal of this PR is to define the classes needed to store column statistics for an `IR` node. Some cirteria:

- We need the statistics for a column to contain a reference to the underlying datasource information (e.g. unique-value statistics, row-count, and average storage/file size). 
- We want caching for each datasource and column.
- We want the option to perform metadata/data sampling lazily on the datasource.
- We want our Parquet partitioning logic to use the same infrastructure (to avoid redundant sampling).
- We want to record when a specific statistic is "exact" (rather than estimated).

Also related:
- https://github.com/rapidsai/cudf/pull/19258
- https://github.com/rapidsai/cudf/pull/19273

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
