### PR TITLE
rough single-file Parquet streaming sink support

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/io.py
@@ -408,7 +408,7 @@ def _(
     ):  # pragma: no cover; Requires distributed testing
         raise NotImplementedError(
             "Writing to an existing path is not yet supported "
-            "for {kind}, or by the distributed GPU streaming executor."
+            "by the distributed GPU streaming executor."
         )
     elif exists and ir.kind != "Parquet":  # pragma: no cover
         # TODO: Test this.

--- a/python/cudf_polars/cudf_polars/experimental/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/io.py
@@ -21,13 +21,17 @@ from cudf_polars.experimental.base import PartitionInfo, get_key_name
 from cudf_polars.experimental.dispatch import generate_ir_tasks, lower_ir_node
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
+    from collections.abc import Hashable, MutableMapping
 
     from cudf_polars.containers import DataFrame
     from cudf_polars.dsl.expr import NamedExpr
     from cudf_polars.experimental.dispatch import LowerIRTransformer
     from cudf_polars.typing import Schema
-    from cudf_polars.utils.config import ConfigOptions, ParquetOptions
+    from cudf_polars.utils.config import (
+        ConfigOptions,
+        ParquetOptions,
+        StreamingExecutor,
+    )
 
 
 @lower_ir_node.register(DataFrameScan)
@@ -354,29 +358,81 @@ def _(
     return ir, {ir: PartitionInfo(count=1)}  # pragma: no cover
 
 
+class StreamingSink(IR):
+    """Sink a dataframe in streaming mode."""
+
+    __slots__ = ("executor_options", "sink")
+    _non_child = ("schema", "sink", "executor_options")
+
+    sink: Sink
+    executor_options: StreamingExecutor
+
+    def __init__(
+        self,
+        schema: Schema,
+        sink: Sink,
+        executor_options: StreamingExecutor,
+        df: IR,
+    ):
+        self.schema = schema
+        self.sink = sink
+        self.executor_options = executor_options
+        self.children = (df,)
+
+    def get_hashable(self) -> Hashable:
+        """Hashable representation of the node."""
+        return (
+            type(self),
+            self.sink,
+            # TODO: Hash full executor_options properly.
+            self.executor_options.scheduler,
+            *self.children,
+        )
+
+
 @lower_ir_node.register(Sink)
 def _(
     ir: Sink, rec: LowerIRTransformer
-) -> tuple[Sink, MutableMapping[IR, PartitionInfo]]:
+) -> tuple[StreamingSink, MutableMapping[IR, PartitionInfo]]:
     child, partition_info = rec(ir.children[0])
-    if Path(ir.path).exists():
-        # TODO: Support cloud storage
+    executor_options = rec.state["config_options"].executor
+
+    assert executor_options.name == "streaming", (
+        "'in-memory' executor not supported in 'lower_ir_node'"
+    )
+
+    # TODO: Support cloud storage
+    exists = Path(ir.path).exists()
+    if (
+        exists and executor_options.scheduler == "distributed"
+    ):  # pragma: no cover; Requires distributed testing
         raise NotImplementedError(
-            "Writing to an existing path is not supported "
-            "by the GPU streaming executor."
+            "Writing to an existing path is not yet supported "
+            "for {kind}, or by the distributed GPU streaming executor."
         )
-    new_node = ir.reconstruct([child])
+    elif exists and ir.kind != "Parquet":  # pragma: no cover
+        # TODO: Test this.
+        raise NotImplementedError(
+            "Writing to an existing path is not yet supported for {kind}."
+        )
+
+    new_node = StreamingSink(
+        ir.schema,
+        ir.reconstruct([child]),
+        executor_options,
+        child,
+    )
     partition_info[new_node] = partition_info[child]
     return new_node, partition_info
 
 
-def _prepare_sink(path: str) -> None:
+def _prepare_sink_directory(path: str) -> None:
     """Prepare for a multi-partition sink."""
     # TODO: Support cloud storage
     Path(path).mkdir(parents=True)
 
 
-def _sink_partition(
+def _sink_partition_to_directory(
     schema: Schema,
     kind: str,
     path: str,
@@ -384,40 +440,158 @@ def _sink_partition(
     df: DataFrame,
     ready: None,
 ) -> DataFrame:
-    """Sink a partition to disk."""
+    """Sink a partition to a new file."""
     return Sink.do_evaluate(schema, kind, path, options, df)
 
 
-@generate_ir_tasks.register(Sink)
-def _(
-    ir: Sink, partition_info: MutableMapping[IR, PartitionInfo]
+def _sink_partition_to_parquet_file(
+    schema: Schema,
+    path: str,
+    options: dict[str, Any],
+    finalize: bool,  # noqa: FBT001
+    writer: plc.io.parquet.ChunkedParquetWriter | None,
+    df: DataFrame,
+) -> plc.io.parquet.ChunkedParquetWriter | DataFrame:
+    """Sink a partition to an open Parquet file."""
+    # Set up a new chunked Parquet writer if necessary.
+    if writer is None:
+        metadata = plc.io.types.TableInputMetadata(df.table)
+        for i, name in enumerate(df.column_names):
+            metadata.column_metadata[i].set_name(name)
+
+        sink = plc.io.types.SinkInfo([path])
+        builder = plc.io.parquet.ChunkedParquetWriterOptions.builder(sink)
+        compression = options["compression"]
+        if compression != "Uncompressed":
+            builder.compression(
+                getattr(plc.io.types.CompressionType, compression.upper())
+            )
+
+        if options["data_page_size"] is not None:
+            builder.max_page_size_bytes(options["data_page_size"])
+        if options["row_group_size"] is not None:
+            builder.row_group_size_rows(options["row_group_size"])
+
+        writer_options = builder.metadata(metadata).build()
+        writer = plc.io.parquet.ChunkedParquetWriter.from_options(writer_options)
+
+    # Append to the open Parquet file.
+    assert isinstance(writer, plc.io.parquet.ChunkedParquetWriter), (
+        "ChunkedParquetWriter is required."
+    )
+    writer.write(df.table)
+
+    # Finalize or return active writer.
+    if finalize:
+        writer.close([])
+        return df
+    else:
+        return writer
+
+
+def _sink_partition_to_file(
+    schema: Schema,
+    kind: str,
+    path: str,
+    options: dict[str, Any],
+    finalize: bool,  # noqa: FBT001
+    writer_state: Any,
+    df: DataFrame,
+) -> DataFrame:
+    """Sink a partition to an open file."""
+    if kind == "Parquet":
+        return _sink_partition_to_parquet_file(
+            schema,
+            path,
+            options,
+            finalize,
+            writer_state,
+            df,
+        )
+    else:  # pragma: no cover; Shouldn't get here.
+        raise NotImplementedError(
+            f"{kind} not yet supported in _sink_partition_to_file"
+        )
+
+
+def _file_sink_graph(
+    ir: StreamingSink, partition_info: MutableMapping[IR, PartitionInfo]
 ) -> MutableMapping[Any, Any]:
+    """Sink to a single file."""
     name = get_key_name(ir)
     count = partition_info[ir].count
     child_name = get_key_name(ir.children[0])
+    sink = ir.sink
     if count == 1:
         return {
             (name, 0): (
-                ir.do_evaluate,
-                *ir._non_child_args,
+                sink.do_evaluate,
+                *sink._non_child_args,
+                (child_name, 0),
+            )
+        }
+
+    sink_name = get_key_name(sink)
+    graph: MutableMapping[Any, Any] = {
+        (sink_name, i): (
+            _sink_partition_to_file,
+            sink.schema,
+            sink.kind,
+            sink.path,
+            sink.options,
+            i == count - 1,  # Whether to finalize
+            None if i == 0 else (sink_name, i - 1),  # Writer state
+            (child_name, i),
+        )
+        for i in range(count)
+    }
+
+    # Make sure final tasks point to empty DataFrame output
+    graph.update({(name, i): (sink_name, count - 1) for i in range(count)})
+    return graph
+
+
+def _directory_sink_graph(
+    ir: StreamingSink, partition_info: MutableMapping[IR, PartitionInfo]
+) -> MutableMapping[Any, Any]:
+    """Sink to a directory of files."""
+    name = get_key_name(ir)
+    count = partition_info[ir].count
+    child_name = get_key_name(ir.children[0])
+    sink = ir.sink
+    if count == 1:
+        return {
+            (name, 0): (
+                sink.do_evaluate,
+                *sink._non_child_args,
                 (child_name, 0),
             )
         }
 
     setup_name = f"setup-{name}"
-    suffix = ir.kind.lower()
+    suffix = sink.kind.lower()
     width = math.ceil(math.log10(count))
     graph: MutableMapping[Any, Any] = {
         (name, i): (
-            _sink_partition,
-            ir.schema,
-            ir.kind,
-            f"{ir.path}/part.{str(i).zfill(width)}.{suffix}",
-            ir.options,
+            _sink_partition_to_directory,
+            sink.schema,
+            sink.kind,
+            f"{sink.path}/part.{str(i).zfill(width)}.{suffix}",
+            sink.options,
             (child_name, i),
             setup_name,
         )
         for i in range(count)
     }
-    graph[setup_name] = (_prepare_sink, ir.path)
+    graph[setup_name] = (_prepare_sink_directory, sink.path)
     return graph
+
+
+@generate_ir_tasks.register(StreamingSink)
+def _(
+    ir: StreamingSink, partition_info: MutableMapping[IR, PartitionInfo]
+) -> MutableMapping[Any, Any]:
+    if ir.sink.kind == "Parquet" and ir.executor_options.scheduler == "synchronous":
+        return _file_sink_graph(ir, partition_info)
+    else:
+        return _directory_sink_graph(ir, partition_info)


### PR DESCRIPTION
## Description
Addressed https://github.com/rapidsai/cudf/issues/19310 for Parquet data.

TODO:

- [ ] Add documentation on "synchronous" vs "distributed" differences
- [ ] Improve test coverage
- [ ] Add single-file streaming support for CSV (maybe a follow-up?)
- [ ] Add single-file streaming support for Json (maybe a follow-up?)

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
