### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
           pyarrow-stubs,
           pytest,
           types-cachetools,
-          "rmm-cu12==26.4.*,>=0.0.0a0; sys_platform=='linux'",
+          "rmm-cu12==26.6.*,>=0.0.0a0; sys_platform=='linux'",
           "--extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/"
         ]
         args: ["--config-file=pyproject.toml",


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.