### PR TITLE
Improve local pandas testing experience

### DIFF
--- a/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
+++ b/python/cudf/cudf/pandas/scripts/run-pandas-tests.sh
@@ -69,7 +69,8 @@ EOF
         # Get the relative path to the test module
         test_module=$(echo "$hit" | cut -d "/" -f 2-)
         # Get the number of directories to go up
-        num_dirs=$(echo "$test_module" | grep -o "/" | wc -l)
+        num_dirs="${test_module//[^\/]/}"
+        num_dirs="${#num_dirs}"
         num_dots=$((num_dirs - 1))
         # Construct the relative import
         relative_import=$(printf "%0.s." $(seq 1 $num_dots))


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR fixes a few small issues with the pandas testing script that make repeated runs of the tests on a non-ephemeral (i.e. not CI) filesystem easier. It prevents changes to the source checkout of pandas itself (only the pandas-tests directory has its imports rewritten) and the pandas-tests directory is properly deleted (the old path was wrong).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
