### PR TITLE
Remove test_scan_hf_url_raises

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -337,7 +337,9 @@ class Scan(IR):
         ):
             raise NotImplementedError("Read from file URI")
         if self.typ == "csv":
-            if any(plc.io.SourceInfo._is_remote_uri(p) for p in self.paths):
+            if any(
+                plc.io.SourceInfo._is_remote_uri(p) for p in self.paths
+            ):  # pragma: no cover; no test yet
                 # This works fine when the file has no leading blank lines,
                 # but currently we do some file introspection
                 # to skip blanks before parsing the header.

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -422,16 +422,6 @@ def test_scan_parquet_chunked(
     )
 
 
-@pytest.mark.xfail(
-    raises=pl.exceptions.ComputeError,
-    reason="Rate limited by Hugging Face",
-    strict=False,
-)
-def test_scan_hf_url_raises():
-    q = pl.scan_csv("hf://datasets/scikit-learn/iris/Iris.csv")
-    assert_ir_translation_raises(q, NotImplementedError)
-
-
 def test_select_arbitrary_order_with_row_index_column(tmp_path):
     df = pl.DataFrame({"a": [1, 2, 3]})
     df.write_parquet(tmp_path / "df.parquet")


### PR DESCRIPTION
## Description
Follow up to https://github.com/rapidsai/cudf/pull/20027

Discussed offline, this test isn't useful at the moment and eventually another version will be written once scanning CSV over remote IO is supported.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
