### PR TITLE
Fix `string.to_pandas` for `nullable` & `arrow_type` cases

### DIFF
--- a/python/cudf/cudf/core/column/string.py
+++ b/python/cudf/cudf/core/column/string.py
@@ -373,11 +373,6 @@ class StringColumn(ColumnBase, Scannable):
             not nullable
             and not arrow_type
             and isinstance(self.dtype, pd.StringDtype)
-            and self.dtype.storage
-            in [
-                "pyarrow",
-                "python",
-            ]
         ):
             if self.dtype.storage == "pyarrow":
                 pa_array = self.to_arrow()


### PR DESCRIPTION
## Description
This PR returns correct results when `nullable` or `arrow_type` are passed to `StringColumn.to_pandas`

This PR:
```
== 199 failed, 78263 passed, 19475 skipped, 1544 xfailed in 279.84s (0:04:39) ==
```

pandas3:
```
== 207 failed, 78255 passed, 19475 skipped, 1544 xfailed in 283.12s (0:04:43) ==
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
