### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/cpp/src/sort/segmented_top_k.cu
+++ b/cpp/src/sort/segmented_top_k.cu
@@ -1,9 +1,9 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "sort_column_impl.cuh"
+#include "sort.hpp"
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>

--- a/cpp/src/sort/sort.cu
+++ b/cpp/src/sort/sort.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,9 +16,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-
-#include <thrust/functional.h>
-#include <thrust/sort.h>
 
 namespace cudf {
 namespace detail {

--- a/cpp/src/sort/sort.hpp
+++ b/cpp/src/sort/sort.hpp
@@ -1,8 +1,14 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/sorting.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
 
 namespace cudf {
 namespace detail {
@@ -11,6 +17,27 @@ namespace detail {
  * @brief The enum specifying which sorting method to use (stable or unstable).
  */
 enum class sort_method : bool { STABLE, UNSTABLE };
+
+/**
+ * @brief Sort indices of a single column.
+ *
+ * This API offers fast sorting for primitive types. It cannot handle nested types and will not
+ * consider `NaN` as equivalent to other `NaN`.
+ *
+ * @tparam method Whether to use stable sort
+ * @param input Column to sort. The column data is not modified.
+ * @param column_order Ascending or descending sort order
+ * @param null_precedence How null rows are to be ordered
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return Sorted indices for the input column.
+ */
+template <sort_method method>
+std::unique_ptr<column> sorted_order(column_view const& input,
+                                     order column_order,
+                                     null_order null_precedence,
+                                     rmm::cuda_stream_view stream,
+                                     rmm::device_async_resource_ref mr);
 
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/src/sort/sort_column.cu
+++ b/cpp/src/sort/sort_column.cu
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "sort.hpp"
 #include "sort_column_impl.cuh"
 #include "sort_radix.hpp"
 

--- a/cpp/src/sort/sort_column_impl.cuh
+++ b/cpp/src/sort/sort_column_impl.cuh
@@ -23,27 +23,6 @@ namespace cudf {
 namespace detail {
 
 /**
- * @brief Sort indices of a single column.
- *
- * This API offers fast sorting for primitive types. It cannot handle nested types and will not
- * consider `NaN` as equivalent to other `NaN`.
- *
- * @tparam method Whether to use stable sort
- * @param input Column to sort. The column data is not modified.
- * @param column_order Ascending or descending sort order
- * @param null_precedence How null rows are to be ordered
- * @param stream CUDA stream used for device memory operations and kernel launches
- * @param mr Device memory resource used to allocate the returned column's device memory
- * @return Sorted indices for the input column.
- */
-template <sort_method method>
-std::unique_ptr<column> sorted_order(column_view const& input,
-                                     order column_order,
-                                     null_order null_precedence,
-                                     rmm::cuda_stream_view stream,
-                                     rmm::device_async_resource_ref mr);
-
-/**
  * @brief Comparator functor needed for single column sort.
  *
  * @tparam Column element type.
@@ -61,16 +40,16 @@ struct simple_comparator {
       }
     }
 
-    auto left_elememt  = d_column.type().id() == type_id::DICTIONARY32
+    auto left_element  = d_column.type().id() == type_id::DICTIONARY32
                            ? d_column.child(dictionary_column_view::keys_column_index)
                               .element<T>(d_column.element<dictionary32>(lhs).value())
                            : d_column.element<T>(lhs);
-    auto right_elememt = d_column.type().id() == type_id::DICTIONARY32
+    auto right_element = d_column.type().id() == type_id::DICTIONARY32
                            ? d_column.child(dictionary_column_view::keys_column_index)
                                .element<T>(d_column.element<dictionary32>(rhs).value())
                            : d_column.element<T>(rhs);
 
-    return relational_compare(left_elememt, right_elememt) ==
+    return relational_compare(left_element, right_element) ==
            (ascending ? weak_ordering::LESS : weak_ordering::GREATER);
   }
   column_device_view const d_column;

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -6,11 +6,13 @@
 #pragma once
 
 #include "sort.hpp"
-#include "sort_column_impl.cuh"
 
+#include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/row_operator/lexicographic.cuh>
 #include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/exec_policy.hpp>
 
 #include <thrust/sequence.h>
 #include <thrust/sort.h>

--- a/cpp/src/sort/stable_sort_column.cu
+++ b/cpp/src/sort/stable_sort_column.cu
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "sort.hpp"
 #include "sort_column_impl.cuh"
 #include "sort_radix.hpp"
 

--- a/cpp/src/sort/top_k.cu
+++ b/cpp/src/sort/top_k.cu
@@ -1,9 +1,9 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "sort_column_impl.cuh"
+#include "sort.hpp"
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.