### PR TITLE
Fix default null_values setting in cudf-polars csv scan

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -670,7 +670,7 @@ class Scan(IR):
             header = 0 if has_header else -1
 
             # polars defaults to no null recognition
-            null_values = [""]
+            null_values = []
             if parse_options["null_values"] is not None:
                 ((typ, nulls),) = parse_options["null_values"].items()
                 if typ == "AllColumnsSingle":

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -289,6 +289,15 @@ def test_scan_csv_null_values(tmp_path, nulls):
     assert_gpu_result_equal(q)
 
 
+def test_scan_csv_empty_string(tmp_path):
+    with (tmp_path / "test.csv").open("w") as f:
+        f.write('''c0,c1,c3\n"",\"abc\","abc,d"''')
+
+    q = pl.scan_csv(tmp_path / "test.csv")
+
+    assert_gpu_result_equal(q)
+
+
 def test_scan_csv_decimal_comma(tmp_path):
     with (tmp_path / "test.csv").open("w") as f:
         f.write("""foo|bar|baz\n1,23|2,34|3,56\n1""")


### PR DESCRIPTION
## Description
- Closes #20343
- Closes pola-rs/polars#24917

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
