### PR TITLE
Fix a few SPDX-related issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,7 +147,7 @@ repos:
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.1.0
+    rev: v1.2.0
     hooks:
       - id: verify-copyright
         name: verify-copyright-cudf

--- a/cpp/include/cudf/hashing/detail/hash_functions.cuh
+++ b/cpp/include/cudf/hashing/detail/hash_functions.cuh
@@ -78,7 +78,7 @@ __device__ inline uint64_t swap_endian(uint64_t x)
 
 /**
  * SPDX-SnippetBegin
- * SPDX-FileCopyrightText: Copyright (c) 2015 Barry Clark
+ * SPDX-SnippetCopyrightText: Copyright (c) 2015 Barry Clark
  * SPDX-License-Identifier: MIT
  *
  * Modified GPU implementation of

--- a/cpp/include/cudf/hashing/detail/hashing.hpp
+++ b/cpp/include/cudf/hashing/detail/hashing.hpp
@@ -61,7 +61,7 @@ std::unique_ptr<column> xxhash_64(table_view const& input,
                                   rmm::device_async_resource_ref mr);
 
 /* SPDX-SnippetBegin
- * SPDX-FileCopyrightText: Copyright 2005-2014 Daniel James.
+ * SPDX-SnippetCopyrightText: Copyright 2005-2014 Daniel James.
  * SPDX-License-Identifier: BSL-1.0
  *
  * Copyright 2005-2014 Daniel James.
@@ -86,7 +86,7 @@ CUDF_HOST_DEVICE constexpr uint32_t hash_combine(uint32_t lhs, uint32_t rhs)
 // SPDX-SnippetEnd
 
 /* SPDX-SnippetBegin
- * SPDX-FileCopyrightText: Copyright 2005-2014 Daniel James.
+ * SPDX-SnippetCopyrightText: Copyright 2005-2014 Daniel James.
  * SPDX-License-Identifier: BSL-1.0
  *
  * Copyright 2005-2014 Daniel James.


### PR DESCRIPTION
## Description
* Bump pre-commit-hooks to v1.2.0
* Snippets should have `SPDX-SnippetCopyrightText`, not `SPDX-FileCopyrightText`

Issue: https://github.com/rapidsai/build-infra/issues/297

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
