### PR TITLE
Fix pytest failures in `test_explode` and `test_repr`

### DIFF
--- a/python/cudf/cudf/tests/series/methods/test_explode.py
+++ b/python/cudf/cudf/tests/series/methods/test_explode.py
@@ -11,7 +11,7 @@ from cudf.testing import assert_eq
 
 @pytest.mark.parametrize(
     "data",
-    [[[1, 2, 3], None, [4], [], [5, 6]], [1, 2, 3, 4, 5]],
+    [[[1, 2, 3], pd.NA, [4], [], [5, 6]], [1, 2, 3, 4, 5]],
 )
 @pytest.mark.parametrize(
     "p_index",
@@ -24,12 +24,11 @@ from cudf.testing import assert_eq
     ],
 )
 def test_explode(data, ignore_index, p_index):
-    pdf = pd.Series(data, index=p_index, name="someseries")
-    gdf = cudf.from_pandas(pdf)
+    gdf = cudf.Series(data, index=p_index, name="someseries")
+    pdf = gdf.to_pandas(arrow_type=True)
 
     expect = pdf.explode(ignore_index)
     got = gdf.explode(ignore_index)
-
     assert_eq(expect, got, check_dtype=False)
 
 


### PR DESCRIPTION
## Description
Contributes to https://github.com/rapidsai/cudf/issues/20816
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
