### PR TITLE
Fix reindex fill_value to only fill newly introduced positions

### DIFF
--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -3831,19 +3831,21 @@ class IndexedFrame(Frame):
             # These are positions where the original data had no corresponding index
             original_index_set = set(self.index)
             new_positions_mask = ~result.index.isin(original_index_set)
-            
+
             # Only fill NA values at new positions
             for col_name in result._column_names:
                 col = result._data[col_name]
-                if hasattr(col, 'fillna'):
+                if hasattr(col, "fillna"):
                     # Create a mask for NA values at new positions only
                     na_mask = col.isna()
                     fill_mask = na_mask & new_positions_mask
-                    
+
                     if fill_mask.any():
                         # Fill only the NA values at new positions
-                        result._data[col_name] = col.where(~fill_mask, fill_value)
-        
+                        result._data[col_name] = col.where(
+                            ~fill_mask, fill_value
+                        )
+
         return self._mimic_inplace(result, inplace=inplace)
 
     def round(self, decimals=0, how="half_even"):

--- a/python/cudf/cudf/tests/series/methods/test_reindex.py
+++ b/python/cudf/cudf/tests/series/methods/test_reindex.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
 
+import pandas as pd
+import pytest
 
 import cudf
-from cudf.testing._utils import (
-    assert_exceptions_equal,
-)
+from cudf.testing import assert_eq
+from cudf.testing._utils import assert_exceptions_equal
 
 
 def test_series_duplicate_index_reindex():
@@ -17,3 +18,119 @@ def test_series_duplicate_index_reindex():
         lfunc_args_and_kwargs=([10, 11, 12, 13], {}),
         rfunc_args_and_kwargs=([10, 11, 12, 13], {}),
     )
+
+
+@pytest.mark.parametrize("fill_value", [3, 99, -1, 0])
+def test_series_reindex_fill_value_preserves_existing_nas(fill_value, nan_as_null):
+    """
+    Test that reindex with fill_value only fills newly introduced positions,
+    not existing NA values.
+    
+    This test reproduces and validates the fix for issue #19854:
+    https://github.com/rapidsai/cudf/issues/19854
+    
+    Before the fix: fill_value was applied to ALL NAs (including existing ones)
+    After the fix: fill_value is only applied to newly introduced positions
+    """
+    gs = cudf.Series([1.0, 2.0, None], nan_as_null=nan_as_null)
+    ps = gs.to_pandas()
+    
+    result = gs.reindex([0, 1, 2, 3], fill_value=fill_value)
+    expected = ps.reindex([0, 1, 2, 3], fill_value=fill_value)
+    
+    assert_eq(result, expected)
+
+
+@pytest.mark.parametrize("fill_value", [99, -5, 0])
+def test_series_reindex_fill_value_multiple_new_positions(fill_value):
+    """Test reindex with multiple new positions."""
+    gs = cudf.Series([1.0, 2.0, None])
+    ps = gs.to_pandas()
+    
+    result = gs.reindex([0, 1, 2, 3, 4, 5], fill_value=fill_value)
+    expected = ps.reindex([0, 1, 2, 3, 4, 5], fill_value=fill_value)
+    
+    assert_eq(result, expected)
+
+
+@pytest.mark.parametrize("fill_value", [99, -1, 0])
+def test_series_reindex_fill_value_no_existing_nas(fill_value):
+    """Test reindex when original series has no NA values."""
+    gs = cudf.Series([1.0, 2.0, 3.0])
+    ps = gs.to_pandas()
+    
+    result = gs.reindex([0, 1, 2, 3, 4], fill_value=fill_value)
+    expected = ps.reindex([0, 1, 2, 3, 4], fill_value=fill_value)
+    
+    assert_eq(result, expected)
+
+
+@pytest.mark.parametrize("fill_value", [99, -1, 0])
+def test_series_reindex_fill_value_all_existing_nas(fill_value):
+    """Test reindex when original series has all NA values."""
+    gs = cudf.Series([None, None, None])
+    ps = gs.to_pandas()
+    
+    result = gs.reindex([0, 1, 2, 3], fill_value=fill_value)
+    expected = ps.reindex([0, 1, 2, 3], fill_value=fill_value)
+    
+    assert_eq(result, expected)
+
+
+@pytest.mark.parametrize("fill_value", [99, -1, 0])
+def test_series_reindex_fill_value_mixed_dtypes(fill_value):
+    """Test reindex with different data types."""
+    gs = cudf.Series([1, 2, None], dtype='int64')
+    ps = gs.to_pandas()
+    
+    result = gs.reindex([0, 1, 2, 3], fill_value=fill_value)
+    expected = ps.reindex([0, 1, 2, 3], fill_value=fill_value)
+    
+    assert_eq(result, expected)
+
+
+@pytest.mark.parametrize("fill_value", ["new", "test", "x"])
+def test_series_reindex_fill_value_string_dtype(fill_value):
+    """Test reindex with string data type."""
+    gs = cudf.Series(['a', 'b', None])
+    ps = gs.to_pandas()
+    
+    result = gs.reindex([0, 1, 2, 3], fill_value=fill_value)
+    expected = ps.reindex([0, 1, 2, 3], fill_value=fill_value)
+    
+    assert_eq(result, expected)
+
+
+def test_series_reindex_fill_value_none():
+    """Test reindex with fill_value=None (should use default NA)."""
+    gs = cudf.Series([1.0, 2.0, None])
+    ps = gs.to_pandas()
+    
+    result = gs.reindex([0, 1, 2, 3], fill_value=None)
+    expected = ps.reindex([0, 1, 2, 3], fill_value=None)
+    
+    assert_eq(result, expected)
+
+
+def test_series_reindex_fill_value_na():
+    """Test reindex with fill_value=cudf.NA."""
+    gs = cudf.Series([1.0, 2.0, None])
+    ps = gs.to_pandas()
+    
+    result = gs.reindex([0, 1, 2, 3], fill_value=cudf.NA)
+    expected = ps.reindex([0, 1, 2, 3], fill_value=cudf.NA)
+    
+    assert_eq(result, expected)
+
+
+@pytest.mark.parametrize("data", [[1.0, 2.0, None], [None, 1.0, 2.0], [1.0, None, 2.0]])
+@pytest.mark.parametrize("fill_value", [0, 99, -1])
+def test_series_reindex_fill_value_various_na_positions(data, fill_value):
+    """Test reindex with NA values at different positions."""
+    gs = cudf.Series(data)
+    ps = gs.to_pandas()
+    
+    result = gs.reindex([0, 1, 2, 3, 4], fill_value=fill_value)
+    expected = ps.reindex([0, 1, 2, 3, 4], fill_value=fill_value)
+    
+    assert_eq(result, expected)

--- a/python/cudf/cudf/tests/series/methods/test_reindex.py
+++ b/python/cudf/cudf/tests/series/methods/test_reindex.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
 
-import pandas as pd
 import pytest
 
 import cudf
@@ -21,23 +20,25 @@ def test_series_duplicate_index_reindex():
 
 
 @pytest.mark.parametrize("fill_value", [3, 99, -1, 0])
-def test_series_reindex_fill_value_preserves_existing_nas(fill_value, nan_as_null):
+def test_series_reindex_fill_value_preserves_existing_nas(
+    fill_value, nan_as_null
+):
     """
     Test that reindex with fill_value only fills newly introduced positions,
     not existing NA values.
-    
+
     This test reproduces and validates the fix for issue #19854:
     https://github.com/rapidsai/cudf/issues/19854
-    
+
     Before the fix: fill_value was applied to ALL NAs (including existing ones)
     After the fix: fill_value is only applied to newly introduced positions
     """
     gs = cudf.Series([1.0, 2.0, None], nan_as_null=nan_as_null)
     ps = gs.to_pandas()
-    
+
     result = gs.reindex([0, 1, 2, 3], fill_value=fill_value)
     expected = ps.reindex([0, 1, 2, 3], fill_value=fill_value)
-    
+
     assert_eq(result, expected)
 
 
@@ -46,10 +47,10 @@ def test_series_reindex_fill_value_multiple_new_positions(fill_value):
     """Test reindex with multiple new positions."""
     gs = cudf.Series([1.0, 2.0, None])
     ps = gs.to_pandas()
-    
+
     result = gs.reindex([0, 1, 2, 3, 4, 5], fill_value=fill_value)
     expected = ps.reindex([0, 1, 2, 3, 4, 5], fill_value=fill_value)
-    
+
     assert_eq(result, expected)
 
 
@@ -58,10 +59,10 @@ def test_series_reindex_fill_value_no_existing_nas(fill_value):
     """Test reindex when original series has no NA values."""
     gs = cudf.Series([1.0, 2.0, 3.0])
     ps = gs.to_pandas()
-    
+
     result = gs.reindex([0, 1, 2, 3, 4], fill_value=fill_value)
     expected = ps.reindex([0, 1, 2, 3, 4], fill_value=fill_value)
-    
+
     assert_eq(result, expected)
 
 
@@ -70,34 +71,34 @@ def test_series_reindex_fill_value_all_existing_nas(fill_value):
     """Test reindex when original series has all NA values."""
     gs = cudf.Series([None, None, None])
     ps = gs.to_pandas()
-    
+
     result = gs.reindex([0, 1, 2, 3], fill_value=fill_value)
     expected = ps.reindex([0, 1, 2, 3], fill_value=fill_value)
-    
+
     assert_eq(result, expected)
 
 
 @pytest.mark.parametrize("fill_value", [99, -1, 0])
 def test_series_reindex_fill_value_mixed_dtypes(fill_value):
     """Test reindex with different data types."""
-    gs = cudf.Series([1, 2, None], dtype='int64')
+    gs = cudf.Series([1, 2, None], dtype="int64")
     ps = gs.to_pandas()
-    
+
     result = gs.reindex([0, 1, 2, 3], fill_value=fill_value)
     expected = ps.reindex([0, 1, 2, 3], fill_value=fill_value)
-    
+
     assert_eq(result, expected)
 
 
 @pytest.mark.parametrize("fill_value", ["new", "test", "x"])
 def test_series_reindex_fill_value_string_dtype(fill_value):
     """Test reindex with string data type."""
-    gs = cudf.Series(['a', 'b', None])
+    gs = cudf.Series(["a", "b", None])
     ps = gs.to_pandas()
-    
+
     result = gs.reindex([0, 1, 2, 3], fill_value=fill_value)
     expected = ps.reindex([0, 1, 2, 3], fill_value=fill_value)
-    
+
     assert_eq(result, expected)
 
 
@@ -105,10 +106,10 @@ def test_series_reindex_fill_value_none():
     """Test reindex with fill_value=None (should use default NA)."""
     gs = cudf.Series([1.0, 2.0, None])
     ps = gs.to_pandas()
-    
+
     result = gs.reindex([0, 1, 2, 3], fill_value=None)
     expected = ps.reindex([0, 1, 2, 3], fill_value=None)
-    
+
     assert_eq(result, expected)
 
 
@@ -116,21 +117,23 @@ def test_series_reindex_fill_value_na():
     """Test reindex with fill_value=cudf.NA."""
     gs = cudf.Series([1.0, 2.0, None])
     ps = gs.to_pandas()
-    
+
     result = gs.reindex([0, 1, 2, 3], fill_value=cudf.NA)
     expected = ps.reindex([0, 1, 2, 3], fill_value=cudf.NA)
-    
+
     assert_eq(result, expected)
 
 
-@pytest.mark.parametrize("data", [[1.0, 2.0, None], [None, 1.0, 2.0], [1.0, None, 2.0]])
+@pytest.mark.parametrize(
+    "data", [[1.0, 2.0, None], [None, 1.0, 2.0], [1.0, None, 2.0]]
+)
 @pytest.mark.parametrize("fill_value", [0, 99, -1])
 def test_series_reindex_fill_value_various_na_positions(data, fill_value):
     """Test reindex with NA values at different positions."""
     gs = cudf.Series(data)
     ps = gs.to_pandas()
-    
+
     result = gs.reindex([0, 1, 2, 3, 4], fill_value=fill_value)
     expected = ps.reindex([0, 1, 2, 3, 4], fill_value=fill_value)
-    
+
     assert_eq(result, expected)


### PR DESCRIPTION
- Fixes issue #19854

## Description
Fixes issue #19854 where `reindex` with `fill_value` was incorrectly filling ALL NA values instead of only newly introduced positions. Now matches pandas behavior.

## Changes
- Modified `_reindex` method to only fill NAs at new positions
- Added comprehensive tests covering various scenarios

Closes #19854

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
