### PR TITLE
Use more pytest fixtures and avoid GPU parameterization in cuDF classic tests

### DIFF
--- a/python/cudf/cudf/tests/test_groupby.py
+++ b/python/cudf/cudf/tests/test_groupby.py
@@ -108,8 +108,8 @@ def pdf(gdf):
     return gdf.to_pandas()
 
 
-@pytest.mark.parametrize("nelem", [2, 3, 100, 1000])
-def test_groupby_mean(nelem):
+def test_groupby_mean():
+    nelem = 20
     got_df = make_frame(DataFrame, nelem=nelem).groupby(["x", "y"]).mean()
     expect_df = (
         make_frame(pd.DataFrame, nelem=nelem).groupby(["x", "y"]).mean()
@@ -117,8 +117,8 @@ def test_groupby_mean(nelem):
     assert_groupby_results_equal(got_df, expect_df)
 
 
-@pytest.mark.parametrize("nelem", [2, 3, 100, 1000])
-def test_groupby_mean_3level(nelem):
+def test_groupby_mean_3level():
+    nelem = 20
     lvls = "z"
     bys = list("xyz")
     got_df = (
@@ -134,8 +134,8 @@ def test_groupby_mean_3level(nelem):
     assert_groupby_results_equal(got_df, expect_df)
 
 
-@pytest.mark.parametrize("nelem", [2, 3, 100, 1000])
-def test_groupby_agg_mean_min(nelem):
+def test_groupby_agg_mean_min():
+    nelem = 20
     got_df = (
         make_frame(DataFrame, nelem=nelem)
         .groupby(["x", "y"])
@@ -149,8 +149,8 @@ def test_groupby_agg_mean_min(nelem):
     assert_groupby_results_equal(got_df, expect_df)
 
 
-@pytest.mark.parametrize("nelem", [2, 3, 100, 1000])
-def test_groupby_agg_min_max_dictargs(nelem):
+def test_groupby_agg_min_max_dictargs():
+    nelem = 20
     expect_df = (
         make_frame(pd.DataFrame, nelem=nelem, extra_vals="ab")
         .groupby(["x", "y"])
@@ -164,8 +164,8 @@ def test_groupby_agg_min_max_dictargs(nelem):
     assert_groupby_results_equal(expect_df, got_df)
 
 
-@pytest.mark.parametrize("nelem", [2, 3, 100, 1000])
-def test_groupby_agg_min_max_dictlist(nelem):
+def test_groupby_agg_min_max_dictlist():
+    nelem = 20
     expect_df = (
         make_frame(pd.DataFrame, nelem=nelem, extra_vals="ab")
         .groupby(["x", "y"])
@@ -336,23 +336,24 @@ def test_groupby_apply():
     assert_groupby_results_equal(expect, got)
 
 
-def create_test_groupby_apply_args_params():
-    def f1(df, k):
-        df["out"] = df["val1"] + df["val2"] + k
-        return df
-
-    def f2(df, k, L):
-        df["out"] = df["val1"] - df["val2"] + (k / L)
-        return df
-
-    def f3(df, k, L, m):
-        df["out"] = ((k * df["val1"]) + (L * df["val2"])) / m
-        return df
-
-    return [(f1, (42,)), (f2, (42, 119)), (f3, (42, 119, 212.1))]
+def f1(df, k):
+    df["out"] = df["val1"] + df["val2"] + k
+    return df
 
 
-@pytest.mark.parametrize("func,args", create_test_groupby_apply_args_params())
+def f2(df, k, L):
+    df["out"] = df["val1"] - df["val2"] + (k / L)
+    return df
+
+
+def f3(df, k, L, m):
+    df["out"] = ((k * df["val1"]) + (L * df["val2"])) / m
+    return df
+
+
+@pytest.mark.parametrize(
+    "func,args", [(f1, (42,)), (f2, (42, 119)), (f3, (42, 119, 212.1))]
+)
 @pytest.mark.skipif(
     PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
     reason="Fails in older versions of pandas",
@@ -600,7 +601,6 @@ def test_groupby_apply_jit_reductions_special_vals(
         )
 
 
-@pytest.mark.parametrize("dtype", ["float64"])
 @pytest.mark.parametrize("func", ["idxmax", "idxmin"])
 @pytest.mark.parametrize(
     "special_val",
@@ -621,21 +621,20 @@ def test_groupby_apply_jit_reductions_special_vals(
     reason="include_groups keyword new in pandas 2.2",
 )
 def test_groupby_apply_jit_idx_reductions_special_vals(
-    func, dtype, dataset, groupby_jit_datasets, special_val
+    func, dataset, groupby_jit_datasets, special_val
 ):
     dataset = groupby_jit_datasets[dataset]
     groupby_apply_jit_idx_reductions_special_vals_inner(
-        func, dataset, dtype, special_val
+        func, dataset, "float64", special_val
     )
 
 
-@pytest.mark.parametrize("dtype", ["int32"])
 @pytest.mark.skipif(
     PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
     reason="Fails in older versions of pandas",
 )
-def test_groupby_apply_jit_sum_integer_overflow(dtype):
-    max = np.iinfo(dtype).max
+def test_groupby_apply_jit_sum_integer_overflow():
+    max = np.iinfo("int32").max
 
     data = DataFrame(
         {
@@ -800,21 +799,8 @@ def test_groupby_apply_jit_basic(func, groupby_jit_data_small):
     run_groupby_apply_jit_test(groupby_jit_data_small, func, ["key1", "key2"])
 
 
-def create_test_groupby_apply_jit_args_params():
-    def f1(df, k):
-        return df["val1"].max() + df["val2"].min() + k
-
-    def f2(df, k, L):
-        return df["val1"].sum() - df["val2"].var() + (k / L)
-
-    def f3(df, k, L, m):
-        return ((k * df["val1"].mean()) + (L * df["val2"].std())) / m
-
-    return [(f1, (42,)), (f2, (42, 119)), (f3, (42, 119, 212.1))]
-
-
 @pytest.mark.parametrize(
-    "func,args", create_test_groupby_apply_jit_args_params()
+    "func,args", [(f1, (42,)), (f2, (42, 119)), (f3, (42, 119, 212.1))]
 )
 @pytest.mark.skipif(
     PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
@@ -981,7 +967,6 @@ def test_groupby_apply_return_reindexed_series(as_index):
     assert_groupby_results_equal(expect, got)
 
 
-@pytest.mark.parametrize("nelem", [2, 3, 100, 500, 1000])
 @pytest.mark.parametrize(
     "func",
     [
@@ -997,8 +982,9 @@ def test_groupby_apply_return_reindexed_series(as_index):
         "prod",
     ],
 )
-def test_groupby_2keys_agg(nelem, func):
+def test_groupby_2keys_agg(func):
     # gdf (Note: lack of multiIndex)
+    nelem = 20
     expect_df = (
         make_frame(pd.DataFrame, nelem=nelem).groupby(["x", "y"]).agg(func)
     )
@@ -1008,8 +994,8 @@ def test_groupby_2keys_agg(nelem, func):
     assert_groupby_results_equal(got_df, expect_df, check_dtype=check_dtype)
 
 
-@pytest.mark.parametrize("num_groups", [2, 3, 10, 50, 100])
-@pytest.mark.parametrize("nelem_per_group", [1, 10, 100])
+@pytest.mark.parametrize("num_groups", [2, 20])
+@pytest.mark.parametrize("nelem_per_group", [1, 10])
 @pytest.mark.parametrize(
     "func",
     ["min", "max", "count", "sum"],
@@ -1760,14 +1746,16 @@ def test_groupby_cumcount(index):
     )
 
 
-@pytest.mark.parametrize("nelem", [2, 3, 1000])
 @pytest.mark.parametrize("as_index", [True, False])
 @pytest.mark.parametrize(
     "agg", ["min", "max", "idxmin", "idxmax", "mean", "count"]
 )
-def test_groupby_datetime(nelem, as_index, agg):
+def test_groupby_datetime(request, as_index, agg):
+    nelem = 20
     if agg == "mean" and as_index is True:
-        return
+        request.applymarker(
+            pytest.mark.xfail(reason="Invalid type/aggregation combination")
+        )
     check_dtype = agg not in ("mean", "count", "idxmin", "idxmax")
     pdf = make_frame(pd.DataFrame, nelem=nelem, with_datetime=True)
     gdf = make_frame(cudf.DataFrame, nelem=nelem, with_datetime=True)
@@ -2440,7 +2428,11 @@ def test_groupby_nonempty_no_keys(pdf):
 @pytest.mark.parametrize(
     "by,data",
     [
-        # ([], []),  # error?
+        pytest.param(
+            [],
+            [],
+            marks=pytest.mark.xfail(reason="dtype always cast to object"),
+        ),
         ([1, 1, 2, 2], [0, 0, 1, 1]),
         ([1, 2, 3, 4], [0, 0, 0, 0]),
         ([1, 2, 1, 2], [0, 1, 1, 1]),
@@ -2460,11 +2452,11 @@ def test_groupby_unique(by, data, dtype):
     assert_groupby_results_equal(expect, got)
 
 
-@pytest.mark.parametrize("nelem", [2, 3, 100, 1000])
 @pytest.mark.parametrize(
     "func", ["cummin", "cummax", "cumcount", "cumsum", "cumprod"]
 )
-def test_groupby_2keys_scan(nelem, func):
+def test_groupby_2keys_scan(func):
+    nelem = 20
     pdf = make_frame(pd.DataFrame, nelem=nelem)
     expect_df = pdf.groupby(["x", "y"], sort=True).agg(func)
     gdf = cudf.from_pandas(pdf)
@@ -2489,12 +2481,12 @@ def test_groupby_2keys_scan(nelem, func):
     assert_groupby_results_equal(got_df, expect_df, check_dtype=check_dtype)
 
 
-@pytest.mark.parametrize("nelem", [100, 1000])
 @pytest.mark.parametrize("method", ["average", "min", "max", "first", "dense"])
 @pytest.mark.parametrize("ascending", [True, False])
 @pytest.mark.parametrize("na_option", ["keep", "top", "bottom"])
 @pytest.mark.parametrize("pct", [False, True])
-def test_groupby_2keys_rank(nelem, method, ascending, na_option, pct):
+def test_groupby_2keys_rank(method, ascending, na_option, pct):
+    nelem = 20
     t = rand_dataframe(
         dtypes_meta=[
             {"dtype": "int64", "null_frequency": 0, "cardinality": 10},
@@ -2575,11 +2567,11 @@ def test_groupby_mix_agg_scan():
         gb.agg(func)
 
 
-@pytest.mark.parametrize("nelem", [2, 3, 100, 1000])
 @pytest.mark.parametrize("shift_perc", [0.5, 1.0, 1.5])
 @pytest.mark.parametrize("direction", [1, -1])
 @pytest.mark.parametrize("fill_value", [None, np.nan, 42])
-def test_groupby_shift_row(nelem, shift_perc, direction, fill_value):
+def test_groupby_shift_row(shift_perc, direction, fill_value):
+    nelem = 20
     pdf = make_frame(pd.DataFrame, nelem=nelem, extra_vals=["val2"])
     gdf = cudf.from_pandas(pdf)
     n_shift = int(nelem * shift_perc) * direction
@@ -2594,7 +2586,6 @@ def test_groupby_shift_row(nelem, shift_perc, direction, fill_value):
     )
 
 
-@pytest.mark.parametrize("nelem", [10, 50, 100, 1000])
 @pytest.mark.parametrize("shift_perc", [0.5, 1.0, 1.5])
 @pytest.mark.parametrize("direction", [1, -1])
 @pytest.mark.parametrize(
@@ -2615,9 +2606,8 @@ def test_groupby_shift_row(nelem, shift_perc, direction, fill_value):
         ),
     ],
 )
-def test_groupby_shift_row_mixed_numerics(
-    nelem, shift_perc, direction, fill_value
-):
+def test_groupby_shift_row_mixed_numerics(shift_perc, direction, fill_value):
+    nelem = 20
     t = rand_dataframe(
         dtypes_meta=[
             {"dtype": "int64", "null_frequency": 0, "cardinality": 10},
@@ -2652,10 +2642,10 @@ def test_groupby_shift_row_mixed_numerics(
 
 # TODO: Shifting list columns is currently unsupported because we cannot
 # construct a null list scalar in python. Support once it is added.
-@pytest.mark.parametrize("nelem", [10, 50, 100, 1000])
 @pytest.mark.parametrize("shift_perc", [0.5, 1.0, 1.5])
 @pytest.mark.parametrize("direction", [1, -1])
-def test_groupby_shift_row_mixed(nelem, shift_perc, direction):
+def test_groupby_shift_row_mixed(shift_perc, direction):
+    nelem = 20
     t = rand_dataframe(
         dtypes_meta=[
             {"dtype": "int64", "null_frequency": 0, "cardinality": 10},
@@ -2688,7 +2678,6 @@ def test_groupby_shift_row_mixed(nelem, shift_perc, direction):
     )
 
 
-@pytest.mark.parametrize("nelem", [10, 50, 100, 1000])
 @pytest.mark.parametrize("shift_perc", [0.5, 1.0, 1.5])
 @pytest.mark.parametrize("direction", [1, -1])
 @pytest.mark.parametrize(
@@ -2702,9 +2691,8 @@ def test_groupby_shift_row_mixed(nelem, shift_perc, direction):
         ]
     ],
 )
-def test_groupby_shift_row_mixed_fill(
-    nelem, shift_perc, direction, fill_value
-):
+def test_groupby_shift_row_mixed_fill(shift_perc, direction, fill_value):
+    nelem = 20
     t = rand_dataframe(
         dtypes_meta=[
             {"dtype": "int64", "null_frequency": 0, "cardinality": 10},
@@ -2746,9 +2734,9 @@ def test_groupby_shift_row_mixed_fill(
     )
 
 
-@pytest.mark.parametrize("nelem", [10, 50, 100, 1000])
 @pytest.mark.parametrize("fill_value", [None, 0, 42])
-def test_groupby_shift_row_zero_shift(nelem, fill_value):
+def test_groupby_shift_row_zero_shift(fill_value):
+    nelem = 20
     t = rand_dataframe(
         dtypes_meta=[
             {"dtype": "int64", "null_frequency": 0, "cardinality": 10},
@@ -2779,10 +2767,10 @@ def test_groupby_shift_row_zero_shift(nelem, fill_value):
     )
 
 
-@pytest.mark.parametrize("nelem", [2, 3, 100, 1000])
 @pytest.mark.parametrize("shift_perc", [0.5, 1.0, 1.5])
 @pytest.mark.parametrize("direction", [1, -1])
-def test_groupby_diff_row(nelem, shift_perc, direction):
+def test_groupby_diff_row(shift_perc, direction):
+    nelem = 20
     pdf = make_frame(pd.DataFrame, nelem=nelem, extra_vals=["val2"])
     gdf = cudf.from_pandas(pdf)
     n_shift = int(nelem * shift_perc) * direction
@@ -2795,10 +2783,10 @@ def test_groupby_diff_row(nelem, shift_perc, direction):
     )
 
 
-@pytest.mark.parametrize("nelem", [10, 50, 100, 1000])
 @pytest.mark.parametrize("shift_perc", [0.5, 1.0, 1.5])
 @pytest.mark.parametrize("direction", [1, -1])
-def test_groupby_diff_row_mixed_numerics(nelem, shift_perc, direction):
+def test_groupby_diff_row_mixed_numerics(shift_perc, direction):
+    nelem = 20
     t = rand_dataframe(
         dtypes_meta=[
             {"dtype": "int64", "null_frequency": 0, "cardinality": 10},
@@ -2832,8 +2820,8 @@ def test_groupby_diff_row_mixed_numerics(nelem, shift_perc, direction):
     )
 
 
-@pytest.mark.parametrize("nelem", [10, 50, 100, 1000])
 def test_groupby_diff_row_zero_shift(nelem):
+    nelem = 20
     t = rand_dataframe(
         dtypes_meta=[
             {"dtype": "int64", "null_frequency": 0, "cardinality": 10},
@@ -2864,12 +2852,12 @@ def test_groupby_diff_row_zero_shift(nelem):
     )
 
 
-@pytest.mark.parametrize("nelem", [10, 100, 1000])
 @pytest.mark.skipif(
     PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
     reason="warning not present in older pandas versions",
 )
 def test_groupby_fillna_multi_value(nelem):
+    nelem = 20
     t = rand_dataframe(
         dtypes_meta=[
             {"dtype": "int64", "null_frequency": 0, "cardinality": 10},
@@ -2913,12 +2901,12 @@ def test_groupby_fillna_multi_value(nelem):
 
 
 # TODO: cudf.fillna does not support decimal column to column fill yet
-@pytest.mark.parametrize("nelem", [10, 100, 1000])
 @pytest.mark.skipif(
     PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
     reason="warning not present in older pandas versions",
 )
 def test_groupby_fillna_multi_value_df(nelem):
+    nelem = 20
     t = rand_dataframe(
         dtypes_meta=[
             {"dtype": "int64", "null_frequency": 0, "cardinality": 10},
@@ -2993,9 +2981,9 @@ def test_groupby_various_by_fillna(by, data, args):
     PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
     reason="warning not present in older pandas versions",
 )
-@pytest.mark.parametrize("nelem", [10, 100, 1000])
 @pytest.mark.parametrize("method", ["ffill", "bfill"])
-def test_groupby_fillna_method(nelem, method):
+def test_groupby_fillna_method(method):
+    nelem = 20
     t = rand_dataframe(
         dtypes_meta=[
             {"dtype": "int64", "null_frequency": 0, "cardinality": 10},
@@ -3485,20 +3473,6 @@ def test_groupby_group_keys(group_keys, by):
     assert_eq(actual, expected)
 
 
-@pytest.fixture
-def df_ngroup():
-    df = cudf.DataFrame(
-        {
-            "a": [2, 2, 1, 1, 2, 3],
-            "b": [1, 2, 1, 2, 1, 2],
-            "c": ["a", "a", "b", "c", "d", "c"],
-        },
-        index=[1, 3, 5, 7, 4, 2],
-    )
-    df.index.name = "foo"
-    return df
-
-
 @pytest.mark.parametrize(
     "by",
     [
@@ -3511,7 +3485,16 @@ def df_ngroup():
     ],
 )
 @pytest.mark.parametrize("ascending", [True, False])
-def test_groupby_ngroup(by, ascending, df_ngroup):
+def test_groupby_ngroup(by, ascending):
+    df_ngroup = cudf.DataFrame(
+        {
+            "a": [2, 2, 1, 1, 2, 3],
+            "b": [1, 2, 1, 2, 1, 2],
+            "c": ["a", "a", "b", "c", "d", "c"],
+        },
+        index=[1, 3, 5, 7, 4, 2],
+    )
+    df_ngroup.index.name = "foo"
     by = by()
     expected = df_ngroup.to_pandas().groupby(by).ngroup(ascending=ascending)
     actual = df_ngroup.groupby(by).ngroup(ascending=ascending)
@@ -3911,7 +3894,6 @@ def test_group_by_value_counts(normalize, sort, ascending, dropna, as_index):
     assert_groupby_results_equal(
         actual,
         expected,
-        check_names=False,
         check_index_type=False,
         as_index=as_index,
         by=["gender", "education"],

--- a/python/cudf/cudf/tests/test_index.py
+++ b/python/cudf/cudf/tests/test_index.py
@@ -25,12 +25,9 @@ from cudf.core.index import CategoricalIndex, DatetimeIndex, Index, RangeIndex
 from cudf.testing import assert_eq
 from cudf.testing._utils import (
     ALL_TYPES,
-    FLOAT_TYPES,
     NUMERIC_TYPES,
     OTHER_TYPES,
     SERIES_OR_INDEX_NAMES,
-    SIGNED_INTEGER_TYPES,
-    UNSIGNED_TYPES,
     assert_column_memory_eq,
     assert_column_memory_ne,
     assert_exceptions_equal,
@@ -309,121 +306,51 @@ def test_set_index_as_property():
     assert_eq(head.index, idx[:5])
 
 
-@pytest.mark.parametrize("name", ["x"])
-def test_index_copy_range(name, deep=True):
-    cidx = cudf.RangeIndex(1, 5)
-    pidx = cidx.to_pandas()
-
-    pidx_copy = pidx.copy(name=name, deep=deep)
-    cidx_copy = cidx.copy(name=name, deep=deep)
-
-    assert_eq(pidx_copy, cidx_copy)
-
-
-@pytest.mark.parametrize("name", ["x"])
-def test_index_copy_datetime(name, deep=True):
-    cidx = cudf.DatetimeIndex(["2001", "2002", "2003"])
-    pidx = cidx.to_pandas()
-
-    pidx_copy = pidx.copy(name=name, deep=deep)
-    cidx_copy = cidx.copy(name=name, deep=deep)
-
-    assert_eq(pidx_copy, cidx_copy)
-
-
-@pytest.mark.parametrize("name", ["x"])
-def test_index_copy_string(name, deep=True):
-    cidx = cudf.Index(["a", "b", "c"])
-    pidx = cidx.to_pandas()
-
-    pidx_copy = pidx.copy(name=name, deep=deep)
-    cidx_copy = cidx.copy(name=name, deep=deep)
-
-    assert_eq(pidx_copy, cidx_copy)
-
-
-@pytest.mark.parametrize("name", ["x"])
-def test_index_copy_integer(name, deep=True):
-    """Test for NumericIndex Copy Casts"""
-    cidx = cudf.Index([1, 2, 3])
-    pidx = cidx.to_pandas()
-
-    pidx_copy = pidx.copy(name=name, deep=deep)
-    cidx_copy = cidx.copy(name=name, deep=deep)
-
-    assert_eq(pidx_copy, cidx_copy)
-
-
-@pytest.mark.parametrize("name", ["x"])
-def test_index_copy_float(name, deep=True):
-    """Test for NumericIndex Copy Casts"""
-    cidx = cudf.Index([1.0, 2.0, 3.0])
-    pidx = cidx.to_pandas()
-
-    pidx_copy = pidx.copy(name=name, deep=deep)
-    cidx_copy = cidx.copy(name=name, deep=deep)
-
-    assert_eq(pidx_copy, cidx_copy)
-
-
-@pytest.mark.parametrize("name", ["x"])
-def test_index_copy_category(name, deep=True):
-    cidx = cudf.core.index.CategoricalIndex([1, 2, 3])
-    pidx = cidx.to_pandas()
-
-    pidx_copy = pidx.copy(name=name, deep=deep)
-    cidx_copy = cidx.copy(name=name, deep=deep)
-
-    assert_column_memory_ne(cidx._column, cidx_copy._column)
-    assert_eq(pidx_copy, cidx_copy)
-
-
-@pytest.mark.parametrize("deep", [True, False])
 @pytest.mark.parametrize(
-    "idx",
+    "data",
     [
-        cudf.DatetimeIndex(["2001", "2002", "2003"]),
-        cudf.Index(["a", "b", "c"]),
-        cudf.Index([1, 2, 3]),
-        cudf.Index([1.0, 2.0, 3.0]),
-        cudf.CategoricalIndex([1, 2, 3]),
-        cudf.CategoricalIndex(["a", "b", "c"]),
+        range(1, 5),
+        [1, 2, 3, 4],
+        pd.DatetimeIndex(["2001", "2002", "2003"]),
+        ["a", "b", "c"],
+        pd.CategoricalIndex(["a", "b", "c"]),
     ],
 )
+@pytest.mark.parametrize("deep", [True, False])
 @pytest.mark.parametrize("copy_on_write", [True, False])
-def test_index_copy_deep(idx, deep, copy_on_write):
-    """Test if deep copy creates a new instance for device data."""
-    idx_copy = idx.copy(deep=deep)
-    original_cow_setting = cudf.get_option("copy_on_write")
-    cudf.set_option("copy_on_write", copy_on_write)
-    if (
-        isinstance(idx._column, cudf.core.column.StringColumn)
-        or not deep
-        or (cudf.get_option("copy_on_write") and not deep)
-    ):
-        # StringColumn is immutable hence, deep copies of a
-        # Index with string dtype will share the same StringColumn.
+def test_index_copy(data, deep, copy_on_write):
+    name = "x"
+    cidx = cudf.Index(data)
+    pidx = cidx.to_pandas()
 
-        # When `copy_on_write` is turned on, Index objects will
-        # have unique column object but they all point to same
-        # data pointers.
-        assert_column_memory_eq(idx._column, idx_copy._column)
-    else:
-        assert_column_memory_ne(idx._column, idx_copy._column)
-    cudf.set_option("copy_on_write", original_cow_setting)
+    pidx_copy = pidx.copy(name=name, deep=deep)
+    cidx_copy = cidx.copy(name=name, deep=deep)
+
+    assert_eq(pidx_copy, cidx_copy)
+
+    with cudf.option_context("copy_on_write", copy_on_write):
+        if not isinstance(cidx, cudf.RangeIndex):
+            if (
+                isinstance(cidx._column, cudf.core.column.StringColumn)
+                or not deep
+                or (copy_on_write and not deep)
+            ):
+                # StringColumn is immutable hence, deep copies of a
+                # Index with string dtype will share the same StringColumn.
+
+                # When `copy_on_write` is turned on, Index objects will
+                # have unique column object but they all point to same
+                # data pointers.
+                assert_column_memory_eq(cidx._column, cidx_copy._column)
+            else:
+                assert_column_memory_ne(cidx._column, cidx_copy._column)
 
 
-@pytest.mark.parametrize("idx", [[1, None, 3, None, 5]])
-def test_index_isna(idx):
+def test_index_isna_notna():
+    idx = [1, None, 3, None, 5]
     pidx = pd.Index(idx, name="idx")
     gidx = cudf.Index(idx, name="idx")
     assert_eq(gidx.isna(), pidx.isna())
-
-
-@pytest.mark.parametrize("idx", [[1, None, 3, None, 5]])
-def test_index_notna(idx):
-    pidx = pd.Index(idx, name="idx")
-    gidx = cudf.Index(idx, name="idx")
     assert_eq(gidx.notna(), pidx.notna())
 
 
@@ -1284,39 +1211,6 @@ def test_index_basic(data, dtype, name):
 
 
 @pytest.mark.parametrize("data", [[1, 2, 3, 4], []])
-@pytest.mark.parametrize("name", [1, "a", None])
-@pytest.mark.parametrize("dtype", SIGNED_INTEGER_TYPES)
-def test_integer_index_apis(data, name, dtype):
-    pindex = pd.Index(data, dtype=dtype, name=name)
-    gindex = cudf.Index(data, dtype=dtype, name=name)
-
-    assert_eq(pindex, gindex)
-    assert gindex.dtype == dtype
-
-
-@pytest.mark.parametrize("data", [[1, 2, 3, 4], []])
-@pytest.mark.parametrize("name", [1, "a", None])
-@pytest.mark.parametrize("dtype", UNSIGNED_TYPES)
-def test_unsigned_integer_index_apis(data, name, dtype):
-    pindex = pd.Index(data, dtype=dtype, name=name)
-    gindex = cudf.Index(data, dtype=dtype, name=name)
-
-    assert_eq(pindex, gindex)
-    assert gindex.dtype == dtype
-
-
-@pytest.mark.parametrize("data", [[1, 2, 3, 4], []])
-@pytest.mark.parametrize("name", [1, "a", None])
-@pytest.mark.parametrize("dtype", FLOAT_TYPES)
-def test_float_index_apis(data, name, dtype):
-    pindex = pd.Index(data, dtype=dtype, name=name)
-    gindex = cudf.Index(data, dtype=dtype, name=name)
-
-    assert_eq(pindex, gindex)
-    assert gindex.dtype == dtype
-
-
-@pytest.mark.parametrize("data", [[1, 2, 3, 4], []])
 @pytest.mark.parametrize("categories", [[1, 2], None])
 @pytest.mark.parametrize(
     "dtype",
@@ -1716,12 +1610,11 @@ def test_index_set_names(idx, names, inplace):
     assert_eq(expected, actual)
 
 
-@pytest.mark.parametrize("idx", [pd.Index([1, 2, 3], name="abc")])
 @pytest.mark.parametrize("level", [1, [0], "abc"])
 @pytest.mark.parametrize("names", [None, "a"])
-def test_index_set_names_error(idx, level, names):
-    pi = idx.copy()
-    gi = cudf.from_pandas(idx)
+def test_index_set_names_error(level, names):
+    pi = pd.Index([1, 2, 3], name="abc")
+    gi = cudf.from_pandas(pi)
 
     assert_exceptions_equal(
         lfunc=pi.set_names,
@@ -1732,13 +1625,12 @@ def test_index_set_names_error(idx, level, names):
 
 
 @pytest.mark.parametrize(
-    "idx",
-    [pd.Index([1, 3, 6]), pd.Index([6, 1, 3])],  # monotonic  # non-monotonic
+    "data", [[1, 3, 6], [6, 1, 3]], ids=["monotonic", "non-monotonic"]
 )
-@pytest.mark.parametrize("key", [list(range(0, 8))])
 @pytest.mark.parametrize("method", [None, "ffill", "bfill", "nearest"])
-def test_get_indexer_single_unique_numeric(idx, key, method):
-    pi = idx
+def test_get_indexer_single_unique_numeric(data, method):
+    key = list(range(0, 8))
+    pi = pd.Index(data)
     gi = cudf.from_pandas(pi)
 
     if (
@@ -1763,22 +1655,19 @@ def test_get_indexer_single_unique_numeric(idx, key, method):
 
 
 @pytest.mark.parametrize(
-    "idx",
-    [pd.RangeIndex(3, 100, 4)],
-)
-@pytest.mark.parametrize(
-    "key",
+    "rng",
     [
-        list(range(1, 20, 3)),
-        list(range(20, 35, 3)),
-        list(range(35, 77, 3)),
-        list(range(77, 110, 3)),
+        range(1, 20, 3),
+        range(20, 35, 3),
+        range(35, 77, 3),
+        range(77, 110, 3),
     ],
 )
 @pytest.mark.parametrize("method", [None, "ffill", "bfill", "nearest"])
 @pytest.mark.parametrize("tolerance", [None, 0, 1, 13, 20])
-def test_get_indexer_rangeindex(idx, key, method, tolerance):
-    pi = idx
+def test_get_indexer_rangeindex(rng, method, tolerance):
+    key = list(rng)
+    pi = pd.RangeIndex(3, 100, 4)
     gi = cudf.from_pandas(pi)
 
     expected = pi.get_indexer(
@@ -1797,13 +1686,9 @@ def test_get_indexer_rangeindex(idx, key, method, tolerance):
     assert_eq(expected, got, check_dtype=True)
 
 
-@pytest.mark.parametrize(
-    "idx",
-    [pd.RangeIndex(3, 100, 4)],
-)
 @pytest.mark.parametrize("key", list(range(1, 110, 3)))
-def test_get_loc_rangeindex(idx, key):
-    pi = idx
+def test_get_loc_rangeindex(key):
+    pi = pd.RangeIndex(3, 100, 4)
     gi = cudf.from_pandas(pi)
     if (
         (key not in pi)
@@ -1828,14 +1713,15 @@ def test_get_loc_rangeindex(idx, key):
 @pytest.mark.parametrize(
     "idx",
     [
-        pd.Index([1, 3, 3, 6]),  # monotonic increasing
-        pd.Index([6, 1, 3, 3]),  # non-monotonic
-        pd.Index([4, 3, 2, 1, 0]),  # monotonic decreasing
+        [1, 3, 3, 6],
+        [6, 1, 3, 3],
+        [4, 3, 2, 1, 0],
     ],
+    ids=["monotonic increasing", "non-monotonic", "monotonic decreasing"],
 )
 @pytest.mark.parametrize("key", [0, 3, 6, 7, 4])
 def test_get_loc_duplicate_numeric(idx, key):
-    pi = idx
+    pi = pd.Index(idx)
     gi = cudf.from_pandas(pi)
 
     if key not in pi:
@@ -1855,15 +1741,16 @@ def test_get_loc_duplicate_numeric(idx, key):
 @pytest.mark.parametrize(
     "idx",
     [
-        pd.Index([-1, 2, 3, 6]),  # monotonic
-        pd.Index([6, 1, 3, 4]),  # non-monotonic
+        [-1, 2, 3, 6],
+        [6, 1, 3, 4],
     ],
+    ids=["monotonic", "non-monotonic"],
 )
 @pytest.mark.parametrize("key", [[0, 3, 1], [6, 7]])
 @pytest.mark.parametrize("method", [None, "ffill", "bfill", "nearest"])
 @pytest.mark.parametrize("tolerance", [None, 1, 2])
 def test_get_indexer_single_duplicate_numeric(idx, key, method, tolerance):
-    pi = idx
+    pi = pd.Index(idx)
     gi = cudf.from_pandas(pi)
 
     if not pi.is_monotonic_increasing and method is not None:
@@ -1884,12 +1771,10 @@ def test_get_indexer_single_duplicate_numeric(idx, key, method, tolerance):
         assert_eq(expected, got)
 
 
-@pytest.mark.parametrize(
-    "idx", [pd.Index(["b", "f", "m", "q"]), pd.Index(["m", "f", "b", "q"])]
-)
+@pytest.mark.parametrize("idx", [["b", "f", "m", "q"], ["m", "f", "b", "q"]])
 @pytest.mark.parametrize("key", ["a", "f", "n", "z"])
 def test_get_loc_single_unique_string(idx, key):
-    pi = idx
+    pi = pd.Index(idx)
     gi = cudf.from_pandas(pi)
 
     if key not in pi:
@@ -1906,13 +1791,11 @@ def test_get_loc_single_unique_string(idx, key):
         assert_eq(expected, got)
 
 
-@pytest.mark.parametrize(
-    "idx", [pd.Index(["b", "f", "m", "q"]), pd.Index(["m", "f", "b", "q"])]
-)
+@pytest.mark.parametrize("idx", [["b", "f", "m", "q"], ["m", "f", "b", "q"]])
 @pytest.mark.parametrize("key", [["a", "f", "n", "z"], ["p", "p", "b"]])
 @pytest.mark.parametrize("method", [None, "ffill", "bfill"])
 def test_get_indexer_single_unique_string(idx, key, method):
-    pi = idx
+    pi = pd.Index(idx)
     gi = cudf.from_pandas(pi)
 
     if not pi.is_monotonic_increasing and method is not None:
@@ -1929,12 +1812,10 @@ def test_get_indexer_single_unique_string(idx, key, method):
         assert_eq(expected, got)
 
 
-@pytest.mark.parametrize(
-    "idx", [pd.Index(["b", "m", "m", "q"]), pd.Index(["m", "f", "m", "q"])]
-)
+@pytest.mark.parametrize("idx", [["b", "m", "m", "q"], ["m", "f", "m", "q"]])
 @pytest.mark.parametrize("key", ["a", "f", "n", "z"])
 def test_get_loc_single_duplicate_string(idx, key):
-    pi = idx
+    pi = pd.Index(idx)
     gi = cudf.from_pandas(pi)
 
     if key not in pi:
@@ -1951,13 +1832,11 @@ def test_get_loc_single_duplicate_string(idx, key):
         assert_eq(expected, got)
 
 
-@pytest.mark.parametrize(
-    "idx", [pd.Index(["b", "m", "m", "q"]), pd.Index(["a", "f", "m", "q"])]
-)
+@pytest.mark.parametrize("idx", [["b", "m", "m", "q"], ["a", "f", "m", "q"]])
 @pytest.mark.parametrize("key", [["a"], ["f", "n", "z"]])
 @pytest.mark.parametrize("method", [None, "ffill", "bfill"])
 def test_get_indexer_single_duplicate_string(idx, key, method):
-    pi = idx
+    pi = pd.Index(idx)
     gi = cudf.from_pandas(pi)
 
     if (
@@ -1984,21 +1863,16 @@ def test_get_indexer_single_duplicate_string(idx, key, method):
 
 
 @pytest.mark.parametrize(
-    "idx",
+    "data",
     [
-        pd.MultiIndex.from_tuples(
-            [(1, 1, 1), (1, 1, 2), (1, 2, 1), (1, 2, 3), (2, 1, 1), (2, 2, 1)]
-        ),
-        pd.MultiIndex.from_tuples(
-            [(2, 1, 1), (1, 2, 3), (1, 2, 1), (1, 1, 2), (2, 2, 1), (1, 1, 1)]
-        ),
-        pd.MultiIndex.from_tuples(
-            [(1, 1, 1), (1, 1, 2), (1, 1, 2), (1, 2, 3), (2, 1, 1), (2, 2, 1)]
-        ),
+        [(1, 1, 1), (1, 1, 2), (1, 2, 1), (1, 2, 3), (2, 1, 1), (2, 2, 1)],
+        [(2, 1, 1), (1, 2, 3), (1, 2, 1), (1, 1, 2), (2, 2, 1), (1, 1, 1)],
+        [(1, 1, 1), (1, 1, 2), (1, 1, 2), (1, 2, 3), (2, 1, 1), (2, 2, 1)],
     ],
 )
 @pytest.mark.parametrize("key", [1, (1, 2), (1, 2, 3), (2, 1, 1), (9, 9, 9)])
-def test_get_loc_multi_numeric(idx, key):
+def test_get_loc_multi_numeric(data, key):
+    idx = pd.MultiIndex.from_tuples(data)
     pi = idx.sort_values()
     gi = cudf.from_pandas(pi)
 
@@ -2017,22 +1891,17 @@ def test_get_loc_multi_numeric(idx, key):
 
 
 @pytest.mark.parametrize(
-    "idx",
+    "data",
     [
-        pd.MultiIndex.from_tuples(
-            [(1, 1, 1), (1, 1, 2), (1, 2, 1), (1, 2, 3), (2, 1, 1), (2, 2, 1)]
-        ),
-        pd.MultiIndex.from_tuples(
-            [(2, 1, 1), (1, 2, 3), (1, 2, 1), (1, 1, 2), (2, 2, 1), (1, 1, 1)]
-        ),
-        pd.MultiIndex.from_tuples(
-            [(1, 1, 1), (1, 1, 2), (1, 1, 24), (1, 2, 3), (2, 1, 1), (2, 2, 1)]
-        ),
+        [(1, 1, 1), (1, 1, 2), (1, 2, 1), (1, 2, 3), (2, 1, 1), (2, 2, 1)],
+        [(2, 1, 1), (1, 2, 3), (1, 2, 1), (1, 1, 2), (2, 2, 1), (1, 1, 1)],
+        [(1, 1, 1), (1, 1, 2), (1, 1, 24), (1, 2, 3), (2, 1, 1), (2, 2, 1)],
     ],
 )
 @pytest.mark.parametrize("key", [[(1, 2, 3)], [(9, 9, 9)]])
 @pytest.mark.parametrize("method", [None, "ffill", "bfill"])
-def test_get_indexer_multi_numeric(idx, key, method):
+def test_get_indexer_multi_numeric(data, key, method):
+    idx = pd.MultiIndex.from_tuples(data)
     pi = idx.sort_values()
     gi = cudf.from_pandas(pi)
 
@@ -2048,14 +1917,6 @@ def test_get_indexer_multi_numeric(idx, key, method):
 
 
 @pytest.mark.parametrize(
-    "idx",
-    [
-        pd.MultiIndex.from_tuples(
-            [(2, 1, 1), (1, 2, 3), (1, 2, 1), (1, 1, 1), (1, 1, 1), (2, 2, 1)]
-        )
-    ],
-)
-@pytest.mark.parametrize(
     "key, result",
     [
         (1, slice(1, 5, 1)),  # deviates
@@ -2065,8 +1926,10 @@ def test_get_indexer_multi_numeric(idx, key, method):
         ((9, 9, 9), None),
     ],
 )
-def test_get_loc_multi_numeric_deviate(idx, key, result):
-    pi = idx
+def test_get_loc_multi_numeric_deviate(key, result):
+    pi = pd.MultiIndex.from_tuples(
+        [(2, 1, 1), (1, 2, 3), (1, 2, 1), (1, 1, 1), (1, 1, 1), (2, 2, 1)]
+    )
     gi = cudf.from_pandas(pi)
 
     with expect_warning_if(
@@ -2138,64 +2001,55 @@ def test_get_indexer_multi_error(method):
 
 
 @pytest.mark.parametrize(
-    "idx",
+    "data",
     [
-        pd.MultiIndex.from_tuples(
-            [
-                ("a", "a", "a"),
-                ("a", "a", "b"),
-                ("a", "b", "a"),
-                ("a", "b", "c"),
-                ("b", "a", "a"),
-                ("b", "c", "a"),
-            ]
-        ),
-        pd.MultiIndex.from_tuples(
-            [
-                ("a", "a", "b"),
-                ("a", "b", "c"),
-                ("b", "a", "a"),
-                ("a", "a", "a"),
-                ("a", "b", "a"),
-                ("b", "c", "a"),
-            ]
-        ),
-        pd.MultiIndex.from_tuples(
-            [
-                ("a", "a", "a"),
-                ("a", "b", "c"),
-                ("b", "a", "a"),
-                ("a", "a", "b"),
-                ("a", "b", "a"),
-                ("b", "c", "a"),
-            ]
-        ),
-        pd.MultiIndex.from_tuples(
-            [
-                ("a", "a", "a"),
-                ("a", "a", "b"),
-                ("a", "a", "b"),
-                ("a", "b", "c"),
-                ("b", "a", "a"),
-                ("b", "c", "a"),
-            ]
-        ),
-        pd.MultiIndex.from_tuples(
-            [
-                ("a", "a", "b"),
-                ("b", "a", "a"),
-                ("b", "a", "a"),
-                ("a", "a", "a"),
-                ("a", "b", "a"),
-                ("b", "c", "a"),
-            ]
-        ),
+        [
+            ("a", "a", "a"),
+            ("a", "a", "b"),
+            ("a", "b", "a"),
+            ("a", "b", "c"),
+            ("b", "a", "a"),
+            ("b", "c", "a"),
+        ],
+        [
+            ("a", "a", "b"),
+            ("a", "b", "c"),
+            ("b", "a", "a"),
+            ("a", "a", "a"),
+            ("a", "b", "a"),
+            ("b", "c", "a"),
+        ],
+        [
+            ("a", "a", "a"),
+            ("a", "b", "c"),
+            ("b", "a", "a"),
+            ("a", "a", "b"),
+            ("a", "b", "a"),
+            ("b", "c", "a"),
+        ],
+        [
+            ("a", "a", "a"),
+            ("a", "a", "b"),
+            ("a", "a", "b"),
+            ("a", "b", "c"),
+            ("b", "a", "a"),
+            ("b", "c", "a"),
+        ],
+        [
+            ("a", "a", "b"),
+            ("b", "a", "a"),
+            ("b", "a", "a"),
+            ("a", "a", "a"),
+            ("a", "b", "a"),
+            ("b", "c", "a"),
+        ],
     ],
 )
 @pytest.mark.parametrize(
     "key", ["a", ("a", "a"), ("a", "b", "c"), ("b", "c", "a"), ("z", "z", "z")]
 )
-def test_get_loc_multi_string(idx, key):
+def test_get_loc_multi_string(data, key):
+    idx = pd.MultiIndex.from_tuples(data)
     pi = idx.sort_values()
     gi = cudf.from_pandas(pi)
 
@@ -2214,45 +2068,40 @@ def test_get_loc_multi_string(idx, key):
 
 
 @pytest.mark.parametrize(
-    "idx",
+    "data",
     [
-        pd.MultiIndex.from_tuples(
-            [
-                ("a", "a", "a"),
-                ("a", "a", "b"),
-                ("a", "b", "a"),
-                ("a", "b", "c"),
-                ("b", "a", "a"),
-                ("b", "c", "a"),
-            ]
-        ),
-        pd.MultiIndex.from_tuples(
-            [
-                ("a", "a", "b"),
-                ("a", "b", "c"),
-                ("b", "a", "a"),
-                ("a", "a", "a"),
-                ("a", "b", "a"),
-                ("b", "c", "a"),
-            ]
-        ),
-        pd.MultiIndex.from_tuples(
-            [
-                ("a", "a", "a"),
-                ("a", "b", "c"),
-                ("b", "a", "a"),
-                ("a", "a", "b"),
-                ("a", "b", "a"),
-                ("b", "c", "a"),
-            ]
-        ),
+        [
+            ("a", "a", "a"),
+            ("a", "a", "b"),
+            ("a", "b", "a"),
+            ("a", "b", "c"),
+            ("b", "a", "a"),
+            ("b", "c", "a"),
+        ],
+        [
+            ("a", "a", "b"),
+            ("a", "b", "c"),
+            ("b", "a", "a"),
+            ("a", "a", "a"),
+            ("a", "b", "a"),
+            ("b", "c", "a"),
+        ],
+        [
+            ("a", "a", "a"),
+            ("a", "b", "c"),
+            ("b", "a", "a"),
+            ("a", "a", "b"),
+            ("a", "b", "a"),
+            ("b", "c", "a"),
+        ],
     ],
 )
 @pytest.mark.parametrize(
     "key", [[("a", "b", "c"), ("b", "c", "a")], [("z", "z", "z")]]
 )
 @pytest.mark.parametrize("method", [None, "ffill", "bfill"])
-def test_get_indexer_multi_string(idx, key, method):
+def test_get_indexer_multi_string(data, key, method):
+    idx = pd.MultiIndex.from_tuples(data)
     pi = idx.sort_values()
     gi = cudf.from_pandas(pi)
 
@@ -2643,8 +2492,9 @@ def test_isin_multiindex(data, values, level, err):
         )
 
 
-@pytest.fixture(
-    params=[
+@pytest.mark.parametrize(
+    "rangeindex",
+    [
         range(np.random.default_rng(seed=0).integers(0, 100)),
         range(9, 12, 2),
         range(20, 30),
@@ -2652,19 +2502,14 @@ def test_isin_multiindex(data, values, level, err):
         range(0, 10, -2),
         range(0, -10, 2),
         range(0, -10, -2),
-    ]
+    ],
 )
-def rangeindex(request):
-    """Create a cudf RangeIndex of different `nrows`"""
-    return cudf.RangeIndex(request.param)
-
-
 @pytest.mark.parametrize(
     "func",
     ["nunique", "min", "max", "any", "values"],
 )
 def test_rangeindex_methods(rangeindex, func):
-    gidx = rangeindex
+    gidx = cudf.RangeIndex(rangeindex)
     pidx = gidx.to_pandas()
 
     if func == "values":
@@ -2827,8 +2672,9 @@ def test_rangeindex_append_return_rangeindex():
     assert_eq(result, expected)
 
 
-@pytest.fixture(
-    params=[
+@pytest.mark.parametrize(
+    "index",
+    [
         range(np.random.default_rng(seed=0).integers(0, 100)),
         range(0, 10, -2),
         range(0, -10, 2),
@@ -2839,13 +2685,8 @@ def test_rangeindex_append_return_rangeindex():
         [None, "a", "3.2", "z", None, None],
         pd.Series(["a", "b", None], dtype="category"),
         np.array([1, 2, 3, None], dtype="datetime64[s]"),
-    ]
+    ],
 )
-def index(request):
-    """Create a cudf Index of different dtypes"""
-    return cudf.Index(request.param)
-
-
 @pytest.mark.parametrize(
     "func",
     [
@@ -2856,7 +2697,7 @@ def index(request):
     ],
 )
 def test_index_methods(index, func):
-    gidx = index
+    gidx = cudf.Index(index)
     pidx = gidx.to_pandas()
 
     if func == "append":
@@ -3003,23 +2844,18 @@ def test_index_to_pandas_nullable(data, expected_dtype):
     assert_eq(pi, expected)
 
 
-class TestIndexScalarGetItem:
-    @pytest.fixture(
-        params=[range(1, 10, 2), [1, 2, 3], ["a", "b", "c"], [1.5, 2.5, 3.5]]
-    )
-    def index_values(self, request):
-        return request.param
+@pytest.mark.parametrize(
+    "index_values",
+    [range(1, 10, 2), [1, 2, 3], ["a", "b", "c"], [1.5, 2.5, 3.5]],
+)
+@pytest.mark.parametrize("i_type", [int, np.int8, np.int32, np.int64])
+def test_scalar_getitem(index_values, i_type):
+    i = i_type(1)
+    index = cudf.Index(index_values)
 
-    @pytest.fixture(params=[int, np.int8, np.int32, np.int64])
-    def i(self, request):
-        return request.param(1)
-
-    def test_scalar_getitem(self, index_values, i):
-        index = cudf.Index(index_values)
-
-        assert not isinstance(index[i], cudf.Index)
-        assert index[i] == index_values[i]
-        assert_eq(index, index.to_pandas())
+    assert not isinstance(index[i], cudf.Index)
+    assert index[i] == index_values[i]
+    assert_eq(index, index.to_pandas())
 
 
 @pytest.mark.parametrize(
@@ -3168,14 +3004,15 @@ def test_from_pandas_rangeindex_return_rangeindex():
 
 
 @pytest.mark.parametrize(
-    "idx",
+    "data",
     [
-        cudf.RangeIndex(1),
-        cudf.DatetimeIndex(np.array([1, 2], dtype="datetime64[ns]")),
-        cudf.TimedeltaIndex(np.array([1, 2], dtype="timedelta64[ns]")),
+        range(1),
+        np.array([1, 2], dtype="datetime64[ns]"),
+        np.array([1, 2], dtype="timedelta64[ns]"),
     ],
 )
-def test_index_to_pandas_nullable_notimplemented(idx):
+def test_index_to_pandas_nullable_notimplemented(data):
+    idx = cudf.Index(data)
     with pytest.raises(NotImplementedError):
         idx.to_pandas(nullable=True)
 
@@ -3311,12 +3148,13 @@ def test_index_datetime_repeat():
 @pytest.mark.parametrize(
     "index",
     [
-        cudf.Index([1]),
-        cudf.RangeIndex(1),
-        cudf.MultiIndex(levels=[[0]], codes=[[0]]),
+        lambda: cudf.Index([1]),
+        lambda: cudf.RangeIndex(1),
+        lambda: cudf.MultiIndex(levels=[[0]], codes=[[0]]),
     ],
 )
 def test_index_assignment_no_shallow_copy(index):
+    index = index()
     df = cudf.DataFrame(range(1))
     df.index = index
     assert df.index is index


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/9999

* Use more pytest fixtures
* Avoids pytest.mark.parametrize with GPU objects
* Eliminate/reduce parameterizations of input size

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
