### PR TITLE
[WIP] Add API to populate "base" column statistics

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/base.py
+++ b/python/cudf_polars/cudf_polars/experimental/base.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Iterator
 
     from cudf_polars.dsl.expr import NamedExpr
+    from cudf_polars.dsl.ir import IR
     from cudf_polars.dsl.nodebase import Node
 
 
@@ -151,3 +152,13 @@ class ColumnStats:
         self.source_info = source_info or DataSourceInfo()
         self.source_name = source_name or name
         self.unique_stats = unique_stats or UniqueStats()
+
+
+class StatsCollector:
+    """Column statistics collector."""
+
+    __slots__ = ("column_stats", "row_count")
+
+    def __init__(self) -> None:
+        self.row_count: dict[IR, ColumnStat[int]] = {}
+        self.column_stats: dict[IR, dict[str, ColumnStats]] = {}

--- a/python/cudf_polars/cudf_polars/experimental/dispatch.py
+++ b/python/cudf_polars/cudf_polars/experimental/dispatch.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
     from cudf_polars.dsl import ir
     from cudf_polars.dsl.ir import IR
-    from cudf_polars.experimental.base import PartitionInfo
+    from cudf_polars.experimental.base import ColumnStats, PartitionInfo, StatsCollector
     from cudf_polars.utils.config import ConfigOptions
 
 
@@ -95,5 +95,36 @@ def generate_ir_tasks(
     See Also
     --------
     task_graph
+    """
+    raise AssertionError(f"Unhandled type {type(ir)}")  # pragma: no cover
+
+
+@singledispatch
+def extract_base_stats(
+    ir: IR, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    """
+    Extract "base" datasource statistics for an IR node.
+
+    Parameters
+    ----------
+    ir
+        The IR node to collect source statistics for.
+    stats
+        The `StatsCollector` object containing known source statistics.
+    config_options
+        GPUEngine configuration options.
+
+    Returns
+    -------
+    base_stats_mapping
+        Mapping between column names and base ``ColumnStats`` objects.
+
+    Notes
+    -----
+    Base column stats correspond to ``ColumnStats`` objects **without**
+    populated ``unique_stats`` information. The purpose of this function
+    is to propagate ``DataSourceInfo`` references for each column of
+    each IR node.
     """
     raise AssertionError(f"Unhandled type {type(ir)}")  # pragma: no cover

--- a/python/cudf_polars/cudf_polars/experimental/statistics.py
+++ b/python/cudf_polars/cudf_polars/experimental/statistics.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities for tracking column statistics."""
+
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING
+
+from cudf_polars.dsl import expr
+from cudf_polars.dsl.ir import (
+    IR,
+    Cache,
+    DataFrameScan,
+    Distinct,
+    GroupBy,
+    HConcat,
+    HStack,
+    Join,
+    Projection,
+    Scan,
+    Select,
+    Sort,
+    Union,
+)
+from cudf_polars.dsl.traversal import post_traversal
+from cudf_polars.experimental.base import (
+    ColumnStats,
+    StatsCollector,
+)
+from cudf_polars.experimental.dispatch import extract_base_stats
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from cudf_polars.utils.config import ConfigOptions
+
+
+def collect_base_stats(root: IR, config_options: ConfigOptions) -> StatsCollector:
+    """
+    Collect base datasource statistics.
+
+    Parameters
+    ----------
+    root
+        Root IR node for collecting base datasource statistics.
+    config_options
+        GPUEngine configuration options.
+    """
+    stats: StatsCollector = StatsCollector()
+    for node in post_traversal([root]):
+        stats.column_stats[node] = extract_base_stats(node, stats, config_options)
+    return stats
+
+
+def _update_unique_stats_columns(
+    child_column_stats: dict[str, ColumnStats],
+    key_names: Sequence[str],
+    config_options: ConfigOptions,
+) -> None:
+    """Update set of unique-stats columns in datasource."""
+    assert config_options.executor.name == "streaming", (
+        "'in-memory' executor not supported in 'add_source_stats'"
+    )
+    unique_fraction = config_options.executor.unique_fraction
+    for name in key_names:
+        if (
+            name not in unique_fraction
+            and (column_stats := child_column_stats.get(name)) is not None
+            and (source_stats := column_stats.source_info) is not None
+        ):
+            source_stats.add_unique_stats_column(column_stats.source_name or name)
+
+
+def _default_extract_base_stats(
+    ir: IR, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    # Default `extract_base_stats` implementation.
+    if len(ir.children) == 1:
+        (child,) = ir.children
+        child_column_stats = stats.column_stats.get(child, {})
+        return {
+            name: child_column_stats.get(name, ColumnStats(name=name))
+            for name in ir.schema
+        }
+    else:
+        # Multi-child nodes loose all information by default.
+        return {name: ColumnStats(name=name) for name in ir.schema}
+
+
+extract_base_stats.register(IR, _default_extract_base_stats)
+
+
+@extract_base_stats.register(Distinct)
+def _(
+    ir: Distinct, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    (child,) = ir.children
+    child_column_stats = stats.column_stats.get(child, {})
+    key_names = ir.subset or ir.schema
+    _update_unique_stats_columns(child_column_stats, list(key_names), config_options)
+    return _default_extract_base_stats(ir, stats, config_options)
+
+
+@extract_base_stats.register(Join)
+def _(
+    ir: Join, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    left, right = ir.children
+    left_column_stats = stats.column_stats.get(left, {})
+    right_column_stats = stats.column_stats.get(right, {})
+    kstats = {
+        n.name: left_column_stats.get(n.name, ColumnStats(name=n.name))
+        for n in ir.left_on
+    }
+    jstats = {
+        name: left_column_stats.get(name, ColumnStats(name=name))
+        for name in left.schema
+        if name not in kstats
+    }
+    suffix = ir.options[3]
+    jstats |= {
+        name if name not in jstats else f"{name}{suffix}": right_column_stats.get(
+            name, ColumnStats(name=name)
+        )
+        for name in right.schema
+        if name not in kstats
+    }
+    return kstats | jstats
+
+
+@extract_base_stats.register(GroupBy)
+def _(
+    ir: GroupBy, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    (child,) = ir.children
+    child_column_stats = stats.column_stats.get(child, {})
+
+    # Update set of source columns we may lazily sample
+    _update_unique_stats_columns(
+        child_column_stats, [n.name for n in ir.keys], config_options
+    )
+
+    return {
+        n.name: child_column_stats.get(n.name, ColumnStats(name=n.name))
+        for n in ir.keys
+    } | {n.name: ColumnStats(name=n.name) for n in ir.agg_requests}
+
+
+@extract_base_stats.register(HStack)
+def _(
+    ir: HStack, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    (child,) = ir.children
+    child_column_stats = stats.column_stats.get(child, {})
+    new_cols = {
+        n.name: child_column_stats.get(n.value.name, ColumnStats(name=n.name))
+        if isinstance(n.value, expr.Col)
+        else ColumnStats(name=n.name)
+        for n in ir.columns
+    }
+    return child_column_stats | new_cols
+
+
+@extract_base_stats.register(Select)
+def _(
+    ir: Select, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    (child,) = ir.children
+    child_column_stats = stats.column_stats.get(child, {})
+    return {
+        n.name: child_column_stats.get(n.value.name, ColumnStats(name=n.name))
+        if isinstance(n.value, expr.Col)
+        else ColumnStats(name=n.name)
+        for n in ir.exprs
+    }
+
+
+@extract_base_stats.register(HConcat)
+def _(
+    ir: HConcat, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    return dict(
+        itertools.chain.from_iterable(
+            stats.column_stats.get(c, {}).items() for c in ir.children
+        )
+    )
+
+
+@extract_base_stats.register(Union)
+def _(
+    ir: Union, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    # TODO: We can preserve matching source statistics
+    return {name: ColumnStats(name=name) for name in ir.schema}
+
+
+def _extract_base_stats_preserve(
+    ir: IR, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    (child,) = ir.children
+    child_column_stats = stats.column_stats.get(child, {})
+    return {
+        name: child_column_stats.get(name, ColumnStats(name=name)) for name in ir.schema
+    }
+
+
+extract_base_stats.register(Cache, _extract_base_stats_preserve)
+extract_base_stats.register(Projection, _extract_base_stats_preserve)
+extract_base_stats.register(Sort, _extract_base_stats_preserve)
+
+
+@extract_base_stats.register(Scan)
+def _(
+    ir: Scan, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    from cudf_polars.experimental.io import _extract_scan_stats
+
+    return _extract_scan_stats(ir, config_options)
+
+
+@extract_base_stats.register(DataFrameScan)
+def _(
+    ir: DataFrameScan, stats: StatsCollector, config_options: ConfigOptions
+) -> dict[str, ColumnStats]:
+    from cudf_polars.experimental.io import _extract_dataframescan_stats
+
+    return _extract_dataframescan_stats(ir)

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -10,6 +10,7 @@ import polars as pl
 from cudf_polars import Translator
 from cudf_polars.experimental.parallel import lower_ir_graph
 from cudf_polars.experimental.shuffle import Shuffle
+from cudf_polars.experimental.statistics import collect_base_stats
 from cudf_polars.testing.asserts import DEFAULT_SCHEDULER, assert_gpu_result_equal
 from cudf_polars.utils.config import ConfigOptions
 
@@ -195,3 +196,31 @@ def test_join_and_slice(zlice):
     # Need sort to match order after a join
     q = left.join(right, on="a", how="inner").sort(pl.col("a")).slice(*zlice)
     assert_gpu_result_equal(q, engine=engine)
+
+
+@pytest.mark.parametrize("how", ["inner", "left", "right"])
+def test_join_base_stats(left, right, how):
+    engine = pl.GPUEngine(
+        raise_on_fail=True,
+        executor="streaming",
+        executor_options={
+            "scheduler": DEFAULT_SCHEDULER,
+            "shuffle_method": "tasks",
+        },
+    )
+
+    q = left.join(right, on="y", how=how)
+    ir = Translator(q._ldf.visit(), engine).translate_ir()
+    stats = collect_base_stats(ir, ConfigOptions.from_polars_engine(engine))
+
+    ir_column_stats = stats.column_stats[ir]
+    left_count, right_count = 15, 9
+    if how in ("inner", "left"):
+        assert ir_column_stats["x"].source_info.row_count.value == left_count
+        assert ir_column_stats["z"].source_info.row_count.value == left_count
+    if how in ("inner", "right"):
+        assert ir_column_stats["xx"].source_info.row_count.value == right_count
+        assert ir_column_stats["zz"].source_info.row_count.value == right_count
+
+    # TODO: Stats for "y" should depend on join type
+    assert ir_column_stats["y"].source_info.row_count.value == left_count


### PR DESCRIPTION
## Description
Closes https://github.com/rapidsai/cudf/issues/19390

- Adds simple `StatsCollector` API
- Adds `collect_base_stats` API (tested in this PR, but not *used* anywhere internally yet)
- Adds `extract_base_stats` dispatch functions and registers IR-specific logic for various IR sub-classes (this dispatch function is used by `collect_base_stats`).

**TODO**: Probably need to iron out `Join` logic and test coverage a bit more.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
