### PR TITLE
Ignore hardcoded versions in deprecated code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -250,7 +250,9 @@ repos:
             [.]rst$|
             [.](avro|parquet|png|orc|gz|pkl|sas7bdat)$|
             ^conda/environments/|
-            ^python/cudf/cudf/VERSION$
+            ^python/cudf/cudf/VERSION$|
+            ^cpp/include/nvtext/byte_pair_encoding.hpp$|
+            ^python/cudf/cudf/core/byte_pair_encoding.py$
   - repo: https://github.com/rapidsai/dependency-file-generator
     rev: v1.20.2
     hooks:


### PR DESCRIPTION
## Description
#21152 and #21157 conflict, causing an issue in deprecation notices that hardcode the RAPIDS version.

This is a temporary workaround to get CI passing again.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
