### PR TITLE
[Multi-GPU Polars] Fix SPMD bootstrap race with session-scoped communicator

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
@@ -266,6 +266,12 @@ class SPMDEngine(StreamingEngine):
 
     Parameters
     ----------
+    comm
+        An already-bootstrapped communicator. When provided, the bootstrap step
+        is skipped and the caller retains ownership; the communicator is **not**
+        closed on shutdown. Pass this to share a single communicator across multiple
+        engine lifetimes (e.g. a session-scoped pytest fixture).
+        When ``None`` (default) a new communicator is bootstrapped automatically.
     rapidsmpf_options
         RapidsMPF-specific options. Defaults to the reading ``RAPIDSMPF_*``
         environment variables.
@@ -300,6 +306,7 @@ class SPMDEngine(StreamingEngine):
     def __init__(
         self,
         *,
+        comm: Communicator | None = None,
         rapidsmpf_options: Options | None = None,
         executor_options: dict[str, Any] | None = None,
         engine_options: dict[str, Any] | None = None,
@@ -315,17 +322,16 @@ class SPMDEngine(StreamingEngine):
             else Options(get_environment_variables())
         )
         mr = RmmResourceAdaptor(rmm.mr.get_current_device_resource())
-        if bootstrap.is_running_with_rrun():
-            comm = bootstrap.create_ucxx_comm(
-                progress_thread=ProgressThread(),
-                type=bootstrap.BackendType.AUTO,
-                options=rapidsmpf_options,
-            )
-        else:
-            comm = single_communicator(
-                progress_thread=ProgressThread(),
-                options=rapidsmpf_options,
-            )
+        if comm is None:
+            if bootstrap.is_running_with_rrun():
+                comm = bootstrap.create_ucxx_comm(
+                    progress_thread=ProgressThread(),
+                    type=bootstrap.BackendType.AUTO,
+                    options=rapidsmpf_options,
+                )
+            else:
+                comm = single_communicator(rapidsmpf_options, ProgressThread())
+        # else: caller-provided comm; the caller retains ownership
 
         py_executor = ThreadPoolExecutor(
             max_workers=cast(

--- a/python/cudf_polars/docs/cudf-polars-mp.md
+++ b/python/cudf_polars/docs/cudf-polars-mp.md
@@ -366,9 +366,12 @@ manager imported from `cudf_polars.experimental.rapidsmpf.frontend.spmd`. On con
 
 1. Bootstraps a communicator: UCXX when running under `rrun`, otherwise a
    single-rank communicator that requires no external library.
+   Pass an already-bootstrapped communicator via `comm=` to skip this step and
+   reuse an existing one (see [Reusing a communicator](#reusing-a-communicator) below).
 2. Creates a RapidsMPF streaming `Context` that owns GPU memory and a CUDA stream pool.
 
-All resources are released when the context exits (or `shutdown()` is called).
+All resources except the (optionally) caller-supplied communicator are released when
+the context exits (or `shutdown()` is called).
 
 ```python
 # multi-GPU launch: rrun -n 4 python my_script.py
@@ -472,10 +475,37 @@ may silently collide with an ID already reserved by an active collective inside 
 The result is guaranteed to be a `pl.DataFrame` containing rows from all ranks in rank order
 (rank 0 first, then rank 1, …, rank N-1).
 
+### Reusing a communicator
+
+By default `SPMDEngine` bootstraps a new UCXX communicator on every construction.
+When running multiple engines in sequence (for example in a test suite or an
+interactive session), bootstrapping repeatedly is unnecessary and can cause race
+conditions in the file-based coordination layer shared by all ranks.
+
+Pass a pre-created communicator via the `comm=` argument to skip the bootstrap
+entirely. The engine **does not** close the communicator on shutdown — the caller
+retains ownership and can reuse it across multiple `SPMDEngine` lifetimes.
+
+```python
+from rapidsmpf import bootstrap
+from rapidsmpf.progress_thread import ProgressThread
+from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
+
+# Bootstrap once.
+comm = bootstrap.create_ucxx_comm(progress_thread=ProgressThread())
+
+# Reuse across multiple engine lifetimes — no re-bootstrap between them.
+with SPMDEngine(comm=comm) as engine:
+    result1 = df1.lazy().collect(engine=engine)
+
+with SPMDEngine(comm=comm) as engine:
+    result2 = df2.lazy().collect(engine=engine)
+```
+
 ### Passing options
 
-`rapidsmpf_options`, `executor_options`, and `engine_options` accept pass-through
-arguments:
+`comm`, `rapidsmpf_options`, `executor_options`, and `engine_options` accept
+pass-through arguments:
 
 ```python
 import rmm
@@ -498,6 +528,10 @@ RapidsMPF `Context` share the same resource), sets the wrapped resource as curre
 restores the original resource on shutdown. To use a custom allocator, call
 `rmm.mr.set_current_device_resource(your_mr)` **before** constructing `SPMDEngine`.
 Do not pre-wrap it in `RmmResourceAdaptor`.
+
+`comm` is an already-bootstrapped communicator. When provided, the bootstrap step
+is skipped and the caller retains ownership (see
+[Reusing a communicator](#reusing-a-communicator)). Defaults to `None`.
 
 `rapidsmpf_options` is an `Options` object passed to the RapidsMPF `Context`. Defaults
 to `None` (uses RapidsMPF defaults).

--- a/python/cudf_polars/tests/experimental/conftest.py
+++ b/python/cudf_polars/tests/experimental/conftest.py
@@ -8,13 +8,18 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from rapidsmpf import bootstrap
 from rapidsmpf.bootstrap import get_nranks, is_running_with_rrun
-from rapidsmpf.config import Options
+from rapidsmpf.communicator.single import new_communicator as single_communicator
+from rapidsmpf.config import Options, get_environment_variables
+from rapidsmpf.progress_thread import ProgressThread
 
 from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+    from rapidsmpf.communicator.communicator import Communicator
 
     from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
 
@@ -30,9 +35,26 @@ def _skip_unless_spmd(request: pytest.FixtureRequest) -> None:
         pytest.skip("skip: SPMD nranks > 1 (mark with pytest.mark.spmd to run)")
 
 
+@pytest.fixture(scope="session")
+def spmd_comm() -> Communicator:
+    """Session-scoped communicator — bootstrapped once and shared across all tests.
+
+    Sharing a single communicator avoids the file-based bootstrap race that can
+    cause hangs when ``create_ucxx_comm()`` is called repeatedly in the same
+    ``rrun`` session (stale barrier files / stale ``ucxx_root_address`` KV entry).
+    """
+    if bootstrap.is_running_with_rrun():
+        return bootstrap.create_ucxx_comm(
+            progress_thread=ProgressThread(),
+            type=bootstrap.BackendType.AUTO,
+        )
+    return single_communicator(Options(get_environment_variables()), ProgressThread())
+
+
 @pytest.fixture
 def engine(
     request: pytest.FixtureRequest,
+    spmd_comm: Communicator,
 ) -> Generator[StreamingEngine, None, None]:
     """Yield a :class:`~cudf_polars.experimental.rapidsmpf.frontend.spmd.SPMDEngine`.
 
@@ -64,6 +86,7 @@ def engine(
     )
 
     with SPMDEngine(
+        comm=spmd_comm,
         rapidsmpf_options=rapidsmpf_options,
         executor_options=executor_options,
         engine_options=params.get("engine_options", {}),

--- a/python/cudf_polars/tests/experimental/test_spmd.py
+++ b/python/cudf_polars/tests/experimental/test_spmd.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from rapidsmpf.bootstrap import is_running_with_rrun
 from rapidsmpf.rmm_resource_adaptor import RmmResourceAdaptor
@@ -18,12 +20,15 @@ from cudf_polars.experimental.rapidsmpf.frontend.spmd import (
     allgather_polars_dataframe,
 )
 
+if TYPE_CHECKING:
+    from rapidsmpf.communicator.communicator import Communicator
+
 pytestmark = pytest.mark.spmd
 
 
-def test_yields_context_and_engine() -> None:
+def test_yields_context_and_engine(spmd_comm: Communicator) -> None:
     """SPMDEngine has comm and context properties."""
-    with SPMDEngine() as engine:
+    with SPMDEngine(comm=spmd_comm) as engine:
         assert engine.comm is not None
         assert engine.context is not None
         assert isinstance(engine, pl.GPUEngine)
@@ -58,15 +63,15 @@ def test_engine_options_reserved_keys() -> None:
             pass
 
 
-def test_engine_options_parquet_options() -> None:
+def test_engine_options_parquet_options(spmd_comm: Communicator) -> None:
     """engine_options forwards parquet_options to GPUEngine without error."""
-    with SPMDEngine(engine_options={"parquet_options": {}}) as engine:
+    with SPMDEngine(comm=spmd_comm, engine_options={"parquet_options": {}}) as engine:
         assert isinstance(engine, pl.GPUEngine)
 
 
-def test_scan() -> None:
+def test_scan(spmd_comm: Communicator) -> None:
     """Each rank scans its own single-row LazyFrame and gets that row back."""
-    with SPMDEngine() as engine:
+    with SPMDEngine(comm=spmd_comm) as engine:
         lf = pl.LazyFrame({"a": [engine.rank], "b": [engine.rank * 10]})
         result = lf.collect(engine=engine)
         assert result.shape == (1, 2)
@@ -74,15 +79,15 @@ def test_scan() -> None:
         assert result["b"].to_list() == [engine.rank * 10]
 
 
-def test_basic_query() -> None:
+def test_basic_query(spmd_comm: Communicator) -> None:
     """A simple in-memory LazyFrame can be collected."""
-    with SPMDEngine() as engine:
+    with SPMDEngine(comm=spmd_comm) as engine:
         result = pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).collect(engine=engine)
     assert result.shape == (3, 2)
     assert result["a"].to_list() == [1, 2, 3]
 
 
-def test_collect_then_lazy_equivalent() -> None:
+def test_collect_then_lazy_equivalent(spmd_comm: Communicator) -> None:
     """collect().lazy() preserves SPMD semantics: an intermediate materialize is a no-op.
 
     In SPMD mode a DataFrame is always rank-local.  When it is wrapped back
@@ -90,7 +95,7 @@ def test_collect_then_lazy_equivalent() -> None:
     re-slicing it across ranks.  So ``lf.collect().lazy().op.collect()`` must
     produce the same result as ``lf.op.collect()``.
     """
-    with SPMDEngine() as engine:
+    with SPMDEngine(comm=spmd_comm) as engine:
         lf = pl.LazyFrame(
             {"a": [engine.rank, engine.rank + 1, engine.rank + 2], "b": [0, 1, 2]}
         )
@@ -105,9 +110,9 @@ def test_collect_then_lazy_equivalent() -> None:
     assert one_step.sort("a").equals(two_step.sort("a"))
 
 
-def test_group_by() -> None:
+def test_group_by(spmd_comm: Communicator) -> None:
     """Group-by on rank-local data, then allgather to verify the global result."""
-    with SPMDEngine() as engine:
+    with SPMDEngine(comm=spmd_comm) as engine:
         lf = pl.LazyFrame({"a": [engine.rank], "b": [engine.rank * 10]})
         local_result = lf.group_by("a").agg(pl.col("b").sum()).collect(engine=engine)
         with reserve_op_id() as op_id:
@@ -121,9 +126,9 @@ def test_group_by() -> None:
         ]
 
 
-def test_allgather_polars_dataframe() -> None:
+def test_allgather_polars_dataframe(spmd_comm: Communicator) -> None:
     """allgather_polars_dataframe collects every rank's contribution in rank order."""
-    with SPMDEngine() as engine:
+    with SPMDEngine(comm=spmd_comm) as engine:
         local = pl.DataFrame({"rank": [engine.rank], "val": [engine.rank * 2]})
         with reserve_op_id() as op_id:
             result = allgather_polars_dataframe(
@@ -134,18 +139,19 @@ def test_allgather_polars_dataframe() -> None:
         assert result["val"].to_list() == [r * 2 for r in range(engine.nranks)]
 
 
-def test_max_workers() -> None:
+def test_max_workers(spmd_comm: Communicator) -> None:
     """executor_options forwards rapidsmpf_py_executor_max_workers to the thread pool."""
     with SPMDEngine(
-        executor_options={"rapidsmpf_py_executor_max_workers": 2}
+        comm=spmd_comm,
+        executor_options={"rapidsmpf_py_executor_max_workers": 2},
     ) as engine:
         result = pl.LazyFrame({"a": [1, 2, 3]}).collect(engine=engine)
     assert result.shape == (3, 1)
 
 
-def test_allgather_polars_dataframe_empty() -> None:
+def test_allgather_polars_dataframe_empty(spmd_comm: Communicator) -> None:
     """allgather handles an empty (zero-row) local DataFrame on every rank."""
-    with SPMDEngine() as engine:
+    with SPMDEngine(comm=spmd_comm) as engine:
         local = pl.DataFrame(
             {"a": pl.Series([], dtype=pl.Int32), "b": pl.Series([], dtype=pl.Float64)}
         )
@@ -158,23 +164,23 @@ def test_allgather_polars_dataframe_empty() -> None:
     assert result.dtypes == [pl.Int32, pl.Float64]
 
 
-def test_mr_wrapped_as_current_inside_context() -> None:
+def test_mr_wrapped_as_current_inside_context(spmd_comm: Communicator) -> None:
     """Inside SPMDEngine the current device resource is RmmResourceAdaptor."""
-    with SPMDEngine():
+    with SPMDEngine(comm=spmd_comm):
         assert isinstance(rmm.mr.get_current_device_resource(), RmmResourceAdaptor)
 
 
-def test_mr_restored_after_context() -> None:
+def test_mr_restored_after_context(spmd_comm: Communicator) -> None:
     """After SPMDEngine exits the original device resource is restored."""
     original = rmm.mr.get_current_device_resource()
-    with SPMDEngine():
+    with SPMDEngine(comm=spmd_comm):
         pass
     assert rmm.mr.get_current_device_resource() is original
 
 
-def test_allgather_polars_dataframe_multi_column() -> None:
+def test_allgather_polars_dataframe_multi_column(spmd_comm: Communicator) -> None:
     """allgather preserves column names, count, and dtypes for multi-column DataFrames."""
-    with SPMDEngine() as engine:
+    with SPMDEngine(comm=spmd_comm) as engine:
         local = pl.DataFrame(
             {
                 "rank": [engine.rank],
@@ -194,3 +200,60 @@ def test_allgather_polars_dataframe_multi_column() -> None:
         assert sorted_result["label"].to_list() == [
             f"r{r}" for r in range(engine.nranks)
         ]
+
+
+# ---------------------------------------------------------------------------
+# Tests specifically for the comm= argument
+# ---------------------------------------------------------------------------
+
+
+def test_comm_argument_reuses_communicator(spmd_comm: Communicator) -> None:
+    """Passing comm= reuses the communicator across two engine lifetimes."""
+    with SPMDEngine(comm=spmd_comm) as engine1:
+        nranks = engine1.nranks
+        rank = engine1.rank
+    # engine1 is shut down; spmd_comm is still alive
+    with SPMDEngine(comm=spmd_comm) as engine2:
+        assert engine2.nranks == nranks
+        assert engine2.rank == rank
+
+
+def test_comm_not_closed_after_engine_shutdown(spmd_comm: Communicator) -> None:
+    """The caller-provided comm survives engine.shutdown()."""
+    with SPMDEngine(comm=spmd_comm):
+        pass  # engine.shutdown() is called on __exit__
+    # spmd_comm must still be accessible — not destroyed by engine teardown
+    assert spmd_comm.rank >= 0
+
+
+def test_comm_argument_mr_still_wrapped(spmd_comm: Communicator) -> None:
+    """MR wrapping still happens even when comm is provided externally."""
+    with SPMDEngine(comm=spmd_comm):
+        assert isinstance(rmm.mr.get_current_device_resource(), RmmResourceAdaptor)
+
+
+def test_comm_sequential_queries(spmd_comm: Communicator) -> None:
+    """Two engines sharing a comm can each execute a query without interference."""
+    with SPMDEngine(comm=spmd_comm) as engine:
+        r1 = pl.LazyFrame({"a": [1, 2]}).collect(engine=engine)
+    with SPMDEngine(comm=spmd_comm) as engine:
+        r2 = pl.LazyFrame({"a": [3, 4]}).collect(engine=engine)
+    assert r1["a"].to_list() == [1, 2]
+    assert r2["a"].to_list() == [3, 4]
+
+
+def test_shutdown_idempotent(spmd_comm: Communicator) -> None:
+    """Calling shutdown() twice does not raise."""
+    engine = SPMDEngine(comm=spmd_comm)
+    engine.shutdown()
+    engine.shutdown()
+
+
+def test_comm_and_context_unavailable_after_shutdown(spmd_comm: Communicator) -> None:
+    """Accessing comm or context after shutdown raises RuntimeError."""
+    engine = SPMDEngine(comm=spmd_comm)
+    engine.shutdown()
+    with pytest.raises(RuntimeError, match="shutdown"):
+        _ = engine.comm
+    with pytest.raises(RuntimeError, match="shutdown"):
+        _ = engine.context

--- a/python/cudf_polars/tests/experimental/test_tracing.py
+++ b/python/cudf_polars/tests/experimental/test_tracing.py
@@ -14,6 +14,7 @@ import pytest
 
 def test_structlog_streaming_node_events():
     """Test that structlog emits 'Streaming Actor' events when tracing is enabled."""
+    pytest.importorskip("structlog")
     code = textwrap.dedent("""\
     import rmm
     import polars as pl

--- a/python/cudf_polars/tests/experimental/test_unique.py
+++ b/python/cudf_polars/tests/experimental/test_unique.py
@@ -16,12 +16,15 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    from rapidsmpf.communicator.communicator import Communicator
+
     from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
 
 
 @pytest.fixture
 def engine(
     request: pytest.FixtureRequest,
+    spmd_comm: Communicator,
 ) -> Generator[StreamingEngine, None, None]:
     params: dict[str, Any] = getattr(request, "param", {})
     executor_options = {
@@ -30,7 +33,7 @@ def engine(
         "dynamic_planning": {},
         **params.get("executor_options", {}),
     }
-    with SPMDEngine(executor_options=executor_options) as engine:
+    with SPMDEngine(comm=spmd_comm, executor_options=executor_options) as engine:
         yield engine
 
 


### PR DESCRIPTION
Running `rrun -n 2 pytest test_spmd.py` constructs `SPMDEngine()` in every test, which calls `create_ucxx_comm()`. The shared bootstrap directory (`RRUN_COORD_DIR`) introduces cross-test races that can lead to intermittent hangs:

* **Barrier race.** Stale barrier files can allow a rank to pass the barrier early, leaving the other rank waiting.
* **Stale KV file.** Rank 1 may read an old `ucxx_root_address` and connect to a dead endpoint.

**Fix**

* Add an optional `comm` argument to `SPMDEngine`. When provided, bootstrap is skipped.
* Introduce a session-scoped pytest fixture that creates the communicator once per `rrun` invocation and reuses it across tests, eliminating both races.
