### PR TITLE
Add note to developer guide about null values being undefined

### DIFF
--- a/cpp/doxygen/developer_guide/DEVELOPER_GUIDE.md
+++ b/cpp/doxygen/developer_guide/DEVELOPER_GUIDE.md
@@ -465,6 +465,21 @@ libcudf APIs _should_ promise to never return "dirty" columns, i.e. columns cont
 data. Therefore, the only problem is if users construct input columns that are not correctly
 sanitized and then pass those into libcudf APIs.
 
+## Null values of fixed-width columns are undefined
+
+For columns of fixed-width types (such as integers, floats, timestamps, and durations), the values
+corresponding to null elements (where the validity mask bit is set to null) are **undefined** and
+may contain arbitrary data. libcudf makes no guarantees about the initialization or content of these
+values.
+
+Code should not assume that null rows in fixed-width columns contain any particular value, including
+zero. Algorithms must rely solely on the validity mask to determine nullness and should not inspect
+the underlying data values for null elements.
+
+This policy applies only to fixed-width types. It does **not** apply to variable-width types
+(strings) or nested types (lists, structs), which have their own requirements as described in the
+sections above.
+
 ## Treat libcudf APIs as if they were asynchronous
 
 libcudf APIs called on the host do not guarantee that the stream is synchronized before returning.


### PR DESCRIPTION
## Description
Adds a note to the developer guide saying that null values are undefined.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
