### PR TITLE
Fix core dump in MemoryCleaner

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
+++ b/java/src/main/java/ai/rapids/cudf/MemoryCleaner.java
@@ -1,6 +1,6 @@
 /*
  *
- *  SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ *  SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *  SPDX-License-Identifier: Apache-2.0
  *
  */


### PR DESCRIPTION
## Description
contributes to #19838

### Root cause 1
There are two threads: shutdown hook thread and clean up thread.
Shutdown hook thread invoke `System.gc` to collect useless objects which referring to Rmm resources, and sleep 1s `t.join(1000)`  to let clean up thread clean the collected objects.
`System.gc` sometimes does not reclaim all the useless objects. Maybe the memory is adequent and `System.gc` do nothing. This behavior should vary according to JVM versions. Then left Rmm objects to shutdown hook and core dump occurs:
```java
      for (CleanerWeakReference cwr : MemoryCleaner.all.values()) {
        cwr.clean();
      }
```

The  `shutdown hook` thread is the last thread because it has the least priority.  Refer to [PR #5955](https://github.com/NVIDIA/spark-rapids/pull/5955), the  `shutdown hook` is reinstalled and runs at last.  When  `shutdown hook` thread runs, the Spark session is closed, and thus can not do any clean. Although I do not the accurate status, IMO we can not do any clean in thutdown hook.


We also wait sometimes when before closing Rmm, this also decreases the possiblities to core dump, but it's not 100% guaranteed.
In `Rmm.shutdown`:
```java

... // wait loop

(MemoryCleaner.bestEffortHasRmmBlockers()) {
      throw new RmmException("Could not shut down RMM there appear to be outstanding allocations");
    }

... // close
```
The above code is catched by Spark and ignored.
Spark code `PluginContainer`
```scala
  override def shutdown(): Unit = {
    executorPlugins.foreach { case (name, plugin) =>
      try {
        logDebug(s"Stopping plugin $name.")
        plugin.shutdown()
      } catch {
        case t: Throwable =>
          logInfo(log"Exception while shutting down plugin ${MDC(LogKeys.CLASS_NAME, name)}.", t)
      }
    }
  }
```

### Root cause 2
Refer to https://github.com/NVIDIA/spark-rapids/pull/13413:
Calls `MemoryCleaner.cleanAllRmmBlockers()` before `clearEventHandler`.

```java
    MemoryCleaner.cleanAllRmmBlockers()

    RmmSpark.clearEventHandler()
    Rmm.clearEventHandler()
    Rmm.shutdown()
```
If calls `cleanAllRmmBlockers` before `Rmm.shutdown`, also core dump.

### changes

- `ShutdownHookThread` is only used to close non-Rmm blockers. 
- `ShutdownHookThread` closes the `CleanerThread` gracefully.
- Add `cleanAllRmmBlockers` to close Rmm blockers.
- Spark-Rapids change https://github.com/NVIDIA/spark-rapids/pull/13413/
- Remove `Runtime.getRuntime().addShutdownHook`, now Spark-Rapids is resposible to install the shutdown hook.

Refactors:

- Make `CleanerWeakReference.close` synchronized and avoid double close.
- Create `CleanerThread` to replace the anonymous class to get Java core dump stack more readable.
- Provide `stopLoops` to stop the `CleanerThread` gracefully.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
