### PR TITLE
Add join `*_match_context` APIs to hash join

### DIFF
--- a/cpp/include/cudf/detail/join/hash_join.cuh
+++ b/cpp/include/cudf/detail/join/hash_join.cuh
@@ -18,6 +18,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/detail/join/join.hpp>
 #include <cudf/hashing.hpp>
+#include <cudf/join/join.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -187,6 +188,30 @@ struct hash_join {
   std::size_t full_join_size(cudf::table_view const& probe,
                              rmm::cuda_stream_view stream,
                              rmm::device_async_resource_ref mr) const;
+
+  /**
+   * @copydoc cudf::hash_join::inner_join_match_context
+   */
+  [[nodiscard]] cudf::join_match_context inner_join_match_context(
+    cudf::table_view const& probe,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const;
+
+  /**
+   * @copydoc cudf::hash_join::left_join_match_context
+   */
+  [[nodiscard]] cudf::join_match_context left_join_match_context(
+    cudf::table_view const& probe,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const;
+
+  /**
+   * @copydoc cudf::hash_join::full_join_match_context
+   */
+  [[nodiscard]] cudf::join_match_context full_join_match_context(
+    cudf::table_view const& probe,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const;
 
  private:
   /**

--- a/cpp/include/cudf/detail/join/hash_join.cuh
+++ b/cpp/include/cudf/detail/join/hash_join.cuh
@@ -214,22 +214,11 @@ struct hash_join {
     rmm::device_async_resource_ref mr) const;
 
  private:
-  /**
-   * @brief Probes the `_hash_table` built from `_build` for tuples in `probe_table`,
-   * and returns the output indices of `build_table` and `probe_table` as a combined table,
-   * i.e. if full join is specified as the join type then left join is called. Behavior
-   * is undefined if the provided `output_size` is smaller than the actual output size.
-   *
-   * @throw cudf::logic_error if build table is empty and `join == INNER_JOIN`.
-   *
-   * @param probe_table Table of probe side columns to join.
-   * @param join The type of join to be performed.
-   * @param output_size Optional value which allows users to specify the exact output size.
-   * @param stream CUDA stream used for device memory operations and kernel launches.
-   * @param mr Device memory resource used to allocate the returned vectors.
-   *
-   * @return Join output indices vector pair.
-   */
+  template <typename OutputIterator>
+  void compute_match_counts(cudf::table_view const& probe,
+                            OutputIterator output_iter,
+                            rmm::cuda_stream_view stream) const;
+
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
   probe_join_indices(cudf::table_view const& probe_table,

--- a/cpp/include/cudf/detail/join/hash_join.cuh
+++ b/cpp/include/cudf/detail/join/hash_join.cuh
@@ -219,6 +219,22 @@ struct hash_join {
                             OutputIterator output_iter,
                             rmm::cuda_stream_view stream) const;
 
+  /**
+   * @brief Probes the `_hash_table` built from `_build` for tuples in `probe_table`,
+   * and returns the output indices of `build_table` and `probe_table` as a combined table,
+   * i.e. if full join is specified as the join type then left join is called. Behavior
+   * is undefined if the provided `output_size` is smaller than the actual output size.
+   *
+   * @throw cudf::logic_error if build table is empty and `join == INNER_JOIN`.
+   *
+   * @param probe_table Table of probe side columns to join.
+   * @param join The type of join to be performed.
+   * @param output_size Optional value which allows users to specify the exact output size.
+   * @param stream CUDA stream used for device memory operations and kernel launches.
+   * @param mr Device memory resource used to allocate the returned vectors.
+   *
+   * @return Join output indices vector pair.
+   */
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
   probe_join_indices(cudf::table_view const& probe_table,

--- a/cpp/include/cudf/join/hash_join.hpp
+++ b/cpp/include/cudf/join/hash_join.hpp
@@ -90,7 +90,7 @@ class hash_join {
    * @note The `hash_join` object must not outlive the table viewed by `build`, else behavior is
    * undefined.
    *
-   * @throws cudf::logic_error if the build table has no columns
+   * @throws std::invalid_argument if the build table has no columns
    *
    * @param build The build table, from which the hash table is built
    * @param compare_nulls Controls whether null join-key values should match or not
@@ -127,8 +127,8 @@ class hash_join {
    * @param mr Device memory resource used to allocate the returned table and columns' device
    * memory.
    *
-   * @throw cudf::logic_error If the input probe table has nulls while this hash_join object was not
-   * constructed with null check.
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
    *
    * @return A pair of columns [`left_indices`, `right_indices`] that can be used to construct
    * the result of performing an inner join between two tables with `build` and `probe`
@@ -152,8 +152,8 @@ class hash_join {
    * @param mr Device memory resource used to allocate the returned table and columns' device
    * memory.
    *
-   * @throw cudf::logic_error If the input probe table has nulls while this hash_join object was not
-   * constructed with null check.
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
    *
    * @return A pair of columns [`left_indices`, `right_indices`] that can be used to construct
    * the result of performing a left join between two tables with `build` and `probe`
@@ -177,8 +177,8 @@ class hash_join {
    * @param mr Device memory resource used to allocate the returned table and columns' device
    * memory.
    *
-   * @throw cudf::logic_error If the input probe table has nulls while this hash_join object was not
-   * constructed with null check.
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
    *
    * @return A pair of columns [`left_indices`, `right_indices`] that can be used to construct
    * the result of performing a full join between two tables with `build` and `probe`
@@ -198,8 +198,8 @@ class hash_join {
    * @param probe The probe table, from which the tuples are probed
    * @param stream CUDA stream used for device memory operations and kernel launches
    *
-   * @throw cudf::logic_error If the input probe table has nulls while this hash_join object was not
-   * constructed with null check.
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
    *
    * @return The exact number of output when performing an inner join between two tables with
    * `build` and `probe` as the join keys .
@@ -214,8 +214,8 @@ class hash_join {
    * @param probe The probe table, from which the tuples are probed
    * @param stream CUDA stream used for device memory operations and kernel launches
    *
-   * @throw cudf::logic_error If the input probe table has nulls while this hash_join object was not
-   * constructed with null check.
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
    *
    * @return The exact number of output when performing a left join between two tables with `build`
    * and `probe` as the join keys .
@@ -232,8 +232,8 @@ class hash_join {
    * @param mr Device memory resource used to allocate the intermediate table and columns' device
    * memory.
    *
-   * @throw cudf::logic_error If the input probe table has nulls while this hash_join object was not
-   * constructed with null check.
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
    *
    * @return The exact number of output when performing a full join between two tables with `build`
    * and `probe` as the join keys .
@@ -258,8 +258,8 @@ class hash_join {
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the result device memory
    *
-   * @throw cudf::logic_error If the input probe table has nulls while this hash_join object was not
-   * constructed with null check.
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
    *
    * @return A join_match_context object containing the probe table view and a device vector
    *         of match counts for each row in the probe table
@@ -283,8 +283,8 @@ class hash_join {
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the result device memory
    *
-   * @throw cudf::logic_error If the input probe table has nulls while this hash_join object was not
-   * constructed with null check.
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
    *
    * @return A join_match_context object containing the probe table view and a device vector
    *         of match counts for each row in the probe table
@@ -308,8 +308,8 @@ class hash_join {
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the result device memory
    *
-   * @throw cudf::logic_error If the input probe table has nulls while this hash_join object was not
-   * constructed with null check.
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
    *
    * @return A join_match_context object containing the probe table view and a device vector
    *         of match counts for each row in the probe table

--- a/cpp/include/cudf/join/hash_join.hpp
+++ b/cpp/include/cudf/join/hash_join.hpp
@@ -121,14 +121,14 @@ class hash_join {
    * an inner join between two tables. @see cudf::inner_join(). Behavior is undefined if the
    * provided `output_size` is smaller than the actual output size.
    *
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
+   *
    * @param probe The probe table, from which the tuples are probed
    * @param output_size Optional value which allows users to specify the exact output size
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the returned table and columns' device
    * memory.
-   *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
-   * not constructed with null check.
    *
    * @return A pair of columns [`left_indices`, `right_indices`] that can be used to construct
    * the result of performing an inner join between two tables with `build` and `probe`
@@ -146,14 +146,14 @@ class hash_join {
    * a left join between two tables. @see cudf::left_join(). Behavior is undefined if the
    * provided `output_size` is smaller than the actual output size.
    *
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
+   *
    * @param probe The probe table, from which the tuples are probed
    * @param output_size Optional value which allows users to specify the exact output size
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the returned table and columns' device
    * memory.
-   *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
-   * not constructed with null check.
    *
    * @return A pair of columns [`left_indices`, `right_indices`] that can be used to construct
    * the result of performing a left join between two tables with `build` and `probe`
@@ -171,14 +171,14 @@ class hash_join {
    * a full join between two tables. @see cudf::full_join(). Behavior is undefined if the
    * provided `output_size` is smaller than the actual output size.
    *
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
+   *
    * @param probe The probe table, from which the tuples are probed
    * @param output_size Optional value which allows users to specify the exact output size
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the returned table and columns' device
    * memory.
-   *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
-   * not constructed with null check.
    *
    * @return A pair of columns [`left_indices`, `right_indices`] that can be used to construct
    * the result of performing a full join between two tables with `build` and `probe`
@@ -195,11 +195,11 @@ class hash_join {
    * Returns the exact number of matches (rows) when performing an inner join with the specified
    * probe table.
    *
-   * @param probe The probe table, from which the tuples are probed
-   * @param stream CUDA stream used for device memory operations and kernel launches
-   *
    * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
    * not constructed with null check.
+   *
+   * @param probe The probe table, from which the tuples are probed
+   * @param stream CUDA stream used for device memory operations and kernel launches
    *
    * @return The exact number of output when performing an inner join between two tables with
    * `build` and `probe` as the join keys .
@@ -211,11 +211,11 @@ class hash_join {
    * Returns the exact number of matches (rows) when performing a left join with the specified probe
    * table.
    *
-   * @param probe The probe table, from which the tuples are probed
-   * @param stream CUDA stream used for device memory operations and kernel launches
-   *
    * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
    * not constructed with null check.
+   *
+   * @param probe The probe table, from which the tuples are probed
+   * @param stream CUDA stream used for device memory operations and kernel launches
    *
    * @return The exact number of output when performing a left join between two tables with `build`
    * and `probe` as the join keys .
@@ -227,13 +227,13 @@ class hash_join {
    * Returns the exact number of matches (rows) when performing a full join with the specified probe
    * table.
    *
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
+   *
    * @param probe The probe table, from which the tuples are probed
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the intermediate table and columns' device
    * memory.
-   *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
-   * not constructed with null check.
    *
    * @return The exact number of output when performing a full join between two tables with `build`
    * and `probe` as the join keys .
@@ -254,12 +254,12 @@ class hash_join {
    * - Determining the total size of a potential join result without materializing it
    * - Planning partitioned join operations for large datasets
    *
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
+   *
    * @param probe The probe table to join with the pre-processed build table
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the result device memory
-   *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
-   * not constructed with null check.
    *
    * @return A join_match_context object containing the probe table view and a device vector
    *         of match counts for each row in the probe table
@@ -279,12 +279,12 @@ class hash_join {
    * For left join, every row in the probe table will have at least one match (either with a
    * matching row from the build table or with a null placeholder).
    *
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
+   *
    * @param probe The probe table to join with the pre-processed build table
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the result device memory
-   *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
-   * not constructed with null check.
    *
    * @return A join_match_context object containing the probe table view and a device vector
    *         of match counts for each row in the probe table
@@ -304,12 +304,12 @@ class hash_join {
    * For full join, this includes matches for probe table rows, and the result may need to be
    * combined with unmatched rows from the build table to get the complete picture.
    *
+   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * not constructed with null check.
+   *
    * @param probe The probe table to join with the pre-processed build table
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the result device memory
-   *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
-   * not constructed with null check.
    *
    * @return A join_match_context object containing the probe table view and a device vector
    *         of match counts for each row in the probe table

--- a/cpp/include/cudf/join/join.hpp
+++ b/cpp/include/cudf/join/join.hpp
@@ -34,6 +34,37 @@ namespace CUDF_EXPORT cudf {
  */
 
 /**
+ * @brief Holds context information about matches between tables during a join operation.
+ *
+ * This structure stores the left table view and a device vector containing the count of
+ * matching rows in the right table for each row in the left table. Used primarily by
+ * inner_join_match_context() to track join match information.
+ */
+struct join_match_context {
+  table_view _left_table;  ///< View of the left table involved in the join operation
+  std::unique_ptr<rmm::device_uvector<size_type>>
+    _match_counts;  ///< A device vector containing the count of matching rows in the right table
+                    ///< for each row in left table
+};
+
+/**
+ * @brief Stores context information for partitioned join operations.
+ *
+ * This structure maintains context for partitioned join operations, containing the match
+ * context from a previous join operation along with the start and end indices that define
+ * the current partition of the left table being processed.
+ *
+ * Used with partitioned_inner_join() to perform large joins in smaller chunks while
+ * preserving the context from the initial match operation.
+ */
+struct join_partition_context {
+  join_match_context
+    left_table_context;      ///< The match context from a previous inner_join_match_context call
+  size_type left_start_idx;  ///< The starting row index of the current left table partition
+  size_type left_end_idx;  ///< The ending row index (exclusive) of the current left table partition
+};
+
+/**
  * @brief Returns a pair of row index vectors corresponding to an
  * inner join between the specified tables.
  *

--- a/cpp/include/cudf/join/sort_merge_join.hpp
+++ b/cpp/include/cudf/join/sort_merge_join.hpp
@@ -287,7 +287,7 @@ class sort_merge_join {
  * Result: {{1}, {0}}
  * @endcode
  *
- * @throw cudf::logic_error if number of elements in `left_keys` or `right_keys`
+ * @throw std::invalid_argument if number of elements in `left_keys` or `right_keys`
  * mismatch.
  *
  * @param[in] left_keys The left table
@@ -329,7 +329,7 @@ sort_merge_inner_join(cudf::table_view const& left_keys,
  * Result: {{1}, {0}}
  * @endcode
  *
- * @throw cudf::logic_error if number of elements in `left_keys` or `right_keys`
+ * @throw std::invalid_argument if number of elements in `left_keys` or `right_keys`
  * mismatch.
  *
  * @param[in] left_keys The left table

--- a/cpp/include/cudf/join/sort_merge_join.hpp
+++ b/cpp/include/cudf/join/sort_merge_join.hpp
@@ -18,6 +18,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
+#include <cudf/join/join.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/export.hpp>
@@ -43,38 +44,6 @@ namespace CUDF_EXPORT cudf {
  */
 class sort_merge_join {
  public:
-  /**
-   * @brief Holds context information about matches between tables during a join operation.
-   *
-   * This structure stores the left table view and a device vector containing the count of
-   * matching rows in the right table for each row in the left table. Used primarily by
-   * inner_join_match_context() to track join match information.
-   */
-  struct match_context {
-    table_view _left_table;  ///< View of the left table involved in the join operation
-    std::unique_ptr<rmm::device_uvector<size_type>>
-      _match_counts;  ///< A device vector containing the count of matching rows in the right table
-                      ///< for each row in left table
-  };
-
-  /**
-   * @brief Stores context information for partitioned join operations.
-   *
-   * This structure maintains context for partitioned join operations, containing the match
-   * context from a previous join operation along with the start and end indices that define
-   * the current partition of the left table being processed.
-   *
-   * Used with partitioned_inner_join() to perform large joins in smaller chunks while
-   * preserving the context from the initial match operation.
-   */
-  struct partition_context {
-    match_context
-      left_table_context;      ///< The match context from a previous inner_join_match_context call
-    size_type left_start_idx;  ///< The starting row index of the current left table partition
-    size_type
-      left_end_idx;  ///< The ending row index (exclusive) of the current left table partition
-  };
-
   /**
    * @brief Construct a sort-merge join object that pre-processes the right table
    * on creation, and can be used on subsequent join operations with multiple
@@ -126,7 +95,7 @@ class sort_merge_join {
    * - Determining the total size of a potential join result without materializing it
    * - Planning partitioned join operations for large datasets
    *
-   * The returned match_context can be used directly with partitioned_inner_join() to
+   * The returned join_match_context can be used directly with partitioned_inner_join() to
    * process large joins in manageable chunks.
    *
    * @param left The left table to join with the pre-processed right table
@@ -134,10 +103,10 @@ class sort_merge_join {
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the result device memory
    *
-   * @return A match_context object containing the left table view and a device vector
+   * @return A join_match_context object containing the left table view and a device vector
    *         of match counts for each row in the left table
    */
-  match_context inner_join_match_context(
+  cudf::join_match_context inner_join_match_context(
     table_view const& left,
     sorted is_left_sorted,
     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
@@ -147,8 +116,8 @@ class sort_merge_join {
    * @brief Performs an inner join between a partition of the left table and the right table.
    *
    * This method executes an inner join operation between a specific partition of the left table
-   * (defined by the partition_context) and the right table that was provided when constructing
-   * the sort_merge_join object. The partition_context must have been previously created by
+   * (defined by the join_partition_context) and the right table that was provided when constructing
+   * the sort_merge_join object. The join_partition_context must have been previously created by
    * calling inner_join_match_context().
    *
    * This partitioning approach enables processing large joins in smaller, memory-efficient chunks,
@@ -180,7 +149,7 @@ class sort_merge_join {
    *   size_type end = std::min(start + 1000, left_table.num_rows());
    *
    *   // Create partition context
-   *   sort_merge_join::partition_context part_ctx{context, start, end};
+   *   cudf::join_partition_context part_ctx{context, start, end};
    *
    *   // Get join indices for this partition
    *   auto [left_indices, right_indices] = join_obj.partitioned_inner_join(part_ctx);
@@ -192,7 +161,7 @@ class sort_merge_join {
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
   partitioned_inner_join(
-    partition_context const& context,
+    cudf::join_partition_context const& context,
     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -489,8 +489,10 @@ std::size_t get_full_join_size(
     // Assume all the indices in invalid_index_map are invalid
     auto invalid_index_map =
       std::make_unique<rmm::device_uvector<size_type>>(right_table_row_count, stream);
-    thrust::uninitialized_fill(
-      rmm::exec_policy(stream), invalid_index_map->begin(), invalid_index_map->end(), int32_t{1});
+    thrust::uninitialized_fill(rmm::exec_policy_nosync(stream),
+                               invalid_index_map->begin(),
+                               invalid_index_map->end(),
+                               int32_t{1});
 
     // Functor to check for index validity since left joins can create invalid indices
     valid_range<size_type> valid(0, right_table_row_count);
@@ -723,7 +725,7 @@ cudf::join_match_context hash_join<Hasher>::inner_join_match_context(
     std::make_unique<rmm::device_uvector<size_type>>(probe.num_rows(), stream, mr);
 
   if (_is_empty) {
-    thrust::fill(rmm::exec_policy(stream), match_counts->begin(), match_counts->end(), 0);
+    thrust::fill(rmm::exec_policy_nosync(stream), match_counts->begin(), match_counts->end(), 0);
   } else {
     compute_match_counts(probe, match_counts->begin(), stream);
   }
@@ -742,7 +744,7 @@ cudf::join_match_context hash_join<Hasher>::left_join_match_context(
     std::make_unique<rmm::device_uvector<size_type>>(probe.num_rows(), stream, mr);
 
   if (_is_empty) {
-    thrust::fill(rmm::exec_policy(stream), match_counts->begin(), match_counts->end(), 1);
+    thrust::fill(rmm::exec_policy_nosync(stream), match_counts->begin(), match_counts->end(), 1);
   } else {
     auto transform = [] __device__(size_type count) { return count == 0 ? 1 : count; };
     auto transformed_output =
@@ -764,7 +766,7 @@ cudf::join_match_context hash_join<Hasher>::full_join_match_context(
     std::make_unique<rmm::device_uvector<size_type>>(probe.num_rows(), stream, mr);
 
   if (_is_empty) {
-    thrust::fill(rmm::exec_policy(stream), match_counts->begin(), match_counts->end(), 1);
+    thrust::fill(rmm::exec_policy_nosync(stream), match_counts->begin(), match_counts->end(), 1);
   } else {
     auto transform = [] __device__(size_type count) { return count == 0 ? 1 : count; };
     auto transformed_output =

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -720,7 +720,8 @@ cudf::join_match_context hash_join<Hasher>::inner_join_match_context(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
-  CUDF_FUNC_RANGE();
+  cudf::scoped_range range{"hash_join::inner_join_match_context"};
+
   auto match_counts =
     std::make_unique<rmm::device_uvector<size_type>>(probe.num_rows(), stream, mr);
 
@@ -739,7 +740,8 @@ cudf::join_match_context hash_join<Hasher>::left_join_match_context(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
-  CUDF_FUNC_RANGE();
+  cudf::scoped_range range{"hash_join::left_join_match_context"};
+
   auto match_counts =
     std::make_unique<rmm::device_uvector<size_type>>(probe.num_rows(), stream, mr);
 
@@ -761,7 +763,8 @@ cudf::join_match_context hash_join<Hasher>::full_join_match_context(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
-  CUDF_FUNC_RANGE();
+  cudf::scoped_range range{"hash_join::full_join_match_context"};
+
   auto match_counts =
     std::make_unique<rmm::device_uvector<size_type>>(probe.num_rows(), stream, mr);
 

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -674,6 +674,177 @@ std::size_t hash_join<Hasher>::full_join_size(cudf::table_view const& probe,
 }
 
 template <typename Hasher>
+cudf::join_match_context hash_join<Hasher>::inner_join_match_context(
+  cudf::table_view const& probe,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
+  CUDF_FUNC_RANGE();
+
+  size_type const probe_table_num_rows{probe.num_rows()};
+  auto match_counts =
+    std::make_unique<rmm::device_uvector<size_type>>(probe_table_num_rows, stream, mr);
+
+  // Return empty counts if build table is empty
+  if (_is_empty) {
+    thrust::fill(rmm::exec_policy(stream), match_counts->begin(), match_counts->end(), 0);
+    return cudf::join_match_context{probe, std::move(match_counts)};
+  }
+
+  CUDF_EXPECTS(_has_nulls || !cudf::has_nested_nulls(probe),
+               "Probe table has nulls while build table was not hashed with null check.");
+
+  auto const preprocessed_probe =
+    cudf::experimental::row::equality::preprocessed_table::create(probe, stream);
+  auto const probe_nulls = cudf::nullate::DYNAMIC{_has_nulls};
+
+  // Common function to compute per-row match counts
+  auto compute_counts = [&](auto equality, auto d_hasher) {
+    auto const iter = cudf::detail::make_counting_transform_iterator(0, pair_fn{d_hasher});
+    _hash_table.count_each(iter,
+                           iter + probe_table_num_rows,
+                           equality,
+                           _hash_table.hash_function(),
+                           match_counts->begin(),
+                           stream.value());
+  };
+
+  // Use primitive row operator logic if build table is compatible
+  if (cudf::is_primitive_row_op_compatible(_build)) {
+    auto const d_hasher = cudf::row::primitive::row_hasher{probe_nulls, preprocessed_probe};
+    auto const d_equal  = cudf::row::primitive::row_equality_comparator{
+      probe_nulls, preprocessed_probe, _preprocessed_build, _nulls_equal};
+    compute_counts(primitive_pair_equal{d_equal}, d_hasher);
+  } else {
+    auto const d_hasher =
+      cudf::experimental::row::hash::row_hasher{preprocessed_probe}.device_hasher(probe_nulls);
+    auto const row_comparator = cudf::experimental::row::equality::two_table_comparator{
+      preprocessed_probe, _preprocessed_build};
+    auto const d_equal = row_comparator.equal_to<false>(probe_nulls, _nulls_equal);
+    compute_counts(pair_equal{d_equal}, d_hasher);
+  }
+
+  return cudf::join_match_context{probe, std::move(match_counts)};
+}
+
+template <typename Hasher>
+cudf::join_match_context hash_join<Hasher>::left_join_match_context(
+  cudf::table_view const& probe,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
+  CUDF_FUNC_RANGE();
+
+  size_type const probe_table_num_rows{probe.num_rows()};
+  auto match_counts =
+    std::make_unique<rmm::device_uvector<size_type>>(probe_table_num_rows, stream, mr);
+
+  if (_is_empty) {
+    // If build table is empty, every probe row matches once (with null)
+    thrust::fill(rmm::exec_policy(stream), match_counts->begin(), match_counts->end(), 1);
+  } else {
+    CUDF_EXPECTS(_has_nulls || !cudf::has_nested_nulls(probe),
+                 "Probe table has nulls while build table was not hashed with null check.");
+
+    auto const preprocessed_probe =
+      cudf::experimental::row::equality::preprocessed_table::create(probe, stream);
+    auto const probe_nulls = cudf::nullate::DYNAMIC{_has_nulls};
+
+    // Transform iterator that converts 0 counts to 1 for left join semantics
+    auto left_join_transform = [] __device__(size_type count) { return count == 0 ? 1 : count; };
+    auto transformed_output =
+      thrust::make_transform_output_iterator(match_counts->begin(), left_join_transform);
+
+    // Common function to compute per-row match counts for left join
+    auto compute_counts = [&](auto equality, auto d_hasher) {
+      auto const iter = cudf::detail::make_counting_transform_iterator(0, pair_fn{d_hasher});
+      _hash_table.count_each(iter,
+                             iter + probe_table_num_rows,
+                             equality,
+                             _hash_table.hash_function(),
+                             transformed_output,
+                             stream.value());
+    };
+
+    // Use primitive row operator logic if build table is compatible
+    if (cudf::is_primitive_row_op_compatible(_build)) {
+      auto const d_hasher = cudf::row::primitive::row_hasher{probe_nulls, preprocessed_probe};
+      auto const d_equal  = cudf::row::primitive::row_equality_comparator{
+        probe_nulls, preprocessed_probe, _preprocessed_build, _nulls_equal};
+      compute_counts(primitive_pair_equal{d_equal}, d_hasher);
+    } else {
+      auto const d_hasher =
+        cudf::experimental::row::hash::row_hasher{preprocessed_probe}.device_hasher(probe_nulls);
+      auto const row_comparator = cudf::experimental::row::equality::two_table_comparator{
+        preprocessed_probe, _preprocessed_build};
+      auto const d_equal = row_comparator.equal_to<false>(probe_nulls, _nulls_equal);
+      compute_counts(pair_equal{d_equal}, d_hasher);
+    }
+  }
+
+  return cudf::join_match_context{probe, std::move(match_counts)};
+}
+
+template <typename Hasher>
+cudf::join_match_context hash_join<Hasher>::full_join_match_context(
+  cudf::table_view const& probe,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
+  CUDF_FUNC_RANGE();
+
+  size_type const probe_table_num_rows{probe.num_rows()};
+  auto match_counts =
+    std::make_unique<rmm::device_uvector<size_type>>(probe_table_num_rows, stream, mr);
+
+  if (_is_empty) {
+    // If build table is empty, every probe row matches once (with null)
+    thrust::fill(rmm::exec_policy(stream), match_counts->begin(), match_counts->end(), 1);
+  } else {
+    CUDF_EXPECTS(_has_nulls || !cudf::has_nested_nulls(probe),
+                 "Probe table has nulls while build table was not hashed with null check.");
+
+    auto const preprocessed_probe =
+      cudf::experimental::row::equality::preprocessed_table::create(probe, stream);
+    auto const probe_nulls = cudf::nullate::DYNAMIC{_has_nulls};
+
+    // Transform iterator that converts 0 counts to 1 for full join semantics
+    // (unmatched build rows are handled separately)
+    auto full_join_transform = [] __device__(size_type count) { return count == 0 ? 1 : count; };
+    auto transformed_output =
+      thrust::make_transform_output_iterator(match_counts->begin(), full_join_transform);
+
+    // For full join, we use left join semantics for probe side counting
+    auto compute_counts = [&](auto equality, auto d_hasher) {
+      auto const iter = cudf::detail::make_counting_transform_iterator(0, pair_fn{d_hasher});
+      _hash_table.count_each(iter,
+                             iter + probe_table_num_rows,
+                             equality,
+                             _hash_table.hash_function(),
+                             transformed_output,
+                             stream.value());
+    };
+
+    // Use primitive row operator logic if build table is compatible
+    if (cudf::is_primitive_row_op_compatible(_build)) {
+      auto const d_hasher = cudf::row::primitive::row_hasher{probe_nulls, preprocessed_probe};
+      auto const d_equal  = cudf::row::primitive::row_equality_comparator{
+        probe_nulls, preprocessed_probe, _preprocessed_build, _nulls_equal};
+      compute_counts(primitive_pair_equal{d_equal}, d_hasher);
+    } else {
+      auto const d_hasher =
+        cudf::experimental::row::hash::row_hasher{preprocessed_probe}.device_hasher(probe_nulls);
+      auto const row_comparator = cudf::experimental::row::equality::two_table_comparator{
+        preprocessed_probe, _preprocessed_build};
+      auto const d_equal = row_comparator.equal_to<false>(probe_nulls, _nulls_equal);
+      compute_counts(pair_equal{d_equal}, d_hasher);
+    }
+  }
+
+  return cudf::join_match_context{probe, std::move(match_counts)};
+}
+
+template <typename Hasher>
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 hash_join<Hasher>::probe_join_indices(cudf::table_view const& probe_table,
@@ -812,6 +983,28 @@ std::size_t hash_join::full_join_size(cudf::table_view const& probe,
                                       rmm::device_async_resource_ref mr) const
 {
   return _impl->full_join_size(probe, stream, mr);
+}
+
+cudf::join_match_context hash_join::inner_join_match_context(
+  cudf::table_view const& probe,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr) const
+{
+  return _impl->inner_join_match_context(probe, stream, mr);
+}
+
+cudf::join_match_context hash_join::left_join_match_context(cudf::table_view const& probe,
+                                                            rmm::cuda_stream_view stream,
+                                                            rmm::device_async_resource_ref mr) const
+{
+  return _impl->left_join_match_context(probe, stream, mr);
+}
+
+cudf::join_match_context hash_join::full_join_match_context(cudf::table_view const& probe,
+                                                            rmm::cuda_stream_view stream,
+                                                            rmm::device_async_resource_ref mr) const
+{
+  return _impl->full_join_match_context(probe, stream, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/join/sort_merge_join.cu
+++ b/cpp/src/join/sort_merge_join.cu
@@ -558,7 +558,7 @@ sort_merge_join::inner_join(table_view const& left,
     });
 }
 
-sort_merge_join::match_context sort_merge_join::inner_join_match_context(
+cudf::join_match_context sort_merge_join::inner_join_match_context(
   table_view const& left,
   sorted is_left_sorted,
   rmm::cuda_stream_view stream,
@@ -606,18 +606,18 @@ sort_merge_join::match_context sort_merge_join::inner_join_match_context(
                         mapping.begin(),
                         unprocessed_matches_per_row.begin());
         stream.synchronize();
-        return match_context{
+        return join_match_context{
           left,
           std::make_unique<rmm::device_uvector<size_type>>(std::move(unprocessed_matches_per_row))};
       }
-      return match_context{left, std::move(matches_per_row)};
+      return join_match_context{left, std::move(matches_per_row)};
     });
 }
 
 // left_partition_end exclusive
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-sort_merge_join::partitioned_inner_join(sort_merge_join::partition_context const& context,
+sort_merge_join::partitioned_inner_join(cudf::join_partition_context const& context,
                                         rmm::cuda_stream_view stream,
                                         rmm::device_async_resource_ref mr)
 {

--- a/cpp/src/join/sort_merge_join.cu
+++ b/cpp/src/join/sort_merge_join.cu
@@ -408,7 +408,8 @@ sort_merge_join::sort_merge_join(table_view const& right,
   cudf::scoped_range range{"sort_merge_join::sort_merge_join"};
   // Sanity checks
   CUDF_EXPECTS(right.num_columns() != 0,
-               "Number of columns the keys table must be non-zero for a join");
+               "Number of columns the keys table must be non-zero for a join",
+               std::invalid_argument);
 
   this->compare_nulls = compare_nulls;
 
@@ -528,9 +529,11 @@ sort_merge_join::inner_join(table_view const& left,
   cudf::scoped_range range{"sort_merge_join::inner_join"};
   // Sanity checks
   CUDF_EXPECTS(left.num_columns() != 0,
-               "Number of columns in left keys must be non-zero for a join");
+               "Number of columns in left keys must be non-zero for a join",
+               std::invalid_argument);
   CUDF_EXPECTS(left.num_columns() == preprocessed_right._null_processed_table_view.num_columns(),
-               "Number of columns must match for a join");
+               "Number of columns must match for a join",
+               std::invalid_argument);
 
   // Preprocessing the left table
   preprocessed_left._table_view = left;
@@ -567,9 +570,11 @@ cudf::join_match_context sort_merge_join::inner_join_match_context(
   cudf::scoped_range range{"sort_merge_join::inner_join_match_context"};
   // Sanity checks
   CUDF_EXPECTS(left.num_columns() != 0,
-               "Number of columns in left keys must be non-zero for a join");
+               "Number of columns in left keys must be non-zero for a join",
+               std::invalid_argument);
   CUDF_EXPECTS(left.num_columns() == preprocessed_right._null_processed_table_view.num_columns(),
-               "Number of columns must match for a join");
+               "Number of columns must match for a join",
+               std::invalid_argument);
 
   // Preprocessing the left table
   preprocessed_left._table_view = left;

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -282,10 +282,10 @@ TEST_P(JoinParameterizedTest, InvalidInput)
   cudf::table_view right({right_first_col, right_second_col, right_third_col});
 
   EXPECT_THROW(inner_join(left, right, {0, 1}, {0, 1, 2}, cudf::null_equality::EQUAL, algo),
-               cudf::logic_error);
+               std::invalid_argument);
 
   EXPECT_THROW(inner_join(left, right, {}, {0, 1, 2}, cudf::null_equality::EQUAL, algo),
-               cudf::logic_error);
+               std::invalid_argument);
 }
 
 TEST_P(JoinParameterizedTest, EmptySentinelRepro)

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -954,10 +954,9 @@ TEST_F(JoinTest, PartitionedInnerJoinWithNulls)
   cudf::sort_merge_join obj(t1.select(right_on), cudf::sorted::NO, compare_nulls, stream);
   auto match_context = obj.inner_join_match_context(
     t0.select(left_on), cudf::sorted::NO, stream, cudf::get_current_device_resource_ref());
-  auto partition_context = cudf::sort_merge_join::partition_context{std::move(match_context), 0, 0};
+  auto partition_context = cudf::join_partition_context{std::move(match_context), 0, 0};
 
-  auto join_and_gather = [&t0, &t1, &obj, stream](
-                           cudf::sort_merge_join::partition_context const& cxt) {
+  auto join_and_gather = [&t0, &t1, &obj, stream](cudf::join_partition_context const& cxt) {
     auto const [left_join_indices, right_join_indices] =
       obj.partitioned_inner_join(cxt, stream, cudf::get_current_device_resource_ref());
 

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -1968,6 +1968,346 @@ TEST_F(JoinTest, HashJoinLargeOutputSize)
   EXPECT_EQ(col_size * col_size, output_size);
 }
 
+TEST_F(JoinTest, HashJoinInnerMatchContext)
+{
+  // Test inner join match context functionality with multiple matches and nulls
+  // Use the same test data as SortMergeInnerJoinSizePerRowWithNulls for consistency
+  column_wrapper<int32_t> col0_0{{3, 1, 2, 0, 2}};
+  strcol_wrapper col0_1({"s1", "s1", "s0", "s4", "s0"}, {true, true, false, true, true});
+  column_wrapper<int32_t> col0_2{{0, 1, 2, 4, 1}};
+
+  column_wrapper<int32_t> col1_0{{2, 2, 0, 4, 3}};
+  strcol_wrapper col1_1({"s1", "s0", "s1", "s2", "s1"}, {true, false, true, true, true});
+  column_wrapper<int32_t> col1_2{{1, 0, 1, 2, 1}, {true, false, true, true, true}};
+
+  CVector cols0, cols1;
+  cols0.emplace_back(col0_0.release());
+  cols0.emplace_back(col0_1.release());
+  cols0.emplace_back(col0_2.release());
+  cols1.emplace_back(col1_0.release());
+  cols1.emplace_back(col1_1.release());
+  cols1.emplace_back(col1_2.release());
+
+  Table t0(std::move(cols0));
+  Table t1(std::move(cols1));
+
+  // Test single column join with null_equality::EQUAL
+  {
+    cudf::hash_join hash_join(t1.select({0}), cudf::null_equality::EQUAL);
+    auto match_context = hash_join.inner_join_match_context(t0.select({0}));
+
+    // Check the match counts for each row
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // Expected: Row 0(3)=1 match, Row 1(1)=0 matches, Row 2(2)=2 matches, Row 3(0)=1 match, Row
+    // 4(2)=2 matches
+    std::vector<cudf::size_type> expected_counts = {1, 0, 2, 1, 2};
+    EXPECT_EQ(h_match_counts, expected_counts);
+
+    // Verify total matches equals inner join size
+    cudf::size_type total_matches =
+      std::accumulate(h_match_counts.begin(), h_match_counts.end(), 0);
+    auto inner_join_size = hash_join.inner_join_size(t0.select({0}));
+    EXPECT_EQ(total_matches, inner_join_size);
+  }
+
+  // Test multi-column join with null_equality::EQUAL
+  {
+    cudf::hash_join hash_join(t1.select({0, 1}), cudf::null_equality::EQUAL);
+    auto match_context = hash_join.inner_join_match_context(t0.select({0, 1}));
+
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // Expected: Row 0(3,s1)=1 match, Row 1(1,s1)=0 matches, Row 2(2,null)=1 match, Row 3(0,s4)=0
+    // matches, Row 4(2,s0)=0 matches
+    std::vector<cudf::size_type> expected_counts = {1, 0, 1, 0, 0};
+    EXPECT_EQ(h_match_counts, expected_counts);
+  }
+
+  // Test single column join with null_equality::UNEQUAL
+  {
+    cudf::hash_join hash_join(t1.select({0}), cudf::null_equality::UNEQUAL);
+    auto match_context = hash_join.inner_join_match_context(t0.select({0}));
+
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // Same as EQUAL for single column since nulls don't affect the integer column matching
+    std::vector<cudf::size_type> expected_counts = {1, 0, 2, 1, 2};
+    EXPECT_EQ(h_match_counts, expected_counts);
+  }
+
+  // Test multi-column join with null_equality::UNEQUAL
+  {
+    cudf::hash_join hash_join(t1.select({0, 1}), cudf::null_equality::UNEQUAL);
+    auto match_context = hash_join.inner_join_match_context(t0.select({0, 1}));
+
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // With UNEQUAL, rows with nulls should not match: Row 0(3,s1)=1 match, others=0 matches
+    std::vector<cudf::size_type> expected_counts = {1, 0, 0, 0, 0};
+    EXPECT_EQ(h_match_counts, expected_counts);
+  }
+}
+
+TEST_F(JoinTest, HashJoinLeftMatchContext)
+{
+  // Test left join match context functionality with comprehensive null handling
+  column_wrapper<int32_t> col0_0{{3, 1, 2, 0, 2}};
+  strcol_wrapper col0_1({"s1", "s1", "s0", "s4", "s0"}, {true, true, false, true, true});
+
+  column_wrapper<int32_t> col1_0{{2, 2, 0, 4, 3}};
+  strcol_wrapper col1_1({"s1", "s0", "s1", "s2", "s1"}, {true, false, true, true, true});
+
+  CVector cols0, cols1;
+  cols0.emplace_back(col0_0.release());
+  cols0.emplace_back(col0_1.release());
+  cols1.emplace_back(col1_0.release());
+  cols1.emplace_back(col1_1.release());
+
+  Table t0(std::move(cols0));
+  Table t1(std::move(cols1));
+
+  // Test single column join - for left join, every row should have at least 1 match
+  {
+    cudf::hash_join hash_join(t1.select({0}), cudf::null_equality::EQUAL);
+    auto match_context = hash_join.left_join_match_context(t0.select({0}));
+
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // For left join: Row 0(3)=1 match, Row 1(1)=1 match(null), Row 2(2)=2 matches, Row 3(0)=1
+    // match, Row 4(2)=2 matches
+    std::vector<cudf::size_type> expected_counts = {1, 1, 2, 1, 2};
+    EXPECT_EQ(h_match_counts, expected_counts);
+
+    // Verify total matches equals left join size
+    cudf::size_type total_matches =
+      std::accumulate(h_match_counts.begin(), h_match_counts.end(), 0);
+    auto left_join_size = hash_join.left_join_size(t0.select({0}));
+    EXPECT_EQ(total_matches, left_join_size);
+  }
+
+  // Test multi-column join with null_equality::EQUAL
+  {
+    cudf::hash_join hash_join(t1.select({0, 1}), cudf::null_equality::EQUAL);
+    auto match_context = hash_join.left_join_match_context(t0.select({0, 1}));
+
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // For left join, all rows get at least 1 match: Row 0(3,s1)=1 match, others=1 match (null)
+    std::vector<cudf::size_type> expected_counts = {1, 1, 1, 1, 1};
+    EXPECT_EQ(h_match_counts, expected_counts);
+  }
+
+  // Test multi-column join with null_equality::UNEQUAL
+  {
+    cudf::hash_join hash_join(t1.select({0, 1}), cudf::null_equality::UNEQUAL);
+    auto match_context = hash_join.left_join_match_context(t0.select({0, 1}));
+
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // For left join with UNEQUAL, all rows still get at least 1 match (nulls for unmatched)
+    std::vector<cudf::size_type> expected_counts = {1, 1, 1, 1, 1};
+    EXPECT_EQ(h_match_counts, expected_counts);
+  }
+}
+
+TEST_F(JoinTest, HashJoinFullMatchContext)
+{
+  // Test full join match context functionality with same comprehensive data
+  column_wrapper<int32_t> col0_0{{3, 1, 2, 0, 2}};
+  strcol_wrapper col0_1({"s1", "s1", "s0", "s4", "s0"}, {true, true, false, true, true});
+
+  column_wrapper<int32_t> col1_0{{2, 2, 0, 4, 3}};
+  strcol_wrapper col1_1({"s1", "s0", "s1", "s2", "s1"}, {true, false, true, true, true});
+
+  CVector cols0, cols1;
+  cols0.emplace_back(col0_0.release());
+  cols0.emplace_back(col0_1.release());
+  cols1.emplace_back(col1_0.release());
+  cols1.emplace_back(col1_1.release());
+
+  Table t0(std::move(cols0));
+  Table t1(std::move(cols1));
+
+  // Test single column join - for full join probe side, every row should have at least 1 match
+  {
+    cudf::hash_join hash_join(t1.select({0}), cudf::null_equality::EQUAL);
+    auto match_context = hash_join.full_join_match_context(t0.select({0}));
+
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // For full join: Row 0(3)=1 match, Row 1(1)=1 match(null), Row 2(2)=2 matches, Row 3(0)=1
+    // match, Row 4(2)=2 matches
+    std::vector<cudf::size_type> expected_counts = {1, 1, 2, 1, 2};
+    EXPECT_EQ(h_match_counts, expected_counts);
+  }
+
+  // Test multi-column join
+  {
+    cudf::hash_join hash_join(t1.select({0, 1}), cudf::null_equality::EQUAL);
+    auto match_context = hash_join.full_join_match_context(t0.select({0, 1}));
+
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // For full join, all rows get at least 1 match
+    std::vector<cudf::size_type> expected_counts = {1, 1, 1, 1, 1};
+    EXPECT_EQ(h_match_counts, expected_counts);
+  }
+}
+
+TEST_F(JoinTest, HashJoinMatchContextEmptyBuild)
+{
+  // Test match context with empty build table
+  column_wrapper<int32_t> col0_0{{3, 1, 2}};
+  column_wrapper<int32_t> col1_0{};  // Empty
+
+  CVector cols0, cols1;
+  cols0.emplace_back(col0_0.release());
+  cols1.emplace_back(col1_0.release());
+
+  Table t0(std::move(cols0));
+  Table t1(std::move(cols1));
+
+  cudf::hash_join hash_join(t1, cudf::null_equality::EQUAL);
+
+  // Test inner join match context
+  {
+    auto match_context = hash_join.inner_join_match_context(t0);
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // All should be 0 for inner join with empty build table
+    std::vector<cudf::size_type> expected_counts = {0, 0, 0};
+    EXPECT_EQ(h_match_counts, expected_counts);
+  }
+
+  // Test left join match context
+  {
+    auto match_context = hash_join.left_join_match_context(t0);
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // All should be 1 for left join (null matches)
+    std::vector<cudf::size_type> expected_counts = {1, 1, 1};
+    EXPECT_EQ(h_match_counts, expected_counts);
+  }
+
+  // Test full join match context
+  {
+    auto match_context = hash_join.full_join_match_context(t0);
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // All should be 1 for full join (null matches)
+    std::vector<cudf::size_type> expected_counts = {1, 1, 1};
+    EXPECT_EQ(h_match_counts, expected_counts);
+  }
+}
+
+TEST_F(JoinTest, HashJoinMatchContextDuplicatesAndEdgeCases)
+{
+  // Test with duplicate keys to ensure multiple matches work correctly
+  column_wrapper<int32_t> col0_0{{1, 1, 2, 2, 3}};
+  strcol_wrapper col0_1({"a", "a", "b", "b", "c"});
+
+  column_wrapper<int32_t> col1_0{{1, 1, 1, 2, 4}};
+  strcol_wrapper col1_1({"a", "a", "a", "b", "d"});
+
+  CVector cols0, cols1;
+  cols0.emplace_back(col0_0.release());
+  cols0.emplace_back(col0_1.release());
+  cols1.emplace_back(col1_0.release());
+  cols1.emplace_back(col1_1.release());
+
+  Table t0(std::move(cols0));
+  Table t1(std::move(cols1));
+
+  // Test inner join with multiple matches per row
+  {
+    cudf::hash_join hash_join(t1.select({0}), cudf::null_equality::EQUAL);
+    auto match_context = hash_join.inner_join_match_context(t0.select({0}));
+
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // Row 0(1)=3 matches, Row 1(1)=3 matches, Row 2(2)=1 match, Row 3(2)=1 match, Row 4(3)=0
+    // matches
+    std::vector<cudf::size_type> expected_counts = {3, 3, 1, 1, 0};
+    EXPECT_EQ(h_match_counts, expected_counts);
+
+    // Verify total matches
+    cudf::size_type total_matches =
+      std::accumulate(h_match_counts.begin(), h_match_counts.end(), 0);
+    auto inner_join_size = hash_join.inner_join_size(t0.select({0}));
+    EXPECT_EQ(total_matches, inner_join_size);
+  }
+
+  // Test multi-column join
+  {
+    cudf::hash_join hash_join(t1.select({0, 1}), cudf::null_equality::EQUAL);
+    auto match_context = hash_join.inner_join_match_context(t0.select({0, 1}));
+
+    std::vector<cudf::size_type> h_match_counts(t0.num_rows());
+    CUDF_CUDA_TRY(cudaMemcpy(h_match_counts.data(),
+                             match_context._match_counts->data(),
+                             sizeof(cudf::size_type) * t0.num_rows(),
+                             cudaMemcpyDeviceToHost));
+
+    // Row 0(1,a)=3 matches, Row 1(1,a)=3 matches, Row 2(2,b)=1 match, Row 3(2,b)=1 match, Row
+    // 4(3,c)=0 matches
+    std::vector<cudf::size_type> expected_counts = {3, 3, 1, 1, 0};
+    EXPECT_EQ(h_match_counts, expected_counts);
+  }
+}
+
 struct JoinDictionaryTest : public cudf::test::BaseFixture {};
 
 TEST_F(JoinDictionaryTest, LeftJoinNoNulls)


### PR DESCRIPTION
## Description
Related to #18677

This PR moves the strong types `join_match_context` and `join_partition_context` out of the `sort_merge_join` class into the public interface, allowing them to be reused in `hash_join`. It also introduces `*_join_match_context` APIs to `hash_join`, enabling per-row match data retrieval to better distribute cuDF workloads for downstream libraries like Spark.

Follow-up work, such as adding partition context retrieval, will be handled in a separate PR to keep the review process simpler.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
