### PR TITLE
Remove 4-byte padding requirement from the Brotli decompressor

### DIFF
--- a/cpp/src/io/comp/debrotli.cu
+++ b/cpp/src/io/comp/debrotli.cu
@@ -193,8 +193,10 @@ inline __device__ uint32_t Log2Floor(uint32_t value) { return 32 - __clz(value);
 inline __device__ uint32_t safe_load_u32(uint8_t const* p, uint8_t const* end)
 {
   if (p >= end) { return 0; }
+
   uint32_t result = 0;
-  memcpy(&result, p, cuda::std::min<size_t>(cuda::std::distance(p, end), sizeof(uint32_t)));
+  cuda::std::memcpy(
+    &result, p, cuda::std::min<size_t>(cuda::std::distance(p, end), sizeof(uint32_t)));
   return result;
 }
 


### PR DESCRIPTION
Remove the debrotli requirement for 4-byte padding at the end of the compressed buffer.

The bit reader previously assumed at least 4 bytes were available when refilling the 32-bit bit buffer (initbits and skipbits), using an unchecked `*reinterpret_cast<uint32_t const*>(p)` when `p < end`. When `p + 4 > end`, this could read past the buffer. This change introduces `safe_load_u32` to read only available bytes (1–4) with bounds checking, so decompression works correctly on buffers of any length without requiring trailing padding.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.