### PR TITLE
Validate PDS-DS Queries Q24, 47, 49, 94

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q24.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q24.py
@@ -137,7 +137,14 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
                 "i_size",
             ]
         )
-        .agg(pl.col(amountone).sum().alias("netpaid"))
+        .agg(
+            # Polars sum() returns 0 for all-null groups; SQL returns NULL.
+            # See https://github.com/rapidsai/cudf/issues/19560.
+            pl.when(pl.col(amountone).count() > 0)
+            .then(pl.col(amountone).sum())
+            .otherwise(None)
+            .alias("netpaid")
+        )
     )
 
     threshold_table = ssales.select(
@@ -150,7 +157,14 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
         frame=(
             ssales.filter(pl.col("i_color") == color)
             .group_by(["c_last_name", "c_first_name", "s_store_name"])
-            .agg(pl.col("netpaid").sum().alias("paid"))
+            .agg(
+                # Polars sum() returns 0 for all-null groups; SQL returns NULL.
+                # See https://github.com/rapidsai/cudf/issues/19560.
+                pl.when(pl.col("netpaid").count() > 0)
+                .then(pl.col("netpaid").sum())
+                .otherwise(None)
+                .alias("paid")
+            )
             .join(threshold_table, how="cross")
             .filter(pl.col("paid") > pl.col("threshold"))
             .select(["c_last_name", "c_first_name", "s_store_name", "paid"])

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q47.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q47.py
@@ -257,15 +257,13 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
                     > 0.1
                 )
             )
-            .with_columns(
-                [
-                    (pl.col("sum_sales") - pl.col("avg_monthly_sales")).alias(
-                        "sales_deviation"
-                    )
-                ]
-            )
             .sort(
-                ["sales_deviation", "d_moy"], nulls_last=True, descending=[False, False]
+                by=[
+                    pl.col("sum_sales") - pl.col("avg_monthly_sales"),
+                    pl.col("d_moy"),
+                ],
+                descending=[False, False],
+                nulls_last=True,
             )
             .select(
                 [
@@ -282,4 +280,8 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
         ),
         sort_by=list(sort_by.items()),
         limit=limit,
+        sort_keys=[
+            (pl.col("sum_sales") - pl.col("avg_monthly_sales"), False),
+            (pl.col("d_moy"), False),
+        ],
     )

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q49.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q49.py
@@ -221,8 +221,8 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
                 (
                     pl.when(pl.col("ws_net_paid").drop_nulls().count() > 0)
                     .then(
-                        pl.col("wr_return_amt").fill_null(0).sum().cast(pl.Float64)
-                        / pl.col("ws_net_paid").fill_null(0).sum().cast(pl.Float64)
+                        pl.col("wr_return_amt").fill_null(0).sum().round(4)
+                        / pl.col("ws_net_paid").fill_null(0).sum().round(4)
                     )
                     .otherwise(None)
                 ).alias("currency_ratio"),
@@ -272,11 +272,8 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
                 (
                     pl.when(pl.col("cs_net_paid").drop_nulls().count() > 0)
                     .then(
-                        pl.col("cr_return_amount")
-                        .fill_null(0)
-                        .sum()
-                        .cast(pl.Float64)  # Note: "amount" not "amt"
-                        / pl.col("cs_net_paid").fill_null(0).sum().cast(pl.Float64)
+                        pl.col("cr_return_amount").fill_null(0).sum().round(4)
+                        / pl.col("cs_net_paid").fill_null(0).sum().round(4)
                     )
                     .otherwise(None)
                 ).alias("currency_ratio"),
@@ -326,8 +323,8 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
                 (
                     pl.when(pl.col("ss_net_paid").drop_nulls().count() > 0)
                     .then(
-                        pl.col("sr_return_amt").fill_null(0).sum().cast(pl.Float64)
-                        / pl.col("ss_net_paid").fill_null(0).sum().cast(pl.Float64)
+                        pl.col("sr_return_amt").fill_null(0).sum().round(4)
+                        / pl.col("ss_net_paid").fill_null(0).sum().round(4)
                     )
                     .otherwise(None)
                 ).alias("currency_ratio"),

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q94.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q94.py
@@ -85,7 +85,9 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     end_date = start_date + pl.duration(days=60)
     multi_warehouse_orders = (
         web_sales.group_by("ws_order_number")
-        .agg([pl.col("ws_warehouse_sk").n_unique().alias("warehouse_count")])
+        .agg(
+            [pl.col("ws_warehouse_sk").drop_nulls().n_unique().alias("warehouse_count")]
+        )
         .filter(pl.col("warehouse_count") > 1)
         .select("ws_order_number")
     )
@@ -109,6 +111,7 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
                 & (pl.col("d_date") <= end_date)
                 & (pl.col("ca_state") == state)
                 & (pl.col("web_company_name") == web_company_name)
+                & pl.col("ws_warehouse_sk").is_not_null()
             )
             .join(
                 multi_warehouse_orders,


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Q24: Handle discrepancy DuckDB and Polars sum of NULLs

Q47: Complex sort expression; need to pass `sort_keys`

Q49: The SQL `CAST(Sum(...) AS DEC(15,4))` rounds to 4 decimal places, so round

Q94: The SQL `ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk` evaluates to UNKNOWN when `ws_warehouse_sk` is NULL. So we need to exclude them.

- Contributes to https://github.com/rapidsai/cudf/issues/21750
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
