### PR TITLE
Revert "Support decimal columns in cudf_polars"

### DIFF
--- a/python/cudf_polars/cudf_polars/containers/dataframe.py
+++ b/python/cudf_polars/cudf_polars/containers/dataframe.py
@@ -29,26 +29,17 @@ __all__: list[str] = ["DataFrame"]
 def _create_polars_column_metadata(
     name: str, dtype: PolarsDataType
 ) -> plc.interop.ColumnMetadata:
-    """Create ColumnMetadata preserving dtype attributes not supported by libcudf."""
-    children_meta = []
-    timezone = ""
-    precision: int | None = None
-
+    """Create ColumnMetadata preserving pl.Struct field names."""
     if isinstance(dtype, pl.Struct):
         children_meta = [
             _create_polars_column_metadata(field.name, field.dtype)
             for field in dtype.fields
         ]
-    elif isinstance(dtype, pl.Datetime):
-        timezone = dtype.time_zone or timezone
-    elif isinstance(dtype, pl.Decimal):
-        precision = dtype.precision
-
+    else:
+        children_meta = []
+    timezone = dtype.time_zone if isinstance(dtype, pl.Datetime) else None
     return plc.interop.ColumnMetadata(
-        name=name,
-        timezone=timezone,
-        precision=precision,
-        children_meta=children_meta,
+        name=name, timezone=timezone or "", children_meta=children_meta
     )
 
 

--- a/python/cudf_polars/cudf_polars/containers/datatype.py
+++ b/python/cudf_polars/cudf_polars/containers/datatype.py
@@ -81,8 +81,6 @@ def _from_polars(dtype: pl.DataType) -> plc.DataType:
         assert_never(dtype.time_unit)
     elif isinstance(dtype, pl.String):
         return plc.DataType(plc.TypeId.STRING)
-    elif isinstance(dtype, pl.Decimal):
-        return plc.DataType(plc.TypeId.DECIMAL128, scale=-dtype.scale)
     elif isinstance(dtype, pl.Null):
         # TODO: Hopefully
         return plc.DataType(plc.TypeId.EMPTY)

--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -1467,16 +1467,6 @@ class GroupBy(IR):
                 else:
                     (child,) = value.children
                 col = child.evaluate(df, context=ExecutionContext.GROUPBY).obj
-
-                if value.name == "median" and col.type().id() in {
-                    plc.TypeId.DECIMAL128,
-                    plc.TypeId.DECIMAL64,
-                    plc.TypeId.DECIMAL32,
-                }:
-                    # libcudf doesn't support median (quantile) with decimal types,
-                    # but Polars returns a float result, so just cast the input.
-                    assert isinstance(child, expr.Col)
-                    col = plc.unary.cast(col, schema[child.name].plc)
             else:
                 # Anything else, we pre-evaluate
                 col = value.evaluate(df, context=ExecutionContext.GROUPBY).obj

--- a/python/cudf_polars/cudf_polars/testing/plugin.py
+++ b/python/cudf_polars/cudf_polars/testing/plugin.py
@@ -175,8 +175,6 @@ EXPECTED_FAILURES: Mapping[str, str | tuple[str, bool]] = {
     "tests/unit/io/test_lazy_parquet.py::test_parquet_schema_arg[False-row_groups]": "allow_missing_columns argument in read_parquet not translated in IR",
     "tests/unit/io/test_lazy_parquet.py::test_parquet_schema_arg[False-prefiltered]": "allow_missing_columns argument in read_parquet not translated in IR",
     "tests/unit/io/test_lazy_parquet.py::test_parquet_schema_arg[False-none]": "allow_missing_columns argument in read_parquet not translated in IR",
-    "tests/unit/datatypes/test_decimal.py::test_decimal_aggregations": "https://github.com/pola-rs/polars/issues/23899",
-    "tests/unit/datatypes/test_decimal.py::test_decimal_arithmetic_schema": "https://github.com/pola-rs/polars/issues/23899",
 }
 
 

--- a/python/cudf_polars/tests/expressions/test_literal.py
+++ b/python/cudf_polars/tests/expressions/test_literal.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import datetime
-
 import pytest
 
 import polars as pl
@@ -97,9 +95,7 @@ def test_select_literal_series():
     assert_gpu_result_equal(q)
 
 
-@pytest.mark.parametrize(
-    "expr", [pl.lit(None), pl.lit(datetime.time(12, 0), dtype=pl.Time())]
-)
+@pytest.mark.parametrize("expr", [pl.lit(None), pl.lit(10, dtype=pl.Decimal())])
 def test_unsupported_literal_raises(expr):
     df = pl.LazyFrame({})
 

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import decimal
 import itertools
 import random
 from datetime import date
@@ -26,7 +25,6 @@ def df():
             "key2": [2, 2, 2, 2, 6, 1, 4, 6, 8],
             "int": [1, 2, 3, 4, 5, 6, 7, 8, 9],
             "int32": pl.Series([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=pl.Int32()),
-            "decimal": [decimal.Decimal("1.23"), None, decimal.Decimal("-0.23")] * 3,
             "uint16_with_null": pl.Series(
                 [1, None, 2, None, None, None, 4, 5, 6], dtype=pl.UInt16()
             ),
@@ -91,7 +89,6 @@ def keys(request):
         [pl.col("float").quantile(0.3, interpolation="lower")],
         [pl.col("float").quantile(0.3, interpolation="midpoint")],
         [pl.col("float").quantile(0.3, interpolation="linear")],
-        [pl.col("decimal").median()],
         [
             pl.col("datetime").max(),
             pl.col("datetime").max().dt.is_leap_year().alias("leapyear"),

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import decimal
 from typing import TYPE_CHECKING
 
 import pytest
@@ -46,14 +45,6 @@ def df():
             "a": [1, 2, 3, None, 4, 5],
             "b": ["ẅ", "x", "y", "z", "123", "abcd"],
             "c": [None, None, 4, 5, -1, 0],
-            "d": [
-                decimal.Decimal("1.23"),
-                None,
-                decimal.Decimal("0.00"),
-                None,
-                decimal.Decimal("-5.67"),
-                None,
-            ],
         }
     )
 

--- a/python/cudf_polars/tests/test_select.py
+++ b/python/cudf_polars/tests/test_select.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import decimal
-
 import pytest
 
 import polars as pl
@@ -27,29 +25,6 @@ def test_select():
     )
 
     assert_gpu_result_equal(query)
-
-
-def test_select_decimal():
-    ldf = pl.LazyFrame(
-        {"a": pl.Series(values=[decimal.Decimal("1.0"), None], dtype=pl.Decimal(3, 1))}
-    )
-    query = ldf.select(pl.col("a"))
-    assert_gpu_result_equal(query)
-
-
-def test_select_decimal_precision_none_result_max_precision():
-    ldf = pl.LazyFrame(
-        {
-            "a": pl.Series(
-                values=[decimal.Decimal("1.0"), None], dtype=pl.Decimal(None, 1)
-            )
-        }
-    )
-    query = ldf.select(pl.col("a"))
-    cpu_result = query.collect()
-    gpu_result = query.collect(engine="gpu")
-    assert cpu_result.schema["a"].precision is None
-    assert gpu_result.schema["a"].precision == 38
 
 
 def test_select_reduce():

--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -275,7 +275,7 @@ cdef class Scalar:
             return decimal.Decimal(
                 (<fixed_point_scalar[decimal128]*>slr).value().value()
             ).scaleb(
-                (<fixed_point_scalar[decimal128]*>slr).type().scale()
+                -(<fixed_point_scalar[decimal128]*>slr).type().scale()
             )
         else:
             raise NotImplementedError(
@@ -647,12 +647,12 @@ def _(py_val: datetime.date, dtype: DataType | None):
 
 @_from_py.register(decimal.Decimal)
 def _(py_val: decimal.Decimal, dtype: DataType | None):
-    scale = py_val.as_tuple().exponent
-    as_int = int(py_val.scaleb(-scale))
+    scale = -py_val.as_tuple().exponent
+    as_int = int(py_val.scaleb(scale))
 
     cdef int128_t val = <int128_t>as_int
 
-    dtype = DataType(type_id.DECIMAL128, scale)
+    dtype = DataType(type_id.DECIMAL128, -scale)
 
     if dtype.id() != type_id.DECIMAL128:
         raise TypeError("Expected dtype to be DECIMAL128")

--- a/python/pylibcudf/tests/test_interop.py
+++ b/python/pylibcudf/tests/test_interop.py
@@ -105,7 +105,7 @@ def test_decimal_other(data_type):
     [plc.TypeId.DECIMAL128, plc.TypeId.DECIMAL64, plc.TypeId.DECIMAL32],
 )
 def test_decimal_respect_metadata_precision(plc_type, request):
-    request.applymarker(
+    request.node.add_marker(
         pytest.mark.xfail(
             parse(pa.__version__) < parse("19.0.0")
             and plc_type in {plc.TypeId.DECIMAL64, plc.TypeId.DECIMAL32},


### PR DESCRIPTION
Reverts rapidsai/cudf#19589

Currently CI is failing as the original PR did not sync with the HEAD of `branch-25.10` to catch presumably, new groupby tests that are failing.

Reverting to unblock CI for now and going to reopen this PR once I can investigate why those tests are failing.