### PR TITLE
Don't skip blank CSV lines rows after the header in cudf-polars scan_csv

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -646,6 +646,7 @@ class Scan(IR):
                     plc.io.csv.CsvReaderOptions.builder(plc.io.SourceInfo([path]))
                     .nrows(n_rows)
                     .skiprows(skiprows + skip_rows)
+                    .skip_blank_lines(skip_blank_lines=False)
                     .lineterminator(str(eol))
                     .quotechar(str(quote))
                     .decimal(decimal)

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -613,3 +613,13 @@ def test_scan_parquet_with_decimal_literal_in_predicate(df, tmp_path):
     )
 
     assert_gpu_result_equal(q)
+
+
+def test_scan_csv_blank_line(tmp_path):
+    data = """c0
+
+polars"""
+    fle = tmp_path / "test.csv"
+    fle.write_text(data)
+    q = pl.scan_csv(fle)
+    assert_gpu_result_equal(q)


### PR DESCRIPTION
## Description
Fixes https://github.com/pola-rs/polars/issues/24986

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
