### PR TITLE
Find RMM before CCCL

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -277,9 +277,6 @@ include(${rapids-cmake-dir}/cpm/rapids_logger.cmake)
 rapids_cpm_rapids_logger(BUILD_EXPORT_SET cudf-exports INSTALL_EXPORT_SET cudf-exports)
 create_logger_macros(CUDF "cudf::default_logger()" include/cudf)
 
-# find rmm
-include(cmake/thirdparty/get_rmm.cmake)
-
 # find jitify
 include(cmake/thirdparty/get_jitify.cmake)
 
@@ -291,6 +288,9 @@ include(cmake/thirdparty/get_nvcomp.cmake)
 
 # find CCCL
 include(cmake/thirdparty/get_cccl.cmake)
+
+# find rmm, should come after including CCCL to allow overriding the CCCL version used for testing
+include(cmake/thirdparty/get_rmm.cmake)
 
 # find croaring
 include(cmake/thirdparty/get_croaring.cmake)


### PR DESCRIPTION
## Description
Since #18235, cudf has not needed CCCL patches. However, that change missed reordering the `get_XXX` includes, so we have still always been cloning and using a separate CCCL version. Fix that by reordering. We also move the search for RMM before searching for NVTX since an RMM build can also supply that.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
