### PR TITLE
Preserve StringDtype variants from pandas inputs for pandas 3

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2886,6 +2886,8 @@ def as_column(
                 # pandas arrays define __arrow_array__ for better
                 # pyarrow.array conversion
                 arbitrary = arbitrary.array
+            if dtype is None and isinstance(arbitrary.dtype, pd.StringDtype):
+                dtype = arbitrary.dtype
             result = as_column(
                 pa.array(arbitrary, from_pandas=True),
                 nan_as_null=nan_as_null,

--- a/python/cudf/cudf/tests/private_objects/test_column.py
+++ b/python/cudf/cudf/tests/private_objects/test_column.py
@@ -414,7 +414,7 @@ def test_as_column_arrow_array(data, pyarrow_kwargs, cudf_kwargs):
     "pd_dtype,expect_dtype",
     [
         # TODO: Nullable float is coming
-        (pd.StringDtype(), np.dtype("O")),
+        (pd.StringDtype(), pd.StringDtype()),
         (pd.UInt8Dtype(), np.dtype("uint8")),
         (pd.UInt16Dtype(), np.dtype("uint16")),
         (pd.UInt32Dtype(), np.dtype("uint32")),
@@ -450,7 +450,7 @@ def test_build_df_from_nullable_pandas_dtype(pd_dtype, expect_dtype):
     "pd_dtype,expect_dtype",
     [
         # TODO: Nullable float is coming
-        (pd.StringDtype(), np.dtype("O")),
+        (pd.StringDtype(), pd.StringDtype()),
         (pd.UInt8Dtype(), np.dtype("uint8")),
         (pd.UInt16Dtype(), np.dtype("uint16")),
         (pd.UInt32Dtype(), np.dtype("uint32")),


### PR DESCRIPTION
## Description
Towards #20818

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
