### PR TITLE
Require list type for is_valid_aggregation and MERGE_LISTS/SETS

### DIFF
--- a/cpp/include/cudf/detail/aggregation/aggregation.hpp
+++ b/cpp/include/cudf/detail/aggregation/aggregation.hpp
@@ -1517,13 +1517,17 @@ struct target_type_impl<Source, aggregation::LAG> {
 
 // Always use list for MERGE_LISTS
 template <typename Source>
-struct target_type_impl<Source, aggregation::MERGE_LISTS> {
+struct target_type_impl<Source,
+                        aggregation::MERGE_LISTS,
+                        std::enable_if_t<cuda::std::is_same_v<Source, cudf::list_view>>> {
   using type = list_view;
 };
 
 // Always use list for MERGE_SETS
 template <typename Source>
-struct target_type_impl<Source, aggregation::MERGE_SETS> {
+struct target_type_impl<Source,
+                        aggregation::MERGE_SETS,
+                        std::enable_if_t<cuda::std::is_same_v<Source, cudf::list_view>>> {
   using type = list_view;
 };
 


### PR DESCRIPTION
## Description
Fixes `cudf::is_valid_aggregation()` to return `false` for `MERGE_LISTS` and `MERGE_SETS` when the `data_type` parameter is not a LIST type.

Closes https://github.com/rapidsai/cudf/issues/19717

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
