### PR TITLE
Use ``--rmm-release-threshold`` for both single- and multi-gpu benchmarks

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -1013,8 +1013,8 @@ def build_parser(num_queries: int = 22) -> argparse.ArgumentParser:
         default=None,
         type=float,
         help=textwrap.dedent("""\
-            Passed to dask_cuda.LocalCUDACluster to control the release
-            threshold for RMM pool memory.
+            Passed to dask_cuda.LocalCUDACluster or CudaAsyncMemoryResource
+            to control the release threshold for RMM pool memory.
             Default: None (no release threshold)"""),
     )
     parser.add_argument(
@@ -1327,7 +1327,9 @@ def run_polars(
             parquet_options = {}
         engine = pl.GPUEngine(
             raise_on_fail=True,
-            memory_resource=rmm.mr.CudaAsyncMemoryResource()
+            memory_resource=rmm.mr.CudaAsyncMemoryResource(
+                release_threshold=args.rmm_release_threshold
+            )
             if run_config.rmm_async
             else None,
             cuda_stream_policy=run_config.stream_policy,


### PR DESCRIPTION
## Description
Both single- and multi-GPU execution can benefit from the `--rmm-release-threshold` argument. This argument was previously ignored for the the `--cluster single` case.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
