### PR TITLE
Pass memory resource to exec_policy_nosync in sort, search, stream_compaction, and partitioning modules

### DIFF
--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -480,7 +480,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
   // Compute partition number for each row
   if (is_power_two(num_partitions)) {
     auto const partitioner = bitwise_partitioner<hash_value_type>(num_partitions);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>(0),
                       cuda::counting_iterator<size_type>(num_rows),
                       row_partition_numbers.begin(),
@@ -489,7 +489,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
                       });
   } else {
     auto const partitioner = modulo_partitioner<hash_value_type>(num_partitions);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>(0),
                       cuda::counting_iterator<size_type>(num_rows),
                       row_partition_numbers.begin(),
@@ -532,8 +532,10 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
 
   // Exclusive scan on histogram to get partition offsets.
   // histogram has num_partitions+1 elements; after scan, histogram[num_partitions] = num_rows.
-  thrust::exclusive_scan(
-    rmm::exec_policy_nosync(stream), histogram.begin(), histogram.end(), histogram.begin());
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                         histogram.begin(),
+                         histogram.end(),
+                         histogram.begin());
 
   // Copy partition offsets to pinned host memory asynchronously
   auto const pinned_offsets = cudf::detail::make_pinned_vector_async(histogram, stream);
@@ -541,7 +543,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
   // Build scatter map: atomically increment partition offsets
   rmm::device_uvector<size_type> scatter_map(num_rows, stream);
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     row_partition_numbers.begin(),
     row_partition_numbers.end(),
     scatter_map.begin(),
@@ -663,7 +665,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
 
   // Compute exclusive scan of all blocks' partition sizes in-place to determine
   // the starting point for each blocks portion of each partition in the output
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          block_partition_sizes.begin(),
                          block_partition_sizes.end(),
                          scanned_block_partition_sizes.data());
@@ -671,7 +673,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
   // Compute exclusive scan of size of each partition to determine offset
   // location of each partition in final output.
   // TODO This can be done independently on a separate stream
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          global_partition_sizes.begin(),
                          global_partition_sizes.end(),
                          global_partition_sizes.begin());
@@ -799,8 +801,10 @@ struct dispatch_map_type {
 
     // `histogram` was created with an extra entry at the end such that an
     // exclusive scan will put the total number of rows at the end
-    thrust::exclusive_scan(
-      rmm::exec_policy_nosync(stream), histogram.begin(), histogram.end(), histogram.begin());
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           histogram.begin(),
+                           histogram.end(),
+                           histogram.begin());
 
     // Copy offsets to host before the transform below modifies the histogram
     auto const partition_offsets = cudf::detail::make_std_vector(histogram, stream);
@@ -811,7 +815,7 @@ struct dispatch_map_type {
 
     // For each `partition_map[i]`, atomically increment the corresponding
     // partition offset to determine `i`s location in the output
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       partition_map.begin<MapType>(),
                       partition_map.end<MapType>(),
                       scatter_map.begin(),

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -87,8 +87,9 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
 
   if (num_partitions == nrows) {
     rmm::device_uvector<cudf::size_type> partition_offsets(num_partitions + 1, stream);
-    thrust::sequence(
-      rmm::exec_policy_nosync(stream), partition_offsets.begin(), partition_offsets.end());
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     partition_offsets.begin(),
+                     partition_offsets.end());
 
     auto uniq_tbl = cudf::detail::gather(input,
                                          rotated_iter_begin,
@@ -130,12 +131,15 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
 
     // offsets (part 2: compute partition offsets):
     rmm::device_uvector<cudf::size_type> partition_offsets(num_partitions + 1, stream);
-    thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            nedges_iter_begin,
                            nedges_iter_begin + num_partitions,
                            partition_offsets.begin());
     // Add the total row count as the last offset
-    thrust::fill_n(rmm::exec_policy_nosync(stream), partition_offsets.end() - 1, 1, nrows);
+    thrust::fill_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   partition_offsets.end() - 1,
+                   1,
+                   nrows);
 
     return std::pair{std::move(uniq_tbl), cudf::detail::make_std_vector(partition_offsets, stream)};
   }

--- a/cpp/src/search/contains_scalar.cu
+++ b/cpp/src/search/contains_scalar.cu
@@ -116,7 +116,7 @@ struct contains_scalar_dispatch {
     // runtime performance over using the comparator in a transform iterator with thrust::count_if.
     auto d_results = rmm::device_uvector<bool>(haystack.size(), stream);
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       begin,
       end,
       d_results.begin(),
@@ -127,8 +127,10 @@ struct contains_scalar_dispatch {
         return d_comp(idx, rhs_index_type{0});  // compare haystack[idx] == needle[0].
       });
 
-    return thrust::count(
-             rmm::exec_policy_nosync(stream), d_results.begin(), d_results.end(), true) > 0;
+    return thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                         d_results.begin(),
+                         d_results.end(),
+                         true) > 0;
   }
 };
 

--- a/cpp/src/search/search_ordered.cu
+++ b/cpp/src/search/search_ordered.cu
@@ -67,7 +67,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
   if (cudf::detail::has_nested_columns(haystack) || cudf::detail::has_nested_columns(needles)) {
     auto const d_comparator = comparator.less<true>(nullate::DYNAMIC{has_nulls});
     if (find_first) {
-      thrust::lower_bound(rmm::exec_policy_nosync(stream),
+      thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           haystack_it,
                           haystack_it + haystack.num_rows(),
                           needles_it,
@@ -75,7 +75,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
                           out_it,
                           d_comparator);
     } else {
-      thrust::upper_bound(rmm::exec_policy_nosync(stream),
+      thrust::upper_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           haystack_it,
                           haystack_it + haystack.num_rows(),
                           needles_it,
@@ -86,7 +86,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
   } else {
     auto const d_comparator = comparator.less<false>(nullate::DYNAMIC{has_nulls});
     if (find_first) {
-      thrust::lower_bound(rmm::exec_policy_nosync(stream),
+      thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           haystack_it,
                           haystack_it + haystack.num_rows(),
                           needles_it,
@@ -94,7 +94,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
                           out_it,
                           d_comparator);
     } else {
-      thrust::upper_bound(rmm::exec_policy_nosync(stream),
+      thrust::upper_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           haystack_it,
                           haystack_it + haystack.num_rows(),
                           needles_it,

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -39,7 +39,7 @@ bool is_sorted(cudf::table_view const& in,
     // the comparator speeds up compile-time significantly over using the comparator directly
     // in thrust::is_sorted.
     auto d_results = rmm::device_uvector<bool>(in.num_rows(), stream);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{in.num_rows()},
                       d_results.begin(),
@@ -47,15 +47,18 @@ bool is_sorted(cudf::table_view const& in,
                         return (idx == 0) || device_comparator(idx - 1, idx);
                       });
 
-    return thrust::count(
-             rmm::exec_policy_nosync(stream), d_results.begin(), d_results.end(), false) == 0;
+    return thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                         d_results.begin(),
+                         d_results.end(),
+                         false) == 0;
   } else {
     auto const device_comparator = comparator.less<false>(has_nested_nulls(in));
 
-    return thrust::is_sorted(rmm::exec_policy_nosync(stream),
-                             cuda::counting_iterator<size_type>{0},
-                             cuda::counting_iterator<size_type>{in.num_rows()},
-                             device_comparator);
+    return thrust::is_sorted(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      cuda::counting_iterator<size_type>{0},
+      cuda::counting_iterator<size_type>{in.num_rows()},
+      device_comparator);
   }
 }
 

--- a/cpp/src/sort/rank.cu
+++ b/cpp/src/sort/rank.cu
@@ -71,7 +71,7 @@ rmm::device_uvector<size_type> sorted_dense_rank(column_view input_col,
   rmm::device_uvector<size_type> dense_rank_sorted(input_size, stream);
 
   auto const comparator_helper = [&](auto const device_comparator) {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<cudf::size_type>{0},
                       cuda::counting_iterator{input_size},
                       dense_rank_sorted.data(),
@@ -89,7 +89,7 @@ rmm::device_uvector<size_type> sorted_dense_rank(column_view input_col,
     comparator_helper(device_comparator);
   }
 
-  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          dense_rank_sorted.begin(),
                          dense_rank_sorted.end(),
                          dense_rank_sorted.data());
@@ -127,7 +127,7 @@ void tie_break_ranks_transform(cudf::device_span<size_type const> dense_rank_sor
   // algorithm: reduce_by_key(dense_rank, 1, n, reduction_tie_breaker)
   // reduction_tie_breaker = min, max, min_count
   rmm::device_uvector<TieType> tie_sorted(sorted_order_view.size(), stream);
-  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         dense_rank_sorted.begin(),
                         dense_rank_sorted.end(),
                         tie_iter,
@@ -143,7 +143,7 @@ void tie_break_ranks_transform(cudf::device_span<size_type const> dense_rank_sor
       [tied_rank = tie_sorted.begin(), transformer] __device__(auto dense_pos) {
         return transformer(tied_rank[dense_pos - 1]);
       }));
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   sorted_tied_rank,
                   sorted_tied_rank + input_size,
                   sorted_order_view.begin<size_type>(),
@@ -156,7 +156,7 @@ void rank_first(column_view sorted_order_view,
                 rmm::cuda_stream_view stream)
 {
   // stable sort order ranking (no ties)
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   cuda::counting_iterator<size_type>{1},
                   cuda::counting_iterator<size_type>{rank_mutable_view.size() + 1},
                   sorted_order_view.begin<size_type>(),
@@ -170,7 +170,7 @@ void rank_dense(cudf::device_span<size_type const> dense_rank_sorted,
                 rmm::cuda_stream_view stream)
 {
   // All equal values have same rank and rank always increases by 1 between groups
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   dense_rank_sorted.begin(),
                   dense_rank_sorted.end(),
                   sorted_order_view.begin<size_type>(),
@@ -342,7 +342,7 @@ std::unique_ptr<column> rank(column_view const& input,
     auto drs            = dense_rank_sorted.data();
     bool const is_dense = (method == rank_method::DENSE);
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       rank_iter,
       rank_iter + input.size(),
       rank_iter,

--- a/cpp/src/sort/segmented_sort.cu
+++ b/cpp/src/sort/segmented_sort.cu
@@ -29,7 +29,7 @@ rmm::device_uvector<size_type> get_segment_indices(size_type num_rows,
   auto offset_begin  = offsets.begin<size_type>();
   auto offset_end    = offsets.end<size_type>();
   auto counting_iter = cuda::counting_iterator<size_type>{0};
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     counting_iter,
                     counting_iter + segment_ids.size(),
                     segment_ids.begin(),

--- a/cpp/src/sort/segmented_top_k.cu
+++ b/cpp/src/sort/segmented_top_k.cu
@@ -105,8 +105,11 @@ std::unique_ptr<column> segmented_top_k_order(column_view const& col,
     size_data_type, total_elements, mask_state::UNALLOCATED, stream, mr);
   auto d_result = result->mutable_view().begin<size_type>();
   // remove the indices marked by resolve_segment_indices
-  thrust::remove_copy(
-    rmm::exec_policy_nosync(stream), d_indices, d_indices + indices->size(), d_result, -1);
+  thrust::remove_copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      d_indices,
+                      d_indices + indices->size(),
+                      d_result,
+                      -1);
 
   auto const num_rows = static_cast<size_type>(offsets->size() - 1);
   return make_lists_column(

--- a/cpp/src/sort/sort_column_impl.cuh
+++ b/cpp/src/sort/sort_column_impl.cuh
@@ -137,8 +137,11 @@ struct column_sorted_order_fn {
     auto itr = cudf::detail::indexalator_factory::make_input_iterator(
       dictionary_column_view(input).indices());
     auto mapped_indices = rmm::device_uvector<size_type>(input.size(), stream);
-    thrust::gather(
-      rmm::exec_policy_nosync(stream), itr, itr + input.size(), map, mapped_indices.begin());
+    thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   itr,
+                   itr + input.size(),
+                   map,
+                   mapped_indices.begin());
 
     // Finally, sort-order the dictionary indices using mapped values
     auto mapped_view = column_view(data_type{type_to_id<size_type>()},

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -61,7 +61,7 @@ std::unique_ptr<column> sorted_order(table_view input,
   std::unique_ptr<column> sorted_indices = cudf::make_numeric_column(
     data_type(type_to_id<size_type>()), input.num_rows(), mask_state::UNALLOCATED, stream, mr);
   mutable_column_view mutable_indices_view = sorted_indices->mutable_view();
-  thrust::sequence(rmm::exec_policy_nosync(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    mutable_indices_view.begin<size_type>(),
                    mutable_indices_view.end<size_type>(),
                    0);
@@ -70,12 +70,12 @@ std::unique_ptr<column> sorted_order(table_view input,
     // Compiling `thrust::*sort*` APIs is expensive.
     // Thus, we should optimize that by using constexpr condition to only compile what we need.
     if constexpr (method == sort_method::STABLE) {
-      thrust::stable_sort(rmm::exec_policy_nosync(stream),
+      thrust::stable_sort(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           mutable_indices_view.begin<size_type>(),
                           mutable_indices_view.end<size_type>(),
                           comparator);
     } else {
-      thrust::sort(rmm::exec_policy_nosync(stream),
+      thrust::sort(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    mutable_indices_view.begin<size_type>(),
                    mutable_indices_view.end<size_type>(),
                    comparator);

--- a/cpp/src/sort/sort_radix.cu
+++ b/cpp/src/sort/sort_radix.cu
@@ -86,7 +86,7 @@ struct sort_radix_fn {
     auto pair_out = rmm::device_uvector<float_pair<T>>(input.size(), stream);
     auto d_out    = pair_out.begin();
 
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       d_in,
@@ -111,7 +111,7 @@ struct sort_radix_fn {
       cub::DeviceRadixSort::SortKeysDescending(
         tmp_stg.data(), tmp_bytes, d_in, d_out, n, decomposer, 0, end_bit, sv);
     }
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       d_out,
                       d_out + input.size(),
                       output.begin<T>(),

--- a/cpp/src/sort/sorted_order_radix.cu
+++ b/cpp/src/sort/sorted_order_radix.cu
@@ -68,7 +68,10 @@ struct sorted_order_radix_fn {
     auto output = rmm::device_uvector<T>(input.size(), stream);
     auto d_out  = output.begin();  // not returned
     auto seqs   = rmm::device_uvector<cudf::size_type>(input.size(), stream);
-    thrust::sequence(rmm::exec_policy_nosync(stream), seqs.begin(), seqs.end(), 0);
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     seqs.begin(),
+                     seqs.end(),
+                     0);
     auto dv_in  = seqs.begin();
     auto dv_out = indices.begin<cudf::size_type>();
 
@@ -107,7 +110,7 @@ struct sorted_order_radix_fn {
     auto dv_out   = indices.begin<cudf::size_type>();
 
     auto zip_out = thrust::make_zip_iterator(d_in, dv_in);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       zip_out,

--- a/cpp/src/stream_compaction/distinct_helpers.cu
+++ b/cpp/src/stream_compaction/distinct_helpers.cu
@@ -33,14 +33,15 @@ rmm::device_uvector<size_type> reduce_by_row(distinct_set_t<RowEqual>& set,
   }
 
   auto reduction_results = rmm::device_uvector<size_type>(num_rows, stream, mr);
-  thrust::uninitialized_fill(rmm::exec_policy_nosync(stream),
-                             reduction_results.begin(),
-                             reduction_results.end(),
-                             reduction_init_value(keep));
+  thrust::uninitialized_fill(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    reduction_results.begin(),
+    reduction_results.end(),
+    reduction_init_value(keep));
 
   auto set_ref = set.ref(cuco::op::insert_and_find);
 
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cuda::counting_iterator<cudf::size_type>{0},
                    cuda::counting_iterator{num_rows},
                    [set_ref, keep, reduction_results = reduction_results.begin()] __device__(

--- a/cpp/src/stream_compaction/stable_distinct.cu
+++ b/cpp/src/stream_compaction/stable_distinct.cu
@@ -47,9 +47,12 @@ std::unique_ptr<table> stable_distinct(table_view const& input,
   auto const output_markers = [&] {
     auto markers = rmm::device_uvector<bool>(input.num_rows(), stream);
     thrust::uninitialized_fill(
-      rmm::exec_policy_nosync(stream), markers.begin(), markers.end(), false);
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      markers.begin(),
+      markers.end(),
+      false);
     thrust::scatter(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::constant_iterator<bool>(true, 0),
       cuda::constant_iterator<bool>(true, static_cast<size_type>(distinct_indices.size())),
       distinct_indices.begin(),

--- a/cpp/src/stream_compaction/unique.cu
+++ b/cpp/src/stream_compaction/unique.cu
@@ -67,7 +67,7 @@ std::unique_ptr<table> unique(table_view const& input,
       auto d_results = rmm::device_uvector<bool>(num_rows, stream);
       auto itr       = cuda::counting_iterator<size_type>{0};
       thrust::transform(
-        rmm::exec_policy_nosync(stream),
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
         itr,
         itr + num_rows,
         d_results.begin(),


### PR DESCRIPTION
## Summary
Passes `cudf::get_current_device_resource_ref()` as an explicit second argument to all `rmm::exec_policy_nosync` calls in this module. Previously these calls relied on the default, which goes through `rmm::mr::get_current_device_resource_ref()`. This change routes them through the cudf wrapper instead, which will later be replaced with a dedicated temporary memory resource.

Part of #20780.