### PR TITLE
Replace gen_rand and gen_rand_series with inlined numpy/cudf in tests

### DIFF
--- a/python/cudf/cudf/tests/series/methods/test_searchsorted.py
+++ b/python/cudf/cudf/tests/series/methods/test_searchsorted.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 import cupy
 import numpy as np
@@ -7,7 +7,6 @@ import pytest
 
 import cudf
 from cudf.testing import assert_eq
-from cudf.testing._utils import gen_rand
 
 
 @pytest.mark.parametrize("side", ["left", "right"])
@@ -15,11 +14,11 @@ from cudf.testing._utils import gen_rand
 @pytest.mark.parametrize("vals_class", ["series", "index"])
 def test_searchsorted(side, obj_class, vals_class):
     nelem = 1000
-    column_data = gen_rand("float64", nelem)
     rng = np.random.default_rng(0)
+    column_data = rng.random(nelem).astype(np.float64) * 2 - 1
     column_mask = rng.choice([True, False], size=nelem)
 
-    values_data = gen_rand("float64", nelem)
+    values_data = rng.random(nelem).astype(np.float64) * 2 - 1
     values_mask = rng.choice([True, False], size=nelem)
 
     sr = cudf.Series(column_data)

--- a/python/cudf/cudf/tests/series/test_binops.py
+++ b/python/cudf/cudf/tests/series/test_binops.py
@@ -25,7 +25,6 @@ from cudf.testing._utils import (
     _decimal_series,
     assert_exceptions_equal,
     expect_warning_if,
-    gen_rand_series,
 )
 
 
@@ -1330,12 +1329,17 @@ def test_operator_func_between_series(
     float_types_as_str, arithmetic_op_method, has_nulls, fill_value
 ):
     count = 1000
-    gdf_series_a = gen_rand_series(
-        float_types_as_str, count, has_nulls=has_nulls, stride=10000
+    rng = np.random.default_rng(0)
+    gdf_series_a = cudf.Series(
+        (rng.random(count).astype(float_types_as_str) * 2 - 1)
     )
-    gdf_series_b = gen_rand_series(
-        float_types_as_str, count, has_nulls=has_nulls, stride=100
+    if has_nulls:
+        gdf_series_a.loc[rng.choice([True, False], count)] = None
+    gdf_series_b = cudf.Series(
+        (rng.random(count).astype(float_types_as_str) * 2 - 1)
     )
+    if has_nulls:
+        gdf_series_b.loc[rng.choice([True, False], count)] = None
     pdf_series_a = gdf_series_a.to_pandas()
     pdf_series_b = gdf_series_b.to_pandas()
 
@@ -1356,9 +1360,12 @@ def test_operator_func_series_and_scalar(
 ):
     count = 1000
     scalar = 59
-    gdf_series = gen_rand_series(
-        float_types_as_str, count, has_nulls=has_nulls, stride=10000
+    rng = np.random.default_rng(0)
+    gdf_series = cudf.Series(
+        (rng.random(count).astype(float_types_as_str) * 2 - 1)
     )
+    if has_nulls:
+        gdf_series.loc[rng.choice([True, False], count)] = None
     pdf_series = gdf_series.to_pandas()
 
     gdf_series_result = getattr(gdf_series, arithmetic_op_method)(


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/19630

Used Cursor to replace these helper functions with inlining data creation.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
