### PR TITLE
Add tests for AUTO and HYBRID (de)compression modes

### DIFF
--- a/cpp/tests/io/compression_common.hpp
+++ b/cpp/tests/io/compression_common.hpp
@@ -75,6 +75,10 @@ struct CompressionTest
       env_vars.emplace_back(nvcomp_policy_env_var, "OFF");
     } else if (comp_impl == "HOST") {
       env_vars.emplace_back(host_comp_env_var, "ON");
+    } else if (comp_impl == "HYBRID") {
+      env_vars.emplace_back(host_comp_env_var, "HYBRID");
+    } else if (comp_impl == "AUTO") {
+      env_vars.emplace_back(host_comp_env_var, "AUTO");
     } else {
       CUDF_FAIL("Invalid test parameter");
     }
@@ -100,6 +104,10 @@ struct DecompressionTest
       env_vars.emplace_back(nvcomp_policy_env_var, "OFF");
     } else if (comp_impl == "HOST") {
       env_vars.emplace_back(host_decomp_env_var, "ON");
+    } else if (comp_impl == "HYBRID") {
+      env_vars.emplace_back(host_decomp_env_var, "HYBRID");
+    } else if (comp_impl == "AUTO") {
+      env_vars.emplace_back(host_decomp_env_var, "AUTO");
     } else {
       CUDF_FAIL("Invalid test parameter");
     }

--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -2398,7 +2398,7 @@ INSTANTIATE_TEST_CASE_P(DeviceInternal,
 
 INSTANTIATE_TEST_CASE_P(Host,
                         OrcDecompressionTest,
-                        ::testing::Combine(::testing::Values("HOST"),
+                        ::testing::Combine(::testing::Values("HOST", "HYBRID", "AUTO"),
                                            ::testing::Values(cudf::io::compression_type::AUTO,
                                                              cudf::io::compression_type::SNAPPY,
                                                              cudf::io::compression_type::ZSTD)));

--- a/cpp/tests/io/parquet_writer_test.cpp
+++ b/cpp/tests/io/parquet_writer_test.cpp
@@ -1485,7 +1485,7 @@ INSTANTIATE_TEST_CASE_P(DeviceInternal,
 
 INSTANTIATE_TEST_CASE_P(Host,
                         ParquetCompressionTest,
-                        ::testing::Combine(::testing::Values("HOST"),
+                        ::testing::Combine(::testing::Values("HOST", "HYBRID", "AUTO"),
                                            ::testing::Values(cudf::io::compression_type::AUTO,
                                                              cudf::io::compression_type::SNAPPY,
                                                              cudf::io::compression_type::ZSTD)));


### PR DESCRIPTION
## Description
Add unit tests for the two newest modes.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
