### PR TITLE
Fix TPC-DS query validation failures due to nulls_last mismatch

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/asserts.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/asserts.py
@@ -46,6 +46,7 @@ def assert_tpch_result_equal(
     abs_tol: float = 1e-08,
     categorical_as_str: bool = False,
     sort_by: list[tuple[str, bool]],
+    nulls_last: bool = True,
     limit: int | None = None,
 ) -> None:
     """
@@ -62,6 +63,13 @@ def assert_tpch_result_equal(
     sort_by : list[tuple[str, bool]]
         The columns to sort by, and the sort order. This *must* be the same
         as the ``sort_by`` and ``descending`` required by the query
+    nulls_last : bool, optional
+        Whether NULLs should be placed last when checking sortedness.
+        Must match the NULL placement used by the query's ``ORDER BY``.
+        DuckDB defaults to NULLS LAST for ``ASC`` and NULLS FIRST for
+        ``DESC``; some TPC-DS queries override this with explicit
+        ``NULLS FIRST`` on all columns, which requires ``nulls_last=False``.
+        Defaults to ``True`` (NULLS LAST), matching DuckDB's ``ASC`` default.
     limit : int | None, optional
         The limit (passed to ``.head``) used in the query, if any. This is
         used to break ties in the ``sort_by`` columns. See notes below.
@@ -206,7 +214,10 @@ def assert_tpch_result_equal(
                 polars.testing.assert_frame_equal(
                     df.select(by),
                     df.select(by).sort(
-                        by=by, descending=descending, maintain_order=True
+                        by=by,
+                        descending=descending,
+                        maintain_order=True,
+                        nulls_last=nulls_last,
                     ),
                 )
             except AssertionError as e:

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q14.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q14.py
@@ -467,4 +467,5 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
             ("i_category_id", False),
         ],
         limit=100,
+        nulls_last=False,
     )

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q23.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q23.py
@@ -183,4 +183,5 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
         ),
         sort_by=list(sort_by.items()),
         limit=limit,
+        nulls_last=False,
     )

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q39.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q39.py
@@ -191,8 +191,9 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
                     pl.col("cov_2").alias("cov"),
                 ]
             )
-            .sort(sort_by.keys(), nulls_last=True)
+            .sort(sort_by.keys(), nulls_last=False)
         ),
         sort_by=list(sort_by.items()),
         limit=None,
+        nulls_last=False,
     )

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q51.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q51.py
@@ -191,4 +191,5 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
         ),
         sort_by=list(sort_by.items()),
         limit=limit,
+        nulls_last=False,
     )

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q71.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q71.py
@@ -170,4 +170,5 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
         ),
         sort_by=[("ext_price", True), ("brand_id", False), ("t_hour", False)],
         limit=None,
+        nulls_last=False,
     )

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -1389,6 +1389,7 @@ class QueryResult:
     frame: pl.LazyFrame
     sort_by: list[tuple[str, bool]]
     limit: int | None = None
+    nulls_last: bool = True
 
 
 def check_input_data_type(
@@ -1473,6 +1474,7 @@ def run_polars_query_iteration(
             expected,
             query_result.sort_by,
             limit=query_result.limit,
+            nulls_last=query_result.nulls_last,
             **get_validation_options(args),
         )
     else:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The sortedness check in `assert_tpch_result_equal` re-sorted results without passing `nulls_last`, so polars defaulted to `nulls_last=False`. This caused validation failures for queries whose results correctly sorted NULLs last . The re-sort moved NULLs to the front and broke the comparison even though the data was correct.

The fix is to sort NULLs last by default in `assert_tpch_result_equal`, and override for queries that require `NULLS FIRST`.

- Contributes to #21750  by fixing 8 / 14 queries that fail due to sorting issues.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
