### PR TITLE
Pass memory resource to exec_policy_nosync in copying, rolling, and merge modules

### DIFF
--- a/cpp/src/copying/sample.cu
+++ b/cpp/src/copying/sample.cu
@@ -61,7 +61,7 @@ std::unique_ptr<table> sample(table_view const& input,
                                           cudf::get_current_device_resource_ref());
     auto gather_map_mutable_view = gather_map->mutable_view();
     // Shuffle all the row indices
-    thrust::shuffle_copy(rmm::exec_policy_nosync(stream),
+    thrust::shuffle_copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          cuda::counting_iterator<size_type>{0},
                          cuda::counting_iterator<size_type>{num_rows},
                          gather_map_mutable_view.begin<size_type>(),

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -116,7 +116,7 @@ struct column_scalar_scatterer_impl {
     auto scalar_iter =
       thrust::make_permutation_iterator(scalar_impl->data(), cuda::make_constant_iterator(0));
 
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     scalar_iter,
                     scalar_iter + scatter_rows,
                     scatter_iter,
@@ -194,7 +194,7 @@ struct column_scalar_scatterer_impl<dictionary32, MapIterator> {
     auto new_indices = std::make_unique<column>(dict_view.get_indices_annotated(), stream, mr);
     auto target_iter = indexalator_factory::make_output_iterator(new_indices->mutable_view());
 
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     scalar_iter,
                     scalar_iter + scatter_rows,
                     scatter_iter,
@@ -390,7 +390,7 @@ std::unique_ptr<column> boolean_mask_scatter(column_view const& input,
                                            cudf::get_current_device_resource_ref());
   auto mutable_indices = indices->mutable_view();
 
-  thrust::sequence(rmm::exec_policy_nosync(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    mutable_indices.begin<size_type>(),
                    mutable_indices.end<size_type>(),
                    0);

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -131,7 +131,11 @@ struct shift_functor {
         return out_of_bounds(size, src_idx) ? *fill : input.element<T>(src_idx);
       };
 
-    thrust::transform(rmm::exec_policy_nosync(stream), index_begin, index_end, data, func_value);
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      index_begin,
+                      index_end,
+                      data,
+                      func_value);
 
     return output;
   }

--- a/cpp/src/merge/merge.cu
+++ b/cpp/src/merge/merge.cu
@@ -253,7 +253,7 @@ index_vector generate_merged_indices(table_view const& left_table,
 
     auto ineq_op = detail::row_lexicographic_tagged_comparator<true>(
       *lhs_device_view, *rhs_device_view, d_column_order, d_null_precedence);
-    thrust::merge(rmm::exec_policy_nosync(stream),
+    thrust::merge(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   left_begin,
                   left_begin + left_size,
                   right_begin,
@@ -263,7 +263,7 @@ index_vector generate_merged_indices(table_view const& left_table,
   } else {
     auto ineq_op = detail::row_lexicographic_tagged_comparator<false>(
       *lhs_device_view, *rhs_device_view, d_column_order, {});
-    thrust::merge(rmm::exec_policy_nosync(stream),
+    thrust::merge(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   left_begin,
                   left_begin + left_size,
                   right_begin,
@@ -304,7 +304,7 @@ index_vector generate_merged_indices_nested(table_view const& left_table,
 
   auto const total_counter = cuda::counting_iterator<cudf::size_type>{0};
   thrust::for_each(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     total_counter,
     total_counter + total_size,
     [merged = merged_indices.data(), left = left_indices_begin, left_size, right_size] __device__(
@@ -389,7 +389,7 @@ struct column_merger {
     // and "gather" into merged_view.data()[indx_merged]
     // from lcol or rcol, depending on side;
     //
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       row_order_.begin(),
                       row_order_.end(),
                       merged_view.begin<Element>(),

--- a/cpp/src/rolling/detail/lead_lag_nested.cuh
+++ b/cpp/src/rolling/detail/lead_lag_nested.cuh
@@ -133,7 +133,7 @@ std::unique_ptr<column> compute_lead_lag_for_nested(aggregation::Kind op,
   auto const input_size = input.size();
   auto const null_index = input.size();
   if (op == aggregation::LEAD) {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       gather_map.begin<size_type>(),
@@ -142,7 +142,7 @@ std::unique_ptr<column> compute_lead_lag_for_nested(aggregation::Kind op,
                           return (row_offset > following[i]) ? null_index : (i + row_offset);
                         }));
   } else {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       gather_map.begin<size_type>(),

--- a/cpp/src/rolling/detail/nth_element.cuh
+++ b/cpp/src/rolling/detail/nth_element.cuh
@@ -147,8 +147,10 @@ std::unique_ptr<column> nth_element(size_type n,
       n, input, preceding, following, min_periods, stream});
 
   auto gather_map = rmm::device_uvector<size_type>(input.size(), stream);
-  thrust::copy(
-    rmm::exec_policy_nosync(stream), gather_iter, gather_iter + input.size(), gather_map.begin());
+  thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+               gather_iter,
+               gather_iter + input.size(),
+               gather_map.begin());
 
   auto gathered = cudf::detail::gather(table_view{{input}},
                                        gather_map,

--- a/cpp/src/rolling/detail/range_utils.cuh
+++ b/cpp/src/rolling/detail/range_utils.cuh
@@ -456,7 +456,7 @@ struct range_window_clamper {
                         mutable_column_view& result,
                         rmm::cuda_stream_view stream) const
   {
-    thrust::copy_n(rmm::exec_policy_nosync(stream),
+    thrust::copy_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cudf::detail::make_counting_transform_iterator(
                      0, unbounded_distance_functor{grouping, direction}),
                    size,
@@ -472,7 +472,7 @@ struct range_window_clamper {
                           mutable_column_view& result,
                           rmm::cuda_stream_view stream) const
   {
-    thrust::copy_n(rmm::exec_policy_nosync(stream),
+    thrust::copy_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cudf::detail::make_counting_transform_iterator(
                      0, current_row_distance_functor{grouping, direction, order, begin}),
                    size,
@@ -489,7 +489,7 @@ struct range_window_clamper {
                       mutable_column_view& result,
                       rmm::cuda_stream_view stream) const
   {
-    thrust::copy_n(rmm::exec_policy_nosync(stream),
+    thrust::copy_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cudf::detail::make_counting_transform_iterator(
                      0,
                      bounded_distance_functor<Grouping, OrderbyT, DeltaT, WindowType>{

--- a/cpp/src/rolling/detail/rolling_collect_list.cu
+++ b/cpp/src/rolling/detail/rolling_collect_list.cu
@@ -50,10 +50,13 @@ std::unique_ptr<column> get_list_child_to_list_row_mapping(cudf::column_view con
                                                  stream,
                                                  cudf::get_current_device_resource_ref());
   auto per_row_mapping_begin = per_row_mapping->mutable_view().template begin<size_type>();
-  thrust::fill_n(rmm::exec_policy_nosync(stream), per_row_mapping_begin, num_child_rows, 0);
+  thrust::fill_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                 per_row_mapping_begin,
+                 num_child_rows,
+                 0);
 
   auto const begin = cuda::counting_iterator<size_type>{0};
-  thrust::scatter_if(rmm::exec_policy_nosync(stream),
+  thrust::scatter_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      begin,
                      begin + offsets.size() - 1,
                      offsets.begin<size_type>(),
@@ -71,7 +74,7 @@ std::unique_ptr<column> get_list_child_to_list_row_mapping(cudf::column_view con
   // For the case with an empty list at index 2:
   //   scatter result == [0, 0, 1, 0, 0, 3, 0, 0, 4, 0, 0, 5, 0]
   //   inclusive_scan == [0, 0, 1, 1, 1, 3, 3, 3, 4, 4, 4, 5, 5]
-  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          per_row_mapping_begin,
                          per_row_mapping_begin + num_child_rows,
                          per_row_mapping_begin,
@@ -134,7 +137,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
                                            stream,
                                            cudf::get_current_device_resource_ref());
 
-  thrust::tabulate(rmm::exec_policy_nosync(stream),
+  thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    new_sizes->mutable_view().template begin<size_type>(),
                    new_sizes->mutable_view().template end<size_type>(),
                    [d_gather_map  = gather_map.template begin<size_type>(),

--- a/cpp/src/rolling/detail/rolling_collect_list.cuh
+++ b/cpp/src/rolling/detail/rolling_collect_list.cuh
@@ -61,7 +61,7 @@ std::unique_ptr<column> create_collect_offsets(size_type input_size,
   // But if min_periods=3, rows at indices 0 and 4 have too few observations, and must return
   // null. The sizes at these positions must be 0, i.e.
   //  prec + foll = [0,3,3,3,0]
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     preceding_begin,
                     preceding_begin + input_size,
                     following_begin,
@@ -110,7 +110,7 @@ std::unique_ptr<column> create_collect_gather_map(column_view const& child_offse
                                             stream,
                                             cudf::get_current_device_resource_ref());
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     cuda::counting_iterator<size_type>{per_row_mapping.size()},
     gather_map->mutable_view().template begin<size_type>(),

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -307,11 +307,12 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
           return nulls_per_group[i] < (d_offsets[i + 1] - d_offsets[i]) &&
                  d_orderby.is_null_nocheck(d_offsets[i]);
         }));
-    auto is_before = thrust::reduce(rmm::exec_policy_nosync(stream),
-                                    it,
-                                    it + offsets.size() - 1,
-                                    false,
-                                    cuda::std::logical_or<>{});
+    auto is_before =
+      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     it,
+                     it + offsets.size() - 1,
+                     false,
+                     cuda::std::logical_or<>{});
     return is_before ? null_order::BEFORE : null_order::AFTER;
   } else {
     // Sort order is DESCENDING
@@ -328,11 +329,12 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
           return nulls_per_group[i] < (d_offsets[i + 1] - d_offsets[i]) &&
                  d_orderby.is_null_nocheck(d_offsets[i + 1] - 1);
         }));
-    auto is_before = thrust::reduce(rmm::exec_policy_nosync(stream),
-                                    it,
-                                    it + offsets.size() - 1,
-                                    false,
-                                    cuda::std::logical_or<>{});
+    auto is_before =
+      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     it,
+                     it + offsets.size() - 1,
+                     false,
+                     cuda::std::logical_or<>{});
     return is_before ? null_order::BEFORE : null_order::AFTER;
   }
 }


### PR DESCRIPTION
## Summary
Passes `cudf::get_current_device_resource_ref()` as an explicit second argument to all `rmm::exec_policy_nosync` calls in this module. Previously these calls relied on the default, which goes through `rmm::mr::get_current_device_resource_ref()`. This change routes them through the cudf wrapper instead, which will later be replaced with a dedicated temporary memory resource.

Part of #20780.