### PR TITLE
Add missing headers to reader_impl_chunking_utils.cu

### DIFF
--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -20,7 +20,12 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_radix_sort.cuh>
+#include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/std/cmath>
+#include <cuda/std/functional>
+#include <cuda/std/optional>
+#include <cuda/std/utility>
 #include <thrust/binary_search.h>
 #include <thrust/sequence.h>
 #include <thrust/transform_scan.h>


### PR DESCRIPTION
## Description
RAPIDS-CCCL nightly CI failed, probably due to missing headers. This should fix it.

https://github.com/NVIDIA/cccl/actions/runs/23127431740

```
FAILED: CMakeFiles/cudf.dir/src/io/parquet/reader_impl_chunking_utils.cu.o
/usr/bin/sccache /home/coder/.conda/envs/rapids/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/home/coder/.conda/envs/rapids/bin/x86_64-conda-linux-gnu-c++ -DBS_THREAD_POOL_ENABLE_PAUSE=1 -DCCCL_AVOID_SORT_UNROLL=1 -DCCCL_DISABLE_PDL -DCUB_DISABLE_NAMESPACE_MAGIC -DCUB_IGNORE_NAMESPACE_MAGIC_ERROR -DCUDF_KVIKIO_REMOTE_IO -DCUDF_LOG_ACTIVE_LEVEL=RAPIDS_LOGGER_LOG_LEVEL_INFO -DJITIFY_PRINT_LOG=0 -DKVIKIO_CUFILE_FOUND -DKVIKIO_CUFILE_VERSION_API_FOUND -DKVIKIO_LIBCURL_FOUND -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_DISABLE_ABI_NAMESPACE -DTHRUST_FORCE_32_BIT_OFFSET_TYPE=1 -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -DTHRUST_IGNORE_ABI_NAMESPACE_ERROR -DZSTD_STATIC_LINKING_ONLY=0N -Dcudf_EXPORTS -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/_deps/dlpack-src/include -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/_deps/jitify-src -I/home/coder/cudf/cpp/include -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/include -I/home/coder/cudf/cpp/src -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/_deps/nanoarrow-src/src -I/include -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/_deps/zstd-src/lib -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/_deps/cccl-src/lib/cmake/thrust/../../../thrust -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/_deps/cccl-src/lib/cmake/cub/../../../cub -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/_deps/nvtx3-src/c/include -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/_deps/cuco-src/include -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/_deps/nanoarrow-build/src -I/home/coder/cudf/cpp/build/conda/cuda-13.0/release/_deps/zstd-src/build/cmake/../../lib -isystem /home/coder/rmm/cpp/include -isystem /home/coder/rmm/cpp/build/conda/cuda-13.0/release/include -isystem /home/coder/.conda/envs/rapids/targets/x86_64-linux/include -isystem /home/coder/.conda/envs/rapids/targets/x86_64-linux/include/cccl -isystem /home/coder/kvikio/cpp/build/conda/cuda-13.0/release/_deps/bs_thread_pool-src/include -isystem /home/coder/kvikio/cpp/include -t=1 -O3 -DNDEBUG -std=c++20 "--generate-code=arch=compute_75,code=[sm_75]" -Xcompiler=-fPIC -Xcompiler=-fvisibility=hidden --expt-extended-lambda --expt-relaxed-constexpr -Werror=all-warnings -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations -diag-suppress=1407 -Xfatbin=-compress-all --compress-mode=size -MD -MT CMakeFiles/cudf.dir/src/io/parquet/reader_impl_chunking_utils.cu.o -MF CMakeFiles/cudf.dir/src/io/parquet/reader_impl_chunking_utils.cu.o.d -x cu -c /home/coder/cudf/cpp/src/io/parquet/reader_impl_chunking_utils.cu -o CMakeFiles/cudf.dir/src/io/parquet/reader_impl_chunking_utils.cu.o
/home/coder/cudf/cpp/src/io/parquet/reader_impl_chunking_utils.cu(805): error: namespace "cuda::std" has no member "ceil"
                                 static_cast<size_t>(cuda::std::ceil(cost * adjustment_ratio));
                                                                ^

1 error detected in the compilation of "/home/coder/cudf/cpp/src/io/parquet/reader_impl_chunking_utils.cu".
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
