### PR TITLE
Use ColumnBase.create over .from_pylibcudf in MultiIndex, groupby, misc.

### DIFF
--- a/python/cudf/cudf/core/_internals/timezones.py
+++ b/python/cudf/cudf/core/_internals/timezones.py
@@ -1,23 +1,13 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import datetime
-import os
 import zoneinfo
-from functools import lru_cache
-from typing import TYPE_CHECKING, Literal
 
-import numpy as np
 import pandas as pd
 
-import pylibcudf as plc
-
 from cudf.options import get_option
-
-if TYPE_CHECKING:
-    from cudf.core.column.datetime import DatetimeColumn
-    from cudf.core.column.timedelta import TimeDeltaColumn
 
 
 def get_compatible_timezone(dtype: pd.DatetimeTZDtype) -> pd.DatetimeTZDtype:
@@ -45,104 +35,3 @@ def get_compatible_timezone(dtype: pd.DatetimeTZDtype) -> pd.DatetimeTZDtype:
         raise NotImplementedError(f"cudf does not support {tz}")
     new_tz = zoneinfo.ZoneInfo(key)
     return pd.DatetimeTZDtype(dtype.unit, new_tz)
-
-
-@lru_cache(maxsize=20)
-def get_tz_data(zone_name: str) -> tuple[DatetimeColumn, TimeDeltaColumn]:
-    """
-    Return timezone data (transition times and UTC offsets) for the
-    given IANA time zone.
-
-    Parameters
-    ----------
-    zone_name: str
-        IANA time zone name
-
-    Returns
-    -------
-    Tuple with two columns containing the transition times
-    and corresponding UTC offsets.
-    """
-    try:
-        # like zoneinfo, we first look in TZPATH
-        tz_table = _find_and_read_tzfile_tzpath(zone_name)
-    except zoneinfo.ZoneInfoNotFoundError:
-        # if that fails, we fall back to using `tzdata`
-        tz_table = _find_and_read_tzfile_tzdata(zone_name)
-    return tz_table
-
-
-def _find_and_read_tzfile_tzpath(
-    zone_name: str,
-) -> tuple[DatetimeColumn, TimeDeltaColumn]:
-    for search_path in zoneinfo.TZPATH:
-        if os.path.isfile(os.path.join(search_path, zone_name)):
-            return _read_tzfile_as_columns(search_path, zone_name)
-    raise zoneinfo.ZoneInfoNotFoundError(zone_name)
-
-
-def _find_and_read_tzfile_tzdata(
-    zone_name: str,
-) -> tuple[DatetimeColumn, TimeDeltaColumn]:
-    import importlib.resources
-
-    package_base = "tzdata.zoneinfo"
-    try:
-        return _read_tzfile_as_columns(
-            str(importlib.resources.files(package_base)), zone_name
-        )
-    # TODO: make it so that the call to libcudf raises a
-    # FileNotFoundError instead of a RuntimeError
-    except (ImportError, FileNotFoundError, UnicodeEncodeError, RuntimeError):
-        # the "except" part of this try-except is basically vendored
-        # from the zoneinfo library.
-        #
-        # There are three types of exception that can be raised that all amount
-        # to "we cannot find this key":
-        #
-        # ImportError: If package_name doesn't exist (e.g. if tzdata is not
-        #   installed, or if there's an error in the folder name like
-        #   Amrica/New_York)
-        # FileNotFoundError: If resource_name doesn't exist in the package
-        #   (e.g. Europe/Krasnoy)
-        # UnicodeEncodeError: If package_name or resource_name are not UTF-8,
-        #   such as keys containing a surrogate character.
-        raise zoneinfo.ZoneInfoNotFoundError(zone_name)
-
-
-def _read_tzfile_as_columns(
-    tzdir: str, zone_name: str
-) -> tuple[DatetimeColumn, TimeDeltaColumn]:
-    plc_table = plc.io.timezone.make_timezone_transition_table(
-        tzdir, zone_name
-    )
-    transition_times_and_offsets = plc_table.columns()
-
-    if not transition_times_and_offsets:
-        from cudf.core.column.column import as_column
-
-        # this happens for UTC-like zones
-        min_date: np.datetime64 = np.int64(np.iinfo("int64").min + 1).astype(
-            np.dtype("M8[s]")
-        )
-        return (as_column([min_date]), as_column([np.timedelta64(0, "s")]))  # type: ignore[return-value]
-
-    from cudf.core.column import ColumnBase
-
-    return tuple(
-        ColumnBase.from_pylibcudf(col) for col in transition_times_and_offsets
-    )  # type: ignore[return-value]
-
-
-def check_ambiguous_and_nonexistent(
-    ambiguous: Literal["NaT"], nonexistent: Literal["NaT"]
-) -> tuple[Literal["NaT"], Literal["NaT"]]:
-    if ambiguous != "NaT":
-        raise NotImplementedError(
-            "Only ambiguous='NaT' is currently supported"
-        )
-    if nonexistent != "NaT":
-        raise NotImplementedError(
-            "Only nonexistent='NaT' is currently supported"
-        )
-    return ambiguous, nonexistent

--- a/python/cudf/cudf/core/column/datetime.py
+++ b/python/cudf/cudf/core/column/datetime.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import calendar
 import functools
 import locale
+import os
 import re
 import warnings
+import zoneinfo
 from locale import nl_langinfo
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -20,9 +22,7 @@ import pylibcudf as plc
 import cudf
 from cudf.core._internals import binaryop
 from cudf.core._internals.timezones import (
-    check_ambiguous_and_nonexistent,
     get_compatible_timezone,
-    get_tz_data,
 )
 from cudf.core.column import as_column, column_empty
 from cudf.core.column.column import ColumnBase
@@ -32,6 +32,7 @@ from cudf.utils.dtypes import (
     _get_base_dtype,
     cudf_dtype_from_pa_type,
     cudf_dtype_to_pa_type,
+    dtype_from_pylibcudf_column,
     get_dtype_of_same_kind,
     get_dtype_of_same_type,
 )
@@ -59,13 +60,6 @@ _dtype_to_format_conversion = {
     "datetime64[s]": "%Y-%m-%d %H:%M:%S",
 }
 
-_DATETIME_SPECIAL_FORMATS = {
-    "%b",
-    "%B",
-    "%A",
-    "%a",
-}
-
 
 def _resolve_binop_resolution(
     left_unit: Literal["s", "ms", "us", "ns"],
@@ -75,6 +69,106 @@ def _resolve_binop_resolution(
     left_idx = units.index(left_unit)
     right_idx = units.index(right_unit)
     return units[max(left_idx, right_idx)]
+
+
+@functools.lru_cache(maxsize=20)
+def _get_tz_data(zone_name: str) -> tuple[ColumnBase, ColumnBase]:
+    """
+    Return timezone data (transition times and UTC offsets) for the
+    given IANA time zone.
+
+    Parameters
+    ----------
+    zone_name: str
+        IANA time zone name
+
+    Returns
+    -------
+    Tuple with two columns containing the transition times
+    and corresponding UTC offsets.
+    """
+    try:
+        # like zoneinfo, we first look in TZPATH
+        tz_table = _find_and_read_tzfile_tzpath(zone_name)
+    except zoneinfo.ZoneInfoNotFoundError:
+        # if that fails, we fall back to using `tzdata`
+        tz_table = _find_and_read_tzfile_tzdata(zone_name)
+    return tz_table
+
+
+def _find_and_read_tzfile_tzpath(
+    zone_name: str,
+) -> tuple[ColumnBase, ColumnBase]:
+    for search_path in zoneinfo.TZPATH:
+        if os.path.isfile(os.path.join(search_path, zone_name)):
+            return _read_tzfile_as_columns(search_path, zone_name)
+    raise zoneinfo.ZoneInfoNotFoundError(zone_name)
+
+
+def _find_and_read_tzfile_tzdata(
+    zone_name: str,
+) -> tuple[ColumnBase, ColumnBase]:
+    import importlib.resources
+
+    package_base = "tzdata.zoneinfo"
+    try:
+        return _read_tzfile_as_columns(
+            str(importlib.resources.files(package_base)), zone_name
+        )
+    # TODO: make it so that the call to libcudf raises a
+    # FileNotFoundError instead of a RuntimeError
+    except (ImportError, FileNotFoundError, UnicodeEncodeError, RuntimeError):
+        # the "except" part of this try-except is basically vendored
+        # from the zoneinfo library.
+        #
+        # There are three types of exception that can be raised that all amount
+        # to "we cannot find this key":
+        #
+        # ImportError: If package_name doesn't exist (e.g. if tzdata is not
+        #   installed, or if there's an error in the folder name like
+        #   Amrica/New_York)
+        # FileNotFoundError: If resource_name doesn't exist in the package
+        #   (e.g. Europe/Krasnoy)
+        # UnicodeEncodeError: If package_name or resource_name are not UTF-8,
+        #   such as keys containing a surrogate character.
+        raise zoneinfo.ZoneInfoNotFoundError(zone_name)
+
+
+def _read_tzfile_as_columns(
+    tzdir: str, zone_name: str
+) -> tuple[ColumnBase, ColumnBase]:
+    plc_table = plc.io.timezone.make_timezone_transition_table(
+        tzdir, zone_name
+    )
+    transition_times_and_offsets = plc_table.columns()
+
+    if not transition_times_and_offsets:
+        # this happens for UTC-like zones
+        min_date: np.datetime64 = np.int64(np.iinfo("int64").min + 1).astype(
+            np.dtype("M8[s]")
+        )
+        return (as_column([min_date]), as_column([np.timedelta64(0, "s")]))
+
+    result = tuple(
+        ColumnBase.create(col, dtype=dtype_from_pylibcudf_column(col))
+        for col in transition_times_and_offsets
+    )
+    assert len(result) == 2  # for mypy
+    return result
+
+
+def _check_ambiguous_and_nonexistent(
+    ambiguous: Literal["NaT"], nonexistent: Literal["NaT"]
+) -> tuple[Literal["NaT"], Literal["NaT"]]:
+    if ambiguous != "NaT":
+        raise NotImplementedError(
+            "Only ambiguous='NaT' is currently supported"
+        )
+    if nonexistent != "NaT":
+        raise NotImplementedError(
+            "Only nonexistent='NaT' is currently supported"
+        )
+    return ambiguous, nonexistent
 
 
 class DatetimeColumn(TemporalBaseColumn):
@@ -689,8 +783,8 @@ class DatetimeColumn(TemporalBaseColumn):
         transitions occur in the time zone database for the given timezone.
         If no transitions occur, the tuple `(False, False)` is returned.
         """
-        transition_times, offsets = get_tz_data(zone_name)
-        offsets = offsets.astype(np.dtype(f"timedelta64[{self.time_unit}]"))  # type: ignore[assignment]
+        transition_times, offsets = _get_tz_data(zone_name)
+        offsets = offsets.astype(np.dtype(f"timedelta64[{self.time_unit}]"))
 
         if len(offsets) == 1:  # no transitions
             return False, False
@@ -747,7 +841,7 @@ class DatetimeColumn(TemporalBaseColumn):
     ) -> DatetimeColumn:
         if tz is None:
             return self.copy()
-        ambiguous, nonexistent = check_ambiguous_and_nonexistent(
+        ambiguous, nonexistent = _check_ambiguous_and_nonexistent(
             ambiguous, nonexistent
         )
         dtype = get_compatible_timezone(pd.DatetimeTZDtype(self.time_unit, tz))
@@ -762,7 +856,7 @@ class DatetimeColumn(TemporalBaseColumn):
             ),
         )
 
-        transition_times, offsets = get_tz_data(tzname)
+        transition_times, offsets = _get_tz_data(tzname)
         transition_times_local = (transition_times + offsets).astype(
             localized.dtype
         )
@@ -832,7 +926,7 @@ class DatetimeTZColumn(DatetimeColumn):
     @functools.cached_property
     def _local_time(self) -> DatetimeColumn:
         """Return the local time as naive timestamps."""
-        transition_times, offsets = get_tz_data(str(self.dtype.tz))  # type: ignore[union-attr]
+        transition_times, offsets = _get_tz_data(str(self.dtype.tz))  # type: ignore[union-attr]
         base_dtype = _get_base_dtype(self.dtype)
         indices = (
             transition_times.astype(base_dtype).searchsorted(
@@ -895,7 +989,7 @@ class DatetimeTZColumn(DatetimeColumn):
     ) -> DatetimeColumn:
         if tz is None:
             return self._local_time
-        ambiguous, nonexistent = check_ambiguous_and_nonexistent(
+        ambiguous, nonexistent = _check_ambiguous_and_nonexistent(
             ambiguous, nonexistent
         )
         raise ValueError(

--- a/python/cudf/cudf/core/groupby/groupby.py
+++ b/python/cudf/cudf/core/groupby/groupby.py
@@ -1198,22 +1198,31 @@ class GroupBy(Serializable, Reducible, Scannable):
                         plc_tables[1],
                         plc.types.NullEquality.EQUAL,
                     )
-                    left_order = ColumnBase.from_pylibcudf(left_plc)
-                    right_order = ColumnBase.from_pylibcudf(right_plc)
+                    left_order = ColumnBase.create(
+                        left_plc, dtype=dtype_from_pylibcudf_column(left_plc)
+                    )
+                    right_order = ColumnBase.create(
+                        right_plc, dtype=dtype_from_pylibcudf_column(right_plc)
+                    )
+                # TODO: Perform inner_join and sort_by_key all in pylibcudf
                 # left order is some permutation of the ordering we
                 # want, and right order is a matching gather map for
                 # the result table. Get the correct order by sorting
                 # the right gather map.
-                right_order = sorting.sort_by_key(
+                plc_right_order = sorting.sort_by_key(
                     [right_order],
                     [left_order],
                     [True],
                     ["first"],
                     stable=False,
                 )[0]
+
                 result = result._gather(
                     GatherMap.from_column_unchecked(
-                        ColumnBase.from_pylibcudf(right_order),
+                        ColumnBase.create(
+                            plc_right_order,
+                            dtype=dtype_from_pylibcudf_column(plc_right_order),
+                        ),
                         len(result),
                         nullify=False,
                     )
@@ -1684,16 +1693,14 @@ class GroupBy(Serializable, Reducible, Scannable):
                     mode="read",
                     scope="internal",
                 ) as (indices_col, keys_col, group_offsets_col):
-                    plc_table = plc.sorting.stable_segmented_sort_by_key(
+                    plc_column = plc.sorting.stable_segmented_sort_by_key(
                         plc.Table([indices_col.plc_column]),
                         plc.Table([keys_col.plc_column]),
                         group_offsets_col.plc_column,
                         [plc.types.Order.ASCENDING],
                         [plc.types.NullOrder.AFTER],
-                    )
-                    indices = ColumnBase.from_pylibcudf(
-                        plc_table.columns()[0]
-                    ).values
+                    ).columns()[0]
+                    indices = cp.array(plc_column.data())
             # Which indices are we going to want?
             want = np.arange(samples_per_group.sum(), dtype=SIZE_TYPE_DTYPE)
             scan = np.empty_like(samples_per_group)
@@ -2497,13 +2504,14 @@ class GroupBy(Serializable, Reducible, Scannable):
                 )
                 x, y = str(x), str(y)
 
-            struct_column = ColumnBase.from_pylibcudf(
-                plc.Column.struct_from_children(
-                    [
-                        self.obj._data[x].plc_column,
-                        self.obj._data[y].plc_column,
-                    ]
-                )
+            plc_column = plc.Column.struct_from_children(
+                [
+                    self.obj._data[x].plc_column,
+                    self.obj._data[y].plc_column,
+                ]
+            )
+            struct_column = ColumnBase.create(
+                plc_column, dtype=dtype_from_pylibcudf_column(plc_column)
             ).set_mask(None, 0)
             column_pair_structs[(x, y)] = struct_column
 
@@ -2536,14 +2544,19 @@ class GroupBy(Serializable, Reducible, Scannable):
         # interleave: combines the correlation or covariance results for each
         # column-pair into a single column
 
-        def interleave_columns(source_columns):
+        def interleave_columns(source_columns: list[ColumnBase]) -> ColumnBase:
+            # Note: assume non-empty
+            result_type = source_columns[0].dtype
             with access_columns(
                 *source_columns, mode="read", scope="internal"
-            ) as source_columns:
-                return ColumnBase.from_pylibcudf(
+            ) as accessed_source_columns:
+                return ColumnBase.create(
                     plc.reshape.interleave_columns(
-                        plc.Table([c.plc_column for c in source_columns])
-                    )
+                        plc.Table(
+                            [c.plc_column for c in accessed_source_columns]
+                        )
+                    ),
+                    result_type,
                 )
 
         res = DataFrame._from_data(

--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -39,6 +39,7 @@ from cudf.errors import MixedTypeError
 from cudf.utils.dtypes import (
     CUDF_STRING_DTYPE,
     SIZE_TYPE_DTYPE,
+    dtype_from_pylibcudf_column,
     is_column_like,
     is_pandas_nullable_extension_dtype,
 )
@@ -2005,8 +2006,12 @@ class MultiIndex(Index):
                 plc_tables[1],
                 plc.types.NullEquality.EQUAL,
             )
-            scatter_map = ColumnBase.from_pylibcudf(left_plc)
-            indices = ColumnBase.from_pylibcudf(right_plc)
+            scatter_map = ColumnBase.create(
+                left_plc, dtype=dtype_from_pylibcudf_column(left_plc)
+            )
+            indices = ColumnBase.create(
+                right_plc, dtype=dtype_from_pylibcudf_column(right_plc)
+            )
         result_series = cudf.Series._from_column(
             result._scatter_by_column(scatter_map, indices)
         )

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -142,13 +142,16 @@ def cudf_dtype_from_pa_type(typ: pa.DataType) -> DtypeObj:
     elif pa.types.is_large_string(typ) or pa.types.is_string(typ):
         return CUDF_STRING_DTYPE
     elif pa.types.is_date(typ):
-        # typ.to_pandas_dtype() produces an ms resolution numpy datetime type.
+        # typ.to_pandas_dtype() produces np.dtype("datetime64[ms]").
         # Conversely pylibcudf will produce TIMESTAMP_DAYS for date types - the most
         # correct answer - and to match pandas cudf will cast to TIMESTAMP_SECONDS
         # (see ColumnBase._wrap_buffers). Therefore we should return a seconds
-        # resolution datetime type here. The pyarrow conversion seems incorrect, so if
-        # that is ever fixed to return a more appropriate type we can remove this branch.
+        # resolution datetime type here. The pyarrow may be changed
+        # https://github.com/apache/arrow/issues/49168.
         return np.dtype("datetime64[s]")
+    elif pa.types.is_null(typ):
+        # Similar to PYLIBCUDF_TO_SUPPORTED_NUMPY_TYPES[plc.types.TypeId.EMPTY]
+        return np.dtype(np.int8)
     else:
         return cudf.api.types.pandas_dtype(typ.to_pandas_dtype())
 


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/21229

Also moves some helper functions that were in `python/cudf/cudf/core/_internals/timezones.py` to the only place they were used in `python/cudf/cudf/core/column/datetime.py` which helps avoid runtime imports.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
