### PR TITLE
Avoid cudf.pandas fallback for `pandas.array.NumpyExtensionArray` of strings

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -3045,8 +3045,10 @@ def as_column(
             if (
                 cudf.get_option("mode.pandas_compatible")
                 and inferred_dtype == "mixed"
-                and not isinstance(
-                    pyarrow_array.type, (pa.ListType, pa.StructType)
+                and not (
+                    pa.types.is_list(pyarrow_array.type)
+                    or pa.types.is_struct(pyarrow_array.type)
+                    or pa.types.is_string(pyarrow_array.type)
                 )
             ):
                 raise MixedTypeError("Cannot create column with mixed types")

--- a/python/cudf/cudf/pandas/_wrappers/pandas.py
+++ b/python/cudf/cudf/pandas/_wrappers/pandas.py
@@ -266,6 +266,10 @@ def ignore_ipython_canary_check(self, **kwargs):
     )
 
 
+def _DataFrame_dtypes(self):
+    return self._fsproxy_slow.dtypes
+
+
 DataFrame = make_final_proxy_type(
     "DataFrame",
     cudf.DataFrame,
@@ -281,7 +285,7 @@ DataFrame = make_final_proxy_type(
         "_accessors": set(),
         "_ipython_canary_method_should_not_exist_": ignore_ipython_canary_check,
         "__iter__": custom_iter,
-        "dtypes": _FastSlowAttribute("dtypes", private=True),
+        "dtypes": property(_DataFrame_dtypes),
     },
 )
 

--- a/python/cudf/cudf/pandas/_wrappers/pandas.py
+++ b/python/cudf/cudf/pandas/_wrappers/pandas.py
@@ -280,6 +280,7 @@ DataFrame = make_final_proxy_type(
         "_constructor_sliced": _FastSlowAttribute("_constructor_sliced"),
         "_accessors": set(),
         "_ipython_canary_method_should_not_exist_": ignore_ipython_canary_check,
+        "__iter__": custom_iter,
         "dtypes": _FastSlowAttribute("dtypes", private=True),
     },
 )

--- a/python/cudf/cudf/pandas/_wrappers/pandas.py
+++ b/python/cudf/cudf/pandas/_wrappers/pandas.py
@@ -266,10 +266,6 @@ def ignore_ipython_canary_check(self, **kwargs):
     )
 
 
-def _DataFrame_dtypes(self):
-    return self._fsproxy_slow.dtypes
-
-
 DataFrame = make_final_proxy_type(
     "DataFrame",
     cudf.DataFrame,
@@ -285,7 +281,6 @@ DataFrame = make_final_proxy_type(
         "_accessors": set(),
         "_ipython_canary_method_should_not_exist_": ignore_ipython_canary_check,
         "__iter__": custom_iter,
-        "dtypes": property(_DataFrame_dtypes),
     },
 )
 

--- a/python/cudf/cudf/tests/series/test_constructors.py
+++ b/python/cudf/cudf/tests/series/test_constructors.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 import pytest
 
 import cudf
+from cudf.core._compat import PANDAS_GE_210
 from cudf.core.column.column import as_column
 from cudf.errors import MixedTypeError
 from cudf.testing import assert_eq
@@ -45,6 +46,19 @@ def test_series_unitness_np_datetimelike_units():
         cudf.Series(data)
     with pytest.raises(TypeError):
         pd.Series(data)
+
+
+def test_from_numpyextensionarray_string_object_pandas_compat_mode():
+    if PANDAS_GE_210:
+        NumpyExtensionArray = pd.arrays.NumpyExtensionArray
+    else:
+        NumpyExtensionArray = pd.arrays.PandasArray
+
+    data = NumpyExtensionArray(np.array(["a", None], dtype=object))
+    with cudf.option_context("mode.pandas_compatible", True):
+        result = cudf.Series(data)
+    expected = pd.Series(data)
+    assert_eq(result, expected)
 
 
 def test_list_category_like_maintains_dtype():


### PR DESCRIPTION
## Description
This was erroneously falling back as this can be represented in cuDF.

Additionally, defines `DataFrame.__iter__` on the proxy object to short circuit to returning `pandas.DataFrame.__iter__` to avoid the fallback logic

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
