### PR TITLE
Fix plc.Scalar.from_py(datetime.datetime) incorrectly localizing naive datetimes

### DIFF
--- a/python/cudf_polars/tests/test_select.py
+++ b/python/cudf_polars/tests/test_select.py
@@ -92,6 +92,12 @@ def test_select_with_cse_with_agg():
     assert_gpu_result_equal(query)
 
 
+def test_select_native_datetime():
+    df = pl.LazyFrame({"c0": [1]})
+    query = df.select(pl.datetime(1969, 12, 7, 20, 47, 14))
+    assert_gpu_result_equal(query)
+
+
 @pytest.mark.parametrize("fmt", ["ndjson", "csv"])
 def test_select_fast_count_unsupported_formats(tmp_path, fmt):
     df = pl.DataFrame({"a": [1, 2, 3]})

--- a/python/pylibcudf/pylibcudf/scalar.pyx
+++ b/python/pylibcudf/pylibcudf/scalar.pyx
@@ -707,7 +707,12 @@ def _(
     cdef DataType c_dtype = dtype
     cdef type_id tid = c_dtype.id()
     if isinstance(py_val, datetime.datetime):
-        epoch_seconds = py_val.timestamp()
+        if py_val.tzinfo is None:
+            # Treat tz-naive datetime as UTC so .timestamp()
+            # does not account for the system's timezone.
+            epoch_seconds = py_val.replace(tzinfo=datetime.timezone.utc).timestamp()
+        else:
+            epoch_seconds = py_val.timestamp()
     else:
         epoch_seconds = (py_val - datetime.date(1970, 1, 1)).total_seconds()
     if tid == type_id.TIMESTAMP_NANOSECONDS:

--- a/python/pylibcudf/tests/test_scalar.py
+++ b/python/pylibcudf/tests/test_scalar.py
@@ -65,6 +65,7 @@ def test_to_py(py_scalar):
     if isinstance(py_scalar, (datetime.datetime, datetime.timedelta)):
         with pytest.raises(NotImplementedError):
             plc.Scalar.from_py(py_scalar).to_py()
+        assert py_scalar == plc.Scalar.from_py(py_scalar).to_arrow().as_py()
     else:
         assert py_scalar == plc.Scalar.from_py(py_scalar).to_py()
 


### PR DESCRIPTION
## Description
closes https://github.com/pola-rs/polars/issues/25549
closes https://github.com/rapidsai/cudf/issues/19044

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
