### PR TITLE
Fully assert the result for test_join_multi in pandas 3

### DIFF
--- a/python/cudf/cudf/tests/reshape/test_join.py
+++ b/python/cudf/cudf/tests/reshape/test_join.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -326,11 +326,6 @@ def test_join_multi(how, column_a, column_b, column_c):
 
     gdf_result = gdf1.join(gdf2, how=how, sort=True)
     pdf_result = df1.join(df2, how=how, sort=True)
-
-    # Make sure columns are in the same order
-    columns = pdf_result.columns.values
-    gdf_result = gdf_result[columns]
-    pdf_result = pdf_result[columns]
 
     assert_join_results_equal(pdf_result, gdf_result, how="inner")
 


### PR DESCRIPTION
## Description
`test_join_multi` failed in pandas 3 because `.values` returned a pandas ExtentionArray that wasn't allow as an argument to `__getitem__`.

This test passes without this supposed workaround so removed it all together.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
