### PR TITLE
Introduce example for external sorting

### DIFF
--- a/cpp/examples/build.sh
+++ b/cpp/examples/build.sh
@@ -17,13 +17,14 @@ eval set -- "$ARGS"
 # shellcheck disable=2078
 while [ : ]; do
   case "$1" in
-    -i | --install)
-        INSTALL_EXAMPLES=true
-        shift
-        ;;
-    --) shift;
-        break
-        ;;
+  -i | --install)
+    INSTALL_EXAMPLES=true
+    shift
+    ;;
+  --)
+    shift
+    break
+    ;;
   esac
 done
 
@@ -64,3 +65,4 @@ build_example nested_types
 build_example parquet_inspect
 build_example parquet_io
 build_example billion_rows
+build_example external_sorting

--- a/cpp/examples/external_sorting/CMakeLists.txt
+++ b/cpp/examples/external_sorting/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
+cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
+
+include(../set_cuda_architecture.cmake)
+
+# initialize cuda architecture
+rapids_cuda_init_architectures(external_sorting)
+
+project(
+  external_sorting
+  VERSION 0.0.1
+  LANGUAGES CXX CUDA
+)
+
+include(../fetch_dependencies.cmake)
+
+include(rapids-cmake)
+rapids_cmake_build_type("Release")
+
+# For now, disable CMake's automatic module scanning for C++ files. There is an sccache bug in the
+# version RAPIDS uses in CI that causes it to handle the resulting -M* flags incorrectly with
+# gcc>=14. We can remove this once we upgrade to a newer sccache version.
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
+# Build and install external sorting example
+add_executable(external_sort sort.cpp parquet_io.cpp)
+target_link_libraries(
+  external_sort PRIVATE cudf::cudf $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp>
+)
+target_compile_features(external_sort PRIVATE cxx_std_20)
+install(TARGETS external_sort DESTINATION bin/examples/libcudf/external_sorting)

--- a/cpp/examples/external_sorting/README.md
+++ b/cpp/examples/external_sorting/README.md
@@ -1,0 +1,145 @@
+# External Sorting Example
+
+This example demonstrates external sorting using libcudf by:
+
+1. **Generating random data**: Creates tables with configurable numbers of columns and rows
+2. **Writing to parquet files**: Stores data across multiple parquet files to simulate external storage
+3. **Multithreaded I/O**: Uses parallel reading and writing for better performance
+4. **Sorting large datasets**: Combines all data and sorts using libcudf's optimized sorting algorithms
+
+## Building
+
+From the cudf cpp directory:
+```bash
+cd examples/external_sorting
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j
+```
+
+## Usage
+
+```bash
+./sort [n_columns] [m_rows_per_file] [num_files] [output_dir]
+```
+
+### Arguments
+
+- **n_columns**: Number of columns in each table (default: 5)
+- **m_rows_per_file**: Number of rows per parquet file (default: 1,000,000)
+- **num_files**: Number of parquet files to create (default: 4)
+- **output_dir**: Directory to store parquet files (default: ./sort_data)
+
+### Examples
+
+```bash
+# Default run: 5 columns, 4 files of 1M rows each (4M total rows)
+./sort
+
+# Custom run: 3 columns, 8 files of 500K rows each (4M total rows)
+./sort 3 500000 8 /tmp/my_sort_test
+
+# Large dataset: 10 columns, 10 files of 2M rows each (20M total rows)
+./sort 10 2000000 10 /data/large_sort
+```
+
+## What it Does
+
+### Phase 1: Data Generation and Storage
+- Generates random tables with mixed data types (int32, float64, int64, float32, int16)
+- Writes each table to a separate parquet file using Snappy compression
+- Uses multithreaded writing for better I/O performance
+
+### Phase 2: Data Reading
+- Reads all parquet files back using multithreaded I/O
+- Concatenates data from multiple threads efficiently
+
+### Phase 3: Data Concatenation
+- Combines all data into a single large table
+- Reports total number of rows processed
+
+### Phase 4: Sorting
+- Sorts the combined dataset by the first column (ascending order)
+- Uses libcudf's optimized sorting algorithms including:
+  - Radix sort for integer types
+  - Multi-path optimization based on data characteristics
+  - Index-based sorting for memory efficiency
+
+### Phase 5: Result Output
+- Writes the sorted result to a parquet file
+- Provides performance metrics for each phase
+
+## Data Types
+
+The example generates columns with different data types to demonstrate libcudf's type system:
+
+- **INT32**: Primary sorting column with large integer values
+- **FLOAT64**: Double precision floating point numbers
+- **INT64**: Long integer values
+- **FLOAT32**: Single precision floating point numbers  
+- **INT16**: Short integer values
+
+Each column type has different value ranges to create diverse datasets for testing.
+
+## Performance Notes
+
+- **Memory Management**: Uses RMM (Rapids Memory Manager) with pooled allocations for optimal GPU memory usage
+- **Stream Management**: Utilizes CUDA stream pools for concurrent operations
+- **I/O Optimization**: Leverages multithreaded parquet I/O for better disk/network throughput
+- **Compression**: Uses Snappy compression for parquet files to reduce storage requirements
+
+## Example Output
+
+```
+External Sorting Example
+========================
+Columns per table: 5
+Rows per file: 1000000
+Number of files: 4
+Total rows: 4000000
+Output directory: ./sort_data
+
+Phase 1: Generating and writing 4 parquet files...
+Generating table 1/4
+Generating table 2/4
+Generating table 3/4
+Generating table 4/4
+Data generation Elapsed Time: 1250ms
+
+Writing parquet files Elapsed Time: 2100ms
+
+Phase 2: Reading parquet files...
+Reading parquet files Elapsed Time: 800ms
+
+Phase 3: Concatenating data...
+Total rows to concatenate: 4000000
+Data concatenation Elapsed Time: 150ms
+
+Phase 4: Sorting data...
+Sorting by first column (ascending)
+Computing sort order Elapsed Time: 320ms
+Gathering sorted data Elapsed Time: 180ms
+
+Phase 5: Writing sorted result...
+Writing sorted result Elapsed Time: 750ms
+
+External sorting completed successfully!
+Summary:
+  Input: 4 files × 1000000 rows × 5 columns
+  Total processed: 4000000 rows
+  Sorted result: ./sort_data/sorted_result.parquet
+```
+
+## Educational Value
+
+This example demonstrates several key libcudf concepts:
+
+- **Column Creation**: Using factory functions to create columns with different types
+- **Table Management**: Working with tables as collections of columns
+- **Memory Management**: Proper use of RMM for GPU memory allocation
+- **I/O Operations**: Reading and writing parquet files with optimal settings
+- **Sorting Algorithms**: Leveraging libcudf's high-performance sorting capabilities
+- **Multithreading**: Using CUDA streams for concurrent operations
+- **Data Concatenation**: Efficiently combining multiple tables
+
+The code serves as a practical reference for building applications that need to process large datasets that don't fit in memory, demonstrating the external sorting pattern commonly used in big data processing.

--- a/cpp/examples/external_sorting/parquet_io.cpp
+++ b/cpp/examples/external_sorting/parquet_io.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "parquet_io.hpp"
+
+#include <cudf/concatenate.hpp>
+#include <cudf/io/parquet.hpp>
+
+#include <algorithm>
+#include <iostream>
+#include <thread>
+
+namespace cudf {
+namespace examples {
+
+void write_parquet_file(const std::string& filepath,
+                        cudf::table_view table_view,
+                        rmm::cuda_stream_view stream)
+{
+  auto sink_info = cudf::io::sink_info(filepath);
+  auto builder   = cudf::io::parquet_writer_options::builder(sink_info, table_view);
+
+  // Create metadata for better compression
+  auto table_metadata = cudf::io::table_input_metadata{table_view};
+  for (cudf::size_type i = 0; i < table_view.num_columns(); ++i) {
+    table_metadata.column_metadata[i].set_name("column_" + std::to_string(i));
+  }
+
+  auto options = builder.metadata(table_metadata).compression(cudf::io::compression_type::SNAPPY);
+  cudf::io::write_parquet(options.build(), stream);
+  stream.synchronize();
+}
+
+void write_task::operator()()
+{
+  std::string filepath = output_dir + "/data_" + std::to_string(file_id) + ".parquet";
+  std::cout << "Writing file: " << filepath << std::endl;
+  write_parquet_file(filepath, table_views[file_id], stream);
+  std::cout << "Completed writing: " << filepath << std::endl;
+}
+
+void read_task::operator()()
+{
+  std::vector<std::unique_ptr<cudf::table>> tables_this_thread;
+
+  // Process files assigned to this thread
+  for (size_t file_idx = thread_id; file_idx < filepaths.size(); file_idx += thread_count) {
+    std::cout << "Thread " << thread_id << " reading: " << filepaths[file_idx] << std::endl;
+
+    auto source_info = cudf::io::source_info(filepaths[file_idx]);
+    auto builder     = cudf::io::parquet_reader_options::builder(source_info);
+    auto options     = builder.build();
+
+    tables_this_thread.push_back(cudf::io::read_parquet(options, stream).tbl);
+  }
+
+  // Concatenate tables read by this thread
+  if (tables_this_thread.size() == 1) {
+    tables[thread_id] = std::move(tables_this_thread[0]);
+  } else if (tables_this_thread.size() > 1) {
+    std::vector<cudf::table_view> table_views;
+    for (auto const& tbl : tables_this_thread) {
+      table_views.push_back(tbl->view());
+    }
+    tables[thread_id] = cudf::concatenate(table_views, stream);
+  }
+
+  stream.synchronize();
+}
+
+std::vector<std::unique_ptr<cudf::table>> read_parquet_files_multithreaded(const std::vector<std::string>& filepaths,
+                                                                           int thread_count,
+                                                                           rmm::cuda_stream_pool& stream_pool)
+{
+  std::vector<std::unique_ptr<cudf::table>> tables(thread_count);
+  std::vector<read_task> read_tasks;
+  std::vector<std::thread> threads;
+
+  // Create read tasks
+  for (int tid = 0; tid < thread_count; ++tid) {
+    read_tasks.emplace_back(
+      read_task{filepaths, tables, tid, thread_count, stream_pool.get_stream()});
+  }
+
+  // Launch threads
+  for (auto& task : read_tasks) {
+    threads.emplace_back(task);
+  }
+
+  // Wait for completion
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  // Remove empty tables
+  tables.erase(std::remove_if(tables.begin(),
+                             tables.end(),
+                             [](const std::unique_ptr<cudf::table>& tbl) { return tbl == nullptr; }),
+              tables.end());
+
+  return tables;
+}
+
+}  // namespace examples
+}  // namespace cudf

--- a/cpp/examples/external_sorting/parquet_io.hpp
+++ b/cpp/examples/external_sorting/parquet_io.hpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/table/table.hpp>
+
+#include <rmm/cuda_stream_pool.hpp>
+#include <rmm/cuda_stream_view.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+/**
+ * @file parquet_io.hpp
+ * @brief Parquet I/O utilities for external sorting example
+ *
+ * This header provides utilities for reading and writing parquet files
+ * with multithreaded support for better performance on large datasets.
+ */
+
+namespace cudf {
+namespace examples {
+
+/**
+ * @brief Write a table to a parquet file
+ *
+ * Writes the given table to a parquet file with Snappy compression.
+ * Column names are automatically generated as "column_0", "column_1", etc.
+ *
+ * @param filepath Path to the output parquet file
+ * @param table_view View of the table to write
+ * @param stream CUDA stream for operations
+ */
+void write_parquet_file(const std::string& filepath,
+                        cudf::table_view table_view,
+                        rmm::cuda_stream_view stream);
+
+/**
+ * @brief Functor for multithreaded parquet writing
+ *
+ * This functor can be used with std::thread to write parquet files
+ * in parallel. Each thread writes one file using its assigned stream.
+ */
+struct write_task {
+  std::string const& output_dir;
+  std::vector<cudf::table_view> const& table_views;
+  int const file_id;
+  rmm::cuda_stream_view stream;
+
+  void operator()();
+};
+
+/**
+ * @brief Functor for multithreaded parquet reading
+ *
+ * This functor can be used with std::thread to read parquet files
+ * in parallel. Each thread processes a subset of files and concatenates
+ * them if multiple files are assigned to the same thread.
+ */
+struct read_task {
+  std::vector<std::string> const& filepaths;
+  std::vector<std::unique_ptr<cudf::table>>& tables;
+  int const thread_id;
+  int const thread_count;
+  rmm::cuda_stream_view stream;
+
+  void operator()();
+};
+
+/**
+ * @brief Read multiple parquet files using multithreading
+ *
+ * Reads a list of parquet files using multiple threads for improved
+ * performance. Files are distributed across threads in round-robin fashion.
+ * Each thread concatenates its assigned files into a single table.
+ *
+ * @param filepaths List of parquet file paths to read
+ * @param thread_count Number of threads to use for reading
+ * @param stream_pool CUDA stream pool for thread synchronization
+ * @return Vector of tables, one per thread (empty tables are filtered out)
+ */
+std::vector<std::unique_ptr<cudf::table>> read_parquet_files_multithreaded(const std::vector<std::string>& filepaths,
+                                                                           int thread_count,
+                                                                           rmm::cuda_stream_pool& stream_pool);
+
+}  // namespace examples
+}  // namespace cudf

--- a/cpp/examples/external_sorting/random_table_generator.cuh
+++ b/cpp/examples/external_sorting/random_table_generator.cuh
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "thrust/iterator/counting_iterator.h"
+#include <cudf/column/column_factories.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/random/uniform_int_distribution.h>
+#include <thrust/random/uniform_real_distribution.h>
+#include <thrust/transform.h>
+
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+/**
+ * @file random_table_generator.cuh
+ * @brief Random table and column generation utilities for external sorting example
+ *
+ * This header provides utilities to generate random tables and columns with various
+ * data types for testing and demonstration purposes. The implementation uses thrust
+ * algorithms for GPU-accelerated generation.
+ */
+
+namespace cudf {
+namespace examples {
+
+/**
+ * @brief Generate a random numeric column using thrust
+ *
+ * Creates a column filled with random values of the specified numeric type.
+ * Uses thrust::uniform_int_distribution for integral types and 
+ * thrust::uniform_real_distribution for floating-point types.
+ *
+ * @tparam T The numeric data type (int32_t, int64_t, float, double, etc.)
+ * @param lower Lower bound of the random values (inclusive)
+ * @param upper Upper bound of the random values (inclusive for int, exclusive for float)
+ * @param num_rows Number of rows in the output column
+ * @param stream CUDA stream for device operations
+ * @param mr Device memory resource for allocations
+ * @return Unique pointer to the generated column
+ */
+template <typename T>
+std::unique_ptr<cudf::column> generate_random_numeric_column(T lower,
+                                                             T upper,
+                                                             cudf::size_type num_rows,
+                                                             rmm::cuda_stream_view stream,
+                                                             rmm::device_async_resource_ref mr)
+{
+  auto col = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_to_id<T>()}, num_rows, cudf::mask_state::UNALLOCATED, stream, mr);
+
+  // Generate random numbers on device using thrust
+  thrust::transform(
+    rmm::exec_policy(stream),
+    thrust::counting_iterator(0),
+    thrust::counting_iterator(num_rows),
+    col->mutable_view().begin<T>(),
+    [lower, upper] __device__(cudf::size_type idx) -> T {
+      thrust::minstd_rand engine;
+      engine.discard(idx);  // Deterministic seeding based on index
+      if constexpr (std::is_integral_v<T>) {
+        thrust::uniform_int_distribution<T> dist(lower, upper);
+        return dist(engine);
+      } else {
+        thrust::uniform_real_distribution<T> dist(lower, upper);
+        return dist(engine);
+      }
+    });
+
+  return col;
+}
+
+/**
+ * @brief Generate a table with n_columns random columns and m_rows
+ *
+ * Creates a table with a mix of different data types to demonstrate libcudf's
+ * type system and provide realistic test data. The column types cycle through:
+ * INT32, FLOAT64, INT64, FLOAT32, INT16.
+ *
+ * Each column type uses different value ranges to create diverse datasets:
+ * - INT32: Large integers with column-specific offsets
+ * - FLOAT64: Double precision floats in range [0, 1000+offset]
+ * - INT64: Large long integers around 1e9-1e10 range
+ * - FLOAT32: Single precision floats with small ranges
+ * - INT16: Short integers with moderate ranges
+ *
+ * @param n_columns Number of columns to generate
+ * @param m_rows Number of rows in each column
+ * @param stream CUDA stream for device operations
+ * @param mr Device memory resource for allocations
+ * @return Unique pointer to the generated table
+ */
+std::unique_ptr<cudf::table> generate_random_table(cudf::size_type n_columns,
+                                                    cudf::size_type m_rows,
+                                                    rmm::cuda_stream_view stream,
+                                                    rmm::device_async_resource_ref mr)
+{
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.reserve(n_columns);
+
+  // Create a mix of different data types for more realistic testing
+  std::vector<cudf::data_type> types = {
+    cudf::data_type{cudf::type_id::INT32},    // Integer column for primary sorting
+    cudf::data_type{cudf::type_id::FLOAT64},  // Double precision floating point
+    cudf::data_type{cudf::type_id::INT64},    // Long integer
+    cudf::data_type{cudf::type_id::FLOAT32},  // Single precision floating point
+    cudf::data_type{cudf::type_id::INT16}     // Short integer
+  };
+
+  for (cudf::size_type i = 0; i < n_columns; ++i) {
+    auto type_idx = i % types.size();
+    switch (types[type_idx].id()) {
+      case cudf::type_id::INT32:
+        columns.emplace_back(generate_random_numeric_column<int32_t>(
+          1000000 + i * 100000, 9999999 + i * 100000, m_rows, stream, mr));
+        break;
+      case cudf::type_id::FLOAT64:
+        columns.emplace_back(
+          generate_random_numeric_column<double>(0.0, 1000.0 + i * 100, m_rows, stream, mr));
+        break;
+      case cudf::type_id::INT64:
+        columns.emplace_back(generate_random_numeric_column<int64_t>(
+          static_cast<int64_t>(1e9) + i * 1000000,
+          static_cast<int64_t>(1e10) + i * 1000000,
+          m_rows,
+          stream,
+          mr));
+        break;
+      case cudf::type_id::FLOAT32:
+        columns.emplace_back(
+          generate_random_numeric_column<float>(10.0f + i, 1000.0f + i * 50, m_rows, stream, mr));
+        break;
+      case cudf::type_id::INT16:
+        columns.emplace_back(generate_random_numeric_column<int16_t>(
+          static_cast<int16_t>(100 + i * 10),
+          static_cast<int16_t>(30000 + i * 1000),
+          m_rows,
+          stream,
+          mr));
+        break;
+      default: break;  // Should not reach here with current types
+    }
+  }
+
+  return std::make_unique<cudf::table>(std::move(columns));
+}
+
+}  // namespace examples
+}  // namespace cudf

--- a/cpp/examples/external_sorting/sort.cpp
+++ b/cpp/examples/external_sorting/sort.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file sort.cpp
+ * @brief External sorting example that creates random data, stores it across multiple parquet files,
+ *        and then reads and sorts the data.
+ *
+ * This example demonstrates:
+ * 1. Generating random tables with configurable numbers of columns and rows
+ * 2. Writing data to multiple parquet files for external storage
+ * 3. Reading the data back using multithreaded I/O
+ * 4. Sorting the combined dataset using libcudf's sorting functionality
+ *
+ * Usage: ./sort [n_columns] [m_rows_per_file] [num_files] [output_dir]
+ *
+ * Example: ./sort 5 1000000 4 /tmp/sort_data
+ * This creates 4 files, each with 5 columns and 1M rows, then sorts the combined 4M row dataset.
+ */
+
+#include "../utilities/timer.hpp"
+#include "parquet_io.hpp"
+#include "random_table_generator.cuh"
+
+#include <cudf/concatenate.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/sorting.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream_pool.hpp>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+
+
+/**
+ * @brief Check if all expected data files already exist
+ */
+bool data_files_exist(const std::string& output_dir, int num_files)
+{
+  for (int i = 0; i < num_files; ++i) {
+    std::string filepath = output_dir + "/data_" + std::to_string(i) + ".parquet";
+    if (!std::filesystem::exists(filepath)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @brief Print usage information
+ */
+void print_usage()
+{
+  std::cout << "\nUsage: sort [n_columns] [m_rows_per_file] [num_files] [output_dir]\n\n"
+            << "Arguments:\n"
+            << "  n_columns       : Number of columns in each table (default: 5)\n"
+            << "  m_rows_per_file : Number of rows per parquet file (default: 1000000)\n"
+            << "  num_files       : Number of parquet files to create (default: 4)\n"
+            << "  output_dir      : Directory to store parquet files (default: ./sort_data)\n\n"
+            << "Example: ./sort 3 500000 8 /tmp/my_sort_test\n"
+            << "This creates 8 files with 3 columns and 500K rows each (4M rows total)\n\n"
+            << "Note: If data files already exist, generation and writing phases will be skipped.\n\n";
+}
+
+/**
+ * @brief Main function
+ */
+int main(int argc, char** argv)
+{
+  // Default parameters
+  cudf::size_type n_columns = 5;
+  cudf::size_type m_rows_per_file = 1000000;
+  int num_files = 4;
+  std::string output_dir = "./sort_data";
+
+  // Parse command line arguments
+  if (argc >= 2) {
+    if (std::string(argv[1]) == "-h" || std::string(argv[1]) == "--help") {
+      print_usage();
+      return 0;
+    }
+    n_columns = std::stoi(argv[1]);
+  }
+  if (argc >= 3) m_rows_per_file = std::stoi(argv[2]);
+  if (argc >= 4) num_files = std::stoi(argv[3]);
+  if (argc >= 5) output_dir = argv[4];
+
+  // Validate parameters
+  if (n_columns <= 0 || m_rows_per_file <= 0 || num_files <= 0) {
+    std::cerr << "Error: All parameters must be positive integers" << std::endl;
+    print_usage();
+    return 1;
+  }
+
+  std::cout << "External Sorting Example" << std::endl;
+  std::cout << "========================" << std::endl;
+  std::cout << "Columns per table: " << n_columns << std::endl;
+  std::cout << "Rows per file: " << m_rows_per_file << std::endl;
+  std::cout << "Number of files: " << num_files << std::endl;
+  std::cout << "Total rows: " << static_cast<int64_t>(m_rows_per_file) * num_files << std::endl;
+  std::cout << "Output directory: " << output_dir << std::endl << std::endl;
+
+  try {
+    // Initialize RMM
+    rmm::mr::cuda_memory_resource cuda_mr{};
+    rmm::mr::pool_memory_resource pool_mr{&cuda_mr, rmm::percent_of_free_device_memory(80)};
+    cudf::set_current_device_resource(&pool_mr);
+
+    // Create stream pool for multithreading
+    auto stream_pool = rmm::cuda_stream_pool(std::max(4, num_files));
+    auto default_stream = cudf::get_default_stream();
+
+    // Create output directory
+    std::filesystem::create_directories(output_dir);
+
+    cudf::examples::timer perf_timer;
+
+    // Check if data files already exist
+    bool files_exist = data_files_exist(output_dir, num_files);
+    
+    if (files_exist) {
+      std::cout << "Data files already exist. Skipping generation and writing phases." << std::endl;
+    } else {
+      // Phase 1: Generate and write random data to parquet files
+      std::cout << "Phase 1: Generating and writing " << num_files << " parquet files..." << std::endl;
+      std::vector<std::unique_ptr<cudf::table>> generated_tables;
+      std::vector<cudf::table_view> table_views;
+
+      for (int i = 0; i < num_files; ++i) {
+        std::cout << "Generating table " << (i + 1) << "/" << num_files << std::endl;
+        auto table = cudf::examples::generate_random_table(n_columns, m_rows_per_file, default_stream, cudf::get_current_device_resource_ref());
+        table_views.push_back(table->view());
+        generated_tables.push_back(std::move(table));
+      }
+
+      std::cout << "Data generation ";
+      perf_timer.print_elapsed_millis();
+      perf_timer.reset();
+
+      // Write files using multithreaded I/O
+      std::vector<cudf::examples::write_task> write_tasks;
+      std::vector<std::thread> write_threads;
+
+      for (int i = 0; i < num_files; ++i) {
+        write_tasks.emplace_back(
+          cudf::examples::write_task{output_dir, table_views, i, stream_pool.get_stream()});
+      }
+
+      for (auto& task : write_tasks) {
+        write_threads.emplace_back(task);
+      }
+
+      for (auto& thread : write_threads) {
+        thread.join();
+      }
+
+      std::cout << "Writing parquet files ";
+      perf_timer.print_elapsed_millis();
+      perf_timer.reset();
+    }
+
+    // Phase 2: Read parquet files
+    std::cout << "\nReading parquet files..." << std::endl;
+    std::vector<std::string> filepaths;
+    for (int i = 0; i < num_files; ++i) {
+      filepaths.push_back(output_dir + "/data_" + std::to_string(i) + ".parquet");
+    }
+
+    int thread_count = std::min(4, num_files);
+    auto read_tables = cudf::examples::read_parquet_files_multithreaded(filepaths, thread_count, stream_pool);
+
+    std::cout << "Reading parquet files ";
+    perf_timer.print_elapsed_millis();
+    perf_timer.reset();
+
+    // Phase 3: Concatenate all data
+    std::cout << "\nConcatenating data..." << std::endl;
+    std::vector<cudf::table_view> read_views;
+    cudf::size_type total_rows = 0;
+
+    for (auto const& tbl : read_tables) {
+      if (tbl != nullptr) {
+        read_views.push_back(tbl->view());
+        total_rows += tbl->num_rows();
+      }
+    }
+
+    std::cout << "Total rows to concatenate: " << total_rows << std::endl;
+    auto combined_table = cudf::concatenate(read_views, default_stream);
+
+    std::cout << "Data concatenation ";
+    perf_timer.print_elapsed_millis();
+    perf_timer.reset();
+
+    // Phase 4: Sort the combined data
+    std::cout << "\nSorting data..." << std::endl;
+    std::cout << "Sorting by first column (ascending)" << std::endl;
+
+    // Create sort order specification (sort by first column)
+    std::vector<cudf::order> column_order{cudf::order::ASCENDING};
+    std::vector<cudf::null_order> null_precedence{cudf::null_order::AFTER};
+
+    // Perform the sort - this returns indices for sorted order
+    auto sorted_indices = cudf::sorted_order(combined_table->view().select({0}), column_order, null_precedence, default_stream);
+
+    std::cout << "Computing sort order ";
+    perf_timer.print_elapsed_millis();
+    perf_timer.reset();
+
+    // Gather the sorted data
+    auto sorted_table = cudf::gather(combined_table->view(), sorted_indices->view(), cudf::out_of_bounds_policy::DONT_CHECK, default_stream);
+
+    std::cout << "Gathering sorted data ";
+    perf_timer.print_elapsed_millis();
+    perf_timer.reset();
+
+    // Phase 5: Write sorted result
+    std::cout << "\nWriting sorted result..." << std::endl;
+    std::string sorted_filepath = output_dir + "/sorted_result.parquet";
+    cudf::examples::write_parquet_file(sorted_filepath, sorted_table->view(), default_stream);
+
+    std::cout << "Writing sorted result ";
+    perf_timer.print_elapsed_millis();
+
+    // Summary
+    std::cout << "\nExternal sorting completed successfully!" << std::endl;
+    std::cout << "Summary:" << std::endl;
+    std::cout << "  Input: " << num_files << " files × " << m_rows_per_file 
+              << " rows × " << n_columns << " columns" << std::endl;
+    std::cout << "  Total processed: " << total_rows << " rows" << std::endl;
+    std::cout << "  Sorted result: " << sorted_filepath << std::endl;
+
+    // Verify first few values to check sorting
+    if (sorted_table->num_rows() > 0) {
+      std::cout << "\nSorting verification (first column values sample):" << std::endl;
+      // Note: In a production example, you might want to copy some values back to host for display
+      std::cout << "Sorted table has " << sorted_table->num_rows() << " rows" << std::endl;
+    }
+
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Description
This PR implements a parallel sorting approach to sort a table distributed across multiple Parquet files. Since the global table is too large to fit in GPU memory, we need to use an external sorting algorithm. In this PR, we use a sampling approach where splitters are selected from the table partitions using which the global table is re-bucketed. Each bucket can then be locally sorted which then gives us the sorted global table.
Ideas to select splitters: (i) Oversampling (ii) Exact quantiles using existing libcudf APIs (iii) Quantile sketch to get approx quantiles.
Progress:
- [X] Random table generator

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
