### PR TITLE
Rearrange variables to reduce padding

### DIFF
--- a/cpp/src/io/parquet/reader_impl_chunking.hpp
+++ b/cpp/src/io/parquet/reader_impl_chunking.hpp
@@ -85,15 +85,24 @@ struct subpass_intermediate_data {
   rmm::device_buffer level_decode_data{};
   cudf::detail::hostdevice_span<PageInfo> pages{};
 
-  // optimization. if the single_subpass flag is set, it means we will only be doing
-  // one subpass for the entire pass. this allows us to skip various pieces of work
-  // during processing. notably, page_buf will not be allocated to hold a compacted
-  // copy of the pages specific to the subpass.
-  bool single_subpass{false};
   cudf::detail::hostdevice_vector<PageInfo> page_buf{};
 
   // for each page in the subpass, the index of our source page in the pass
   rmm::device_uvector<size_t> page_src_index{0, cudf::get_default_stream()};
+
+  // For each page, the index into the column's string offset buffer
+  // Used for non-dictionary, non-FLBA string columns
+  rmm::device_uvector<size_t> page_string_offset_indices{0, cudf::get_default_stream()};
+
+  // String offset buffer for non-dictionary, non-FLBA string columns
+  // Contains pre-computed offsets into the string data. Allocated once per subpass
+  // in preprocess_subpass_pages() and reused across all output chunks in the subpass.
+  rmm::device_uvector<uint32_t> string_offset_buffer{0, cudf::get_default_stream()};
+
+  // temporary space for DELTA_BYTE_ARRAY decoding. this only needs to live until
+  // gpu::DecodeDeltaByteArray returns.
+  rmm::device_uvector<uint8_t> delta_temp_buf{0, cudf::get_default_stream()};
+
   // for each column in the file (indexed by _input_columns.size())
   // the number of associated pages for this subpass
   std::vector<size_t> column_page_count;
@@ -101,26 +110,19 @@ struct subpass_intermediate_data {
   cudf::detail::hostdevice_vector<PageNestingDecodeInfo> page_nesting_decode_info{};
 
   std::vector<row_range> output_chunk_read_info;
-  std::size_t current_output_chunk{0};
-
-  // temporary space for DELTA_BYTE_ARRAY decoding. this only needs to live until
-  // gpu::DecodeDeltaByteArray returns.
-  rmm::device_uvector<uint8_t> delta_temp_buf{0, cudf::get_default_stream()};
-
-  uint32_t kernel_mask{0};
 
   // skip_rows and num_rows values for this particular subpass. in absolute row indices.
   size_t skip_rows;
   size_t num_rows;
+  size_t current_output_chunk{0};
 
-  // String offset buffer for non-dictionary, non-FLBA string columns
-  // Contains pre-computed offsets into the string data. Allocated once per subpass
-  // in preprocess_subpass_pages() and reused across all output chunks in the subpass.
-  rmm::device_uvector<uint32_t> string_offset_buffer{0, cudf::get_default_stream()};
+  uint32_t kernel_mask{0};
 
-  // For each page, the index into the column's string offset buffer
-  // Used for non-dictionary, non-FLBA string columns
-  rmm::device_uvector<size_t> page_string_offset_indices{0, cudf::get_default_stream()};
+  // optimization. if the single_subpass flag is set, it means we will only be doing
+  // one subpass for the entire pass. this allows us to skip various pieces of work
+  // during processing. notably, page_buf will not be allocated to hold a compacted
+  // copy of the pages specific to the subpass.
+  bool single_subpass{false};
 };
 
 /**
@@ -140,14 +142,9 @@ struct pass_intermediate_data {
   std::vector<rmm::device_buffer> raw_page_data;
 
   // rowgroup, chunk and page information for the current pass.
-  bool has_compressed_data{false};
   std::vector<row_group_info> row_groups{};
   cudf::detail::hostdevice_vector<ColumnChunkDesc> chunks{};
   cudf::detail::hostdevice_vector<PageInfo> pages{};
-
-  // base memory used for the pass itself (compressed data in the loaded chunks and any
-  // decompressed dictionary pages)
-  size_t base_mem_size{0};
 
   // offsets to each group of input pages (by column/schema, indexed by _input_columns.size())
   // so if we had 2 columns/schemas, with page keys
@@ -162,7 +159,12 @@ struct pass_intermediate_data {
   rmm::device_uvector<size_t> string_offset_sizes{0, cudf::get_default_stream()};
   rmm::device_uvector<string_index_pair> str_dict_index{0, cudf::get_default_stream()};
 
-  int level_type_size{0};
+  // currently active subpass
+  std::unique_ptr<subpass_intermediate_data> subpass{};
+
+  // base memory used for the pass itself (compressed data in the loaded chunks and any
+  // decompressed dictionary pages)
+  size_t base_mem_size{0};
 
   // skip_rows / num_rows for this pass.
   // NOTE: skip_rows is the absolute row index in the file.
@@ -173,8 +175,9 @@ struct pass_intermediate_data {
   // subpass. it does not get updated as a subpass iterates through output chunks.
   size_t processed_rows{0};
 
-  // currently active subpass
-  std::unique_ptr<subpass_intermediate_data> subpass{};
+  int level_type_size{0};
+
+  bool has_compressed_data{false};
 };
 
 }  // namespace cudf::io::parquet::detail


### PR DESCRIPTION
Rearrange variables in the parquet pass_intermediate_data and subpass_intermediate_data structs to reduce padding. This should fix [these build errors](https://github.com/rapidsai/cudf/actions/runs/20930645865/job/60140649515?pr=20999). 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
