### PR TITLE
Pass memory resource to exec_policy_nosync in reductions and quantiles modules

### DIFF
--- a/cpp/src/quantiles/quantile.cu
+++ b/cpp/src/quantiles/quantile.cu
@@ -82,7 +82,7 @@ struct quantile_functor {
     if (!cudf::is_dictionary(input.type())) {
       auto sorted_data =
         thrust::make_permutation_iterator(input.data<StorageType>(), ordered_indices);
-      thrust::transform(rmm::exec_policy_nosync(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         q_device.begin(),
                         q_device.end(),
                         d_output->template begin<StorageResult>(),
@@ -94,7 +94,7 @@ struct quantile_functor {
     } else {
       auto sorted_data = thrust::make_permutation_iterator(
         dictionary::detail::make_dictionary_iterator<T>(*d_input), ordered_indices);
-      thrust::transform(rmm::exec_policy_nosync(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         q_device.begin(),
                         q_device.end(),
                         d_output->template begin<StorageResult>(),

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -199,11 +199,12 @@ std::unique_ptr<column> compute_approx_percentiles(tdigest_column_view const& in
           offsets_begin,
           cuda::std::prev(thrust::upper_bound(thrust::seq, offsets_begin, offsets_end, i)));
       }));
-  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                keys,
-                                keys + weight.size(),
-                                weight.begin<double>(),
-                                cumulative_weights->mutable_view().begin<double>());
+  thrust::inclusive_scan_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    keys,
+    keys + weight.size(),
+    weight.begin<double>(),
+    cumulative_weights->mutable_view().begin<double>());
 
   auto percentiles_cdv = column_device_view::create(percentiles, stream);
 
@@ -288,20 +289,20 @@ std::unique_ptr<column> make_empty_tdigests_column(size_type num_rows,
 {
   auto offsets = cudf::make_fixed_width_column(
     data_type(type_id::INT32), num_rows + 1, mask_state::UNALLOCATED, stream, mr);
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                offsets->mutable_view().begin<size_type>(),
                offsets->mutable_view().end<size_type>(),
                0);
 
   auto min_col = cudf::make_numeric_column(
     data_type(type_id::FLOAT64), num_rows, mask_state::UNALLOCATED, stream, mr);
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                min_col->mutable_view().begin<double>(),
                min_col->mutable_view().end<double>(),
                0);
   auto max_col = cudf::make_numeric_column(
     data_type(type_id::FLOAT64), num_rows, mask_state::UNALLOCATED, stream, mr);
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                max_col->mutable_view().begin<double>(),
                max_col->mutable_view().end<double>(),
                0);
@@ -354,7 +355,7 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
                                 [] __device__(auto const x) { return x == 0; },
                                 stream) == static_cast<std::size_t>(input.size());
   auto row_size_iter = cuda::make_constant_iterator(all_empty_rows ? 0 : percentiles.size());
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          row_size_iter,
                          row_size_iter + input.size() + 1,
                          offsets->mutable_view().begin<size_type>());
@@ -376,8 +377,11 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
       detail::size_begin(tdv),
       cuda::proclaim_return_type<size_type>(
         [] __device__(size_type tdigest_size) -> size_type { return tdigest_size == 0; }));
-    auto const null_count = thrust::reduce(
-      rmm::exec_policy_nosync(stream), tdigest_is_empty, tdigest_is_empty + tdv.size(), 0);
+    auto const null_count =
+      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     tdigest_is_empty,
+                     tdigest_is_empty + tdv.size(),
+                     0);
     if (null_count == 0) {
       return std::pair<rmm::device_buffer, size_type>{rmm::device_buffer{}, null_count};
     }

--- a/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
+++ b/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
@@ -652,7 +652,7 @@ size_t compute_simple_cluster_count(int delta,
   // worst-case sizes
   auto iter = cuda::counting_iterator<cudf::size_type>{0};
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     iter,
     iter + num_groups,
     group_num_clusters.begin(),
@@ -665,8 +665,9 @@ size_t compute_simple_cluster_count(int delta,
     }));
 
   // total size
-  return thrust::reduce(
-    rmm::exec_policy_nosync(stream), group_num_clusters.begin(), group_num_clusters.end());
+  return thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        group_num_clusters.begin(),
+                        group_num_clusters.end());
 }
 
 /**
@@ -683,7 +684,7 @@ void compute_cluster_starts(cluster_info& cinfo, rmm::cuda_stream_view stream)
       [group_num_clusters = cinfo.num_clusters.begin(), num_groups] __device__(size_type index) {
         return index == num_groups ? 0 : group_num_clusters[index];
       }));
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          cluster_size,
                          cluster_size + num_groups + 1,
                          cinfo.cluster_start.begin(),
@@ -827,8 +828,9 @@ cluster_info generate_group_cluster_info(int delta,
   // Note: group_cluster_start does not need to be updated.
   cinfo.total_clusters =
     (simple_mem_usage <= max_simple_cluster_usage)
-      ? thrust::reduce(
-          rmm::exec_policy_nosync(stream), cinfo.num_clusters.begin(), cinfo.num_clusters.end())
+      ? thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       cinfo.num_clusters.begin(),
+                       cinfo.num_clusters.end())
       : allocated_clusters;
 
   stream.synchronize();
@@ -860,7 +862,9 @@ std::unique_ptr<column> build_output_column(size_type num_rows,
     if (!has_nulls) { return 0; }
     auto iter = cudf::detail::make_counting_transform_iterator(
       0, cuda::proclaim_return_type<size_type>(is_stub_digest));
-    return thrust::reduce(rmm::exec_policy_nosync(stream), iter, iter + num_rows);
+    return thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                          iter,
+                          iter + num_rows);
   }();
 
   // if there are no stub tdigests, we can return immediately.
@@ -879,7 +883,7 @@ std::unique_ptr<column> build_output_column(size_type num_rows,
   auto remove_stubs = [&](column_view const& col, size_type num_stubs) {
     auto result = cudf::make_numeric_column(
       data_type{type_id::FLOAT64}, col.size() - num_stubs, mask_state::UNALLOCATED, stream, mr);
-    thrust::remove_copy_if(rmm::exec_policy_nosync(stream),
+    thrust::remove_copy_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            col.begin<double>(),
                            col.end<double>(),
                            cuda::counting_iterator<cudf::size_type>{0},
@@ -894,7 +898,7 @@ std::unique_ptr<column> build_output_column(size_type num_rows,
   // adjust offsets.
   rmm::device_uvector<size_type> sizes(num_rows, stream);
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator<cudf::size_type>{0} + num_rows,
     sizes.begin(),
@@ -906,7 +910,7 @@ std::unique_ptr<column> build_output_column(size_type num_rows,
       [sizes = sizes.begin(), is_stub_digest, num_rows] __device__(size_type i) {
         return i == num_rows || is_stub_digest(i) ? 0 : sizes[i];
       }));
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          iter,
                          iter + num_rows + 1,
                          offsets->mutable_view().begin<size_type>(),
@@ -1042,7 +1046,7 @@ std::unique_ptr<column> compute_tdigests(int delta,
     mean_col.begin<double>(), weight_col.begin<double>(), cuda::make_discard_iterator()));
 
   auto const num_values = std::distance(centroids_begin, centroids_end);
-  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         keys,
                         keys + num_values,              // keys
                         centroids_begin,                // values
@@ -1163,7 +1167,7 @@ struct typed_group_tdigest {
     auto max_col = cudf::make_numeric_column(
       data_type{type_id::FLOAT64}, num_groups, mask_state::UNALLOCATED, stream, mr);
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<cudf::size_type>{0},
       cuda::counting_iterator<cudf::size_type>{0} + num_groups,
       thrust::make_zip_iterator(cuda::std::make_tuple(min_col->mutable_view().begin<double>(),
@@ -1242,7 +1246,7 @@ struct typed_reduce_tdigest {
     auto max_col = cudf::make_numeric_column(
       data_type{type_id::FLOAT64}, 1, mask_state::UNALLOCATED, stream, mr);
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<cudf::size_type>{0},
       cuda::counting_iterator<cudf::size_type>{0} + 1,
       thrust::make_zip_iterator(cuda::std::make_tuple(min_col->mutable_view().begin<double>(),
@@ -1440,7 +1444,7 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
     thrust::make_transform_iterator(thrust::make_zip_iterator(cuda::std::make_tuple(
                                       tdv.min_begin(), cudf::tdigest::detail::size_begin(tdv))),
                                     tdigest_min{});
-  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         group_labels,
                         group_labels + num_group_labels,
                         min_iter,
@@ -1455,7 +1459,7 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
     thrust::make_transform_iterator(thrust::make_zip_iterator(cuda::std::make_tuple(
                                       tdv.max_begin(), cudf::tdigest::detail::size_begin(tdv))),
                                     tdigest_max{});
-  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         group_labels,
                         group_labels + num_group_labels,
                         max_iter,
@@ -1472,13 +1476,13 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
     0,
     group_num_clusters_func<decltype(group_offsets)>{group_offsets,
                                                      tdigest_offsets.begin<size_type>()});
-  thrust::replace_if(rmm::exec_policy_nosync(stream),
+  thrust::replace_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      merged_min_col->mutable_view().begin<double>(),
                      merged_min_col->mutable_view().end<double>(),
                      group_num_clusters,
                      group_is_empty{},
                      0);
-  thrust::replace_if(rmm::exec_policy_nosync(stream),
+  thrust::replace_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      merged_max_col->mutable_view().begin<double>(),
                      merged_max_col->mutable_view().end<double>(),
                      group_num_clusters,
@@ -1499,17 +1503,18 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
   // generate group keys for all centroids in the entire column
   rmm::device_uvector<size_type> group_keys(num_centroids, stream, temp_mr);
   auto iter = cuda::counting_iterator<cudf::size_type>{0};
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     iter,
                     iter + num_centroids,
                     group_keys.begin(),
                     group_key_func<decltype(group_labels)>{
                       group_labels, tdigest_offsets.begin<size_type>(), tdigest_offsets.size()});
-  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                group_keys.begin(),
-                                group_keys.begin() + num_centroids,
-                                merged_weights.begin(),
-                                cumulative_weights.begin());
+  thrust::inclusive_scan_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    group_keys.begin(),
+    group_keys.begin() + num_centroids,
+    merged_weights.begin(),
+    cumulative_weights.begin());
 
   auto const delta = max_centroids;
 
@@ -1525,7 +1530,7 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
       auto pinned_mr = cudf::get_pinned_memory_resource();
 
       rmm::device_uvector<size_type> _p_group_offsets(num_groups + 1, stream, pinned_mr);
-      thrust::copy(rmm::exec_policy_nosync(stream),
+      thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    group_offsets,
                    group_offsets + _p_group_offsets.size(),
                    _p_group_offsets.begin());
@@ -1534,13 +1539,13 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
       rmm::device_uvector<double> p_cumulative_weights(cumulative_weights, stream, pinned_mr);
 
       rmm::device_uvector<size_type> p_tdigest_offsets(tdigest_offsets.size(), stream, pinned_mr);
-      thrust::copy(rmm::exec_policy_nosync(stream),
+      thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    tdigest_offsets.begin<size_type>(),
                    tdigest_offsets.begin<size_type>() + p_tdigest_offsets.size(),
                    p_tdigest_offsets.begin());
 
       rmm::device_uvector<size_type> _p_group_labels(num_group_labels, stream, pinned_mr);
-      thrust::copy(rmm::exec_policy_nosync(stream),
+      thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    group_labels,
                    group_labels + num_group_labels,
                    _p_group_labels.begin());

--- a/cpp/src/reductions/all.cu
+++ b/cpp/src/reductions/all.cu
@@ -58,7 +58,7 @@ struct all_fn {
     }();
     auto d_result =
       cudf::detail::device_scalar<int32_t>(1, stream, cudf::get_current_device_resource_ref());
-    thrust::for_each_n(rmm::exec_policy_nosync(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        cuda::counting_iterator<size_type>{0},
                        input.size(),
                        all_true_fn<decltype(iter)>{iter, d_result.data()});

--- a/cpp/src/reductions/any.cu
+++ b/cpp/src/reductions/any.cu
@@ -58,7 +58,7 @@ struct any_fn {
     }();
     auto d_result =
       cudf::detail::device_scalar<int32_t>(0, stream, cudf::get_current_device_resource_ref());
-    thrust::for_each_n(rmm::exec_policy_nosync(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        cuda::counting_iterator<size_type>{0},
                        input.size(),
                        any_true_fn<decltype(iter)>{iter, d_result.data()});

--- a/cpp/src/reductions/distinct_count.cu
+++ b/cpp/src/reductions/distinct_count.cu
@@ -101,7 +101,7 @@ struct has_nans {
   {
     auto input_device_view = cudf::column_device_view::create(input, stream);
     auto device_view       = *input_device_view;
-    return thrust::any_of(rmm::exec_policy_nosync(stream),
+    return thrust::any_of(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           cuda::counting_iterator<cudf::size_type>{0},
                           cuda::counting_iterator<cudf::size_type>{input.size()},
                           check_for_nan<T>(device_view));

--- a/cpp/src/reductions/extrema_utils.cuh
+++ b/cpp/src/reductions/extrema_utils.cuh
@@ -65,10 +65,16 @@ class arg_minmax_dispatcher {
     auto const pos = [&] {
       if constexpr (K == aggregation::ARGMIN) {
         return thrust::min_element(
-          rmm::exec_policy_nosync(stream), it, it + size, std::forward<Args>(args)...);
+          rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+          it,
+          it + size,
+          std::forward<Args>(args)...);
       } else {
         return thrust::max_element(
-          rmm::exec_policy_nosync(stream), it, it + size, std::forward<Args>(args)...);
+          rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+          it,
+          it + size,
+          std::forward<Args>(args)...);
       }
     }();
     return static_cast<size_type>(cuda::std::distance(it, pos));

--- a/cpp/src/reductions/histogram.cu
+++ b/cpp/src/reductions/histogram.cu
@@ -133,10 +133,11 @@ compute_row_frequencies(table_view const& input,
 
   // Construct a vector to store reduced counts and init to zero
   rmm::device_uvector<histogram_count_type> reduction_results(num_rows, stream, mr);
-  thrust::uninitialized_fill(rmm::exec_policy_nosync(stream),
-                             reduction_results.begin(),
-                             reduction_results.end(),
-                             histogram_count_type{0});
+  thrust::uninitialized_fill(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    reduction_results.begin(),
+    reduction_results.end(),
+    histogram_count_type{0});
 
   // Construct a hash set
   auto row_set =
@@ -156,7 +157,7 @@ compute_row_frequencies(table_view const& input,
   // Compute frequencies (aka distinct counts) for the input rows.
   // Note that we consider null and NaNs as always equal.
   thrust::for_each(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<std::size_t>{0},
     cuda::counting_iterator<std::size_t>{num_rows},
     [set_ref = row_set_ref,

--- a/cpp/src/reductions/nth_element.cu
+++ b/cpp/src/reductions/nth_element.cu
@@ -41,13 +41,16 @@ std::unique_ptr<cudf::scalar> nth_element(column_view const& col,
                                       }));
     rmm::device_uvector<size_type> null_skipped_index(col.size(), stream);
     // null skipped index for valids only.
-    thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            bitmask_iterator,
                            bitmask_iterator + col.size(),
                            null_skipped_index.begin());
 
-    auto n_pos = thrust::upper_bound(
-      rmm::exec_policy_nosync(stream), null_skipped_index.begin(), null_skipped_index.end(), n);
+    auto n_pos =
+      thrust::upper_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                          null_skipped_index.begin(),
+                          null_skipped_index.end(),
+                          n);
     auto null_skipped_n = n_pos - null_skipped_index.begin();
     return cudf::detail::get_element(col, null_skipped_n, stream, mr);
   } else {

--- a/cpp/src/reductions/scan/ewm.cu
+++ b/cpp/src/reductions/scan/ewm.cu
@@ -141,11 +141,12 @@ rmm::device_uvector<cudf::size_type> null_roll_up(column_view const& input,
     cuda::proclaim_return_type<int>([] __device__(int valid) -> int { return 1 - valid; }));
 
   // valid mask {1, 0, 1, 0, 0, 1} leads to output array {0, 0, 1, 0, 1, 2}
-  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                invalid_it,
-                                invalid_it + input.size() - 1,
-                                invalid_it,
-                                std::next(output.begin()));
+  thrust::inclusive_scan_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    invalid_it,
+    invalid_it + input.size() - 1,
+    invalid_it,
+    std::next(output.begin()));
   return output;
 }
 
@@ -165,49 +166,53 @@ rmm::device_uvector<T> compute_ewma_adjust(column_view const& input,
     auto data =
       thrust::make_zip_iterator(cuda::std::make_tuple(valid_it, nullcnt.begin(), input.begin<T>()));
 
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     data,
-                                     data + input.size(),
-                                     pairs.begin(),
-                                     ewma_adjust_nulls_functor<T, true>{beta},
-                                     recurrence_functor<T>{});
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      data,
+      data + input.size(),
+      pairs.begin(),
+      ewma_adjust_nulls_functor<T, true>{beta},
+      recurrence_functor<T>{});
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       pairs.begin(),
                       pairs.end(),
                       output.begin(),
                       [] __device__(pair_type<T> pair) -> T { return pair.second; });
 
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     data,
-                                     data + input.size(),
-                                     pairs.begin(),
-                                     ewma_adjust_nulls_functor<T, false>{beta},
-                                     recurrence_functor<T>{});
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      data,
+      data + input.size(),
+      pairs.begin(),
+      ewma_adjust_nulls_functor<T, false>{beta},
+      recurrence_functor<T>{});
 
   } else {
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     input.begin<T>(),
-                                     input.end<T>(),
-                                     pairs.begin(),
-                                     ewma_adjust_no_nulls_functor<T, true>{beta},
-                                     recurrence_functor<T>{});
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      input.begin<T>(),
+      input.end<T>(),
+      pairs.begin(),
+      ewma_adjust_no_nulls_functor<T, true>{beta},
+      recurrence_functor<T>{});
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       pairs.begin(),
                       pairs.end(),
                       output.begin(),
                       [] __device__(pair_type<T> pair) -> T { return pair.second; });
     auto itr = cuda::counting_iterator<size_type>{0};
 
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     itr,
-                                     itr + input.size(),
-                                     pairs.begin(),
-                                     ewma_adjust_no_nulls_functor<T, false>{beta},
-                                     recurrence_functor<T>{});
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      itr,
+      itr + input.size(),
+      pairs.begin(),
+      ewma_adjust_no_nulls_functor<T, false>{beta},
+      recurrence_functor<T>{});
   }
 
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     pairs.begin(),
     pairs.end(),
     output.begin(),
@@ -239,12 +244,13 @@ rmm::device_uvector<T> compute_ewma_noadjust(column_view const& input,
   if (!input.has_nulls()) {
     auto data = thrust::make_zip_iterator(
       cuda::std::make_tuple(input.begin<T>(), cuda::counting_iterator<size_type>{0}));
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     data,
-                                     data + input.size(),
-                                     pairs.begin(),
-                                     ewma_noadjust_no_nulls_functor<T>{beta},
-                                     recurrence_functor<T>{});
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      data,
+      data + input.size(),
+      pairs.begin(),
+      ewma_noadjust_no_nulls_functor<T>{beta},
+      recurrence_functor<T>{});
 
   } else {
     auto device_view = column_device_view::create(input, stream);
@@ -253,16 +259,17 @@ rmm::device_uvector<T> compute_ewma_noadjust(column_view const& input,
     auto data = thrust::make_zip_iterator(cuda::std::make_tuple(
       input.begin<T>(), cuda::counting_iterator<size_type>{0}, valid_it, nullcnt.begin()));
 
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     data,
-                                     data + input.size(),
-                                     pairs.begin(),
-                                     ewma_noadjust_nulls_functor<T>{beta},
-                                     recurrence_functor<T>());
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      data,
+      data + input.size(),
+      pairs.begin(),
+      ewma_noadjust_nulls_functor<T>{beta},
+      recurrence_functor<T>());
   }
 
   // copy the second elements to the output for now
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     pairs.begin(),
                     pairs.end(),
                     output.begin(),

--- a/cpp/src/reductions/scan/rank_scan.cu
+++ b/cpp/src/reductions/scan/rank_scan.cu
@@ -67,7 +67,7 @@ std::unique_ptr<column> rank_generator(column_view const& order_by,
   auto mutable_ranks = ranks->mutable_view();
 
   auto const comparator_helper = [&](auto const device_comparator) {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>(0),
                       cuda::counting_iterator<size_type>(order_by.size()),
                       mutable_ranks.begin<size_type>(),
@@ -85,7 +85,7 @@ std::unique_ptr<column> rank_generator(column_view const& order_by,
     comparator_helper(device_comparator);
   }
 
-  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          mutable_ranks.begin<size_type>(),
                          mutable_ranks.end<size_type>(),
                          mutable_ranks.begin<size_type>(),
@@ -133,7 +133,7 @@ std::unique_ptr<column> inclusive_one_normalized_percent_rank_scan(
   auto percent_rank_result = cudf::make_fixed_width_column(
     data_type{type_to_id<result_type>()}, rank_view.size(), mask_state::UNALLOCATED, stream, mr);
 
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     rank_view.begin<size_type>(),
                     rank_view.end<size_type>(),
                     percent_rank_result->mutable_view().begin<result_type>(),

--- a/cpp/src/reductions/scan/scan_exclusive.cu
+++ b/cpp/src/reductions/scan/scan_exclusive.cu
@@ -60,7 +60,7 @@ struct scan_dispatcher {
 
     // CUB 2.0.0 requires that the binary operator returns the same type as the identity.
     auto const binary_op = cudf::detail::cast_functor<T>(Op{});
-    thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            begin,
                            begin + input.size(),
                            output.data<T>(),

--- a/cpp/src/reductions/scan/scan_inclusive.cu
+++ b/cpp/src/reductions/scan/scan_inclusive.cu
@@ -44,11 +44,12 @@ std::pair<rmm::device_buffer, size_type> mask_scan(column_view const& input_view
   auto valid_itr = detail::make_validity_iterator(*d_input);
 
   auto first_null_position = [&] {
-    size_type const first_null = thrust::find_if_not(rmm::exec_policy_nosync(stream),
-                                                     valid_itr,
-                                                     valid_itr + input_view.size(),
-                                                     cuda::std::identity{}) -
-                                 valid_itr;
+    size_type const first_null =
+      thrust::find_if_not(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                          valid_itr,
+                          valid_itr + input_view.size(),
+                          cuda::std::identity{}) -
+      valid_itr;
     size_type const exclusive_offset = (inclusive == scan_type::EXCLUSIVE) ? 1 : 0;
     return std::min(input_view.size(), first_null + exclusive_offset);
   }();
@@ -78,7 +79,7 @@ struct scan_functor {
 
     // CUB 2.0.0 requires that the binary operator returns the same type as the identity.
     auto const binary_op = cudf::detail::cast_functor<T>(Op{});
-    thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            begin,
                            begin + input_view.size(),
                            result.data<T>(),
@@ -133,8 +134,10 @@ struct scan_functor<Op, T> {
         return static_cast<size_type>(mask == nullptr || bit_is_set(mask, idx));
       }));
 
-    thrust::inclusive_scan(
-      rmm::exec_policy_nosync(stream), begin, begin + input_view.size(), result.data<size_type>());
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           begin,
+                           begin + input_view.size(),
+                           result.data<size_type>());
 
     CUDF_CHECK_CUDA(stream.value());
     return output_column;

--- a/cpp/src/reductions/segmented/counts.cu
+++ b/cpp/src/reductions/segmented/counts.cu
@@ -35,7 +35,10 @@ rmm::device_uvector<size_type> segmented_counts(bitmask_type const* null_mask,
 
   rmm::device_uvector<size_type> valid_counts(num_segments, stream, mr);
   thrust::adjacent_difference(
-    rmm::exec_policy_nosync(stream), offsets.begin() + 1, offsets.end(), valid_counts.begin());
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    offsets.begin() + 1,
+    offsets.end(),
+    valid_counts.begin());
   return valid_counts;
 }
 

--- a/cpp/src/reductions/segmented/nunique.cu
+++ b/cpp/src/reductions/segmented/nunique.cu
@@ -64,7 +64,7 @@ std::unique_ptr<cudf::column> segmented_nunique(column_view const& col,
       *d_col, row_equal, null_handling, offsets.data(), labels.data()};
 
     auto identifiers = rmm::device_uvector<size_type>(col.size(), stream);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{col.size()},
                       identifiers.begin(),

--- a/cpp/src/reductions/segmented/simple.cuh
+++ b/cpp/src/reductions/segmented/simple.cuh
@@ -235,17 +235,18 @@ std::unique_ptr<column> fixed_point_segmented_reduction(
                                                   stream,
                                                   cudf::get_current_device_resource_ref());
 
-      auto const max_count = thrust::reduce(rmm::exec_policy_nosync(stream),
-                                            counts.begin(),
-                                            counts.end(),
-                                            size_type{0},
-                                            cuda::maximum<size_type>{});
+      auto const max_count =
+        thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       counts.begin(),
+                       counts.end(),
+                       size_type{0},
+                       cuda::maximum<size_type>{});
 
       auto const new_scale = numeric::scale_type{col.type().scale() * max_count};
 
       // adjust values in each segment to match the new scale
       auto const d_col = column_device_view::create(col, stream);
-      thrust::transform(rmm::exec_policy_nosync(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         d_col->begin<InputType>(),
                         d_col->end<InputType>(),
                         d_col->begin<InputType>(),

--- a/cpp/src/reductions/simple.cuh
+++ b/cpp/src/reductions/simple.cuh
@@ -312,12 +312,13 @@ struct same_element_type_dispatcher {
     // We will do reduction to find the ARGMIN/ARGMAX index, then return the element at that index.
     auto const binop_generator =
       cudf::reduction::detail::arg_minmax_binop_generator::create<Op>(input, stream);
-    auto const binary_op  = cudf::detail::cast_functor<size_type>(binop_generator.binop());
-    auto const minmax_idx = thrust::reduce(rmm::exec_policy_nosync(stream),
-                                           cuda::counting_iterator<cudf::size_type>{0},
-                                           cuda::counting_iterator{input.size()},
-                                           size_type{0},
-                                           binary_op);
+    auto const binary_op = cudf::detail::cast_functor<size_type>(binop_generator.binop());
+    auto const minmax_idx =
+      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     cuda::counting_iterator<cudf::size_type>{0},
+                     cuda::counting_iterator{input.size()},
+                     size_type{0},
+                     binary_op);
 
     return cudf::detail::get_element(input, minmax_idx, stream, mr);
   }

--- a/cpp/src/reductions/sum_with_overflow.cu
+++ b/cpp/src/reductions/sum_with_overflow.cu
@@ -138,21 +138,23 @@ std::unique_ptr<cudf::scalar> sum_with_overflow(
 
   if (col.has_nulls()) {
     // Use null-aware transform functor
-    result = thrust::transform_reduce(rmm::exec_policy_nosync(stream),
-                                      counting_iter,
-                                      counting_iter + col.size(),
-                                      null_aware_to_sum_overflow{dcol_ptr},
-                                      initial_value,
-                                      overflow_sum_op{});
+    result = thrust::transform_reduce(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      counting_iter,
+      counting_iter + col.size(),
+      null_aware_to_sum_overflow{dcol_ptr},
+      initial_value,
+      overflow_sum_op{});
   } else {
     // Use direct iterator for non-null case
     auto input_iter = dcol->begin<int64_t>();
-    result          = thrust::transform_reduce(rmm::exec_policy_nosync(stream),
-                                      input_iter,
-                                      input_iter + col.size(),
-                                      to_sum_overflow{},
-                                      initial_value,
-                                      overflow_sum_op{});
+    result          = thrust::transform_reduce(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      input_iter,
+      input_iter + col.size(),
+      to_sum_overflow{},
+      initial_value,
+      overflow_sum_op{});
   }
 
   // Create result struct scalar with {sum: int64_t, overflow: bool}

--- a/cpp/src/reductions/unique_count.cu
+++ b/cpp/src/reductions/unique_count.cu
@@ -33,21 +33,24 @@ cudf::size_type unique_count(table_view const& keys,
     // the comparator speeds up compile-time significantly without much degradation in
     // runtime performance over using the comparator directly in thrust::count_if.
     auto d_results = rmm::device_uvector<bool>(keys.num_rows(), stream);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{keys.num_rows()},
                       d_results.begin(),
                       [comp] __device__(auto i) { return (i == 0 or not comp(i, i - 1)); });
 
     return static_cast<size_type>(
-      thrust::count(rmm::exec_policy_nosync(stream), d_results.begin(), d_results.end(), true));
+      thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    d_results.begin(),
+                    d_results.end(),
+                    true));
   } else {
     auto const comp =
       row_comp.equal_to<false>(nullate::DYNAMIC{has_nested_nulls(keys)}, nulls_equal);
     // Using thrust::copy_if with the comparator directly will compile more slowly but
     // improves runtime by up to 2x over the transform/count approach above.
     return thrust::count_if(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<cudf::size_type>{0},
       cuda::counting_iterator<cudf::size_type>{keys.num_rows()},
       [comp] __device__(cudf::size_type i) { return (i == 0 or not comp(i, i - 1)); });

--- a/cpp/src/reductions/unique_count_column.cu
+++ b/cpp/src/reductions/unique_count_column.cu
@@ -68,7 +68,7 @@ cudf::size_type unique_count(column_view const& input,
     cudf::detail::row::equality::nan_equal_physical_equality_comparator{});
 
   return thrust::count_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator<cudf::size_type>{num_rows},
     [count_nulls, nan_is_null, should_check_nan, device_view, comp] __device__(cudf::size_type i) {


### PR DESCRIPTION
## Summary
Passes `cudf::get_current_device_resource_ref()` as an explicit second argument to all `rmm::exec_policy_nosync` calls in this module. Previously these calls relied on the default, which goes through `rmm::mr::get_current_device_resource_ref()`. This change routes them through the cudf wrapper instead, which will later be replaced with a dedicated temporary memory resource.

Part of #20780.