### PR TITLE
[Multi-GPU Polars] Ray mode in PDSH benchmarks

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -1943,9 +1943,7 @@ def run_polars_ray(
             "--collect-traces is not yet supported with --cluster ray."
         )
     if run_config.rmm_async:
-        raise NotImplementedError(
-            "--rmm-async is not supported with --cluster ray."
-        )
+        raise NotImplementedError("--rmm-async is not supported with --cluster ray.")
     executor_options = get_executor_options(run_config, benchmark=benchmark)
     # "runtime", "cluster" are reserved — ray_execution sets them
     executor_options.pop("runtime", None)


### PR DESCRIPTION
Update the PDSH benchmarks to support `--cluster=ray` runs.

Run using something like:
```bash 
python \
  python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py \
  --executor=streaming \
  --suffix="" \
  --spill-device=0.5 \
  --shuffle=rapidsmpf \
  --runtime=rapidsmpf \
  --stream-policy=pool \
  --no-print-results --no-summarize \
  --iterations=10 \
  --path /datasets/datasets/tpch-rs/scale-10 \
  --cluster ray \
  1
```