### PR TITLE
Don't remove double casts in cudf_polars

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -1011,11 +1011,8 @@ def _(
     # Push casts into literals so we can handle Cast(Literal(Null))
     if isinstance(inner, expr.Literal):
         return inner.astype(dtype)
-    elif isinstance(inner, expr.Cast):
-        # Translation of Len/Count-agg put in a cast, remove double
-        # casts if we have one.
-        (inner,) = inner.children
-    return expr.Cast(dtype, inner)
+    else:
+        return expr.Cast(dtype, inner)
 
 
 @_translate_expr.register

--- a/python/cudf_polars/tests/expressions/test_casting.py
+++ b/python/cudf_polars/tests/expressions/test_casting.py
@@ -52,3 +52,9 @@ def test_cast_unsupported(tests):
     assert_ir_translation_raises(
         df.select(pl.col("a").cast(totype)), NotImplementedError
     )
+
+
+def test_allow_double_cast():
+    df = pl.LazyFrame({"c0": [1000]})
+    query = df.select(pl.col("c0").cast(pl.Boolean).cast(pl.Int8))
+    assert_gpu_result_equal(query)


### PR DESCRIPTION
## Description
closes https://github.com/pola-rs/polars/issues/25564

This was added back in https://github.com/rapidsai/cudf/pull/16192, but it probably pre-dated some improvements in aggregation expressions.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
