### PR TITLE
Add missing CUDA stream to cudf-polars left-semi join

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -2359,7 +2359,7 @@ class Join(IR):
         join_fn, left_policy, right_policy = cls._joiners(how)
         if right_policy is None:
             # Semi join
-            lg = join_fn(left_on.table, right_on.table, null_equality)
+            lg = join_fn(left_on.table, right_on.table, null_equality, stream)
             table = plc.copying.gather(left.table, lg, left_policy, stream=stream)
             result = DataFrame.from_table(
                 table, left.column_names, left.dtypes, stream=stream


### PR DESCRIPTION
## Description

https://github.com/rapidsai/cudf/pull/20291 missed a spot in `Join` where we need to pass the CUDA stream to the pylibcudf join function. This shows up in PDSH query 4.
