### PR TITLE
Fix racechecks reported in parquet gpuEncodePages kernel

### DIFF
--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -156,6 +156,7 @@ struct delta_byte_array_decoder {
 
       // copy prefixes into string data.
       string_scan(out, last_string, idx, end, string_off, lane_id);
+      __syncwarp();
 
       // save the position of the last computed string. this will be used in
       // the next iteration to reconstruct the string in lane 0.

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -1862,6 +1862,7 @@ CUDF_KERNEL void __launch_bounds__(block_size, 8)
   // for BYTE_STREAM_SPLIT, s->cur now points to the end of the first stream.
   // need it to point to the end of the Nth stream.
   if (is_split_stream and t == 0) { s->cur += (dtype_len_out - 1) * s->page.num_valid; }
+  __syncthreads();
   finish_page_encode<block_size>(
     s, s->cur, pages, comp_in, comp_out, comp_results, write_v2_headers);
 }


### PR DESCRIPTION
## Description
Fixes racecheck errors reported by compute-sanitizer in the `ParquetWriterTest.ByteStreamSplit`, `ParquetWriterTest.ByteStreamSplitStruct` tests
```
[ RUN      ] ParquetWriterTest.ByteStreamSplit
========= Error: Race reported between Read access at void cudf::io::parquet::detail::gpuEncodePages<(int)128>(cudf::device_span<cudf::io::parquet::detail::EncPage, (unsigned long)18446744073709551615>, cudf::device_span<cudf::device_span<const unsigned char, (unsigned long)18446744073709551615>, (unsigned long)18446744073709551615>, cudf::device_span<cudf::device_span<unsigned char, (unsigned long)18446744073709551615>, (unsigned long)18446744073709551615>, cudf::device_span<cudf::io::detail::codec_exec_result, (unsigned long)18446744073709551615>, bool, bool)+0x4bc0 in page_enc.cu:1866
=========     and Write access at void cudf::io::parquet::detail::gpuEncodePages<(int)128>(cudf::device_span<cudf::io::parquet::detail::EncPage, (unsigned long)18446744073709551615>, cudf::device_span<cudf::device_span<const unsigned char, (unsigned long)18446744073709551615>, (unsigned long)18446744073709551615>, cudf::device_span<cudf::device_span<unsigned char, (unsigned long)18446744073709551615>, (unsigned long)18446744073709551615>, cudf::device_span<cudf::io::detail::codec_exec_result, (unsigned long)18446744073709551615>, bool, bool)+0x4c10 in page_enc.cu:1864 [12 hazards]
=========

```
The contention is likely on the `s` and `s->cur` variables which are set in thread 0 `(t==0)` but read immediately by all threads when calling the `finish_page_encode()` funnction.
Adding a `__syncthreads()` call between the `if( ... t==0)` and the call to `finish_page_encode()` clears the racecheck error.

And the `ParquetWriterTest.WriteFixedLenByteArray` test
```
[ RUN      ] ParquetWriterTest.WriteFixedLenByteArray
========= Warning: Race reported between Read access at cudf::io::parquet::detail::<unnamed>::delta_byte_array_decoder::calculate_string_values(unsigned char *, unsigned int, unsigned int, unsigned int)::[lambda(unsigned char *, unsigned int, unsigned int) (instance 1)]::operator ()(unsigned char *, unsigned int, unsigned int) const+0x13d50 in page_delta_decode.cu:157
=========     and Write access at cudf::io::parquet::detail::<unnamed>::delta_byte_array_decoder::calculate_string_values(unsigned char *, unsigned int, unsigned int, unsigned int)::[lambda(unsigned char *, unsigned int, unsigned int) (instance 1)]::operator ()(unsigned char *, unsigned int, unsigned int) const+0x14520 in page_delta_decode.cu:166 [8 hazards]

```
The contention appears to be on the `last_string` variable which is read for the call to `string_scan` by all threads and written to only on specific threads.
Adding a `__syncwarp()` between the `string_scan()` call and the if `ln_idx` and `lane_id` statement clears the racecheck error.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
