### PR TITLE
Fix mypy pinning on rmm

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
           pyarrow-stubs,
           pytest,
           types-cachetools,
-          "rmm-cu12==26.2.*,>=0.0.0a0; sys_platform=='linux'",
+          "rmm-cu12==26.4.*,>=0.0.0a0; sys_platform=='linux'",
           "--extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/"
         ]
         args: ["--config-file=pyproject.toml",

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -142,6 +142,9 @@ sed_runner "s|/tree/\\bmain\\b/|/tree/${RAPIDS_BRANCH_NAME}/|g" python/cudf_pola
 sed_runner "s|CUDF_TAG release/[0-9]\+\.[0-9]\+|CUDF_TAG ${RAPIDS_BRANCH_NAME}|g" cpp/examples/versions.cmake
 sed_runner "s|CUDF_TAG \\bmain\\b|CUDF_TAG ${RAPIDS_BRANCH_NAME}|g" cpp/examples/versions.cmake
 
+# .pre-commit-config.yaml
+sed_runner "/rmm-cu[0-9]*==/ s/==.*\*,/==${NEXT_SHORT_TAG_PEP440}.*,/g" .pre-commit-config.yaml
+
 # CI files
 for FILE in .github/workflows/*.yaml .github/workflows/*.yml; do
   sed_runner "/shared-workflows/ s|@.*|@${WORKFLOW_BRANCH_REF}|g" "${FILE}"


### PR DESCRIPTION
## Description
`.pre-commit-config.yaml` has a `mypy` hook that pinned to rmm from 26.2. This PR fixes that for the 26.04 release and updates `ci/release/update-version.sh` to accommodate this for the future.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
