### PR TITLE
Add support for dictionary types in the row hasher

### DIFF
--- a/cpp/tests/row_operator/row_operator_tests.cu
+++ b/cpp/tests/row_operator/row_operator_tests.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -389,4 +389,75 @@ TEST_F(RowOperatorTest, TestPrimitiveRowHasher64BitHash)
   auto const expected = cudf::test::fixed_width_column_wrapper<std::uint64_t>{
     {4246796580750024372ul, 15516826743637085169ul, 9462334144942111946ul}};
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(results, expected);
+}
+
+TEST_F(RowOperatorTest, TestRowHasherDictionaryColumn)
+{
+  // Dictionary and equivalent string column should produce identical hashes.
+  // This also verifies same logical values get same hashes (e.g., "baz" at rows 0 and 2).
+  auto const dict_col =
+    cudf::test::dictionary_column_wrapper<std::string>({"baz", "foo", "baz", "bar", "foo"});
+  auto const str_col = cudf::test::strings_column_wrapper({"baz", "foo", "baz", "bar", "foo"});
+
+  auto const stream = cudf::get_default_stream();
+  auto const dict_row_hasher =
+    cudf::detail::row::hash::row_hasher(cudf::table_view{{dict_col}}, stream);
+  auto const str_row_hasher =
+    cudf::detail::row::hash::row_hasher(cudf::table_view{{str_col}}, stream);
+
+  auto const dict_hasher =
+    dict_row_hasher.device_hasher<cudf::hashing::detail::XXHash_64>(cudf::nullate::DYNAMIC{false});
+  auto const str_hasher =
+    str_row_hasher.device_hasher<cudf::hashing::detail::XXHash_64>(cudf::nullate::DYNAMIC{false});
+
+  auto dict_results = cudf::test::fixed_width_column_wrapper<std::uint64_t>{{0, 0, 0, 0, 0}};
+  auto str_results  = cudf::test::fixed_width_column_wrapper<std::uint64_t>{{0, 0, 0, 0, 0}};
+
+  thrust::transform(rmm::exec_policy_nosync(stream),
+                    thrust::counting_iterator<cudf::size_type>{0},
+                    thrust::counting_iterator<cudf::size_type>{5},
+                    cudf::mutable_column_view{dict_results}.begin<std::uint64_t>(),
+                    dict_hasher);
+  thrust::transform(rmm::exec_policy_nosync(stream),
+                    thrust::counting_iterator<cudf::size_type>{0},
+                    thrust::counting_iterator<cudf::size_type>{5},
+                    cudf::mutable_column_view{str_results}.begin<std::uint64_t>(),
+                    str_hasher);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(dict_results, str_results);
+}
+
+TEST_F(RowOperatorTest, TestRowHasherDictionaryColumnWithNulls)
+{
+  auto const dict_col =
+    cudf::test::dictionary_column_wrapper<int64_t>({100, 200, 300, 100, 200}, {1, 0, 1, 0, 1});
+  auto const int_col =
+    cudf::test::fixed_width_column_wrapper<int64_t>({100, 200, 300, 100, 200}, {1, 0, 1, 0, 1});
+
+  auto const stream = cudf::get_default_stream();
+  auto const dict_row_hasher =
+    cudf::detail::row::hash::row_hasher(cudf::table_view{{dict_col}}, stream);
+  auto const int_row_hasher =
+    cudf::detail::row::hash::row_hasher(cudf::table_view{{int_col}}, stream);
+
+  auto const dict_hasher =
+    dict_row_hasher.device_hasher<cudf::hashing::detail::XXHash_64>(cudf::nullate::DYNAMIC{true});
+  auto const int_hasher =
+    int_row_hasher.device_hasher<cudf::hashing::detail::XXHash_64>(cudf::nullate::DYNAMIC{true});
+
+  auto dict_results = cudf::test::fixed_width_column_wrapper<std::uint64_t>{{0, 0, 0, 0, 0}};
+  auto int_results  = cudf::test::fixed_width_column_wrapper<std::uint64_t>{{0, 0, 0, 0, 0}};
+
+  thrust::transform(rmm::exec_policy_nosync(stream),
+                    thrust::counting_iterator<cudf::size_type>{0},
+                    thrust::counting_iterator<cudf::size_type>{5},
+                    cudf::mutable_column_view{dict_results}.begin<std::uint64_t>(),
+                    dict_hasher);
+  thrust::transform(rmm::exec_policy_nosync(stream),
+                    thrust::counting_iterator<cudf::size_type>{0},
+                    thrust::counting_iterator<cudf::size_type>{5},
+                    cudf::mutable_column_view{int_results}.begin<std::uint64_t>(),
+                    int_hasher);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(dict_results, int_results);
 }


### PR DESCRIPTION
## Description
Closes https://github.com/rapidsai/cudf/issues/20979

This PR updates the row hasher to correctly hash dictionary types.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
