### PR TITLE
Add empty input gtest for cudf::transform

### DIFF
--- a/cpp/tests/transform/integration/unary_transform_test.cpp
+++ b/cpp/tests/transform/integration/unary_transform_test.cpp
@@ -618,6 +618,28 @@ __device__ void transform(void* user_data, cudf::size_type row,
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view());
 }
 
+TEST_F(StringOperationTest, EmptyInput)
+{
+  std::string rtn_bool = R"***(
+  __device__ void transform(bool * out, cudf::string_view a, cudf::string_view b){
+    *out =  a.find(b) != cudf::string_view::npos;
+  }
+  )***";
+
+  auto empty = cudf::test::strings_column_wrapper();
+  auto result =
+    cudf::transform({empty, empty}, rtn_bool, cudf::data_type(cudf::type_id::BOOL8), false);
+  EXPECT_EQ(0, result->size());
+
+  std::string rtn_str = R"***(
+  __device__ void transform(cudf::string_view * out, cudf::string_view a, cudf::string_view b){
+    *out =  (a==b ? a : cudf::string_view{});
+  }
+  )***";
+  result = cudf::transform({empty, empty}, rtn_str, cudf::data_type(cudf::type_id::STRING), false);
+  EXPECT_EQ(0, result->size());
+}
+
 struct NullTest : public cudf::test::BaseFixture {
  protected:
   char const* const cuda =


### PR DESCRIPTION
## Description
Adds a gtest for `cudf::transform` that passes a table with empty columns.
The feature already exists but the gtest was missing.
This usage can be helpful to pre-compile a set of custom UDFs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
