### PR TITLE
Adopt workflow dispatch pattern for compute sanitizer workflows

### DIFF
--- a/.github/workflows/compute-sanitizer-run.yaml
+++ b/.github/workflows/compute-sanitizer-run.yaml
@@ -1,16 +1,7 @@
-name: Compute Sanitizer Run
+name: Compute Sanitizer
+run-name: "Compute Sanitizer ${{ inputs.tool_name }}"
 
 on:
-  workflow_call:
-    inputs:
-      tool_name:
-        required: true
-        type: string
-        description: "Compute sanitizer tool to run (memcheck, racecheck, initcheck, synccheck)"
-      test_names:
-        required: true
-        type: string
-        description: "JSON array of test names to run"
   workflow_dispatch:
     inputs:
       tool_name:
@@ -23,13 +14,31 @@ on:
           - initcheck
           - synccheck
       test_names:
-        required: true
+        required: false
         type: string
-        description: "JSON array of test names to run"
+        description: "JSON array of test names to run (discovers all tests if empty)"
+        default: ""
 
 jobs:
+  discover-sanitizer-tests:
+    if: ${{ inputs.test_names == '' }}
+    runs-on: linux-amd64-cpu4
+    container:
+      image: rapidsai/ci-conda:26.06-latest
+    outputs:
+      tests: ${{ steps.find-tests.outputs.tests }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Discover test executables
+        id: find-tests
+        shell: bash
+        run: |
+          ./ci/discover_libcudf_tests.sh
   run-sanitizer-tests:
     name: Run ${{ inputs.tool_name }} on ${{ matrix.test_name }}
+    needs: discover-sanitizer-tests
+    if: ${{ !cancelled() }}
     runs-on: linux-amd64-gpu-l4-latest-1
     container:
       image: rapidsai/ci-conda:26.06-latest
@@ -38,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_name: ${{ fromJson(inputs.test_names) }}
+        test_name: ${{ fromJson(inputs.test_names || needs.discover-sanitizer-tests.outputs.tests) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/compute-sanitizer-trigger.yaml
+++ b/.github/workflows/compute-sanitizer-trigger.yaml
@@ -1,6 +1,6 @@
-name: Compute Sanitizer Weekend
+name: Trigger Compute Sanitizer
 
-# This workflow runs all compute-sanitizer tools on all libcudf tests weekly.
+# This workflow triggers compute-sanitizer runs for all libcudf tests weekly.
 # WARNING: This is very resource intensive and runs hundreds of GPU jobs.
 # For targeted testing, manually trigger compute-sanitizer-run.yaml with specific tool_name and test_names.
 
@@ -10,31 +10,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  discover-sanitizer-tests:
-    runs-on: linux-amd64-cpu4
-    container:
-      image: rapidsai/ci-conda:26.06-latest
-    outputs:
-      tests: ${{ steps.find-tests.outputs.tests }}
+  trigger-racecheck:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      - name: Discover test executables
-        id: find-tests
-        shell: bash
+      - uses: actions/checkout@v5
+      - name: Trigger racecheck
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          ./ci/discover_libcudf_tests.sh
-  run-sanitizer-tests-racecheck:
-    name: compute-sanitizer racecheck tests
-    needs: discover-sanitizer-tests
-    uses: ./.github/workflows/compute-sanitizer-run.yaml
-    with:
-      tool_name: "racecheck"
-      test_names: ${{ needs.discover-sanitizer-tests.outputs.tests }}
-  run-sanitizer-tests-synccheck:
-    name: compute-sanitizer synccheck tests
-    needs: discover-sanitizer-tests
-    uses: ./.github/workflows/compute-sanitizer-run.yaml
-    with:
-      tool_name: "synccheck"
-      test_names: ${{ needs.discover-sanitizer-tests.outputs.tests }}
+          gh workflow run compute-sanitizer-run.yaml \
+            -f tool_name="racecheck"
+  trigger-synccheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Trigger synccheck
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run compute-sanitizer-run.yaml \
+            -f tool_name="synccheck"


### PR DESCRIPTION
## Description
Adopt the dispatch pattern from [rapidsai/workflows](https://github.com/rapidsai/workflows/blob/main/.github/workflows/nightly-pipeline-trigger.yaml) so that the compute sanitizer workflows make sense in the Actions UI.

- **Trigger workflow** (`compute-sanitizer-trigger.yaml`): Renamed to "Trigger Compute Sanitizer". Uses `gh workflow run` instead of `workflow_call` to dispatch the run workflow. This is now a lightweight scheduler.
- **Run workflow** (`compute-sanitizer-run.yaml`): Renamed to "Compute Sanitizer" with a `run-name` of "Compute Sanitizer {tool}". Absorbs test discovery (when `test_names` is not provided). Drops `workflow_call` trigger.

Previously, the actual GPU job runs appeared under "Compute Sanitizer Trigger" (because `workflow_call` nests runs under the caller), while "Compute Sanitizer Run" only showed manual dispatches. This was confusing and backwards. Now, the heavy runs appear under "Compute Sanitizer" with descriptive names, and the lightweight scheduler appears under "Trigger Compute Sanitizer".

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.