### PR TITLE
Ignore UserWarning from pandas 3.0 about obj.round on temporal types

### DIFF
--- a/python/cudf/cudf/tests/series/methods/test_round.py
+++ b/python/cudf/cudf/tests/series/methods/test_round.py
@@ -129,7 +129,7 @@ def test_series_round_decimal(
         pytest.param(
             pd.Series([34224, 324324, 324342], dtype="datetime64[ns]"),
             marks=pytest.mark.filterwarnings(
-                "ignore:obj.round has no effect:UserWarning:"
+                "ignore:obj.round has no effect:UserWarning"
             ),
         ),
         pd.Series([224.242, None, 2424.234324], dtype="category"),


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/20816

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
