### PR TITLE
Add streams to cudf_polars.dsl.expressions.string

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -330,26 +330,39 @@ class StringFunction(Expr):
             return Column(
                 plc.strings.combine.concatenate(
                     plc.Table([col.obj for col in broadcasted]),
-                    plc.Scalar.from_py(delimiter, self.dtype.plc_type),
+                    plc.Scalar.from_py(
+                        delimiter, self.dtype.plc_type, stream=df.stream
+                    ),
                     None
                     if ignore_nulls
-                    else plc.Scalar.from_py(None, self.dtype.plc_type),
+                    else plc.Scalar.from_py(
+                        None, self.dtype.plc_type, stream=df.stream
+                    ),
                     None,
                     plc.strings.combine.SeparatorOnNulls.NO,
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
         elif self.name is StringFunction.Name.ConcatVertical:
             (child,) = self.children
-            column = child.evaluate(df, context=context).astype(self.dtype)
+            column = child.evaluate(df, context=context).astype(
+                self.dtype,
+            )
             delimiter, ignore_nulls = self.options
             if column.null_count > 0 and not ignore_nulls:
-                return Column(plc.Column.all_null_like(column.obj, 1), dtype=self.dtype)
+                return Column(
+                    plc.Column.all_null_like(column.obj, 1, stream=df.stream),
+                    dtype=self.dtype,
+                )
             return Column(
                 plc.strings.combine.join_strings(
                     column.obj,
-                    plc.Scalar.from_py(delimiter, self.dtype.plc_type),
-                    plc.Scalar.from_py(None, self.dtype.plc_type),
+                    plc.Scalar.from_py(
+                        delimiter, self.dtype.plc_type, stream=df.stream
+                    ),
+                    plc.Scalar.from_py(None, self.dtype.plc_type, stream=df.stream),
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
@@ -358,18 +371,24 @@ class StringFunction(Expr):
             # polars pads based on bytes, libcudf by visual width
             # only pass chars if the visual width matches the byte length
             column = self.children[0].evaluate(df, context=context)
-            col_len_bytes = plc.strings.attributes.count_bytes(column.obj)
-            col_len_chars = plc.strings.attributes.count_characters(column.obj)
+            col_len_bytes = plc.strings.attributes.count_bytes(
+                column.obj, stream=df.stream
+            )
+            col_len_chars = plc.strings.attributes.count_characters(
+                column.obj, stream=df.stream
+            )
             equal = plc.binaryop.binary_operation(
                 col_len_bytes,
                 col_len_chars,
                 plc.binaryop.BinaryOperator.NULL_EQUALS,
                 plc.DataType(plc.TypeId.BOOL8),
+                stream=df.stream,
             )
             if not plc.reduce.reduce(
                 equal,
                 plc.aggregation.all(),
                 plc.DataType(plc.TypeId.BOOL8),
+                stream=df.stream,
             ).to_py():
                 raise InvalidOperationError(
                     "zfill only supports ascii strings with no unicode characters"
@@ -380,22 +399,31 @@ class StringFunction(Expr):
                 if width.value is None:
                     return Column(
                         plc.Column.from_scalar(
-                            plc.Scalar.from_py(None, self.dtype.plc_type),
+                            plc.Scalar.from_py(
+                                None, self.dtype.plc_type, stream=df.stream
+                            ),
                             column.size,
+                            stream=df.stream,
                         ),
                         self.dtype,
                     )
                 return Column(
-                    plc.strings.padding.zfill(column.obj, width.value), self.dtype
+                    plc.strings.padding.zfill(
+                        column.obj, width.value, stream=df.stream
+                    ),
+                    self.dtype,
                 )
             else:
                 col_width = self.children[1].evaluate(df, context=context)
                 assert isinstance(col_width, Column)
                 all_gt_0 = plc.binaryop.binary_operation(
                     col_width.obj,
-                    plc.Scalar.from_py(0, plc.DataType(plc.TypeId.INT64)),
+                    plc.Scalar.from_py(
+                        0, plc.DataType(plc.TypeId.INT64), stream=df.stream
+                    ),
                     plc.binaryop.BinaryOperator.GREATER_EQUAL,
                     plc.DataType(plc.TypeId.BOOL8),
+                    stream=df.stream,
                 )
 
                 if (
@@ -404,12 +432,15 @@ class StringFunction(Expr):
                         all_gt_0,
                         plc.aggregation.all(),
                         plc.DataType(plc.TypeId.BOOL8),
+                        stream=df.stream,
                     ).to_py()
                 ):  # pragma: no cover
                     raise InvalidOperationError("fill conversion failed.")
 
                 return Column(
-                    plc.strings.padding.zfill_by_widths(column.obj, col_width.obj),
+                    plc.strings.padding.zfill_by_widths(
+                        column.obj, col_width.obj, stream=df.stream
+                    ),
                     self.dtype,
                 )
 
@@ -426,11 +457,14 @@ class StringFunction(Expr):
                     else pat.obj
                 )
                 return Column(
-                    plc.strings.find.contains(column.obj, pattern), dtype=self.dtype
+                    plc.strings.find.contains(column.obj, pattern, stream=df.stream),
+                    dtype=self.dtype,
                 )
             else:
                 return Column(
-                    plc.strings.contains.contains_re(column.obj, self._regex_program),
+                    plc.strings.contains.contains_re(
+                        column.obj, self._regex_program, stream=df.stream
+                    ),
                     dtype=self.dtype,
                 )
         elif self.name is StringFunction.Name.ContainsAny:
@@ -439,16 +473,18 @@ class StringFunction(Expr):
             plc_column = child.evaluate(df, context=context).obj
             plc_targets = arg.evaluate(df, context=context).obj
             if ascii_case_insensitive:
-                plc_column = plc.strings.case.to_lower(plc_column)
-                plc_targets = plc.strings.case.to_lower(plc_targets)
+                plc_column = plc.strings.case.to_lower(plc_column, stream=df.stream)
+                plc_targets = plc.strings.case.to_lower(plc_targets, stream=df.stream)
             contains = plc.strings.find_multiple.contains_multiple(
                 plc_column,
                 plc_targets,
+                stream=df.stream,
             )
             binary_or = functools.partial(
                 plc.binaryop.binary_operation,
                 op=plc.binaryop.BinaryOperator.BITWISE_OR,
                 output_type=self.dtype.plc_type,
+                stream=df.stream,
             )
             return Column(
                 functools.reduce(binary_or, contains.columns()),
@@ -459,8 +495,11 @@ class StringFunction(Expr):
             plc_column = child.evaluate(df, context=context).obj
             return Column(
                 plc.unary.cast(
-                    plc.strings.contains.count_re(plc_column, self._regex_program),
+                    plc.strings.contains.count_re(
+                        plc_column, self._regex_program, stream=df.stream
+                    ),
                     self.dtype.plc_type,
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
@@ -469,15 +508,14 @@ class StringFunction(Expr):
             plc_column = self.children[0].evaluate(df, context=context).obj
             return Column(
                 plc.strings.extract.extract_single(
-                    plc_column, self._regex_program, group_index - 1
+                    plc_column, self._regex_program, group_index - 1, stream=df.stream
                 ),
                 dtype=self.dtype,
             )
         elif self.name is StringFunction.Name.ExtractGroups:
             plc_column = self.children[0].evaluate(df, context=context).obj
             plc_table = plc.strings.extract.extract(
-                plc_column,
-                self._regex_program,
+                plc_column, self._regex_program, stream=df.stream
             )
             return Column(
                 plc.Column.struct_from_children(plc_table.columns()),
@@ -491,33 +529,40 @@ class StringFunction(Expr):
                 assert isinstance(expr, Literal)
                 plc_column = plc.strings.find.find(
                     plc_column,
-                    plc.Scalar.from_py(expr.value, expr.dtype.plc_type),
+                    plc.Scalar.from_py(
+                        expr.value, expr.dtype.plc_type, stream=df.stream
+                    ),
+                    stream=df.stream,
                 )
             else:
                 plc_column = plc.strings.findall.find_re(
-                    plc_column,
-                    self._regex_program,
+                    plc_column, self._regex_program, stream=df.stream
                 )
             # Polars returns None for not found, libcudf returns -1
             new_mask, null_count = plc.transform.bools_to_mask(
                 plc.binaryop.binary_operation(
                     plc_column,
-                    plc.Scalar.from_py(-1, plc_column.type()),
+                    plc.Scalar.from_py(-1, plc_column.type(), stream=df.stream),
                     plc.binaryop.BinaryOperator.NOT_EQUAL,
                     plc.DataType(plc.TypeId.BOOL8),
-                )
+                    stream=df.stream,
+                ),
+                stream=df.stream,
             )
             plc_column = plc.unary.cast(
-                plc_column.with_mask(new_mask, null_count), self.dtype.plc_type
+                plc_column.with_mask(new_mask, null_count),
+                self.dtype.plc_type,
+                stream=df.stream,
             )
             return Column(plc_column, dtype=self.dtype)
         elif self.name is StringFunction.Name.JsonDecode:
             plc_column = self.children[0].evaluate(df, context=context).obj
             plc_table_with_metadata = plc.io.json.read_json_from_string_column(
                 plc_column,
-                plc.Scalar.from_py("\n"),
-                plc.Scalar.from_py("NULL"),
+                plc.Scalar.from_py("\n", stream=df.stream),
+                plc.Scalar.from_py("NULL", stream=df.stream),
                 _dtypes_for_json_decode(self.dtype),
+                stream=df.stream,
             )
             return Column(
                 plc.Column.struct_from_children(plc_table_with_metadata.columns),
@@ -527,16 +572,20 @@ class StringFunction(Expr):
             (child, expr) = self.children
             plc_column = child.evaluate(df, context=context).obj
             assert isinstance(expr, Literal)
-            json_path = plc.Scalar.from_py(expr.value, expr.dtype.plc_type)
+            json_path = plc.Scalar.from_py(
+                expr.value, expr.dtype.plc_type, stream=df.stream
+            )
             return Column(
-                plc.json.get_json_object(plc_column, json_path),
+                plc.json.get_json_object(plc_column, json_path, stream=df.stream),
                 dtype=self.dtype,
             )
         elif self.name is StringFunction.Name.LenBytes:
             plc_column = self.children[0].evaluate(df, context=context).obj
             return Column(
                 plc.unary.cast(
-                    plc.strings.attributes.count_bytes(plc_column), self.dtype.plc_type
+                    plc.strings.attributes.count_bytes(plc_column, stream=df.stream),
+                    self.dtype.plc_type,
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
@@ -544,8 +593,11 @@ class StringFunction(Expr):
             plc_column = self.children[0].evaluate(df, context=context).obj
             return Column(
                 plc.unary.cast(
-                    plc.strings.attributes.count_characters(plc_column),
+                    plc.strings.attributes.count_characters(
+                        plc_column, stream=df.stream
+                    ),
                     self.dtype.plc_type,
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
@@ -575,8 +627,13 @@ class StringFunction(Expr):
             return Column(
                 plc.strings.slice.slice_strings(
                     column.obj,
-                    plc.Scalar.from_py(start, plc.DataType(plc.TypeId.INT32)),
-                    plc.Scalar.from_py(stop, plc.DataType(plc.TypeId.INT32)),
+                    plc.Scalar.from_py(
+                        start, plc.DataType(plc.TypeId.INT32), stream=df.stream
+                    ),
+                    plc.Scalar.from_py(
+                        stop, plc.DataType(plc.TypeId.INT32), stream=df.stream
+                    ),
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
@@ -600,7 +657,9 @@ class StringFunction(Expr):
                 )
             else:
                 assert isinstance(expr, Literal)
-                by = plc.Scalar.from_py(expr.value, expr.dtype.plc_type)
+                by = plc.Scalar.from_py(
+                    expr.value, expr.dtype.plc_type, stream=df.stream
+                )
                 # See https://github.com/pola-rs/polars/issues/11640
                 # for SplitN vs SplitExact edge case behaviors
                 max_splits = n if is_split_n else 0
@@ -608,13 +667,16 @@ class StringFunction(Expr):
                     column.obj,
                     by,
                     max_splits - 1,
+                    stream=df.stream,
                 )
                 children = plc_table.columns()
                 ref_column = children[0]
                 if (remainder := n - len(children)) > 0:
                     # Reach expected number of splits by padding with nulls
                     children.extend(
-                        plc.Column.all_null_like(ref_column, ref_column.size())
+                        plc.Column.all_null_like(
+                            ref_column, ref_column.size(), stream=df.stream
+                        )
                         for _ in range(remainder + int(not is_split_n))
                     )
                 if not is_split_n:
@@ -638,7 +700,9 @@ class StringFunction(Expr):
             child, expr = self.children
             plc_column = child.evaluate(df, context=context).obj
             assert isinstance(expr, Literal)
-            target = plc.Scalar.from_py(expr.value, expr.dtype.plc_type)
+            target = plc.Scalar.from_py(
+                expr.value, expr.dtype.plc_type, stream=df.stream
+            )
             if self.name == StringFunction.Name.StripPrefix:
                 find = plc.strings.find.starts_with
                 start = len(expr.value)
@@ -648,17 +712,23 @@ class StringFunction(Expr):
                 start = 0
                 end = -len(expr.value)
 
-            mask = find(plc_column, target)
+            mask = find(plc_column, target, stream=df.stream)
             sliced = plc.strings.slice.slice_strings(
                 plc_column,
-                plc.Scalar.from_py(start, plc.DataType(plc.TypeId.INT32)),
-                plc.Scalar.from_py(end, plc.DataType(plc.TypeId.INT32)),
+                plc.Scalar.from_py(
+                    start, plc.DataType(plc.TypeId.INT32), stream=df.stream
+                ),
+                plc.Scalar.from_py(
+                    end, plc.DataType(plc.TypeId.INT32), stream=df.stream
+                ),
+                stream=df.stream,
             )
             return Column(
                 plc.copying.copy_if_else(
                     sliced,
                     plc_column,
                     mask,
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
@@ -675,7 +745,12 @@ class StringFunction(Expr):
             else:
                 side = plc.strings.SideType.BOTH
             return Column(
-                plc.strings.strip.strip(column.obj, side, chars.obj_scalar),
+                plc.strings.strip.strip(
+                    column.obj,
+                    side,
+                    chars.obj_scalar,
+                    stream=df.stream,
+                ),
                 dtype=self.dtype,
             )
 
@@ -686,15 +761,17 @@ class StringFunction(Expr):
             if self.children[1].value is None:
                 return Column(
                     plc.Column.from_scalar(
-                        plc.Scalar.from_py(None, self.dtype.plc_type),
+                        plc.Scalar.from_py(None, self.dtype.plc_type, stream=df.stream),
                         column.size,
+                        stream=df.stream,
                     ),
                     self.dtype,
                 )
             elif self.children[1].value == 0:
                 result = plc.Column.from_scalar(
-                    plc.Scalar.from_py("", self.dtype.plc_type),
+                    plc.Scalar.from_py("", self.dtype.plc_type, stream=df.stream),
                     column.size,
+                    stream=df.stream,
                 )
                 if column.obj.null_mask():
                     result = result.with_mask(
@@ -708,9 +785,14 @@ class StringFunction(Expr):
                 return Column(
                     plc.strings.slice.slice_strings(
                         column.obj,
-                        plc.Scalar.from_py(start, plc.DataType(plc.TypeId.INT32)),
-                        plc.Scalar.from_py(end, plc.DataType(plc.TypeId.INT32)),
+                        plc.Scalar.from_py(
+                            start, plc.DataType(plc.TypeId.INT32), stream=df.stream
+                        ),
+                        plc.Scalar.from_py(
+                            end, plc.DataType(plc.TypeId.INT32), stream=df.stream
+                        ),
                         None,
+                        stream=df.stream,
                     ),
                     self.dtype,
                 )
@@ -723,16 +805,22 @@ class StringFunction(Expr):
             if end is None:
                 return Column(
                     plc.Column.from_scalar(
-                        plc.Scalar.from_py(None, self.dtype.plc_type),
+                        plc.Scalar.from_py(None, self.dtype.plc_type, stream=df.stream),
                         column.size,
+                        stream=df.stream,
                     ),
                     self.dtype,
                 )
             return Column(
                 plc.strings.slice.slice_strings(
                     column.obj,
-                    plc.Scalar.from_py(0, plc.DataType(plc.TypeId.INT32)),
-                    plc.Scalar.from_py(end, plc.DataType(plc.TypeId.INT32)),
+                    plc.Scalar.from_py(
+                        0, plc.DataType(plc.TypeId.INT32), stream=df.stream
+                    ),
+                    plc.Scalar.from_py(
+                        end, plc.DataType(plc.TypeId.INT32), stream=df.stream
+                    ),
+                    stream=df.stream,
                 ),
                 self.dtype,
             )
@@ -740,10 +828,16 @@ class StringFunction(Expr):
         columns = [child.evaluate(df, context=context) for child in self.children]
         if self.name is StringFunction.Name.Lowercase:
             (column,) = columns
-            return Column(plc.strings.case.to_lower(column.obj), dtype=self.dtype)
+            return Column(
+                plc.strings.case.to_lower(column.obj, stream=df.stream),
+                dtype=self.dtype,
+            )
         elif self.name is StringFunction.Name.Uppercase:
             (column,) = columns
-            return Column(plc.strings.case.to_upper(column.obj), dtype=self.dtype)
+            return Column(
+                plc.strings.case.to_upper(column.obj, stream=df.stream),
+                dtype=self.dtype,
+            )
         elif self.name is StringFunction.Name.EndsWith:
             column, suffix = columns
             return Column(
@@ -752,6 +846,7 @@ class StringFunction(Expr):
                     suffix.obj_scalar
                     if column.size != suffix.size and suffix.is_scalar
                     else suffix.obj,
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
@@ -763,6 +858,7 @@ class StringFunction(Expr):
                     prefix.obj_scalar
                     if column.size != prefix.size and prefix.is_scalar
                     else prefix.obj,
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
@@ -774,22 +870,27 @@ class StringFunction(Expr):
             if plc_col.null_count() == plc_col.size():
                 return Column(
                     plc.Column.from_scalar(
-                        plc.Scalar.from_py(None, self.dtype.plc_type),
+                        plc.Scalar.from_py(None, self.dtype.plc_type, stream=df.stream),
                         plc_col.size(),
+                        stream=df.stream,
                     ),
                     self.dtype,
                 )
             if format is None:
                 # Polars begins inference with the first non null value
                 if plc_col.null_mask() is not None:
-                    boolmask = plc.unary.is_valid(plc_col)
+                    boolmask = plc.unary.is_valid(plc_col, stream=df.stream)
                     table = plc.stream_compaction.apply_boolean_mask(
-                        plc.Table([plc_col]), boolmask
+                        plc.Table([plc_col]), boolmask, stream=df.stream
                     )
                     filtered = table.columns()[0]
-                    first_valid_data = plc.copying.get_element(filtered, 0).to_py()
+                    first_valid_data = plc.copying.get_element(
+                        filtered, 0, stream=df.stream
+                    ).to_py()
                 else:
-                    first_valid_data = plc.copying.get_element(plc_col, 0).to_py()
+                    first_valid_data = plc.copying.get_element(
+                        plc_col, 0, stream=df.stream
+                    ).to_py()
 
                 # See https://github.com/rapidsai/cudf/issues/20202 for we type ignore
                 format = _infer_datetime_format(first_valid_data)  # type: ignore[arg-type]
@@ -799,27 +900,28 @@ class StringFunction(Expr):
                     )
 
             is_timestamps = plc.strings.convert.convert_datetime.is_timestamp(
-                plc_col, format
+                plc_col, format, stream=df.stream
             )
             if strict:
                 if not plc.reduce.reduce(
                     is_timestamps,
                     plc.aggregation.all(),
                     plc.DataType(plc.TypeId.BOOL8),
+                    stream=df.stream,
                 ).to_py():
                     raise InvalidOperationError("conversion from `str` failed.")
             else:
                 not_timestamps = plc.unary.unary_operation(
-                    is_timestamps, plc.unary.UnaryOperator.NOT
+                    is_timestamps, plc.unary.UnaryOperator.NOT, stream=df.stream
                 )
-                null = plc.Scalar.from_py(None, plc_col.type())
+                null = plc.Scalar.from_py(None, plc_col.type(), stream=df.stream)
                 plc_col = plc.copying.boolean_mask_scatter(
-                    [null], plc.Table([plc_col]), not_timestamps
+                    [null], plc.Table([plc_col]), not_timestamps, stream=df.stream
                 ).columns()[0]
 
             return Column(
                 plc.strings.convert.convert_datetime.to_timestamps(
-                    plc_col, self.dtype.plc_type, format
+                    plc_col, self.dtype.plc_type, format, stream=df.stream
                 ),
                 dtype=self.dtype,
             )
@@ -832,6 +934,7 @@ class StringFunction(Expr):
                     col_target.obj_scalar,
                     col_repl.obj_scalar,
                     maxrepl=n,
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
@@ -839,7 +942,7 @@ class StringFunction(Expr):
             col_column, col_target, col_repl = columns
             return Column(
                 plc.strings.replace.replace_multiple(
-                    col_column.obj, col_target.obj, col_repl.obj
+                    col_column.obj, col_target.obj, col_repl.obj, stream=df.stream
                 ),
                 dtype=self.dtype,
             )
@@ -853,13 +956,14 @@ class StringFunction(Expr):
                 # TODO: Maybe accept a string scalar in
                 # cudf::strings::pad to avoid DtoH transfer
                 # See https://github.com/rapidsai/cudf/issues/20202 for we type ignore
-                width: int = width_col.obj.to_scalar().to_py()  # type: ignore[assignment, no-redef]
+                width: int = width_col.obj.to_scalar(stream=df.stream).to_py()  # type: ignore[assignment, no-redef]
             return Column(
                 plc.strings.padding.pad(
                     column.obj,
                     width,  # type: ignore[arg-type]
                     plc.strings.SideType.LEFT,
                     char,  # type: ignore[arg-type]
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
@@ -872,22 +976,29 @@ class StringFunction(Expr):
                 (char,) = self.options
                 # TODO: Maybe accept a string scalar in
                 # cudf::strings::pad to avoid DtoH transfer
-                width: int = width_col.obj.to_scalar().to_py()  # type: ignore[assignment, no-redef]
+                width: int = width_col.obj.to_scalar(stream=df.stream).to_py()  # type: ignore[assignment, no-redef]
             return Column(
                 plc.strings.padding.pad(
                     column.obj,
                     width,  # type: ignore[arg-type]
                     plc.strings.SideType.RIGHT,
                     char,  # type: ignore[arg-type]
+                    stream=df.stream,
                 ),
                 dtype=self.dtype,
             )
         elif self.name is StringFunction.Name.Reverse:
             (column,) = columns
-            return Column(plc.strings.reverse.reverse(column.obj), dtype=self.dtype)
+            return Column(
+                plc.strings.reverse.reverse(column.obj, stream=df.stream),
+                dtype=self.dtype,
+            )
         elif self.name is StringFunction.Name.Titlecase:
             (column,) = columns
-            return Column(plc.strings.capitalize.title(column.obj), dtype=self.dtype)
+            return Column(
+                plc.strings.capitalize.title(column.obj, stream=df.stream),
+                dtype=self.dtype,
+            )
         raise NotImplementedError(
             f"StringFunction {self.name}"
         )  # pragma: no cover; handled by init raising


### PR DESCRIPTION
## Description

This adds streams to all pylibcudf operations in `cudf_polars.dsl.expressions.string`, excluding

- `broadcast`
- `Column.astype`
- `Column.obj_scalar`

which require more extensive changes.

Split off https://github.com/rapidsai/cudf/pull/20291.