### PR TITLE
Skip failing cudf-polars test due to hash groupby bug

### DIFF
--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -266,6 +266,9 @@ def test_groupby_agg_broadcast_raises(df):
 
 @pytest.mark.parametrize("nrows", [30, 300, 300_000])
 @pytest.mark.parametrize("nkeys", [1, 2, 4])
+@pytest.mark.skip(
+    reason=" Hash groupby bug: See https://github.com/rapidsai/cudf/issues/20345"
+)
 def test_groupby_maintain_order_random(nrows, nkeys, with_nulls):
     key_names = [f"key{key}" for key in range(nkeys)]
     rng = random.Random(2)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Example failure: https://github.com/rapidsai/cudf/actions/runs/18757451976/job/53525313996?pr=20350#step:10:2276

It's not failing in all CI jobs, so I'm skipping the test for now. If we find the exact conditions causing it to fail, we can add guard and xfail the test. The underlying issue is described in #20345.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
