### PR TITLE
Fix CPU PDS* runs

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -1760,7 +1760,7 @@ def run_polars(
                 date_type,
                 validation_files,
             )
-        case "single" | "distributed":
+        case "single" | "distributed" | None:
             run_polars_single_or_dask(
                 benchmark,
                 args,


### PR DESCRIPTION
PR adds a simple fix for running in cpu mode for pds* execution:

```
python -m cudf_polars.experimental.benchmarks.pdsds \
    --scale "$SCALE" \
    --path "$DATA" \
    --suffix "" \
    --executor cpu \
    --iterations 2 \
    --explain \
    --no-print-results \
    -o "$OUTPUT" \
    "$QUERIES" \
    2>&1 | tee "$LOG"
```

cc @Matt711 