### PR TITLE
Deprecate astype(copy=None)

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -2066,8 +2066,6 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         copy: bool | None = None,
         errors: Literal["raise", "ignore"] = "raise",
     ) -> Self:
-        if copy is None:
-            copy = True
         if is_dict_like(dtype):
             if len(set(dtype.keys()) - set(self._column_names)) > 0:  # type: ignore[union-attr]
                 raise KeyError(

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -423,6 +423,12 @@ class Frame(BinaryOperand, Scannable, Serializable):
     ) -> Self:
         if copy is None:
             copy = True
+            warnings.warn(
+                "`copy=None` is deprecated in 25.12 and will be removed in a future release. "
+                "Explicitly pass `copy=True` or `copy=False` to avoid this warning.",
+                FutureWarning,
+                stacklevel=2,
+            )
         if not copy:
             if all(
                 dtype.get(col_name, col.dtype) == col.dtype

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -2062,8 +2062,6 @@ class Series(SingleColumnFrame, IndexedFrame):
         copy: bool | None = None,
         errors: Literal["raise", "ignore"] = "raise",
     ) -> Self:
-        if copy is None:
-            copy = True
         if cudf.get_option("mode.pandas_compatible"):
             if inspect.isclass(dtype) and issubclass(
                 dtype, pd.api.extensions.ExtensionDtype

--- a/python/cudf/cudf/tests/dataframe/methods/test_astype.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_astype.py
@@ -280,3 +280,13 @@ def test_dataframe_astype_no_copy(copy):
     result = gdf.astype("int64", copy=copy)
     assert_eq(result, gdf)
     assert (result is gdf) is (not copy)
+
+
+def test_astype_copy_none_warns():
+    df = cudf.DataFrame({"a": [1, 2, 3]})
+
+    with pytest.warns(
+        FutureWarning,
+        match="`copy=None` is deprecated",
+    ):
+        df.astype("int64", copy=None)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Pandas `astype` is bool only. https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.astype.html
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
