### PR TITLE
Fix jitify error on exit from FILTER_TEST

### DIFF
--- a/cpp/tests/filter/filter_test.cpp
+++ b/cpp/tests/filter/filter_test.cpp
@@ -17,6 +17,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/random.hpp>
+#include <cudf_test/testing_main.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/iterator.cuh>
@@ -315,3 +316,5 @@ __device__ void filter(bool* out,
 }
 
 }  // namespace filters
+
+CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
## Description
Fixes jitify error on exit from FILTER_TEST in a debug build.
```
[  PASSED  ] 30 tests.
terminate called after throwing an instance of 'std::runtime_error'
  what():  Jitify fatal error: 
```
Simply adds the `CUDF_TEST_PROGRAM_MAIN()` macro to the `filter_test.cpp`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
