### PR TITLE
Require nvcc 12.9 in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ for a minimal build of libcudf without using conda are also listed below.
 Compilers:
 
 * `gcc` version 13.3+
-* `nvcc` version 12.2+
+* `nvcc` version 12.9+
 * `cmake` version 3.29.6+
 
 CUDA/GPU Runtime:


### PR DESCRIPTION
## Description
cuDF requires nvcc 12.9 to compile from source. This updates our contributing guide to reflect this requirement.

Hangs in cicc have been observed when compiling `stable_sort_column.cu` with CUDA 12.8 for certain architectures, but CUDA 12.9 works fine.

See also nvbug 5825703.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
