### PR TITLE
Use new modules for RMM CudaStreamFlags

### DIFF
--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -30,8 +30,7 @@ import os
 import warnings
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
-from rmm.pylibrmm.cuda_stream import CudaStreamFlags
-from rmm.pylibrmm.cuda_stream_pool import CudaStreamPool
+from rmm.pylibrmm import CudaStreamFlags, CudaStreamPool
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -776,7 +776,7 @@ def test_cuda_stream_policy_from_config(*, rapidsmpf_single_available: bool) -> 
         executor_options={"runtime": "rapidsmpf"},
         cuda_stream_policy={
             "pool_size": 32,
-            "flags": rmm.pylibrmm.cuda_stream.CudaStreamFlags.NON_BLOCKING,
+            "flags": rmm.pylibrmm.CudaStreamFlags.NON_BLOCKING,
         },
     )
     if rapidsmpf_single_available:
@@ -784,8 +784,7 @@ def test_cuda_stream_policy_from_config(*, rapidsmpf_single_available: bool) -> 
         assert isinstance(config.cuda_stream_policy, CUDAStreamPoolConfig)
         assert config.cuda_stream_policy.pool_size == 32
         assert (
-            config.cuda_stream_policy.flags
-            == rmm.pylibrmm.cuda_stream.CudaStreamFlags.NON_BLOCKING
+            config.cuda_stream_policy.flags == rmm.pylibrmm.CudaStreamFlags.NON_BLOCKING
         )
         config.cuda_stream_policy.build().get_stream()  # no exception
     else:
@@ -841,10 +840,7 @@ def test_cuda_stream_policy_default_rapidsmpf(monkeypatch: pytest.MonkeyPatch) -
     )
     assert isinstance(config.cuda_stream_policy, CUDAStreamPoolConfig)
     assert config.cuda_stream_policy.pool_size == 16
-    assert (
-        config.cuda_stream_policy.flags
-        == rmm.pylibrmm.cuda_stream.CudaStreamFlags.NON_BLOCKING
-    )
+    assert config.cuda_stream_policy.flags == rmm.pylibrmm.CudaStreamFlags.NON_BLOCKING
 
     # "new" user argument
     monkeypatch.setenv("CUDF_POLARS__CUDA_STREAM_POLICY", "new")


### PR DESCRIPTION
## Description
Fixes a deprecation warning from RMM.

```
DeprecationWarning: rmm.pylibrmm.cuda_stream is deprecated; use rmm.pylibrmm.stream.CudaStreamFlags for stream flags, and rmm.pylibrmm.stream.Stream for stream objects.
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
