### PR TITLE
Avoid Column materialization in RangeIndex.nans_to_nulls

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -182,7 +182,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
         return cls._from_data(col_accessor)
 
     @_performance_tracking
-    def nans_to_nulls(self):
+    def nans_to_nulls(self) -> Self:
         result = []
         for col in self._columns:
             converted = col.nans_to_nulls()

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -3413,6 +3413,10 @@ class RangeIndex(Index):
 
         return self._column.isin(values).values
 
+    @_performance_tracking
+    def nans_to_nulls(self) -> Self:
+        return self.copy()
+
     def __pos__(self) -> Self:
         return self.copy()
 

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -1890,7 +1890,7 @@ class IndexedFrame(Frame):
         )
 
     @_performance_tracking
-    def nans_to_nulls(self):
+    def nans_to_nulls(self) -> Self:
         """
         Convert nans (if any) to nulls
 


### PR DESCRIPTION
## Description
Follow up to https://github.com/rapidsai/cudf/pull/20314

Realized after review we can avoid materializing the `range` to a `Column`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
