### PR TITLE
Fix clang-tools version pinning

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -12,7 +12,6 @@ dependencies:
 - c-compiler
 - cachetools
 - certifi
-- clang-tools=20.1.4
 - clang-tools==20.1.4
 - clang==20.1.4
 - cmake>=3.30.4

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -12,7 +12,6 @@ dependencies:
 - c-compiler
 - cachetools
 - certifi
-- clang-tools=20.1.4
 - clang-tools==20.1.4
 - clang==20.1.4
 - cmake>=3.30.4

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -563,7 +563,7 @@ dependencies:
       - output_types: conda
         packages:
           - clang==20.1.4
-          - clang-tools=20.1.4
+          - clang-tools==20.1.4
   clang_tidy:
     common:
       - output_types: conda


### PR DESCRIPTION
## Description

We specify this in two places, use the exact pin rather than fuzzy pin in both.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
