### PR TITLE
Fix deprecation warnings for set_as_build_table

### DIFF
--- a/cpp/src/join/filtered_join.cu
+++ b/cpp/src/join/filtered_join.cu
@@ -387,6 +387,8 @@ filtered_join::filtered_join(cudf::table_view const& build,
 {
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 filtered_join::filtered_join(cudf::table_view const& build,
                              null_equality compare_nulls,
                              set_as_build_table reuse_tbl,
@@ -405,6 +407,7 @@ filtered_join::filtered_join(cudf::table_view const& build,
   : filtered_join(build, compare_nulls, reuse_tbl, cudf::detail::CUCO_DESIRED_LOAD_FACTOR, stream)
 {
 }
+#pragma GCC diagnostic pop
 
 std::unique_ptr<rmm::device_uvector<size_type>> filtered_join::semi_join(
   cudf::table_view const& probe,


### PR DESCRIPTION
## Description
Fixes deprecation warnings introduced by https://github.com/rapidsai/cudf/pull/21982

```
[177+3+54=233] Building CUDA object CMakeFiles/cudf.dir/src/join/filtered_join.cu.o
/cudf/cpp/src/join/filtered_join.cu:394:7: warning: 'set_as_build_table' is deprecated: Use filtered_join constructors without set_as_build_table [-Wdeprecated-declarations]
  394 |                              rmm::cuda_stream_view stream)
      |       ^
/cudf/cpp/include/cudf/join/filtered_join.hpp:39:78: note: declared here
   39 | enum class [[deprecated(
      |                                                                              ^                 
/cudf/cpp/src/join/filtered_join.cu: In constructor 'cudf::filtered_join::filtered_join(const cudf::table_view&, cudf::null_equality, cudf::set_as_build_table, double, rmm::cuda_stream_view)':
/cudf/cpp/src/join/filtered_join.cu:397:109: warning: 'set_as_build_table' is deprecated: Use filtered_join constructors without set_as_build_table [-Wdeprecated-declarations]
  397 |   CUDF_EXPECTS(reuse_tbl == set_as_build_table::RIGHT,
      |                                                                                                             ^    
/cudf/cpp/include/cudf/join/filtered_join.hpp:39:78: note: declared here
   39 | enum class [[deprecated(
      |                                                                              ^                 
/cudf/cpp/src/join/filtered_join.cu: At global scope:
/cudf/cpp/src/join/filtered_join.cu:404:7: warning: 'set_as_build_table' is deprecated: Use filtered_join constructors without set_as_build_table [-Wdeprecated-declarations]
  404 |                              rmm::cuda_stream_view stream)
      |       ^
/cudf/cpp/include/cudf/join/filtered_join.hpp:39:78: note: declared here
   39 | enum class [[deprecated(
      |                                                                              ^                 
/cudf/cpp/src/join/filtered_join.cu: In constructor 'cudf::filtered_join::filtered_join(const cudf::table_view&, cudf::null_equality, cudf::set_as_build_table, rmm::cuda_stream_view)':
/cudf/cpp/src/join/filtered_join.cu:404:104: warning: 'cudf::filtered_join::filtered_join(const cudf::table_view&, cudf::null_equality, cudf::set_as_build_table, double, rmm::cuda_stream_view)' is deprecated: Use the constructor without set_as_build_table [-Wdeprecated-declarations]
  404 |                              rmm::cuda_stream_view stream)
      |                                                                                                        ^
/cudf/cpp/src/join/filtered_join.cu:390:1: note: declared here
  390 | filtered_join::filtered_join(cudf::table_view const& build,
      | ^~~~~~~~~~~~~

```

The pragma workaround should be removed once the `set_as_build_table` is officially deleted.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
