### PR TITLE
Make stream a required parameter for from_libcudf methods

### DIFF
--- a/python/cudf/cudf/_lib/strings_udf.pyx
+++ b/python/cudf/cudf/_lib/strings_udf.pyx
@@ -26,6 +26,7 @@ def column_to_string_view_array(plc_Column strings_col):
     with nogil:
         c_buffer = move(cpp_to_string_view_array(input_view))
 
+    # TODO: Is it OK to use the default stream here?
     return DeviceBuffer.c_from_unique_ptr(move(c_buffer))
 
 

--- a/python/cudf/cudf/_lib/strings_udf.pyx
+++ b/python/cudf/cudf/_lib/strings_udf.pyx
@@ -16,6 +16,7 @@ from pylibcudf.libcudf.strings_udf cimport (
 )
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.pylibrmm.device_buffer cimport DeviceBuffer
+from rmm.pylibrmm.stream import DEFAULT_STREAM
 
 import numpy as np
 
@@ -27,7 +28,7 @@ def column_to_string_view_array(plc_Column strings_col):
         c_buffer = move(cpp_to_string_view_array(input_view))
 
     # TODO: Is it OK to use the default stream here?
-    return DeviceBuffer.c_from_unique_ptr(move(c_buffer))
+    return DeviceBuffer.c_from_unique_ptr(move(c_buffer), DEFAULT_STREAM)
 
 
 def column_from_managed_udf_string_array(DeviceBuffer d_buffer):
@@ -38,7 +39,8 @@ def column_from_managed_udf_string_array(DeviceBuffer d_buffer):
     with nogil:
         c_result = move(cpp_column_from_managed_udf_string_array(data, size))
 
-    return plc_Column.from_libcudf(move(c_result))
+    # TODO: Is it OK to use the default stream here?
+    return plc_Column.from_libcudf(move(c_result), DEFAULT_STREAM)
 
 
 def get_character_flags_table_ptr():

--- a/python/cudf/cudf/_lib/strings_udf.pyx
+++ b/python/cudf/cudf/_lib/strings_udf.pyx
@@ -27,7 +27,6 @@ def column_to_string_view_array(plc_Column strings_col):
     with nogil:
         c_buffer = move(cpp_to_string_view_array(input_view))
 
-    # TODO: Is it OK to use the default stream here?
     return DeviceBuffer.c_from_unique_ptr(move(c_buffer), DEFAULT_STREAM)
 
 
@@ -39,7 +38,6 @@ def column_from_managed_udf_string_array(DeviceBuffer d_buffer):
     with nogil:
         c_result = move(cpp_column_from_managed_udf_string_array(data, size))
 
-    # TODO: Is it OK to use the default stream here?
     return plc_Column.from_libcudf(move(c_result), DEFAULT_STREAM)
 
 

--- a/python/pylibcudf/pylibcudf/column.pxd
+++ b/python/pylibcudf/pylibcudf/column.pxd
@@ -56,7 +56,10 @@ cdef class Column:
     cdef mutable_column_view mutable_view(self) nogil
 
     @staticmethod
-    cdef Column from_libcudf(unique_ptr[column] libcudf_col, Stream stream=*)
+    cdef Column from_libcudf(
+        unique_ptr[column] libcudf_col,
+        Stream stream,
+    )
 
     @staticmethod
     cdef Column from_column_view(const column_view& cv, Column owner)

--- a/python/pylibcudf/pylibcudf/column.pyx
+++ b/python/pylibcudf/pylibcudf/column.pyx
@@ -559,7 +559,10 @@ cdef class Column:
         )
 
     @staticmethod
-    cdef Column from_libcudf(unique_ptr[column] libcudf_col, Stream stream=None):
+    cdef Column from_libcudf(
+        unique_ptr[column] libcudf_col,
+        Stream stream,
+    ):
         """Create a Column from a libcudf column.
 
         This method is for pylibcudf's functions to use to ingest outputs of

--- a/python/pylibcudf/pylibcudf/column_factories.pxd
+++ b/python/pylibcudf/pylibcudf/column_factories.pxd
@@ -16,7 +16,8 @@ ctypedef fused MaskArg:
 
 
 cpdef Column make_empty_column(
-    MakeEmptyColumnOperand type_or_id
+    MakeEmptyColumnOperand type_or_id,
+    Stream stream=*,
 )
 
 cpdef Column make_numeric_column(

--- a/python/pylibcudf/pylibcudf/column_factories.pyi
+++ b/python/pylibcudf/pylibcudf/column_factories.pyi
@@ -4,7 +4,10 @@ from rmm.pylibrmm.stream import Stream
 from pylibcudf.column import Column
 from pylibcudf.types import DataType, MaskState, TypeId
 
-def make_empty_column(type_or_id: DataType | TypeId) -> Column: ...
+def make_empty_column(
+    type_or_id: DataType | TypeId,
+    stream: Stream | None = None,
+) -> Column: ...
 def make_numeric_column(
     type_: DataType, size: int, mstate: MaskState, stream: Stream | None = None
 ) -> Column: ...

--- a/python/pylibcudf/pylibcudf/column_factories.pyx
+++ b/python/pylibcudf/pylibcudf/column_factories.pyx
@@ -28,7 +28,7 @@ __all__ = [
     "make_timestamp_column",
 ]
 
-cpdef Column make_empty_column(MakeEmptyColumnOperand type_or_id):
+cpdef Column make_empty_column(MakeEmptyColumnOperand type_or_id, Stream stream=None):
     """Creates an empty column of the specified type.
 
     For details, see :cpp:func::`make_empty_column`.
@@ -45,6 +45,7 @@ cpdef Column make_empty_column(MakeEmptyColumnOperand type_or_id):
     """
     cdef unique_ptr[column] result
     cdef type_id id
+    stream = _get_stream(stream)
 
     if MakeEmptyColumnOperand is object:
         if isinstance(type_or_id, TypeId):
@@ -65,7 +66,7 @@ cpdef Column make_empty_column(MakeEmptyColumnOperand type_or_id):
         raise TypeError(
             "Must pass a TypeId or DataType"
         )
-    return Column.from_libcudf(move(result))
+    return Column.from_libcudf(move(result), stream)
 
 
 cpdef Column make_numeric_column(


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This change ensures that we never create an rmm buffer that is not tied to the stream provided via an API.

Contributes to #15163 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
