### PR TITLE
Fix `isin` test failures

### DIFF
--- a/python/cudf/cudf/tests/series/methods/test_isin.py
+++ b/python/cudf/cudf/tests/series/methods/test_isin.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
@@ -8,9 +8,6 @@ import pytest
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.testing import assert_eq
-from cudf.testing._utils import (
-    expect_warning_if,
-)
 
 
 @pytest.mark.parametrize(
@@ -105,11 +102,9 @@ def test_isin_datetime(data, values):
     psr = pd.Series(data)
     gsr = cudf.Series(psr)
 
-    is_len_str = isinstance(next(iter(values), None), str) and len(data)
-    with expect_warning_if(is_len_str):
-        got = gsr.isin(values)
-    with expect_warning_if(is_len_str):
-        expected = psr.isin(values)
+    got = gsr.isin(values)
+    expected = psr.isin(values)
+
     assert_eq(got, expected)
 
 


### PR DESCRIPTION
## Description
This PR fixes all remaining test failures in `python/cudf/cudf/tests/series/methods/test_isin.py`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
