### PR TITLE
Use cupy array instead of numba device array as inputs to jit routines

### DIFF
--- a/python/cudf/cudf/utils/queryutils.py
+++ b/python/cudf/cudf/utils/queryutils.py
@@ -5,12 +5,13 @@ import ast
 import datetime
 from typing import Any
 
+import cupy as cp
 import numpy as np
 from numba import cuda
 
 import cudf
 from cudf.core.buffer import acquire_spill_lock
-from cudf.core.column import column_empty
+from cudf.core.column import as_column
 from cudf.utils import applyutils
 from cudf.utils._numba import _CUDFNumbaConfig
 from cudf.utils.dtypes import (
@@ -223,10 +224,7 @@ def query_execute(df, expr, callenv):
             "query only supports numeric, datetime, timedelta, or bool dtypes."
         )
 
-    colarrays = [
-        cuda.as_cuda_array(col.data_array_view(mode="read"))
-        for col in colarrays
-    ]
+    colarrays = [col.data_array_view(mode="read") for col in colarrays]
 
     kernel = compiled["kernel"]
     # process env args
@@ -250,11 +248,10 @@ def query_execute(df, expr, callenv):
 
     # allocate output buffer
     nrows = len(df)
-    out = column_empty(nrows, dtype=np.dtype(np.bool_))
-    out = out.set_mask(None)
+    out = cp.empty(nrows, dtype=np.dtype(np.bool_))
     # run kernel
     args = [out, *colarrays, *envargs]
     with _CUDFNumbaConfig():
         kernel.forall(nrows)(*args)
     out_mask = applyutils.make_aggregate_nullmask(df, columns=columns)
-    return out.set_mask(out_mask).fillna(False)
+    return as_column(out).set_mask(out_mask).fillna(False)


### PR DESCRIPTION
## Description
xref https://github.com/rapidsai/cudf/pull/19855#discussion_r2323540719

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
