### PR TITLE
Use a managed pool by default in rmm when cudf is imported

### DIFF
--- a/python/cudf/cudf/__init__.py
+++ b/python/cudf/cudf/__init__.py
@@ -74,6 +74,7 @@ from cudf.options import (
 
 
 def configure_mr():
+    """Configure all libraries to use the best available or selected rmm mr."""
     import os
     import warnings
 

--- a/python/cudf/cudf/__init__.py
+++ b/python/cudf/cudf/__init__.py
@@ -81,6 +81,93 @@ from cudf.options import (
 cuda.set_memory_manager(RMMNumbaManager)
 cupy.cuda.set_allocator(rmm_cupy_allocator)
 
+
+def configure_mr():
+    import os
+    import warnings
+
+    import pylibcudf
+    import rmm.mr
+
+    if (
+        "RAPIDS_NO_INITIALIZE" in os.environ
+        or "CUDF_NO_INITIALIZE" in os.environ
+    ):
+        return
+
+    try:
+        # The default mode is "managed_pool" if UVM is supported, otherwise "pool"
+        managed_memory_is_supported = (
+            pylibcudf.utils._is_concurrent_managed_access_supported()
+        )
+    except RuntimeError as e:
+        warnings.warn(str(e))
+        return
+
+    cudf_rmm_mode = os.getenv("CUDF_RMM_MODE")
+    cudf_pandas_rmm_mode = os.getenv("CUDF_PANDAS_RMM_MODE")
+    rmm_mode = cudf_pandas_rmm_mode or cudf_rmm_mode
+    if rmm_mode is None:
+        rmm_mode = "managed_pool" if managed_memory_is_supported else "pool"
+
+    # Check if a non-default memory resource is set
+    current_mr = rmm.mr.get_current_device_resource()
+    if not isinstance(current_mr, rmm.mr.CudaMemoryResource):
+        # Warn only if the user explicitly set CUDF_PANDAS_RMM_MODE or CUDF_RMM_MODE
+        if cudf_rmm_mode:
+            warnings.warn(
+                "cudf detected an already configured memory resource, ignoring "
+                f"'CUDF_RMM_MODE={rmm_mode}'",
+                UserWarning,
+            )
+        if cudf_pandas_rmm_mode:
+            warnings.warn(
+                "cudf.pandas detected an already configured memory resource, "
+                f"ignoring 'CUDF_PANDAS_RMM_MODE={rmm_mode}'",
+                UserWarning,
+            )
+        return
+
+    free_memory, _ = rmm.mr.available_device_memory()
+    free_memory = int(round(float(free_memory) * 0.80 / 256) * 256)
+    new_mr = current_mr
+
+    if rmm_mode == "pool":
+        new_mr = rmm.mr.PoolMemoryResource(
+            current_mr,
+            initial_pool_size=free_memory,
+        )
+    elif rmm_mode == "async":
+        new_mr = rmm.mr.CudaAsyncMemoryResource(initial_pool_size=free_memory)
+    elif "managed" in rmm_mode:
+        if not managed_memory_is_supported:
+            raise ValueError(
+                "Managed memory is not supported on this system, so the "
+                f"requested {rmm_mode=} is invalid."
+            )
+        if rmm_mode == "managed":
+            new_mr = rmm.mr.PrefetchResourceAdaptor(
+                rmm.mr.ManagedMemoryResource()
+            )
+        elif rmm_mode == "managed_pool":
+            new_mr = rmm.mr.PrefetchResourceAdaptor(
+                rmm.mr.PoolMemoryResource(
+                    rmm.mr.ManagedMemoryResource(),
+                    initial_pool_size=free_memory,
+                )
+            )
+        else:
+            raise ValueError(f"Unsupported {rmm_mode=}")
+        pylibcudf.prefetch.enable()
+    elif rmm_mode != "cuda":
+        raise ValueError(f"Unsupported {rmm_mode=}")
+
+    rmm.mr.set_current_device_resource(new_mr)
+
+
+configure_mr()
+
+
 del cuda
 del cupy
 del rmm_cupy_allocator

--- a/python/cudf/cudf/pandas/__init__.py
+++ b/python/cudf/cudf/pandas/__init__.py
@@ -2,12 +2,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import warnings
-
-import pylibcudf
-import rmm.mr
-
 from .fast_slow_proxy import (
     as_proxy_object,
     is_proxy_instance,
@@ -36,73 +30,6 @@ def install():
     loader = ModuleAccelerator.install("pandas", "cudf", "pandas")
     global LOADED
     LOADED = loader is not None
-    if (
-        "RAPIDS_NO_INITIALIZE" in os.environ
-        or "CUDF_NO_INITIALIZE" in os.environ
-    ):
-        return
-
-    try:
-        # The default mode is "managed_pool" if UVM is supported, otherwise "pool"
-        managed_memory_is_supported = (
-            pylibcudf.utils._is_concurrent_managed_access_supported()
-        )
-    except RuntimeError as e:
-        warnings.warn(str(e))
-        return
-
-    rmm_mode = os.getenv("CUDF_PANDAS_RMM_MODE")
-    rmm_mode_explicitly_set = rmm_mode is not None
-    if rmm_mode is None:
-        rmm_mode = "managed_pool" if managed_memory_is_supported else "pool"
-
-    # Check if a non-default memory resource is set
-    current_mr = rmm.mr.get_current_device_resource()
-    if not isinstance(current_mr, rmm.mr.CudaMemoryResource):
-        # Warn only if the user explicitly set CUDF_PANDAS_RMM_MODE
-        if rmm_mode_explicitly_set:
-            warnings.warn(
-                "cudf.pandas detected an already configured memory resource, ignoring "
-                f"'CUDF_PANDAS_RMM_MODE={rmm_mode}'",
-                UserWarning,
-            )
-        return
-
-    free_memory, _ = rmm.mr.available_device_memory()
-    free_memory = int(round(float(free_memory) * 0.80 / 256) * 256)
-    new_mr = current_mr
-
-    if rmm_mode == "pool":
-        new_mr = rmm.mr.PoolMemoryResource(
-            current_mr,
-            initial_pool_size=free_memory,
-        )
-    elif rmm_mode == "async":
-        new_mr = rmm.mr.CudaAsyncMemoryResource(initial_pool_size=free_memory)
-    elif "managed" in rmm_mode:
-        if not managed_memory_is_supported:
-            raise ValueError(
-                "Managed memory is not supported on this system, so the "
-                f"requested {rmm_mode=} is invalid."
-            )
-        if rmm_mode == "managed":
-            new_mr = rmm.mr.PrefetchResourceAdaptor(
-                rmm.mr.ManagedMemoryResource()
-            )
-        elif rmm_mode == "managed_pool":
-            new_mr = rmm.mr.PrefetchResourceAdaptor(
-                rmm.mr.PoolMemoryResource(
-                    rmm.mr.ManagedMemoryResource(),
-                    initial_pool_size=free_memory,
-                )
-            )
-        else:
-            raise ValueError(f"Unsupported {rmm_mode=}")
-        pylibcudf.prefetch.enable()
-    elif rmm_mode != "cuda":
-        raise ValueError(f"Unsupported {rmm_mode=}")
-
-    rmm.mr.set_current_device_resource(new_mr)
 
 
 def pytest_load_initial_conftests(early_config, parser, args):


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Resolves #19161 by copying over the logic from cudf.pandas.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
