### PR TITLE
Replace `thrust::get` with `cuda::std::get`

### DIFF
--- a/cpp/src/io/parquet/io_utils/parquet_io_utils.cpp
+++ b/cpp/src/io/parquet/io_utils/parquet_io_utils.cpp
@@ -16,6 +16,9 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device_memory_resource.hpp>
 
+#include <cuda/std/tuple>
+#include <thrust/iterator/zip_iterator.h>
+
 #include <numeric>
 
 /**
@@ -121,9 +124,9 @@ fetch_byte_ranges_to_device_async(
     std::lock_guard<std::mutex> lock(mutex);
 
     std::for_each(iter, iter + io_offsets.size(), [&](auto const& tuple) {
-      auto const io_offset = thrust::get<0>(tuple);
-      auto const io_size   = thrust::get<1>(tuple);
-      auto const dest      = thrust::get<2>(tuple);
+      auto const io_offset = cuda::std::get<0>(tuple);
+      auto const io_size   = cuda::std::get<1>(tuple);
+      auto const dest      = cuda::std::get<2>(tuple);
 
       // Directly read the column chunk data to the device
       // buffer if supported


### PR DESCRIPTION
## Description
This minor PR replaces the use of outdated `thrust::get` (added in PR #21360) with `cuda::std::get` and includes required corresponding header files. 

This is needed to fix CCCL's failing nightly build

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
