### PR TITLE
Fix `replace` pytest

### DIFF
--- a/python/cudf/cudf/tests/dataframe/methods/test_replace.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_replace.py
@@ -173,4 +173,11 @@ def test_replace_multiple_rows(datadir):
     pdf.replace([np.inf, -np.inf], np.nan, inplace=True)
     gdf.replace([np.inf, -np.inf], np.nan, inplace=True)
 
+    # pandas 3 reads nullable parquet columns as Float64; cast to float64 to
+    # match cudf's representation before comparing.
+    # TODO: Remove this cast after https://github.com/rapidsai/cudf/issues/22018 is resolved.
+    pdf = pdf.astype(
+        {c: "float64" for c, d in pdf.dtypes.items() if d == pd.Float64Dtype()}
+    )
+
     assert_eq(pdf, gdf, check_dtype=False)


### PR DESCRIPTION
## Description
 Root cause: Pandas 3 reads parquet columns that contain nulls as Float64 (nullable), whereas cudf reads them as        
  float64. After replace([np.inf, -np.inf], np.nan), the pandas frame has <NA> for those null entries while cudf has nan 
  — causing assert_eq to fail even with check_dtype=False.                                                               
                                                                                                                         
  Fix: Cast Float64 columns in the pandas frame to float64 (matching cudf's representation) before the comparison. This  
  is specifically for Pickup Census Tract and Dropoff Census Tract, the two columns that have nulls in this parquet file.
   
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
