### PR TITLE
Account for non-fixed `pandas.offsets.Day` in `date_range` for pandas 3

### DIFF
--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -905,7 +905,8 @@ def date_range(
     elif isinstance(freq, str):
         offset = pd.tseries.frequencies.to_offset(freq)
         if not isinstance(
-            offset, (pd.tseries.offsets.Tick, pd.tseries.offsets.Week)
+            offset,
+            (pd.tseries.offsets.Tick, pd.offsets.Day, pd.tseries.offsets.Week),
         ):
             raise ValueError(
                 f"Unrecognized frequency string {freq}. cuDF does "

--- a/python/cudf/cudf/tests/groupby/test_resample.py
+++ b/python/cudf/cudf/tests/groupby/test_resample.py
@@ -152,8 +152,8 @@ def test_dataframe_resample_level():
         ("ms", "1s", "s"),
         ("s", "1min", "s"),
         ("1min", "30s", "s"),
-        ("24h", "240h", "s"),
-        ("240h", "24h", "s"),
+        ("1D", "10D", "s"),
+        ("10D", "1D", "s"),
     ],
 )
 def test_resampling_frequency_conversion(in_freq, sampling_freq, out_freq):


### PR DESCRIPTION
## Description
`pandas.offsets.Day` in pandas 3 is no longer a subclass of a `Tick` and is now a non-fixed frequency. 

We'll need to now special case this object in `date_range` to maintain behavior. There are tests in `test_date_range` that were failing due to this case, but they are still failing because pandas 3 now tries to interpret string arguments as microsecond frequency instead of nanossecond 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
