### PR TITLE
Change to use non-detail APIs in some libcudf benchmarks

### DIFF
--- a/cpp/benchmarks/io/parquet/parquet_reader_filter.cpp
+++ b/cpp/benchmarks/io/parquet/parquet_reader_filter.cpp
@@ -11,7 +11,7 @@
 
 #include <cudf/binaryop.hpp>
 #include <cudf/copying.hpp>
-#include <cudf/detail/sequence.hpp>
+#include <cudf/filling.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/strings/utilities.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -132,10 +132,7 @@ struct filter_generator<DataType> {
 
     auto num_selected = static_cast<cudf::size_type>(num_rows * selectivity);
 
-    auto indices = cudf::detail::sequence(num_rows,
-                                          cudf::numeric_scalar<cudf::size_type>{0},
-                                          cudf::get_default_stream(),
-                                          cudf::get_current_device_resource_ref());
+    auto indices = cudf::sequence(num_rows, cudf::numeric_scalar<cudf::size_type>{0});
 
     auto copy_mask = cudf::binary_operation(indices->view(),
                                             cudf::numeric_scalar<cudf::size_type>{num_selected},

--- a/cpp/benchmarks/reduction/scan_structs.cpp
+++ b/cpp/benchmarks/reduction/scan_structs.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,7 +8,7 @@
 #include <benchmarks/common/table_utilities.hpp>
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/scan.hpp>
+#include <cudf/reduction.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <nvbench/nvbench.cuh>
@@ -46,8 +46,7 @@ static void nvbench_structs_scan(nvbench::state& state)
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
   std::unique_ptr<cudf::column> result = nullptr;
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    result = cudf::detail::scan_inclusive(
-      input_view, *agg, null_policy, stream, cudf::get_current_device_resource_ref());
+    result = cudf::scan(input_view, *agg, cudf::scan_type::INCLUSIVE, null_policy, stream);
   });
 
   state.add_element_count(input_view.size());


### PR DESCRIPTION
## Description
Changes source of some libcudf benchmarks to use public equivalent of detail functions.
Part of ongoing effort to minimize exported detail functions.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
