### PR TITLE
Fix astype `CategoricalDtype` cases.

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2264,6 +2264,7 @@ class ColumnBase(Serializable, BinaryOperand, Reducible):
     def as_categorical_column(
         self, dtype: CategoricalDtype
     ) -> CategoricalColumn:
+        na_sentinel = -1
         if dtype._categories is not None:
             # Re-label self w.r.t. the provided categories
             codes = self._label_encoding(cats=dtype._categories)
@@ -2276,6 +2277,10 @@ class ColumnBase(Serializable, BinaryOperand, Reducible):
                 cats = cats.dropna()
             dtype = CategoricalDtype(categories=cats, ordered=dtype.ordered)
         codes_with_mask = codes.set_mask(self.mask, self.null_count)
+        codes_with_mask = codes_with_mask.copy_if_else(
+            plc.Scalar.from_py(None, dtype_to_pylibcudf_type(codes.dtype)),
+            codes_with_mask != na_sentinel,
+        )
         codes_typed = cast(
             "cudf.core.column.numerical.NumericalColumn", codes_with_mask
         ).astype(dtype._codes_dtype)

--- a/python/cudf/cudf/core/dtypes.py
+++ b/python/cudf/cudf/core/dtypes.py
@@ -277,7 +277,7 @@ class CategoricalDtype(_BaseDtype):
             getattr(categories, "dtype", None),
             (IntervalDtype, pd.IntervalDtype),
         ):
-            dtype = DEFAULT_STRING_DTYPE
+            dtype = getattr(categories, "dtype", DEFAULT_STRING_DTYPE)
         else:
             dtype = None
 

--- a/python/cudf/cudf/tests/series/methods/test_astype.py
+++ b/python/cudf/cudf/tests/series/methods/test_astype.py
@@ -1284,7 +1284,12 @@ def test_categorical_typecast(data, categories):
     gd_data = cudf.from_pandas(data)
     cat_type = pd.CategoricalDtype(categories)
 
-    assert_eq(pd_data.astype(cat_type), gd_data.astype(cat_type))
+    actual = gd_data.astype(cat_type)
+    warns = actual.null_count != gd_data.null_count
+    with expect_warning_if(warns, pd.errors.Pandas4Warning):
+        expected = pd_data.astype(cat_type)
+
+    assert_eq(expected, actual)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
This PR fixes issue in `pandas3` branch where codes weren't being correctly generated.

`pandas3`:
```
= 1301 failed, 77138 passed, 19472 skipped, 1554 xfailed in 493.54s (0:08:13) ==
```

This PR:
```
= 1261 failed, 77178 passed, 19472 skipped, 1554 xfailed in 504.02s (0:08:24) ==
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
