### PR TITLE
Fix approx distinct count nan handling

### DIFF
--- a/cpp/src/reductions/approx_distinct_count.cu
+++ b/cpp/src/reductions/approx_distinct_count.cu
@@ -19,6 +19,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda/functional>
+#include <cuda/std/type_traits>
 #include <thrust/iterator/counting_iterator.h>
 
 #include <cmath>
@@ -106,12 +107,14 @@ struct row_is_valid {
  */
 template <typename Hasher>
 struct nan_to_null_hasher {
+  using result_type = cuda::std::invoke_result_t<Hasher, cudf::size_type>;
+
   Hasher base_hasher;
   table_device_view d_table;
 
-  __device__ hash_value_type operator()(cudf::size_type row_idx) const noexcept
+  __device__ result_type operator()(cudf::size_type row_idx) const noexcept
   {
-    constexpr auto null_hash = cuda::std::numeric_limits<hash_value_type>::max();
+    constexpr auto null_hash = cuda::std::numeric_limits<result_type>::max();
 
     for (cudf::size_type col_idx = 0; col_idx < d_table.num_columns(); ++col_idx) {
       auto const& col = d_table.column(col_idx);


### PR DESCRIPTION
## Description
This PR fixes a bug uncovered by the cuco version bump. The cuco update is required for Spark 26.04, as it enables full support for deletion vectors.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
