### PR TITLE
Remove pyarrow string_view workarounds in pylibcudf/cudf

### DIFF
--- a/python/cudf/cudf/testing/testing.py
+++ b/python/cudf/cudf/testing/testing.py
@@ -17,20 +17,12 @@ from cudf.core.dtype.validators import is_dtype_obj_numeric
 from cudf.core.missing import NA, NaT
 from cudf.utils.dtypes import CUDF_STRING_DTYPE
 
-pa_types = pa.types
-
-
-def _is_string_view(dtype: pa.DataType) -> bool:
-    return hasattr(pa_types, "is_string_view") and pa_types.is_string_view(
-        dtype
-    )
-
 
 def _map_string_view_to_string(dtype: pa.DataType) -> pa.DataType:
     """Convert string_view -> string"""
-    if _is_string_view(dtype):
+    if pa.types.is_string_view(dtype):
         return pa.string()
-    if pa_types.is_list(dtype):
+    if pa.types.is_list(dtype):
         return pa.list_(_map_string_view_to_string(dtype.value_type))
     return dtype
 

--- a/python/pylibcudf/pylibcudf/types.pyx
+++ b/python/pylibcudf/pylibcudf/types.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from libc.stddef cimport size_t
@@ -53,6 +53,7 @@ try:
         pa.bool_(): type_id.BOOL8,
         pa.string(): type_id.STRING,
         pa.large_string(): type_id.STRING,
+        pa.string_view(): type_id.STRING,
         pa.duration('s'): type_id.DURATION_SECONDS,
         pa.duration('ms'): type_id.DURATION_MILLISECONDS,
         pa.duration('us'): type_id.DURATION_MICROSECONDS,
@@ -65,14 +66,10 @@ try:
         pa.null(): type_id.EMPTY,
     }
 
-    # New in pyarrow 18.0.0
-    if (string_view := getattr(pa, "string_view", None)) is not None:
-        ARROW_TO_PYLIBCUDF_TYPES[string_view()] = type_id.STRING
-
     LIBCUDF_TO_ARROW_TYPES = {
         v: k for k, v in ARROW_TO_PYLIBCUDF_TYPES.items()
     }
-    # Because we map 2-3 pyarrow string types to type_id.STRING,
+    # Because we map 3 pyarrow string types to type_id.STRING,
     # just map type_id.STRING to pa.string
     LIBCUDF_TO_ARROW_TYPES[type_id.STRING] = pa.string()
 except ImportError as e:


### PR DESCRIPTION
## Description
This workaround is no longer needed since pyarrow 19 is now our minimum version

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
