### PR TITLE
Move CategoricalDtype higher in cudf.dtype elif chain for pandas 3

### DIFF
--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -82,6 +82,8 @@ def dtype(arbitrary: Any) -> DtypeObj:
     pd_dtype = pd.api.types.pandas_dtype(arbitrary)  # noqa: TID251
     if isinstance(pd_dtype, pd.StringDtype):
         return pd_dtype
+    elif isinstance(pd_dtype, pd.CategoricalDtype):
+        return CategoricalDtype(pd_dtype.categories, pd_dtype.ordered)
     elif is_pandas_nullable_extension_dtype(pd_dtype):
         if isinstance(pd_dtype, pd.ArrowDtype):
             arrow_type = pd_dtype.pyarrow_dtype
@@ -103,8 +105,6 @@ def dtype(arbitrary: Any) -> DtypeObj:
             return dtype(pd_dtype.numpy_dtype)
     elif isinstance(pd_dtype, pd.core.dtypes.dtypes.NumpyEADtype):
         return dtype(pd_dtype.numpy_dtype)
-    elif isinstance(pd_dtype, pd.CategoricalDtype):
-        return CategoricalDtype(pd_dtype.categories, pd_dtype.ordered)
     elif isinstance(pd_dtype, pd.IntervalDtype):
         return IntervalDtype(pd_dtype.subtype, pd_dtype.closed)
     elif isinstance(pd_dtype, pd.DatetimeTZDtype):


### PR DESCRIPTION
## Description
The `is_pandas_nullable_extension_dtype` branch would have captured a `CategoricalDtype` with e.g. `pandas.StringDtype` (the new default) which is not designed to expect a `CategoricalDtype`. Fixes 17 test failures.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
