### PR TITLE
Add utility for deferring allocations on a stream

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/sort.py
@@ -24,7 +24,6 @@ from cudf_polars.experimental.shuffle import _simple_shuffle_graph
 from cudf_polars.experimental.utils import _concat, _fallback_inform, _lower_ir_fallback
 from cudf_polars.utils.config import ShuffleMethod
 from cudf_polars.utils.cuda_stream import (
-    deferred_dealloc_stream,
     get_dask_cuda_stream,
     get_joined_cuda_stream,
 )
@@ -325,7 +324,7 @@ class RMPFIntegrationSortedShuffle:  # pragma: no cover
 
         by = options["by"]
 
-        with deferred_dealloc_stream(context, [df, sort_boundaries]) as stream:
+        with context.stream_ordered_after(df, sort_boundaries) as stream:
             splits = find_sort_splits(
                 df.select(by).table,
                 sort_boundaries.table,

--- a/python/cudf_polars/cudf_polars/utils/cuda_stream.py
+++ b/python/cudf_polars/cudf_polars/utils/cuda_stream.py
@@ -1,21 +1,17 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """CUDA stream utilities."""
 
 from __future__ import annotations
 
-import contextlib
 from typing import TYPE_CHECKING
 
 import pylibcudf as plc
 from rmm.pylibrmm.stream import DEFAULT_STREAM, Stream
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Sequence
-
-    from cudf_polars.containers import DataFrame
-    from cudf_polars.dsl.ir import IRExecutionContext
+    from collections.abc import Callable, Sequence
 
 
 def get_dask_cuda_stream() -> Stream:
@@ -72,56 +68,3 @@ def get_joined_cuda_stream(
     downstream = get_cuda_stream()
     join_cuda_streams(downstreams=(downstream,), upstreams=upstreams)
     return downstream
-
-
-@contextlib.contextmanager
-def deferred_dealloc_stream(
-    context: IRExecutionContext, dfs: Sequence[DataFrame]
-) -> Generator[Stream, None, None]:
-    """
-    Get a joined CUDA stream, with stream ordering for safe deallocation of inputs.
-
-    Parameters
-    ----------
-    context
-        The execution context, which is used to get the new CUDA stream.
-    dfs
-        The dataframes to join.
-
-    Yields
-    ------
-    CUDA stream that is joined to the given streams.
-
-    Notes
-    -----
-    The interaction between Python's refcounting and CUDA streams is tricky. In general,
-    deallocation (when an object's refcount reaches zero) of our objects is
-    a stream ordered operation. ``DataFrame.__del__`` will eventually deallocate some
-    RMM memory on some stream.
-
-    .. code-block::
-
-       x = ...      # valid on some stream A
-       y = func(x)  # valid on some stream B
-       del x        # deallocates x *on stream A*
-
-    We need to ensure that the deallocation happens *after* the operation on stream B completes,
-    i.e. it needs to be downstream of ``func(x)`` completing.
-
-    To accomplish this, we provide this context manager. You provide the inputs (typically the
-    stream-ordered objects that are passed into some function), and we ensure that:
-
-    1. The inputs are all valid on the stream yielded by entering
-       the context manager.
-    2. The deallocation of the inputs happens after the result is ready
-       on the stream yielded by entering the context manager.
-    """
-    # ensure that the inputs are downstream of result_stream (i.e. valid on result_stream)
-    result_stream = get_joined_cuda_stream(
-        context.get_cuda_stream, upstreams=[df.stream for df in dfs]
-    )
-
-    yield result_stream
-
-    # ensure that the inputs are downstream of result_stream (so that deallocation happens after the result is ready)
-    join_cuda_streams(downstreams=[df.stream for df in dfs], upstreams=[result_stream])


### PR DESCRIPTION
## Description

cudf-polars has multiple places where we

1. have one or more stream-ordered inputs to some function
2. apply some operation on some other stream (the result stream)
3. ensure that the stream-ordered deallocation of the inputs happens after the result is ready on the result stream.

This PR adds a context manager to handle that.