### PR TITLE
Move to pyarrow and numpy to run_constrained

### DIFF
--- a/conda/recipes/pylibcudf/recipe.yaml
+++ b/conda/recipes/pylibcudf/recipe.yaml
@@ -67,14 +67,15 @@ requirements:
     - python
     - typing_extensions >=4.0.0
     - pandas >=2.0,<2.4.0dev0
-    - numpy >=1.23,<3.0a0
-    - pyarrow>=14.0.0,<20.0.0a0
     - libcudf =${{ version }}
     - ${{ pin_compatible("rmm", upper_bound="x.x") }}
     - fsspec >=0.6.0
     - cuda-python >=12.9.1,<13.0a0
     - nvtx >=0.2.1
     - packaging
+  run_constrained:
+    - numpy >=1.23,<3.0a0
+    - pyarrow>=14.0.0,<20.0.0a0
   ignore_run_exports:
     from_package:
       - cuda-cudart-dev

--- a/conda/recipes/pylibcudf/recipe.yaml
+++ b/conda/recipes/pylibcudf/recipe.yaml
@@ -73,7 +73,7 @@ requirements:
     - cuda-python >=12.9.1,<13.0a0
     - nvtx >=0.2.1
     - packaging
-  run_constrained:
+  run_constraints:
     - numpy >=1.23,<3.0a0
     - pyarrow>=14.0.0,<20.0.0a0
   ignore_run_exports:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This is a follow-up to #19657 to remove hard pyarrow and numpy requirements from the pylibcudf conda recipe.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
