### PR TITLE
Ensure `cudf_polars.__git_commit__` is available

### DIFF
--- a/python/cudf_polars/pyproject.toml
+++ b/python/cudf_polars/pyproject.toml
@@ -56,6 +56,9 @@ Homepage = "https://github.com/rapidsai/cudf"
 [tool.setuptools]
 license-files = ["LICENSE"]
 
+[tool.setuptools.package-data]
+cudf_polars = ["GIT_COMMIT"]
+
 [tool.setuptools.dynamic]
 version = {file = "cudf_polars/VERSION"}
 


### PR DESCRIPTION
## Description

This updates our packaging configuration for `cudf_polars` to include the file `GIT_COMMIT` in the source and binary distributions. Without it, we're apparently not including the `GIT_COMMIT` file generated by rapids-build-backend.

```
❯ uv pip install --upgrade --prerelease=allow --extra-index-url "https://pypi.anaconda.org/rapidsai-wheels-nightly/simple" "cudf-polars-cu12"                                                                                                                                                                   
❯ python -c 'import cudf_polars; print(cudf_polars.__git_commit__)'  # empty string
```

With this change, building the wheel inside the same container as CI

```
docker run \
  --rm \
  --gpus all \
  --pull=always \
  --volume $PWD:/repo \
  --workdir /repo \
  -it rapidsai/ci-wheel:25.10-cuda12.9.1-rockylinux8-py3.13
```

followed by

```
export RAPIDS_BUILD_TYPE=nightly
export RAPIDS_REPOSITORY=rapidsai/cudf

export RAPIDS_REF_NAME=branch-25.10
export RAPIDS_NIGHTLY_DATE=2025-07-30

ci/build_wheel_cudf_polars.sh

```

shows that the commit is added:

```
  adding 'cudf_polars/GIT_COMMIT'
```
