### PR TITLE
Fix window var() test failures from float rounding

### DIFF
--- a/python/cudf_polars/tests/test_window_functions.py
+++ b/python/cudf_polars/tests/test_window_functions.py
@@ -86,7 +86,12 @@ def test_over(df: pl.LazyFrame, partition_by, agg_expr):
 
     q = df.with_columns(window_expr)
 
-    assert_gpu_result_equal(q)
+    # CPU: 1.333333333333333
+    # GPU: 1.333333333333334
+    # Classic floating-point gotcha: looks the same, but the test fails
+    assert_gpu_result_equal(
+        q, check_exact=False, rtol=1e-15, atol=1e-15
+    ) if "var" in str(agg_expr) else assert_gpu_result_equal(q)
 
 
 def test_over_with_sort(df: pl.LazyFrame):


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Adds relative and absolute tolerances to the window var tests.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
