### PR TITLE
Skip filtering Parquet row groups with dictionaries if there are non-dict encoded pages

### DIFF
--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -423,9 +423,15 @@ std::vector<byte_range_info> aggregate_reader_metadata::get_dictionary_page_byte
             auto dictionary_offset = int64_t{0};
             auto dictionary_size   = int64_t{0};
 
-            // If any columns lack the page indexes then just return without modifying the
-            // row_group_info.
-            if (col_chunk.offset_index.has_value() and col_chunk.column_index.has_value()) {
+            // Make sure that the column chunk doesn't have any non-dictionary encoded pages
+            auto const has_only_dict_encoded_pages = std::all_of(
+              col_meta.encodings.cbegin(), col_meta.encodings.cend(), [](auto const& encoding) {
+                return encoding == Encoding::PLAIN_DICTIONARY or
+                       encoding == Encoding::RLE_DICTIONARY;
+              });
+
+            if (has_only_dict_encoded_pages and col_chunk.offset_index.has_value() and
+                col_chunk.column_index.has_value()) {
               auto const& offset_index = col_chunk.offset_index.value();
               auto const num_pages     = offset_index.page_locations.size();
 

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -423,15 +423,17 @@ std::vector<byte_range_info> aggregate_reader_metadata::get_dictionary_page_byte
             auto dictionary_offset = int64_t{0};
             auto dictionary_size   = int64_t{0};
 
-            // Make sure that the column chunk doesn't have any non-dictionary encoded pages
-            auto const has_only_dict_encoded_pages = std::all_of(
-              col_meta.encodings.cbegin(), col_meta.encodings.cend(), [](auto const& encoding) {
-                return encoding == Encoding::PLAIN_DICTIONARY or
-                       encoding == Encoding::RLE_DICTIONARY;
-              });
+            // Make sure that we have page index and the column chunk doesn't have any
+            // non-dictionary encoded pages
+            auto const has_page_index_and_only_dict_encoded_pages =
+              col_chunk.offset_index.has_value() and col_chunk.column_index.has_value() and
+              std::all_of(
+                col_meta.encodings.cbegin(), col_meta.encodings.cend(), [](auto const& encoding) {
+                  return encoding == Encoding::PLAIN_DICTIONARY or
+                         encoding == Encoding::RLE_DICTIONARY;
+                });
 
-            if (has_only_dict_encoded_pages and col_chunk.offset_index.has_value() and
-                col_chunk.column_index.has_value()) {
+            if (has_page_index_and_only_dict_encoded_pages) {
               auto const& offset_index = col_chunk.offset_index.value();
               auto const num_pages     = offset_index.page_locations.size();
 


### PR DESCRIPTION
## Description

This PR adds a check to ensure that only the column chunks that have only dictionary encoded pages participate in dictionary-page based row group filtering in the new parquet reader.

Note that we can't GTest the PR as cuDF's parquet writer decides and uses single encoding type for data pages of a column chunk. Also note that this is a preemptive fix and we hadn't yet come across a test with the hybrid scan reader. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
