### PR TITLE
Fix DataChunkSourceTest by syncing default stream

### DIFF
--- a/cpp/tests/io/text/data_chunk_source_test.cpp
+++ b/cpp/tests/io/text/data_chunk_source_test.cpp
@@ -33,7 +33,7 @@ void test_source(std::string const& content, cudf::io::text::data_chunk_source c
     // full contents
     auto reader      = source.create_reader();
     auto const chunk = reader->get_next_chunk(content.size(), stream);
-    cudaStreamSynchronize(stream.value());
+    stream.synchronize();
     EXPECT_EQ(chunk->size(), content.size());
     EXPECT_EQ(chunk_to_host(*chunk), content);
   }
@@ -42,7 +42,7 @@ void test_source(std::string const& content, cudf::io::text::data_chunk_source c
     auto reader = source.create_reader();
     reader->skip_bytes(4);
     auto const chunk = reader->get_next_chunk(content.size(), stream);
-    cudaStreamSynchronize(stream.value());
+    stream.synchronize();
     EXPECT_EQ(chunk->size(), content.size() - 4);
     EXPECT_EQ(chunk_to_host(*chunk), content.substr(4));
   }
@@ -51,7 +51,7 @@ void test_source(std::string const& content, cudf::io::text::data_chunk_source c
     auto reader       = source.create_reader();
     auto const chunk1 = reader->get_next_chunk(5, stream);
     auto const chunk2 = reader->get_next_chunk(content.size() - 5, stream);
-    cudaStreamSynchronize(stream.value());
+    stream.synchronize();
     EXPECT_EQ(chunk1->size(), 5);
     EXPECT_EQ(chunk2->size(), content.size() - 5);
     EXPECT_EQ(chunk_to_host(*chunk1), content.substr(0, 5));
@@ -62,7 +62,7 @@ void test_source(std::string const& content, cudf::io::text::data_chunk_source c
     auto reader       = source.create_reader();
     auto const chunk1 = reader->get_next_chunk(content.size() / 2, stream);
     auto const chunk2 = reader->get_next_chunk(content.size() - content.size() / 2, stream);
-    cudaStreamSynchronize(stream.value());
+    stream.synchronize();
     EXPECT_EQ(chunk1->size(), content.size() / 2);
     EXPECT_EQ(chunk2->size(), content.size() - content.size() / 2);
     EXPECT_EQ(chunk_to_host(*chunk1), content.substr(0, content.size() / 2));
@@ -72,11 +72,11 @@ void test_source(std::string const& content, cudf::io::text::data_chunk_source c
     // reading too many bytes
     auto reader      = source.create_reader();
     auto const chunk = reader->get_next_chunk(content.size() + 10, stream);
-    cudaStreamSynchronize(stream.value());
+    stream.synchronize();
     EXPECT_EQ(chunk->size(), content.size());
     EXPECT_EQ(chunk_to_host(*chunk), content);
     auto next_chunk = reader->get_next_chunk(1, stream);
-    cudaStreamSynchronize(stream.value());
+    stream.synchronize();
     EXPECT_EQ(next_chunk->size(), 0);
   }
   {
@@ -84,7 +84,7 @@ void test_source(std::string const& content, cudf::io::text::data_chunk_source c
     auto reader = source.create_reader();
     reader->skip_bytes(content.size() + 10);
     auto const next_chunk = reader->get_next_chunk(1, stream);
-    cudaStreamSynchronize(stream.value());
+    stream.synchronize();
     EXPECT_EQ(next_chunk->size(), 0);
   }
 }


### PR DESCRIPTION
## Description
Fixes the DataChunkSourceTest libcudf gtest by syncing on the default stream. 
The test results failed when run under libcudf debug build.
Syncing before checking the results now passes the tests.

Closes #20450 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
