### PR TITLE
Replace thrust::copy_if calls with cudf::detail::copy_if

### DIFF
--- a/cpp/src/io/orc/reader_impl_decode.cu
+++ b/cpp/src/io/orc/reader_impl_decode.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,6 +15,7 @@
 #include <cudf/detail/null_mask.hpp>
 #include <cudf/detail/structs/utilities.hpp>
 #include <cudf/detail/transform.hpp>
+#include <cudf/detail/utilities/algorithm.cuh>
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/io/config_utils.hpp>
@@ -28,7 +29,6 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/utility>
-#include <thrust/copy.h>
 #include <thrust/fill.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -292,13 +292,14 @@ void update_null_mask(cudf::detail::hostdevice_2dvector<column_desc>& chunks,
       if (child_valid_map_base != nullptr) {
         rmm::device_uvector<uint32_t> dst_idx(child_mask_len, stream);
         // Copy indexes at which the parent has valid value.
-        thrust::copy_if(rmm::exec_policy_nosync(stream),
-                        thrust::make_counting_iterator(0),
-                        thrust::make_counting_iterator(0) + parent_mask_len,
-                        dst_idx.begin(),
-                        [parent_valid_map_base] __device__(auto idx) {
-                          return bit_is_set(parent_valid_map_base, idx);
-                        });
+        cudf::detail::copy_if(
+          thrust::counting_iterator<size_type>(0),
+          thrust::counting_iterator<size_type>(parent_mask_len),
+          dst_idx.begin(),
+          [parent_valid_map_base] __device__(auto idx) {
+            return bit_is_set(parent_valid_map_base, idx);
+          },
+          stream);
 
         auto merged_null_mask = cudf::detail::create_null_mask(
           parent_mask_len, mask_state::ALL_NULL, rmm::cuda_stream_view(stream), mr);

--- a/cpp/src/lists/dremel.cu
+++ b/cpp/src/lists/dremel.cu
@@ -6,6 +6,7 @@
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/iterator.cuh>
+#include <cudf/detail/utilities/algorithm.cuh>
 #include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/lists/detail/dremel.hpp>
@@ -17,7 +18,6 @@
 
 #include <cuda/functional>
 #include <cuda/std/tuple>
-#include <thrust/copy.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/gather.h>
@@ -87,12 +87,12 @@ dremel_data get_encoding(column_view h_col,
     rmm::device_uvector<size_type> empties(lcv.size(), stream);
     auto d_off = lcv.offsets().data<size_type>();
 
-    auto empties_idx_end =
-      thrust::copy_if(rmm::exec_policy_nosync(stream),
-                      thrust::make_counting_iterator(start),
-                      thrust::make_counting_iterator(end),
-                      empties_idx.begin(),
-                      [d_off] __device__(auto i) { return d_off[i] == d_off[i + 1]; });
+    auto empties_idx_end = cudf::detail::copy_if(
+      thrust::counting_iterator<size_type>(start),
+      thrust::counting_iterator<size_type>(end),
+      empties_idx.begin(),
+      [d_off] __device__(auto i) { return d_off[i] == d_off[i + 1]; },
+      stream);
     auto empties_end = thrust::gather(rmm::exec_policy_nosync(stream),
                                       empties_idx.begin(),
                                       empties_idx_end,

--- a/cpp/src/reductions/histogram.cu
+++ b/cpp/src/reductions/histogram.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,6 +9,7 @@
 #include <cudf/detail/iterator.cuh>
 #include <cudf/detail/row_operator/equality.cuh>
 #include <cudf/detail/row_operator/hashing.cuh>
+#include <cudf/detail/utilities/algorithm.cuh>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
@@ -21,7 +22,6 @@
 #include <cuda/atomic>
 #include <cuda/functional>
 #include <cuda/std/tuple>
-#include <thrust/copy.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/uninitialized_fill.h>
 
@@ -186,8 +186,7 @@ compute_row_frequencies(table_view const& input,
 
   // Reduction results above are either group sizes of equal rows, or `0`.
   // The final output is non-zero group sizes only.
-  thrust::copy_if(
-    rmm::exec_policy_nosync(stream), input_it, input_it + num_rows, output_it, is_not_zero{});
+  cudf::detail::copy_if(input_it, input_it + num_rows, output_it, is_not_zero{}, stream);
 
   return {std::move(distinct_indices), std::move(distinct_counts)};
 }

--- a/cpp/src/rolling/detail/rolling_collect_list.cu
+++ b/cpp/src/rolling/detail/rolling_collect_list.cu
@@ -13,7 +13,6 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/functional>
-#include <thrust/copy.h>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 #include <thrust/functional.h>
@@ -119,11 +118,11 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
                                                 gather_map.size() - num_child_nulls,
                                                 mask_state::UNALLOCATED,
                                                 stream);
-  thrust::copy_if(rmm::exec_policy_nosync(stream),
-                  gather_map.template begin<size_type>(),
-                  gather_map.template end<size_type>(),
-                  new_gather_map->mutable_view().template begin<size_type>(),
-                  input_row_not_null);
+  cudf::detail::copy_if(gather_map.template begin<size_type>(),
+                        gather_map.template end<size_type>(),
+                        new_gather_map->mutable_view().template begin<size_type>(),
+                        input_row_not_null,
+                        stream);
 
   // Recalculate offsets after null entries are purged.
   auto new_sizes = make_fixed_width_column(

--- a/cpp/src/stream_compaction/distinct_helpers.hpp
+++ b/cpp/src/stream_compaction/distinct_helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,7 +19,6 @@
 #include <cuco/static_set.cuh>
 #include <cuda/functional>
 #include <cuda/std/iterator>
-#include <thrust/copy.h>
 #include <thrust/iterator/counting_iterator.h>
 
 namespace cudf::detail {

--- a/cpp/src/stream_compaction/stream_compaction_common.cuh
+++ b/cpp/src/stream_compaction/stream_compaction_common.cuh
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <cudf/detail/utilities/algorithm.cuh>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/utilities/bit.hpp>
 
@@ -11,7 +12,6 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/std/iterator>
-#include <thrust/copy.h>
 #include <thrust/iterator/counting_iterator.h>
 
 namespace cudf {
@@ -89,13 +89,13 @@ OutputIterator unique_copy(InputIterator first,
                            rmm::cuda_stream_view stream)
 {
   size_type const last_index = cuda::std::distance(first, last) - 1;
-  return thrust::copy_if(
-    rmm::exec_policy_nosync(stream),
+  return cudf::detail::copy_if(
     first,
     last,
     thrust::counting_iterator<size_type>(0),
     output,
-    unique_copy_fn<InputIterator, BinaryPredicate>{first, keep, comp, last_index});
+    unique_copy_fn<InputIterator, BinaryPredicate>{first, keep, comp, last_index},
+    stream);
 }
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/src/stream_compaction/unique.cu
+++ b/cpp/src/stream_compaction/unique.cu
@@ -15,6 +15,7 @@
 #include <cudf/detail/row_operator/equality.cuh>
 #include <cudf/detail/sorting.hpp>
 #include <cudf/detail/stream_compaction.hpp>
+#include <cudf/detail/utilities/algorithm.cuh>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
@@ -28,7 +29,6 @@
 
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
-#include <thrust/copy.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/counting_iterator.h>
 
@@ -72,12 +72,12 @@ std::unique_ptr<table> unique(table_view const& input,
         itr + num_rows,
         d_results.begin(),
         unique_copy_fn<decltype(itr), decltype(row_equal)>{itr, keep, row_equal, num_rows - 1});
-      auto result_end = thrust::copy_if(rmm::exec_policy_nosync(stream),
-                                        itr,
-                                        itr + num_rows,
-                                        d_results.begin(),
-                                        mutable_view->begin<size_type>(),
-                                        cuda::std::identity{});
+      auto result_end = cudf::detail::copy_if(itr,
+                                              itr + num_rows,
+                                              d_results.begin(),
+                                              mutable_view->begin<size_type>(),
+                                              cuda::std::identity{},
+                                              stream);
       return static_cast<size_type>(
         cuda::std::distance(mutable_view->begin<size_type>(), result_end));
     } else {

--- a/cpp/src/text/wordpiece_tokenize.cu
+++ b/cpp/src/text/wordpiece_tokenize.cu
@@ -35,7 +35,6 @@
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/limits>
-#include <thrust/copy.h>
 #include <thrust/execution_policy.h>
 #include <thrust/find.h>
 #include <thrust/iterator/transform_iterator.h>
@@ -238,11 +237,11 @@ wordpiece_vocabulary::wordpiece_vocabulary(cudf::strings_column_view const& inpu
   // get the indices of all the ## prefixed entries
   auto sub_map_indices = rmm::device_uvector<cudf::size_type>(vocabulary->size(), stream);
   auto const end =
-    thrust::copy_if(rmm::exec_policy_nosync(stream),
-                    zero_itr,
-                    thrust::counting_iterator<cudf::size_type>(sub_map_indices.size()),
-                    sub_map_indices.begin(),
-                    copy_pieces_fn{*d_vocabulary});
+    cudf::detail::copy_if(zero_itr,
+                          thrust::counting_iterator<cudf::size_type>(sub_map_indices.size()),
+                          sub_map_indices.begin(),
+                          copy_pieces_fn{*d_vocabulary},
+                          stream);
   sub_map_indices.resize(cuda::std::distance(sub_map_indices.begin(), end), stream);
 
   // build a 2nd map with just the ## prefixed items


### PR DESCRIPTION
## Description
First pass a changing the `thrust::copy_if` calls to the internal `cudf::detail::copy_if` which uses CUB and can support int64 ranges. This should also make it easier to change `size_type` in the future.
Most of the ones in this PR are straightforward. Others to follow in a separate PR are more involved.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
