### PR TITLE
Handle edge case dectection in pds-h validation

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/asserts.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/asserts.py
@@ -203,8 +203,6 @@ def assert_tpch_result_equal(
         # result:   [ [a, b, c], [d, d + epsilon] ]
         # expected: [ [a, b, c], [d - epsilon, d] ]
 
-        sort_by_cols, sort_by_descending = zip(*sort_by, strict=True)
-
         sort_by_descending_list = list(sort_by_descending)
         (split_at,) = (
             left.select(sort_by_cols)

--- a/python/cudf_polars/tests/testing/test_asserts.py
+++ b/python/cudf_polars/tests/testing/test_asserts.py
@@ -218,12 +218,6 @@ def test_assert_tpch_result_equal_split_at_lexicographic_not_per_column_max() ->
 
 
 def test_assert_tpch_result_equal_split_at_ascending_so_lt_is_valid() -> None:
-    """With ORDER BY a DESC, .lt(split_at_val) is wrong for the 'before' filter.
-
-    We must use the query's sort order for split_at and .lt/.gt per column so
-    \"strictly before\" is correct. Here left and right differ in the non-tie
-    row (2,b) vs (2,c); we must raise ValidationError.
-    """
     left = pl.DataFrame({"a": [3, 2, 1], "c": ["a", "b", "x"]})
     right = pl.DataFrame({"a": [3, 2, 1], "c": ["a", "c", "x"]})
     with pytest.raises(ValidationError, match="Result mismatch in non-ties part"):
@@ -236,12 +230,6 @@ def test_assert_tpch_result_equal_split_at_ascending_so_lt_is_valid() -> None:
 
 
 def test_assert_tpch_result_equal_split_at_uses_query_order_mixed_asc_desc() -> None:
-    """With ORDER BY a DESC, b ASC, ascending-only split_at gives the wrong row.
-
-    Rows (3,1), (3,2), (2,3). Query order last = (2,3); ascending last = (3,2).
-    Left and right differ only in (3,2) (c='b' vs 'X'). We must raise.
-    With ascending-only split_at we put (3,2) in ties and falsely pass.
-    """
     left = pl.DataFrame({"a": [3, 3, 2], "b": [1, 2, 3], "c": ["a", "b", "c"]})
     right = pl.DataFrame({"a": [3, 3, 2], "b": [1, 2, 3], "c": ["a", "X", "c"]})
     with pytest.raises(ValidationError, match="Result mismatch in non-ties part"):


### PR DESCRIPTION
## Description

This fixes some edge cases in our pds-h benchmark validation.

As a reminder, different engines might have non-material differences in things like sort stability, which makes simply comparing two dataframes too strict. Our validation handles this by computing a "split point" which partitions the result and expected dataframes into two parts:

1. All parts less than the largest value of the `sort_by` column
2. All parts equal to the largest value of the `sort_by` column

This worked well for some queries, but failed to handle floating-point precision issues. For example, suppose you have two dataframes:

```
result  : [a, b, c, d, d+ε]
expected: [a, b, c, d-ε, d]
```

And we do a `sort_by` / `limit` on that column.

So long as $\epsilon$ is less than our abs_tol for equality, these two should be considered equal. Our split point detection failed to account for this though. Our split logic is based on `result`, we'd use $d + \epsilon$ as the split point, resulting in `[ [first_part], [ties_part] ]` partitions like:

```
result:   [ [a, b, c, d],      [d+ε] ]
expected: [ [a, b, c, d-ε, d], []    ]
```

This PR updates how we do splitting to handle this case. We'll still use the max(result), $d + \epsilon$ as the split point. But when considering "ties" equal to that point in `result` and `expected`, we'll consider anything closer than $\lvert \frac{\epsilon}{2} \rvert$ of the split point as equal, and thus in the ties part. (I haven't actually worked through the math on whether to use $\epsilon$ or $\frac{\epsilon}{2}$ yet...)
