### PR TITLE
Change `date_range` time unit inferencing logic

### DIFF
--- a/python/cudf/cudf/core/tools/datetimes.py
+++ b/python/cudf/cudf/core/tools/datetimes.py
@@ -1062,10 +1062,8 @@ def _infer_date_range_unit(
         if freq.kwds.get("nanoseconds", 0) != 0:
             return "ns"
     elif isinstance(freq, str):
-        # Check for nanosecond frequency strings like "5ns", "10N"
-        stripped = freq.lstrip("-0123456789")
-        if stripped.lower() in ("ns",) or stripped == "N":
-            return "ns"
+        offset = DateOffset._from_freqstr(freq)
+        return _infer_date_range_unit(offset, unit, start, end)
     return "us"
 
 


### PR DESCRIPTION
## Description
This PR changes the default time unit for strings to `datetime` conversions to `us` to match with pandas3.

`pandas3`:
```
= 1249 failed, 77187 passed, 19475 skipped, 1554 xfailed in 503.36s (0:08:23) ==
```

This PR:
```
= 1063 failed, 77373 passed, 19475 skipped, 1554 xfailed in 504.51s (0:08:24) ==
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
