### PR TITLE
Avoid storing all executor options in `StreamingSink`

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/io.py
@@ -363,23 +363,24 @@ def _(
 class StreamingSink(IR):
     """Sink a dataframe in streaming mode."""
 
-    __slots__ = ("executor_options", "sink")
-    _non_child = ("schema", "sink", "executor_options")
+    __slots__ = ("sink", "sink_to_directory")
+    _non_child = ("schema", "sink", "sink_to_directory")
     _n_non_child_args = 0
 
     sink: Sink
-    executor_options: StreamingExecutor
+    sink_to_directory: bool
 
     def __init__(
         self,
         schema: Schema,
         sink: Sink,
-        executor_options: StreamingExecutor,
         df: IR,
-    ):
+        *,
+        sink_to_directory: bool,
+    ) -> None:
         self.schema = schema
         self.sink = sink
-        self.executor_options = executor_options
+        self.sink_to_directory = sink_to_directory
         self._non_child_args = ()
         self.children = (df,)
 
@@ -407,11 +408,13 @@ def _(
             "please remove the target directory before calling 'collect'. "
         )
 
+    sink_to_directory = executor_options.sink_to_directory
+    assert sink_to_directory is not None  # set in StreamingExecutor.__post_init__
     new_node = StreamingSink(
         ir.schema,
         ir.reconstruct([child]),
-        executor_options,
         child,
+        sink_to_directory=sink_to_directory,
     )
     partition_info[new_node] = partition_info[child]
     return new_node, partition_info
@@ -621,7 +624,7 @@ def _(
     partition_info: MutableMapping[IR, PartitionInfo],
     context: IRExecutionContext,
 ) -> MutableMapping[Any, Any]:
-    if ir.executor_options.sink_to_directory:
+    if ir.sink_to_directory:
         return _directory_sink_graph(ir, partition_info, context=context)
     else:
         return _file_sink_graph(ir, partition_info, context=context)

--- a/python/cudf_polars/cudf_polars/experimental/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/io.py
@@ -374,10 +374,11 @@ class StreamingSink(IR):
         self,
         schema: Schema,
         sink: Sink,
+        sink_to_directory: bool,  # noqa: FBT001
         df: IR,
-        *,
-        sink_to_directory: bool,
     ) -> None:
+        # Order must match ``_non_child`` + ``children`` so :meth:`Node.__reduce__`
+        # / ``reconstruct`` round-trip over pickling (e.g. Dask workers).
         self.schema = schema
         self.sink = sink
         self.sink_to_directory = sink_to_directory
@@ -413,8 +414,8 @@ def _(
     new_node = StreamingSink(
         ir.schema,
         ir.reconstruct([child]),
+        sink_to_directory,
         child,
-        sink_to_directory=sink_to_directory,
     )
     partition_info[new_node] = partition_info[child]
     return new_node, partition_info

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/io.py
@@ -816,7 +816,7 @@ async def sink_node(
         count_width = math.ceil(math.log10(metadata.local_count))
         count_width = max(count_width, 6)
 
-        if ir.executor_options.sink_to_directory:
+        if ir.sink_to_directory:
             _prepare_sink_directory(ir.sink.path)
             i = 0
             while (msg := await ch_in.recv(context)) is not None:


### PR DESCRIPTION
## Description
We currently pass **all** executor options to every `StreamingSink` instance. This is a problem now that these options can include non-pickleable things (like a Dask/Ray context). Let's avoid doing this.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
