### PR TITLE
Log RMM stats at the end of the query

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/tracing.py
+++ b/python/cudf_polars/cudf_polars/dsl/tracing.py
@@ -32,10 +32,13 @@ LOG_TRACES = _HAS_STRUCTLOG and _bool_converter(
     os.environ.get("CUDF_POLARS_LOG_TRACES", "0")
 )
 LOG_MEMORY = LOG_TRACES and _bool_converter(
-    os.environ.get("CUDF_POLARS_LOG_TRACES_MEMORY", "1")
+    os.environ.get("CUDF_POLARS_LOG_TRACES_MEMORY", "0")
 )
 LOG_DATAFRAMES = LOG_TRACES and _bool_converter(
     os.environ.get("CUDF_POLARS_LOG_TRACES_DATAFRAMES", "1")
+)
+LOG_COMPLETION_MEMORY = LOG_TRACES and _bool_converter(
+    os.environ.get("CUDF_POLARS_LOG_TRACES_COMPLETION_MEMORY", "1")
 )
 
 CUDF_POLARS_NVTX_DOMAIN = "cudf_polars"
@@ -218,3 +221,43 @@ def log_do_evaluate(
             return result
 
         return wrapper
+
+
+def log_pipeline_complete() -> None:
+    """
+    Log information about the pipeline completion.
+
+    Notes
+    -----
+    LOG_TRACES must be enabled. This logs at the ``Scope.PLAN`` level.
+    If RMM statistics are enabled, then the current allocation statistics are logged.
+    """
+    if not LOG_TRACES:
+        return
+    else:  # pragma: no cover; requires CUDF_POLARS_LOG_TRACES=1
+        mr = rmm.mr.get_current_device_resource()
+        if isinstance(mr, rmm.mr.StatisticsResourceAdaptor):
+            stats = mr.allocation_counts
+        elif isinstance(mr, rmm.mr.UpstreamResourceAdaptor) and isinstance(
+            upstream_mr := mr.get_upstream(), rmm.mr.StatisticsResourceAdaptor
+        ):
+            stats = upstream_mr.allocation_counts
+        else:
+            stats = None
+
+        log = structlog.get_logger()
+        kwargs: dict[str, Any] = {}
+        if stats:
+            kwargs.update(
+                rmm_current_bytes=stats.current_bytes,
+                rmm_current_count=stats.current_count,
+                rmm_peak_bytes=stats.peak_bytes,
+                rmm_peak_count=stats.peak_count,
+                rmm_total_bytes=stats.total_bytes,
+                rmm_total_count=stats.total_count,
+            )
+        log.info(
+            "Pipeline complete",
+            **kwargs,
+            scope=Scope.PLAN.value,
+        )

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/core.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/core.py
@@ -33,6 +33,7 @@ import cudf_polars.experimental.rapidsmpf.repartition
 import cudf_polars.experimental.rapidsmpf.union  # noqa: F401
 from cudf_polars.containers import DataFrame
 from cudf_polars.dsl.ir import DataFrameScan, IRExecutionContext, Join, Scan, Union
+from cudf_polars.dsl.tracing import log_pipeline_complete
 from cudf_polars.dsl.traversal import CachingVisitor, traversal
 from cudf_polars.experimental.dispatch import lower_ir_node
 from cudf_polars.experimental.rapidsmpf.collectives import ReserveOpIDs
@@ -308,6 +309,7 @@ def evaluate_pipeline(
         if _initial_mr is not None:
             rmm.mr.set_current_device_resource(_original_mr)
 
+        log_pipeline_complete()
         return result, metadata_collector
 
 

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/dask.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/dask.py
@@ -13,6 +13,7 @@ from rapidsmpf.streaming.core.context import Context
 
 import polars as pl
 
+from cudf_polars.dsl.tracing import log_pipeline_complete
 from cudf_polars.experimental.dask_registers import DaskRegisterManager
 
 if TYPE_CHECKING:
@@ -165,7 +166,7 @@ def _evaluate_pipeline_dask(
     dask_context = get_worker_context(dask_worker)
     with Context(dask_context.comm, dask_context.br, options) as rmpf_context:
         # IDs are already reserved by the caller, just pass them through
-        return callback(
+        result = callback(
             ir,
             partition_info,
             config_options,
@@ -174,3 +175,6 @@ def _evaluate_pipeline_dask(
             rmpf_context,
             collect_metadata=collect_metadata,
         )
+
+    log_pipeline_complete()
+    return result

--- a/python/cudf_polars/tests/test_tracing.py
+++ b/python/cudf_polars/tests/test_tracing.py
@@ -116,4 +116,4 @@ def test_log_query_plan() -> None:
     assert b"scope=plan" in result or b"'scope': 'plan'" in result
     assert b"ir_id" in result
     assert b"ir_type" in result
-    assert b"children_ir_ids" in result
+    assert b"Pipeline complete" in result


### PR DESCRIPTION
## Description

This emits a log record (per worker, if distributed) at the end of a query execution. For now, we just include the RMM statistics if they're enabled.

Examples:

```
# distributed
CUDF_POLARS_LOG_TRACES=1 CUDF_POLARS_LOG_TRACES_MEMORY=0 python -m cudf_polars.experimental.benchmarks.pdsh --path /datasets/toaugspurger/tpch-rs/scale-10 --suffix "" --iterations 2 --no-print-results --no-summarize --runtime rapidsmpf --n-workers 2 --cluster distributed --collect-traces 9
$ tail -n 1 pdsh_results.jsonl | jq '.records."9"[0].traces[-2:]' 
[
  {
    "rmm_current_bytes": 0,
    "rmm_current_count": 0,
    "rmm_peak_bytes": 2897691937,
    "rmm_peak_count": 26,
    "rmm_total_bytes": 4464324518,
    "rmm_total_count": 243,
    "scope": "plan",
    "event": "Pipeline complete",
    "query_id": 9,
    "iteration": 0,
    "level": "info",
    "process": 2386567,
    "thread": 140484055996224,
    "timestamp": "2026-03-02 08:54:33.449157"
  },
  {
    "rmm_current_bytes": 0,
    "rmm_current_count": 0,
    "rmm_peak_bytes": 2897691937,
    "rmm_peak_count": 26,
    "rmm_total_bytes": 4464324518,
    "rmm_total_count": 243,
    "scope": "plan",
    "event": "Pipeline complete",
    "query_id": 9,
    "iteration": 0,
    "level": "info",
    "process": 2386567,
    "thread": 140484055996224,
    "timestamp": "2026-03-02 08:54:33.449539"
  }
]

# single
$ CUDF_POLARS_LOG_TRACES=1 CUDF_POLARS_LOG_TRACES_MEMORY=0 python -m cudf_polars.experimental.benchmarks.pdsh --path /datasets/toaugspurger/tpch-rs/scale-10 --suffix "" --iterations 2 --no-print-results --no-summarize --runtime rapidsmpf --cluster single --collect-traces 9
$ tail -n 1 pdsh_results.jsonl | jq '.records."9"[0].traces[-1]' 
{
  "rmm_current_bytes": 0,
  "rmm_current_count": 0,
  "rmm_peak_bytes": 6008934361,
  "rmm_peak_count": 74,
  "rmm_total_bytes": 10141123413,
  "rmm_total_count": 761,
  "scope": "plan",
  "event": "Pipeline complete",
  "query_id": 9,
  "iteration": 0,
  "level": "info",
  "process": 2382311,
  "thread": 139776135718720,
  "timestamp": "2026-03-02 08:53:38.474774"
}
```
