### PR TITLE
Pin to CUDA 12 image for integration tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -352,7 +352,8 @@ jobs:
       sha: ${{ inputs.sha }}
       node_type: "gpu-l4-latest-1"
       continue-on-error: true
-      container_image: "rapidsai/ci-conda:25.10-latest"
+      # TODO: Switch to ci-conda:25-10-latest when XGBoost has CUDA 13 packages
+      container_image: "rapidsai/ci-conda:25.10-cuda12.9.1-ubuntu24.04-py3.13"
       script: |
         ci/cudf_pandas_scripts/third-party-integration/test.sh python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
   pandas-tests:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Until https://github.com/dmlc/xgboost/issues/11648 and https://github.com/rapidsai/xgboost-feedstock/issues/100 are resolved we need to run the integration tests on CUDA 12 so that we can still test xgboost.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
