### PR TITLE
Fix StringDtype dask serialization in pandas 3

### DIFF
--- a/python/cudf/cudf/tests/dask/test_serialize.py
+++ b/python/cudf/cudf/tests/dask/test_serialize.py
@@ -389,7 +389,7 @@ def test_serialize_sliced_string():
     # https://github.com/rapidsai/cudf/issues/7735
     data = ["hi", "hello", None]
     pd_series = pd.Series(data, dtype=pd.StringDtype())
-    gd_series = cudf.Series(data, dtype="str")
+    gd_series = cudf.Series(data, dtype=pd_series.dtype)
     sliced = gd_series[0:3]
     serialized_gd_series = gd_series.serialize()
     serialized_sliced = sliced.serialize()


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/20818

Also changes `test_serialize_sliced_string` slightly as `pd.StringDtype()` (without arguments) doesn't have the same `na_value` as the same default string type (`NA` vs `nan`)

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
