### PR TITLE
Update spark-rapdis-jni action to use PR's base.ref and fix issue of ccache version in dockerfile

### DIFF
--- a/.github/workflows/spark-rapids-jni.yaml
+++ b/.github/workflows/spark-rapids-jni.yaml
@@ -13,10 +13,11 @@ jobs:
         with:
           repository: NVIDIA/spark-rapids-jni
           submodules: recursive
+          ref: ${{ github.event.pull_request.base.ref }}
       - uses: actions/checkout@v4
         with:
           path: thirdparty/cudf
       - name: "Build spark-rapids-jni"
         run: |
           mkdir target
-          CMAKE_CUDA_ARCHITECTURES=90 LIBCUDF_DEPENDENCY_MODE=latest USE_GDS=on scl enable gcc-toolset-14 build/buildcpp.sh
+          source build/env.sh && CMAKE_CUDA_ARCHITECTURES=90 LIBCUDF_DEPENDENCY_MODE=latest USE_GDS=on ${sclCMD} build/buildcpp.sh

--- a/java/ci/Dockerfile.rocky
+++ b/java/ci/Dockerfile.rocky
@@ -27,13 +27,14 @@ ARG TARGETPLATFORM=linux/amd64
 # check available official arm-based docker images at https://hub.docker.com/r/nvidia/cuda/tags (OS/ARCH)
 FROM --platform=$TARGETPLATFORM nvidia/cuda:$CUDA_VERSION-devel-rockylinux$OS_RELEASE
 ARG TOOLSET_VERSION=14
+ARG CMAKE_VERSION=3.30.7
+ARG CCACHE_VERSION=4.11.2
 ### Install basic requirements
 RUN dnf --enablerepo=powertools install -y  scl-utils gcc-toolset-11 gcc-toolset-${TOOLSET_VERSION} git zlib-devel maven tar wget patch ninja-build boost-devel
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir /usr/local/rapids /rapids && chmod 777 /usr/local/rapids /rapids
 
 # 3.22.3+: CUDA architecture 'native' support + flexible CMAKE_<LANG>_*_LAUNCHER for ccache
-ARG CMAKE_VERSION=3.30.7
 # default x86_64 from x86 build, aarch64 cmake for arm build
 ARG CMAKE_ARCH=x86_64
 RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz && \
@@ -42,7 +43,6 @@ RUN cd /usr/local && wget --quiet https://github.com/Kitware/CMake/releases/down
 ENV PATH /usr/local/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}/bin:$PATH
 
 # ccache for interactive builds
-ARG CCACHE_VERSION=4.6
 RUN cd /tmp && wget --quiet https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz && \
    tar zxf ccache-${CCACHE_VERSION}.tar.gz && \
    rm ccache-${CCACHE_VERSION}.tar.gz && \

--- a/java/ci/README.md
+++ b/java/ci/README.md
@@ -42,7 +42,8 @@ git clone --recursive https://github.com/rapidsai/cudf.git -b branch-25.10
 ```bash
 cd cudf
 export WORKSPACE=`pwd`
-scl enable gcc-toolset-14 "java/ci/build-in-docker.sh"
+source java/ci/env.sh
+${sclCMD} "java/ci/build-in-docker.sh"
 ```
 
 ### The output

--- a/java/ci/env.sh
+++ b/java/ci/env.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -ex
+export sclCMD=${sclCMD:-"scl enable gcc-toolset-14"}


### PR DESCRIPTION

## Description
follow-up of https://github.com/rapidsai/cudf/pull/19500

1. Provide env.sh to provide common place for build ENVs
2. Update ccache version to pass compilation in gcc14
3. Update spark-rapids-jni workflow to checkout code based on cudf PR's base ref instead of repo default branch

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
