### PR TITLE
Use new nvCOMP API to better estimate decompression memory requirements

### DIFF
--- a/cpp/src/io/comp/common.cpp
+++ b/cpp/src/io/comp/common.cpp
@@ -23,19 +23,6 @@
 
 namespace cudf::io::detail {
 
-[[nodiscard]] std::optional<nvcomp::compression_type> to_nvcomp_compression(
-  compression_type compression)
-{
-  switch (compression) {
-    case compression_type::GZIP: return nvcomp::compression_type::GZIP;
-    case compression_type::LZ4: return nvcomp::compression_type::LZ4;
-    case compression_type::SNAPPY: return nvcomp::compression_type::SNAPPY;
-    case compression_type::ZLIB: return nvcomp::compression_type::DEFLATE;
-    case compression_type::ZSTD: return nvcomp::compression_type::ZSTD;
-    default: return std::nullopt;
-  }
-}
-
 [[nodiscard]] std::string compression_type_name(compression_type compression)
 {
   switch (compression) {

--- a/cpp/src/io/comp/common_internal.hpp
+++ b/cpp/src/io/comp/common_internal.hpp
@@ -49,8 +49,18 @@ constexpr double default_host_device_decompression_work_ratio = 100;
 // single GPU block; higher values lead to more host compression in HYBRID mode
 constexpr double default_host_device_compression_work_ratio = 100;
 
-[[nodiscard]] std::optional<nvcomp::compression_type> to_nvcomp_compression(
-  compression_type compression);
+[[nodiscard]] constexpr std::optional<nvcomp::compression_type> to_nvcomp_compression(
+  compression_type compression)
+{
+  switch (compression) {
+    case compression_type::GZIP: return nvcomp::compression_type::GZIP;
+    case compression_type::LZ4: return nvcomp::compression_type::LZ4;
+    case compression_type::SNAPPY: return nvcomp::compression_type::SNAPPY;
+    case compression_type::ZLIB: return nvcomp::compression_type::DEFLATE;
+    case compression_type::ZSTD: return nvcomp::compression_type::ZSTD;
+    default: return std::nullopt;
+  }
+}
 
 struct sorted_codec_parameters {
   rmm::device_uvector<device_span<uint8_t const>> inputs;

--- a/cpp/src/io/comp/decompression.cpp
+++ b/cpp/src/io/comp/decompression.cpp
@@ -666,23 +666,19 @@ size_t get_uncompressed_size(compression_type compression, host_span<uint8_t con
   auto nvcomp_disabled   = nvcomp_type.has_value() ? nvcomp::is_decompression_disabled(*nvcomp_type)
                                                    : "invalid compression type";
   if (nvcomp_disabled) {
-    CUDF_FAIL("Cannot compute decompression scratch size for " + compression_type_name(compression) + 
-              " compression: " + nvcomp_disabled.value() + 
-              ". This function requires nvcomp library support for the specified compression type.");
+    CUDF_FAIL("Cannot compute decompression scratch size for " +
+              compression_type_name(compression));
   }
-    return nvcomp::batched_decompress_temp_size_ex(
-      nvcomp_type.value(), inputs, max_uncomp_chunk_size, max_total_uncomp_size, stream);
+  return nvcomp::batched_decompress_temp_size_ex(
+    nvcomp_type.value(), inputs, max_uncomp_chunk_size, max_total_uncomp_size, stream);
 }
 
-[[nodiscard]] constexpr bool is_decompression_scratch_size_ex_supported(
-  compression_type compression)
-{  
+[[nodiscard]] bool is_decompression_scratch_size_ex_supported(compression_type compression)
+{
   auto const nvcomp_type = to_nvcomp_compression(compression);
   auto nvcomp_disabled   = nvcomp_type.has_value() ? nvcomp::is_decompression_disabled(*nvcomp_type)
                                                    : "invalid compression type";
-  if (nvcomp_disabled) {
-    return false;
-  }
+  if (nvcomp_disabled) { return false; }
   return nvcomp::is_batched_decompress_temp_size_ex_supported(nvcomp_type.value());
 }
 

--- a/cpp/src/io/comp/decompression.cpp
+++ b/cpp/src/io/comp/decompression.cpp
@@ -37,7 +37,6 @@
 #include <cstdint>
 #include <cstring>  // memset
 #include <future>
-#include <numeric>
 #include <sstream>
 
 namespace cudf::io::detail {
@@ -649,6 +648,42 @@ size_t get_uncompressed_size(compression_type compression, host_span<uint8_t con
   if (di.type == compression_type::BROTLI) return get_gpu_debrotli_scratch_size(di.num_pages);
   // only Brotli kernel requires scratch memory
   return 0;
+}
+
+[[nodiscard]] size_t get_decompression_scratch_size_ex(
+  compression_type compression,
+  device_span<device_span<uint8_t const> const> inputs,
+  size_t max_uncomp_chunk_size,
+  size_t max_total_uncomp_size,
+  rmm::cuda_stream_view stream)
+{
+  if (compression == compression_type::NONE or
+      get_host_engine_state(compression) == host_engine_state::ON) {
+    return 0;
+  }
+
+  auto const nvcomp_type = to_nvcomp_compression(compression);
+  auto nvcomp_disabled   = nvcomp_type.has_value() ? nvcomp::is_decompression_disabled(*nvcomp_type)
+                                                   : "invalid compression type";
+  if (nvcomp_disabled) {
+    CUDF_FAIL("Cannot compute decompression scratch size for " + compression_type_name(compression) + 
+              " compression: " + nvcomp_disabled.value() + 
+              ". This function requires nvcomp library support for the specified compression type.");
+  }
+    return nvcomp::batched_decompress_temp_size_ex(
+      nvcomp_type.value(), inputs, max_uncomp_chunk_size, max_total_uncomp_size, stream);
+}
+
+[[nodiscard]] constexpr bool is_decompression_scratch_size_ex_supported(
+  compression_type compression)
+{  
+  auto const nvcomp_type = to_nvcomp_compression(compression);
+  auto nvcomp_disabled   = nvcomp_type.has_value() ? nvcomp::is_decompression_disabled(*nvcomp_type)
+                                                   : "invalid compression type";
+  if (nvcomp_disabled) {
+    return false;
+  }
+  return nvcomp::is_batched_decompress_temp_size_ex_supported(nvcomp_type.value());
 }
 
 size_t decompress(compression_type compression,

--- a/cpp/src/io/comp/decompression.hpp
+++ b/cpp/src/io/comp/decompression.hpp
@@ -56,7 +56,8 @@ struct decompression_info {
 /**
  * @brief Functor which returns total scratch space required based on the compressed input data.
  *
- * Might launch a kernel. Should be used only if is_decompression_scratch_size_ex_supported returns true.
+ * Might launch a kernel. Should be used only if is_decompression_scratch_size_ex_supported returns
+ * true.
  */
 [[nodiscard]] size_t get_decompression_scratch_size_ex(
   compression_type compression,
@@ -66,9 +67,10 @@ struct decompression_info {
   rmm::cuda_stream_view stream);
 
 /**
- * @brief Checks if the decompression scratch size can be computed using the extended API of the nvcomp library.
+ * @brief Checks if the decompression scratch size can be computed using the extended API of the
+ * nvcomp library.
  */
-[[nodiscard]] constexpr bool is_decompression_scratch_size_ex_supported(compression_type compression);
+[[nodiscard]] bool is_decompression_scratch_size_ex_supported(compression_type compression);
 
 /**
  * @brief Computes the uncompressed sizes of Snappy-compressed input data.

--- a/cpp/src/io/comp/decompression.hpp
+++ b/cpp/src/io/comp/decompression.hpp
@@ -50,9 +50,25 @@ struct decompression_info {
 /**
  * @brief Functor which returns total scratch space required based on computed decompression_info
  * data.
- *
  */
 [[nodiscard]] size_t get_decompression_scratch_size(decompression_info const& di);
+
+/**
+ * @brief Functor which returns total scratch space required based on the compressed input data.
+ *
+ * Might launch a kernel. Should be used only if is_decompression_scratch_size_ex_supported returns true.
+ */
+[[nodiscard]] size_t get_decompression_scratch_size_ex(
+  compression_type compression,
+  device_span<device_span<uint8_t const> const> inputs,
+  size_t max_uncomp_chunk_size,
+  size_t max_total_uncomp_size,
+  rmm::cuda_stream_view stream);
+
+/**
+ * @brief Checks if the decompression scratch size can be computed using the extended API of the nvcomp library.
+ */
+[[nodiscard]] constexpr bool is_decompression_scratch_size_ex_supported(compression_type compression);
 
 /**
  * @brief Computes the uncompressed sizes of Snappy-compressed input data.

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -16,9 +16,9 @@
 
 #include "nvcomp_adapter.hpp"
 
-#include "io/utilities/getenv_or.hpp"
 #include "nvcomp_adapter.cuh"
 
+#include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/io/config_utils.hpp>
 #include <cudf/logger.hpp>
 #include <cudf/utilities/error.hpp>
@@ -558,6 +558,110 @@ std::optional<std::string> is_decompression_disabled_impl(compression_type compr
   return "Unsupported compression type";
 }
 
+#if NVCOMP_VER_MAJOR >= 5
+// Dispatcher for nvcompBatched<format>DecompressGetTempSizeSync
+template <typename... Args>
+auto batched_decompress_get_temp_size_sync(compression_type compression,
+                                           void const* const* device_compressed_chunk_ptrs,
+                                           size_t const* device_compressed_chunk_bytes,
+                                           size_t num_chunks,
+                                           size_t max_uncompressed_chunk_bytes,
+                                           size_t* temp_bytes,
+                                           size_t max_total_uncompressed_bytes,
+                                           nvcompStatus_t* device_statuses,
+                                           cudaStream_t stream)
+{
+  switch (compression) {
+    case compression_type::SNAPPY:
+      return nvcompBatchedSnappyDecompressGetTempSizeSync(device_compressed_chunk_ptrs,
+                                                          device_compressed_chunk_bytes,
+                                                          num_chunks,
+                                                          max_uncompressed_chunk_bytes,
+                                                          temp_bytes,
+                                                          max_total_uncompressed_bytes,
+                                                          nvcompBatchedSnappyDecompressDefaultOpts,
+                                                          device_statuses,
+                                                          stream);
+    case compression_type::ZSTD:
+      return nvcompBatchedZstdDecompressGetTempSizeSync(device_compressed_chunk_ptrs,
+                                                        device_compressed_chunk_bytes,
+                                                        num_chunks,
+                                                        max_uncompressed_chunk_bytes,
+                                                        temp_bytes,
+                                                        max_total_uncompressed_bytes,
+                                                        nvcompBatchedZstdDecompressDefaultOpts,
+                                                        device_statuses,
+                                                        stream);
+    case compression_type::LZ4:
+      return nvcompBatchedLZ4DecompressGetTempSizeSync(device_compressed_chunk_ptrs,
+                                                       device_compressed_chunk_bytes,
+                                                       num_chunks,
+                                                       max_uncompressed_chunk_bytes,
+                                                       temp_bytes,
+                                                       max_total_uncompressed_bytes,
+                                                       nvcompBatchedLZ4DecompressDefaultOpts,
+                                                       device_statuses,
+                                                       stream);
+    case compression_type::DEFLATE:
+      return nvcompBatchedDeflateDecompressGetTempSizeSync(
+        device_compressed_chunk_ptrs,
+        device_compressed_chunk_bytes,
+        num_chunks,
+        max_uncompressed_chunk_bytes,
+        temp_bytes,
+        max_total_uncompressed_bytes,
+        nvcompBatchedDeflateDecompressDefaultOpts,
+        device_statuses,
+        stream);
+    case compression_type::GZIP:
+      return nvcompBatchedGzipDecompressGetTempSizeSync(device_compressed_chunk_ptrs,
+                                                        device_compressed_chunk_bytes,
+                                                        num_chunks,
+                                                        max_uncompressed_chunk_bytes,
+                                                        temp_bytes,
+                                                        max_total_uncompressed_bytes,
+                                                        nvcompBatchedGzipDecompressDefaultOpts,
+                                                        device_statuses,
+                                                        stream);
+    default: UNSUPPORTED_COMPRESSION(compression);
+  }
+}
+
+#endif
+
+// Overload for internal use that takes device pointers and sizes directly
+size_t batched_decompress_temp_size_ex(compression_type compression,
+                                       device_span<void const* const> input_data_ptrs,
+                                       device_span<size_t const> input_data_sizes,
+                                       size_t max_uncomp_chunk_size,
+                                       size_t max_total_uncomp_size,
+                                       rmm::cuda_stream_view stream)
+{
+#if NVCOMP_VER_MAJOR >= 5
+  size_t temp_size = 0;
+  auto d_statuses  = rmm::device_uvector<nvcompStatus_t>(input_data_ptrs.size(), stream);
+  nvcompStatus_t const nvcomp_status =
+    batched_decompress_get_temp_size_sync(compression,
+                                          input_data_ptrs.data(),
+                                          input_data_sizes.data(),
+                                          input_data_ptrs.size(),
+                                          max_uncomp_chunk_size,
+                                          &temp_size,
+                                          max_total_uncomp_size,
+                                          d_statuses.data(),
+                                          stream.value());
+  CHECK_NVCOMP_STATUS(nvcomp_status);
+  auto const h_statuses = cudf::detail::make_host_vector(d_statuses, stream);
+  for (auto const& status : h_statuses) {
+    CHECK_NVCOMP_STATUS(status);
+  }
+  return temp_size;
+#else
+  return batched_decompress_temp_size(
+    compression, input_data_ptrs.size(), max_uncomp_chunk_size, max_total_uncomp_size);
+#endif
+}
+
 }  // namespace
 
 size_t batched_decompress_temp_size(compression_type compression,
@@ -577,6 +681,27 @@ size_t batched_decompress_temp_size(compression_type compression,
   return temp_size;
 }
 
+size_t batched_decompress_temp_size_ex(compression_type compression,
+                                       device_span<device_span<uint8_t const> const> inputs,
+                                       size_t max_uncomp_chunk_size,
+                                       size_t max_total_uncomp_size,
+                                       rmm::cuda_stream_view stream)
+{
+  auto const [d_input_ptrs, d_input_sizes] = create_get_temp_size_args(inputs, stream);
+
+  return batched_decompress_temp_size_ex(
+    compression, d_input_ptrs, d_input_sizes, max_uncomp_chunk_size, max_total_uncomp_size, stream);
+}
+
+constexpr bool is_batched_decompress_temp_size_ex_supported()
+{
+#if NVCOMP_VER_MAJOR >= 5
+  return true;
+#else
+  return false;
+#endif
+}
+
 void batched_decompress(compression_type compression,
                         device_span<device_span<uint8_t const> const> inputs,
                         device_span<device_span<uint8_t> const> outputs,
@@ -591,10 +716,16 @@ void batched_decompress(compression_type compression,
   auto const nvcomp_args = create_batched_nvcomp_args(inputs, outputs, stream);
   rmm::device_uvector<size_t> actual_uncompressed_data_sizes(num_chunks, stream);
   rmm::device_uvector<nvcompStatus_t> nvcomp_statuses(num_chunks, stream);
+
   // Temporary space required for decompression
-  auto const temp_size = batched_decompress_temp_size(
-    compression, num_chunks, max_uncomp_chunk_size, max_total_uncomp_size);
+  auto const temp_size = batched_decompress_temp_size_ex(compression,
+                                                         nvcomp_args.input_data_ptrs,
+                                                         nvcomp_args.input_data_sizes,
+                                                         max_uncomp_chunk_size,
+                                                         max_total_uncomp_size,
+                                                         stream);
   rmm::device_buffer scratch(temp_size, stream);
+
   auto const nvcomp_status = batched_decompress_async(compression,
 #if NVCOMP_VER_MAJOR >= 5
                                                       use_hw_decompression(),

--- a/cpp/src/io/comp/nvcomp_adapter.cpp
+++ b/cpp/src/io/comp/nvcomp_adapter.cpp
@@ -693,14 +693,7 @@ size_t batched_decompress_temp_size_ex(compression_type compression,
     compression, d_input_ptrs, d_input_sizes, max_uncomp_chunk_size, max_total_uncomp_size, stream);
 }
 
-constexpr bool is_batched_decompress_temp_size_ex_supported()
-{
-#if NVCOMP_VER_MAJOR >= 5
-  return true;
-#else
-  return false;
-#endif
-}
+
 
 void batched_decompress(compression_type compression,
                         device_span<device_span<uint8_t const> const> inputs,

--- a/cpp/src/io/comp/nvcomp_adapter.cuh
+++ b/cpp/src/io/comp/nvcomp_adapter.cuh
@@ -48,6 +48,12 @@ batched_args create_batched_nvcomp_args(device_span<device_span<uint8_t const> c
                                         rmm::cuda_stream_view stream);
 
 /**
+ * @brief Prepares device arrays of input pointers and sizes for use with nvCOMP temp size APIs.
+ */
+std::pair<rmm::device_uvector<void const*>, rmm::device_uvector<size_t>> create_get_temp_size_args(
+  device_span<device_span<uint8_t const> const> inputs, rmm::cuda_stream_view stream);
+
+/**
  * @brief Convert nvcomp statuses and output sizes into cuIO compression results.
  */
 void update_compression_results(device_span<nvcompStatus_t const> nvcomp_stats,

--- a/cpp/src/io/comp/nvcomp_adapter.hpp
+++ b/cpp/src/io/comp/nvcomp_adapter.hpp
@@ -19,6 +19,7 @@
 #include "io/comp/compression.hpp"
 
 #include <cudf/io/nvcomp_adapter.hpp>
+#include <cudf/io/types.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -85,7 +86,14 @@ size_t batched_decompress_temp_size(compression_type compression,
   size_t max_total_uncomp_size,
   rmm::cuda_stream_view stream);
 
-[[nodiscard]] constexpr bool is_batched_decompress_temp_size_ex_supported();
+[[nodiscard]] constexpr bool is_batched_decompress_temp_size_ex_supported(compression_type compression)
+{
+#if NVCOMP_VER_MAJOR >= 5
+  return compression == compression_type::ZSTD;
+#else
+  return false;
+#endif
+}
 
 /**
  * @brief Gets the maximum size any chunk could compress to in the batch.

--- a/cpp/src/io/comp/nvcomp_adapter.hpp
+++ b/cpp/src/io/comp/nvcomp_adapter.hpp
@@ -86,14 +86,7 @@ size_t batched_decompress_temp_size(compression_type compression,
   size_t max_total_uncomp_size,
   rmm::cuda_stream_view stream);
 
-[[nodiscard]] constexpr bool is_batched_decompress_temp_size_ex_supported(compression_type compression)
-{
-#if NVCOMP_VER_MAJOR >= 5
-  return compression == compression_type::ZSTD;
-#else
-  return false;
-#endif
-}
+[[nodiscard]] bool is_batched_decompress_temp_size_ex_supported(compression_type compression);
 
 /**
  * @brief Gets the maximum size any chunk could compress to in the batch.

--- a/cpp/src/io/comp/nvcomp_adapter.hpp
+++ b/cpp/src/io/comp/nvcomp_adapter.hpp
@@ -64,6 +64,30 @@ size_t batched_decompress_temp_size(compression_type compression,
                                     size_t max_total_uncomp_size);
 
 /**
+ * @brief Return the amount of temporary space required in bytes for a given decompression
+ * operation using synchronous nvcomp APIs.
+ *
+ * The size returned reflects the size of the scratch buffer to be passed to
+ * `batched_decompress_async`. This version uses the sync APIs which are more precise, but
+ * potentially require a kernel launch.
+ *
+ * @param[in] compression Compression type
+ * @param[in] inputs Device span of compressed data chunks
+ * @param[in] max_uncomp_chunk_size Maximum size of any single uncompressed chunk
+ * @param[in] max_total_uncomp_size Maximum total size of uncompressed data
+ * @param[in] stream CUDA stream to use
+ * @returns The total required size in bytes
+ */
+[[nodiscard]] size_t batched_decompress_temp_size_ex(
+  compression_type compression,
+  device_span<device_span<uint8_t const> const> inputs,
+  size_t max_uncomp_chunk_size,
+  size_t max_total_uncomp_size,
+  rmm::cuda_stream_view stream);
+
+[[nodiscard]] constexpr bool is_batched_decompress_temp_size_ex_supported();
+
+/**
  * @brief Gets the maximum size any chunk could compress to in the batch.
  *
  * @param compression Compression type

--- a/cpp/src/io/parquet/reader_impl_chunking.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking.cu
@@ -276,7 +276,11 @@ void reader_impl::setup_next_subpass(read_mode mode)
 
     // include scratch space needed for decompression. for certain codecs (eg ZSTD) this
     // can be considerable.
-    include_decompression_scratch_size(pass.chunks, pass.pages, c_info, _stream);
+    if (is_first_subpass) {
+      pass.decomp_scratch_sizes =
+        compute_decompression_scratch_sizes(pass.chunks, pass.pages, _stream);
+    }
+    include_decompression_scratch_size(pass.decomp_scratch_sizes, c_info, _stream);
 
     auto iter               = thrust::make_counting_iterator(0);
     auto const pass_max_row = pass.skip_rows + pass.num_rows;

--- a/cpp/src/io/parquet/reader_impl_chunking.hpp
+++ b/cpp/src/io/parquet/reader_impl_chunking.hpp
@@ -133,6 +133,7 @@ struct pass_intermediate_data {
   rmm::device_uvector<size_type> page_offsets{0, cudf::get_default_stream()};
 
   rmm::device_buffer decomp_dict_data{0, cudf::get_default_stream()};
+  rmm::device_uvector<size_t> decomp_scratch_sizes{0, cudf::get_default_stream()};
   rmm::device_uvector<string_index_pair> str_dict_index{0, cudf::get_default_stream()};
 
   int level_type_size{0};

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cuh
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cuh
@@ -228,11 +228,18 @@ void detect_malformed_pages(device_span<PageInfo const> pages,
                             rmm::cuda_stream_view stream);
 
 /**
+ * @brief Computes the per-page scratch space required for decompression.
+ */
+rmm::device_uvector<size_t> compute_decompression_scratch_sizes(
+  device_span<ColumnChunkDesc const> chunks,
+  device_span<PageInfo const> pages,
+  rmm::cuda_stream_view stream);
+
+/**
  * @brief Add the cost of decompression codec scratch space to the per-page cumulative
  * size information
  */
-void include_decompression_scratch_size(device_span<ColumnChunkDesc const> chunks,
-                                        device_span<PageInfo const> pages,
+void include_decompression_scratch_size(device_span<size_t const> pages,
                                         device_span<cumulative_page_info> c_info,
                                         rmm::cuda_stream_view stream);
 

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cuh
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cuh
@@ -374,6 +374,9 @@ struct decomp_sum {
   __device__ inline decompression_info operator()(decompression_info const& a,
                                                   decompression_info const& b) const
   {
+    // Ignore uncompressed blocks: if either a or b is uncompressed, return the other
+    if (a.type == compression_type::NONE and b.type != compression_type::NONE) return b;
+    if (b.type == compression_type::NONE and a.type != compression_type::NONE) return a;
     return {a.type,
             a.num_pages + b.num_pages,
             cuda::std::max(a.max_page_decompressed_size, b.max_page_decompressed_size),


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
