### PR TITLE
Add missing includes for `<cuda/functional>` and `<cuda/iterator>`

### DIFF
--- a/cpp/benchmarks/quantiles/tdigest.cpp
+++ b/cpp/benchmarks/quantiles/tdigest.cpp
@@ -9,6 +9,7 @@
 #include <cudf/filling.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
+#include <cuda/functional>
 #include <cuda/iterator>
 
 #include <nvbench/nvbench.cuh>

--- a/cpp/benchmarks/string/experimental/stringview_compare.cu
+++ b/cpp/benchmarks/string/experimental/stringview_compare.cu
@@ -19,6 +19,7 @@
 #include <rmm/exec_policy.hpp>
 
 #include <cub/device/device_merge_sort.cuh>
+#include <cuda/functional>
 #include <thrust/count.h>
 #include <thrust/for_each.h>
 #include <thrust/gather.h>

--- a/cpp/src/groupby/hash/compute_global_memory_aggs.cuh
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs.cuh
@@ -15,6 +15,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/iterator>
 #include <thrust/for_each.h>
 #include <thrust/transform.h>
 

--- a/cpp/src/groupby/sort/group_rank_scan.cu
+++ b/cpp/src/groupby/sort/group_rank_scan.cu
@@ -18,6 +18,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/limits>

--- a/cpp/src/interop/to_arrow_host.cu
+++ b/cpp/src/interop/to_arrow_host.cu
@@ -31,6 +31,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/functional>
 #include <thrust/binary_search.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>

--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -41,6 +41,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/functional>
 #include <thrust/count.h>
 #include <thrust/host_vector.h>
 #include <thrust/iterator/counting_iterator.h>

--- a/cpp/src/io/json/json_normalization.cu
+++ b/cpp/src/io/json/json_normalization.cu
@@ -19,6 +19,7 @@
 
 #include <cub/device/device_copy.cuh>
 #include <cuda/atomic>
+#include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/iterator>

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -36,6 +36,7 @@
 
 #include <cooperative_groups.h>
 #include <cooperative_groups/memcpy_async.h>
+#include <cuda/functional>
 #include <cuda/std/climits>
 #include <cuda/std/iterator>
 #include <cuda/std/limits>

--- a/cpp/src/io/parquet/page_data.cu
+++ b/cpp/src/io/parquet/page_data.cu
@@ -11,6 +11,7 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/functional>
 #include <cuda/iterator>
 #include <thrust/iterator/transform_iterator.h>
 

--- a/cpp/src/join/distinct_hash_join.cu
+++ b/cpp/src/join/distinct_hash_join.cu
@@ -26,6 +26,7 @@
 #include <cooperative_groups.h>
 #include <cub/block/block_scan.cuh>
 #include <cuco/static_set.cuh>
+#include <cuda/functional>
 #include <cuda/std/tuple>
 #include <thrust/fill.h>
 #include <thrust/iterator/counting_iterator.h>

--- a/cpp/src/join/filter_join_indices.cu
+++ b/cpp/src/join/filter_join_indices.cu
@@ -28,6 +28,7 @@
 
 #include <cub/cub.cuh>
 #include <cuco/static_set.cuh>
+#include <cuda/functional>
 #include <cuda/iterator>
 #include <cuda/std/tuple>
 #include <thrust/iterator/zip_iterator.h>

--- a/cpp/src/join/sort_merge_join.cu
+++ b/cpp/src/join/sort_merge_join.cu
@@ -37,6 +37,7 @@
 #include <cub/device/device_select.cuh>
 #include <cub/device/device_transform.cuh>
 #include <cuda/functional>
+#include <cuda/iterator>
 #include <cuda/std/iterator>
 #include <cuda/std/tuple>
 #include <thrust/binary_search.h>

--- a/cpp/src/reductions/scan/scan_inclusive.cu
+++ b/cpp/src/reductions/scan/scan_inclusive.cu
@@ -22,6 +22,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/functional>
 #include <cuda/std/functional>
 #include <thrust/find.h>
 #include <thrust/iterator/counting_iterator.h>

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -22,6 +22,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <cuda/functional>
 #include <cuda/std/functional>
 
 namespace cudf {

--- a/cpp/src/search/contains_table_impl.cuh
+++ b/cpp/src/search/contains_table_impl.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -20,6 +20,7 @@
 #include <rmm/mr/polymorphic_allocator.hpp>
 
 #include <cuco/static_set.cuh>
+#include <cuda/functional>
 #include <thrust/iterator/counting_iterator.h>
 
 namespace cudf::detail {

--- a/cpp/src/strings/extract/extract_all.cu
+++ b/cpp/src/strings/extract/extract_all.cu
@@ -21,6 +21,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cuda/functional>
 #include <thrust/transform_scan.h>
 
 namespace cudf {

--- a/cpp/src/text/wordpiece_tokenize.cu
+++ b/cpp/src/text/wordpiece_tokenize.cu
@@ -32,6 +32,7 @@
 #include <cooperative_groups/scan.h>
 #include <cub/cub.cuh>
 #include <cuco/static_map.cuh>
+#include <cuda/functional>
 #include <cuda/std/functional>
 #include <cuda/std/iterator>
 #include <cuda/std/limits>


### PR DESCRIPTION
## Description

Fixes a [CCCL nightly CI build failure](https://github.com/NVIDIA/cccl/actions/runs/23279043739/job/67688181922) caused by `cpp/benchmarks/quantiles/tdigest.cpp` using `cuda::proclaim_return_type` without directly including `<cuda/functional>`. The symbol was previously available through a transitive include from `<cuda/iterator>` which CCCL has since removed.

An audit of the full codebase found 16 additional files with similar issues, relying on transitive includes for symbols from `<cuda/functional>` or `<cuda/iterator>`. This PR adds direct includes to all affected files, improving IWYU (include-what-you-use) adherence.

### `#include <cuda/functional>` added to 16 files

**Build failure (triggered the CCCL nightly failure):**
- `cpp/benchmarks/quantiles/tdigest.cpp`

**Highest risk — relying on transitive include from third-party `cuco`:**
- `cpp/src/search/contains_table_impl.cuh`
- `cpp/src/join/distinct_hash_join.cu`
- `cpp/src/join/filter_join_indices.cu`

**Medium risk — relying on transitive include from cudf's own headers:**
- `cpp/benchmarks/string/experimental/stringview_compare.cu`
- `cpp/src/interop/to_arrow_host.cu`
- `cpp/src/reductions/scan/scan_inclusive.cu`
- `cpp/src/strings/extract/extract_all.cu`
- `cpp/src/text/wordpiece_tokenize.cu`
- `cpp/src/io/parquet/page_data.cu`
- `cpp/src/io/csv/reader_impl.cu`
- `cpp/src/io/orc/writer_impl.cu`
- `cpp/src/rolling/grouped_rolling.cu`
- `cpp/src/io/json/json_normalization.cu`

### `#include <cuda/iterator>` added to 3 files

**Highest risk — no transitive coverage found:**
- `cpp/src/groupby/hash/compute_global_memory_aggs.cuh`

**Medium risk — covered transitively by cudf headers:**
- `cpp/src/groupby/sort/group_rank_scan.cu`
- `cpp/src/join/sort_merge_join.cu`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.