### PR TITLE
Fix uninitialized variable and misaligned write in parquet generic decoder

### DIFF
--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -1054,6 +1054,8 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
     if (not page_mask[page_idx]) {
       pp->num_nulls  = pp->num_rows;
       pp->num_valids = 0;
+      // Set s->nesting info = nullptr to bypass `null_count_back_copier` at return
+      s->nesting_info = nullptr;
       return;
     }
   }

--- a/cpp/src/io/parquet/page_decode.cuh
+++ b/cpp/src/io/parquet/page_decode.cuh
@@ -748,7 +748,10 @@ static __device__ void update_list_offsets_for_pruned_pages(page_state_s* state)
       int const idx                 = nesting_info.value_count;
       cudf::size_type const offset =
         next_nesting_info.value_count + next_nesting_info.page_start_value;
-      (reinterpret_cast<cudf::size_type*>(nesting_info.data_out))[idx] = offset;
+
+      // Write the offset safely to avoid misaligned access for boolean lists
+      uint8_t* write_ptr = nesting_info.data_out + (idx * sizeof(cudf::size_type));
+      cuda::std::memcpy(write_ptr, &offset, sizeof(cudf::size_type));
     }
   }
 }


### PR DESCRIPTION
## Description

Contributes to #19469

This PR fixes two minor bugs when a page is skipped for decoding in the parquet generic decoder. The bugs were discovered while working on #19469. The first fix initializes s->nesting_info = nullptr to avoid invalid null back copy at return. The second fix uses `cuda::std::memcpy` to write list offsets which may be written to a misaligned address in case of a boolean lists.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
