### PR TITLE
Add pylibcudf interface to cudf::round_decimal

### DIFF
--- a/python/pylibcudf/pylibcudf/libcudf/round.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/round.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t
 from libcpp.memory cimport unique_ptr
@@ -17,6 +17,14 @@ cdef extern from "cudf/round.hpp" namespace "cudf" nogil:
         HALF_EVEN
 
     cdef unique_ptr[column] round (
+        const column_view& input,
+        int32_t decimal_places,
+        rounding_method method,
+        cuda_stream_view stream,
+        device_memory_resource* mr
+    ) except +libcudf_exception_handler
+
+    cdef unique_ptr[column] round_decimal (
         const column_view& input,
         int32_t decimal_places,
         rounding_method method,

--- a/python/pylibcudf/pylibcudf/round.pxd
+++ b/python/pylibcudf/pylibcudf/round.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t
 from pylibcudf.libcudf.round cimport rounding_method
@@ -10,6 +10,14 @@ from rmm.pylibrmm.memory_resource cimport DeviceMemoryResource
 
 
 cpdef Column round(
+    Column source,
+    int32_t decimal_places = *,
+    rounding_method round_method = *,
+    Stream stream = *,
+    DeviceMemoryResource mr = *
+)
+
+cpdef Column round_decimal(
     Column source,
     int32_t decimal_places = *,
     rounding_method round_method = *,

--- a/python/pylibcudf/pylibcudf/round.pyi
+++ b/python/pylibcudf/pylibcudf/round.pyi
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import IntEnum
@@ -13,6 +13,13 @@ class RoundingMethod(IntEnum):
     HALF_EVEN = ...
 
 def round(
+    source: Column,
+    decimal_places: int = 0,
+    round_method: RoundingMethod = RoundingMethod.HALF_UP,
+    stream: Stream | None = None,
+    mr: DeviceMemoryResource | None = None,
+) -> Column: ...
+def round_decimal(
     source: Column,
     decimal_places: int = 0,
     round_method: RoundingMethod = RoundingMethod.HALF_UP,

--- a/python/pylibcudf/pylibcudf/round.pyx
+++ b/python/pylibcudf/pylibcudf/round.pyx
@@ -1,9 +1,13 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t
 from libcpp.memory cimport unique_ptr
 from libcpp.utility cimport move
-from pylibcudf.libcudf.round cimport round as cpp_round, rounding_method
+from pylibcudf.libcudf.round cimport (
+    round as cpp_round,
+    round_decimal as cpp_round_decimal,
+    rounding_method,
+)
 
 from pylibcudf.libcudf.round import \
     rounding_method as RoundingMethod  # no-cython-lint
@@ -26,6 +30,10 @@ cpdef Column round(
     DeviceMemoryResource mr=None
 ):
     """Rounds all the values in a column to the specified number of decimal places.
+
+    .. deprecated:: release 26.04
+        round is deprecated for float type.
+        Use ``round_decimal`` for decimal and integer types.
 
     For details, see :cpp:func:`round`.
 
@@ -55,6 +63,54 @@ cpdef Column round(
 
     with nogil:
         c_result = cpp_round(
+            source.view(),
+            decimal_places,
+            round_method,
+            stream.view(),
+            mr.get_mr()
+        )
+
+    return Column.from_libcudf(move(c_result), stream, mr)
+
+
+cpdef Column round_decimal(
+    Column source,
+    int32_t decimal_places = 0,
+    rounding_method round_method = rounding_method.HALF_UP,
+    Stream stream=None,
+    DeviceMemoryResource mr=None
+):
+    """Rounds all the values in a column to the specified number of decimal places.
+    Only decimal and integer types are supported.
+
+    For details, see :cpp:func:`round_decimal`.
+
+    Parameters
+    ----------
+    source : Column
+        The Column for which to round values.
+    decimal_places: int32_t, optional
+        The number of decimal places to round to (default 0)
+    round_method: rounding_method, optional
+        The method by which to round each value.
+        Can be one of { RoundingMethod.HALF_UP, RoundingMethod.HALF_EVEN }
+        (default rounding_method.HALF_UP)
+    stream : Stream | None
+        CUDA stream on which to perform the operation.
+    mr : DeviceMemoryResource | None
+        Device memory resource used to allocate the returned column's device memory.
+
+    Returns
+    -------
+    pylibcudf.Column
+        A Column with values rounded
+    """
+    cdef unique_ptr[column] c_result
+    stream = _get_stream(stream)
+    mr = _get_memory_resource(mr)
+
+    with nogil:
+        c_result = cpp_round_decimal(
             source.view(),
             decimal_places,
             round_method,


### PR DESCRIPTION
## Description
Adds a pylibcudf interface for `cudf::round_decimal` and deprecates the pylibcudf interface to `cudf::round`.

Reference #21319 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
