### PR TITLE
Suppress NVRTC warning from stdint.h

### DIFF
--- a/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
+++ b/cpp/cmake/Modules/JitifyPreprocessKernels.cmake
@@ -48,7 +48,7 @@ function(jit_preprocess_files)
         $<TARGET_FILE:jitify_preprocess> ${ARG_FILE} -o ${ARG_OUTPUT_DIR} -i -std=c++20
         -remove-unused-globals -D_FILE_OFFSET_BITS=64 -D__CUDACC_RTC__ -DCUDF_RUNTIME_JIT
         -I${CUDF_SOURCE_DIR}/include -I${CUDF_SOURCE_DIR}/src ${includes}
-        --no-preinclude-workarounds --no-replace-pragma-once
+        --no-preinclude-workarounds --no-replace-pragma-once --diag-suppress=47
       COMMENT "Custom command to JIT-compile files."
     )
   endforeach()


### PR DESCRIPTION
## Description
Fixes a warning from jitify compile with NVRTC when including C++ stdlib stdint.h or cstdint.
```
cuda/std/cstdint(105): warning #47-D: incompatible redefinition of macro "INTPTR_MIN" (declared at line 16 of stdint.h)
  #  define INTPTR_MIN  INT64_MIN
            ^

cuda/std/cstdint(106): warning #47-D: incompatible redefinition of macro "INTPTR_MAX" (declared at line 18 of stdint.h)
  #  define INTPTR_MAX  INT64_MAX
            ^

cuda/std/cstdint(107): warning #47-D: incompatible redefinition of macro "UINTPTR_MAX" (declared at line 20 of stdint.h)
  #  define UINTPTR_MAX UINT64_MAX
            ^

cuda/std/cstdint(109): warning #47-D: incompatible redefinition of macro "INTMAX_MIN" (declared at line 17 of stdint.h)
  #  define INTMAX_MIN  INT64_MIN
            ^

cuda/std/cstdint(110): warning #47-D: incompatible redefinition of macro "INTMAX_MAX" (declared at line 19 of stdint.h)
  #  define INTMAX_MAX  INT64_MAX
            ^

cuda/std/cstdint(111): warning #47-D: incompatible redefinition of macro "UINTMAX_MAX" (declared at line 21 of stdint.h)
  #  define UINTMAX_MAX UINT64_MAX
            ^

cuda/std/cstdint(113): warning #47-D: incompatible redefinition of macro "PTRDIFF_MIN" (declared at line 22 of stdint.h)
  #  define PTRDIFF_MIN INT64_MIN
            ^

cuda/std/cstdint(114): warning #47-D: incompatible redefinition of macro "PTRDIFF_MAX" (declared at line 23 of stdint.h)
  #  define PTRDIFF_MAX INT64_MAX
            ^


D22-125 [1265+2+10=1276] Custom command to JIT-compile files.
cuda/std/cstdint(105): warning #47-D: incompatible redefinition of macro "INTPTR_MIN" (declared at line 16 of stdint.h)
  #  define INTPTR_MIN  INT64_MIN
            ^

cuda/std/cstdint(106): warning #47-D: incompatible redefinition of macro "INTPTR_MAX" (declared at line 18 of stdint.h)
  #  define INTPTR_MAX  INT64_MAX
            ^

cuda/std/cstdint(107): warning #47-D: incompatible redefinition of macro "UINTPTR_MAX" (declared at line 20 of stdint.h)
  #  define UINTPTR_MAX UINT64_MAX
            ^

cuda/std/cstdint(109): warning #47-D: incompatible redefinition of macro "INTMAX_MIN" (declared at line 17 of stdint.h)
  #  define INTMAX_MIN  INT64_MIN
            ^

cuda/std/cstdint(110): warning #47-D: incompatible redefinition of macro "INTMAX_MAX" (declared at line 19 of stdint.h)
  #  define INTMAX_MAX  INT64_MAX
            ^

cuda/std/cstdint(111): warning #47-D: incompatible redefinition of macro "UINTMAX_MAX" (declared at line 21 of stdint.h)
  #  define UINTMAX_MAX UINT64_MAX
            ^

cuda/std/cstdint(113): warning #47-D: incompatible redefinition of macro "PTRDIFF_MIN" (declared at line 22 of stdint.h)
  #  define PTRDIFF_MIN INT64_MIN
            ^

cuda/std/cstdint(114): warning #47-D: incompatible redefinition of macro "PTRDIFF_MAX" (declared at line 23 of stdint.h)
  #  define PTRDIFF_MAX INT64_MAX
            ^


D22-125 [1265+1+11=1276] Custom command to JIT-compile files.
cuda/std/cstdint(105): warning #47-D: incompatible redefinition of macro "INTPTR_MIN" (declared at line 16 of stdint.h)
  #  define INTPTR_MIN  INT64_MIN
            ^

cuda/std/cstdint(106): warning #47-D: incompatible redefinition of macro "INTPTR_MAX" (declared at line 18 of stdint.h)
  #  define INTPTR_MAX  INT64_MAX
            ^

cuda/std/cstdint(107): warning #47-D: incompatible redefinition of macro "UINTPTR_MAX" (declared at line 20 of stdint.h)
  #  define UINTPTR_MAX UINT64_MAX
            ^

cuda/std/cstdint(109): warning #47-D: incompatible redefinition of macro "INTMAX_MIN" (declared at line 17 of stdint.h)
  #  define INTMAX_MIN  INT64_MIN
            ^

cuda/std/cstdint(110): warning #47-D: incompatible redefinition of macro "INTMAX_MAX" (declared at line 19 of stdint.h)
  #  define INTMAX_MAX  INT64_MAX
            ^

cuda/std/cstdint(111): warning #47-D: incompatible redefinition of macro "UINTMAX_MAX" (declared at line 21 of stdint.h)
  #  define UINTMAX_MAX UINT64_MAX
            ^

cuda/std/cstdint(113): warning #47-D: incompatible redefinition of macro "PTRDIFF_MIN" (declared at line 22 of stdint.h)
  #  define PTRDIFF_MIN INT64_MIN
            ^

cuda/std/cstdint(114): warning #47-D: incompatible redefinition of macro "PTRDIFF_MAX" (declared at line 23 of stdint.h)
  #  define PTRDIFF_MAX INT64_MAX
            ^

```

This suppresses the warning by adding the compile flag `'diag-suppress=47` to the `JitifyPreprocessKernels.cmake`


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
