### PR TITLE
Run cudf-polars-polars-tests on changes in test_python file group

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -284,6 +284,7 @@ jobs:
     needs: wheel-build-cudf-polars
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.10
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       # This selects "ARCH=amd64 + the latest supported Python + CUDA".
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))


### PR DESCRIPTION
## Description
Similar to the other Python based jobs, I believe the `cudf-polars-polars-tests` job only needs to run on relevant changes to Python files

e.g. https://github.com/rapidsai/cudf/pull/19816 removes a Python file. None of the other Python test jobs ran except `cudf-polars-polars-tests`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
