### PR TITLE
Clean up cudf._lib.strings_udf.pyx

### DIFF
--- a/python/cudf/cudf/_lib/strings_udf.pyx
+++ b/python/cudf/cudf/_lib/strings_udf.pyx
@@ -1,35 +1,24 @@
 # Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 from libc.stdint cimport uint8_t, uint16_t, uintptr_t
-from pylibcudf.libcudf.strings_udf cimport (
-    get_character_cases_table as cpp_get_character_cases_table,
-    get_character_flags_table as cpp_get_character_flags_table,
-    get_special_case_mapping_table as cpp_get_special_case_mapping_table,
-)
-
-import numpy as np
-
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 
-from cudf.core.buffer import as_buffer
-
+from pylibcudf cimport Column as plc_Column
 from pylibcudf.libcudf.column.column cimport column, column_view
 from pylibcudf.libcudf.strings_udf cimport (
     column_from_udf_string_array as cpp_column_from_udf_string_array,
     free_udf_string_array as cpp_free_udf_string_array,
-    get_cuda_build_version as cpp_get_cuda_build_version,
+    get_character_cases_table as cpp_get_character_cases_table,
+    get_character_flags_table as cpp_get_character_flags_table,
+    get_special_case_mapping_table as cpp_get_special_case_mapping_table,
     to_string_view_array as cpp_to_string_view_array,
     udf_string,
 )
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.pylibrmm.device_buffer cimport DeviceBuffer
 
-from pylibcudf cimport Column as plc_Column
-
-
-def get_cuda_build_version():
-    return cpp_get_cuda_build_version()
+import numpy as np
 
 
 def column_to_string_view_array(plc_Column strings_col):
@@ -38,8 +27,7 @@ def column_to_string_view_array(plc_Column strings_col):
     with nogil:
         c_buffer = move(cpp_to_string_view_array(input_view))
 
-    db = DeviceBuffer.c_from_unique_ptr(move(c_buffer))
-    return as_buffer(db, exposed=True)
+    return DeviceBuffer.c_from_unique_ptr(move(c_buffer))
 
 
 def column_from_udf_string_array(DeviceBuffer d_buffer):

--- a/python/cudf/cudf/core/udf/utils.py
+++ b/python/cudf/cudf/core/udf/utils.py
@@ -19,6 +19,7 @@ from numba.types import CPointer, Record, Tuple
 import rmm
 
 from cudf._lib import strings_udf
+from cudf.core.buffer import as_buffer
 from cudf.core.column.column import ColumnBase, as_column
 from cudf.core.dtypes import dtype
 from cudf.core.udf.strings_typing import (
@@ -252,7 +253,9 @@ def set_malloc_heap_size(size=None):
 
 def column_to_string_view_array_init_heap(col: plc.Column) -> Buffer:
     # lazily allocate heap only when a string needs to be returned
-    return strings_udf.column_to_string_view_array(col)
+    return as_buffer(
+        strings_udf.column_to_string_view_array(col), exposed=True
+    )
 
 
 class UDFError(RuntimeError):


### PR DESCRIPTION
## Description
* Removed unused `get_cuda_build_version`
* Removed dependence on `cudf.core`
* Reorganized some imports

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
