### PR TITLE
include pytorch conda packages in CUDA 13 test env

### DIFF
--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -81,6 +81,7 @@ dependencies:
 - python-confluent-kafka
 - python-xxhash
 - python>=3.11
+- pytorch>=2.10.0
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.4.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -81,6 +81,7 @@ dependencies:
 - python-confluent-kafka
 - python-xxhash
 - python>=3.11
+- pytorch>=2.10.0
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.4.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -924,7 +924,10 @@ dependencies:
               cuda: "12.*"
             packages:
               - pytorch>=2.4.0
-          # TODO: add a 13.x entry here when pytorch has CUDA 13 packages (https://github.com/pytorch/pytorch/issues/159779)
+          - matrix:
+              cuda: "13.*"
+            packages:
+              - pytorch>=2.10.0
           - matrix:
             packages:
   test_python_cudf_polars:


### PR DESCRIPTION
## Description

There are now `pytorch` CUDA 13 packages (started with `pytorch` 2.10: https://github.com/conda-forge/pytorch-cpu-feedstock/pull/477)

This adds them to the test environment so they'll be tested in CUDA 13 integration testing jobs.

More details on the history of PyTorch in those jobs: https://github.com/rapidsai/cudf/pull/20748#issuecomment-3599641360

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.