### PR TITLE
Fix type inconsistencies in `diff` pytests

### DIFF
--- a/python/cudf/cudf/tests/dataframe/methods/test_diff.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_diff.py
@@ -48,7 +48,7 @@ def test_diff_decimal_dtypes(precision, scale, dtype):
         np.random.default_rng(seed=42).uniform(10.5, 75.5, (10, 6)),
         dtype=dtype(precision=precision, scale=scale),
     )
-    pdf = gdf.to_pandas()
+    pdf = gdf.to_pandas(arrow_type=True)
 
     actual = gdf.diff()
     expected = pdf.diff()
@@ -90,10 +90,16 @@ def test_diff_many_dtypes():
     pdf = pd.DataFrame(
         {
             "dates": pd.date_range("2020-01-01", "2020-01-06", freq="D"),
-            "bools": [True, True, True, False, True, True],
-            "floats": [1.0, 2.0, 3.5, np.nan, 5.0, -1.7],
-            "ints": [1, 2, 3, 3, 4, 5],
-            "nans_nulls": [np.nan, None, None, np.nan, np.nan, None],
+            "bools": pd.array(
+                [True, True, True, False, True, True], dtype="boolean"
+            ),
+            "floats": pd.array(
+                [1.0, 2.0, 3.5, np.nan, 5.0, -1.7], dtype="Float64"
+            ),
+            "ints": pd.array([1, 2, 3, 3, 4, 5], dtype="Int64"),
+            "nans_nulls": pd.array(
+                [np.nan, None, None, np.nan, np.nan, None], dtype="Float64"
+            ),
         }
     )
     gdf = cudf.from_pandas(pdf)


### PR DESCRIPTION
## Description
This PR fixes 5 pytest failures in `python/cudf/cudf/tests/dataframe/methods/test_diff.py` by converting to arrow types.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
