### PR TITLE
fix(conda): matrix out noarch builds by cuda-major version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,7 @@ jobs:
       date: ${{ inputs.date }}
       script: ci/build_python_noarch.sh
       sha: ${{ inputs.sha }}
-      pure-conda: true
+      pure-conda: cuda_major
   upload-conda:
     needs: [cpp-build, python-build, python-build-noarch]
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -178,7 +178,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_python_noarch.sh
-      pure-conda: true
+      pure-conda: cuda_major
   conda-python-cudf-tests:
     needs: [conda-python-build, conda-python-build-noarch, changed-files]
     secrets: inherit

--- a/ci/build_python_noarch.sh
+++ b/ci/build_python_noarch.sh
@@ -66,5 +66,5 @@ rapids-telemetry-record sccache-stats-custreamz.txt sccache --show-adv-stats
 # remove build_cache directory
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
 
-RAPIDS_PACKAGE_NAME="$(rapids-package-name conda_python cudf-noarch --pure)"
+RAPIDS_PACKAGE_NAME="$(rapids-package-name conda_python cudf-noarch --pure --cuda "${RAPIDS_CUDA_VERSION}")"
 export RAPIDS_PACKAGE_NAME

--- a/ci/test_notebooks.sh
+++ b/ci/test_notebooks.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 rapids-logger "Downloading artifacts from previous jobs"
 CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name conda_python cudf)")
-PYTHON_NOARCH_CHANNEL=$(rapids-download-from-github "$(rapids-package-name conda_python cudf-noarch --pure)")
+PYTHON_NOARCH_CHANNEL=$(rapids-download-from-github "$(rapids-package-name conda_python cudf-noarch --pure --cuda "${RAPIDS_CUDA_VERSION}")")
 
 rapids-logger "Generate notebook testing dependencies"
 

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 rapids-logger "Downloading artifacts from previous jobs"
 CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name conda_python cudf)")
-PYTHON_NOARCH_CHANNEL=$(rapids-download-from-github "$(rapids-package-name conda_python cudf-noarch --pure)")
+PYTHON_NOARCH_CHANNEL=$(rapids-download-from-github "$(rapids-package-name conda_python cudf-noarch --pure --cuda "${RAPIDS_CUDA_VERSION}")")
 
 rapids-logger "Generate Python testing dependencies"
 


### PR DESCRIPTION
xref https://github.com/rapidsai/shared-workflows/pull/459
xref https://github.com/rapidsai/cudf/pull/20654
xref https://github.com/rapidsai/cudf/pull/20613

Currently these noarch builds have a dependency on the major cuda version, so we need to fan out the builds by cuda major.  Potential followup here to make the builds properly pure (removing dependency on `cuda-version`)