### PR TITLE
Remove 'flaky' marker from `test_segmented_gather`

### DIFF
--- a/python/pylibcudf/tests/test_lists.py
+++ b/python/pylibcudf/tests/test_lists.py
@@ -161,8 +161,6 @@ def test_reverse(list_column):
     assert_column_eq(expect, got)
 
 
-# https://github.com/rapidsai/cudf/issues/19346
-@pytest.mark.flaky(reruns=5)
 def test_segmented_gather(test_data):
     list_column1, list_column2 = test_data[0]
 


### PR DESCRIPTION
## Description

https://github.com/rapidsai/cudf/pull/19345 added a flaky marker for a test that was failing in CI. This removes that marker to see if it's failing.

xref https://github.com/rapidsai/cudf/issues/19346
