### PR TITLE
Use no_validity() instead of null_probability(0) in benchmarks profile

### DIFF
--- a/cpp/benchmarks/common/generate_input.cu
+++ b/cpp/benchmarks/common/generate_input.cu
@@ -1063,12 +1063,10 @@ std::unique_ptr<cudf::column> create_string_column(cudf::size_type num_rows,
   auto const num_matches = (static_cast<int64_t>(num_rows) * hit_rate) / 100;
 
   // Create a randomized gather-map to build a column out of the strings in data.
-  data_profile gather_profile =
-    data_profile_builder().cardinality(0).null_probability(0.0).distribution(
-      cudf::type_id::INT32, distribution_id::UNIFORM, 1, data_view.size() - 1);
+  data_profile gather_profile = data_profile_builder().cardinality(0).no_validity().distribution(
+    cudf::type_id::INT32, distribution_id::UNIFORM, 1, data_view.size() - 1);
   auto gather_table =
     create_random_table({cudf::type_id::INT32}, row_count{num_rows}, gather_profile);
-  gather_table->get_column(0).set_null_mask(rmm::device_buffer{}, 0);
 
   // Create scatter map by placing 0-index values throughout the gather-map
   auto scatter_data = cudf::sequence(num_matches,

--- a/cpp/benchmarks/common/generate_input.hpp
+++ b/cpp/benchmarks/common/generate_input.hpp
@@ -449,14 +449,14 @@ class data_profile {
  * For example, `data_profile` initialization
  * @code{.pseudo}
  * data_profile profile;
- * profile.set_null_probability(0.0);
+ * profile.set_null_probability(0.01);
  * profile.set_cardinality(0);
  * profile.set_distribution_params(cudf::type_id::INT32, distribution_id::UNIFORM, 0, 100);
  * @endcode
  * becomes
  * @code{.pseudo}
  * data_profile const profile =
- *   data_profile_builder().cardinality(0).null_probability(0.0).distribution(
+ *   data_profile_builder().cardinality(0).null_probability(0.01).distribution(
  *     cudf::type_id::INT32, distribution_id::UNIFORM, 0, 100);
  * @endcode
  * The builder makes it easier to have immutable `data_profile` objects even with the complex


### PR DESCRIPTION
## Description
The `no_validity()` for a `data_profile` for generating benchmark data is more reliable than `null_probability(0,0)` since no mask is created.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
