### PR TITLE
Fix pds-h benchmark with `--suffix`

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -1273,12 +1273,7 @@ def check_input_data_type(run_config: RunConfig) -> Literal["decimal", "float"]:
 
     This is determined by looking at the ``c_acctbal`` column of the customer table.
     """
-    if run_config.suffix == "":
-        path = Path(run_config.dataset_path) / f"customer{run_config.suffix}"
-    else:
-        path = (Path(run_config.dataset_path) / "customer").with_suffix(
-            run_config.suffix
-        )
+    path = (Path(run_config.dataset_path) / "customer").with_suffix(run_config.suffix)
     t = pl.scan_parquet(path).select(pl.col("c_acctbal")).collect_schema()["c_acctbal"]
 
     if t.is_decimal():


### PR DESCRIPTION
## Description

Spotted by @rjzamora in https://github.com/rapidsai/cudf/pull/21388#discussion_r2841153921, I broke the pds-h benchmarks with a `--suffix` was provided by not being consistent with whether a leading `.` is required.

This updates our CLI parser to always prefix the suffix with a `.` if a suffix is provided.

I've tested locally against single-file (with `--suffix=".parquet"`) and multi-file (with `--suffix=""`).