### PR TITLE
Add new xfails for xarray release

### DIFF
--- a/python/cudf/cudf/pandas/scripts/conftest-patch.py
+++ b/python/cudf/cudf/pandas/scripts/conftest-patch.py
@@ -6867,6 +6867,8 @@ NODEIDS_THAT_FAIL_WITH_CUDF_PANDAS = {
     "tests/generic/test_to_xarray.py::TestDataFrameToXArray::test_to_xarray_index_types[uint32]",
     "tests/generic/test_to_xarray.py::TestDataFrameToXArray::test_to_xarray_index_types[uint64]",
     "tests/generic/test_to_xarray.py::TestDataFrameToXArray::test_to_xarray_index_types[uint8]",
+    "tests/generic/test_to_xarray.py::TestSeriesToXArray::test_to_xarray_index_types[string-python]",
+    "tests/generic/test_to_xarray.py::TestSeriesToXArray::test_to_xarray_index_types[string-pyarrow]",
     "tests/groupby/aggregate/test_aggregate.py::test_agg_grouping_is_list_tuple",
     "tests/groupby/aggregate/test_aggregate.py::test_agg_multiple_with_as_index_false_subset_to_a_single_column",
     "tests/groupby/aggregate/test_aggregate.py::test_agg_str_with_kwarg_axis_1_raises[count]",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
We have two new failures in the pandas test suite that I started seeing yesterday. I strongly suspect that these are due to [the new xarray release](https://pypi.org/project/xarray/). Adding to the xfail list for now to unblock our CI.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
