### PR TITLE
Replace cudf.datasets with inlined creation in cudf classic tests

### DIFF
--- a/python/cudf/cudf/tests/dataframe/methods/test_reductions.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_reductions.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import cupy as cp
@@ -567,18 +567,84 @@ def test_empty_dataframe_any(axis):
     assert_eq(got, expected, check_index_type=False)
 
 
+_REDUCTION_NAMES = [
+    "Alice",
+    "Bob",
+    "Charlie",
+    "Dan",
+    "Edith",
+    "Frank",
+    "George",
+    "Hannah",
+    "Ingrid",
+    "Jerry",
+    "Kevin",
+    "Laura",
+    "Michael",
+    "Norbert",
+    "Oliver",
+    "Patricia",
+    "Quinn",
+    "Ray",
+    "Sarah",
+    "Tim",
+    "Ursula",
+    "Victor",
+    "Wendy",
+    "Xavier",
+    "Yvonne",
+    "Zelda",
+]
+
+
 @pytest.mark.parametrize(
     "data",
     [
-        lambda: cudf.datasets.randomdata(
-            nrows=10, dtypes={"a": "category", "b": int, "c": float, "d": int}
-        ),
-        lambda: cudf.datasets.randomdata(
-            nrows=10, dtypes={"a": "category", "b": int, "c": float, "d": str}
-        ),
-        lambda: cudf.datasets.randomdata(
-            nrows=10, dtypes={"a": bool, "b": int, "c": float, "d": str}
-        ),
+        lambda: (
+            lambda r=np.random.default_rng(0): cudf.from_pandas(
+                pd.DataFrame(
+                    {
+                        "a": pd.Categorical.from_codes(
+                            r.integers(0, len(_REDUCTION_NAMES), 10),
+                            _REDUCTION_NAMES,
+                        ),
+                        "b": r.poisson(1000, 10),
+                        "c": r.random(10) * 2 - 1,
+                        "d": r.poisson(1000, 10),
+                    },
+                    columns=["a", "b", "c", "d"],
+                )
+            )
+        )(),
+        lambda: (
+            lambda r=np.random.default_rng(0): cudf.from_pandas(
+                pd.DataFrame(
+                    {
+                        "a": pd.Categorical.from_codes(
+                            r.integers(0, len(_REDUCTION_NAMES), 10),
+                            _REDUCTION_NAMES,
+                        ),
+                        "b": r.poisson(1000, 10),
+                        "c": r.random(10) * 2 - 1,
+                        "d": r.choice(_REDUCTION_NAMES, 10),
+                    },
+                    columns=["a", "b", "c", "d"],
+                )
+            )
+        )(),
+        lambda: (
+            lambda r=np.random.default_rng(0): cudf.from_pandas(
+                pd.DataFrame(
+                    {
+                        "a": r.choice([True, False], 10),
+                        "b": r.poisson(1000, 10),
+                        "c": r.random(10) * 2 - 1,
+                        "d": r.choice(_REDUCTION_NAMES, 10),
+                    },
+                    columns=["a", "b", "c", "d"],
+                )
+            )
+        )(),
         lambda: cudf.DataFrame(),
         lambda: cudf.DataFrame({"a": [0, 1, 2], "b": [1, None, 3]}),
         lambda: cudf.DataFrame(

--- a/python/cudf/cudf/tests/dataframe/methods/test_reindex.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_reindex.py
@@ -1,13 +1,43 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 
+import numpy as np
 import pandas as pd
 import pytest
 
 import cudf
 from cudf.testing import assert_eq
 from cudf.testing._utils import assert_exceptions_equal
+
+_NAMES = [
+    "Alice",
+    "Bob",
+    "Charlie",
+    "Dan",
+    "Edith",
+    "Frank",
+    "George",
+    "Hannah",
+    "Ingrid",
+    "Jerry",
+    "Kevin",
+    "Laura",
+    "Michael",
+    "Norbert",
+    "Oliver",
+    "Patricia",
+    "Quinn",
+    "Ray",
+    "Sarah",
+    "Tim",
+    "Ursula",
+    "Victor",
+    "Wendy",
+    "Xavier",
+    "Yvonne",
+    "Zelda",
+]
 
 
 @pytest.mark.parametrize("copy", [True, False])
@@ -35,13 +65,18 @@ from cudf.testing._utils import assert_exceptions_equal
     ],
 )
 def test_dataframe_reindex(copy, args, gd_kwargs):
-    reindex_data = cudf.datasets.randomdata(
-        nrows=6,
-        dtypes={
-            "a": "category",
-            "c": float,
-            "d": str,
-        },
+    rng = np.random.default_rng(0)
+    reindex_data = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "a": pd.Categorical.from_codes(
+                    rng.integers(0, len(_NAMES), 6), _NAMES
+                ),
+                "c": rng.random(6) * 2 - 1,
+                "d": rng.choice(_NAMES, size=6),
+            },
+            columns=["a", "c", "d"],
+        )
     )
     pdf, gdf = reindex_data.to_pandas(), reindex_data
     assert_eq(
@@ -75,9 +110,16 @@ def test_dataframe_reindex(copy, args, gd_kwargs):
     ],
 )
 def test_dataframe_reindex_fill_value(args, kwargs, fill_value):
-    reindex_data_numeric = cudf.datasets.randomdata(
-        nrows=6,
-        dtypes={"a": float, "b": float, "c": float},
+    rng = np.random.default_rng(0)
+    reindex_data_numeric = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "a": rng.random(6) * 2 - 1,
+                "b": rng.random(6) * 2 - 1,
+                "c": rng.random(6) * 2 - 1,
+            },
+            columns=["a", "b", "c"],
+        )
     )
     pdf, gdf = reindex_data_numeric.to_pandas(), reindex_data_numeric
     assert_eq(
@@ -90,8 +132,18 @@ def test_dataframe_reindex_fill_value(args, kwargs, fill_value):
 def test_dataframe_reindex_change_dtype(copy):
     index = pd.date_range("12/29/2009", periods=10, freq="D")
     columns = ["a", "b", "c", "d", "e"]
-    gdf = cudf.datasets.randomdata(
-        nrows=6, dtypes={"a": "category", "c": float, "d": str}
+    rng = np.random.default_rng(0)
+    gdf = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "a": pd.Categorical.from_codes(
+                    rng.integers(0, len(_NAMES), 6), _NAMES
+                ),
+                "c": rng.random(6) * 2 - 1,
+                "d": rng.choice(_NAMES, size=6),
+            },
+            columns=["a", "c", "d"],
+        )
     )
     pdf = gdf.to_pandas()
     # Validate reindexes both labels and column names when
@@ -106,7 +158,17 @@ def test_dataframe_reindex_change_dtype(copy):
 @pytest.mark.parametrize("copy", [True, False])
 def test_series_categorical_reindex(copy):
     index = [-3, 0, 3, 0, -2, 1, 3, 4, 6]
-    gdf = cudf.datasets.randomdata(nrows=6, dtypes={"a": "category"})
+    rng = np.random.default_rng(0)
+    gdf = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "a": pd.Categorical.from_codes(
+                    rng.integers(0, len(_NAMES), 6), _NAMES
+                )
+            },
+            columns=["a"],
+        )
+    )
     pdf = gdf.to_pandas()
     assert_eq(pdf["a"].reindex(copy=True), gdf["a"].reindex(copy=copy))
     assert_eq(
@@ -121,7 +183,10 @@ def test_series_categorical_reindex(copy):
 @pytest.mark.parametrize("copy", [True, False])
 def test_series_float_reindex(copy):
     index = [-3, 0, 3, 0, -2, 1, 3, 4, 6]
-    gdf = cudf.datasets.randomdata(nrows=6, dtypes={"c": float})
+    rng = np.random.default_rng(0)
+    gdf = cudf.from_pandas(
+        pd.DataFrame({"c": rng.random(6) * 2 - 1}, columns=["c"])
+    )
     pdf = gdf.to_pandas()
     assert_eq(pdf["c"].reindex(copy=True), gdf["c"].reindex(copy=copy))
     assert_eq(
@@ -136,7 +201,10 @@ def test_series_float_reindex(copy):
 @pytest.mark.parametrize("copy", [True, False])
 def test_series_string_reindex(copy):
     index = [-3, 0, 3, 0, -2, 1, 3, 4, 6]
-    gdf = cudf.datasets.randomdata(nrows=6, dtypes={"d": str})
+    rng = np.random.default_rng(0)
+    gdf = cudf.from_pandas(
+        pd.DataFrame({"d": rng.choice(_NAMES, size=6)}, columns=["d"])
+    )
     pdf = gdf.to_pandas()
     assert_eq(pdf["d"].reindex(copy=True), gdf["d"].reindex(copy=copy))
     assert_eq(

--- a/python/cudf/cudf/tests/input_output/test_csv.py
+++ b/python/cudf/cudf/tests/input_output/test_csv.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import codecs
@@ -1112,11 +1112,50 @@ def test_csv_reader_byte_range(tmp_path, segment_bytes):
 def test_csv_reader_byte_range_type_corner_case(tmp_path):
     fname = tmp_path / "tmp_csvreader_file17.csv"
 
-    cudf.datasets.timeseries(
-        start="2000-01-01",
-        end="2000-01-02",
-        dtypes={"name": str, "id": int, "x": float, "y": float},
-    ).to_csv(fname, chunksize=100000)
+    _names = [
+        "Alice",
+        "Bob",
+        "Charlie",
+        "Dan",
+        "Edith",
+        "Frank",
+        "George",
+        "Hannah",
+        "Ingrid",
+        "Jerry",
+        "Kevin",
+        "Laura",
+        "Michael",
+        "Norbert",
+        "Oliver",
+        "Patricia",
+        "Quinn",
+        "Ray",
+        "Sarah",
+        "Tim",
+        "Ursula",
+        "Victor",
+        "Wendy",
+        "Xavier",
+        "Yvonne",
+        "Zelda",
+    ]
+    rng = np.random.default_rng(0)
+    index = pd.DatetimeIndex(
+        pd.date_range("2000-01-01", "2000-01-02", freq="1s", name="timestamp")
+    )
+    n = len(index)
+    pdf = pd.DataFrame(
+        {
+            "id": rng.poisson(1000, size=n),
+            "name": rng.choice(_names, size=n),
+            "x": rng.random(n) * 2 - 1,
+            "y": rng.random(n) * 2 - 1,
+        },
+        index=index,
+        columns=["id", "name", "x", "y"],
+    )
+    cudf.from_pandas(pdf).to_csv(fname, chunksize=100000)
 
     byte_range = (2_147_483_648, 0)
     with pytest.raises(ValueError, match="Invalid byte range offset"):

--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
@@ -329,20 +329,32 @@ def test_concat_string_index_name(myindex):
 
 
 def test_pandas_concat_compatibility_axis1():
-    d1 = cudf.datasets.randomdata(
-        3, dtypes={"a": float, "ind": float}
+    rng = np.random.default_rng(0)
+    ind = rng.random(3) * 2 - 1
+    d1 = cudf.from_pandas(
+        pd.DataFrame(
+            {"a": rng.random(3) * 2 - 1, "ind": ind}, columns=["a", "ind"]
+        )
     ).set_index("ind")
-    d2 = cudf.datasets.randomdata(
-        3, dtypes={"b": float, "ind": float}
+    d2 = cudf.from_pandas(
+        pd.DataFrame(
+            {"b": rng.random(3) * 2 - 1, "ind": ind}, columns=["b", "ind"]
+        )
     ).set_index("ind")
-    d3 = cudf.datasets.randomdata(
-        3, dtypes={"c": float, "ind": float}
+    d3 = cudf.from_pandas(
+        pd.DataFrame(
+            {"c": rng.random(3) * 2 - 1, "ind": ind}, columns=["c", "ind"]
+        )
     ).set_index("ind")
-    d4 = cudf.datasets.randomdata(
-        3, dtypes={"d": float, "ind": float}
+    d4 = cudf.from_pandas(
+        pd.DataFrame(
+            {"d": rng.random(3) * 2 - 1, "ind": ind}, columns=["d", "ind"]
+        )
     ).set_index("ind")
-    d5 = cudf.datasets.randomdata(
-        3, dtypes={"e": float, "ind": float}
+    d5 = cudf.from_pandas(
+        pd.DataFrame(
+            {"e": rng.random(3) * 2 - 1, "ind": ind}, columns=["e", "ind"]
+        )
     ).set_index("ind")
 
     pd1 = d1.to_pandas()

--- a/python/cudf/cudf/tests/test_spilling.py
+++ b/python/cudf/cudf/tests/test_spilling.py
@@ -187,10 +187,22 @@ def test_creations(manager: SpillManager):
     df = single_column_df()
     assert single_column_df_data(df).owner.spillable
 
-    df = cudf.datasets.timeseries(dtypes={"a": float})
+    rng = np.random.default_rng(0)
+    index = pandas.DatetimeIndex(
+        pandas.date_range(
+            "2000-01-01", "2000-01-31", freq="1s", name="timestamp"
+        )
+    )
+    pdf = pandas.DataFrame(
+        {"a": rng.random(len(index)) * 2 - 1}, index=index, columns=["a"]
+    )
+    df = cudf.from_pandas(pdf)
     assert single_column_df_data(df).owner.spillable
 
-    df = cudf.datasets.randomdata(dtypes={"a": float})
+    rng = np.random.default_rng(0)
+    df = cudf.from_pandas(
+        pandas.DataFrame({"a": rng.random(10) * 2 - 1}, columns=["a"])
+    )
     assert single_column_df_data(df).owner.spillable
 
 

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -19,6 +19,35 @@ import dask_cudf
 
 rng = np.random.default_rng(seed=0)
 
+_NAMES = [
+    "Alice",
+    "Bob",
+    "Charlie",
+    "Dan",
+    "Edith",
+    "Frank",
+    "George",
+    "Hannah",
+    "Ingrid",
+    "Jerry",
+    "Kevin",
+    "Laura",
+    "Michael",
+    "Norbert",
+    "Oliver",
+    "Patricia",
+    "Quinn",
+    "Ray",
+    "Sarah",
+    "Tim",
+    "Ursula",
+    "Victor",
+    "Wendy",
+    "Xavier",
+    "Yvonne",
+    "Zelda",
+]
+
 
 def test_from_dict_backend_dispatch():
     # Test ddf.from_dict cudf-backend dispatch
@@ -213,7 +242,7 @@ def test_set_index(nelem):
 def test_set_index_quantile(nelem, nparts, by):
     df = cudf.DataFrame()
     df["a"] = np.ascontiguousarray(np.arange(nelem)[::-1])
-    df["b"] = rng.choice(cudf.datasets.names, size=nelem)
+    df["b"] = rng.choice(_NAMES, size=nelem)
     ddf = dd.from_pandas(df, npartitions=nparts)
 
     with pytest.warns(FutureWarning, match="deprecated"):
@@ -683,7 +712,16 @@ def test_dataframe_assign_col():
 
 def test_dataframe_set_index():
     random.seed(0)
-    df = cudf.datasets.randomdata(26, dtypes={"a": float, "b": int})
+    rng = np.random.default_rng(0)
+    df = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "a": rng.random(26) * 2 - 1,
+                "b": rng.poisson(1000, size=26),
+            },
+            columns=["a", "b"],
+        )
+    )
     df["str"] = list("abcdefghijklmnopqrstuvwxyz")
     pdf = df.to_pandas()
 
@@ -701,7 +739,17 @@ def test_dataframe_set_index():
 
 def test_series_describe():
     random.seed(0)
-    sr = cudf.datasets.randomdata(20)["x"]
+    rng = np.random.default_rng(0)
+    sr = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "id": rng.poisson(1000, size=20),
+                "x": rng.random(20) * 2 - 1,
+                "y": rng.random(20) * 2 - 1,
+            },
+            columns=["id", "x", "y"],
+        )
+    )["x"]
     psr = sr.to_pandas()
 
     dsr = dask_cudf.from_cudf(sr, npartitions=4)
@@ -716,7 +764,17 @@ def test_series_describe():
 
 def test_dataframe_describe():
     random.seed(0)
-    df = cudf.datasets.randomdata(20)
+    rng = np.random.default_rng(0)
+    df = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "id": rng.poisson(1000, size=20),
+                "x": rng.random(20) * 2 - 1,
+                "y": rng.random(20) * 2 - 1,
+            },
+            columns=["id", "x", "y"],
+        )
+    )
     pdf = df.to_pandas()
 
     ddf = dask_cudf.from_cudf(df, npartitions=4)

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -131,7 +131,17 @@ def test_groupby_agg(func, aggregation, pdf):
 def test_groupby_agg_empty_partition(tmpdir, split_out):
     # Write random and empty cudf DataFrames
     # to two distinct files.
-    df = cudf.datasets.randomdata()
+    rng = np.random.default_rng(0)
+    df = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "id": rng.poisson(1000, size=10),
+                "x": rng.random(10) * 2 - 1,
+                "y": rng.random(10) * 2 - 1,
+            },
+            columns=["id", "x", "y"],
+        )
+    )
     df.to_parquet(str(tmpdir.join("f0.parquet")))
     cudf.DataFrame(
         columns=["id", "x", "y"],
@@ -443,7 +453,16 @@ def test_groupby_reset_index_drop_True():
 
 
 def test_groupby_mean_sort_false():
-    df = cudf.datasets.randomdata(nrows=150, dtypes={"a": int, "b": int})
+    state = np.random.RandomState(0)
+    df = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "a": state.poisson(1000, size=150),
+                "b": state.poisson(1000, size=150),
+            },
+            columns=["a", "b"],
+        )
+    )
     ddf = dask_cudf.from_cudf(df, 1)
     pddf = dd.from_pandas(df.to_pandas(), 1)
 
@@ -474,9 +493,47 @@ def test_groupby_reset_index_dtype():
     assert a.reset_index().dtypes.iloc[0] == "int8"
 
 
+_NAMES = [
+    "Alice",
+    "Bob",
+    "Charlie",
+    "Dan",
+    "Edith",
+    "Frank",
+    "George",
+    "Hannah",
+    "Ingrid",
+    "Jerry",
+    "Kevin",
+    "Laura",
+    "Michael",
+    "Norbert",
+    "Oliver",
+    "Patricia",
+    "Quinn",
+    "Ray",
+    "Sarah",
+    "Tim",
+    "Ursula",
+    "Victor",
+    "Wendy",
+    "Xavier",
+    "Yvonne",
+    "Zelda",
+]
+
+
 def test_groupby_reset_index_names():
-    df = cudf.datasets.randomdata(
-        nrows=10, dtypes={"a": str, "b": int, "c": int}
+    rng = np.random.default_rng(0)
+    df = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "a": rng.choice(_NAMES, size=10),
+                "b": rng.poisson(1000, size=10),
+                "c": rng.poisson(1000, size=10),
+            },
+            columns=["a", "b", "c"],
+        )
     )
     pdf = df.to_pandas()
 
@@ -554,9 +611,17 @@ def test_groupby_categorical_key():
 def test_groupby_agg_params(
     npartitions, split_every, split_out, fused, as_index
 ):
-    df = cudf.datasets.randomdata(
-        nrows=150,
-        dtypes={"name": str, "a": int, "b": int, "c": float},
+    rng = np.random.default_rng(0)
+    df = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "a": rng.poisson(1000, size=150),
+                "b": rng.poisson(1000, size=150),
+                "c": rng.random(150) * 2 - 1,
+                "name": rng.choice(_NAMES, size=150),
+            },
+            columns=["a", "b", "c", "name"],
+        )
     )
     df["a"] = [0, 1, 2] * 50
     ddf = dask_cudf.from_cudf(df, npartitions)
@@ -814,8 +879,16 @@ def test_groupby_all_columns(func):
 
 
 def test_groupby_shuffle():
-    df = cudf.datasets.randomdata(
-        nrows=640, dtypes={"a": str, "b": int, "c": int}
+    rng = np.random.default_rng(0)
+    df = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "a": rng.choice(_NAMES, size=640),
+                "b": rng.poisson(1000, size=640),
+                "c": rng.poisson(1000, size=640),
+            },
+            columns=["a", "b", "c"],
+        )
     )
     gddf = dask_cudf.from_cudf(df, 8)
     spec = {"b": "mean", "c": "max"}

--- a/python/dask_cudf/dask_cudf/tests/test_onehot.py
+++ b/python/dask_cudf/dask_cudf/tests/test_onehot.py
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -9,6 +10,35 @@ from dask import dataframe as dd
 import cudf
 
 import dask_cudf
+
+_NAMES = [
+    "Alice",
+    "Bob",
+    "Charlie",
+    "Dan",
+    "Edith",
+    "Frank",
+    "George",
+    "Hannah",
+    "Ingrid",
+    "Jerry",
+    "Kevin",
+    "Laura",
+    "Michael",
+    "Norbert",
+    "Oliver",
+    "Patricia",
+    "Quinn",
+    "Ray",
+    "Sarah",
+    "Tim",
+    "Ursula",
+    "Victor",
+    "Wendy",
+    "Xavier",
+    "Yvonne",
+    "Zelda",
+]
 
 
 def test_get_dummies_cat():
@@ -86,14 +116,22 @@ def test_get_dummies_cat_index():
 
 
 def test_get_dummies_large():
-    gdf = cudf.datasets.randomdata(
-        nrows=200000,
-        dtypes={
-            "C": int,
-            "first": "category",
-            "b": float,
-            "second": "category",
-        },
+    rng = np.random.default_rng(0)
+    n = 200000
+    gdf = cudf.from_pandas(
+        pd.DataFrame(
+            {
+                "C": rng.poisson(1000, n),
+                "first": pd.Categorical.from_codes(
+                    rng.integers(0, len(_NAMES), n), _NAMES
+                ),
+                "b": rng.random(n) * 2 - 1,
+                "second": pd.Categorical.from_codes(
+                    rng.integers(0, len(_NAMES), n), _NAMES
+                ),
+            },
+            columns=["C", "first", "b", "second"],
+        )
     )
     df = gdf.to_pandas()
     ddf = dd.from_pandas(df, npartitions=25)

--- a/python/dask_cudf/dask_cudf/tests/test_reductions.py
+++ b/python/dask_cudf/dask_cudf/tests/test_reductions.py
@@ -1,6 +1,8 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+import numpy as np
+import pandas as pd
 import pytest
 
 import dask
@@ -12,6 +14,35 @@ import dask_cudf
 from dask_cudf.tests.utils import _make_random_frame
 
 _reducers = ["sum", "count", "mean", "var", "std", "min", "max"]
+
+_NAMES = [
+    "Alice",
+    "Bob",
+    "Charlie",
+    "Dan",
+    "Edith",
+    "Frank",
+    "George",
+    "Hannah",
+    "Ingrid",
+    "Jerry",
+    "Kevin",
+    "Laura",
+    "Michael",
+    "Norbert",
+    "Oliver",
+    "Patricia",
+    "Quinn",
+    "Ray",
+    "Sarah",
+    "Tim",
+    "Ursula",
+    "Victor",
+    "Wendy",
+    "Xavier",
+    "Yvonne",
+    "Zelda",
+]
 
 
 def _get_reduce_fn(name):
@@ -36,17 +67,49 @@ def test_series_reduce(reducer):
 @pytest.mark.parametrize(
     "data",
     [
-        cudf.datasets.randomdata(
-            nrows=10000,
-            dtypes={"a": "category", "b": int, "c": float, "d": int},
-        ),
-        cudf.datasets.randomdata(
-            nrows=10000,
-            dtypes={"a": "category", "b": int, "c": float, "d": str},
-        ),
-        cudf.datasets.randomdata(
-            nrows=10000, dtypes={"a": bool, "b": int, "c": float, "d": str}
-        ),
+        (
+            lambda r=np.random.default_rng(0): cudf.from_pandas(
+                pd.DataFrame(
+                    {
+                        "a": pd.Categorical.from_codes(
+                            r.integers(0, len(_NAMES), 10000), _NAMES
+                        ),
+                        "b": r.poisson(1000, 10000),
+                        "c": r.random(10000) * 2 - 1,
+                        "d": r.poisson(1000, 10000),
+                    },
+                    columns=["a", "b", "c", "d"],
+                )
+            )
+        )(),
+        (
+            lambda r=np.random.default_rng(0): cudf.from_pandas(
+                pd.DataFrame(
+                    {
+                        "a": pd.Categorical.from_codes(
+                            r.integers(0, len(_NAMES), 10000), _NAMES
+                        ),
+                        "b": r.poisson(1000, 10000),
+                        "c": r.random(10000) * 2 - 1,
+                        "d": r.choice(_NAMES, 10000),
+                    },
+                    columns=["a", "b", "c", "d"],
+                )
+            )
+        )(),
+        (
+            lambda r=np.random.default_rng(0): cudf.from_pandas(
+                pd.DataFrame(
+                    {
+                        "a": r.choice([True, False], 10000),
+                        "b": r.poisson(1000, 10000),
+                        "c": r.random(10000) * 2 - 1,
+                        "d": r.choice(_NAMES, 10000),
+                    },
+                    columns=["a", "b", "c", "d"],
+                )
+            )
+        )(),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/19630

Cursor generated replacement of `cudf.datasets` APIs in tests with inlining test data

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
