### PR TITLE
Remove/Replace uses of numba.cuda arrays in pytest benchmarks and tests

### DIFF
--- a/python/cudf/benchmarks/API/bench_dataframe.py
+++ b/python/cudf/benchmarks/API/bench_dataframe.py
@@ -4,7 +4,6 @@
 
 import string
 
-import numba.cuda
 import numpy
 import pandas as pd
 import pyarrow as pa
@@ -174,12 +173,6 @@ def bench_from_arrow(benchmark, N):
 @pytest.mark.parametrize("N", NUM_ROWS)
 def bench_construction(benchmark, N):
     benchmark(cudf.DataFrame, {None: cupy.random.rand(N)})
-
-
-@pytest.mark.parametrize("N", NUM_ROWS)
-@pytest.mark.pandas_incompatible
-def bench_construction_numba_device_array(benchmark, N):
-    benchmark(cudf.DataFrame, numba.cuda.to_device(numpy.ones((100, N))))
 
 
 @benchmark_with_object(cls="dataframe", dtype="float", cols=6)

--- a/python/cudf/cudf/tests/dataframe/methods/test_where.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_where.py
@@ -4,7 +4,6 @@ import cupy as cp
 import numpy as np
 import pandas as pd
 import pytest
-from numba import cuda
 
 import cudf
 from cudf.testing import assert_eq
@@ -170,10 +169,8 @@ def test_frame_series_where_other():
         ),
         (
             pd.DataFrame({"p": [-2, 3, -4, -79], "k": [9, 10, 11, 12]}),
-            cuda.to_device(
-                np.array(
-                    [[True, True], [False, True], [True, False], [False, True]]
-                )
+            cp.array(
+                [[True, True], [False, True], [True, False], [False, True]]
             ),
             None,
             None,

--- a/python/cudf/cudf/tests/dataframe/test_constructors.py
+++ b/python/cudf/cudf/tests/dataframe/test_constructors.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from numba import cuda
 
 import cudf
 from cudf.core.column.column import as_column
@@ -1060,15 +1059,10 @@ def test_change_column_dtype_in_empty():
 def test_dataframe_init_from_arrays_cols(data, cols, index):
     gd_data = data
     if isinstance(data, cp.ndarray):
-        # pandas can't handle cp arrays in general
+        # pandas can't handle cupy arrays
         pd_data = data.get()
-
-        # additional test for building DataFrame with gpu array whose
-        # cuda array interface has no `descr` attribute
-        numba_data = cuda.as_cuda_array(data)
     else:
         pd_data = data
-        numba_data = None
 
     # verify with columns & index
     pdf = pd.DataFrame(pd_data, columns=cols, index=index)
@@ -1086,10 +1080,6 @@ def test_dataframe_init_from_arrays_cols(data, cols, index):
     gdf = cudf.DataFrame(gd_data)
 
     assert_eq(pdf, gdf, check_dtype=False)
-
-    if numba_data is not None:
-        gdf = cudf.DataFrame(numba_data)
-        assert_eq(pdf, gdf, check_dtype=False)
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/private_objects/test_column.py
+++ b/python/cudf/cudf/tests/private_objects/test_column.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from numba import cuda
 
 import rmm
 
@@ -256,7 +255,7 @@ def test_column_zero_length_slice():
     the_column = x[1:]["a"]._column
 
     expect = np.array([], dtype="int8")
-    got = cuda.as_cuda_array(the_column.data).copy_to_host()
+    got = cp.asarray(the_column.data).get()
 
     np.testing.assert_array_equal(expect, got)
 

--- a/python/cudf/cudf/tests/series/test_constructors.py
+++ b/python/cudf/cudf/tests/series/test_constructors.py
@@ -6,7 +6,6 @@ import types
 import zoneinfo
 
 import cupy as cp
-import numba.cuda
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -947,23 +946,16 @@ def test_series_arrow_decimal_types_roundtrip(pa_type):
         assert_eq(pdf, gdf)
 
 
-@pytest.mark.parametrize("module", ["cupy", "numba"])
-def test_cuda_array_interface_interop_in(
-    numeric_and_temporal_types_as_str, module
-):
-    if module == "cupy":
-        module_constructor = cp.array
-        if numeric_and_temporal_types_as_str.startswith(
-            "datetime"
-        ) or numeric_and_temporal_types_as_str.startswith("timedelta"):
-            pytest.skip(
-                f"cupy doesn't support {numeric_and_temporal_types_as_str}"
-            )
-    elif module == "numba":
-        module_constructor = numba.cuda.to_device
+def test_cuda_array_interface_interop_in(numeric_and_temporal_types_as_str):
+    if numeric_and_temporal_types_as_str.startswith(
+        "datetime"
+    ) or numeric_and_temporal_types_as_str.startswith("timedelta"):
+        pytest.skip(
+            f"cupy doesn't support {numeric_and_temporal_types_as_str}"
+        )
 
     np_data = np.arange(10).astype(numeric_and_temporal_types_as_str)
-    module_data = module_constructor(np_data)
+    module_data = cp.array(np_data)
 
     pd_data = pd.Series(np_data)
     # Test using a specific function for __cuda_array_interface__ here
@@ -977,27 +969,13 @@ def test_cuda_array_interface_interop_in(
     assert_eq(pd_data, gdf["test"])
 
 
-@pytest.mark.parametrize("module", ["cupy", "numba"])
-def test_cuda_array_interface_interop_out(
-    numeric_and_temporal_types_as_str, module
-):
-    if module == "cupy":
-        module_constructor = cp.asarray
-
-        def to_host_function(x):
-            return cp.asnumpy(x)
-    elif module == "numba":
-        module_constructor = numba.cuda.as_cuda_array
-
-        def to_host_function(x):
-            return x.copy_to_host()
-
+def test_cuda_array_interface_interop_out(numeric_and_temporal_types_as_str):
     np_data = np.arange(10).astype(numeric_and_temporal_types_as_str)
     cudf_data = cudf.Series(np_data)
     assert isinstance(cudf_data.__cuda_array_interface__, dict)
 
-    module_data = module_constructor(cudf_data)
-    got = to_host_function(module_data)
+    module_data = cp.asarray(cudf_data)
+    got = cp.asnumpy(module_data)
 
     expect = np_data
 
@@ -1048,11 +1026,9 @@ def test_cuda_array_interface_as_column(
 
     if mask_type == "bools":
         if nulls == "some":
-            obj.__cuda_array_interface__["mask"] = numba.cuda.to_device(mask)
+            obj.__cuda_array_interface__["mask"] = cp.asarray(mask)
         elif nulls == "all":
-            obj.__cuda_array_interface__["mask"] = numba.cuda.to_device(
-                [False] * 10
-            )
+            obj.__cuda_array_interface__["mask"] = cp.array([False] * 10)
 
     expect = sr
     got = cudf.Series(obj)


### PR DESCRIPTION
## Description

cupy arrays should generally be our `__cuda_array_interface__` reference object instead of numba array constructors, `numba.cuda.as_cuda_array` or `numba.cuda.to_device`.

Removes usage where we already have redundant cupy coverage and replaces otherwise.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
