### PR TITLE
Fix docs for cudf::index_of_first_set_bit API

### DIFF
--- a/cpp/include/cudf/null_mask.hpp
+++ b/cpp/include/cudf/null_mask.hpp
@@ -285,13 +285,13 @@ std::vector<size_type> batch_null_count(host_span<bitmask_type const* const> bit
 
 /**
  * @brief Given a validity bitmask, returns the index of the first set bit
- * in the range `[start, stop)`.
+ * in the range `[start, stop)` relative to start
  *
  * @param bitmask Validity bitmask residing in device memory
  * @param start Index of the first bit to check (inclusive)
  * @param stop Index of the last bit to check (exclusive)
  * @param stream CUDA stream used for device memory operations and kernel launches
- * @return The index of the first set bit in the specified range,
+ * @return The index of the first set bit in the specified range relative to start,
  *         or `stop-start` if no set bit is found (all nulls)
  */
 size_type index_of_first_set_bit(bitmask_type const* bitmask,

--- a/python/pylibcudf/pylibcudf/null_mask.pyx
+++ b/python/pylibcudf/pylibcudf/null_mask.pyx
@@ -292,7 +292,8 @@ cpdef size_type index_of_first_set_bit(
     size_type stop,
     Stream stream=None
 ):
-    """Given a validity bitmask, returns the index of the first valid element.
+    """Given a validity bitmask, returns the index of the first valid element
+    relative to ``start``.
 
     For details, see :cpp:func:`index_of_first_set_bit`.
 
@@ -310,7 +311,7 @@ cpdef size_type index_of_first_set_bit(
     Returns
     -------
     int
-        The number of null elements in the specified range.
+        The index of the first set bit relative to ``start``
     """
     if not py_is_span(bitmask):
         raise TypeError(


### PR DESCRIPTION
## Description
Fixes the docs for the pylibcudf API and also makes it clearer the returned index is relative to the `start` parameter offset.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
