### PR TITLE
Fix all udf pytests

### DIFF
--- a/python/cudf/cudf/tests/dataframe/methods/test_apply.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_apply.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 import decimal
 import math


### PR DESCRIPTION
## Description
This PR fixes type assertion issues in udf tests. 
`pandas3`:

```
== 766 failed, 77673 passed, 19475 skipped, 1551 xfailed in 493.01s (0:08:13) ==
```
This PR:
```
== 486 failed, 77953 passed, 19475 skipped, 1551 xfailed in 486.86s (0:08:06) ==
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
