### PR TITLE
Add error handling for non-existent columns in Parquet reader

### DIFF
--- a/cpp/src/io/parquet/reader_impl_helpers.cpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.cpp
@@ -1712,6 +1712,11 @@ aggregate_reader_metadata::select_columns(
           });
         if (found_path != all_paths.end()) {
           valid_selected_paths.push_back({selected_path, found_path->schema_idx});
+        } else {
+          // Ensure that selected path matches a path in all_paths
+          CUDF_EXPECTS(found_path != all_paths.end(),
+                       "Encountered non existent column in selected path",
+                       std::invalid_argument);
         }
       }
     }

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -3220,3 +3220,112 @@ TEST_F(ParquetReaderTest, DeviceWriteAsyncThrows)
     FAIL() << "Unexpected exception thrown: " << e.what();
   }
 }
+
+// Tests if correctly raises an error when a non existent column is specified in the read
+TEST_F(ParquetReaderTest, NonExistentColumnParamThrows)
+{
+  {
+    // clang-format off
+    auto a = cudf::test::fixed_width_column_wrapper<int>{1,2,3,4,5,6};
+    auto b = cudf::test::fixed_width_column_wrapper<float>{1.0f,2.0f,3.0f, 4.0f, 5.0f, 6.0f};
+    auto c = cudf::test::strings_column_wrapper{{"a", "b", "c", "d", "e", "f"}};
+    // clang-format on
+
+    cudf::table_view tbl{{a, b, c}};
+
+    cudf::io::table_input_metadata md(tbl);
+    md.column_metadata[0].set_name("a");
+    md.column_metadata[1].set_name("b");
+    md.column_metadata[2].set_name("c");
+
+    auto filepath = temp_env->get_temp_filepath("NonExistentColumnParamThrows.parquet");
+    cudf::io::parquet_writer_options write_opts =
+      cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, tbl).metadata(md);
+    cudf::io::write_parquet(write_opts);
+
+    // Request a non existent field
+    cudf::io::parquet_reader_options read_opts =
+      cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath})
+        .columns({"a", "d"});
+
+    try {
+      auto _ = cudf::io::read_parquet(read_opts);
+      FAIL() << "Expected exception for non existent column parameter";
+      // Test fails if no exception is thrown
+    } catch (const std::invalid_argument&) {
+      // Test passes if invalid_argument is thrown (expected test exception)
+    } catch (const std::exception& e) {
+      // Test fails if any other exception is thrown
+      FAIL() << "Unexpected exception thrown: " << e.what();
+    }
+  }
+  {
+    auto b = cudf::test::fixed_width_column_wrapper<float>{1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+
+    // Build STRUCT column 'a'
+    auto x        = cudf::test::fixed_width_column_wrapper<int>{1, 2, 3, 4, 5, 6};
+    auto y        = cudf::test::strings_column_wrapper{"u", "v", "w", "x", "y", "z"};
+    auto a_struct = cudf::test::structs_column_wrapper{{x, y}}.release();
+
+    cudf::table_view tbl({*a_struct, b});
+
+    auto filepath = temp_env->get_temp_filepath("NonExistentColumnParamThrows2.parquet");
+    cudf::io::table_input_metadata md(tbl);
+    md.column_metadata[0].set_name("a");
+    md.column_metadata[1].set_name("b");
+    md.column_metadata[0].child(0).set_name("x");
+    md.column_metadata[0].child(1).set_name("y");
+
+    auto write_opts =
+      cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, tbl).metadata(md);
+    cudf::io::write_parquet(write_opts);
+
+    // Request a valid subfield and an invalid one: "a.x" (ok) and "a.z" (missing)
+    auto read_opts = cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath})
+                       .columns({"a.x", "a.z"});
+
+    try {
+      auto _ = cudf::io::read_parquet(read_opts);
+      FAIL() << "Expected exception for non existent column parameter";
+      // Test fails if no exception is thrown
+    } catch (const std::invalid_argument&) {
+      // Test passes if invalid_argument is thrown (expected test exception)
+    } catch (const std::exception& e) {
+      // Test fails if any other exception is thrown
+      FAIL() << "Unexpected exception thrown: " << e.what();
+    }
+  }
+  {
+    // Make two flat columns
+    auto A = cudf::test::fixed_width_column_wrapper<int>{1, 2, 3, 4, 5, 6};
+    auto b = cudf::test::strings_column_wrapper{"a", "b", "c", "d", "e", "f"};
+
+    cudf::table_view tbl{{A, b}};
+
+    auto filepath = temp_env->get_temp_filepath("NonExistentColumnParamThrows3.parquet");
+    cudf::io::table_input_metadata md(tbl);
+
+    // top-level name is "A" (uppercase), not "a"
+    md.column_metadata[0].set_name("A");
+    md.column_metadata[1].set_name("b");
+
+    auto write_opts =
+      cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, tbl).metadata(md);
+    cudf::io::write_parquet(write_opts);
+
+    // Request lowercase "a" -> should not match uppercase "A" (case-sensitive)
+    auto read_opts = cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath})
+                       .columns({"a", "b"});
+
+    try {
+      auto _ = cudf::io::read_parquet(read_opts);
+      FAIL() << "Expected exception for non existent column parameter";
+      // Test fails if no exception is thrown
+    } catch (const std::invalid_argument&) {
+      // Test passes if invalid_argument is thrown (expected test exception)
+    } catch (const std::exception& e) {
+      // Test fails if any other exception is thrown
+      FAIL() << "Unexpected exception thrown: " << e.what();
+    }
+  }
+}


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Adds error handling to `cudf::io::parquet::detail::aggregate_reader_metadata::select_columns()` to throw when projected column names are not present in the file. Previously, the Parquet reader was ignoring these columns.

Additonally, updated existing tests for selecting struct columns to also properly error when column names are non existent.

Closes:
[#18664](https://github.com/rapidsai/cudf/issues/18664)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
