### PR TITLE
Change .str.starts/endswith with tuple argument to match any pattern instead of pairwise matching

### DIFF
--- a/python/cudf/cudf/core/accessors/string.py
+++ b/python/cudf/cudf/core/accessors/string.py
@@ -3790,12 +3790,6 @@ class StringMethods(BaseAccessor):
         method: Callable[[plc.Column, plc.Column | plc.Scalar], plc.Column],
         pat: str | tuple[str, ...],
     ) -> Series | Index:
-        if isinstance(pat, tuple) and all(isinstance(p, str) for p in pat):
-            pat = as_column(pat, dtype=CUDF_STRING_DTYPE)  # type: ignore[assignment]
-        elif not isinstance(pat, str):
-            raise TypeError(
-                f"expected a string or tuple, not {type(pat).__name__}"
-            )
         return self._return_or_inplace(
             self._column.starts_ends_with(method, pat)  # type: ignore[arg-type]
         )
@@ -3806,12 +3800,8 @@ class StringMethods(BaseAccessor):
 
         Parameters
         ----------
-        pat : str or list-like
-            If `str` is an `str`, evaluates whether each string of
-            series ends with `pat`.
-            If `pat` is a list-like, evaluates whether `self[i]`
-            ends with `pat[i]`.
-            Regular expressions are not accepted.
+        pat : str or tuple[str, ...]
+            String pattern or tuple of patterns. Regular expressions are not accepted.
 
         Returns
         -------
@@ -3853,12 +3843,8 @@ class StringMethods(BaseAccessor):
 
         Parameters
         ----------
-        pat : str or list-like
-            If `str` is an `str`, evaluates whether each string of
-            series starts with `pat`.
-            If `pat` is a list-like, evaluates whether `self[i]`
-            starts with `pat[i]`.
-            Regular expressions are not accepted.
+        pat : str or tuple[str, ...]
+            String pattern or tuple of patterns. Regular expressions are not accepted.
 
         Returns
         -------

--- a/python/cudf/cudf/tests/series/accessors/test_str.py
+++ b/python/cudf/cudf/tests/series/accessors/test_str.py
@@ -1387,25 +1387,16 @@ def test_string_starts_ends(data, pat):
     ],
 )
 def test_string_starts_ends_list_like_pat(data, pat):
-    gs = cudf.Series(data)
+    pd_data = pd.Series(data)
+    cudf_data = cudf.Series(data)
 
-    starts_expected = []
-    ends_expected = []
-    for i in range(len(pat)):
-        if data[i] is None:
-            starts_expected.append(None)
-            ends_expected.append(None)
-        else:
-            if pat[i] is None:
-                starts_expected.append(False)
-                ends_expected.append(False)
-            else:
-                starts_expected.append(data[i].startswith(pat[i]))
-                ends_expected.append(data[i].endswith(pat[i]))
-    starts_expected = pd.Series(starts_expected)
-    ends_expected = pd.Series(ends_expected)
-    assert_eq(starts_expected, gs.str.startswith(pat), check_dtype=False)
-    assert_eq(ends_expected, gs.str.endswith(pat), check_dtype=False)
+    result = cudf_data.str.startswith(pat)
+    expected = pd_data.str.startswith(pat)
+    assert_eq(result, expected)
+
+    result = cudf_data.str.endswith(pat)
+    expected = pd_data.str.endswith(pat)
+    assert_eq(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/20237

The prior behavior was documented and tested but did not match pandas behavior; therefore, labeling as breaking. 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
