### PR TITLE
Fix racecheck in nvtext wordpiece tokenizer kernel

### DIFF
--- a/cpp/src/text/wordpiece_tokenize.cu
+++ b/cpp/src/text/wordpiece_tokenize.cu
@@ -652,6 +652,7 @@ CUDF_KERNEL void find_words_kernel(cudf::column_device_view const d_strings,
       }
       itr += tile_size;
     }
+    tile.sync();
     // keep track of how much of start_words/end_words we used
     last_idx = cg::reduce(tile, last_idx, cg::greater<cudf::size_type>{}) + 1;
 
@@ -666,6 +667,7 @@ CUDF_KERNEL void find_words_kernel(cudf::column_device_view const d_strings,
       first_word   = (count > words_found) ? start_words[words_found] : no_word;
       output_count = cuda::std::min(words_found, max_words - word_count);
     }
+    tile.sync();
 
     // copy results to the output
     auto out_starts = d_start_words + word_count;


### PR DESCRIPTION
## Description
Fixes racecheck error reported in the nvtext `find_words_kernel` in the wordpiece tokenizer.
Partial error output:
```
========= Warning: Race reported between Write access at void nvtext::detail::<unnamed>::find_words_kernel<(int)32>(cudf::column_device_view, const char *, const long *, long *, int *)+0xb20 in wordpiece_tokenize.cu:650
=========     and Read access at bool thrust::detail::equal_to_value<int>::operator ()<int>(const T1 &) const+0x1520 in internal_functional.h:78 [4 hazards]
=========     and Read access at bool thrust::detail::equal_to_value<int>::operator ()<int>(const T1 &) const+0x1770 in internal_functional.h:78 [36 hazards]
=========     and Read access at bool thrust::detail::equal_to_value<int>::operator ()<int>(const T1 &) const+0x1860 in internal_functional.h:78 [16 hazards]
=========     and Read access at bool thrust::detail::equal_to_value<int>::operator ()<int>(const T1 &) const+0x18d0 in internal_functional.h:78 [24 hazards]
=========
========= Warning: Race reported between Write access at void nvtext::detail::<unnamed>::find_words_kernel<(int)32>(cudf::column_device_view, const char *, const long *, long *, int *)+0x9a0 in wordpiece_tokenize.cu:644
=========     and Read access at bool thrust::detail::equal_to_value<int>::operator ()<int>(const T1 &) const+0xe80 in internal_functional.h:78 [4 hazards]
=========     and Read access at bool thrust::detail::equal_to_value<int>::operator ()<int>(const T1 &) const+0xfe0 in internal_functional.h:78 [4 hazards]
=========     and Read access at bool thrust::detail::equal_to_value<int>::operator ()<int>(const T1 &) const+0x10b0 in internal_functional.h:78 [16 hazards]
=========     and Read access at bool thrust::detail::equal_to_value<int>::operator ()<int>(const T1 &) const+0x1120 in internal_functional.h:78 [20 hazards]
=========     and Read access at bool thrust::detail::equal_to_value<int>::operator ()<int>(const T1 &) const+0x11a0 in internal_functional.h:78 [24 hazards]
=========     and Read access at bool thrust::detail::equal_to_value<int>::operator ()<int>(const T1 &) const+0x1210 in internal_functional.h:78 [8 hazards]
=========
========= Warning: Race reported between Read access at void nvtext::detail::<unnamed>::find_words_kernel<(int)32>(cudf::column_device_view, const char *, const long *, long *, int *)+0x2360 in wordpiece_tokenize.cu:675
=========     and Write access at T2 thrust::system::detail::sequential::remove_if<thrust::detail::seq_t, int *, thrust::detail::equal_to_value<int>>(thrust::system::detail::sequential::execution_policy<T1> &, T2, T2, T3)+0x1030 in remove.h:71 [4 hazards]
=========     and Write access at T2 thrust::system::detail::sequential::remove_if<thrust::detail::seq_t, int *, thrust::detail::equal_to_value<int>>(thrust::system::detail::sequential::execution_policy<T1> &, T2, T2, T3)+0x1110 in remove.h:71 [12 hazards]
=========     and Write access at T2 thrust::system::detail::sequential::remove_if<thrust::detail::seq_t, int *, thrust::detail::equal_to_value<int>>(thrust::system::detail::sequential::execution_policy<T1> &, T2, T2, T3)+0x1190 in remove.h:71 [8 hazards]
=========     and Write access at T2 thrust::system::detail::sequential::remove_if<thrust::detail::seq_t, int *, thrust::detail::equal_to_value<int>>(thrust::system::detail::sequential::execution_policy<T1> &, T2, T2, T3)+0x1200 in remove.h:71 [20 hazards]
=========
========= Warning: Race reported between Read access at void nvtext::detail::<unnamed>::find_words_kernel<(int)32>(cudf::column_device_view, const char *, const long *, long *, int *)+0x2390 in wordpiece_tokenize.cu:677
=========     and Write access at T2 thrust::system::detail::sequential::remove_if<thrust::detail::seq_t, int *, thrust::detail::equal_to_value<int>>(thrust::system::detail::sequential::execution_policy<T1> &, T2, T2, T3)+0x17d0 in remove.h:71 [20 hazards]
=========     and Write access at T2 thrust::system::detail::sequential::remove_if<thrust::detail::seq_t, int *, thrust::detail::equal_to_value<int>>(thrust::system::detail::sequential::execution_policy<T1> &, T2, T2, T3)+0x18c0 in remove.h:71 [12 hazards]
=========     and Write access at T2 thrust::system::detail::sequential::remove_if<thrust::detail::seq_t, int *, thrust::detail::equal_to_value<int>>(thrust::system::detail::sequential::execution_policy<T1> &, T2, T2, T3)+0x1950 in remove.h:71 [12 hazards]
=========

```
Adding additional `sync()` calls in the kernel fixes the errors.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
