### PR TITLE
[WIP] Use a lower bound when estimating the partial file-size

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/base.py
+++ b/python/cudf_polars/cudf_polars/experimental/base.py
@@ -118,7 +118,7 @@ class DataSourceInfo:
         """Return unique-value statistics for a column."""
         raise NotImplementedError("Sub-class must implement unique_stats.")
 
-    def storage_size(self, column: str) -> ColumnStat[int]:
+    def partial_file_size(self, column: str) -> ColumnStat[int]:
         """Return the average column size for a single file."""
         return ColumnStat[int]()
 
@@ -214,13 +214,13 @@ class ColumnSourceInfo:
             return UniqueStats()
 
     @property
-    def storage_size(self) -> ColumnStat[int]:
+    def partial_file_size(self) -> ColumnStat[int]:
         """Return the average column size for a single file."""
-        # We don't need to handle concatenated statistics for ``storage_size``.
+        # We don't need to handle concatenated statistics for ``partial_file_size``.
         # Just return the storage size of the first table source.
         if self.table_source_pairs:
             table_source, column_name = self.table_source_pairs[0]
-            return table_source.storage_size(column_name)
+            return table_source.partial_file_size(column_name)
         else:  # pragma: no cover; We never call this for empty table sources.
             return ColumnStat[int]()
 

--- a/python/cudf_polars/cudf_polars/experimental/base.py
+++ b/python/cudf_polars/cudf_polars/experimental/base.py
@@ -118,8 +118,23 @@ class DataSourceInfo:
         """Return unique-value statistics for a column."""
         raise NotImplementedError("Sub-class must implement unique_stats.")
 
-    def partial_file_size(self, column: str) -> ColumnStat[int]:
-        """Return the average column size for a single file."""
+    def partial_file_size(
+        self, column: str, *, element_size: int = 1
+    ) -> ColumnStat[int]:
+        """
+        Return the average column size for a single file.
+
+        Parameters
+        ----------
+        column
+            The column name.
+        element_size
+            The minimum storage size of each element in the column.
+
+        Returns
+        -------
+        The average column size for a single file.
+        """
         return ColumnStat[int]()
 
     @property
@@ -213,14 +228,26 @@ class ColumnSourceInfo:
             # wasn't marked as "needing" unique-stats.
             return UniqueStats()
 
-    @property
-    def partial_file_size(self) -> ColumnStat[int]:
-        """Return the average column size for a single file."""
+    def partial_file_size(self, *, element_size: int = 1) -> ColumnStat[int]:
+        """
+        Return the average column size for a single file.
+
+        Parameters
+        ----------
+        element_size
+            The minimum storage size of each element in the column.
+
+        Returns
+        -------
+        The average column size for a single file.
+        """
         # We don't need to handle concatenated statistics for ``partial_file_size``.
         # Just return the storage size of the first table source.
         if self.table_source_pairs:
             table_source, column_name = self.table_source_pairs[0]
-            return table_source.partial_file_size(column_name)
+            return table_source.partial_file_size(
+                column_name, element_size=element_size
+            )
         else:  # pragma: no cover; We never call this for empty table sources.
             return ColumnStat[int]()
 

--- a/python/cudf_polars/cudf_polars/experimental/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/io.py
@@ -127,7 +127,19 @@ class ScanPartitionPlan:
             column_stats = stats.column_stats.get(ir, {})
             column_sizes: list[int] = []
             for cs in column_stats.values():
-                partial_file_size = cs.source_info.partial_file_size
+                element_size = 1
+                if (dtype := ir.schema.get(cs.name)) is not None:
+                    if dtype.id() in (
+                        plc.TypeId.STRING,
+                        plc.TypeId.FLOAT64,
+                        plc.TypeId.INT64,
+                    ):
+                        element_size = 8
+                    elif dtype.id() in (plc.TypeId.FLOAT32, plc.TypeId.INT32):
+                        element_size = 4
+                partial_file_size = cs.source_info.partial_file_size(
+                    element_size=element_size
+                )
                 if partial_file_size.value is not None:
                     column_sizes.append(partial_file_size.value)
 
@@ -811,9 +823,23 @@ class ParquetSourceInfo(DataSourceInfo):
         self._update_unique_stats(column)
         return self._unique_stats.get(column, UniqueStats())
 
-    def partial_file_size(self, column: str) -> ColumnStat[int]:
+    def partial_file_size(
+        self, column: str, *, element_size: int = 1
+    ) -> ColumnStat[int]:
         """Return the average column size for a single file."""
-        return self.metadata.mean_size_per_file.get(column, ColumnStat[int]())
+        file_count = len(self.paths)
+        row_count = self.row_count.value
+        partial_mean_size = self.metadata.mean_size_per_file.get(
+            column, ColumnStat[int]()
+        ).value
+        if file_count and row_count and partial_mean_size:
+            # NOTE: We set a lower bound on the partial mean size using
+            # the product of the expected element size and the row count.
+            # Dictionary encoding can make the on-disk size much smaller
+            # than it will be in memory.
+            min_value = element_size * (row_count // file_count)
+            return ColumnStat[int](max(min_value, partial_mean_size))
+        return ColumnStat[int]()
 
     def add_unique_stats_column(self, column: str) -> None:
         """Add a column needing unique-value information."""

--- a/python/cudf_polars/cudf_polars/experimental/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/io.py
@@ -127,9 +127,9 @@ class ScanPartitionPlan:
             column_stats = stats.column_stats.get(ir, {})
             column_sizes: list[int] = []
             for cs in column_stats.values():
-                storage_size = cs.source_info.storage_size
-                if storage_size.value is not None:
-                    column_sizes.append(storage_size.value)
+                partial_file_size = cs.source_info.partial_file_size
+                if partial_file_size.value is not None:
+                    column_sizes.append(partial_file_size.value)
 
             if (file_size := sum(column_sizes)) > 0:
                 if file_size > blocksize:
@@ -811,7 +811,7 @@ class ParquetSourceInfo(DataSourceInfo):
         self._update_unique_stats(column)
         return self._unique_stats.get(column, UniqueStats())
 
-    def storage_size(self, column: str) -> ColumnStat[int]:
+    def partial_file_size(self, column: str) -> ColumnStat[int]:
         """Return the average column size for a single file."""
         return self.metadata.mean_size_per_file.get(column, ColumnStat[int]())
 

--- a/python/cudf_polars/tests/experimental/test_stats.py
+++ b/python/cudf_polars/tests/experimental/test_stats.py
@@ -66,7 +66,7 @@ def test_base_stats_dataframescan(df, engine):
     assert source_info_x.row_count.exact
 
     # Storage stats should not be available
-    assert source_info_x.storage_size.value is None
+    assert source_info_x.partial_file_size().value is None
 
     # Check unique stats.
     # We need to use force=True to sample unique-value statistics,
@@ -150,11 +150,11 @@ def test_base_stats_parquet(
 
     # Storage stats should be available
     if max_footer_samples:
-        assert source_info_x.storage_size.value > 0
-        assert source_info_y.storage_size.value > 0
+        assert source_info_x.partial_file_size().value > 0
+        assert source_info_y.partial_file_size().value > 0
     else:
-        assert source_info_x.storage_size.value is None
-        assert source_info_y.storage_size.value is None
+        assert source_info_x.partial_file_size().value is None
+        assert source_info_y.partial_file_size().value is None
 
     # source._unique_stats should be empty
     assert set(table_source_info._unique_stats) == set()


### PR DESCRIPTION
## Description
While working on https://github.com/rapidsai/cudf/pull/20161, I discovered that cudf-polars can significantly underestimate the in-memory size of a Parquet string column. In order to estimate the in-memory size, we currently use column-chunk metadata from the Parquet file. This metadata stores the uncompressed byte size of each column. However, the uncompressed size may still include **dictionary encoding**. This means the metadata value can be significantly smaller than the real in-memory footprint. This is especially true when the column has a small unique-value count.

There are many possible ways to improve our partial file-size estimate. This PR takes a relatively simple approach: We set a lower-bound on the partial file-size estimate. This lower bound simply corresponds to the size of a single element (e.g. 8 bytes for strings) and multiplies that value by the estimated average row-count in a file.

**NOTE**: This change will probably degrade the performance of some PDS-H queries, because it will result in a larger partition count for dictionary-encoded data. For example, our partition size for Query 1 is currently very aggressive - It is roughly ~5x larger than we are expecting from the `blocksize` argument. The flip side of this issue is that we can probably handle a slightly-larger blocksize configuration (or a higher spilling limit) with the changes in this PR.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
