### PR TITLE
Fix return type of str.ip2int to uint32

### DIFF
--- a/python/cudf/cudf/core/accessors/string.py
+++ b/python/cudf/cudf/core/accessors/string.py
@@ -147,7 +147,7 @@ class StringMethods(BaseAccessor):
         >>> s.str.ip2int()
         0    212336897
         1    167772161
-        dtype: int64
+        dtype: uint32
 
         Returns 0's if any string is not an IP.
 
@@ -156,7 +156,7 @@ class StringMethods(BaseAccessor):
         0    212336897
         1    167772161
         2            0
-        dtype: int64
+        dtype: uint32
         """
         return self._return_or_inplace(self._column.ipv4_to_integers())
 

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -1102,7 +1102,7 @@ class StringColumn(ColumnBase, Scannable):
                 "cudf.core.column.numerical.NumericalColumn",
                 ColumnBase.create(
                     plc_column,
-                    get_dtype_of_same_kind(self.dtype, np.dtype(np.int64)),
+                    get_dtype_of_same_kind(self.dtype, np.dtype(np.uint32)),
                 ),
             )
 

--- a/python/cudf/cudf/tests/series/accessors/test_str.py
+++ b/python/cudf/cudf/tests/series/accessors/test_str.py
@@ -768,12 +768,16 @@ def test_string_ip4_to_int():
     gsr = cudf.Series(
         ["", None, "hello", "41.168.0.1", "127.0.0.1", "41.197.0.1"]
     )
-    expected = cudf.Series([0, None, 0, 698875905, 2130706433, 700776449])
+    expected = cudf.Series(
+        [0, None, 0, 698875905, 2130706433, 700776449], dtype="uint32"
+    )
 
     got = gsr.str.ip2int()
+    assert got.dtype == np.dtype("uint32")
     assert_eq(expected, got)
 
     got = gsr.str.ip_to_int()  # alias
+    assert got.dtype == np.dtype("uint32")
     assert_eq(expected, got)
 
 


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/21320

Broke in https://github.com/rapidsai/cudf/pull/21265 (I trusted the docstring which I suspect isn't running in our doctests).

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
