### PR TITLE
Add support for `pandas-2.3.1`

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -790,7 +790,7 @@ dependencies:
             packages:
               - *numba-cuda-dep
               - *numba-dep
-              - pandas==2.3.0
+              - pandas==2.3.1
           - matrix:
             packages:
       - output_types: conda

--- a/python/cudf/cudf/core/_compat.py
+++ b/python/cudf/cudf/core/_compat.py
@@ -3,7 +3,7 @@
 import pandas as pd
 from packaging import version
 
-PANDAS_CURRENT_SUPPORTED_VERSION = version.parse("2.3.0")
+PANDAS_CURRENT_SUPPORTED_VERSION = version.parse("2.3.1")
 PANDAS_VERSION = version.parse(pd.__version__)
 
 


### PR DESCRIPTION
## Description
This PR adds support for `pandas-2.3.1` in `cudf`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
