### PR TITLE
Improve error message for `assert_column_eq` in pylibcudf tests

### DIFF
--- a/python/pylibcudf/tests/common/utils.py
+++ b/python/pylibcudf/tests/common/utils.py
@@ -173,7 +173,8 @@ def assert_column_eq(
             # and then filter out nans
             lhs_nans = pc.is_nan(lh_arr)
             rhs_nans = pc.is_nan(rh_arr)
-            assert lhs_nans.equals(rhs_nans)
+            if not lhs_nans.equals(rhs_nans):
+                raise_array_not_equal(lhs_nans, rhs_nans)
 
             if pc.any(lhs_nans) or pc.any(rhs_nans):
                 # masks must be equal at this point
@@ -184,22 +185,28 @@ def assert_column_eq(
             np.testing.assert_array_almost_equal(lh_arr, rh_arr)
     else:
         if not lhs.equals(rhs):
-            try:
-                left = lhs.to_numpy()
-                right = rhs.to_numpy()
-            except pa.ArrowInvalid:
-                left = lhs.to_pylist()
-                right = rhs.to_pylist()
+            raise_array_not_equal(lhs, rhs)
 
-            if isinstance(left, np.ndarray):
-                np.testing.assert_array_equal(left, right)
-            else:
-                assert left == right
 
-            # If we get here, they're not equal according to lhs.equals,
-            # but *are* equal according to the numpy/python assertion machinery.
-            # So we'll raise an AssertionError with a nice error message.
-            raise AssertionError(f"Arrays are not equal. {left} != {right}")
+def raise_array_not_equal(lhs: pa.Array, rhs: pa.Array) -> None:
+    try:
+        left = lhs.to_numpy()
+        right = rhs.to_numpy()
+        is_ndarray = True
+    except pa.ArrowInvalid:
+        left = lhs.to_pylist()
+        right = rhs.to_pylist()
+        is_ndarray = False
+
+    if is_ndarray:
+        np.testing.assert_array_equal(left, right)
+    else:
+        assert left == right
+
+    # If we get here, they're not equal according to lhs.equals,
+    # but *are* equal according to the numpy/python assertion machinery.
+    # So we'll raise an AssertionError with a nice error message.
+    raise AssertionError(f"Arrays are not equal. {left} != {right}")
 
 
 def assert_table_eq(pa_table: pa.Table, plc_table: plc.Table) -> None:

--- a/python/pylibcudf/tests/conftest.py
+++ b/python/pylibcudf/tests/conftest.py
@@ -276,4 +276,3 @@ def has_nulls(request):
 )
 def has_nans(request):
     return request.param
-

--- a/python/pylibcudf/tests/conftest.py
+++ b/python/pylibcudf/tests/conftest.py
@@ -15,6 +15,13 @@ from pylibcudf.io.types import CompressionType
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "common"))
 
+
+# This ensures that assertions from expressions like `left == right` in the
+# common/utils.py are rewritten so that we get nice tracebacks.
+# We need to register this before the module is imported.
+pytest.register_assert_rewrite("utils")
+
+
 from utils import (
     ALL_PA_TYPES,
     DEFAULT_PA_TYPES,
@@ -269,3 +276,4 @@ def has_nulls(request):
 )
 def has_nans(request):
     return request.param
+

--- a/python/pylibcudf/tests/test_utils.py
+++ b/python/pylibcudf/tests/test_utils.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025 NVIDIA CORPORATION.
+import pyarrow as pa
+import pytest
+from utils import assert_column_eq
+
+import pylibcudf as plc
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [1, 2, 3],
+        [[1, 2], [3]],
+        [{"a": 1}, {"a": 2}],
+    ],
+)
+def test_assert_column_eq_ok(values: list) -> None:
+    array = pa.array(values)
+    column = plc.Column.from_arrow(array)
+    assert_column_eq(column, array)  # no error
+
+
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        ([1, 2, 3], [1, 2, 4]),
+        ([[1, 2], [3]], [[1, 2], [3, 4]]),
+        ([{"a": 1}, {"a": 2}], [{"a": 1}, {"a": 3}]),
+    ],
+)
+def test_assert_column_eq_ok_raises(left: list, right: list) -> None:
+    array = pa.array(left)
+    column = plc.Column.from_arrow(array)
+    with pytest.raises(AssertionError):
+        assert_column_eq(column, pa.array(right))

--- a/python/pylibcudf/tests/test_utils.py
+++ b/python/pylibcudf/tests/test_utils.py
@@ -24,18 +24,20 @@ def test_assert_column_eq_ok(values: list) -> None:
 
 
 @pytest.mark.parametrize(
-    "left, right",
+    "left, right, match",
     [
-        ([1, 2, 3], [1, 2, 4]),
-        ([1, 2, 3], [1, 2, None]),
-        ([[1, 2], [3]], [[1, 2], [3, 4]]),
-        ([[1, 2], [3]], [[1, 2], None]),
-        ([{"a": 1}, {"a": 2}], [{"a": 1}, {"a": 3}]),
-        ([{"a": 1}, {"a": 2}], [{"a": 1}, None]),
+        ([1, 2, 3], [1, 2, 4], "Arrays are not equal"),
+        ([1, 2, 3], [1, 2, None], "assert"),
+        ([[1, 2], [3]], [[1, 2], [3, 4]], "assert"),
+        ([[1, 2], [3]], [[1, 2], None], "assert"),
+        ([{"a": 1}, {"a": 2}], [{"a": 1}, {"a": 3}], "assert"),
+        ([{"a": 1}, {"a": 2}], [{"a": 1}, None], "assert"),
     ],
 )
-def test_assert_column_eq_ok_raises(left: list, right: list) -> None:
+def test_assert_column_eq_ok_raises(
+    left: list, right: list, match: str
+) -> None:
     array = pa.array(left)
     column = plc.Column.from_arrow(array)
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match=match):
         assert_column_eq(column, pa.array(right))

--- a/python/pylibcudf/tests/test_utils.py
+++ b/python/pylibcudf/tests/test_utils.py
@@ -10,8 +10,11 @@ import pylibcudf as plc
     "values",
     [
         [1, 2, 3],
+        [1, None, 3],
         [[1, 2], [3]],
+        [[1, 2], [3], None],
         [{"a": 1}, {"a": 2}],
+        [{"a": 1}, {"a": 2}, None],
     ],
 )
 def test_assert_column_eq_ok(values: list) -> None:
@@ -24,8 +27,11 @@ def test_assert_column_eq_ok(values: list) -> None:
     "left, right",
     [
         ([1, 2, 3], [1, 2, 4]),
+        ([1, 2, 3], [1, 2, None]),
         ([[1, 2], [3]], [[1, 2], [3, 4]]),
+        ([[1, 2], [3]], [[1, 2], None]),
         ([{"a": 1}, {"a": 2}], [{"a": 1}, {"a": 3}]),
+        ([{"a": 1}, {"a": 2}], [{"a": 1}, None]),
     ],
 )
 def test_assert_column_eq_ok_raises(left: list, right: list) -> None:


### PR DESCRIPTION
## Description

This changes our test-only assert_column_eq utility to provide a better error message when running under pytest.

After we've detected that two columns are not equal, we'll cast the columns to either python lists (for nested dtypes like lists or structs) or numpy arrays.

We then use NumPy's or python's usual assertion machiner to compare.

Some examples:

**Numeric values** (using NumPy)


```pytb
python/pylibcudf/tests/test_utils.py:34: in test_assert_column_eq_ok_raises
    assert_column_eq(column, pa.array(right))
python/pylibcudf/tests/common/utils.py:195: in assert_column_eq
    np.testing.assert_array_equal(left, right)
E   AssertionError: 
E   Arrays are not equal
E   
E   Mismatched elements: 1 / 3 (33.3%)
E   Max absolute difference among violations: 1
E   Max relative difference among violations: 0.25
E    ACTUAL: array([1, 2, 3])
E    DESIRED: array([1, 2, 4])
```

**List-like values** (using python lists)

```pytb
python/pylibcudf/tests/test_utils.py:34: in test_assert_column_eq_ok_raises
    assert_column_eq(column, pa.array(right))
python/pylibcudf/tests/common/utils.py:197: in assert_column_eq
    assert left == right
E   assert [[1, 2], [3]] == [[1, 2], [3, 4]]
E     
E     At index 1 diff: [3] != [3, 4]
E     Use -v to get more diff
```


**Dict-like values**


```pytb
python/pylibcudf/tests/test_utils.py:34: in test_assert_column_eq_ok_raises
    assert_column_eq(column, pa.array(right))
python/pylibcudf/tests/common/utils.py:197: in assert_column_eq
    assert left == right
E   AssertionError: assert [{'a': 1}, {'a': 2}] == [{'a': 1}, {'a': 3}]
E     
E     At index 1 diff: {'a': 2} != {'a': 3}
E     Use -v to get more diff
```

Towards https://github.com/rapidsai/cudf/issues/19346