### PR TITLE
fix(deps): bump `pyarrow` floor in conda recipes

### DIFF
--- a/conda/recipes/cudf/recipe.yaml
+++ b/conda/recipes/cudf/recipe.yaml
@@ -94,7 +94,7 @@ requirements:
     - numba-cuda >=0.22.2
     - numba >=0.60.0,<0.62.0
     - numpy >=1.23,<3.0
-    - pyarrow>=15.0.0,<22.0.0
+    - pyarrow>=19.0.0
     - libcudf =${{ version }}
     - pylibcudf =${{ version }}
     - ${{ pin_compatible("rmm", upper_bound="x.x") }}

--- a/conda/recipes/pylibcudf/recipe.yaml
+++ b/conda/recipes/pylibcudf/recipe.yaml
@@ -99,7 +99,7 @@ requirements:
     - packaging
   run_constraints:
     - numpy >=1.23,<3.0
-    - pyarrow>=15.0.0,<22.0.0
+    - pyarrow>=19.0.0
   ignore_run_exports:
     from_package:
       - cuda-cudart-dev


### PR DESCRIPTION
Everything else is using `>=19` for `Decimal32` support (among others)
