### PR TITLE
Pin duckdb<1.4 in test_python_narwhals

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -899,6 +899,7 @@ dependencies:
               - pytest-env
               - sqlframe
               - ibis-framework[duckdb]
+              - duckdb<1.4.0
   depends_on_libcudf:
     common:
       - output_types: conda


### PR DESCRIPTION
## Description
I believe the duckdb 1.4 release is causing some Narwhals tests to fail e.g. https://github.com/rapidsai/cudf/actions/runs/17772838602/job/50515353242?pr=19941 (and I think the [Narwhals CI is also failing with similar tracebacks](https://github.com/narwhals-dev/narwhals/actions/runs/17766808825/job/50492144758)), so pinning this dependency to get the CI back to green


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
