### PR TITLE
Enable hash-groupby for decimal64 type and MEAN aggregation

### DIFF
--- a/cpp/include/cudf/detail/aggregation/device_aggregators.cuh
+++ b/cpp/include/cudf/detail/aggregation/device_aggregators.cuh
@@ -29,24 +29,6 @@
 #include <cuda/std/type_traits>
 
 namespace cudf::detail {
-/// Checks if an aggregation kind needs to operate on the underlying storage type
-template <aggregation::Kind k>
-__device__ constexpr bool uses_underlying_type()
-{
-  return k == aggregation::MIN or k == aggregation::MAX or k == aggregation::SUM;
-}
-
-/// Gets the underlying target type for the given source type and aggregation kind
-template <typename Source, aggregation::Kind k>
-using underlying_target_t =
-  cuda::std::conditional_t<uses_underlying_type<k>(),
-                           cudf::device_storage_type_t<cudf::detail::target_type_t<Source, k>>,
-                           cudf::detail::target_type_t<Source, k>>;
-
-/// Gets the underlying source type for the given source type and aggregation kind
-template <typename Source, aggregation::Kind k>
-using underlying_source_t =
-  cuda::std::conditional_t<uses_underlying_type<k>(), cudf::device_storage_type_t<Source>, Source>;
 
 template <typename Source, aggregation::Kind k>
 struct update_target_element {

--- a/cpp/src/groupby/hash/flatten_single_pass_aggs.cpp
+++ b/cpp/src/groupby/hash/flatten_single_pass_aggs.cpp
@@ -58,7 +58,6 @@ class groupby_simple_aggregations_collector final
   std::vector<std::unique_ptr<aggregation>> visit(data_type col_type,
                                                   cudf::detail::mean_aggregation const&) override
   {
-    (void)col_type;
     CUDF_EXPECTS(is_fixed_width(col_type), "MEAN aggregation expects fixed width type");
     std::vector<std::unique_ptr<aggregation>> aggs;
     aggs.push_back(make_sum_aggregation());
@@ -152,6 +151,17 @@ flatten_single_pass_aggs(host_span<aggregation_request const> requests,
   }
 
   return std::make_tuple(table_view(columns), std::move(agg_kinds), std::move(aggs));
+}
+
+std::vector<aggregation::Kind> get_simple_aggregations(groupby_aggregation const& agg,
+                                                       data_type values_type)
+{
+  std::vector<aggregation::Kind> agg_kinds;
+  groupby_simple_aggregations_collector collector;
+  for (auto& agg_s : agg.get_simple_aggregations(values_type, collector)) {
+    agg_kinds.push_back(agg_s->kind);
+  }
+  return agg_kinds;
 }
 
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/flatten_single_pass_aggs.hpp
+++ b/cpp/src/groupby/hash/flatten_single_pass_aggs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,28 @@
 
 namespace cudf::groupby::detail::hash {
 
-// flatten aggs to filter in single pass aggs
+/**
+ * @brief Flatten any appropriate compound aggregations into single pass aggs
+ *
+ * For example, a MEAN aggregation will be flattened into a SUM and a COUNT_VALID aggregation.
+ *
+ * @param requests The aggregation requests
+ * @param stream The CUDA stream
+ * @return A tuple containing the flattened table view, the aggregation kinds, and the aggregations
+ */
 std::tuple<table_view,
            cudf::detail::host_vector<aggregation::Kind>,
            std::vector<std::unique_ptr<aggregation>>>
 flatten_single_pass_aggs(host_span<aggregation_request const> requests,
                          rmm::cuda_stream_view stream);
 
+/**
+ * @brief Get simple aggregations from groupby aggregation
+ *
+ * @param agg The groupby aggregation
+ * @param values_type The data type for the aggregation
+ * @return A vector of aggregation kinds
+ */
+std::vector<aggregation::Kind> get_simple_aggregations(groupby_aggregation const& agg,
+                                                       data_type values_type);
 }  // namespace cudf::groupby::detail::hash

--- a/cpp/src/groupby/hash/global_memory_aggregator.cuh
+++ b/cpp/src/groupby/hash/global_memory_aggregator.cuh
@@ -39,7 +39,8 @@ struct update_target_element_gmem {
 };
 
 template <typename Source>
-  requires(cudf::is_fixed_width<Source>() && cudf::has_atomic_support<Source>())
+  requires(cudf::is_fixed_width<Source>() &&
+           cudf::has_atomic_support<device_storage_type_t<Source>>())
 struct update_target_element_gmem<Source, cudf::aggregation::MIN> {
   __device__ void operator()(cudf::mutable_column_device_view target,
                              cudf::size_type target_index,
@@ -47,7 +48,8 @@ struct update_target_element_gmem<Source, cudf::aggregation::MIN> {
                              cuda::std::byte* source,
                              cudf::size_type source_index) const noexcept
   {
-    using DeviceType          = cudf::detail::underlying_target_t<Source, aggregation::MIN>;
+    using DeviceType =
+      cudf::device_storage_type_t<cudf::detail::target_type_t<Source, cudf::aggregation::MIN>>;
     DeviceType* source_casted = reinterpret_cast<DeviceType*>(source);
     cudf::detail::atomic_min(&target.element<DeviceType>(target_index),
                              static_cast<DeviceType>(source_casted[source_index]));
@@ -55,7 +57,8 @@ struct update_target_element_gmem<Source, cudf::aggregation::MIN> {
 };
 
 template <typename Source>
-  requires(cudf::is_fixed_width<Source>() && cudf::has_atomic_support<Source>())
+  requires(cudf::is_fixed_width<Source>() &&
+           cudf::has_atomic_support<device_storage_type_t<Source>>())
 struct update_target_element_gmem<Source, cudf::aggregation::MAX> {
   __device__ void operator()(cudf::mutable_column_device_view target,
                              cudf::size_type target_index,
@@ -63,7 +66,8 @@ struct update_target_element_gmem<Source, cudf::aggregation::MAX> {
                              cuda::std::byte* source,
                              cudf::size_type source_index) const noexcept
   {
-    using DeviceType          = cudf::detail::underlying_target_t<Source, aggregation::MAX>;
+    using DeviceType =
+      cudf::device_storage_type_t<cudf::detail::target_type_t<Source, cudf::aggregation::MAX>>;
     DeviceType* source_casted = reinterpret_cast<DeviceType*>(source);
     cudf::detail::atomic_max(&target.element<DeviceType>(target_index),
                              static_cast<DeviceType>(source_casted[source_index]));
@@ -71,7 +75,8 @@ struct update_target_element_gmem<Source, cudf::aggregation::MAX> {
 };
 
 template <typename Source>
-  requires(cudf::is_fixed_width<Source>() && cudf::has_atomic_support<Source>() &&
+  requires(cudf::is_fixed_width<Source>() &&
+           cudf::has_atomic_support<device_storage_type_t<Source>>() &&
            !cudf::is_timestamp<Source>())
 struct update_target_element_gmem<Source, cudf::aggregation::SUM> {
   __device__ void operator()(cudf::mutable_column_device_view target,
@@ -80,7 +85,8 @@ struct update_target_element_gmem<Source, cudf::aggregation::SUM> {
                              cuda::std::byte* source,
                              cudf::size_type source_index) const noexcept
   {
-    using DeviceType          = cudf::detail::underlying_target_t<Source, aggregation::SUM>;
+    using DeviceType =
+      cudf::device_storage_type_t<cudf::detail::target_type_t<Source, cudf::aggregation::SUM>>;
     DeviceType* source_casted = reinterpret_cast<DeviceType*>(source);
     cudf::detail::atomic_add(&target.element<DeviceType>(target_index),
                              static_cast<DeviceType>(source_casted[source_index]));

--- a/cpp/src/groupby/hash/groupby.cu
+++ b/cpp/src/groupby/hash/groupby.cu
@@ -15,6 +15,7 @@
  */
 
 #include "compute_groupby.hpp"
+#include "flatten_single_pass_aggs.hpp"
 #include "groupby/common/utils.hpp"
 #include "helpers.cuh"
 
@@ -102,6 +103,51 @@ std::unique_ptr<table> dispatch_groupby(table_view const& keys,
       keys, requests, skip_rows_with_nulls, d_row_equal, d_row_hash, cache, stream, mr);
   }
 }
+
+// check if the target_type of the aggregation/type pair supports atomic operations
+struct can_use_hash_groupby_fn {
+  template <typename T, aggregation::Kind K>
+    requires(cudf::is_nested<T>())
+  bool operator()() const
+  {
+    // Currently, input values (not keys) of STRUCT and LIST types are not supported in any of
+    // hash-based aggregations. For those situations, we fallback to sort-based aggregations.
+    return false;
+  }
+
+  template <aggregation::Kind k>
+  constexpr static bool uses_underlying_type()
+  {
+    return k == aggregation::MIN or k == aggregation::MAX or k == aggregation::SUM;
+  }
+
+  template <typename T, aggregation::Kind K>
+    requires(cudf::is_fixed_point<T>())
+  bool operator()() const
+  {
+    using TargetType       = cudf::detail::target_type_t<T, K>;
+    using DeviceTargetType = cuda::std::
+      conditional_t<uses_underlying_type<K>(), cudf::device_storage_type_t<TargetType>, TargetType>;
+    if constexpr (std::is_void_v<DeviceTargetType>) {
+      return false;
+    } else {
+      return cudf::has_atomic_support<DeviceTargetType>();
+    }
+  }
+
+  template <typename T, aggregation::Kind K>
+    requires(not cudf::is_nested<T>() and not cudf::is_fixed_point<T>())
+  bool operator()() const
+  {
+    using TargetType = cudf::detail::target_type_t<T, K>;
+    if constexpr (std::is_void_v<TargetType>) {
+      return false;
+    } else {
+      return cudf::has_atomic_support<TargetType>();
+    }
+  }
+};
+
 }  // namespace
 
 /**
@@ -120,13 +166,13 @@ bool can_use_hash_groupby(host_span<aggregation_request const> requests)
                           ? cudf::dictionary_column_view(r.values).keys().type()
                           : r.values.type();
 
-    // Currently, input values (not keys) of STRUCT and LIST types are not supported in any of
-    // hash-based aggregations. For those situations, we fallback to sort-based aggregations.
-    if (v_type.id() == type_id::STRUCT or v_type.id() == type_id::LIST) { return false; }
-
     return std::all_of(r.aggregations.begin(), r.aggregations.end(), [v_type](auto const& a) {
-      return cudf::has_atomic_support(cudf::detail::target_type(v_type, a->kind)) and
-             is_hash_aggregation(a->kind);
+      if (not is_hash_aggregation(a->kind)) { return false; }
+      // compound aggregations are made up of simple aggregations
+      auto const agg_kinds = get_simple_aggregations(*a, v_type);
+      return std::all_of(agg_kinds.begin(), agg_kinds.end(), [v_type = v_type](auto k) {
+        return cudf::detail::dispatch_type_and_aggregation(v_type, k, can_use_hash_groupby_fn{});
+      });
     });
   });
 }

--- a/cpp/src/groupby/hash/shared_memory_aggregator.cuh
+++ b/cpp/src/groupby/hash/shared_memory_aggregator.cuh
@@ -37,15 +37,17 @@ struct update_target_element_shmem {
 };
 
 template <typename Source>
-  requires(cudf::is_fixed_width<Source>() && cudf::has_atomic_support<Source>())
+  requires(cudf::is_fixed_width<Source>() &&
+           cudf::has_atomic_support<device_storage_type_t<Source>>())
 struct update_target_element_shmem<Source, cudf::aggregation::MIN> {
   __device__ void operator()(cuda::std::byte* target,
                              cudf::size_type target_index,
                              cudf::column_device_view source,
                              cudf::size_type source_index) const noexcept
   {
-    using DeviceTarget = cudf::detail::underlying_target_t<Source, aggregation::MIN>;
-    using DeviceSource = cudf::detail::underlying_source_t<Source, aggregation::MIN>;
+    using DeviceTarget =
+      cudf::device_storage_type_t<cudf::detail::target_type_t<Source, cudf::aggregation::MIN>>;
+    using DeviceSource = cudf::device_storage_type_t<Source>;
 
     DeviceTarget* target_casted = reinterpret_cast<DeviceTarget*>(target);
     cudf::detail::atomic_min(&target_casted[target_index],
@@ -54,15 +56,17 @@ struct update_target_element_shmem<Source, cudf::aggregation::MIN> {
 };
 
 template <typename Source>
-  requires(cudf::is_fixed_width<Source>() && cudf::has_atomic_support<Source>())
+  requires(cudf::is_fixed_width<Source>() &&
+           cudf::has_atomic_support<device_storage_type_t<Source>>())
 struct update_target_element_shmem<Source, cudf::aggregation::MAX> {
   __device__ void operator()(cuda::std::byte* target,
                              cudf::size_type target_index,
                              cudf::column_device_view source,
                              cudf::size_type source_index) const noexcept
   {
-    using DeviceTarget = cudf::detail::underlying_target_t<Source, aggregation::MAX>;
-    using DeviceSource = cudf::detail::underlying_source_t<Source, aggregation::MAX>;
+    using DeviceTarget =
+      cudf::device_storage_type_t<cudf::detail::target_type_t<Source, cudf::aggregation::MAX>>;
+    using DeviceSource = cudf::device_storage_type_t<Source>;
 
     DeviceTarget* target_casted = reinterpret_cast<DeviceTarget*>(target);
     cudf::detail::atomic_max(&target_casted[target_index],
@@ -71,7 +75,8 @@ struct update_target_element_shmem<Source, cudf::aggregation::MAX> {
 };
 
 template <typename Source>
-  requires(cudf::is_fixed_width<Source>() && cudf::has_atomic_support<Source>() &&
+  requires(cudf::is_fixed_width<Source>() &&
+           cudf::has_atomic_support<device_storage_type_t<Source>>() &&
            !cudf::is_timestamp<Source>())
 struct update_target_element_shmem<Source, cudf::aggregation::SUM> {
   __device__ void operator()(cuda::std::byte* target,
@@ -79,8 +84,9 @@ struct update_target_element_shmem<Source, cudf::aggregation::SUM> {
                              cudf::column_device_view source,
                              cudf::size_type source_index) const noexcept
   {
-    using DeviceTarget = cudf::detail::underlying_target_t<Source, aggregation::SUM>;
-    using DeviceSource = cudf::detail::underlying_source_t<Source, aggregation::SUM>;
+    using DeviceTarget =
+      cudf::device_storage_type_t<cudf::detail::target_type_t<Source, cudf::aggregation::SUM>>;
+    using DeviceSource = cudf::device_storage_type_t<Source>;
 
     DeviceTarget* target_casted = reinterpret_cast<DeviceTarget*>(target);
     cudf::detail::atomic_add(&target_casted[target_index],


### PR DESCRIPTION
## Description
Enables hash-based groupby for decimal64 for aggregations MIN, MAX, SUM, and MEAN aggregation types.
Fixes a check for hash-groupby that requires atomic support on the target type for specific aggregation kinds.
Also simplifies the aggregation functors used on MIN, MAX, and SUM for global and shared memory logic paths.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
