### PR TITLE
Fix `pl.Expr.split_exact` children result for null data

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -688,13 +688,13 @@ class StringFunction(Expr):
                 )
                 children = plc_table.columns()
                 ref_column = children[0]
-                if (remainder := n - len(children)) > 0:
+                if (remainder := n + int(not is_split_n) - len(children)) > 0:
                     # Reach expected number of splits by padding with nulls
                     children.extend(
                         plc.Column.all_null_like(
                             ref_column, ref_column.size(), stream=df.stream
                         )
-                        for _ in range(remainder + int(not is_split_n))
+                        for _ in range(remainder)
                     )
                 if not is_split_n:
                     children = children[: n + 1]

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -258,6 +258,12 @@ def test_split_exact_inclusive_unsupported(ldf_split):
     assert_ir_translation_raises(q, NotImplementedError)
 
 
+def test_split_exact_null_correct_children():
+    df = pl.LazyFrame({"a": ["a_b", None]})
+    q = df.slice(1).select(pl.col("a").str.split_exact("_", 1))
+    assert_gpu_result_equal(q)
+
+
 @pytest.mark.parametrize("cache", [True, False], ids=lambda cache: f"{cache=}")
 @pytest.mark.parametrize("strict", [True, False], ids=lambda strict: f"{strict=}")
 @pytest.mark.parametrize("exact", [True, False], ids=lambda exact: f"{exact=}")


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/21646

@wence- identified an off-by-one error when trying to pad the children of a struct column in the result. Verified locally this fixes `test_stringfunction.py::test_split_exact[1]` when run with rapidsmpf

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
