### PR TITLE
Fix all binops failures

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2440,7 +2440,9 @@ class ColumnBase(Serializable, BinaryOperand, Reducible):
             output = {
                 "shape": (len(self),),
                 "strides": (self.dtype.itemsize,),
-                "typestr": self.dtype.str,
+                "typestr": self.dtype.numpy_dtype.str
+                if not isinstance(self.dtype, np.dtype)
+                else self.dtype.str,
                 "data": (
                     data_buf.ptr + self.offset * self.dtype.itemsize,
                     False,

--- a/python/cudf/cudf/tests/dataframe/test_binops.py
+++ b/python/cudf/cudf/tests/dataframe/test_binops.py
@@ -382,12 +382,12 @@ def test_df_sr_binop(psr, colnames, binary_op):
     data = [[3.0, 2.0, 5.0], [3.0, None, 5.0], [6.0, 7.0, np.nan]]
     data = dict(zip(colnames, data, strict=True))
 
-    gsr = cudf.Series(psr).astype("float64")
+    gsr = cudf.Series(psr).astype("Float64")
 
-    gdf = cudf.DataFrame(data)
-    pdf = gdf.to_pandas(nullable=True)
+    gdf = cudf.DataFrame(data).astype("Float64")
+    pdf = gdf.to_pandas()
 
-    psr = gsr.to_pandas(nullable=True)
+    psr = gsr.to_pandas()
 
     try:
         expect = binary_op(pdf, psr)
@@ -399,12 +399,12 @@ def test_df_sr_binop(psr, colnames, binary_op):
         with pytest.raises(ValueError):
             binary_op(gsr, gdf)
     else:
-        got = binary_op(gdf, gsr).to_pandas(nullable=True)
-        assert_eq(expect, got, check_dtype=False, check_like=True)
+        got = binary_op(gdf, gsr)
+        assert_eq(expect, got)
 
         expect = binary_op(psr, pdf)
-        got = binary_op(gsr, gdf).to_pandas(nullable=True)
-        assert_eq(expect, got, check_dtype=False, check_like=True)
+        got = binary_op(gsr, gdf)
+        assert_eq(expect, got)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
This PR fixes binops failures:
1. By updating the pytest correctly.
2. By allowing cai to be constructed for nullable pandas types.


`pandas3`:
```
== 742 failed, 77697 passed, 19475 skipped, 1551 xfailed in 494.85s (0:08:14) ==
```
This PR:
```
== 686 failed, 77753 passed, 19475 skipped, 1551 xfailed in 494.02s (0:08:14) ==
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
