### PR TITLE
Pass memory resource to exec_policy_nosync in dictionary, interop, and replace modules

### DIFF
--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -158,7 +158,7 @@ struct dispatch_compute_indices {
     auto result_itr =
       cudf::detail::indexalator_factory::make_output_iterator(result->mutable_view());
     // new indices values are computed by matching the concatenated keys to the new key set
-    thrust::lower_bound(rmm::exec_policy_nosync(stream),
+    thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         begin,
                         end,
                         all_itr,
@@ -240,7 +240,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
     }));
   // the indices offsets (pair.second) are for building the map
   thrust::lower_bound(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     children_offsets.begin() + 1,
     children_offsets.end(),
     indices_itr,

--- a/cpp/src/dictionary/detail/merge.cu
+++ b/cpp/src/dictionary/detail/merge.cu
@@ -40,7 +40,7 @@ std::unique_ptr<column> merge(dictionary_column_view const& lcol,
     cudf::detail::indexalator_factory::make_output_iterator(indices_column->mutable_view());
 
   // merge the input indices columns into the output column
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     row_order.begin(),
                     row_order.end(),
                     output_iter,

--- a/cpp/src/dictionary/encode.cu
+++ b/cpp/src/dictionary/encode.cu
@@ -98,7 +98,7 @@ std::unique_ptr<column> encode(column_view const& input,
   // and keep track of the indices of the unique values
   auto d_indices = rmm::device_uvector<size_type>(input.size(), stream);
   auto d_input   = column_device_view::create(input, stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     d_indices.begin(),
@@ -109,7 +109,9 @@ std::unique_ptr<column> encode(column_view const& input,
   keys_indices.resize(cuda::std::distance(keys_indices.begin(), keys_end), stream);
 
   // sort the keys_indices so we can use lower-bound on them
-  thrust::sort(rmm::exec_policy_nosync(stream), keys_indices.begin(), keys_indices.end());
+  thrust::sort(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+               keys_indices.begin(),
+               keys_indices.end());
 
   // use keys_indices to retrieve the keys
   auto const oob_policy   = cudf::out_of_bounds_policy::DONT_CHECK;
@@ -122,7 +124,7 @@ std::unique_ptr<column> encode(column_view const& input,
   // call lower-bound with keys_indices and d_indices to get the output indices_column
   auto d_result =
     cudf::detail::indexalator_factory::make_output_iterator(indices_column->mutable_view());
-  thrust::lower_bound(rmm::exec_policy_nosync(stream),
+  thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       keys_indices.begin(),
                       keys_indices.end(),
                       d_indices.begin(),

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -67,7 +67,7 @@ std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_
   auto map_itr =
     cudf::detail::indexalator_factory::make_output_iterator(map_indices->mutable_view());
   // init to max to identify new nulls
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                map_itr,
                map_itr + keys_view.size(),
                max_size);  // all valid indices are less than this value
@@ -82,7 +82,9 @@ std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_
                                                stream,
                                                cudf::get_current_device_resource_ref());
       auto itr = cudf::detail::indexalator_factory::make_output_iterator(positions->mutable_view());
-      thrust::sequence(rmm::exec_policy_nosync(stream), itr, itr + keys_view.size());
+      thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       itr,
+                       itr + keys_view.size());
       return positions;
     }();
     // copy the non-removed keys ( keys_to_keep_fn(idx)==true )
@@ -96,7 +98,7 @@ std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_
       cudf::detail::indexalator_factory::make_input_iterator(keys_positions->view());
     // build indices mapper
     // Example scatter([0,1,2][0,2,4][max,max,max,max,max]) => [0,max,1,max,2]
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     positions_itr,
                     positions_itr + filtered_view.size(),
                     filtered_itr,
@@ -177,7 +179,9 @@ std::unique_ptr<column> remove_unused_keys(dictionary_column_view const& diction
   auto const matches = [&] {
     // build keys index to verify against indices values
     rmm::device_uvector<int32_t> keys_positions(keys_size, stream);
-    thrust::sequence(rmm::exec_policy_nosync(stream), keys_positions.begin(), keys_positions.end());
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     keys_positions.begin(),
+                     keys_positions.end());
     // wrap the indices for comparison in contains()
     column_view keys_positions_view(
       data_type{type_id::INT32}, keys_size, keys_positions.data(), nullptr, 0);

--- a/cpp/src/dictionary/search.cu
+++ b/cpp/src/dictionary/search.cu
@@ -73,7 +73,11 @@ struct find_index_fn {
     auto keys_view   = column_device_view::create(input.keys(), stream);
     auto const begin = keys_view->begin<Element>();
     auto const end   = keys_view->end<Element>();
-    auto const iter  = thrust::find(rmm::exec_policy_nosync(stream), begin, end, find_key);
+    auto const iter =
+      thrust::find(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   begin,
+                   end,
+                   find_key);
     return type_dispatcher(input.indices().type(),
                            dispatch_scalar_index{},
                            cuda::std::distance(begin, iter),

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -90,8 +90,11 @@ struct set_keys_dispatch_fn {
     auto indices_map = rmm::device_uvector<size_type>(old_keys.size(), stream);
     create_indices_map_fn<T, decltype(keys_itr)> map_fn{
       *d_old_keys, keys_itr, keys_itr + new_keys.size(), d_sorted_indices};
-    thrust::transform(
-      rmm::exec_policy_nosync(stream), iota, iota + old_keys.size(), indices_map.begin(), map_fn);
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      iota,
+                      iota + old_keys.size(),
+                      indices_map.begin(),
+                      map_fn);
 
     // map the old indices to the new set
     auto indices_column = cudf::make_numeric_column(
@@ -100,8 +103,11 @@ struct set_keys_dispatch_fn {
       cudf::detail::indexalator_factory::make_output_iterator(indices_column->mutable_view());
     auto d_input = cudf::column_device_view::create(input.parent(), stream);
     apply_indices_map_fn apply_fn{*d_input, indices_map.data()};
-    thrust::transform(
-      rmm::exec_policy_nosync(stream), iota, iota + input.size(), d_new_indices, apply_fn);
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      iota,
+                      iota + input.size(),
+                      d_new_indices,
+                      apply_fn);
 
     // compute the nulls (any indices < 0)
     auto d_indices = cudf::detail::indexalator_factory::make_input_iterator(indices_column->view());

--- a/cpp/src/interop/from_arrow_device.cu
+++ b/cpp/src/interop/from_arrow_device.cu
@@ -190,7 +190,7 @@ dispatch_tuple_t dispatch_from_arrow_device::operator()<cudf::string_view>(
     // build strings into gather input form
     auto d_indices =
       rmm::device_uvector<cudf::strings::detail::string_index_pair>(size, stream, mr);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<cudf::size_type>{offset},
                       cuda::counting_iterator<cudf::size_type>{offset + size},
                       d_indices.begin(),

--- a/cpp/src/interop/from_arrow_host.cu
+++ b/cpp/src/interop/from_arrow_host.cu
@@ -375,10 +375,11 @@ std::tuple<std::unique_ptr<column>, int64_t, int64_t> copy_offsets_column(
   if (offset != 0) {
     auto begin = result->mutable_view().template begin<OffsetType>();
     auto end   = begin + offsets->length;
-    thrust::transform(
-      rmm::exec_policy_nosync(stream), begin, end, begin, [offset] __device__(auto o) {
-        return o - offset;
-      });
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      begin,
+                      end,
+                      begin,
+                      [offset] __device__(auto o) { return o - offset; });
   }
   return std::tuple{std::move(result), offset, length};
 }

--- a/cpp/src/interop/from_arrow_host_strings.cu
+++ b/cpp/src/interop/from_arrow_host_strings.cu
@@ -99,7 +99,7 @@ std::unique_ptr<column> from_arrow_stringview(ArrowSchemaView const* schema,
   // create indices to string fragments for the make_strings_column gather
   auto d_indices = rmm::device_uvector<string_index_pair>(input->length, stream, mr);
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator{static_cast<cudf::size_type>(input->length)},
     d_indices.begin(),

--- a/cpp/src/interop/to_arrow_host.cu
+++ b/cpp/src/interop/to_arrow_host.cu
@@ -434,7 +434,7 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
 
   // count the number of long-ish strings -- ones that cannot be inlined
   auto const num_longer_strings = thrust::count_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator<cudf::size_type>{col.size()},
     [d_offsets] __device__(auto idx) {
@@ -483,13 +483,13 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
       0, cuda::proclaim_return_type<int64_t>([] __device__(auto idx) {
         return (idx + 1) * max_size;
       }));
-    thrust::lower_bound(rmm::exec_policy_nosync(stream),
+    thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         d_offsets,
                         d_offsets + longer_strings.size(),
                         bound_itr,
                         bound_itr + num_buffers,
                         buffer_indices.begin());
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       buffer_indices.begin(),
                       buffer_indices.end(),
                       buffer_offsets.begin(),
@@ -513,7 +513,7 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
 
   // now build BinaryView objects from the strings in device memory
   auto d_items = rmm::device_uvector<ArrowBinaryView>(col.size(), stream);
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<cudf::size_type>{0},
                      col.size(),
                      strings_to_binary_view{*d_strings, d_offsets, buffer_offsets, d_items.data()});

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -88,7 +88,7 @@ std::unique_ptr<cudf::column> clamp_string_column(strings_column_view const& inp
   auto fn = clamp_strings_fn<OptionalScalarIterator, ReplaceScalarIterator>{
     d_input, lo_itr, lo_replace_itr, hi_itr, hi_replace_itr};
   rmm::device_uvector<cudf::strings::detail::string_index_pair> indices(input.size(), stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     indices.begin(),
@@ -170,7 +170,7 @@ std::unique_ptr<cudf::column> clamp_dictionary_column(dictionary_column_view con
 
   auto fn = clamp_dictionary_fn<T, OptionalIterator, ReplaceIterator>{
     *d_input, lo_itr, lo_index_itr, hi_itr, hi_index_itr};
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     indices_itr,
@@ -226,7 +226,7 @@ std::unique_ptr<cudf::column> clamper(column_view const& input,
 
   auto input_pair_iterator =
     make_optional_iterator<T>(*input_device_view, nullate::DYNAMIC{input.has_nulls()});
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     input_pair_iterator,
                     input_pair_iterator + input.size(),
                     scalar_zip_itr,

--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -147,7 +147,7 @@ struct normalize_nans_and_zeros_kernel_forwarder {
                   rmm::cuda_stream_view stream)
     requires(std::is_floating_point_v<T>)
   {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<cudf::size_type>{0},
                       cuda::counting_iterator{in.size()},
                       out.head<T>(),

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -217,7 +217,7 @@ struct replace_nulls_scalar_kernel_forwarder {
     auto device_in   = cudf::column_device_view::create(input, stream);
 
     auto func = replace_nulls_functor<col_type>{s1.data()};
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       input.data<col_type>(),
                       input.data<col_type>() + input.size(),
                       cudf::detail::make_validity_iterator(*device_in),
@@ -281,13 +281,19 @@ std::unique_ptr<cudf::column> replace_nulls_policy_impl(cudf::column_view const&
 
   auto func = cudf::detail::replace_policy_functor();
   if (replace_policy == cudf::replace_policy::PRECEDING) {
-    thrust::inclusive_scan(
-      rmm::exec_policy_nosync(stream), in_begin, in_begin + input.size(), gm_begin, func);
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           in_begin,
+                           in_begin + input.size(),
+                           gm_begin,
+                           func);
   } else {
     auto in_rbegin = cuda::std::make_reverse_iterator(in_begin + input.size());
     auto gm_rbegin = cuda::std::make_reverse_iterator(gm_begin + gather_map.size());
-    thrust::inclusive_scan(
-      rmm::exec_policy_nosync(stream), in_rbegin, in_rbegin + input.size(), gm_rbegin, func);
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           in_rbegin,
+                           in_rbegin + input.size(),
+                           gm_rbegin,
+                           func);
   }
 
   auto output = cudf::detail::gather(cudf::table_view({input}),


### PR DESCRIPTION
## Summary
Passes `cudf::get_current_device_resource_ref()` as an explicit second argument to all `rmm::exec_policy_nosync` calls in this module. Previously these calls relied on the default, which goes through `rmm::mr::get_current_device_resource_ref()`. This change routes them through the cudf wrapper instead, which will later be replaced with a dedicated temporary memory resource.

Part of #20780.