### PR TITLE
Add missing standard library headers to groupby/hash and jit files

### DIFF
--- a/cpp/src/groupby/hash/compute_global_memory_aggs.cu
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs.cu
@@ -5,6 +5,8 @@
 
 #include "compute_global_memory_aggs.cuh"
 
+#include <span>
+
 namespace cudf::groupby::detail::hash {
 
 template std::pair<std::unique_ptr<table>, rmm::device_uvector<size_type>>

--- a/cpp/src/groupby/hash/compute_global_memory_aggs.cuh
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs.cuh
@@ -18,6 +18,11 @@
 #include <thrust/for_each.h>
 #include <thrust/tabulate.h>
 
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <utility>
+
 namespace cudf::groupby::detail::hash {
 
 namespace {

--- a/cpp/src/groupby/hash/compute_global_memory_aggs.hpp
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs.hpp
@@ -12,6 +12,11 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <utility>
+
 namespace cudf::groupby::detail::hash {
 template <typename SetType>
 std::pair<std::unique_ptr<table>, rmm::device_uvector<size_type>> compute_global_memory_aggs(

--- a/cpp/src/groupby/hash/compute_global_memory_aggs_null.cu
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs_null.cu
@@ -5,6 +5,8 @@
 
 #include "compute_global_memory_aggs.cuh"
 
+#include <span>
+
 namespace cudf::groupby::detail::hash {
 
 template std::pair<std::unique_ptr<table>, rmm::device_uvector<size_type>>

--- a/cpp/src/groupby/hash/output_utils.cu
+++ b/cpp/src/groupby/hash/output_utils.cu
@@ -23,6 +23,14 @@
 #include <thrust/scatter.h>
 #include <thrust/transform.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <span>
+#include <utility>
+#include <vector>
+
 namespace cudf::groupby::detail::hash {
 namespace {
 

--- a/cpp/src/groupby/hash/output_utils.hpp
+++ b/cpp/src/groupby/hash/output_utils.hpp
@@ -15,6 +15,11 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
+
 namespace cudf::groupby::detail::hash {
 
 /**

--- a/cpp/src/jit/row_ir.cpp
+++ b/cpp/src/jit/row_ir.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,11 @@
 #include <algorithm>
 #include <format>
 #include <iostream>
+#include <iterator>
 #include <numeric>
+#include <span>
+#include <stdexcept>
+#include <utility>
 
 namespace cudf {
 

--- a/cpp/src/jit/row_ir.hpp
+++ b/cpp/src/jit/row_ir.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,12 +14,15 @@
 #include <rmm/resource_ref.hpp>
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <span>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <variant>
 #include <vector>
 


### PR DESCRIPTION
Add missing standard library headers to `cpp/src/groupby/hash/` and `cpp/src/jit/row_ir.*` files. Fixes builds for Velox.