### PR TITLE
Hide pinned pool instantiation to avoid symbol conflicts with nvcomp

### DIFF
--- a/cpp/src/utilities/host_memory.cpp
+++ b/cpp/src/utilities/host_memory.cpp
@@ -1,7 +1,21 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
+
+// clang-format off
+// Forward declaring this type with hidden visibility supersedes the upstream
+// declaration and therefore hides instantiations in this file. This prevents
+// the specific symbol conflict observed in
+// https://github.com/rapidsai/rmm/issues/2219 between nvcomp's instantiation
+// of pool_memory_resource<pinned_host_memory_resource> and libcudf's, but it
+// does not fix the broader issues around rmm's symbol visibility that are
+// raised in that issue. Those will be fixed upstream at a later date.
+namespace rmm::mr {
+template <typename Upstream>
+class pool_memory_resource;
+}
+// clang-format on
 
 #include "io/utilities/getenv_or.hpp"
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This change is a minimal changeset to resolve the nvcomp/cudf incompatibility described in https://github.com/rapidsai/rmm/issues/2219. The broader issues around rmm's template classes being unsafe to instantiate and pass across DSO boundaries will need to be fixed in rmm, but those are out of scope for the immediate release. This change simply avoids one particular conflict that we have observed in our actual current use cases by declaring the `pool_memory_resource` class with different visibility in this particular TU before instantiating the problematic template that was colliding with nvcomp (`pool_memory_resource<pinned_host_memory_resource>`).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
