### PR TITLE
Add stream parameter to indexalator make_input_optional_iterator

### DIFF
--- a/cpp/src/dictionary/replace.cu
+++ b/cpp/src/dictionary/replace.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -125,11 +125,11 @@ std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
 
   // now build the new indices by doing replace-null on the updated indices
   auto const input_indices = input_view.get_indices_annotated();
-  auto new_indices =
-    replace_indices(input_indices,
-                    cudf::detail::indexalator_factory::make_input_optional_iterator(*scalar_index),
-                    stream,
-                    mr);
+  auto new_indices         = replace_indices(
+    input_indices,
+    cudf::detail::indexalator_factory::make_input_optional_iterator(*scalar_index, stream),
+    stream,
+    mr);
   new_indices->set_null_mask(rmm::device_buffer{0, stream, mr}, 0);
 
   return make_dictionary_column(

--- a/cpp/tests/iterator/indexalator_test.cu
+++ b/cpp/tests/iterator/indexalator_test.cu
@@ -42,29 +42,6 @@ TYPED_TEST(IndexalatorTest, input_iterator)
   this->iterator_test_thrust(expected_values, it_dev, host_values.size());
 }
 
-TYPED_TEST(IndexalatorTest, pair_iterator)
-{
-  using T = TypeParam;
-
-  auto host_values = cudf::test::make_type_param_vector<T>({0, 6, 0, -14, 13, 64, -13, -120, 115});
-  auto validity    = std::vector<bool>({0, 1, 1, 1, 1, 1, 0, 1, 1});
-
-  auto d_col = cudf::test::fixed_width_column_wrapper<T>(
-    host_values.begin(), host_values.end(), validity.begin());
-
-  auto expected_values =
-    thrust::host_vector<cuda::std::pair<cudf::size_type, bool>>(host_values.size());
-  std::transform(
-    host_values.begin(),
-    host_values.end(),
-    validity.begin(),
-    expected_values.begin(),
-    [](T v, bool b) { return cuda::std::make_pair(static_cast<cudf::size_type>(v), b); });
-
-  auto it_dev = cudf::detail::indexalator_factory::make_input_pair_iterator(d_col);
-  this->iterator_test_thrust(expected_values, it_dev, host_values.size());
-}
-
 TYPED_TEST(IndexalatorTest, optional_iterator)
 {
   using T = TypeParam;


### PR DESCRIPTION
## Description
Adds `stream` parameter to `indexalator::make_input_optional_iterator` scalar utility function.
The stream is needed to call the `is_valid()` function on the given scalar.
Also removes the `indexalator::make_input_pair_iterator` and its gtest since it is not used and basically the same as the `make_input_optional_iterator`

Addresses some of https://github.com/rapidsai/cudf/issues/21530

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
