### PR TITLE
Fix `strftime` callers in `pandas3`

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -69,6 +69,7 @@ from cudf.utils.dtypes import (
     dtype_from_pylibcudf_column,
     dtype_to_pylibcudf_type,
     find_common_type,
+    get_dtype_of_same_kind,
     is_mixed_with_object_dtype,
 )
 from cudf.utils.performance_tracking import _performance_tracking
@@ -3333,7 +3334,11 @@ class DatetimeIndex(Index):
             Date format string (e.g. "%Y-%m-%d").
         """
         return Index._from_column(
-            self._column.strftime(date_format), name=self.name
+            self._column.strftime(
+                date_format,
+                dtype=get_dtype_of_same_kind(self.dtype, DEFAULT_STRING_DTYPE),
+            ),
+            name=self.name,
         )
 
     @cached_property

--- a/python/cudf/cudf/core/series.py
+++ b/python/cudf/cudf/core/series.py
@@ -4910,7 +4910,12 @@ class DatetimeProperties(BaseDatelikeProperties):
                     f"for tracking purposes."
                 )
         return self._return_result_like_self(
-            self.series._column.strftime(format=date_format)
+            self.series._column.strftime(
+                format=date_format,
+                dtype=get_dtype_of_same_kind(
+                    self.series.dtype, DEFAULT_STRING_DTYPE
+                ),
+            )
         )
 
     @copy_docstring(DatetimeIndex.tz_localize)


### PR DESCRIPTION
## Description
This PR fixes all callers of `strftime` to correctly pass the missing dtype parameter.

pandas3:
```
= 1568 failed, 76871 passed, 19472 skipped, 1554 xfailed in 499.86s (0:08:19) ==
```

This PR:
```
= 1301 failed, 77138 passed, 19472 skipped, 1554 xfailed in 493.54s (0:08:13) ==
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
