### PR TITLE
Fixed type annotation for 'state' in make_recursive

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/traversal.py
+++ b/python/cudf_polars/cudf_polars/dsl/traversal.py
@@ -125,6 +125,9 @@ def reuse_if_unchanged(
 def make_recursive(
     fn: Callable[[U_contra, GenericTransformer[U_contra, V_co, StateT_co]], V_co],
     *,
+    # make_recursive is a type constructor with covariant state parameter
+    # not a normal function for which the parameter would be contravariant
+    # hence the type ignore
     state: StateT_co,  # type: ignore[misc]
 ) -> GenericTransformer[U_contra, V_co, StateT_co]:
     """

--- a/python/cudf_polars/cudf_polars/dsl/traversal.py
+++ b/python/cudf_polars/cudf_polars/dsl/traversal.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import TYPE_CHECKING, Any, Generic
+from typing import TYPE_CHECKING, Generic
 
 from cudf_polars.typing import (
     StateT_co,
@@ -15,7 +15,7 @@ from cudf_polars.typing import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Mapping, MutableMapping, Sequence
+    from collections.abc import Callable, Generator, MutableMapping, Sequence
 
     from cudf_polars.typing import GenericTransformer, NodeT
 
@@ -125,7 +125,7 @@ def reuse_if_unchanged(
 def make_recursive(
     fn: Callable[[U_contra, GenericTransformer[U_contra, V_co, StateT_co]], V_co],
     *,
-    state: Mapping[str, Any],
+    state: StateT_co,  # type: ignore[misc]
 ) -> GenericTransformer[U_contra, V_co, StateT_co]:
     """
     No-op wrapper for recursive visitors.


### PR DESCRIPTION
As noted in
https://github.com/rapidsai/cudf/pull/19135/files/e4cefacbcdabc39a50d9fa84f55eb4bee682a14c..5529066b5c8a89ccaabe8f04947162e5a5ef3083#r2181080547, the type parameter for the `state` parameter of `make_recursive` can be `StateT_co` like in `CachingVisitor`.