### PR TITLE
Make IntervalColumn more agnostic to pandas extension types

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -23,7 +23,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
-from pandas.core.arrays.arrow.extension_types import ArrowIntervalType
 
 import pylibcudf as plc
 from rmm.pylibrmm.stream import DEFAULT_STREAM
@@ -1362,8 +1361,6 @@ class ColumnBase(Serializable, BinaryOperand, Reducible):
                 "yet supported in pyarrow, see: "
                 "https://github.com/apache/arrow/issues/20213"
             )
-        elif isinstance(array.type, ArrowIntervalType):
-            return cudf.core.column.IntervalColumn.from_arrow(array)
         elif pa.types.is_null(array.type):
             # default "empty" type
             array = array.cast(pa.string())

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -5420,7 +5420,7 @@ class IntervalIndex(Index):
 
     @property
     def closed(self) -> Literal["left", "right", "neither", "both"]:
-        return self.dtype.closed
+        return self._column.closed
 
     @property
     def closed_left(self) -> bool:


### PR DESCRIPTION
## Description
Broken off from https://github.com/rapidsai/cudf/pull/21546

With cudf now supporting pandas extension types natively, this PR makes some additional cleanups to make IntervalColumn more agnostic to extension dtype objects in their self.dtype attribute.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
