### PR TITLE
Add no_racecheck filter to snap, unsnap, and inflate kernel names

### DIFF
--- a/cpp/src/io/comp/gpuinflate.cu
+++ b/cpp/src/io/comp/gpuinflate.cu
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright (C) 2002-2013 Mark Adler, all rights reserved
- * SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0 AND Zlib
  */
 
@@ -1024,10 +1024,10 @@ __device__ int parse_gzip_header(uint8_t const* src, size_t src_size)
  */
 template <int block_size>
 CUDF_KERNEL void __launch_bounds__(block_size)
-  inflate_kernel(device_span<device_span<uint8_t const> const> inputs,
-                 device_span<device_span<uint8_t> const> outputs,
-                 device_span<codec_exec_result> results,
-                 gzip_header_included parse_hdr)
+  inflate_kernel_no_racecheck(device_span<device_span<uint8_t const> const> inputs,
+                              device_span<device_span<uint8_t> const> outputs,
+                              device_span<codec_exec_result> results,
+                              gzip_header_included parse_hdr)
 {
   __shared__ __align__(16) inflate_state_s state_g;
 
@@ -1363,7 +1363,7 @@ void gpuinflate(device_span<device_span<uint8_t const> const> inputs,
 {
   constexpr int block_size = 128;  // Threads per block
   if (inputs.size() > 0) {
-    inflate_kernel<block_size>
+    inflate_kernel_no_racecheck<block_size>
       <<<inputs.size(), block_size, 0, stream.value()>>>(inputs, outputs, results, parse_hdr);
   }
 }

--- a/cpp/src/io/comp/snap.cu
+++ b/cpp/src/io/comp/snap.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -224,9 +224,9 @@ static __device__ uint32_t Match60(uint8_t const* src1,
  * @param[in] count Number of blocks to compress
  */
 CUDF_KERNEL void __launch_bounds__(128)
-  snap_kernel(device_span<device_span<uint8_t const> const> inputs,
-              device_span<device_span<uint8_t> const> outputs,
-              device_span<codec_exec_result> results)
+  snap_kernel_no_racecheck(device_span<device_span<uint8_t const> const> inputs,
+                           device_span<device_span<uint8_t> const> outputs,
+                           device_span<codec_exec_result> results)
 {
   __shared__ __align__(16) snap_state_s state_g;
 
@@ -318,7 +318,7 @@ void gpu_snap(device_span<device_span<uint8_t const> const> inputs,
   dim3 dim_block(128, 1);  // 4 warps per stream, 1 stream per block
   dim3 dim_grid(inputs.size(), 1);
   if (inputs.size() > 0) {
-    snap_kernel<<<dim_grid, dim_block, 0, stream.value()>>>(inputs, outputs, results);
+    snap_kernel_no_racecheck<<<dim_grid, dim_block, 0, stream.value()>>>(inputs, outputs, results);
   }
 }
 


### PR DESCRIPTION
## Description
Adds the `_no_racecheck` suffix the `snap_kernel`, `unsnap_kernel` and `inflate_kernel` kernel names to prevent compute-sanitizer racecheck from reporting racecheck errors. These kernels were determined to be correct and compute-sanitizer is reporting false positives due to the complexity of the warp execution patterns.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
