### PR TITLE
Optionally capture Shuffle Stats in cudf-polars pdsh benchmarks

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -52,6 +52,7 @@ class Record:
 
     query: int
     duration: float
+    shuffle_stats: dict[str, dict[str, int | float]] | None = None
 
 
 @dataclasses.dataclass
@@ -187,7 +188,8 @@ class RunConfig:
     records: dict[int, list[Record]] = dataclasses.field(default_factory=dict)
     dataset_path: Path
     scale_factor: int | float
-    shuffle: str | None = None
+    shuffle: Literal["rapidsmpf", "tasks"] | None = None
+    gather_shuffle_stats: bool = False
     broadcast_join_limit: int | None = None
     blocksize: int | None = None
     max_rows_per_partition: int | None = None
@@ -202,6 +204,12 @@ class RunConfig:
     rapidsmpf_spill: bool
     spill_device: float
     query_set: str
+
+    def __post_init__(self) -> None:  # noqa: D105
+        if self.gather_shuffle_stats and self.shuffle != "rapidsmpf":
+            raise ValueError(
+                "gather_shuffle_stats is only supported for streaming executor."
+            )
 
     @classmethod
     def from_args(cls, args: argparse.Namespace) -> RunConfig:
@@ -251,6 +259,7 @@ class RunConfig:
             scheduler=scheduler,
             n_workers=args.n_workers,
             shuffle=args.shuffle,
+            gather_shuffle_stats=args.rapidsmpf_dask_statistics,
             broadcast_join_limit=args.broadcast_join_limit,
             dataset_path=path,
             scale_factor=scale_factor,
@@ -414,6 +423,7 @@ def initialize_dask_cluster(run_config: RunConfig, args: argparse.Namespace):  #
                     {
                         "dask_spill_device": str(run_config.spill_device),
                         "dask_statistics": str(args.rapidsmpf_dask_statistics),
+                        "dask_print_statistics": str(args.rapidsmpf_print_statistics),
                         "oom_protection": str(args.rapidsmpf_oom_protection),
                     }
                 ),
@@ -630,6 +640,12 @@ def parse_args(
         "--rapidsmpf-dask-statistics",
         action=argparse.BooleanOptionalAction,
         default=False,
+        help="Collect rapidsmpf shuffle statistics. The output will be stored in the 'shuffle_stats' field of each record.",
+    )
+    parser.add_argument(
+        "--rapidsmpf-print-statistics",
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Print rapidsmpf shuffle statistics on each Dask worker upon completion.",
     )
     parser.add_argument(
@@ -729,6 +745,17 @@ def run_polars(
 
             result = execute_query(q_id, i, q, run_config, args, engine)
 
+            if run_config.shuffle == "rapidsmpf" and run_config.gather_shuffle_stats:
+                from rapidsmpf.integrations.dask.shuffler import (
+                    clear_shuffle_statistics,
+                    gather_shuffle_statistics,
+                )
+
+                shuffle_stats = gather_shuffle_statistics(client)  # type: ignore[arg-type]
+                clear_shuffle_statistics(client)  # type: ignore[arg-type]
+            else:
+                shuffle_stats = None
+
             if args.validate and run_config.executor != "cpu":
                 try:
                     assert_gpu_result_equal(
@@ -743,7 +770,7 @@ def run_polars(
                     print(f"❌ Query {q_id} failed validation!\n{e}")
 
             t1 = time.monotonic()
-            record = Record(query=q_id, duration=t1 - t0)
+            record = Record(query=q_id, duration=t1 - t0, shuffle_stats=shuffle_stats)
             if args.print_results:
                 print(result)
 


### PR DESCRIPTION
## Description

This updates the PDSH benchmarks to gather and persist the shuffle stats from rapidsmpf after each query iteration. For example:

```
❯ python python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py \
    --path /datasets/toaugspurger/tpch/scale-100/ --no-print-results  \
    --executor streaming --scheduler distributed --n-workers=8 --protocol=ucx  \
    --shuffle=rapidsmpf --rapidsmpf-dask-statistics --no-rapidsmpf-print-statistics \
    --iterations=1 --rmm-async 3
```

Will write the shuffle stats to the `pdsh_results.jsonl` file:

```
❯ tail -n 1 pdsh_results.jsonl | jq '.records."3"'                                                                                                                                                                                                                                                                                                        (base)
[
  {
    "query": 3,
    "duration": 5.394909042050131,
    "shuffle_stats": {
      "event-loop-check-future-finish": {
        "count": 561426,
        "value": 0.07810913599999943
      },
      ...
    }
  }
]
```

Additionally, we use the new configuration option from https://github.com/rapidsai/rapidsmpf/pull/448 to control whether statistics are printed to stdout.

Blocked by https://github.com/rapidsai/rapidsmpf/pull/452, which add the ability to clear statistics (which we do between each query iteration).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
