### PR TITLE
Update `loc` pytests

### DIFF
--- a/python/cudf/cudf/tests/dataframe/indexing/test_loc.py
+++ b/python/cudf/cudf/tests/dataframe/indexing/test_loc.py
@@ -790,7 +790,13 @@ def test_sliced_indexing():
 )
 @pytest.mark.parametrize("is_dataframe", [True, False])
 def test_loc_datetime_index(sli, is_dataframe):
-    sli = slice(pd.to_datetime(sli.start), pd.to_datetime(sli.stop))
+    # Preserve None as None (not NaT) so pandas treats it as an open bound.
+    # pd.to_datetime(None) returns NaT, which pandas rejects as a slice
+    # bound on a non-monotonic datetime index.
+    sli = slice(
+        pd.to_datetime(sli.start) if sli.start is not None else None,
+        pd.to_datetime(sli.stop) if sli.stop is not None else None,
+    )
 
     if is_dataframe is True:
         pd_data = pd.DataFrame(
@@ -890,7 +896,9 @@ def test_dataframe_loc_iloc_inplace_update_with_RHS_dataframe():
 
 
 def test_dataframe_loc_inplace_update_with_invalid_RHS_df_columns():
-    gdf = cudf.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    # Use float columns so both cudf and pandas can hold NaN when aligning
+    # RHS columns that don't match the loc selection (int64 can't hold NaN).
+    gdf = cudf.DataFrame({"x": [1.0, 2.0, 3.0], "y": [4.0, 5.0, 6.0]})
     pdf = gdf.to_pandas()
 
     actual = gdf.loc[[0, 2], ["x", "y"]] = cudf.DataFrame(


### PR DESCRIPTION
## Description
test_loc_datetime_index[True/False-sli2] — sli2 = slice("2001", None). The test was converting None via pd.to_datetime(None) → NaT, which pandas now rejects as a slice bound on a non-monotonic datetime index. Fixed by preserving None as None in the slice conversion.

test_dataframe_loc_inplace_update_with_invalid_RHS_df_columns — When assigning a DataFrame with misaligned columns via loc, the missing column fills with NaN. pandas now raises TypeError when trying to store NaN into an int64 column. Fixed by using float64 columns in the initial DataFrame so both cudf and pandas can hold the NaN values.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
