### PR TITLE
Fix OOB memory access in JSON reader ingest_raw utility

### DIFF
--- a/cpp/tests/io/json/json_utils.cuh
+++ b/cpp/tests/io/json/json_utils.cuh
@@ -33,7 +33,7 @@ std::vector<cudf::io::table_with_metadata> split_byte_range_reading(
   auto total_source_size = [&sources]() {
     return std::accumulate(sources.begin(), sources.end(), 0ul, [=](size_t sum, auto& source) {
       auto const size = source->size();
-      return sum + size;
+      return sum + size + 1;
     });
   }();
   auto find_first_delimiter_in_chunk =


### PR DESCRIPTION
## Description
Fixes out-of-bounds memory reads in the JSON reader `ingest_raw` internal utility.
Error found in the nightly memcheck and can be reproduced using:
```
compute-sanitizer --tool memcheck gtests/JSON_TEST --gtest_filter=JsonReaderTest/JsonReaderTest.ByteRange_MultiSource/0 --rmm_mode=cuda
```
Error reported:
```
========= COMPUTE-SANITIZER
Note: Google Test filter = JsonReaderTest/JsonReaderTest.ByteRange_MultiSource/0
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from JsonReaderTest/JsonReaderTest
[ RUN      ] JsonReaderTest/JsonReaderTest.ByteRange_MultiSource/0
========= Program hit cudaErrorInvalidValue (error 1) due to "invalid argument" on CUDA API call to cudaMemcpyAsync_ptsz.
=========     Saved host backtrace up to driver entry point at error
=========         Host Frame: cudf::io::json::detail::ingest_raw_input(cudf::device_span<char, 18446744073709551615ul>, cudf::host_span<std::unique_ptr<cudf::io::datasource, std::default_delete<cudf::io::datasource> >, 18446744073709551615ul>, unsigned long, unsigned long, char, rmm::cuda_stream_view) [0xd51b19] in libcudf.so
=========         Host Frame: std::vector<cudf::io::table_with_metadata, std::allocator<cudf::io::table_with_metadata> > split_byte_range_reading<int>(cudf::host_span<std::unique_ptr<cudf::io::datasource, std::default_delete<cudf::io::datasource> >, 18446744073709551615ul>, cudf::host_span<std::unique_ptr<cudf::io::datasource, std::default_delete<cudf::io::datasource> >, 18446744073709551615ul>, cudf::io::json_reader_options const&, cudf::io::json_reader_options const&, int, rmm::cuda_stream_view, rmm::detail::cccl_async_resource_ref<cuda::mr::__4::basic_resource_ref<(cuda::mr::__4::_AllocType)1, cuda::mr::__4::device_accessible> >) [0x1bd7a1] in JSON_TEST
...
```
The `cudaMemcpyAsync` call was writing past the end of the allocated device memory buffer.

Once this was fixed, another error appears reading past the end of the buffer returned by `ingest_raw`.
This is fixed by clamping the returned size to at most the size of the device buffer itself.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
