### PR TITLE
Reduce execution times for parquet dictionary tests

### DIFF
--- a/cpp/tests/io/parquet_common.cpp
+++ b/cpp/tests/io/parquet_common.cpp
@@ -251,8 +251,8 @@ int read_dict_bits(std::unique_ptr<cudf::io::datasource> const& source,
                    cudf::io::parquet::PageLocation const& page_loc)
 {
   using namespace cudf::io::parquet;
-  CUDF_EXPECTS(page_loc.offset > 0, "Cannot find page header");
-  CUDF_EXPECTS(page_loc.compressed_page_size > 0, "Invalid page header length");
+  CUDF_EXPECTS(page_loc.offset > 0, "Cannot find data page header");
+  CUDF_EXPECTS(page_loc.compressed_page_size > 0, "Invalid data page header length");
 
   PageHeader page_hdr;
   auto const page_buf = source->host_read(page_loc.offset, page_loc.compressed_page_size);

--- a/cpp/tests/io/parquet_misc_test.cpp
+++ b/cpp/tests/io/parquet_misc_test.cpp
@@ -127,27 +127,27 @@ TYPED_TEST(ParquetWriterDeltaTest, SupportedDeltaListSliced)
 // Base test fixture for size-parameterized tests
 class ParquetSizedTest : public ::cudf::test::BaseFixtureWithParam<int> {};
 
-// test the allowed bit widths for dictionary encoding
+// test the allowed bit widths: [1, 25) for dictionary encoding
 INSTANTIATE_TEST_SUITE_P(ParquetDictionaryTest,
                          ParquetSizedTest,
-                         testing::Range(1, 25),
+                         testing::Range(2, 25, 3),
                          testing::PrintToStringParamName());
 
 TEST_P(ParquetSizedTest, DictionaryTest)
 {
   unsigned int const cardinality = (1 << (GetParam() - 1)) + 1;
-  unsigned int const nrows       = std::max(cardinality * 3 / 2, 3'000'000U);
+  unsigned int const nrows       = std::max(cardinality * 3 / 2, 500'000U);
 
   auto const elements = cudf::detail::make_counting_transform_iterator(
     0, [cardinality](auto i) { return std::to_string(i % cardinality); });
   auto const col0     = cudf::test::strings_column_wrapper(elements, elements + nrows);
   auto const expected = table_view{{col0}};
 
-  auto const filepath = temp_env->get_temp_filepath("DictionaryTest.parquet");
+  auto buffer = std::vector<char>{};
   // set row group size so that there will be only one row group
   // no compression so we can easily read page data
   cudf::io::parquet_writer_options out_opts =
-    cudf::io::parquet_writer_options::builder(cudf::io::sink_info{filepath}, expected)
+    cudf::io::parquet_writer_options::builder(cudf::io::sink_info(&buffer), expected)
       .compression(cudf::io::compression_type::NONE)
       .stats_level(cudf::io::statistics_freq::STATISTICS_COLUMN)
       .dictionary_policy(cudf::io::dictionary_policy::ALWAYS)
@@ -155,31 +155,31 @@ TEST_P(ParquetSizedTest, DictionaryTest)
       .row_group_size_bytes(512 * 1024 * 1024);
   cudf::io::write_parquet(out_opts);
 
+  auto const buffer_span =
+    cudf::host_span<std::byte>(reinterpret_cast<std::byte*>(buffer.data()), buffer.size());
   cudf::io::parquet_reader_options default_in_opts =
-    cudf::io::parquet_reader_options::builder(cudf::io::source_info{filepath});
+    cudf::io::parquet_reader_options::builder(cudf::io::source_info(buffer_span));
   auto const result = cudf::io::read_parquet(default_in_opts);
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(expected, result.tbl->view());
 
   // make sure dictionary was used
-  auto const source = cudf::io::datasource::create(filepath);
+  auto const source = cudf::io::datasource::create(buffer_span);
   cudf::io::parquet::FileMetaData fmd;
 
   read_footer(source, &fmd);
-  auto used_dict = [&fmd]() {
-    for (auto enc : fmd.row_groups[0].columns[0].meta_data.encodings) {
-      if (enc == cudf::io::parquet::Encoding::PLAIN_DICTIONARY or
-          enc == cudf::io::parquet::Encoding::RLE_DICTIONARY) {
-        return true;
-      }
-    }
-    return false;
-  };
-  EXPECT_TRUE(used_dict());
+  auto const used_dict =
+    std::all_of(fmd.row_groups.front().columns.front().meta_data.encodings.begin(),
+                fmd.row_groups.front().columns.front().meta_data.encodings.end(),
+                [](auto const& enc) {
+                  return enc == cudf::io::parquet::Encoding::PLAIN_DICTIONARY or
+                         enc == cudf::io::parquet::Encoding::RLE_DICTIONARY;
+                });
+  EXPECT_TRUE(used_dict);
 
   // and check that the correct number of bits was used
-  auto const oi    = read_offset_index(source, fmd.row_groups[0].columns[0]);
-  auto const nbits = read_dict_bits(source, oi.page_locations[0]);
+  auto const oi    = read_offset_index(source, fmd.row_groups.front().columns.front());
+  auto const nbits = read_dict_bits(source, oi.page_locations.front());
   EXPECT_EQ(nbits, GetParam());
 }
 

--- a/cpp/tests/io/parquet_misc_test.cpp
+++ b/cpp/tests/io/parquet_misc_test.cpp
@@ -127,10 +127,11 @@ TYPED_TEST(ParquetWriterDeltaTest, SupportedDeltaListSliced)
 // Base test fixture for size-parameterized tests
 class ParquetSizedTest : public ::cudf::test::BaseFixtureWithParam<int> {};
 
-// test the allowed bit widths: [1, 25) for dictionary encoding
+// Test the allowed bit widths: [1, 25) for dictionary encoding
+// Note: Using a step of 3 and avoiding bit width of 24 to reduce the test suite execution time
 INSTANTIATE_TEST_SUITE_P(ParquetDictionaryTest,
                          ParquetSizedTest,
-                         testing::Range(2, 25, 3),
+                         testing::Range(2, 24, 3),
                          testing::PrintToStringParamName());
 
 TEST_P(ParquetSizedTest, DictionaryTest)


### PR DESCRIPTION
## Description

Related to #14750 (CC: @vuule)

This PR reduces the execution time for parquet dictionary tests by using a step of 3 for the cardinality range as well as using a host buffer (instead of a file) to read/write parquet data

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
