### PR TITLE
Derive and use page mask at subpass level for chunked reads

### DIFF
--- a/cpp/src/io/parquet/experimental/hybrid_scan_chunking.cu
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_chunking.cu
@@ -50,6 +50,9 @@ void hybrid_scan_reader_impl::handle_chunking(
   if (!_pass_itm_data) {
     // setup the next pass
     setup_next_pass(std::move(column_chunk_buffers), options);
+
+    // Must be called as soon as we create the pass
+    set_pass_page_mask(data_page_mask);
   }
 
   auto& pass = *_pass_itm_data;
@@ -80,9 +83,6 @@ void hybrid_scan_reader_impl::handle_chunking(
       setup_next_pass(std::move(column_chunk_buffers), options);
     }
   }
-
-  // Must be called before `setup_next_subpass()` to select pages to decompress
-  set_page_mask(data_page_mask);
 
   // setup the next sub pass
   setup_next_subpass(read_mode::READ_ALL);

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
@@ -486,7 +486,9 @@ void hybrid_scan_reader_impl::reset_internal_state()
   _file_preprocessed = false;
   _has_page_index    = false;
   _pass_itm_data.reset();
-  _page_mask.clear();
+  _pass_page_mask.clear();
+  _subpass_page_mask.clear();
+  _subpass_page_mask.clear();
   _output_metadata.reset();
   _options.timestamp_type = cudf::data_type{};
   _options.num_rows       = std::nullopt;
@@ -683,17 +685,18 @@ table_with_metadata hybrid_scan_reader_impl::finalize_output(
   }
 }
 
-void hybrid_scan_reader_impl::set_page_mask(cudf::host_span<std::vector<bool> const> data_page_mask)
+void hybrid_scan_reader_impl::set_pass_page_mask(
+  cudf::host_span<std::vector<bool> const> data_page_mask)
 {
   auto const& pass   = _pass_itm_data;
   auto const& chunks = pass->chunks;
 
-  _page_mask             = cudf::detail::make_empty_host_vector<bool>(pass->pages.size(), _stream);
+  _pass_page_mask        = cudf::detail::make_empty_host_vector<bool>(pass->pages.size(), _stream);
   auto const num_columns = _input_columns.size();
 
   // Handle the empty page mask case
   if (data_page_mask.empty()) {
-    std::fill(_page_mask.begin(), _page_mask.end(), true);
+    std::fill(_pass_page_mask.begin(), _pass_page_mask.end(), true);
     return;
   }
 
@@ -701,23 +704,38 @@ void hybrid_scan_reader_impl::set_page_mask(cudf::host_span<std::vector<bool> co
     thrust::counting_iterator<size_t>(0),
     thrust::counting_iterator(_input_columns.size()),
     [&](auto col_idx) {
-      auto const& col_page_mask = data_page_mask[col_idx];
-      size_t num_inserted_pages = 0;
+      auto const& col_page_mask      = data_page_mask[col_idx];
+      size_t num_inserted_data_pages = 0;
 
       for (size_t chunk_idx = col_idx; chunk_idx < chunks.size(); chunk_idx += num_columns) {
-        if (chunks[chunk_idx].num_dict_pages > 0) { _page_mask.push_back(true); }
-        // Sanitize the column's page mask and insert
-        CUDF_EXPECTS(col_page_mask.size() >= num_inserted_pages + chunks[chunk_idx].num_data_pages,
-                     "Encountered invalid data page mask size");
-        _page_mask.insert(
-          _page_mask.end(),
-          col_page_mask.begin() + num_inserted_pages,
-          col_page_mask.begin() + num_inserted_pages + chunks[chunk_idx].num_data_pages);
-        num_inserted_pages += chunks[chunk_idx].num_data_pages;
+        // Insert a true value for each dictionary page
+        if (chunks[chunk_idx].num_dict_pages > 0) { _pass_page_mask.push_back(true); }
+
+        // Number of data pages in this column chunk
+        auto const num_data_pages_this_col_chunk = chunks[chunk_idx].num_data_pages;
+
+        // Make sure we have enough page mask for this column chunk
+        CUDF_EXPECTS(
+          col_page_mask.size() >= num_inserted_data_pages + num_data_pages_this_col_chunk,
+          "Encountered invalid data page mask size");
+
+        // Insert page mask for this column chunk
+        _pass_page_mask.insert(
+          _pass_page_mask.end(),
+          col_page_mask.begin() + num_inserted_data_pages,
+          col_page_mask.begin() + num_inserted_data_pages + num_data_pages_this_col_chunk);
+
+        // Update the number of inserted data pages
+        num_inserted_data_pages += num_data_pages_this_col_chunk;
       }
-      CUDF_EXPECTS(num_inserted_pages == col_page_mask.size(),
+      // Make sure we inserted exactly the number of data pages for this column
+      CUDF_EXPECTS(num_inserted_data_pages == col_page_mask.size(),
                    "Encountered mismatch in number of data pages and page mask size");
     });
+
+  // Make sure we inserted exactly the number of pages for this pass
+  CUDF_EXPECTS(_pass_page_mask.size() == pass->pages.size(),
+               "Encountered mismatch in number of pass pages and page mask size");
 }
 
 }  // namespace cudf::io::parquet::experimental::detail

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
@@ -217,11 +217,11 @@ class hybrid_scan_reader_impl : public parquet::detail::reader_impl {
                           rmm::cuda_stream_view stream);
 
   /**
-   * @brief Set the mask for pages
+   * @brief Set the page mask for the pass pages
    *
    * @param data_page_mask Input data page mask from page-pruning step
    */
-  void set_page_mask(cudf::host_span<std::vector<bool> const> data_page_mask);
+  void set_pass_page_mask(cudf::host_span<std::vector<bool> const> data_page_mask);
 
   /**
    * @brief Fill a BOOL8 row mask column with the specified value

--- a/cpp/src/io/parquet/reader_impl.hpp
+++ b/cpp/src/io/parquet/reader_impl.hpp
@@ -178,6 +178,11 @@ class reader_impl {
   void setup_next_subpass(read_mode mode);
 
   /**
+   * @brief Copies over the relevant page mask information for the subpass
+   */
+  void set_subpass_page_mask();
+
+  /**
    * @brief Read a chunk of data and return an output table.
    *
    * This function is called internally and expects all preprocessing steps have already been done.
@@ -417,8 +422,11 @@ class reader_impl {
   // _output_buffers associated schema indices
   std::vector<int> _output_column_schemas;
 
-  // Page mask for filtering out data pages
-  cudf::detail::host_vector<bool> _page_mask;
+  // Page mask for filtering out pass data pages
+  cudf::detail::host_vector<bool> _pass_page_mask;
+
+  // Page mask for filtering out subpass data pages
+  cudf::detail::host_vector<bool> _subpass_page_mask;
 
   // _output_buffers associated metadata
   std::unique_ptr<table_metadata> _output_metadata;

--- a/cpp/src/io/parquet/reader_impl_chunking.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking.cu
@@ -23,6 +23,7 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <thrust/gather.h>
 #include <thrust/transform_scan.h>
 
 #include <numeric>
@@ -337,6 +338,9 @@ void reader_impl::setup_next_subpass(read_mode mode)
   std::transform(
     h_spans.begin(), h_spans.end(), subpass.column_page_count.begin(), get_span_size{});
 
+  // Set the page mask information for the pass
+  set_subpass_page_mask();
+
   // decompress the data pages in this subpass; also decompress the dictionary pages in this pass,
   // if this is the first subpass in the pass
   if (pass.has_compressed_data) {
@@ -344,7 +348,7 @@ void reader_impl::setup_next_subpass(read_mode mode)
       decompress_page_data(pass.chunks,
                            is_first_subpass ? pass.pages : host_span<PageInfo>{},
                            subpass.pages,
-                           _page_mask,
+                           _subpass_page_mask,
                            _stream,
                            _mr);
 
@@ -662,6 +666,26 @@ void reader_impl::compute_output_chunks_for_subpass()
   // compute the splits
   subpass.output_chunk_read_info = compute_page_splits_by_row(
     c_info, subpass.pages, subpass.skip_rows, subpass.num_rows, _output_chunk_read_limit, _stream);
+}
+
+void reader_impl::set_subpass_page_mask()
+{
+  auto const& pass    = _pass_itm_data;
+  auto const& subpass = pass->subpass;
+
+  _subpass_page_mask = cudf::detail::make_host_vector<bool>(subpass->pages.size(), _stream);
+
+  if (_pass_page_mask.empty() or subpass->single_subpass) {
+    std::fill(_subpass_page_mask.begin(), _subpass_page_mask.end(), true);
+    return;
+  }
+
+  auto const host_page_src_index = cudf::detail::make_host_vector(subpass->page_src_index, _stream);
+  thrust::gather(thrust::seq,
+                 host_page_src_index.begin(),
+                 host_page_src_index.end(),
+                 _pass_page_mask.begin(),
+                 _subpass_page_mask.begin());
 }
 
 }  // namespace cudf::io::parquet::detail


### PR DESCRIPTION
## Description
This PR implements deriving and using a page mask at subpass level in Parquet reader. This is to enable chunked reading in the next-gen reader.

Note: Chunking is being implemented in the next-gen parquet reader in another PR so there are no tests for this in the current PR but a future PR will test this.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
