### PR TITLE
Don't assume cudf_polars benchmarking scale factor is always an integer

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -277,10 +277,15 @@ class RunConfig:
             scale_factor = _infer_scale_factor(name, path, args.suffix)
         if path is None:
             path = f"{args.root}/scale-{scale_factor}"
+
+        scale_factor = float(scale_factor)
         try:
-            scale_factor = int(scale_factor)
+            scale_factor_int = int(scale_factor)
         except ValueError:
-            scale_factor = float(scale_factor)
+            pass
+        else:
+            if scale_factor_int == scale_factor:
+                scale_factor = scale_factor_int
 
         if "pdsh" in name and args.scale is not None:
             # Validate the user-supplied scale factor


### PR DESCRIPTION
## Description
While working on https://github.com/rapidsai/cudf/pull/20164 and testing with a fractional scale factor (e.g. 0.1) I noticed the results would report truncate reported scale factor. After this fix e.g.
```
Iteration Summary
=======================================
query: 0
path: .../cudf/sf0.1
scale_factor: 0.1
executor: in-memory
iterations: 1
---------------------------------------
min time : 0.0017
max time : 0.0017
mean time: 0.0017
=======================================
query: 1
path: .../cudf/sf0.1
scale_factor: 0.1
executor: in-memory
iterations: 1
---------------------------------------
min time : 0.2730
max time : 0.2730
mean time: 0.2730
=======================================
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
