### PR TITLE
Add zstd kernels to compute-sanitizer filter parameter

### DIFF
--- a/ci/run_compute_sanitizer_test.sh
+++ b/ci/run_compute_sanitizer_test.sh
@@ -68,7 +68,7 @@ fi
 # Run compute-sanitizer on the specified test
 compute-sanitizer \
   --tool "${TOOL_NAME}" \
-  --kernel-name-exclude kns=nvcomp \
+  --kernel-name-exclude kns=nvcomp,kns=zstd \
   --error-exitcode=1 \
   "${TEST_EXECUTABLE}" \
   "$@"


### PR DESCRIPTION
Adds the `zstd` pattern to the kernel name exclude filter on the `compute-sanitizer` command.
The `zstd` kernels are from the `nvcomp` library and not part of libcudf.

This will suppress errors like the following from the `compute-sanitizer` runs
```
[ RUN      ] ParquetStringsTest.ReadLargeStrings
========= Warning: Race reported between Write access at zstd::lz_compression_kernel(zstd::CompressBlockShare *, unsigned char *, int *, const int *, unsigned char *, unsigned long, unsigned long *, unsigned long)+0x28b0
=========     and Write access at zstd::lz_compression_kernel(zstd::CompressBlockShare *, unsigned char *, int *, const int *, unsigned char *, unsigned long, unsigned long *, unsigned long)+0x3d20 [812800 hazards]
========= 
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
