### PR TITLE
Update boost version to 1.79 for JNI dockerfile

### DIFF
--- a/java/ci/Dockerfile.rocky
+++ b/java/ci/Dockerfile.rocky
@@ -30,7 +30,7 @@ ARG TOOLSET_VERSION=14
 ARG CMAKE_VERSION=3.30.7
 ARG CCACHE_VERSION=4.11.2
 ### Install basic requirements
-RUN dnf --enablerepo=powertools install -y  scl-utils gcc-toolset-11 gcc-toolset-${TOOLSET_VERSION} git zlib-devel maven tar wget patch ninja-build boost-devel
+RUN dnf --enablerepo=powertools install -y  scl-utils gcc-toolset-11 gcc-toolset-${TOOLSET_VERSION} git zlib-devel maven tar wget patch ninja-build
 ## pre-create the CMAKE_INSTALL_PREFIX folder, set writable by any user for Jenkins
 RUN mkdir /usr/local/rapids /rapids && chmod 777 /usr/local/rapids /rapids
 
@@ -57,6 +57,16 @@ RUN cd /tmp && wget --quiet https://github.com/ccache/ccache/releases/download/v
       cmake --build . --parallel 4 --target install" && \
    cd ../.. && \
    rm -rf ccache-${CCACHE_VERSION}
+
+## install a version of boost that is needed for arrow/parquet to work
+RUN cd /usr/local && wget --quiet https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.gz && \
+  tar -xzf boost_1_79_0.tar.gz && \
+  rm boost_1_79_0.tar.gz && \
+  cd boost_1_79_0 && \
+  ./bootstrap.sh --prefix=/usr/local && \
+  ./b2 install --prefix=/usr/local --with-filesystem --with-system && \
+   cd /usr/local && \
+   rm -rf boost_1_79_0
 
 # disable cuda container constraints to allow running w/ elder drivers on data-center GPUs
 ENV NVIDIA_DISABLE_REQUIRE="true"


### PR DESCRIPTION
## Description
Fix https://github.com/rapidsai/cudf/issues/19879

The default boost-devel (1.66.x) is incompatible with the recent arrow update. 

This change, which is ported from JNI repo, has been verified internally.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
