### PR TITLE
Use uname -m instead of arch command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Instructions for a minimal build environment without conda are included below.
 # create the conda environment (assuming in base `cudf` directory)
 # note: RAPIDS currently doesn't support `channel_priority: strict`;
 # use `channel_priority: flexible` instead
-conda env create --name cudf_dev --file conda/environments/all_cuda-130_arch-$(arch).yaml
+conda env create --name cudf_dev --file conda/environments/all_cuda-130_arch-$(uname -m).yaml
 # activate the environment
 conda activate cudf_dev
 ```


### PR DESCRIPTION
## Description
Follow-up to https://github.com/rapidsai/cudf/pull/20500 to use a more POSIX-compliant command.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
