### PR TITLE
Use current system architecture in conda environment creation command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Instructions for a minimal build environment without conda are included below.
 # create the conda environment (assuming in base `cudf` directory)
 # note: RAPIDS currently doesn't support `channel_priority: strict`;
 # use `channel_priority: flexible` instead
-conda env create --name cudf_dev --file conda/environments/all_cuda-130_arch-x86_64.yaml
+conda env create --name cudf_dev --file conda/environments/all_cuda-130_arch-$(arch).yaml
 # activate the environment
 conda activate cudf_dev
 ```


### PR DESCRIPTION
## Description
This fixes a conda environment creation command to support both `x86_64` and `aarch64` systems.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
