### PR TITLE
Deprecate left semi- and anti- join functional APIs

### DIFF
--- a/cpp/include/cudf/join/join.hpp
+++ b/cpp/include/cudf/join/join.hpp
@@ -192,6 +192,8 @@ full_join(cudf::table_view const& left_keys,
  * @brief Returns a vector of row indices corresponding to a left semi-join
  * between the specified tables.
  *
+ * @deprecated Use the object-oriented filtered_join API instead
+ *
  * The returned vector contains the row indices from the left table
  * for which there is a matching row in the right table.
  *
@@ -211,7 +213,7 @@ full_join(cudf::table_view const& left_keys,
  * the result of performing a left semi join between two tables with
  * `left_keys` and `right_keys` as the join keys .
  */
-std::unique_ptr<rmm::device_uvector<size_type>> left_semi_join(
+[[deprecated]] std::unique_ptr<rmm::device_uvector<size_type>> left_semi_join(
   cudf::table_view const& left_keys,
   cudf::table_view const& right_keys,
   null_equality compare_nulls       = null_equality::EQUAL,
@@ -221,6 +223,8 @@ std::unique_ptr<rmm::device_uvector<size_type>> left_semi_join(
 /**
  * @brief Returns a vector of row indices corresponding to a left anti join
  * between the specified tables.
+ *
+ * @deprecated Use the object-oriented filtered_join API instead
  *
  * The returned vector contains the row indices from the left table
  * for which there is no matching row in the right table.
@@ -244,7 +248,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> left_semi_join(
  * the result of performing a left anti join between two tables with
  * `left_keys` and `right_keys` as the join keys .
  */
-std::unique_ptr<rmm::device_uvector<size_type>> left_anti_join(
+[[deprecated]] std::unique_ptr<rmm::device_uvector<size_type>> left_anti_join(
   cudf::table_view const& left_keys,
   cudf::table_view const& right_keys,
   null_equality compare_nulls       = null_equality::EQUAL,

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -22,6 +22,7 @@
 #include <cudf/detail/search.hpp>
 #include <cudf/dictionary/detail/update_keys.hpp>
 #include <cudf/join/join.hpp>
+#include <cudf/join/filtered_join.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
@@ -61,6 +62,12 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_semi_anti_join(
     thrust::sequence(rmm::exec_policy(stream), result->begin(), result->end());
     return result;
   }
+
+  cudf::filtered_join obj(right_keys, compare_nulls, cudf::set_as_build_table::RIGHT, stream);
+  if(kind == join_kind::LEFT_SEMI_JOIN) {
+    return obj.semi_join(left_keys, stream, mr);
+  }
+  return obj.anti_join(left_keys, stream, mr);
 
   // Materialize a `flagged` boolean array to generate a gather map.
   // Previously, the gather map was generated directly without this array but by calling to

--- a/cpp/src/join/semi_join.cu
+++ b/cpp/src/join/semi_join.cu
@@ -21,8 +21,8 @@
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/search.hpp>
 #include <cudf/dictionary/detail/update_keys.hpp>
-#include <cudf/join/join.hpp>
 #include <cudf/join/filtered_join.hpp>
+#include <cudf/join/join.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
@@ -64,38 +64,8 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> left_semi_anti_join(
   }
 
   cudf::filtered_join obj(right_keys, compare_nulls, cudf::set_as_build_table::RIGHT, stream);
-  if(kind == join_kind::LEFT_SEMI_JOIN) {
-    return obj.semi_join(left_keys, stream, mr);
-  }
+  if (kind == join_kind::LEFT_SEMI_JOIN) { return obj.semi_join(left_keys, stream, mr); }
   return obj.anti_join(left_keys, stream, mr);
-
-  // Materialize a `flagged` boolean array to generate a gather map.
-  // Previously, the gather map was generated directly without this array but by calling to
-  // `map.contains` inside the `thrust::copy_if` kernel. However, that led to increasing register
-  // usage and reducing performance, as reported here: https://github.com/rapidsai/cudf/pull/10511.
-  auto const flagged = cudf::detail::contains(right_keys,
-                                              left_keys,
-                                              compare_nulls,
-                                              nan_equality::ALL_EQUAL,
-                                              stream,
-                                              cudf::get_current_device_resource_ref());
-
-  auto const left_num_rows = left_keys.num_rows();
-  auto gather_map =
-    std::make_unique<rmm::device_uvector<cudf::size_type>>(left_num_rows, stream, mr);
-
-  // gather_map_end will be the end of valid data in gather_map
-  auto gather_map_end =
-    thrust::copy_if(rmm::exec_policy(stream),
-                    thrust::counting_iterator<size_type>(0),
-                    thrust::counting_iterator<size_type>(left_num_rows),
-                    gather_map->begin(),
-                    [kind, d_flagged = flagged.begin()] __device__(size_type const idx) {
-                      return *(d_flagged + idx) == (kind == join_kind::LEFT_SEMI_JOIN);
-                    });
-
-  gather_map->resize(cuda::std::distance(gather_map->begin(), gather_map_end), stream);
-  return gather_map;
 }
 
 }  // namespace detail

--- a/cpp/tests/join/semi_anti_join_tests.cpp
+++ b/cpp/tests/join/semi_anti_join_tests.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "cudf/join/join.hpp"
-
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
@@ -129,14 +127,10 @@ TEST_F(JoinTest, TestSimple)
   auto left  = cudf::table_view{{left_col0}};
   auto right = cudf::table_view{{right_col0}};
 
-  auto result    = left_semi_join(left, right);
-  auto result_cv = cudf::column_view(cudf::data_type{cudf::type_to_id<cudf::size_type>()},
-                                     result->size(),
-                                     result->data(),
-                                     nullptr,
-                                     0);
-  column_wrapper<cudf::size_type> expected{0, 1};
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result_cv);
+  auto result = left_semi_join(left, right, {0}, {0}, cudf::null_equality::EQUAL);
+  column_wrapper<cudf::size_type> expected_column{0, 1};
+  auto expected = cudf::table_view{{expected_column}};
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected, *result);
 }
 
 std::pair<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>> get_saj_tables(
@@ -334,9 +328,8 @@ TEST_F(JoinTest, AntiJoinWithStructsAndNullsOnOneSide)
   auto left  = cudf::table_view{{left_col0}};
   auto right = cudf::table_view{{right_col0}};
 
-  auto result      = cudf::left_anti_join(left, right);
-  auto result_span = cudf::device_span<cudf::size_type const>{*result};
-  auto result_col  = cudf::column_view{result_span};
-  auto expected    = column_wrapper<cudf::size_type>{1};
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result_col);
+  auto result               = left_anti_join(left, right, {0}, {0}, cudf::null_equality::UNEQUAL);
+  auto expected_indices_col = column_wrapper<cudf::size_type>{1};
+  auto expected             = cudf::gather(left, expected_indices_col);
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*expected, *result);
 }


### PR DESCRIPTION
## Description
Contributes to https://github.com/rapidsai/cudf/issues/19180

This PR uses the object-oriented `filtered_join` class in the left semi- and anti- join APIs. These functional APIs will be removed in a later release.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
