### PR TITLE
Add missing CUDA stream in cudf_polars Distinct

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -2603,6 +2603,7 @@ class Distinct(IR):
                 keep,
                 plc.types.NullEquality.EQUAL,
                 plc.types.NanEquality.ALL_EQUAL,
+                df.stream,
             )
         # TODO: Is this sortedness setting correct
         result = DataFrame(


### PR DESCRIPTION
## Description

The call to `plc.stream_compaction.distinct` / `stable_distinct` was missing the CUDA stream, leading to occasional segmentation faults while executing
