### PR TITLE
xfail(strict=False) test_scan_hf_url_raises due to rate limiting

### DIFF
--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -417,6 +417,11 @@ def test_scan_parquet_chunked(
     )
 
 
+@pytest.mark.xfail(
+    raises=pl.exceptions.ComputeError,
+    reason="Rate limited by Hugging Face",
+    strict=False,
+)
 def test_scan_hf_url_raises():
     q = pl.scan_csv("hf://datasets/scikit-learn/iris/Iris.csv")
     assert_ir_translation_raises(q, NotImplementedError)


### PR DESCRIPTION
## Description
It appears this test actually makes a network request to Hugging Face via Polars which can fail if Hugging Face rate limits us e.g. https://github.com/rapidsai/cudf/actions/runs/17837593656/job/50721165949?pr=19996#step:11:2692 

In the future, this test should probably mock the network call as to also be polite to HF. 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
