### PR TITLE
Remove unnecessary work from `read_parquet_metadata`

### DIFF
--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -84,7 +84,7 @@ metadata::metadata(cudf::host_span<uint8_t const> footer_bytes)
 aggregate_reader_metadata::aggregate_reader_metadata(FileMetaData const& parquet_metadata,
                                                      bool use_arrow_schema,
                                                      bool has_cols_from_mismatched_srcs)
-  : aggregate_reader_metadata_base({}, false, false, true)
+  : aggregate_reader_metadata_base({}, false, false)
 {
   // Just copy over the FileMetaData struct to the internal metadata struct
   per_file_metadata.emplace_back(metadata{parquet_metadata}.get_file_metadata());
@@ -94,7 +94,7 @@ aggregate_reader_metadata::aggregate_reader_metadata(FileMetaData const& parquet
 aggregate_reader_metadata::aggregate_reader_metadata(cudf::host_span<uint8_t const> footer_bytes,
                                                      bool use_arrow_schema,
                                                      bool has_cols_from_mismatched_srcs)
-  : aggregate_reader_metadata_base({}, false, false, true)
+  : aggregate_reader_metadata_base({}, false, false)
 {
   // Re-initialize internal variables here as base class was initialized without a source
   per_file_metadata.emplace_back(metadata{footer_bytes}.get_file_metadata());

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -87,7 +87,7 @@ aggregate_reader_metadata::aggregate_reader_metadata(FileMetaData const& parquet
   : aggregate_reader_metadata_base({}, false, false)
 {
   // Just copy over the FileMetaData struct to the internal metadata struct
-  per_file_metadata = std::vector<metadata_base>{metadata{parquet_metadata}.get_file_metadata()};
+  per_file_metadata.emplace_back(metadata{parquet_metadata}.get_file_metadata());
   initialize_internals(use_arrow_schema, has_cols_from_mismatched_srcs);
 }
 
@@ -97,7 +97,7 @@ aggregate_reader_metadata::aggregate_reader_metadata(cudf::host_span<uint8_t con
   : aggregate_reader_metadata_base({}, false, false)
 {
   // Re-initialize internal variables here as base class was initialized without a source
-  per_file_metadata = std::vector<metadata_base>{metadata{footer_bytes}.get_file_metadata()};
+  per_file_metadata.emplace_back(metadata{footer_bytes}.get_file_metadata());
   initialize_internals(use_arrow_schema, has_cols_from_mismatched_srcs);
 }
 

--- a/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_helpers.cpp
@@ -84,7 +84,7 @@ metadata::metadata(cudf::host_span<uint8_t const> footer_bytes)
 aggregate_reader_metadata::aggregate_reader_metadata(FileMetaData const& parquet_metadata,
                                                      bool use_arrow_schema,
                                                      bool has_cols_from_mismatched_srcs)
-  : aggregate_reader_metadata_base({}, false, false)
+  : aggregate_reader_metadata_base({}, false, false, true)
 {
   // Just copy over the FileMetaData struct to the internal metadata struct
   per_file_metadata.emplace_back(metadata{parquet_metadata}.get_file_metadata());
@@ -94,7 +94,7 @@ aggregate_reader_metadata::aggregate_reader_metadata(FileMetaData const& parquet
 aggregate_reader_metadata::aggregate_reader_metadata(cudf::host_span<uint8_t const> footer_bytes,
                                                      bool use_arrow_schema,
                                                      bool has_cols_from_mismatched_srcs)
-  : aggregate_reader_metadata_base({}, false, false)
+  : aggregate_reader_metadata_base({}, false, false, true)
 {
   // Re-initialize internal variables here as base class was initialized without a source
   per_file_metadata.emplace_back(metadata{footer_bytes}.get_file_metadata());

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -529,7 +529,8 @@ reader_impl::reader_impl(std::size_t chunk_read_limit,
   _metadata = std::make_unique<aggregate_reader_metadata>(
     _sources,
     options.is_enabled_use_arrow_schema(),
-    options.get_columns().has_value() and options.is_enabled_allow_mismatched_pq_schemas(), true);
+    options.get_columns().has_value() and options.is_enabled_allow_mismatched_pq_schemas(),
+    true);
 
   // Number of input sources
   _num_sources = _sources.size();
@@ -1038,7 +1039,8 @@ parquet_metadata read_parquet_metadata(host_span<std::unique_ptr<datasource> con
   constexpr auto has_column_projection = false;
 
   // Open and parse the source dataset metadata
-  auto metadata = aggregate_reader_metadata(sources, use_arrow_schema, has_column_projection, false);
+  auto metadata =
+    aggregate_reader_metadata(sources, use_arrow_schema, has_column_projection, false);
 
   return parquet_metadata{parquet_schema{walk_schema(&metadata, 0)},
                           metadata.get_num_rows(),

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -529,8 +529,7 @@ reader_impl::reader_impl(std::size_t chunk_read_limit,
   _metadata = std::make_unique<aggregate_reader_metadata>(
     _sources,
     options.is_enabled_use_arrow_schema(),
-    options.get_columns().has_value() and options.is_enabled_allow_mismatched_pq_schemas(),
-    true);
+    options.get_columns().has_value() and options.is_enabled_allow_mismatched_pq_schemas());
 
   // Number of input sources
   _num_sources = _sources.size();

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -529,7 +529,7 @@ reader_impl::reader_impl(std::size_t chunk_read_limit,
   _metadata = std::make_unique<aggregate_reader_metadata>(
     _sources,
     options.is_enabled_use_arrow_schema(),
-    options.get_columns().has_value() and options.is_enabled_allow_mismatched_pq_schemas());
+    options.get_columns().has_value() and options.is_enabled_allow_mismatched_pq_schemas(), true);
 
   // Number of input sources
   _num_sources = _sources.size();
@@ -1038,7 +1038,7 @@ parquet_metadata read_parquet_metadata(host_span<std::unique_ptr<datasource> con
   constexpr auto has_column_projection = false;
 
   // Open and parse the source dataset metadata
-  auto metadata = aggregate_reader_metadata(sources, use_arrow_schema, has_column_projection);
+  auto metadata = aggregate_reader_metadata(sources, use_arrow_schema, has_column_projection, false);
 
   return parquet_metadata{parquet_schema{walk_schema(&metadata, 0)},
                           metadata.get_num_rows(),

--- a/cpp/src/io/parquet/reader_impl_helpers.cpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.cpp
@@ -337,7 +337,8 @@ metadata::metadata(datasource* source, bool read_page_indexes)
   auto const has_strings = std::any_of(
     schema.begin(), schema.end(), [](auto const& elem) { return elem.type == Type::BYTE_ARRAY; });
 
-  if (read_page_indexes and has_strings and not row_groups.empty() and not row_groups.front().columns.empty()) {
+  if (read_page_indexes and has_strings and not row_groups.empty() and
+      not row_groups.front().columns.empty()) {
     // column index and offset index are encoded back to back.
     // the first column of the first row group will have the first column index, the last
     // column of the last row group will have the final offset index.
@@ -378,7 +379,7 @@ std::vector<metadata> aggregate_reader_metadata::metadatas_from_sources(
   host_span<std::unique_ptr<datasource> const> sources, bool read_page_indexes)
 {
   // Avoid using the thread pool for a single source
-  if (sources.size() == 1) { 
+  if (sources.size() == 1) {
     std::vector<metadata> result;
     result.emplace_back(sources[0].get(), read_page_indexes);
     return result;

--- a/cpp/src/io/parquet/reader_impl_helpers.cpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.cpp
@@ -378,7 +378,11 @@ std::vector<metadata> aggregate_reader_metadata::metadatas_from_sources(
   host_span<std::unique_ptr<datasource> const> sources)
 {
   // Avoid using the thread pool for a single source
-  if (sources.size() == 1) { return {metadata{sources[0].get()}}; }
+  if (sources.size() == 1) { 
+    std::vector<metadata> result;
+    result.emplace_back(sources[0].get());
+    return result;
+  }
 
   std::vector<std::future<metadata>> metadata_ctor_tasks;
   metadata_ctor_tasks.reserve(sources.size());

--- a/cpp/src/io/parquet/reader_impl_helpers.cpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.cpp
@@ -307,7 +307,7 @@ void metadata::sanitize_schema()
   process(0);
 }
 
-metadata::metadata(datasource* source)
+metadata::metadata(datasource* source, bool read_page_indexes)
 {
   constexpr auto header_len = sizeof(file_header_s);
   constexpr auto ender_len  = sizeof(file_ender_s);
@@ -337,7 +337,7 @@ metadata::metadata(datasource* source)
   auto const has_strings = std::any_of(
     schema.begin(), schema.end(), [](auto const& elem) { return elem.type == Type::BYTE_ARRAY; });
 
-  if (has_strings and not row_groups.empty() and not row_groups.front().columns.empty()) {
+  if (read_page_indexes and has_strings and not row_groups.empty() and not row_groups.front().columns.empty()) {
     // column index and offset index are encoded back to back.
     // the first column of the first row group will have the first column index, the last
     // column of the last row group will have the final offset index.
@@ -375,12 +375,12 @@ metadata::metadata(datasource* source)
 }
 
 std::vector<metadata> aggregate_reader_metadata::metadatas_from_sources(
-  host_span<std::unique_ptr<datasource> const> sources)
+  host_span<std::unique_ptr<datasource> const> sources, bool read_page_indexes)
 {
   // Avoid using the thread pool for a single source
   if (sources.size() == 1) { 
     std::vector<metadata> result;
-    result.emplace_back(sources[0].get());
+    result.emplace_back(sources[0].get(), read_page_indexes);
     return result;
   }
 
@@ -388,7 +388,7 @@ std::vector<metadata> aggregate_reader_metadata::metadatas_from_sources(
   metadata_ctor_tasks.reserve(sources.size());
   for (auto const& source : sources) {
     metadata_ctor_tasks.emplace_back(cudf::detail::host_worker_pool().submit_task(
-      [source = source.get()] { return metadata{source}; }));
+      [source = source.get(), read_page_indexes] { return metadata{source, read_page_indexes}; }));
   }
   std::vector<metadata> metadatas;
   metadatas.reserve(sources.size());
@@ -611,8 +611,9 @@ void aggregate_reader_metadata::column_info_for_row_group(row_group_info& rg_inf
 aggregate_reader_metadata::aggregate_reader_metadata(
   host_span<std::unique_ptr<datasource> const> sources,
   bool use_arrow_schema,
-  bool has_cols_from_mismatched_srcs)
-  : per_file_metadata(metadatas_from_sources(sources)),
+  bool has_cols_from_mismatched_srcs,
+  bool read_page_indexes)
+  : per_file_metadata(metadatas_from_sources(sources, read_page_indexes)),
     keyval_maps(collect_keyval_metadata()),
     schema_idx_maps(init_schema_idx_maps(has_cols_from_mismatched_srcs)),
     num_rows(calc_num_rows()),

--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -114,7 +114,7 @@ struct row_group_info {
  */
 struct metadata : public FileMetaData {
   metadata() = default;
-  explicit metadata(datasource* source);
+  explicit metadata(datasource* source, bool read_page_indexes = true);
   metadata(metadata const& other) = delete;
   metadata(metadata&& other) = default;
   metadata& operator=(metadata const& other) = delete;
@@ -153,7 +153,7 @@ class aggregate_reader_metadata {
    * @brief Create a metadata object from each element in the source vector
    */
   static std::vector<metadata> metadatas_from_sources(
-    host_span<std::unique_ptr<datasource> const> sources);
+    host_span<std::unique_ptr<datasource> const> sources, bool read_page_indexes = true);
 
   /**
    * @brief Collect the keyvalue maps from each per-file metadata object into a vector of maps.
@@ -334,7 +334,8 @@ class aggregate_reader_metadata {
  public:
   aggregate_reader_metadata(host_span<std::unique_ptr<datasource> const> sources,
                             bool use_arrow_schema,
-                            bool has_cols_from_mismatched_srcs);
+                            bool has_cols_from_mismatched_srcs,
+                            bool read_page_indexes);
 
   [[nodiscard]] RowGroup const& get_row_group(size_type row_group_index, size_type src_idx) const;
 

--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -335,7 +335,7 @@ class aggregate_reader_metadata {
   aggregate_reader_metadata(host_span<std::unique_ptr<datasource> const> sources,
                             bool use_arrow_schema,
                             bool has_cols_from_mismatched_srcs,
-                            bool read_page_indexes);
+                            bool read_page_indexes = true);
 
   [[nodiscard]] RowGroup const& get_row_group(size_type row_group_index, size_type src_idx) const;
 

--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -115,6 +115,12 @@ struct row_group_info {
 struct metadata : public FileMetaData {
   metadata() = default;
   explicit metadata(datasource* source);
+  metadata(metadata const& other) = delete;
+  metadata(metadata&& other) = default;
+  metadata& operator=(metadata const& other) = delete;
+  metadata& operator=(metadata&& other) = default;
+  ~metadata() = default;
+  
   void sanitize_schema();
 };
 

--- a/cpp/src/io/parquet/reader_impl_helpers.hpp
+++ b/cpp/src/io/parquet/reader_impl_helpers.hpp
@@ -115,12 +115,12 @@ struct row_group_info {
 struct metadata : public FileMetaData {
   metadata() = default;
   explicit metadata(datasource* source, bool read_page_indexes = true);
-  metadata(metadata const& other) = delete;
-  metadata(metadata&& other) = default;
+  metadata(metadata const& other)            = delete;
+  metadata(metadata&& other)                 = default;
   metadata& operator=(metadata const& other) = delete;
-  metadata& operator=(metadata&& other) = default;
-  ~metadata() = default;
-  
+  metadata& operator=(metadata&& other)      = default;
+  ~metadata()                                = default;
+
   void sanitize_schema();
 };
 

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -669,11 +669,12 @@ def parse_args(
     )
     parser.add_argument(
         "--rmm-pool-size",
-        default=0.5,
+        default=None,
         type=float,
         help=textwrap.dedent("""\
             Fraction of total GPU memory to allocate for RMM pool.
-            Default: 0.5 (50%% of GPU memory)"""),
+            Default: 0.5 (50%% of GPU memory) when --no-rmm-async,
+                     None when --rmm-async"""),
     )
     parser.add_argument(
         "--rmm-release-threshold",
@@ -777,7 +778,14 @@ def parse_args(
         default=False,
         help="Enable statistics planning.",
     )
-    return parser.parse_args(args)
+
+    parsed_args = parser.parse_args(args)
+
+    if parsed_args.rmm_pool_size is None and not parsed_args.rmm_async:
+        # The default rmm pool size depends on the rmm_async flag
+        parsed_args.rmm_pool_size = 0.5
+
+    return parsed_args
 
 
 def run_polars(


### PR DESCRIPTION
## Description
Two changes that significantly speed up `read_parquet_metadata`:

1. Skip parsing page indexes because they are not used in `read_parquet_metadata`.
2. Avoid accidental copies of the `metadata` object, which can have **many** dynamic allocations.

Measured PDS-H total time reduction from 54s to 33s.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
