### PR TITLE
Handle NVMLError_NotSupported in cudf-polars

### DIFF
--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -89,7 +89,11 @@ def get_total_device_memory() -> int | None:
     maybe_handle = get_device_handle()
 
     if maybe_handle is not None:
-        return pynvml.nvmlDeviceGetMemoryInfo(maybe_handle).total
+        try:
+            return pynvml.nvmlDeviceGetMemoryInfo(maybe_handle).total
+        except pynvml.NVMLError_NotSupported:  # pragma: no cover
+            # System doesn't have proper "GPU memory".
+            return None
     else:  # pragma: no cover
         return None
 


### PR DESCRIPTION
## Description

Fixes a regression in https://github.com/rapidsai/cudf/pull/19895, which changed the logic for when we catch this exception and fall back to the default device memory size.