### PR TITLE
Change thrust::make_discard_iterator to cuda::make_discard_iterator

### DIFF
--- a/cpp/benchmarks/io/fst.cu
+++ b/cpp/benchmarks/io/fst.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,7 +19,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 
-#include <thrust/iterator/discard_iterator.h>
+#include <cuda/iterator>
 
 #include <nvbench/nvbench.cuh>
 
@@ -136,7 +136,7 @@ void BM_FST_JSON_no_outidx(nvbench::state& state)
     parser.Transduce(d_input.data(),
                      static_cast<SymbolOffsetT>(d_input.size()),
                      output_gpu.device_ptr(),
-                     thrust::make_discard_iterator(),
+                     cuda::make_discard_iterator(),
                      output_gpu_size.device_ptr(),
                      start_state,
                      stream.value());
@@ -174,8 +174,8 @@ void BM_FST_JSON_no_out(nvbench::state& state)
     // Allocate device-side temporary storage & run algorithm
     parser.Transduce(d_input.data(),
                      static_cast<SymbolOffsetT>(d_input.size()),
-                     thrust::make_discard_iterator(),
-                     thrust::make_discard_iterator(),
+                     cuda::make_discard_iterator(),
+                     cuda::make_discard_iterator(),
                      output_gpu_size.device_ptr(),
                      start_state,
                      stream.value());
@@ -214,7 +214,7 @@ void BM_FST_JSON_no_str(nvbench::state& state)
     // Allocate device-side temporary storage & run algorithm
     parser.Transduce(d_input.data(),
                      static_cast<SymbolOffsetT>(d_input.size()),
-                     thrust::make_discard_iterator(),
+                     cuda::make_discard_iterator(),
                      out_indexes_gpu.device_ptr(),
                      output_gpu_size.device_ptr(),
                      start_state,

--- a/cpp/include/cudf/detail/algorithms/copy_if.cuh
+++ b/cpp/include/cudf/detail/algorithms/copy_if.cuh
@@ -13,10 +13,10 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_select.cuh>
+#include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/stream_ref>
 #include <thrust/copy.h>
-#include <thrust/iterator/discard_iterator.h>
 
 namespace cudf::detail {
 
@@ -235,7 +235,7 @@ void copy_if_async(InputIterator begin,
   auto const num_items = cuda::std::distance(begin, end);
 
   auto tmp_bytes = std::size_t{0};
-  auto no_out    = thrust::make_discard_iterator<int>();
+  auto no_out    = cuda::make_discard_iterator<int>();
   CUDF_CUDA_TRY(cub::DeviceSelect::If(
     nullptr, tmp_bytes, begin, output, no_out, num_items, predicate, stream.value()));
 
@@ -265,7 +265,7 @@ void copy_if_async(InputIterator begin,
   auto const num_items = cuda::std::distance(begin, end);
 
   auto tmp_bytes = std::size_t{0};
-  auto no_out    = thrust::make_discard_iterator<int>();
+  auto no_out    = cuda::make_discard_iterator<int>();
   CUDF_CUDA_TRY(cub::DeviceSelect::FlaggedIf(
     nullptr, tmp_bytes, begin, stencil, result, no_out, num_items, predicate, stream.value()));
 

--- a/cpp/include/cudf/detail/algorithms/reduce.cuh
+++ b/cpp/include/cudf/detail/algorithms/reduce.cuh
@@ -13,9 +13,9 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_reduce.cuh>
+#include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/stream_ref>
-#include <thrust/iterator/discard_iterator.h>
 
 namespace cudf::detail {
 
@@ -171,7 +171,7 @@ void reduce_by_key_async(KeysInputIterator keys_begin,
                                                keys_output,
                                                values_begin,
                                                values_output,
-                                               thrust::make_discard_iterator(),
+                                               cuda::make_discard_iterator(),
                                                op,
                                                num_items,
                                                stream.value()));
@@ -185,7 +185,7 @@ void reduce_by_key_async(KeysInputIterator keys_begin,
                                                keys_output,
                                                values_begin,
                                                values_output,
-                                               thrust::make_discard_iterator(),
+                                               cuda::make_discard_iterator(),
                                                op,
                                                num_items,
                                                stream.value()));

--- a/cpp/src/copying/contiguous_split.cu
+++ b/cpp/src/copying/contiguous_split.cu
@@ -25,13 +25,13 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/utility>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/iterator_categories.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
@@ -1351,7 +1351,7 @@ std::unique_ptr<packed_partition_buf_size_and_dst_buf_info> compute_splits(
                           keys,
                           keys + num_bufs,
                           values,
-                          thrust::make_discard_iterator(),
+                          cuda::make_discard_iterator(),
                           d_buf_sizes);
   }
 
@@ -1888,7 +1888,7 @@ struct contiguous_split_state {
                           keys,
                           keys + num_batches_total,
                           values,
-                          thrust::make_discard_iterator(),
+                          cuda::make_discard_iterator(),
                           dst_valid_count_output_iterator{d_orig_dst_buf_info.data()});
 
     detail::cuda_memcpy<dst_buf_info>(h_orig_dst_buf_info, d_orig_dst_buf_info, stream);

--- a/cpp/src/groupby/sort/group_bitwise.cu
+++ b/cpp/src/groupby/sort/group_bitwise.cu
@@ -17,8 +17,8 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/iterator>
 #include <cuda/std/functional>
-#include <thrust/iterator/discard_iterator.h>
 
 namespace cudf::groupby::detail {
 
@@ -42,7 +42,7 @@ struct bitwise_group_reduction_functor {
       cudf::detail::reduce_by_key_async(group_labels.data(),
                                         group_labels.data() + group_labels.size(),
                                         inp_iter,
-                                        thrust::make_discard_iterator(),
+                                        cuda::make_discard_iterator(),
                                         out_iter,
                                         binop,
                                         stream);

--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -18,9 +18,9 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/iterator>
 #include <cuda/std/tuple>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
@@ -154,7 +154,7 @@ std::unique_ptr<column> group_covariance(column_view const& values_0,
   cudf::detail::reduce_by_key_async(group_labels.begin(),
                                     group_labels.end(),
                                     corr_iter,
-                                    thrust::make_discard_iterator(),
+                                    cuda::make_discard_iterator(),
                                     d_result,
                                     cuda::std::plus<result_type>(),
                                     stream);

--- a/cpp/src/groupby/sort/group_count.cu
+++ b/cpp/src/groupby/sort/group_count.cu
@@ -17,7 +17,6 @@
 #include <cuda/functional>
 #include <cuda/iterator>
 #include <thrust/adjacent_difference.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
 namespace cudf {
@@ -52,7 +51,7 @@ std::unique_ptr<column> group_count_valid(column_view const& values,
     cudf::detail::reduce_by_key_async(group_labels.begin(),
                                       group_labels.end(),
                                       bitmask_iterator,
-                                      thrust::make_discard_iterator(),
+                                      cuda::make_discard_iterator(),
                                       result->mutable_view().begin<size_type>(),
                                       cuda::std::plus<size_type>(),
                                       stream);
@@ -60,7 +59,7 @@ std::unique_ptr<column> group_count_valid(column_view const& values,
     cudf::detail::reduce_by_key_async(group_labels.begin(),
                                       group_labels.end(),
                                       cuda::make_constant_iterator(1),
-                                      thrust::make_discard_iterator(),
+                                      cuda::make_discard_iterator(),
                                       result->mutable_view().begin<size_type>(),
                                       cuda::std::plus<size_type>(),
                                       stream);

--- a/cpp/src/groupby/sort/group_m2.cu
+++ b/cpp/src/groupby/sort/group_m2.cu
@@ -19,7 +19,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
-#include <thrust/iterator/discard_iterator.h>
+#include <cuda/iterator>
 #include <thrust/transform.h>
 
 namespace cudf {
@@ -67,7 +67,7 @@ void compute_m2_fn(column_device_view const& values,
   cudf::detail::reduce_by_key_async(group_labels.begin(),
                                     group_labels.end(),
                                     m2_vals.begin(),
-                                    thrust::make_discard_iterator(),
+                                    cuda::make_discard_iterator(),
                                     d_result,
                                     cuda::std::plus<ResultType>(),
                                     stream);

--- a/cpp/src/groupby/sort/group_nth_element.cu
+++ b/cpp/src/groupby/sort/group_nth_element.cu
@@ -19,8 +19,8 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/iterator>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/scatter.h>
@@ -88,7 +88,7 @@ std::unique_ptr<column> group_nth_element(column_view const& values,
         cudf::detail::reduce_by_key_async(group_labels.begin(),
                                           group_labels.end(),
                                           bitmask_iterator,
-                                          thrust::make_discard_iterator(),
+                                          cuda::make_discard_iterator(),
                                           group_count.begin(),
                                           cuda::std::plus<size_type>(),
                                           stream);

--- a/cpp/src/groupby/sort/group_nunique.cu
+++ b/cpp/src/groupby/sort/group_nunique.cu
@@ -14,8 +14,8 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/iterator>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
 namespace cudf {
@@ -115,7 +115,7 @@ std::unique_ptr<column> group_nunique(column_view const& values,
   cudf::detail::reduce_by_key_async(group_labels.begin(),
                                     group_labels.end(),
                                     d_result.begin(),
-                                    thrust::make_discard_iterator(),
+                                    cuda::make_discard_iterator(),
                                     result->mutable_view().begin<size_type>(),
                                     cuda::std::plus<size_type>(),
                                     stream);

--- a/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
+++ b/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
@@ -22,9 +22,9 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/iterator>
 #include <cuda/std/functional>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/reduce.h>
 
 namespace cudf {
@@ -161,7 +161,7 @@ struct group_reduction_functor<
                             group_labels.data(),
                             group_labels.data() + group_labels.size(),
                             inp_iter,
-                            thrust::make_discard_iterator(),
+                            cuda::make_discard_iterator(),
                             out_iter,
                             cuda::std::equal_to{},
                             binop);
@@ -224,7 +224,7 @@ struct group_reduction_functor<
                             group_labels.data(),
                             group_labels.data() + group_labels.size(),
                             inp_iter,
-                            thrust::make_discard_iterator(),
+                            cuda::make_discard_iterator(),
                             out_iter,
                             cuda::std::equal_to{},
                             binop);

--- a/cpp/src/groupby/sort/group_std.cu
+++ b/cpp/src/groupby/sort/group_std.cu
@@ -21,9 +21,9 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/iterator>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/transform.h>
 
@@ -81,7 +81,7 @@ void reduce_by_key_fn(column_device_view const& values,
   cudf::detail::reduce_by_key_async(group_labels.begin(),
                                     group_labels.end(),
                                     vars.begin(),
-                                    thrust::make_discard_iterator(),
+                                    cuda::make_discard_iterator(),
                                     d_result,
                                     cuda::std::plus<ResultType>(),
                                     stream);

--- a/cpp/src/io/fst/agent_dfa.cuh
+++ b/cpp/src/io/fst/agent_dfa.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -8,10 +8,10 @@
 
 #include <cub/cub.cuh>
 #include <cuda/functional>
+#include <cuda/iterator>
 #include <cuda/std/array>
 #include <cuda/std/type_traits>
 #include <thrust/execution_policy.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/sequence.h>
 
 namespace cudf::io::fst::detail {
@@ -772,9 +772,9 @@ __launch_bounds__(int32_t(AgentDFAPolicy::BLOCK_THREADS)) CUDF_KERNEL
   // static constexpr int32_t MIN_TRANSLATED_OUT = DfaT::MIN_TRANSLATED_OUT;
   static constexpr int32_t num_max_translated_out = DfaT::MAX_TRANSLATED_OUT;
   static constexpr bool discard_out_index =
-    ::cuda::std::is_same<TransducedIndexOutItT, thrust::discard_iterator<>>::value;
+    ::cuda::std::is_same<TransducedIndexOutItT, cuda::discard_iterator>::value;
   static constexpr bool discard_out_it =
-    ::cuda::std::is_same<TransducedOutItT, thrust::discard_iterator<>>::value;
+    ::cuda::std::is_same<TransducedOutItT, cuda::discard_iterator>::value;
   using NonWriteCoalescingT =
     DFAWriteCallbackWrapper<num_max_translated_out,
                             decltype(dfa.InitTranslationTable(transducer_table_storage)),

--- a/cpp/src/io/json/json_column.cu
+++ b/cpp/src/io/json/json_column.cu
@@ -24,10 +24,10 @@
 
 #include <cuda/atomic>
 #include <cuda/functional>
+#include <cuda/iterator>
 #include <cuda/std/utility>
 #include <thrust/for_each.h>
 #include <thrust/gather.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>
@@ -157,7 +157,7 @@ reduce_to_column_tree(tree_meta_t const& tree,
                              sorted_col_ids.begin(),
                              sorted_col_ids.end(),
                              ordered_node_ids.begin(),
-                             thrust::make_discard_iterator(),
+                             cuda::make_discard_iterator(),
                              unique_node_ids.begin());
 
   thrust::copy_n(

--- a/cpp/src/io/json/json_normalization.cu
+++ b/cpp/src/io/json/json_normalization.cu
@@ -24,7 +24,6 @@
 #include <cuda/std/iterator>
 #include <thrust/binary_search.h>
 #include <thrust/gather.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/remove.h>
 
@@ -313,7 +312,7 @@ void normalize_single_quotes(datasource::owning_buffer<rmm::device_buffer>& inda
   parser.Transduce(reinterpret_cast<SymbolT const*>(indata.data()),
                    static_cast<SymbolOffsetT>(indata.size()),
                    static_cast<SymbolT*>(outbuf.data()),
-                   thrust::make_discard_iterator(),
+                   cuda::make_discard_iterator(),
                    outbuf_size.data(),
                    normalize_quotes::start_state,
                    stream);
@@ -397,7 +396,7 @@ std::
   cudf::detail::device_scalar<SymbolOffsetT> outbuf_indices_size(stream, mr);
   parser.Transduce(inbuf.data(),
                    static_cast<SymbolOffsetT>(inbuf.size()),
-                   thrust::make_discard_iterator(),
+                   cuda::make_discard_iterator(),
                    outbuf_indices.data(),
                    outbuf_indices_size.data(),
                    normalize_whitespace::start_state,

--- a/cpp/src/io/json/json_tree.cu
+++ b/cpp/src/io/json/json_tree.cu
@@ -34,7 +34,6 @@
 #include <thrust/fill.h>
 #include <thrust/gather.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
@@ -558,7 +557,7 @@ std::pair<size_t, rmm::device_uvector<size_type>> remapped_field_nodes_after_uni
   key_set.insert_and_find_async(counting_iter,
                                 counting_iter + num_keys,
                                 found_keys.begin(),
-                                thrust::make_discard_iterator(),
+                                cuda::make_discard_iterator(),
                                 stream.value());
   // set.size will synchronize the stream before return.
   return {key_set.size(stream), std::move(found_keys)};

--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -27,9 +27,9 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/iterator>
 #include <cuda/std/iterator>
 #include <cuda/std/tuple>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform.h>
@@ -1456,8 +1456,8 @@ void get_stack_context(device_span<SymbolT const> json_in,
   // Run FST to estimate the sizes of translated buffers
   json_to_stack_ops_fst.Transduce(json_in.begin(),
                                   static_cast<SymbolOffsetT>(json_in.size()),
-                                  thrust::make_discard_iterator(),
-                                  thrust::make_discard_iterator(),
+                                  cuda::make_discard_iterator(),
+                                  cuda::make_discard_iterator(),
                                   d_num_stack_ops.data(),
                                   to_stack_op::start_state,
                                   stream);
@@ -1473,7 +1473,7 @@ void get_stack_context(device_span<SymbolT const> json_in,
                                   static_cast<SymbolOffsetT>(json_in.size()),
                                   stack_ops.data(),
                                   stack_op_indices.data(),
-                                  thrust::make_discard_iterator(),
+                                  cuda::make_discard_iterator(),
                                   to_stack_op::start_state,
                                   stream);
 
@@ -1535,7 +1535,7 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> pr
     cuda::std::make_reverse_iterator(
       thrust::make_zip_iterator(filtered_tokens_out.data(), filtered_token_indices_out.data()) +
       tokens.size()),
-    thrust::make_discard_iterator(),
+    cuda::make_discard_iterator(),
     d_num_selected_tokens.data(),
     token_filter::start_state,
     stream);
@@ -1608,8 +1608,8 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
     fix_stack_of_excess_chars.Transduce(zip_in,
                                         static_cast<SymbolOffsetT>(json_in.size()),
                                         stack_symbols.data(),
-                                        thrust::make_discard_iterator(),
-                                        thrust::make_discard_iterator(),
+                                        cuda::make_discard_iterator(),
+                                        cuda::make_discard_iterator(),
                                         fix_stack_of_excess_chars::start_state,
                                         stream);
 
@@ -1646,8 +1646,8 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
   // Run FST to estimate the size of output buffers
   json_to_tokens_fst.Transduce(zip_in,
                                static_cast<SymbolOffsetT>(json_in.size()),
-                               thrust::make_discard_iterator(),
-                               thrust::make_discard_iterator(),
+                               cuda::make_discard_iterator(),
+                               cuda::make_discard_iterator(),
                                num_written_tokens.data(),
                                tokenizer_pda::start_state,
                                stream);
@@ -1661,7 +1661,7 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
                                static_cast<SymbolOffsetT>(json_in.size()),
                                tokens.data() + delimiter_offset,
                                tokens_indices.data() + delimiter_offset,
-                               thrust::make_discard_iterator(),
+                               cuda::make_discard_iterator(),
                                tokenizer_pda::start_state,
                                stream);
 

--- a/cpp/src/io/parquet/experimental/hybrid_scan_chunking.cu
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_chunking.cu
@@ -18,9 +18,9 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/iterator>
 #include <thrust/binary_search.h>
 #include <thrust/host_vector.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/transform_scan.h>
 
 #include <numeric>

--- a/cpp/src/io/parquet/page_enc.cu
+++ b/cpp/src/io/parquet/page_enc.cu
@@ -23,6 +23,7 @@
 
 #include <cooperative_groups.h>
 #include <cub/cub.cuh>
+#include <cuda/iterator>
 #include <cuda/std/chrono>
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
@@ -31,7 +32,6 @@
 #include <cuda/std/utility>
 #include <thrust/binary_search.h>
 #include <thrust/gather.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/merge.h>

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -22,7 +22,6 @@
 #include <cub/device/device_radix_sort.cuh>
 #include <cuda/iterator>
 #include <thrust/binary_search.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/sequence.h>
 #include <thrust/transform_scan.h>
 #include <thrust/unique.h>
@@ -320,7 +319,7 @@ adjust_cumulative_sizes(device_span<cumulative_page_info const> c_info,
   auto const key_offsets_end = cudf::detail::reduce_by_key(page_keys,
                                                            page_keys + pages.size(),
                                                            cuda::make_constant_iterator(1),
-                                                           thrust::make_discard_iterator(),
+                                                           cuda::make_discard_iterator(),
                                                            key_offsets.begin(),
                                                            cuda::std::plus<>{},
                                                            stream)
@@ -656,7 +655,7 @@ void detect_malformed_pages(device_span<PageInfo const> pages,
   auto const row_counts_end   = cudf::detail::reduce_by_key(page_keys,
                                                           page_keys + pages.size(),
                                                           size_iter,
-                                                          thrust::make_discard_iterator(),
+                                                          cuda::make_discard_iterator(),
                                                           row_counts_begin,
                                                           cuda::std::plus<>{},
                                                           stream)

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -19,8 +19,8 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/iterator>
 #include <thrust/fill.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
@@ -1007,7 +1007,7 @@ void reader_impl::allocate_columns(read_mode mode, size_t skip_rows, size_t num_
       cudf::detail::reduce_by_key(reduction_keys,
                                   reduction_keys + num_keys_this_iter,
                                   size_input.cbegin(),
-                                  thrust::make_discard_iterator(),
+                                  cuda::make_discard_iterator(),
                                   sizes.d_begin() + (key_start / subpass.pages.size()),
                                   cuda::std::plus<>{},
                                   _stream);

--- a/cpp/src/io/parquet/reader_impl_preprocess_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess_utils.cu
@@ -20,7 +20,6 @@
 #include <cuda/iterator>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/sequence.h>
@@ -571,7 +570,7 @@ void decode_page_headers(pass_intermediate_data& pass,
   auto const page_counts_end = cudf::detail::reduce_by_key(page_keys,
                                                            page_keys + pass.pages.size(),
                                                            cuda::make_constant_iterator(1),
-                                                           thrust::make_discard_iterator(),
+                                                           cuda::make_discard_iterator(),
                                                            page_counts.begin(),
                                                            cuda::std::plus<>{},
                                                            stream)

--- a/cpp/src/join/hash_join.cu
+++ b/cpp/src/join/hash_join.cu
@@ -31,7 +31,6 @@
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/scatter.h>
 #include <thrust/uninitialized_fill.h>
@@ -454,7 +453,7 @@ std::size_t get_full_join_size(
                               iter + probe_table_num_rows,
                               equality,
                               hash_table.hash_function(),
-                              thrust::make_discard_iterator(),
+                              cuda::make_discard_iterator(),
                               out_build_begin,
                               stream.value());
   } else {
@@ -470,7 +469,7 @@ std::size_t get_full_join_size(
                                 iter + probe_table_num_rows,
                                 equality,
                                 hash_table.hash_function(),
-                                thrust::make_discard_iterator(),
+                                cuda::make_discard_iterator(),
                                 out_build_begin,
                                 stream.value());
     };

--- a/cpp/src/lists/combine/concatenate_rows.cu
+++ b/cpp/src/lists/combine/concatenate_rows.cu
@@ -20,8 +20,8 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/iterator>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 
@@ -104,7 +104,7 @@ generate_regrouped_offsets_and_null_mask(table_device_view const& input,
   cudf::detail::reduce_by_key_async(keys,
                                     keys + (input.num_rows() * input.num_columns()),
                                     values,
-                                    thrust::make_discard_iterator(),
+                                    cuda::make_discard_iterator(),
                                     offsets->mutable_view().begin<size_type>(),
                                     cuda::std::plus<size_type>(),
                                     stream);
@@ -169,7 +169,7 @@ rmm::device_uvector<size_type> generate_null_counts(table_device_view const& inp
   cudf::detail::reduce_by_key_async(keys,
                                     keys + (input.num_rows() * input.num_columns()),
                                     null_values,
-                                    thrust::make_discard_iterator(),
+                                    cuda::make_discard_iterator(),
                                     null_counts.data(),
                                     cuda::std::plus<size_type>(),
                                     stream);

--- a/cpp/src/lists/dremel.cu
+++ b/cpp/src/lists/dremel.cu
@@ -24,7 +24,6 @@
 #include <thrust/gather.h>
 #include <thrust/host_vector.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 
 #include <functional>
@@ -324,7 +323,7 @@ dremel_data get_encoding(column_view h_col,
                                      thrust::make_counting_iterator(column_ends[level + 1]),
                                      input_parent_zip_it,
                                      input_child_zip_it,
-                                     thrust::make_discard_iterator(),
+                                     cuda::make_discard_iterator(),
                                      output_zip_it);
 
     curr_rep_values_size = ends.second - output_zip_it;
@@ -411,7 +410,7 @@ dremel_data get_encoding(column_view h_col,
                                      thrust::make_counting_iterator(curr_rep_values_size),
                                      input_parent_zip_it,
                                      input_child_zip_it,
-                                     thrust::make_discard_iterator(),
+                                     cuda::make_discard_iterator(),
                                      output_zip_it);
 
     curr_rep_values_size = ends.second - output_zip_it;

--- a/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
+++ b/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
@@ -34,7 +34,6 @@
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/merge.h>
@@ -1042,16 +1041,16 @@ std::unique_ptr<column> compute_tdigests(int delta,
 
   // reduce the centroids into the clusters
   auto output = thrust::make_zip_iterator(cuda::std::make_tuple(
-    mean_col.begin<double>(), weight_col.begin<double>(), thrust::make_discard_iterator()));
+    mean_col.begin<double>(), weight_col.begin<double>(), cuda::make_discard_iterator()));
 
   auto const num_values = std::distance(centroids_begin, centroids_end);
   thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
                         keys,
-                        keys + num_values,                // keys
-                        centroids_begin,                  // values
-                        thrust::make_discard_iterator(),  // key output
-                        output,                           // output
-                        cuda::std::equal_to{},            // key equality check
+                        keys + num_values,              // keys
+                        centroids_begin,                // values
+                        cuda::make_discard_iterator(),  // key output
+                        output,                         // output
+                        cuda::std::equal_to{},          // key equality check
                         merge_centroids{});
 
   // generate offsets column. if we are running in the simple case, cinfo.cluster_start will not
@@ -1447,7 +1446,7 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
                         group_labels,
                         group_labels + num_group_labels,
                         min_iter,
-                        thrust::make_discard_iterator(),
+                        cuda::make_discard_iterator(),
                         merged_min_col->mutable_view().begin<double>(),
                         cuda::std::equal_to{},  // key equality check
                         cuda::minimum{});
@@ -1462,7 +1461,7 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
                         group_labels,
                         group_labels + num_group_labels,
                         max_iter,
-                        thrust::make_discard_iterator(),
+                        cuda::make_discard_iterator(),
                         merged_max_col->mutable_view().begin<double>(),
                         cuda::std::equal_to{},  // key equality check
                         cuda::maximum{});

--- a/cpp/src/sort/rank.cu
+++ b/cpp/src/sort/rank.cu
@@ -22,10 +22,10 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
+#include <cuda/iterator>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
@@ -131,7 +131,7 @@ void tie_break_ranks_transform(cudf::device_span<size_type const> dense_rank_sor
                         dense_rank_sorted.begin(),
                         dense_rank_sorted.end(),
                         tie_iter,
-                        thrust::make_discard_iterator(),
+                        cuda::make_discard_iterator(),
                         tie_sorted.begin(),
                         cuda::std::equal_to{},
                         tie_breaker);

--- a/cpp/src/text/bpe/byte_pair_encoding.cu
+++ b/cpp/src/text/bpe/byte_pair_encoding.cu
@@ -31,7 +31,6 @@
 #include <thrust/copy.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
 #include <thrust/merge.h>
 #include <thrust/remove.h>
 #include <thrust/unique.h>
@@ -435,7 +434,7 @@ std::unique_ptr<cudf::column> byte_pair_encoding(cudf::strings_column_view const
                        chars_end,      //
                        sep_char,       // byte to insert
                        d_input_chars,  // original data
-                       thrust::make_discard_iterator(),
+                       cuda::make_discard_iterator(),
                        d_chars);  // result
 
   return cudf::make_strings_column(input.size(),


### PR DESCRIPTION
## Description
Replaces the `thrust::make_discard_iterator` with `cuda::make_discard_iterator` in the libcudf source files.

There are still 2 files that do not compile when `thrust::make_discard_iterator` is replaced with  `cuda::make_discard_iterator`.
Opened a CCCL issue to look into it: https://github.com/NVIDIA/cccl/issues/7783


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
