### PR TITLE
Revert oldest `numba` dependency to `0.60.0`

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -56,7 +56,7 @@ dependencies:
 - ninja
 - notebook
 - numba-cuda>=0.19.1,<0.20.0a0
-- numba>=0.61.0,<0.62.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - nvidia-ml-py

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -57,7 +57,7 @@ dependencies:
 - ninja
 - notebook
 - numba-cuda>=0.19.1,<0.20.0a0
-- numba>=0.61.0,<0.62.0a0
+- numba>=0.60.0,<0.62.0a0
 - numpy>=1.23,<3.0a0
 - numpydoc
 - nvidia-ml-py

--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -71,8 +71,7 @@ requirements:
     - pandas >=2.0,<2.4.0dev0
     - cupy >=12.0.0
     - numba-cuda >=0.19.1,<0.20.0a0
-    # TODO: Revert to numba>=0.60.0,<0.62.0a0 once https://github.com/NVIDIA/numba-cuda/pull/403 is released.
-    - numba >=0.61.0,<0.62.0a0
+    - numba >=0.60.0,<0.62.0a0
     - numpy >=1.23,<3.0a0
     - pyarrow>=14.0.0,<20.0.0a0
     - libcudf =${{ version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -666,8 +666,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - cachetools
-          # TODO: Revert to numba>=0.60.0,<0.62.0a0 once https://github.com/NVIDIA/numba-cuda/pull/403 is released.
-          - &numba numba>=0.61.0,<0.62.0a0
+          - &numba numba>=0.60.0,<0.62.0a0
           - nvtx>=0.2.1
           - packaging
           - rich
@@ -838,10 +837,7 @@ dependencies:
         matrices:
           - matrix: {dependencies: "oldest"}
             packages:
-              # TODO: Revert to numpy==1.23.* once
-              # https://github.com/NVIDIA/numba-cuda/pull/403 is released and
-              # we revert to an oldest pinning of numba==0.60.0.
-              - numpy==1.24.*
+              - numpy==1.23.*
               # pyarrow 14 is fine in some circumstances but we require pyarrow
               # 15 in our CI tests in order to get a lz4-c that is compatible
               # with cudf_kafka's dependencies.

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "fsspec>=0.6.0",
     "libcudf==25.10.*,>=0.0.0a0",
     "numba-cuda[cu12]>=0.19.1,<0.20.0a0",
-    "numba>=0.61.0,<0.62.0a0",
+    "numba>=0.60.0,<0.62.0a0",
     "numpy>=1.23,<3.0a0",
     "nvtx>=0.2.1",
     "packaging",

--- a/python/pylibcudf/pyproject.toml
+++ b/python/pylibcudf/pyproject.toml
@@ -45,7 +45,7 @@ test = [
     "mmh3",
     "nanoarrow",
     "numba-cuda[cu12]>=0.19.1,<0.20.0a0",
-    "numba>=0.61.0,<0.62.0a0",
+    "numba>=0.60.0,<0.62.0a0",
     "pandas",
     "pyarrow>=14.0.0,<20.0.0a0,!=17.0.0; platform_machine=='aarch64'",
     "pyarrow>=14.0.0,<20.0.0a0; platform_machine=='x86_64'",


### PR DESCRIPTION
With the merge of https://github.com/rapidsai/cudf/pull/19794 we now depend on `numba-cuda>=0.19.1` which includes the changes from https://github.com/NVIDIA/numba-cuda/pull/403. This should allow us to relax this constraint. 