### PR TITLE
Fix racecheck in join mark_retrieve_kernel

### DIFF
--- a/cpp/src/join/mark_join.cu
+++ b/cpp/src/join/mark_join.cu
@@ -228,6 +228,7 @@ CUDF_KERNEL __launch_bounds__(block_size) void mark_retrieve_kernel(
       }
     }
   }
+  block.sync();
 
   // Drain the partially filled warp-local buffer left after the final scan iteration.
   if (build_buffer_offset > 0) {


### PR DESCRIPTION
## Description
The weekend compute-sanitizer runs reported a racecheck in the `cpp/src/join/mark_join.cu` `mark_retrieve_kernel`
```
[ RUN      ] JoinImpl/SemiAntiJoinTest.SemiJoinWithStructsAndNulls/0
========= Warning: Race reported between Write access at void cudf::detail::<unnamed>::mark_retrieve_kernel<(int)1024, (bool)0>(cuco::bucket_storage_ref<cuco::pair<unsigned int, cudf::detail::row::lhs_index_type>, (int)1, cuco::extent<unsigned long, (unsigned long)18446744073709551615>>, cuco::pair<unsigned int, cudf::detail::row::lhs_index_type>, int *, int *, long)+0x610 in mark_join.cu:211
=========     and Read access at void cudf::detail::<unnamed>::mark_retrieve_kernel<(int)1024, (bool)0>(cuco::bucket_storage_ref<cuco::pair<unsigned int, cudf::detail::row::lhs_index_type>, (int)1, cuco::extent<unsigned long, (unsigned long)18446744073709551615>>, cuco::pair<unsigned int, cudf::detail::row::lhs_index_type>, int *, int *, long)+0xfb0 in mark_join.cu:238 [8 hazards]
=========
[       OK ] JoinImpl/SemiAntiJoinTest.SemiJoinWithStructsAndNulls/0 (1423 ms)
```

This can be reproduced using the following command:
```
compute-sanitizer --tool racecheck --force-blocking-launches --kernel-name-exclude kns=nvcomp,kns=zstd,kns=_no_sanitize,kns=_no_racecheck  gtests/JOIN_TEST --gtest_filter=JoinImpl/SemiAntiJoinTest.SemiJoinWithStructsAndNulls/0 --rmm_mode=cuda
```

The specified lines indicate a racecheck on writing to the `build_buffer` shared memory variable:
https://github.com/rapidsai/cudf/blob/9ba0eb36f55712dae230ebb1b40b7fa1326fe147/cpp/src/join/mark_join.cu#L211
and reading the `build_buffer` at:
https://github.com/rapidsai/cudf/blob/9ba0eb36f55712dae230ebb1b40b7fa1326fe147/cpp/src/join/mark_join.cu#L238

Adding `block.sync()` between these two fixes the issue.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
