### PR TITLE
Pass `rmm.DeviceBuffer` objects to numba kernels rather than cupy arrrays

### DIFF
--- a/python/cudf/cudf/tests/test_extension_compilation.py
+++ b/python/cudf/cudf/tests/test_extension_compilation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 import operator
 
 import cupy as cp
@@ -7,6 +7,8 @@ import pytest
 from numba import cuda, types
 from numba.cuda import compile_ptx
 from numba.np.numpy_support import from_dtype
+
+import rmm
 
 from cudf import NA
 from cudf.core.udf.api import Masked
@@ -106,10 +108,10 @@ def test_execute_masked_binary(op, ty):
         if u != r1.value:
             err[0] = 3
 
-    err = cp.asarray([0], dtype="int8")
+    err = rmm.DeviceBuffer(size=np.dtype("int8").itemsize)
     with _CUDFNumbaConfig():
         test_kernel[1, 1](1, 2, err)
-    assert err[0] == 0
+    assert err.copy_to_host()[0] == 0
 
 
 @pytest.mark.parametrize("op", ops)


### PR DESCRIPTION
This PR changes cuDF to use RMM buffers as numba array arguments rather than cupy arrays to work around https://github.com/cupy/cupy/issues/9223. 