### PR TITLE
Clean testing/_utils.py

### DIFF
--- a/python/cudf/cudf/testing/_utils.py
+++ b/python/cudf/cudf/testing/_utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import itertools
 import string
-import time
 from collections import abc
 from contextlib import contextmanager
 from decimal import Decimal
@@ -12,23 +11,11 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 import pytest
-from numba.core.typing import signature as nb_signature
-from numba.core.typing.templates import AbstractTemplate
-from numba.cuda.cudadecl import registry as cuda_decl_registry
-from numba.cuda.cudaimpl import lower as cuda_lower
 
 import pylibcudf as plc
 
 import cudf
 from cudf.core.column.column import as_column
-from cudf.core.udf.strings_lowering import (
-    cast_string_view_to_managed_udf_string,
-)
-from cudf.core.udf.strings_typing import (
-    StringView,
-    managed_udf_string,
-    string_view,
-)
 from cudf.utils import dtypes as dtypeutils
 from cudf.utils.temporal import unit_to_nanoseconds_conversion
 
@@ -291,11 +278,6 @@ def _decimal_series(input, dtype):
     )
 
 
-@contextmanager
-def does_not_raise():
-    yield
-
-
 def assert_column_memory_eq(lhs: ColumnBase, rhs: ColumnBase):
     """Assert the memory location and size of `lhs` and `rhs` are equivalent.
 
@@ -391,57 +373,3 @@ def expect_warning_if(condition, warning=FutureWarning, *args, **kwargs):
             yield
     else:
         yield
-
-
-def sv_to_managed_udf_str(sv):
-    """
-    Cast a string_view object to a managed_udf_string object
-
-    This placeholder function never runs in python
-    It exists only for numba to have something to replace
-    with the typing and lowering code below
-
-    This is similar conceptually to needing a translation
-    engine to emit an expression in target language "B" when
-    there is no equivalent in the source language "A" to
-    translate from. This function effectively defines the
-    expression in language "A" and the associated typing
-    and lowering describe the translation process, despite
-    the expression having no meaning in language "A"
-    """
-    pass
-
-
-@cuda_decl_registry.register_global(sv_to_managed_udf_str)
-class StringViewToUDFStringDecl(AbstractTemplate):
-    def generic(self, args, kws):
-        if isinstance(args[0], StringView) and len(args) == 1:
-            return nb_signature(managed_udf_string, string_view)
-
-
-@cuda_lower(sv_to_managed_udf_str, string_view)
-def sv_to_udf_str_testing_lowering(context, builder, sig, args):
-    return cast_string_view_to_managed_udf_string(
-        context, builder, sig.args[0], sig.return_type, args[0]
-    )
-
-
-class cudf_timeout:
-    """
-    Context manager to raise a TimeoutError after a specified number of seconds.
-    """
-
-    def __init__(self, timeout):
-        self.timeout = timeout
-
-    def __enter__(self):
-        self.start_time = time.perf_counter()
-
-    def __exit__(self, *args):
-        elapsed_time = (
-            time.perf_counter() - self.start_time
-        )  # Calculate elapsed time
-        if elapsed_time >= self.timeout:
-            raise TimeoutError(
-                f"Expected to finish in {self.timeout=} seconds but took {elapsed_time=} seconds"
-            )

--- a/python/cudf/cudf/tests/test_cuda_array_interface.py
+++ b/python/cudf/cudf/tests/test_cuda_array_interface.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019-2025, NVIDIA CORPORATION.
 
 import types
-from contextlib import ExitStack as does_not_raise
+from contextlib import nullcontext as does_not_raise
 
 import cupy
 import numba.cuda

--- a/python/cudf/cudf/tests/test_dataframe.py
+++ b/python/cudf/cudf/tests/test_dataframe.py
@@ -13,7 +13,7 @@ import string
 import textwrap
 import warnings
 from collections import OrderedDict, defaultdict, namedtuple
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext as does_not_raise
 from copy import copy
 
 import cupy
@@ -40,7 +40,6 @@ from cudf.testing._utils import (
     DATETIME_TYPES,
     NUMERIC_TYPES,
     assert_exceptions_equal,
-    does_not_raise,
     expect_warning_if,
     gen_rand,
 )

--- a/python/cudf/cudf/tests/test_dlpack.py
+++ b/python/cudf/cudf/tests/test_dlpack.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019-2025, NVIDIA CORPORATION.
 
 import itertools
-from contextlib import ExitStack as does_not_raise
+from contextlib import nullcontext as does_not_raise
 
 import cupy
 import numpy as np

--- a/python/cudf/cudf/tests/test_udf_masked_ops.py
+++ b/python/cudf/cudf/tests/test_udf_masked_ops.py
@@ -5,6 +5,10 @@ import operator
 import numpy as np
 import pytest
 from numba import cuda
+from numba.core.typing import signature as nb_signature
+from numba.core.typing.templates import AbstractTemplate
+from numba.cuda.cudadecl import registry as cuda_decl_registry
+from numba.cuda.cudaimpl import lower as cuda_lower
 
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
@@ -16,13 +20,53 @@ from cudf.core.udf._ops import (
     unary_ops,
 )
 from cudf.core.udf.api import Masked
+from cudf.core.udf.strings_lowering import (
+    cast_string_view_to_managed_udf_string,
+)
+from cudf.core.udf.strings_typing import (
+    StringView,
+    managed_udf_string,
+    string_view,
+)
 from cudf.core.udf.utils import precompiled
 from cudf.testing import assert_eq
 from cudf.testing._utils import (
     _decimal_series,
     parametrize_numeric_dtypes_pairwise,
-    sv_to_managed_udf_str,
 )
+
+
+def sv_to_managed_udf_str(sv):
+    """
+    Cast a string_view object to a managed_udf_string object
+
+    This placeholder function never runs in python
+    It exists only for numba to have something to replace
+    with the typing and lowering code below
+
+    This is similar conceptually to needing a translation
+    engine to emit an expression in target language "B" when
+    there is no equivalent in the source language "A" to
+    translate from. This function effectively defines the
+    expression in language "A" and the associated typing
+    and lowering describe the translation process, despite
+    the expression having no meaning in language "A"
+    """
+    pass
+
+
+@cuda_decl_registry.register_global(sv_to_managed_udf_str)
+class StringViewToUDFStringDecl(AbstractTemplate):
+    def generic(self, args, kws):
+        if isinstance(args[0], StringView) and len(args) == 1:
+            return nb_signature(managed_udf_string, string_view)
+
+
+@cuda_lower(sv_to_managed_udf_str, string_view)
+def sv_to_udf_str_testing_lowering(context, builder, sig, args):
+    return cast_string_view_to_managed_udf_string(
+        context, builder, sig.args[0], sig.return_type, args[0]
+    )
 
 
 @pytest.fixture(scope="module")

--- a/python/cudf/cudf_pandas_tests/test_disable_pandas_accelerator.py
+++ b/python/cudf/cudf_pandas_tests/test_disable_pandas_accelerator.py
@@ -2,30 +2,26 @@
 
 import os
 import subprocess
+import sys
 
 import pytest
-
-from cudf.testing import _utils as utils
 
 
 @pytest.mark.flaky(reruns=3, reruns_delay=30)
 def test_disable_pandas_accelerator_multi_threaded():
     data_directory = os.path.dirname(os.path.abspath(__file__))
-    # Create a copy of the current environment variables
-    env = os.environ.copy()
 
-    with utils.cudf_timeout(20):
-        sp_completed = subprocess.run(
-            [
-                "python",
-                "-m",
-                "cudf.pandas",
-                data_directory + "/data/disable_cudf_pandas_multi_thread.py",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-        )
+    sp_completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "cudf.pandas",
+            data_directory + "/data/disable_cudf_pandas_multi_thread.py",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
     assert sp_completed.returncode == 0
     output = sp_completed.stdout
 

--- a/python/dask_cudf/dask_cudf/tests/test_accessor.py
+++ b/python/dask_cudf/dask_cudf/tests/test_accessor.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2019-2025, NVIDIA CORPORATION.
 
+from contextlib import nullcontext as does_not_raise
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -10,7 +12,6 @@ from dask import dataframe as dd
 
 from cudf import DataFrame, Series, date_range
 from cudf.testing import assert_eq
-from cudf.testing._utils import does_not_raise
 
 import dask_cudf
 


### PR DESCRIPTION
## Description
Working to have less places where we define "testing utilities" e.g. `conftest.py` vs `testing/*.py`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
