### PR TITLE
Remove remaining uses of ColumnBase.from_pylibcudf

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -1286,26 +1286,13 @@ class ColumnBase(Serializable, BinaryOperand, Reducible):
                         type=array.type.value_type,
                     )
                 )
-            codes_dtype = cudf_dtype_from_pa_type(codes.type)
-            result = cls.create(plc.Column.from_arrow(codes), codes_dtype)
-
-            # For categories, handle special cases:
-            # - NULL type (empty categoricals): use from_pylibcudf to infer type
-            # - ExtensionType (intervals): arrow conversion may return pandas dtype
-            if pa.types.is_null(dictionary.type) or isinstance(
-                dictionary.type, pa.ExtensionType
-            ):
-                categories = cls.from_pylibcudf(
-                    plc.Column.from_arrow(dictionary)
-                )
-            else:
-                categories_dtype = cudf_dtype_from_pa_type(dictionary.type)
-                categories = cls.create(
-                    plc.Column.from_arrow(dictionary), categories_dtype
-                )
+            categories_dtype = cudf_dtype_from_pa_type(dictionary.type)
+            categories = cls.create(
+                plc.Column.from_arrow(dictionary), categories_dtype
+            )
 
             return ColumnBase.create(
-                result.plc_column,
+                plc.Column.from_arrow(codes),
                 CategoricalDtype(
                     categories=categories, ordered=array.type.ordered
                 ),
@@ -3141,33 +3128,13 @@ def as_column(
                         categories=new_cats, ordered=arbitrary.dtype.ordered
                     )
                     arbitrary = arbitrary.astype(new_dtype)
-                elif (
-                    isinstance(
-                        arbitrary.dtype.categories.dtype, pd.IntervalDtype
-                    )
-                    and dtype is None
-                ):
-                    # Conversion to arrow converts IntervalDtype to StructDtype
-                    dtype = CategoricalDtype(
-                        categories=arbitrary.dtype.categories,
-                        ordered=arbitrary.dtype.ordered,
-                    )
             result = as_column(
                 pa.array(arbitrary, from_pandas=True),
                 nan_as_null=nan_as_null,
                 dtype=dtype,
                 length=length,
             )
-            if isinstance(arbitrary.dtype, pd.IntervalDtype):
-                # Wrap StructColumn as IntervalColumn with proper metadata
-                result = ColumnBase.create(
-                    result.plc_column,
-                    IntervalDtype(
-                        subtype=arbitrary.dtype.subtype,
-                        closed=arbitrary.dtype.closed,
-                    ),
-                )
-            elif (
+            if (
                 isinstance(arbitrary.dtype, pd.CategoricalDtype)
                 and is_pandas_nullable_extension_dtype(
                     arbitrary.dtype.categories.dtype

--- a/python/cudf/cudf/core/column/numerical.py
+++ b/python/cudf/cudf/core/column/numerical.py
@@ -29,6 +29,7 @@ from cudf.utils.dtypes import (
     CUDF_STRING_DTYPE,
     cudf_dtype_from_pa_type,
     cudf_dtype_to_pa_type,
+    dtype_from_pylibcudf_column,
     dtype_to_pylibcudf_type,
     find_common_type,
     get_dtype_of_same_kind,
@@ -849,10 +850,12 @@ class NumericalColumn(NumericalBaseColumn):
     ) -> plc.Scalar | ColumnBase:
         """Align fill_value for .fillna based on column type."""
         if is_scalar(fill_value):
-            cudf_obj = ColumnBase.from_pylibcudf(
-                plc.Column.from_scalar(
-                    pa_scalar_to_plc_scalar(pa.scalar(fill_value)), 1
-                )
+            plc_col = plc.Column.from_scalar(
+                pa_scalar_to_plc_scalar(pa.scalar(fill_value)), 1
+            )
+            cudf_obj = ColumnBase.create(
+                plc_col,
+                dtype=dtype_from_pylibcudf_column(plc_col),
             )
             if not cudf_obj.can_cast_safely(self.dtype):
                 raise TypeError(

--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -8502,7 +8502,10 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
 
         plc_columns = tbl.columns()
         cudf_cols = (
-            ColumnBase.from_pylibcudf(plc_col) for plc_col in plc_columns
+            ColumnBase.create(
+                plc_col, dtype=dtype_from_pylibcudf_column(plc_col)
+            )
+            for plc_col in plc_columns
         )
         # We only have child names if the source is a pylibcudf.io.TableWithMetadata.
         if child_names is not None:

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -380,7 +380,7 @@ class Index(SingleColumnFrame):
                 raise ValueError("Metadata dict must only contain a name")
             name = metadata.get("name")
         return cls._from_column(
-            ColumnBase.from_pylibcudf(col),
+            ColumnBase.create(col, dtype=dtype_from_pylibcudf_column(col)),
             name=name,
         )
 

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -64,6 +64,7 @@ from cudf.utils.docutils import copy_docstring
 from cudf.utils.dtypes import (
     CUDF_STRING_DTYPE,
     _get_nan_for_dtype,
+    dtype_from_pylibcudf_column,
     find_common_type,
     get_dtype_of_same_kind,
     is_mixed_with_object_dtype,
@@ -3863,7 +3864,7 @@ class Series(SingleColumnFrame, IndexedFrame):
             name = metadata.get("name")
             index = metadata.get("index")
         return cls._from_column(
-            ColumnBase.from_pylibcudf(col),
+            ColumnBase.create(col, dtype=dtype_from_pylibcudf_column(col)),
             name=name,
             index=index,
         )

--- a/python/cudf/cudf/tests/private_objects/test_nrt_stats.py
+++ b/python/cudf/cudf/tests/private_objects/test_nrt_stats.py
@@ -1,5 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
+import numpy as np
 import pytest
 from numba.cuda import config
 from numba.cuda.memory_management.nrt import rtsys
@@ -77,8 +78,9 @@ def test_string_udf_free_kernel(monkeypatch):
 
     with _CUDFNumbaConfig():
         kernel.forall(len(sr))(*launch_args)
-    col = ColumnBase.from_pylibcudf(
-        strings_udf.column_from_managed_udf_string_array(ans_col)
+    col = ColumnBase.create(
+        strings_udf.column_from_managed_udf_string_array(ans_col),
+        dtype=np.dtype(object),
     )
 
     # MemInfos that own the strings should still be alive

--- a/python/cudf/cudf/tests/testing/test_assert_column_equal.py
+++ b/python/cudf/cudf/tests/testing/test_assert_column_equal.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyarrow as pa
@@ -57,8 +57,8 @@ def test_assert_column_memory_basic_same(arrow_arrays):
     plc_col = data.plc_column
 
     # Create two references to same underlying data
-    left = cudf.core.column.ColumnBase.from_pylibcudf(plc_col)
-    right = cudf.core.column.ColumnBase.from_pylibcudf(plc_col)
+    left = cudf.core.column.ColumnBase.create(plc_col, dtype=data.dtype)
+    right = cudf.core.column.ColumnBase.create(plc_col, dtype=data.dtype)
 
     assert_column_memory_eq(left, right)
     with pytest.raises(AssertionError):

--- a/python/cudf/cudf/utils/dtypes.py
+++ b/python/cudf/cudf/utils/dtypes.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, TypeGuard
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+from pandas.core.arrays.arrow.extension_types import ArrowIntervalType
 from pandas.core.computation.common import result_type_many
 
 import pylibcudf as plc
@@ -128,17 +129,17 @@ def cudf_dtype_to_pa_type(dtype: DtypeObj) -> pa.DataType:
 def cudf_dtype_from_pa_type(typ: pa.DataType) -> DtypeObj:
     """Given a pyarrow dtype, converts it into the equivalent cudf dtype."""
     if pa.types.is_list(typ):
-        return cudf.core.dtypes.ListDtype.from_arrow(typ)
+        return cudf.ListDtype.from_arrow(typ)
     elif pa.types.is_struct(typ):
-        return cudf.core.dtypes.StructDtype.from_arrow(typ)
+        return cudf.StructDtype.from_arrow(typ)
     elif pa.types.is_decimal(typ):
         if isinstance(typ, pa.Decimal256Type):
             raise NotImplementedError("cudf does not support Decimal256Type")
         if isinstance(typ, pa.Decimal32Type):
-            return cudf.core.dtypes.Decimal32Dtype.from_arrow(typ)
+            return cudf.Decimal32Dtype.from_arrow(typ)
         if isinstance(typ, pa.Decimal64Type):
-            return cudf.core.dtypes.Decimal64Dtype.from_arrow(typ)
-        return cudf.core.dtypes.Decimal128Dtype.from_arrow(typ)
+            return cudf.Decimal64Dtype.from_arrow(typ)
+        return cudf.Decimal128Dtype.from_arrow(typ)
     elif pa.types.is_large_string(typ) or pa.types.is_string(typ):
         return CUDF_STRING_DTYPE
     elif pa.types.is_date(typ):
@@ -152,6 +153,8 @@ def cudf_dtype_from_pa_type(typ: pa.DataType) -> DtypeObj:
     elif pa.types.is_null(typ):
         # Similar to PYLIBCUDF_TO_SUPPORTED_NUMPY_TYPES[plc.types.TypeId.EMPTY]
         return np.dtype(np.int8)
+    elif isinstance(typ, ArrowIntervalType):
+        return cudf.IntervalDtype.from_arrow(typ)
     else:
         return cudf.api.types.pandas_dtype(typ.to_pandas_dtype())
 


### PR DESCRIPTION
## Description
Towards https://github.com/rapidsai/cudf/issues/21229

There remains no use of `ColumnBase.from_pylibcudf` within cuDF after this PR. I haven't removed the method entirely yet as I should probably audit other RAPIDS libraries to ensure they are not using this method either.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
