### PR TITLE
Add option to reset memory resource in PDSH benchmarks

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -839,11 +839,11 @@ def parse_args(
         help="Enable statistics planning.",
     )
     parser.add_argument(
-        "--reset-memory-resource-pool",
+        "--reset-memory-resource",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=False,
         help=(
-            "Reset the memory resource pool between each iteration. "
+            "Reset the memory resource between each iteration. "
             "Note: this only affects the single-node cluster."
         ),
     )
@@ -937,7 +937,7 @@ def run_polars(
             if args.print_results:
                 print(result)
 
-            if run_config.executor != "cpu" and args.reset_memory_resource_pool:
+            if run_config.executor != "cpu" and args.reset_memory_resource:
                 import cudf_polars.callback
 
                 cudf_polars.callback.default_memory_resource.cache_clear()


### PR DESCRIPTION
## Description

This adds a CLI flag to reset the memory pool between iterations in the PDSH benchmark.
 
We really only expect this to have an effect for the default memory resource, which uses UVM. We've observed some instability in memory usage, which this flag might help address.

The main decision point here is whether to reset the memory resource by default or not. IMO, we do want to reset it to improve the stability of the benchmark between iterations. But this would be a change from previous behavior so I've left the default as not reseting the memory resource.

Here's a screenshot of an nsys profile for two iterations of query 2:

<img width="2391" height="353" alt="image" src="https://github.com/user-attachments/assets/1ea8bf4e-f286-484d-8741-a2d07c43b143" />

On the left is `--reset-memory-resource`. You can see "Managed memory usage" drop to zero after the first iteration as the memory resource is dropped and its memory freed.

On the right is `--no-reset-memory-resource`. The reference to the MR is cached, and so memory is never freed from the pool.