### PR TITLE
Disable codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
-#Configuration File for CodeCov
+# Configuration File for CodeCov
+comment: false
 coverage:
   status:
     project: off
@@ -7,6 +8,5 @@ coverage:
         target: auto
         threshold: 5%
         informational: true  # The coverage will always pass
-
 github_checks:
     annotations: true


### PR DESCRIPTION
## Description
This PR disables codecov comments on PRs. We do not act on this data and it has been considered a small nuisance by several RAPIDS libraries.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
