### PR TITLE
Additional gtests error checks for string/timestamp convert libcudf APIs

### DIFF
--- a/cpp/include/cudf/strings/convert/convert_datetime.hpp
+++ b/cpp/include/cudf/strings/convert/convert_datetime.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ namespace strings {
  * @brief Returns a new timestamp column converting a strings column into
  * timestamps using the provided format pattern.
  *
- * The format pattern can include the following specifiers: "%Y,%y,%m,%d,%H,%I,%p,%M,%S,%f,%z"
+ * The format pattern can include the following specifiers:
  *
  * | Specifier | Description |
  * | :-------: | ----------- |
@@ -94,7 +94,7 @@ std::unique_ptr<column> to_timestamps(
  * @brief Verifies the given strings column can be parsed to timestamps using the provided format
  * pattern.
  *
- * The format pattern can include the following specifiers: "%Y,%y,%m,%d,%H,%I,%p,%M,%S,%f,%z"
+ * The format pattern can include the following specifiers:
  *
  * | Specifier | Description |
  * | :-------: | ----------- |
@@ -125,6 +125,9 @@ std::unique_ptr<column> to_timestamps(
  * This will return a column of type BOOL8 where a `true` row indicates the corresponding
  * input string can be parsed correctly with the given format.
  *
+ * @throw std::invalid_argument if the `format` string is empty
+ * @throw std::invalid_argument if a specifier is not supported
+ *
  * @param input Strings instance for this operation
  * @param format String specifying the timestamp format in strings
  * @param stream CUDA stream used for device memory operations and kernel launches
@@ -141,7 +144,7 @@ std::unique_ptr<column> is_timestamp(
  * @brief Returns a new strings column converting a timestamp column into
  * strings using the provided format pattern.
  *
- * The format pattern can include the following specifiers: "%Y,%y,%m,%d,%H,%I,%p,%M,%S,%f,%z,%Z"
+ * The format pattern can include the following specifiers:
  *
  * | Specifier | Description |
  * | :-------: | ----------- |
@@ -230,9 +233,10 @@ std::unique_ptr<column> is_timestamp(
  * }
  * @endcode
  *
- * @throw cudf::logic_error if `timestamps` column parameter is not a timestamp type.
- * @throw cudf::logic_error if the `format` string is empty
- * @throw cudf::logic_error if `names.size()` is an invalid size. Must be 0 or 40 strings.
+ * @throw std::invalid_argument if `timestamps` column parameter is not a timestamp type.
+ * @throw std::invalid_argument if the `format` string is empty
+ * @throw std::invalid_argument if `names.size()` is an invalid size. Must be 0 or 40 strings.
+ * @throw std::invalid_argument if a specifier is not supported
  *
  * @param timestamps Timestamp values to convert
  * @param format The string specifying output format.

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -135,7 +135,7 @@ struct format_compiler {
         items.push_back(format_item::new_literal(ch));
         continue;
       }
-      CUDF_EXPECTS(length > 0, "Unfinished specifier in timestamp format");
+      CUDF_EXPECTS(length > 0, "Unfinished specifier in timestamp format", std::invalid_argument);
 
       ch = *str++;
       length--;
@@ -145,7 +145,9 @@ struct format_compiler {
         continue;
       }
       if (ch >= '0' && ch <= '9') {
-        CUDF_EXPECTS(*str == 'f', "precision not supported for specifier: " + std::string(1, *str));
+        CUDF_EXPECTS(*str == 'f',
+                     "precision not supported for specifier: " + std::string(1, *str),
+                     std::invalid_argument);
         specifiers[*str] = static_cast<int8_t>(ch - '0');
         ch               = *str++;
         length--;
@@ -153,7 +155,8 @@ struct format_compiler {
 
       // check if the specifier found is supported
       CUDF_EXPECTS(specifiers.find(ch) != specifiers.end(),
-                   "invalid format specifier: " + std::string(1, ch));
+                   "invalid format specifier: " + std::string(1, ch),
+                   std::invalid_argument);
 
       // create the format item for this specifier
       items.push_back(format_item::new_specifier(ch, specifiers[ch]));
@@ -428,7 +431,7 @@ struct dispatch_to_timestamps_fn {
                   rmm::cuda_stream_view) const
     requires(not cudf::is_timestamp<T>())
   {
-    CUDF_FAIL("Only timestamps type are expected");
+    CUDF_FAIL("Only timestamps type are expected", std::invalid_argument);
   }
 };
 
@@ -441,10 +444,9 @@ std::unique_ptr<cudf::column> to_timestamps(strings_column_view const& input,
                                             rmm::cuda_stream_view stream,
                                             rmm::device_async_resource_ref mr)
 {
-  if (input.is_empty())
-    return make_empty_column(timestamp_type);  // make_timestamp_column(timestamp_type, 0);
+  if (input.is_empty()) { return make_empty_column(timestamp_type); }
 
-  CUDF_EXPECTS(!format.empty(), "Format parameter must not be empty.");
+  CUDF_EXPECTS(!format.empty(), "Format parameter must not be empty.", std::invalid_argument);
 
   auto d_strings = column_device_view::create(input.parent(), stream);
 
@@ -682,7 +684,7 @@ std::unique_ptr<cudf::column> is_timestamp(strings_column_view const& input,
   size_type strings_count = input.size();
   if (strings_count == 0) return make_empty_column(type_id::BOOL8);
 
-  CUDF_EXPECTS(!format.empty(), "Format parameter must not be empty.");
+  CUDF_EXPECTS(!format.empty(), "Format parameter must not be empty.", std::invalid_argument);
 
   auto d_strings = column_device_view::create(input.parent(), stream);
 
@@ -1123,7 +1125,7 @@ struct dispatch_from_timestamps_fn {
   strings_children operator()(Args&&...) const
     requires(not cudf::is_timestamp<T>())
   {
-    CUDF_FAIL("Only timestamps type are expected");
+    CUDF_FAIL("Only timestamps type are expected", std::invalid_argument);
   }
 };
 
@@ -1138,9 +1140,10 @@ std::unique_ptr<column> from_timestamps(column_view const& timestamps,
 {
   if (timestamps.is_empty()) return make_empty_column(type_id::STRING);
 
-  CUDF_EXPECTS(!format.empty(), "Format parameter must not be empty.");
+  CUDF_EXPECTS(!format.empty(), "Format parameter must not be empty.", std::invalid_argument);
   CUDF_EXPECTS(names.is_empty() || names.size() == format_names_size,
-               "Invalid size for format names.");
+               "Invalid size for format names.",
+               std::invalid_argument);
 
   auto const d_names = column_device_view::create(names.parent(), stream);
 

--- a/cpp/tests/strings/datetime_tests.cpp
+++ b/cpp/tests/strings/datetime_tests.cpp
@@ -625,18 +625,22 @@ TEST_F(StringsDatetimeTest, Errors)
                cudf::logic_error);
   EXPECT_THROW(
     cudf::strings::to_timestamps(view, cudf::data_type{cudf::type_id::TIMESTAMP_SECONDS}, ""),
-    cudf::logic_error);
+    std::invalid_argument);
   EXPECT_THROW(
     cudf::strings::to_timestamps(view, cudf::data_type{cudf::type_id::TIMESTAMP_SECONDS}, "%2Y"),
-    cudf::logic_error);
+    std::invalid_argument);
   EXPECT_THROW(
     cudf::strings::to_timestamps(view, cudf::data_type{cudf::type_id::TIMESTAMP_SECONDS}, "%g"),
-    cudf::logic_error);
+    std::invalid_argument);
 
   cudf::test::fixed_width_column_wrapper<int64_t> invalid_timestamps{1530705600};
-  EXPECT_THROW(cudf::strings::from_timestamps(invalid_timestamps), cudf::logic_error);
+  EXPECT_THROW(cudf::strings::from_timestamps(invalid_timestamps), std::invalid_argument);
   cudf::test::fixed_width_column_wrapper<cudf::timestamp_s, cudf::timestamp_s::rep> timestamps{
     1530705600};
-  EXPECT_THROW(cudf::strings::from_timestamps(timestamps, ""), cudf::logic_error);
-  EXPECT_THROW(cudf::strings::from_timestamps(timestamps, "%A %B", view), cudf::logic_error);
+  EXPECT_THROW(cudf::strings::from_timestamps(timestamps, ""), std::invalid_argument);
+  EXPECT_THROW(cudf::strings::from_timestamps(timestamps, "%B", view), std::invalid_argument);
+
+  EXPECT_THROW(cudf::strings::is_timestamp(view, "%D"), std::invalid_argument);
+  EXPECT_THROW(cudf::strings::is_timestamp(view, "%p %"), std::invalid_argument);
+  EXPECT_THROW(cudf::strings::from_timestamps(timestamps, "%Y:%H", view), std::invalid_argument);
 }


### PR DESCRIPTION
## Description
Converts generic `cudf::logic_error` exceptions to more appropriate `std::invalid_argument` exceptions and adds additional gtests for those cases. Also update the doxygen as appropriate.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
