### PR TITLE
Drop warnings in `test_reductions.py`

### DIFF
--- a/python/cudf/cudf/tests/series/methods/test_reductions.py
+++ b/python/cudf/cudf/tests/series/methods/test_reductions.py
@@ -842,10 +842,7 @@ def test_timedelta_reduction_ops(
     gsr = cudf.Series(data_non_overflow, dtype=timedelta_types_as_str)
     psr = gsr.to_pandas()
 
-    if len(psr) > 0 and psr.isnull().all() and reduction_methods == "median":
-        expected = getattr(psr, reduction_methods)()
-    else:
-        expected = getattr(psr, reduction_methods)()
+    expected = getattr(psr, reduction_methods)()
     actual = getattr(gsr, reduction_methods)()
     if pd.isna(expected) and pd.isna(actual):
         pass


### PR DESCRIPTION
## Description
This PR drops warnings that vanish in `3.0`

Towards: https://github.com/rapidsai/cudf/issues/20816
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
