### PR TITLE
Hide RMM pinned pool symbols to prevent ODR conflict

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1005,6 +1005,11 @@ SECTIONS
 ]=]
 )
 target_link_options(cudf PRIVATE "$<HOST_LINK:${CUDF_BINARY_DIR}/fatbin.ld>")
+# Hide RMM pool_memory_resource symbols to avoid ODR violations with nvcomp. See
+# https://github.com/rapidsai/rmm/issues/2219
+target_link_options(
+  cudf PRIVATE "LINKER:--version-script=${CUDF_SOURCE_DIR}/src/utilities/symbols.map"
+)
 
 add_library(cudf::cudf ALIAS cudf)
 

--- a/cpp/src/utilities/symbols.map
+++ b/cpp/src/utilities/symbols.map
@@ -1,0 +1,5 @@
+{
+  local:
+    *rmm*pool_memory_resource*pinned_host_memory_resource*;
+    *rmm*stream_ordered_memory_resource*pool_memory_resource*pinned_host_memory_resource*;
+};


### PR DESCRIPTION
## Description
This is a minimal fix for an ODR conflict. Closes https://github.com/rapidsai/rmm/issues/2219.

This is tightly scoped to avoid changes in RMM that could propagate to other RAPIDS libraries or non-RAPIDS users of RMM.

At build time, cuDF will use the included symbol map so that `ld` marks the conflicting symbols for `rmm::mr::pool_memory_resource<rmm::mr::pinned_host_memory_resource>` as `t` (local) rather than `W` (weak global).

We are targeting 26.02 for this fix, and we can remove it in a later release once we've fixed the symbol visibility issues in RMM.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
