### PR TITLE
Round up small-type groupby outputs to 4-byte boundary

### DIFF
--- a/cpp/src/groupby/hash/output_utils.cu
+++ b/cpp/src/groupby/hash/output_utils.cu
@@ -57,10 +57,10 @@ struct result_column_creator {
     auto const make_uninitialized_column = [&](data_type d_type, size_type size, mask_state state) {
       auto const type_size = cudf::size_of(d_type);
       if (type_size < 4) {
-        auto adjusted_size = cudf::util::round_up_safe(size, static_cast<size_type>(4));
-        auto buffer        = rmm::device_buffer(adjusted_size * type_size, stream, mr);
-        auto mask          = create_null_mask(size, state, stream, mr);
-        auto null_count    = state == mask_state::UNINITIALIZED ? 0 : state_null_count(state, size);
+        auto adjusted_size    = cudf::util::round_up_safe(size, static_cast<size_type>(4));
+        auto buffer           = rmm::device_buffer(adjusted_size * type_size, stream, mr);
+        auto mask             = create_null_mask(size, state, stream, mr);
+        auto const null_count = state_null_count(state, size);
         return std::make_unique<column>(
           d_type, size, std::move(buffer), std::move(mask), null_count);
       }


### PR DESCRIPTION
## Description
A temporary workaround of https://github.com/NVIDIA/cccl/issues/6430

This PR updates the groupby logic to round up output buffer sizes to a 4-byte boundary when the column data type is smaller than 4 bytes. This prevents false-positive memcheck failures from CCCL, where 4B CAS loops are used to emulate 1B or 2B atomic operations.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
