### PR TITLE
Workaround unsupported unary function in a groupby context in PDS-DS Q94

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q94.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q94.py
@@ -84,10 +84,9 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     start_date = pl.lit(start_date_py, dtype=pl.Datetime("us"))
     end_date = start_date + pl.duration(days=60)
     multi_warehouse_orders = (
-        web_sales.group_by("ws_order_number")
-        .agg(
-            [pl.col("ws_warehouse_sk").drop_nulls().n_unique().alias("warehouse_count")]
-        )
+        web_sales.filter(pl.col("ws_warehouse_sk").is_not_null())
+        .group_by("ws_order_number")
+        .agg(pl.col("ws_warehouse_sk").n_unique().alias("warehouse_count"))
         .filter(pl.col("warehouse_count") > 1)
         .select("ws_order_number")
     )


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Follow up to https://github.com/rapidsai/cudf/pull/22007. `drop_nulls` is not supported in that context. So workaround it by per-filtering the nulls.

- Contributes to #21750 
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
