### PR TITLE
Fix UTF8 data generator in libcudf benchmarks utility

### DIFF
--- a/cpp/benchmarks/common/generate_input.cu
+++ b/cpp/benchmarks/common/generate_input.cu
@@ -464,7 +464,7 @@ struct string_generator {
       if (i == end - 1 && ch >= '\x7F') ch = ' ';  // last element ASCII only.
       if (ch >= '\x7F') {                          // x7F is at the top edge of ASCII
         chars[i++] = '\xC4';                       // these characters are assigned two bytes
-        ch         = ch | 0x80;
+        ch         = (ch >> 2) | 0x80;
       }
       chars[i] = static_cast<char>(ch);
     }


### PR DESCRIPTION
## Description
Fixes the `string_generator` utility logic to produce valid random UTF8 bytes. The 2nd byte requires the top 2 bits to be `10`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
