### PR TITLE
Remove from_pylibcudf/_with_dtype_metadata in IO readers/rolling

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -8451,19 +8451,17 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
             tbl = table
             if not (
                 isinstance(metadata, dict)
-                and 1 <= len(metadata) <= 2
+                and 1 <= len(metadata) <= 3
                 and "columns" in metadata
-                and (
-                    len(metadata) != 2 or {"columns", "index"} == set(metadata)
-                )
+                and (not set(metadata) - {"columns", "child_names", "index"})
             ):
                 raise ValueError(
-                    "Must pass a metadata dict with column names and optionally indices only "
+                    "Must pass a metadata dict with keys 'columns' and "
+                    "optionally 'child_names' and 'index' only "
                     "when table is a pylibcudf.Table "
                 )
             column_names = metadata["columns"]
-            # TODO: Allow user to include this in metadata?
-            child_names = None
+            child_names = metadata.get("child_names")  # type: ignore[assignment]
             index = metadata.get("index")
         else:
             raise ValueError(

--- a/python/cudf/cudf/core/window/rolling.py
+++ b/python/cudf/cudf/core/window/rolling.py
@@ -23,7 +23,7 @@ from cudf.core.column.column import ColumnBase, as_column
 from cudf.core.copy_types import GatherMap
 from cudf.core.mixins import GetAttrGetItemMixin, Reducible
 from cudf.core.multiindex import MultiIndex
-from cudf.utils.dtypes import SIZE_TYPE_DTYPE
+from cudf.utils.dtypes import SIZE_TYPE_DTYPE, dtype_from_pylibcudf_column
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -370,14 +370,15 @@ class Rolling(GetAttrGetItemMixin, _RollingBase, Reducible):
                 min_periods = 1
 
         with source_column.access(mode="read", scope="internal"):
-            col = ColumnBase.from_pylibcudf(
-                plc.rolling.rolling_window(
-                    source_column.plc_column,
-                    pre,
-                    fwd,
-                    min_periods,
-                    rolling_agg,
-                )
+            plc_result = plc.rolling.rolling_window(
+                source_column.plc_column,
+                pre,
+                fwd,
+                min_periods,
+                rolling_agg,
+            )
+            col = ColumnBase.create(
+                plc_result, dtype_from_pylibcudf_column(plc_result)
             )
 
         if isinstance(agg_name, str):

--- a/python/cudf/cudf/io/dlpack.py
+++ b/python/cudf/cudf/io/dlpack.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from cudf.core.column import ColumnBase
 from cudf.core.column_accessor import ColumnAccessor
 from cudf.core.dataframe import DataFrame
 from cudf.core.series import Series
+from cudf.utils.dtypes import dtype_from_pylibcudf_column
 
 
 def from_dlpack(pycapsule_obj) -> Series | DataFrame:
@@ -40,7 +41,12 @@ def from_dlpack(pycapsule_obj) -> Series | DataFrame:
     data = ColumnAccessor(
         dict(
             enumerate(
-                (ColumnBase.from_pylibcudf(col) for col in plc_table.columns())
+                (
+                    ColumnBase.create(
+                        col, dtype=dtype_from_pylibcudf_column(col)
+                    )
+                    for col in plc_table.columns()
+                )
             )
         ),
         verify=False,

--- a/python/cudf/cudf/io/json.py
+++ b/python/cudf/cudf/io/json.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 import pylibcudf as plc
 
-from cudf.core.column import ColumnBase, access_columns
+from cudf.core.column import access_columns
 from cudf.core.dataframe import DataFrame
 from cudf.core.dtypes import (
     CategoricalDtype,
@@ -208,14 +208,13 @@ def read_json(
                     )
                 )
             )
-            data = {
-                name: ColumnBase.from_pylibcudf(col)
-                for name, col in zip(res_col_names, res_cols, strict=True)
-            }
-            df = DataFrame._from_data(data)
-            # TODO: _add_df_col_struct_names expects dict but receives Mapping
-            ioutils._add_df_col_struct_names(df, res_child_names)
-            return df
+            return DataFrame.from_pylibcudf(
+                plc.Table(res_cols),
+                metadata={
+                    "columns": res_col_names,
+                    "child_names": res_child_names,
+                },
+            )
         else:
             table_w_meta = plc.io.json.read_json(
                 plc.io.json._setup_json_reader_options(

--- a/python/cudf/cudf/io/parquet.py
+++ b/python/cudf/cudf/io/parquet.py
@@ -26,7 +26,6 @@ from pylibcudf import expressions as plc_expr
 
 from cudf.api.types import is_list_like
 from cudf.core.column import (
-    ColumnBase,
     access_columns,
     as_column,
     column_empty,
@@ -1411,14 +1410,14 @@ def _read_parquet(
                         [concatenated_columns[i], columns.pop()]
                     )
 
-            data = {
-                name: ColumnBase.from_pylibcudf(col)
-                for name, col in zip(
-                    column_names, concatenated_columns, strict=True
-                )
-            }
-            df = DataFrame._from_data(data)
-            ioutils._add_df_col_struct_names(df, child_names)
+            plc_table = plc.Table(concatenated_columns)
+            df = DataFrame.from_pylibcudf(
+                plc_table,
+                metadata={
+                    "columns": column_names,
+                    "child_names": child_names,
+                },
+            )
             df = _process_metadata(
                 df,
                 column_names,

--- a/python/cudf/cudf/utils/ioutils.py
+++ b/python/cudf/cudf/utils/ioutils.py
@@ -21,12 +21,11 @@ import pyarrow as pa
 import cudf
 from cudf.api.types import is_list_like
 from cudf.core._compat import PANDAS_LT_300
-from cudf.core.dtypes import recursively_update_struct_names
 from cudf.utils.docutils import docfmt_partial
 from cudf.utils.dtypes import cudf_dtype_to_pa_type, np_dtypes_to_pandas_dtypes
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Hashable, Mapping
+    from collections.abc import Callable, Hashable
 
     from cudf.core.dataframe import DataFrame
 
@@ -2391,13 +2390,3 @@ def _prefetch_remote_buffers(
 
     else:
         return paths
-
-
-def _add_df_col_struct_names(
-    df: DataFrame, child_names_dict: Mapping[Any, Any]
-) -> None:
-    for name, child_names in child_names_dict.items():
-        col = df._data[name]
-        df._data[name] = col._with_type_metadata(
-            recursively_update_struct_names(col.dtype, child_names)
-        )


### PR DESCRIPTION
## Description
Moves toward using `create` for a standardized way to construct a `ColumnBase` from a `pylibcudf.Column`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
