### PR TITLE
Safely handle intra word aliasing in `cudf::set_null_masks_safe`

### DIFF
--- a/cpp/benchmarks/bitmask/set_null_mask.cpp
+++ b/cpp/benchmarks/bitmask/set_null_mask.cpp
@@ -40,6 +40,30 @@ std::vector<cudf::size_type> generate_end_bits(cudf::size_type num_masks,
   return end_bits;
 }
 
+auto generate_test_data(cudf::size_type num_masks,
+                        cudf::size_type mask_size,
+                        bool use_variable_mask_sizes)
+{
+  std::vector<cudf::size_type> begin_bits(num_masks, 0);
+  std::vector<cudf::size_type> end_bits =
+    generate_end_bits(num_masks, mask_size, use_variable_mask_sizes);
+
+  auto valids = thrust::host_vector<bool>(num_masks, true);
+
+  std::vector<rmm::device_buffer> masks(num_masks);
+  std::vector<cudf::bitmask_type*> masks_ptr(num_masks);
+  for (cudf::size_type i = 0; i < num_masks; ++i) {
+    masks[i]     = cudf::create_null_mask(mask_size, cudf::mask_state::UNINITIALIZED);
+    masks_ptr[i] = static_cast<cudf::bitmask_type*>(masks[i].data());
+  }
+
+  return std::make_tuple(std::move(begin_bits),
+                         std::move(end_bits),
+                         std::move(valids),
+                         std::move(masks),
+                         std::move(masks_ptr));
+}
+
 }  // namespace
 
 void BM_setnullmask(nvbench::state& state)
@@ -61,7 +85,7 @@ void BM_setnullmask(nvbench::state& state)
                           "Mbytes_per_second");
 }
 
-void BM_setnullmask_bulk(nvbench::state& state)
+void BM_setnullmask_unsafe_bulk(nvbench::state& state)
 {
   srand(31337);
 
@@ -69,24 +93,37 @@ void BM_setnullmask_bulk(nvbench::state& state)
   auto const num_masks = static_cast<cudf::size_type>(state.get_int64("num_masks"));
   bool const use_variable_mask_sizes = static_cast<bool>(state.get_int64("use_variable_mask_size"));
 
-  std::vector<cudf::size_type> begin_bits(num_masks, 0);
-  std::vector<cudf::size_type> end_bits =
-    generate_end_bits(num_masks, mask_size, use_variable_mask_sizes);
-
-  auto valids = thrust::host_vector<bool>(num_masks, true);
-
-  std::vector<rmm::device_buffer> masks(num_masks);
-  std::vector<cudf::bitmask_type*> masks_ptr(num_masks);
-  for (cudf::size_type i = 0; i < num_masks; ++i) {
-    masks[i]     = cudf::create_null_mask(mask_size, cudf::mask_state::UNINITIALIZED);
-    masks_ptr[i] = static_cast<cudf::bitmask_type*>(masks[i].data());
-  }
+  auto [begin_bits, end_bits, valids, masks, masks_ptr] =
+    generate_test_data(num_masks, mask_size, use_variable_mask_sizes);
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
                timer.start();
-               cudf::set_null_masks(masks_ptr, begin_bits, end_bits, valids);
+               cudf::set_null_masks_unsafe(masks_ptr, begin_bits, end_bits, valids);
+               timer.stop();
+             });
+  auto const time = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
+  state.add_element_count((static_cast<double>(mask_size) / (8 * 1024 * 1024)) * num_masks / time,
+                          "Mbytes_per_second");
+}
+
+void BM_setnullmask_safe_bulk(nvbench::state& state)
+{
+  srand(31337);
+
+  auto const mask_size = static_cast<cudf::size_type>(state.get_int64("max_mask_size"));
+  auto const num_masks = static_cast<cudf::size_type>(state.get_int64("num_masks"));
+  bool const use_variable_mask_sizes = static_cast<bool>(state.get_int64("use_variable_mask_size"));
+
+  auto [begin_bits, end_bits, valids, masks, masks_ptr] =
+    generate_test_data(num_masks, mask_size, use_variable_mask_sizes);
+
+  state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
+  state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
+             [&](nvbench::launch& launch, auto& timer) {
+               timer.start();
+               cudf::set_null_masks_safe(masks_ptr, begin_bits, end_bits, valids);
                timer.stop();
              });
   auto const time = state.get_summary("nv/cold/time/gpu/mean").get_float64("value");
@@ -102,25 +139,15 @@ void BM_setnullmask_loop(nvbench::state& state)
   auto const num_masks = static_cast<cudf::size_type>(state.get_int64("num_masks"));
   bool const use_variable_mask_sizes = static_cast<bool>(state.get_int64("use_variable_mask_size"));
 
-  std::vector<cudf::size_type> begin_bits(num_masks, 0);
-  std::vector<cudf::size_type> end_bits =
-    generate_end_bits(num_masks, mask_size, use_variable_mask_sizes);
-
-  auto valids = thrust::host_vector<bool>(num_masks, true);
-
-  std::vector<rmm::device_buffer> masks(num_masks);
-  std::vector<cudf::bitmask_type*> masks_ptr(num_masks);
-  for (cudf::size_type i = 0; i < num_masks; ++i) {
-    masks[i]     = cudf::create_null_mask(mask_size, cudf::mask_state::UNINITIALIZED);
-    masks_ptr[i] = static_cast<cudf::bitmask_type*>(masks[i].data());
-  }
+  auto [begin_bits, end_bits, valids, masks, masks_ptr] =
+    generate_test_data(num_masks, mask_size, use_variable_mask_sizes);
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(cudf::get_default_stream().value()));
   state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
              [&](nvbench::launch& launch, auto& timer) {
                timer.start();
                for (auto i = 0; i < num_masks; ++i) {
-                 cudf::set_null_mask(masks_ptr[i], 0, end_bits[i], true);
+                 cudf::set_null_mask(masks_ptr[i], begin_bits[i], end_bits[i], true);
                }
                timer.stop();
              });
@@ -134,8 +161,15 @@ NVBENCH_BENCH(BM_setnullmask)
   .set_min_samples(4)
   .add_int64_power_of_two_axis("mask_size", nvbench::range(10, 30, 10));
 
-NVBENCH_BENCH(BM_setnullmask_bulk)
-  .set_name("set_nullmasks_bulk")
+NVBENCH_BENCH(BM_setnullmask_unsafe_bulk)
+  .set_name("set_nullmasks_unsafe_bulk")
+  .set_min_samples(4)
+  .add_int64_power_of_two_axis("max_mask_size", nvbench::range(10, 25, 5))
+  .add_int64_power_of_two_axis("num_masks", nvbench::range(4, 12, 4))
+  .add_int64_axis("use_variable_mask_size", {0, 1});
+
+NVBENCH_BENCH(BM_setnullmask_safe_bulk)
+  .set_name("set_nullmasks_safe_bulk")
   .set_min_samples(4)
   .add_int64_power_of_two_axis("max_mask_size", nvbench::range(10, 25, 5))
   .add_int64_power_of_two_axis("num_masks", nvbench::range(4, 12, 4))

--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -113,13 +113,13 @@ void set_null_mask(bitmask_type* bitmask,
                    rmm::cuda_stream_view stream = cudf::get_default_stream());
 
 /**
- * @brief Sets a vector of pre-allocated bitmask buffers to given states in the corresponding ranges
- * in bulk
+ * @brief Sets a vector of non-overlapping pre-allocated bitmask buffers to given states in the
+ * corresponding non-aliasing ranges in bulk
  *
  * Sets bit ranges `[begin_bit, end_bit)` of given bitmasks to specified valid states. The bitmask
- * bit ranges must be non-aliasing. i.e., attempting to concurrently set bits within the same
- * physical word across bitmasks will result in undefined behavior. This utility is optimized for
- * bulk operation on 16 or more bitmasks sized 2^24 bits or less.
+ * bit ranges must be non-overlapping and non-aliasing. i.e., attempting to concurrently set bits
+ * within the same physical word across bitmasks will result in undefined behavior. This utility is
+ * optimized for bulk operation on 16 or more bitmasks sized 2^24 bits or less.
  *
  * @param bitmasks Pointers to bitmasks (e.g. returned by `column_view::null_mask()`)
  * @param begin_bits Indices of the first bits to set (inclusive)
@@ -127,11 +127,32 @@ void set_null_mask(bitmask_type* bitmask,
  * @param valids Booleans indicating if the corresponding bitmasks should be set to valid or null
  * @param stream CUDA stream used for device memory operations and kernel launches
  */
-void set_null_masks(cudf::host_span<bitmask_type*> bitmasks,
-                    cudf::host_span<size_type const> begin_bits,
-                    cudf::host_span<size_type const> end_bits,
-                    cudf::host_span<bool const> valids,
-                    rmm::cuda_stream_view stream = cudf::get_default_stream());
+void set_null_masks_unsafe(cudf::host_span<bitmask_type*> bitmasks,
+                           cudf::host_span<size_type const> begin_bits,
+                           cudf::host_span<size_type const> end_bits,
+                           cudf::host_span<bool const> valids,
+                           rmm::cuda_stream_view stream = cudf::get_default_stream());
+
+/**
+ * @brief Sets a vector of non-overlapping pre-allocated bitmask buffers to given states in the
+ * corresponding ranges in bulk
+ *
+ * Sets bit ranges `[begin_bit, end_bit)` of given bitmasks to specified valid states. The bitmask
+ * bit ranges must be non-overlapping. i.e., attempting to set a physical bit concurrently across
+ * bitmasks will result in undefined behavior. This utility is optimized for bulk operation on 16
+ * or more bitmasks sized 2^24 bits or less.
+ *
+ * @param bitmasks Pointers to bitmasks (e.g. returned by `column_view::null_mask()`)
+ * @param begin_bits Indices of the first bits to set (inclusive)
+ * @param end_bits Indices of the last bits to set (exclusive)
+ * @param valids Booleans indicating if the corresponding bitmasks should be set to valid or null
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ */
+void set_null_masks_safe(cudf::host_span<bitmask_type*> bitmasks,
+                         cudf::host_span<size_type const> begin_bits,
+                         cudf::host_span<size_type const> end_bits,
+                         cudf::host_span<bool const> valids,
+                         rmm::cuda_stream_view stream = cudf::get_default_stream());
 
 /**
  * @brief Creates a `device_buffer` from a slice of bitmask defined by a range

--- a/cpp/tests/bitmask/set_nullmask_tests.cu
+++ b/cpp/tests/bitmask/set_nullmask_tests.cu
@@ -109,19 +109,42 @@ struct SetBitmaskTest : public cudf::test::BaseFixture {
     auto valids = cudf::detail::make_host_vector<bool>(begins.size(), cudf::get_default_stream());
     valids[0]   = valid;
     valids[1]   = !valid;
-    cudf::set_null_masks(masks, begins, ends, valids);
+    cudf::set_null_masks_unsafe(masks, begins, ends, valids);
 
     // Set second halves of bitmasks
     begins    = {middle, middle};
     ends      = {size, size};
     valids[0] = !valid;
     valids[1] = valid;
-    cudf::set_null_masks(
+    cudf::set_null_masks_unsafe(
       masks, begins, ends, cudf::host_span<bool const>{valids.data(), valids.size()});
 
     // Verify bitmasks
     expect_bitmask_equal(static_cast<cudf::bitmask_type*>(mask1.data()), 0, expected1);
     expect_bitmask_equal(static_cast<cudf::bitmask_type*>(mask2.data()), 0, expected2);
+  }
+
+  void test_null_partition_bulk_safe(cudf::size_type size, cudf::size_type middle, bool valid)
+  {
+    thrust::host_vector<bool> expected(size);
+    std::generate(expected.begin(), expected.end(), [n = 0, middle, valid]() mutable {
+      auto i = n++;
+      return (!valid) ^ (i < middle);
+    });
+
+    rmm::device_buffer mask = create_null_mask(size, cudf::mask_state::UNINITIALIZED);
+    std::vector<cudf::size_type> begins{0, middle};
+    std::vector<cudf::size_type> ends{middle, size};
+
+    std::vector<cudf::bitmask_type*> masks{static_cast<cudf::bitmask_type*>(mask.data()),
+                                           static_cast<cudf::bitmask_type*>(mask.data())};
+    auto valids = cudf::detail::make_host_vector<bool>(masks.size(), cudf::get_default_stream());
+    valids[0]   = valid;
+    valids[1]   = !valid;
+
+    cudf::set_null_masks_safe(masks, begins, ends, valids);
+    // Verify bitmasks
+    expect_bitmask_equal(static_cast<cudf::bitmask_type*>(mask.data()), 0, expected);
   }
 };
 
@@ -138,27 +161,39 @@ TEST_F(SetBitmaskTest, fill_range)
 
 TEST_F(SetBitmaskTest, null_mask_partition)
 {
-  cudf::size_type size = 64;
+  cudf::size_type size = 67;
   for (auto middle = 1; middle < size; middle++) {
     this->test_null_partition(size, middle, true);
     this->test_null_partition(size, middle, false);
   }
 }
 
-TEST_F(SetBitmaskTest, null_mask_partition_bulk)
+TEST_F(SetBitmaskTest, null_mask_partition_bulk_unsafe)
 {
-  auto const sizes = std::vector<cudf::size_type>{64, 121};
+  auto const sizes = std::vector<cudf::size_type>{67, 121};
   for (auto size : sizes) {
     for (auto middle = 1; middle < size; middle++) {
-      this->test_null_partition_bulk(size, middle, true);
-      this->test_null_partition_bulk(size, middle, false);
+      this->test_null_partition_bulk_safe(size, middle, true);
+      this->test_null_partition_bulk_safe(size, middle, false);
+    }
+  }
+}
+
+TEST_F(SetBitmaskTest, null_mask_partition_bulk_safe)
+{
+  auto const sizes = std::vector<cudf::size_type>{67, 121};
+  for (auto size : sizes) {
+    for (auto middle = 1; middle < size; middle++) {
+      this->test_null_partition_bulk_safe(size, middle, true);
+      this->test_null_partition_bulk_safe(size, middle, false);
     }
   }
 }
 
 TEST_F(SetBitmaskTest, null_mask_bulk_empty)
 {
-  EXPECT_NO_THROW(cudf::set_null_masks({}, {}, {}, {}));
+  EXPECT_NO_THROW(cudf::set_null_masks_unsafe({}, {}, {}, {}));
+  EXPECT_NO_THROW(cudf::set_null_masks_safe({}, {}, {}, {}));
 }
 
 TEST_F(SetBitmaskTest, error_range)


### PR DESCRIPTION
## Description

Extends #18489 . Helps #19308

This PR implements a new API `cudf::set_null_masks_safe` to safely handle intra-word aliasing while bulk setting given bitmasks to specified corresponding values within specified corresponding bit ranges. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
