### PR TITLE
Pin `deltalake` in cudf-polars-polars-tests CI job

### DIFF
--- a/ci/test_cudf_polars_polars_tests.sh
+++ b/ci/test_cudf_polars_polars_tests.sh
@@ -30,9 +30,9 @@ git clone https://github.com/pola-rs/polars.git --branch "${TAG}" --depth 1
 rapids-logger "Install polars test requirements"
 # We don't need to pick up dependencies from polars-cloud, so we remove it.
 sed -i '/^polars-cloud$/d' polars/py-polars/requirements-dev.txt
-# Deltalake release 1.0.0 contains breaking changes for Polars. So we're adding an upper pinning temporarily
-# until things get resolved. Tracking Issue: https://github.com/pola-rs/polars/issues/22999
-sed -i 's/^deltalake>=0.15.0.*/deltalake>=0.15.0,<1.0.0/' polars/py-polars/requirements-dev.txt
+# Deltalake release 1.2.0 contains breaking changes for Polars.
+# Tracking issue: https://github.com/pola-rs/polars/issues/24872
+sed -i 's/^deltalake>=1.1.4/deltalake>=1.1.4,<1.2.0/' polars/py-polars/requirements-dev.txt
 # pyiceberg depends on a non-documented attribute of pydantic.
 # AttributeError: 'pydantic_core._pydantic_core.ValidationInfo' object has no attribute 'current_schema_id'
 sed -i 's/^pydantic>=2.0.0.*/pydantic>=2.0.0,<2.12.0/' polars/py-polars/requirements-dev.txt


### PR DESCRIPTION
## Description

https://github.com/rapidsai/cudf/actions/runs/18488298392 failed with

```
_internal.DeltaError: Kernel error: Error interacting with object store...
```

on one of the polars tests. A recent update to deltalake seems to be causing that to error now.

I'm tracking that investigation in https://github.com/pola-rs/polars/issues/24872, but we can add the pin here for now.
