### PR TITLE
Ensure cudf.pandas proxy object tests populate test-local type maps

### DIFF
--- a/python/cudf/cudf_pandas_tests/test_fast_slow_proxy.py
+++ b/python/cudf/cudf_pandas_tests/test_fast_slow_proxy.py
@@ -342,10 +342,7 @@ def slow_and_intermediate_with_doc():
     return Slow, SlowIntermediate
 
 
-def test_doc(
-    fast_and_intermediate_with_doc,
-    slow_and_intermediate_with_doc,
-):
+def test_doc(fast_and_intermediate_with_doc, slow_and_intermediate_with_doc):
     Fast, FastIntermediate = fast_and_intermediate_with_doc
     Slow, SlowIntermediate = slow_and_intermediate_with_doc
 
@@ -377,10 +374,7 @@ def test_doc(
     )
 
 
-def test_dir(
-    fast_and_intermediate_with_doc,
-    slow_and_intermediate_with_doc,
-):
+def test_dir(fast_and_intermediate_with_doc, slow_and_intermediate_with_doc):
     Fast, FastIntermediate = fast_and_intermediate_with_doc
     Slow, SlowIntermediate = slow_and_intermediate_with_doc
 
@@ -416,9 +410,7 @@ def test_dir(
     ],
 )
 def test_dir_bound_method(
-    fast_and_intermediate_with_doc,
-    slow_and_intermediate_with_doc,
-    check,
+    fast_and_intermediate_with_doc, slow_and_intermediate_with_doc, check
 ):
     """This test will fail because dir for bound methods is currently
     incorrect, but we have no way to fix it without materializing the slow


### PR DESCRIPTION
## Description
Sometimes we see this flaky cudf.pandas test

```bash
FAILED python/cudf/cudf_pandas_tests/test_fast_slow_proxy.py::test_dir - AssertionError: assert ['__class__',...'__eq__', ...] == ['__annotate_...__doc__', ...]
  
  At index 0 diff: '__class__' != '__annotate_func__'
  Right contains one more item: 'prop'
  
  Full diff:
    [
  -     '__annotate_func__',
        '__class__',
        '__delattr__',
        '__dict__',
        '__dir__',
        '__doc__',
        '__eq__',
        '__firstlineno__',
        '__format__',
        '__ge__',
        '__getattribute__',
        '__getstate__',
        '__gt__',
        '__hash__',
        '__init__',
        '__init_subclass__',
        '__le__',
        '__lt__',
        '__module__',
        '__ne__',
        '__new__',
        '__reduce__',
        '__reduce_ex__',
        '__repr__',
        '__setattr__',
        '__sizeof__',
        '__static_attributes__',
        '__str__',
        '__subclasshook__',
        '__weakref__',
        'intermediate',
        'method',
        'prop',
    ]

```

These tests create types and populate the global, cached type maps with `make_final_proxy_type` and `make_intermediate_proxy_type`. This test can probably be made non-flaky by ensuring these tests are modifying maps local to the test

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
