### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/python/cudf_polars/tests/expressions/test_sort.py
+++ b/python/cudf_polars/tests/expressions/test_sort.py
@@ -99,3 +99,9 @@ def test_setsorted(request, descending, nulls_last, with_nulls):
         assert a.order == (
             plc.types.Order.DESCENDING if descending else plc.types.Order.ASCENDING
         )
+
+
+def test_sort_concat_filtered_to_empty():
+    df = pl.LazyFrame({"a": [1, 2, 3]})
+    q = pl.concat([df.filter(pl.col("a") == 0), df.filter(pl.col("a") == 4)]).sort("a")
+    assert_gpu_result_equal(q)


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.