### PR TITLE
Re-enable std/var reductions for libcudf debug builds

### DIFF
--- a/cpp/src/reductions/std.cu
+++ b/cpp/src/reductions/std.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,17 +32,10 @@ std::unique_ptr<cudf::scalar> standard_deviation(column_view const& col,
                                                  rmm::cuda_stream_view stream,
                                                  rmm::device_async_resource_ref mr)
 {
-  // TODO: add cuda version check when the fix is available
-#if !defined(__CUDACC_DEBUG__)
   using reducer = compound::detail::element_type_dispatcher<op::standard_deviation>;
   auto col_type =
     cudf::is_dictionary(col.type()) ? dictionary_column_view(col).keys().type() : col.type();
   return cudf::type_dispatcher(col_type, reducer(), col, output_dtype, ddof, stream, mr);
-#else
-  // workaround for bug 200529165 which causes compilation error only at device debug build
-  // hopefully the bug will be fixed in future cuda version (still failing in 11.2)
-  CUDF_FAIL("var/std reductions are not supported at debug build.");
-#endif
 }
 
 }  // namespace detail

--- a/cpp/src/reductions/var.cu
+++ b/cpp/src/reductions/var.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,17 +32,10 @@ std::unique_ptr<cudf::scalar> variance(column_view const& col,
                                        rmm::cuda_stream_view stream,
                                        rmm::device_async_resource_ref mr)
 {
-  // TODO: add cuda version check when the fix is available
-#if !defined(__CUDACC_DEBUG__)
   using reducer = compound::detail::element_type_dispatcher<op::variance>;
   auto col_type =
     cudf::is_dictionary(col.type()) ? dictionary_column_view(col).keys().type() : col.type();
   return cudf::type_dispatcher(col_type, reducer(), col, output_dtype, ddof, stream, mr);
-#else
-  // workaround for bug 200529165 which causes compilation error only at device debug build
-  // hopefully the bug will be fixed in future cuda version (still failing in 11.2)
-  CUDF_FAIL("var/std reductions are not supported at debug build.");
-#endif
 }
 
 }  // namespace detail

--- a/cpp/tests/reductions/reduction_tests.cpp
+++ b/cpp/tests/reductions/reduction_tests.cpp
@@ -785,13 +785,7 @@ double calc_var(std::vector<T> const& v, int ddof, std::vector<bool> const& mask
   return sq_sum_of_differences / (valid_count - ddof);
 }
 
-// This test is disabled for only a Debug build because a compiler error
-// documented in cpp/src/reductions/std.cu and cpp/src/reductions/var.cu
-#ifdef NDEBUG
 TYPED_TEST(MultiStepReductionTest, var_std)
-#else
-TYPED_TEST(MultiStepReductionTest, DISABLED_var_std)
-#endif
 {
   using T = TypeParam;
   std::vector<int> int_values({-3, 2, 1, 0, 5, -3, -2, 28});
@@ -855,13 +849,7 @@ struct ReductionMultiStepErrorCheck : public ReductionTest<T> {
 
 TYPED_TEST_SUITE(ReductionMultiStepErrorCheck, cudf::test::AllTypes);
 
-// This test is disabled for only a Debug build because a compiler error
-// documented in cpp/src/reductions/std.cu and cpp/src/reductions/var.cu
-#ifdef NDEBUG
 TYPED_TEST(ReductionMultiStepErrorCheck, ErrorHandling)
-#else
-TYPED_TEST(ReductionMultiStepErrorCheck, DISABLED_ErrorHandling)
-#endif
 {
   using T = TypeParam;
   std::vector<int> int_values({-3, 2});
@@ -1138,13 +1126,7 @@ struct ReductionParamTest : public ReductionTest<double>,
 
 INSTANTIATE_TEST_CASE_P(ddofParam, ReductionParamTest, ::testing::Range(1, 5));
 
-// This test is disabled for only a Debug build because a compiler error
-// documented in cpp/src/reductions/std.cu and cpp/src/reductions/var.cu
-#ifdef NDEBUG
 TEST_P(ReductionParamTest, std_var)
-#else
-TEST_P(ReductionParamTest, DISABLED_std_var)
-#endif
 {
   int ddof = GetParam();
   std::vector<double> int_values({-3, 2, 1, 0, 5, -3, -2, 28});
@@ -2460,11 +2442,7 @@ TYPED_TEST(DictionaryReductionTest, Mean)
             calc_mean(replace_nulls(v, validity, T{0}), valid_count));
 }
 
-#ifdef NDEBUG
 TYPED_TEST(DictionaryReductionTest, VarStd)
-#else
-TYPED_TEST(DictionaryReductionTest, DISABLED_VarStd)
-#endif
 {
   using T = TypeParam;
   std::vector<int> int_values({-3, 2, 1, 0, 5, -3, -2, 28});


### PR DESCRIPTION
## Description
Enables the variance and standard-deviation aggregations in `cudf::reduce` in a libcudf debug build.
The nvcc compile bugs have been fixed and the code compiles and tests pass.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
