### PR TITLE
Compile `libcudf_kafka` and `cudf_kafka` with C++20

### DIFF
--- a/cpp/libcudf_kafka/CMakeLists.txt
+++ b/cpp/libcudf_kafka/CMakeLists.txt
@@ -29,6 +29,10 @@ project(
 # Set a default build type if none was specified
 rapids_cmake_build_type(Release)
 
+# Set C++ standard globally to ensure all targets use C++20
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # For now, disable CMake's automatic module scanning for C++ files. There is an sccache bug in the
 # version RAPIDS uses in CI that causes it to handle the resulting -M* flags incorrectly with
 # gcc>=14. We can remove this once we upgrade to a newer sccache version.
@@ -83,11 +87,8 @@ if(TARGET conda_env)
 endif()
 
 set_target_properties(
-  cudf_kafka
-  PROPERTIES BUILD_RPATH "\$ORIGIN"
-             INSTALL_RPATH "\$ORIGIN" # set target compile options
-             CXX_STANDARD 20
-             CXX_STANDARD_REQUIRED ON
+  cudf_kafka PROPERTIES BUILD_RPATH "\$ORIGIN" INSTALL_RPATH
+                                               "\$ORIGIN" # set target compile options
 )
 
 add_library(cudf_kafka::cudf_kafka ALIAS cudf_kafka)

--- a/cpp/libcudf_kafka/tests/CMakeLists.txt
+++ b/cpp/libcudf_kafka/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -28,6 +28,8 @@ function(ConfigureTest test_name)
     ${test_name}
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${CUDF_KAFKA_BINARY_DIR}/gtests>"
                INSTALL_RPATH "\$ORIGIN/../../../lib"
+               CXX_STANDARD 20
+               CXX_STANDARD_REQUIRED ON
   )
   target_link_libraries(
     ${test_name} PRIVATE GTest::gmock GTest::gmock_main GTest::gtest_main cudf_kafka

--- a/python/cudf_kafka/CMakeLists.txt
+++ b/python/cudf_kafka/CMakeLists.txt
@@ -22,6 +22,13 @@ project(
   LANGUAGES CXX
 )
 
+# Set C++ standard to match other cudf Python packages
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Disable CMake's automatic module scanning for C++ files due to sccache bug with gcc>=14
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 find_package(cudf_kafka "${RAPIDS_VERSION}" REQUIRED)
 
 if(NOT cudf_kafka_FOUND)


### PR DESCRIPTION
## Description

Continuation of #19065, hopefully the last one.

Discovered that the kafka components are not compiled using C++20, unlike the rest of libcudf/cuDF.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
