### PR TITLE
Modify unit tests that use deprecated copy keyword in pandas 3

### DIFF
--- a/python/cudf/cudf/tests/dataframe/methods/test_astype.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_astype.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
@@ -15,26 +15,27 @@ def test_df_series_dataframe_astype_copy(copy):
     gdf = cudf.DataFrame({"col1": [1, 2], "col2": [3, 4]})
     pdf = gdf.to_pandas()
 
-    assert_eq(
-        gdf.astype(dtype="float", copy=copy),
-        pdf.astype(dtype="float", copy=copy),
-    )
+    result = gdf.astype(dtype="float", copy=copy)
+    with pytest.warns(pd.errors.Pandas4Warning):
+        expected = pdf.astype(dtype="float", copy=copy)
+    assert_eq(result, expected)
     assert_eq(gdf, pdf)
 
     gsr = cudf.Series([1, 2])
     psr = gsr.to_pandas()
 
-    assert_eq(
-        gsr.astype(dtype="float", copy=copy),
-        psr.astype(dtype="float", copy=copy),
-    )
+    result = gsr.astype(dtype="float", copy=copy)
+    with pytest.warns(pd.errors.Pandas4Warning):
+        expected = psr.astype(dtype="float", copy=copy)
+    assert_eq(result, expected)
     assert_eq(gsr, psr)
 
     gsr = cudf.Series([1, 2])
     psr = gsr.to_pandas()
 
     actual = gsr.astype(dtype="int64", copy=copy)
-    expected = psr.astype(dtype="int64", copy=copy)
+    with pytest.warns(pd.errors.Pandas4Warning):
+        expected = psr.astype(dtype="int64", copy=copy)
     assert_eq(expected, actual)
     assert_eq(gsr, psr)
     actual[0] = 3
@@ -47,33 +48,34 @@ def test_df_series_dataframe_astype_dtype_dict(copy):
     gdf = cudf.DataFrame({"col1": [1, 2], "col2": [3, 4]})
     pdf = gdf.to_pandas()
 
-    assert_eq(
-        gdf.astype(dtype={"col1": "float"}, copy=copy),
-        pdf.astype(dtype={"col1": "float"}, copy=copy),
-    )
+    result = gdf.astype(dtype={"col1": "float"}, copy=copy)
+    with pytest.warns(pd.errors.Pandas4Warning):
+        expected = pdf.astype(dtype={"col1": "float"}, copy=copy)
+    assert_eq(result, expected)
     assert_eq(gdf, pdf)
 
     gsr = cudf.Series([1, 2])
     psr = gsr.to_pandas()
 
-    assert_eq(
-        gsr.astype(dtype={None: "float"}, copy=copy),
-        psr.astype(dtype={None: "float"}, copy=copy),
-    )
+    result = gsr.astype(dtype={None: "float"}, copy=copy)
+    with pytest.warns(pd.errors.Pandas4Warning):
+        expected = psr.astype(dtype={None: "float"}, copy=copy)
+    assert_eq(result, expected)
     assert_eq(gsr, psr)
 
     assert_exceptions_equal(
         lfunc=psr.astype,
         rfunc=gsr.astype,
-        lfunc_args_and_kwargs=([], {"dtype": {"a": "float"}, "copy": copy}),
-        rfunc_args_and_kwargs=([], {"dtype": {"a": "float"}, "copy": copy}),
+        lfunc_args_and_kwargs=([], {"dtype": {"a": "float"}}),
+        rfunc_args_and_kwargs=([], {"dtype": {"a": "float"}}),
     )
 
     gsr = cudf.Series([1, 2])
     psr = gsr.to_pandas()
 
     actual = gsr.astype({None: "int64"}, copy=copy)
-    expected = psr.astype({None: "int64"}, copy=copy)
+    with pytest.warns(pd.errors.Pandas4Warning):
+        expected = psr.astype({None: "int64"}, copy=copy)
     assert_eq(expected, actual)
     assert_eq(gsr, psr)
 

--- a/python/cudf/cudf/tests/dataframe/methods/test_reindex.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_reindex.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -96,11 +96,9 @@ def test_dataframe_reindex_change_dtype(copy):
     pdf = gdf.to_pandas()
     # Validate reindexes both labels and column names when
     # index=index_labels and columns=column_labels
-    assert_eq(
-        pdf.reindex(index=index, columns=columns, copy=True),
-        gdf.reindex(index=index, columns=columns, copy=copy),
-        check_freq=False,
-    )
+    expected = pdf.reindex(index=index, columns=columns)
+    result = gdf.reindex(index=index, columns=columns, copy=copy)
+    assert_eq(result, expected, check_freq=False)
 
 
 @pytest.mark.parametrize("copy", [True, False])
@@ -123,12 +121,10 @@ def test_series_float_reindex(copy):
     index = [-3, 0, 3, 0, -2, 1, 3, 4, 6]
     gdf = cudf.datasets.randomdata(nrows=6, dtypes={"c": float})
     pdf = gdf.to_pandas()
-    assert_eq(pdf["c"].reindex(copy=True), gdf["c"].reindex(copy=copy))
+    assert_eq(pdf["c"].reindex(), gdf["c"].reindex(copy=copy))
+    assert_eq(pdf["c"].reindex(index), gdf["c"].reindex(index, copy=copy))
     assert_eq(
-        pdf["c"].reindex(index, copy=True), gdf["c"].reindex(index, copy=copy)
-    )
-    assert_eq(
-        pdf["c"].reindex(index=index, copy=True),
+        pdf["c"].reindex(index=index),
         gdf["c"].reindex(index=index, copy=copy),
     )
 


### PR DESCRIPTION
## Description
The `copy` keyword in several methods is deprecated in pandas 3.0 because copy-on-write by default makes them unnecessary. This PR only addresses our pandas usages of the `copy` keyword in cudf unit tests.

When enabling copy-on-write in cuDF, https://github.com/rapidsai/cudf/issues/21019, I expect these unit tests to change again to assert we also raise a warning that our `copy` keywords are unnecessary 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
