### PR TITLE
Use libnvcomp conda package

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -41,6 +41,7 @@ dependencies:
 - jupyter_client
 - libcurand-dev
 - libkvikio==25.8.*,>=0.0.0a0
+- libnvcomp==4.2.0.11
 - librdkafka>=2.8.0,<2.9.0a0
 - librmm==25.8.*,>=0.0.0a0
 - make
@@ -58,7 +59,6 @@ dependencies:
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
-- nvcomp==4.2.0.11
 - nvtx>=0.2.1
 - openpyxl
 - packaging

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -42,6 +42,7 @@ dependencies:
 - libcufile-dev
 - libcurand-dev
 - libkvikio==25.8.*,>=0.0.0a0
+- libnvcomp==4.2.0.11
 - librdkafka>=2.8.0,<2.9.0a0
 - librmm==25.8.*,>=0.0.0a0
 - make
@@ -59,7 +60,6 @@ dependencies:
 - numba>=0.59.1,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
-- nvcomp==4.2.0.11
 - nvtx>=0.2.1
 - openpyxl
 - packaging

--- a/conda/recipes/libcudf/recipe.yaml
+++ b/conda/recipes/libcudf/recipe.yaml
@@ -72,7 +72,7 @@ cache:
         then:
           - libcufile-dev
       - cuda-version =${{ cuda_version }}
-      - nvcomp ${{ nvcomp_version }}
+      - libnvcomp ${{ nvcomp_version }}
       - dlpack ${{ dlpack_version }}
       - librdkafka ${{ librdkafka_version }}
       - flatbuffers =${{ flatbuffers_version }}
@@ -106,7 +106,7 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - libkvikio =${{ minor_version }}
         - librmm =${{ minor_version }}
-        - nvcomp ${{ nvcomp_version }}
+        - libnvcomp ${{ nvcomp_version }}
         - rapids-logger =0.1
         - zlib ${{ zlib_version }}
         - cuda-cudart-dev
@@ -116,7 +116,7 @@ outputs:
         - if: linux and x86_64
           then:
             - libcufile
-        - nvcomp ${{ nvcomp_version }}
+        - libnvcomp ${{ nvcomp_version }}
         - librmm =${{ minor_version }}
         - libkvikio =${{ minor_version }}
         - dlpack ${{ dlpack_version }}
@@ -136,7 +136,7 @@ outputs:
           - librdkafka
           - libzlib
           - librmm
-          - nvcomp
+          - libnvcomp
     tests:
       - script:
         - test -f $PREFIX/include/cudf/column/column.hpp
@@ -178,7 +178,7 @@ outputs:
           - librdkafka
           - librmm
           - libzlib
-          - nvcomp
+          - libnvcomp
     tests:
       - script:
         - test -f $PREFIX/lib/libcudf_kafka.so
@@ -247,7 +247,7 @@ outputs:
           - librdkafka
           - librmm
           - libzlib
-          - nvcomp
+          - libnvcomp
     about:
       homepage: ${{ load_from_file("python/libcudf/pyproject.toml").project.urls.Homepage }}
       license: ${{ load_from_file("python/libcudf/pyproject.toml").project.license.text }}
@@ -296,7 +296,7 @@ outputs:
           - librdkafka
           - librmm
           - libzlib
-          - nvcomp
+          - libnvcomp
     about:
       homepage: ${{ load_from_file("python/libcudf/pyproject.toml").project.urls.Homepage }}
       license: ${{ load_from_file("python/libcudf/pyproject.toml").project.license.text }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -458,7 +458,7 @@ dependencies:
       - output_types: conda
         packages:
           # Align nvcomp version with rapids-cmake
-          - nvcomp==4.2.0.11
+          - libnvcomp==4.2.0.11
     specific:
       - output_types: [requirements, pyproject]
         matrices:


### PR DESCRIPTION
## Description
The `nvcomp` conda package is being split into a C++ package `libnvcomp` and a Python bindings package `nvcomp`. We want to use the C++ package only, so we are adopting `libnvcomp`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
