### PR TITLE
Remove stale xfail markers for pandas bugs fixed in 3.0

### DIFF
--- a/python/cudf/cudf/tests/indexes/index/test_attributes.py
+++ b/python/cudf/cudf/tests/indexes/index/test_attributes.py
@@ -116,14 +116,6 @@ def test_index_iter_error(data, all_supported_types_as_str):
 
 @pytest.mark.parametrize("data", [[], [1]])
 def test_index_values_host(data, all_supported_types_as_str, request):
-    request.applymarker(
-        pytest.mark.xfail(
-            len(data) > 0
-            and all_supported_types_as_str
-            in {"timedelta64[us]", "timedelta64[ms]", "timedelta64[s]"},
-            reason=f"wrong result for {all_supported_types_as_str}",
-        )
-    )
     gdi = cudf.Index(data, dtype=all_supported_types_as_str)
     pdi = pd.Index(data, dtype=all_supported_types_as_str)
 

--- a/python/cudf/cudf/tests/indexes/index/test_constructor.py
+++ b/python/cudf/cudf/tests/indexes/index/test_constructor.py
@@ -242,15 +242,6 @@ def test_empty_index_init():
 
 @pytest.mark.parametrize("data", [[1, 2, 3], range(0, 10)])
 def test_index_with_index_dtype(request, data, all_supported_types_as_str):
-    request.applymarker(
-        pytest.mark.xfail(
-            isinstance(data, list)
-            and all_supported_types_as_str
-            in {"timedelta64[us]", "timedelta64[ms]", "timedelta64[s]"},
-            reason=f"wrong result for {all_supported_types_as_str}",
-        )
-    )
-
     pidx = pd.Index(data)
     gidx = cudf.Index(data)
 

--- a/python/cudf/cudf/tests/series/accessors/test_str.py
+++ b/python/cudf/cudf/tests/series/accessors/test_str.py
@@ -2017,9 +2017,9 @@ def test_string_char_types(request, type_op, data_char_types):
     ps = pd.Series(data_char_types)
     request.applymarker(
         pytest.mark.xfail(
-            condition=type_op == "isdigit"
-            and any(x == "7¼" or x == "⅕" for x in data_char_types),
-            reason="https://github.com/pandas-dev/pandas/issues/63372",
+            condition=type_op == "islower"
+            and data_char_types[0] == r"¯\_(ツ)_/¯",
+            reason=f"{type_op} different for {data_char_types} in pyarrow",
         )
     )
     request.applymarker(

--- a/python/cudf/cudf/tests/series/methods/test_astype.py
+++ b/python/cudf/cudf/tests/series/methods/test_astype.py
@@ -864,14 +864,6 @@ def test_series_astype_numeric_to_other(
         pytest.skip(
             f"Casting {all_supported_types_as_str} to {as_dtype} for test data is invalid."
         )
-    request.applymarker(
-        pytest.mark.xfail(
-            all_supported_types_as_str
-            in {"timedelta64[us]", "timedelta64[ms]", "timedelta64[s]"}
-            and as_dtype == "str",
-            reason=f"Casting {all_supported_types_as_str} to {as_dtype} is incorrect.",
-        )
-    )
     psr = pd.Series([1, 2, 3], dtype=all_supported_types_as_str)
     gsr = cudf.from_pandas(psr)
     assert_eq(psr.astype(as_dtype), gsr.astype(as_dtype))

--- a/python/cudf/cudf/tests/series/test_np_ufuncs.py
+++ b/python/cudf/cudf/tests/series/test_np_ufuncs.py
@@ -48,15 +48,6 @@ def test_ufunc_series(request, numpy_ufunc, has_nulls, indexed):
             reason="Can't call cupy on column with nulls",
         )
     )
-    request.applymarker(
-        pytest.mark.xfail(
-            condition=numpy_ufunc.__name__.startswith("bitwise")
-            and numpy_ufunc != np.bitwise_count
-            and indexed
-            and has_nulls,
-            reason="https://github.com/pandas-dev/pandas/issues/52500",
-        )
-    )
 
     N = 100
     # Avoid zeros in either array to skip division by 0 errors. Also limit the


### PR DESCRIPTION
## Summary

- Remove strict xfail markers that reference pandas issues now resolved in pandas 3.0
- Affected markers referenced: `pandas-dev/pandas#63372` (isdigit with vulgar fractions), `pandas-dev/pandas#52500` (bitwise ops with indexed nullable Series), timedelta to str casting, and timedelta64 index values_host/constructor issues
- These tests now pass with pandas 3.0 and the strict xfails cause unexpected pass (XPASS) failures