### PR TITLE
Revert the multithreaded optimization in the CSV reader

### DIFF
--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -977,7 +977,7 @@ table_with_metadata read_csv(cudf::io::datasource* source,
 
         // Count how many rows were quoted to determine the fast path
         auto const num_quoted =
-          thrust::count(rmm::exec_policy(stream), is_quoted.begin(), is_quoted.end(), true);
+          thrust::count(rmm::exec_policy_nosync(stream), is_quoted.begin(), is_quoted.end(), true);
         if (num_quoted == 0) {
           // Fast path: no rows were quoted, skip replacement entirely
           out_columns[col_idx] = make_column(*buffer, nullptr, std::nullopt, stream);


### PR DESCRIPTION
## Description
The multi-threaded optimization causes issues for Spark-RAPIDS, https://github.com/NVIDIA/spark-rapids/issues/14197.

Reverting the optimization for now.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
