### PR TITLE
Fix slowdown in cudf-polars distributed tests

### DIFF
--- a/python/cudf_polars/tests/experimental/conftest.py
+++ b/python/cudf_polars/tests/experimental/conftest.py
@@ -7,7 +7,7 @@ import os
 import pytest
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="session")
 def dask_cluster(pytestconfig, worker_id):
     if (
         pytestconfig.getoption("--scheduler") == "distributed"


### PR DESCRIPTION
## Description

This fixes the slowdown we observed recently in the cudf-polars distributed tests (e.g. https://github.com/rapidsai/cudf/actions/runs/18088209118/job/51465191815?pr=20130#step:11:2848, which took 2+ hours). c82f0fceeda changed how we set up the dask cluster, and inadvertently changed the scope of the fixture. We want it to run once at the start of the test sesssion, not per function.
