### PR TITLE
Require CUDA builds of pytorch for the third-party integration tests

### DIFF
--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
@@ -216,7 +216,7 @@ dependencies:
       - output_types: conda
         packages:
           - numpy
-          - pytorch>=2.4.0
+          - "pytorch>=2.4.0=*cuda*"
   test_seaborn:
     common:
       - output_types: conda


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Currently it's possible to install the CPU-only build of pytorch which would of course fail the third-party integration tests. We should always install the CUDA build.

Fixes: https://github.com/rapidsai/cudf/actions/runs/17906982064/job/50929793566
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
