### PR TITLE
Pass memory resource to exec_policy_nosync in lists module

### DIFF
--- a/cpp/src/lists/combine/concatenate_list_elements.cu
+++ b/cpp/src/lists/combine/concatenate_list_elements.cu
@@ -56,7 +56,7 @@ std::unique_ptr<column> concatenate_lists_ignore_null(column_view const& input,
   // into row offsets of the root column. Those entry offsets are subtracted by the first entry
   // offset to output zero-based offsets.
   auto const iter = cuda::counting_iterator<size_type>{0};
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     iter,
                     iter + num_rows + 1,
                     d_out_offsets,
@@ -171,7 +171,7 @@ std::unique_ptr<column> gather_list_entries(column_view const& input,
 
   // Fill the gather map with indices of the lists from the child column of the input column.
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     num_rows,
     [d_row_offsets,

--- a/cpp/src/lists/combine/concatenate_rows.cu
+++ b/cpp/src/lists/combine/concatenate_rows.cu
@@ -110,7 +110,7 @@ generate_regrouped_offsets_and_null_mask(table_device_view const& input,
                                     stream);
 
   // convert to offsets
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          offsets->view().begin<size_type>(),
                          offsets->view().begin<size_type>() + input.num_rows() + 1,
                          offsets->mutable_view().begin<size_type>(),

--- a/cpp/src/lists/contains.cu
+++ b/cpp/src/lists/contains.cu
@@ -162,7 +162,7 @@ void index_of(InputIterator input_it,
 {
   auto const keys_dv_ptr       = column_device_view::create(search_keys, stream);
   auto const key_validity_iter = cudf::detail::make_validity_iterator<true>(*keys_dv_ptr);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     input_it,
                     input_it + num_rows,
                     output_it,
@@ -245,7 +245,7 @@ std::unique_ptr<column> to_contains(std::unique_ptr<column>&& key_positions,
   auto const positions_begin = key_positions->view().template begin<size_type>();
   auto result                = make_numeric_column(
     data_type{type_id::BOOL8}, key_positions->size(), mask_state::UNALLOCATED, stream, mr);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     positions_begin,
                     positions_begin + key_positions->size(),
                     result->mutable_view().template begin<bool>(),
@@ -342,7 +342,7 @@ std::unique_ptr<column> contains_nulls(lists_column_view const& lists,
   auto const lists_cdv_ptr = column_device_view::create(lists_cv, stream);
 
   thrust::tabulate(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     out_begin,
     out_begin + lists.size(),
     cuda::proclaim_return_type<bool>([lists = cudf::detail::lists_column_device_view{

--- a/cpp/src/lists/copying/concatenate.cu
+++ b/cpp/src/lists/copying/concatenate.cu
@@ -66,7 +66,7 @@ std::unique_ptr<column> merge_offsets(host_span<lists_column_view const> columns
         (c.offset() > 0 ? cudf::detail::get_value<size_type>(c.offsets(), c.offset(), stream) : 0);
       column_device_view offsets(c.offsets(), nullptr, nullptr);
       thrust::transform(
-        rmm::exec_policy_nosync(stream),
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
         offsets.begin<size_type>() + c.offset(),
         offsets.begin<size_type>() + c.offset() + c.size() + 1,
         d_merged_offsets.begin<size_type>() + count,

--- a/cpp/src/lists/copying/copying.cu
+++ b/cpp/src/lists/copying/copying.cu
@@ -48,7 +48,7 @@ std::unique_ptr<cudf::column> copy_slice(lists_column_view const& lists,
 
   // Compute the offsets column of the result:
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     offsets_data + start,
     offsets_data + end + 1,  // size of offsets column is 1 greater than slice length
     out_offsets.data(),

--- a/cpp/src/lists/copying/scatter_helper.cu
+++ b/cpp/src/lists/copying/scatter_helper.cu
@@ -176,7 +176,7 @@ struct list_child_constructor {
                                                       mr);
 
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<cudf::size_type>{0},
       cuda::counting_iterator{child_column->size()},
       child_column->mutable_view().begin<T>(),
@@ -228,7 +228,7 @@ struct list_child_constructor {
     auto const null_string_view = string_view{nullptr, 0};  // placeholder for factory function
 
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<size_type>{0},
       cuda::counting_iterator{static_cast<size_type>(string_views.size())},
       string_views.begin(),
@@ -295,7 +295,7 @@ struct list_child_constructor {
     // For instance, if a parent list_device_view has 3 elements, it should have 3 corresponding
     // child list_device_view instances.
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<size_type>{0},
       cuda::counting_iterator{static_cast<size_type>(child_list_views.size())},
       child_list_views.begin(),

--- a/cpp/src/lists/count_elements.cu
+++ b/cpp/src/lists/count_elements.cu
@@ -48,7 +48,7 @@ std::unique_ptr<column> count_elements(lists_column_view const& input,
                                         mr);
 
   // fill in the sizes
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator<cudf::size_type>{input.size()},
                     output->mutable_view().begin<size_type>(),

--- a/cpp/src/lists/dremel.cu
+++ b/cpp/src/lists/dremel.cu
@@ -91,11 +91,12 @@ dremel_data get_encoding(column_view h_col,
       empties_idx.begin(),
       [d_off] __device__(auto i) { return d_off[i] == d_off[i + 1]; },
       stream);
-    auto empties_end = thrust::gather(rmm::exec_policy_nosync(stream),
-                                      empties_idx.begin(),
-                                      empties_idx_end,
-                                      lcv.offsets().begin<size_type>(),
-                                      empties.begin());
+    auto empties_end =
+      thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     empties_idx.begin(),
+                     empties_idx_end,
+                     lcv.offsets().begin<size_type>(),
+                     empties.begin());
 
     auto empties_size = empties_end - empties.begin();
     return std::make_tuple(std::move(empties), std::move(empties_idx), empties_size);
@@ -318,15 +319,16 @@ dremel_data get_encoding(column_view h_col,
     auto output_zip_it =
       thrust::make_zip_iterator(cuda::std::make_tuple(rep_level.begin(), def_level.begin()));
 
-    auto ends = thrust::merge_by_key(rmm::exec_policy_nosync(stream),
-                                     empties.begin(),
-                                     empties.begin() + empties_size,
-                                     cuda::counting_iterator{column_offsets[level + 1]},
-                                     cuda::counting_iterator{column_ends[level + 1]},
-                                     input_parent_zip_it,
-                                     input_child_zip_it,
-                                     cuda::make_discard_iterator(),
-                                     output_zip_it);
+    auto ends =
+      thrust::merge_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           empties.begin(),
+                           empties.begin() + empties_size,
+                           cuda::counting_iterator{column_offsets[level + 1]},
+                           cuda::counting_iterator{column_ends[level + 1]},
+                           input_parent_zip_it,
+                           input_child_zip_it,
+                           cuda::make_discard_iterator(),
+                           output_zip_it);
 
     curr_rep_values_size = ends.second - output_zip_it;
 
@@ -338,12 +340,14 @@ dremel_data get_encoding(column_view h_col,
         return (i + 1 < size) && (off[i] == off[i + 1]);
       }));
     rmm::device_uvector<size_type> scan_out(offset_size_at_level, stream);
-    thrust::exclusive_scan(
-      rmm::exec_policy_nosync(stream), scan_it, scan_it + offset_size_at_level, scan_out.begin());
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           scan_it,
+                           scan_it + offset_size_at_level,
+                           scan_out.begin());
 
     // Add scan output to existing offsets to get new offsets into merged rep level values
     new_offsets = rmm::device_uvector<size_type>(offset_size_at_level, stream);
-    thrust::for_each_n(rmm::exec_policy_nosync(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        cuda::counting_iterator<cudf::size_type>{0},
                        offset_size_at_level,
                        [off      = lcv.offsets().data<size_type>() + column_offsets[level],
@@ -354,7 +358,7 @@ dremel_data get_encoding(column_view h_col,
 
     // Set rep level values at level starts to appropriate rep level
     auto scatter_it = cuda::make_constant_iterator(level);
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     scatter_it,
                     scatter_it + new_offsets.size() - 1,
                     new_offsets.begin(),
@@ -405,15 +409,16 @@ dremel_data get_encoding(column_view h_col,
     auto output_zip_it =
       thrust::make_zip_iterator(cuda::std::make_tuple(rep_level.begin(), def_level.begin()));
 
-    auto ends = thrust::merge_by_key(rmm::exec_policy_nosync(stream),
-                                     transformed_empties,
-                                     transformed_empties + empties_size,
-                                     cuda::counting_iterator<cudf::size_type>{0},
-                                     cuda::counting_iterator{curr_rep_values_size},
-                                     input_parent_zip_it,
-                                     input_child_zip_it,
-                                     cuda::make_discard_iterator(),
-                                     output_zip_it);
+    auto ends =
+      thrust::merge_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           transformed_empties,
+                           transformed_empties + empties_size,
+                           cuda::counting_iterator<cudf::size_type>{0},
+                           cuda::counting_iterator{curr_rep_values_size},
+                           input_parent_zip_it,
+                           input_child_zip_it,
+                           cuda::make_discard_iterator(),
+                           output_zip_it);
 
     curr_rep_values_size = ends.second - output_zip_it;
 
@@ -426,12 +431,14 @@ dremel_data get_encoding(column_view h_col,
         return (i + 1 < size) && (off[i] == off[i + 1]);
       }));
     rmm::device_uvector<size_type> scan_out(offset_size_at_level, stream);
-    thrust::exclusive_scan(
-      rmm::exec_policy_nosync(stream), scan_it, scan_it + offset_size_at_level, scan_out.begin());
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           scan_it,
+                           scan_it + offset_size_at_level,
+                           scan_out.begin());
 
     // Add scan output to existing offsets to get new offsets into merged rep level values
     rmm::device_uvector<size_type> temp_new_offsets(offset_size_at_level, stream);
-    thrust::for_each_n(rmm::exec_policy_nosync(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        cuda::counting_iterator<cudf::size_type>{0},
                        offset_size_at_level,
                        [off      = lcv.offsets().data<size_type>() + column_offsets[level],
@@ -444,7 +451,7 @@ dremel_data get_encoding(column_view h_col,
 
     // Set rep level values at level starts to appropriate rep level
     auto scatter_it = cuda::make_constant_iterator(level);
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     scatter_it,
                     scatter_it + new_offsets.size() - 1,
                     new_offsets.begin(),

--- a/cpp/src/lists/explode.cu
+++ b/cpp/src/lists/explode.cu
@@ -120,7 +120,7 @@ std::unique_ptr<table> explode(table_view const& input_table,
   // This looks like an off-by-one bug, but what is going on here is that we need to reduce each
   // result from `lower_bound` by 1 to build the correct gather map. This can be accomplished by
   // skipping the first entry and using the result of `lower_bound` directly.
-  thrust::lower_bound(rmm::exec_policy_nosync(stream),
+  thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       offsets_minus_one,
                       offsets_minus_one + explode_col.size(),
                       counting_iter,
@@ -161,7 +161,7 @@ std::unique_ptr<table> explode_position(table_view const& input_table,
   // result from `lower_bound` by 1 to build the correct gather map. This can be accomplished by
   // skipping the first entry and using the result of `lower_bound` directly.
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     counting_iter,
     counting_iter + gather_map.size(),
     gather_map.begin(),
@@ -207,7 +207,7 @@ std::unique_ptr<table> explode_outer(table_view const& input_table,
       [offsets, offsets_size = explode_col.size() - 1] __device__(int idx) {
         return (idx > offsets_size || (offsets[idx + 1] != offsets[idx])) ? 0 : 1;
       }));
-  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          null_or_empty,
                          null_or_empty + explode_col.size(),
                          null_or_empty_offset.begin());
@@ -271,8 +271,10 @@ std::unique_ptr<table> explode_outer(table_view const& input_table,
   auto loop_count = std::max(sliced_child.size(), explode_col.size());
 
   // Fill in gather map with all the child column's entries
-  thrust::for_each(
-    rmm::exec_policy_nosync(stream), counting_iter, counting_iter + loop_count, fill_gather_maps);
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   counting_iter,
+                   counting_iter + loop_count,
+                   fill_gather_maps);
 
   return build_table(
     input_table,

--- a/cpp/src/lists/extract.cu
+++ b/cpp/src/lists/extract.cu
@@ -59,7 +59,7 @@ std::unique_ptr<cudf::column> make_index_child(column_view const& indices,
                                          mask_state::UNALLOCATED,
                                          stream,
                                          cudf::get_current_device_resource_ref());
-  thrust::copy_n(rmm::exec_policy_nosync(stream),
+  thrust::copy_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  null_replaced_iter_begin,
                  indices.size(),
                  index_child->mutable_view().begin<size_type>());
@@ -85,7 +85,7 @@ std::unique_ptr<cudf::column> make_index_child(size_type index,
                         mask_state::UNALLOCATED,
                         stream,
                         cudf::get_current_device_resource_ref());
-  thrust::fill_n(rmm::exec_policy_nosync(stream),
+  thrust::fill_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  index_child->mutable_view().begin<size_type>(),
                  num_rows,
                  index);

--- a/cpp/src/lists/interleave_columns.cu
+++ b/cpp/src/lists/interleave_columns.cu
@@ -57,7 +57,7 @@ generate_list_offsets_and_validities(table_view const& input,
 
   // Compute list sizes and validities.
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     cuda::counting_iterator<size_type>{num_output_lists},
     d_offsets,
@@ -76,8 +76,10 @@ generate_list_offsets_and_validities(table_view const& input,
     }));
 
   // Compute offsets from sizes.
-  thrust::exclusive_scan(
-    rmm::exec_policy_nosync(stream), d_offsets, d_offsets + num_output_lists + 1, d_offsets);
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                         d_offsets,
+                         d_offsets + num_output_lists + 1,
+                         d_offsets);
 
   return {std::move(list_offsets), std::move(validities)};
 }
@@ -196,7 +198,7 @@ struct interleave_list_entries_impl<T, std::enable_if_t<std::is_same_v<T, cudf::
                                                                           stream);
     auto comp_fn =
       compute_string_sizes_and_interleave_lists_fn{*table_dv_ptr, d_list_offsets, indices.data()};
-    thrust::for_each_n(rmm::exec_policy_nosync(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        cuda::counting_iterator<size_type>{0},
                        num_output_lists,
                        comp_fn);
@@ -230,7 +232,7 @@ struct interleave_list_entries_impl<T, std::enable_if_t<cudf::is_fixed_width<T>(
       rmm::device_uvector<int8_t>(data_has_null_mask ? num_output_entries : 0, stream);
 
     thrust::for_each_n(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<size_type>{0},
       num_output_lists,
       [num_cols,

--- a/cpp/src/lists/reverse.cu
+++ b/cpp/src/lists/reverse.cu
@@ -43,7 +43,7 @@ std::unique_ptr<column> reverse(lists_column_view const& input,
   auto gather_map = rmm::device_uvector<size_type>(child.size(), stream);
 
   // Build a segmented reversed order for the child column.
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      child.size(),
                      [list_offsets = out_offsets->view().begin<size_type>(),

--- a/cpp/src/lists/segmented_sort.cu
+++ b/cpp/src/lists/segmented_sort.cu
@@ -37,7 +37,7 @@ std::unique_ptr<column> build_output_offsets(lists_column_view const& input,
 {
   auto output_offset = make_numeric_column(
     input.offsets().type(), input.size() + 1, mask_state::UNALLOCATED, stream, mr);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     input.offsets_begin(),
                     input.offsets_end(),
                     output_offset->mutable_view().begin<size_type>(),

--- a/cpp/src/lists/sequences.cu
+++ b/cpp/src/lists/sequences.cu
@@ -116,7 +116,10 @@ struct sequences_functor<T, std::enable_if_t<is_supported<T>()>> {
     auto const steps_begin  = steps ? steps.value().template begin<T>() : nullptr;
 
     auto const op = tabulator<T>{n_lists, n_elements, starts_begin, steps_begin, offsets};
-    thrust::tabulate(rmm::exec_policy_nosync(stream), result_begin, result_begin + n_elements, op);
+    thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     result_begin,
+                     result_begin + n_elements,
+                     op);
 
     return result;
   }

--- a/cpp/src/lists/set_operations.cu
+++ b/cpp/src/lists/set_operations.cu
@@ -105,8 +105,11 @@ std::unique_ptr<column> have_overlap(lists_column_view const& lhs,
   // `overlap_results` only stores the results of non-empty lists.
   // We need to initialize `false` for the entire output array then scatter these results over.
   thrust::uninitialized_fill(
-    rmm::exec_policy_nosync(stream), result_begin, result_begin + num_rows, false);
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    result_begin,
+    result_begin + num_rows,
+    false);
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   overlap_results.begin(),
                   overlap_results.begin() + num_non_empty_segments,
                   list_indices.begin(),

--- a/cpp/src/lists/stream_compaction/apply_boolean_mask.cu
+++ b/cpp/src/lists/stream_compaction/apply_boolean_mask.cu
@@ -72,7 +72,7 @@ std::unique_ptr<column> apply_boolean_mask(lists_column_view const& input,
 
     // Could have attempted an exclusive_scan(), but it would not compute the last entry.
     // Instead, inclusive_scan(), followed by writing `0` to the head of the offsets column.
-    thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            sizes_begin,
                            sizes_end,
                            output_offsets_view.begin<size_type>() + 1);

--- a/cpp/src/lists/utilities.cu
+++ b/cpp/src/lists/utilities.cu
@@ -55,7 +55,7 @@ std::unique_ptr<column> get_normalized_offsets(lists_column_view const& input,
                                          cudf::mask_state::UNALLOCATED,
                                          stream,
                                          mr);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     input.offsets_begin(),
                     input.offsets_end(),
                     out_offsets->mutable_view().begin<size_type>(),


### PR DESCRIPTION
## Summary
Passes `cudf::get_current_device_resource_ref()` as an explicit second argument to all `rmm::exec_policy_nosync` calls in this module. Previously these calls relied on the default, which goes through `rmm::mr::get_current_device_resource_ref()`. This change routes them through the cudf wrapper instead, which will later be replaced with a dedicated temporary memory resource.

Part of #20780.