### PR TITLE
Support `over` expression (window mapping) in cudf-polars

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
@@ -10,13 +10,16 @@ from typing import TYPE_CHECKING, Any
 
 import pylibcudf as plc
 
-from cudf_polars.containers import Column
+from cudf_polars.containers import Column, DataFrame
 from cudf_polars.dsl import expr
 from cudf_polars.dsl.expressions.base import ExecutionContext, Expr
+from cudf_polars.dsl.utils.reshape import broadcast
 from cudf_polars.dsl.utils.windows import offsets_to_windows, range_window_bounds
 
 if TYPE_CHECKING:
-    from cudf_polars.containers import DataFrame, DataType
+    from collections.abc import Sequence
+
+    from cudf_polars.containers import DataType
     from cudf_polars.typing import ClosedInterval, Duration
 
 __all__ = ["GroupedRollingWindow", "RollingWindow", "to_request"]
@@ -152,12 +155,142 @@ class RollingWindow(Expr):
 
 
 class GroupedRollingWindow(Expr):
-    __slots__ = ("options",)
-    _non_child = ("dtype", "options")
+    """
+    Compute a window ``.over(...)`` aggregation and broadcast to rows.
 
-    def __init__(self, dtype: DataType, options: Any, agg: Expr, *by: Expr) -> None:
+    Notes
+    -----
+    - This expression node currently implements **grouped window mapping**
+      (aggregate once per group, then broadcast back), not rolling windows.
+    - It can be extended later to support `rolling(...).over(...)`
+      when polars supports that expression.
+    """
+
+    __slots__ = ("named_aggs", "options", "post")
+    _non_child = ("dtype", "options", "named_aggs", "post")
+
+    def __init__(
+        self,
+        dtype: DataType,
+        options: Any,
+        named_aggs: Sequence[expr.NamedExpr],
+        post: expr.NamedExpr,
+        *by: Expr,
+    ) -> None:
         self.dtype = dtype
         self.options = options
-        self.children = (agg, *by)
+        self.named_aggs = tuple(named_aggs)
+        self.post = post
+        self.children = tuple(by)
         self.is_pointwise = False
-        raise NotImplementedError("Grouped rolling window not implemented")
+
+    def do_evaluate(  # noqa: D102
+        self, df: DataFrame, *, context: ExecutionContext = ExecutionContext.FRAME
+    ) -> Column:
+        if context != ExecutionContext.FRAME:
+            raise RuntimeError(
+                "Window mapping (.over) can only be evaluated at the frame level"
+            )  # pragma: no cover; translation raises first
+        by_cols = list(
+            broadcast(
+                *(
+                    b.evaluate(df, context=ExecutionContext.FRAME)
+                    for b in self.children
+                ),
+                target_length=df.num_rows,
+            )
+        )
+        by_tbl = plc.Table([c.obj for c in by_cols])
+
+        sorted_flag = (
+            plc.types.Sorted.YES
+            if all(k.is_sorted for k in by_cols)
+            else plc.types.Sorted.NO
+        )
+        grouper = plc.groupby.GroupBy(
+            by_tbl,
+            null_handling=plc.types.NullPolicy.INCLUDE,
+            keys_are_sorted=sorted_flag,
+            column_order=[k.order for k in by_cols],
+            null_precedence=[k.null_order for k in by_cols],
+        )
+
+        gb_requests: list[plc.groupby.GroupByRequest] = []
+        out_names: list[str] = []
+        out_dtypes: list[DataType] = []
+        for ne in self.named_aggs:
+            val = ne.value
+            out_names.append(ne.name)
+            out_dtypes.append(val.dtype)
+
+            if isinstance(val, expr.Len):
+                # Count rows per group via sum(1).
+                ones = plc.Column.from_scalar(
+                    plc.Scalar.from_py(1, plc.DataType(plc.TypeId.INT32)), df.num_rows
+                )
+                gb_requests.append(
+                    plc.groupby.GroupByRequest(ones, [plc.aggregation.sum()])
+                )
+            elif isinstance(val, expr.Agg):
+                (child,) = (
+                    val.children if val.name != "quantile" else (val.children[0],)
+                )
+                col = child.evaluate(df, context=ExecutionContext.FRAME).obj
+                gb_requests.append(plc.groupby.GroupByRequest(col, [val.agg_request]))
+            else:  # pragma: no cover
+                raise NotImplementedError(
+                    f"Unsupported expression inside over(...): {type(val)}"
+                )
+
+        group_keys_tbl, value_tables = grouper.aggregate(gb_requests)
+        out_cols = [t.columns()[0] for t in value_tables]
+
+        # Build gather maps to broadcast per-group results to all rows.
+        # Also left-join input keys to group-keys so every input row appears exactly once.
+        lg, rg = plc.join.left_join(
+            by_tbl, group_keys_tbl, plc.types.NullEquality.EQUAL
+        )
+
+        # Reorder the gather maps to preserve left/input order
+        left_rows, right_rows = by_tbl.num_rows(), group_keys_tbl.num_rows()
+        init = plc.Scalar.from_py(0, plc.types.SIZE_TYPE)
+        step = plc.Scalar.from_py(1, plc.types.SIZE_TYPE)
+        left_order = plc.copying.gather(
+            plc.Table([plc.filling.sequence(left_rows, init, step)]),
+            lg,
+            plc.copying.OutOfBoundsPolicy.DONT_CHECK,
+        )
+        right_order = plc.copying.gather(
+            plc.Table([plc.filling.sequence(right_rows, init, step)]),
+            rg,
+            plc.copying.OutOfBoundsPolicy.NULLIFY,
+        )
+        # Sort both maps by (left_order, right_order), then use the reordered right map
+        # to gather group aggregates in the original row order.
+        _, rg = plc.sorting.stable_sort_by_key(
+            plc.Table([lg, rg]),
+            plc.Table([*left_order.columns(), *right_order.columns()]),
+            [plc.types.Order.ASCENDING, plc.types.Order.ASCENDING],
+            [plc.types.NullOrder.AFTER, plc.types.NullOrder.AFTER],
+        ).columns()
+
+        # Broadcast each aggregated result back to row-shape using the right map.
+        broadcasted_cols = [
+            Column(
+                plc.copying.gather(
+                    plc.Table([col]),
+                    rg,
+                    plc.copying.OutOfBoundsPolicy.NULLIFY,
+                ).columns()[0],
+                name=named_expr.name,
+                dtype=dtype,
+            )
+            for named_expr, dtype, col in zip(
+                self.named_aggs, out_dtypes, out_cols, strict=True
+            )
+        ]
+
+        # Create a temporary DataFrame with the broadcasted columns named by their
+        # placeholder names from agg decomposition, then evaluate the post-expression.
+        df = DataFrame(broadcasted_cols)
+        return self.post.value.evaluate(df, context=ExecutionContext.FRAME)

--- a/python/cudf_polars/cudf_polars/dsl/utils/aggregations.py
+++ b/python/cudf_polars/cudf_polars/dsl/utils/aggregations.py
@@ -153,7 +153,7 @@ def decompose_single_agg(
             )
         elif agg.name == "mean":
             post_agg_col: expr.Expr = expr.Col(
-                DataType(pl.Float64), name
+                DataType(pl.Float64()), name
             )  # libcudf promotes to float64
             if agg.dtype.plc.id() == plc.TypeId.FLOAT32:
                 # Cast back to float32 to match Polars

--- a/python/cudf_polars/tests/expressions/test_rolling.py
+++ b/python/cudf_polars/tests/expressions/test_rolling.py
@@ -14,6 +14,19 @@ from cudf_polars.testing.asserts import (
 from cudf_polars.utils.versions import POLARS_VERSION_LT_130
 
 
+@pytest.fixture
+def df():
+    return pl.LazyFrame(
+        {
+            "g": [1, 1, 2, 2, 2],
+            "x": [1, 2, 3, 4, 5],
+            "x_alt": [1, 100, 3, 4, 50],
+            "g2": ["a", "a", "b", "a", "a"],
+            "g_null": [1, None, 1, None, 2],
+        }
+    )
+
+
 @pytest.mark.parametrize("time_unit", ["ns", "us", "ms"])
 def test_rolling_datetime(time_unit):
     dates = [
@@ -124,14 +137,6 @@ def test_invalid_duration_spec_raises_in_translation():
     assert_ir_translation_raises(q, pl.exceptions.InvalidOperationError)
 
 
-def test_grouped_rolling():
-    df = pl.LazyFrame({"a": [1, 2, 3, 4, 5, 6], "b": [1, 2, 1, 3, 1, 2]})
-
-    q = df.select(pl.col("a").min().over("b"))
-
-    assert_ir_translation_raises(q, NotImplementedError)
-
-
 def test_rolling_inside_groupby_raises():
     df = pl.LazyFrame(
         {"keys": [1, 1, 1, 2], "orderby": [1, 2, 4, 2], "values": [1, 2, 3, 4]}
@@ -141,4 +146,55 @@ def test_rolling_inside_groupby_raises():
     with pytest.raises(pl.exceptions.InvalidOperationError):
         q.collect(engine="in-memory")
 
+    assert_ir_translation_raises(q, NotImplementedError)
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pl.col("x").sum().over("g"),
+        pl.len().over("g"),
+        pl.col("x").cast(pl.Float64).mean().round(1).over("g"),
+        pl.col("x_alt").quantile(0.5, interpolation="lower").over("g"),
+        pl.col("x").sum().over("g", "g2"),
+        pl.col("x").sum().over(pl.col("g") % 2),
+        pl.col("x").sum().over("g_null"),
+        pl.col("x").cast(pl.Float32).mean().over("g"),
+        pl.col("x").sum().over(pl.lit(1)),
+    ],
+    ids=[
+        "sum_broadcast",
+        "len_broadcast",
+        "mean_round",
+        "quantile_lower",
+        "multi_key_partition",
+        "expr_partition",
+        "null_keys",
+        "mean_float32_promotion",
+        "literal_partition",
+    ],
+)
+def test_over_group_various(df, expr):
+    q = df.select(out=expr)
+    assert_gpu_result_equal(q)
+
+
+def test_window_over_group_sum_all_null_group_is_zero(df):
+    q = df.with_columns(
+        pl.when(pl.col("g") == 1)
+        .then(pl.lit(None, dtype=pl.Int64))
+        .otherwise(pl.col("x"))
+        .alias("null")
+    ).select(s=pl.col("null").sum().over("g"))
+    assert_gpu_result_equal(q)
+
+
+def test_over_with_order_by_not_supported_translation(df):
+    q = df.select(s=pl.col("x").sum().over("g", order_by="x"))
+    assert_ir_translation_raises(q, NotImplementedError)
+
+
+@pytest.mark.parametrize("strategy", ["explode", "join"], ids=["explode", "join"])
+def test_over_with_mapping_strategy_not_supported(df, strategy):
+    q = df.select(s=pl.col("x").sum().over("g", mapping_strategy=strategy))
     assert_ir_translation_raises(q, NotImplementedError)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
- Closes #16227
Note this PR implements grouped window aggregations (not really rolling). I think we can keep the name `GroupedRollingWindow` though because polars can support expressions like `rolling(...).over(..)` in the future.

Also contributes to #19200 and helps unblock PDS-DS queries 12, 20, 47, 51, 57, 89, 98
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
