### PR TITLE
Remove unneeded pandas 3 FutureWarning filters from test_binops.py/test_apply.py

### DIFF
--- a/python/cudf/cudf/tests/dataframe/test_binops.py
+++ b/python/cudf/cudf/tests/dataframe/test_binops.py
@@ -8,7 +8,7 @@ import pytest
 
 import cudf
 from cudf.testing import assert_eq
-from cudf.testing._utils import assert_exceptions_equal, expect_warning_if
+from cudf.testing._utils import assert_exceptions_equal
 
 
 @pytest.mark.parametrize(
@@ -437,19 +437,7 @@ def test_df_sr_binop_col_order(op):
     gsr = cudf.Series([1, 2, 3, 4, 5], index=["a", "b", "d", "0", "12"])
     psr = gsr.to_pandas()
 
-    with expect_warning_if(
-        op
-        in {
-            operator.eq,
-            operator.lt,
-            operator.le,
-            operator.gt,
-            operator.ge,
-            operator.ne,
-        },
-        FutureWarning,
-    ):
-        expect = op(pdf, psr).astype("float")
+    expect = op(pdf, psr).astype("float")
     out = op(gdf, gsr).astype("float")
     got = out[expect.columns]
 

--- a/python/cudf/cudf/tests/groupby/test_apply.py
+++ b/python/cudf/cudf/tests/groupby/test_apply.py
@@ -248,14 +248,8 @@ def test_groupby_apply_jit_unary_reductions(
             reason=("https://github.com/rapidsai/cudf/issues/14860"),
         )
     )
-    warn_condition = (
-        dataset == "nans"
-        and func in {"idxmax", "idxmin"}
-        and dtype.kind == "f"
-    )
     dataset = groupby_jit_datasets[dataset].copy(deep=True)
-    with expect_warning_if(warn_condition, FutureWarning):
-        groupby_apply_jit_reductions_test_inner(func, dataset, dtype)
+    groupby_apply_jit_reductions_test_inner(func, dataset, dtype)
 
 
 # test unary reductions for special values


### PR DESCRIPTION
## Description
Removing these filters no longer fails these tests.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
