### PR TITLE
Use larger node for cpp-linters job in nightly tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,7 @@ jobs:
       sha: ${{ inputs.sha }}
       script: "ci/cpp_linters.sh"
       file_to_upload: iwyu_results.txt
+      node_type: cpu16
   conda-python-cudf-tests:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The nightly workflow has been silently failing on this job ([example](https://github.com/rapidsai/cudf/actions/runs/20651999970/job/59298298092)). That most likely indicates an OOM, especially since the same job is passing in PR CI and the only difference is that [PR CI is already using a larger node for this job](https://github.com/rapidsai/cudf/blob/77d3ca3653e530b1637f5a8470172c4c457cfb15/.github/workflows/pr.yaml#L155). This PR makes the same change for nightlies to see if that fixes them.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
