### PR TITLE
Parquet: Only fill in null values for string lengths

### DIFF
--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -98,12 +98,8 @@ __device__ void decode_fixed_width_values(
   int const skipped_leaf_values = s->page.skipped_leaf_values;
 
   // decode values
-  int pos = start;
-  while (pos < end) {
-    int const batch_size = min(max_batch_size, end - pos);
-    int const target_pos = pos + batch_size;
-    int const thread_pos = pos + t;
-
+  int thread_pos = start + t;
+  while (thread_pos < end) {
     // Index from value buffer (doesn't include nulls) to final array (has gaps for nulls)
     int const dst_pos = [&]() {
       if constexpr (copy_mode_t == copy_mode::DIRECT) {
@@ -115,9 +111,8 @@ __device__ void decode_fixed_width_values(
       }
     }();
 
-    // target_pos will always be properly bounded by num_rows, but dst_pos may be negative (values
-    // before first_row) in the flat hierarchy case.
-    if (thread_pos < target_pos && dst_pos >= 0) {
+    // dst_pos may be negative (values before first_row) for non-lists.
+    if (dst_pos >= 0) {
       // nesting level that is storing actual leaf values
 
       // src_pos represents the logical row position we want to read from. But in the case of
@@ -174,7 +169,7 @@ __device__ void decode_fixed_width_values(
       }
     }
 
-    pos += batch_size;
+    thread_pos += max_batch_size;
   }
 }
 
@@ -197,13 +192,8 @@ __device__ inline void decode_fixed_width_split_values(
   int const skipped_leaf_values = s->page.skipped_leaf_values;
 
   // decode values
-  int pos = start;
-  while (pos < end) {
-    int const batch_size = min(max_batch_size, end - pos);
-
-    int const target_pos = pos + batch_size;
-    int const thread_pos = pos + t;
-
+  int thread_pos = start + t;
+  while (thread_pos < end) {
     // Index from value buffer (doesn't include nulls) to final array (has gaps for nulls)
     int const dst_pos = [&]() {
       if constexpr (copy_mode_t == copy_mode::DIRECT) {
@@ -215,9 +205,8 @@ __device__ inline void decode_fixed_width_split_values(
       }
     }();
 
-    // target_pos will always be properly bounded by num_rows, but dst_pos may be negative (values
-    // before first_row) in the flat hierarchy case.
-    if (thread_pos < target_pos && dst_pos >= 0) {
+    // dst_pos may be negative (values before first_row) for non-lists.
+    if (dst_pos >= 0) {
       // src_pos represents the logical row position we want to read from. But in the case of
       // nested hierarchies (lists), there is no 1:1 mapping of rows to values. So src_pos
       // has to take into account the # of values we have to skip in the page to get to the
@@ -281,7 +270,7 @@ __device__ inline void decode_fixed_width_split_values(
       }
     }
 
-    pos += batch_size;
+    thread_pos += max_batch_size;
   }
 }
 
@@ -1209,22 +1198,22 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
     valid_count = next_valid_count;
   }
 
-  // Zero-fill null positions after decoding valid values
-  if (should_process_nulls) {
-    uint32_t const dtype_len = has_strings_t ? sizeof(cudf::size_type) : s->dtype_len;
-    int const num_values     = [&]() {
-      if constexpr (has_lists_t) {
-        auto const& ni = s->nesting_info[s->col.max_nesting_depth - 1];
-        return ni.valid_map_offset - init_valid_map_offset;
-      } else {
-        return s->num_rows;
-      }
-    }();
-    zero_fill_null_positions_shared<decode_block_size_t>(
-      s, dtype_len, init_valid_map_offset, num_values, t);
-  }
-
   if constexpr (has_strings_t) {
+    // Zero-fill null positions after decoding valid values
+    if (should_process_nulls) {
+      uint32_t const dtype_len = has_strings_t ? sizeof(cudf::size_type) : s->dtype_len;
+      int const num_values     = [&]() {
+        if constexpr (has_lists_t) {
+          auto const& ni = s->nesting_info[s->col.max_nesting_depth - 1];
+          return ni.valid_map_offset - init_valid_map_offset;
+        } else {
+          return s->num_rows;
+        }
+      }();
+      zero_fill_null_positions_shared<decode_block_size_t>(
+        s, dtype_len, init_valid_map_offset, num_values, t);
+    }
+
     // For large strings, update the initial string buffer offset to be used during large string
     // column construction. Otherwise, convert string sizes to final offsets.
 

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -330,10 +330,6 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
 
   // Must be evaluated after setup_local_page_info
   bool const has_repetition = s->col.max_level[level_type::REPETITION] > 0;
-
-  // Capture initial valid_map_offset before any processing that might modify it
-  int const init_valid_map_offset = s->nesting_info[s->col.max_nesting_depth - 1].valid_map_offset;
-
   // Write list offsets and exit if the page does not need to be decoded
   if (not page_mask[page_idx]) {
     auto& page = pages[page_idx];
@@ -425,14 +421,6 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
     }
 
     block.sync();
-  }
-
-  // Zero-fill null positions after decoding valid values
-  auto const& ni = s->nesting_info[s->col.max_nesting_depth - 1];
-  if (ni.valid_map != nullptr) {
-    int const num_values = ni.valid_map_offset - init_valid_map_offset;
-    zero_fill_null_positions_shared<decode_block_size>(
-      s, s->dtype_len, init_valid_map_offset, num_values, static_cast<int>(block.thread_rank()));
   }
 
   if (block.thread_rank() == 0 and s->error != 0) { set_error(s->error, error_code); }


### PR DESCRIPTION
Followup to [PR# 19643](https://github.com/rapidsai/cudf/pull/19643). This changes it so the parquet decode doesn't fill in null values for anything except string lengths. This matches the [updated dev guide](https://github.com/rapidsai/cudf/pull/20645). Note that list offsets are automatically filled in by a later step. Benchmarks show no measurable improvement, but it's still a good idea to do less work.  

This also includes minor changes to simplify thread-out-of-bounds checking in the decode loops. 

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
