### PR TITLE
Fix null_count incorrectly marked as pointwise

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/unary.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/unary.py
@@ -145,6 +145,7 @@ class UnaryFunction(Expr):
             "cum_prod",
             "cum_sum",
             "drop_nulls",
+            "null_count",
             "rank",
             "shift",
             "shift_and_fill",


### PR DESCRIPTION
## Summary
- `UnaryFunction("null_count")` was incorrectly marked `is_pointwise=True`. It is a scalar aggregation (returns 1 row with the count of null values), not a pointwise operation.
- In the streaming executor with dynamic planning, this caused expression decomposition to treat `null_count` as a pass-through while decomposing sibling aggregations (e.g. `count`). The resulting mismatched `HConcat` broadcast a 1-row aggregation result to match multi-million-row raw data, producing a huge intermediate table that overflowed in cross joins.
- Fixes TPC-DS query 28 at scale 100 (`len(col) - null_count(col)` pattern from Polars optimizing `count(drop_nulls(col))`).

## Detail

Polars optimizes `col.drop_nulls().count()` into `len(col) - null_count(col)`. During expression decomposition for multi-partition streaming execution:

1. `len(col)` (`is_pointwise=False`) → correctly decomposed into partial/repartition/final → 1-row result from `decomposed_ir_A`
2. `null_count(col)` (`is_pointwise=True` ← **bug**) → returned as-is, still reading from `input_scan` (millions of rows)

These two different input IRs were combined in an `HConcat(should_broadcast=True)`, broadcasting the 1-row result to match the raw scan. The multi-million-row output then flowed into the cross join and hit `OverflowError: The resulting table exceeds the column size limit`.

## Fix

Add `"null_count"` to the non-pointwise exclusion list in `UnaryFunction.__init__`. This causes the `Select` containing `null_count` to fall back to single-partition execution via `_lower_ir_fallback`, where all aggregation expressions correctly evaluate on the complete data and produce 1 row.

A follow-up could add proper decomposition support for `null_count` (partial null_count → repartition → final sum) to restore multi-partition execution for these expressions.