### PR TITLE
Undeprecate the byte-pair-encoding APIs

### DIFF
--- a/cpp/include/nvtext/byte_pair_encoding.hpp
+++ b/cpp/include/nvtext/byte_pair_encoding.hpp
@@ -63,8 +63,6 @@ struct bpe_merge_pairs {
 /**
  * @brief Create a nvtext::bpe_merge_pairs from a strings column
  *
- * @deprecated Since 26.04
- *
  * The input column should contain a unique pair of strings per line separated by
  * a single space. An incorrect format or non-unique entries will result in
  * undefined behavior.
@@ -87,15 +85,13 @@ struct bpe_merge_pairs {
  * @param mr Memory resource to allocate any returned objects
  * @return A nvtext::bpe_merge_pairs object
  */
-[[deprecated]] std::unique_ptr<bpe_merge_pairs> load_merge_pairs(
+std::unique_ptr<bpe_merge_pairs> load_merge_pairs(
   cudf::strings_column_view const& merge_pairs,
   rmm::cuda_stream_view stream      = cudf::get_default_stream(),
   rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref());
 
 /**
  * @brief Byte pair encode the input strings.
- *
- * @deprecated Since 26.04
  *
  * The encoding algorithm rebuilds each string by matching substrings
  * in the `merge_pairs` table and iteratively removing the minimum ranked pair
@@ -121,7 +117,7 @@ struct bpe_merge_pairs {
  * @param mr Memory resource to allocate any returned objects.
  * @return An encoded column of strings.
  */
-[[deprecated]] std::unique_ptr<cudf::column> byte_pair_encoding(
+std::unique_ptr<cudf::column> byte_pair_encoding(
   cudf::strings_column_view const& input,
   bpe_merge_pairs const& merges_pairs,
   cudf::string_scalar const& separator = cudf::string_scalar(" "),

--- a/python/cudf/cudf/core/byte_pair_encoding.py
+++ b/python/cudf/cudf/core/byte_pair_encoding.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 import pylibcudf as plc
 
 from cudf.core.series import Series
@@ -14,9 +12,6 @@ class BytePairEncoder:
     """
     Given a merge pairs strings series, performs byte pair encoding on
     a strings series using the provided separator.
-
-    .. deprecated:: 26.04
-        BytePairEncoder is deprecated and will be removed in a future version.
 
     Parameters
     ----------
@@ -29,11 +24,6 @@ class BytePairEncoder:
     """
 
     def __init__(self, merges_pair: Series) -> None:
-        warnings.warn(
-            "BytePairEncoder is deprecated and will be removed in a future version.",
-            FutureWarning,
-            stacklevel=2,
-        )
         self.merge_pairs = plc.nvtext.byte_pair_encode.BPEMergePairs(
             merges_pair._column.plc_column
         )

--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -700,11 +700,6 @@ class StringColumn(ColumnBase, Scannable):
         merge_pairs: plc.nvtext.byte_pair_encode.BPEMergePairs,
         separator: str,
     ) -> Self:
-        warnings.warn(
-            "byte_pair_encoding is deprecated and will be removed in a future version.",
-            FutureWarning,
-            stacklevel=2,
-        )
         with self.access(mode="read", scope="internal"):
             plc_column = plc.nvtext.byte_pair_encode.byte_pair_encoding(
                 self.plc_column,


### PR DESCRIPTION
## Description
There has been recent renewed interest on prototyping using this feature from the python API.
Removing the deprecation declaration and warnings while this work is underway.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
