### PR TITLE
Temporarily increase max_days_without_success for nightly CI check

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -65,6 +65,8 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: cudf
+          # TODO: Fix nightly CI and remove this line
+          max_days_without_success: 30
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
Increases `max_days_without_success` to 30 days to allow PRs to proceed while nightly CI issues are being resolved.