### PR TITLE
Remove more unneeded detail header includes from libcudf benchmarks

### DIFF
--- a/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,6 @@
 
 #include <cudf_test/column_wrapper.hpp>
 
-#include <cudf/ast/detail/operators.cuh>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/binaryop.hpp>
 #include <cudf/filling.hpp>

--- a/cpp/benchmarks/common/ndsh_data_generator/table_helpers.cpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/table_helpers.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,6 @@
 #include <benchmarks/common/nvtx_ranges.hpp>
 
 #include <cudf/aggregation.hpp>
-#include <cudf/ast/detail/operators.cuh>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>

--- a/cpp/benchmarks/io/csv/csv_reader_options.cpp
+++ b/cpp/benchmarks/io/csv/csv_reader_options.cpp
@@ -8,7 +8,6 @@
 #include <benchmarks/io/cuio_common.hpp>
 #include <benchmarks/io/nvbench_helpers.hpp>
 
-#include <cudf/detail/utilities/default_stream.hpp>
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/io/csv.hpp>
 

--- a/cpp/benchmarks/search/contains_table.cpp
+++ b/cpp/benchmarks/search/contains_table.cpp
@@ -1,13 +1,13 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <benchmarks/common/generate_input.hpp>
 #include <benchmarks/common/memory_stats.hpp>
 
-#include <cudf/detail/search.hpp>
 #include <cudf/lists/list_view.hpp>
+#include <cudf/search.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
@@ -41,12 +41,7 @@ static void nvbench_contains_table(nvbench::state& state, nvbench::type_list<Typ
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto const stream_view = rmm::cuda_stream_view{launch.get_stream()};
     [[maybe_unused]] auto const result =
-      cudf::detail::contains(haystack->view(),
-                             needles->view(),
-                             cudf::null_equality::EQUAL,
-                             cudf::nan_equality::ALL_EQUAL,
-                             stream_view,
-                             cudf::get_current_device_resource_ref());
+      cudf::contains(haystack->view().column(0), needles->view().column(0), stream_view);
   });
 
   state.add_buffer_size(

--- a/cpp/benchmarks/string/factory.cpp
+++ b/cpp/benchmarks/string/factory.cpp
@@ -1,14 +1,14 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <benchmarks/common/generate_input.hpp>
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/strings/utilities.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/device_uvector.hpp>
@@ -29,8 +29,7 @@ static void bench_factory(nvbench::state& state)
   auto const sv     = cudf::strings_column_view(column->view());
 
   auto stream    = cudf::get_default_stream();
-  auto mr        = cudf::get_current_device_resource_ref();
-  auto d_strings = cudf::strings::detail::create_string_vector_from_column(sv, stream, mr);
+  auto d_strings = cudf::strings::create_string_vector_from_column(sv);
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
   auto const data_size = column->alloc_size();

--- a/cpp/benchmarks/type_dispatcher/type_dispatcher.cu
+++ b/cpp/benchmarks/type_dispatcher/type_dispatcher.cu
@@ -1,11 +1,10 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_view.hpp>
-#include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/grid_1d.cuh>
 #include <cudf/filling.hpp>
 #include <cudf/scalar/scalar_factories.hpp>


### PR DESCRIPTION
## Description
Removes more `detail` header includes from benchmarks source. Most of these are not needed.
A couple were replaced with public API equivalents.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
