### PR TITLE
More pytest fixtures and avoid GPU params in cuDF classic tests

### DIFF
--- a/python/cudf/cudf/tests/test_testing.py
+++ b/python/cudf/cudf/tests/test_testing.py
@@ -149,17 +149,18 @@ def test_basic_assert_series_equal(
 
 
 @pytest.mark.parametrize(
-    "other",
+    "other_data",
     [
-        as_column(["1", "2", "3"]),
-        as_column([[1], [2], [3]]),
-        as_column([{"a": 1}, {"a": 2}, {"a": 3}]),
+        ["1", "2", "3"],
+        [[1], [2], [3]],
+        [{"a": 1}, {"a": 2}, {"a": 3}],
     ],
 )
-def test_assert_column_equal_dtype_edge_cases(other):
+def test_assert_column_equal_dtype_edge_cases(other_data):
     # string series should be 100% different
     # even when the elements are the same
     base = as_column([1, 2, 3])
+    other = as_column(other_data)
 
     # for these dtypes, the diff should always be 100% regardless of the values
     with pytest.raises(

--- a/python/cudf/cudf/tests/test_transform.py
+++ b/python/cudf/cudf/tests/test_transform.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 
 
 import numpy as np
@@ -7,14 +7,12 @@ import pytest
 from cudf import Series
 from cudf.testing._utils import NUMERIC_TYPES
 
-supported_types = NUMERIC_TYPES
-
 
 def _generic_function(a):
     return a**3
 
 
-@pytest.mark.parametrize("dtype", supported_types)
+@pytest.mark.parametrize("dtype", NUMERIC_TYPES)
 @pytest.mark.parametrize(
     "udf,testfunc",
     [

--- a/python/cudf/cudf/tests/test_unaops.py
+++ b/python/cudf/cudf/tests/test_unaops.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2019-2025, NVIDIA CORPORATION.
 
-import itertools
-import operator
 from decimal import Decimal
 
 import numpy as np
@@ -10,8 +8,6 @@ import pytest
 
 from cudf import Series
 from cudf.testing import _utils as utils, assert_eq
-
-_unaops = [operator.abs, operator.invert, operator.neg, np.ceil, np.floor]
 
 
 @pytest.mark.parametrize("dtype", utils.NUMERIC_TYPES)
@@ -54,29 +50,6 @@ def test_series_pandas_methods_empty(mth):
     sr = Series(arr)
     psr = pd.Series(arr)
     np.testing.assert_equal(getattr(sr, mth)(), getattr(psr, mth)())
-
-
-def generate_valid_scalar_unaop_combos():
-    results = []
-
-    # All ops valid for integer values
-    int_values = [0, 1, -1]
-    int_dtypes = utils.INTEGER_TYPES
-    int_ops = _unaops
-
-    results += list(itertools.product(int_values, int_dtypes, int_ops))
-
-    float_values = [0.0, 1.0, -1.1]
-    float_dtypes = utils.FLOAT_TYPES
-    float_ops = [op for op in _unaops if op is not operator.invert]
-    results += list(itertools.product(float_values, float_dtypes, float_ops))
-
-    bool_values = [True, False]
-    bool_dtypes = ["bool"]
-    bool_ops = [op for op in _unaops if op is not operator.neg]
-    results += list(itertools.product(bool_values, bool_dtypes, bool_ops))
-
-    return results
 
 
 def test_series_bool_neg():


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/9999

* Use more pytest fixtures
* Avoid GPU objects in `pytest.mark.parametrize`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
