### PR TITLE
Remove FutureWarning checks from series/test_pct_change

### DIFF
--- a/python/cudf/cudf/tests/series/methods/test_pct_change.py
+++ b/python/cudf/cudf/tests/series/methods/test_pct_change.py
@@ -6,15 +6,8 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.api.extensions import no_default
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
-from cudf.testing._utils import expect_warning_if
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="warning not present in older pandas versions",
-)
 @pytest.mark.parametrize(
     "data",
     [
@@ -28,23 +21,12 @@ from cudf.testing._utils import expect_warning_if
     ],
 )
 @pytest.mark.parametrize("periods", [-5, 0, 5])
-@pytest.mark.parametrize(
-    "fill_method", ["ffill", "bfill", "pad", "backfill", no_default, None]
-)
-def test_series_pct_change(data, periods, fill_method):
+def test_series_pct_change(data, periods):
     cs = cudf.Series(data)
     ps = cs.to_pandas()
 
-    if np.abs(periods) <= len(cs):
-        with expect_warning_if(fill_method not in (no_default, None)):
-            got = cs.pct_change(periods=periods, fill_method=fill_method)
-        with expect_warning_if(
-            (
-                fill_method not in (no_default, None)
-                or (fill_method is not None and ps.isna().any())
-            )
-        ):
-            expected = ps.pct_change(periods=periods, fill_method=fill_method)
-        np.testing.assert_array_almost_equal(
-            got.to_numpy(na_value=np.nan), expected
-        )
+    got = cs.pct_change(periods=periods)
+    expected = ps.pct_change(periods=periods)
+    np.testing.assert_array_almost_equal(
+        got.to_numpy(na_value=np.nan), expected
+    )


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/20877

The API changes were done in https://github.com/rapidsai/cudf/pull/20823

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
