### PR TITLE
Add nvtx ranges to public APIs of the experimental parquet reader

### DIFF
--- a/cpp/src/io/parquet/experimental/hybrid_scan.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan.cpp
@@ -16,6 +16,7 @@
 
 #include "hybrid_scan_impl.hpp"
 
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/io/experimental/hybrid_scan.hpp>
 #include <cudf/utilities/error.hpp>
 
@@ -33,22 +34,30 @@ hybrid_scan_reader::~hybrid_scan_reader() = default;
 
 [[nodiscard]] text::byte_range_info hybrid_scan_reader::page_index_byte_range() const
 {
+  CUDF_FUNC_RANGE();
+
   return _impl->page_index_byte_range();
 }
 
 [[nodiscard]] FileMetaData hybrid_scan_reader::parquet_metadata() const
 {
+  CUDF_FUNC_RANGE();
+
   return _impl->parquet_metadata();
 }
 
 void hybrid_scan_reader::setup_page_index(cudf::host_span<uint8_t const> page_index_bytes) const
 {
+  CUDF_FUNC_RANGE();
+
   return _impl->setup_page_index(page_index_bytes);
 }
 
 std::vector<cudf::size_type> hybrid_scan_reader::all_row_groups(
   parquet_reader_options const& options) const
 {
+  CUDF_FUNC_RANGE();
+
   CUDF_EXPECTS(options.get_row_groups().size() <= 1,
                "Encountered invalid size of row group indices in parquet reader options");
 
@@ -61,6 +70,8 @@ std::vector<cudf::size_type> hybrid_scan_reader::all_row_groups(
 size_type hybrid_scan_reader::total_rows_in_row_groups(
   cudf::host_span<size_type const> row_group_indices) const
 {
+  CUDF_FUNC_RANGE();
+
   if (row_group_indices.empty()) { return 0; }
 
   auto const input_row_group_indices =
@@ -73,6 +84,8 @@ std::vector<cudf::size_type> hybrid_scan_reader::filter_row_groups_with_stats(
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream) const
 {
+  CUDF_FUNC_RANGE();
+
   // Temporary vector with row group indices from the first source
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
@@ -84,6 +97,7 @@ std::pair<std::vector<text::byte_range_info>, std::vector<text::byte_range_info>
 hybrid_scan_reader::secondary_filters_byte_ranges(
   cudf::host_span<size_type const> row_group_indices, parquet_reader_options const& options) const
 {
+  CUDF_FUNC_RANGE();
   // Temporary vector with row group indices from the first source
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
@@ -97,6 +111,8 @@ std::vector<cudf::size_type> hybrid_scan_reader::filter_row_groups_with_dictiona
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream) const
 {
+  CUDF_FUNC_RANGE();
+
   // Temporary vector with row group indices from the first source
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
@@ -113,6 +129,8 @@ std::vector<cudf::size_type> hybrid_scan_reader::filter_row_groups_with_bloom_fi
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream) const
 {
+  CUDF_FUNC_RANGE();
+
   // Temporary vector with row group indices from the first source
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
@@ -129,6 +147,8 @@ std::unique_ptr<cudf::column> hybrid_scan_reader::build_row_mask_with_page_index
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
+  CUDF_FUNC_RANGE();
+
   // Temporary vector with row group indices from the first source
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
@@ -140,6 +160,8 @@ std::unique_ptr<cudf::column> hybrid_scan_reader::build_row_mask_with_page_index
 hybrid_scan_reader::filter_column_chunks_byte_ranges(
   cudf::host_span<size_type const> row_group_indices, parquet_reader_options const& options) const
 {
+  CUDF_FUNC_RANGE();
+
   // Temporary vector with row group indices from the first source
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
@@ -155,6 +177,8 @@ table_with_metadata hybrid_scan_reader::materialize_filter_columns(
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream) const
 {
+  CUDF_FUNC_RANGE();
+
   // Temporary vector with row group indices from the first source
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
@@ -171,6 +195,8 @@ table_with_metadata hybrid_scan_reader::materialize_filter_columns(
 hybrid_scan_reader::payload_column_chunks_byte_ranges(
   cudf::host_span<size_type const> row_group_indices, parquet_reader_options const& options) const
 {
+  CUDF_FUNC_RANGE();
+
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};
 
@@ -185,6 +211,8 @@ table_with_metadata hybrid_scan_reader::materialize_payload_columns(
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream) const
 {
+  CUDF_FUNC_RANGE();
+
   // Temporary vector with row group indices from the first source
   auto const input_row_group_indices =
     std::vector<std::vector<size_type>>{{row_group_indices.begin(), row_group_indices.end()}};

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -20,6 +20,7 @@
 #include "io/parquet/reader_impl_helpers.hpp"
 #include "io/utilities/row_selection.hpp"
 
+#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/logger.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
@@ -72,6 +73,8 @@ namespace {
 
 metadata::metadata(cudf::host_span<uint8_t const> footer_bytes)
 {
+  CUDF_FUNC_RANGE();
+
   CompactProtocolReader cp(footer_bytes.data(), footer_bytes.size());
   cp.read(this);
   CUDF_EXPECTS(cp.InitSchema(this), "Cannot initialize schema");

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
@@ -20,7 +20,6 @@
 #include "hybrid_scan_helpers.hpp"
 #include "io/parquet/reader_impl_chunking_utils.cuh"
 
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/stream_compaction.hpp>
 #include <cudf/detail/structs/utilities.hpp>
 #include <cudf/detail/transform.hpp>
@@ -169,8 +168,6 @@ std::vector<std::vector<size_type>> hybrid_scan_reader_impl::filter_row_groups_w
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream)
 {
-  CUDF_FUNC_RANGE();
-
   CUDF_EXPECTS(not row_group_indices.empty(), "Empty input row group indices encountered");
   CUDF_EXPECTS(options.get_filter().has_value(), "Encountered empty converted filter expression");
 
@@ -195,8 +192,6 @@ hybrid_scan_reader_impl::secondary_filters_byte_ranges(
   cudf::host_span<std::vector<size_type> const> row_group_indices,
   parquet_reader_options const& options)
 {
-  CUDF_FUNC_RANGE();
-
   CUDF_EXPECTS(not row_group_indices.empty(), "Empty input row group indices encountered");
   CUDF_EXPECTS(options.get_filter().has_value(), "Filter expression must not be empty");
 
@@ -230,8 +225,6 @@ hybrid_scan_reader_impl::filter_row_groups_with_dictionary_pages(
   parquet_reader_options const& options,
   rmm::cuda_stream_view stream)
 {
-  CUDF_FUNC_RANGE();
-
   CUDF_EXPECTS(not row_group_indices.empty(), "Empty input row group indices encountered");
   CUDF_EXPECTS(options.get_filter().has_value(), "Encountered empty converted filter expression");
 
@@ -302,8 +295,6 @@ std::vector<std::vector<size_type>> hybrid_scan_reader_impl::filter_row_groups_w
   CUDF_EXPECTS(not row_group_indices.empty(), "Empty input row group indices encountered");
   CUDF_EXPECTS(options.get_filter().has_value(), "Encountered empty converted filter expression");
 
-  CUDF_FUNC_RANGE();
-
   select_columns(read_columns_mode::FILTER_COLUMNS, options);
 
   table_metadata metadata;
@@ -331,8 +322,6 @@ std::unique_ptr<cudf::column> hybrid_scan_reader_impl::build_row_mask_with_page_
   CUDF_EXPECTS(not row_group_indices.empty(), "Empty input row group indices encountered");
   CUDF_EXPECTS(options.get_filter().has_value(), "Encountered empty converted filter expression");
 
-  CUDF_FUNC_RANGE();
-
   select_columns(read_columns_mode::FILTER_COLUMNS, options);
 
   table_metadata metadata;
@@ -355,8 +344,6 @@ std::pair<std::vector<byte_range_info>, std::vector<cudf::size_type>>
 hybrid_scan_reader_impl::get_input_column_chunk_byte_ranges(
   cudf::host_span<std::vector<size_type> const> row_group_indices) const
 {
-  CUDF_FUNC_RANGE();
-
   // Descriptors for all the chunks that make up the selected columns
   auto const num_input_columns = _input_columns.size();
   auto const num_row_groups =
@@ -438,8 +425,6 @@ table_with_metadata hybrid_scan_reader_impl::materialize_filter_columns(
   CUDF_EXPECTS(not row_group_indices.empty(), "Empty input row group indices encountered");
   CUDF_EXPECTS(options.get_filter().has_value(), "Encountered empty converted filter expression");
 
-  CUDF_FUNC_RANGE();
-
   reset_internal_state();
 
   table_metadata metadata;
@@ -476,8 +461,6 @@ table_with_metadata hybrid_scan_reader_impl::materialize_payload_columns(
   CUDF_EXPECTS(not row_group_indices.empty(), "Empty input row group indices encountered");
   CUDF_EXPECTS(row_mask.null_count() == 0,
                "Row mask must not have any nulls when materializing payload column");
-
-  CUDF_FUNC_RANGE();
 
   reset_internal_state();
 
@@ -728,8 +711,6 @@ table_with_metadata hybrid_scan_reader_impl::finalize_output(
 void hybrid_scan_reader_impl::set_pass_page_mask(
   cudf::host_span<std::vector<bool> const> data_page_mask)
 {
-  CUDF_FUNC_RANGE();
-
   auto const& pass   = _pass_itm_data;
   auto const& chunks = pass->chunks;
 


### PR DESCRIPTION
## Description
Contributes to #19469

This PR moves the NVTX ranges from detail to public APIs of the experimental Parquet reader.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
