### PR TITLE
Fix deprecation warning in JNI for parquet_reader_options::builder.names()

### DIFF
--- a/java/src/main/native/src/ChunkedReaderJni.cpp
+++ b/java/src/main/native/src/ChunkedReaderJni.cpp
@@ -76,7 +76,7 @@ Java_ai_rapids_cudf_ParquetChunkedReader_create(JNIEnv* env,
 
     auto opts_builder = cudf::io::parquet_reader_options::builder(source);
     if (n_filter_col_names.size() > 0) {
-      opts_builder = opts_builder.columns(n_filter_col_names.as_cpp_vector());
+      opts_builder = opts_builder.column_names(n_filter_col_names.as_cpp_vector());
     }
     auto const read_opts = opts_builder.convert_strings_to_categories(false)
                              .timestamp_type(cudf::data_type(static_cast<cudf::type_id>(unit)))


### PR DESCRIPTION
## Description
Fixes call to deprecated `parquet_reader_options::builder.names()` by changing it to call the replacement `parquet_reader_options::builder.column_names()`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
