### PR TITLE
Remove CUDF_EXPORT from cudf::detail::contains

### DIFF
--- a/cpp/benchmarks/search/contains_scalar.cpp
+++ b/cpp/benchmarks/search/contains_scalar.cpp
@@ -1,12 +1,12 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <benchmarks/common/generate_input.hpp>
 
-#include <cudf/detail/search.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/search.hpp>
 #include <cudf/types.hpp>
 
 #include <nvbench/nvbench.cuh>
@@ -36,7 +36,7 @@ static void nvbench_contains_scalar(nvbench::state& state)
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto const stream_view             = rmm::cuda_stream_view{launch.get_stream()};
-    [[maybe_unused]] auto const result = cudf::detail::contains(*haystack, *needle, stream_view);
+    [[maybe_unused]] auto const result = cudf::contains(*haystack, *needle, stream_view);
   });
 }
 

--- a/cpp/include/cudf/detail/search.hpp
+++ b/cpp/include/cudf/detail/search.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
 
-namespace CUDF_EXPORT cudf {
+namespace cudf {
 namespace detail {
 
 /**
@@ -92,4 +92,4 @@ rmm::device_uvector<bool> contains(table_view const& haystack,
                                    rmm::device_async_resource_ref mr);
 
 }  // namespace detail
-}  // namespace CUDF_EXPORT cudf
+}  // namespace cudf

--- a/cpp/include/cudf/search.hpp
+++ b/cpp/include/cudf/search.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -132,7 +132,7 @@ bool contains(column_view const& haystack,
  * @brief Check if the given `needles` values exists in the `haystack` column.
  *
  * The new column will have type BOOL and have the same size and null mask as the input `needles`
- * column. That is, any null row in the `needles` column will result in a nul row in the output
+ * column. That is, any null row in the `needles` column will result in a null row in the output
  * column.
  *
  * @throws cudf::logic_error If `haystack.type() != needles.type()`


### PR DESCRIPTION
## Description
Minor change to remove `CUDF_EXPORT` declaration from some `detail` functions that do not require it.
Also changes the call in `SEARCH_NVBENCH` to use `cudf::contains` instead of `cudf::detail::contains`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
