### PR TITLE
fix verify-hardcoded-versions issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -274,6 +274,7 @@ repos:
             ^conda/environments/|
             RAPIDS_BRANCH$|
             [.](md|rst|avro|parquet|png|orc|gz|pkl|sas7bdat)$|
+            ^python/cudf/cudf/tests|
             ^python/cudf/cudf/VERSION$
       - id: verify-pyproject-license
         # ignore the top-level pyproject.toml, which doesn't


### PR DESCRIPTION
## Description

Fixes this `pre-commit` error on `release/26.04`:

```text
In file RAPIDS_BRANCH:1:9:
 release/26.04
warning: do not hard-code version, read from VERSION file instead
```

And this one on `main`:

```text
In file python/cudf/cudf/tests/dataframe/test_binops.py:677:24:
         lambda: [25.5, 26.6, 27.7, 28.8],
warning: do not hard-code version, read from VERSION file instead
```

See https://github.com/rapidsai/pre-commit-hooks/issues/121 for details

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
