### PR TITLE
Skip scan decimal introspection logic when there are no decimals in the schema

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -390,6 +390,20 @@ def _cast_literals_to_physical_types(
     return node
 
 
+def _prepare_parquet_predicate(
+    predicate: expr.Expr,
+    paths: list[str],
+    schema: Schema,
+    columns: list[str] | None,
+) -> expr.Expr:
+    cols = columns or list(schema.keys())
+    if any(isinstance(schema[c].polars_type, pl.Decimal) for c in cols if c in schema):
+        return _cast_literals_to_physical_types(
+            predicate, _parquet_physical_types(paths, cols)
+        )
+    return predicate
+
+
 def _align_parquet_schema(df: DataFrame, schema: Schema) -> DataFrame:
     # TODO: Alternatively set the schema of the parquet reader to decimal128
     cast_list = []
@@ -815,11 +829,8 @@ class Scan(IR):
             if predicate is not None and row_index is None:
                 # Can't apply filters during read if we have a row index.
                 filters = to_parquet_filter(
-                    _cast_literals_to_physical_types(
-                        predicate.value,
-                        _parquet_physical_types(
-                            paths, with_columns or list(schema.keys())
-                        ),
+                    _prepare_parquet_predicate(
+                        predicate.value, paths, schema, with_columns
                     ),
                     stream=stream,
                 )

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/io.py
@@ -24,8 +24,7 @@ from cudf_polars.dsl.ir import (
     DataFrameScan,
     Scan,
     Sink,
-    _cast_literals_to_physical_types,
-    _parquet_physical_types,
+    _prepare_parquet_predicate,
 )
 from cudf_polars.dsl.to_ast import to_parquet_filter
 from cudf_polars.experimental.base import (
@@ -591,12 +590,8 @@ def make_rapidsmpf_read_parquet_node(
         filter_obj = None
         if ir.predicate is not None:
             filter_expr = to_parquet_filter(
-                _cast_literals_to_physical_types(
-                    ir.predicate.value,
-                    _parquet_physical_types(
-                        ir.paths,
-                        ir.with_columns or list(ir.schema.keys()),
-                    ),
+                _prepare_parquet_predicate(
+                    ir.predicate.value, ir.paths, ir.schema, ir.with_columns
                 ),
                 stream=stream,
             )


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Small optimization that skips the parquet metadata read used to prepare the filter predicate when decimals exists when there are no decimals in the schema.
- Closes https://github.com/rapidsai/cudf/issues/20214
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
