### PR TITLE
Don't run serial cudf_pandas tests when testing multiple pandas versions

### DIFF
--- a/ci/cudf_pandas_scripts/run_tests.sh
+++ b/ci/cudf_pandas_scripts/run_tests.sh
@@ -116,7 +116,6 @@ python -m pytest -p cudf.pandas \
 # More details: https://github.com/rapidsai/cudf/pull/16930#issuecomment-2707873968
 python -m pytest -p cudf.pandas \
     --ignore=./python/cudf/cudf_pandas_tests/third_party_integration_tests/ \
-    --numprocesses=1 \
     -k "profiler" \
     ./python/cudf/cudf_pandas_tests/
 
@@ -133,6 +132,7 @@ for version in "${versions[@]}"; do
         --numprocesses=8 \
         --dist=worksteal \
         -k "not profiler" \
+        -m "not serial" \
         --cov-config=./python/cudf/.coveragerc \
         --cov=cudf \
         --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cudf-pandas-coverage.xml" \
@@ -141,7 +141,6 @@ for version in "${versions[@]}"; do
 
     python -m pytest -p cudf.pandas \
         --ignore=./python/cudf/cudf_pandas_tests/third_party_integration_tests/ \
-        --numprocesses=1 \
         -k "profiler" \
         ./python/cudf/cudf_pandas_tests/
 done


### PR DESCRIPTION
## Description
`test_rmm_option_on_import`, which was marked as `serial` (https://github.com/rapidsai/cudf/pull/19345), appears to still flakily fail e.g. https://github.com/rapidsai/cudf/actions/runs/16531500545/job/46759205034?pr=19506.

It appears when testing `cudf_pandas` tests with different versions, we also need to add `-m "not serial"`

Additionally, removed an unnecessary `--numprocesses=1` when wanting to invoke tests with 1 process i.e. just avoid using `pytest-xdist` entirely

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
