### PR TITLE
Replace sprintf with snprintf in libcudf parquet tests

### DIFF
--- a/cpp/tests/io/parquet_common.cpp
+++ b/cpp/tests/io/parquet_common.cpp
@@ -480,7 +480,7 @@ ascending()
 {
   std::array<char, 10> buf;
   auto elements = cudf::detail::make_counting_transform_iterator(0, [&buf](auto i) {
-    sprintf(buf.data(), "%09d", i);
+    snprintf(buf.data(), buf.size(), "%09d", i);
     return std::string(buf.data());
   });
   return cudf::test::strings_column_wrapper(elements, elements + num_ordered_rows);
@@ -492,7 +492,7 @@ descending()
 {
   std::array<char, 10> buf;
   auto elements = cudf::detail::make_counting_transform_iterator(0, [&buf](auto i) {
-    sprintf(buf.data(), "%09d", static_cast<short>(num_ordered_rows - i));
+    snprintf(buf.data(), buf.size(), "%09d", static_cast<short>(num_ordered_rows - i));
     return std::string(buf.data());
   });
   return cudf::test::strings_column_wrapper(elements, elements + num_ordered_rows);
@@ -504,7 +504,7 @@ unordered()
 {
   std::array<char, 10> buf;
   auto elements = cudf::detail::make_counting_transform_iterator(0, [&buf](auto i) {
-    sprintf(buf.data(), "%09d", (i % 2 == 0) ? i : (num_ordered_rows - i));
+    snprintf(buf.data(), buf.size(), "%09d", (i % 2 == 0) ? i : (num_ordered_rows - i));
     return std::string(buf.data());
   });
   return cudf::test::strings_column_wrapper(elements, elements + num_ordered_rows);

--- a/cpp/tests/io/parquet_common.cpp
+++ b/cpp/tests/io/parquet_common.cpp
@@ -478,8 +478,8 @@ template <typename T>
 std::enable_if_t<std::is_same_v<T, cudf::string_view>, cudf::test::strings_column_wrapper>
 ascending()
 {
-  std::array<char, 10> buf;
-  auto elements = cudf::detail::make_counting_transform_iterator(0, [&buf](auto i) {
+  auto elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
+    std::array<char, 30> buf;
     snprintf(buf.data(), buf.size(), "%09d", i);
     return std::string(buf.data());
   });
@@ -490,8 +490,8 @@ template <typename T>
 std::enable_if_t<std::is_same_v<T, cudf::string_view>, cudf::test::strings_column_wrapper>
 descending()
 {
-  std::array<char, 10> buf;
-  auto elements = cudf::detail::make_counting_transform_iterator(0, [&buf](auto i) {
+  auto elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
+    std::array<char, 30> buf;
     snprintf(buf.data(), buf.size(), "%09d", static_cast<short>(num_ordered_rows - i));
     return std::string(buf.data());
   });
@@ -502,8 +502,8 @@ template <typename T>
 std::enable_if_t<std::is_same_v<T, cudf::string_view>, cudf::test::strings_column_wrapper>
 unordered()
 {
-  std::array<char, 10> buf;
-  auto elements = cudf::detail::make_counting_transform_iterator(0, [&buf](auto i) {
+  auto elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
+    std::array<char, 30> buf;
     snprintf(buf.data(), buf.size(), "%09d", (i % 2 == 0) ? i : (num_ordered_rows - i));
     return std::string(buf.data());
   });

--- a/cpp/tests/io/parquet_experimental_reader_test.cpp
+++ b/cpp/tests/io/parquet_experimental_reader_test.cpp
@@ -134,9 +134,9 @@ cudf::test::strings_column_wrapper constant_strings(cudf::size_type value)
 {
   CUDF_EXPECTS(value >= 0 && value <= 9999, "String value must be between 0000 and 9999");
 
-  std::array<char, 5> buf;
   auto elements =
-    thrust::make_transform_iterator(thrust::make_constant_iterator(value), [&buf](auto i) {
+    thrust::make_transform_iterator(thrust::make_constant_iterator(value), [](auto i) {
+      std::array<char, 30> buf;
       snprintf(buf.data(), buf.size(), "%04d", i);
       return std::string(buf.data());
     });

--- a/cpp/tests/io/parquet_experimental_reader_test.cpp
+++ b/cpp/tests/io/parquet_experimental_reader_test.cpp
@@ -137,7 +137,7 @@ cudf::test::strings_column_wrapper constant_strings(cudf::size_type value)
   std::array<char, 5> buf;
   auto elements =
     thrust::make_transform_iterator(thrust::make_constant_iterator(value), [&buf](auto i) {
-      sprintf(buf.data(), "%04d", i);
+      snprintf(buf.data(), buf.size(), "%04d", i);
       return std::string(buf.data());
     });
   return cudf::test::strings_column_wrapper(elements, elements + num_ordered_rows);

--- a/cpp/tests/io/parquet_v2_test.cpp
+++ b/cpp/tests/io/parquet_v2_test.cpp
@@ -696,7 +696,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndex)
   // fixed length strings
   auto str1_elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
     std::array<char, 30> buf;
-    sprintf(buf.data(), "%012d", i);
+    snprintf(buf.data(), buf.size(), "%012d", i);
     return std::string(buf.data());
   });
   auto col0          = cudf::test::strings_column_wrapper(str1_elements, str1_elements + num_rows);
@@ -718,7 +718,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndex)
   // mixed length strings
   auto str2_elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
     std::array<char, 30> buf;
-    sprintf(buf.data(), "%d", i);
+    snprintf(buf.data(), buf.size(), "%d", i);
     return std::string(buf.data());
   });
   auto col7          = cudf::test::strings_column_wrapper(str2_elements, str2_elements + num_rows);
@@ -790,7 +790,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexNulls)
   // fixed length strings
   auto str1_elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
     std::array<char, 30> buf;
-    sprintf(buf.data(), "%012d", i);
+    snprintf(buf.data(), buf.size(), "%012d", i);
     return std::string(buf.data());
   });
   auto col0          = cudf::test::strings_column_wrapper(str1_elements, str1_elements + num_rows);
@@ -822,7 +822,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexNulls)
   // mixed length strings
   auto str2_elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
     std::array<char, 30> buf;
-    sprintf(buf.data(), "%d", i);
+    snprintf(buf.data(), buf.size(), "%d", i);
     return std::string(buf.data());
   });
   auto col7 = cudf::test::strings_column_wrapper(str2_elements, str2_elements + num_rows, valids);
@@ -900,7 +900,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexNullColumn)
   // fixed length strings
   auto str1_elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
     std::array<char, 30> buf;
-    sprintf(buf.data(), "%012d", i);
+    snprintf(buf.data(), buf.size(), "%012d", i);
     return std::string(buf.data());
   });
   auto col0          = cudf::test::strings_column_wrapper(str1_elements, str1_elements + num_rows);
@@ -917,7 +917,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexNullColumn)
   // mixed length strings
   auto str2_elements = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
     std::array<char, 30> buf;
-    sprintf(buf.data(), "%d", i);
+    snprintf(buf.data(), buf.size(), "%d", i);
     return std::string(buf.data());
   });
   auto col3          = cudf::test::strings_column_wrapper(str2_elements, str2_elements + num_rows);


### PR DESCRIPTION
## Description
Changes the sprintf usage to snprintf to prevent stack-overflow error in parquet gtests.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
