### PR TITLE
Run pandas compatibility tests in isolated virtual environments

### DIFF
--- a/ci/cudf_pandas_scripts/run_tests.sh
+++ b/ci/cudf_pandas_scripts/run_tests.sh
@@ -85,21 +85,21 @@ output=$(python ci/utils/filter_package_versions.py dependencies.yaml run_common
 
 read -r -a versions <<< "${output}"
 
-if [[ "${RAPIDS_PY_VERSION}" < "3.13" ]]; then
+if python -c "import sys; print(sys.version_info < (3, 13))" | grep -q True; then
     for VERSION in "${versions[@]}"; do
         echo "Running tests for pandas==${VERSION}"
 
         # Create isolated environment
         python -m venv venv_${VERSION}
+        # shellcheck disable=SC1090
         source venv_${VERSION}/bin/activate
-        unset PIP_CONSTRAINT
 
         pip install --upgrade pip
 
         # Install cudf + dependencies (reuse wheel install logic)
         rapids-pip-retry install \
             --constraint ./constraints.txt \
-            --constraint "${PIP_CONSTRAINT}" \
+            ${PIP_CONSTRAINT:+--constraint "${PIP_CONSTRAINT}"} \
             "$(echo "${CUDF_WHEELHOUSE}"/cudf_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)[test,cudf-pandas-tests]" \
             "$(echo "${LIBCUDF_WHEELHOUSE}"/libcudf_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)" \
             "$(echo "${PYLIBCUDF_WHEELHOUSE}"/pylibcudf_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)"


### PR DESCRIPTION
## Description
This PR updates pandas compatibility testing in CI to run each version in an isolated virtual environment.

### Motivation
Previously, multiple pandas versions were installed sequentially in the same environment, which could lead to:
- Dependency conflicts
- Incompatibility with the fixed Python version
- Binary incompatibility issues (e.g., pandas/numpy ABI mismatch)

### Changes
- Introduced per-version virtual environments for pandas compatibility testing
- Preserved existing version selection logic using dynamic discovery
- Reused existing RAPIDS installation and pytest commands
- Ensured clean dependency isolation across test runs

### Notes
This improves reproducibility and prevents environment contamination between test runs.

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
