### PR TITLE
Fix racecheck reported by DATA_CHUNK_SOURCE_TEST in inflate_kernel

### DIFF
--- a/cpp/src/io/comp/gpuinflate.cu
+++ b/cpp/src/io/comp/gpuinflate.cu
@@ -1121,7 +1121,6 @@ CUDF_KERNEL void __launch_bounds__(block_size)
       copy_stored(state, t);
     }
     if (state->blast) break;
-    //__syncthreads();
   }
   __syncthreads();
   // Output decompression status and length


### PR DESCRIPTION
## Description
The `DATA_CHUNK_SOURCE_TEST` reports several racecheck errors in compute-sanitizer like the following:
```
[ RUN      ] Nvcomp/DataChunkDecompressionTest.BgzipSource/1
========= Error: Race reported between Read access at void cudf::io::detail::<unnamed>::inflate_kernel<(int)128>(cudf::device_span<const cudf::device_span<const unsigned char, (unsigned long)18446744073709551615>, (unsigned long)18446744073709551615>, cudf::device_span<const cudf::device_span<unsigned char, (unsigned long)18446744073709551615>, (unsigned long)18446744073709551615>, cudf::device_span<cudf::io::detail::codec_exec_result, (unsigned long)18446744073709551615>, cudf::io::detail::gzip_header_included)+0x850 in gpuinflate.cu:1068
=========     and Write access at void cudf::io::detail::<unnamed>::inflate_kernel<(int)128>(cudf::device_span<const cudf::device_span<const unsigned char, (unsigned long)18446744073709551615>, (unsigned long)18446744073709551615>, cudf::device_span<const cudf::device_span<unsigned char, (unsigned long)18446744073709551615>, (unsigned long)18446744073709551615>, cudf::device_span<cudf::io::detail::codec_exec_result, (unsigned long)18446744073709551615>, cudf::io::detail::gzip_header_included)+0x11380 in gpuinflate.cu:1077 [2092 hazards]

```
This identified `cudf::io::detail::inflate_kernel` reading the `state->err` variable on all threads while thread 0 may be resetting it before the other threads have read it.
The variable is checked as part of a while-loop which has a `__syncthreads()` at the bottom of the loop.
Moving the `__syncthreads()` to the top of the loop clears the racecheck error since all threads will have the same `state->err` value upon entering or continuing the while-loop.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
