### PR TITLE
Use cudaDeviceGetAttribute to get ComputeMode for CUDA13

### DIFF
--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -199,9 +199,19 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getNativeComputeMode(JNIEnv* env
     cudf::jni::auto_set_device(env);
     int device;
     CUDF_CUDA_TRY(cudaGetDevice(&device));
+
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 13000
+    // CUDA 13.0+ removed computeMode from cudaDeviceProp
+    // Return computeMode from cudaDeviceGetAttribute
+    int compute_mode;
+    CUDF_CUDA_TRY(cudaDeviceGetAttribute(&compute_mode, cudaDevAttrComputeMode, device));
+    return compute_mode;
+#else
+    // CUDA 12.x and earlier
     cudaDeviceProp device_prop;
     CUDF_CUDA_TRY(cudaGetDeviceProperties(&device_prop, device));
     return device_prop.computeMode;
+#endif
   }
   CATCH_STD(env, -2);
 }


### PR DESCRIPTION
## Description
CUDA13 doesn't support get compute mode from cudaDeviceProp.computeMode.
It's changed to use  cudaDeviceGetAttribute.
Use macro CUDART_VERSION > 13000 to detect building on cuda13
And keep the original code for cuda12 in else part.

close #19644

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
