### PR TITLE
Make nvCOMP ZLIB (de)compression available by default

### DIFF
--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -522,13 +522,7 @@ std::optional<std::string> is_compression_disabled_impl(compression_type compres
                                                         feature_status_parameters params)
 {
   switch (compression) {
-    case compression_type::DEFLATE: {
-      if (not params.are_all_integrations_enabled) {
-        return "DEFLATE compression is experimental, you can enable it through "
-               "`LIBCUDF_NVCOMP_POLICY` environment variable.";
-      }
-      return std::nullopt;
-    }
+    case compression_type::DEFLATE: 
     case compression_type::LZ4:
     case compression_type::SNAPPY:
     case compression_type::ZSTD:
@@ -544,7 +538,6 @@ std::optional<std::string> is_decompression_disabled_impl(compression_type compr
                                                           feature_status_parameters params)
 {
   switch (compression) {
-    case compression_type::DEFLATE:
     case compression_type::GZIP: {
       if (not params.are_all_integrations_enabled) {
         return "DEFLATE decompression is experimental, you can enable it through "
@@ -552,6 +545,7 @@ std::optional<std::string> is_decompression_disabled_impl(compression_type compr
       }
       return std::nullopt;
     }
+    case compression_type::DEFLATE:
     case compression_type::LZ4:
     case compression_type::SNAPPY:
     case compression_type::ZSTD: {

--- a/cpp/tests/io/comp/comp_test.cpp
+++ b/cpp/tests/io/comp/comp_test.cpp
@@ -340,8 +340,9 @@ TEST_F(NvcompConfigTest, Compression)
   auto const& comp_disabled = nvcomp::is_compression_disabled;
 
   EXPECT_FALSE(comp_disabled(compression_type::DEFLATE, {true, true}));
-  // all integrations enabled required
-  EXPECT_TRUE(comp_disabled(compression_type::DEFLATE, {false, true}));
+  EXPECT_FALSE(comp_disabled(compression_type::DEFLATE, {false, true}));
+  // stable integrations enabled required
+  EXPECT_TRUE(comp_disabled(compression_type::DEFLATE, {false, false}));
 
   EXPECT_FALSE(comp_disabled(compression_type::ZSTD, {true, true}));
   EXPECT_FALSE(comp_disabled(compression_type::ZSTD, {false, true}));
@@ -360,8 +361,9 @@ TEST_F(NvcompConfigTest, Decompression)
   auto const& decomp_disabled = nvcomp::is_decompression_disabled;
 
   EXPECT_FALSE(decomp_disabled(compression_type::DEFLATE, {true, true}));
-  // all integrations enabled required
-  EXPECT_TRUE(decomp_disabled(compression_type::DEFLATE, {false, true}));
+  EXPECT_FALSE(decomp_disabled(compression_type::DEFLATE, {false, true}));
+  // stable integrations enabled required
+  EXPECT_TRUE(decomp_disabled(compression_type::DEFLATE, {false, false}));
 
   EXPECT_FALSE(decomp_disabled(compression_type::ZSTD, {true, true}));
   EXPECT_FALSE(decomp_disabled(compression_type::ZSTD, {false, true}));


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
