### PR TITLE
Adjust node type for devcontainer job

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -316,7 +316,7 @@ jobs:
     needs: telemetry-setup
     uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-25.08
     with:
-      node_type: "cpu32"
+      node_type: "cpu16"
       arch: '["amd64"]'
       cuda: '["12.9"]'
       build_command: |


### PR DESCRIPTION
## Description

I noticed that https://github.com/nv-gha-runners/enterprise-runner-configuration/blob/main/docs/runner-groups.md didn't contain a "cpu32" node type we were requesting. This is unlikely to fix the devcontainer failures, but giving it a shot anyway.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
