### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -81,6 +81,7 @@ dependencies:
 - python-confluent-kafka
 - python-xxhash
 - python>=3.11
+- pytorch>=2.10.0
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.4.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -81,6 +81,7 @@ dependencies:
 - python-confluent-kafka
 - python-xxhash
 - python>=3.11
+- pytorch>=2.10.0
 - rapids-build-backend>=0.4.0,<0.5.0
 - rapids-dask-dependency==26.4.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -924,7 +924,10 @@ dependencies:
               cuda: "12.*"
             packages:
               - pytorch>=2.4.0
-          # TODO: add a 13.x entry here when pytorch has CUDA 13 packages (https://github.com/pytorch/pytorch/issues/159779)
+          - matrix:
+              cuda: "13.*"
+            packages:
+              - pytorch>=2.10.0
           - matrix:
             packages:
   test_python_cudf_polars:


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.