### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING
 
 with contextlib.suppress(ImportError):
     from cudf_polars.experimental.benchmarks.utils import (
+        build_parser,
+        parse_args,
         run_duckdb,
         run_polars,
     )
@@ -84,20 +86,18 @@ class PDSDSDuckDBQueries(PDSDSQueries):
 
 
 if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Run PDS-DS benchmarks.")
+    parser = build_parser(num_queries=99)
     parser.add_argument(
         "--engine",
         choices=["polars", "duckdb"],
         default="polars",
         help="Which engine to use for executing the benchmarks or to validate results.",
     )
-    args, extra_args = parser.parse_known_args()
+    args = parse_args(parser=parser)
 
     if args.engine == "polars":
-        run_polars(PDSDSPolarsQueries, extra_args, num_queries=99)
+        run_polars(PDSDSPolarsQueries, args, num_queries=99)
     elif args.engine == "duckdb":
-        run_duckdb(PDSDSDuckDBQueries, extra_args, num_queries=99)
+        run_duckdb(PDSDSDuckDBQueries, args, num_queries=99)
     else:
         raise ValueError(f"Invalid engine: {args.engine}")

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
@@ -24,7 +24,9 @@ import polars as pl
 with contextlib.suppress(ImportError):
     from cudf_polars.experimental.benchmarks.utils import (
         RunConfig,
+        build_parser,
         get_data,
+        parse_args,
         run_duckdb,
         run_polars,
     )
@@ -1809,20 +1811,18 @@ class PDSHDuckDBQueries:
 
 
 if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Run PDS-H benchmarks.")
+    parser = build_parser(num_queries=22)
     parser.add_argument(
         "--engine",
         choices=["polars", "duckdb"],
         default="polars",
         help="Which engine to use for executing the benchmarks or to validate results.",
     )
-    args, extra_args = parser.parse_known_args()
+    args = parse_args(parser=parser)
 
     if args.engine == "polars":
-        run_polars(PDSHQueries, extra_args, num_queries=22)
+        run_polars(PDSHQueries, args, num_queries=22)
     elif args.engine == "duckdb":
-        run_duckdb(PDSHDuckDBQueries, extra_args, num_queries=22)
+        run_duckdb(PDSHDuckDBQueries, args, num_queries=22)
     else:
         raise ValueError(f"Invalid engine: {args.engine}")

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -820,10 +820,8 @@ def _query_type(num_queries: int) -> Callable[[str | int], list[int]]:
     return parse
 
 
-def parse_args(
-    args: Sequence[str] | None = None, num_queries: int = 22
-) -> argparse.Namespace:
-    """Parse command line arguments."""
+def build_parser(num_queries: int = 22) -> argparse.ArgumentParser:
+    """Build the argument parser for PDS-H/PDS-DS benchmarks."""
     parser = argparse.ArgumentParser(
         prog="Cudf-Polars PDS-H Benchmarks",
         description="Experimental streaming-executor benchmarks.",
@@ -1196,6 +1194,17 @@ def parse_args(
             - silent : Silently fall back to single partition"""),
     )
 
+    return parser
+
+
+def parse_args(
+    args: Sequence[str] | None = None,
+    num_queries: int = 22,
+    parser: argparse.ArgumentParser | None = None,
+) -> argparse.Namespace:
+    """Parse command line arguments."""
+    if parser is None:
+        parser = build_parser(num_queries)
     parsed_args = parser.parse_args(args)
 
     if parsed_args.rmm_pool_size is None and not parsed_args.rmm_async:
@@ -1284,11 +1293,10 @@ def check_input_data_type(run_config: RunConfig) -> Literal["decimal", "float"]:
 
 def run_polars(
     benchmark: Any,
-    options: Sequence[str] | None = None,
+    args: argparse.Namespace,
     num_queries: int = 22,
 ) -> None:
     """Run the queries using the given benchmark and executor options."""
-    args = parse_args(options, num_queries=num_queries)
     vars(args).update({"query_set": benchmark.name})
     run_config = RunConfig.from_args(args)
     validation_failures: list[int] = []
@@ -1713,10 +1721,9 @@ def execute_duckdb_query(
 
 
 def run_duckdb(
-    duckdb_queries_cls: Any, options: Sequence[str] | None = None, *, num_queries: int
+    duckdb_queries_cls: Any, args: argparse.Namespace, *, num_queries: int
 ) -> None:
     """Run the benchmark with DuckDB."""
-    args = parse_args(options, num_queries=num_queries)
     vars(args).update({"query_set": duckdb_queries_cls.name})
     run_config = RunConfig.from_args(args)
     records: defaultdict[int, list[Record]] = defaultdict(list)


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.