### PR TITLE
Pass memory resource to exec_policy_nosync in groupby module

### DIFF
--- a/cpp/src/groupby/common/m2_var_std.cu
+++ b/cpp/src/groupby/common/m2_var_std.cu
@@ -45,7 +45,7 @@ struct m2_functor {
                 size_type size,
                 rmm::cuda_stream_view stream) const noexcept
   {
-    thrust::tabulate(rmm::exec_policy_nosync(stream),
+    thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      target,
                      target + size,
                      [sum_sqr, sum, count] __device__(size_type const idx) {
@@ -134,7 +134,10 @@ std::unique_ptr<column> compute_variance_std(TransformFunc&& transform_fn,
 
   auto const out_it =
     thrust::make_zip_iterator(output->mutable_view().begin<TargetType>(), validity.begin());
-  thrust::tabulate(rmm::exec_policy_nosync(stream), out_it, out_it + size, transform_fn);
+  thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   out_it,
+                   out_it + size,
+                   transform_fn);
 
   auto [null_mask, null_count] =
     cudf::detail::valid_if(validity.begin(), validity.end(), cuda::std::identity{}, stream, mr);

--- a/cpp/src/groupby/hash/compute_global_memory_aggs.cuh
+++ b/cpp/src/groupby/hash/compute_global_memory_aggs.cuh
@@ -50,7 +50,7 @@ rmm::device_uvector<size_type> compute_matching_keys(bitmask_type const* row_bit
 
   // Need to set to sentinel value for rows that are null (if any).
   // The sentinel value will then be used to identify null rows instead of using the bitmask.
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>(0),
                     cuda::counting_iterator<size_type>(num_rows),
                     key_indices.begin(),
@@ -104,7 +104,7 @@ std::pair<std::unique_ptr<table>, rmm::device_uvector<size_type>> compute_aggs_d
                                           mr);
   auto d_results_ptr  = mutable_table_device_view::create(*agg_results, stream);
 
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<int64_t>{0},
                      num_rows * static_cast<int64_t>(h_agg_kinds.size()),
                      compute_single_pass_aggs_dense_output_fn{
@@ -139,7 +139,7 @@ std::pair<std::unique_ptr<table>, rmm::device_uvector<size_type>> compute_aggs_s
   auto d_results_ptr = mutable_table_device_view::create(*agg_results, stream);
 
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     num_rows,
     compute_single_pass_aggs_sparse_output_fn{key_set.ref(cuco::op::insert_and_find),

--- a/cpp/src/groupby/hash/compute_groupby.cu
+++ b/cpp/src/groupby/hash/compute_groupby.cu
@@ -101,7 +101,7 @@ std::unique_ptr<table> compute_groupby(table_view const& keys,
 
     rmm::device_uvector<hash_value_type> hashes(
       num_keys, stream, cudf::get_current_device_resource_ref());
-    thrust::tabulate(rmm::exec_policy_nosync(stream),
+    thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      hashes.begin(),
                      hashes.end(),
                      [d_row_hash, row_bitmask] __device__(size_type const idx) {
@@ -136,7 +136,7 @@ std::unique_ptr<table> compute_groupby(table_view const& keys,
   // In case of no requests, we still need to generate a set of unique keys.
   if (requests.empty()) {
     thrust::for_each_n(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<cudf::size_type>{0},
       num_keys,
       [set_ref = set.ref(cuco::op::insert), row_bitmask] __device__(size_type const idx) mutable {

--- a/cpp/src/groupby/hash/compute_single_pass_aggs.cuh
+++ b/cpp/src/groupby/hash/compute_single_pass_aggs.cuh
@@ -84,10 +84,11 @@ std::pair<rmm::device_uvector<size_type>, bool> compute_single_pass_aggs(
                                                         stream);
   // Initialize it with a sentinel value, so later we can identify which ones are unused and which
   // ones need to be updated.
-  thrust::uninitialized_fill(rmm::exec_policy_nosync(stream),
-                             global_mapping_indices.begin(),
-                             global_mapping_indices.end(),
-                             cudf::detail::CUDF_SIZE_TYPE_SENTINEL);
+  thrust::uninitialized_fill(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    global_mapping_indices.begin(),
+    global_mapping_indices.end(),
+    cudf::detail::CUDF_SIZE_TYPE_SENTINEL);
   // Compute the cardinality (the number of unique keys) encounter by each thread block.
   rmm::device_uvector<size_type> block_cardinality(grid_size, stream);
 
@@ -127,7 +128,7 @@ std::pair<rmm::device_uvector<size_type>, bool> compute_single_pass_aggs(
     auto key_transform_map = compute_key_transform_map(
       num_rows, unique_keys, stream, cudf::get_current_device_resource_ref());
     thrust::for_each_n(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<cudf::size_type>{0},
       grid_size * GROUPBY_BLOCK_SIZE,
       [key_transform_map      = key_transform_map.begin(),

--- a/cpp/src/groupby/hash/output_utils.cu
+++ b/cpp/src/groupby/hash/output_utils.cu
@@ -170,7 +170,7 @@ rmm::device_uvector<size_type> compute_key_transform_map(
   // indices (indices of the keys in the final output table, which contains only the extracted
   // unique keys). Only these extracted unique keys are mapped.
   rmm::device_uvector<size_type> key_transform_map(num_total_keys, stream, mr);
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   cuda::counting_iterator<cudf::size_type>{0},
                   cuda::counting_iterator{static_cast<size_type>(unique_key_indices.size())},
                   unique_key_indices.begin(),
@@ -185,7 +185,7 @@ rmm::device_uvector<size_type> compute_target_indices(device_span<size_type cons
                                                       rmm::device_async_resource_ref mr)
 {
   rmm::device_uvector<size_type> target_indices(input.size(), stream, mr);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     input.begin(),
                     input.end(),
                     target_indices.begin(),

--- a/cpp/src/groupby/sort/group_argmax.cu
+++ b/cpp/src/groupby/sort/group_argmax.cu
@@ -40,7 +40,7 @@ std::unique_ptr<column> group_argmax(column_view const& values,
   // We do not use cudf::gather since we can move the null-mask separately.
   auto indices_view = indices->view();
   auto output       = rmm::device_uvector<size_type>(indices_view.size(), stream, mr);
-  thrust::gather(rmm::exec_policy_nosync(stream),
+  thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  indices_view.begin<size_type>(),    // map first
                  indices_view.end<size_type>(),      // map last
                  key_sort_order.begin<size_type>(),  // input

--- a/cpp/src/groupby/sort/group_argmin.cu
+++ b/cpp/src/groupby/sort/group_argmin.cu
@@ -41,7 +41,7 @@ std::unique_ptr<column> group_argmin(column_view const& values,
   // We do not use cudf::gather since we can move the null-mask separately.
   auto indices_view = indices->view();
   auto output       = rmm::device_uvector<size_type>(indices_view.size(), stream, mr);
-  thrust::gather(rmm::exec_policy_nosync(stream),
+  thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  indices_view.begin<size_type>(),    // map first
                  indices_view.end<size_type>(),      // map last
                  key_sort_order.begin<size_type>(),  // input

--- a/cpp/src/groupby/sort/group_collect.cu
+++ b/cpp/src/groupby/sort/group_collect.cu
@@ -59,7 +59,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
   rmm::device_uvector<size_type> null_purged_sizes(num_groups, stream);
 
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     cuda::counting_iterator<size_type>{num_groups},
     null_purged_sizes.begin(),
@@ -88,7 +88,7 @@ std::unique_ptr<column> group_collect(column_view const& values,
     auto offsets_column = make_numeric_column(
       data_type(type_to_id<size_type>()), num_groups + 1, mask_state::UNALLOCATED, stream, mr);
 
-    thrust::copy(rmm::exec_policy_nosync(stream),
+    thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  group_offsets.begin(),
                  group_offsets.end(),
                  offsets_column->mutable_view().template begin<size_type>());

--- a/cpp/src/groupby/sort/group_correlation.cu
+++ b/cpp/src/groupby/sort/group_correlation.cu
@@ -185,7 +185,7 @@ std::unique_ptr<column> group_correlation(column_view const& covariance,
                                     stream,
                                     mr);
   auto d_result    = result->mutable_view().begin<result_type>();
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     covariance.begin<result_type>(),
                     covariance.end<result_type>(),
                     stddev_iter,

--- a/cpp/src/groupby/sort/group_count.cu
+++ b/cpp/src/groupby/sort/group_count.cu
@@ -80,10 +80,11 @@ std::unique_ptr<column> group_count_all(cudf::device_span<size_type const> group
 
   if (num_groups == 0) { return result; }
 
-  thrust::adjacent_difference(rmm::exec_policy_nosync(stream),
-                              group_offsets.begin() + 1,
-                              group_offsets.end(),
-                              result->mutable_view().begin<size_type>());
+  thrust::adjacent_difference(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    group_offsets.begin() + 1,
+    group_offsets.end(),
+    result->mutable_view().begin<size_type>());
   return result;
 }
 

--- a/cpp/src/groupby/sort/group_count_scan.cu
+++ b/cpp/src/groupby/sort/group_count_scan.cu
@@ -35,22 +35,24 @@ std::unique_ptr<column> count_scan(column_view const& values,
   auto resultview = result->mutable_view();
   // aggregation::COUNT_ALL
   if (nulls == null_policy::INCLUDE) {
-    thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                  group_labels.begin(),
-                                  group_labels.end(),
-                                  cuda::make_constant_iterator<size_type>(1),
-                                  resultview.begin<size_type>());
+    thrust::inclusive_scan_by_key(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      group_labels.begin(),
+      group_labels.end(),
+      cuda::make_constant_iterator<size_type>(1),
+      resultview.begin<size_type>());
   } else {  // aggregation::COUNT_VALID
     auto d_values = cudf::column_device_view::create(values, stream);
     auto itr      = cudf::detail::make_counting_transform_iterator(
       0, [d_values = *d_values] __device__(auto idx) -> cudf::size_type {
         return d_values.is_valid(idx);
       });
-    thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                  group_labels.begin(),
-                                  group_labels.end(),
-                                  itr,
-                                  resultview.begin<size_type>());
+    thrust::inclusive_scan_by_key(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      group_labels.begin(),
+      group_labels.end(),
+      itr,
+      resultview.begin<size_type>());
   }
   return result;
 }

--- a/cpp/src/groupby/sort/group_histogram.cu
+++ b/cpp/src/groupby/sort/group_histogram.cu
@@ -120,7 +120,7 @@ std::unique_ptr<column> group_merge_histogram(column_view const& values,
   // That is equivalent to creating a new lists column (view) from the input lists column
   // with new offsets gathered as below.
   auto new_offsets = rmm::device_uvector<size_type>(num_groups + 1, stream);
-  thrust::gather(rmm::exec_policy_nosync(stream),
+  thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  group_offsets.begin(),
                  group_offsets.end(),
                  lists_cv.offsets_begin(),

--- a/cpp/src/groupby/sort/group_m2.cu
+++ b/cpp/src/groupby/sort/group_m2.cu
@@ -61,8 +61,11 @@ void compute_m2_fn(column_device_view const& values,
   // using the transform-iterator directly in reduce_by_key
   // improves compile-time significantly.
   auto m2_vals = rmm::device_uvector<ResultType>(values.size(), stream);
-  thrust::transform(
-    rmm::exec_policy_nosync(stream), itr, itr + values.size(), m2_vals.begin(), m2_fn);
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    itr,
+                    itr + values.size(),
+                    m2_vals.begin(),
+                    m2_fn);
 
   cudf::detail::reduce_by_key_async(group_labels.begin(),
                                     group_labels.end(),

--- a/cpp/src/groupby/sort/group_merge_lists.cu
+++ b/cpp/src/groupby/sort/group_merge_lists.cu
@@ -40,7 +40,7 @@ std::unique_ptr<column> group_merge_lists(column_view const& values,
   //
   //   then, the output offsets_column is [0, 5, 8].
   //
-  thrust::gather(rmm::exec_policy_nosync(stream),
+  thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  group_offsets.begin(),
                  group_offsets.end(),
                  lists_column_view(values).offsets_begin(),

--- a/cpp/src/groupby/sort/group_merge_m2.cu
+++ b/cpp/src/groupby/sort/group_merge_m2.cu
@@ -88,7 +88,11 @@ std::unique_ptr<column> merge_m2(column_view const& values,
                                        count_valid.template begin<count_type>(),
                                        mean_values.template begin<result_type>(),
                                        M2_values.template begin<result_type>()};
-  thrust::transform(rmm::exec_policy_nosync(stream), iter, iter + num_groups, out_iter, fn);
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    iter,
+                    iter + num_groups,
+                    out_iter,
+                    fn);
 
   // Output is a structs column containing the merged values of `COUNT_VALID`, `MEAN`, and `M2`.
   std::vector<std::unique_ptr<column>> out_columns;

--- a/cpp/src/groupby/sort/group_nth_element.cu
+++ b/cpp/src/groupby/sort/group_nth_element.cu
@@ -47,13 +47,16 @@ std::unique_ptr<column> group_nth_element(column_view const& values,
   auto nth_index = rmm::device_uvector<size_type>(num_groups, stream);
   // TODO: replace with async version
   thrust::uninitialized_fill_n(
-    rmm::exec_policy_nosync(stream), nth_index.begin(), num_groups, values.size());
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    nth_index.begin(),
+    num_groups,
+    values.size());
 
   // nulls_policy::INCLUDE (equivalent to pandas nth(dropna=None) but return nulls for n
   if (null_handling == null_policy::INCLUDE || !values.has_nulls()) {
     // Returns index of nth value.
     thrust::transform_if(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       group_sizes.begin<size_type>(),
       group_sizes.end<size_type>(),
       group_offsets.begin(),
@@ -75,11 +78,12 @@ std::unique_ptr<column> group_nth_element(column_view const& values,
                                       }));
     rmm::device_uvector<size_type> intra_group_index(values.size(), stream);
     // intra group index for valids only.
-    thrust::exclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                  group_labels.begin(),
-                                  group_labels.end(),
-                                  bitmask_iterator,
-                                  intra_group_index.begin());
+    thrust::exclusive_scan_by_key(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      group_labels.begin(),
+      group_labels.end(),
+      bitmask_iterator,
+      intra_group_index.begin());
     // group_size to recalculate n if n<0
     rmm::device_uvector<size_type> group_count = [&] {
       if (n < 0) {
@@ -97,7 +101,7 @@ std::unique_ptr<column> group_nth_element(column_view const& values,
       }
     }();
     // gather the valid index == n
-    thrust::scatter_if(rmm::exec_policy_nosync(stream),
+    thrust::scatter_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        cuda::counting_iterator<size_type>{0},
                        cuda::counting_iterator<size_type>{values.size()},
                        group_labels.begin(),                   // map

--- a/cpp/src/groupby/sort/group_nunique.cu
+++ b/cpp/src/groupby/sort/group_nunique.cu
@@ -92,7 +92,7 @@ std::unique_ptr<column> group_nunique(column_view const& values,
                                     null_handling,
                                     group_offsets.data(),
                                     group_labels.data()};
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{values.size()},
                       d_result.begin(),

--- a/cpp/src/groupby/sort/group_quantiles.cu
+++ b/cpp/src/groupby/sort/group_quantiles.cu
@@ -103,7 +103,7 @@ struct quantiles_functor {
     // For each group, calculate quantile
     if (!cudf::is_dictionary(values.type())) {
       auto values_iter = values_view->begin<T>();
-      thrust::for_each_n(rmm::exec_policy_nosync(stream),
+      thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          cuda::counting_iterator<cudf::size_type>{0},
                          num_groups,
                          calculate_quantile_fn<ResultType, decltype(values_iter)>{
@@ -117,7 +117,7 @@ struct quantiles_functor {
                            null_count.data()});
     } else {
       auto values_iter = cudf::dictionary::detail::make_dictionary_iterator<T>(*values_view);
-      thrust::for_each_n(rmm::exec_policy_nosync(stream),
+      thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          cuda::counting_iterator<cudf::size_type>{0},
                          num_groups,
                          calculate_quantile_fn<ResultType, decltype(values_iter)>{

--- a/cpp/src/groupby/sort/group_rank_scan.cu
+++ b/cpp/src/groupby/sort/group_rank_scan.cu
@@ -104,7 +104,7 @@ std::unique_ptr<column> rank_generator(column_view const& grouped_values,
     auto const permuted_equal =
       permuted_row_equality_comparator(d_equal, value_order.begin<size_type>());
 
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>(0),
                       cuda::counting_iterator<size_type>(grouped_values.size()),
                       mutable_ranks.begin<size_type>(),
@@ -130,13 +130,14 @@ std::unique_ptr<column> rank_generator(column_view const& grouped_values,
                              cuda::std::reverse_iterator(mutable_ranks.end<size_type>())};
     }
   }();
-  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                group_labels_begin,
-                                group_labels_begin + group_labels.size(),
-                                mutable_rank_begin,
-                                mutable_rank_begin,
-                                cuda::std::equal_to{},
-                                scan_op);
+  thrust::inclusive_scan_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    group_labels_begin,
+    group_labels_begin + group_labels.size(),
+    mutable_rank_begin,
+    mutable_rank_begin,
+    cuda::std::equal_to{},
+    scan_op);
   return ranks;
 }
 }  // namespace
@@ -193,7 +194,7 @@ std::unique_ptr<column> first_rank_scan(column_view const& grouped_values,
   auto ranks = make_fixed_width_column(
     data_type{type_to_id<size_type>()}, group_labels.size(), mask_state::UNALLOCATED, stream, mr);
   auto mutable_ranks = ranks->mutable_view();
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>(0),
                     cuda::counting_iterator<size_type>(group_labels.size()),
                     mutable_ranks.begin<size_type>(),
@@ -227,7 +228,7 @@ std::unique_ptr<column> average_rank_scan(column_view const& grouped_values,
   auto ranks    = make_fixed_width_column(
     data_type{type_to_id<double>()}, group_labels.size(), mask_state::UNALLOCATED, stream, mr);
   auto mutable_ranks = ranks->mutable_view();
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     max_rank->view().begin<size_type>(),
                     max_rank->view().end<size_type>(),
                     min_rank->view().begin<size_type>(),
@@ -275,7 +276,7 @@ std::unique_ptr<column> group_rank_to_percentage(rank_method const method,
     return group_size == 1 ? 0.0 : ((rank - 1.0) / (group_size - 1));
   };
   if (method == rank_method::DENSE) {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>(0),
                       cuda::counting_iterator<size_type>(group_labels.size()),
                       mutable_ranks.begin<double>(),
@@ -296,7 +297,7 @@ std::unique_ptr<column> group_rank_to_percentage(rank_method const method,
                                  : one_normalized(r, last_rank);
                       });
   } else {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>(0),
                       cuda::counting_iterator<size_type>(group_labels.size()),
                       mutable_ranks.begin<double>(),

--- a/cpp/src/groupby/sort/group_replace_nulls.cu
+++ b/cpp/src/groupby/sort/group_replace_nulls.cu
@@ -45,19 +45,26 @@ std::unique_ptr<column> group_replace_nulls(cudf::column_view const& grouped_val
   auto func = cudf::detail::replace_policy_functor();
   cuda::std::equal_to<cudf::size_type> eq;
   if (replace_policy == cudf::replace_policy::PRECEDING) {
-    thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                  group_labels.begin(),
-                                  group_labels.begin() + size,
-                                  in_begin,
-                                  gm_begin,
-                                  eq,
-                                  func);
+    thrust::inclusive_scan_by_key(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      group_labels.begin(),
+      group_labels.begin() + size,
+      in_begin,
+      gm_begin,
+      eq,
+      func);
   } else {
     auto gl_rbegin = cuda::std::make_reverse_iterator(group_labels.begin() + size);
     auto in_rbegin = cuda::std::make_reverse_iterator(in_begin + size);
     auto gm_rbegin = cuda::std::make_reverse_iterator(gm_begin + size);
     thrust::inclusive_scan_by_key(
-      rmm::exec_policy_nosync(stream), gl_rbegin, gl_rbegin + size, in_rbegin, gm_rbegin, eq, func);
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      gl_rbegin,
+      gl_rbegin + size,
+      in_rbegin,
+      gm_rbegin,
+      eq,
+      func);
   }
 
   auto output = cudf::detail::gather(cudf::table_view({grouped_value}),

--- a/cpp/src/groupby/sort/group_scan_util.cuh
+++ b/cpp/src/groupby/sort/group_scan_util.cuh
@@ -107,13 +107,14 @@ struct group_scan_functor<K, T, std::enable_if_t<is_group_scan_supported<K, T>()
 
     // Perform segmented scan.
     auto const do_scan = [&](auto const& inp_iter, auto const& out_iter, auto const& binop) {
-      thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                    group_labels.begin(),
-                                    group_labels.end(),
-                                    inp_iter,
-                                    out_iter,
-                                    cuda::std::equal_to{},
-                                    binop);
+      thrust::inclusive_scan_by_key(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        group_labels.begin(),
+        group_labels.end(),
+        inp_iter,
+        out_iter,
+        cuda::std::equal_to{},
+        binop);
     };
 
     if (values.has_nulls()) {
@@ -152,13 +153,14 @@ struct group_scan_functor<K,
 
     // Perform segmented scan.
     auto const do_scan = [&](auto const& inp_iter, auto const& out_iter, auto const& binop) {
-      thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                    group_labels.begin(),
-                                    group_labels.end(),
-                                    inp_iter,
-                                    out_iter,
-                                    cuda::std::equal_to{},
-                                    binop);
+      thrust::inclusive_scan_by_key(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        group_labels.begin(),
+        group_labels.end(),
+        inp_iter,
+        out_iter,
+        cuda::std::equal_to{},
+        binop);
     };
 
     if (values.has_nulls()) {
@@ -194,13 +196,14 @@ struct group_scan_functor<K,
 
     auto const binop_generator =
       cudf::reduction::detail::arg_minmax_binop_generator::create<K>(values, stream);
-    thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                  group_labels.begin(),
-                                  group_labels.end(),
-                                  cuda::counting_iterator<size_type>{0},
-                                  gather_map.begin(),
-                                  cuda::std::equal_to{},
-                                  binop_generator.binop());
+    thrust::inclusive_scan_by_key(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      group_labels.begin(),
+      group_labels.end(),
+      cuda::counting_iterator<size_type>{0},
+      gather_map.begin(),
+      cuda::std::equal_to{},
+      binop_generator.binop());
 
     //
     // Gather the children elements of the prefix min/max struct elements first.

--- a/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
+++ b/cpp/src/groupby/sort/group_single_pass_reduction_util.cuh
@@ -156,14 +156,15 @@ struct group_reduction_functor<
 
     // Perform segmented reduction.
     auto const do_reduction = [&](auto const& inp_iter, auto const& out_iter, auto const& binop) {
-      thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
-                            group_labels.data(),
-                            group_labels.data() + group_labels.size(),
-                            inp_iter,
-                            cuda::make_discard_iterator(),
-                            out_iter,
-                            cuda::std::equal_to{},
-                            binop);
+      thrust::reduce_by_key(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        group_labels.data(),
+        group_labels.data() + group_labels.size(),
+        inp_iter,
+        cuda::make_discard_iterator(),
+        out_iter,
+        cuda::std::equal_to{},
+        binop);
     };
 
     auto const d_values_ptr = column_device_view::create(values, stream);
@@ -219,14 +220,15 @@ struct group_reduction_functor<
 
     // Perform segmented reduction to find ARGMIN/ARGMAX.
     auto const do_reduction = [&](auto const& inp_iter, auto const& out_iter, auto const& binop) {
-      thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
-                            group_labels.data(),
-                            group_labels.data() + group_labels.size(),
-                            inp_iter,
-                            cuda::make_discard_iterator(),
-                            out_iter,
-                            cuda::std::equal_to{},
-                            binop);
+      thrust::reduce_by_key(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        group_labels.data(),
+        group_labels.data() + group_labels.size(),
+        inp_iter,
+        cuda::make_discard_iterator(),
+        out_iter,
+        cuda::std::equal_to{},
+        binop);
     };
 
     auto const count_iter   = cuda::counting_iterator<ResultType>{0};

--- a/cpp/src/groupby/sort/group_std.cu
+++ b/cpp/src/groupby/sort/group_std.cu
@@ -74,8 +74,11 @@ void reduce_by_key_fn(column_device_view const& values,
   // using the transform-iterator directly in thrust::reduce_by_key
   // improves compile-time significantly.
   auto vars = rmm::device_uvector<ResultType>(values.size(), stream);
-  thrust::transform(
-    rmm::exec_policy_nosync(stream), itr, itr + values.size(), vars.begin(), var_fn);
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    itr,
+                    itr + values.size(),
+                    vars.begin(),
+                    var_fn);
 
   cudf::detail::reduce_by_key_async(group_labels.begin(),
                                     group_labels.end(),
@@ -127,7 +130,7 @@ struct var_functor {
     auto null_count   = cudf::detail::device_scalar<cudf::size_type>(0, stream, mr);
     auto d_null_count = null_count.data();
     thrust::for_each_n(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<cudf::size_type>{0},
       group_sizes.size(),
       [d_result = *result_view, d_group_sizes, ddof, d_null_count] __device__(size_type i) {

--- a/cpp/src/groupby/sort/sort_helper.cu
+++ b/cpp/src/groupby/sort/sort_helper.cu
@@ -150,17 +150,22 @@ sort_groupby_helper::index_vector const& sort_groupby_helper::group_offsets(
     auto const row_eq = permuted_row_equality_comparator(d_key_equal, sorted_order);
     auto const ufn    = cudf::detail::unique_copy_fn<decltype(itr), decltype(row_eq)>{
       itr, duplicate_keep_option::KEEP_FIRST, row_eq, size - 1};
-    thrust::transform(rmm::exec_policy_nosync(stream), itr, itr + size, result.begin(), ufn);
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      itr,
+                      itr + size,
+                      result.begin(),
+                      ufn);
     result_end = cudf::detail::copy_if(
       itr, itr + size, result.begin(), group_offsets->begin(), cuda::std::identity{}, stream);
   } else {
     auto const d_key_equal = comparator.equal_to<false>(
       cudf::nullate::DYNAMIC{cudf::has_nested_nulls(_keys)}, null_equality::EQUAL);
-    result_end = thrust::unique_copy(rmm::exec_policy_nosync(stream),
-                                     cuda::counting_iterator<size_type>{0},
-                                     cuda::counting_iterator<size_type>{size},
-                                     group_offsets->begin(),
-                                     permuted_row_equality_comparator(d_key_equal, sorted_order));
+    result_end =
+      thrust::unique_copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                          cuda::counting_iterator<size_type>{0},
+                          cuda::counting_iterator<size_type>{size},
+                          group_offsets->begin(),
+                          permuted_row_equality_comparator(d_key_equal, sorted_order));
   }
 
   auto const num_groups = cuda::std::distance(group_offsets->begin(), result_end);


### PR DESCRIPTION
## Summary
Passes `cudf::get_current_device_resource_ref()` as an explicit second argument to all `rmm::exec_policy_nosync` calls in this module. Previously these calls relied on the default, which goes through `rmm::mr::get_current_device_resource_ref()`. This change routes them through the cudf wrapper instead, which will later be replaced with a dedicated temporary memory resource.

Part of #20780.