### PR TITLE
Exclude sqlglot version 28.7 from CI

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -952,7 +952,7 @@ dependencies:
               - sqlframe
               - ibis-framework[duckdb]
               - duckdb<1.4.0
-              - # Exclude broken version: https://github.com/tobymao/sqlglot/issues/6908
+              # Exclude broken version: https://github.com/tobymao/sqlglot/issues/6908
               - sqlglot!=28.7.*
   depends_on_libcudf:
     common:

--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/dependencies.yaml
@@ -290,7 +290,7 @@ dependencies:
               # ibis 11 is the first version that supports duckdb 1.4.0
               - ibis-framework[duckdb]>=11.0.0
               - duckdb>=1.4.0
-              - # Exclude broken version: https://github.com/tobymao/sqlglot/issues/6908
+              # Exclude broken version: https://github.com/tobymao/sqlglot/issues/6908
               - sqlglot!=28.7.*
   test_hvplot:
     common:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Follow up to #21271 to only exclude the version of sqlglot with the bug. And does the same for the narwhal CI job.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
