### PR TITLE
Remove unneeded type check in cudf::strings::slice_strings

### DIFF
--- a/cpp/src/strings/slice.cu
+++ b/cpp/src/strings/slice.cu
@@ -327,17 +327,8 @@ std::unique_ptr<column> slice_strings(strings_column_view const& input,
                "Parameter starts must have the same number of rows as strings.");
   CUDF_EXPECTS(stops_column.size() == input.size(),
                "Parameter stops must have the same number of rows as strings.");
-  CUDF_EXPECTS(cudf::have_same_types(starts_column, stops_column),
-               "Parameters starts and stops must be of the same type.",
-               cudf::data_type_error);
   CUDF_EXPECTS(starts_column.null_count() == 0, "Parameter starts must not contain nulls.");
   CUDF_EXPECTS(stops_column.null_count() == 0, "Parameter stops must not contain nulls.");
-  CUDF_EXPECTS(starts_column.type().id() != data_type{type_id::BOOL8}.id(),
-               "Positions values must not be bool type.",
-               cudf::data_type_error);
-  CUDF_EXPECTS(is_fixed_width(starts_column.type()),
-               "Positions values must be fixed width type.",
-               cudf::data_type_error);
 
   auto starts_iter = cudf::detail::indexalator_factory::make_input_iterator(starts_column);
   auto stops_iter  = cudf::detail::indexalator_factory::make_input_iterator(stops_column);

--- a/cpp/tests/strings/slice_tests.cpp
+++ b/cpp/tests/strings/slice_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -255,6 +255,18 @@ TEST_F(StringsSliceTest, MaxPositions)
 
   results = cudf::strings::slice_strings(strings_column, -10, -19, -1);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
+}
+
+TEST_F(StringsSliceTest, MixedTypePositions)
+{
+  auto input =
+    cudf::test::strings_column_wrapper({"a", "bc", "def", "ghij", "klmno", "pqrstu", "éuvwxyz"});
+  auto sv       = cudf::strings_column_view(input);
+  auto starts   = cudf::test::fixed_width_column_wrapper<int16_t>({0, 1, 2, 3, 4, 5, 6});
+  auto stops    = cudf::test::fixed_width_column_wrapper<int64_t>({1, 2, 3, 4, 5, 6, 7});
+  auto expected = cudf::test::strings_column_wrapper({"a", "c", "f", "j", "o", "u", "z"});
+  auto results  = cudf::strings::slice_strings(sv, starts, stops);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(results->view(), expected);
 }
 
 TEST_F(StringsSliceTest, MultiByteChars)


### PR DESCRIPTION
## Description
Removes unneeded type check on the `starts` and `stops` column parameters in the `cudf::strings::slice_strings` API.
Both types are checked for valid index-types (integers) but the starts/stops types themselves do not need to match.
Also, added a gtest to show this is possible and supported now.

Closes #20435 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
