### PR TITLE
Remove expect_warning_if in series/test_np_ufuncs.py

### DIFF
--- a/python/cudf/cudf/tests/series/test_np_ufuncs.py
+++ b/python/cudf/cudf/tests/series/test_np_ufuncs.py
@@ -14,7 +14,7 @@ from cudf.core._compat import (
     PANDAS_VERSION,
 )
 from cudf.testing import assert_eq
-from cudf.testing._utils import expect_warning_if, set_random_null_mask_inplace
+from cudf.testing._utils import set_random_null_mask_inplace
 
 
 @pytest.mark.skipif(
@@ -99,25 +99,26 @@ def test_ufunc_series(request, numpy_ufunc, has_nulls, indexed):
             assert_eq(g, e, check_exact=False)
     else:
         if has_nulls:
-            with expect_warning_if(
-                numpy_ufunc
-                in (
-                    np.isfinite,
-                    np.isinf,
-                    np.isnan,
-                    np.logical_and,
-                    np.logical_not,
-                    np.logical_or,
-                    np.logical_xor,
-                    np.signbit,
-                    np.equal,
-                    np.greater,
-                    np.greater_equal,
-                    np.less,
-                    np.less_equal,
-                    np.not_equal,
-                )
+            if numpy_ufunc in (
+                np.isfinite,
+                np.isinf,
+                np.isnan,
+                np.logical_and,
+                np.logical_not,
+                np.logical_or,
+                np.logical_xor,
+                np.signbit,
+                np.equal,
+                np.greater,
+                np.greater_equal,
+                np.less,
+                np.less_equal,
+                np.not_equal,
             ):
+                # cuDF .to_pandas for bools with nulls represents missing as None,
+                # should this be np.nan?
+                expect = expect.astype(object).mask(mask, None)
+            else:
                 expect[mask] = np.nan
             assert_eq(got, expect, check_exact=False)
 


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/20877

Applies the same change as https://github.com/rapidsai/cudf/pull/20823 in `dataframe/test_np_ufuncs.py`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
