### PR TITLE
Fix segfault in `HYBRID_SCAN_MULTITHREAD_NVBENCH`

### DIFF
--- a/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_multithread.cpp
+++ b/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_multithread.cpp
@@ -104,11 +104,13 @@ void BM_hybrid_scan_multithreaded_read_common(nvbench::state& state,
                  [](auto& source_sink) { return source_sink.make_source_info(); });
 
   auto filepaths = std::vector<std::string>{};
-  filepaths.reserve(source_info_vector.size());
-  std::transform(source_info_vector.begin(),
-                 source_info_vector.end(),
-                 std::back_inserter(filepaths),
-                 [](auto const& source_info) { return source_info.filepaths().front(); });
+  if (source_type == io_type::FILEPATH) {
+    filepaths.reserve(source_info_vector.size());
+    std::transform(source_info_vector.begin(),
+                   source_info_vector.end(),
+                   std::back_inserter(filepaths),
+                   [](auto const& source_info) { return source_info.filepaths().front(); });
+  }
 
   auto mem_stats_logger = cudf::memory_stats_logger();
 


### PR DESCRIPTION
The `HYBRID_SCAN_MULTITHREAD_NVBENCH` benchmark segfaults on its first run because `drop_page_cache_if_enabled` unconditionally extracts filepaths from `source_info` objects via `.front()` on an empty vector. The benchmark only uses `PINNED_BUFFER` sources which have no filepaths, causing undefined behavior.

This PR guards the filepaths extraction with an `io_type::FILEPATH` check. For non-file sources, `drop_page_cache_if_enabled` receives an empty vector which is a no-op.

Closes #21659.