### PR TITLE
Backport #21051

### DIFF
--- a/cpp/src/io/parquet/delta_binary.cuh
+++ b/cpp/src/io/parquet/delta_binary.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -282,6 +282,9 @@ struct delta_binary_decoder {
     int const lane_id = t % warp_size;
 
     while (current_value_idx < skip && current_value_idx < num_encoded_values(true)) {
+      // calc_mini_block_values only runs in warp 0, but writes to current_value_idx,
+      // so everyone must sync before we diverge
+      __syncthreads();
       if (t < warp_size) {
         calc_mini_block_values(lane_id);
         if (lane_id == 0) { setup_next_mini_block(true); }

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -752,7 +752,8 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     set_error(static_cast<int32_t>(decode_error::DELTA_PARAMS_UNSUPPORTED), error_code);
     return;
   }
-
+  // db->init_binary_block below resets db->values_per_mb
+  block.sync();
   // if this is a bounds page, then we need to decode up to the first mini-block
   // that has a value we need, and set string_offset to the position of the first value in the
   // string data block.
@@ -761,6 +762,9 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     if (warp.meta_group_rank() == 0) {
       // string_off is only valid on thread 0
       auto const string_off = db->skip_values_and_sum(s->page.start_val);
+      // Threads in the warp might diverge and read in skip_values_and_sum
+      // after lane 0 reinits below.
+      warp.sync();
       if (warp.thread_rank() == 0) {
         string_offset = string_off;
 


### PR DESCRIPTION
## Description

This fixes racecheck errors in the parquet `decode_delta_length_byte_array_kernel` implementation.

Backport of #21051.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
