### PR TITLE
Account of pandas.NamedAgg subclass change in pandas 3

### DIFF
--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -1753,7 +1753,7 @@ class GroupBy(Serializable, Reducible, Scannable):
             columns, aggs_per_column = zip(
                 *(
                     (self.obj._data[x[0]], x[1])
-                    if isinstance(x, tuple)
+                    if isinstance(x, (tuple, NamedAgg))
                     else _raise_invalid_type(x)
                     for x in kwargs.values()
                 ),


### PR DESCRIPTION
## Description
pandas 3 changed `NamedAgg` from inheriting from a `NamedTuple` to being a dataclass https://github.com/pandas-dev/pandas/pull/62729. To fix `test_dataframe_agg` in pandas 3, we can no longer check for `tuple` instances to capture `NamedAgg`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
