### PR TITLE
Pass timeout-minutes to devcontainer CI job

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -527,6 +527,7 @@ jobs:
       arch: '["amd64", "arm64"]'
       cuda: '["13.1"]'
       node_type: "cpu8"
+      timeout-minutes: 45
       env: |
         SCCACHE_DIST_MAX_RETRIES=inf
         SCCACHE_SERVER_LOG=sccache=debug


### PR DESCRIPTION
## Description
I just encountered a CI job which was already taking +2 hours on the devcontainer job https://github.com/rapidsai/cudf/actions/runs/22506114355/job/65205004852?pr=21607

This workflow has a default `timeout-minutes` of 360 minutes, so this stuck job may have continued to run for 4 more hours.
https://github.com/rapidsai/shared-workflows/blob/main/.github/workflows/build-in-devcontainer.yaml#L36

It appears this job _should_ take 10-20 minutes, so passing 45 minutes should be a conservative limit. Open to suggestions if this limit is too long/short

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
