### PR TITLE
Pass memory resource explicitly to remove implicit default mr usage (Part 1)

### DIFF
--- a/cpp/include/cudf/detail/copy_if_else.cuh
+++ b/cpp/include/cudf/detail/copy_if_else.cuh
@@ -161,7 +161,8 @@ std::unique_ptr<column> copy_if_else(bool nullable,
 
   // if we have validity in the output
   if (nullable) {
-    cudf::detail::device_scalar<size_type> valid_count{0, stream};
+    cudf::detail::device_scalar<size_type> valid_count{
+      0, stream, cudf::get_current_device_resource_ref()};
 
     // call the kernel
     copy_if_else_kernel<block_size, Element, LeftIter, RightIter, FilterFn, true>

--- a/cpp/include/cudf/detail/copy_range.cuh
+++ b/cpp/include/cudf/detail/copy_range.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -145,7 +145,8 @@ void copy_range(SourceValueIterator source_value_begin,
   auto grid = cudf::detail::grid_1d{num_items, block_size, 1};
 
   if (target.nullable()) {
-    cudf::detail::device_scalar<size_type> null_count(target.null_count(), stream);
+    cudf::detail::device_scalar<size_type> null_count(
+      target.null_count(), stream, cudf::get_current_device_resource_ref());
 
     auto kernel =
       copy_range_kernel<block_size, SourceValueIterator, SourceValidityIterator, T, true>;

--- a/cpp/include/cudf/detail/sizes_to_offsets_iterator.cuh
+++ b/cpp/include/cudf/detail/sizes_to_offsets_iterator.cuh
@@ -259,8 +259,9 @@ auto sizes_to_offsets(SizesIterator begin,
   static_assert(std::is_integral_v<SizeType>,
                 "Only numeric types are supported by sizes_to_offsets");
 
-  using LastType    = std::conditional_t<std::is_signed_v<SizeType>, int64_t, uint64_t>;
-  auto last_element = cudf::detail::device_scalar<LastType>(0, stream);
+  using LastType = std::conditional_t<std::is_signed_v<SizeType>, int64_t, uint64_t>;
+  auto last_element =
+    cudf::detail::device_scalar<LastType>(0, stream, cudf::get_current_device_resource_ref());
   auto output_itr =
     make_sizes_to_offsets_iterator(result, result + std::distance(begin, end), last_element.data());
   // This function uses the type of the initialization parameter as the accumulator type

--- a/cpp/include/cudf/detail/valid_if.cuh
+++ b/cpp/include/cudf/detail/valid_if.cuh
@@ -91,7 +91,8 @@ std::pair<rmm::device_buffer, size_type> valid_if(InputIterator begin,
 
   size_type null_count{0};
   if (size > 0) {
-    cudf::detail::device_scalar<size_type> valid_count{0, stream};
+    cudf::detail::device_scalar<size_type> valid_count{
+      0, stream, cudf::get_current_device_resource_ref()};
 
     constexpr size_type block_size{256};
     grid_1d grid{size, block_size};

--- a/cpp/include/cudf/reduction/detail/reduction.cuh
+++ b/cpp/include/cudf/reduction/detail/reduction.cuh
@@ -112,7 +112,8 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
 {
   auto const binary_op     = cudf::detail::cast_functor<OutputType>(op.get_binary_op());
   auto const initial_value = init.value_or(op.template get_identity<OutputType>());
-  auto dev_result          = cudf::detail::device_scalar<OutputType>{initial_value, stream};
+  auto dev_result          = cudf::detail::device_scalar<OutputType>{
+    initial_value, stream, cudf::get_current_device_resource_ref()};
 
   // Allocate temporary storage
   rmm::device_buffer d_temp_storage;
@@ -125,7 +126,8 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                             binary_op,
                             initial_value,
                             stream.value());
-  d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+  d_temp_storage =
+    rmm::device_buffer{temp_storage_bytes, stream, cudf::get_current_device_resource_ref()};
 
   // Run reduction
   cub::DeviceReduce::Reduce(d_temp_storage.data(),
@@ -175,7 +177,8 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
   auto const binary_op     = cudf::detail::cast_functor<IntermediateType>(op.get_binary_op());
   auto const initial_value = op.template get_identity<IntermediateType>();
 
-  cudf::detail::device_scalar<IntermediateType> intermediate_result{initial_value, stream};
+  cudf::detail::device_scalar<IntermediateType> intermediate_result{
+    initial_value, stream, cudf::get_current_device_resource_ref()};
 
   // Allocate temporary storage
   rmm::device_buffer d_temp_storage;
@@ -188,7 +191,8 @@ std::unique_ptr<scalar> reduce(InputIterator d_in,
                             binary_op,
                             initial_value,
                             stream.value());
-  d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+  d_temp_storage =
+    rmm::device_buffer{temp_storage_bytes, stream, cudf::get_current_device_resource_ref()};
 
   // Run reduction
   cub::DeviceReduce::Reduce(d_temp_storage.data(),

--- a/cpp/include/cudf_test/column_wrapper.hpp
+++ b/cpp/include/cudf_test/column_wrapper.hpp
@@ -963,7 +963,8 @@ class dictionary_column_wrapper : public detail::column_wrapper {
     wrapped =
       cudf::dictionary::encode(fixed_width_column_wrapper<KeyElementTo, SourceElementT>(begin, end),
                                cudf::data_type{type_id::INT32},
-                               cudf::test::get_default_stream());
+                               cudf::test::get_default_stream(),
+                               cudf::get_current_device_resource_ref());
   }
 
   /**
@@ -1162,7 +1163,8 @@ class dictionary_column_wrapper<std::string> : public detail::column_wrapper {
   {
     wrapped = cudf::dictionary::encode(strings_column_wrapper(begin, end),
                                        cudf::data_type{type_id::INT32},
-                                       cudf::test::get_default_stream());
+                                       cudf::test::get_default_stream(),
+                                       cudf::get_current_device_resource_ref());
   }
 
   /**
@@ -1927,7 +1929,8 @@ class structs_column_wrapper : public detail::column_wrapper {
                                         std::move(child_columns),
                                         null_count,
                                         std::move(null_mask),
-                                        cudf::test::get_default_stream());
+                                        cudf::test::get_default_stream(),
+                                        cudf::get_current_device_resource_ref());
   }
 
   template <typename V>

--- a/cpp/src/column/column_factories.cpp
+++ b/cpp/src/column/column_factories.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -170,7 +170,11 @@ std::unique_ptr<column> make_dictionary_from_scalar(scalar const& s,
   CUDF_EXPECTS(s.is_valid(stream), "cannot create a dictionary with a null key");
   return make_dictionary_column(
     make_column_from_scalar(s, 1, stream, mr),
-    make_column_from_scalar(numeric_scalar<int32_t>(0, true, stream), size, stream, mr),
+    make_column_from_scalar(
+      numeric_scalar<int32_t>(0, true, stream, cudf::get_current_device_resource_ref()),
+      size,
+      stream,
+      mr),
     rmm::device_buffer{0, stream, mr},
     0);
 }

--- a/cpp/src/column/column_factories.cu
+++ b/cpp/src/column/column_factories.cu
@@ -49,7 +49,11 @@ std::unique_ptr<cudf::column> column_from_scalar_dispatch::operator()<cudf::stri
   if (!value.is_valid(stream)) {
     return make_strings_column(
       size,
-      make_column_from_scalar(numeric_scalar<int32_t>(0, true, stream), size + 1, stream, mr),
+      make_column_from_scalar(
+        numeric_scalar<int32_t>(0, true, stream, cudf::get_current_device_resource_ref()),
+        size + 1,
+        stream,
+        mr),
       rmm::device_buffer{},
       size,
       cudf::detail::create_null_mask(size, mask_state::ALL_NULL, stream, mr));

--- a/cpp/src/copying/concatenate.cu
+++ b/cpp/src/copying/concatenate.cu
@@ -153,7 +153,8 @@ size_type concatenate_masks(device_span<column_device_view const> d_views,
                             size_type output_size,
                             rmm::cuda_stream_view stream)
 {
-  cudf::detail::device_scalar<size_type> d_valid_count(0, stream);
+  cudf::detail::device_scalar<size_type> d_valid_count(
+    0, stream, cudf::get_current_device_resource_ref());
   constexpr size_type block_size{256};
   cudf::detail::grid_1d config(output_size, block_size);
   concatenate_masks_kernel<block_size>
@@ -256,7 +257,8 @@ std::unique_ptr<column> fused_concatenate(host_span<column_view const> views,
   auto out_view     = out_col->mutable_view();
   auto d_out_view   = mutable_column_device_view::create(out_view, stream);
 
-  cudf::detail::device_scalar<size_type> d_valid_count(0, stream);
+  cudf::detail::device_scalar<size_type> d_valid_count(
+    0, stream, cudf::get_current_device_resource_ref());
 
   // Launch kernel
   constexpr size_type block_size{256};

--- a/cpp/src/copying/get_element.cu
+++ b/cpp/src/copying/get_element.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -84,7 +84,8 @@ struct get_element_functor {
   {
     auto dict_view    = dictionary_column_view(input);
     auto indices_iter = detail::indexalator_factory::make_input_iterator(dict_view.indices());
-    numeric_scalar<size_type> key_index_scalar{index, true, stream};
+    numeric_scalar<size_type> key_index_scalar{
+      index, true, stream, cudf::get_current_device_resource_ref()};
     auto d_key_index = get_scalar_device_view(key_index_scalar);
     auto d_col       = column_device_view::create(input, stream);
 

--- a/cpp/src/copying/sample.cu
+++ b/cpp/src/copying/sample.cu
@@ -54,8 +54,11 @@ std::unique_ptr<table> sample(table_view const& input,
 
     return detail::gather(input, begin, begin + n, out_of_bounds_policy::DONT_CHECK, stream, mr);
   } else {
-    auto gather_map =
-      make_numeric_column(data_type{type_id::INT32}, num_rows, mask_state::UNALLOCATED, stream);
+    auto gather_map              = make_numeric_column(data_type{type_id::INT32},
+                                          num_rows,
+                                          mask_state::UNALLOCATED,
+                                          stream,
+                                          cudf::get_current_device_resource_ref());
     auto gather_map_mutable_view = gather_map->mutable_view();
     // Shuffle all the row indices
     thrust::shuffle_copy(rmm::exec_policy_nosync(stream),

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -180,11 +180,12 @@ struct column_scalar_scatterer_impl<dictionary32, MapIterator> {
                                      rmm::cuda_stream_view stream,
                                      rmm::device_async_resource_ref mr) const
   {
-    auto dict_target =
-      dictionary::detail::add_keys(dictionary_column_view(target),
-                                   make_column_from_scalar(source.get(), 1, stream)->view(),
-                                   stream,
-                                   mr);
+    auto dict_target = dictionary::detail::add_keys(
+      dictionary_column_view(target),
+      make_column_from_scalar(source.get(), 1, stream, cudf::get_current_device_resource_ref())
+        ->view(),
+      stream,
+      mr);
     auto dict_view    = dictionary_column_view(dict_target->view());
     auto scalar_index = dictionary::detail::get_index(
       dict_view, source.get(), stream, cudf::get_current_device_resource_ref());
@@ -382,8 +383,11 @@ std::unique_ptr<column> boolean_mask_scatter(column_view const& input,
                                              rmm::cuda_stream_view stream,
                                              rmm::device_async_resource_ref mr)
 {
-  auto indices = cudf::make_numeric_column(
-    data_type{type_id::INT32}, target.size(), mask_state::UNALLOCATED, stream);
+  auto indices         = cudf::make_numeric_column(data_type{type_id::INT32},
+                                           target.size(),
+                                           mask_state::UNALLOCATED,
+                                           stream,
+                                           cudf::get_current_device_resource_ref());
   auto mutable_indices = indices->mutable_view();
 
   thrust::sequence(rmm::exec_policy_nosync(stream),

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -59,8 +59,11 @@ std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_
   auto const max_size     = dictionary_column.size();
 
   // create/init indices map array
-  auto map_indices =
-    make_fixed_width_column(indices_type, keys_view.size(), mask_state::UNALLOCATED, stream);
+  auto map_indices = make_fixed_width_column(indices_type,
+                                             keys_view.size(),
+                                             mask_state::UNALLOCATED,
+                                             stream,
+                                             cudf::get_current_device_resource_ref());
   auto map_itr =
     cudf::detail::indexalator_factory::make_output_iterator(map_indices->mutable_view());
   // init to max to identify new nulls
@@ -73,8 +76,11 @@ std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_
   std::unique_ptr<column> keys_column = [&] {
     // create keys positions column to identify original key positions after removing they keys
     auto keys_positions = [&] {
-      auto positions = make_fixed_width_column(
-        indices_type, keys_view.size(), cudf::mask_state::UNALLOCATED, stream);
+      auto positions = make_fixed_width_column(indices_type,
+                                               keys_view.size(),
+                                               cudf::mask_state::UNALLOCATED,
+                                               stream,
+                                               cudf::get_current_device_resource_ref());
       auto itr = cudf::detail::indexalator_factory::make_output_iterator(positions->mutable_view());
       thrust::sequence(rmm::exec_policy_nosync(stream), itr, itr + keys_view.size());
       return positions;

--- a/cpp/src/dictionary/replace.cu
+++ b/cpp/src/dictionary/replace.cu
@@ -118,7 +118,11 @@ std::unique_ptr<column> replace_nulls(dictionary_column_view const& input,
 
   // first add the replacement to the keys so only the indices need to be processed
   auto input_matched = dictionary::detail::add_keys(
-    input, make_column_from_scalar(replacement, 1, stream)->view(), stream, mr);
+    input,
+    make_column_from_scalar(replacement, 1, stream, cudf::get_current_device_resource_ref())
+      ->view(),
+    stream,
+    mr);
   auto const input_view = dictionary_column_view(input_matched->view());
   auto const scalar_index =
     get_index(input_view, replacement, stream, cudf::get_current_device_resource_ref());

--- a/cpp/src/filling/fill.cu
+++ b/cpp/src/filling/fill.cu
@@ -69,7 +69,8 @@ struct in_place_fill_range_dispatch {
   {
     auto unscaled = static_cast<cudf::fixed_point_scalar<T> const&>(value).value(stream);
     using RepType = typename T::rep;
-    auto s        = cudf::numeric_scalar<RepType>(unscaled, value.is_valid(stream), stream);
+    auto s        = cudf::numeric_scalar<RepType>(
+      unscaled, value.is_valid(stream), stream, cudf::get_current_device_resource_ref());
     in_place_fill<RepType>(destination, begin, end, s, stream);
   }
 
@@ -155,7 +156,8 @@ std::unique_ptr<cudf::column> out_of_place_fill_range_dispatch::operator()<cudf:
   }
 
   // add the scalar to get the output dictionary key-set
-  auto scalar_column = cudf::make_column_from_scalar(value, 1, stream);
+  auto scalar_column =
+    cudf::make_column_from_scalar(value, 1, stream, cudf::get_current_device_resource_ref());
   auto target_matched =
     cudf::dictionary::detail::add_keys(target, scalar_column->view(), stream, mr);
   cudf::column_view const target_indices =

--- a/cpp/src/groupby/hash/compute_groupby.cu
+++ b/cpp/src/groupby/hash/compute_groupby.cu
@@ -14,6 +14,7 @@
 #include <cudf/detail/gather.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
@@ -58,21 +59,30 @@ std::unique_ptr<table> compute_groupby(table_view const& keys,
 
   [[maybe_unused]] auto const [row_bitmask_data, row_bitmask] =
     [&]() -> std::pair<rmm::device_buffer, bitmask_type const*> {
-    if (!skip_rows_with_nulls) { return {rmm::device_buffer{0, stream}, nullptr}; }
+    if (!skip_rows_with_nulls) {
+      return {rmm::device_buffer{0, stream, cudf::get_current_device_resource_ref()}, nullptr};
+    }
 
     if (keys.num_columns() == 1) {
       auto const& keys_col = keys.column(0);
       // Only use the input null mask directly if the keys table was not sliced.
-      if (keys_col.offset() == 0) { return {rmm::device_buffer{0, stream}, keys_col.null_mask()}; }
+      if (keys_col.offset() == 0) {
+        return {rmm::device_buffer{0, stream, cudf::get_current_device_resource_ref()},
+                keys_col.null_mask()};
+      }
       // If the keys table was sliced, we need to copy the null mask to ensure its first bit aligns
       // with the first row of the keys table.
-      auto null_mask_data  = cudf::copy_bitmask(keys_col, stream);
+      auto null_mask_data =
+        cudf::copy_bitmask(keys_col, stream, cudf::get_current_device_resource_ref());
       auto const null_mask = static_cast<bitmask_type const*>(null_mask_data.data());
       return {std::move(null_mask_data), null_mask};
     }
 
-    auto [null_mask_data, null_count] = cudf::bitmask_and(keys, stream);
-    if (null_count == 0) { return {rmm::device_buffer{0, stream}, nullptr}; }
+    auto [null_mask_data, null_count] =
+      cudf::bitmask_and(keys, stream, cudf::get_current_device_resource_ref());
+    if (null_count == 0) {
+      return {rmm::device_buffer{0, stream, cudf::get_current_device_resource_ref()}, nullptr};
+    }
 
     auto const null_mask = static_cast<bitmask_type const*>(null_mask_data.data());
     return {std::move(null_mask_data), null_mask};
@@ -85,10 +95,12 @@ std::unique_ptr<table> compute_groupby(table_view const& keys,
       });
 
     if (num_columns <= HASH_CACHING_THRESHOLD) {
-      return rmm::device_uvector<hash_value_type>{0, stream};
+      return rmm::device_uvector<hash_value_type>{
+        0, stream, cudf::get_current_device_resource_ref()};
     }
 
-    rmm::device_uvector<hash_value_type> hashes(num_keys, stream);
+    rmm::device_uvector<hash_value_type> hashes(
+      num_keys, stream, cudf::get_current_device_resource_ref());
     thrust::tabulate(rmm::exec_policy_nosync(stream),
                      hashes.begin(),
                      hashes.end(),
@@ -131,7 +143,8 @@ std::unique_ptr<table> compute_groupby(table_view const& keys,
         if (!row_bitmask || cudf::bit_is_set(row_bitmask, idx)) { set_ref.insert(idx); }
       });
 
-    rmm::device_uvector<size_type> unique_key_indices(num_keys, stream);
+    rmm::device_uvector<size_type> unique_key_indices(
+      num_keys, stream, cudf::get_current_device_resource_ref());
     auto const keys_end       = set.retrieve_all(unique_key_indices.begin(), stream.value());
     auto const key_gather_map = device_span<size_type const>{
       unique_key_indices.data(),

--- a/cpp/src/groupby/hash/output_utils.cu
+++ b/cpp/src/groupby/hash/output_utils.cu
@@ -101,8 +101,12 @@ struct result_column_creator {
       }
       return {rmm::device_buffer{}, 0};
     }();
-    return create_structs_hierarchy(
-      output_size, make_children(output_size), null_count, std::move(null_mask), stream);
+    return create_structs_hierarchy(output_size,
+                                    make_children(output_size),
+                                    null_count,
+                                    std::move(null_mask),
+                                    stream,
+                                    cudf::get_current_device_resource_ref());
   }
 };
 

--- a/cpp/src/groupby/sort/aggregate.cpp
+++ b/cpp/src/groupby/sort/aggregate.cpp
@@ -49,7 +49,8 @@ auto column_view_with_common_nulls(column_view const& column_0,
                                    column_view const& column_1,
                                    rmm::cuda_stream_view stream)
 {
-  auto [new_nullmask, null_count] = cudf::bitmask_and(table_view{{column_0, column_1}}, stream);
+  auto [new_nullmask, null_count] = cudf::bitmask_and(
+    table_view{{column_0, column_1}}, stream, cudf::get_current_device_resource_ref());
   if (null_count == 0) { return std::make_tuple(std::move(new_nullmask), column_0, column_1); }
   auto column_view_with_new_nullmask = [](auto const& col, void* nullmask, auto null_count) {
     return column_view(col.type(),

--- a/cpp/src/groupby/sort/scan.cpp
+++ b/cpp/src/groupby/sort/scan.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -146,10 +146,12 @@ void scan_result_functor::operator()<aggregation::RANK>(aggregation const& agg)
   auto const group_labels_view = column_view(cudf::device_span<size_type const>(group_labels));
   auto const gather_map        = [&]() {
     if (is_presorted()) {  // assumes both keys and values are sorted, Spark does this.
-      return cudf::detail::sequence(group_labels.size(),
-                                    *cudf::make_fixed_width_scalar(size_type{0}, stream),
-                                    stream,
-                                    cudf::get_current_device_resource_ref());
+      return cudf::detail::sequence(
+        group_labels.size(),
+        *cudf::make_fixed_width_scalar(
+          size_type{0}, stream, cudf::get_current_device_resource_ref()),
+        stream,
+        cudf::get_current_device_resource_ref());
     } else {
       auto sort_order = (rank_agg._method == rank_method::FIRST ? cudf::detail::stable_sorted_order
                                                                        : cudf::detail::sorted_order);

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -86,11 +86,12 @@ column_view sort_groupby_helper::key_sort_order(rmm::cuda_stream_view stream)
   if (_key_sorted_order) { return sliced_key_sorted_order(); }
 
   if (_keys_pre_sorted == sorted::YES) {
-    _key_sorted_order = cudf::detail::sequence(_keys.num_rows(),
-                                               numeric_scalar<size_type>(0, true, stream),
-                                               numeric_scalar<size_type>(1, true, stream),
-                                               stream,
-                                               cudf::get_current_device_resource_ref());
+    _key_sorted_order = cudf::detail::sequence(
+      _keys.num_rows(),
+      numeric_scalar<size_type>(0, true, stream, cudf::get_current_device_resource_ref()),
+      numeric_scalar<size_type>(1, true, stream, cudf::get_current_device_resource_ref()),
+      stream,
+      cudf::get_current_device_resource_ref());
     return sliced_key_sorted_order();
   }
 
@@ -193,8 +194,11 @@ column_view sort_groupby_helper::unsorted_keys_labels(rmm::cuda_stream_view stre
 {
   if (_unsorted_keys_labels) return _unsorted_keys_labels->view();
 
-  column_ptr temp_labels = make_numeric_column(
-    data_type(type_to_id<size_type>()), _keys.num_rows(), mask_state::ALL_NULL, stream);
+  column_ptr temp_labels = make_numeric_column(data_type(type_to_id<size_type>()),
+                                               _keys.num_rows(),
+                                               mask_state::ALL_NULL,
+                                               stream,
+                                               cudf::get_current_device_resource_ref());
 
   auto group_labels_view = cudf::column_view(data_type(type_to_id<size_type>()),
                                              group_labels(stream).size(),
@@ -223,7 +227,8 @@ column_view sort_groupby_helper::keys_bitmask_column(rmm::cuda_stream_view strea
   auto [row_bitmask, null_count] =
     cudf::detail::bitmask_and(_keys, stream, cudf::get_current_device_resource_ref());
 
-  auto const zero = numeric_scalar<int8_t>(0, true, stream);
+  auto const zero =
+    numeric_scalar<int8_t>(0, true, stream, cudf::get_current_device_resource_ref());
   // Create a temporary variable and only set _keys_bitmask_column right before the return.
   // This way, a 2nd (parallel) call to this will not be given a partially created object.
   auto keys_bitmask_column = cudf::detail::sequence(

--- a/cpp/src/hash/md5_hash.cu
+++ b/cpp/src/hash/md5_hash.cu
@@ -279,7 +279,8 @@ std::unique_ptr<column> md5(table_view const& input,
 {
   if (input.num_columns() == 0 || input.num_rows() == 0) {
     // Return the MD5 hash of a zero-length input.
-    string_scalar const string_128bit("d41d8cd98f00b204e9orig98ecf8427e", true, stream);
+    string_scalar const string_128bit(
+      "d41d8cd98f00b204e9orig98ecf8427e", true, stream, cudf::get_current_device_resource_ref());
     return make_column_from_scalar(string_128bit, input.num_rows(), stream, mr);
   }
 


### PR DESCRIPTION
## Description
Replaces implicit uses of the default memory resource `cudf::get_current_device_resource_ref()` with explicit mr parameter passing across the cudf codebase. 

Affected areas include: column, copy, groupby, hash, detail headers

Entire PR is just passing the defaulted argument explicitly. This will make it easy to find and replace `cudf::get_current_device_resource_ref()` with temporary_mr  in follow up PR as proposed in https://github.com/rapidsai/cudf/issues/20780

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
