### PR TITLE
Update rapids-dependency-file-generator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -158,7 +158,7 @@ repos:
       - id: verify-codeowners
         args: [--fix, --project-prefix=cudf]
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.19.1
+    rev: v1.20.0
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,7 +161,7 @@ repos:
     rev: v1.20.0
     hooks:
       - id: rapids-dependency-file-generator
-        args: ["--clean"]
+        args: ["--clean", "--warn-all", "--strict"]
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:


### PR DESCRIPTION
This PR updates the rapids-dependency-file-generator hook to get https://github.com/rapidsai/dependency-file-generator/pull/163.
