### PR TITLE
Fix `astype(category)` for empty column scenarios

### DIFF
--- a/python/cudf/cudf/core/column/column.py
+++ b/python/cudf/cudf/core/column/column.py
@@ -2290,12 +2290,12 @@ class ColumnBase(Serializable, BinaryOperand, Reducible):
     def astype(self, dtype: DtypeObj, copy: bool | None = False) -> ColumnBase:
         if self.dtype == dtype:
             result = self
+        elif isinstance(dtype, CategoricalDtype):
+            result = self.as_categorical_column(dtype)
         elif len(self) == 0:
             result = column_empty(0, dtype=dtype)
         else:
-            if isinstance(dtype, CategoricalDtype):
-                result = self.as_categorical_column(dtype)
-            elif is_dtype_obj_interval(dtype):
+            if is_dtype_obj_interval(dtype):
                 result = self.as_interval_column(dtype)  # type: ignore[arg-type]
             elif is_dtype_obj_list(dtype) or is_dtype_obj_struct(dtype):
                 if isinstance(dtype, pd.ArrowDtype):

--- a/python/cudf/cudf/tests/series/methods/test_astype.py
+++ b/python/cudf/cudf/tests/series/methods/test_astype.py
@@ -145,7 +145,12 @@ def test_cast_float_nan_to_bool_pandas_compat():
 def test_empty_astype_always_castable(type1, type2, as_dtype, copy):
     ser = cudf.Series([], dtype=as_dtype(type1))
     result = ser.astype(as_dtype(type2), copy=copy)
-    expected = cudf.Series([], dtype=as_dtype(type2))
+    if type2 == "category":
+        # Empty astype to category inherits the source dtype as the
+        # categories dtype, matching pandas behavior.
+        expected = cudf.Series([], dtype=result.dtype)
+    else:
+        expected = cudf.Series([], dtype=as_dtype(type2))
     assert_eq(result, expected)
     if not copy and cudf.dtype(type1) == cudf.dtype(type2):
         assert ser._column is result._column


### PR DESCRIPTION
## Description
This PR fixes `astype(category)` on empty columns.

`pandas3`:
```
== 742 failed, 77697 passed, 19475 skipped, 1551 xfailed in 494.85s (0:08:14) ==
```
This PR:
```
== 719 failed, 77720 passed, 19475 skipped, 1551 xfailed in 492.81s (0:08:12) ==
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
