### PR TITLE
Fix nightly CI failues with numpy 1.26

### DIFF
--- a/python/cudf/cudf/core/_compat.py
+++ b/python/cudf/cudf/core/_compat.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
 import pandas as pd
 from packaging import version
 
@@ -14,6 +13,3 @@ PANDAS_GT_214 = PANDAS_VERSION > version.parse("2.1.4")
 PANDAS_GE_220 = PANDAS_VERSION >= version.parse("2.2.0")
 PANDAS_GE_230 = PANDAS_VERSION >= version.parse("2.3.0")
 PANDAS_LT_300 = PANDAS_VERSION < version.parse("3.0.0")
-
-NUMPY_VERSION = version.parse(np.__version__)
-NUMPY_LT_200 = NUMPY_VERSION < version.parse("2.0.0")

--- a/python/cudf/cudf/tests/dataframe/methods/test_sort_values.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_sort_values.py
@@ -9,11 +9,6 @@ import pytest
 
 import cudf
 from cudf import DataFrame, option_context
-from cudf.core._compat import (
-    NUMPY_LT_200,
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq
 from cudf.testing._utils import assert_exceptions_equal, expect_warning_if
 
@@ -42,13 +37,7 @@ def test_sort_values_nans_pandas_compat():
 
 @pytest.mark.parametrize("index", ["a", "b", ["a", "b"]])
 def test_dataframe_sort_values_ignore_index(index, ignore_index):
-    if (
-        isinstance(index, list)
-        and not ignore_index
-        and (
-            NUMPY_LT_200 or PANDAS_VERSION >= PANDAS_CURRENT_SUPPORTED_VERSION
-        )
-    ):
+    if isinstance(index, list) and not ignore_index:
         pytest.skip(
             reason="Unstable sorting by pandas(numpy): https://github.com/pandas-dev/pandas/issues/57531"
         )
@@ -61,7 +50,7 @@ def test_dataframe_sort_values_ignore_index(index, ignore_index):
     pdf = gdf.to_pandas()
 
     expect = pdf.sort_values(list(pdf.columns), ignore_index=ignore_index)
-    got = gdf.sort_values((gdf.columns), ignore_index=ignore_index)
+    got = gdf.sort_values(list(gdf.columns), ignore_index=ignore_index)
 
     assert_eq(expect, got)
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Fix the nightly CI failures in https://github.com/rapidsai/cudf/actions/runs/22564322982/attempts/1. The binop test only raised a deprecation wanring for numpy < 1.26. And the skip condition for the sort test was relaxed due to a tie breaking issue.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
