### PR TITLE
Fix racecheck/synccheck in JSON parse_fn_string_parallel kernel

### DIFF
--- a/cpp/src/io/utilities/data_casting.cu
+++ b/cpp/src/io/utilities/data_casting.cu
@@ -603,8 +603,9 @@ CUDF_KERNEL void parse_fn_string_parallel(str_tuple_it str_tuples,
         using ErrorReduce = cub::BlockReduce<bool, BLOCK_SIZE>;
         __shared__ typename ErrorReduce::TempStorage temp_storage_error;
         __shared__ bool error_reduced;
-        error_reduced = ErrorReduce(temp_storage_error).Sum(error);  // TODO use cub::LogicalOR.
+        auto berr = ErrorReduce(temp_storage_error).Sum(error);  // TODO use cub::LogicalOR.
         // only valid in thread0, so shared memory is used for broadcast.
+        if (lane == 0) error_reduced = berr;
         __syncthreads();
         error = error_reduced;
       }


### PR DESCRIPTION
## Description
Fixes a racecheck in the `cudf::io::json::detail:parse_fn_string_parallel` kernel found by compute-sanitizer:
```
[ RUN      ] JSONTypeCastTest.ErrorNulls
========= Error: Race reported between Write access at void cudf::io::json::detail::parse_fn_string_parallel<(bool)0, (int)8, thrust::transform_iterator<cudf::io::json::detail::to_string_view_pair<char>, thrust::zip_iterator<cuda::std::__4::tuple<const int *, const int *>>, thrust::use_default, thrust::use_default>>(T3, int, int *, unsigned int *, int *, cudf::io::parse_options_view, int *, cudf::detail::input_offsetalator, char *)+0x3380 in data_casting.cu:606
=========     and Write access at void cudf::io::json::detail::parse_fn_string_parallel<(bool)0, (int)8, thrust::transform_iterator<cudf::io::json::detail::to_string_view_pair<char>, thrust::zip_iterator<cuda::std::__4::tuple<const int *, const int *>>, thrust::use_default, thrust::use_default>>(T3, int, int *, unsigned int *, int *, cudf::io::parse_options_view, int *, cudf::detail::input_offsetalator, char *)+0x3380 in data_casting.cu:606 [27 hazards]
=========
[       OK ] JSONTypeCastTest.ErrorNulls (3313 ms)

```
The kernel has a shared variable `error_reduced` that is being set by all threads in the block.
The fix here introduces a local variable which is updated by `cub::BlockReduce` and then the shared `error_reduced` can be updated in just one thread (`lane==0`).

This removes the racecheck and also fixes the synccheck error which produced indeterminate results failing the `JSONTypeCastTest.ErrorNulls` gtest in `JSON_TEST`.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
