### PR TITLE
Simplify clang dependency spec

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -10,8 +10,7 @@ files:
       - build_all
       - build_cpp
       - build_python_common
-      - clang_format
-      - clang_tidy
+      - clang
       - cuda
       - cuda_version
       - depends_on_cupy
@@ -22,6 +21,7 @@ files:
       - depends_on_rmm
       - develop
       - docs
+      - iwyu
       - notebooks
       - py_version
       - pyarrow_run
@@ -124,10 +124,11 @@ files:
     includes:
       - build_all
       - build_base
-      - clang_tidy
+      - clang
       - cuda
       - cuda_version
       - develop
+      - iwyu
       - py_version
   docs:
     output: none
@@ -558,18 +559,16 @@ dependencies:
       - output_types: conda
         packages:
           - &doxygen doxygen=1.9.1 # pre-commit hook needs a specific version.
-  clang_format:
+  clang:
     common:
       - output_types: conda
         packages:
           - clang==20.1.4
           - clang-tools==20.1.4
-  clang_tidy:
+  iwyu:
     common:
       - output_types: conda
         packages:
-          - clang==20.1.4
-          - clang-tools==20.1.4
           - include-what-you-use==0.24.0
   docs:
     common:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This is a slight simplification on https://github.com/rapidsai/cudf/pull/19529/ by having clang versions specified in only one place and splitting out include-what-you-use.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
