### PR TITLE
Fix retry in fetch_polars_versions

### DIFF
--- a/ci/utils/fetch_polars_versions.py
+++ b/ci/utils/fetch_polars_versions.py
@@ -78,7 +78,7 @@ def get_polars_versions(polars_range, latest_only=False):
             if attempt == max_attempts - 1:
                 raise e
             # Just retry retryable errors
-            if (
+            if "unreachable" in e.reason or (
                 code
                 in {
                     http.HTTPStatus.REQUEST_TIMEOUT,


### PR DESCRIPTION
## Description

In
https://github.com/rapidsai/cudf/actions/runs/23539459514/job/68526641951?pr=21927#step:13:383, we hit an `AttributeError` trying to access the non-existent `URLError.code` attribute.

This changes that to first check the `.reason` code for text like "unreachable", which was the original cause of the error in that particular case.
