### PR TITLE
Allow DatetimeIndex with freq in as_column

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -3209,7 +3209,7 @@ def as_column(
             )
         elif (
             cudf.get_option("mode.pandas_compatible")
-            and isinstance(arbitrary, (pd.DatetimeIndex, pd.TimedeltaIndex))
+            and isinstance(arbitrary, pd.TimedeltaIndex)
             and arbitrary.freq is not None
         ):
             raise NotImplementedError("freq is not implemented yet")

--- a/python/cudf/cudf/tests/indexes/index/test_constructor.py
+++ b/python/cudf/cudf/tests/indexes/index/test_constructor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import re
@@ -219,8 +219,11 @@ def test_index_mixed_dtype_error(data):
 def test_index_date_duration_freq_error(cls):
     s = cls([1, 2, 3], freq="infer")
     with cudf.option_context("mode.pandas_compatible", True):
-        with pytest.raises(NotImplementedError):
-            cudf.Index(s)
+        if cls is pd.TimedeltaIndex:
+            with pytest.raises(NotImplementedError):
+                cudf.Index(s)
+        else:
+            assert_eq(cudf.Index(s), s)
 
 
 def test_index_empty_from_pandas(all_supported_types_as_str):


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
After #18778 we should support allow this. This change results in a large number of changes to conftest-patch.py that require a variety of fixes and improvements. Rather than bundle those all into one PR, this PR just flips the switch so that downstream PRs can actually fix the outstanding issues.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
