### PR TITLE
Use reduction_axis for dataframes

### DIFF
--- a/python/cudf/cudf/core/dataframe.py
+++ b/python/cudf/cudf/core/dataframe.py
@@ -6582,7 +6582,7 @@ class DataFrame(IndexedFrame, GetAttrGetItemMixin):
                         ) from err
                     else:
                         raise
-            if axis == 2:
+            if reduction_axis == 2:
                 return _apply_reduction(
                     as_column(axis_0_results, nan_as_null=False), op, kwargs
                 )


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The variable conditionally reassigned in the code was changed previously but not the later conditional using that variable.

Before:
`== 689 failed, 77747 passed, 19478 skipped, 1551 xfailed in 573.81s (0:09:33) ==`
After:
`== 670 failed, 77766 passed, 19478 skipped, 1551 xfailed in 581.15s (0:09:41) ==`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
