### PR TITLE
Deduplicate libcudf examples CMake files

### DIFF
--- a/cpp/examples/billion_rows/CMakeLists.txt
+++ b/cpp/examples/billion_rows/CMakeLists.txt
@@ -32,6 +32,10 @@ add_library(groupby_results OBJECT groupby_results.cpp)
 target_link_libraries(groupby_results PRIVATE cudf::cudf)
 target_compile_features(groupby_results PRIVATE cxx_std_20)
 
+# Creates a billion rows example executable and installs it.
+#
+# Arguments: target_name  - Name of the CMake target and resulting executable source_file  - Source
+# file to compile for the example
 function(add_billion_rows_example target_name source_file)
   add_executable(${target_name} ${source_file})
   target_link_libraries(

--- a/cpp/examples/hybrid_scan_io/CMakeLists.txt
+++ b/cpp/examples/hybrid_scan_io/CMakeLists.txt
@@ -32,6 +32,10 @@ add_library(
 target_compile_features(hybrid_scan_utils PRIVATE cxx_std_20)
 target_link_libraries(hybrid_scan_utils PRIVATE cudf::cudf)
 
+# Creates a hybrid scan example executable and installs it.
+#
+# Arguments: target_name  - Name of the CMake target and resulting executable source_file  - Source
+# file to compile for the example
 function(add_hybrid_scan_example target_name source_file)
   add_executable(${target_name} ${source_file})
   target_link_libraries(

--- a/cpp/examples/parquet_io/CMakeLists.txt
+++ b/cpp/examples/parquet_io/CMakeLists.txt
@@ -30,6 +30,10 @@ add_library(parquet_io_utils OBJECT common_utils.cpp io_source.cpp)
 target_compile_features(parquet_io_utils PRIVATE cxx_std_20)
 target_link_libraries(parquet_io_utils PRIVATE cudf::cudf)
 
+# Creates a parquet I/O example executable and installs it.
+#
+# Arguments: target_name  - Name of the CMake target and resulting executable source_file  - Source
+# file to compile for the example
 function(add_parquet_io_example target_name source_file)
   add_executable(${target_name} ${source_file})
   target_link_libraries(

--- a/cpp/examples/string_transforms/CMakeLists.txt
+++ b/cpp/examples/string_transforms/CMakeLists.txt
@@ -28,6 +28,10 @@ set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 list(APPEND CUDF_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr)
 
+# Creates a string transforms example executable and installs it.
+#
+# Arguments: target_name  - Name of the CMake target and resulting executable source_file  - Source
+# file to compile for the example
 function(add_string_transforms_example target_name source_file)
   add_executable(${target_name} ${source_file})
   target_compile_features(${target_name} PRIVATE cxx_std_20)

--- a/cpp/examples/strings/CMakeLists.txt
+++ b/cpp/examples/strings/CMakeLists.txt
@@ -28,6 +28,10 @@ set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 list(APPEND CUDF_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr)
 
+# Creates a strings example executable and installs it.
+#
+# Arguments: target_name  - Name of the CMake target and resulting executable source_file  - Source
+# file to compile for the example
 function(add_strings_example target_name source_file)
   add_executable(${target_name} ${source_file})
   target_compile_features(${target_name} PRIVATE cxx_std_20)


### PR DESCRIPTION
## Description

This PR deduplicates libcudf examples CMake files by moving repetitive code into (example-wise) common functions. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
