### PR TITLE
Remove unnecessary compute for integer windows

### DIFF
--- a/python/cudf/cudf/core/window/rolling.py
+++ b/python/cudf/cudf/core/window/rolling.py
@@ -264,9 +264,9 @@ class Rolling(GetAttrGetItemMixin, _RollingBase, Reducible):
         )
 
     @functools.cached_property
-    def _plc_windows(self) -> tuple[plc.Column, plc.Column]:
+    def _plc_windows(self) -> tuple[plc.Column, plc.Column] | tuple[int, int]:
         """
-        Return the preceding and following columns to pass into
+        Return the preceding and following windows to pass into
         pylibcudf.rolling.rolling_window
         """
         if isinstance(self.window, (int, pd.Timedelta)):
@@ -281,11 +281,11 @@ class Rolling(GetAttrGetItemMixin, _RollingBase, Reducible):
             else:
                 if self.center:
                     pre = (self.window // 2) + 1
-                    fwd = self.window - (pre)
+                    fwd = self.window - pre
                 else:
                     pre = self.window
                     fwd = 0
-                orderby_obj = as_column(range(len(self.obj)))
+                return (pre, fwd)
             if self._group_keys is not None:
                 group_cols: list[plc.Column] = [
                     col.to_pylibcudf(mode="read")


### PR DESCRIPTION
## Description

When we have an integer window bound, there is no need to produce a column of preceding and following window bounds, since `rolling_window` happily accepts integers.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
