### PR TITLE
Use `RAPIDS_BRANCH` in cmake-format invocations that need rapids-cmake configs

### DIFF
--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -17,10 +17,10 @@ rapids-dependency-file-generator \
 rapids-mamba-retry env create --yes -f "${ENV_YAML_DIR}/env.yaml" -n checks
 conda activate checks
 
-RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
+RAPIDS_BRANCH="$(cat "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../RAPIDS_BRANCH)"
 
-FORMAT_FILE_URL="https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_VERSION_MAJOR_MINOR}/cmake-format-rapids-cmake.json"
-export RAPIDS_CMAKE_FORMAT_FILE=/tmp/rapids_cmake_ci/cmake-formats-rapids-cmake.json
+FORMAT_FILE_URL="https://raw.githubusercontent.com/rapidsai/rapids-cmake/${RAPIDS_BRANCH}/cmake-format-rapids-cmake.json"
+export RAPIDS_CMAKE_FORMAT_FILE=/tmp/rapids_cmake_ci/cmake-format-rapids-cmake.json
 mkdir -p "$(dirname "${RAPIDS_CMAKE_FORMAT_FILE}")"
 wget -O ${RAPIDS_CMAKE_FORMAT_FILE} "${FORMAT_FILE_URL}"
 


### PR DESCRIPTION
This uses `RAPIDS_BRANCH` in style checks where we reference rapids-cmake configs for `cmake-format`.

xref: https://github.com/rapidsai/build-planning/issues/224
