### PR TITLE
Enable merge barriers

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -6,3 +6,4 @@ branch_checker: true
 label_checker: true
 release_drafter: true
 forward_merger: true
+merge_barriers: true


### PR DESCRIPTION
Enable the `merge_barriers` setting in `.github/ops-bot.yaml` to enable the new merge barriers plugin.
