### PR TITLE
Fix multi-partition `Filter` bug

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -370,6 +370,14 @@ def _(
             ),
         )
 
+    if partition_info[child].count > 1 and not all(
+        expr.is_pointwise for expr in traversal([ir.mask.value])
+    ):
+        # TODO: Use expression decomposition to lower Filter
+        return _lower_ir_fallback(
+            ir, rec, msg="This filter is not supported for multiple partitions."
+        )
+
     new_node = ir.reconstruct([child])
     partition_info[new_node] = partition_info[child]
     return new_node, partition_info

--- a/python/cudf_polars/cudf_polars/experimental/parallel.py
+++ b/python/cudf_polars/cudf_polars/experimental/parallel.py
@@ -374,6 +374,7 @@ def _(
         expr.is_pointwise for expr in traversal([ir.mask.value])
     ):
         # TODO: Use expression decomposition to lower Filter
+        # See: https://github.com/rapidsai/cudf/issues/20076
         return _lower_ir_fallback(
             ir, rec, msg="This filter is not supported for multiple partitions."
         )

--- a/python/cudf_polars/tests/experimental/test_filter.py
+++ b/python/cudf_polars/tests/experimental/test_filter.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/python/cudf_polars/tests/experimental/test_filter.py
+++ b/python/cudf_polars/tests/experimental/test_filter.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+
+from cudf_polars.testing.asserts import (
+    DEFAULT_SCHEDULER,
+    assert_gpu_result_equal,
+)
+
+
+@pytest.fixture(scope="module")
+def engine():
+    return pl.GPUEngine(
+        raise_on_fail=True,
+        executor="streaming",
+        executor_options={"max_rows_per_partition": 3, "scheduler": DEFAULT_SCHEDULER},
+    )
+
+
+@pytest.fixture(scope="module")
+def df():
+    return pl.LazyFrame(
+        {
+            "a": [1, 2, 3, 4, 5, 6, 7],
+            "b": [1, 1, 1, 1, 1, 1, 1],
+            "c": [2, 4, 6, 8, 10, 12, 14],
+        }
+    )
+
+
+def test_filter_pointwise(df, engine):
+    query = df.filter(pl.col("a") > 3)
+    assert_gpu_result_equal(query, engine=engine)
+
+
+def test_filter_non_pointwise(df, engine):
+    query = df.filter(pl.col("a") > pl.col("a").max())
+    with pytest.warns(
+        UserWarning, match="This filter is not supported for multiple partitions."
+    ):
+        assert_gpu_result_equal(query, engine=engine)


### PR DESCRIPTION
## Description
While experimenting with the new [StatsPlanningOptions](https://github.com/rapidsai/cudf/blob/5faa1db15728fa588d8e87cf0dcdb228dcc5ab45/python/cudf_polars/cudf_polars/utils/config.py#L294), I discovered a pre-existing bug in `lower_ir_node.register(Filter)`. We are failing to check for non-pointwise expressions in `Filter.mask` before treating the `Filter` operation as "pointwise".

This PR "fixes" the bug by falling back to a single partition. For 25.12, we can probably add multi-partition support to non-pointwise filters (if necessary).

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
