### PR TITLE
Run pytest-benchmarks in CI with --benchmark-disable

### DIFF
--- a/ci/test_python_cudf.sh
+++ b/ci/test_python_cudf.sh
@@ -43,6 +43,7 @@ rapids-logger "pytest cudf"
 
 rapids-logger "pytest for cudf benchmarks"
 ./ci/run_cudf_pytest_benchmarks.sh \
+  --benchmark-disable \
   --numprocesses=8 \
   --dist=worksteal \
   --cov-config=.coveragerc \
@@ -52,6 +53,7 @@ rapids-logger "pytest for cudf benchmarks"
 
 rapids-logger "pytest for cudf benchmarks using pandas"
 ./ci/run_cudf_pandas_pytest_benchmarks.sh \
+  --benchmark-disable \
   --numprocesses=8 \
   --dist=worksteal \
   --cov-config=.coveragerc \

--- a/python/cudf/benchmarks/API/bench_dataframe.py
+++ b/python/cudf/benchmarks/API/bench_dataframe.py
@@ -165,18 +165,18 @@ def bench_construction_with_framelike(
     )
 
 
-@pytest.mark.parametrize("N", [100, 1_000_000, 100_000_000])
+@pytest.mark.parametrize("N", NUM_ROWS)
 def bench_from_arrow(benchmark, N):
     rng = numpy.random.default_rng(seed=10)
     benchmark(cudf.DataFrame, {None: pa.array(rng.random(N))})
 
 
-@pytest.mark.parametrize("N", [100, 1_000_000])
+@pytest.mark.parametrize("N", NUM_ROWS)
 def bench_construction(benchmark, N):
     benchmark(cudf.DataFrame, {None: cupy.random.rand(N)})
 
 
-@pytest.mark.parametrize("N", [100, 100_000])
+@pytest.mark.parametrize("N", NUM_ROWS)
 @pytest.mark.pandas_incompatible
 def bench_construction_numba_device_array(benchmark, N):
     benchmark(cudf.DataFrame, numba.cuda.to_device(numpy.ones((100, N))))

--- a/python/cudf/benchmarks/API/bench_functions.py
+++ b/python/cudf/benchmarks/API/bench_functions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 """Benchmarks of free functions that accept cudf objects."""
 
@@ -12,21 +12,15 @@ from utils import benchmark_with_object
 @pytest_cases.parametrize_with_cases(
     "objs", prefix="concat", cases="cases_functions"
 )
-@pytest.mark.parametrize(
-    "axis",
-    [
-        1,
-    ],
-)
 @pytest.mark.parametrize("join", ["inner", "outer"])
 @pytest.mark.parametrize("ignore_index", [True, False])
 def bench_concat_axis_1(benchmark, objs, axis, join, ignore_index):
     benchmark(
-        cudf.concat, objs=objs, axis=axis, join=join, ignore_index=ignore_index
+        cudf.concat, objs=objs, axis=1, join=join, ignore_index=ignore_index
     )
 
 
-@pytest.mark.parametrize("size", [10_000, 100_000])
+@pytest.mark.parametrize("size", NUM_ROWS)
 @pytest.mark.parametrize("cardinality", [10, 100, 1000])
 @pytest.mark.parametrize("dtype", [cupy.bool_, cupy.float64])
 def bench_get_dummies_high_cardinality(benchmark, size, cardinality, dtype):

--- a/python/cudf/benchmarks/API/bench_index.py
+++ b/python/cudf/benchmarks/API/bench_index.py
@@ -3,11 +3,11 @@
 """Benchmarks of Index methods."""
 
 import pytest
-from config import cudf, cupy
+from config import NUM_ROWS, cudf, cupy
 from utils import benchmark_with_object
 
 
-@pytest.mark.parametrize("N", [100, 1_000_000])
+@pytest.mark.parametrize("N", NUM_ROWS)
 def bench_construction(benchmark, N):
     benchmark(cudf.Index, cupy.random.rand(N))
 
@@ -17,6 +17,7 @@ def bench_sort_values(benchmark, index):
     benchmark(index.sort_values)
 
 
-def bench_large_unique_categories_repr(benchmark):
-    pi = cudf.CategoricalIndex(range(100_000_000))
+@pytest.mark.parametrize("N", NUM_ROWS)
+def bench_large_unique_categories_repr(benchmark, N):
+    pi = cudf.CategoricalIndex(range(N))
     benchmark(repr, pi)

--- a/python/cudf/benchmarks/API/bench_series.py
+++ b/python/cudf/benchmarks/API/bench_series.py
@@ -3,11 +3,11 @@
 """Benchmarks of Series methods."""
 
 import pytest
-from config import cudf, cupy
+from config import NUM_ROWS, cudf, cupy
 from utils import benchmark_with_object
 
 
-@pytest.mark.parametrize("N", [100, 1_000_000])
+@pytest.mark.parametrize("N", NUM_ROWS)
 def bench_construction(benchmark, N):
     benchmark(cudf.Series, cupy.random.rand(N))
 


### PR DESCRIPTION
## Description
Since we want to run these benchmark in CI for correctness (no runtime errors), the `--benchmark-disable` flag:

> Disable benchmarks. Benchmarked functions are only ran once and no stats are reported. Use this is you want to run the test but don’t do any benchmarking.

xref https://pytest-benchmark.readthedocs.io/en/latest/usage.html

Additionally, uses the `NUM_ROWS` variable more consistently to benchmark with smaller data sizes in CI 

With these changes, the pytest benchmarks now run in about less than 1 minute while previously they ran in around 10 minutes.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
