### PR TITLE
Switch date type in pandas PDSH queries

### DIFF
--- a/python/cudf/cudf/pandas/_benchmarks/pdsh.py
+++ b/python/cudf/cudf/pandas/_benchmarks/pdsh.py
@@ -22,7 +22,6 @@ cudf.pandas.install()
 
 import pandas as pd  # noqa: E402
 
-
 from cudf.pandas._benchmarks.utils import (  # noqa: E402
     get_data,
     run_pandas,


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Pandas doesn't support comparing python dates and datetime64s. Lets switch to the latter so we can run these queries with pandas.

Closes #21100 
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
