### PR TITLE
Add notes to failing polars test

### DIFF
--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -16,6 +16,7 @@ DESELECTED_TESTS=(
     "tests/unit/test_polars_import.py::test_fork_safety" # test started to hang in polars-1.14
     "tests/unit/operations/test_join.py::test_join_4_columns_with_validity" # fails in some systems, see https://github.com/pola-rs/polars/issues/19870
     "tests/unit/io/test_csv.py::test_read_web_file" # fails in rockylinux8 due to SSL CA issues
+    "tests/unit/io/test_lazy_parquet.py::test_scan_parquet_local_with_async" # Will fail until we have https://github.com/pola-rs/polars/pull/26616
     # TODO: Debug and re-enable the following tests
     "tests/unit/sql/test_distinct.py::test_distinct_with_full_outer_join" # SQLite in CI doesn't support FULL OUTER JOIN
     "tests/unit/sql/test_distinct.py::test_distinct_basic_single_column"


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
In https://github.com/rapidsai/cudf/pull/21451 (specifically https://github.com/rapidsai/cudf/pull/21451/changes/af1a38fcc11f3a917feecf2ab75a0effc75c103d) we skipped an unrelated polars test that had started failing. This PR adds more information on why that test is actually failing (see https://github.com/pola-rs/polars/pull/26616).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
