### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/python/pylibcudf/pylibcudf/interop.pyx
+++ b/python/pylibcudf/pylibcudf/interop.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from cpython.pycapsule cimport (
@@ -10,9 +10,6 @@ from cpython.pycapsule cimport (
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
 
-from functools import singledispatch
-import warnings
-
 from pylibcudf.libcudf.interop cimport (
     DLManagedTensor,
     from_dlpack as cpp_from_dlpack,
@@ -23,19 +20,9 @@ from pylibcudf.libcudf.table.table cimport table
 from rmm.pylibrmm.stream cimport Stream
 from rmm.pylibrmm.memory_resource cimport DeviceMemoryResource
 
-from .column cimport Column
-from .scalar cimport Scalar
 from .table cimport Table
-from .types cimport DataType
 from .utils cimport _get_stream, _get_memory_resource
 from ._interop_helpers import ColumnMetadata
-
-try:
-    import pyarrow as pa
-    pa_err = None
-except ImportError as e:
-    pa = None
-    pa_err = e
 
 
 __all__ = [
@@ -45,126 +32,6 @@ __all__ = [
     "to_arrow",
     "to_dlpack",
 ]
-
-
-def _deprecated_to_arrow_warning():
-    warnings.warn(
-        "pylibcudf.interop.to_arrow is deprecated; call the object's .to_arrow(...) "
-        "method instead (e.g., Table.to_arrow, Column.to_arrow, etc.).",
-        FutureWarning,
-        stacklevel=2,
-    )
-
-
-def _deprecated_from_arrow_warning():
-    warnings.warn(
-        "pylibcudf.interop.from_arrow is deprecated; use class methods instead "
-        "(e.g., Table.from_arrow, Column.from_arrow, etc.).",
-        FutureWarning,
-        stacklevel=2,
-    )
-
-
-@singledispatch
-def from_arrow(pyarrow_object, *, DataType data_type=None):
-    """Create a cudf object from a pyarrow object.
-
-    Parameters
-    ----------
-    pyarrow_object : Union[pyarrow.Array, pyarrow.Table, pyarrow.Scalar]
-        The PyArrow object to convert.
-
-    Returns
-    -------
-    Union[Table, Scalar]
-        The converted object of type corresponding to the input type in cudf.
-    """
-    if pa_err is not None:
-        raise RuntimeError(
-            "pyarrow was not found on your system. Please "
-            "pip install pylibcudf with the [pyarrow] extra for a "
-            "compatible pyarrow version."
-        ) from pa_err
-    _deprecated_from_arrow_warning()
-    raise TypeError(
-        f"Unsupported type {type(pyarrow_object)} for conversion from arrow"
-    )
-
-
-@singledispatch
-def to_arrow(plc_object, **kwargs):
-    """Convert to a PyArrow object.
-
-    Parameters
-    ----------
-    plc_object : Union[Column, Table, Scalar]
-        The cudf object to convert.
-    metadata : list
-        The metadata to attach to the columns of the table.
-
-    Returns
-    -------
-    Union[pyarrow.Array, pyarrow.Table, pyarrow.Scalar]
-        The converted object of type corresponding to the input type in PyArrow.
-    """
-    if pa_err is not None:
-        raise RuntimeError(
-            "pyarrow was not found on your system. Please "
-            "pip install pylibcudf with the [pyarrow] extra for a "
-            "compatible pyarrow version."
-        ) from pa_err
-    _deprecated_to_arrow_warning()
-    raise TypeError(f"Unsupported type {type(plc_object)} for conversion to arrow")
-
-
-if pa is not None:
-    @from_arrow.register(pa.DataType)
-    def _from_arrow_datatype(pyarrow_object):
-        _deprecated_from_arrow_warning()
-        return DataType.from_arrow(pyarrow_object)
-
-    @from_arrow.register(pa.Table)
-    def _from_arrow_table(pyarrow_object, *, DataType data_type=None):
-        _deprecated_from_arrow_warning()
-        return Table.from_arrow(pyarrow_object, dtype=data_type)
-
-    @from_arrow.register(pa.Scalar)
-    def _from_arrow_scalar(
-        pyarrow_object,
-        *,
-        DataType data_type=None,
-        Stream stream = None
-    ):
-        _deprecated_from_arrow_warning()
-        return Scalar.from_arrow(pyarrow_object, dtype=data_type, stream=stream)
-
-    @from_arrow.register(pa.Array)
-    def _from_arrow_column(pyarrow_object, *, DataType data_type=None):
-        _deprecated_from_arrow_warning()
-        return Column.from_arrow(pyarrow_object, dtype=data_type)
-
-    @to_arrow.register(DataType)
-    def _to_arrow_datatype(plc_object, **kwargs):
-        """Convert a datatype to arrow."""
-        _deprecated_to_arrow_warning()
-        return plc_object.to_arrow(**kwargs)
-
-    @to_arrow.register(Table)
-    def _to_arrow_table(plc_object, metadata=None):
-        """Create a PyArrow table from a pylibcudf table."""
-        _deprecated_to_arrow_warning()
-        return plc_object.to_arrow(metadata=metadata)
-
-    @to_arrow.register(Column)
-    def _to_arrow_array(plc_object, metadata=None):
-        """Create a PyArrow array from a pylibcudf column."""
-        _deprecated_to_arrow_warning()
-        return plc_object.to_arrow(metadata=metadata)
-
-    @to_arrow.register(Scalar)
-    def _to_arrow_scalar(plc_object, metadata=None):
-        _deprecated_to_arrow_warning()
-        return plc_object.to_arrow(metadata=metadata)
 
 
 cpdef Table from_dlpack(

--- a/python/pylibcudf/tests/test_interop.py
+++ b/python/pylibcudf/tests/test_interop.py
@@ -243,15 +243,3 @@ def test_arrow_object_lifetime():
     except ValueError:
         # Ignore the exception. A failure in this test is a seg fault
         pass
-
-
-def test_deprecate_arrow_interop_apis():
-    with pytest.warns(
-        FutureWarning, match="pylibcudf.interop.from_arrow is deprecated"
-    ):
-        foo = plc.interop.from_arrow(pa.array([1]))
-
-    with pytest.warns(
-        FutureWarning, match="pylibcudf.interop.to_arrow is deprecated"
-    ):
-        plc.interop.to_arrow(foo)


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.