### PR TITLE
Remove test_infer_objects_no_reference from cudf_pandas xfail list

### DIFF
--- a/python/cudf/cudf/pandas/scripts/conftest-patch.py
+++ b/python/cudf/cudf/pandas/scripts/conftest-patch.py
@@ -1173,7 +1173,6 @@ NODEIDS_THAT_FAIL_WITH_CUDF_PANDAS = {
     "tests/copy_view/test_methods.py::test_get[key1]",
     "tests/copy_view/test_methods.py::test_groupby_column_index_in_references",
     "tests/copy_view/test_methods.py::test_infer_objects",
-    "tests/copy_view/test_methods.py::test_infer_objects_no_reference",
     "tests/copy_view/test_methods.py::test_insert_series",
     "tests/copy_view/test_methods.py::test_isetitem",
     "tests/copy_view/test_methods.py::test_isetitem_frame",


### PR DESCRIPTION
## Description
Appears this test started xpassing e.g. https://github.com/rapidsai/cudf/actions/runs/23174475055/job/67426668740?pr=21807#step:13:3720. Not sure if this is flaky but removing as it's seen on several builds

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
