### PR TITLE
Compatibility for rapidsmpf's unspill_partitions

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -108,7 +108,6 @@ class RMPFIntegration:  # pragma: no cover
                 unspill_partitions(
                     shuffler.extract(partition_id),
                     br=context.br,
-                    stream=DEFAULT_STREAM,
                     allow_overbooking=True,
                     statistics=context.statistics,
                 ),

--- a/python/cudf_polars/cudf_polars/experimental/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/sort.py
@@ -323,7 +323,6 @@ class RMPFIntegrationSortedShuffle:  # pragma: no cover
                 unspill_partitions(
                     shuffler.extract(partition_id),
                     br=context.br,
-                    stream=DEFAULT_STREAM,
                     allow_overbooking=True,
                     statistics=context.statistics,
                 ),


### PR DESCRIPTION
## Description

https://github.com/rapidsai/rapidsmpf/pull/515 removed the `stream` argument from `unspill_partitions`.
