### PR TITLE
Ignore scalars when broadcasting for string operations in cudf-polars

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -312,8 +312,10 @@ class StringFunction(Expr):
                 for child in self.children
             ]
 
+            non_unit_sizes = [c.size for c in columns if c.size != 1]
             broadcasted = broadcast(
-                *columns, target_length=max(col.size for col in columns)
+                *columns,
+                target_length=max(non_unit_sizes) if non_unit_sizes else None,
             )
 
             delimiter, ignore_nulls = self.options

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -868,3 +868,10 @@ def test_len_bytes(ldf):
 def test_len_chars(ldf):
     q = ldf.select(pl.col("a").str.len_chars())
     assert_gpu_result_equal(q)
+
+
+def test_string_concat_empty_frame():
+    lf = pl.LazyFrame({"a": pl.Series([], dtype=pl.String)})
+    q = lf.select(pl.lit(", ") + pl.col("a"))
+
+    assert_gpu_result_equal(q)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Closes #19892 
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
