### PR TITLE
Fix numpy `ufunc` return type

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -55,7 +55,6 @@ from cudf.core.dtypes import (
     CategoricalDtype,
     IntervalDtype,
 )
-from cudf.core.frame import Frame
 from cudf.core.join._join_helpers import _match_join_keys
 from cudf.core.single_column_frame import SingleColumnFrame
 from cudf.errors import MixedTypeError
@@ -1481,7 +1480,7 @@ class Index(SingleColumnFrame):
             if ret._column.has_nulls():
                 ret = ret.fillna(op == "__ne__")
 
-            if not isinstance(other, Frame):
+            if isinstance(ret, Index):
                 return ret.values
         return ret
 


### PR DESCRIPTION
## Description
This PR fixes all pytest failures in `python/cudf/cudf/tests/indexes/test_np_ufuncs.py` by returning the correct class type.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
