### PR TITLE
Ensure Lineariser channels in scan_node are shutdown on error in cudf_polars

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/io.py
@@ -554,12 +554,13 @@ async def scan_node(
                 )
             await ch_out.drain(context)
 
-        async with shutdown_on_error(context, *lineariser.input_channels, trace_ir=ir):
-            tasks = [lineariser.drain()]
-            tasks.extend(
-                _producer(i, ch_in) for i, ch_in in enumerate(lineariser.input_channels)
-            )
-            await asyncio.gather(*tasks)
+        async with (
+            shutdown_on_error(context, *lineariser.input_channels, trace_ir=ir),
+            asyncio.TaskGroup() as tg,
+        ):
+            tg.create_task(lineariser.drain())
+            for i, ch_in in enumerate(lineariser.input_channels):
+                tg.create_task(_producer(i, ch_in))
 
 
 def make_rapidsmpf_read_parquet_node(


### PR DESCRIPTION
## Description
Similarly found as https://github.com/rapidsai/cudf/pull/21850, Claude found that the `Lineariser.input_channels` in the `scan_node` would not be shutdown if a task failed.

Also uses the TaskGroup instead of the gather API now that we support Python >=3.11 (and assuming we want to cancel the other task on failure)

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
