### PR TITLE
Move test_unaops/test_unique/test_transform.py to new cudf classic test directory structure

### DIFF
--- a/python/cudf/cudf/tests/conftest.py
+++ b/python/cudf/cudf/tests/conftest.py
@@ -194,3 +194,49 @@ def set_decomp_env_vars(monkeypatch, request):
         for key, value in env_vars.items():
             m.setenv(key, value)
         yield
+
+
+signed_integer_types = ["int8", "int16", "int32", "int64"]
+unsigned_integer_types = ["uint8", "uint16", "uint32", "uint64"]
+float_types = ["float32", "float64"]
+
+
+@pytest.fixture(params=signed_integer_types + unsigned_integer_types)
+def integer_types_as_str(request):
+    """
+    - "int8", "int16", "int32", "int64"
+    - "uint8", "uint16", "uint32", "uint64"
+    """
+    return request.param
+
+
+@pytest.fixture(
+    params=signed_integer_types + unsigned_integer_types + float_types
+)
+def numeric_types_as_str(request):
+    """
+    - "int8", "int16", "int32", "int64"
+    - "uint8", "uint16", "uint32", "uint64"
+    - "float32", "float64"
+    """
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        "min",
+        "max",
+        "sum",
+        "product",
+        "quantile",
+        "all",
+        "any",
+        "std",
+        "var",
+        "median",
+        "kurtosis",
+        "skew",
+    ]
+)
+def reduction_methods(request):
+    return request.param

--- a/python/cudf/cudf/tests/series/test_apply.py
+++ b/python/cudf/cudf/tests/series/test_apply.py
@@ -1,18 +1,16 @@
-# Copyright (c) 2018-2025, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 
 
 import numpy as np
 import pytest
 
 from cudf import Series
-from cudf.testing._utils import NUMERIC_TYPES
 
 
 def _generic_function(a):
     return a**3
 
 
-@pytest.mark.parametrize("dtype", NUMERIC_TYPES)
 @pytest.mark.parametrize(
     "udf,testfunc",
     [
@@ -20,10 +18,10 @@ def _generic_function(a):
         (lambda x: x in [1, 2, 3, 4], lambda ser: np.isin(ser, [1, 2, 3, 4])),
     ],
 )
-def test_apply_python_lambda(dtype, udf, testfunc):
-    size = 500
+def test_apply_python_lambda(numeric_types_as_str, udf, testfunc):
+    size = 50
     rng = np.random.default_rng(seed=0)
-    lhs_arr = rng.random(size).astype(dtype)
+    lhs_arr = rng.random(size).astype(numeric_types_as_str)
     lhs_ser = Series(lhs_arr)
 
     out_ser = lhs_ser.apply(udf)

--- a/python/cudf/cudf/tests/series/test_reductions.py
+++ b/python/cudf/cudf/tests/series/test_reductions.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from cudf import Series
+
+
+@pytest.mark.parametrize("data", [[], [1, 2, 3]])
+def test_series_pandas_methods(data, reduction_methods):
+    arr = np.array(data)
+    sr = Series(arr)
+    psr = pd.Series(arr)
+    np.testing.assert_equal(
+        getattr(sr, reduction_methods)(), getattr(psr, reduction_methods)()
+    )

--- a/python/cudf/cudf/tests/series/test_unary.py
+++ b/python/cudf/cudf/tests/series/test_unary.py
@@ -3,26 +3,21 @@
 from decimal import Decimal
 
 import numpy as np
-import pandas as pd
-import pytest
 
 from cudf import Series
-from cudf.testing import _utils as utils, assert_eq
+from cudf.testing import assert_eq
 
 
-@pytest.mark.parametrize("dtype", utils.NUMERIC_TYPES)
-def test_series_abs(dtype):
+def test_series_abs(numeric_types_as_str):
     rng = np.random.default_rng(seed=0)
-    arr = (rng.random(1000) * 100).astype(dtype)
+    arr = (rng.random(100) * 100).astype(numeric_types_as_str)
     sr = Series(arr)
     np.testing.assert_equal(sr.abs().to_numpy(), np.abs(arr))
     np.testing.assert_equal(abs(sr).to_numpy(), abs(arr))
 
 
-@pytest.mark.parametrize("dtype", utils.INTEGER_TYPES)
-def test_series_invert(dtype):
-    rng = np.random.default_rng(seed=0)
-    arr = (rng.random(1000) * 100).astype(dtype)
+def test_series_invert(integer_types_as_str):
+    arr = np.array([0, 1, 2], dtype=integer_types_as_str)
     sr = Series(arr)
     np.testing.assert_equal((~sr).to_numpy(), np.invert(arr))
     np.testing.assert_equal((~sr).to_numpy(), ~arr)
@@ -33,23 +28,6 @@ def test_series_neg():
     arr = rng.random(100) * 100
     sr = Series(arr)
     np.testing.assert_equal((-sr).to_numpy(), -arr)
-
-
-@pytest.mark.parametrize("mth", ["min", "max", "sum", "product"])
-def test_series_pandas_methods(mth):
-    rng = np.random.default_rng(seed=0)
-    arr = (1 + rng.random(5) * 100).astype(np.int64)
-    sr = Series(arr)
-    psr = pd.Series(arr)
-    np.testing.assert_equal(getattr(sr, mth)(), getattr(psr, mth)())
-
-
-@pytest.mark.parametrize("mth", ["min", "max", "sum", "product", "quantile"])
-def test_series_pandas_methods_empty(mth):
-    arr = np.array([])
-    sr = Series(arr)
-    psr = pd.Series(arr)
-    np.testing.assert_equal(getattr(sr, mth)(), getattr(psr, mth)())
 
 
 def test_series_bool_neg():


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/9999

* Adding more shared fixtures in `conftest.py` where applicable
* Further simplify tests

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
