### PR TITLE
Fix logic for number of unique values generated by data profile in benchmarks

### DIFF
--- a/cpp/benchmarks/common/generate_input.cu
+++ b/cpp/benchmarks/common/generate_input.cu
@@ -549,7 +549,7 @@ struct create_rand_col_fn {
                                            thrust::minstd_rand& engine,
                                            cudf::size_type num_rows)
   {
-    if (profile.get_cardinality() == 0 || profile.get_cardinality() >= num_rows) {
+    if (profile.get_cardinality() >= num_rows) {
       return create_distinct_rows_column<T>(profile, engine, num_rows);
     }
     return create_random_column<T>(profile, engine, num_rows);

--- a/cpp/benchmarks/common/generate_input.hpp
+++ b/cpp/benchmarks/common/generate_input.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -238,8 +238,11 @@ class data_profile {
 
   double bool_probability_true           = 0.5;
   std::optional<double> null_probability = 0.01;
-  cudf::size_type cardinality            = 2000;
-  cudf::size_type avg_run_length         = 4;
+  cudf::size_type cardinality =
+    2000;  /// Upper bound on the number of unique values generated if `0 <= cardinality < n`, where
+           /// `n` is the total number of values to be generated. If `cardinality >= n`, n` unique
+           /// values of the requested data type are generated.
+  cudf::size_type avg_run_length = 4;
 
  public:
   template <typename T,

--- a/cpp/benchmarks/join/generate_input_tables.cuh
+++ b/cpp/benchmarks/join/generate_input_tables.cuh
@@ -158,8 +158,9 @@ std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>> generate_i
     static_cast<cudf::size_type>(build_table_numrows / multiplicity);
 
   double const null_probability = Nullable ? 0.3 : 0;
-  auto const profile =
-    data_profile{data_profile_builder().null_probability(null_probability).cardinality(0)};
+  auto const profile            = data_profile{data_profile_builder()
+                                      .null_probability(null_probability)
+                                      .cardinality(unique_rows_build_table_numrows + 1)};
   auto unique_rows_build_table =
     create_random_table(key_types, row_count{unique_rows_build_table_numrows + 1}, profile, 1);
 
@@ -227,7 +228,7 @@ std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>> generate_i
   auto probe_cols = probe_table->release();
   for (auto i = 0; i < num_payload_cols; i++) {
     build_cols.emplace_back(cudf::sequence(build_table_numrows, *init));
-    probe_cols.emplace_back(cudf::sequence(build_table_numrows, *init));
+    probe_cols.emplace_back(cudf::sequence(probe_table_numrows, *init));
   }
 
   return std::pair{std::make_unique<cudf::table>(std::move(build_cols)),


### PR DESCRIPTION
## Description
This PR clarifies and corrects the usage of cardinality in the data generator. When the cardinality `c` is a non-negative integer less than the total number of values to be generated, then the number of unique elements in the output is at most `c`. Otherwise, if the cardinality is greater than or equal to the total number of values required, then the cardinality of the output is enforced i.e. the number of unique elements in the output is exactly `c`. 

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
