### PR TITLE
Minor cleanup and fixes for libcudf generate_input.cu

### DIFF
--- a/cpp/benchmarks/join/join_common.hpp
+++ b/cpp/benchmarks/join/join_common.hpp
@@ -15,19 +15,12 @@
 
 #include <cudf/ast/expressions.hpp>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/valid_if.cuh>
 #include <cudf/filling.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
-
-#include <cuda/std/functional>
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/transform_iterator.h>
-#include <thrust/random/linear_congruential_engine.h>
-#include <thrust/random/uniform_int_distribution.h>
 
 #include <nvbench/nvbench.cuh>
 


### PR DESCRIPTION
## Description
Some minor cleanup in the benchmarks/common/generate_input.cu including:
- replace most `cudf::detail::valid_if` calls with `cudf::bools_to_mask`
- add anonymous namespace which found a few unused functions that could be deleted
- fixed UTF8 generation of multi-byte characters
-  removed unneeded header includes
-  forced sizes to 0 in null rows when creating offsets for generated list columns

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
