### PR TITLE
Use page mask to skip decompression of pruned subpass pages

### DIFF
--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -30,7 +30,6 @@
 
 #include <cub/device/device_radix_sort.cuh>
 #include <thrust/binary_search.h>
-#include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/logical.h>
 #include <thrust/sequence.h>
@@ -127,8 +126,8 @@ void codec_stats::add_pages(host_span<ColumnChunkDesc const> chunks,
                             host_span<bool const> page_mask)
 {
   // Create a page mask iterator that defaults to true if the page_mask is empty
-  auto page_mask_iter =
-    page_mask.empty() ? thrust::make_constant_iterator(true) : page_mask.begin();
+  auto page_mask_iter = cudf::detail::make_counting_transform_iterator(
+    0, [&](auto i) { return page_mask.empty() ? true : page_mask[i]; });
 
   // Zip iterator for iterating over pages and the page mask
   auto zip_iter = thrust::make_zip_iterator(pages.begin(), page_mask_iter);


### PR DESCRIPTION
## Description

Contributes to #17896

Fix the `page_mask_iter` such that the `page_mask` is actually used to skip decompression of pruned out pages instead of getting constantly set to `page_mask.begin()`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
