### PR TITLE
Enforce cudf_polars `cardinality_factor` and `scheduler` deprecations

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -20,7 +20,6 @@ import textwrap
 import time
 import traceback
 import uuid
-import warnings
 from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
@@ -359,7 +358,6 @@ class RunConfig:
     runtime: str
     stream_policy: str | None
     cluster: str
-    scheduler: str  # Deprecated, kept for backward compatibility
     n_workers: int
     versions: PackageVersions = dataclasses.field(
         default_factory=PackageVersions.collect
@@ -414,7 +412,6 @@ class RunConfig:
         """Create a RunConfig from command line arguments."""
         executor: ExecutorType = args.executor
         cluster = args.cluster
-        scheduler = args.scheduler
         runtime = args.runtime
         stream_policy = args.stream_policy
 
@@ -422,35 +419,9 @@ class RunConfig:
         if stream_policy == "auto":
             stream_policy = None
 
-        # Deal with deprecated scheduler argument
-        # and non-streaming executors
+        # Deal with non-streaming executors
         if executor == "in-memory" or executor == "cpu":
-            cluster = None
-            scheduler = None
-        elif scheduler is not None:
-            if cluster is not None:
-                raise ValueError(
-                    "Cannot specify both -s/--scheduler and -c/--cluster. "
-                    "Please use -c/--cluster only."
-                )
-            else:
-                warnings.warn(
-                    "The -s/--scheduler argument is deprecated. Use -c/--cluster instead.",
-                    FutureWarning,
-                    stacklevel=2,
-                )
-            cluster = "single" if scheduler == "synchronous" else "distributed"
-        elif cluster is not None:
-            match cluster:
-                case "single":
-                    scheduler = "synchronous"
-                case "distributed":
-                    scheduler = "distributed"
-                case "spmd":  # launched via rrun, not Dask
-                    scheduler = None
-        else:
             cluster = "single"
-            scheduler = "synchronous"
 
         path = args.path
         name = args.query_set
@@ -520,7 +491,6 @@ class RunConfig:
             queries=args.query,
             executor=executor,
             cluster=cluster,
-            scheduler=scheduler,
             runtime=runtime,
             stream_policy=stream_policy,
             n_workers=args.n_workers,
@@ -967,19 +937,6 @@ def build_parser(num_queries: int = 22) -> argparse.ArgumentParser:
                 - distributed : Use Dask for multi-GPU execution
                 - spmd        : SPMD execution via rrun launcher
                 - ray         : Ray actor-based multi-GPU execution"""),
-    )
-    parser.add_argument(
-        "-s",
-        "--scheduler",
-        default=None,
-        type=str,
-        choices=["synchronous", "distributed"],
-        help=textwrap.dedent("""\
-            *Deprecated*: Use --cluster instead.
-
-            Scheduler type to use with the 'streaming' executor.
-                - synchronous : Run locally in a single process
-                - distributed : Use Dask for multi-GPU execution"""),
     )
     parser.add_argument(
         "--runtime",

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -27,7 +27,6 @@ import functools
 import importlib.util
 import json
 import os
-import warnings
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 from rmm.pylibrmm import CudaStreamFlags, CudaStreamPool
@@ -56,7 +55,6 @@ __all__ = [
     "RayContext",
     "Runtime",
     "SPMDContext",
-    "Scheduler",  # Deprecated, kept for backward compatibility
     "ShuffleMethod",
     "StreamingExecutor",
     "StreamingFallbackMode",
@@ -176,20 +174,6 @@ class Cluster(enum.StrEnum):
     DISTRIBUTED = "distributed"
     SPMD = "spmd"
     RAY = "ray"
-
-
-class Scheduler(enum.StrEnum):
-    """
-    **Deprecated**: Use :class:`Cluster` instead.
-
-    The scheduler to use for the task-based streaming executor.
-
-    * ``Scheduler.SYNCHRONOUS`` : Single-GPU execution (use ``Cluster.SINGLE`` instead)
-    * ``Scheduler.DISTRIBUTED`` : Multi-GPU execution (use ``Cluster.DISTRIBUTED`` instead)
-    """
-
-    SYNCHRONOUS = "synchronous"
-    DISTRIBUTED = "distributed"
 
 
 class ShuffleMethod(enum.StrEnum):
@@ -591,12 +575,6 @@ class StreamingExecutor:
         * ``Cluster.DISTRIBUTED``: Multi-GPU distributed execution (requires
           an active Dask cluster)
 
-    scheduler
-        **Deprecated**: Use ``cluster`` instead.
-
-        For backward compatibility:
-        * ``Scheduler.SYNCHRONOUS`` maps to ``Cluster.SINGLE``
-        * ``Scheduler.DISTRIBUTED`` maps to ``Cluster.DISTRIBUTED``
     fallback_mode
         How to handle errors when the GPU engine fails to execute a query.
         ``StreamingFallbackMode.WARN`` by default.
@@ -707,13 +685,6 @@ class StreamingExecutor:
             default=None,
         )
     )
-    scheduler: Scheduler | None = dataclasses.field(
-        default_factory=_make_default_factory(
-            f"{_env_prefix}__SCHEDULER",
-            Scheduler.__call__,
-            default=None,
-        )
-    )
     fallback_mode: StreamingFallbackMode = dataclasses.field(
         default_factory=_make_default_factory(
             f"{_env_prefix}__FALLBACK_MODE",
@@ -796,30 +767,7 @@ class StreamingExecutor:
                 raise ValueError("The rapidsmpf streaming engine requires rapidsmpf.")
             object.__setattr__(self, "shuffle_method", "rapidsmpf")
 
-        # Handle backward compatibility for deprecated scheduler parameter
-        if self.scheduler is not None:
-            if self.cluster is not None:
-                raise ValueError(
-                    "Cannot specify both 'scheduler' and 'cluster'. "
-                    "The 'scheduler' parameter is deprecated. "
-                    "Please use only 'cluster' instead."
-                )
-            else:
-                warnings.warn(
-                    """The 'scheduler' parameter is deprecated. Please use 'cluster' instead.
-                    Use 'cluster="single"' instead of 'scheduler="synchronous"' and "
-                    'cluster="distributed"' instead of 'scheduler="distributed"'.""",
-                    FutureWarning,
-                    stacklevel=2,
-                )
-            # Map old scheduler values to new cluster values
-            if self.scheduler == "synchronous":
-                object.__setattr__(self, "cluster", Cluster.SINGLE)
-            elif self.scheduler == "distributed":
-                object.__setattr__(self, "cluster", Cluster.DISTRIBUTED)
-            # Clear scheduler to avoid confusion
-            object.__setattr__(self, "scheduler", None)
-        elif self.cluster is None:
+        if self.cluster is None:
             object.__setattr__(self, "cluster", Cluster.SINGLE)
         assert self.cluster is not None, "Expected cluster to be set."
 

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -345,46 +345,6 @@ def test_validate_cluster() -> None:
         )
 
 
-def test_scheduler_deprecated() -> None:
-    # Test that using deprecated scheduler parameter emits warning
-    # and correctly maps to cluster parameter
-
-    # Test scheduler="synchronous" maps to cluster="single"
-    with pytest.warns(FutureWarning, match="'scheduler' parameter is deprecated"):
-        config = ConfigOptions.from_polars_engine(
-            pl.GPUEngine(
-                executor="streaming",
-                executor_options={"scheduler": "synchronous"},
-            )
-        )
-    assert config.executor.name == "streaming"
-    assert config.executor.cluster == "single"
-    assert config.executor.scheduler is None  # Should be cleared after mapping
-
-    # Test scheduler="distributed" maps to cluster="distributed"
-    with pytest.warns(FutureWarning, match="'scheduler' parameter is deprecated"):
-        config = ConfigOptions.from_polars_engine(
-            pl.GPUEngine(
-                executor="streaming",
-                executor_options={"scheduler": "distributed"},
-            )
-        )
-    assert config.executor.name == "streaming"
-    assert config.executor.cluster == "distributed"
-    assert config.executor.scheduler is None  # Should be cleared after mapping
-
-    # Test that specifying both cluster and scheduler raises an error
-    with pytest.raises(
-        ValueError, match="Cannot specify both 'scheduler' and 'cluster'"
-    ):
-        ConfigOptions.from_polars_engine(
-            pl.GPUEngine(
-                executor="streaming",
-                executor_options={"cluster": "single", "scheduler": "synchronous"},
-            )
-        )
-
-
 def test_validate_shuffle_method_defaults(
     *,
     rapidsmpf_distributed_available: bool,


### PR DESCRIPTION
## Description
* `cardinality_factor` deprecated in 25.08 https://github.com/rapidsai/cudf/pull/19273
* `scheduler` deprecated in 25.12 https://github.com/rapidsai/cudf/pull/20252

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
