### PR TITLE
Use cudf::test::iterator utilities instead of make_counting_transform_iterator as appropriate

### DIFF
--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -696,9 +696,8 @@ TEST_F(MergeBitmaskTest, TestBitmaskOr)
   EXPECT_EQ(result2_null_count, 1);
   EXPECT_EQ(result3_null_count, 0);
 
-  auto all_but_index3 =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; });
-  auto null3 = std::get<0>(
+  auto all_but_index3 = cudf::test::iterators::null_at(3);
+  auto null3          = std::get<0>(
     cudf::test::detail::make_null_mask(all_but_index3, all_but_index3 + input2.num_rows()));
 
   EXPECT_EQ(nullptr, result1_mask.data());

--- a/cpp/tests/copying/scatter_list_tests.cpp
+++ b/cpp/tests/copying/scatter_list_tests.cpp
@@ -1,11 +1,12 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/column/column_view.hpp>
@@ -154,8 +155,7 @@ TYPED_TEST(TypedScatterListsTest, NullableListsOfNullableFixedWidth)
   auto src_child = cudf::test::fixed_width_column_wrapper<T, int32_t>{{9, 9, 9, 9, 8, 8, 8},
                                                                       {1, 1, 1, 0, 1, 1, 1}};
 
-  auto src_list_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2; });
+  auto src_list_validity = cudf::test::iterators::null_at(2);
   auto [null_mask, null_count] =
     cudf::test::detail::make_null_mask(src_list_validity, src_list_validity + 3);
   // One null list row, and one row with nulls.
@@ -178,8 +178,7 @@ TYPED_TEST(TypedScatterListsTest, NullableListsOfNullableFixedWidth)
   auto expected_child_ints = cudf::test::fixed_width_column_wrapper<T, int32_t>{
     {8, 8, 8, 1, 1, 9, 9, 9, 9, 3, 3, 4, 4, 6, 6}, {1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1}};
 
-  auto expected_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 5; });
+  auto expected_validity = cudf::test::iterators::null_at(5);
   std::tie(null_mask, null_count) =
     cudf::test::detail::make_null_mask(expected_validity, expected_validity + 7);
   auto expected_lists_column = cudf::make_lists_column(
@@ -244,23 +243,23 @@ TEST_F(ScatterListsTest, ListsOfNullableStrings)
                            scatter_map,
                            cudf::table_view({target_list_column}));
 
-  auto expected_strings = cudf::test::strings_column_wrapper{
-    {"california",
-     "dreaming",
-     "one",
-     "one",
-     "all",
-     "the",
-     "leaves",
-     "are",
-     "brown",
-     "three",
-     "three",
-     "four",
-     "four",
-     "five",
-     "five"},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 0 && i != 7; })};
+  auto expected_strings =
+    cudf::test::strings_column_wrapper{{"california",
+                                        "dreaming",
+                                        "one",
+                                        "one",
+                                        "all",
+                                        "the",
+                                        "leaves",
+                                        "are",
+                                        "brown",
+                                        "three",
+                                        "three",
+                                        "four",
+                                        "four",
+                                        "five",
+                                        "five"},
+                                       cudf::test::iterators::nulls_at({0, 7})};
 
   auto expected_lists = cudf::make_lists_column(
     6,
@@ -298,21 +297,21 @@ TEST_F(ScatterListsTest, EmptyListsOfNullableStrings)
                            scatter_map,
                            cudf::table_view({target_list_column}));
 
-  auto expected_strings = cudf::test::strings_column_wrapper{
-    {"california",
-     "dreaming",
-     "one",
-     "one",
-     "all",
-     "the",
-     "leaves",
-     "are",
-     "brown",
-     "three",
-     "three",
-     "five",
-     "five"},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 0 && i != 7; })};
+  auto expected_strings =
+    cudf::test::strings_column_wrapper{{"california",
+                                        "dreaming",
+                                        "one",
+                                        "one",
+                                        "all",
+                                        "the",
+                                        "leaves",
+                                        "are",
+                                        "brown",
+                                        "three",
+                                        "three",
+                                        "five",
+                                        "five"},
+                                       cudf::test::iterators::nulls_at({0, 7})};
 
   auto expected_lists = cudf::make_lists_column(
     6,
@@ -330,8 +329,7 @@ TEST_F(ScatterListsTest, NullableListsOfNullableStrings)
     {"all", "the", "leaves", "are", "brown", "california", "dreaming"},
     {true, true, true, false, true, false, true}};
 
-  auto src_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; });
+  auto src_validity            = cudf::test::iterators::null_at(1);
   auto [null_mask, null_count] = cudf::test::detail::make_null_mask(src_validity, src_validity + 3);
   auto src_list_column         = cudf::make_lists_column(
     3,
@@ -353,24 +351,23 @@ TEST_F(ScatterListsTest, NullableListsOfNullableStrings)
                            scatter_map,
                            cudf::table_view({target_list_column}));
 
-  auto expected_strings = cudf::test::strings_column_wrapper{
-    {"california",
-     "dreaming",
-     "one",
-     "one",
-     "all",
-     "the",
-     "leaves",
-     "are",
-     "brown",
-     "three",
-     "three",
-     "five",
-     "five"},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 0 && i != 7; })};
+  auto expected_strings =
+    cudf::test::strings_column_wrapper{{"california",
+                                        "dreaming",
+                                        "one",
+                                        "one",
+                                        "all",
+                                        "the",
+                                        "leaves",
+                                        "are",
+                                        "brown",
+                                        "three",
+                                        "three",
+                                        "five",
+                                        "five"},
+                                       cudf::test::iterators::nulls_at({0, 7})};
 
-  auto expected_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 4; });
+  auto expected_validity = cudf::test::iterators::null_at(4);
   std::tie(null_mask, null_count) =
     cudf::test::detail::make_null_mask(expected_validity, expected_validity + 6);
   auto expected_lists = cudf::make_lists_column(
@@ -448,8 +445,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfLists)
   using T = TypeParam;
 
   auto src_list_column = cudf::test::lists_column_wrapper<T, int32_t>{
-    {{{1, 1, 1, 1}, {2, 2, 2, 2}}, {{3, 3, 3, 3}, {}}, {}},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2; })};
+    {{{1, 1, 1, 1}, {2, 2, 2, 2}}, {{3, 3, 3, 3}, {}}, {}}, cudf::test::iterators::null_at(2)};
 
   auto target_list_column =
     cudf::test::lists_column_wrapper<T, int32_t>{{{9, 9, 9}, {8, 8, 8}, {7, 7, 7}},
@@ -465,14 +461,13 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfLists)
     cudf::table_view({src_list_column}), scatter_map, cudf::table_view({target_list_column}));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(
-    cudf::test::lists_column_wrapper<T, int32_t>{
-      {{{3, 3, 3, 3}, {}},
-       {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
-       {{1, 1, 1, 1}, {2, 2, 2, 2}},
-       {{9, 9}, {8, 8}, {7, 7}},
-       {},
-       {{3, 3}, {2, 2}, {1, 1}}},
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 4; })},
+    cudf::test::lists_column_wrapper<T, int32_t>{{{{3, 3, 3, 3}, {}},
+                                                  {{6, 6, 6}, {5, 5, 5}, {4, 4, 4}},
+                                                  {{1, 1, 1, 1}, {2, 2, 2, 2}},
+                                                  {{9, 9}, {8, 8}, {7, 7}},
+                                                  {},
+                                                  {{3, 3}, {2, 2}, {1, 1}}},
+                                                 cudf::test::iterators::null_at(4)},
     ret->get_column(0));
 }
 
@@ -568,7 +563,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
       9, 9, 9, 9,
       8, 8, 8
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; })
+    cudf::test::iterators::null_at(3)
   };
 
   auto source_strings = cudf::test::strings_column_wrapper{
@@ -576,7 +571,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
       "nine",  "nine",  "nine", "nine",
       "eight", "eight", "eight"
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 5; })
+    cudf::test::iterators::null_at(5)
   };
   // clang-format on
 
@@ -627,7 +622,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
       4, 4,
       5, 5
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 8; })
+    cudf::test::iterators::null_at(8)
   };
 
   auto expected_strings = cudf::test::strings_column_wrapper{
@@ -639,7 +634,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
       "four",  "four",
       "five",  "five"
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; })
+    cudf::test::iterators::null_at(1)
   };
   // clang-format on
 
@@ -663,7 +658,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
       9, 9, 9, 9,
       8, 8, 8
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; })
+    cudf::test::iterators::null_at(3)
   };
 
   auto source_strings = cudf::test::strings_column_wrapper{
@@ -671,13 +666,12 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
       "nine",  "nine",  "nine", "nine",
       "eight", "eight", "eight"
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 5; })
+    cudf::test::iterators::null_at(5)
   };
   // clang-format on
 
-  auto source_structs = cudf::test::structs_column_wrapper{
-    {source_numerics, source_strings},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
+  auto source_structs = cudf::test::structs_column_wrapper{{source_numerics, source_strings},
+                                                           cudf::test::iterators::null_at(1)};
 
   auto source_lists =
     cudf::make_lists_column(2, offsets_column{0, 4, 7}.release(), source_structs.release(), 0, {});
@@ -723,7 +717,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
       4, 4,
       5, 5
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i != 6) && (i != 8); })
+    cudf::test::iterators::nulls_at({6, 8})
   };
 
   auto expected_strings = cudf::test::strings_column_wrapper{
@@ -735,13 +729,12 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
       "four",  "four",
       "five",  "five"
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i != 1) && (i != 6); })
+    cudf::test::iterators::nulls_at({1, 6})
   };
   // clang-format on
 
-  auto expected_structs = cudf::test::structs_column_wrapper{
-    {expected_numerics, expected_strings},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 6; })};
+  auto expected_structs = cudf::test::structs_column_wrapper{{expected_numerics, expected_strings},
+                                                             cudf::test::iterators::null_at(6)};
 
   auto expected_lists = cudf::make_lists_column(
     6, offsets_column{0, 3, 5, 9, 11, 13, 15}.release(), expected_structs.release(), 0, {});
@@ -761,7 +754,7 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
       9, 9, 9, 9,
       8, 8, 8
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; })
+    cudf::test::iterators::null_at(3)
   };
 
   auto source_strings = cudf::test::strings_column_wrapper{
@@ -769,13 +762,12 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
       "nine",  "nine",  "nine", "nine",
       "eight", "eight", "eight"
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 5; })
+    cudf::test::iterators::null_at(5)
   };
   // clang-format on
 
-  auto source_structs = cudf::test::structs_column_wrapper{
-    {source_numerics, source_strings},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
+  auto source_structs = cudf::test::structs_column_wrapper{{source_numerics, source_strings},
+                                                           cudf::test::iterators::null_at(1)};
 
   auto source_lists = cudf::make_lists_column(
     3, offsets_column{0, 4, 7, 7}.release(), source_structs.release(), 0, {});
@@ -820,7 +812,7 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
       3, 3,
       5, 5
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i != 6) && (i != 8); })
+    cudf::test::iterators::nulls_at({6, 8})
   };
 
   auto expected_strings = cudf::test::strings_column_wrapper{
@@ -831,13 +823,12 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
       "three", "three",
       "five",  "five"
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i != 1) && (i != 6); })
+    cudf::test::iterators::nulls_at({1, 6})
   };
   // clang-format on
 
-  auto expected_structs = cudf::test::structs_column_wrapper{
-    {expected_numerics, expected_strings},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 6; })};
+  auto expected_structs = cudf::test::structs_column_wrapper{{expected_numerics, expected_strings},
+                                                             cudf::test::iterators::null_at(6)};
 
   auto expected_lists = cudf::make_lists_column(
     6, offsets_column{0, 3, 5, 9, 11, 11, 13}.release(), expected_structs.release(), 0, {});
@@ -857,7 +848,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
       9, 9, 9, 9,
       8, 8, 8
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; })
+    cudf::test::iterators::null_at(3)
   };
 
   auto source_strings = cudf::test::strings_column_wrapper{
@@ -865,16 +856,14 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
       "nine",  "nine",  "nine", "nine",
       "eight", "eight", "eight"
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 5; })
+    cudf::test::iterators::null_at(5)
   };
   // clang-format on
 
-  auto source_structs = cudf::test::structs_column_wrapper{
-    {source_numerics, source_strings},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
+  auto source_structs = cudf::test::structs_column_wrapper{{source_numerics, source_strings},
+                                                           cudf::test::iterators::null_at(1)};
 
-  auto source_list_null_mask_begin =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2; });
+  auto source_list_null_mask_begin = cudf::test::iterators::null_at(2);
 
   auto [null_mask, null_count] = cudf::test::detail::make_null_mask(
     source_list_null_mask_begin, source_list_null_mask_begin + 3);
@@ -923,7 +912,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
       3, 3,
       5, 5
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i != 6) && (i != 8); })
+    cudf::test::iterators::nulls_at({6, 8})
   };
 
   auto expected_strings = cudf::test::strings_column_wrapper{
@@ -934,16 +923,14 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
       "three", "three",
       "five",  "five"
     },
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1 && i != 6; })
+    cudf::test::iterators::nulls_at({1, 6})
   };
   // clang-format on
 
-  auto expected_structs = cudf::test::structs_column_wrapper{
-    {expected_numerics, expected_strings},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 6; })};
+  auto expected_structs = cudf::test::structs_column_wrapper{{expected_numerics, expected_strings},
+                                                             cudf::test::iterators::null_at(6)};
 
-  auto expected_lists_null_mask_begin =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 4; });
+  auto expected_lists_null_mask_begin = cudf::test::iterators::null_at(4);
 
   std::tie(null_mask, null_count) = cudf::test::detail::make_null_mask(
     expected_lists_null_mask_begin, expected_lists_null_mask_begin + 6);

--- a/cpp/tests/hashing/md5_test.cpp
+++ b/cpp/tests/hashing/md5_test.cpp
@@ -1,11 +1,12 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/hashing.hpp>
@@ -95,7 +96,7 @@ TEST_F(MD5HashTest, EmptyNullEquivalence)
 
 TEST_F(MD5HashTest, StringLists)
 {
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 0; });
+  auto validity = cudf::test::iterators::null_at(0);
 
   // Test of data serialization: a string should hash the same as a list of
   // strings that concatenate to the same input.
@@ -166,7 +167,7 @@ TEST_F(MD5HashTest, TestBoolListsWithNulls)
   cudf::test::fixed_width_column_wrapper<bool> const col3(
     {0, 0, 0, 1, 1, 0, 0, 0, 1}, {true, false, false, true, true, false, false, false, true});
 
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; });
+  auto validity = cudf::test::iterators::null_at(1);
   cudf::test::lists_column_wrapper<bool> const list_col({{false, false, false},
                                                          {true},
                                                          {},
@@ -206,7 +207,7 @@ TYPED_TEST(MD5HashListTestTyped, TestListsWithNulls)
   cudf::test::fixed_width_column_wrapper<T> const col3({0, 0, 0, 64, 49, 0, 0, 0, 102},
                                                        {1, 0, 0, 1, 1, 0, 0, 0, 1});
 
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; });
+  auto validity = cudf::test::iterators::null_at(1);
   cudf::test::lists_column_wrapper<T> const list_col(
     {{0, 0, 0}, {}, {}, {{32, 0, 64}, validity}, {27, 49}, {18, 68}, {100}, {101}, {102}},
     validity);

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -946,8 +946,7 @@ TEST_P(JsonReaderRecordTest, JsonLinesObjectsMissingData)
   EXPECT_EQ(result.metadata.schema_info[1].name, "col3");
   EXPECT_EQ(result.metadata.schema_info[2].name, "col1");
 
-  auto col1_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 0; });
+  auto col1_validity = cudf::test::iterators::null_at(0);
   auto col2_validity =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i == 0; });
 

--- a/cpp/tests/io/json/json_type_cast_test.cpp
+++ b/cpp/tests/io/json/json_type_cast_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -49,7 +49,7 @@ TEST_F(JSONTypeCastTest, String)
   auto mr           = cudf::get_current_device_resource_ref();
   auto const type   = cudf::data_type{cudf::type_id::STRING};
 
-  auto in_valids = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 4; });
+  auto in_valids = null_at(4);
   std::vector<char const*> input_values{"this", "is", "null", "of", "", "strings", R"("null")"};
   cudf::test::strings_column_wrapper input(input_values.begin(), input_values.end(), in_valids);
 
@@ -72,8 +72,7 @@ TEST_F(JSONTypeCastTest, String)
     stream,
     mr);
 
-  auto out_valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2 and i != 4; });
+  auto out_valids = nulls_at({2, 4});
   std::vector<char const*> expected_values{"this", "is", "", "of", "", "strings", "null"};
   cudf::test::strings_column_wrapper expected(
     expected_values.begin(), expected_values.end(), out_valids);

--- a/cpp/tests/io/parquet_chunked_writer_test.cpp
+++ b/cpp/tests/io/parquet_chunked_writer_test.cpp
@@ -7,6 +7,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/io_metadata_utilities.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
 
 #include <cudf/io/parquet.hpp>
@@ -142,7 +143,7 @@ TEST_F(ParquetChunkedWriterTest, Strings)
 TEST_F(ParquetChunkedWriterTest, ListColumn)
 {
   auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
-  auto valids2 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; });
+  auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;
 
@@ -261,7 +262,7 @@ TEST_F(ParquetChunkedWriterTest, ListOfStruct)
 TEST_F(ParquetChunkedWriterTest, ListOfStructOfStructOfListOfList)
 {
   auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
-  auto valids2 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; });
+  auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;
 
@@ -413,7 +414,7 @@ TEST_F(ParquetChunkedWriterTest, MismatchedStructure)
 TEST_F(ParquetChunkedWriterTest, MismatchedStructureList)
 {
   auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
-  auto valids2 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; });
+  auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;
 
@@ -556,7 +557,7 @@ TEST_F(ParquetChunkedWriterTest, ForcedNullabilityList)
   srand(31337);
 
   auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
-  auto valids2 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; });
+  auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;
 

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -752,8 +752,7 @@ TEST_F(ParquetReaderTest, DecimalRead)
         reinterpret_cast<std::byte const*>(decimals_parquet.data()), decimals_parquet.size()}});
     auto result = cudf::io::read_parquet(read_opts);
 
-    auto validity =
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 50; });
+    auto validity = cudf::test::iterators::null_at(50);
 
     EXPECT_EQ(result.tbl->view().num_columns(), 3);
 

--- a/cpp/tests/io/parquet_v2_test.cpp
+++ b/cpp/tests/io/parquet_v2_test.cpp
@@ -291,7 +291,7 @@ TEST_P(ParquetV2Test, SlicedTable)
   // [[[]]]
   // [NULL, [], NULL, [[]]]
   auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
-  auto valids2 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; });
+  auto valids2 = cudf::test::iterators::null_at(3);
   lcw col4{{
              {{{{1, 2, 3, 4}, valids}}, {{{5, 6, 7}, valids}, {8, 9}}},
              {{{{10, 11}, {12}}, {{13}, {14, 15, 16}}, {{17, 18}}}, valids},
@@ -384,7 +384,7 @@ TEST_P(ParquetV2Test, ListColumn)
   auto const is_v2 = GetParam();
 
   auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
-  auto valids2 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; });
+  auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;
 
@@ -499,7 +499,7 @@ TEST_P(ParquetV2Test, StructOfList)
     {48, 27, 25, 31, 351, 351}, {true, true, true, true, true, false}};
 
   auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
-  auto valids2 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; });
+  auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;
 

--- a/cpp/tests/lists/explode_tests.cpp
+++ b/cpp/tests/lists/explode_tests.cpp
@@ -1,10 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -93,8 +94,7 @@ TEST_F(ExplodeTest, SingleNull)
 
   constexpr auto null = 0;
 
-  auto first_invalid =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 0; });
+  auto first_invalid = cudf::test::iterators::null_at(0);
 
   LCW a({LCW{null}, LCW{5, 6}, LCW{}, LCW{0, 3}}, first_invalid);
   FCW b({100, 200, 300, 400});
@@ -586,8 +586,7 @@ TEST_F(ExplodeOuterTest, SingleNull)
 
   constexpr auto null = 0;
 
-  auto first_invalid =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 0; });
+  auto first_invalid = cudf::test::iterators::null_at(0);
 
   LCW a({LCW{null}, LCW{5, 6}, LCW{}, LCW{0, 3}}, first_invalid);
   FCW b({100, 200, 300, 400});
@@ -679,8 +678,7 @@ TEST_F(ExplodeOuterTest, SequentialNulls)
 
   constexpr auto null = 0;
 
-  auto third_invalid =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2; });
+  auto third_invalid = cudf::test::iterators::null_at(2);
 
   LCW a{LCW({1, 2, null}, third_invalid), LCW{3, 4}, LCW{}, LCW{}, LCW{5, 6, 7}};
   FCW b{100, 200, 300, 400, 500};
@@ -874,8 +872,7 @@ TEST_F(ExplodeOuterTest, NestedNulls)
   LCW a({LCW{LCW{1, 2}, LCW{7, 6, 5}}, LCW{LCW{null}}, LCW{LCW{0, 3}, LCW{5}, LCW{2, 1}}}, valids);
   FCW b({100, 200, 300});
 
-  auto expected_valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2; });
+  auto expected_valids = cudf::test::iterators::null_at(2);
   LCW expected_a({LCW{1, 2}, LCW{7, 6, 5}, LCW{null}, LCW{0, 3}, LCW{5}, LCW{2, 1}},
                  expected_valids);
   FCW expected_b({100, 100, 200, 300, 300, 300});

--- a/cpp/tests/rolling/collect_ops_test.cpp
+++ b/cpp/tests/rolling/collect_ops_test.cpp
@@ -978,19 +978,18 @@ TYPED_TEST(TypedCollectListTest, GroupedTimeRangeRollingWindowWithMinPeriods)
     min_periods,
     *cudf::make_collect_list_aggregation<cudf::rolling_aggregation>());
 
-  auto const expected_result = cudf::test::lists_column_wrapper<T, int32_t>{
-    {{10, 11, 12, 13},
-     {10, 11, 12, 13},
-     {10, 11, 12, 13, 14},
-     {10, 11, 12, 13, 14},
-     {10, 11, 12, 13, 14},
-     {},
-     {},
-     {},
-     {}},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) {
-      return i < 5;
-    })}.release();
+  auto const expected_result =
+    cudf::test::lists_column_wrapper<T, int32_t>{{{10, 11, 12, 13},
+                                                  {10, 11, 12, 13},
+                                                  {10, 11, 12, 13, 14},
+                                                  {10, 11, 12, 13, 14},
+                                                  {10, 11, 12, 13, 14},
+                                                  {},
+                                                  {},
+                                                  {},
+                                                  {}},
+                                                 cudf::test::iterators::nulls_at({5, 6, 7, 8})}
+      .release();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result->view(), result->view());
 
@@ -1036,19 +1035,18 @@ TYPED_TEST(TypedCollectListTest, GroupedTimeRangeRollingWindowWithNullsAndMinPer
   auto null_at_1 = cudf::test::iterators::null_at(1);
 
   // In the results, `11` and `21` should be nulls.
-  auto const expected_result = cudf::test::lists_column_wrapper<T, int32_t>{
-    {{{10, 11, 12, 13}, null_at_1},
-     {{10, 11, 12, 13}, null_at_1},
-     {{10, 11, 12, 13, 14}, null_at_1},
-     {{10, 11, 12, 13, 14}, null_at_1},
-     {{10, 11, 12, 13, 14}, null_at_1},
-     {},
-     {},
-     {},
-     {}},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) {
-      return i < 5;
-    })}.release();
+  auto const expected_result =
+    cudf::test::lists_column_wrapper<T, int32_t>{{{{10, 11, 12, 13}, null_at_1},
+                                                  {{10, 11, 12, 13}, null_at_1},
+                                                  {{10, 11, 12, 13, 14}, null_at_1},
+                                                  {{10, 11, 12, 13, 14}, null_at_1},
+                                                  {{10, 11, 12, 13, 14}, null_at_1},
+                                                  {},
+                                                  {},
+                                                  {},
+                                                  {}},
+                                                 cudf::test::iterators::nulls_at({5, 6, 7, 8})}
+      .release();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result->view(), result->view());
 
@@ -1104,19 +1102,19 @@ TEST_F(CollectListTest, GroupedTimeRangeRollingWindowOnStringsWithMinPeriods)
     min_periods,
     *cudf::make_collect_list_aggregation<cudf::rolling_aggregation>());
 
-  auto const expected_result = cudf::test::lists_column_wrapper<cudf::string_view>{
-    {{"10", "11", "12", "13"},
-     {"10", "11", "12", "13"},
-     {"10", "11", "12", "13", "14"},
-     {"10", "11", "12", "13", "14"},
-     {"10", "11", "12", "13", "14"},
-     {},
-     {},
-     {},
-     {}},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) {
-      return i < 5;
-    })}.release();
+  auto const expected_result =
+    cudf::test::lists_column_wrapper<cudf::string_view>{
+      {{"10", "11", "12", "13"},
+       {"10", "11", "12", "13"},
+       {"10", "11", "12", "13", "14"},
+       {"10", "11", "12", "13", "14"},
+       {"10", "11", "12", "13", "14"},
+       {},
+       {},
+       {},
+       {}},
+      cudf::test::iterators::nulls_at({5, 6, 7, 8})}
+      .release();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result->view(), result->view());
 
@@ -1161,19 +1159,19 @@ TEST_F(CollectListTest, GroupedTimeRangeRollingWindowOnStringsWithNullsAndMinPer
   auto null_at_1 = cudf::test::iterators::null_at(1);
 
   // In the results, `11` and `21` should be nulls.
-  auto const expected_result = cudf::test::lists_column_wrapper<cudf::string_view>{
-    {{{"10", "11", "12", "13"}, null_at_1},
-     {{"10", "11", "12", "13"}, null_at_1},
-     {{"10", "11", "12", "13", "14"}, null_at_1},
-     {{"10", "11", "12", "13", "14"}, null_at_1},
-     {{"10", "11", "12", "13", "14"}, null_at_1},
-     {},
-     {},
-     {},
-     {}},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) {
-      return i < 5;
-    })}.release();
+  auto const expected_result =
+    cudf::test::lists_column_wrapper<cudf::string_view>{
+      {{{"10", "11", "12", "13"}, null_at_1},
+       {{"10", "11", "12", "13"}, null_at_1},
+       {{"10", "11", "12", "13", "14"}, null_at_1},
+       {{"10", "11", "12", "13", "14"}, null_at_1},
+       {{"10", "11", "12", "13", "14"}, null_at_1},
+       {},
+       {},
+       {},
+       {}},
+      cudf::test::iterators::nulls_at({5, 6, 7, 8})}
+      .release();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result->view(), result->view());
 
@@ -1199,7 +1197,7 @@ TEST_F(CollectListTest, GroupedTimeRangeRollingWindowOnStringsWithNullsAndMinPer
        {},
        {},
        {}},
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i < 5; })}
+      cudf::test::iterators::nulls_at({5, 6, 7, 8})}
       .release();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_result_with_nulls_excluded->view(),
@@ -1254,8 +1252,7 @@ TYPED_TEST(TypedCollectListTest, GroupedTimeRangeRollingWindowOnStructsWithMinPe
   auto expected_offsets_column =
     cudf::test::fixed_width_column_wrapper<cudf::size_type>{0, 4, 8, 13, 18, 23, 23, 23, 23, 23}
       .release();
-  auto expected_validity_iter =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i < 5; });
+  auto expected_validity_iter = cudf::test::iterators::nulls_at({5, 6, 7, 8});
   auto [null_mask, null_count] =
     cudf::test::detail::make_null_mask(expected_validity_iter, expected_validity_iter + 9);
   auto expected_result = cudf::make_lists_column(9,

--- a/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
+++ b/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/random.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/testing_main.hpp>
@@ -337,9 +338,8 @@ TEST_F(ApplyBooleanMask, StructOfListsFiltering)
 {
   using namespace cudf::test;
 
-  auto lists_column = lists_column_wrapper<int32_t>{
-    {{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 2; })};
+  auto lists_column =
+    lists_column_wrapper<int32_t>{{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}}, iterators::null_at(2)};
 
   auto structs_column = structs_column_wrapper{{lists_column}};
 
@@ -350,9 +350,8 @@ TEST_F(ApplyBooleanMask, StructOfListsFiltering)
 
   // Compare against expected values;
 
-  auto expected_lists_column = lists_column_wrapper<int32_t>{
-    {{0, 0}, {2, 2}, {4, 4}},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; })};
+  auto expected_lists_column =
+    lists_column_wrapper<int32_t>{{{0, 0}, {2, 2}, {4, 4}}, iterators::null_at(1)};
 
   auto expected_structs_column = structs_column_wrapper{{expected_lists_column}};
 

--- a/cpp/tests/structs/structs_column_tests.cpp
+++ b/cpp/tests/structs/structs_column_tests.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/testing_main.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -178,25 +179,25 @@ TYPED_TEST(TypedStructColumnWrapperTest, TestStructsContainingLists)
   // Check that the last two rows are null for all members.
 
   // For `Name` member, indices 4 and 5 are null.
-  auto expected_names_col = cudf::test::strings_column_wrapper{
-    names.begin(), names.end(), cudf::detail::make_counting_transform_iterator(0, [](auto i) {
-      return i < 4;
-    })}.release();
+  auto expected_names_col =
+    cudf::test::strings_column_wrapper{
+      names.begin(), names.end(), cudf::test::iterators::nulls_at({4, 5})}
+      .release();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(struct_col->view().child(0), expected_names_col->view());
 
   // For the `List` member, indices 4, 5 should be null.
-  auto expected_last_two_lists_col = cudf::test::lists_column_wrapper<TypeParam, int32_t>{
-    {
-      {1, 2, 3},
-      {4},
-      {5, 6},
-      {},
-      {7, 8},  // Null.
-      {9}      // Null.
-    },
-    cudf::detail::make_counting_transform_iterator(
-      0, [](auto i) { return i < 4; })}.release();
+  auto expected_last_two_lists_col =
+    cudf::test::lists_column_wrapper<TypeParam, int32_t>{{
+                                                           {1, 2, 3},
+                                                           {4},
+                                                           {5, 6},
+                                                           {},
+                                                           {7, 8},  // Null.
+                                                           {9}      // Null.
+                                                         },
+                                                         cudf::test::iterators::nulls_at({4, 5})}
+      .release();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(struct_col->view().child(1),
                                       expected_last_two_lists_col->view());
@@ -234,12 +235,9 @@ TYPED_TEST(TypedStructColumnWrapperTest, StructOfStructs)
   EXPECT_EQ(struct_2->view().child(1).size(), num_rows);
 
   // Verify that the child/grandchild columns are as expected.
-  auto expected_names_col =
-    cudf::test::strings_column_wrapper(
-      names.begin(),
-      names.end(),
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 0 && i != 4; }))
-      .release();
+  auto expected_names_col = cudf::test::strings_column_wrapper(
+                              names.begin(), names.end(), cudf::test::iterators::nulls_at({0, 4}))
+                              .release();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_names_col, struct_2->child(1).child(0));
 
@@ -314,12 +312,9 @@ TYPED_TEST(TypedStructColumnWrapperTest, TestNullMaskPropagationForNonNullStruct
 
   // Top-struct has 1 null (at index 0).
   // Bottom-level struct had no nulls, but must now report nulls
-  auto expected_names_col =
-    cudf::test::strings_column_wrapper(
-      names.begin(),
-      names.end(),
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 0; }))
-      .release();
+  auto expected_names_col = cudf::test::strings_column_wrapper(
+                              names.begin(), names.end(), cudf::test::iterators::null_at(0))
+                              .release();
 
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(*expected_names_col, struct_2->child(1).child(0));
 
@@ -472,9 +467,7 @@ TYPED_TEST(TypedStructColumnWrapperTest, StructOfListOfStruct)
 
   auto structs_col =
     structs_column_wrapper{
-      {ints_col},
-      cudf::detail::make_counting_transform_iterator(
-        0, [](auto i) { return i < 6; })  // Last 4 structs are null.
+      {ints_col}, cudf::test::iterators::nulls_at({6, 7, 8, 9})  // Last 4 structs are null.
     }
       .release();
 
@@ -587,12 +580,10 @@ TYPED_TEST(TypedStructColumnWrapperTest, CopyColumnFromView)
     fixed_width_column_wrapper<T, int32_t>{{0, 1, 2, 3, 4, 5}, {1, 1, 1, 1, 1, 0}};
 
   auto lists_column = lists_column_wrapper<T, int32_t>{
-    {{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 4; })};
+    {{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}}, iterators::null_at(4)};
 
-  auto structs_column = structs_column_wrapper{
-    {numeric_column, lists_column},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 3; })};
+  auto structs_column =
+    structs_column_wrapper{{numeric_column, lists_column}, iterators::null_at(3)};
 
   auto clone_structs_column = cudf::column(structs_column);
 


### PR DESCRIPTION
## Description
Changes some of the usages in `cpp/tests/` that use the `cudf::detail::make_counting_transform_iterator` to build validity iterators to use the equivalent `cudf::test::iterators` utilities. This is an attempt to minimize usage of `cudf::detail` utilities outside of libcudf.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
