### PR TITLE
Add boto3/botocore/aiobotocore to common test dependencies

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -864,6 +864,9 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
+          - aiobotocore>=2.2.0
+          - boto3>=1.21.21
+          - botocore>=1.24.21
           - cramjam
           - *fastavro
           - hypothesis>=6.131.7
@@ -874,9 +877,6 @@ dependencies:
           - zstandard
       - output_types: conda
         packages:
-          - aiobotocore>=2.2.0
-          - boto3>=1.21.21
-          - botocore>=1.24.21
           - msgpack-python
           - moto>=4.0.8
       - output_types: [pyproject, requirements]

--- a/python/cudf/pyproject.toml
+++ b/python/cudf/pyproject.toml
@@ -51,6 +51,9 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
+    "aiobotocore>=2.2.0",
+    "boto3>=1.21.21",
+    "botocore>=1.24.21",
     "cramjam",
     "fastavro>=0.22.9",
     "hypothesis>=6.131.7",


### PR DESCRIPTION
## Description
Follow up to https://github.com/rapidsai/cudf/pull/20473, it appears without these pip fails to create a combined environment of all the RAPIDS dependencies ([example](https://github.com/rapidsai/devcontainers/actions/runs/19058603284/job/54433828223?pr=606#step:11:4231)).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
