### PR TITLE
Remove CUDA 11 Workarounds

### DIFF
--- a/cpp/include/cudf/detail/device_scalar.hpp
+++ b/cpp/include/cudf/detail/device_scalar.hpp
@@ -35,15 +35,7 @@ class device_scalar : public rmm::device_scalar<T> {
 #endif
   ~device_scalar() = default;
 
-// Implementation is the same as what compiler should generate
-// Could not use default move constructor as 11.8 compiler fails to generate it
-#ifdef __CUDACC__
-#pragma nv_exec_check_disable
-#endif
-  device_scalar(device_scalar&& other) noexcept
-    : rmm::device_scalar<T>{std::move(other)}, bounce_buffer{std::move(other.bounce_buffer)}
-  {
-  }
+  device_scalar(device_scalar&& other) noexcept      = default;
   device_scalar& operator=(device_scalar&&) noexcept = default;
 
   device_scalar(device_scalar const&)            = delete;

--- a/cpp/include/cudf/fixed_point/fixed_point.hpp
+++ b/cpp/include/cudf/fixed_point/fixed_point.hpp
@@ -20,6 +20,7 @@
 #include <cudf/fixed_point/temporary.hpp>
 #include <cudf/types.hpp>
 
+#include <cuda/std/functional>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
@@ -71,24 +72,6 @@ CUDF_HOST_DEVICE constexpr inline auto is_supported_representation_type()
 
 // Helper functions for `fixed_point` type
 namespace detail {
-
-/**
- * @brief Returns the smaller of the given scales
- *
- * @param a The left-hand side value to compare
- * @param b The right-hand side value to compare
- * @return The smaller of the given scales
- */
-CUDF_HOST_DEVICE constexpr inline scale_type min(scale_type const& a, scale_type const& b)
-{
-  // TODO This is a temporary workaround because <cuda/std/functional> is not self-contained when
-  // built with NVRTC 11.8. Replace this with cuda::std::min once the underlying issue is resolved.
-#ifdef __CUDA_ARCH__
-  return scale_type{min(static_cast<int>(a), static_cast<int>(b))};
-#else
-  return std::min(a, b);
-#endif
-}
 
 /**
  * @brief A function for integer exponentiation by squaring.
@@ -687,7 +670,7 @@ template <typename Rep1, Radix Rad1>
 CUDF_HOST_DEVICE inline fixed_point<Rep1, Rad1> operator+(fixed_point<Rep1, Rad1> const& lhs,
                                                           fixed_point<Rep1, Rad1> const& rhs)
 {
-  auto const scale = detail::min(lhs._scale, rhs._scale);
+  auto const scale = cuda::std::min(lhs._scale, rhs._scale);
   auto const sum   = lhs.rescaled(scale)._value + rhs.rescaled(scale)._value;
 
 #if defined(__CUDACC_DEBUG__)
@@ -705,7 +688,7 @@ template <typename Rep1, Radix Rad1>
 CUDF_HOST_DEVICE inline fixed_point<Rep1, Rad1> operator-(fixed_point<Rep1, Rad1> const& lhs,
                                                           fixed_point<Rep1, Rad1> const& rhs)
 {
-  auto const scale = detail::min(lhs._scale, rhs._scale);
+  auto const scale = cuda::std::min(lhs._scale, rhs._scale);
   auto const diff  = lhs.rescaled(scale)._value - rhs.rescaled(scale)._value;
 
 #if defined(__CUDACC_DEBUG__)
@@ -753,7 +736,7 @@ template <typename Rep1, Radix Rad1>
 CUDF_HOST_DEVICE inline bool operator==(fixed_point<Rep1, Rad1> const& lhs,
                                         fixed_point<Rep1, Rad1> const& rhs)
 {
-  auto const scale = detail::min(lhs._scale, rhs._scale);
+  auto const scale = cuda::std::min(lhs._scale, rhs._scale);
   return lhs.rescaled(scale)._value == rhs.rescaled(scale)._value;
 }
 
@@ -762,7 +745,7 @@ template <typename Rep1, Radix Rad1>
 CUDF_HOST_DEVICE inline bool operator!=(fixed_point<Rep1, Rad1> const& lhs,
                                         fixed_point<Rep1, Rad1> const& rhs)
 {
-  auto const scale = detail::min(lhs._scale, rhs._scale);
+  auto const scale = cuda::std::min(lhs._scale, rhs._scale);
   return lhs.rescaled(scale)._value != rhs.rescaled(scale)._value;
 }
 
@@ -771,7 +754,7 @@ template <typename Rep1, Radix Rad1>
 CUDF_HOST_DEVICE inline bool operator<=(fixed_point<Rep1, Rad1> const& lhs,
                                         fixed_point<Rep1, Rad1> const& rhs)
 {
-  auto const scale = detail::min(lhs._scale, rhs._scale);
+  auto const scale = cuda::std::min(lhs._scale, rhs._scale);
   return lhs.rescaled(scale)._value <= rhs.rescaled(scale)._value;
 }
 
@@ -780,7 +763,7 @@ template <typename Rep1, Radix Rad1>
 CUDF_HOST_DEVICE inline bool operator>=(fixed_point<Rep1, Rad1> const& lhs,
                                         fixed_point<Rep1, Rad1> const& rhs)
 {
-  auto const scale = detail::min(lhs._scale, rhs._scale);
+  auto const scale = cuda::std::min(lhs._scale, rhs._scale);
   return lhs.rescaled(scale)._value >= rhs.rescaled(scale)._value;
 }
 
@@ -789,7 +772,7 @@ template <typename Rep1, Radix Rad1>
 CUDF_HOST_DEVICE inline bool operator<(fixed_point<Rep1, Rad1> const& lhs,
                                        fixed_point<Rep1, Rad1> const& rhs)
 {
-  auto const scale = detail::min(lhs._scale, rhs._scale);
+  auto const scale = cuda::std::min(lhs._scale, rhs._scale);
   return lhs.rescaled(scale)._value < rhs.rescaled(scale)._value;
 }
 
@@ -798,7 +781,7 @@ template <typename Rep1, Radix Rad1>
 CUDF_HOST_DEVICE inline bool operator>(fixed_point<Rep1, Rad1> const& lhs,
                                        fixed_point<Rep1, Rad1> const& rhs)
 {
-  auto const scale = detail::min(lhs._scale, rhs._scale);
+  auto const scale = cuda::std::min(lhs._scale, rhs._scale);
   return lhs.rescaled(scale)._value > rhs.rescaled(scale)._value;
 }
 
@@ -807,7 +790,7 @@ template <typename Rep1, Radix Rad1>
 CUDF_HOST_DEVICE inline fixed_point<Rep1, Rad1> operator%(fixed_point<Rep1, Rad1> const& lhs,
                                                           fixed_point<Rep1, Rad1> const& rhs)
 {
-  auto const scale     = detail::min(lhs._scale, rhs._scale);
+  auto const scale     = cuda::std::min(lhs._scale, rhs._scale);
   auto const remainder = lhs.rescaled(scale)._value % rhs.rescaled(scale)._value;
   return fixed_point<Rep1, Rad1>{scaled_integer<Rep1>{remainder, scale}};
 }

--- a/cpp/include/cudf/utilities/bit.hpp
+++ b/cpp/include/cudf/utilities/bit.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/cudf/utilities/bit.hpp
+++ b/cpp/include/cudf/utilities/bit.hpp
@@ -29,21 +29,6 @@
 
 namespace CUDF_EXPORT cudf {
 namespace detail {
-// @cond
-// Work around a bug in NVRTC that fails to compile assert() in constexpr
-// functions (fixed after CUDA 11.0)
-#if defined __GNUC__
-#define LIKELY(EXPR) __builtin_expect(!!(EXPR), 1)
-#else
-#define LIKELY(EXPR) (!!(EXPR))
-#endif
-
-#ifdef NDEBUG
-#define constexpr_assert(CHECK) static_cast<void>(0)
-#else
-#define constexpr_assert(CHECK) (LIKELY(CHECK) ? void(0) : [] { assert(!#CHECK); }())
-#endif
-// @endcond
 
 /**
  * @brief Returns the number of bits the given type can hold.
@@ -158,7 +143,7 @@ CUDF_HOST_DEVICE inline bool bit_value_or(bitmask_type const* bitmask,
  */
 constexpr CUDF_HOST_DEVICE inline bitmask_type set_least_significant_bits(size_type n)
 {
-  constexpr_assert(0 <= n && n < static_cast<size_type>(detail::size_in_bits<bitmask_type>()));
+  assert(0 <= n && n < static_cast<size_type>(detail::size_in_bits<bitmask_type>()));
   return ((bitmask_type{1} << n) - 1);
 }
 
@@ -173,7 +158,7 @@ constexpr CUDF_HOST_DEVICE inline bitmask_type set_least_significant_bits(size_t
 constexpr CUDF_HOST_DEVICE inline bitmask_type set_most_significant_bits(size_type n)
 {
   constexpr size_type word_size{detail::size_in_bits<bitmask_type>()};
-  constexpr_assert(0 <= n && n < word_size);
+  assert(0 <= n && n < word_size);
   return ~((bitmask_type{1} << (word_size - n)) - 1);
 }
 

--- a/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
+++ b/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
@@ -211,6 +211,9 @@ def test_index_generator():
     tm.assert_equal(pi, xi)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:DataFrameGroupBy.apply operated on the grouping columns"
+)
 def test_groupby_apply_fallback(dataframe, groupby_udf):
     pdf, df = dataframe
     tm.assert_equal(
@@ -302,6 +305,9 @@ def test_df_from_series(series):
     tm.assert_frame_equal(pd.DataFrame(psr), xpd.DataFrame(sr))
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Setting an item of incompatible dtype is deprecated"
+)
 def test_iloc_change_type(series):
     psr, sr = series
     psr.iloc[0] = "a"
@@ -441,7 +447,9 @@ def test_is_sparse():
     psa = pd.arrays.SparseArray([0, 0, 1, 0])
     xsa = xpd.arrays.SparseArray([0, 0, 1, 0])
 
-    assert pd.api.types.is_sparse(psa) == xpd.api.types.is_sparse(xsa)  # noqa: TID251
+    assert isinstance(psa.dtype, pd.SparseDtype) == isinstance(
+        xsa.dtype, xpd.SparseDtype
+    )
 
 
 def test_is_file_like():
@@ -479,6 +487,9 @@ def test_infer_freq():
     assert expected == got
 
 
+@pytest.mark.filterwarnings(
+    "ignore:DataFrameGroupBy.apply operated on the grouping columns"
+)
 def test_groupby_grouper_fallback(dataframe, groupby_udf):
     pdf, df = dataframe
     tm.assert_equal(
@@ -928,7 +939,7 @@ def test_namedagg_namedtuple():
     result = df.groupby("kind").agg(
         min_height=pd.NamedAgg(column="height", aggfunc="min"),
         max_height=pd.NamedAgg(column="height", aggfunc="max"),
-        average_weight=pd.NamedAgg(column="weight", aggfunc=np.mean),
+        average_weight=pd.NamedAgg(column="weight", aggfunc="mean"),
     )
     expected = xpd.DataFrame(
         {
@@ -1177,6 +1188,9 @@ def test_index_new():
     tm.assert_equal(expected, got)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:DataFrameGroupBy.apply operated on the grouping columns"
+)
 @pytest.mark.xfail(not LOADED, reason="Should not fail in accelerated mode")
 def test_groupby_apply_callable_referencing_pandas(dataframe):
     pdf, df = dataframe
@@ -1590,19 +1604,31 @@ def test_arrow_string_arrays():
     pd_s = pd.Series(["a", "b", "c"])
 
     cu_arr = xpd.arrays.ArrowStringArray._from_sequence(
-        cu_s, dtype=xpd.StringDtype("pyarrow")
+        cu_s, dtype=xpd.StringDtype(storage="pyarrow")
     )
     pd_arr = pd.arrays.ArrowStringArray._from_sequence(
-        pd_s, dtype=pd.StringDtype("pyarrow")
+        pd_s, dtype=pd.StringDtype(storage="pyarrow")
     )
 
     tm.assert_equal(cu_arr, pd_arr)
 
+    xpd_pa_np_storage_type = (
+        xpd.StringDtype("pyarrow_numpy")
+        if PANDAS_VERSION < version.parse("2.3.1")
+        else pd.StringDtype(storage="pyarrow", na_value=np.nan)
+    )
+
+    pd_pa_np_storage_type = (
+        pd.StringDtype("pyarrow_numpy")
+        if PANDAS_VERSION < version.parse("2.3.1")
+        else pd.StringDtype(storage="pyarrow", na_value=np.nan)
+    )
+
     cu_arr = xpd.core.arrays.string_arrow.ArrowStringArray._from_sequence(
-        cu_s, dtype=xpd.StringDtype("pyarrow_numpy")
+        cu_s, dtype=xpd_pa_np_storage_type
     )
     pd_arr = pd.core.arrays.string_arrow.ArrowStringArray._from_sequence(
-        pd_s, dtype=pd.StringDtype("pyarrow_numpy")
+        pd_s, dtype=pd_pa_np_storage_type
     )
 
     tm.assert_equal(cu_arr, pd_arr)


### PR DESCRIPTION
## Description

Issue #19381

Remove workarounds specific to CUDA 11 since we don't support it any more.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
