### PR TITLE
Passthrough unary ops through Parquet predicate pushdown

### DIFF
--- a/cpp/src/io/parquet/bloom_filter_reader.cu
+++ b/cpp/src/io/parquet/bloom_filter_reader.cu
@@ -210,10 +210,12 @@ class bloom_filter_expression_converter : public equality_literals_collector {
     auto const op       = expr.get_operator();
 
     if (auto* v = dynamic_cast<ast::column_reference const*>(&operands[0].get())) {
-      // First operand should be column reference, second should be literal.
-      CUDF_EXPECTS(cudf::ast::detail::ast_operator_arity(op) == 2,
-                   "Only binary operations are supported on column reference");
-      CUDF_EXPECTS(dynamic_cast<ast::literal const*>(&operands[1].get()) != nullptr,
+      // First operand should be column reference, second (if binary operation)should be literal.
+      CUDF_EXPECTS(cudf::ast::detail::ast_operator_arity(op) == 1 or
+                     cudf::ast::detail::ast_operator_arity(op) == 2,
+                   "Only unary and binary operations are supported on column reference");
+      CUDF_EXPECTS(cudf::ast::detail::ast_operator_arity(op) == 1 or
+                     dynamic_cast<ast::literal const*>(&operands[1].get()) != nullptr,
                    "Second operand of binary operation with column reference must be a literal");
       v->accept(*this);
 
@@ -622,17 +624,20 @@ std::reference_wrapper<ast::expression const> equality_literals_collector::visit
   auto const op       = expr.get_operator();
 
   if (auto* v = dynamic_cast<ast::column_reference const*>(&operands[0].get())) {
-    // First operand should be column reference, second should be literal.
-    CUDF_EXPECTS(cudf::ast::detail::ast_operator_arity(op) == 2,
-                 "Only binary operations are supported on column reference");
-    auto const literal_ptr = dynamic_cast<ast::literal const*>(&operands[1].get());
-    CUDF_EXPECTS(literal_ptr != nullptr,
+    // First operand should be column reference, second (if binary operation)should be literal.
+    CUDF_EXPECTS(cudf::ast::detail::ast_operator_arity(op) == 1 or
+                   cudf::ast::detail::ast_operator_arity(op) == 2,
+                 "Only unary and binary operations are supported on column reference");
+    CUDF_EXPECTS(cudf::ast::detail::ast_operator_arity(op) == 1 or
+                   dynamic_cast<ast::literal const*>(&operands[1].get()) != nullptr,
                  "Second operand of binary operation with column reference must be a literal");
+
     v->accept(*this);
 
     // Push to the corresponding column's literals list iff equality predicate is seen
     if (op == ast_operator::EQUAL) {
-      auto const col_idx = v->get_column_index();
+      auto const literal_ptr = dynamic_cast<ast::literal const*>(&operands[1].get());
+      auto const col_idx     = v->get_column_index();
       _literals[col_idx].emplace_back(const_cast<ast::literal*>(literal_ptr));
     }
   } else {

--- a/cpp/src/io/parquet/predicate_pushdown.cpp
+++ b/cpp/src/io/parquet/predicate_pushdown.cpp
@@ -126,6 +126,9 @@ std::optional<std::vector<std::vector<size_type>>> aggregate_reader_metadata::ap
     stats_columns_collector{filter.get(), static_cast<size_type>(output_dtypes.size())}
       .get_stats_columns_mask();
 
+  // Return early if no columns will participate in stats based filtering
+  if (stats_columns_mask.empty()) { return std::nullopt; }
+
   // Converts Column chunk statistics to a table
   // where min(col[i]) = columns[i*2], max(col[i])=columns[i*2+1]
   // For each column, it contains #sources * #column_chunks_per_src rows

--- a/cpp/src/io/parquet/stats_filter_helpers.hpp
+++ b/cpp/src/io/parquet/stats_filter_helpers.hpp
@@ -311,6 +311,8 @@ class stats_expression_converter : public stats_columns_collector {
 
  private:
   ast::tree _stats_expr;
+  cudf::numeric_scalar<bool> _always_true_scalar{true};
+  ast::literal const _always_true{_always_true_scalar};
 };
 
 }  // namespace cudf::io::parquet::detail


### PR DESCRIPTION
## Description
Contributes to #20125

Passthrough expressions with unary operators such as `IS_NULL` through Parquet predicate pushdown filters.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
