### PR TITLE
Fix "--executor" pytest parameter for cudf-polars

### DIFF
--- a/ci/run_cudf_polars_pytests.sh
+++ b/ci/run_cudf_polars_pytests.sh
@@ -12,7 +12,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cudf_polars/
 python -m pytest --cache-clear "$@" tests --executor in-memory
 
 # Test the default "streaming" executor
-python -m pytest --cache-clear "$@" tests
+python -m pytest --cache-clear "$@" tests --executor streaming
 
 # Test the "streaming" executor with small blocksize
 python -m pytest --cache-clear "$@" tests --executor streaming --blocksize-mode small

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -18,7 +18,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--executor",
         action="store",
-        default="in-memory",
+        default="streaming",
         choices=("in-memory", "streaming"),
         help="Executor to use for GPUEngine.",
     )


### PR DESCRIPTION
## Description
The default value for the `--executor` pytest parameter is still `"in-memory"`. This means we are currently running the in-memory tests twice in CI.

The good news is that the `--blocksize-mode small` tests have still been hitting the `"streaming"` engine, so I'm pretty sure there is no need to worry about 25.08.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
