### PR TITLE
Enforce pandas 3 timedelta frequency string deprecation

### DIFF
--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -7,7 +7,6 @@ import calendar
 import functools
 import locale
 import re
-import warnings
 from locale import nl_langinfo
 from typing import TYPE_CHECKING, Literal, cast
 
@@ -392,22 +391,6 @@ class DatetimeColumn(TemporalBaseColumn):
         freq: str,
     ) -> ColumnBase:
         # https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timedelta.resolution_string.html
-        old_to_new_freq_map = {
-            "H": "h",
-            "N": "ns",
-            "T": "min",
-            "L": "ms",
-            "U": "us",
-            "S": "s",
-        }
-        if freq in old_to_new_freq_map:
-            warnings.warn(
-                f"{freq} is deprecated and will be "
-                "removed in a future version, please use "
-                f"{old_to_new_freq_map[freq]} instead.",
-                FutureWarning,
-            )
-            freq = old_to_new_freq_map[freq]
         rounding_fequency_map = {
             "D": plc.datetime.RoundingFrequency.DAY,
             "h": plc.datetime.RoundingFrequency.HOUR,

--- a/python/cudf/cudf/tests/series/accessors/test_dt.py
+++ b/python/cudf/cudf/tests/series/accessors/test_dt.py
@@ -153,12 +153,12 @@ def test_day_month_name(meth, klass):
         "S",
     ],
 )
-def test_datetime_ceil_raise_warning(freqstr):
+def test_datetime_ceil_invalid_freq_raises(freqstr):
     t = cudf.Series(
         ["2001-01-01 00:04:45", "2001-01-01 00:04:58", "2001-01-01 00:05:04"],
         dtype="datetime64[ns]",
     )
-    with pytest.warns(FutureWarning):
+    with pytest.raises(ValueError):
         t.dt.ceil(freqstr)
 
 


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/20877

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
