### PR TITLE
Disable shallow clone for Jitify dependency in CMake configuration

### DIFF
--- a/cpp/cmake/thirdparty/get_jitify.cmake
+++ b/cpp/cmake/thirdparty/get_jitify.cmake
@@ -20,7 +20,7 @@ function(find_and_configure_jitify)
     jitify 2.0.0
     GIT_REPOSITORY https://github.com/NVIDIA/jitify.git
     GIT_TAG 70783a3ad7b0cad2992a26a1ebf8fbe3d6b44e25 # jitify2 branch as of 5th Aug 2025
-    GIT_SHALLOW TRUE
+    GIT_SHALLOW FALSE
     DOWNLOAD_ONLY TRUE
   )
   set(JITIFY_INCLUDE_DIR


### PR DESCRIPTION
## Description
Change GIT_SHALLOW from TRUE to FALSE to ensure complete repository history is available during build. This improves build stability by providing access to the complete Git history when needed.

This change affects the Jitify dependency configuration in `cpp/cmake/thirdparty/get_jitify.cmake` and helps prevent potential build issues that may occur when the build system requires access to the full Git repository history.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.