### PR TITLE
Fix racecheck in ORC decode_column_data_kernel

### DIFF
--- a/cpp/src/io/orc/stripe_data.cu
+++ b/cpp/src/io/orc/stripe_data.cu
@@ -1482,6 +1482,7 @@ static __device__ void DecodeRowPositions(orcdec_state_s* s,
   if (t < s->u.rowdec.nz_count) {
     s->u.rowdec.row[t] = 0;  // Skipped values (below first_row)
   }
+  __syncthreads();
   while (s->u.rowdec.nz_count < s->top.data.max_vals &&
          s->top.data.cur_row + s->top.data.nrows < s->top.data.end_row) {
     uint32_t const remaining_rows = s->top.data.end_row - (s->top.data.cur_row + s->top.data.nrows);
@@ -1504,6 +1505,7 @@ static __device__ void DecodeRowPositions(orcdec_state_s* s,
       } else {
         row_plus1 = 0;
       }
+      __syncthreads();
       if (t == nrows - 1) { s->u.rowdec.nz_count = min(nz_count, s->top.data.max_vals); }
       __syncthreads();
 
@@ -1514,7 +1516,6 @@ static __device__ void DecodeRowPositions(orcdec_state_s* s,
       nz_pos   = (valid) ? nz_count : 0;
       if (t == 0) { s->top.data.nrows = last_row; }
       if (valid && nz_pos - 1 < s->u.rowdec.nz_count) { s->u.rowdec.row[nz_pos - 1] = row_plus1; }
-      __syncthreads();
     } else {
       // All values are valid
       nrows = min(nrows, s->top.data.max_vals - s->u.rowdec.nz_count);
@@ -1524,8 +1525,8 @@ static __device__ void DecodeRowPositions(orcdec_state_s* s,
         s->top.data.nrows += nrows;
         s->u.rowdec.nz_count += nrows;
       }
-      __syncthreads();
     }
+    __syncthreads();
   }
 }
 


### PR DESCRIPTION
## Description
Fixes a racecheck found by compute sanitizer when running the `ORC_TEST` `OrcWriterTest/OrcWriterTestDecimal.Decimal` test reported as follows:
```
[ RUN      ] OrcWriterTest/OrcWriterTestDecimal.Decimal64/6
========= Error: Race reported between Read access at void cudf::io::orc::detail::DecodeRowPositions<cub::BlockReduce<unsigned int, (int)1024, (cub::BlockReduceAlgorithm)2, (int)1, (int)1>::TempStorage>(cudf::io::orc::detail::orcdec_state_s *, unsigned long, int, T1 &)+0x23290 in stripe_data.cu:1482
=========     and Write access at void cudf::io::orc::detail::DecodeRowPositions<cub::BlockReduce<unsigned int, (int)1024, (cub::BlockReduceAlgorithm)2, (int)1, (int)1>::TempStorage>(cudf::io::orc::detail::orcdec_state_s *, unsigned long, int, T1 &)+0x23720 in stripe_data.cu:1507 [4 hazards]
=========
[       OK ] OrcWriterTest/OrcWriterTestDecimal.Decimal64/6 (2025 ms)

```

Several references to variable `s->u.rowdec.nz_count` in multiple block threads race against setting this variable in individual threads at line 1509
```
if (t == nrows - 1) { s->u.rowdec.nz_count = min(nz_count, s->top.data.max_vals); }
```
Adding 2 additional `__syncthreads()` calls fixes the racecheck. 
Also, two `__syncthreads()` were replaced by one at the bottom of the while-loop since each were at the bottom of the if and else paths in the while.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
