### PR TITLE
Usage of `template` keyword required for some nvcc and gcc combinations

### DIFF
--- a/cpp/tests/iterator/optional_iterator_test.cuh
+++ b/cpp/tests/iterator/optional_iterator_test.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -67,20 +67,22 @@ void null_optional_iterator(IteratorTest<T>& testFixture)
                  [](auto s, bool b) { return cuda::std::optional<T>{s}; });
 
   // GPU test for correct null mapping
-  testFixture.iterator_test_thrust(
-    optional_values, d_col->optional_begin<T>(cudf::nullate::DYNAMIC{true}), host_values.size());
+  testFixture.iterator_test_thrust(optional_values,
+                                   d_col->template optional_begin<T>(cudf::nullate::DYNAMIC{true}),
+                                   host_values.size());
 
   testFixture.iterator_test_thrust(
-    optional_values, d_col->optional_begin<T>(cudf::nullate::YES{}), host_values.size());
+    optional_values, d_col->template optional_begin<T>(cudf::nullate::YES{}), host_values.size());
   testFixture.iterator_test_thrust(
-    optional_values, d_col->optional_begin<T>(cudf::nullate::YES{}), host_values.size());
+    optional_values, d_col->template optional_begin<T>(cudf::nullate::YES{}), host_values.size());
 
   // GPU test for ignoring null mapping
-  testFixture.iterator_test_thrust(
-    value_all_valid, d_col->optional_begin<T>(cudf::nullate::DYNAMIC{false}), host_values.size());
+  testFixture.iterator_test_thrust(value_all_valid,
+                                   d_col->template optional_begin<T>(cudf::nullate::DYNAMIC{false}),
+                                   host_values.size());
 
   testFixture.iterator_test_thrust(
-    value_all_valid, d_col->optional_begin<T>(cudf::nullate::NO{}), host_values.size());
+    value_all_valid, d_col->template optional_begin<T>(cudf::nullate::NO{}), host_values.size());
   testFixture.iterator_test_thrust(
-    value_all_valid, d_col->optional_begin<T>(cudf::nullate::NO{}), host_values.size());
+    value_all_valid, d_col->template optional_begin<T>(cudf::nullate::NO{}), host_values.size());
 }


### PR DESCRIPTION
## Description
When compiling with some combinations of nvcc and gcc we will get compiler errors unless we use the `template` keyword when using `optional_begin`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
