### PR TITLE
Skip Narwhals pandas get_dtype_backend[pyarrow] tests after ArrowDtype proxy changes

### DIFF
--- a/ci/test_narwhals.sh
+++ b/ci/test_narwhals.sh
@@ -110,8 +110,11 @@ test_pandas_object_series \
 
 # test_dtypes: With cudf.pandas loaded, to_pandas() preserves Arrow dtypes like list and struct, so pandas
 # columns aren't object anymore. The test expects object, causing a mismatch.
+# test_get_dtype_backend: We now preserve arrow extension dtypes
+# (e.g. bool[pyarrow], duration[ns][pyarrow]).
 TESTS_THAT_NEED_NARWHALS_FIX_FOR_CUDF_PANDAS=" \
-test_dtypes \
+test_dtypes or \
+(test_get_dtype_backend and pyarrow and (pandas or modin)) \
 "
 
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 NARWHALS_DEFAULT_CONSTRUCTORS=pandas python -m pytest \


### PR DESCRIPTION
## Description
PR #19960 introduced an `ArrowDtype` proxy, which subclasses `pandas.api.extensions.ExtensionDtype`. This causes pandas to now expose additional arrow-backed dtypes (e.g., `bool[pyarrow]`, `duration[ns][pyarrow]`) through the `ExtensionDtype` when cudf.pandas is active.

We'll skip these test for now, until narwhals updates the the test.

CC @galipremsagar @mroeschke 
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
