### PR TITLE
Remove deprecation warnings from benchmarks/ndsh/utilities.cpp

### DIFF
--- a/cpp/benchmarks/ndsh/utilities.cpp
+++ b/cpp/benchmarks/ndsh/utilities.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -312,7 +312,7 @@ std::unique_ptr<table_with_names> read_parquet(
 {
   CUDF_BENCHMARK_RANGE();
   auto builder = cudf::io::parquet_reader_options_builder(source_info);
-  if (!columns.empty()) { builder.columns(columns); }
+  if (!columns.empty()) { builder.column_names(columns); }
   if (predicate) { builder.filter(*predicate); }
   auto const options       = builder.build();
   auto table_with_metadata = cudf::io::read_parquet(options);


### PR DESCRIPTION
## Description
Removes deprecation warnings from `cpp/benchmarks/ndsh/utilities.cpp` for the `cudf::io::parquet_reader_options_builder.columns()` function. Changed it to use the replacement `cudf::io::parquet_reader_options_builder.column_names()` function instead.

```
Building CXX object benchmarks/CMakeFiles/NDSH_Q05_NVBENCH.dir/ndsh/utilities.cpp.o
/cudf/cpp/benchmarks/ndsh/utilities.cpp: In function 'std::unique_ptr<table_with_names> read_parquet(const cudf::io::source_info&, const std::vector<std::__cxx11::basic_string<char> >&, const std::unique_ptr<cudf::ast::operation>&)':
/cudf/cpp/benchmarks/ndsh/utilities.cpp:315:42: warning: 'cudf::io::parquet_reader_options_builder& cudf::io::parquet_reader_options_builder::columns(std::vector<std::__cxx11::basic_string<char> >)' is deprecated: Use `column_names` instead. [-Wdeprecated-declarations]
  315 |   if (!columns.empty()) { builder.columns(columns); }
      |                           ~~~~~~~~~~~~~~~^~~~~~~~~
In file included from /cudf/cpp/benchmarks/ndsh/utilities.hpp:11,
                 from /cudf/cpp/benchmarks/ndsh/utilities.cpp:6:
/cudf/cpp/include/cudf/io/parquet.hpp:528:81: note: declared here
  528 |   [[deprecated("Use `column_names` instead.")]] parquet_reader_options_builder& columns(
      |                                                                                 ^~~~~~~

```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
