### PR TITLE
Add reduction with overflow detection

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -661,6 +661,7 @@ add_library(
   src/reductions/std.cu
   src/reductions/sum.cu
   src/reductions/sum_of_squares.cu
+  src/reductions/sum_with_overflow.cu
   src/reductions/var.cu
   src/replace/clamp.cu
   src/replace/nans.cu

--- a/cpp/include/cudf/detail/aggregation/aggregation.hpp
+++ b/cpp/include/cudf/detail/aggregation/aggregation.hpp
@@ -185,7 +185,9 @@ class sum_aggregation final : public rolling_aggregation,
  * @brief Derived class for specifying a sum_with_overflow aggregation
  */
 class sum_with_overflow_aggregation final : public groupby_aggregation,
-                                            public groupby_scan_aggregation {
+                                            public groupby_scan_aggregation,
+                                            public reduce_aggregation,
+                                            public segmented_reduce_aggregation {
  public:
   sum_with_overflow_aggregation() : aggregation(SUM_WITH_OVERFLOW) {}
 

--- a/cpp/include/cudf/reduction.hpp
+++ b/cpp/include/cudf/reduction.hpp
@@ -131,13 +131,13 @@ std::unique_ptr<scalar> reduce(
  * @brief  Computes the reduction of the values in all rows of a column with overflow detection
  *
  * This function performs reduction operations with overflow detection, currently supporting
- * only SUM aggregation. For SUM operations, overflow is detected during accumulation and
- * the function returns a pair where the first scalar contains the result (potentially partial
+ * only SUM_WITH_OVERFLOW aggregation. For SUM operations, overflow is detected during accumulation
+ * and the function returns a pair where the first scalar contains the result (potentially partial
  * if overflow occurred) and the second scalar contains a boolean indicating whether overflow
  * was detected.
  *
- * Only SUM aggregation is supported. For other aggregation types, this function will throw
- * cudf::logic_error.
+ * Only SUM_WITH_OVERFLOW aggregation is supported. For other aggregation types, this function will
+ * throw cudf::logic_error.
  *
  * Any null values are skipped for the operation.
  * If the reduction fails, both output scalars return with `%is_valid()==false`.
@@ -147,11 +147,11 @@ std::unique_ptr<scalar> reduce(
  * The input column must be an arithmetic type. The output sum scalar type matches the input
  * column type to preserve precision during overflow detection.
  *
- * @throw cudf::logic_error if aggregation type is not SUM.
+ * @throw cudf::logic_error if aggregation type is not SUM_WITH_OVERFLOW.
  * @throw cudf::logic_error if input column data type is not arithmetic.
  *
  * @param col Input column view (must be arithmetic type)
- * @param agg Aggregation operator (must be SUM aggregation)
+ * @param agg Aggregation operator (must be SUM_WITH_OVERFLOW aggregation)
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate the returned scalars' device memory
  * @returns A std::pair where first scalar contains the sum result and second scalar contains
@@ -168,16 +168,16 @@ std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> reduce_with_overflow
  *         and an initial value
  *
  * This function performs reduction operations with overflow detection and an initial value,
- * currently supporting only SUM aggregation.
+ * currently supporting only SUM_WITH_OVERFLOW aggregation.
  *
  * @see cudf::reduce_with_overflow_check(column_view const&, reduce_aggregation const&,
  * rmm::cuda_stream_view, rmm::device_async_resource_ref) for more details
  *
- * @throw cudf::logic_error if aggregation type is not SUM.
+ * @throw cudf::logic_error if aggregation type is not SUM_WITH_OVERFLOW.
  * @throw cudf::logic_error if input column data type is not arithmetic.
  *
  * @param col Input column view (must be arithmetic type)
- * @param agg Aggregation operator (must be SUM aggregation)
+ * @param agg Aggregation operator (must be SUM_WITH_OVERFLOW aggregation)
  * @param init The initial value of the reduction
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate the returned scalars' device memory

--- a/cpp/include/cudf/reduction.hpp
+++ b/cpp/include/cudf/reduction.hpp
@@ -144,13 +144,13 @@ std::unique_ptr<scalar> reduce(
  *
  * For empty or all-null input, the result is a null scalar for the sum and false for overflow.
  *
- * The input column must be an arithmetic type. The output sum scalar type matches the input
- * column type to preserve precision during overflow detection.
+ * The input column must be int64_t type. The output sum scalar type is int64_t and the
+ * overflow flag is bool to preserve precision during overflow detection.
  *
  * @throw cudf::logic_error if aggregation type is not SUM_WITH_OVERFLOW.
- * @throw cudf::logic_error if input column data type is not arithmetic.
+ * @throw cudf::logic_error if input column data type is not int64_t.
  *
- * @param col Input column view (must be arithmetic type)
+ * @param col Input column view (must be int64_t type)
  * @param agg Aggregation operator (must be SUM_WITH_OVERFLOW aggregation)
  * @param stream CUDA stream used for device memory operations and kernel launches
  * @param mr Device memory resource used to allocate the returned scalars' device memory
@@ -174,9 +174,9 @@ std::pair<std::unique_ptr<scalar>, std::unique_ptr<scalar>> reduce_with_overflow
  * rmm::cuda_stream_view, rmm::device_async_resource_ref) for more details
  *
  * @throw cudf::logic_error if aggregation type is not SUM_WITH_OVERFLOW.
- * @throw cudf::logic_error if input column data type is not arithmetic.
+ * @throw cudf::logic_error if input column data type is not int64_t.
  *
- * @param col Input column view (must be arithmetic type)
+ * @param col Input column view (must be int64_t type)
  * @param agg Aggregation operator (must be SUM_WITH_OVERFLOW aggregation)
  * @param init The initial value of the reduction
  * @param stream CUDA stream used for device memory operations and kernel launches

--- a/cpp/include/cudf/reduction/detail/reduction_functions.hpp
+++ b/cpp/include/cudf/reduction/detail/reduction_functions.hpp
@@ -52,6 +52,27 @@ std::unique_ptr<scalar> sum(column_view const& col,
                             rmm::device_async_resource_ref mr);
 
 /**
+ * @brief Computes sum with overflow detection of int64_t elements in input column
+ *
+ * Returns a struct scalar with {sum: int64_t, overflow: bool} fields.
+ * Only supports int64_t input columns.
+ *
+ * @throw cudf::logic_error if input column type is not int64_t
+ *
+ * @param col input column to compute sum with overflow detection (must be int64_t)
+ * @param output_dtype data type of return type (must be struct)
+ * @param init initial value of the sum
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned scalar's device memory
+ * @return Struct scalar with sum and overflow flag
+ */
+std::unique_ptr<scalar> sum_with_overflow(column_view const& col,
+                                          data_type const output_dtype,
+                                          std::optional<std::reference_wrapper<scalar const>> init,
+                                          rmm::cuda_stream_view stream,
+                                          rmm::device_async_resource_ref mr);
+
+/**
  * @brief Computes minimum of elements in input column
  *
  * If all elements in input column are null, output scalar is null.
@@ -383,6 +404,22 @@ std::unique_ptr<scalar> nunique(column_view const& col,
                                 data_type const output_dtype,
                                 rmm::cuda_stream_view stream,
                                 rmm::device_async_resource_ref mr);
+
+/**
+ * @brief Computes sum of int64_t column with overflow detection
+ *
+ * @param col Input column of int64_t values
+ * @param output_dtype Output data type (must be STRUCT)
+ * @param init Optional initial value for the reduction
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned scalar's device memory
+ * @return Struct scalar containing {sum: int64_t, overflow: bool}
+ */
+std::unique_ptr<scalar> sum_with_overflow(column_view const& col,
+                                          data_type const output_dtype,
+                                          std::optional<std::reference_wrapper<scalar const>> init,
+                                          rmm::cuda_stream_view stream,
+                                          rmm::device_async_resource_ref mr);
 
 }  // namespace reduction::detail
 }  // namespace CUDF_EXPORT cudf

--- a/cpp/src/aggregation/aggregation.cpp
+++ b/cpp/src/aggregation/aggregation.cpp
@@ -480,6 +480,10 @@ template CUDF_EXPORT std::unique_ptr<groupby_aggregation>
 make_sum_with_overflow_aggregation<groupby_aggregation>();
 template CUDF_EXPORT std::unique_ptr<groupby_scan_aggregation>
 make_sum_with_overflow_aggregation<groupby_scan_aggregation>();
+template CUDF_EXPORT std::unique_ptr<reduce_aggregation>
+make_sum_with_overflow_aggregation<reduce_aggregation>();
+template CUDF_EXPORT std::unique_ptr<segmented_reduce_aggregation>
+make_sum_with_overflow_aggregation<segmented_reduce_aggregation>();
 
 /// Factory to create a PRODUCT aggregation
 template <typename Base>

--- a/cpp/src/reductions/sum_with_overflow.cu
+++ b/cpp/src/reductions/sum_with_overflow.cu
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/detail/iterator.cuh>
+#include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/reduction/detail/reduction_functions.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/functional.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/reduce.h>
+#include <thrust/transform_reduce.h>
+
+#include <limits>
+
+namespace cudf::reduction::detail {
+
+// Simple pair to hold sum and overflow flag
+struct sum_overflow_result {
+  int64_t sum;
+  bool overflow;
+
+  __host__ __device__ sum_overflow_result() : sum(0), overflow(false) {}
+  __host__ __device__ sum_overflow_result(int64_t s, bool o) : sum(s), overflow(o) {}
+};
+
+// Binary operator for combining sum_overflow_result values
+struct overflow_sum_op {
+  __host__ __device__ sum_overflow_result operator()(sum_overflow_result const& lhs,
+                                                     sum_overflow_result const& rhs) const
+  {
+    // If either operand already has overflow, result has overflow
+    if (lhs.overflow || rhs.overflow) {
+      // Still compute the sum for consistency, but mark as overflow
+      // This addition may wrap but we've already detected overflow
+      return sum_overflow_result{lhs.sum + rhs.sum, true};
+    }
+
+    // Check for overflow BEFORE performing the addition to avoid UB
+    bool overflow_detected = false;
+
+    // Check for positive overflow: would the addition exceed INT64_MAX?
+    if (rhs.sum > 0 && lhs.sum > std::numeric_limits<int64_t>::max() - rhs.sum) {
+      overflow_detected = true;
+    }
+    // Check for negative overflow: would the addition go below INT64_MIN?
+    else if (rhs.sum < 0 && lhs.sum < std::numeric_limits<int64_t>::min() - rhs.sum) {
+      overflow_detected = true;
+    }
+
+    // Perform the addition (safe if no overflow detected)
+    int64_t const result_sum = lhs.sum + rhs.sum;
+
+    return sum_overflow_result{result_sum, overflow_detected};
+  }
+};
+
+// Transform function to convert int64_t values to sum_overflow_result
+struct to_sum_overflow {
+  __host__ __device__ sum_overflow_result operator()(int64_t value) const
+  {
+    return sum_overflow_result{value, false};
+  }
+};
+
+// Transform functor for null-aware conversion using index
+struct null_aware_to_sum_overflow {
+  cudf::column_device_view const* dcol_ptr;
+
+  __host__ __device__ null_aware_to_sum_overflow(cudf::column_device_view const* dcol)
+    : dcol_ptr(dcol)
+  {
+  }
+
+  __device__ sum_overflow_result operator()(cudf::size_type idx) const
+  {
+    return dcol_ptr->is_valid(idx) ? sum_overflow_result{dcol_ptr->element<int64_t>(idx), false}
+                                   : sum_overflow_result{0, false};
+  }
+};
+
+std::unique_ptr<cudf::scalar> sum_with_overflow(
+  column_view const& col,
+  cudf::data_type const output_dtype,
+  std::optional<std::reference_wrapper<scalar const>> init,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  CUDF_FUNC_RANGE();
+
+  // SUM_WITH_OVERFLOW only supports int64_t input
+  CUDF_EXPECTS(col.type().id() == cudf::type_id::INT64,
+               "SUM_WITH_OVERFLOW only supports int64_t input types");
+
+  // Handle empty column
+  if (col.size() == 0 || col.size() == col.null_count()) {
+    // Create struct with {null sum, false overflow}
+    auto sum_scalar =
+      cudf::make_default_constructed_scalar(cudf::data_type{cudf::type_id::INT64}, stream, mr);
+    sum_scalar->set_valid_async(false, stream);
+    auto overflow_scalar = cudf::make_fixed_width_scalar<bool>(false, stream, mr);
+
+    std::vector<std::unique_ptr<cudf::column>> children;
+    children.push_back(cudf::make_column_from_scalar(*sum_scalar, 1, stream, mr));
+    children.push_back(cudf::make_column_from_scalar(*overflow_scalar, 1, stream, mr));
+    auto table_data = cudf::table(std::move(children));
+    return cudf::make_struct_scalar(table_data.view(), stream, mr);
+  }
+
+  // Create device view
+  auto dcol = cudf::column_device_view::create(col, stream);
+
+  // Set up initial value
+  sum_overflow_result initial_value{0, false};
+  if (init.has_value() && init.value().get().is_valid(stream)) {
+    auto const& init_scalar = static_cast<cudf::numeric_scalar<int64_t> const&>(init.value().get());
+    initial_value.sum       = init_scalar.value(stream);
+  }
+
+  // Perform the reduction using thrust::transform_reduce
+  auto counting_iter = thrust::make_counting_iterator<cudf::size_type>(0);
+  auto dcol_ptr      = dcol.get();
+  sum_overflow_result result;
+
+  if (col.has_nulls()) {
+    // Use null-aware transform functor
+    result = thrust::transform_reduce(rmm::exec_policy(stream),
+                                      counting_iter,
+                                      counting_iter + col.size(),
+                                      null_aware_to_sum_overflow{dcol_ptr},
+                                      initial_value,
+                                      overflow_sum_op{});
+  } else {
+    // Use direct iterator for non-null case
+    auto input_iter = dcol->begin<int64_t>();
+    result          = thrust::transform_reduce(rmm::exec_policy(stream),
+                                      input_iter,
+                                      input_iter + col.size(),
+                                      to_sum_overflow{},
+                                      initial_value,
+                                      overflow_sum_op{});
+  }
+
+  // Create result struct scalar with {sum: int64_t, overflow: bool}
+  auto sum_scalar      = cudf::make_fixed_width_scalar<int64_t>(result.sum, stream, mr);
+  auto overflow_scalar = cudf::make_fixed_width_scalar<bool>(result.overflow, stream, mr);
+
+  // Create struct scalar using cudf::make_struct_scalar with table_view
+  std::vector<std::unique_ptr<cudf::column>> children;
+  children.push_back(cudf::make_column_from_scalar(*sum_scalar, 1, stream, mr));
+  children.push_back(cudf::make_column_from_scalar(*overflow_scalar, 1, stream, mr));
+  auto table_data = cudf::table(std::move(children));
+  return cudf::make_struct_scalar(table_data.view(), stream, mr);
+}
+
+}  // namespace cudf::reduction::detail


### PR DESCRIPTION
## Description
Contributes to #19243

This PR introduces `reduce_with_overflow_check`, which accepts the `SUM_WITH_OVERFLOW` aggregation kind and returns a pair consisting of the sum result and a boolean indicating whether an overflow occurred. Currently, only `INT64` aggregations are supported.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
