### PR TITLE
Avoid querying device memory on systems without it in dask-cudf

### DIFF
--- a/python/dask_cudf/dask_cudf/io/parquet.py
+++ b/python/dask_cudf/dask_cudf/io/parquet.py
@@ -52,12 +52,16 @@ def _get_device_size():
         if index and not index.isnumeric():
             # This means index is UUID. This works for both MIG and non-MIG device UUIDs.
             handle = pynvml.nvmlDeviceGetHandleByUUID(str.encode(index))
+            if pynvml.nvmlDeviceIsMigDeviceHandle(handle):
+                handle = pynvml.nvmlDeviceGetDeviceHandleFromMigDeviceHandle(
+                    handle
+                )
         else:
             # This is a device index
             handle = pynvml.nvmlDeviceGetHandleByIndex(int(index))
         return pynvml.nvmlDeviceGetMemoryInfo(handle).total
 
-    except ValueError:
+    except (ValueError, pynvml.NVMLError_NotSupported):
         # Fall back to a conservative 8GiB default
         return 8 * 1024**3
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR updates the dask-cudf's `_get_device_size` (which is used to determine the blocksize when reading parquet files) to catch `pynvml.NVMLError_NotSupported`, which is raised on systems without traditional dedicated GPU memory.

Related PR #19575
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
