### PR TITLE
Fix dtype issues in `test_between.py`

### DIFF
--- a/python/cudf/cudf/tests/series/methods/test_between.py
+++ b/python/cudf/cudf/tests/series/methods/test_between.py
@@ -61,4 +61,4 @@ def test_series_between_with_null(data, dtype, left, right, inclusive):
     expected = ps.between(left, right, inclusive=inclusive)
     actual = gs.between(left, right, inclusive=inclusive)
 
-    assert_eq(expected, actual.to_pandas())
+    assert_eq(expected, actual)


### PR DESCRIPTION
## Description
This PR fixes all pytest failures in `python/cudf/cudf/tests/series/methods/test_between.py` but propagating correct dtypes.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
