### PR TITLE
Expose `filter` and `columns` parquet reader builder options to python

### DIFF
--- a/python/pylibcudf/pylibcudf/io/parquet.pxd
+++ b/python/pylibcudf/pylibcudf/io/parquet.pxd
@@ -53,6 +53,8 @@ cdef class ParquetReaderOptionsBuilder:
     cpdef ParquetReaderOptionsBuilder use_pandas_metadata(self, bool val)
     cpdef ParquetReaderOptionsBuilder allow_mismatched_pq_schemas(self, bool val)
     cpdef ParquetReaderOptionsBuilder use_arrow_schema(self, bool val)
+    cpdef ParquetReaderOptionsBuilder filter(self, Expression filter)
+    cpdef ParquetReaderOptionsBuilder columns(self, list col_names)
     cpdef build(self)
 
 

--- a/python/pylibcudf/pylibcudf/io/parquet.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet.pyx
@@ -171,7 +171,7 @@ cdef class ParquetReaderOptions:
         -------
         None
         """
-        self.c_obj.set_filter(<expression &>dereference(filter.c_obj.get()))
+        self.c_obj.set_filter(<expression &>dereference(filter.c_obj))
 
 
 cdef class ParquetReaderOptionsBuilder:
@@ -239,6 +239,41 @@ cdef class ParquetReaderOptionsBuilder:
         ParquetReaderOptionsBuilder
         """
         self.c_obj.use_arrow_schema(val)
+        return self
+
+    cpdef ParquetReaderOptionsBuilder filter(self, Expression filter):
+        """
+        Sets AST based filter for predicate pushdown.
+
+        Parameters
+        ----------
+        filter : Expression
+            AST expression to use as filter
+
+        Returns
+        -------
+        None
+        """
+        self.c_obj.filter(<expression &>dereference(filter.c_obj))
+        return self
+
+    cpdef ParquetReaderOptionsBuilder columns(self, list col_names):
+        """
+        Sets names of the columns to be read.
+
+        Parameters
+        ----------
+        col_names : list
+            List of column names
+
+        Returns
+        -------
+        None
+        """
+        cdef vector[string] vec
+        for name in col_names:
+            vec.push_back(<string>str(name).encode())
+        self.c_obj.columns(vec)
         return self
 
     cpdef build(self):

--- a/python/pylibcudf/pylibcudf/io/parquet.pyx
+++ b/python/pylibcudf/pylibcudf/io/parquet.pyx
@@ -252,7 +252,7 @@ cdef class ParquetReaderOptionsBuilder:
 
         Returns
         -------
-        None
+        ParquetReaderOptionsBuilder
         """
         self.c_obj.filter(<expression &>dereference(filter.c_obj))
         return self
@@ -263,12 +263,12 @@ cdef class ParquetReaderOptionsBuilder:
 
         Parameters
         ----------
-        col_names : list
+        col_names : list[str]
             List of column names
 
         Returns
         -------
-        None
+        ParquetReaderOptionsBuilder
         """
         cdef vector[string] vec
         for name in col_names:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Exposes `filter` and `columns` options so we can use chaining style when building the options object before passing them to the reader.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
