### PR TITLE
fix(noarch): use noarch build script in noarch build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
-      script: ci/build_python.sh
+      script: ci/build_python_noarch.sh
       sha: ${{ inputs.sha }}
       pure-conda: true
   upload-conda:


### PR DESCRIPTION
Running the same build script twice (by accident) leads to artifact collisions.

Followup to https://github.com/rapidsai/cudf/pull/20613
