### PR TITLE
Honor user-passed stream in slice_strings for scalar inputs

### DIFF
--- a/python/pylibcudf/pylibcudf/strings/slice.pyx
+++ b/python/pylibcudf/pylibcudf/strings/slice.pyx
@@ -85,17 +85,14 @@ cpdef Column slice_strings(
 
     elif ColumnOrScalar is Scalar:
         if start is None:
-            stream = _get_stream(None)
             start = Scalar.from_libcudf(
                 cpp_make_fixed_width_scalar(0, stream.view(), mr.get_mr())
             )
         if stop is None:
-            stream = _get_stream(None)
             stop = Scalar.from_libcudf(
                 cpp_make_fixed_width_scalar(0, stream.view(), mr.get_mr())
             )
         if step is None:
-            stream = _get_stream(None)
             step = Scalar.from_libcudf(
                 cpp_make_fixed_width_scalar(1, stream.view(), mr.get_mr())
             )


### PR DESCRIPTION
## Description
`stream` is initialized above from the function input, so we shouldn't need to reinitialize a default stream here

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
