### PR TITLE
Fix OOM in PDS-DS Q78

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q78.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q78.py
@@ -153,10 +153,9 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
                 .alias("ws_sp"),
             ]
         )
-        .rename({"d_year": "ws_sold_year"})
         .select(
             [
-                "ws_sold_year",
+                pl.col("d_year").alias("ws_sold_year"),
                 "ws_item_sk",
                 "ws_bill_customer_sk",
                 "ws_qty",
@@ -191,10 +190,9 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
                 .alias("cs_sp"),
             ]
         )
-        .rename({"d_year": "cs_sold_year"})
         .select(
             [
-                "cs_sold_year",
+                pl.col("d_year").alias("cs_sold_year"),
                 "cs_item_sk",
                 "cs_bill_customer_sk",
                 "cs_qty",
@@ -229,7 +227,16 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
                 .alias("ss_sp"),
             ]
         )
-        .rename({"d_year": "ss_sold_year"})
+        .select(
+            [
+                pl.col("d_year").alias("ss_sold_year"),
+                "ss_item_sk",
+                "ss_customer_sk",
+                "ss_qty",
+                "ss_wc",
+                "ss_sp",
+            ]
+        )
     )
     result = (
         ss.join(


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The OOM came about because`first` is not a supported streaming groupby aggregation. Therefore we repartition back to a single partition and go OOM (at SF1K). But we don't need `first` in the first place. The SQL is `d_year AS ws_sold_year` which is a rename / alias.

- Contributes to https://github.com/rapidsai/cudf/issues/21750
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
