### PR TITLE
Fix racecheck in parquet decode_page_data_generic kernel

### DIFF
--- a/cpp/src/io/parquet/decode_fixed.cu
+++ b/cpp/src/io/parquet/decode_fixed.cu
@@ -1107,7 +1107,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
   while ((s->error == 0) && (processed_count < s->page.num_input_values) &&
          (s->input_row_count <= last_row)) {
     int next_valid_count;
-
+    block.sync();
     // only need to process definition levels if this is a nullable column
     if (should_process_nulls) {
       processed_count += def_decoder.decode_next(t);
@@ -1189,7 +1189,6 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size_t, 8)
         decode_values.template operator()<copy_mode::DIRECT>();
       }
     }
-    block.sync();
 
     valid_count = next_valid_count;
   }


### PR DESCRIPTION
## Description
Fixes a racecheck condition found in the `cudf::io::parquet::detail::decode_page_data_generic` kernel found in several gtests using compute-sanitizer:
```
[ RUN      ] ParquetDeletionVectorsTest.NoRowIndexColumn
========= Error: Race reported between Write access at void cudf::io::parquet::detail::<unnamed>::decode_page_data_generic<unsigned char, (int)128, (cudf::io::parquet::detail::decode_kernel_mask)32>(cudf::io::parquet::detail::PageInfo *, cudf::device_span<const cudf::io::parquet::detail::ColumnChunkDesc, (unsigned long)18446744073709551615>, unsigned long, unsigned long, cudf::device_span<const bool, (unsigned long)18446744073709551615>, cudf::device_span<unsigned long, (unsigned long)18446744073709551615>, cudf::device_span<const unsigned long, (unsigned long)18446744073709551615>, unsigned int *)+0x6e60 in decode_fixed.cu:1146
=========     and Read access at void cudf::io::parquet::detail::<unnamed>::decode_page_data_generic<unsigned char, (int)128, (cudf::io::parquet::detail::decode_kernel_mask)32>(cudf::io::parquet::detail::PageInfo *, cudf::device_span<const cudf::io::parquet::detail::ColumnChunkDesc, (unsigned long)18446744073709551615>, unsigned long, unsigned long, cudf::device_span<const bool, (unsigned long)18446744073709551615>, cudf::device_span<unsigned long, (unsigned long)18446744073709551615>, cudf::device_span<const unsigned long, (unsigned long)18446744073709551615>, unsigned int *)+0x6cb0 in decode_fixed.cu:1108 [260 hazards]
=========     and Read access at void cudf::io::parquet::detail::<unnamed>::decode_page_data_generic<unsigned char, (int)128, (cudf::io::parquet::detail::decode_kernel_mask)32>(cudf::io::parquet::detail::PageInfo *, cudf::device_span<const cudf::io::parquet::detail::ColumnChunkDesc, (unsigned long)18446744073709551615>, unsigned long, unsigned long, cudf::device_span<const bool, (unsigned long)18446744073709551615>, cudf::device_span<unsigned long, (unsigned long)18446744073709551615>, cudf::device_span<const unsigned long, (unsigned long)18446744073709551615>, unsigned int *)+0x13c00 in decode_fixed.cu:1108 [8304 hazards]

```

The `s->input_row_count` variable may be reset by thread 0 (line 1146) before it is read by other threads in the block (line 1108). Moving the `block.sync()` from the bottom of the while-loop to the top prevents the racecheck without introducing any additional sync calls.

Fixes (some) racecheck errors in the following tests:
- `PARQUET_DELETION_VECTORS_TEST`
- `PARQUET_TEST`
- `HYBRID_SCAN_TEST`
- `LARGE_STRINGS_TEST`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
