### PR TITLE
Fix OOB memcheck error in group_rank_to_percentage utility

### DIFF
--- a/cpp/src/groupby/sort/group_rank_scan.cu
+++ b/cpp/src/groupby/sort/group_rank_scan.cu
@@ -300,7 +300,7 @@ std::unique_ptr<column> group_rank_to_percentage(rank_method const method,
                        double const r   = is_double ? d_rank[row_index] : s_rank[row_index];
                        auto const count = dcount[labels[row_index]];
                        size_type const last_rank_index = offsets[labels[row_index]] + count - 1;
-                       auto const last_rank            = s_rank[last_rank_index];
+                       auto const last_rank = last_rank_index < 0 ? 1 : s_rank[last_rank_index];
                        return percentage == rank_percentage::ZERO_NORMALIZED
                                 ? r / last_rank
                                 : one_normalized(r, last_rank);


### PR DESCRIPTION
## Description
Fixes out-of-bounds memory read access in `cudf::groupby::detail::group_rank_to_percentage` utility.
```
========= Invalid __global__ read of size 4 bytes
=========     at cudf::groupby::detail::group_rank_to_percentage(cudf::rank_method, cudf::rank_percentage, const cudf::column_view &, const cudf::column_view &, cudf::device_span<const int, (unsigned long)18446744073709551615>, cudf::device_span<const int, (unsigned long)18446744073709551615>, rmm::cuda_stream_view, cuda::mr::__4::basic_resource_ref<(cuda::mr::__4::_AllocType)1, cuda::mr::__4::device_accessible>)::[lambda(int) (instance 1)]::operator ()(int) const+0x1650 in group_rank_scan.cu:313
=========     by thread (0,0,0) in block (0,0,0)
=========     Access at 0x7beb8dc01dfc is out of bounds
=========     and is 4 bytes before the nearest allocation at 0x7beb8dc01e00 of size 400 bytes
=========         Device Frame: thrust::cuda_cub::__tabulate::functor<double *, cudf::groupby::detail::group_rank_to_percentage(cudf::rank_method, cudf::rank_percentage, const cudf::column_view &, const cudf::column_view &, cudf::device_span<const int, (unsigned long)18446744073709551615>, cudf::device_span<const int, (unsigned long)18446744073709551615>, rmm::cuda_stream_view, cuda::mr::__4::basic_resource_ref<(cuda::mr::__4::_AllocType)1, cuda::mr::__4::device_accessible>)::[lambda(int) (instance 1)], long>::operator ()(long)+0x1520 in tabulate.h:66
...
```

This was found using compute-sanitizer on the following pytest command in `/cudf/python/cudf/cudf/tests`:
```
pytest test_groupby.py -k'test_groupby_2keys_rank[True-keep-True-dense-100]'
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
