### PR TITLE
Update memory usage test

### DIFF
--- a/python/cudf/cudf/tests/dataframe/methods/test_memory_usage.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_memory_usage.py
@@ -51,8 +51,10 @@ def test_memory_usage(deep, index, set_index):
 
     gdf = cudf.from_pandas(df)
 
-    if index and set_index is None:
-        # Special Case: Assume RangeIndex size == 0
+    if index and isinstance(gdf.index, cudf.RangeIndex):
+        # cudf RangeIndex always reports 0 bytes (ignores deep).
+        # pandas may return non-zero (e.g. set_index on an arange column
+        # is optimised to a RangeIndex in pandas 3), so compare separately.
         with expect_warning_if(deep, UserWarning):
             assert gdf.index.memory_usage(deep=deep) == 0
 


### PR DESCRIPTION
## Description
This PR generalizes the RangeIndex guard from set_index is None (which only caught the default
  index) to isinstance(gdf.index, cudf.RangeIndex), which also catches the case where pandas optimizes a set_index("A") on an
  np.arange column back into a RangeIndex.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
