### PR TITLE
Reduce parameters for JSON_READER_NVBENCH to improve setup runtime

### DIFF
--- a/cpp/benchmarks/io/json/json_reader_input.cpp
+++ b/cpp/benchmarks/io/json/json_reader_input.cpp
@@ -160,6 +160,6 @@ NVBENCH_BENCH_TYPES(BM_json_read_io, NVBENCH_TYPE_AXES(io_list))
 NVBENCH_BENCH_TYPES(BM_json_read_compressed_io, NVBENCH_TYPE_AXES(compression_list))
   .set_name("json_read_compressed_io")
   .set_type_axes_names({"compression_type"})
-  .add_int64_power_of_two_axis("data_size", nvbench::range(20, 29, 1))
+  .add_int64_power_of_two_axis("data_size", nvbench::range(20, 25, 1))
   .add_int64_axis("num_sources", nvbench::range(1, 5, 1))
   .set_min_samples(4);


### PR DESCRIPTION
## Description
Reduces the nvbench parameter `data_size` range for `json_read_compressed_io` to improve overall runtime for data setup.
**This reduces the runtime from 15.5m to 2.5m**. Times are based on using the `--profile` parameter and so reflects mostly setup time and not the actual benchmark measured logic. Most of the setup time in this case is building the large compressed input data for the reader.
The `JSON_READER_NVBENCH` has the longest setup time and one of only a few measured at over 2 minutes.
The goal is to improve runtime for benchmarks automation checks. The `data_size` parameter is available to be overriden on the command-line in case a larger scope is needed for a local run.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
