### PR TITLE
Filter pandas warning in dask_cudf test

### DIFF
--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -625,14 +625,13 @@ def test_groupby_agg_params(
         1 if split_out == "use_dask_default" else split_out
     )
 
-    # Compute for easier multiindex handling
-    gf = gr.compute()
-
     with warnings.catch_warnings():
         # dask<=2025.7.0 uses a deprecated "grouper" attribute
         # in some of these computations. We'll silence the warning
         # here and fix it upstream.
         warnings.filterwarnings("ignore", category=FutureWarning)
+        # Compute for easier multiindex handling
+        gf = gr.compute()
         pf = pr.compute()
 
     # Reset index and sort by groupby columns


### PR DESCRIPTION
## Description

This fixes a CI failure (observed at https://github.com/rapidsai/cudf/actions/runs/17267746615/job/49006444548?pr=19793#step:10:1636) coming from a pandas warning triggered by dask.dataframe's usage of pandas. We'll filter it here and fix it upstream.