### PR TITLE
Bump librdkafka to >=2.11.1,<2.12.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -44,7 +44,7 @@ dependencies:
 - libkvikio==26.4.*,>=0.0.0a0
 - libnvcomp-dev==5.1.0.21
 - libnvjitlink-dev
-- librdkafka>=2.8.0,<2.9.0
+- librdkafka>=2.11.1,<2.12.0
 - librmm==26.4.*,>=0.0.0a0
 - make
 - mmh3

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -44,7 +44,7 @@ dependencies:
 - libkvikio==26.4.*,>=0.0.0a0
 - libnvcomp-dev==5.1.0.21
 - libnvjitlink-dev
-- librdkafka>=2.8.0,<2.9.0
+- librdkafka>=2.11.1,<2.12.0
 - librmm==26.4.*,>=0.0.0a0
 - make
 - mmh3

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -44,7 +44,7 @@ dependencies:
 - libkvikio==26.4.*,>=0.0.0a0
 - libnvcomp-dev==5.1.0.21
 - libnvjitlink-dev
-- librdkafka>=2.8.0,<2.9.0
+- librdkafka>=2.11.1,<2.12.0
 - librmm==26.4.*,>=0.0.0a0
 - make
 - mmh3

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -44,7 +44,7 @@ dependencies:
 - libkvikio==26.4.*,>=0.0.0a0
 - libnvcomp-dev==5.1.0.21
 - libnvjitlink-dev
-- librdkafka>=2.8.0,<2.9.0
+- librdkafka>=2.11.1,<2.12.0
 - librmm==26.4.*,>=0.0.0a0
 - make
 - mmh3

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -505,7 +505,7 @@ dependencies:
       - output_types: conda
         packages:
           - flatbuffers==24.3.25
-          - librdkafka>=2.8.0,<2.9.0
+          - librdkafka>=2.11.1,<2.12.0
   depends_on_libnvcomp:
     common:
       - output_types: conda


### PR DESCRIPTION
## Description
Scanning https://anaconda.org/channels/conda-forge/packages/librdkafka, it appears that 2.11.1 is the first version to support Python 3.14. I think this is the cause of the devcontainer conda failures e.g. https://github.com/rapidsai/cudf/actions/runs/23554430068/job/68577154587?pr=21921 (below).

So this PR bumps `librdkafka` and follows our similar, narrow pinning so we support Python 3.14 as well. However, the [python-confluent-kafka recipe](https://github.com/conda-forge/python-confluent-kafka-feedstock/blob/main/recipe/meta.yaml#L38) specifies `- librdkafka >={{ version }}` so we're effectively also pinning `python-confluent-kafka` even though it was unpinned on our side in https://github.com/rapidsai/cudf/pull/21540
```
The following packages are incompatible
├─ librdkafka >=2.8.0,<2.9.0 * is requested and can be installed;
├─ python-confluent-kafka =* * is installable with the potential options
│  ├─ python-confluent-kafka 2.1.0 would require
│  │  └─ librdkafka >=2.1.0,<2.2.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.1.1 would require
│  │  └─ librdkafka >=2.1.1,<2.2.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.10.0 would require
│  │  └─ librdkafka >=2.10.0,<2.11.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.10.1 would require
│  │  └─ librdkafka >=2.10.1,<2.11.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.11.0 would require
│  │  └─ librdkafka >=2.11.0,<2.12.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.11.1 would require
│  │  └─ librdkafka >=2.11.1,<2.12.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.12.2 would require
│  │  └─ librdkafka >=2.12.1,<2.13.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.13.0 would require
│  │  └─ librdkafka >=2.13.0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.13.2 would require
│  │  └─ librdkafka >=2.13.2 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.2.0 would require
│  │  └─ librdkafka >=2.2.0,<2.3.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.3.0 would require
│  │  └─ librdkafka >=2.3.0,<2.4.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.4.0 would require
│  │  └─ librdkafka >=2.4.0,<2.5.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.5.0 would require
│  │  └─ librdkafka >=2.5.0,<2.6.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.5.3 would require
│  │  └─ librdkafka >=2.5.3,<2.6.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.6.0 would require
│  │  └─ librdkafka >=2.6.0,<2.7.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.6.1 would require
│  │  └─ librdkafka >=2.6.1,<2.7.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 2.8.0 would require
│  │  └─ python_abi =3.10 *_cp310, which can be installed;
│  ├─ python-confluent-kafka 2.8.0 would require
│  │  └─ python_abi =3.11 *_cp311, which can be installed;
│  ├─ python-confluent-kafka 2.8.0 would require
│  │  └─ python_abi =3.12 *_cp312, which can be installed;
│  ├─ python-confluent-kafka 2.8.0 would require
│  │  └─ python_abi =3.13 *_cp313, which can be installed;
│  ├─ python-confluent-kafka 2.8.0 would require
│  │  └─ python_abi =3.9 *_cp39, which can be installed;
│  ├─ python-confluent-kafka [0.11.0|0.11.4|0.9.4] would require
│  │  └─ librdkafka [==0.9.4 *|>=0.9.4,<0.9.5.0a0 *], which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 0.11.4 would require
│  │  └─ librdkafka >=0.11.0,<0.12 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 0.11.4 would require
│  │  └─ librdkafka >=0.11.5,<0.11.6.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 1.0.1 would require
│  │  └─ librdkafka >=1.0.1,<1.0.2.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka [1.1.0|1.3.0] would require
│  │  └─ python_abi =* *_cp27mu, which can be installed;
│  ├─ python-confluent-kafka [1.1.0|1.3.0] would require
│  │  └─ python_abi =* *_cp36m, which can be installed;
│  ├─ python-confluent-kafka [1.1.0|1.3.0] would require
│  │  └─ python_abi =* *_cp37m, which can be installed;
│  ├─ python-confluent-kafka [1.1.0|1.3.0] would require
│  │  └─ python_abi =* *_cp38, which can be installed;
│  ├─ python-confluent-kafka 1.3.0 would require
│  │  └─ librdkafka >=1.4.0,<1.5.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka [1.3.0|1.5.0] would require
│  │  └─ librdkafka >=1.5.0,<1.6.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka [1.5.0|1.6.0] would require
│  │  └─ librdkafka >=1.6.0,<1.7.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 1.7.0 would require
│  │  └─ librdkafka >=1.7.0,<1.8.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 1.8.2 would require
│  │  └─ librdkafka >=1.8.2.0inf.2,<1.9.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ python-confluent-kafka 1.9.0 would require
│  │  └─ librdkafka >=1.9.1,<1.10.0a0 *, which conflicts with any installable versions previously reported;
│  └─ python-confluent-kafka [1.9.0|1.9.2] would require
│     └─ librdkafka >=1.9.2,<1.10.0a0 *, which conflicts with any installable versions previously reported;
└─ python =3.14 * is not installable because there are no viable options
   ├─ python [3.14.0|3.14.1|3.14.2|3.14.3] would require
   │  └─ python_abi =3.14 *_cp314, which conflicts with any installable versions previously reported;
   ├─ python [3.14.0|3.14.1|3.14.2|3.14.3] would require
   │  └─ python_abi =3.14 *_cp314t, which conflicts with any installable versions previously reported;
   └─ python [3.14.0rc1|3.14.0rc2|3.14.0rc3] would require
      └─ _python_rc =* *, which does not exist (perhaps a missing channel).
``` 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
