### PR TITLE
Add parquet-sampling configuration options

### DIFF
--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -153,6 +153,17 @@ class ParquetOptions:
     pass_read_limit
         Limit on the amount of memory used for reading and decompressing data
         or 0 if there is no limit.
+    max_footer_samples
+        Maximum number of file footers to sample for metadata. This
+        option is currently used by the streaming executor to gather
+        datasource statistics before generating a physical plan. Set to
+        ``0`` to avoid metadata sampling.
+    max_row_group_samples
+        Maximum number of row-groups to sample for unique-value statistics.
+        This option may be used by the streaming executor to optimize
+        the physical plan. Set to ``0`` to avoid row-group sampling. Note
+        that row-group sampling will also be skipped if ``max_footer_samples``
+        is set to ``0``.
     """
 
     _env_prefix = "CUDF_POLARS__PARQUET_OPTIONS"
@@ -172,6 +183,16 @@ class ParquetOptions:
             f"{_env_prefix}__PASS_READ_LIMIT", int, default=0
         )
     )
+    max_footer_samples: int = dataclasses.field(
+        default_factory=_make_default_factory(
+            f"{_env_prefix}__MAX_FOOTER_SAMPLES", int, default=3
+        )
+    )
+    max_row_group_samples: int = dataclasses.field(
+        default_factory=_make_default_factory(
+            f"{_env_prefix}__MAX_ROW_GROUP_SAMPLES", int, default=1
+        )
+    )
 
     def __post_init__(self) -> None:  # noqa: D105
         if not isinstance(self.chunked, bool):
@@ -180,6 +201,10 @@ class ParquetOptions:
             raise TypeError("chunk_read_limit must be an int")
         if not isinstance(self.pass_read_limit, int):
             raise TypeError("pass_read_limit must be an int")
+        if not isinstance(self.max_footer_samples, int):
+            raise TypeError("max_footer_samples must be an int")
+        if not isinstance(self.max_row_group_samples, int):
+            raise TypeError("max_row_group_samples must be an int")
 
 
 def default_blocksize(scheduler: str) -> int:

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -157,13 +157,14 @@ class ParquetOptions:
         Maximum number of file footers to sample for metadata. This
         option is currently used by the streaming executor to gather
         datasource statistics before generating a physical plan. Set to
-        ``0`` to avoid metadata sampling.
+        0 to avoid metadata sampling. Default is 3.
     max_row_group_samples
         Maximum number of row-groups to sample for unique-value statistics.
         This option may be used by the streaming executor to optimize
-        the physical plan. Set to ``0`` to avoid row-group sampling. Note
-        that row-group sampling will also be skipped if ``max_footer_samples``
-        is set to ``0``.
+        the physical plan. Default is 1.
+
+        Set to 0 to avoid row-group sampling. Note that row-group sampling
+        will also be skipped if ``max_footer_samples`` is 0.
     """
 
     _env_prefix = "CUDF_POLARS__PARQUET_OPTIONS"

--- a/python/cudf_polars/tests/experimental/test_scan.py
+++ b/python/cudf_polars/tests/experimental/test_scan.py
@@ -88,15 +88,15 @@ def test_split_scan_predicate(tmp_path, df, mask):
 
 @pytest.mark.parametrize("n_files", [1, 3])
 @pytest.mark.parametrize("row_group_size", [None, 10_000])
-@pytest.mark.parametrize("max_file_samples", [3, 0])
-@pytest.mark.parametrize("max_rg_samples", [1, 0])
+@pytest.mark.parametrize("max_footer_samples", [3, 0])
+@pytest.mark.parametrize("max_row_group_samples", [1, 0])
 def test_source_statistics(
     tmp_path,
     df,
     n_files,
     row_group_size,
-    max_file_samples,
-    max_rg_samples,
+    max_footer_samples,
+    max_row_group_samples,
 ):
     from cudf_polars.experimental.io import (
         _clear_source_info_cache,
@@ -119,26 +119,26 @@ def test_source_statistics(
             "target_partition_size": 10_000,
             "scheduler": DEFAULT_SCHEDULER,
         },
+        parquet_options={
+            "max_footer_samples": max_footer_samples,
+            "max_row_group_samples": max_row_group_samples,
+        },
     )
     ir = Translator(q._ldf.visit(), engine).translate_ir()
-    column_stats = _extract_scan_stats(
-        ir,
-        max_file_samples=max_file_samples,
-        max_rg_samples=max_rg_samples,
-    )
+    column_stats = _extract_scan_stats(ir, ConfigOptions.from_polars_engine(engine))
 
     # Source info is the same for all columns
     source_info = column_stats["x"].source_info
     assert source_info is column_stats["y"].source_info
     assert source_info is column_stats["z"].source_info
-    if max_file_samples:
+    if max_footer_samples:
         assert source_info.row_count.value == df.height
         assert source_info.row_count.exact
     else:
         assert source_info.row_count.value is None
 
     # Storage stats should be available
-    if max_file_samples:
+    if max_footer_samples:
         assert source_info.storage_size("x").value > 0
         assert source_info.storage_size("y").value > 0
     else:
@@ -153,7 +153,7 @@ def test_source_statistics(
     # source._unique_stats should be empty
     assert set(source_info._unique_stats) == set()
 
-    if max_file_samples and max_rg_samples:
+    if max_footer_samples and max_row_group_samples:
         assert source_info.unique_stats("x").count.value == df.height
         assert source_info.unique_stats("x").fraction.value == 1.0
     else:
@@ -161,13 +161,13 @@ def test_source_statistics(
         assert source_info.unique_stats("x").fraction.value is None
 
     # source_info._unique_stats should only contain 'x'
-    if max_file_samples and max_rg_samples:
+    if max_footer_samples and max_row_group_samples:
         assert set(source_info._unique_stats) == {"x"}
     else:
         assert set(source_info._unique_stats) == set()
 
     # Check add_unique_stats_column behavior
-    if max_file_samples and max_rg_samples:
+    if max_footer_samples and max_row_group_samples:
         # Can add a "bad"/missing key column
         source_info.add_unique_stats_column("foo")
         assert set(source_info._unique_stats) == {"x"}
@@ -198,7 +198,7 @@ def test_source_statistics_csv(tmp_path, df):
         },
     )
     ir = Translator(q._ldf.visit(), engine).translate_ir()
-    column_stats = _extract_scan_stats(ir)
+    column_stats = _extract_scan_stats(ir, ConfigOptions.from_polars_engine(engine))
 
     # Source info should be empty for CSV
     source_info = column_stats["x"].source_info

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -402,7 +402,16 @@ def test_cardinality_factor_compat() -> None:
         )
 
 
-@pytest.mark.parametrize("option", ["chunked", "chunk_read_limit", "pass_read_limit"])
+@pytest.mark.parametrize(
+    "option",
+    [
+        "chunked",
+        "chunk_read_limit",
+        "pass_read_limit",
+        "max_footer_samples",
+        "max_row_group_samples",
+    ],
+)
 def test_validate_parquet_options(option: str) -> None:
     with pytest.raises(TypeError, match=f"{option} must be"):
         ConfigOptions.from_polars_engine(


### PR DESCRIPTION
## Description
Closes https://github.com/rapidsai/cudf/issues/19389

Adds `max_footer_samples` and `max_row_group_samples` configuration options to control metadata/row-group sampling. Although these configuration options are only *used* by the streaming executor, it felt more natural to add these to `ParquetOptions` (since they are definitely Parquet specific).

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
