### PR TITLE
Pin pydantic<2.12 in ci/test_cudf_polars_polars_tests.sh

### DIFF
--- a/ci/test_cudf_polars_polars_tests.sh
+++ b/ci/test_cudf_polars_polars_tests.sh
@@ -33,6 +33,9 @@ sed -i '/^polars-cloud$/d' polars/py-polars/requirements-dev.txt
 # Deltalake release 1.0.0 contains breaking changes for Polars. So we're adding an upper pinning temporarily
 # until things get resolved. Tracking Issue: https://github.com/pola-rs/polars/issues/22999
 sed -i 's/^deltalake>=0.15.0.*/deltalake>=0.15.0,<1.0.0/' polars/py-polars/requirements-dev.txt
+# pyiceberg depends on a non-documented attribute of pydantic.
+# AttributeError: 'pydantic_core._pydantic_core.ValidationInfo' object has no attribute 'current_schema_id'
+sed -i 's/^pydantic>=2.0.0.*/pydantic>=2.0.0,<2.12.0/' polars/py-polars/requirements-dev.txt
 rapids-pip-retry install -r polars/py-polars/requirements-dev.txt -r polars/py-polars/requirements-ci.txt
 
 # shellcheck disable=SC2317


### PR DESCRIPTION
## Description
pydantic made a release today, and pyiceberg was relying on [non-documented](https://docs.pydantic.dev/latest/api/pydantic_core_schema/#pydantic_core.core_schema.ValidationInfo) functionality that was removed

```python
AttributeError: 'pydantic_core._pydantic_core.ValidationInfo' object has no attribute 'current_schema_id'
```

So I think it's sufficient just to pin pydantic in our cudf_polars polars test job

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
