### PR TITLE
Fix orc pytest failures

### DIFF
--- a/cpp/src/io/statistics/statistics_type_identification.cuh
+++ b/cpp/src/io/statistics/statistics_type_identification.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,9 +37,11 @@ struct conversion_map;
 template <is_int96_timestamp INT96>
 struct conversion_map<io_file_format::ORC, INT96> {
   using types = std::tuple<std::pair<cudf::timestamp_s, cudf::timestamp_ns>,
+                           std::pair<cudf::timestamp_ms, cudf::timestamp_ns>,
                            std::pair<cudf::timestamp_us, cudf::timestamp_ns>,
                            std::pair<cudf::timestamp_ns, cudf::timestamp_ns>,
                            std::pair<cudf::duration_s, cudf::duration_ns>,
+                           std::pair<cudf::duration_ms, cudf::duration_ns>,
                            std::pair<cudf::duration_us, cudf::duration_ns>,
                            std::pair<cudf::duration_ns, cudf::duration_ns>>;
 };

--- a/python/cudf/cudf/tests/input_output/test_orc.py
+++ b/python/cudf/cudf/tests/input_output/test_orc.py
@@ -607,7 +607,11 @@ def normalized_equals(value1, value2):
     if isinstance(value1, float) or isinstance(value2, float):
         return np.isclose(value1, value2)
 
-    return value1 == value2
+    try:
+        assert_eq(value1, value2)
+        return True
+    except AssertionError:
+        return False
 
 
 @pytest.mark.parametrize("stats_freq", ["STRIPE", "ROWGROUP"])
@@ -1473,8 +1477,10 @@ def test_orc_writer_lists_empty_rg():
     df = cudf.read_orc(buffer)
     assert_eq(df, cudf_in)
 
-    pdf_out = pd.read_orc(buffer)
-    assert_eq(pdf_in, pdf_out)
+    # Compare via pyarrow since pd.read_orc converts nullable integer
+    # lists to float arrays ([None] -> [nan]), losing the original types.
+    pa_out = orc.ORCFile(buffer).read()
+    assert pa_out.equals(cudf_in.to_arrow())
 
 
 def test_statistics_sum_overflow():
@@ -1647,7 +1653,13 @@ def run_orc_columns_and_index_param(index_obj, index, columns):
     expected = pd.read_orc(buffer, columns=columns)
     got = cudf.read_orc(buffer, columns=columns)
 
-    assert_eq(expected, got, check_index_type=True)
+    # When columns is an empty list, pandas uses dtype='object' for
+    # the empty column Index while cudf uses dtype='str'. Avoid
+    # checking the column index type in that case.
+    check_col_type = columns is None or len(columns) > 0
+    assert_eq(
+        expected, got, check_index_type=True, check_column_type=check_col_type
+    )
 
 
 @pytest.mark.parametrize("index_obj", [None, [10, 11, 12], ["x", "y", "z"]])


### PR DESCRIPTION
## Description
This PR fixes all 16 orc pytest failures.
Cpp bug:
```
// The conversion map tells the statistics system how to normalize
// column types before computing min/max. For ORC, all timestamps
// must be converted to nanoseconds because split_nanosecond_timestamp()
// in stats_enc.cu expects nanosecond input.

What happened without the fix: A datetime64[ms] column with min value 1970-07-11 07:00:35.528 (stored as 16527635528 ms since epoch) was passed directly to split_nanosecond_timestamp() which interpreted it as nanoseconds:


split_nanosecond_timestamp(16527635528)
  → treats as 16,527,635,528 nanoseconds
  → 16,527 milliseconds + 635,528 nanoseconds remainder
  → ORC stats report min = 16,527 ms = 16.527 seconds
  → 1970-01-01 00:00:16.527  ← WRONG (off by ~1,000,000x)
With the fix: The value is first converted to nanoseconds via time_point_cast:


16527635528 ms → 16,527,635,528,000,000 ns (via conversion map)
split_nanosecond_timestamp(16527635528000000)
  → 16,527,635,528 milliseconds + 0 nanoseconds remainder
  → ORC stats report min = 16,527,635,528 ms
  → 1970-07-11 07:00:35.528  ← CORRECT
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
