### PR TITLE
Remove unneeded cudaMemcpy() calls

### DIFF
--- a/cpp/src/quantiles/quantiles_util.hpp
+++ b/cpp/src/quantiles/quantiles_util.hpp
@@ -17,17 +17,6 @@
 
 namespace cudf {
 namespace detail {
-template <typename Result, typename T>
-CUDF_HOST_DEVICE inline Result get_array_value(T const* devarr, size_type location)
-{
-  T result;
-#if defined(__CUDA_ARCH__)
-  result = devarr[location];
-#else
-  CUDF_CUDA_TRY(cudaMemcpy(&result, devarr + location, sizeof(T), cudaMemcpyDefault));
-#endif
-  return static_cast<Result>(result);
-}
 
 namespace interpolate {
 template <typename Result, typename T>

--- a/cpp/tests/interop/to_arrow_device_test.cpp
+++ b/cpp/tests/interop/to_arrow_device_test.cpp
@@ -248,17 +248,10 @@ struct BaseArrowFixture : public cudf::test::BaseFixture {
                               ArrowArray const* expected,
                               ArrowArray const* actual)
   {
-    std::vector<uint8_t> actual_bytes;
-    std::vector<uint8_t> expected_bytes;
-    expected_bytes.resize(nbytes);
-    actual_bytes.resize(nbytes);
-
-    // synchronous copies so we don't have to worry about async weirdness
-    cudaMemcpy(
-      expected_bytes.data(), expected->buffers[buffer_idx], nbytes, cudaMemcpyDeviceToHost);
-    cudaMemcpy(actual_bytes.data(), actual->buffers[buffer_idx], nbytes, cudaMemcpyDeviceToHost);
-
-    ASSERT_EQ(expected_bytes, actual_bytes);
+    auto const dt       = cudf::data_type{cudf::type_id::UINT8};
+    auto actual_bytes   = cudf::column_view(dt, nbytes, actual->buffers[buffer_idx], nullptr, 0);
+    auto expected_bytes = cudf::column_view(dt, nbytes, expected->buffers[buffer_idx], nullptr, 0);
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(actual_bytes, expected_bytes);
   }
 
   void compare_arrays(ArrowSchema const* schema,

--- a/cpp/tests/search/search_test.cpp
+++ b/cpp/tests/search/search_test.cpp
@@ -1813,7 +1813,7 @@ TEST_F(SearchTest, multi_contains_empty_input_set_string)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(*result, expect);
 }
 
-TEST_F(SearchTest, multi_contains_primitive_nan_unequal_bug)
+TEST_F(SearchTest, multi_contains_primitive_nan_unequal)
 {
   auto nan_val = std::numeric_limits<float>::quiet_NaN();
 
@@ -1827,12 +1827,8 @@ TEST_F(SearchTest, multi_contains_primitive_nan_unequal_bug)
                                        cudf::get_default_stream(),
                                        cudf::get_current_device_resource_ref());
 
-  thrust::host_vector<bool> result_host(result.size());
-  CUDF_CUDA_TRY(cudaMemcpy(
-    result_host.data(), result.data(), result.size() * sizeof(bool), cudaMemcpyDeviceToHost));
-
   // With nan_equality::UNEQUAL, NaN should not match NaN
-  EXPECT_FALSE(result_host[0]);
+  EXPECT_FALSE(result.front_element(cudf::get_default_stream()));
 }
 
 template <typename T>

--- a/cpp/tests/sort/sort_test.cpp
+++ b/cpp/tests/sort/sort_test.cpp
@@ -73,15 +73,9 @@ TYPED_TEST(Sort, WithNullMax)
   } else {
     // for bools only validate that the null element landed at the back, since
     // the rest of the values are equivalent and yields random sorted order.
-    auto to_host = [](cudf::column_view const& col) {
-      thrust::host_vector<int32_t> h_data(col.size());
-      CUDF_CUDA_TRY(cudaMemcpy(
-        h_data.data(), col.data<int32_t>(), h_data.size() * sizeof(int32_t), cudaMemcpyDefault));
-      return h_data;
-    };
-    thrust::host_vector<int32_t> h_exp = to_host(expected);
-    thrust::host_vector<int32_t> h_got = to_host(got->view());
-    EXPECT_EQ(h_exp[h_exp.size() - 1], h_got[h_got.size() - 1]);
+    auto const last_idx = got->size();
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(cudf::slice(got->view(), {last_idx - 1, last_idx}).back(),
+                                   cudf::slice(expected, {last_idx - 1, last_idx}).back());
 
     // Run test for sort and sort_by_key
     cudf::test::fixed_width_column_wrapper<int32_t> expected_for_bool{{0, 3, 5, 1, 4, 2}};
@@ -112,15 +106,8 @@ TYPED_TEST(Sort, WithNullMin)
   } else {
     // for bools only validate that the null element landed at the front, since
     // the rest of the values are equivalent and yields random sorted order.
-    auto to_host = [](cudf::column_view const& col) {
-      thrust::host_vector<int32_t> h_data(col.size());
-      CUDF_CUDA_TRY(cudaMemcpy(
-        h_data.data(), col.data<int32_t>(), h_data.size() * sizeof(int32_t), cudaMemcpyDefault));
-      return h_data;
-    };
-    thrust::host_vector<int32_t> h_exp = to_host(expected);
-    thrust::host_vector<int32_t> h_got = to_host(got->view());
-    EXPECT_EQ(h_exp.front(), h_got.front());
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(cudf::slice(got->view(), {0, 1}).front(),
+                                   cudf::slice(expected, {0, 1}).front());
 
     // Run test for sort and sort_by_key
     cudf::test::fixed_width_column_wrapper<int32_t> expected_for_bool{{2, 0, 3, 1, 4}};
@@ -150,15 +137,8 @@ TYPED_TEST(Sort, WithMixedNullOrder)
   } else {
     // for bools only validate that the null element landed at the front, since
     // the rest of the values are equivalent and yields random sorted order.
-    auto to_host = [](cudf::column_view const& col) {
-      thrust::host_vector<int32_t> h_data(col.size());
-      CUDF_CUDA_TRY(cudaMemcpy(
-        h_data.data(), col.data<int32_t>(), h_data.size() * sizeof(int32_t), cudaMemcpyDefault));
-      return h_data;
-    };
-    thrust::host_vector<int32_t> h_exp = to_host(expected);
-    thrust::host_vector<int32_t> h_got = to_host(got->view());
-    EXPECT_EQ(h_exp.front(), h_got.front());
+    CUDF_TEST_EXPECT_COLUMNS_EQUAL(cudf::slice(got->view(), {0, 1}).front(),
+                                   cudf::slice(expected, {0, 1}).front());
   }
 
   // Run test for sort and sort_by_key

--- a/cpp/tests/utilities/tdigest_utilities.cpp
+++ b/cpp/tests/utilities/tdigest_utilities.cpp
@@ -77,15 +77,8 @@ std::unique_ptr<column> make_expected_tdigest_column(std::vector<expected_tdiges
     auto tdigests =
       cudf::make_structs_column(tdigest.mean.size(), std::move(inner_children), 0, {});
 
-    std::vector<size_type> h_offsets{0, tdigest.mean.size()};
-    auto offsets =
-      cudf::make_fixed_width_column(data_type{type_id::INT32}, 2, mask_state::UNALLOCATED);
-    CUDF_CUDA_TRY(cudaMemcpy(offsets->mutable_view().begin<size_type>(),
-                             h_offsets.data(),
-                             sizeof(size_type) * 2,
-                             cudaMemcpyDefault));
-
-    auto list = cudf::make_lists_column(1, std::move(offsets), std::move(tdigests), 0, {});
+    auto offsets = cudf::test::fixed_width_column_wrapper<int32_t>({0, tdigest.mean.size()});
+    auto list    = cudf::make_lists_column(1, offsets.release(), std::move(tdigests), 0, {});
 
     auto min_col = cudf::test::fixed_width_column_wrapper<double>({tdigest.min});
     auto max_col = cudf::test::fixed_width_column_wrapper<double>({tdigest.max});


### PR DESCRIPTION
## Description
Removes some calls to `cudaMemcpy` that are not needed in gtests. Also removed one unused utility in libcudf.
This should help minimize stream race conditions when testing with non-default streams.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
