### PR TITLE
Re-enable `dtype=category` in pandas-3.0 branch

### DIFF
--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -100,6 +100,8 @@ def dtype(arbitrary: Any) -> DtypeObj:
     pd_dtype = pd.api.types.pandas_dtype(arbitrary)  # noqa: TID251
     if isinstance(pd_dtype, PANDAS_NUMPY_DTYPE):
         return dtype(pd_dtype.numpy_dtype)
+    elif isinstance(pd_dtype, pd.CategoricalDtype):
+        return CategoricalDtype(pd_dtype.categories, pd_dtype.ordered)
     elif isinstance(pd_dtype, pd.IntervalDtype):
         return IntervalDtype(pd_dtype.subtype, pd_dtype.closed)
     elif (


### PR DESCRIPTION
## Description
Looks like we somehow removed this capability in `3.0` branch. Enabling it back.
This enables:
```
cudf.Series(dtype='category')
```
`pandas3`:
```
= 3109 failed, 74513 passed, 19466 skipped, 1540 xfailed, 7 errors in 647.34s (0:10:47) =
```
This PR:
```
= 2298 failed, 76141 passed, 19472 skipped, 1554 xfailed in 493.77s (0:08:13) ==
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
