### PR TITLE
Add note that --rmm-async only affects distributed scheduler.

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -646,7 +646,7 @@ def parse_args(
         "--rmm-async",
         action=argparse.BooleanOptionalAction,
         default=False,
-        help="Use RMM async memory resource.",
+        help="Use RMM async memory resource. Note: only affects distributed scheduler!",
     )
     parser.add_argument(
         "--rapidsmpf-oom-protection",


### PR DESCRIPTION
## Description
The PDS-H queries don't obey `--rmm-async` unless using the distributed scheduler. This adds a note to the docs.

Perhaps we should solve this differently, so that `--rmm-async` actually works for all schedulers?

A workaround is setting `POLARS_GPU_ENABLE_CUDA_MANAGED_MEMORY=0`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
