### PR TITLE
Increase cpp-memcheck test timeout

### DIFF
--- a/ci/test_cpp_memcheck.sh
+++ b/ci/test_cpp_memcheck.sh
@@ -11,7 +11,7 @@ source ./ci/test_cpp_common.sh
 
 rapids-logger "Memcheck gtests with rmm_mode=cuda"
 
-timeout 3h ./ci/run_cudf_memcheck_ctests.sh && EXITCODE=$? || EXITCODE=$?;
+timeout 3.5h ./ci/run_cudf_memcheck_ctests.sh && EXITCODE=$? || EXITCODE=$?;
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 # shellcheck disable=SC2086


### PR DESCRIPTION
## Description
Increases the timeout for the nightly compute-sanitizer memcheck runs from 3 hours to 3.5 hours.
The nightly runs usually complete in about 2.5 hours but some slower runners will hit the timeout and I've estimated an additional 10 minutes would suffice. Changing to 3.5 hours also allows a buffer for future tests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
