### PR TITLE
Pin `numpy<2.4.0a0` in mypy pre-commit environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,8 +35,8 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [
-          numpy,
           polars,
+          "numpy<2.4.0a0",
           pyarrow-stubs,
           pytest,
           types-cachetools,


### PR DESCRIPTION
## Description

We have some recent CI failures from the mypy check. Debugging locally, I see that we get the recently released numpy 2.4.0 release candidate. I'm not sure how we get an RC there, but I'll look into it, along with the typing issues it's flagging.

For now, just pin to avoid the RC.