### PR TITLE
Separate row mask and page mask computation and usage

### DIFF
--- a/cpp/include/cudf/io/experimental/hybrid_scan.hpp
+++ b/cpp/include/cudf/io/experimental/hybrid_scan.hpp
@@ -51,6 +51,15 @@ namespace io::parquet::experimental {
  */
 
 /**
+ * @brief Whether to compute and use a page mask using the row mask to skip decompression and
+ * decoding of the masked pages
+ */
+enum class use_data_page_mask : bool {
+  YES = true,  ///< Compute and use a data page mask
+  NO  = false  ///< Do not compute or use a data page mask
+};
+
+/**
  * @brief The experimental parquet reader class to optimally read parquet files subject to
  *        highly selective filters, called a Hybrid Scan operation
  *
@@ -171,15 +180,15 @@ namespace io::parquet::experimental {
  * }
  * @endcode
  *
- * Filter column page pruning (OPTIONAL): Once the row groups are filtered, the next step is to
- * optionally prune the data pages within the current span of row groups subject to the same filter
- * expression using page statistics contained in the page index of the parquet file. To get started,
- * first set up the page index using the `setup_page_index()` function if not previously done and
- * then filter the data pages using the `filter_data_pages_with_stats()` function. This function
- * returns a row mask. i.e. BOOL8 column indicating which rows may survive in the materialized table
- * of filter columns (first reader pass), and a data page mask. i.e. a vector of boolean host
- * vectors indicating which data pages for each filter column need to be processed to materialize
- * the table filter columns (first reader pass).
+ * Build an initial row mask: Once the row groups are filtered, the next step is to build an
+ * initial row mask column to indicate which rows in the current span of row groups will survive in
+ * the read table. This initial row mask may either be a BOOL8 cudf column of size equal to the
+ * total number of rows in the current span of row groups (computed by `total_rows_in_row_groups()`)
+ * containing all `true` values. Alternatively, the row mask may be built with
+ * the `build_row_mask_with_page_index_stats()` function and contain a `true` value for only the
+ * rows that survive the page-level statistics from the page index subject to the same filter as row
+ * groups. Note that this step requires the page index to be set up using the `setup_page_index()`
+ * function.
  * @code{.cpp}
  * // If not already done, get the page index byte range
  * auto page_index_byte_range = reader->page_index_byte_range();
@@ -190,24 +199,28 @@ namespace io::parquet::experimental {
  * // If not already done, Set up the page index now
  * reader->setup_page_index(page_index_bytes);
  *
- * // Optional: Prune filter column data pages using statistics in page index
- * auto [row_mask, data_page_mask] =
- *   reader->filter_data_pages_with_stats(current_row_group_indices, options, stream, mr);
+ * // Build a row mask column containing all `true` values
+ * auto const num_rows = reader->total_rows_in_row_groups(current_row_group_indices);
+ * auto row_mask = cudf::make_numeric_column(
+ *     cudf::data_type{cudf::type_id::BOOL8}, num_rows, rmm::device_buffer{}, 0, stream, mr);
+ *
+ * // Alternatively, build a row mask column indicating only the rows that survive the page-level
+ * statistics in the page index
+ * row_mask = reader->build_row_mask_with_page_index_stats(current_row_group_indices, options,
+ *                                                         stream, mr);
  * @endcode
  *
- * Materialize filter columns: Once we are finished with pruning row groups and filter column data
- * pages, the next step is to materialize filter columns into a table (first reader pass). This is
+ * Materialize filter columns: Once we are done with pruning row groups and constructing the row
+ * mask, the next step is to materialize filter columns into a table (first reader pass). This is
  * done using the `materialize_filter_columns()` function. This function requires a vector of device
- * buffers containing column chunk data for the current list of row groups, and the data page and
- * row masks obtained from the page pruning step. The function returns a table of materialized
- * filter columns and also updates the row mask column to only the valid rows that satisfy the
- * filter expression. If no row group pruning is needed, pass a span of all row group indices from
- * `all_row_groups()` function as the current list of row groups. Similarly, if no page pruning is
- * desired, pass an empty span as data page mask and a mutable view of a BOOL8 column of size equal
- * to total number of rows in the current row groups list (computed by `total_rows_in_row_groups()`)
- * containing all `true` values as row mask. Further, the byte ranges for the required column chunk
- * data may be obtained using the `filter_column_chunks_byte_ranges()` function and read into a
- * corresponding vector of vectors of device buffers.
+ * buffers containing column chunk data for the current list of row groups, and a mutable view of
+ * the current row mask. The function optionally builds a mask for the current data pages using the
+ * input row mask to skip decompression and decoding of the pruned pages based on the
+ * `mask_data_pages` argument. The filter columns are then read into a table and filtered based on
+ * the filter expression and the row mask is updated to only indicate the rows that survive in the
+ * read table. The final table is returned. The byte ranges for the required column chunk data may
+ * be obtained using the `filter_column_chunks_byte_ranges()` function and read into a corresponding
+ * vector of vectors of device buffers.
  * @code{.cpp}
  * // Get byte ranges of column chunk byte ranges from the reader
  * auto const filter_column_chunk_byte_ranges =
@@ -219,24 +232,21 @@ namespace io::parquet::experimental {
  *
  * // Materialize the table with only the filter columns
  * auto [filter_table, filter_metadata] =
- *   reader->materialize_filter_columns(data_page_mask,
- *                                      current_row_group_indices,
+ *   reader->materialize_filter_columns(current_row_group_indices,
  *                                      std::move(filter_column_chunk_buffers),
  *                                      row_mask->mutable_view(),
+ *                                      use_data_page_mask::YES/NO,
  *                                      options,
  *                                      stream);
  * @endcode
  *
  * Materialize payload columns: Once the filter columns are materialized, the final step is to
  * materialize the payload columns into another table (second reader pass). This is done using the
- * `materialize_payload_columns()` function. This function requires a vector of device buffers
- * containing column chunk data for the current list of row groups, and the updated row mask from
- * the `materialize_filter_columns()`. The function uses the row mask - may be a BOOL8 column of
- * size equal to total number of rows in the current row groups list containing all `true` values if
- * no pruning is desired - to internally prune payload column data pages and mask the materialized
- * payload columns to the desired rows. Similar to the first reader pass, the byte ranges for the
- * required column chunk data may be obtained using the `payload_column_chunks_byte_ranges()`
- * function and read into a corresponding vector of vectors of device buffers.
+ * `materialize_payload_columns()` function which is identical to the `materialize_filter_columns()`
+ * in terms of functionality except that it accepts an immutable view of the row mask and uses it to
+ * filter the read output table before returning it. The byte ranges for the required column chunk
+ * data may be obtained using the `payload_column_chunks_byte_ranges()` function and read into a
+ * corresponding vector of vectors of device buffers.
  * @code{.cpp}
  * // Get column chunk byte ranges from the reader
  * auto const payload_column_chunk_byte_ranges =
@@ -251,6 +261,7 @@ namespace io::parquet::experimental {
  *   reader->materialize_payload_columns(current_row_group_indices,
  *                                       std::move(payload_column_chunk_buffers),
  *                                       row_mask->view(),
+ *                                       use_data_page_mask::YES/NO,
  *                                       options,
  *                                       stream);
  * @endcode
@@ -258,7 +269,7 @@ namespace io::parquet::experimental {
  * Once both reader passes are complete, the filter and payload column tables may be trivially
  * combined by releasing the columns from both tables and moving them into a new cudf table.
  *
- * @note The performance advantage of this reader is most pronounced when the filter expression
+ * @note The performance advantage of this reader is most prominent when the filter expression
  * is highly selective, i.e. when the data in filter columns are at least partially ordered and the
  * number of rows that survive the filter is small compared to the total number of rows in the
  * parquet file. Otherwise, the performance is identical to the `cudf::io::read_parquet()` function.
@@ -390,21 +401,21 @@ class hybrid_scan_reader {
     rmm::cuda_stream_view stream) const;
 
   /**
-   * @brief Filter data pages of filter columns using page statistics from page index metadata
+   * @brief Builds a boolean column indicating which rows survive the page statistics in the page
+   * index
    *
    * @param row_group_indices Input row groups indices
    * @param options Parquet reader options
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the returned column's device memory
-   * @return A pair of boolean column indicating rows corresponding to data pages after
-   *         page-pruning, and a list of boolean vectors indicating which data pages are not pruned,
-   *         one per filter column.
+   * @return A boolean column indicating which filter column rows survive the statistics in the page
+   * index
    */
-  [[nodiscard]] std::pair<std::unique_ptr<cudf::column>, std::vector<std::vector<bool>>>
-  filter_data_pages_with_stats(cudf::host_span<size_type const> row_group_indices,
-                               parquet_reader_options const& options,
-                               rmm::cuda_stream_view stream,
-                               rmm::device_async_resource_ref mr) const;
+  [[nodiscard]] std::unique_ptr<cudf::column> build_row_mask_with_page_index_stats(
+    cudf::host_span<size_type const> row_group_indices,
+    parquet_reader_options const& options,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const;
 
   /**
    * @brief Get byte ranges of column chunks of filter columns
@@ -421,20 +432,19 @@ class hybrid_scan_reader {
    * @brief Materializes filter columns and updates the input row mask to only the rows
    *        that exist in the output table
    *
-   * @param page_mask Boolean vectors indicating which data pages are not pruned, one per filter
-   *                  column. All data pages considered not pruned if empty
    * @param row_group_indices Input row groups indices
    * @param column_chunk_buffers Device buffers containing column chunk data of filter columns
    * @param[in,out] row_mask Mutable boolean column indicating surviving rows from page pruning
+   * @param mask_data_pages Whether to build and use a data page mask using the row mask
    * @param options Parquet reader options
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @return Table of materialized filter columns and metadata
    */
   [[nodiscard]] table_with_metadata materialize_filter_columns(
-    cudf::host_span<std::vector<bool> const> page_mask,
     cudf::host_span<size_type const> row_group_indices,
     std::vector<rmm::device_buffer> column_chunk_buffers,
     cudf::mutable_column_view row_mask,
+    use_data_page_mask mask_data_pages,
     parquet_reader_options const& options,
     rmm::cuda_stream_view stream) const;
 
@@ -455,6 +465,7 @@ class hybrid_scan_reader {
    * @param row_group_indices Input row groups indices
    * @param column_chunk_buffers Device buffers containing column chunk data of payload columns
    * @param row_mask Boolean column indicating which rows need to be read. All rows read if empty
+   * @param mask_data_pages Whether to build and use a data page mask using the row mask
    * @param options Parquet reader options
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @return Table of materialized payload columns and metadata
@@ -463,6 +474,7 @@ class hybrid_scan_reader {
     cudf::host_span<size_type const> row_group_indices,
     std::vector<rmm::device_buffer> column_chunk_buffers,
     cudf::column_view row_mask,
+    use_data_page_mask mask_data_pages,
     parquet_reader_options const& options,
     rmm::cuda_stream_view stream) const;
 

--- a/cpp/src/io/parquet/experimental/hybrid_scan.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan.cpp
@@ -123,17 +123,17 @@ std::vector<cudf::size_type> hybrid_scan_reader::filter_row_groups_with_bloom_fi
     .front();
 }
 
-std::pair<std::unique_ptr<cudf::column>, std::vector<std::vector<bool>>>
-hybrid_scan_reader::filter_data_pages_with_stats(cudf::host_span<size_type const> row_group_indices,
-                                                 parquet_reader_options const& options,
-                                                 rmm::cuda_stream_view stream,
-                                                 rmm::device_async_resource_ref mr) const
+std::unique_ptr<cudf::column> hybrid_scan_reader::build_row_mask_with_page_index_stats(
+  cudf::host_span<size_type const> row_group_indices,
+  parquet_reader_options const& options,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
 {
   // Temporary vector with row group indices from the first source
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
 
-  return _impl->filter_data_pages_with_stats(input_row_group_indices, options, stream, mr);
+  return _impl->build_row_mask_with_page_index_stats(input_row_group_indices, options, stream, mr);
 }
 
 [[nodiscard]] std::vector<text::byte_range_info>
@@ -148,10 +148,10 @@ hybrid_scan_reader::filter_column_chunks_byte_ranges(
 }
 
 table_with_metadata hybrid_scan_reader::materialize_filter_columns(
-  cudf::host_span<std::vector<bool> const> data_page_mask,
   cudf::host_span<size_type const> row_group_indices,
   std::vector<rmm::device_buffer> column_chunk_buffers,
   cudf::mutable_column_view row_mask,
+  use_data_page_mask mask_data_pages,
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream) const
 {
@@ -159,10 +159,10 @@ table_with_metadata hybrid_scan_reader::materialize_filter_columns(
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
 
-  return _impl->materialize_filter_columns(data_page_mask,
-                                           input_row_group_indices,
+  return _impl->materialize_filter_columns(input_row_group_indices,
                                            std::move(column_chunk_buffers),
                                            row_mask,
+                                           mask_data_pages,
                                            options,
                                            stream);
 }
@@ -181,6 +181,7 @@ table_with_metadata hybrid_scan_reader::materialize_payload_columns(
   cudf::host_span<size_type const> row_group_indices,
   std::vector<rmm::device_buffer> column_chunk_buffers,
   cudf::column_view row_mask,
+  use_data_page_mask mask_data_pages,
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream) const
 {
@@ -188,8 +189,12 @@ table_with_metadata hybrid_scan_reader::materialize_payload_columns(
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
 
-  return _impl->materialize_payload_columns(
-    input_row_group_indices, std::move(column_chunk_buffers), row_mask, options, stream);
+  return _impl->materialize_payload_columns(input_row_group_indices,
+                                            std::move(column_chunk_buffers),
+                                            row_mask,
+                                            mask_data_pages,
+                                            options,
+                                            stream);
 }
 
 }  // namespace cudf::io::parquet::experimental

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.hpp
@@ -237,19 +237,20 @@ class aggregate_reader_metadata : public aggregate_reader_metadata_base {
     rmm::cuda_stream_view stream) const;
 
   /**
-   * @brief Filter data pages using statistics page-level statistics based on predicate filter
+   * @brief Builds a row mask based on the data pages that survive page-level statistics based on
+   * predicate filter
    *
    * @param row_group_indices Input row groups indices
    * @param output_dtypes Datatypes of output columns
    * @param output_column_schemas schema indices of output columns
-   * @param filter AST expression to filter data pages based on `PageIndex` statistics
+   * @param filter AST expression to filter data pages based on page index statistics
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the returned column's device memory
    *
    * @return A boolean column representing a mask of rows surviving the predicate filter at
    *         page-level
    */
-  [[nodiscard]] std::unique_ptr<cudf::column> filter_data_pages_with_stats(
+  [[nodiscard]] std::unique_ptr<cudf::column> build_row_mask_with_page_index_stats(
     cudf::host_span<std::vector<size_type> const> row_group_indices,
     cudf::host_span<cudf::data_type const> output_dtypes,
     cudf::host_span<cudf::size_type const> output_column_schemas,

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
@@ -312,8 +312,7 @@ std::vector<std::vector<size_type>> hybrid_scan_reader_impl::filter_row_groups_w
     stream);
 }
 
-std::pair<std::unique_ptr<cudf::column>, std::vector<std::vector<bool>>>
-hybrid_scan_reader_impl::filter_data_pages_with_stats(
+std::unique_ptr<cudf::column> hybrid_scan_reader_impl::build_row_mask_with_page_index_stats(
   cudf::host_span<std::vector<size_type> const> row_group_indices,
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream,
@@ -331,18 +330,13 @@ hybrid_scan_reader_impl::filter_data_pages_with_stats(
                "Columns names in filter expression must be convertible to index references");
   auto output_dtypes = get_output_types(_output_buffers_template);
 
-  auto row_mask =
-    _extended_metadata->filter_data_pages_with_stats(row_group_indices,
-                                                     output_dtypes,
-                                                     _output_column_schemas,
-                                                     expr_conv.get_converted_expr().value(),
-                                                     stream,
-                                                     mr);
-
-  auto data_page_mask = _extended_metadata->compute_data_page_mask(
-    row_mask->view(), row_group_indices, output_dtypes, _output_column_schemas, stream);
-
-  return {std::move(row_mask), std::move(data_page_mask)};
+  return _extended_metadata->build_row_mask_with_page_index_stats(
+    row_group_indices,
+    output_dtypes,
+    _output_column_schemas,
+    expr_conv.get_converted_expr().value(),
+    stream,
+    mr);
 }
 
 std::pair<std::vector<byte_range_info>, std::vector<cudf::size_type>>
@@ -420,10 +414,10 @@ hybrid_scan_reader_impl::payload_column_chunks_byte_ranges(
 }
 
 table_with_metadata hybrid_scan_reader_impl::materialize_filter_columns(
-  cudf::host_span<std::vector<bool> const> data_page_mask,
   cudf::host_span<std::vector<size_type> const> row_group_indices,
   std::vector<rmm::device_buffer> column_chunk_buffers,
   cudf::mutable_column_view row_mask,
+  use_data_page_mask mask_data_pages,
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream)
 {
@@ -442,11 +436,13 @@ table_with_metadata hybrid_scan_reader_impl::materialize_filter_columns(
 
   select_columns(read_columns_mode::FILTER_COLUMNS, options);
 
-  // If the data page mask is empty, fill the row mask with all true values
-  if (data_page_mask.empty()) {
-    auto const value = cudf::numeric_scalar<bool>(true, true, stream);
-    cudf::fill_in_place(row_mask, 0, row_mask.size(), value, stream);
-  }
+  auto output_dtypes = get_output_types(_output_buffers_template);
+
+  auto data_page_mask =
+    (mask_data_pages == use_data_page_mask::YES)
+      ? _extended_metadata->compute_data_page_mask(
+          row_mask, row_group_indices, output_dtypes, _output_column_schemas, stream)
+      : std::vector<std::vector<bool>>{};
 
   prepare_data(row_group_indices, std::move(column_chunk_buffers), data_page_mask, options);
 
@@ -457,6 +453,7 @@ table_with_metadata hybrid_scan_reader_impl::materialize_payload_columns(
   cudf::host_span<std::vector<size_type> const> row_group_indices,
   std::vector<rmm::device_buffer> column_chunk_buffers,
   cudf::column_view row_mask,
+  use_data_page_mask mask_data_pages,
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream)
 {
@@ -472,8 +469,11 @@ table_with_metadata hybrid_scan_reader_impl::materialize_payload_columns(
 
   auto output_dtypes = get_output_types(_output_buffers_template);
 
-  auto data_page_mask = _extended_metadata->compute_data_page_mask(
-    row_mask, row_group_indices, output_dtypes, _output_column_schemas, stream);
+  auto data_page_mask =
+    (mask_data_pages == use_data_page_mask::YES)
+      ? _extended_metadata->compute_data_page_mask(
+          row_mask, row_group_indices, output_dtypes, _output_column_schemas, stream)
+      : std::vector<std::vector<bool>>{};
 
   prepare_data(row_group_indices, std::move(column_chunk_buffers), data_page_mask, options);
 

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.hpp
@@ -120,13 +120,13 @@ class hybrid_scan_reader_impl : public parquet::detail::reader_impl {
     rmm::cuda_stream_view stream);
 
   /**
-   * @copydoc cudf::io::experimental::hybrid_scan::filter_data_pages_with_stats
+   * @copydoc cudf::io::experimental::hybrid_scan::build_row_mask_with_page_index_stats
    */
-  [[nodiscard]] std::pair<std::unique_ptr<cudf::column>, std::vector<std::vector<bool>>>
-  filter_data_pages_with_stats(cudf::host_span<std::vector<size_type> const> row_group_indices,
-                               parquet_reader_options const& options,
-                               rmm::cuda_stream_view stream,
-                               rmm::device_async_resource_ref mr);
+  [[nodiscard]] std::unique_ptr<cudf::column> build_row_mask_with_page_index_stats(
+    cudf::host_span<std::vector<size_type> const> row_group_indices,
+    parquet_reader_options const& options,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
 
   /**
    * @brief Fetches byte ranges of column chunks of filter columns
@@ -144,10 +144,10 @@ class hybrid_scan_reader_impl : public parquet::detail::reader_impl {
    * @copydoc cudf::io::experimental::hybrid_scan::materialize_filter_columns
    */
   [[nodiscard]] table_with_metadata materialize_filter_columns(
-    cudf::host_span<std::vector<bool> const> data_page_pask,
     cudf::host_span<std::vector<size_type> const> row_group_indices,
     std::vector<rmm::device_buffer> column_chunk_buffers,
     cudf::mutable_column_view row_mask,
+    use_data_page_mask mask_data_pages,
     parquet_reader_options const& options,
     rmm::cuda_stream_view stream);
 
@@ -170,6 +170,7 @@ class hybrid_scan_reader_impl : public parquet::detail::reader_impl {
     cudf::host_span<std::vector<size_type> const> row_group_indices,
     std::vector<rmm::device_buffer> column_chunk_buffers,
     cudf::column_view row_mask,
+    use_data_page_mask mask_data_pages,
     parquet_reader_options const& options,
     rmm::cuda_stream_view stream);
 

--- a/cpp/src/io/parquet/experimental/page_index_filter.cu
+++ b/cpp/src/io/parquet/experimental/page_index_filter.cu
@@ -602,7 +602,7 @@ struct is_row_required_fn {
 
 }  // namespace
 
-std::unique_ptr<cudf::column> aggregate_reader_metadata::filter_data_pages_with_stats(
+std::unique_ptr<cudf::column> aggregate_reader_metadata::build_row_mask_with_page_index_stats(
   cudf::host_span<std::vector<size_type> const> row_group_indices,
   cudf::host_span<cudf::data_type const> output_dtypes,
   cudf::host_span<cudf::size_type const> output_column_schemas,

--- a/cpp/tests/io/experimental/hybrid_scan_filters_test.cpp
+++ b/cpp/tests/io/experimental/hybrid_scan_filters_test.cpp
@@ -29,6 +29,8 @@
 
 #include <src/io/parquet/parquet_gpu.hpp>
 
+using namespace cudf::io;
+
 namespace {
 
 /**
@@ -48,15 +50,14 @@ auto filter_row_groups_with_dictionaries(cudf::host_span<uint8_t const> file_buf
                                          rmm::device_async_resource_ref mr)
 {
   // Create reader options with empty source info
-  cudf::io::parquet_reader_options options =
-    cudf::io::parquet_reader_options::builder().filter(filter_expression);
+  parquet_reader_options options = parquet_reader_options::builder().filter(filter_expression);
 
   // Fetch footer and page index bytes from the buffer.
   auto const footer_buffer = fetch_footer_bytes(file_buffer_span);
 
   // Create hybrid scan reader with footer bytes
   auto const reader =
-    std::make_unique<cudf::io::parquet::experimental::hybrid_scan_reader>(footer_buffer, options);
+    std::make_unique<parquet::experimental::hybrid_scan_reader>(footer_buffer, options);
 
   // Get page index byte range from the reader
   auto const page_index_byte_range = reader->page_index_byte_range();
@@ -115,8 +116,7 @@ TEST_F(HybridScanFiltersTest, TestMetadata)
   auto filter_expression = cudf::ast::operation(cudf::ast::ast_operator::LESS, col_ref_0, literal);
 
   // Create reader options with empty source info
-  cudf::io::parquet_reader_options options =
-    cudf::io::parquet_reader_options::builder().filter(filter_expression);
+  parquet_reader_options options = parquet_reader_options::builder().filter(filter_expression);
 
   // Input file buffer span
   auto const file_buffer_span = cudf::host_span<uint8_t const>(
@@ -127,7 +127,7 @@ TEST_F(HybridScanFiltersTest, TestMetadata)
 
   // Create hybrid scan reader with footer bytes
   auto const reader =
-    std::make_unique<cudf::io::parquet::experimental::hybrid_scan_reader>(footer_buffer, options);
+    std::make_unique<parquet::experimental::hybrid_scan_reader>(footer_buffer, options);
 
   // Get Parquet file metadata from the reader
   auto parquet_metadata = reader->parquet_metadata();
@@ -184,8 +184,7 @@ TEST_F(HybridScanFiltersTest, FilterRowGroupsWithStats)
   auto filter_expression = cudf::ast::operation(cudf::ast::ast_operator::LESS, col_ref_0, literal);
 
   // Create reader options with empty source info
-  cudf::io::parquet_reader_options options =
-    cudf::io::parquet_reader_options::builder().filter(filter_expression);
+  parquet_reader_options options = parquet_reader_options::builder().filter(filter_expression);
 
   // Input file buffer span
   auto const file_buffer_span = cudf::host_span<uint8_t const>(
@@ -196,7 +195,7 @@ TEST_F(HybridScanFiltersTest, FilterRowGroupsWithStats)
 
   // Create hybrid scan reader with footer bytes
   auto const reader =
-    std::make_unique<cudf::io::parquet::experimental::hybrid_scan_reader>(footer_buffer, options);
+    std::make_unique<parquet::experimental::hybrid_scan_reader>(footer_buffer, options);
 
   // Get all row groups from the reader
   auto input_row_group_indices = reader->all_row_groups(options);
@@ -248,63 +247,54 @@ TYPED_TEST(PageFilteringWithPageIndexStats, FilterPagesWithPageIndexStats)
     reinterpret_cast<uint8_t const*>(file_buffer.data()), file_buffer.size());
 
   // Helper function to test data page filteration using page index stats
-  auto const test_filter_data_pages_with_stats =
-    [&](cudf::ast::operation const& filter_expression,
-        cudf::size_type const num_filter_columns,
-        cudf::size_type const expected_num_pages_after_page_index_filter,
-        rmm::cuda_stream_view stream      = cudf::get_default_stream(),
-        rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) {
-      // Create reader options with empty source info
-      cudf::io::parquet_reader_options options =
-        cudf::io::parquet_reader_options::builder().filter(filter_expression);
+  auto const test_filter_data_pages_with_stats = [&](cudf::ast::operation const& filter_expression,
+                                                     cudf::size_type const expected_surviving_rows,
+                                                     rmm::cuda_stream_view stream =
+                                                       cudf::get_default_stream(),
+                                                     rmm::device_async_resource_ref mr =
+                                                       cudf::get_current_device_resource_ref()) {
+    // Create reader options with empty source info
+    parquet_reader_options options = parquet_reader_options::builder().filter(filter_expression);
 
-      // Fetch footer and page index bytes from the buffer.
-      auto const footer_buffer = fetch_footer_bytes(file_buffer_span);
+    // Fetch footer and page index bytes from the buffer.
+    auto const footer_buffer = fetch_footer_bytes(file_buffer_span);
 
-      // Create hybrid scan reader with footer bytes
-      auto const reader = std::make_unique<cudf::io::parquet::experimental::hybrid_scan_reader>(
-        footer_buffer, options);
+    // Create hybrid scan reader with footer bytes
+    auto const reader =
+      std::make_unique<parquet::experimental::hybrid_scan_reader>(footer_buffer, options);
 
-      // Get all row groups from the reader
-      auto input_row_group_indices = reader->all_row_groups(options);
+    // Get all row groups from the reader
+    auto input_row_group_indices = reader->all_row_groups(options);
 
-      // Span to track current row group indices
-      auto current_row_group_indices = cudf::host_span<cudf::size_type>(input_row_group_indices);
+    // Span to track current row group indices
+    auto current_row_group_indices = cudf::host_span<cudf::size_type>(input_row_group_indices);
 
-      // Calling `filter_data_pages_with_stats` before setting up the page index should raise an
-      // error
-      EXPECT_THROW(std::ignore = reader->filter_data_pages_with_stats(
-                     current_row_group_indices, options, stream, mr),
-                   std::runtime_error);
+    // Calling `filter_data_pages_with_stats` before setting up the page index should raise an
+    // error
+    EXPECT_THROW(std::ignore = reader->build_row_mask_with_page_index_stats(
+                   current_row_group_indices, options, stream, mr),
+                 std::runtime_error);
 
-      // Set up the page index
-      auto const page_index_byte_range = reader->page_index_byte_range();
-      auto const page_index_buffer =
-        fetch_page_index_bytes(file_buffer_span, page_index_byte_range);
-      reader->setup_page_index(page_index_buffer);
+    // Set up the page index
+    auto const page_index_byte_range = reader->page_index_byte_range();
+    auto const page_index_buffer = fetch_page_index_bytes(file_buffer_span, page_index_byte_range);
+    reader->setup_page_index(page_index_buffer);
 
-      // Filter the data pages with page index stats
-      auto const [row_mask, data_page_mask] =
-        reader->filter_data_pages_with_stats(current_row_group_indices, options, stream, mr);
-      EXPECT_EQ(data_page_mask.size(), num_filter_columns);
+    // Filter the data pages with page index stats
+    auto const row_mask =
+      reader->build_row_mask_with_page_index_stats(current_row_group_indices, options, stream, mr);
 
-      auto const expected_num_rows = reader->total_rows_in_row_groups(current_row_group_indices);
-      EXPECT_EQ(row_mask->type().id(), cudf::type_id::BOOL8);
-      EXPECT_EQ(row_mask->size(), expected_num_rows);
-      EXPECT_EQ(row_mask->null_count(), 0);
+    auto const expected_num_rows = reader->total_rows_in_row_groups(current_row_group_indices);
+    EXPECT_EQ(row_mask->type().id(), cudf::type_id::BOOL8);
+    EXPECT_EQ(row_mask->size(), expected_num_rows);
+    EXPECT_EQ(row_mask->null_count(), 0);
 
-      // Half the pages should survive the page index filter
-
-      // Count the number of pages that survive the page index filter
-      auto const num_pages_after_page_index_filter =
-        std::accumulate(data_page_mask.begin(),
-                        data_page_mask.end(),
-                        cudf::size_type{0},
-                        [](auto sum, auto const& page_mask) {
-                          return sum + std::count(page_mask.cbegin(), page_mask.cend(), true);
-                        });
-      EXPECT_EQ(num_pages_after_page_index_filter, expected_num_pages_after_page_index_filter);
-    };
+    // Half the rows should survive the page index filter
+    auto const host_row_mask = cudf::detail::make_host_vector<bool>(
+      {row_mask->view().data<bool>(), static_cast<size_t>(row_mask->view().size())}, stream);
+    EXPECT_EQ(std::count(host_row_mask.begin(), host_row_mask.end(), true),
+              expected_surviving_rows);
+  };
 
   // Filtering AST - table[0] < 100
   {
@@ -312,12 +302,11 @@ TYPED_TEST(PageFilteringWithPageIndexStats, FilterPagesWithPageIndexStats)
     auto const literal     = cudf::ast::literal(literal_value);
     auto const col_ref     = cudf::ast::column_name_reference("col0");
     auto filter_expression = cudf::ast::operation(cudf::ast::ast_operator::LESS, col_ref, literal);
-    auto constexpr num_filter_columns = 1;
-    // Half the pages should be filtered out by the page index filter
-    auto constexpr expected_num_pages_after_page_index_filter =
-      num_concat * (num_ordered_rows / page_size_for_ordered_tests) / 2;
-    test_filter_data_pages_with_stats(
-      filter_expression, num_filter_columns, expected_num_pages_after_page_index_filter);
+    // Half the pages (signed) or 3/4th the pages (unsigned) should be filtered out by the page
+    // index filter
+    auto constexpr expected_surviving_rows =
+      (num_concat * num_ordered_rows) / (std::is_signed_v<T> ? 4 : 2);
+    test_filter_data_pages_with_stats(filter_expression, expected_surviving_rows);
   }
 
   // Filtering AST - table[2] >= 10000
@@ -327,12 +316,11 @@ TYPED_TEST(PageFilteringWithPageIndexStats, FilterPagesWithPageIndexStats)
     auto col_ref       = cudf::ast::column_name_reference("col2");
     auto filter_expression =
       cudf::ast::operation(cudf::ast::ast_operator::GREATER_EQUAL, col_ref, literal);
-    auto constexpr num_filter_columns = 1;
-    // Half the pages should be filtered out by the page index filter
-    auto constexpr expected_num_pages_after_page_index_filter =
-      num_concat * (num_ordered_rows / page_size_for_ordered_tests) / 2;
-    test_filter_data_pages_with_stats(
-      filter_expression, num_filter_columns, expected_num_pages_after_page_index_filter);
+    // Half the pages (signed) or 3/4th the pages (unsigned) should be filtered out by the page
+    // index filter
+    auto constexpr expected_surviving_rows =
+      (num_concat * num_ordered_rows) / (std::is_signed_v<T> ? 4 : 2);
+    test_filter_data_pages_with_stats(filter_expression, expected_surviving_rows);
   }
 
   // Filtering AST - table[0] < 50 AND table[2] < "000010000"
@@ -351,11 +339,9 @@ TYPED_TEST(PageFilteringWithPageIndexStats, FilterPagesWithPageIndexStats)
 
     auto filter_expression = cudf::ast::operation(
       cudf::ast::ast_operator::LOGICAL_AND, filter_expression1, filter_expression2);
-    auto constexpr num_filter_columns = 2;
     // Only one page per num_concat per filter column should survive
-    auto constexpr expected_num_pages_after_page_index_filter = 1 * num_concat * num_filter_columns;
-    test_filter_data_pages_with_stats(
-      filter_expression, num_filter_columns, expected_num_pages_after_page_index_filter);
+    auto constexpr expected_surviving_rows = num_concat * page_size_for_ordered_tests;
+    test_filter_data_pages_with_stats(filter_expression, expected_surviving_rows);
   }
 
   // Filtering AST - table[0] > 150 OR table[2] < "000005000"
@@ -374,12 +360,10 @@ TYPED_TEST(PageFilteringWithPageIndexStats, FilterPagesWithPageIndexStats)
 
     auto filter_expression = cudf::ast::operation(
       cudf::ast::ast_operator::LOGICAL_OR, filter_expression1, filter_expression2);
-    auto constexpr num_filter_columns = 2;
     // Two pages (3rd and 0th from respective conditions) per num_concat per filter column should
     // survive
-    auto constexpr expected_num_pages_after_page_index_filter = 2 * num_concat * num_filter_columns;
-    test_filter_data_pages_with_stats(
-      filter_expression, num_filter_columns, expected_num_pages_after_page_index_filter);
+    auto constexpr expected_surviving_rows = 2 * num_concat * page_size_for_ordered_tests;
+    test_filter_data_pages_with_stats(filter_expression, expected_surviving_rows);
   }
 }
 
@@ -677,7 +661,7 @@ TYPED_TEST(RowGroupFilteringWithDictTest, FilterFewLiteralsTyped)
 
   // Specifying ZSTD compression to explicitly test decompression of dictionary pages
   auto const buffer =
-    std::get<1>(create_parquet_with_stats<T, num_concat>(100, cudf::io::compression_type::ZSTD));
+    std::get<1>(create_parquet_with_stats<T, num_concat>(100, compression_type::ZSTD));
 
   // For string tests use `col2` containing constant "0100" and for temporal types use `col1`
   // containing low cardinality descending values. For all other types use `col0`
@@ -782,7 +766,7 @@ TYPED_TEST(RowGroupFilteringWithDictTest, FilterManyLiteralsTyped)
   auto constexpr num_concat = 1;
   // Specifying no compression to explicitly test uncompressed dictionary pages
   auto const buffer =
-    std::get<1>(create_parquet_with_stats<T, num_concat>(100, cudf::io::compression_type::NONE));
+    std::get<1>(create_parquet_with_stats<T, num_concat>(100, compression_type::NONE));
 
   // For string tests use `col2` containing constant "0100" and for temporal types use `col1`
   // containing low cardinality descending values. For all other types use `col0`

--- a/cpp/tests/io/experimental/hybrid_scan_test.cpp
+++ b/cpp/tests/io/experimental/hybrid_scan_test.cpp
@@ -35,6 +35,8 @@
 
 auto constexpr bloom_filter_alignment = 32;
 
+using namespace cudf::io;
+
 namespace {
 
 /**
@@ -59,8 +61,7 @@ auto hybrid_scan(std::vector<char>& buffer,
                  rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>& aligned_mr)
 {
   // Create reader options with empty source info
-  cudf::io::parquet_reader_options options =
-    cudf::io::parquet_reader_options::builder().filter(filter_expression);
+  parquet_reader_options options = parquet_reader_options::builder().filter(filter_expression);
 
   // Set payload column names if provided
   if (payload_column_names.has_value()) { options.set_columns(payload_column_names.value()); }
@@ -74,7 +75,7 @@ auto hybrid_scan(std::vector<char>& buffer,
 
   // Create hybrid scan reader with footer bytes
   auto const reader =
-    std::make_unique<cudf::io::parquet::experimental::hybrid_scan_reader>(footer_buffer, options);
+    std::make_unique<parquet::experimental::hybrid_scan_reader>(footer_buffer, options);
 
   // Get Parquet file metadata from the reader
   [[maybe_unused]] auto const parquet_metadata = reader->parquet_metadata();
@@ -141,10 +142,8 @@ auto hybrid_scan(std::vector<char>& buffer,
   }
 
   // Filter data pages with page index stats
-  auto [row_mask, data_page_mask] =
-    reader->filter_data_pages_with_stats(current_row_group_indices, options, stream, mr);
-
-  EXPECT_EQ(data_page_mask.size(), num_filter_columns);
+  auto row_mask =
+    reader->build_row_mask_with_page_index_stats(current_row_group_indices, options, stream, mr);
 
   // Get column chunk byte ranges from the reader
   auto const filter_column_chunk_byte_ranges =
@@ -156,10 +155,10 @@ auto hybrid_scan(std::vector<char>& buffer,
 
   // Materialize the table with only the filter columns
   auto [filter_table, filter_metadata] =
-    reader->materialize_filter_columns(data_page_mask,
-                                       current_row_group_indices,
+    reader->materialize_filter_columns(current_row_group_indices,
                                        std::move(filter_column_chunk_buffers),
                                        row_mask->mutable_view(),
+                                       parquet::experimental::use_data_page_mask::YES,
                                        options,
                                        stream);
 
@@ -168,14 +167,15 @@ auto hybrid_scan(std::vector<char>& buffer,
     reader->payload_column_chunks_byte_ranges(current_row_group_indices, options);
 
   // Fetch column chunk device buffers from the input buffer
-  [[maybe_unused]] auto payload_column_chunk_buffers =
+  auto payload_column_chunk_buffers =
     fetch_byte_ranges(file_buffer_span, payload_column_chunk_byte_ranges, stream, mr);
 
   // Materialize the table with only the payload columns
-  [[maybe_unused]] auto [payload_table, payload_metadata] =
+  auto [payload_table, payload_metadata] =
     reader->materialize_payload_columns(current_row_group_indices,
                                         std::move(payload_column_chunk_buffers),
                                         row_mask->view(),
+                                        parquet::experimental::use_data_page_mask::YES,
                                         options,
                                         stream);
 
@@ -224,11 +224,11 @@ TEST_F(HybridScanTest, PruneRowGroupsOnlyAndScanAllColumns)
   // Check equivalence (equal without checking nullability) with the parquet file read with the
   // original reader
   {
-    cudf::io::parquet_reader_options const options =
-      cudf::io::parquet_reader_options::builder(
-        cudf::io::source_info(cudf::host_span<char>(parquet_buffer.data(), parquet_buffer.size())))
+    parquet_reader_options const options =
+      parquet_reader_options::builder(
+        source_info(cudf::host_span<char>(parquet_buffer.data(), parquet_buffer.size())))
         .filter(filter_expression);
-    auto [expected_tbl, expected_meta] = cudf::io::read_parquet(options, stream);
+    auto [expected_tbl, expected_meta] = read_parquet(options, stream);
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected_tbl->select({0}), read_filter_table->view());
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected_tbl->select({1, 2}), read_payload_table->view());
   }
@@ -271,11 +271,11 @@ TEST_F(HybridScanTest, PruneRowGroupsOnlyAndScanSelectColumns)
 
     CUDF_EXPECTS(read_filter_table->num_rows() == read_payload_table->num_rows(),
                  "Filter and payload tables should have the same number of rows");
-    cudf::io::parquet_reader_options const options =
-      cudf::io::parquet_reader_options::builder(
-        cudf::io::source_info(cudf::host_span<char>(parquet_buffer.data(), parquet_buffer.size())))
+    parquet_reader_options const options =
+      parquet_reader_options::builder(
+        source_info(cudf::host_span<char>(parquet_buffer.data(), parquet_buffer.size())))
         .filter(filter_expression);
-    auto [expected_tbl, expected_meta] = cudf::io::read_parquet(options, stream);
+    auto [expected_tbl, expected_meta] = read_parquet(options, stream);
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected_tbl->select({0}), read_filter_table->view());
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected_tbl->select({2}), read_payload_table->view());
   }
@@ -294,11 +294,11 @@ TEST_F(HybridScanTest, PruneRowGroupsOnlyAndScanSelectColumns)
 
     CUDF_EXPECTS(read_filter_table->num_rows() == read_payload_table->num_rows(),
                  "Filter and payload tables should have the same number of rows");
-    cudf::io::parquet_reader_options const options =
-      cudf::io::parquet_reader_options::builder(
-        cudf::io::source_info(cudf::host_span<char>(parquet_buffer.data(), parquet_buffer.size())))
+    parquet_reader_options const options =
+      parquet_reader_options::builder(
+        source_info(cudf::host_span<char>(parquet_buffer.data(), parquet_buffer.size())))
         .filter(filter_expression);
-    auto [expected_tbl, expected_meta] = cudf::io::read_parquet(options, stream);
+    auto [expected_tbl, expected_meta] = read_parquet(options, stream);
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected_tbl->select({0}), read_filter_table->view());
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected_tbl->select({2, 1}), read_payload_table->view());
   }
@@ -337,11 +337,11 @@ TEST_F(HybridScanTest, PruneDataPagesOnlyAndScanAllColumns)
   // Check equivalence (equal without checking nullability) with the parquet file read with the
   // original reader
   {
-    cudf::io::parquet_reader_options const options =
-      cudf::io::parquet_reader_options::builder(
-        cudf::io::source_info(cudf::host_span<char>(buffer.data(), buffer.size())))
+    parquet_reader_options const options =
+      parquet_reader_options::builder(
+        source_info(cudf::host_span<char>(buffer.data(), buffer.size())))
         .filter(filter_expression);
-    auto [expected_tbl, expected_meta] = cudf::io::read_parquet(options, stream);
+    auto [expected_tbl, expected_meta] = read_parquet(options, stream);
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected_tbl->select({0}), read_filter_table->view());
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected_tbl->select({1, 2}), read_payload_table->view());
   }


### PR DESCRIPTION
## Description

Contributes to #19526

This PR separates the computation of row mask and data page mask for filter columns providing more control to the `materialize_filter_columns`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
