### PR TITLE
Temporarily disable conda-java-tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
       - conda-python-build
       - conda-python-cudf-tests
       - conda-python-other-tests
-      - conda-java-tests
+#     - conda-java-tests
       - conda-notebook-tests
       - docs-build
       - wheel-build-libcudf
@@ -132,7 +132,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-25.12
     with:
       enable_check_generated_files: false
-      ignored_pr_jobs: "telemetry-summarize spark-rapids-jni"
+      ignored_pr_jobs: "telemetry-summarize spark-rapids-jni conda-java-tests"
   conda-cpp-build:
     needs: checks
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,18 +80,18 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       script: "ci/test_python_other.sh"
-  conda-java-tests:
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.12
-    with:
-      build_type: ${{ inputs.build_type }}
-      branch: ${{ inputs.branch }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
-      node_type: "gpu-l4-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:25.12-latest"
-      script: "ci/test_java.sh"
+# conda-java-tests:
+#   secrets: inherit
+#   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.12
+#   with:
+#     build_type: ${{ inputs.build_type }}
+#     branch: ${{ inputs.branch }}
+#     date: ${{ inputs.date }}
+#     sha: ${{ inputs.sha }}
+#     node_type: "gpu-l4-latest-1"
+#     arch: "amd64"
+#     container_image: "rapidsai/ci-conda:25.12-latest"
+#     script: "ci/test_java.sh"
   conda-notebook-tests:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.12


### PR DESCRIPTION
## Description
Until we can get a proper fix for #20159 / #20160, this PR disables `conda-java-tests`.

PRs will still run the job but it is not required to merge. Nightly tests will skip the job completely.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
