### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/cpp/benchmarks/ast/polynomials.cpp
+++ b/cpp/benchmarks/ast/polynomials.cpp
@@ -1,13 +1,13 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <benchmarks/common/generate_input.hpp>
+#include <benchmarks/common/nvtx_ranges.hpp>
 
 #include <cudf/ast/expressions.hpp>
 #include <cudf/column/column.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/transform.hpp>
 #include <cudf/utilities/error.hpp>
@@ -84,7 +84,7 @@ void BM_ast_polynomials(nvbench::state& state)
   state.add_global_memory_writes<key_type>(num_rows);
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
-    cudf::scoped_range range{"benchmark_iteration"};
+    cudf::benchmark::scoped_range range{"benchmark_iteration"};
 
     switch (engine) {
       case engine_type::AST: {

--- a/cpp/benchmarks/binaryop/polynomials.cpp
+++ b/cpp/benchmarks/binaryop/polynomials.cpp
@@ -1,14 +1,14 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <benchmarks/common/generate_input.hpp>
+#include <benchmarks/common/nvtx_ranges.hpp>
 
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/types.hpp>
 
@@ -55,7 +55,7 @@ static void BM_binaryop_polynomials(nvbench::state& state)
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     // computes polynomials: (((ax + b)x + c)x + d)x + e... = ax**4 + bx**3 + cx**2 + dx + e....
-    cudf::scoped_range range{"benchmark_iteration"};
+    cudf::benchmark::scoped_range range{"benchmark_iteration"};
     rmm::cuda_stream_view stream{launch.get_stream().get_stream()};
     std::vector<std::unique_ptr<cudf::column>> intermediates;
 

--- a/cpp/benchmarks/common/nvtx_ranges.hpp
+++ b/cpp/benchmarks/common/nvtx_ranges.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,11 +9,26 @@
 
 namespace cudf::benchmark {
 /**
- * @brief Tag type for the NVTX domain
+ * @brief Tag type for the libcudf benchmark NVTX domain
  */
 struct benchmark_domain {
   static constexpr char const* name{"benchmarks"};  ///< Name of the domain
 };
+
+/**
+ * @brief Alias for an NVTX range in the libcudf benchmark domain.
+ *
+ * Customizes an NVTX range with the given input.
+ *
+ * Example:
+ * ```
+ * void some_function(){
+ *    cudf::benchmark::scoped_range rng{"custom_name"}; // Customizes range name
+ *    ...
+ * }
+ * ```
+ */
+using scoped_range = ::nvtx3::scoped_range_in<benchmark_domain>;
 
 }  // namespace cudf::benchmark
 

--- a/cpp/benchmarks/io/orc/orc_reader_multithreaded.cpp
+++ b/cpp/benchmarks/io/orc/orc_reader_multithreaded.cpp
@@ -1,14 +1,14 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <benchmarks/common/generate_input.hpp>
 #include <benchmarks/common/memory_stats.hpp>
+#include <benchmarks/common/nvtx_ranges.hpp>
 #include <benchmarks/io/cuio_common.hpp>
 #include <benchmarks/io/nvbench_helpers.hpp>
 
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/detail/utilities/stream_pool.hpp>
 #include <cudf/io/orc.hpp>
 #include <cudf/utilities/default_stream.hpp>
@@ -92,7 +92,7 @@ void BM_orc_multithreaded_read_common(nvbench::state& state,
   auto mem_stats_logger = cudf::memory_stats_logger();
 
   {
-    cudf::scoped_range range{("(read) " + label).c_str()};
+    cudf::benchmark::scoped_range range{("(read) " + label).c_str()};
     state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
                [&](nvbench::launch& launch, auto& timer) {
                  auto read_func = [&](int index) {
@@ -122,7 +122,7 @@ void BM_orc_multithreaded_read_common(nvbench::state& state,
 void BM_orc_multithreaded_read_mixed(nvbench::state& state)
 {
   auto label = get_label("mixed", state);
-  cudf::scoped_range range{label.c_str()};
+  cudf::benchmark::scoped_range range{label.c_str()};
   BM_orc_multithreaded_read_common(
     state, {cudf::type_id::INT32, cudf::type_id::DECIMAL64, cudf::type_id::STRING}, label);
 }
@@ -130,21 +130,21 @@ void BM_orc_multithreaded_read_mixed(nvbench::state& state)
 void BM_orc_multithreaded_read_fixed_width(nvbench::state& state)
 {
   auto label = get_label("fixed width", state);
-  cudf::scoped_range range{label.c_str()};
+  cudf::benchmark::scoped_range range{label.c_str()};
   BM_orc_multithreaded_read_common(state, {cudf::type_id::INT32}, label);
 }
 
 void BM_orc_multithreaded_read_string(nvbench::state& state)
 {
   auto label = get_label("string", state);
-  cudf::scoped_range range{label.c_str()};
+  cudf::benchmark::scoped_range range{label.c_str()};
   BM_orc_multithreaded_read_common(state, {cudf::type_id::STRING}, label);
 }
 
 void BM_orc_multithreaded_read_list(nvbench::state& state)
 {
   auto label = get_label("list", state);
-  cudf::scoped_range range{label.c_str()};
+  cudf::benchmark::scoped_range range{label.c_str()};
   BM_orc_multithreaded_read_common(state, {cudf::type_id::LIST}, label);
 }
 
@@ -169,7 +169,7 @@ void BM_orc_multithreaded_read_chunked_common(nvbench::state& state,
   auto mem_stats_logger = cudf::memory_stats_logger();
 
   {
-    cudf::scoped_range range{("(read) " + label).c_str()};
+    cudf::benchmark::scoped_range range{("(read) " + label).c_str()};
     std::vector<cudf::io::table_with_metadata> chunks;
     state.exec(nvbench::exec_tag::sync | nvbench::exec_tag::timer,
                [&](nvbench::launch& launch, auto& timer) {
@@ -211,7 +211,7 @@ void BM_orc_multithreaded_read_chunked_common(nvbench::state& state,
 void BM_orc_multithreaded_read_chunked_mixed(nvbench::state& state)
 {
   auto label = get_label("mixed", state);
-  cudf::scoped_range range{label.c_str()};
+  cudf::benchmark::scoped_range range{label.c_str()};
   BM_orc_multithreaded_read_chunked_common(
     state, {cudf::type_id::INT32, cudf::type_id::DECIMAL64, cudf::type_id::STRING}, label);
 }
@@ -219,21 +219,21 @@ void BM_orc_multithreaded_read_chunked_mixed(nvbench::state& state)
 void BM_orc_multithreaded_read_chunked_fixed_width(nvbench::state& state)
 {
   auto label = get_label("fixed width", state);
-  cudf::scoped_range range{label.c_str()};
+  cudf::benchmark::scoped_range range{label.c_str()};
   BM_orc_multithreaded_read_chunked_common(state, {cudf::type_id::INT32}, label);
 }
 
 void BM_orc_multithreaded_read_chunked_string(nvbench::state& state)
 {
   auto label = get_label("string", state);
-  cudf::scoped_range range{label.c_str()};
+  cudf::benchmark::scoped_range range{label.c_str()};
   BM_orc_multithreaded_read_chunked_common(state, {cudf::type_id::STRING}, label);
 }
 
 void BM_orc_multithreaded_read_chunked_list(nvbench::state& state)
 {
   auto label = get_label("list", state);
-  cudf::scoped_range range{label.c_str()};
+  cudf::benchmark::scoped_range range{label.c_str()};
   BM_orc_multithreaded_read_chunked_common(state, {cudf::type_id::LIST}, label);
 }
 auto const thread_range    = std::vector<nvbench::int64_t>{1, 2, 4, 8};

--- a/cpp/benchmarks/transform/polynomials.cpp
+++ b/cpp/benchmarks/transform/polynomials.cpp
@@ -4,10 +4,10 @@
  */
 
 #include <benchmarks/common/generate_input.hpp>
+#include <benchmarks/common/nvtx_ranges.hpp>
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/transform.hpp>
 #include <cudf/types.hpp>
 
@@ -56,7 +56,7 @@ static void BM_transform_polynomials(nvbench::state& state)
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     // computes polynomials: (((ax + b)x + c)x + d)x + e... = ax**4 + bx**3 + cx**2 + dx + e....
 
-    cudf::scoped_range range{"benchmark_iteration"};
+    cudf::benchmark::scoped_range range{"benchmark_iteration"};
 
     std::string type = cudf::type_to_name(cudf::data_type{cudf::type_to_id<key_type>()});
 

--- a/cpp/doxygen/developer_guide/BENCHMARKING.md
+++ b/cpp/doxygen/developer_guide/BENCHMARKING.md
@@ -42,6 +42,21 @@ For generating benchmark input data, helper functions are available at [cpp/benc
 * `create_random_column` can generate a column filled with random data. The random data parameters are configurable.
 * `create_random_table` can generate a table of columns filled with random data. The random data parameters are configurable.
 
+## NVTX Ranges
+
+In order to aid in performance measurement, add NVTX ranges to the data generation and/or
+the function being measured. Use either the `CUDF_BENCHMARK_RANGE` or `cudf::benchmark::scoped_range`
+for declaring NVTX ranges in the current scope as appropriate:
+- Use the `CUDF_BENCHMARK_RANGE()` macro if you want to use the name of the function as the name of the
+NVTX range
+- Use `cudf::benchmark::scoped_range rng{"custom_name"};` to provide a custom name for the current scope's
+NVTX range
+
+For more information about NVTX, see [here](https://github.com/NVIDIA/NVTX/tree/dev/c).
+
+Do not use the libcudf nvtx range classes in benchmark source code to help separate the execution
+scope properly in the NSight Compute tools.
+
 ## What should we benchmark?
 
 In general, we should benchmark all features over a range of data sizes and types, so that we can


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.