### PR TITLE
Fuse drop_nulls into n_unique

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expressions/aggregation.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/aggregation.py
@@ -59,7 +59,11 @@ class Agg(Expr):
             req = plc.aggregation.median()
         elif name == "n_unique":
             # TODO: datatype of result
-            req = plc.aggregation.nunique(null_handling=plc.types.NullPolicy.INCLUDE)
+            req = plc.aggregation.nunique(
+                null_handling=plc.types.NullPolicy.EXCLUDE
+                if options
+                else plc.types.NullPolicy.INCLUDE
+            )
         elif name == "first" or name == "last":
             req = None
         elif name == "mean":

--- a/python/cudf_polars/cudf_polars/dsl/utils/aggregations.py
+++ b/python/cudf_polars/cudf_polars/dsl/utils/aggregations.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """Utilities for rewriting aggregations."""
@@ -167,6 +167,16 @@ def decompose_single_agg(
             child = agg.children[0]
         else:
             (child,) = agg.children
+        # Fuse drop_nulls().n_unique() into nunique(null_handling=EXCLUDE)
+        # rather than materializing a filtered intermediate column.
+        if (
+            agg.name == "n_unique"
+            and isinstance(child, expr.UnaryFunction)
+            and child.name == "drop_nulls"
+        ):
+            (child,) = child.children
+            agg = expr.Agg(agg.dtype, "n_unique", (True,), agg.context, child)
+            named_expr = named_expr.reconstruct(agg)
         needs_masking = agg.name in {"min", "max"} and plc.traits.is_floating_point(
             child.dtype.plc_type
         )

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -356,6 +356,13 @@ def test_groupby_nunique(df: pl.LazyFrame, column):
     assert_gpu_result_equal(q, check_row_order=False)
 
 
+@pytest.mark.parametrize("column", ["int", "string", "uint16_with_null"])
+def test_groupby_nunique_drop_nulls(df: pl.LazyFrame, column):
+    q = df.group_by("key1").agg(pl.col(column).drop_nulls().n_unique())
+
+    assert_gpu_result_equal(q, check_row_order=False)
+
+
 def test_groupby_null_count(df: pl.LazyFrame):
     q = df.group_by("key1").agg(pl.col("uint16_with_null").null_count())
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Since pylibcudf supports excluding nulls from a unique count, we can avoid materializing an intermediate column and fuse these two nodes when they appear together in an aggregation. This changes adds support for `drop_nulls` in this specific context. Full support in aggregations when not a child of `n_unique` is left for future work.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
