### PR TITLE
Change missing value repr for string from <NA> to None

### DIFF
--- a/python/cudf/cudf/core/accessors/string.py
+++ b/python/cudf/cudf/core/accessors/string.py
@@ -289,7 +289,7 @@ class StringMethods(BaseAccessor):
         >>> s.str.cat(['A', 'B', 'C', 'D'], sep=',')
         0     a,A
         1     b,B
-        2    <NA>
+        2    None
         3     d,D
         dtype: object
 
@@ -479,8 +479,8 @@ class StringMethods(BaseAccessor):
         dtype: list
         >>> ser.str.join(sep='_', string_na_rep='k')
         0    a_b_k
-        1     <NA>
-        2     <NA>
+        1     None
+        2     None
         3      c_d
         dtype: object
 
@@ -489,8 +489,8 @@ class StringMethods(BaseAccessor):
 
         >>> ser.str.join(sep=[None, '^', '.', '-'], sep_na_rep='+')
         0    a+b+
-        1    <NA>
-        2    <NA>
+        1    None
+        2    None
         3     c-d
         dtype: object
         """
@@ -592,7 +592,7 @@ class StringMethods(BaseAccessor):
               0     1
         0     a     1
         1     b     2
-        2  <NA>  <NA>
+        2  None  None
 
         A pattern with one group will return a DataFrame with one
         column if expand=True.
@@ -601,14 +601,14 @@ class StringMethods(BaseAccessor):
               0
         0     1
         1     2
-        2  <NA>
+        2  None
 
         A pattern with one group will return a Series if expand=False.
 
         >>> s.str.extract(r'[ab](\d)', expand=False)
         0       1
         1       2
-        2    <NA>
+        2    None
         dtype: object
 
         .. pandas-compat::
@@ -679,7 +679,7 @@ class StringMethods(BaseAccessor):
         1                 dog
         2    house and parrot
         3                  23
-        4                <NA>
+        4                None
         dtype: object
         >>> s1.str.contains('og', regex=False)
         0    False
@@ -956,7 +956,7 @@ class StringMethods(BaseAccessor):
         >>> s
         0     foo
         1     fuz
-        2    <NA>
+        2    None
         dtype: object
 
         When pat is a string and regex is True (the default), the given pat
@@ -967,7 +967,7 @@ class StringMethods(BaseAccessor):
         >>> s.str.replace('f.', 'ba', regex=True)
         0     bao
         1     baz
-        2    <NA>
+        2    None
         dtype: object
 
         When pat is a string and `regex` is False, every pat is replaced
@@ -976,7 +976,7 @@ class StringMethods(BaseAccessor):
         >>> s.str.replace('f.', 'ba', regex=False)
         0     foo
         1     fuz
-        2    <NA>
+        2    None
         dtype: object
 
         .. pandas-compat::
@@ -2325,8 +2325,8 @@ class StringMethods(BaseAccessor):
         dtype: object
         >>> s.str.get(10)
         0       d
-        1    <NA>
-        2    <NA>
+        1    None
+        2    None
         dtype: object
         >>> s.str.get(1)
         0    e
@@ -2497,7 +2497,7 @@ class StringMethods(BaseAccessor):
         >>> s
         0            this is a regular sentence
         1    https://docs.python.org/index.html
-        2                                  <NA>
+        2                                  None
         dtype: object
 
         In the default setting, the string is split by whitespace.
@@ -2541,8 +2541,8 @@ class StringMethods(BaseAccessor):
         >>> s.str.split(expand=True)
                                             0     1     2        3         4
         0                                this    is     a  regular  sentence
-        1  https://docs.python.org/index.html  <NA>  <NA>     <NA>      <NA>
-        2                                <NA>  <NA>  <NA>     <NA>      <NA>
+        1  https://docs.python.org/index.html  None  None     None      None
+        2                                None  None  None     None      None
         """
 
         if expand not in (True, False):
@@ -2674,7 +2674,7 @@ class StringMethods(BaseAccessor):
         >>> s
         0                       this is a regular sentence
         1    https://docs.python.org/3/tutorial/index.html
-        2                                             <NA>
+        2                                             None
         dtype: object
 
         In the default setting, the string is split by whitespace.
@@ -2709,14 +2709,14 @@ class StringMethods(BaseAccessor):
         dtype: list
 
         When using ``expand=True``, the split elements will expand
-        out into separate columns. If ``<NA>`` value is present,
+        out into separate columns. If a null value is present,
         it is propagated throughout the columns during the split.
 
         >>> s.str.rsplit(n=2, expand=True)
                                                        0        1         2
         0                                      this is a  regular  sentence
-        1  https://docs.python.org/3/tutorial/index.html     <NA>      <NA>
-        2                                           <NA>     <NA>      <NA>
+        1  https://docs.python.org/3/tutorial/index.html     None      None
+        2                                           None     None      None
 
         For slightly more complex use cases like splitting the
         html document name from a url, a combination of parameter
@@ -2724,9 +2724,9 @@ class StringMethods(BaseAccessor):
 
         >>> s.str.rsplit("/", n=1, expand=True)
                                             0           1
-        0          this is a regular sentence        <NA>
+        0          this is a regular sentence        None
         1  https://docs.python.org/3/tutorial  index.html
-        2                                <NA>        <NA>
+        2                                None        None
         """
 
         if expand not in (True, False):
@@ -2797,7 +2797,7 @@ class StringMethods(BaseAccessor):
         >>> s.str.split_part(delimiter="_", index=1)
         0       b
         1       e
-        2    <NA>
+        2    None
         dtype: object
         """
 
@@ -3098,7 +3098,7 @@ class StringMethods(BaseAccessor):
         0      -1
         1       1
         2    1000
-        3    <NA>
+        3    None
         dtype: object
 
         Note that ``None`` is not string, therefore it is converted
@@ -3109,7 +3109,7 @@ class StringMethods(BaseAccessor):
         0     -01
         1     001
         2    1000
-        3    <NA>
+        3    None
         dtype: object
         """
         if not is_integer(width):
@@ -3145,31 +3145,31 @@ class StringMethods(BaseAccessor):
         >>> s.str.center(1)
         0       a
         1       b
-        2    <NA>
+        2    None
         3       d
         dtype: object
         >>> s.str.center(1, fillchar='-')
         0       a
         1       b
-        2    <NA>
+        2    None
         3       d
         dtype: object
         >>> s.str.center(2, fillchar='-')
         0      a-
         1      b-
-        2    <NA>
+        2    None
         3      d-
         dtype: object
         >>> s.str.center(5, fillchar='-')
         0    --a--
         1    --b--
-        2     <NA>
+        2     None
         3    --d--
         dtype: object
         >>> s.str.center(6, fillchar='-')
         0    --a---
         1    --b---
-        2      <NA>
+        2      None
         3    --d---
         dtype: object
         """
@@ -3290,19 +3290,19 @@ class StringMethods(BaseAccessor):
         0    1. Ant.
         1    2. Bee!\n
         2    3. Cat?\t
-        3         <NA>
+        3         None
         dtype: object
         >>> s.str.strip()
         0    1. Ant.
         1    2. Bee!
         2    3. Cat?
-        3       <NA>
+        3       None
         dtype: object
         >>> s.str.strip('123.!? \n\t')
         0     Ant
         1     Bee
         2     Cat
-        3    <NA>
+        3    None
         dtype: object
         """
         return self._return_or_inplace(
@@ -3346,7 +3346,7 @@ class StringMethods(BaseAccessor):
         0     Ant.
         1     Bee!\n
         2     Cat?\t
-        3       <NA>
+        3       None
         dtype: object
         """
         return self._return_or_inplace(
@@ -3392,13 +3392,13 @@ class StringMethods(BaseAccessor):
         0    1. Ant.
         1    2. Bee!\n
         2    3. Cat?\t
-        3         <NA>
+        3         None
         dtype: object
         >>> s.str.rstrip('.!? \n\t')
         0    1. Ant
         1    2. Bee
         2    3. Cat
-        3      <NA>
+        3      None
         dtype: object
         """
         return self._return_or_inplace(
@@ -3873,7 +3873,7 @@ class StringMethods(BaseAccessor):
         0     bat
         1    bear
         2     caT
-        3    <NA>
+        3    None
         dtype: object
         >>> s.str.endswith('t')
         0     True
@@ -3924,7 +3924,7 @@ class StringMethods(BaseAccessor):
         0     bat
         1    Bear
         2     cat
-        3    <NA>
+        3    None
         dtype: object
         >>> s.str.startswith('b')
         0     True

--- a/python/cudf/cudf/core/column/temporal_base.py
+++ b/python/cudf/cudf/core/column/temporal_base.py
@@ -84,10 +84,8 @@ class TemporalBaseColumn(ColumnBase, Scannable):
             # call-overload must be ignored because numpy stubs only accept literal
             # time unit strings, but we're passing self.time_unit which is valid at runtime
             fill_value = self._NP_SCALAR(fill_value, self.time_unit)  # type: ignore[call-overload]
-        elif (
-            cudf.get_option("mode.pandas_compatible")
-            and is_scalar(fill_value)
-            and not isinstance(fill_value, (self._NP_SCALAR, self._PD_SCALAR))
+        elif is_scalar(fill_value) and not isinstance(
+            fill_value, (self._NP_SCALAR, self._PD_SCALAR)
         ):
             raise MixedTypeError(
                 f"Cannot use fill_value of type {type(fill_value)} with "

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -940,8 +940,8 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
     ... ])
     >>> df
        0     1     2     3             4
-    0  5  cats  jump  <NA>          <NA>
-    1  2  dogs   dig   7.5          <NA>
+    0  5  cats  jump  <NA>          None
+    1  2  dogs   dig   7.5          None
     2  3  cows   moo  -2.1  occasionally
 
     Convert from a Pandas DataFrame:
@@ -6803,7 +6803,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
         >>> df.mode()
           species  legs  wings
         0    bird     2    0.0
-        1    <NA>  <NA>    2.0
+        1    None  <NA>    2.0
 
         Setting ``dropna=False``, ``NA`` values are considered and they can be
         the mode (like for wings).

--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -1039,7 +1039,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
         >>> ser
         0       a
         1       b
-        2    <NA>
+        2    None
         3       c
         dtype: object
         >>> ser.fillna('z')
@@ -1249,7 +1249,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
         ...                    'toy': [None, 'Batmobile', 'Joker']})
         >>> df
             age                           born    name        toy
-        0     5                           NaT  Alfred       <NA>
+        0     5                           NaT  Alfred        None
         1     6  1939-05-27 00:00:00.000000000  Batman  Batmobile
         2  <NA>  1940-04-25 00:00:00.000000000              Joker
         >>> df.isna()
@@ -1330,7 +1330,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
         ...                    'toy': [None, 'Batmobile', 'Joker']})
         >>> df
             age                           born    name        toy
-        0     5                           NaT  Alfred       <NA>
+        0     5                           NaT  Alfred        None
         1     6  1939-05-27 00:00:00.000000000  Batman  Batmobile
         2  <NA>  1940-04-25 00:00:00.000000000              Joker
         >>> df.notna()

--- a/python/cudf/cudf/core/indexed_frame.py
+++ b/python/cudf/cudf/core/indexed_frame.py
@@ -766,10 +766,10 @@ class IndexedFrame(Frame):
         dtype: object
         >>> s.replace({'a': None})
         0       b
-        1    <NA>
-        2    <NA>
+        1    None
+        2    None
         3       b
-        4    <NA>
+        4    None
         dtype: object
 
         If there is a mismatch in types of the values in
@@ -4340,7 +4340,7 @@ class IndexedFrame(Frame):
         >>> df
                name        toy                           born
         0    Alfred  Batmobile  1940-04-25 00:00:00.000000000
-        1    Batman       <NA>                            NaT
+        1    Batman       None                            NaT
         2  Catwoman   Bullwhip                            NaT
 
         Drop the rows where at least one element is null.
@@ -4362,7 +4362,7 @@ class IndexedFrame(Frame):
         >>> df.dropna(how='all')
                name        toy                           born
         0    Alfred  Batmobile  1940-04-25 00:00:00.000000000
-        1    Batman       <NA>                            NaT
+        1    Batman       None                            NaT
         2  Catwoman   Bullwhip                            NaT
 
         Keep only the rows with at least 2 non-null values.

--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -247,8 +247,8 @@ def concat(
     1      d       4    dog
     >>> cudf.concat([df1, df3], sort=False)
       letter  number animal
-    0      a       1   <NA>
-    1      b       2   <NA>
+    0      a       1   None
+    1      b       2   None
     0      c       3    cat
     1      d       4    dog
 
@@ -983,8 +983,8 @@ def pivot(
               c
         b     1     2      3
         a
-        1   one   two   <NA>
-        2  <NA>  <NA>  three
+        1   one   two   None
+        2  None  None  three
 
     """
     values_is_list = True

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -529,7 +529,7 @@ class Series(SingleColumnFrame, IndexedFrame):
         >>> cudf.Series.from_arrow(pa.array(["a", "b", None]))
         0       a
         1       b
-        2    <NA>
+        2    None
         dtype: object
         """
         return cls._from_column(ColumnBase.from_arrow(array))
@@ -1036,7 +1036,7 @@ class Series(SingleColumnFrame, IndexedFrame):
         10       a
         11       b
         12       c
-        13    <NA>
+        13    None
         15       d
         Name: sample, dtype: object
         >>> series.to_frame()
@@ -1044,7 +1044,7 @@ class Series(SingleColumnFrame, IndexedFrame):
         10      a
         11      b
         12      c
-        13   <NA>
+        13   None
         15      d
         """
         res = self._to_frame(name=name, index=self.index)
@@ -1175,7 +1175,7 @@ class Series(SingleColumnFrame, IndexedFrame):
         >>> s
         0      cat
         1      dog
-        2     <NA>
+        2     None
         3   rabbit
         dtype: object
 
@@ -1186,8 +1186,8 @@ class Series(SingleColumnFrame, IndexedFrame):
         >>> s.map({'cat': 'kitten', 'dog': 'puppy'})
         0   kitten
         1    puppy
-        2     <NA>
-        3     <NA>
+        2     None
+        3     None
         dtype: object
 
         It also accepts numeric functions:
@@ -1678,7 +1678,7 @@ class Series(SingleColumnFrame, IndexedFrame):
         >>> ser = cudf.Series(['', None, 'abc'])
         >>> ser
         0
-        1    <NA>
+        1    None
         2     abc
         dtype: object
         >>> ser.dropna()
@@ -3036,15 +3036,15 @@ class Series(SingleColumnFrame, IndexedFrame):
         0       a
         1       a
         2       b
-        3    <NA>
+        3    None
         4       b
-        5    <NA>
+        5    None
         6       c
         dtype: object
         >>> series.unique()
         0       a
         1       b
-        2    <NA>
+        2    None
         3       c
         dtype: object
         """

--- a/python/cudf/cudf/tests/dataframe/test_repr.py
+++ b/python/cudf/cudf/tests/dataframe/test_repr.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import textwrap
@@ -30,7 +30,7 @@ def test_null_dataframe(ncols):
     gdf = cudf.DataFrame(data)
     pdf = gdf.to_pandas()
     with pd.option_context("display.max_columns", int(ncols)):
-        pdf_repr = repr(pdf).replace("NaN", "<NA>").replace("None", "<NA>")
+        pdf_repr = repr(pdf).replace("NaN", "<NA>")
         assert pdf_repr.split() == repr(gdf).split()
 
 
@@ -183,98 +183,67 @@ def test_dataframe_sliced(gdf, slc, max_seq_items, max_rows):
         sliced_gdf = gdf[slc]
         sliced_pdf = pdf[slc]
 
-        expected_repr = repr(sliced_pdf).replace("None", "<NA>")
+        expected_repr = repr(sliced_pdf)
         actual_repr = repr(sliced_gdf)
 
         assert expected_repr == actual_repr
 
 
 @pytest.mark.parametrize(
-    "df,pandas_special_case",
+    "df",
     [
-        (pd.DataFrame({"a": [1, 2, 3]}, index=[10, 20, None]), False),
-        (
-            pd.DataFrame(
-                {
-                    "a": [1, None, 3],
-                    "string_col": ["hello", "world", "rapids"],
-                },
-                index=[None, "a", "b"],
-            ),
-            True,
+        pd.DataFrame({"a": [1, 2, 3]}, index=[10, 20, None]),
+        pd.DataFrame(
+            {
+                "a": [1, None, 3],
+                "string_col": ["hello", "world", "rapids"],
+            },
+            index=[None, "a", "b"],
         ),
-        (pd.DataFrame([], index=[None, "a", "b"]), False),
-        (pd.DataFrame({"aa": [None, None]}, index=[None, None]), False),
-        (pd.DataFrame({"aa": [1, 2, 3]}, index=[None, None, None]), False),
-        (
-            pd.DataFrame(
-                {"aa": [None, 2, 3]},
-                index=np.array([1, None, None], dtype="datetime64[ns]"),
-            ),
-            False,
+        pd.DataFrame([], index=[None, "a", "b"]),
+        pd.DataFrame({"aa": [None, None]}, index=[None, None]),
+        pd.DataFrame({"aa": [1, 2, 3]}, index=[None, None, None]),
+        pd.DataFrame(
+            {"aa": [None, 2, 3]},
+            index=np.array([1, None, None], dtype="datetime64[ns]"),
         ),
-        (
-            pd.DataFrame(
-                {"aa": [None, 2, 3]},
-                index=np.array([100, None, None], dtype="datetime64[ns]"),
-            ),
-            False,
+        pd.DataFrame(
+            {"aa": [None, 2, 3]},
+            index=np.array([100, None, None], dtype="datetime64[ns]"),
         ),
-        (
-            pd.DataFrame(
-                {"aa": [None, None, None]},
-                index=np.array([None, None, None], dtype="datetime64[ns]"),
-            ),
-            False,
+        pd.DataFrame(
+            {"aa": [None, None, None]},
+            index=np.array([None, None, None], dtype="datetime64[ns]"),
         ),
-        (
-            pd.DataFrame(
-                {"aa": [1, None, 3]},
-                index=np.array([10, 15, None], dtype="datetime64[ns]"),
-            ),
-            False,
+        pd.DataFrame(
+            {"aa": [1, None, 3]},
+            index=np.array([10, 15, None], dtype="datetime64[ns]"),
         ),
-        (
-            pd.DataFrame(
-                {"a": [1, 2, None], "v": [10, None, 22], "p": [100, 200, 300]}
-            ).set_index(["a", "v"]),
-            False,
-        ),
-        (
-            pd.DataFrame(
-                {
-                    "a": [1, 2, None],
-                    "v": ["n", "c", "a"],
-                    "p": [None, None, None],
-                }
-            ).set_index(["a", "v"]),
-            False,
-        ),
-        (
-            pd.DataFrame(
-                {
-                    "a": np.array([1, None, None], dtype="datetime64[ns]"),
-                    "v": ["n", "c", "a"],
-                    "p": [None, None, None],
-                }
-            ).set_index(["a", "v"]),
-            False,
-        ),
+        pd.DataFrame(
+            {"a": [1, 2, None], "v": [10, None, 22], "p": [100, 200, 300]}
+        ).set_index(["a", "v"]),
+        pd.DataFrame(
+            {
+                "a": [1, 2, None],
+                "v": ["n", "c", "a"],
+                "p": [None, None, None],
+            }
+        ).set_index(["a", "v"]),
+        pd.DataFrame(
+            {
+                "a": np.array([1, None, None], dtype="datetime64[ns]"),
+                "v": ["n", "c", "a"],
+                "p": [None, None, None],
+            }
+        ).set_index(["a", "v"]),
     ],
 )
-def test_dataframe_null_index_repr(df, pandas_special_case):
+def test_dataframe_null_index_repr(df):
     pdf = df
     gdf = cudf.from_pandas(pdf)
 
-    expected_repr = repr(pdf).replace("NaN", "<NA>").replace("None", "<NA>")
+    expected_repr = repr(pdf).replace("NaN", "<NA>")
     actual_repr = repr(gdf)
-
-    if pandas_special_case:
-        # Pandas inconsistently print Index null values
-        # as `None` at some places and `NaN` at few other places
-        # Whereas cudf is consistent with strings `null` values
-        # to be printed as `None` everywhere.
-        actual_repr = repr(gdf).replace("None", "<NA>")
 
     assert expected_repr.split() == actual_repr.split()
 

--- a/python/cudf/cudf/tests/series/test_repr.py
+++ b/python/cudf/cudf/tests/series/test_repr.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import textwrap
@@ -34,7 +34,7 @@ def test_null_series(nrows, all_supported_types_as_str, request):
         ps = sr.to_pandas()
 
     with pd.option_context("display.max_rows", int(nrows)):
-        psrepr = repr(ps).replace("NaN", "<NA>").replace("None", "<NA>")
+        psrepr = repr(ps).replace("NaN", "<NA>")
         if "UInt" in psrepr:
             psrepr = psrepr.replace("UInt", "uint")
         elif "Int" in psrepr:
@@ -76,75 +76,51 @@ def test_float_series(x):
 
 
 @pytest.mark.parametrize(
-    "sr,pandas_special_case",
+    "sr",
     [
-        (pd.Series([1, 2, 3], index=[10, 20, None]), False),
-        (pd.Series([1, None, 3], name="a", index=[None, "a", "b"]), True),
-        (pd.Series(None, index=[None, "a", "b"], dtype="float"), True),
-        (pd.Series([None, None], name="aa", index=[None, None]), False),
-        (pd.Series([1, 2, 3], index=[None, None, None]), False),
-        (
-            pd.Series(
-                [None, 2, 3],
-                index=np.array([1, None, None], dtype="datetime64[ns]"),
-            ),
-            False,
+        pd.Series([1, 2, 3], index=[10, 20, None]),
+        pd.Series([1, None, 3], name="a", index=[None, "a", "b"]),
+        pd.Series(None, index=[None, "a", "b"], dtype="float"),
+        pd.Series([None, None], name="aa", index=[None, None]),
+        pd.Series([1, 2, 3], index=[None, None, None]),
+        pd.Series(
+            [None, 2, 3],
+            index=np.array([1, None, None], dtype="datetime64[ns]"),
         ),
-        (
-            pd.Series(
-                [None, None, None],
-                index=np.array([None, None, None], dtype="datetime64[ns]"),
-            ),
-            False,
+        pd.Series(
+            [None, None, None],
+            index=np.array([None, None, None], dtype="datetime64[ns]"),
         ),
-        (
-            pd.Series(
-                [1, None, 3],
-                index=np.array([10, 15, None], dtype="datetime64[ns]"),
-            ),
-            False,
+        pd.Series(
+            [1, None, 3],
+            index=np.array([10, 15, None], dtype="datetime64[ns]"),
         ),
-        (
-            pd.DataFrame(
-                {"a": [1, 2, None], "v": [10, None, 22], "p": [100, 200, 300]}
-            ).set_index(["a", "v"])["p"],
-            False,
-        ),
-        (
-            pd.DataFrame(
-                {
-                    "a": [1, 2, None],
-                    "v": ["n", "c", "a"],
-                    "p": [None, None, None],
-                }
-            ).set_index(["a", "v"])["p"],
-            False,
-        ),
-        (
-            pd.DataFrame(
-                {
-                    "a": np.array([1, None, None], dtype="datetime64[ns]"),
-                    "v": ["n", "c", "a"],
-                    "p": [None, None, None],
-                }
-            ).set_index(["a", "v"])["p"],
-            False,
-        ),
+        pd.DataFrame(
+            {"a": [1, 2, None], "v": [10, None, 22], "p": [100, 200, 300]}
+        ).set_index(["a", "v"])["p"],
+        pd.DataFrame(
+            {
+                "a": [1, 2, None],
+                "v": ["n", "c", "a"],
+                "p": [None, None, None],
+            }
+        ).set_index(["a", "v"])["p"],
+        pd.DataFrame(
+            {
+                "a": np.array([1, None, None], dtype="datetime64[ns]"),
+                "v": ["n", "c", "a"],
+                "p": [None, None, None],
+            }
+        ).set_index(["a", "v"])["p"],
     ],
 )
-def test_series_null_index_repr(sr, pandas_special_case):
+def test_series_null_index_repr(sr):
     psr = sr
     gsr = cudf.from_pandas(psr)
 
-    expected_repr = repr(psr).replace("NaN", "<NA>").replace("None", "<NA>")
+    expected_repr = repr(psr).replace("NaN", "<NA>")
     actual_repr = repr(gsr)
 
-    if pandas_special_case:
-        # Pandas inconsistently print Index null values
-        # as `None` at some places and `NaN` at few other places
-        # Whereas cudf is consistent with strings `null` values
-        # to be printed as `None` everywhere.
-        actual_repr = repr(gsr).replace("None", "<NA>")
     assert expected_repr.split() == actual_repr.split()
 
 
@@ -517,12 +493,6 @@ def test_empty_series_name():
 @pytest.mark.parametrize("item", [0, slice(0, 1)])
 @pytest.mark.parametrize("data", [["a"], ["a", None], [None]])
 def test_string_repr(data, item, request):
-    if data == [None]:
-        request.applymarker(
-            pytest.mark.xfail(
-                reason="Missing value repr should be <NA> instead of None",
-            )
-        )
     ps = pd.Series(data, dtype="str", name="nice name")
     gs = cudf.Series(data, dtype="str", name="nice name")
 

--- a/python/cudf/cudf/utils/docutils.py
+++ b/python/cudf/cudf/utils/docutils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -263,13 +263,13 @@ doc_describe = docfmt_partial(
         unique           3    <NA>      3
         top              d    <NA>      a
         freq             1    <NA>      1
-        mean          <NA>     2.0   <NA>
-        std           <NA>     1.0   <NA>
-        min           <NA>     1.0   <NA>
-        25%           <NA>     1.5   <NA>
-        50%           <NA>     2.0   <NA>
-        75%           <NA>     2.5   <NA>
-        max           <NA>     3.0   <NA>
+        mean          None     2.0   None
+        std           None     1.0   None
+        min           None     1.0   None
+        25%           None     1.5   None
+        50%           None     2.0   None
+        75%           None     2.5   None
+        max           None     3.0   None
 
         Describing a column from a ``DataFrame`` by accessing it as an
         attribute.
@@ -333,12 +333,12 @@ doc_describe = docfmt_partial(
         unique           3    <NA>
         top              d    <NA>
         freq             1    <NA>
-        mean          <NA>     2.0
-        std           <NA>     1.0
-        min           <NA>     1.0
-        25%           <NA>     1.5
-        50%           <NA>     2.0
-        75%           <NA>     2.5
-        max           <NA>     3.0
+        mean          None     2.0
+        std           None     1.0
+        min           None     1.0
+        25%           None     1.5
+        50%           None     2.0
+        75%           None     2.5
+        max           None     3.0
 """
 )


### PR DESCRIPTION
## Description
In order to remove more gating of `mode.pandas_compatible` to match pandas more closely, we'll need to match how pandas repr shows null values for the default string type in pandas 2. 

Prior, we would always use `<NA>`, but pandas uses `None` (or `NaN`) for their default string type and `<NA>` if it's a nullable string type like `ArrowDtype` or `StringDtype(na_value=NA)`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
