### PR TITLE
Prefer `Column.astype` over `plc.unary.cast` in the fill null unary function expression

### DIFF
--- a/python/cudf_polars/cudf_polars/containers/datatype.py
+++ b/python/cudf_polars/cudf_polars/containers/datatype.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 
 from functools import cache
 
-from typing_extensions import assert_never
-
 import polars as pl
 
 import pylibcudf as plc
@@ -16,96 +14,100 @@ import pylibcudf as plc
 __all__ = ["DataType"]
 
 
+POLARS_TO_PLC_TYPE = {
+    pl.Boolean: plc.TypeId.BOOL8,
+    pl.Int8: plc.TypeId.INT8,
+    pl.Int16: plc.TypeId.INT16,
+    pl.Int32: plc.TypeId.INT32,
+    pl.Int64: plc.TypeId.INT64,
+    pl.UInt8: plc.TypeId.UINT8,
+    pl.UInt16: plc.TypeId.UINT16,
+    pl.UInt32: plc.TypeId.UINT32,
+    pl.UInt64: plc.TypeId.UINT64,
+    pl.Float32: plc.TypeId.FLOAT32,
+    pl.Float64: plc.TypeId.FLOAT64,
+    pl.Date: plc.TypeId.TIMESTAMP_DAYS,
+    pl.String: plc.TypeId.STRING,
+    pl.Null: plc.TypeId.EMPTY,
+}
+
+PLC_TO_POLARS_TYPE = {v: k for k, v in POLARS_TO_PLC_TYPE.items()}
+
+TIME_UNIT_TO_PLC_DATETIME_TYPE = {
+    "ms": plc.TypeId.TIMESTAMP_MILLISECONDS,
+    "us": plc.TypeId.TIMESTAMP_MICROSECONDS,
+    "ns": plc.TypeId.TIMESTAMP_NANOSECONDS,
+}
+PLC_DATETIME_TYPE_TO_TIME_UNIT = {
+    v: k for k, v in TIME_UNIT_TO_PLC_DATETIME_TYPE.items()
+}
+
+TIME_UNIT_TO_PLC_DURATION_TYPE = {
+    "ms": plc.TypeId.DURATION_MILLISECONDS,
+    "us": plc.TypeId.DURATION_MICROSECONDS,
+    "ns": plc.TypeId.DURATION_NANOSECONDS,
+}
+PLC_DURATION_TYPE_TO_TIME_UNIT = {
+    v: k for k, v in TIME_UNIT_TO_PLC_DURATION_TYPE.items()
+}
+
+
 @cache
 def _from_polars(dtype: pl.DataType) -> plc.DataType:
-    """
-    Convert a polars datatype to a pylibcudf one.
+    if type(dtype) in POLARS_TO_PLC_TYPE:
+        return plc.DataType(POLARS_TO_PLC_TYPE[type(dtype)])
 
-    Parameters
-    ----------
-    dtype
-        Polars dtype to convert
+    if isinstance(dtype, pl.Datetime):
+        return plc.DataType(TIME_UNIT_TO_PLC_DATETIME_TYPE[dtype.time_unit])
 
-    Returns
-    -------
-    Matching pylibcudf DataType object.
+    if isinstance(dtype, pl.Duration):
+        return plc.DataType(TIME_UNIT_TO_PLC_DURATION_TYPE[dtype.time_unit])
 
-    Raises
-    ------
-    NotImplementedError
-        For unsupported conversions.
-    """
-    if isinstance(dtype, pl.Boolean):
-        return plc.DataType(plc.TypeId.BOOL8)
-    elif isinstance(dtype, pl.Int8):
-        return plc.DataType(plc.TypeId.INT8)
-    elif isinstance(dtype, pl.Int16):
-        return plc.DataType(plc.TypeId.INT16)
-    elif isinstance(dtype, pl.Int32):
-        return plc.DataType(plc.TypeId.INT32)
-    elif isinstance(dtype, pl.Int64):
-        return plc.DataType(plc.TypeId.INT64)
-    if isinstance(dtype, pl.UInt8):
-        return plc.DataType(plc.TypeId.UINT8)
-    elif isinstance(dtype, pl.UInt16):
-        return plc.DataType(plc.TypeId.UINT16)
-    elif isinstance(dtype, pl.UInt32):
-        return plc.DataType(plc.TypeId.UINT32)
-    elif isinstance(dtype, pl.UInt64):
-        return plc.DataType(plc.TypeId.UINT64)
-    elif isinstance(dtype, pl.Float32):
-        return plc.DataType(plc.TypeId.FLOAT32)
-    elif isinstance(dtype, pl.Float64):
-        return plc.DataType(plc.TypeId.FLOAT64)
-    elif isinstance(dtype, pl.Date):
-        return plc.DataType(plc.TypeId.TIMESTAMP_DAYS)
-    elif isinstance(dtype, pl.Time):
+    if isinstance(dtype, pl.Time):
         raise NotImplementedError("Time of day dtype not implemented")
-    elif isinstance(dtype, pl.Datetime):
-        if dtype.time_unit == "ms":
-            return plc.DataType(plc.TypeId.TIMESTAMP_MILLISECONDS)
-        elif dtype.time_unit == "us":
-            return plc.DataType(plc.TypeId.TIMESTAMP_MICROSECONDS)
-        elif dtype.time_unit == "ns":
-            return plc.DataType(plc.TypeId.TIMESTAMP_NANOSECONDS)
-        assert dtype.time_unit is not None  # pragma: no cover
-        assert_never(dtype.time_unit)
-    elif isinstance(dtype, pl.Duration):
-        if dtype.time_unit == "ms":
-            return plc.DataType(plc.TypeId.DURATION_MILLISECONDS)
-        elif dtype.time_unit == "us":
-            return plc.DataType(plc.TypeId.DURATION_MICROSECONDS)
-        elif dtype.time_unit == "ns":
-            return plc.DataType(plc.TypeId.DURATION_NANOSECONDS)
-        assert dtype.time_unit is not None  # pragma: no cover
-        assert_never(dtype.time_unit)
-    elif isinstance(dtype, pl.String):
-        return plc.DataType(plc.TypeId.STRING)
-    elif isinstance(dtype, pl.Null):
-        # TODO: Hopefully
-        return plc.DataType(plc.TypeId.EMPTY)
-    elif isinstance(dtype, pl.List):
-        # Recurse to catch unsupported inner types
+
+    if isinstance(dtype, pl.List):
         _ = _from_polars(dtype.inner)
         return plc.DataType(plc.TypeId.LIST)
-    elif isinstance(dtype, pl.Struct):
-        # Recurse to catch unsupported field types
+
+    if isinstance(dtype, pl.Struct):
         for field in dtype.fields:
             _ = _from_polars(field.dtype)
         return plc.DataType(plc.TypeId.STRUCT)
-    else:
-        raise NotImplementedError(f"{dtype=} conversion not supported")
+
+    raise NotImplementedError(f"{dtype=} conversion not supported")
+
+
+@cache
+def _to_polars(dtype: plc.DataType) -> pl.DataType:
+    type_id = dtype.id()
+
+    if type_id in PLC_TO_POLARS_TYPE:
+        return PLC_TO_POLARS_TYPE[type_id]()
+
+    if type_id in PLC_DATETIME_TYPE_TO_TIME_UNIT:
+        return pl.Datetime(PLC_DATETIME_TYPE_TO_TIME_UNIT[type_id])
+
+    if type_id in PLC_DURATION_TYPE_TO_TIME_UNIT:
+        return pl.Duration(PLC_DURATION_TYPE_TO_TIME_UNIT[type_id])
+
+    # TODO: STRUCT and LIST support
+    raise NotImplementedError(f"{dtype=} conversion not supported")
 
 
 class DataType:
     """A datatype, preserving polars metadata."""
 
-    polars: pl.datatypes.DataType
+    polars: pl.DataType | pl.Field
     plc: plc.DataType
 
-    def __init__(self, polars_dtype: pl.DataType) -> None:
-        self.polars = polars_dtype
-        self.plc = _from_polars(polars_dtype)
+    def __init__(self, dtype: pl.Field | pl.DataType | plc.DataType) -> None:
+        if isinstance(dtype, (pl.DataType, pl.Field)):
+            self.polars = dtype
+            self.plc = _from_polars(dtype)
+        elif isinstance(dtype, plc.DataType):
+            self.polars = _to_polars(dtype)
+            self.plc = dtype
 
     def id(self) -> plc.TypeId:
         """The pylibcudf.TypeId of this DataType."""

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
@@ -62,7 +62,8 @@ class PDSDSQueriesMeta(type):
         if valid_query(name):
             q_num = int(name[1:])
             module: ModuleType = importlib.import_module(
-                f"cudf_polars.experimental.benchmarks.pdsds_queries.q{q_num}"
+                # f"cudf_polars.experimental.benchmarks.pdsds_queries.q{q_num}"
+                f"cudf_polars.experimental.benchmarks.pdsds_queries_no_decimals.q{q_num}"
             )
             return getattr(module, cls.q_impl)
         raise AttributeError(f"{name} is not a valid query name")
@@ -166,12 +167,12 @@ def run_validate(options: Sequence[str] | None = None) -> None:
         if run_config.executor == "cpu":
             test_result = polars_query.collect(new_streaming=True)
         else:
-            try:
-                test_result = polars_query.collect(engine=engine)
-            except Exception as e:
-                failures.append(q_id)
-                print(f"❌ Query {q_id} failed validation: GPU execution failed.\n{e}")
-                continue
+            # try:
+            test_result = polars_query.collect(engine=engine)
+            # except Exception as e:
+            #     failures.append(q_id)
+            #     print(f"❌ Query {q_id} failed validation: GPU execution failed.\n{e}")
+            #     continue
 
         try:
             assert_frame_equal(

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
@@ -62,8 +62,7 @@ class PDSDSQueriesMeta(type):
         if valid_query(name):
             q_num = int(name[1:])
             module: ModuleType = importlib.import_module(
-                # f"cudf_polars.experimental.benchmarks.pdsds_queries.q{q_num}"
-                f"cudf_polars.experimental.benchmarks.pdsds_queries_no_decimals.q{q_num}"
+                f"cudf_polars.experimental.benchmarks.pdsds_queries.q{q_num}"
             )
             return getattr(module, cls.q_impl)
         raise AttributeError(f"{name} is not a valid query name")
@@ -167,12 +166,12 @@ def run_validate(options: Sequence[str] | None = None) -> None:
         if run_config.executor == "cpu":
             test_result = polars_query.collect(new_streaming=True)
         else:
-            # try:
-            test_result = polars_query.collect(engine=engine)
-            # except Exception as e:
-            #     failures.append(q_id)
-            #     print(f"❌ Query {q_id} failed validation: GPU execution failed.\n{e}")
-            #     continue
+            try:
+                test_result = polars_query.collect(engine=engine)
+            except Exception as e:
+                failures.append(q_id)
+                print(f"❌ Query {q_id} failed validation: GPU execution failed.\n{e}")
+                continue
 
         try:
             assert_frame_equal(

--- a/python/cudf_polars/cudf_polars/utils/dtypes.py
+++ b/python/cudf_polars/cudf_polars/utils/dtypes.py
@@ -21,18 +21,20 @@ __all__ = [
 
 def can_cast(from_: plc.DataType, to: plc.DataType) -> bool:
     """
-    Can we cast (via :func:`~.pylibcudf.unary.cast`) between two datatypes.
+    Determine whether a cast between two datatypes is supported by cudf-polars.
 
     Parameters
     ----------
-    from_
+    from_ : pylibcudf.DataType
         Source datatype
-    to
+
+    to : pylibcudf.DataType
         Target datatype
 
     Returns
     -------
-    True if casting is supported, False otherwise
+    bool
+        True if the cast is supported, False otherwise.
     """
     to_is_empty = to.id() == plc.TypeId.EMPTY
     from_is_empty = from_.id() == plc.TypeId.EMPTY

--- a/python/cudf_polars/tests/test_drop_nulls.py
+++ b/python/cudf_polars/tests/test_drop_nulls.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
@@ -43,6 +43,11 @@ def test_drop_null(null_data):
 )
 def test_fill_null(null_data, value):
     q = null_data.select(pl.col("a").fill_null(value))
+    assert_gpu_result_equal(q)
+
+
+def test_fill_null_with_string():
+    q = pl.LazyFrame({"a": [None, "a"]}).select(pl.col("a").fill_null("b"))
     assert_gpu_result_equal(q)
 
 

--- a/python/cudf_polars/tests/utils/test_dtypes.py
+++ b/python/cudf_polars/tests/utils/test_dtypes.py
@@ -45,6 +45,55 @@ def test_unhandled_dtype_conversion_raises(pltype):
         _ = DataType(pltype)
 
 
+@pytest.mark.parametrize(
+    "plc_dtype, polars_dtype",
+    [
+        (plc.DataType(plc.TypeId.BOOL8), pl.Boolean()),
+        (plc.DataType(plc.TypeId.INT8), pl.Int8()),
+        (plc.DataType(plc.TypeId.INT16), pl.Int16()),
+        (plc.DataType(plc.TypeId.INT32), pl.Int32()),
+        (plc.DataType(plc.TypeId.INT64), pl.Int64()),
+        (plc.DataType(plc.TypeId.UINT8), pl.UInt8()),
+        (plc.DataType(plc.TypeId.UINT16), pl.UInt16()),
+        (plc.DataType(plc.TypeId.UINT32), pl.UInt32()),
+        (plc.DataType(plc.TypeId.UINT64), pl.UInt64()),
+        (plc.DataType(plc.TypeId.FLOAT32), pl.Float32()),
+        (plc.DataType(plc.TypeId.FLOAT64), pl.Float64()),
+        (plc.DataType(plc.TypeId.TIMESTAMP_DAYS), pl.Date()),
+        (plc.DataType(plc.TypeId.EMPTY), pl.Null()),
+        (plc.DataType(plc.TypeId.STRING), pl.String()),
+        (plc.DataType(plc.TypeId.TIMESTAMP_MILLISECONDS), pl.Datetime("ms")),
+        (plc.DataType(plc.TypeId.TIMESTAMP_MICROSECONDS), pl.Datetime("us")),
+        (plc.DataType(plc.TypeId.TIMESTAMP_NANOSECONDS), pl.Datetime("ns")),
+        (plc.DataType(plc.TypeId.DURATION_MILLISECONDS), pl.Duration("ms")),
+        (plc.DataType(plc.TypeId.DURATION_MICROSECONDS), pl.Duration("us")),
+        (plc.DataType(plc.TypeId.DURATION_NANOSECONDS), pl.Duration("ns")),
+    ],
+    ids=lambda d: f"{d!r}",
+)
+def test_plc_to_polars_dtype(plc_dtype, polars_dtype):
+    dtype = DataType(plc_dtype)
+    assert dtype.polars == polars_dtype
+    assert dtype.plc == plc_dtype
+
+
+@pytest.mark.parametrize(
+    "plc_dtype",
+    [
+        plc.DataType(plc.TypeId.LIST),
+        plc.DataType(plc.TypeId.STRUCT),
+        plc.DataType(plc.TypeId.DICTIONARY32),
+        plc.DataType(plc.TypeId.DECIMAL32),
+        plc.DataType(plc.TypeId.DECIMAL64),
+        plc.DataType(plc.TypeId.DECIMAL128),
+    ],
+    ids=lambda d: f"{d.id().name}",
+)
+def test_unhandled_plc_dtype_conversion_raises(plc_dtype):
+    with pytest.raises(NotImplementedError):
+        _ = DataType(plc_dtype)
+
+
 def test_is_order_preserving_cast():
     assert is_order_preserving_cast(INT8, INT8)  # Same type
     assert is_order_preserving_cast(INT8, INT16)  # Smaller type


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Contributes to https://github.com/rapidsai/cudf/issues/19476 by replacing the direct call to `plc.unary.cast` with `Column.astype` in the `fill_null` unary function expression.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
