### PR TITLE
ci(labeler): update labeler action to @v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,26 +1,34 @@
 # Documentation for config - https://github.com/actions/labeler#common-examples
 
 Python:
-  - 'python/**'
-  - 'notebooks/**'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - 'python/**'
+        - 'notebooks/**'
 cudf.pandas:
-  - 'python/cudf/cudf/pandas/**'
-  - 'python/cudf/cudf_pandas_tests/**'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - 'python/cudf/cudf/pandas/**'
+        - 'python/cudf/cudf_pandas_tests/**'
 cudf-polars:
-  - 'python/cudf_polars/**'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - 'python/cudf_polars/**'
 pylibcudf:
-  - 'python/pylibcudf/**'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - 'python/pylibcudf/**'
 libcudf:
-  - 'cpp/**'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - 'cpp/**'
 CMake:
-  - '**/CMakeLists.txt'
-  - '**/cmake/**'
-  - '**/*.cmake'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - '**/CMakeLists.txt'
+        - '**/cmake/**'
+        - '**/*.cmake'
 Java:
-  - 'java/**'
+  - changed-files:
+      any-glob-to-any-file:
+        - 'java/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,6 @@ jobs:
         persist-credentials: false
         sparse-checkout: .github/labeler.yml
         sparse-checkout-cone-mode: false
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Bumps the version of `actions/labeler` to `@v5` and updates the syntax in
the `labeler.yml` file to account for breaking changes in that version bump.

xref: rapidsai/ops#2968
