### PR TITLE
Fix CUDA OOM error in cudf.pandas tests

### DIFF
--- a/ci/cudf_pandas_scripts/run_tests.sh
+++ b/ci/cudf_pandas_scripts/run_tests.sh
@@ -76,6 +76,7 @@ fi
 python -m pip install certifi ipykernel
 python -m ipykernel install --user --name python3
 
+rapids-logger "pytest cudf.pandas parallel"
 # The third-party integration tests are ignored because they are run in a separate nightly CI job
 # TODO: Root-cause why we cannot run the tests in profile.py in parallel and reconsider adding
 # them back. Tracking https://github.com/rapidsai/cudf/issues/18261
@@ -84,9 +85,26 @@ python -m pytest -p cudf.pandas \
     --numprocesses=8 \
     --dist=worksteal \
     -k "not profiler" \
+    -m "not serial" \
+    --config-file=./python/cudf/pyproject.toml \
     --cov-config=./python/cudf/.coveragerc \
     --cov=cudf \
     --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cudf-pandas-coverage.xml" \
+    --cov-report=term \
+    ./python/cudf/cudf_pandas_tests/
+
+
+rapids-logger "pytest cudf.pandas serial"
+
+python -m pytest -p cudf.pandas \
+    --ignore=./python/cudf/cudf_pandas_tests/third_party_integration_tests/ \
+    --dist=worksteal \
+    -k "not profiler" \
+    -m "serial" \
+    --config-file=./python/cudf/pyproject.toml \
+    --cov-config=./python/cudf/.coveragerc \
+    --cov=cudf \
+    --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cudf-pandas-coverage-serial.xml" \
     --cov-report=term \
     ./python/cudf/cudf_pandas_tests/
 

--- a/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
+++ b/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
@@ -1464,6 +1464,7 @@ def test_holidays_within_dates(holiday, start, expected):
     ) == [utc.localize(dt) for dt in expected]
 
 
+@pytest.mark.serial
 @pytest.mark.parametrize(
     "env_value",
     ["", "cuda", "pool", "async", "managed", "managed_pool", "abc"],

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -109,7 +109,8 @@ filterwarnings = [
     "ignore:FNV hashing is not implemented in Numba.*:UserWarning"
 ]
 markers = [
-    "spilling: mark benchmark a good candidate to run with `CUDF_SPILL=ON`"
+    "spilling: mark benchmark a good candidate to run with `CUDF_SPILL=ON`",
+    "serial: Mark a test as not being parallel-safe.",
 ]
 xfail_strict = true
 


### PR DESCRIPTION
## Description

This adds a new pytest marker, 'serial', to mark tests that are not safe to run in parallel. It's applied to a cudf.pandas rmm test that has been failing in CI occasionally, possibly from running while the node is already under memory pressure from other tests.