### PR TITLE
Fix `copy-on-write` failures related to `astype`

### DIFF
--- a/python/cudf/cudf/core/frame.py
+++ b/python/cudf/cudf/core/frame.py
@@ -490,7 +490,7 @@ class Frame(BinaryOperand, Scannable, Serializable):
                 dtype.get(col_name, col.dtype) == col.dtype
                 for col_name, col in self._column_labels_and_values
             ):
-                return self
+                return self.copy(deep=False)
         casted = (
             col.astype(dtype.get(col_name, col.dtype), copy=copy)
             for col_name, col in self._column_labels_and_values

--- a/python/cudf/cudf/tests/dataframe/methods/test_astype.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_astype.py
@@ -281,4 +281,6 @@ def test_dataframe_astype_no_copy(copy):
     gdf = cudf.DataFrame({"a": [1, 2], "b": [3, 4]})
     result = gdf.astype("int64", copy=copy)
     assert_eq(result, gdf)
-    assert (result is gdf) is (not copy)
+    # Under CoW, copy=False returns a shallow copy (distinct object) rather
+    # than self; identity is not guaranteed regardless of copy parameter.
+    assert result is not gdf

--- a/python/cudf/cudf/tests/indexes/index/methods/test_astype.py
+++ b/python/cudf/cudf/tests/indexes/index/methods/test_astype.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -25,4 +25,5 @@ def test_index_astype_no_copy(copy):
     gidx = cudf.Index([1, 2, 3], dtype="int64")
     result = gidx.astype("int64", copy=copy)
     assert_eq(result, gidx)
-    assert (result is gidx) is (not copy)
+    # Under CoW, copy=False returns a shallow copy (distinct object).
+    assert result is not gidx

--- a/python/cudf/cudf/tests/series/methods/test_astype.py
+++ b/python/cudf/cudf/tests/series/methods/test_astype.py
@@ -153,9 +153,12 @@ def test_empty_astype_always_castable(type1, type2, as_dtype, copy):
     else:
         expected = cudf.Series([], dtype=as_dtype(type2))
     assert_eq(result, expected)
-    if not copy and cudf.dtype(type1) == cudf.dtype(type2):
+    if not copy and type1 == type2 == "category":
+        # Categorical shallow copy reuses the same column object.
         assert ser._column is result._column
     else:
+        # Under CoW, copy=False returns a shallow copy (distinct column
+        # object sharing the same buffer), so column identity never holds.
         assert ser._column is not result._column
 
 
@@ -1328,7 +1331,8 @@ def test_series_astype_no_copy(copy):
     gsr = cudf.Series([1, 2, 3])
     result = gsr.astype("int64", copy=copy)
     assert_eq(result, gsr)
-    assert (result is gsr) is (not copy)
+    # Under CoW, copy=False returns a shallow copy (distinct object).
+    assert result is not gsr
 
 
 def test_astype_aware_to_naive_raises():


### PR DESCRIPTION
## Description
Root cause

  Frame.astype() with copy=False when no type conversion is needed returned self directly, making the result the same
  Python object as the original. This completely bypassed cudf's Copy-on-Write mechanism — mutations to the result
  propagated back to the original, contradicting pandas 3 CoW semantics (always-on since pandas 3.0).

  Fix

  cudf/core/frame.py: Return self.copy(deep=False) instead of self. A shallow copy creates a distinct object that shares
  the underlying GPU buffer via the CoW _slices WeakSet. When either the result or the original is subsequently mutated,
  make_single_owner_inplace() detects multiple references and makes a private copy before writing, leaving the other
  object untouched.

  Test updates

  Three sets of tests asserted pre-CoW identity guarantees that no longer hold:

  - test_dataframe_astype_no_copy, test_series_astype_no_copy, test_index_astype_no_copy: Changed assert (result is
  original) is (not copy) → assert result is not original. Under CoW, copy=False always returns a distinct object
  (shallow copy), not self.
  - test_empty_astype_always_castable: Changed the copy=False + same-dtype branch from assert ser._column is
  result._column → assert ser._column is not result._column. Under CoW, copy(deep=False) creates a new column object even
   when sharing the buffer. The category→category case is exempted: categorical's shallow copy inherently reuses the same
   column object.


This PR:
```
== 23 failed, 78438 passed, 19475 skipped, 1542 xfailed in 268.00s (0:04:27) ===
```
`pandas3`:
```
== 31 failed, 78432 passed, 19475 skipped, 1542 xfailed in 268.27s (0:04:28) ===
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
