### PR TITLE
Ensure table chunks are unspilled and available

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/core.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/core.py
@@ -143,7 +143,12 @@ def evaluate_logical_plan(
     # Keep chunks alive until after concatenation to prevent
     # use-after-free with stream-ordered allocations
     messages = output.release()
-    chunks = [TableChunk.from_message(msg) for msg in messages]
+    chunks = [
+        TableChunk.from_message(msg).make_available_and_spill(
+            br, allow_overbooking=True
+        )
+        for msg in messages
+    ]
     dfs = [
         DataFrame.from_table(
             chunk.table_view(),

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
@@ -58,7 +58,11 @@ async def get_small_table(
     """
     small_chunks = []
     while (msg := await ch_small.data.recv(context)) is not None:
-        small_chunks.append(TableChunk.from_message(msg))
+        small_chunks.append(
+            TableChunk.from_message(msg).make_available_and_spill(
+                context.br(), allow_overbooking=True
+            )
+        )
     assert small_chunks, "Empty small side"
 
     return [
@@ -124,7 +128,9 @@ async def broadcast_join_node(
 
         # Stream through large side, joining with the small-side
         while (msg := await large_ch.data.recv(context)) is not None:
-            large_chunk = TableChunk.from_message(msg)
+            large_chunk = TableChunk.from_message(msg).make_available_and_spill(
+                context.br(), allow_overbooking=True
+            )
             seq_num = msg.sequence_number
             large_df = DataFrame.from_table(
                 large_chunk.table_view(),

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
@@ -68,8 +68,11 @@ async def concatenate_node(
                 msg = await ch_in.data.recv(context)
                 if msg is None:
                     break
-                chunk = TableChunk.from_message(msg)
-                chunks.append(chunk)
+                chunks.append(
+                    TableChunk.from_message(msg).make_available_and_spill(
+                        context.br(), allow_overbooking=True
+                    )
+                )
 
             # Process collected chunks
             if chunks:

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/shuffle.py
@@ -216,7 +216,9 @@ async def local_shuffle_node(
                     break
 
                 # Extract TableChunk from message
-                chunk = TableChunk.from_message(msg)
+                chunk = TableChunk.from_message(msg).make_available_and_spill(
+                    context.br(), allow_overbooking=True
+                )
 
                 # Get the table view and insert into shuffler
                 local_shuffle.insert_chunk(chunk)

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/union.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/union.py
@@ -62,7 +62,9 @@ async def union_node(
                     context,
                     Message(
                         msg.sequence_number + seq_num_offset,
-                        TableChunk.from_message(msg),
+                        TableChunk.from_message(msg).make_available_and_spill(
+                            context.br(), allow_overbooking=True
+                        ),
                     ),
                 )
             seq_num_offset += num_ch_chunks


### PR DESCRIPTION
When https://github.com/rapidsai/rapidsmpf/pull/640 is merged, we need to make sure that table chunks are not spilled when we use them. 

Depend on https://github.com/rapidsai/rapidsmpf/pull/651