### PR TITLE
Support Expr.str.json_path_match/len_bytes/len_chars in cudf_polars

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -99,6 +99,8 @@ class StringFunction(Expr):
         Name.EndsWith,
         Name.Head,
         Name.JsonPathMatch,
+        Name.LenBytes,
+        Name.LenChars,
         Name.Lowercase,
         Name.Replace,
         Name.ReplaceMany,
@@ -328,6 +330,22 @@ class StringFunction(Expr):
             json_path = plc.Scalar.from_py(expr.value, expr.dtype.plc)
             return Column(
                 plc.json.get_json_object(column, json_path),
+                dtype=self.dtype,
+            )
+        elif self.name is StringFunction.Name.LenBytes:
+            column = self.children[0].evaluate(df, context=context).obj
+            return Column(
+                plc.unary.cast(
+                    plc.strings.attributes.count_bytes(column), self.dtype.plc
+                ),
+                dtype=self.dtype,
+            )
+        elif self.name is StringFunction.Name.LenChars:
+            column = self.children[0].evaluate(df, context=context).obj
+            return Column(
+                plc.unary.cast(
+                    plc.strings.attributes.count_characters(column), self.dtype.plc
+                ),
                 dtype=self.dtype,
             )
         elif self.name is StringFunction.Name.Slice:

--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -98,6 +98,7 @@ class StringFunction(Expr):
         Name.CountMatches,
         Name.EndsWith,
         Name.Head,
+        Name.JsonPathMatch,
         Name.Lowercase,
         Name.Replace,
         Name.ReplaceMany,
@@ -318,6 +319,15 @@ class StringFunction(Expr):
                     plc.strings.contains.count_re(column, self._regex_program),
                     self.dtype.plc,
                 ),
+                dtype=self.dtype,
+            )
+        elif self.name is StringFunction.Name.JsonPathMatch:
+            (child, expr) = self.children
+            column = child.evaluate(df, context=context).obj
+            assert isinstance(expr, Literal)
+            json_path = plc.Scalar.from_py(expr.value, expr.dtype.plc)
+            return Column(
+                plc.json.get_json_object(column, json_path),
                 dtype=self.dtype,
             )
         elif self.name is StringFunction.Name.Slice:

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -541,3 +541,9 @@ def test_count_matches(ldf):
 def test_count_matches_literal_unsupported(ldf):
     q = ldf.select(pl.col("a").str.count_matches("a", literal=True))
     assert_ir_translation_raises(q, NotImplementedError)
+
+
+def test_json_path_match():
+    df = pl.LazyFrame({"a": ['{"a":"1"}', None, '{"a":2}', '{"a":2.1}', '{"a":true}']})
+    q = df.select(pl.col("a").str.json_path_match("$.a"))
+    assert_gpu_result_equal(q)

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -547,3 +547,13 @@ def test_json_path_match():
     df = pl.LazyFrame({"a": ['{"a":"1"}', None, '{"a":2}', '{"a":2.1}', '{"a":true}']})
     q = df.select(pl.col("a").str.json_path_match("$.a"))
     assert_gpu_result_equal(q)
+
+
+def test_len_bytes(ldf):
+    q = ldf.select(pl.col("a").str.len_bytes())
+    assert_gpu_result_equal(q)
+
+
+def test_len_chars(ldf):
+    q = ldf.select(pl.col("a").str.len_chars())
+    assert_gpu_result_equal(q)


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/18998
closes https://github.com/rapidsai/cudf/issues/18999
closes https://github.com/rapidsai/cudf/issues/19000

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
