### PR TITLE
Switch host_vector and host_span dependency

### DIFF
--- a/cpp/include/cudf/column/column_view.hpp
+++ b/cpp/include/cudf/column/column_view.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cudf/types.hpp>
+#include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>

--- a/cpp/include/cudf/detail/utilities/cuda_memcpy.hpp
+++ b/cpp/include/cudf/detail/utilities/cuda_memcpy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cudf/utilities/error.hpp>
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/span.hpp>
 

--- a/cpp/include/cudf/detail/utilities/host_vector.hpp
+++ b/cpp/include/cudf/detail/utilities/host_vector.hpp
@@ -20,6 +20,7 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/export.hpp>
 #include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/span.hpp>
 
 #include <rmm/aligned.hpp>
 
@@ -210,6 +211,17 @@ class host_vector : public thrust::host_vector<T, rmm_host_allocator<T>> {
   host_vector(rmm_host_allocator<T> const& alloc) : base(alloc) {}
 
   host_vector(size_t size, rmm_host_allocator<T> const& alloc) : base(size, alloc) {}
+
+  [[nodiscard]] operator host_span<T const>() const
+  {
+    return host_span<T const>{
+      base::data(), base::size(), base::get_allocator().is_device_accessible()};
+  }
+
+  [[nodiscard]] operator host_span<T>()
+  {
+    return host_span<T>{base::data(), base::size(), base::get_allocator().is_device_accessible()};
+  }
 };
 
 }  // namespace detail

--- a/cpp/include/cudf/utilities/span.hpp
+++ b/cpp/include/cudf/utilities/span.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <cudf/detail/utilities/host_vector.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/export.hpp>
 
@@ -234,26 +233,6 @@ struct host_span : public cudf::detail::span_base<T, Extent, host_span<T, Extent
                                  std::declval<C&>().data()))> (*)[],
                                T (*)[]>>* = nullptr>  // NOLINT
   constexpr host_span(C const& in) : base(thrust::raw_pointer_cast(in.data()), in.size())
-  {
-  }
-
-  /// Constructor from a host_vector
-  /// @param in The host_vector to construct the span from
-  template <typename OtherT,
-            // Only supported containers of types convertible to T
-            std::enable_if_t<std::is_convertible_v<OtherT (*)[], T (*)[]>>* = nullptr>  // NOLINT
-  constexpr host_span(cudf::detail::host_vector<OtherT>& in)
-    : base(in.data(), in.size()), _is_device_accessible{in.get_allocator().is_device_accessible()}
-  {
-  }
-
-  /// Constructor from a const host_vector
-  /// @param in The host_vector to construct the span from
-  template <typename OtherT,
-            // Only supported containers of types convertible to T
-            std::enable_if_t<std::is_convertible_v<OtherT (*)[], T (*)[]>>* = nullptr>  // NOLINT
-  constexpr host_span(cudf::detail::host_vector<OtherT> const& in)
-    : base(in.data(), in.size()), _is_device_accessible{in.get_allocator().is_device_accessible()}
   {
   }
 

--- a/cpp/src/groupby/hash/flatten_single_pass_aggs.hpp
+++ b/cpp/src/groupby/hash/flatten_single_pass_aggs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <cudf/aggregation.hpp>
+#include <cudf/detail/utilities/host_vector.hpp>
 #include <cudf/groupby.hpp>
-#include <cudf/utilities/span.hpp>
 
 #include <memory>
 #include <tuple>

--- a/cpp/src/io/csv/csv_gpu.hpp
+++ b/cpp/src/io/csv/csv_gpu.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@
 
 #include "io/utilities/parsing_utils.cuh"
 
+#include <cudf/detail/utilities/host_vector.hpp>
 #include <cudf/types.hpp>
-#include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 


### PR DESCRIPTION
## Description
Replaces the `cudf::host_span(cudf::detail::host_vector)` constructor with `cudf::host_span` cast operator method on `cudf::detail::host_vector`. This means changes to `cudf::detail::host_vector` requires minimal compile dependencies.

The `cudf::detail::host_vector` is only currently used in 44 places in 21 files while the `cudf::host_span` is used in 1191 places in 189 files. So changes to `host_vector` required recompiling most of libcudf. Switching the dependency means changes to `host_vector` will have less impact on an incremental build.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
