### PR TITLE
Add missing return after state.skip() in libcudf benchmarks

### DIFF
--- a/cpp/benchmarks/merge/merge_strings.cpp
+++ b/cpp/benchmarks/merge/merge_strings.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -21,6 +21,7 @@ void nvbench_merge_strings(nvbench::state& state)
   if (static_cast<std::size_t>(2 * num_rows) * static_cast<std::size_t>(row_width) >=
       static_cast<std::size_t>(std::numeric_limits<cudf::size_type>::max())) {
     state.skip("Skip benchmarks greater than size_type limit");
+    return;
   }
 
   data_profile const table_profile =

--- a/cpp/benchmarks/reduction/reduce.cpp
+++ b/cpp/benchmarks/reduction/reduce.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -42,6 +42,7 @@ static void reduction(nvbench::state& state, nvbench::type_list<DataType, nvbenc
 {
   if (cudf::is_chrono<DataType>() && kind != cudf::aggregation::MIN) {
     state.skip("Skip chrono types for some aggregations");
+    return;
   }
 
   auto const size      = static_cast<cudf::size_type>(state.get_int64("size"));

--- a/cpp/benchmarks/replace/nulls.cpp
+++ b/cpp/benchmarks/replace/nulls.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,6 +23,7 @@ static void replace_nulls(nvbench::state& state)
   if (static_cast<std::size_t>(n_rows) * static_cast<std::size_t>(max_width) >=
       static_cast<std::size_t>(std::numeric_limits<cudf::size_type>::max())) {
     state.skip("Skip benchmarks greater than size_type limit");
+    return;
   }
 
   data_profile const table_profile = data_profile_builder().distribution(

--- a/cpp/benchmarks/reshape/interleave.cpp
+++ b/cpp/benchmarks/reshape/interleave.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,6 +20,7 @@ static void bench_interleave(nvbench::state& state)
   if (static_cast<std::size_t>(num_rows) * static_cast<std::size_t>(row_width) * num_cols >=
       static_cast<std::size_t>(std::numeric_limits<cudf::size_type>::max())) {
     state.skip("Skip benchmarks greater than size_type limit");
+    return;
   }
 
   data_profile const str_profile = data_profile_builder().distribution(

--- a/cpp/benchmarks/stream_compaction/unique.cpp
+++ b/cpp/benchmarks/stream_compaction/unique.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -86,6 +86,7 @@ void nvbench_unique_list(nvbench::state& state, nvbench::type_list<Type, nvbench
   // KEEP_FIRST and KEEP_ANY are equivalent for unique
   if constexpr (Keep == cudf::duplicate_keep_option::KEEP_ANY) {
     state.skip("Skip unwanted benchmarks.");
+    return;
   }
 
   auto const size               = state.get_int64("ColumnSize");


### PR DESCRIPTION
## Description
Adds a missing `return;` after calls to `state.skip()` in various nvbench benchmarks. The `skip()` tells the nvbench tools to not run/record the metrics for a specific run. It is used in places to more easily and clearly identify unwanted data types, aggregations, sizes for measurement. Without the following `return` the code still executes but is just not measured.
Adding the `return` prevents unneeded setup processing.

This will help with #20538 since it improves the setup runtime for `MERGE_NVBENCH` from 2 minutes to 12 seconds.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
