### PR TITLE
Enable copy-on-write in cudf.pandas

### DIFF
--- a/python/cudf/cudf/pandas/scripts/conftest-patch.py
+++ b/python/cudf/cudf/pandas/scripts/conftest-patch.py
@@ -10605,6 +10605,7 @@ NODEIDS_THAT_ARE_FLAKY_WITH_COPY_ON_WRITE: set[str] = {
     "tests/strings/test_find_replace.py::test_contains[string=str[python]]",
     "tests/strings/test_find_replace.py::test_contains[string=string[pyarrow]]",
     "tests/window/moments/test_moments_consistency_rolling.py::test_rolling_consistency_series_cov_corr[series_data1-rolling_consistency_cases0-False-0]",
+    "tests/window/test_dtypes.py::test_dataframe_dtypes[category-None-max-expected_data1-None]",
     "tests/window/test_dtypes.py::test_dataframe_dtypes[category-None-min-expected_data2-None]",
     "tests/window/test_dtypes.py::test_dataframe_dtypes[category-None-std-expected_data5-None]",
     "tests/window/test_dtypes.py::test_dataframe_dtypes[category-None-sum-expected_data3-None]",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This change is made in preparation for pandas 3.0. We already have some discrepancies with being a perfect pandas replacement, but as we work to close that gap in #18659 we're OK with switching this default behavior so that we can run to where the puck will soon be as far as aiming for pandas 3.0 compatibility. 

Closes #19946

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
