### PR TITLE
remove cuspatial references, avoid triggering tests on clang-format config changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -83,7 +83,7 @@ IncludeCategories:
     Priority:        4
   - Regex:           '^<(nvtext|cudf_kafka)' # other libcudf includes
     Priority:        5
-  - Regex:           '^<(cugraph|cuml|cuspatial|raft|kvikio)' # Other RAPIDS includes
+  - Regex:           '^<(cugraph|cuml|raft|kvikio)' # Other RAPIDS includes
     Priority:        6
   - Regex:           '^<rmm/' # RMM includes
     Priority:        7

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -85,6 +85,7 @@ jobs:
           - '!python/**'
         test_cudf_pandas:
           - '**'
+          - '!.clang-format'
           - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
@@ -95,6 +96,7 @@ jobs:
           - '!notebooks/**'
         test_java:
           - '**'
+          - '!.clang-format'
           - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
@@ -106,6 +108,7 @@ jobs:
           - '!python/**'
         test_notebooks:
           - '**'
+          - '!.clang-format'
           - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'
@@ -114,6 +117,7 @@ jobs:
           - '!java/**'
         test_python:
           - '**'
+          - '!.clang-format'
           - '!.devcontainer/**'
           - '!CONTRIBUTING.md'
           - '!README.md'


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/197

* removes references to `cuspatial` in `.clang-format`
* updates `changed-files` configuration, so future PRs that only touch `.clang-format` do not trigger a full run of all CI

## Notes for Reviewers

### How I tested this

Looked for references like this:

```shell
git grep -i -E 'cuproj|cuspatial'
```

### Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
