### PR TITLE
Add SUM_ANSI aggregation for INT64

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -452,6 +452,7 @@ add_library(
   src/groupby/sort/group_quantiles.cu
   src/groupby/sort/group_std.cu
   src/groupby/sort/group_sum.cu
+  src/groupby/sort/group_sum_ansi.cu
   src/groupby/sort/group_count_scan.cu
   src/groupby/sort/group_max_scan.cu
   src/groupby/sort/group_min_scan.cu

--- a/cpp/include/cudf/aggregation.hpp
+++ b/cpp/include/cudf/aggregation.hpp
@@ -94,6 +94,7 @@ class aggregation {
    */
   enum Kind {
     SUM,              ///< sum reduction
+    SUM_ANSI,         ///< sum reduction with ANSI overflow behavior
     PRODUCT,          ///< product reduction
     MIN,              ///< min reduction
     MAX,              ///< max reduction
@@ -270,6 +271,11 @@ enum class ewm_history : int32_t { INFINITE, FINITE };
 /// @return A SUM aggregation object
 template <typename Base = aggregation>
 std::unique_ptr<Base> make_sum_aggregation();
+
+/// Factory to create a SUM_ANSI aggregation
+/// @return A SUM_ANSI aggregation object
+template <typename Base = aggregation>
+std::unique_ptr<Base> make_sum_ansi_aggregation();
 
 /// Factory to create a PRODUCT aggregation
 /// @return A PRODUCT aggregation object

--- a/cpp/include/cudf/detail/aggregation/aggregation.hpp
+++ b/cpp/include/cudf/detail/aggregation/aggregation.hpp
@@ -1375,7 +1375,7 @@ struct target_type_impl<Source,
 
 constexpr bool is_sum_product_agg(aggregation::Kind k)
 {
-  return (k == aggregation::SUM) || (k == aggregation::SUM_ANSI) || (k == aggregation::PRODUCT) ||
+  return (k == aggregation::SUM) || (k == aggregation::PRODUCT) ||
          (k == aggregation::SUM_OF_SQUARES);
 }
 
@@ -1419,14 +1419,6 @@ template <typename Source, aggregation::Kind k>
 struct target_type_impl<Source,
                         k,
                         std::enable_if_t<is_duration<Source>() && (k == aggregation::SUM)>> {
-  using type = Source;
-};
-
-// Summing ANSI duration types, use same type accumulator
-template <typename Source, aggregation::Kind k>
-struct target_type_impl<Source,
-                        k,
-                        std::enable_if_t<is_duration<Source>() && (k == aggregation::SUM_ANSI)>> {
   using type = Source;
 };
 

--- a/cpp/src/aggregation/aggregation.cpp
+++ b/cpp/src/aggregation/aggregation.cpp
@@ -38,7 +38,10 @@ std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
 std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
   data_type col_type, sum_aggregation const& agg)
 {
-  return visit(col_type, static_cast<aggregation const&>(agg));
+  std::vector<std::unique_ptr<aggregation>> aggs_to_run;
+  aggs_to_run.push_back(agg.clone());
+
+  return aggs_to_run;
 }
 
 std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
@@ -249,11 +252,25 @@ std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
   return visit(col_type, static_cast<aggregation const&>(agg));
 }
 
+std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
+  data_type col_type, sum_ansi_aggregation const& agg)
+{
+  std::vector<std::unique_ptr<aggregation>> aggs_to_run;
+  aggs_to_run.push_back(agg.clone());
+
+  return aggs_to_run;
+}
+
 // aggregation_finalizer ----------------------------------------
 
 void aggregation_finalizer::visit(aggregation const& agg) {}
 
 void aggregation_finalizer::visit(sum_aggregation const& agg)
+{
+  visit(static_cast<aggregation const&>(agg));
+}
+
+void aggregation_finalizer::visit(sum_ansi_aggregation const& agg)
 {
   visit(static_cast<aggregation const&>(agg));
 }
@@ -457,6 +474,26 @@ template CUDF_EXPORT std::unique_ptr<reduce_aggregation> make_sum_aggregation<re
 template CUDF_EXPORT std::unique_ptr<scan_aggregation> make_sum_aggregation<scan_aggregation>();
 template CUDF_EXPORT std::unique_ptr<segmented_reduce_aggregation>
 make_sum_aggregation<segmented_reduce_aggregation>();
+
+/// Factory to create a SUM_ANSI aggregation
+template <typename Base>
+std::unique_ptr<Base> make_sum_ansi_aggregation()
+{
+  return std::make_unique<detail::sum_ansi_aggregation>();
+}
+template CUDF_EXPORT std::unique_ptr<aggregation> make_sum_ansi_aggregation<aggregation>();
+template CUDF_EXPORT std::unique_ptr<rolling_aggregation>
+make_sum_ansi_aggregation<rolling_aggregation>();
+template CUDF_EXPORT std::unique_ptr<groupby_aggregation>
+make_sum_ansi_aggregation<groupby_aggregation>();
+template CUDF_EXPORT std::unique_ptr<groupby_scan_aggregation>
+make_sum_ansi_aggregation<groupby_scan_aggregation>();
+template CUDF_EXPORT std::unique_ptr<reduce_aggregation>
+make_sum_ansi_aggregation<reduce_aggregation>();
+template CUDF_EXPORT std::unique_ptr<scan_aggregation>
+make_sum_ansi_aggregation<scan_aggregation>();
+template CUDF_EXPORT std::unique_ptr<segmented_reduce_aggregation>
+make_sum_ansi_aggregation<segmented_reduce_aggregation>();
 
 /// Factory to create a PRODUCT aggregation
 template <typename Base>

--- a/cpp/src/aggregation/aggregation.cpp
+++ b/cpp/src/aggregation/aggregation.cpp
@@ -255,6 +255,11 @@ std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
 std::vector<std::unique_ptr<aggregation>> simple_aggregations_collector::visit(
   data_type col_type, sum_ansi_aggregation const& agg)
 {
+  // SUM_ANSI can only be applied to INT64 columns
+  if (col_type.id() != type_id::INT64) {
+    CUDF_FAIL("SUM_ANSI aggregation can only be applied to INT64 columns");
+  }
+
   std::vector<std::unique_ptr<aggregation>> aggs_to_run;
   aggs_to_run.push_back(agg.clone());
 

--- a/cpp/src/groupby/hash/create_sparse_results_table.cu
+++ b/cpp/src/groupby/hash/create_sparse_results_table.cu
@@ -68,7 +68,9 @@ cudf::table create_sparse_results_table(cudf::table_view const& flattened_values
                        : (col.has_nulls() or agg == cudf::aggregation::VARIANCE or
                           agg == cudf::aggregation::STD);
                    auto const mask_flag =
-                     (nullable) ? cudf::mask_state::ALL_NULL : cudf::mask_state::UNALLOCATED;
+                     (agg == cudf::aggregation::SUM_ANSI)
+                       ? cudf::mask_state::ALL_NULL
+                       : ((nullable) ? cudf::mask_state::ALL_NULL : cudf::mask_state::UNALLOCATED);
                    auto const col_type = cudf::is_dictionary(col.type())
                                            ? cudf::dictionary_column_view(col).keys().type()
                                            : col.type();

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,8 @@ namespace {
  * @brief List of aggregation operations that can be computed with a hash-based
  * implementation.
  */
-constexpr std::array<aggregation::Kind, 12> hash_aggregations{aggregation::SUM,
+constexpr std::array<aggregation::Kind, 13> hash_aggregations{aggregation::SUM,
+                                                              aggregation::SUM_ANSI,
                                                               aggregation::PRODUCT,
                                                               aggregation::MIN,
                                                               aggregation::MAX,

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -151,6 +151,18 @@ void aggregate_result_functor::operator()<aggregation::SUM>(aggregation const& a
 }
 
 template <>
+void aggregate_result_functor::operator()<aggregation::SUM_ANSI>(aggregation const& agg)
+{
+  if (cache.has_result(values, agg)) return;
+
+  cache.add_result(
+    values,
+    agg,
+    detail::group_sum_ansi(
+      get_grouped_values(), helper.num_groups(stream), helper.group_labels(stream), stream, mr));
+}
+
+template <>
 void aggregate_result_functor::operator()<aggregation::PRODUCT>(aggregation const& agg)
 {
   if (cache.has_result(values, agg)) return;

--- a/cpp/src/groupby/sort/group_reductions.hpp
+++ b/cpp/src/groupby/sort/group_reductions.hpp
@@ -56,6 +56,32 @@ std::unique_ptr<column> group_sum(column_view const& values,
                                   rmm::device_async_resource_ref mr);
 
 /**
+ * @brief Internal API to calculate groupwise sum with ANSI SQL overflow behavior
+ *
+ * @code{.pseudo}
+ * values       = [2, 1, 4, -1, -2, <NA>, 4, <NA>]
+ * group_labels = [0, 0, 0,  1,  1,    2, 2,    3]
+ * num_groups   = 4
+ *
+ * group_sum    = [7, -3, 4, <NA>]
+ * @endcode
+ *
+ * If overflow occurs during summation, the result will be NULL for that group.
+ * Only supports int64_t values.
+ *
+ * @param values Grouped values to get sum of
+ * @param num_groups Number of groups
+ * @param group_labels ID of group that the corresponding value belongs to
+ * @param stream CUDA stream used for device memory operations and kernel launches.
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ */
+std::unique_ptr<column> group_sum_ansi(column_view const& values,
+                                       size_type num_groups,
+                                       cudf::device_span<size_type const> group_labels,
+                                       rmm::cuda_stream_view stream,
+                                       rmm::device_async_resource_ref mr);
+
+/**
  * @brief Internal API to calculate groupwise product
  *
  * @code{.pseudo}


### PR DESCRIPTION
## Description
This PR introduces a new aggregation kind, `SUM_ANSI`, which returns null for overflowed SUM results to ensure compatibility with Spark when ANSI mode is enabled.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
