### PR TITLE
[WIP] RapidsMPF "single" shuffle integration

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -263,10 +263,15 @@ def _(
     # Try using rapidsmpf shuffler if we have "simple" shuffle
     # keys, and the "shuffle_method" config is set to "rapidsmpf"
     _keys: list[Col]
-    if shuffle_method == "rapidsmpf" and len(
+    if shuffle_method in ("rapidsmpf", "rapidsmpf-single") and len(
         _keys := [ne.value for ne in ir.keys if isinstance(ne.value, Col)]
     ) == len(ir.keys):  # pragma: no cover
-        from rapidsmpf.integrations.dask import rapidsmpf_shuffle_graph
+        if shuffle_method == "rapidsmpf-single":
+            from rapidsmpf.integrations.single import (
+                single_rapidsmpf_shuffle_graph as rapidsmpf_shuffle_graph,
+            )
+        else:
+            from rapidsmpf.integrations.dask import rapidsmpf_shuffle_graph
 
         shuffle_on = [k.name for k in _keys]
 

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -82,8 +82,17 @@ def get_total_device_memory() -> int | None:
 
 
 @functools.cache
-def rapidsmpf_available() -> bool:  # pragma: no cover
-    """Query whether rapidsmpf is available as a shuffle method."""
+def rapidsmpf_single_available() -> bool:  # pragma: no cover
+    """Query whether rapidsmpf is available as a single-process shuffle method."""
+    try:
+        return importlib.util.find_spec("rapidsmpf.integrations.single") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+@functools.cache
+def rapidsmpf_distributed_available() -> bool:  # pragma: no cover
+    """Query whether rapidsmpf is available as a distributed shuffle method."""
     try:
         return importlib.util.find_spec("rapidsmpf.integrations.dask") is not None
     except (ImportError, ValueError):
@@ -129,15 +138,21 @@ class ShuffleMethod(str, enum.Enum):
     The method to use for shuffling data between workers with the streaming executor.
 
     * ``ShuffleMethod.TASKS`` : Use the task-based shuffler.
-    * ``ShuffleMethod.RAPIDSMPF`` : Use the rapidsmpf scheduler.
+    * ``ShuffleMethod.RAPIDSMPF`` : Use the rapidsmpf shuffler.
+    * ``ShuffleMethod._RAPIDSMPF_SINGLE`` : Use the single-process rapidsmpf shuffler.
 
-    With :class:`cudf_polars.utils.config.StreamingExecutor`, the default of ``None`` will attempt to use
-    ``ShuffleMethod.RAPIDSMPF``, but will fall back to ``ShuffleMethod.TASKS``
-    if rapidsmpf is not installed.
+    With :class:`cudf_polars.utils.config.StreamingExecutor`, the default of ``None``
+    will attempt to use ``ShuffleMethod.RAPIDSMPF`` for the distributed scheduler,
+    but will fall back to ``ShuffleMethod.TASKS`` if rapidsmpf is not installed.
+
+    The user should **not** specify ``ShuffleMethod._RAPIDSMPF_SINGLE`` directly.
+    A setting of ``ShuffleMethod.RAPIDSMPF`` will be converted to the single-process
+    shuffler automatically when the 'synchronous' scheduler is active.
     """
 
     TASKS = "tasks"
     RAPIDSMPF = "rapidsmpf"
+    _RAPIDSMPF_SINGLE = "rapidsmpf-single"
 
 
 T = TypeVar("T")
@@ -411,24 +426,32 @@ class StreamingExecutor:
     def __post_init__(self) -> None:  # noqa: D105
         # Handle shuffle_method defaults for streaming executor
         if self.shuffle_method is None:
-            if self.scheduler == "distributed" and rapidsmpf_available():
+            if self.scheduler == "distributed" and rapidsmpf_distributed_available():
                 # For distributed scheduler, prefer rapidsmpf if available
                 object.__setattr__(self, "shuffle_method", "rapidsmpf")
             else:
+                # Otherwise, use task-based shuffle for now.
+                # TODO: Evaluate single-process shuffle by default.
                 object.__setattr__(self, "shuffle_method", "tasks")
-        else:
+        elif self.shuffle_method == "rapidsmpf-single":
+            # The user should NOT specify "rapidsmpf-single" directly.
+            raise ValueError("rapidsmpf-single is not a supported shuffle method.")
+        elif self.shuffle_method == "rapidsmpf":
+            # Check that we have rapidsmpf installed
             if (
                 self.scheduler == "distributed"
-                and self.shuffle_method == "rapidsmpf"
-                and not rapidsmpf_available()
+                and not rapidsmpf_distributed_available()
             ):
                 raise ValueError(
-                    "rapidsmpf shuffle method requested, but rapidsmpf is not installed"
+                    "rapidsmpf shuffle method requested, but rapidsmpf.integrations.dask is not installed."
                 )
-        if self.scheduler == "synchronous" and self.shuffle_method == "rapidsmpf":
-            raise ValueError(
-                "rapidsmpf shuffle method is not supported for synchronous scheduler"
-            )
+            elif self.scheduler == "synchronous" and not rapidsmpf_single_available():
+                raise ValueError(
+                    "rapidsmpf shuffle method requested, but rapidsmpf is not installed."
+                )
+            # Select "rapidsmpf-single" for the synchronous
+            if self.scheduler == "synchronous":
+                object.__setattr__(self, "shuffle_method", "rapidsmpf-single")
 
         # frozen dataclass, so use object.__setattr__
         object.__setattr__(

--- a/python/cudf_polars/tests/experimental/test_rapidsmpf.py
+++ b/python/cudf_polars/tests/experimental/test_rapidsmpf.py
@@ -68,3 +68,39 @@ def test_join_rapidsmpf(
     q = left.join(right, on="y", how="inner")
 
     assert_gpu_result_equal(q, engine=engine, check_row_order=False)
+
+
+@pytest.mark.parametrize("max_rows_per_partition", [1, 5])
+def test_join_rapidsmpf_single(max_rows_per_partition: int) -> None:
+    # check that we have a rapidsmpf cluster running
+    pytest.importorskip("rapidsmpf")
+
+    # Setup the GPUEngine config
+    engine = pl.GPUEngine(
+        raise_on_fail=True,
+        executor="streaming",
+        executor_options={
+            "max_rows_per_partition": max_rows_per_partition,
+            "broadcast_join_limit": 2,
+            "shuffle_method": "rapidsmpf",
+            "scheduler": "synchronous",
+        },
+    )
+
+    left = pl.LazyFrame(
+        {
+            "x": range(15),
+            "y": [1, 2, 3] * 5,
+            "z": [1.0, 2.0, 3.0, 4.0, 5.0] * 3,
+        }
+    )
+    right = pl.LazyFrame(
+        {
+            "xx": range(6),
+            "y": [2, 4, 3] * 2,
+            "zz": [1, 2] * 3,
+        }
+    )
+    q = left.join(right, on="y", how="inner")
+
+    assert_gpu_result_equal(q, engine=engine, check_row_order=False)


### PR DESCRIPTION
## Description
Depends on https://github.com/rapidsai/rapidsmpf/pull/380

Enables the `"rapidsmpf"` shuffle options to work with cudf-polars when the `"synchronous"` scheduler is active.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
