### PR TITLE
Pass memory resource explicitly to remove implicit default mr usage (Part 3)

### DIFF
--- a/cpp/src/rolling/detail/lead_lag_nested.cuh
+++ b/cpp/src/rolling/detail/lead_lag_nested.cuh
@@ -123,9 +123,12 @@ std::unique_ptr<column> compute_lead_lag_for_nested(aggregation::Kind op,
 
   auto static constexpr size_data_type = data_type{type_to_id<size_type>()};
 
-  auto gather_map_column =
-    make_numeric_column(size_data_type, input.size(), mask_state::UNALLOCATED, stream);
-  auto gather_map = gather_map_column->mutable_view();
+  auto gather_map_column = make_numeric_column(size_data_type,
+                                               input.size(),
+                                               mask_state::UNALLOCATED,
+                                               stream,
+                                               cudf::get_current_device_resource_ref());
+  auto gather_map        = gather_map_column->mutable_view();
 
   auto const input_size = input.size();
   auto const null_index = input.size();

--- a/cpp/src/rolling/detail/optimized_unbounded_window.cpp
+++ b/cpp/src/rolling/detail/optimized_unbounded_window.cpp
@@ -67,7 +67,8 @@ std::unique_ptr<column> aggregation_based_rolling_window(table_view const& group
   agg_requests.front().aggregations.push_back(convert_to<cudf::groupby_aggregation>(aggr));
 
   auto group_by = cudf::groupby::groupby{group_keys, cudf::null_policy::INCLUDE, cudf::sorted::YES};
-  auto aggregation_results           = group_by.aggregate(agg_requests, stream);
+  auto aggregation_results =
+    group_by.aggregate(agg_requests, stream, cudf::get_current_device_resource_ref());
   auto const& aggregation_result_col = aggregation_results.second.front().results.front();
 
   using cudf::groupby::detail::sort::sort_groupby_helper;
@@ -94,9 +95,11 @@ std::unique_ptr<column> reduction_based_rolling_window(column_view const& input,
   auto const reduce_results = [&] {
     auto const return_dtype = cudf::detail::target_type(input.type(), aggr.kind);
     if (aggr.kind == aggregation::COUNT_ALL) {
-      return cudf::make_fixed_width_scalar(input.size(), stream);
+      return cudf::make_fixed_width_scalar(
+        input.size(), stream, cudf::get_current_device_resource_ref());
     } else if (aggr.kind == aggregation::COUNT_VALID) {
-      return cudf::make_fixed_width_scalar(input.size() - input.null_count(), stream);
+      return cudf::make_fixed_width_scalar(
+        input.size() - input.null_count(), stream, cudf::get_current_device_resource_ref());
     } else {
       return cudf::reduction::detail::reduce(input,
                                              *convert_to<cudf::reduce_aggregation>(aggr),

--- a/cpp/src/rolling/detail/range_utils.cuh
+++ b/cpp/src/rolling/detail/range_utils.cuh
@@ -15,6 +15,7 @@
 #include <cudf/rolling.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_checks.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
@@ -623,7 +624,10 @@ struct range_window_clamper {
       auto const value =
         static_cast<fixed_point_scalar<OrderbyT> const*>(row_delta)->fixed_point_value(stream);
       auto const new_scalar = cudf::fixed_point_scalar<OrderbyT>{
-        value.rescaled(numeric::scale_type{orderby.type().scale()}), true, stream};
+        value.rescaled(numeric::scale_type{orderby.type().scale()}),
+        true,
+        stream,
+        cudf::get_current_device_resource_ref()};
       return window_bounds<OrderbyT>(
         orderby, direction, order, grouping, nulls_at_start, &new_scalar, stream, mr);
     }

--- a/cpp/src/rolling/detail/rolling.cuh
+++ b/cpp/src/rolling/detail/rolling.cuh
@@ -449,7 +449,8 @@ struct rolling_window_launcher {
       auto const d_inp_ptr         = column_device_view::create(input, stream);
       auto const d_default_out_ptr = column_device_view::create(default_outputs, stream);
       auto const d_out_ptr = mutable_column_device_view::create(output->mutable_view(), stream);
-      auto d_valid_count   = cudf::detail::device_scalar<size_type>{0, stream};
+      auto d_valid_count =
+        cudf::detail::device_scalar<size_type>{0, stream, cudf::get_current_device_resource_ref()};
 
       auto constexpr block_size = 256;
       auto const grid           = cudf::detail::grid_1d(input.size(), block_size);

--- a/cpp/src/rolling/detail/rolling_collect_list.cu
+++ b/cpp/src/rolling/detail/rolling_collect_list.cu
@@ -44,8 +44,11 @@ std::unique_ptr<column> get_list_child_to_list_row_mapping(cudf::column_view con
 
   auto const num_child_rows{
     cudf::detail::get_value<size_type>(offsets, offsets.size() - 1, stream)};
-  auto per_row_mapping = make_fixed_width_column(
-    data_type{type_to_id<size_type>()}, num_child_rows, mask_state::UNALLOCATED, stream);
+  auto per_row_mapping       = make_fixed_width_column(data_type{type_to_id<size_type>()},
+                                                 num_child_rows,
+                                                 mask_state::UNALLOCATED,
+                                                 stream,
+                                                 cudf::get_current_device_resource_ref());
   auto per_row_mapping_begin = per_row_mapping->mutable_view().template begin<size_type>();
   thrust::fill_n(rmm::exec_policy_nosync(stream), per_row_mapping_begin, num_child_rows, 0);
 
@@ -116,7 +119,8 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
   auto new_gather_map = make_fixed_width_column(data_type{type_to_id<size_type>()},
                                                 gather_map.size() - num_child_nulls,
                                                 mask_state::UNALLOCATED,
-                                                stream);
+                                                stream,
+                                                mr);
   cudf::detail::copy_if_async(gather_map.template begin<size_type>(),
                               gather_map.template end<size_type>(),
                               new_gather_map->mutable_view().template begin<size_type>(),
@@ -124,8 +128,11 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
                               stream);
 
   // Recalculate offsets after null entries are purged.
-  auto new_sizes = make_fixed_width_column(
-    data_type{type_to_id<size_type>()}, input.size(), mask_state::UNALLOCATED, stream);
+  auto new_sizes = make_fixed_width_column(data_type{type_to_id<size_type>()},
+                                           input.size(),
+                                           mask_state::UNALLOCATED,
+                                           stream,
+                                           cudf::get_current_device_resource_ref());
 
   thrust::tabulate(rmm::exec_policy_nosync(stream),
                    new_sizes->mutable_view().template begin<size_type>(),

--- a/cpp/src/rolling/detail/rolling_collect_list.cuh
+++ b/cpp/src/rolling/detail/rolling_collect_list.cuh
@@ -44,8 +44,12 @@ std::unique_ptr<column> create_collect_offsets(size_type input_size,
 {
   // Materialize offsets column.
   auto static constexpr size_data_type = data_type{type_to_id<size_type>()};
-  auto sizes = make_fixed_width_column(size_data_type, input_size, mask_state::UNALLOCATED, stream);
-  auto mutable_sizes = sizes->mutable_view();
+  auto sizes                           = make_fixed_width_column(size_data_type,
+                                       input_size,
+                                       mask_state::UNALLOCATED,
+                                       stream,
+                                       cudf::get_current_device_resource_ref());
+  auto mutable_sizes                   = sizes->mutable_view();
 
   // Consider the following preceding/following values:
   //    preceding = [1,2,2,2,2]
@@ -100,8 +104,11 @@ std::unique_ptr<column> create_collect_gather_map(column_view const& child_offse
                                                   PrecedingIter preceding_iter,
                                                   rmm::cuda_stream_view stream)
 {
-  auto gather_map = make_fixed_width_column(
-    data_type{type_to_id<size_type>()}, per_row_mapping.size(), mask_state::UNALLOCATED, stream);
+  auto gather_map = make_fixed_width_column(data_type{type_to_id<size_type>()},
+                                            per_row_mapping.size(),
+                                            mask_state::UNALLOCATED,
+                                            stream,
+                                            cudf::get_current_device_resource_ref());
   thrust::transform(
     rmm::exec_policy_nosync(stream),
     cuda::counting_iterator<size_type>{0},

--- a/cpp/src/rolling/detail/rolling_udf.cuh
+++ b/cpp/src/rolling/detail/rolling_udf.cuh
@@ -72,7 +72,8 @@ std::unique_ptr<column> rolling_window_udf(column_view const& input,
     udf_agg._output_type, input.size(), cudf::mask_state::UNINITIALIZED, stream, mr);
 
   auto output_view = output->mutable_view();
-  cudf::detail::device_scalar<size_type> device_valid_count{0, stream};
+  cudf::detail::device_scalar<size_type> device_valid_count{
+    0, stream, cudf::get_current_device_resource_ref()};
 
   std::string kernel_reflection =
     jitify2::reflection::Template("cudf::rolling::jit::gpu_rolling_new")  //

--- a/cpp/src/rolling/range_window_bounds.cpp
+++ b/cpp/src/rolling/range_window_bounds.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,6 +8,7 @@
 #include <cudf/rolling/range_window_bounds.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 
 namespace cudf {
 namespace {
@@ -33,7 +34,9 @@ struct range_scalar_constructor {
                                      rmm::cuda_stream_view stream) const
   {
     return std::make_unique<duration_scalar<T>>(
-      static_cast<duration_scalar<T> const&>(range_scalar_), stream);
+      static_cast<duration_scalar<T> const&>(range_scalar_),
+      stream,
+      cudf::get_current_device_resource_ref());
   }
 
   template <typename T, CUDF_ENABLE_IF(cudf::is_numeric<T>() && not cudf::is_boolean<T>())>
@@ -41,7 +44,8 @@ struct range_scalar_constructor {
                                      rmm::cuda_stream_view stream) const
   {
     return std::make_unique<numeric_scalar<T>>(static_cast<numeric_scalar<T> const&>(range_scalar_),
-                                               stream);
+                                               stream,
+                                               cudf::get_current_device_resource_ref());
   }
 
   template <typename T, CUDF_ENABLE_IF(cudf::is_fixed_point<T>())>
@@ -49,7 +53,9 @@ struct range_scalar_constructor {
                                      rmm::cuda_stream_view stream) const
   {
     return std::make_unique<fixed_point_scalar<T>>(
-      static_cast<fixed_point_scalar<T> const&>(range_scalar_), stream);
+      static_cast<fixed_point_scalar<T> const&>(range_scalar_),
+      stream,
+      cudf::get_current_device_resource_ref());
   }
 };
 }  // namespace
@@ -67,14 +73,14 @@ range_window_bounds::range_window_bounds(extent_type extent_,
 
 range_window_bounds range_window_bounds::unbounded(data_type type, rmm::cuda_stream_view stream)
 {
-  auto s = make_default_constructed_scalar(type, stream);
+  auto s = make_default_constructed_scalar(type, stream, cudf::get_current_device_resource_ref());
   s->set_valid_async(true, stream);
   return {extent_type::UNBOUNDED, std::move(s), stream};
 }
 
 range_window_bounds range_window_bounds::current_row(data_type type, rmm::cuda_stream_view stream)
 {
-  auto s = make_default_constructed_scalar(type, stream);
+  auto s = make_default_constructed_scalar(type, stream, cudf::get_current_device_resource_ref());
   s->set_valid_async(true, stream);
   return {extent_type::CURRENT_ROW, std::move(s), stream};
 }

--- a/cpp/src/search/contains_scalar.cu
+++ b/cpp/src/search/contains_scalar.cu
@@ -93,10 +93,11 @@ struct contains_scalar_dispatch {
     // In addition, haystack and needle structure compatibility will be checked later on by
     // constructor of the table comparator.
 
-    auto const haystack_tv   = table_view{{haystack}};
-    auto const needle_as_col = make_column_from_scalar(needle, 1, stream);
-    auto const needle_tv     = table_view{{needle_as_col->view()}};
-    auto const has_nulls     = has_nested_nulls(haystack_tv) || has_nested_nulls(needle_tv);
+    auto const haystack_tv = table_view{{haystack}};
+    auto const needle_as_col =
+      make_column_from_scalar(needle, 1, stream, cudf::get_current_device_resource_ref());
+    auto const needle_tv = table_view{{needle_as_col->view()}};
+    auto const has_nulls = has_nested_nulls(haystack_tv) || has_nested_nulls(needle_tv);
 
     auto const comparator =
       cudf::detail::row::equality::two_table_comparator(haystack_tv, needle_tv, stream);

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -67,8 +67,10 @@ struct column_fast_sort_fn {
                                                 stream,
                                                 cudf::get_current_device_resource_ref());
     mutable_column_view output_view = temp_col->mutable_view();
-    auto temp_indices               = cudf::column(
-      cudf::column_view(indices.type(), indices.size(), indices.head(), nullptr, 0), stream);
+    auto temp_indices =
+      cudf::column(cudf::column_view(indices.type(), indices.size(), indices.head(), nullptr, 0),
+                   stream,
+                   cudf::get_current_device_resource_ref());
 
     // DeviceSegmentedSort is faster than DeviceSegmentedRadixSort at this time
     auto fast_sort_impl = [stream](bool ascending, [[maybe_unused]] auto&&... args) {
@@ -155,8 +157,11 @@ std::unique_ptr<column> fast_segmented_sorted_order(column_view const& input,
 {
   // Unfortunately, CUB's segmented sort functions cannot accept iterators.
   // We have to build a pre-filled sequence of indices as input.
-  auto sorted_indices =
-    cudf::detail::sequence(input.size(), numeric_scalar<size_type>{0, true, stream}, stream, mr);
+  auto sorted_indices = cudf::detail::sequence(
+    input.size(),
+    numeric_scalar<size_type>{0, true, stream, cudf::get_current_device_resource_ref()},
+    stream,
+    mr);
   auto indices_view = sorted_indices->mutable_view();
 
   cudf::type_dispatcher<dispatch_storage_type>(input.type(),

--- a/cpp/src/sort/top_k.cu
+++ b/cpp/src/sort/top_k.cu
@@ -140,7 +140,10 @@ std::unique_ptr<column> top_k_order(column_view const& col,
   if (k == 0 || col.is_empty()) { return make_empty_column(cudf::type_to_id<size_type>()); }
   if (k >= col.size()) {
     return cudf::detail::sequence(
-      col.size(), numeric_scalar<size_type>(0, true, stream), stream, mr);
+      col.size(),
+      numeric_scalar<size_type>(0, true, stream, cudf::get_current_device_resource_ref()),
+      stream,
+      mr);
   }
 
   auto const temp_mr = cudf::get_current_device_resource_ref();

--- a/cpp/src/strings/case.cu
+++ b/cpp/src/strings/case.cu
@@ -424,7 +424,7 @@ std::unique_ptr<column> convert_case(strings_column_view const& input,
   // after the threshold check above. The check makes very little impact for long strings
   // but results in a large performance gain when the input contains no special characters.
   constexpr int64_t bytes_per_thread = 4;
-  cudf::detail::device_scalar<int64_t> mb_count(0, stream);
+  cudf::detail::device_scalar<int64_t> mb_count(0, stream, cudf::get_current_device_resource_ref());
   auto const grid = cudf::detail::grid_1d(chars_size, block_size, bytes_per_thread);
   mismatch_multibytes_kernel<bytes_per_thread>
     <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -32,7 +32,7 @@ std::unique_ptr<column> to_booleans(strings_column_view const& input,
 {
   size_type strings_count = input.size();
   if (strings_count == 0) {
-    return make_numeric_column(data_type{type_id::BOOL8}, 0, mask_state::UNALLOCATED, stream);
+    return make_numeric_column(data_type{type_id::BOOL8}, 0, mask_state::UNALLOCATED, stream, mr);
   }
 
   CUDF_EXPECTS(true_string.is_valid(stream) && true_string.size() > 0,

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -690,7 +690,7 @@ std::unique_ptr<column> to_durations(strings_column_view const& input,
 {
   size_type strings_count = input.size();
   if (strings_count == 0) {
-    return make_duration_column(duration_type, 0, mask_state::UNALLOCATED, stream);
+    return make_duration_column(duration_type, 0, mask_state::UNALLOCATED, stream, mr);
   }
 
   CUDF_EXPECTS(!format.empty(), "Format parameter must not be empty.");

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -88,7 +88,8 @@ std::unique_ptr<column> to_floats(strings_column_view const& input,
 {
   size_type strings_count = input.size();
   if (strings_count == 0) {
-    return make_numeric_column(output_type, 0, mask_state::UNALLOCATED, stream);
+    return make_numeric_column(
+      output_type, 0, mask_state::UNALLOCATED, stream, cudf::get_current_device_resource_ref());
   }
   auto strings_column = column_device_view::create(input.parent(), stream);
   auto d_strings      = *strings_column;

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -268,7 +268,7 @@ std::unique_ptr<column> to_integers(strings_column_view const& input,
 {
   size_type strings_count = input.size();
   if (strings_count == 0) {
-    return make_numeric_column(output_type, 0, mask_state::UNALLOCATED, stream);
+    return make_numeric_column(output_type, 0, mask_state::UNALLOCATED, stream, mr);
   }
 
   // Create integer output column copying the strings null-mask

--- a/cpp/src/strings/convert/convert_ipv4.cu
+++ b/cpp/src/strings/convert/convert_ipv4.cu
@@ -68,7 +68,7 @@ std::unique_ptr<column> ipv4_to_integers(strings_column_view const& input,
 {
   size_type strings_count = input.size();
   if (strings_count == 0) {
-    return make_numeric_column(data_type{type_id::UINT32}, 0, mask_state::UNALLOCATED, stream);
+    return make_numeric_column(data_type{type_id::UINT32}, 0, mask_state::UNALLOCATED, stream, mr);
   }
 
   auto strings_column = column_device_view::create(input.parent(), stream);

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -234,7 +234,8 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
   }
 
   {  // Copy offsets columns with single kernel launch
-    cudf::detail::device_scalar<size_type> d_valid_count(0, stream);
+    cudf::detail::device_scalar<size_type> d_valid_count(
+      0, stream, cudf::get_current_device_resource_ref());
 
     constexpr size_type block_size{256};
     cudf::detail::grid_1d config(offsets_count, block_size);

--- a/cpp/src/strings/like.cu
+++ b/cpp/src/strings/like.cu
@@ -370,8 +370,9 @@ std::unique_ptr<column> like(strings_column_view const& input,
                              rmm::cuda_stream_view stream,
                              rmm::device_async_resource_ref mr)
 {
-  auto const ptn = string_scalar(pattern, true, stream);
-  auto const esc = string_scalar(escape_character, true, stream);
+  auto const ptn = string_scalar(pattern, true, stream, cudf::get_current_device_resource_ref());
+  auto const esc =
+    string_scalar(escape_character, true, stream, cudf::get_current_device_resource_ref());
   return like(input, ptn, esc, stream, mr);
 }
 

--- a/cpp/src/strings/replace/backref_re.cu
+++ b/cpp/src/strings/replace/backref_re.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -110,7 +110,8 @@ std::unique_ptr<column> replace_with_backrefs(strings_column_view const& input,
   auto const parse_result                    = parse_backrefs(replacement, group_count);
   rmm::device_uvector<backref_type> backrefs = cudf::detail::make_device_uvector_async(
     parse_result.second, stream, cudf::get_current_device_resource_ref());
-  string_scalar repl_scalar(parse_result.first, true, stream);
+  string_scalar repl_scalar(
+    parse_result.first, true, stream, cudf::get_current_device_resource_ref());
   string_view const d_repl_template = repl_scalar.value(stream);
 
   auto const d_strings = column_device_view::create(input.parent(), stream);

--- a/cpp/src/strings/replace/multi.cu
+++ b/cpp/src/strings/replace/multi.cu
@@ -330,7 +330,7 @@ std::unique_ptr<column> replace_character_parallel(strings_column_view const& in
 
   // Count the number of targets in the entire column.
   // Note this may over-count in the case where a target spans adjacent strings.
-  cudf::detail::device_scalar<int64_t> d_count(0, stream);
+  cudf::detail::device_scalar<int64_t> d_count(0, stream, cudf::get_current_device_resource_ref());
   auto const num_blocks = util::div_rounding_up_safe(
     util::div_rounding_up_safe(chars_bytes, static_cast<int64_t>(bytes_per_thread)), block_size);
   count_targets<<<num_blocks, block_size, 0, stream.value()>>>(fn, chars_bytes, d_count.data());

--- a/cpp/src/strings/replace/replace.cu
+++ b/cpp/src/strings/replace/replace.cu
@@ -277,7 +277,8 @@ std::unique_ptr<column> replace_character_parallel(strings_column_view const& in
 
   // Count the number of targets in the entire column.
   // Note this may over-count in the case where a target spans adjacent strings.
-  cudf::detail::device_scalar<int64_t> d_target_count(0, stream);
+  cudf::detail::device_scalar<int64_t> d_target_count(
+    0, stream, cudf::get_current_device_resource_ref());
   constexpr int64_t block_size         = 512;
   constexpr size_type bytes_per_thread = 4;
   auto const num_blocks                = util::div_rounding_up_safe(

--- a/cpp/src/strings/search/find.cu
+++ b/cpp/src/strings/search/find.cu
@@ -427,8 +427,9 @@ std::unique_ptr<column> contains_fn(strings_column_view const& strings,
   CUDF_EXPECTS(target.is_valid(stream), "Parameter target must be valid.");
   if (target.size() == 0)  // empty target string returns true
   {
-    auto const true_scalar = make_fixed_width_scalar<bool>(true, stream);
-    auto results           = make_column_from_scalar(*true_scalar, strings.size(), stream, mr);
+    auto const true_scalar =
+      make_fixed_width_scalar<bool>(true, stream, cudf::get_current_device_resource_ref());
+    auto results = make_column_from_scalar(*true_scalar, strings.size(), stream, mr);
     results->set_null_mask(cudf::detail::copy_bitmask(strings.parent(), stream, mr),
                            strings.null_count());
     return results;

--- a/cpp/src/strings/search/find_multiple.cu
+++ b/cpp/src/strings/search/find_multiple.cu
@@ -67,11 +67,12 @@ std::unique_ptr<column> find_multiple(strings_column_view const& input,
                     });
   results->set_null_count(0);
 
-  auto offsets = cudf::detail::sequence(strings_count + 1,
-                                        numeric_scalar<size_type>(0, true, stream),
-                                        numeric_scalar<size_type>(targets_count, true, stream),
-                                        stream,
-                                        mr);
+  auto offsets = cudf::detail::sequence(
+    strings_count + 1,
+    numeric_scalar<size_type>(0, true, stream, cudf::get_current_device_resource_ref()),
+    numeric_scalar<size_type>(targets_count, true, stream, cudf::get_current_device_resource_ref()),
+    stream,
+    mr);
   return make_lists_column(
     strings_count, std::move(offsets), std::move(results), 0, rmm::device_buffer{0, stream, mr});
 }

--- a/cpp/src/strings/split/split.cuh
+++ b/cpp/src/strings/split/split.cuh
@@ -517,7 +517,7 @@ std::pair<std::unique_ptr<column>, rmm::device_uvector<string_index_pair>> split
   delimiter_fn.chars_bytes         = chars_bytes;
 
   // count the number of delimiters in the entire column
-  cudf::detail::device_scalar<int64_t> d_count(0, stream);
+  cudf::detail::device_scalar<int64_t> d_count(0, stream, cudf::get_current_device_resource_ref());
   if (chars_bytes > 0) {
     constexpr int64_t block_size         = 512;
     constexpr size_type bytes_per_thread = 4;

--- a/cpp/src/structs/copying/concatenate.cu
+++ b/cpp/src/structs/copying/concatenate.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -53,8 +53,11 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
   // if any of the input columns have nulls, construct the output mask
   bool const has_nulls =
     std::any_of(columns.begin(), columns.end(), [](auto const& col) { return col.has_nulls(); });
-  rmm::device_buffer null_mask = create_null_mask(
-    total_length, has_nulls ? mask_state::UNINITIALIZED : mask_state::UNALLOCATED, stream);
+  rmm::device_buffer null_mask =
+    create_null_mask(total_length,
+                     has_nulls ? mask_state::UNINITIALIZED : mask_state::UNALLOCATED,
+                     stream,
+                     cudf::get_current_device_resource_ref());
   auto null_mask_data = static_cast<bitmask_type*>(null_mask.data());
   auto const null_count =
     has_nulls ? cudf::detail::concatenate_masks(columns, null_mask_data, stream) : size_type{0};

--- a/cpp/src/text/minhash.cu
+++ b/cpp/src/text/minhash.cu
@@ -454,7 +454,8 @@ std::unique_ptr<cudf::column> minhash_fn(cudf::strings_column_view const& input,
                              block_size};
   auto const hashes_size = input.chars_size(stream);
   auto d_hashes          = rmm::device_uvector<hash_value_type>(hashes_size, stream);
-  auto d_threshold_count = cudf::detail::device_scalar<cudf::size_type>(0, stream);
+  auto d_threshold_count = cudf::detail::device_scalar<cudf::size_type>(
+    0, stream, cudf::get_current_device_resource_ref());
 
   minhash_seed_kernel<HashFunction>
     <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(*d_strings,
@@ -540,7 +541,8 @@ std::unique_ptr<cudf::column> minhash_ngrams_fn(
                              block_size};
   auto const hashes_size = input.child().size();
   auto d_hashes          = rmm::device_uvector<hash_value_type>(hashes_size, stream);
-  auto d_threshold_count = cudf::detail::device_scalar<cudf::size_type>(0, stream);
+  auto d_threshold_count = cudf::detail::device_scalar<cudf::size_type>(
+    0, stream, cudf::get_current_device_resource_ref());
 
   auto d_list = cudf::detail::lists_column_device_view(*d_input);
   minhash_ngrams_kernel<HashFunction>
@@ -593,9 +595,11 @@ std::unique_ptr<cudf::column> build_list_result(cudf::column_view const& input,
                                                 rmm::device_async_resource_ref mr)
 {
   // build the offsets for the output lists column
-  auto const zero = cudf::numeric_scalar<cudf::size_type>(0, true, stream);
-  auto const size = cudf::numeric_scalar<cudf::size_type>(seeds_size, true, stream);
-  auto offsets    = cudf::detail::sequence(input.size() + 1, zero, size, stream, mr);
+  auto const zero =
+    cudf::numeric_scalar<cudf::size_type>(0, true, stream, cudf::get_current_device_resource_ref());
+  auto const size = cudf::numeric_scalar<cudf::size_type>(
+    seeds_size, true, stream, cudf::get_current_device_resource_ref());
+  auto offsets = cudf::detail::sequence(input.size() + 1, zero, size, stream, mr);
   hashes->set_null_mask(rmm::device_buffer{}, 0);  // children have no nulls
 
   // build the lists column from the offsets and the hashes


### PR DESCRIPTION
## Description
Replaces implicit uses of the default memory resource `cudf::get_current_device_resource_ref()` with explicit mr parameter passing across the cudf codebase. 

Affected areas include: rolling, search, sort, strings, structs, text.

Entire PR is just passing the defaulted argument explicitly. This will make it easy to find and replace `cudf::get_current_device_resource_ref()` with temporary_mr  in follow up PR as proposed in https://github.com/rapidsai/cudf/issues/20780

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
