### PR TITLE
Update RapidsMPF imports 

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/core.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/core.py
@@ -8,10 +8,10 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
-from rapidsmpf.buffer.buffer import MemoryType
-from rapidsmpf.buffer.resource import BufferResource, LimitAvailableMemory
 from rapidsmpf.communicator.single import new_communicator
 from rapidsmpf.config import Options, get_environment_variables
+from rapidsmpf.memory.buffer import MemoryType
+from rapidsmpf.memory.buffer_resource import BufferResource, LimitAvailableMemory
 from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
 from rapidsmpf.streaming.core.context import Context
 from rapidsmpf.streaming.core.leaf_node import pull_from_channel

--- a/python/cudf_polars/cudf_polars/experimental/spilling.py
+++ b/python/cudf_polars/cudf_polars/experimental/spilling.py
@@ -8,9 +8,9 @@ from typing import TYPE_CHECKING, Any
 
 from dask.sizeof import sizeof
 from distributed import get_worker
-from rapidsmpf.buffer.buffer import MemoryType
 from rapidsmpf.integrations.dask.core import get_worker_context
 from rapidsmpf.integrations.dask.spilling import SpillableWrapper
+from rapidsmpf.memory.buffer import MemoryType
 
 from cudf_polars.containers import DataFrame
 


### PR DESCRIPTION
Update the `rapidsmpf.memory` imports to match the new structure: https://github.com/rapidsai/rapidsmpf/pull/673