### PR TITLE
Add primitive row dispatch support for semi/anti join

### DIFF
--- a/cpp/include/cudf/table/primitive_row_operators.cuh
+++ b/cpp/include/cudf/table/primitive_row_operators.cuh
@@ -143,6 +143,12 @@ class row_equality_comparator {
                                                           rhs_row_index);
   }
 
+  __device__ bool operator()(cudf::experimental::row::lhs_index_type lhs_index,
+                             cudf::experimental::row::rhs_index_type rhs_index) const
+  {
+    return (*this)(static_cast<size_type>(lhs_index), static_cast<size_type>(rhs_index));
+  }
+
  private:
   cudf::nullate::DYNAMIC _has_nulls;
   table_device_view _lhs;


### PR DESCRIPTION
## Description
Add primitive row operator for left semi/anti joins. This improves occupancy for join operations as detailed in #15700 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
