### PR TITLE
`DatetimeIndex.serialize()` headers are msgpack serializable

### DIFF
--- a/python/cudf/cudf/tests/dask/test_serialize.py
+++ b/python/cudf/cudf/tests/dask/test_serialize.py
@@ -117,6 +117,7 @@ from cudf.testing import assert_eq
                 "OGbssOJLUI",
             ]
         ),
+        lambda: cudf.date_range("2000-01-01", periods=12, freq="10s"),
     ],
     ids=itertools.count(),
 )


### PR DESCRIPTION
## Description

https://github.com/rapidsai/cudf/pull/20709 and
https://github.com/rapidsai/cudf/pull/18778 recently changed DatetimeIndex to preserve `freq` in more places.

This exposed an issue in how we serialize the properties of a DatetimeIndex: a `DateOffset` instance isn't serializable by msgpack. Distributed msgpack serialize the headers of messages, and so putting the `DateOffset` freq there caused issues.

Instead of inserting the `DateOffset` itself, we insert the `kwds` that can be used to reconstruct it when deserializing.

Note that this is targeted at `release/25.12`, because that's where https://github.com/rapidsai/cudf/pull/18778 and https://github.com/rapidsai/cudf/pull/20709 landed and this is affecting dask shuffle operations.

Closes https://github.com/rapidsai/dask-upstream-testing/issues/88
