### PR TITLE
Increase timeout for the devcontainer build workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -536,7 +536,7 @@ jobs:
       arch: '["amd64", "arm64"]'
       cuda: '["13.1"]'
       node_type: "cpu8"
-      timeout-minutes: 60
+      timeout-minutes: 90
       env: |
         SCCACHE_DIST_MAX_RETRIES=inf
         SCCACHE_SERVER_LOG=sccache=debug


### PR DESCRIPTION
## Description
Increases the timeout for the `devcontainer` workflow build from 60 minutes to 90 minutes.
This was increased from 45 to 60 last week but it seems that is not enough.

https://github.com/rapidsai/cudf/actions/runs/22856078272/job/66296692960?pr=21693

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
