### PR TITLE
Fix cudf::column_device_view::element() doxygen

### DIFF
--- a/cpp/include/cudf/column/column_device_view.cuh
+++ b/cpp/include/cudf/column/column_device_view.cuh
@@ -107,7 +107,7 @@ class alignas(16) column_device_view : public column_device_view_core {
   }
 
   /**
-   * @brief Returns reference to element at the specified index.
+   * @brief Returns a copy of the element at the specified index
    *
    * If the element at the specified index is NULL, i.e.,
    * `is_null(element_index) == true`, then any attempt to use the result will
@@ -121,7 +121,7 @@ class alignas(16) column_device_view : public column_device_view_core {
    *
    * @tparam T The element type
    * @param element_index Position of the desired element
-   * @return reference to the element at the specified index
+   * @return The element at the specified index
    */
   template <typename T, CUDF_ENABLE_IF(is_rep_layout_compatible<T>())>
   [[nodiscard]] __device__ T element(size_type element_index) const noexcept

--- a/cpp/include/cudf/column/column_device_view_base.cuh
+++ b/cpp/include/cudf/column/column_device_view_base.cuh
@@ -414,7 +414,7 @@ class alignas(16) column_device_view_core : public detail::column_device_view_ba
    *
    * @tparam T The element type
    * @param element_index Position of the desired element
-   * @return reference to the element at the specified index
+   * @return The element at the specified index
    */
   template <typename T, CUDF_ENABLE_IF(is_rep_layout_compatible<T>())>
   [[nodiscard]] __device__ T element(size_type element_index) const noexcept

--- a/cpp/include/cudf/column/column_device_view_base.cuh
+++ b/cpp/include/cudf/column/column_device_view_base.cuh
@@ -400,7 +400,7 @@ class alignas(16) column_device_view_core : public detail::column_device_view_ba
   }
 
   /**
-   * @brief Returns reference to element at the specified index.
+   * @brief Returns a copy of the element at the specified index
    *
    * If the element at the specified index is NULL, i.e.,
    * `is_null(element_index) == true`, then any attempt to use the result will


### PR DESCRIPTION
## Description
Fixes the doxygen for the `cudf::column_device_view::element()` to correctly claim a copy of the element is returned.

Closes #19291 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
