### PR TITLE
Use numba-cuda >=0.14.0,<0.15.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -54,7 +54,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.15.2,<0.16.0a0
+- numba-cuda>=0.14.0,<0.15.0a0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -55,7 +55,7 @@ dependencies:
 - nbsphinx
 - ninja
 - notebook
-- numba-cuda>=0.15.2,<0.16.0a0
+- numba-cuda>=0.14.0,<0.15.0a0
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc

--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -69,7 +69,7 @@ requirements:
     - typing_extensions >=4.0.0
     - pandas >=2.0,<2.4.0dev0
     - cupy >=12.0.0
-    - numba-cuda >=0.15.2,<0.16.0a0
+    - numba-cuda >=0.14.0,<0.15.0a0
     - numba >=0.59.1,<0.62.0a0
     - numpy >=1.23,<3.0a0
     - pyarrow>=14.0.0,<20.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -673,7 +673,7 @@ dependencies:
           - typing_extensions>=4.0.0
       - output_types: [conda]
         packages:
-          - &numba-cuda-dep numba-cuda>=0.15.2,<0.16.0a0
+          - &numba-cuda-dep numba-cuda>=0.14.0,<0.15.0a0
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file
@@ -695,7 +695,7 @@ dependencies:
         matrices:
           - matrix: {cuda: "12.*"}
             packages:
-              - &numba-cuda-cu12-dep numba-cuda[cu12]>=0.15.2,<0.16.0a0
+              - &numba-cuda-cu12-dep numba-cuda[cu12]>=0.14.0,<0.15.0a0
           - matrix: # Fallback for no matrix
             packages:
               - *numba-cuda-cu12-dep
@@ -795,7 +795,7 @@ dependencies:
           - matrix: {dependencies: "oldest"}
             packages:
               - numba==0.59.1
-              - numba-cuda==0.15.2
+              - numba-cuda==0.14.0
               - pandas==2.0.*
           - matrix: {dependencies: "latest"}
             packages:

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "cupy-cuda12x>=12.0.0",
     "fsspec>=0.6.0",
     "libcudf==25.8.*,>=0.0.0a0",
-    "numba-cuda[cu12]>=0.15.2,<0.16.0a0",
+    "numba-cuda[cu12]>=0.14.0,<0.15.0a0",
     "numba>=0.59.1,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
     "nvtx>=0.2.1",


### PR DESCRIPTION
## Description
Correction for #19413.

We need to use `numba-cuda>=0.14.0,<0.15.0` so that we don't get the new CUDA bindings.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
