### PR TITLE
Backport #21033: Add new pinned vector factory functions

### DIFF
--- a/cpp/benchmarks/io/text/multibyte_split.cpp
+++ b/cpp/benchmarks/io/text/multibyte_split.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -119,10 +119,9 @@ static void bench_multibyte_split(nvbench::state& state,
 
   auto const delim_factor = static_cast<double>(delim_percent) / 100;
   std::unique_ptr<cudf::io::datasource> datasource;
-  auto device_input = create_random_input(file_size_approx, delim_factor, 0.05, delim);
-  auto host_input   = std::vector<char>{};
-  auto host_pinned_input =
-    cudf::detail::make_pinned_vector_async<char>(0, cudf::get_default_stream());
+  auto device_input      = create_random_input(file_size_approx, delim_factor, 0.05, delim);
+  auto host_input        = std::vector<char>{};
+  auto host_pinned_input = cudf::detail::make_host_vector<char>(0, cudf::get_default_stream());
 
   if (source_type != data_chunk_source_type::device &&
       source_type != data_chunk_source_type::host_pinned) {
@@ -131,9 +130,10 @@ static void bench_multibyte_split(nvbench::state& state,
       cudf::get_default_stream());
   }
   if (source_type == data_chunk_source_type::host_pinned) {
-    host_pinned_input.resize(static_cast<std::size_t>(device_input.size()));
-    CUDF_CUDA_TRY(cudaMemcpy(
-      host_pinned_input.data(), device_input.data(), host_pinned_input.size(), cudaMemcpyDefault));
+    host_pinned_input = cudf::detail::make_pinned_vector(
+      cudf::device_span<char const>{device_input.data(),
+                                    static_cast<std::size_t>(device_input.size())},
+      cudf::get_default_stream());
   }
 
   auto source = [&] {

--- a/cpp/include/cudf/detail/utilities/vector_factories.hpp
+++ b/cpp/include/cudf/detail/utilities/vector_factories.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -411,7 +411,7 @@ host_vector<typename Container::value_type> make_host_vector_async(Container con
  * using a pinned memory resource.
  *
  * @tparam T The type of the data to copy
- * @param source_data The device data to copy
+ * @param v The device data to copy
  * @param stream The stream on which to perform the copy
  * @return The data copied to the host
  */
@@ -474,6 +474,99 @@ host_vector<T> make_pinned_vector(size_t size, rmm::cuda_stream_view stream)
 {
   auto result = make_pinned_vector_async<T>(size, stream);
   stream.synchronize();
+  return result;
+}
+
+/**
+ * @brief Asynchronously construct a pinned `cudf::detail::host_vector` containing a copy of data
+ * from a `device_span`
+ *
+ * @note This function does not synchronize `stream` after the copy.
+ *
+ * @tparam T The type of the data to copy
+ * @param v The device data to copy
+ * @param stream The stream on which to perform the copy
+ * @return The data copied to pinned host memory
+ */
+template <typename T>
+host_vector<T> make_pinned_vector_async(device_span<T const> v, rmm::cuda_stream_view stream)
+{
+  auto result = make_pinned_vector_async<T>(v.size(), stream);
+  cuda_memcpy_async<T>(result, v, stream);
+  return result;
+}
+
+/**
+ * @brief Asynchronously construct a pinned `cudf::detail::host_vector` containing a copy of data
+ * from a device container
+ *
+ * @note This function does not synchronize `stream` after the copy.
+ *
+ * @tparam Container The type of the container to copy from
+ * @param c The input device container from which to copy
+ * @param stream The stream on which to perform the copy
+ * @return The data copied to pinned host memory
+ */
+template <typename Container>
+host_vector<typename Container::value_type> make_pinned_vector_async(Container const& c,
+                                                                     rmm::cuda_stream_view stream)
+  requires(std::is_convertible_v<Container, device_span<typename Container::value_type const>>)
+{
+  return make_pinned_vector_async(device_span<typename Container::value_type const>{c}, stream);
+}
+
+/**
+ * @brief Synchronously construct a pinned `cudf::detail::host_vector` containing a copy of data
+ * from a `device_span`
+ *
+ * @note This function synchronizes `stream` after the copy.
+ *
+ * @tparam T The type of the data to copy
+ * @param v The device data to copy
+ * @param stream The stream on which to perform the copy
+ * @return The data copied to pinned host memory
+ */
+template <typename T>
+host_vector<T> make_pinned_vector(device_span<T const> v, rmm::cuda_stream_view stream)
+{
+  auto result = make_pinned_vector_async(v, stream);
+  stream.synchronize();
+  return result;
+}
+
+/**
+ * @brief Synchronously construct a pinned `cudf::detail::host_vector` containing a copy of data
+ * from a device container
+ *
+ * @note This function synchronizes `stream` after the copy.
+ *
+ * @tparam Container The type of the container to copy from
+ * @param c The input device container from which to copy
+ * @param stream The stream on which to perform the copy
+ * @return The data copied to pinned host memory
+ */
+template <typename Container>
+host_vector<typename Container::value_type> make_pinned_vector(Container const& c,
+                                                               rmm::cuda_stream_view stream)
+  requires(std::is_convertible_v<Container, device_span<typename Container::value_type const>>)
+{
+  return make_pinned_vector(device_span<typename Container::value_type const>{c}, stream);
+}
+
+/**
+ * @brief Synchronously construct a pinned `cudf::detail::host_vector` containing a copy of data
+ * from a `host_span`
+ *
+ * @tparam T The type of the data to copy
+ * @param v The host data to copy
+ * @param stream The stream on which to allocate memory
+ * @return The data copied to pinned host memory
+ */
+template <typename T>
+host_vector<T> make_pinned_vector(host_span<T const> v, rmm::cuda_stream_view stream)
+{
+  auto result = make_pinned_vector<T>(v.size(), stream);
+  std::copy(v.begin(), v.end(), result.begin());
   return result;
 }
 

--- a/cpp/src/io/comp/compression.cpp
+++ b/cpp/src/io/comp/compression.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -324,8 +324,7 @@ void host_compress(compression_type compression,
   auto const h_outputs  = cudf::detail::make_host_vector_async(outputs, stream);
   stream.synchronize();
 
-  auto h_results = cudf::detail::make_pinned_vector<codec_exec_result>(num_chunks, stream);
-  cudf::detail::cuda_memcpy<codec_exec_result>(h_results, results, stream);
+  auto h_results = cudf::detail::make_pinned_vector<codec_exec_result>(results, stream);
 
   std::vector<std::future<std::pair<size_t, size_t>>> tasks;
   auto const num_streams =
@@ -335,8 +334,7 @@ void host_compress(compression_type compression,
     auto const cur_stream = streams[i % streams.size()];
     if (h_results[i].status == codec_status::SKIPPED) { continue; }
     auto task = [d_in = h_inputs[i], d_out = h_outputs[i], cur_stream, compression, i]() {
-      auto h_in = cudf::detail::make_pinned_vector_async<uint8_t>(d_in.size(), cur_stream);
-      cudf::detail::cuda_memcpy<uint8_t>(h_in, d_in, cur_stream);
+      auto h_in = cudf::detail::make_pinned_vector<uint8_t>(d_in, cur_stream);
 
       auto const h_out = compress(compression, h_in);
       h_in.clear();  // Free pinned memory as soon as possible

--- a/cpp/src/io/comp/decompression.cpp
+++ b/cpp/src/io/comp/decompression.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -566,8 +566,7 @@ void host_decompress(compression_type compression,
   for (size_t i = 0; i < num_chunks; ++i) {
     auto const cur_stream = streams[i % streams.size()];
     auto task = [d_in = h_inputs[i], d_out = h_outputs[i], cur_stream, compression]() -> size_t {
-      auto h_in = cudf::detail::make_pinned_vector_async<uint8_t>(d_in.size(), cur_stream);
-      cudf::detail::cuda_memcpy<uint8_t>(h_in, d_in, cur_stream);
+      auto h_in = cudf::detail::make_pinned_vector_async<uint8_t>(d_in, cur_stream);
 
       auto h_out             = cudf::detail::make_pinned_vector<uint8_t>(d_out.size(), cur_stream);
       auto const uncomp_size = decompress(compression, h_in, h_out);

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -1164,10 +1164,7 @@ cudf::detail::hostdevice_vector<uint8_t> allocate_and_encode_blobs(
 
   // get stats_merge_groups[num_stat_blobs - 1] via a host pinned bounce buffer
   auto const max_blobs = [&]() {
-    auto max_blobs_element =
-      cudf::detail::make_pinned_vector_async<statistics_merge_group>(1, stream);
-    cudf::detail::cuda_memcpy<statistics_merge_group>(
-      max_blobs_element,
+    auto max_blobs_element = cudf::detail::make_pinned_vector<statistics_merge_group>(
       cudf::device_span<statistics_merge_group>{stats_merge_groups.device_ptr(num_stat_blobs - 1),
                                                 1},
       stream);

--- a/cpp/src/io/parquet/experimental/page_index_filter.cu
+++ b/cpp/src/io/parquet/experimental/page_index_filter.cu
@@ -1123,10 +1123,9 @@ thrust::host_vector<bool> aggregate_reader_metadata::compute_data_page_mask(
   auto const num_ranges = static_cast<cudf::size_type>(page_row_offsets.size() - 1);
   rmm::device_uvector<bool> device_data_page_mask(num_ranges, stream, mr);
   // Use a pinned bounce buffer to avoid pageable h2d copy
-  auto host_page_offsets =
-    cudf::detail::make_pinned_vector_async<cudf::size_type>(page_row_offsets.size(), stream);
-  std::move(page_row_offsets.begin(), page_row_offsets.end(), host_page_offsets.begin());
-  auto page_offsets = cudf::detail::make_device_uvector_async(host_page_offsets, stream, mr);
+  auto pinned_page_offsets = cudf::detail::make_pinned_vector(
+    cudf::host_span<cudf::size_type const>{page_row_offsets}, stream);
+  auto page_offsets = cudf::detail::make_device_uvector_async(pinned_page_offsets, stream, mr);
   thrust::transform(
     rmm::exec_policy_nosync(stream),
     thrust::counting_iterator(0),
@@ -1135,13 +1134,8 @@ thrust::host_vector<bool> aggregate_reader_metadata::compute_data_page_mask(
     search_fenwick_tree_functor{fenwick_tree_level_ptrs.data(), page_offsets.data(), num_ranges});
 
   //  Copy over search results to host
-  auto host_results =
-    cudf::detail::make_pinned_vector_async<bool>(device_data_page_mask.size(), stream);
-  cudf::detail::cuda_memcpy_async(
-    cudf::host_span<bool>(host_results.data(), host_results.size()),
-    cudf::device_span<bool const>(device_data_page_mask.data(), device_data_page_mask.size()),
-    stream);
-  auto const total_pages = page_row_offsets.size() - num_columns;
+  auto host_results      = cudf::detail::make_pinned_vector_async(device_data_page_mask, stream);
+  auto const total_pages = pinned_page_offsets.size() - num_columns;
   auto data_page_mask    = thrust::host_vector<bool>(total_pages, stream);
   auto host_results_iter = host_results.begin();
   stream.synchronize();

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -397,12 +397,7 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
   update_output_nullmasks_for_pruned_pages(_subpass_page_mask, skip_rows, num_rows);
 
   // Copy over initial string offsets from device
-  auto h_initial_str_offsets =
-    cudf::detail::make_pinned_vector_async<size_t>(initial_str_offsets.size(), _stream);
-  cudf::detail::cuda_memcpy_async(
-    cudf::host_span<size_t>{h_initial_str_offsets},
-    cudf::device_span<size_t const>{initial_str_offsets.data(), initial_str_offsets.size()},
-    _stream);
+  auto h_initial_str_offsets = cudf::detail::make_pinned_vector_async(initial_str_offsets, _stream);
 
   if (auto const error = error_code.value_sync(_stream); error != 0) {
     CUDF_FAIL("Parquet data decode failed with code(s) " + kernel_error::to_string(error));
@@ -451,12 +446,10 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
     }
   }
   // Write the final offsets for list and string columns in a batched manner
-  auto pinned_final_offsets =
-    cudf::detail::make_pinned_vector_async<cudf::size_type>(final_offsets.size(), _stream);
+  auto pinned_final_offsets = cudf::detail::make_pinned_vector(
+    cudf::host_span<cudf::size_type const>{final_offsets}, _stream);
   auto pinned_out_buffers =
-    cudf::detail::make_pinned_vector_async<cudf::size_type*>(out_buffers.size(), _stream);
-  std::move(final_offsets.begin(), final_offsets.end(), pinned_final_offsets.begin());
-  std::move(out_buffers.begin(), out_buffers.end(), pinned_out_buffers.begin());
+    cudf::detail::make_pinned_vector(cudf::host_span<cudf::size_type* const>{out_buffers}, _stream);
   write_final_offsets(pinned_final_offsets, pinned_out_buffers, _stream);
 
   // update null counts in the final column buffers
@@ -1008,18 +1001,15 @@ void reader_impl::update_output_nullmasks_for_pruned_pages(cudf::host_span<bool 
 
   // Use a bounce buffer to avoid pageable copies
   auto pinned_null_masks =
-    cudf::detail::make_pinned_vector_async<bitmask_type*>(null_masks.size(), _stream);
-  auto pinned_begin_bits =
-    cudf::detail::make_pinned_vector_async<cudf::size_type>(begin_bits.size(), _stream);
-  auto pinned_end_bits =
-    cudf::detail::make_pinned_vector_async<cudf::size_type>(end_bits.size(), _stream);
-  std::move(null_masks.begin(), null_masks.end(), pinned_null_masks.begin());
-  std::move(begin_bits.begin(), begin_bits.end(), pinned_begin_bits.begin());
-  std::move(end_bits.begin(), end_bits.end(), pinned_end_bits.begin());
+    cudf::detail::make_pinned_vector(cudf::host_span<bitmask_type* const>{null_masks}, _stream);
+  auto const pinned_begin_bits =
+    cudf::detail::make_pinned_vector(cudf::host_span<cudf::size_type const>{begin_bits}, _stream);
+  auto const pinned_end_bits =
+    cudf::detail::make_pinned_vector(cudf::host_span<cudf::size_type const>{end_bits}, _stream);
 
   // Bulk update the nullmasks if the number of pages is above the threshold
-  if (null_masks.size() >= min_nullmasks_for_bulk_update) {
-    auto pinned_valids = cudf::detail::make_pinned_vector_async<bool>(null_masks.size(), _stream);
+  if (pinned_null_masks.size() >= min_nullmasks_for_bulk_update) {
+    auto pinned_valids = cudf::detail::make_pinned_vector<bool>(pinned_null_masks.size(), _stream);
     std::fill(pinned_valids.begin(), pinned_valids.end(), false);
     cudf::set_null_masks_safe(
       pinned_null_masks, pinned_begin_bits, pinned_end_bits, pinned_valids, _stream);
@@ -1029,7 +1019,7 @@ void reader_impl::update_output_nullmasks_for_pruned_pages(cudf::host_span<bool 
     auto nullmask_iter = thrust::make_zip_iterator(cuda::std::make_tuple(
       pinned_null_masks.begin(), pinned_begin_bits.begin(), pinned_end_bits.begin()));
     std::for_each(
-      nullmask_iter, nullmask_iter + null_masks.size(), [&](auto const& nullmask_tuple) {
+      nullmask_iter, nullmask_iter + pinned_null_masks.size(), [&](auto const& nullmask_tuple) {
         cudf::set_null_mask(cuda::std::get<0>(nullmask_tuple),
                             cuda::std::get<1>(nullmask_tuple),
                             cuda::std::get<2>(nullmask_tuple),

--- a/cpp/src/io/parquet/reader_impl_chunking.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking.cu
@@ -327,11 +327,7 @@ void reader_impl::setup_next_subpass(read_mode mode)
     subpass.pages = subpass.page_buf;
   }
 
-  auto h_spans = cudf::detail::make_pinned_vector_async<page_span>(page_indices.size(), _stream);
-  cudf::detail::cuda_memcpy_async(
-    cudf::host_span<page_span>{h_spans.data(), page_indices.size()},
-    cudf::device_span<page_span const>{page_indices.data(), page_indices.size()},
-    _stream);
+  auto h_spans = cudf::detail::make_pinned_vector_async(page_indices, _stream);
   subpass.pages.device_to_host_async(_stream);
 
   _stream.synchronize();
@@ -694,12 +690,7 @@ void reader_impl::set_subpass_page_mask()
   }
 
   // Use the pass page index mask to gather the subpass page mask from the pass level page mask
-  auto host_page_src_index =
-    cudf::detail::make_pinned_vector_async<size_t>(subpass->page_src_index.size(), _stream);
-  cudf::detail::cuda_memcpy(
-    cudf::host_span<size_t>{host_page_src_index.data(), subpass->page_src_index.size()},
-    cudf::device_span<size_t const>{subpass->page_src_index.data(), subpass->page_src_index.size()},
-    _stream);
+  auto host_page_src_index = cudf::detail::make_pinned_vector(subpass->page_src_index, _stream);
   thrust::gather(thrust::seq,
                  host_page_src_index.begin(),
                  host_page_src_index.end(),

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -363,12 +363,7 @@ std::tuple<rmm::device_uvector<page_span>, size_t, size_t> compute_next_subpass(
   auto [aggregated_info, page_keys_by_split] = adjust_cumulative_sizes(c_info, pages, stream);
 
   // bring back to the cpu
-  auto h_aggregated_info =
-    cudf::detail::make_pinned_vector_async<cumulative_page_info>(aggregated_info.size(), stream);
-  cudf::detail::cuda_memcpy(
-    cudf::host_span<cumulative_page_info>{h_aggregated_info.data(), aggregated_info.size()},
-    cudf::device_span<cumulative_page_info const>{aggregated_info.data(), aggregated_info.size()},
-    stream);
+  auto h_aggregated_info = cudf::detail::make_pinned_vector(aggregated_info, stream);
 
 #if defined(CHUNKING_DEBUG)
   print_cumulative_page_info(h_aggregated_info, "adjusted");
@@ -420,12 +415,7 @@ std::vector<row_range> compute_page_splits_by_row(device_span<cumulative_page_in
   auto [aggregated_info, page_keys_by_split] = adjust_cumulative_sizes(c_info, pages, stream);
 
   // bring back to the cpu
-  auto h_aggregated_info =
-    cudf::detail::make_pinned_vector_async<cumulative_page_info>(aggregated_info.size(), stream);
-  cudf::detail::cuda_memcpy(
-    cudf::host_span<cumulative_page_info>{h_aggregated_info.data(), aggregated_info.size()},
-    cudf::device_span<cumulative_page_info const>{aggregated_info.data(), aggregated_info.size()},
-    stream);
+  auto h_aggregated_info = cudf::detail::make_pinned_vector(aggregated_info, stream);
 
 #if defined(CHUNKING_DEBUG)
   print_cumulative_page_info(h_aggregated_info, "adjusted");
@@ -678,10 +668,8 @@ void detect_malformed_pages(device_span<PageInfo const> pages,
     row_counts_begin, row_counts_end, compacted_row_counts_begin, row_counts_nonzero{}, stream);
   if (compacted_row_counts_end != compacted_row_counts_begin) {
     auto const found_row_count = [&]() {
-      auto found_row_count = cudf::detail::make_pinned_vector_async<size_type>(1, stream);
-      cudf::detail::cuda_memcpy(cudf::host_span<size_type>{found_row_count.data(), 1},
-                                cudf::device_span<size_type const>{compacted_row_counts.data(), 1},
-                                stream);
+      auto found_row_count = cudf::detail::make_pinned_vector(
+        cudf::device_span<size_type const>{compacted_row_counts.data(), 1}, stream);
       return found_row_count.front();
     }();
 
@@ -721,13 +709,8 @@ rmm::device_uvector<size_t> compute_decompression_scratch_sizes(
                                 decomp_sum{});
 
   // retrieve to host so we can get compression scratch sizes
-  auto h_decomp_info =
-    cudf::detail::make_pinned_vector_async<decompression_info>(decomp_info.size(), stream);
-  cudf::detail::cuda_memcpy(
-    cudf::host_span<decompression_info>(h_decomp_info.data(), decomp_info.size()),
-    cudf::device_span<decompression_info const>(decomp_info.data(), decomp_info.size()),
-    stream);
-  auto temp_cost = cudf::detail::make_pinned_vector_async<size_t>(pages.size(), stream);
+  auto temp_cost     = cudf::detail::make_pinned_vector_async<size_t>(pages.size(), stream);
+  auto h_decomp_info = cudf::detail::make_pinned_vector(decomp_info, stream);
   std::transform(h_decomp_info.begin(), h_decomp_info.end(), temp_cost.begin(), [](auto const& d) {
     return cudf::io::detail::get_decompression_scratch_size(d);
   });


### PR DESCRIPTION
## Description

Backport of #21033

Add new pinned vector factory functions and use them across Parquet libcudf.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.