### PR TITLE
Remove paths from cudf-polars Scan Trace properties

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/explain.py
+++ b/python/cudf_polars/cudf_polars/experimental/explain.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import functools
+import os.path
 from collections.abc import Mapping, Sequence
 from itertools import groupby
 from typing import TYPE_CHECKING, Any, Self, TypeAlias
@@ -273,6 +274,7 @@ def _serialize_properties(ir: IR) -> dict[str, Serializable]:
 def _(ir: Scan) -> dict[str, Serializable]:
     return {
         "typ": ir.typ,
+        "prefix": os.path.commonprefix(ir.paths),
         "predicate": _serialize_expr(ir.predicate) if ir.predicate else None,
     }
 

--- a/python/cudf_polars/tests/experimental/test_explain.py
+++ b/python/cudf_polars/tests/experimental/test_explain.py
@@ -515,10 +515,14 @@ def test_serialize_query():
 
 @pytest.mark.parametrize("predicate", [None, pl.col("a") > 1])
 def test_scan_properties(tmp_path: Path, predicate: pl.Expr | None):
-    pl.DataFrame({"a": [1, 2, 3]}).write_parquet(tmp_path / "test.parquet")
+    root = tmp_path.joinpath("test.parquet")
+    root.mkdir(parents=True, exist_ok=True)
+    for path in ["a", "b", "c"]:
+        pl.DataFrame({"a": [1, 2, 3]}).write_parquet(root / path)
 
     q = pl.scan_parquet(tmp_path / "test.parquet")
     expected_properties: dict[str, Any] = {
+        "prefix": f"{root}/",
         "typ": "parquet",
         "predicate": None,
     }


### PR DESCRIPTION
## Description

This removes the 'paths' list from the `properties` of the `Scan` trace and explain nodes. 'paths' can be arbitrarily large, and so isn't a good candidate for storing in a trace.