### PR TITLE
Reintroduce `Buffer.nbytes` property

### DIFF
--- a/python/cudf/cudf/core/buffer/buffer.py
+++ b/python/cudf/cudf/core/buffer/buffer.py
@@ -154,6 +154,12 @@ class BufferOwner(Serializable):
         return self._size
 
     @property
+    def nbytes(self) -> int:
+        """Size of the buffer in bytes."""
+        # Note: this property is used by `distributed.utils.nbytes`, please do not remove.
+        return self._size
+
+    @property
     def owner(self) -> object:
         """Object owning the memory of the buffer."""
         return self._owner
@@ -255,6 +261,12 @@ class Buffer(Serializable):
     @property
     def size(self) -> int:
         """Size of the buffer in bytes."""
+        return self._size
+
+    @property
+    def nbytes(self) -> int:
+        """Size of the buffer in bytes."""
+        # Note: this property is used by `distributed.utils.nbytes`, please do not remove.
         return self._size
 
     @property


### PR DESCRIPTION
The `nbytes` property is relied on by [`distributed.utils.nbytes`](https://github.com/dask/distributed/blob/f4cfecc48856d5f0fbf7f840fbecdb17544fd30e/distributed/utils.py#L1179-L1187) to determine the object's size, another alternative is to provide `__len__` but now neither are available, which broke both UCXX and Dask-CUDA tests.

This change reintroduces that attribute with a comment justifying why it's still needed to prevent future removal.