### PR TITLE
[BUG] Set `query_set` arg when validating/running cudf-polars PDS-DS benchmarks

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -217,7 +217,7 @@ class RunConfig:
         scale_factor = args.scale
 
         if scale_factor is None:
-            if "pdsh" in name:
+            if "pdsds" in name:
                 raise ValueError(
                     "--scale is required for PDS-DS benchmarks.\n"
                     "TODO: This will be inferred once we maintain a map of scale factors to row counts."


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Follows up https://github.com/rapidsai/cudf/pull/19631. I didn't set the set `query_set` (ie. the benchmark name `pdsh` or `pdsds`) arg when running the PDS-DS benchmarks in validation mode (ie. `--engine validate`) or the DuckDB benchmarks (ie. `--engine duckdb`). Therefore we'd get this error
```
$ python python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py --engine duckdb 12 --root tpcds_parquet --scale 1.0
Traceback (most recent call last):
  File "/home/coder/cudf/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py", line 218, in <module>
    run_duckdb(PDSDSDuckDBQueries, extra_args)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/coder/cudf/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py", line 109, in run_duckdb
    run_config = RunConfig.from_args(args)
  File "/home/coder/cudf/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py", line 216, in from_args
    name = args.query_set
           ^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'query_set'
```
This PR fixes this error.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
