### PR TITLE
Resolve the race condition in the mixed join retrieval kernel.

### DIFF
--- a/cpp/src/join/mixed_join_size_kernel.cuh
+++ b/cpp/src/join/mixed_join_size_kernel.cuh
@@ -77,17 +77,7 @@ __device__ __forceinline__ auto standalone_count(
       return count;
     }
 
-    // Move to next bucket using precomputed step
     probe_idx = (probe_idx + step) % extent;
-
-    // Detect full cycle completion
-    if (probe_idx == static_cast<std::size_t>(hash_idx.first)) {
-      // Handle outer join logic: non-matching rows are counted as 1 match
-      if ((join_type == join_kind::LEFT_JOIN || join_type == join_kind::FULL_JOIN) && count == 0) {
-        return 1;
-      }
-      return count;
-    }
   }
 }
 


### PR DESCRIPTION
## Description
This PR addresses a critical probing logic bug in the new mixed join custom kernel, where the block-level counter was incorrectly used as the global counter to determine each block’s output buffer write offset. It also resolves potential overflow issues that can occur when handling very large datasets.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
