### PR TITLE
Remove some unneeded libcudf debug-specific code paths

### DIFF
--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -160,8 +160,6 @@ struct dispatch_compute_indices {
     auto result_itr =
       cudf::detail::indexalator_factory::make_output_iterator(result->mutable_view());
     // new indices values are computed by matching the concatenated keys to the new key set
-
-#ifdef NDEBUG
     thrust::lower_bound(rmm::exec_policy_nosync(stream),
                         begin,
                         end,
@@ -169,19 +167,6 @@ struct dispatch_compute_indices {
                         all_itr + all_indices.size(),
                         result_itr,
                         cuda::std::less<Element>());
-#else
-    // There is a problem with thrust::lower_bound and the output_indexalator.
-    // https://github.com/NVIDIA/thrust/issues/1452; thrust team created nvbug 3322776
-    // This is a workaround.
-    thrust::transform(rmm::exec_policy_nosync(stream),
-                      all_itr,
-                      all_itr + all_indices.size(),
-                      result_itr,
-                      [begin, end] __device__(auto key) {
-                        auto itr = thrust::lower_bound(thrust::seq, begin, end, key);
-                        return static_cast<size_type>(cuda::std::distance(begin, itr));
-                      });
-#endif
     return result;
   }
 

--- a/cpp/tests/strings/fixed_point_tests.cpp
+++ b/cpp/tests/strings/fixed_point_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -303,11 +303,7 @@ TEST_F(StringsConvertTest, IsFixedPoint)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*results, expected64_scaled);
 }
 
-#ifdef NDEBUG
 TEST_F(StringsConvertTest, FixedPointStringConversionOperator)
-#else
-TEST_F(StringsConvertTest, DISABLED_FixedPointStringConversionOperator)
-#endif
 {
   auto const max = cuda::std::numeric_limits<__int128_t>::max();
 


### PR DESCRIPTION
## Description
Removes some debug-specific code paths in libcudf which were originally implemented to workaround some compiler issues which no longer appear on nvcc 13.1.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
