### PR TITLE
Fix value counts expression when the column has nulls

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/unary.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/unary.py
@@ -257,9 +257,9 @@ class UnaryFunction(Expr):
                 )
                 for child in self.children
             ]
-            (keys_table, (counts_table,)) = plc.groupby.GroupBy(df.table).aggregate(
-                gb_requests
-            )
+            (keys_table, (counts_table,)) = plc.groupby.GroupBy(
+                df.table, null_handling=plc.types.NullPolicy.INCLUDE
+            ).aggregate(gb_requests)
             if sort:
                 sort_indices = plc.sorting.stable_sorted_order(
                     counts_table,

--- a/python/cudf_polars/tests/expressions/test_struct.py
+++ b/python/cudf_polars/tests/expressions/test_struct.py
@@ -27,8 +27,8 @@ def test_field_getitem(request, ldf):
             reason="not supported until polars 1.31",
         )
     )
-    query = ldf.select(pl.col("a").struct[0])
-    assert_gpu_result_equal(query)
+    q = ldf.select(pl.col("a").struct[0])
+    assert_gpu_result_equal(q)
 
 
 @pytest.mark.parametrize("fields", [("b",), ("b", "d"), ("^b.*|f.*$",)])
@@ -39,8 +39,8 @@ def test_field(request, ldf, fields):
             reason="not supported until polars 1.31",
         )
     )
-    query = ldf.select(pl.col("a").struct.field(*fields))
-    assert_gpu_result_equal(query)
+    q = ldf.select(pl.col("a").struct.field(*fields))
+    assert_gpu_result_equal(q)
 
 
 def test_unnest(request, ldf):
@@ -50,8 +50,8 @@ def test_unnest(request, ldf):
             reason="not supported until polars 1.31",
         )
     )
-    query = ldf.select(pl.col("a").struct.unnest())
-    assert_gpu_result_equal(query)
+    q = ldf.select(pl.col("a").struct.unnest())
+    assert_gpu_result_equal(q)
 
 
 def test_json_encode(request, ldf):
@@ -61,12 +61,12 @@ def test_json_encode(request, ldf):
             reason="not supported until polars 1.31",
         )
     )
-    query = ldf.select(pl.col("a").struct.json_encode())
-    assert_gpu_result_equal(query)
+    q = ldf.select(pl.col("a").struct.json_encode())
+    assert_gpu_result_equal(q)
 
     ldf_newlines = pl.LazyFrame({"a": [{"b": "c\nd", "d": "\r\nz"}]})
-    query = ldf_newlines.select(pl.col("a").struct.json_encode())
-    assert_gpu_result_equal(query)
+    q = ldf_newlines.select(pl.col("a").struct.json_encode())
+    assert_gpu_result_equal(q)
 
 
 def test_rename_fields(request, ldf):
@@ -76,17 +76,15 @@ def test_rename_fields(request, ldf):
             reason="not supported until polars 1.31",
         )
     )
-    query = ldf.select(
-        pl.col("a").struct.rename_fields(["1", "2", "3"]).struct.unnest()
-    )
-    assert_gpu_result_equal(query)
+    q = ldf.select(pl.col("a").struct.rename_fields(["1", "2", "3"]).struct.unnest())
+    assert_gpu_result_equal(q)
 
 
 def test_with_fields(ldf):
-    query = ldf.select(
+    q = ldf.select(
         pl.col("a").struct.with_fields(pl.field("b").str.len_chars()).struct.unnest()
     )
-    assert_ir_translation_raises(query, NotImplementedError)
+    assert_ir_translation_raises(q, NotImplementedError)
 
 
 @pytest.mark.parametrize(
@@ -101,47 +99,51 @@ def test_prefix_suffix_fields(request, ldf, expr):
             reason="not supported until polars 1.31",
         )
     )
-    query = ldf.select(expr("foo").struct.unnest())
-    assert_gpu_result_equal(query)
+    q = ldf.select(expr("foo").struct.unnest())
+    assert_gpu_result_equal(q)
 
 
 def test_map_field_names(ldf):
-    query = ldf.select(pl.col("a").name.map_fields(lambda x: x.upper()).struct.unnest())
-    assert_ir_translation_raises(query, NotImplementedError)
+    q = ldf.select(pl.col("a").name.map_fields(lambda x: x.upper()).struct.unnest())
+    assert_ir_translation_raises(q, NotImplementedError)
 
 
 @pytest.mark.parametrize("name", [None, "my_count"])
 @pytest.mark.parametrize("normalize", [True, False])
 def test_value_counts(ldf, name, normalize):
     # sort=True since order is non-deterministic
-    query = ldf.select(
-        pl.col("a").value_counts(sort=True, name=name, normalize=normalize)
-    )
-    assert_gpu_result_equal(query)
+    q = ldf.select(pl.col("a").value_counts(sort=True, name=name, normalize=normalize))
+    assert_gpu_result_equal(q)
 
 
 def test_value_counts_normalize_div_by_zero():
     ldf = pl.LazyFrame({"a": []}, schema={"a": pl.Int64()})
-    query = ldf.select(pl.col("a").value_counts(normalize=True))
-    assert_gpu_result_equal(query)
+    q = ldf.select(pl.col("a").value_counts(normalize=True))
+    assert_gpu_result_equal(q)
 
 
 def test_groupby_value_counts_notimplemented():
     lgb = pl.LazyFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]}).group_by("a")
     value_counts_expr = pl.col("b").value_counts()
-    query = lgb.agg(value_counts_expr)
-    assert_ir_translation_raises(query, NotImplementedError)
+    q = lgb.agg(value_counts_expr)
+    assert_ir_translation_raises(q, NotImplementedError)
 
-    query = lgb.agg(value_counts_expr.first())
-    assert_ir_translation_raises(query, NotImplementedError)
+    q = lgb.agg(value_counts_expr.first())
+    assert_ir_translation_raises(q, NotImplementedError)
 
 
 def test_struct(ldf):
-    query = ldf.select(pl.struct(pl.all()))
-    assert_gpu_result_equal(query)
+    q = ldf.select(pl.struct(pl.all()))
+    assert_gpu_result_equal(q)
 
 
 def test_nested_struct():
     ldf = pl.LazyFrame({"a": [{"x": {"i": 0, "j": 0}, "y": {"i": 0, "k": 1}}]})
-    query = ldf.select(pl.struct(pl.all()))
-    assert_gpu_result_equal(query)
+    q = ldf.select(pl.struct(pl.all()))
+    assert_gpu_result_equal(q)
+
+
+def test_value_counts_with_nulls(ldf):
+    ldf_with_nulls = ldf.select(c=pl.Series(["x", None, "y", "x", None, "x"]))
+    q = ldf_with_nulls.select(pl.col("c").value_counts(sort=True))
+    assert_gpu_result_equal(q)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Closes #19523. This is really a one-line fix. We need to pass `null_handling=plc.types.NullPolicy.INCLUDE` to `GroupBy` in the value counts expression implementation. This ensures that we group by nulls keys too. PR also replaces `query` with `q` to match convention used in other cudf-polars tests.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
