### PR TITLE
Add noinline declaration to secondary type-dispatching row-operators in Debug build

### DIFF
--- a/cpp/include/cudf/detail/row_operator/equality.cuh
+++ b/cpp/include/cudf/detail/row_operator/equality.cuh
@@ -261,8 +261,11 @@ class device_row_comparator {
     }
 
     template <typename Element>
-    __attribute__((noinline)) __device__ bool operator()(
-      size_type const lhs_element_index, size_type const rhs_element_index) const noexcept
+#ifndef NDEBUG
+    __attribute__((noinline))
+#endif
+    __device__ bool
+    operator()(size_type const lhs_element_index, size_type const rhs_element_index) const noexcept
       requires(cudf::is_dictionary<Element>())
     {
       if (check_nulls) {
@@ -291,8 +294,11 @@ class device_row_comparator {
     }
 
     template <typename Element>
-    __attribute__((noinline)) __device__ bool operator()(
-      size_type const lhs_element_index, size_type const rhs_element_index) const noexcept
+#ifndef NDEBUG
+    __attribute__((noinline))
+#endif
+    __device__ bool
+    operator()(size_type const lhs_element_index, size_type const rhs_element_index) const noexcept
       requires(has_nested_columns and cudf::is_nested<Element>())
     {
       column_device_view lcol = lhs.slice(lhs_element_index, 1);

--- a/cpp/include/cudf/detail/row_operator/lexicographic.cuh
+++ b/cpp/include/cudf/detail/row_operator/lexicographic.cuh
@@ -348,8 +348,11 @@ class device_row_comparator {
     }
 
     template <typename Element>
-    __device__ cuda::std::pair<cudf::detail::weak_ordering, int> operator()(
-      size_type const lhs_element_index, size_type const rhs_element_index) const noexcept
+#ifndef NDEBUG
+    __attribute__((noinline))
+#endif
+    __device__ cuda::std::pair<cudf::detail::weak_ordering, int>
+    operator()(size_type const lhs_element_index, size_type const rhs_element_index) const noexcept
       requires(cudf::is_dictionary<Element>())
     {
       if (_check_nulls) {
@@ -394,8 +397,11 @@ class device_row_comparator {
      * with the depth at which a null value was encountered.
      */
     template <typename Element>
-    __device__ cuda::std::pair<cudf::detail::weak_ordering, int> operator()(
-      size_type const lhs_element_index, size_type const rhs_element_index) const noexcept
+#ifndef NDEBUG
+    __attribute__((noinline))
+#endif
+    __device__ cuda::std::pair<cudf::detail::weak_ordering, int>
+    operator()(size_type const lhs_element_index, size_type const rhs_element_index) const noexcept
       requires(has_nested_columns and cuda::std::is_same_v<Element, cudf::struct_view>)
     {
       column_device_view lcol = _lhs;
@@ -437,8 +443,11 @@ class device_row_comparator {
      * with the depth at which a null value was encountered.
      */
     template <typename Element>
-    __device__ cuda::std::pair<cudf::detail::weak_ordering, int> operator()(
-      size_type lhs_element_index, size_type rhs_element_index)
+#ifndef NDEBUG
+    __attribute__((noinline))
+#endif
+    __device__ cuda::std::pair<cudf::detail::weak_ordering, int>
+    operator()(size_type lhs_element_index, size_type rhs_element_index)
       requires(has_nested_columns and cuda::std::is_same_v<Element, cudf::list_view>)
     {
       auto const is_l_row_null = _lhs.is_null(lhs_element_index);


### PR DESCRIPTION
## Description
Adds the `noinline` attribute declaration to the row-operator specializations that require secondary calls to the type-dispatcher. This includes the nested types like list and struct which require a 2nd dispatch for the children types as well as dictionary types which require a 2nd dispatch for its key types.
This improves compile time or a Debug build for those source files that require the row-operators. 
The Debug builds appeared to hang (or at least not finish in 1.5 hours)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
