### PR TITLE
Add no_sanitizer filter to compute-sanitizer script

### DIFF
--- a/ci/run_compute_sanitizer_test.sh
+++ b/ci/run_compute_sanitizer_test.sh
@@ -65,11 +65,13 @@ if [ ! -x "${TEST_EXECUTABLE}" ]; then
   exit 1
 fi
 
+CS_EXCLUDE_NAMES="kns=nvcomp,kns=zstd,kns=_no_sanitize,kns=_no_${TOOL_NAME}"
+
 # Run compute-sanitizer on the specified test
 compute-sanitizer \
   --tool "${TOOL_NAME}" \
   --force-blocking-launches \
-  --kernel-name-exclude kns=nvcomp,kns=zstd \
+  --kernel-name-exclude "${CS_EXCLUDE_NAMES}" \
   --error-exitcode=1 \
   "${TEST_EXECUTABLE}" \
   "$@"


### PR DESCRIPTION
## Description
Adds proactive filter for kernel names to be ignored during the racecheck/synccheck compute-sanitizer runs.
If `_no_sanitize` appears in the kernel name, it will not be analyzed by either racecheck or synccheck
Corresponding `_no_racecheck` and `_no_synccheck` can be added to a kernel name to filter it appropriately.
These filters will not applied to the nightly memcheck runs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
