### PR TITLE
Construct cuDF classic Decimal32/64Columns from RMM buffers

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -122,18 +122,6 @@ def _can_values_be_equal(left: DtypeObj, right: DtypeObj) -> bool:
     return False
 
 
-def pa_mask_buffer_to_mask(mask_buf: pa.Buffer, size: int) -> Buffer:
-    """
-    Convert PyArrow mask buffer to cuDF mask buffer
-    """
-    mask_size = plc.null_mask.bitmask_allocation_size_bytes(size)
-    if mask_buf.size < mask_size:
-        dbuf = rmm.DeviceBuffer(size=mask_size)
-        dbuf.copy_from_host(np.asarray(mask_buf).view("u1"))
-        return as_buffer(dbuf)
-    return as_buffer(mask_buf)
-
-
 class ColumnBase(Serializable, BinaryOperand, Reducible):
     """
     A ColumnBase stores columnar data in device memory.

--- a/python/cudf/cudf/core/column/decimal.py
+++ b/python/cudf/cudf/core/column/decimal.py
@@ -4,20 +4,20 @@ from __future__ import annotations
 
 import warnings
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
-import cupy as cp
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 
 import pylibcudf as plc
+import rmm
 
 import cudf
 from cudf.api.types import is_scalar
 from cudf.core._internals import binaryop
-from cudf.core.buffer import acquire_spill_lock, as_buffer
-from cudf.core.column.column import ColumnBase, pa_mask_buffer_to_mask
+from cudf.core.buffer import acquire_spill_lock
+from cudf.core.column.column import ColumnBase
 from cudf.core.column.numerical_base import NumericalBaseColumn
 from cudf.core.dtypes import (
     Decimal32Dtype,
@@ -95,6 +95,47 @@ class DecimalBaseColumn(NumericalBaseColumn):
         raise NotImplementedError(
             "Decimals are not yet supported via `__cuda_array_interface__`"
         )
+
+    @classmethod
+    def _from_32_64_arrow(
+        cls,
+        data: pa.Array,
+        *,
+        view_type: Literal["int32", "int64"],
+        plc_type: plc.TypeId,
+        step: int,
+    ) -> Self:
+        # Can remove when pyarrow 19 is the minimum version
+        mask_buf, data_buf = data.buffers()
+        rmm_data_buffer = rmm.DeviceBuffer.to_device(
+            np.frombuffer(data_buf)
+            .view(view_type)[::step]
+            .copy()
+            .view("uint8")
+        )
+        plc_column = plc.Column.from_rmm_buffer(
+            rmm_data_buffer,
+            plc.DataType(plc_type, -data.type.scale),
+            len(data),
+            [],
+        )
+        if mask_buf is not None:
+            mask_size = plc.null_mask.bitmask_allocation_size_bytes(len(data))
+            if mask_buf.size < mask_size:
+                rmm_mask_buffer = rmm.DeviceBuffer(size=mask_size)
+                rmm_mask_buffer.copy_from_host(
+                    np.asarray(mask_buf).view("uint8")
+                )
+            else:
+                rmm_mask_buffer = rmm.DeviceBuffer.to_device(
+                    np.frombuffer(mask_buf).view("uint8")
+                )
+            plc_column = plc_column.with_mask(
+                plc.gpumemoryview(rmm_mask_buffer), data.null_count
+            )
+        column = cls.from_pylibcudf(plc_column)
+        column.dtype.precision = data.type.precision
+        return column
 
     def element_indexing(self, index: int):
         result = super().element_indexing(index)
@@ -323,21 +364,8 @@ class Decimal32Column(DecimalBaseColumn):
 
     @classmethod
     def from_arrow(cls, data: pa.Array) -> Self:
-        dtype = Decimal32Dtype.from_arrow(data.type)
-        mask_buf = data.buffers()[0]
-        mask = (
-            mask_buf
-            if mask_buf is None
-            else pa_mask_buffer_to_mask(mask_buf, len(data))
-        )
-        data_128 = cp.array(np.frombuffer(data.buffers()[1]).view("int32"))
-        data_32 = data_128[::4].copy()
-        return cls(
-            data=as_buffer(data_32.view("uint8")),
-            size=len(data),
-            dtype=dtype,
-            offset=data.offset,
-            mask=mask,
+        return cls._from_32_64_arrow(
+            data, view_type="int32", plc_type=plc.TypeId.DECIMAL32, step=4
         )
 
     def to_arrow(self) -> pa.Array:
@@ -460,21 +488,8 @@ class Decimal64Column(DecimalBaseColumn):
 
     @classmethod
     def from_arrow(cls, data: pa.Array) -> Self:
-        dtype = Decimal64Dtype.from_arrow(data.type)
-        mask_buf = data.buffers()[0]
-        mask = (
-            mask_buf
-            if mask_buf is None
-            else pa_mask_buffer_to_mask(mask_buf, len(data))
-        )
-        data_128 = cp.array(np.frombuffer(data.buffers()[1]).view("int64"))
-        data_64 = data_128[::2].copy()
-        return cls(
-            data=as_buffer(data_64.view("uint8")),
-            size=len(data),
-            dtype=dtype,
-            offset=data.offset,
-            mask=mask,
+        return cls._from_32_64_arrow(
+            data, view_type="int64", plc_type=plc.TypeId.DECIMAL64, step=2
         )
 
     def to_arrow(self) -> pa.Array:

--- a/python/cudf/cudf/core/column/interval.py
+++ b/python/cudf/cudf/core/column/interval.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pyarrow as pa
 
 import cudf
-from cudf.core.column.column import as_column, pa_mask_buffer_to_mask
+from cudf.core.column.column import as_column
 from cudf.core.column.struct import StructColumn
 from cudf.core.dtypes import IntervalDtype
 from cudf.utils.dtypes import is_dtype_obj_interval
@@ -60,25 +60,7 @@ class IntervalColumn(StructColumn):
     @classmethod
     def from_arrow(cls, data: pa.Array) -> Self:
         new_col = super().from_arrow(data.storage)
-        size = len(data)
-        dtype = IntervalDtype.from_arrow(data.type)
-        mask = data.buffers()[0]
-        if mask is not None:
-            mask = pa_mask_buffer_to_mask(mask, len(data))
-
-        offset = data.offset
-        null_count = data.null_count
-        children = new_col.children
-
-        return cls(
-            data=None,
-            size=size,
-            dtype=dtype,
-            mask=mask,
-            offset=offset,
-            null_count=null_count,
-            children=children,  # type: ignore[arg-type]
-        )
+        return new_col._with_type_metadata(IntervalDtype.from_arrow(data.type))  # type: ignore[return-value]
 
     def to_arrow(self) -> pa.Array:
         typ = self.dtype.to_arrow()


### PR DESCRIPTION
## Description
Precursor of https://github.com/rapidsai/cudf/issues/18726 towards consistently constructing a cuDF column with a pylibcudf Column

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
