### PR TITLE
Add missing includes for cuda::std::abs

### DIFF
--- a/cpp/include/cudf/strings/detail/convert/string_to_float.cuh
+++ b/cpp/include/cudf/strings/detail/convert/string_to_float.cuh
@@ -8,9 +8,8 @@
 #include <cudf/strings/detail/convert/is_float.cuh>
 #include <cudf/strings/string_view.cuh>
 
+#include <cuda/std/cmath>
 #include <cuda/std/limits>
-
-#include <cmath>
 
 namespace cudf {
 namespace strings {

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -24,6 +24,7 @@
 
 #include <cuda/functional>
 #include <cuda/iterator>
+#include <cuda/std/cmath>
 #include <cuda/std/utility>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>


### PR DESCRIPTION
## Description
Followup of https://github.com/rapidsai/cudf/pull/21703

This PR addresses https://github.com/rapidsai/cudf/pull/21703#discussion_r2950628694 to add missing includes for `cuda::std::abs`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
