### PR TITLE
Fix `parquet_options` in pdsh benchmark

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -937,7 +937,7 @@ def run_polars(
                 "use_rapidsmpf_native": run_config.native_parquet,
             }
         else:
-            parquet_options = None
+            parquet_options = {}
         engine = pl.GPUEngine(
             raise_on_fail=True,
             memory_resource=rmm.mr.CudaAsyncMemoryResource()

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -1053,6 +1053,8 @@ class ConfigOptions:
             user_executor = os.environ.get(f"{env_prefix}__EXECUTOR", "streaming")
         user_executor_options = engine.config.get("executor_options", {})
         user_parquet_options = engine.config.get("parquet_options", {})
+        if user_parquet_options is None:
+            user_parquet_options = {}
         # This is set in polars, and so can't be overridden by the environment
         user_raise_on_fail = engine.config.get("raise_on_fail", False)
         user_memory_resource_config = engine.config.get("memory_resource_config", None)

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -236,6 +236,16 @@ def test_parquet_options(executor: str) -> None:
     assert config.parquet_options.n_output_chunks == 16
 
 
+def test_parquet_options_from_none() -> None:
+    config = ConfigOptions.from_polars_engine(
+        pl.GPUEngine(
+            executor="streaming",
+            parquet_options=None,
+        )
+    )
+    assert config.parquet_options.chunked is True
+
+
 def test_validate_streaming_executor_shuffle_method(
     *, rapidsmpf_distributed_available: bool, rapidsmpf_single_available: bool
 ) -> None:


### PR DESCRIPTION
## Description

The `parquet_options` argument to `pl.GPUEngine` needs to be a mapping, rather than `None`. But since passing `None` here is clearly a natural thing to do, we'll also support that.