### PR TITLE
Deprecate Series.data

### DIFF
--- a/cpp/src/io/utilities/hostdevice_vector.hpp
+++ b/cpp/src/io/utilities/hostdevice_vector.hpp
@@ -27,7 +27,6 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
-#include <rmm/mr/host/host_memory_resource.hpp>
 
 namespace cudf::detail {
 

--- a/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
@@ -702,6 +702,7 @@ class GroupedRollingWindow(Expr):
             plc.Scalar.from_py(1, plc.types.SIZE_TYPE),
         )
 
+        order_index: plc.Column | None
         if rank_named := unary_window_ops["rank"]:
             if self._order_by_expr is not None:
                 _, _, ob_desc, ob_nulls_last = self.options


### PR DESCRIPTION
## Description
This could return a private `Buffer` object which I don't think we want to expose.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
