### PR TITLE
Migrate to new CCCL memory resource interface

### DIFF
--- a/cpp/examples/hybrid_scan_io/io_source.hpp
+++ b/cpp/examples/hybrid_scan_io/io_source.hpp
@@ -53,14 +53,14 @@ struct pinned_allocator : public std::allocator<T> {
 
   T* allocate(std::size_t n)
   {
-    auto ptr = mr.allocate_async(n * sizeof(T), rmm::RMM_DEFAULT_HOST_ALIGNMENT, stream);
+    auto ptr = mr.allocate(stream, n * sizeof(T), rmm::RMM_DEFAULT_HOST_ALIGNMENT);
     stream.synchronize();
     return static_cast<T*>(ptr);
   }
 
   void deallocate(T* ptr, std::size_t n)
   {
-    mr.deallocate_async(ptr, n * sizeof(T), rmm::RMM_DEFAULT_HOST_ALIGNMENT, stream);
+    mr.deallocate(stream, ptr, n * sizeof(T), rmm::RMM_DEFAULT_HOST_ALIGNMENT);
   }
 
  private:

--- a/cpp/examples/parquet_io/io_source.hpp
+++ b/cpp/examples/parquet_io/io_source.hpp
@@ -53,14 +53,14 @@ struct pinned_allocator : public std::allocator<T> {
 
   T* allocate(std::size_t n)
   {
-    auto ptr = mr.allocate_async(n * sizeof(T), rmm::RMM_DEFAULT_HOST_ALIGNMENT, stream);
+    auto ptr = mr.allocate(stream, n * sizeof(T), rmm::RMM_DEFAULT_HOST_ALIGNMENT);
     stream.synchronize();
     return static_cast<T*>(ptr);
   }
 
   void deallocate(T* ptr, std::size_t n) noexcept
   {
-    mr.deallocate_async(ptr, n * sizeof(T), rmm::RMM_DEFAULT_HOST_ALIGNMENT, stream);
+    mr.deallocate(stream, ptr, n * sizeof(T), rmm::RMM_DEFAULT_HOST_ALIGNMENT);
   }
 
  private:

--- a/cpp/include/cudf/detail/utilities/host_vector.hpp
+++ b/cpp/include/cudf/detail/utilities/host_vector.hpp
@@ -126,7 +126,7 @@ class rmm_host_allocator {
   {
     if (cnt > this->max_size()) { throw std::bad_alloc(); }  // end if
     auto const result =
-      mr.allocate_async(cnt * sizeof(value_type), rmm::RMM_DEFAULT_HOST_ALIGNMENT, stream);
+      mr.allocate(stream, cnt * sizeof(value_type), rmm::RMM_DEFAULT_HOST_ALIGNMENT);
     // Synchronize to ensure the memory is allocated before thrust::host_vector initialization
     // TODO: replace thrust::host_vector with a type that does not require synchronization
     stream.synchronize();
@@ -145,7 +145,7 @@ class rmm_host_allocator {
    */
   inline void deallocate(pointer p, size_type cnt) noexcept
   {
-    mr.deallocate_async(p, cnt * sizeof(value_type), rmm::RMM_DEFAULT_HOST_ALIGNMENT, stream);
+    mr.deallocate(stream, p, cnt * sizeof(value_type), rmm::RMM_DEFAULT_HOST_ALIGNMENT);
   }
 
   /**

--- a/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
+++ b/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
@@ -71,7 +71,7 @@ class stream_checking_resource_adaptor final : public rmm::mr::device_memory_res
   void* do_allocate(std::size_t bytes, rmm::cuda_stream_view stream) override
   {
     verify_stream(stream);
-    return upstream_.allocate_async(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT, stream);
+    return upstream_.allocate(stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
   }
 
   /**
@@ -86,7 +86,7 @@ class stream_checking_resource_adaptor final : public rmm::mr::device_memory_res
   void do_deallocate(void* ptr, std::size_t bytes, rmm::cuda_stream_view stream) noexcept override
   {
     verify_stream(stream);
-    upstream_.deallocate_async(ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT, stream);
+    upstream_.deallocate(stream, ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
   }
 
   /**

--- a/cpp/src/utilities/host_memory.cpp
+++ b/cpp/src/utilities/host_memory.cpp
@@ -48,22 +48,22 @@ class fixed_pinned_pool_memory_resource {
     CUDF_LOG_INFO("Pinned pool size = %zu", pool_size_);
 
     // Allocate full size from the pinned pool to figure out the beginning and end address
-    pool_begin_ = pool_->allocate_async(pool_size_, stream_);
+    pool_begin_ = pool_->allocate(stream_, pool_size_);
     pool_end_   = static_cast<void*>(static_cast<uint8_t*>(pool_begin_) + pool_size_);
-    pool_->deallocate_async(pool_begin_, pool_size_, stream_);
+    pool_->deallocate(stream_, pool_begin_, pool_size_);
   }
 
   void* allocate_async(std::size_t bytes, std::size_t alignment, cuda::stream_ref stream)
   {
     if (bytes <= pool_size_) {
       try {
-        return pool_->allocate_async(bytes, alignment, stream);
+        return pool_->allocate(stream, bytes, alignment);
       } catch (...) {
         // If the pool is exhausted, fall back to the upstream memory resource
       }
     }
 
-    return upstream_mr_.allocate_async(bytes, alignment, stream);
+    return upstream_mr_.allocate(stream, bytes, alignment);
   }
 
   void* allocate_async(std::size_t bytes, cuda::stream_ref stream)
@@ -88,9 +88,9 @@ class fixed_pinned_pool_memory_resource {
                         cuda::stream_ref stream) noexcept
   {
     if (bytes <= pool_size_ && ptr >= pool_begin_ && ptr < pool_end_) {
-      pool_->deallocate_async(ptr, bytes, alignment, stream);
+      pool_->deallocate(stream, ptr, bytes, alignment);
     } else {
-      upstream_mr_.deallocate_async(ptr, bytes, alignment, stream);
+      upstream_mr_.deallocate(stream, ptr, bytes, alignment);
     }
   }
 

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -683,7 +683,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_allocInternal(JNIEnv* env,
     cudf::jni::auto_set_device(env);
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref();
     auto c_stream = rmm::cuda_stream_view(reinterpret_cast<cudaStream_t>(stream));
-    void* ret     = mr.allocate_async(size, rmm::CUDA_ALLOCATION_ALIGNMENT, c_stream);
+    void* ret     = mr.allocate(c_stream, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
     return reinterpret_cast<jlong>(ret);
   }
   JNI_CATCH(env, 0);
@@ -698,7 +698,7 @@ Java_ai_rapids_cudf_Rmm_free(JNIEnv* env, jclass clazz, jlong ptr, jlong size, j
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref();
     void* cptr                        = reinterpret_cast<void*>(ptr);
     auto c_stream = rmm::cuda_stream_view(reinterpret_cast<cudaStream_t>(stream));
-    mr.deallocate_async(cptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT, c_stream);
+    mr.deallocate(c_stream, cptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   }
   JNI_CATCH(env, );
 }


### PR DESCRIPTION
## Description
Updates cudf to use the new CCCL memory resource interface.

Part of https://github.com/rapidsai/rmm/issues/2126.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
