### PR TITLE
Add pytest stubs and remove ujson usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     rev: 'v1.13.0'
     hooks:
       - id: mypy
-        additional_dependencies: [types-cachetools, pyarrow-stubs, numpy, types-ujson, pytest]
+        additional_dependencies: [types-cachetools, pyarrow-stubs, numpy, pytest]
         args: ["--config-file=pyproject.toml",
                "python/cudf/cudf",
                "python/pylibcudf/pylibcudf",

--- a/python/cudf/cudf/io/orc.py
+++ b/python/cudf/cudf/io/orc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import itertools
+import json
 import warnings
 from typing import TYPE_CHECKING, Literal
 
@@ -24,11 +25,6 @@ from cudf.core.index import CategoricalIndex, RangeIndex
 from cudf.core.multiindex import MultiIndex
 from cudf.utils import ioutils
 from cudf.utils.dtypes import cudf_dtype_from_pa_type, dtype_to_pylibcudf_type
-
-try:
-    import ujson as json  # type: ignore[import-untyped]
-except ImportError:
-    import json
 
 if TYPE_CHECKING:
     from cudf.core.column import ColumnBase

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import io
 import itertools
+import json
 import math
 import operator
 import shutil
@@ -39,11 +40,6 @@ from cudf.core.reshape import concat
 from cudf.options import get_option
 from cudf.utils import ioutils
 from cudf.utils.performance_tracking import _performance_tracking
-
-try:
-    import ujson as json  # type: ignore[import-untyped]
-except ImportError:
-    import json
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Hashable, Sequence


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
pytest stubs are just added for completeness and didn't require any fixes. I removed ujson usage because we never test it to validate that it actually works for us. If we find that this meaningfully slows down particular use cases we can easily add it back (with proper testing), although at this point the better option would be to migrate to orjson, which is both faster and more correct.

Contributes to #11661 
Split out from #20547 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
