### PR TITLE
Fix join bug that shows up in `Index.difference`

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2804,7 +2804,7 @@ class RangeIndex(Index):
             return index
         # Evenly spaced values can return a
         # RangeIndex instead of a materialized Index.
-        if not index._column.has_nulls():
+        if not index._column.has_nulls() and len(index) > 1:
             uniques = cupy.unique(cupy.diff(index.values))
             if len(uniques) == 1 and (diff := uniques[0].get()) != 0:
                 new_range = range(index[0], index[-1] + diff, diff)

--- a/python/cudf/cudf/core/join/_join_helpers.py
+++ b/python/cudf/cudf/core/join/_join_helpers.py
@@ -88,7 +88,16 @@ def _match_join_keys(
         return _match_categorical_dtypes_both(lcol, rcol, how)  # type: ignore[arg-type]
     elif left_is_categorical or right_is_categorical:
         if left_is_categorical:
-            if how in {"left", "leftsemi", "leftanti"}:
+            if how in {"leftsemi", "leftanti"}:
+                # Decategorize both sides and find a common type
+                # instead of casting right to left's categorical
+                # type, which would introduce spurious nulls for
+                # right values not in the left categories.
+                common_type = find_common_type(
+                    (ltype.categories.dtype, rtype)  # type: ignore[union-attr]
+                )
+                return lcol.astype(common_type), rcol.astype(common_type)
+            if how == "left":
                 return lcol, rcol.astype(ltype)
             common_type = get_dtype_of_same_kind(rtype, ltype.categories.dtype)  # type: ignore[union-attr]
         else:


### PR DESCRIPTION
## Description
This PR fixes join code for `leftanti` and thus resolving `Index.difference` failures.

`pandas3`:
```
== 766 failed, 77673 passed, 19475 skipped, 1551 xfailed in 493.01s (0:08:13) ==
```

This PR:
```
== 742 failed, 77697 passed, 19475 skipped, 1551 xfailed in 490.23s (0:08:10) ==
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
