### PR TITLE
Add Java JNI interface to get Gpu UUID

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/Cuda.java
+++ b/java/src/main/java/ai/rapids/cudf/Cuda.java
@@ -271,6 +271,16 @@ public class Cuda {
   }
 
   /**
+   * Gets the GPU UUID of the current device.
+   *
+   * @return UUID of the current device as a byte array.
+   */
+  public static byte[] getGpuUuid() {
+    return getNativeGpuUuid();
+  }
+
+
+  /**
    * Mapping: cudaMemGetInfo(size_t *free, size_t *total)
    */
   public static native CudaMemInfo memGetInfo() throws CudaException;
@@ -399,6 +409,14 @@ public class Cuda {
    * @throws CudaException on any error
    */
   static native int getNativeComputeMode() throws CudaException;
+
+  /**
+   * Gets the Gpu UUID of the current device.
+   *
+   * @return UUID of the current device as a byte array.
+   * @throws CudaException on any error
+   */
+  static native byte[] getNativeGpuUuid() throws CudaException;
 
   /**
    * Gets the major CUDA compute capability of the current device.

--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -216,6 +216,21 @@ JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getNativeComputeMode(JNIEnv* env
   CATCH_STD(env, -2);
 }
 
+JNIEXPORT jbyteArray JNICALL Java_ai_rapids_cudf_Cuda_getNativeGpuUuid(JNIEnv* env, jclass)
+{
+  try {
+    cudf::jni::auto_set_device(env);
+    int device;
+    CUDF_CUDA_TRY(cudaGetDevice(&device));
+    cudaDeviceProp device_prop;
+    CUDF_CUDA_TRY(cudaGetDeviceProperties(&device_prop, device));
+    jbyteArray result = env->NewByteArray(16);
+    env->SetByteArrayRegion(result, 0, 16, (jbyte*)(device_prop.uuid.bytes));
+    return result;
+  }
+  CATCH_STD(env, nullptr);
+}
+
 JNIEXPORT jint JNICALL Java_ai_rapids_cudf_Cuda_getComputeCapabilityMajor(JNIEnv* env, jclass)
 {
   try {

--- a/java/src/main/native/src/CudaJni.cpp
+++ b/java/src/main/native/src/CudaJni.cpp
@@ -224,9 +224,8 @@ JNIEXPORT jbyteArray JNICALL Java_ai_rapids_cudf_Cuda_getNativeGpuUuid(JNIEnv* e
     CUDF_CUDA_TRY(cudaGetDevice(&device));
     cudaDeviceProp device_prop;
     CUDF_CUDA_TRY(cudaGetDeviceProperties(&device_prop, device));
-    jbyteArray result = env->NewByteArray(16);
-    env->SetByteArrayRegion(result, 0, 16, (jbyte*)(device_prop.uuid.bytes));
-    return result;
+    cudf::jni::native_jbyteArray jbytes{env, (jbyte*)device_prop.uuid.bytes, 16};
+    return jbytes.get_jArray();
   }
   CATCH_STD(env, nullptr);
 }

--- a/java/src/test/java/ai/rapids/cudf/CudaTest.java
+++ b/java/src/test/java/ai/rapids/cudf/CudaTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CudaTest {
@@ -32,6 +33,15 @@ public class CudaTest {
     assert Cuda.getDriverVersion() >= 1000;
     assert Cuda.getRuntimeVersion() >= 1000;
     assertEquals(Cuda.getNativeComputeMode(), Cuda.getComputeMode().nativeId);
+
+    // test UUID
+    byte[] uuid = Cuda.getGpuUuid();
+    assertEquals(uuid.length, 16);
+    long v = 0;
+    for (int i = 0; i < uuid.length; i++) {
+      v += uuid[i];
+    }
+    assertNotEquals(0, v);
   }
 
   @Tag("noSanitizer")


### PR DESCRIPTION
## Description

Contributes to https://github.com/NVIDIA/spark-rapids/issues/12982
Different GPU should generate different UUID sequences.
I plan to use GPU card UUID to participate in the calculation of initial seed, so post this PR to expose the Gpu UUID.

The seed will be calculated on Java side, the following informations will parqicipate in the intial seed:
- Gpu card UUID
- Current timestamp
- Java process ID
- Java process start time
- an static incremental sequence ID on Java side.
......
Maybe more to make sure no same UUID sequences are generated.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
