### PR TITLE
Fix validation for datetimes coming from arrow

### DIFF
--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -126,9 +126,7 @@ def cudf_dtype_to_pa_type(dtype: DtypeObj) -> pa.DataType:
 
 
 def cudf_dtype_from_pa_type(typ: pa.DataType) -> DtypeObj:
-    """Given a cuDF pyarrow dtype, converts it into the equivalent
-    cudf pandas dtype.
-    """
+    """Given a pyarrow dtype, converts it into the equivalent cudf dtype."""
     if pa.types.is_list(typ):
         return cudf.core.dtypes.ListDtype.from_arrow(typ)
     elif pa.types.is_struct(typ):
@@ -143,6 +141,14 @@ def cudf_dtype_from_pa_type(typ: pa.DataType) -> DtypeObj:
         raise NotImplementedError("cudf does not support Decimal256Type")
     elif pa.types.is_large_string(typ) or pa.types.is_string(typ):
         return CUDF_STRING_DTYPE
+    elif pa.types.is_date(typ):
+        # typ.to_pandas_dtype() produces an ms resolution numpy datetime type.
+        # Conversely pylibcudf will produce TIMESTAMP_DAYS for date types - the most
+        # correct answer - and to match pandas cudf will cast to TIMESTAMP_SECONDS
+        # (see ColumnBase._wrap_buffers). Therefore we should return a seconds
+        # resolution datetime type here. The pyarrow conversion seems incorrect, so if
+        # that is ever fixed to return a more appropriate type we can remove this branch.
+        return np.dtype("datetime64[s]")
     else:
         return cudf.api.types.pandas_dtype(typ.to_pandas_dtype())
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
pyarrow date objects produce a ms resolution datetime when converting to pandas:
```python
>>> pa.date32().to_pandas_dtype()
dtype('<M8[ms]')
```
This is inconsistent with both of the datetime resolution choices we would expect and handle gracefully internally (seconds or days). To fix this, this PR adds special-casing to convert the dtype's resolution to seconds.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
