### PR TITLE
Remove more pandas<3 version checks in cuDF

### DIFF
--- a/python/cudf/cudf/api/types.py
+++ b/python/cudf/cudf/api/types.py
@@ -20,7 +20,6 @@ from pandas.api import types as pd_types  # noqa: TID251
 import pylibcudf as plc
 
 import cudf
-from cudf.core._compat import PANDAS_LT_300
 from cudf.core.dtypes import (  # noqa: F401
     _BaseDtype,
     _is_categorical_dtype,
@@ -473,22 +472,13 @@ def is_any_real_numeric_dtype(arr_or_dtype) -> bool:
     )
 
 
-def _is_datetime64tz_dtype(obj):
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        assert PANDAS_LT_300, "Need to drop after pandas-3.0 support is added."
-        return _wrap_pandas_is_dtype_api(pd_types.is_datetime64tz_dtype)(obj)
-
-
 def is_datetime64tz_dtype(obj):
-    # Do not remove until pandas 3.0 support is added.
-    assert PANDAS_LT_300, "Need to drop after pandas-3.0 support is added."
     warnings.warn(
         "is_datetime64tz_dtype is deprecated and will be removed in a future "
         "version.",
         FutureWarning,
     )
-    return _is_datetime64tz_dtype(obj)
+    return _wrap_pandas_is_dtype_api(pd_types.is_datetime64tz_dtype)(obj)
 
 
 # TODO: The below alias is removed for now since improving cudf categorical

--- a/python/cudf/cudf/core/_compat.py
+++ b/python/cudf/cudf/core/_compat.py
@@ -6,8 +6,3 @@ from packaging import version
 
 PANDAS_CURRENT_SUPPORTED_VERSION = version.parse("2.3.3")
 PANDAS_VERSION = version.parse(pd.__version__)
-
-
-PANDAS_GE_220 = PANDAS_VERSION >= version.parse("2.2.0")
-PANDAS_GE_230 = PANDAS_VERSION >= version.parse("2.3.0")
-PANDAS_LT_300 = PANDAS_VERSION < version.parse("3.0.0")

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -17,7 +17,6 @@ from pandas.api.extensions import ExtensionDtype
 from pandas.core.arrays.arrow.extension_types import ArrowIntervalType
 
 import cudf
-from cudf.core._compat import PANDAS_LT_300
 from cudf.core.abc import Serializable
 from cudf.utils.docutils import doc_apply
 from cudf.utils.dtypes import (
@@ -1169,8 +1168,6 @@ def is_categorical_dtype(obj):
     bool
         Whether or not the array-like or dtype is of a categorical dtype.
     """
-    # Do not remove until pandas 3.0 support is added.
-    assert PANDAS_LT_300, "Need to drop after pandas-3.0 support is added."
     warnings.warn(
         "is_categorical_dtype is deprecated and will be removed in a future "
         "version. Use isinstance(dtype, cudf.CategoricalDtype) instead",

--- a/python/cudf/cudf/tests/indexes/test_np_ufuncs.py
+++ b/python/cudf/cudf/tests/indexes/test_np_ufuncs.py
@@ -8,20 +8,11 @@ import pytest
 from packaging.version import parse
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_LT_300,
-)
 from cudf.testing import assert_eq
 
 
 def test_ufunc_index(request, numpy_ufunc):
     # Note: This test assumes that all ufuncs are unary or binary.
-    request.applymarker(
-        pytest.mark.xfail(
-            condition=numpy_ufunc == np.matmul and PANDAS_LT_300,
-            reason="Fixed by https://github.com/pandas-dev/pandas/pull/57079",
-        )
-    )
     request.applymarker(
         pytest.mark.xfail(
             condition=numpy_ufunc in {np.ceil, np.floor, np.trunc}


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/20816

`is_datetime64tz_dtype` and `is_categorical_dtype` did not get removed for pandas 3.0, and may not for 4.0 so we can remove them when we investigate the next major release.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
