### PR TITLE
Switch default time resolutions for `DatetimeIndex` & `TimedeltaIndex`

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -25,7 +25,6 @@ from cudf.api.types import (
     is_integer,
     is_list_like,
     is_scalar,
-    is_string_dtype,
 )
 from cudf.core._internals import copying, sorting
 from cudf.core.accessors import StringMethods


### PR DESCRIPTION
## Description
This PR changes string like inputs to be parsed as `us` and all other inputs as `ns` if dtype is not passed to `DatetimeIndex` & `TimedeltaIndex`
`pandas3`:
```
== 77 failed, 78386 passed, 19475 skipped, 1542 xfailed in 286.59s (0:04:46) ===
```
This PR:
```
== 74 failed, 78389 passed, 19475 skipped, 1542 xfailed in 270.37s (0:04:30) ===
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
