### PR TITLE
Fix `polars.concat_str` with one column in cudf_polars

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -318,6 +318,8 @@ class StringFunction(Expr):
                 ).astype(self.dtype, stream=df.stream)
                 for child in self.children
             ]
+            if len(columns) == 1:
+                return columns[0]
 
             non_unit_sizes = [c.size for c in columns if c.size != 1]
             broadcasted = broadcast(

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -892,3 +892,9 @@ def test_string_concat_empty_frame():
     q = lf.select(pl.lit(", ") + pl.col("a"))
 
     assert_gpu_result_equal(q)
+
+
+def test_single_column_concat_str():
+    lf = pl.LazyFrame({"c0": ["a", "b"]})
+    q = lf.select(pl.concat_str(pl.col("c0")))
+    assert_gpu_result_equal(q)


### PR DESCRIPTION
## Description
closes https://github.com/pola-rs/polars/issues/25193

It appears `cudf::strings::concatenate` expects 2+ column in the input table, but we can short circuit in Python

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
