### PR TITLE
Add timeout to cudf-polars tests

### DIFF
--- a/ci/test_cudf_polars_with_rapidsmpf.sh
+++ b/ci/test_cudf_polars_with_rapidsmpf.sh
@@ -48,6 +48,7 @@ rapids-logger "Running cudf_polars tests with rapidsmpf"
     --no-cov \
     --numprocesses=8 \
     --dist=worksteal \
+    --timeout 300 \
     -v \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars-rapidsmpf.xml"
 

--- a/ci/test_python_other.sh
+++ b/ci/test_python_other.sh
@@ -46,6 +46,7 @@ rapids-logger "pytest cudf-polars"
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars.xml" \
   --numprocesses=8 \
   --dist=worksteal \
+    --timeout 300 \
   --cov-config=./pyproject.toml \
   --cov=cudf_polars \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/cudf-polars-coverage.xml" \

--- a/ci/test_wheel_cudf_polars.sh
+++ b/ci/test_wheel_cudf_polars.sh
@@ -74,6 +74,7 @@ for version in "${VERSIONS[@]}"; do
         "${COVERAGE_ARGS[@]}" \
         --numprocesses=8 \
         --dist=worksteal \
+        --timeout 300 \
         --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars-${version}.xml"
 
     if [ $? -ne 0 ]; then

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -75,6 +75,7 @@ dependencies:
 - pytest-cov
 - pytest-httpserver
 - pytest-rerunfailures!=16.0.0
+- pytest-timeout
 - pytest-xdist
 - pytest<9.0.0a0
 - python-confluent-kafka>=2.8.0,<2.9.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -76,6 +76,7 @@ dependencies:
 - pytest-cov
 - pytest-httpserver
 - pytest-rerunfailures!=16.0.0
+- pytest-timeout
 - pytest-xdist
 - pytest<9.0.0a0
 - python-confluent-kafka>=2.8.0,<2.9.0a0

--- a/conda/environments/all_cuda-130_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-130_arch-aarch64.yaml
@@ -75,6 +75,7 @@ dependencies:
 - pytest-cov
 - pytest-httpserver
 - pytest-rerunfailures!=16.0.0
+- pytest-timeout
 - pytest-xdist
 - pytest<9.0.0a0
 - python-confluent-kafka>=2.8.0,<2.9.0a0

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -76,6 +76,7 @@ dependencies:
 - pytest-cov
 - pytest-httpserver
 - pytest-rerunfailures!=16.0.0
+- pytest-timeout
 - pytest-xdist
 - pytest<9.0.0a0
 - python-confluent-kafka>=2.8.0,<2.9.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -912,6 +912,7 @@ dependencies:
         packages:
           - rich
           - pytest-httpserver
+          - pytest-timeout
   test_python_narwhals:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/cudf_polars/pyproject.toml
+++ b/python/cudf_polars/pyproject.toml
@@ -44,6 +44,7 @@ test = [
     "numpy>=1.23,<3.0a0",
     "pytest-cov",
     "pytest-httpserver",
+    "pytest-timeout",
     "pytest-xdist",
     "pytest<9.0.0a0",
     "rich",


### PR DESCRIPTION
## Description

This adds a 5-minute timeout to each test in cudf-polars, using `pytest-timeout`. We've observed some hangs, especially in the cudf-polars-rapidsmpf environment

- https://github.com/rapidsai/cudf/actions/runs/19519352413/job/55881494392?pr=20575
- https://github.com/rapidsai/cudf/actions/runs/19513139414/job/55861194232?pr=20507

This will interrupt the test (using a signal) if it hasn't been completed by the timeout. I've added to all the cudf-polars tests, not just the rapidsmpf ones.