### PR TITLE
Handle missing nightly runs in pandas tests job

### DIFF
--- a/ci/cudf_pandas_scripts/pandas-tests/run.sh
+++ b/ci/cudf_pandas_scripts/pandas-tests/run.sh
@@ -71,7 +71,7 @@ MAIN_RUN_ID=$(
 
 if [[ -z "${MAIN_RUN_ID}" ]]; then
     rapids-logger "No MAIN_RUN_ID found, exiting."
-    exit 0
+    exit ${EXITCODE}
 fi
 
 rapids-logger "Fetching latest available results from nightly: ${MAIN_RUN_ID}"


### PR DESCRIPTION
## Description
Fixes: #20067

This PR Fixes an issue where there are no nightly runs and goes into a hang.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
