### PR TITLE
avoid passing `start` as keyword argument to `np.arange`

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2938,7 +2938,7 @@ class RangeIndex(Index):
     @cached_property
     @_performance_tracking
     def values_host(self) -> np.ndarray:
-        return np.arange(start=self.start, stop=self.stop, step=self.step)
+        return np.arange(self.start, self.stop, self.step)
 
     @_performance_tracking
     def to_numpy(self) -> np.ndarray:

--- a/python/dask_cudf/dask_cudf/backends.py
+++ b/python/dask_cudf/dask_cudf/backends.py
@@ -129,9 +129,7 @@ def _get_non_empty_data(
         date_data = cudf.date_range("2001-01-01", periods=2, freq=s.time_unit)  # type: ignore[attr-defined]
         return date_data.tz_localize(str(s.dtype.tz))._column
     elif s.dtype.kind in "fiubmM":
-        return cudf.core.column.as_column(
-            np.arange(start=0, stop=2, dtype=s.dtype)
-        )
+        return cudf.core.column.as_column(np.arange(0, 2, dtype=s.dtype))
     elif isinstance(s.dtype, cudf.core.dtypes.DecimalDtype):
         return cudf.core.column.as_column(range(2), dtype=s.dtype)
     else:

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -622,9 +622,7 @@ def test_hash_object_dispatch(index):
 )
 def test_make_meta_backends(index):
     dtypes = ["int8", "int32", "int64", "float64"]
-    df = cudf.DataFrame(
-        {dt: np.arange(start=0, stop=3, dtype=dt) for dt in dtypes}
-    )
+    df = cudf.DataFrame({dt: np.arange(0, 3, dtype=dt) for dt in dtypes})
     df["strings"] = ["cat", "dog", "fish"]
     df["cats"] = df["strings"].astype("category")
     df["time_s"] = np.array(


### PR DESCRIPTION
In the upcoming NumPy 2.4 release, calling `numpy.arange` with `start` as keyword argument will be reported by type-checkers as an error. Refer to the [NumPy 2.4.0rc1](https://github.com/numpy/numpy/releases/tag/v2.4.0rc1) release notes for the details.

This updates three such uses of `arange`, towards #20782.