### PR TITLE
rapidsmpf compatibility in unspill_partitions

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/shuffle.py
@@ -121,7 +121,6 @@ class RMPFIntegration:  # pragma: no cover
                     shuffler.extract(partition_id),
                     br=context.br,
                     allow_overbooking=True,
-                    statistics=context.statistics,
                 ),
                 br=context.br,
                 stream=DEFAULT_STREAM,

--- a/python/cudf_polars/cudf_polars/experimental/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/sort.py
@@ -386,7 +386,6 @@ class RMPFIntegrationSortedShuffle:  # pragma: no cover
                     shuffler.extract(partition_id),
                     br=context.br,
                     allow_overbooking=True,
-                    statistics=context.statistics,
                 ),
                 br=context.br,
                 stream=stream,


### PR DESCRIPTION
## Description

https://github.com/rapidsai/rapidsmpf/pull/871 removed the `statistics` argument from `unspill_partitions`.