### PR TITLE
Pass memory resource explicitly to remove implicit default mr usage (Part 2)

### DIFF
--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -976,8 +976,10 @@ table_with_metadata read_csv(cudf::io::datasource* source,
     auto const num_string_cols = string_col_indices.size();
     if (num_string_cols > 0) {
       auto const quotechar = parse_opts.quotechar;
-      cudf::string_scalar quotechar_scalar(std::string(1, quotechar), true, stream);
-      cudf::string_scalar dblquotechar_scalar(std::string(2, quotechar), true, stream);
+      cudf::string_scalar quotechar_scalar(
+        std::string(1, quotechar), true, stream, cudf::get_current_device_resource_ref());
+      cudf::string_scalar dblquotechar_scalar(
+        std::string(2, quotechar), true, stream, cudf::get_current_device_resource_ref());
       constexpr size_t max_tasks = 4;
       auto const cols_per_task   = cudf::util::div_rounding_up_safe(num_string_cols, max_tasks);
       auto const num_tasks       = cudf::util::div_rounding_up_safe(num_string_cols, cols_per_task);
@@ -996,7 +998,9 @@ table_with_metadata read_csv(cudf::io::datasource* source,
           out_columns[col_idx] = make_column(*buffer, nullptr, std::nullopt, col_stream);
         } else {
           auto replaced_all_col = cudf::strings::detail::replace(
-            cudf::make_strings_column(*buffer->_strings, col_stream)->view(),
+            cudf::make_strings_column(
+              *buffer->_strings, col_stream, cudf::get_current_device_resource_ref())
+              ->view(),
             dblquotechar_scalar,
             quotechar_scalar,
             -1,

--- a/cpp/src/io/csv/writer_impl.cu
+++ b/cpp/src/io/csv/writer_impl.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -135,8 +135,10 @@ struct column_to_strings_fn {
   std::unique_ptr<column> operator()(column_view const& column) const
     requires(std::is_same_v<column_type, bool>)
   {
-    string_scalar true_string{options_.get_true_value(), true, stream_};
-    string_scalar false_string{options_.get_false_value(), true, stream_};
+    string_scalar true_string{
+      options_.get_true_value(), true, stream_, cudf::get_current_device_resource_ref()};
+    string_scalar false_string{
+      options_.get_false_value(), true, stream_, cudf::get_current_device_resource_ref()};
     return cudf::strings::detail::from_booleans(column, true_string, false_string, stream_, mr_);
   }
 
@@ -151,7 +153,10 @@ struct column_to_strings_fn {
     }
 
     // handle special characters: {delimiter, '\n', "} in row:
-    string_scalar delimiter{std::string{options_.get_inter_column_delimiter()}, true, stream_};
+    string_scalar delimiter{std::string{options_.get_inter_column_delimiter()},
+                            true,
+                            stream_,
+                            cudf::get_current_device_resource_ref()};
 
     auto d_column = column_device_view::create(column_v, stream_);
     escape_strings_fn fn{*d_column, delimiter.value(stream_)};
@@ -343,19 +348,21 @@ void write_chunked(data_sink* out_sink,
 
   CUDF_EXPECTS(str_column_view.size() > 0, "Unexpected empty strings column.");
 
-  cudf::string_scalar newline{options.get_line_terminator(), true, stream};
+  cudf::string_scalar newline{
+    options.get_line_terminator(), true, stream, cudf::get_current_device_resource_ref()};
 
   // use strings concatenate to build the final CSV output in device memory
   auto contents_w_nl = [&] {
     auto const total_size =
       str_column_view.chars_size(stream) + (newline.size() * str_column_view.size());
-    auto const empty_str = string_scalar("", true, stream);
+    auto const empty_str = string_scalar("", true, stream, cudf::get_current_device_resource_ref());
     // use join_strings when the output will be less than 2GB
     if (total_size < static_cast<int64_t>(std::numeric_limits<size_type>::max())) {
       return cudf::strings::detail::join_strings(str_column_view, newline, empty_str, stream, mr)
         ->release();
     }
-    auto nl_col = cudf::make_column_from_scalar(newline, str_column_view.size(), stream);
+    auto nl_col = cudf::make_column_from_scalar(
+      newline, str_column_view.size(), stream, cudf::get_current_device_resource_ref());
     // convert the last element into an empty string by resetting the last offset value
     auto& offsets     = nl_col->child(strings_column_view::offsets_column_index);
     auto offsets_view = offsets.mutable_view();
@@ -464,9 +471,12 @@ void write_csv(data_sink* out_sink,
       // (using null representation and delimiter):
       //
       auto str_concat_col = [&] {
-        cudf::string_scalar delimiter_str{
-          std::string{options.get_inter_column_delimiter()}, true, stream};
-        cudf::string_scalar options_narep{options.get_na_rep(), true, stream};
+        cudf::string_scalar delimiter_str{std::string{options.get_inter_column_delimiter()},
+                                          true,
+                                          stream,
+                                          cudf::get_current_device_resource_ref()};
+        cudf::string_scalar options_narep{
+          options.get_na_rep(), true, stream, cudf::get_current_device_resource_ref()};
         if (str_table_view.num_columns() > 1)
           return cudf::strings::detail::concatenate(str_table_view,
                                                     delimiter_str,

--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -1434,7 +1434,8 @@ void get_stack_context(device_span<SymbolT const> json_in,
   constexpr StackSymbolT read_symbol = 'x';
 
   // Number of stack operations in the input (i.e., number of '{', '}', '[', ']' outside of quotes)
-  cudf::detail::device_scalar<SymbolOffsetT> d_num_stack_ops(stream);
+  cudf::detail::device_scalar<SymbolOffsetT> d_num_stack_ops(
+    stream, cudf::get_current_device_resource_ref());
 
   // Prepare finite-state transducer that only selects '{', '}', '[', ']' outside of quotes
   constexpr auto max_translation_table_size =
@@ -1636,7 +1637,8 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> ge
   std::size_t constexpr max_tokens_per_struct = 6;
   auto const max_token_out_count =
     cudf::util::div_rounding_up_safe(json_in.size(), min_chars_per_struct) * max_tokens_per_struct;
-  cudf::detail::device_scalar<std::size_t> num_written_tokens{stream};
+  cudf::detail::device_scalar<std::size_t> num_written_tokens{
+    stream, cudf::get_current_device_resource_ref()};
   // In case we're recovering on invalid JSON lines, post-processing the token stream requires to
   // see a JSON-line delimiter as the very first item
   SymbolOffsetT const delimiter_offset =

--- a/cpp/src/io/json/write_json.cpp
+++ b/cpp/src/io/json/write_json.cpp
@@ -26,6 +26,7 @@
 #include <cudf/structs/structs_column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 
@@ -156,8 +157,10 @@ std::unique_ptr<column> leaf_column_to_strings(column_view const& column,
   if (cudf::is_timestamp(column.type())) { return timestamp_to_strings(column, stream, mr); }
   if (cudf::is_duration(column.type())) { return duration_to_strings(column, stream, mr); }
   if (cudf::is_boolean(column.type())) {
-    string_scalar const true_value(options.get_true_value(), true, stream);
-    string_scalar const false_value(options.get_false_value(), true, stream);
+    string_scalar const true_value(
+      options.get_true_value(), true, stream, cudf::get_current_device_resource_ref());
+    string_scalar const false_value(
+      options.get_false_value(), true, stream, cudf::get_current_device_resource_ref());
     return cudf::strings::detail::from_booleans(column, true_value, false_value, stream, mr);
   }
   if (cudf::is_integral(column.type())) {
@@ -190,13 +193,13 @@ struct column_to_strings_fn {
     : options_(options),
       stream_(stream),
       mr_(std::move(mr)),
-      narep(options.get_na_rep(), true, stream),
-      struct_value_separator(",", true, stream),
-      struct_row_begin_wrap("{", true, stream),
-      struct_row_end_wrap("}", true, stream),
-      list_value_separator(",", true, stream),
-      list_row_begin_wrap("[", true, stream),
-      list_row_end_wrap("]", true, stream)
+      narep(options.get_na_rep(), true, stream, cudf::get_current_device_resource_ref()),
+      struct_value_separator(",", true, stream, cudf::get_current_device_resource_ref()),
+      struct_row_begin_wrap("{", true, stream, cudf::get_current_device_resource_ref()),
+      struct_row_end_wrap("}", true, stream, cudf::get_current_device_resource_ref()),
+      list_value_separator(",", true, stream, cudf::get_current_device_resource_ref()),
+      list_row_begin_wrap("[", true, stream, cudf::get_current_device_resource_ref()),
+      list_row_end_wrap("]", true, stream, cudf::get_current_device_resource_ref())
   {
   }
 
@@ -372,10 +375,13 @@ void write_json_uncompressed(data_sink* out_sink,
   }();
 
   auto const line_terminator = std::string(options.is_enabled_lines() ? "\n" : ",");
-  string_scalar const d_line_terminator_with_row_end{"}" + line_terminator, true, stream};
-  string_scalar const d_line_terminator{line_terminator, true, stream};
+  string_scalar const d_line_terminator_with_row_end{
+    "}" + line_terminator, true, stream, cudf::get_current_device_resource_ref()};
+  string_scalar const d_line_terminator{
+    line_terminator, true, stream, cudf::get_current_device_resource_ref()};
   std::string const list_braces{"[]"};
-  string_scalar const d_list_braces{list_braces, true, stream};
+  string_scalar const d_list_braces{
+    list_braces, true, stream, cudf::get_current_device_resource_ref()};
 
   if (!options.is_enabled_lines()) {
     if (out_sink->is_device_write_preferred(1)) {

--- a/cpp/src/io/orc/reader_impl_chunking.cu
+++ b/cpp/src/io/orc/reader_impl_chunking.cu
@@ -14,6 +14,7 @@
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/logger.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/device_buffer.hpp>
 #include <rmm/exec_policy.hpp>
@@ -251,7 +252,10 @@ void reader_impl::preprocess_file(read_mode mode)
 
     return (has_timestamp_column && !_options.ignore_timezone_in_stripe_footer)
              ? cudf::detail::make_timezone_transition_table(
-                 {}, selected_stripes[0].stripe_footer->writerTimezone, _stream)
+                 {},
+                 selected_stripes[0].stripe_footer->writerTimezone,
+                 _stream,
+                 cudf::get_current_device_resource_ref())
              : std::make_unique<cudf::table>();
   }();
 

--- a/cpp/src/io/orc/reader_impl_decode.cu
+++ b/cpp/src/io/orc/reader_impl_decode.cu
@@ -392,7 +392,8 @@ void decode_stream_data(int64_t num_dicts,
     update_null_mask(chunks, out_buffers, stream, mr);
   }
 
-  cudf::detail::device_scalar<size_type> error_count(0, stream);
+  cudf::detail::device_scalar<size_type> error_count(
+    0, stream, cudf::get_current_device_resource_ref());
   decode_column_data(chunks.base_device_ptr(),
                      global_dict.data(),
                      row_groups,

--- a/cpp/src/io/orc/reader_impl_helpers.cpp
+++ b/cpp/src/io/orc/reader_impl_helpers.cpp
@@ -5,6 +5,8 @@
 
 #include "reader_impl_helpers.hpp"
 
+#include <cudf/utilities/memory_resource.hpp>
+
 namespace cudf::io::orc::detail {
 
 std::unique_ptr<column> create_empty_column(size_type orc_col_id,
@@ -55,12 +57,16 @@ std::unique_ptr<column> create_empty_column(size_type orc_col_id,
                                                     stream));
         children_schema[idx].name = get_map_child_col_name(idx);
       }
-      return make_lists_column(
-        0,
-        make_empty_column(type_id::INT32),
-        make_structs_column(0, std::move(child_columns), 0, rmm::device_buffer{0, stream}, stream),
-        0,
-        rmm::device_buffer{0, stream});
+      return make_lists_column(0,
+                               make_empty_column(type_id::INT32),
+                               make_structs_column(0,
+                                                   std::move(child_columns),
+                                                   0,
+                                                   rmm::device_buffer{0, stream},
+                                                   stream,
+                                                   cudf::get_current_device_resource_ref()),
+                               0,
+                               rmm::device_buffer{0, stream});
     }
 
     case STRUCT: {
@@ -75,8 +81,12 @@ std::unique_ptr<column> create_empty_column(size_type orc_col_id,
                                                     schema_info.children.back(),
                                                     stream));
       }
-      return make_structs_column(
-        0, std::move(child_columns), 0, rmm::device_buffer{0, stream}, stream);
+      return make_structs_column(0,
+                                 std::move(child_columns),
+                                 0,
+                                 rmm::device_buffer{0, stream},
+                                 stream,
+                                 cudf::get_current_device_resource_ref());
     }
 
     case DECIMAL: {

--- a/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_impl.cpp
@@ -387,7 +387,8 @@ std::unique_ptr<cudf::column> hybrid_scan_reader_impl::build_all_true_row_mask(
   CUDF_EXPECTS(not row_group_indices.empty(), "Empty input row group indices encountered");
 
   auto const num_rows = total_rows_in_row_groups(row_group_indices);
-  auto true_scalar    = cudf::numeric_scalar<bool>(true, true, stream);
+  auto true_scalar =
+    cudf::numeric_scalar<bool>(true, true, stream, cudf::get_current_device_resource_ref());
   return cudf::make_column_from_scalar(true_scalar, num_rows, stream, mr);
 }
 

--- a/cpp/src/io/parquet/experimental/page_index_filter.cu
+++ b/cpp/src/io/parquet/experimental/page_index_filter.cu
@@ -21,8 +21,10 @@
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/logger.hpp>
 #include <cudf/null_mask.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -881,7 +883,8 @@ std::unique_ptr<cudf::column> aggregate_reader_metadata::build_row_mask_with_pag
 
   // Return early if no columns will participate in stats based page filtering
   if (stats_columns_mask.empty()) {
-    auto const scalar_true = cudf::numeric_scalar<bool>(true, true, stream);
+    auto const scalar_true =
+      cudf::numeric_scalar<bool>(true, true, stream, cudf::get_current_device_resource_ref());
     return cudf::make_column_from_scalar(scalar_true, total_rows, stream, mr);
   }
 

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -371,8 +371,10 @@ std::unique_ptr<cudf::column> multibyte_split(cudf::io::text::data_chunk_source 
     reader->skip_bytes(chunk_offset);
     // amortize output chunk allocations over 8 worst-case outputs. This limits the overallocation
     constexpr auto max_growth = 8;
-    output_builder<byte_offset> row_offset_storage(ITEMS_PER_CHUNK, max_growth, stream);
-    output_builder<char> char_storage(ITEMS_PER_CHUNK, max_growth, stream);
+    output_builder<byte_offset> row_offset_storage(
+      ITEMS_PER_CHUNK, max_growth, stream, cudf::get_current_device_resource_ref());
+    output_builder<char> char_storage(
+      ITEMS_PER_CHUNK, max_growth, stream, cudf::get_current_device_resource_ref());
 
     auto streams = cudf::detail::fork_streams(stream, concurrency);
 

--- a/cpp/src/io/utilities/data_casting.cu
+++ b/cpp/src/io/utilities/data_casting.cu
@@ -821,7 +821,8 @@ static std::unique_ptr<column> parse_string(string_view_pair_it str_tuples,
   constexpr auto warps_per_block  = 8;
   constexpr int threads_per_block = cudf::detail::warp_size * warps_per_block;
   auto num_blocks                 = cudf::util::div_rounding_up_safe(col_size, warps_per_block);
-  auto str_counter                = cudf::numeric_scalar(size_type{0}, true, stream);
+  auto str_counter =
+    cudf::numeric_scalar(size_type{0}, true, stream, cudf::get_current_device_resource_ref());
 
   // TODO run these independent kernels in parallel streams.
   if (max_length > SINGLE_THREAD_THRESHOLD) {
@@ -922,7 +923,8 @@ std::unique_ptr<column> parse_data(
   CUDF_FUNC_RANGE();
 
   if (col_size == 0) { return make_empty_column(col_type); }
-  auto d_null_count    = cudf::detail::device_scalar<size_type>(null_count, stream);
+  auto d_null_count = cudf::detail::device_scalar<size_type>(
+    null_count, stream, cudf::get_current_device_resource_ref());
   auto null_count_data = d_null_count.data();
   if (null_mask.is_empty()) {
     null_mask = cudf::create_null_mask(col_size, mask_state::ALL_VALID, stream, mr);

--- a/cpp/src/io/utilities/type_inference.cu
+++ b/cpp/src/io/utilities/type_inference.cu
@@ -10,6 +10,7 @@
 #include <cudf/detail/device_scalar.hpp>
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 
 #include <cub/block/block_reduce.cuh>
 #include <cuda/std/tuple>
@@ -231,7 +232,8 @@ cudf::io::column_type_histogram infer_column_type(OptionsView const& options,
   constexpr int block_size = 128;
 
   auto const grid_size = (size + block_size - 1) / block_size;
-  auto d_column_info   = cudf::detail::device_scalar<cudf::io::column_type_histogram>(stream);
+  auto d_column_info   = cudf::detail::device_scalar<cudf::io::column_type_histogram>(
+    stream, cudf::get_current_device_resource_ref());
   CUDF_CUDA_TRY(cudaMemsetAsync(
     d_column_info.data(), 0, sizeof(cudf::io::column_type_histogram), stream.value()));
 

--- a/cpp/src/join/conditional_join.cu
+++ b/cpp/src/join/conditional_join.cu
@@ -18,6 +18,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -87,7 +88,8 @@ std::unique_ptr<rmm::device_uvector<size_type>> conditional_join_anti_semi(
     join_size = size.value(stream);
   }
 
-  cudf::detail::device_scalar<std::size_t> write_index(0, stream);
+  cudf::detail::device_scalar<std::size_t> write_index(
+    0, stream, cudf::get_current_device_resource_ref());
 
   auto left_indices = std::make_unique<rmm::device_uvector<size_type>>(join_size, stream, mr);
 
@@ -225,7 +227,8 @@ conditional_join(table_view const& left,
                      std::make_unique<rmm::device_uvector<size_type>>(0, stream, mr));
   }
 
-  cudf::detail::device_scalar<std::size_t> write_index(0, stream);
+  cudf::detail::device_scalar<std::size_t> write_index(
+    0, stream, cudf::get_current_device_resource_ref());
 
   auto left_indices  = std::make_unique<rmm::device_uvector<size_type>>(join_size, stream, mr);
   auto right_indices = std::make_unique<rmm::device_uvector<size_type>>(join_size, stream, mr);

--- a/cpp/src/join/filter_join_indices.cu
+++ b/cpp/src/join/filter_join_indices.cu
@@ -19,6 +19,7 @@
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -220,7 +221,8 @@ filter_join_indices(cudf::table_view const& left,
     // Find the number of indices passing the filter i.e. rows that are valid according to the
     // predicate CUB APIs are used instead of Thrust to enable 64-bit operations on index vectors of
     // size greater than integer limits
-    cudf::detail::device_scalar<std::size_t> d_num_valid(stream);
+    cudf::detail::device_scalar<std::size_t> d_num_valid(stream,
+                                                         cudf::get_current_device_resource_ref());
     {
       auto const predicate_it =
         cuda::transform_iterator{predicate_results_ptr,

--- a/cpp/src/join/key_remapping.cu
+++ b/cpp/src/join/key_remapping.cu
@@ -341,7 +341,8 @@ class key_remap_table : public key_remap_table_interface {
     rmm::device_uvector<cudf::size_type> counts(build_num_rows, stream);
     thrust::fill(rmm::exec_policy_nosync(stream), counts.begin(), counts.end(), 0);
 
-    cudf::detail::device_scalar<cudf::size_type> d_distinct_count{0, stream};
+    cudf::detail::device_scalar<cudf::size_type> d_distinct_count{
+      0, stream, cudf::get_current_device_resource_ref()};
 
     auto set_ref = _hash_table.ref(cuco::op::insert_and_find);
 

--- a/cpp/src/join/sort_merge_join.cu
+++ b/cpp/src/join/sort_merge_join.cu
@@ -278,8 +278,9 @@ merge<LargerIterator, SmallerIterator>::inner(rmm::cuda_stream_view stream,
   auto match_offsets =
     cudf::detail::make_zeroed_device_uvector_async<int64_t>(match_counts->size(), stream, temp_mr);
   // Use pinned memory as bounce buffer for efficient device-to-host transfer of the last element
-  auto last_element = cudf::detail::device_scalar<int64_t>(0, stream);
-  auto output_itr   = cudf::detail::make_sizes_to_offsets_iterator(
+  auto last_element =
+    cudf::detail::device_scalar<int64_t>(0, stream, cudf::get_current_device_resource_ref());
+  auto output_itr = cudf::detail::make_sizes_to_offsets_iterator(
     match_offsets.begin(), match_offsets.end(), last_element.data());
   thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
                          match_counts->begin(),

--- a/cpp/src/json/json_path.cu
+++ b/cpp/src/json/json_path.cu
@@ -983,7 +983,10 @@ std::unique_ptr<cudf::column> get_json_object(cudf::strings_column_view const& c
   if (!std::get<0>(preprocess).has_value()) {
     // Create a proper all-null strings column with valid structure (offsets + chars children)
     auto offsets = cudf::make_column_from_scalar(
-      cudf::numeric_scalar<int32_t>(0, true, stream), col.size() + 1, stream, mr);
+      cudf::numeric_scalar<int32_t>(0, true, stream, cudf::get_current_device_resource_ref()),
+      col.size() + 1,
+      stream,
+      mr);
 
     return make_strings_column(
       col.size(),
@@ -1027,7 +1030,8 @@ std::unique_ptr<cudf::column> get_json_object(cudf::strings_column_view const& c
     cudf::detail::create_null_mask(col.size(), mask_state::UNINITIALIZED, stream, mr);
 
   // compute results
-  cudf::detail::device_scalar<size_type> d_valid_count{0, stream};
+  cudf::detail::device_scalar<size_type> d_valid_count{
+    0, stream, cudf::get_current_device_resource_ref()};
 
   get_json_object_kernel<block_size>
     <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(

--- a/cpp/src/lists/dremel.cu
+++ b/cpp/src/lists/dremel.cu
@@ -120,8 +120,11 @@ dremel_data get_encoding(column_view h_col,
   }
   std::unique_ptr<column> empty_list_offset_col;
   if (has_empty_list_offsets) {
-    empty_list_offset_col = make_fixed_width_column(
-      data_type(type_to_id<size_type>()), 1, mask_state::UNALLOCATED, stream);
+    empty_list_offset_col = make_fixed_width_column(data_type(type_to_id<size_type>()),
+                                                    1,
+                                                    mask_state::UNALLOCATED,
+                                                    stream,
+                                                    cudf::get_current_device_resource_ref());
     CUDF_CUDA_TRY(cudaMemsetAsync(
       empty_list_offset_col->mutable_view().head(), 0, sizeof(size_type), stream.value()));
     std::function<column_view(column_view const&)> normalize_col = [&](column_view const& col) {

--- a/cpp/src/lists/extract.cu
+++ b/cpp/src/lists/extract.cu
@@ -46,14 +46,19 @@ std::unique_ptr<cudf::column> make_index_child(column_view const& indices,
 {
   // New column, near identical to `indices`, except with null values replaced.
   // `segmented_gather()` on a null index should produce a null row.
-  if (not indices.nullable()) { return std::make_unique<column>(indices, stream); }
+  if (not indices.nullable()) {
+    return std::make_unique<column>(indices, stream, cudf::get_current_device_resource_ref());
+  }
 
   auto const d_indices = column_device_view::create(indices, stream);
   // Replace null indices with MAX_SIZE_TYPE, so that gather() returns null for them.
   auto const null_replaced_iter_begin =
     cudf::detail::make_null_replacement_iterator(*d_indices, std::numeric_limits<size_type>::max());
-  auto index_child =
-    make_numeric_column(data_type{type_id::INT32}, indices.size(), mask_state::UNALLOCATED, stream);
+  auto index_child = make_numeric_column(data_type{type_id::INT32},
+                                         indices.size(),
+                                         mask_state::UNALLOCATED,
+                                         stream,
+                                         cudf::get_current_device_resource_ref());
   thrust::copy_n(rmm::exec_policy_nosync(stream),
                  null_replaced_iter_begin,
                  indices.size(),
@@ -75,7 +80,11 @@ std::unique_ptr<cudf::column> make_index_child(size_type index,
                                                rmm::cuda_stream_view stream)
 {
   auto index_child =  // [index, index, index, ..., index]
-    make_numeric_column(data_type{type_id::INT32}, num_rows, mask_state::UNALLOCATED, stream);
+    make_numeric_column(data_type{type_id::INT32},
+                        num_rows,
+                        mask_state::UNALLOCATED,
+                        stream,
+                        cudf::get_current_device_resource_ref());
   thrust::fill_n(rmm::exec_policy_nosync(stream),
                  index_child->mutable_view().begin<size_type>(),
                  num_rows,
@@ -92,10 +101,11 @@ std::unique_ptr<cudf::column> make_index_child(size_type index,
  */
 std::unique_ptr<cudf::column> make_index_offsets(size_type num_lists, rmm::cuda_stream_view stream)
 {
-  return cudf::detail::sequence(num_lists + 1,
-                                cudf::scalar_type_t<size_type>(0, true, stream),
-                                stream,
-                                cudf::get_current_device_resource_ref());
+  return cudf::detail::sequence(
+    num_lists + 1,
+    cudf::scalar_type_t<size_type>(0, true, stream, cudf::get_current_device_resource_ref()),
+    stream,
+    cudf::get_current_device_resource_ref());
 }
 
 }  // namespace

--- a/cpp/src/reductions/minmax.cu
+++ b/cpp/src/reductions/minmax.cu
@@ -71,13 +71,15 @@ auto reduce_device(InputIterator d_in,
                    rmm::cuda_stream_view stream)
 {
   OutputType identity{};
-  cudf::detail::device_scalar<OutputType> result{identity, stream};
+  cudf::detail::device_scalar<OutputType> result{
+    identity, stream, cudf::get_current_device_resource_ref()};
 
   // Allocate temporary storage
   size_t storage_bytes = 0;
   cub::DeviceReduce::Reduce(
     nullptr, storage_bytes, d_in, result.data(), num_items, binary_op, identity, stream.value());
-  auto temp_storage = rmm::device_buffer{storage_bytes, stream};
+  auto temp_storage =
+    rmm::device_buffer{storage_bytes, stream, cudf::get_current_device_resource_ref()};
 
   // Run reduction
   cub::DeviceReduce::Reduce(temp_storage.data(),

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -133,7 +133,11 @@ std::unique_ptr<cudf::column> clamp_dictionary_column(dictionary_column_view con
     auto add_scalar_key            = [&](scalar const& key, scalar const& key_replace) {
       if (key.is_valid(stream)) {
         result = dictionary::detail::add_keys(
-          matched_view, make_column_from_scalar(key_replace, 1, stream)->view(), stream, mr);
+          matched_view,
+          make_column_from_scalar(key_replace, 1, stream, cudf::get_current_device_resource_ref())
+            ->view(),
+          stream,
+          mr);
         matched_view = dictionary_column_view(result->view());
       }
     };

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -125,7 +125,8 @@ struct replace_nulls_column_kernel_forwarder {
     auto device_out         = cudf::mutable_column_device_view::create(output_view, stream);
     auto device_replacement = cudf::column_device_view::create(replacement, stream);
 
-    cudf::detail::device_scalar<cudf::size_type> valid_counter(0, stream);
+    cudf::detail::device_scalar<cudf::size_type> valid_counter(
+      0, stream, cudf::get_current_device_resource_ref());
     cudf::size_type* valid_count = valid_counter.data();
 
     replace<<<grid.num_blocks, BLOCK_SIZE, 0, stream.value()>>>(

--- a/cpp/src/replace/replace.cu
+++ b/cpp/src/replace/replace.cu
@@ -172,7 +172,8 @@ struct replace_kernel_forwarder {
                                            rmm::cuda_stream_view stream,
                                            rmm::device_async_resource_ref mr)
   {
-    cudf::detail::device_scalar<cudf::size_type> valid_counter(0, stream);
+    cudf::detail::device_scalar<cudf::size_type> valid_counter(
+      0, stream, cudf::get_current_device_resource_ref());
     cudf::size_type* valid_count = valid_counter.data();
 
     auto replace = [&] {


### PR DESCRIPTION
## Description
Replaces implicit uses of the default memory resource `cudf::get_current_device_resource_ref()` with explicit mr parameter passing across the cudf codebase. 

Affected areas include: I/O, json_path, join, lists, replace.

Entire PR is just passing the defaulted argument explicitly. This will make it easy to find and replace `cudf::get_current_device_resource_ref()` with temporary_mr  in follow up PR as proposed in https://github.com/rapidsai/cudf/issues/20780

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
