### PR TITLE
Require `--scale` for PDS-DS benchmarks (due to nonlinear scaling)

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
@@ -57,8 +57,6 @@ def valid_query(name: str) -> bool:
 class PDSDSQueriesMeta(type):
     """Metaclass used for query lookup."""
 
-    name: str = "pdsds"
-
     def __getattr__(cls, name: str):  # type: ignore
         """Query lookup."""
         if valid_query(name):
@@ -74,6 +72,7 @@ class PDSDSQueries(metaclass=PDSDSQueriesMeta):
     """Base class for query loading."""
 
     q_impl: str
+    name: str = "pdsds"
 
 
 class PDSDSPolarsQueries(PDSDSQueries):

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
@@ -57,6 +57,8 @@ def valid_query(name: str) -> bool:
 class PDSDSQueriesMeta(type):
     """Metaclass used for query lookup."""
 
+    name: str = "pdsds"
+
     def __getattr__(cls, name: str):  # type: ignore
         """Query lookup."""
         if valid_query(name):

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
@@ -39,6 +39,8 @@ os.environ["KVIKIO_NTHREADS"] = os.environ.get("KVIKIO_NTHREADS", "8")
 class PDSHQueries:
     """PDS-H query definitions."""
 
+    name: str = "pdsh"
+
     @staticmethod
     def q0(run_config: RunConfig) -> pl.LazyFrame:
         """Query 0."""

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -216,7 +216,7 @@ class RunConfig:
         scale_factor = args.scale
 
         if scale_factor is None:
-            if "pdsds" in name:
+            if path is None and "pdsds" in name:
                 raise ValueError(
                     "--scale is required for PDS-DS benchmarks.\n"
                     "TODO: This will be inferred once we maintain a map of scale factors to row counts."

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -16,7 +16,6 @@ import textwrap
 import time
 from collections import defaultdict
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, assert_never
 
 import nvtx
@@ -41,6 +40,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
+    from pathlib import Path
 
 
 ExecutorType = Literal["in-memory", "streaming", "cpu"]
@@ -174,7 +174,7 @@ def _infer_scale_factor(name: str, path: str | Path, suffix: str) -> int | float
 
 @dataclasses.dataclass(kw_only=True)
 class RunConfig:
-    """Results for a PDS-H query run."""
+    """Results for a PDS-H or PDS-DS query run."""
 
     queries: list[int]
     suffix: str
@@ -201,6 +201,7 @@ class RunConfig:
     rapidsmpf_oom_protection: bool
     rapidsmpf_spill: bool
     spill_device: float
+    query_set: str
 
     @classmethod
     def from_args(cls, args: argparse.Namespace) -> RunConfig:
@@ -212,7 +213,7 @@ class RunConfig:
             scheduler = None
 
         path = args.path
-        name = Path(sys.argv[0]).name
+        name = args.query_set
         scale_factor = args.scale
 
         if scale_factor is None:
@@ -262,6 +263,7 @@ class RunConfig:
             spill_device=args.spill_device,
             rapidsmpf_spill=args.rapidsmpf_spill,
             max_rows_per_partition=args.max_rows_per_partition,
+            query_set=args.query_set,
         )
 
     def serialize(self, engine: pl.GPUEngine | None) -> dict:
@@ -688,6 +690,7 @@ def run_polars(
 ) -> None:
     """Run the queries using the given benchmark and executor options."""
     args = parse_args(options, num_queries=num_queries)
+    vars(args).update({"query_set": benchmark.name})
     run_config = RunConfig.from_args(args)
     validation_failures: list[int] = []
 

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -216,7 +216,7 @@ class RunConfig:
         scale_factor = args.scale
 
         if scale_factor is None:
-            if path is None and "pdsds" in name:
+            if "pdsds" in name:
                 raise ValueError(
                     "--scale is required for PDS-DS benchmarks.\n"
                     "TODO: This will be inferred once we maintain a map of scale factors to row counts."


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Contributes to #19200. Unlike PDS-H, which scales linearly with row counts, PDS-DS tables scale nonlinearly, so we cannot infer the scale factor from a single table’s row count.

In the future, we can relax this requirement by maintaining a map of scale factors to expected row counts for PDS-DS tables.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
