### PR TITLE
Fix ambiguous stream constructor

### DIFF
--- a/cpp/tests/utilities/identify_stream_usage.cpp
+++ b/cpp/tests/utilities/identify_stream_usage.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -51,7 +51,7 @@ namespace test {
 rmm::cuda_stream_view const get_default_stream()
 {
   static rmm::cuda_stream stream{};
-  return {stream};
+  return stream;
 }
 
 #ifdef STREAM_MODE_TESTING


### PR DESCRIPTION
## Description

This fixes an ambiguous stream constructor error. RMM added a new conversion from `rmm::cuda_stream` to `cuda::stream_ref` in https://github.com/rapidsai/rmm/pull/2326, creating the ambiguity.

```
FAILED: CMakeFiles/cudf_identify_stream_usage_mode_cudf.dir/tests/utilities/identify_stream_usage.cpp.o
/usr/bin/sccache /home/coder/.conda/envs/rapids/bin/x86_64-conda-linux-gnu-c++ -DCCCL_DISABLE_PDL -DCUB_DISABLE_NAMESPACE_MAGIC -DCUB_IGNORE_NAMESPACE_MAGIC_ERROR -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_DISABLE_ABI_NAMESPACE -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -DTHRUST_IGNORE_ABI_NAMESPACE_ERROR -Dcudf_identify_stream_usage_mode_cudf_EXPORTS -I/home/coder/cudf/cpp/include -I/home/coder/cudf/cpp/build/conda/cuda-13.1/release/_deps/cccl-src/lib/cmake/thrust/../../../thrust -I/home/coder/cudf/cpp/build/conda/cuda-13.1/release/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include -I/home/coder/cudf/cpp/build/conda/cuda-13.1/release/_deps/cccl-src/lib/cmake/cub/../../../cub -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /home/coder/.conda/envs/rapids/include  -I/home/coder/.conda/envs/rapids/targets/x86_64-linux/include -I/home/coder/.conda/envs/rapids/targets/x86_64-linux/include/cccl -O3 -DNDEBUG -std=gnu++20 -fPIC -Wall -Werror -Wno-unknown-pragmas -Wno-error=deprecated-declarations -MD -MT CMakeFiles/cudf_identify_stream_usage_mode_cudf.dir/tests/utilities/identify_stream_usage.cpp.o -MF CMakeFiles/cudf_identify_stream_usage_mode_cudf.dir/tests/utilities/identify_stream_usage.cpp.o.d -o CMakeFiles/cudf_identify_stream_usage_mode_cudf.dir/tests/utilities/identify_stream_usage.cpp.o -c /home/coder/cudf/cpp/tests/utilities/identify_stream_usage.cpp
/home/coder/cudf/cpp/tests/utilities/identify_stream_usage.cpp: In function 'const rmm::cuda_stream_view cudf::get_default_stream()':
/home/coder/cudf/cpp/tests/utilities/identify_stream_usage.cpp:54:17: error: conversion from '<brace-enclosed initializer list>' to 'const rmm::cuda_stream_view' is ambiguous
   54 |   return {stream};
      |                 ^
In file included from /home/coder/.conda/envs/rapids/include/rmm/device_buffer.hpp:8,
                 from /home/coder/cudf/cpp/include/cudf/utilities/span.hpp:11,
                 from /home/coder/cudf/cpp/include/cudf/detail/utilities/stream_pool.hpp:9,
                 from /home/coder/cudf/cpp/tests/utilities/identify_stream_usage.cpp:6:
/home/coder/.conda/envs/rapids/include/rmm/cuda_stream_view.hpp:55:3: note: candidate: 'rmm::cuda_stream_view::cuda_stream_view(cuda::__4::stream_ref)'
   55 |   cuda_stream_view(cuda::stream_ref stream) noexcept;
      |   ^~~~~~~~~~~~~~~~
/home/coder/.conda/envs/rapids/include/rmm/cuda_stream_view.hpp:33:3: note: candidate: 'constexpr rmm::cuda_stream_view::cuda_stream_view(rmm::cuda_stream_view&&)'
   33 |   cuda_stream_view(cuda_stream_view&&)      = default;  ///< @default_move_constructor
      |   ^~~~~~~~~~~~~~~~
/home/coder/.conda/envs/rapids/include/rmm/cuda_stream_view.hpp:32:3: note: candidate: 'constexpr rmm::cuda_stream_view::cuda_stream_view(const rmm::cuda_stream_view&)'
   32 |   cuda_stream_view(cuda_stream_view const&) = default;  ///< @default_copy_constructor
      |   ^~~~~~~~~~~~~~~~
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
