### PR TITLE
Use larger datatypes when calculating mean and other groupby-aggs

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/groupby.py
@@ -135,7 +135,7 @@ def decompose(
                 decompose(
                     f"{next(names)}__mean_count",
                     Agg(
-                        DataType(pl.Int32()),
+                        DataType(pl.Int64()),
                         "count",
                         False,  # noqa: FBT003
                         ExecutionContext.GROUPBY,


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/21706

For groupby mean aggregations, we decompose the mean as a SUM / COUNT. The COUNT aggregation used `Int32` dtype which caused overflow errors in our PDS-H benchmarks. Hence, switching to `Int64`.