### PR TITLE
Add a timeout for the rapidsmpf test run

### DIFF
--- a/ci/run_cudf_polars_with_rapidsmpf_pytests.sh
+++ b/ci/run_cudf_polars_with_rapidsmpf_pytests.sh
@@ -14,7 +14,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cudf_polars/
 
 # Run experimental tests with the "single" cluster mode and the "rapidsmpf" runtime
 rapids-logger "Running experimental tests with the 'rapidsmpf' runtime"
-python -m pytest --cache-clear "$@" "tests/experimental" \
+timeout 10m python -m pytest --cache-clear "$@" "tests/experimental" \
     --executor streaming \
     --cluster single \
     --runtime rapidsmpf


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This test has been hanging and wasting lots of CI cycles and blocking merges.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
