### PR TITLE
[FEA] Remove excessive copies of JITIFY's ProgramData during JIT kernel launch

### DIFF
--- a/cpp/src/jit/cache.cpp
+++ b/cpp/src/jit/cache.cpp
@@ -112,7 +112,7 @@ std::size_t try_parse_numeric_env_var(char const* const env_name, std::size_t de
 }
 }  // namespace
 
-jitify2::ProgramCache<>& jit::program_cache::get(jitify2::PreprocessedProgramData preprog)
+jitify2::ProgramCache<>& jit::program_cache::get(jitify2::PreprocessedProgramData const& preprog)
 {
   std::lock_guard<std::mutex> const caches_lock(_caches_mutex);
 
@@ -138,7 +138,7 @@ jitify2::ProgramCache<>& jit::program_cache::get(jitify2::PreprocessedProgramDat
   return *(existing_cache->second);
 }
 
-jitify2::ProgramCache<>& jit::get_program_cache(jitify2::PreprocessedProgramData preprog)
+jitify2::ProgramCache<>& jit::get_program_cache(jitify2::PreprocessedProgramData const& preprog)
 {
   return cudf::get_context().program_cache().get(preprog);
 }

--- a/cpp/src/jit/cache.hpp
+++ b/cpp/src/jit/cache.hpp
@@ -39,10 +39,10 @@ class program_cache {
   program_cache& operator=(program_cache&&)      = delete;
   ~program_cache()                               = default;
 
-  jitify2::ProgramCache<>& get(jitify2::PreprocessedProgramData preprog);
+  jitify2::ProgramCache<>& get(jitify2::PreprocessedProgramData const& preprog);
 };
 
-jitify2::ProgramCache<>& get_program_cache(jitify2::PreprocessedProgramData preprog);
+jitify2::ProgramCache<>& get_program_cache(jitify2::PreprocessedProgramData const& preprog);
 
 }  // namespace jit
 }  // namespace cudf


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This MR removes the excessive copies of the programdata, which was being copied on every kernel launch. The program data contains compressed un-compiled C++ code of CUDF's headers, which is very large.
This impacts both small and large columns/tables.

Follows-up https://github.com/rapidsai/cudf/issues/19625

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
