### PR TITLE
[Multi-GPU Polars] Enable Dask frontend in benchmarks

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils.py
@@ -448,6 +448,8 @@ class RunConfig:
                     scheduler = "distributed"
                 case "spmd":  # launched via rrun, not Dask
                     scheduler = None
+                case "dask":
+                    scheduler = None
         else:
             cluster = "single"
             scheduler = "synchronous"
@@ -960,13 +962,14 @@ def build_parser(num_queries: int = 22) -> argparse.ArgumentParser:
         "--cluster",
         default=None,
         type=str,
-        choices=["single", "distributed", "spmd", "ray"],
+        choices=["single", "distributed", "spmd", "ray", "dask"],
         help=textwrap.dedent("""\
             Cluster type to use with the 'streaming' executor.
                 - single      : Run locally in a single process
                 - distributed : Use Dask for multi-GPU execution
                 - spmd        : SPMD execution via rrun launcher
-                - ray         : Ray actor-based multi-GPU execution"""),
+                - ray         : Ray actor-based multi-GPU execution
+                - dask        : Dask based multi-GPU execution (new frontend API)"""),
     )
     parser.add_argument(
         "-s",
@@ -1792,6 +1795,16 @@ def run_polars(
                 date_type,
                 validation_files,
             )
+        case "dask":
+            run_polars_dask(
+                benchmark,
+                args,
+                run_config,
+                parquet_options,
+                numeric_type,
+                date_type,
+                validation_files,
+            )
         case "single" | "distributed" | None:
             run_polars_single_or_dask(
                 benchmark,
@@ -2003,6 +2016,66 @@ def run_polars_ray(
         else:
             print("✅ All validated queries passed.")
     # engine holds ray_client (not JSON-serializable); serialize without it
+    args.output.write(json.dumps(run_config.serialize(engine=None)))
+    args.output.write("\n")
+    sys.exit(1 if (query_failures or validation_failures) else 0)
+
+
+def run_polars_dask(
+    benchmark: Any,
+    args: argparse.Namespace,
+    run_config: RunConfig,
+    parquet_options: dict[str, Any],
+    numeric_type: str,
+    date_type: str,
+    validation_files: dict[int, Path] | None,
+) -> None:
+    """Run benchmark queries using the new Dask execution mode."""
+    from cudf_polars.experimental.rapidsmpf.frontend.dask import DaskEngine
+
+    if run_config.collect_traces:
+        raise NotImplementedError(
+            "--collect-traces is not yet supported with --cluster dask."
+        )
+    if run_config.rmm_async:
+        raise NotImplementedError(
+            "--rmm-async is not yet supported with --cluster dask."
+        )
+    executor_options = get_executor_options(run_config, benchmark=benchmark)
+    executor_options.pop("runtime", None)  # reserved — DaskEngine sets it
+    executor_options.pop("cluster", None)  # reserved — DaskEngine sets it
+    engine_options: dict[str, Any] = {
+        "cuda_stream_policy": run_config.stream_policy,
+        "parquet_options": parquet_options,
+    }
+    with DaskEngine(
+        executor_options=executor_options,
+        engine_options=engine_options,
+    ) as engine:
+        run_config = dataclasses.replace(run_config, n_workers=engine.nranks)
+        records, plans, validation_failures, query_failures = _run_query_loop(
+            benchmark,
+            args,
+            run_config,
+            engine,
+            None,
+            numeric_type,
+            date_type,
+            validation_files,
+        )
+    run_config = dataclasses.replace(run_config, records=dict(records), plans=plans)
+    if args.summarize:
+        run_config.summarize()
+    if args.validate and run_config.executor != "cpu":
+        print("\nValidation Summary")
+        print("==================")
+        if validation_failures:
+            print(
+                f"{len(validation_failures)} queries failed validation: {sorted(set(validation_failures))}"
+            )
+        else:
+            print("✅ All validated queries passed.")
+    # engine holds dask_client (not JSON-serializable); serialize without it
     args.output.write(json.dumps(run_config.serialize(engine=None)))
     args.output.write("\n")
     sys.exit(1 if (query_failures or validation_failures) else 0)


### PR DESCRIPTION
Add `--cluster dask` to the benchmark runner.

* Wire up `DaskEngine` (from #21812) as a benchmark execution path.
* Add `"dask"` to the `--cluster` choices.