### PR TITLE
Remove extraneous host_memory_resource include

### DIFF
--- a/cpp/src/io/utilities/hostdevice_vector.hpp
+++ b/cpp/src/io/utilities/hostdevice_vector.hpp
@@ -27,7 +27,6 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
-#include <rmm/mr/host/host_memory_resource.hpp>
 
 namespace cudf::detail {
 


### PR DESCRIPTION
## Description
This removes an extraneous include to help with https://github.com/rapidsai/rmm/issues/2090.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
