### PR TITLE
Fix all explode failures

### DIFF
--- a/python/cudf/cudf/tests/dataframe/methods/test_explode.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_explode.py
@@ -69,10 +69,11 @@ def test_explode_preserve_categorical():
     ],
 )
 def test_explode(data, labels, ignore_index, p_index, label_to_explode):
-    pdf = pd.DataFrame(data, index=p_index, columns=labels)
+    gdf = cudf.DataFrame(data, index=p_index, columns=labels)
+    pdf = gdf.to_pandas(arrow_type=True)
     gdf = cudf.from_pandas(pdf)
 
     expect = pdf.explode(label_to_explode, ignore_index)
     got = gdf.explode(label_to_explode, ignore_index)
 
-    assert_eq(expect, got, check_dtype=False)
+    assert_eq(expect, got)


### PR DESCRIPTION
## Description
This PR fixes all `explode` failures by switching to arrow types for comparison.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
