### PR TITLE
Fix the statistics_mr in benchmark fixture

### DIFF
--- a/cpp/benchmarks/fixture/benchmark_fixture.hpp
+++ b/cpp/benchmarks/fixture/benchmark_fixture.hpp
@@ -98,9 +98,9 @@ class memory_stats_logger {
   memory_stats_logger()
     : existing_mr(cudf::get_current_device_resource_ref()),
       statistics_mr(
-        rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource>(existing_mr))
+        rmm::mr::statistics_resource_adaptor<rmm::device_async_resource_ref>(existing_mr))
   {
-    cudf::set_current_device_resource(&statistics_mr);
+    cudf::set_current_device_resource_ref(&statistics_mr);
   }
 
   ~memory_stats_logger() { cudf::set_current_device_resource_ref(existing_mr); }
@@ -112,7 +112,7 @@ class memory_stats_logger {
 
  private:
   rmm::device_async_resource_ref existing_mr;
-  rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource> statistics_mr;
+  rmm::mr::statistics_resource_adaptor<rmm::device_async_resource_ref> statistics_mr;
 };
 
 }  // namespace cudf


### PR DESCRIPTION
## Description
This PR fixes a bug introduced in #20386, where the data memory resource was updated to use the new async resource reference, but the statistics based on the new ref was still calling the legacy memory resource setter, leading to a runtime crash.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
