### PR TITLE
Add force-blocking-launches to run_compute_sanitizer_test script

### DIFF
--- a/ci/run_compute_sanitizer_test.sh
+++ b/ci/run_compute_sanitizer_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -68,6 +68,7 @@ fi
 # Run compute-sanitizer on the specified test
 compute-sanitizer \
   --tool "${TOOL_NAME}" \
+  --force-blocking-launches \
   --kernel-name-exclude kns=nvcomp,kns=zstd \
   --error-exitcode=1 \
   "${TEST_EXECUTABLE}" \


### PR DESCRIPTION
## Description
The weekend compute-sanitizer runs are failing with segfaults which cannot be reproduced locally.
It is possible that `compute-sanitizer` itself is running out of memory:
 https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html#memory-footprint
Adding the `--force-blocking-launches` as recommended in this PR.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
