### PR TITLE
Upgrade `gcc-toolset` for Java/JNI build to version 14

### DIFF
--- a/.github/workflows/spark-rapids-jni.yaml
+++ b/.github/workflows/spark-rapids-jni.yaml
@@ -19,4 +19,4 @@ jobs:
       - name: "Build spark-rapids-jni"
         run: |
           mkdir target
-          CMAKE_CUDA_ARCHITECTURES=90 LIBCUDF_DEPENDENCY_MODE=latest USE_GDS=on scl enable gcc-toolset-11 build/buildcpp.sh
+          CMAKE_CUDA_ARCHITECTURES=90 LIBCUDF_DEPENDENCY_MODE=latest USE_GDS=on scl enable gcc-toolset-14 build/buildcpp.sh

--- a/java/ci/Dockerfile.rocky
+++ b/java/ci/Dockerfile.rocky
@@ -26,7 +26,7 @@ ARG TARGETPLATFORM=linux/amd64
 # multi-platform build with: docker buildx build --platform linux/arm64,linux/amd64 <ARGS> on either amd64 or arm64 host
 # check available official arm-based docker images at https://hub.docker.com/r/nvidia/cuda/tags (OS/ARCH)
 FROM --platform=$TARGETPLATFORM nvidia/cuda:$CUDA_VERSION-devel-rockylinux$OS_RELEASE
-ARG TOOLSET_VERSION=11
+ARG TOOLSET_VERSION=14
 ### Install basic requirements
 RUN dnf --enablerepo=powertools install -y  scl-utils gcc-toolset-${TOOLSET_VERSION} git zlib-devel maven tar wget patch ninja-build boost-devel
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -42,7 +42,7 @@ git clone --recursive https://github.com/rapidsai/cudf.git -b branch-25.10
 ```bash
 cd cudf
 export WORKSPACE=`pwd`
-scl enable gcc-toolset-11 "java/ci/build-in-docker.sh"
+scl enable gcc-toolset-14 "java/ci/build-in-docker.sh"
 ```
 
 ### The output


### PR DESCRIPTION
As RAPIDS is moving to gcc-14, we should upgrade the rest of the build system (Java/JNI) to match it.

This only changes in the build and test for Java/JNI, no implementation change is needed.

Build for `spark-rapids-jni` will not pass until https://github.com/NVIDIA/spark-rapids-jni/pull/3568 is merged.