### PR TITLE
Fix mypy pinning on rmm (26.06)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
           pyarrow-stubs,
           pytest,
           types-cachetools,
-          "rmm-cu12==26.4.*,>=0.0.0a0; sys_platform=='linux'",
+          "rmm-cu12==26.6.*,>=0.0.0a0; sys_platform=='linux'",
           "--extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/"
         ]
         args: ["--config-file=pyproject.toml",


### PR DESCRIPTION
## Description
This is a follow-up to #21925 that applies the version update for `main` on 26.06. In the future this will be automated by `ci/release/update-version.sh` changes from the previous PR, this is just a one-off fix for the 26.06 release.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
