### PR TITLE
Fix unsanitized nulls from strings_column_wrapper inputs in gtests

### DIFF
--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -662,8 +662,7 @@ TYPED_TEST(TransformTest, StringScalarComparison)
 {
   using Executor = TypeParam;
 
-  auto c_0 =
-    cudf::test::strings_column_wrapper({"1", "12", "123", "23"}, {true, true, false, true});
+  auto c_0   = cudf::test::strings_column_wrapper({"1", "12", "", "23"}, {true, true, false, true});
   auto table = cudf::table_view{{c_0}};
 
   auto literal_value = cudf::string_scalar("2");

--- a/cpp/tests/copying/get_value_tests.cpp
+++ b/cpp/tests/copying/get_value_tests.cpp
@@ -96,7 +96,7 @@ TEST_F(StringGetValueTest, GetEmpty)
 
 TEST_F(StringGetValueTest, GetFromNullable)
 {
-  cudf::test::strings_column_wrapper col({"this", "is", "a", "test"}, {false, true, false, true});
+  cudf::test::strings_column_wrapper col({"", "is", "", "test"}, {false, true, false, true});
   auto s = cudf::get_element(col, 1);
 
   auto typed_s = static_cast<cudf::string_scalar const*>(s.get());
@@ -107,7 +107,7 @@ TEST_F(StringGetValueTest, GetFromNullable)
 
 TEST_F(StringGetValueTest, GetNull)
 {
-  cudf::test::strings_column_wrapper col({"this", "is", "a", "test"}, {false, true, false, true});
+  cudf::test::strings_column_wrapper col({"", "is", "", "test"}, {false, true, false, true});
   auto s = cudf::get_element(col, 2);
 
   EXPECT_FALSE(s->is_valid());
@@ -341,7 +341,7 @@ TEST_F(ListGetStringValueTest, NonNestedGetNonNullNonEmpty)
   using LCW = cudf::test::lists_column_wrapper<cudf::string_view>;
 
   LCW col{LCW({"aaa", "Héllo"}, this->odds_valid()), LCW{}, LCW{""}, LCW{"42"}};
-  cudf::test::strings_column_wrapper expected_data({"aaa", "Héllo"}, this->odds_valid());
+  cudf::test::strings_column_wrapper expected_data({"", "Héllo"}, this->odds_valid());
   cudf::size_type index = 0;
 
   auto s       = cudf::get_element(col, index);
@@ -549,7 +549,7 @@ struct ListGetStructValueTest : public cudf::test::BaseFixture {
   {
     // {int: 1, string: NULL, list: NULL}
     return this->make_test_structs_column({{1}, {1}},
-                                          cudf::test::strings_column_wrapper({"aa"}, {false}),
+                                          cudf::test::strings_column_wrapper({""}, {false}),
                                           LCWinner_t({{}}, all_nulls()),
                                           no_nulls());
   }
@@ -824,7 +824,7 @@ TYPED_TEST(StructGetValueTestTyped, mixed_types_valid_with_nulls)
 
   // col fields
   cudf::test::fixed_width_column_wrapper<TypeParam> f1({1, 2, 3}, {true, false, true});
-  cudf::test::strings_column_wrapper f2({"aa", "bbb", "c"}, {false, false, true});
+  cudf::test::strings_column_wrapper f2({"", "", "c"}, {false, false, true});
   cudf::test::dictionary_column_wrapper<TypeParam, uint32_t> f3(
     {42, 42, 24}, validity_mask_t{true, true, true}.begin());
   LCW f4({LCW{8, 8, 8}, LCW{9, 9}, LCW{10}}, validity_mask_t{false, false, false}.begin());

--- a/cpp/tests/copying/scatter_list_tests.cpp
+++ b/cpp/tests/copying/scatter_list_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -220,9 +220,9 @@ TEST_F(ScatterListsTest, ListsOfStrings)
 
 TEST_F(ScatterListsTest, ListsOfNullableStrings)
 {
-  auto src_strings_column = cudf::test::strings_column_wrapper{
-    {"all", "the", "leaves", "are", "brown", "california", "dreaming"},
-    {true, true, true, false, true, false, true}};
+  auto src_strings_column =
+    cudf::test::strings_column_wrapper{{"all", "the", "leaves", "", "brown", "", "dreaming"},
+                                       {true, true, true, false, true, false, true}};
 
   auto src_list_column = cudf::make_lists_column(
     2,
@@ -245,14 +245,14 @@ TEST_F(ScatterListsTest, ListsOfNullableStrings)
                            cudf::table_view({target_list_column}));
 
   auto expected_strings = cudf::test::strings_column_wrapper{
-    {"california",
+    {"",
      "dreaming",
      "one",
      "one",
      "all",
      "the",
      "leaves",
-     "are",
+     "",
      "brown",
      "three",
      "three",
@@ -274,9 +274,9 @@ TEST_F(ScatterListsTest, ListsOfNullableStrings)
 
 TEST_F(ScatterListsTest, EmptyListsOfNullableStrings)
 {
-  auto src_strings_column = cudf::test::strings_column_wrapper{
-    {"all", "the", "leaves", "are", "brown", "california", "dreaming"},
-    {true, true, true, false, true, false, true}};
+  auto src_strings_column =
+    cudf::test::strings_column_wrapper{{"all", "the", "leaves", "", "brown", "", "dreaming"},
+                                       {true, true, true, false, true, false, true}};
 
   auto src_list_column = cudf::make_lists_column(
     3,
@@ -299,14 +299,14 @@ TEST_F(ScatterListsTest, EmptyListsOfNullableStrings)
                            cudf::table_view({target_list_column}));
 
   auto expected_strings = cudf::test::strings_column_wrapper{
-    {"california",
+    {"",
      "dreaming",
      "one",
      "one",
      "all",
      "the",
      "leaves",
-     "are",
+     "",
      "brown",
      "three",
      "three",
@@ -326,9 +326,9 @@ TEST_F(ScatterListsTest, EmptyListsOfNullableStrings)
 
 TEST_F(ScatterListsTest, NullableListsOfNullableStrings)
 {
-  auto src_strings_column = cudf::test::strings_column_wrapper{
-    {"all", "the", "leaves", "are", "brown", "california", "dreaming"},
-    {true, true, true, false, true, false, true}};
+  auto src_strings_column =
+    cudf::test::strings_column_wrapper{{"all", "the", "leaves", "", "brown", "", "dreaming"},
+                                       {true, true, true, false, true, false, true}};
 
   auto src_validity =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 1; });
@@ -354,14 +354,14 @@ TEST_F(ScatterListsTest, NullableListsOfNullableStrings)
                            cudf::table_view({target_list_column}));
 
   auto expected_strings = cudf::test::strings_column_wrapper{
-    {"california",
+    {"",
      "dreaming",
      "one",
      "one",
      "all",
      "the",
      "leaves",
-     "are",
+     "",
      "brown",
      "three",
      "three",
@@ -574,7 +574,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
   auto source_strings = cudf::test::strings_column_wrapper{
     {
       "nine",  "nine",  "nine", "nine",
-      "eight", "eight", "eight"
+      "eight", "", "eight"
     },
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 5; })
   };
@@ -632,7 +632,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
 
   auto expected_strings = cudf::test::strings_column_wrapper{
     {
-      "eight", "eight", "eight",
+      "eight", "", "eight",
       "one",   "one",
       "nine",  "nine",  "nine", "nine",
       "three", "three",
@@ -651,7 +651,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }
 
-TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
+TYPED_TEST(TypedScatterListsTest, ListsOfNullgitStructs)
 {
   using T               = TypeParam;
   using offsets_column  = cudf::test::fixed_width_column_wrapper<cudf::size_type>;
@@ -669,7 +669,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
   auto source_strings = cudf::test::strings_column_wrapper{
     {
       "nine",  "nine",  "nine", "nine",
-      "eight", "eight", "eight"
+      "eight", "", "eight"
     },
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 5; })
   };
@@ -728,9 +728,9 @@ TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
 
   auto expected_strings = cudf::test::strings_column_wrapper{
     {
-      "eight", "eight", "eight",
+      "eight", "", "eight",
       "one",   "one",
-      "nine",  "nine",  "nine", "nine",
+      "nine",  "",  "nine", "nine",
       "three", "three",
       "four",  "four",
       "five",  "five"
@@ -767,7 +767,7 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
   auto source_strings = cudf::test::strings_column_wrapper{
     {
       "nine",  "nine",  "nine", "nine",
-      "eight", "eight", "eight"
+      "eight", "", "eight"
     },
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 5; })
   };
@@ -825,9 +825,9 @@ TYPED_TEST(TypedScatterListsTest, EmptyListsOfStructs)
 
   auto expected_strings = cudf::test::strings_column_wrapper{
     {
-      "eight", "eight", "eight",
+      "eight", "", "eight",
       "one",   "one",
-      "nine",  "nine",  "nine", "nine",
+      "nine",  "",  "nine", "nine",
       "three", "three",
       "five",  "five"
     },
@@ -863,7 +863,7 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
   auto source_strings = cudf::test::strings_column_wrapper{
     {
       "nine",  "nine",  "nine", "nine",
-      "eight", "eight", "eight"
+      "eight", "", "eight"
     },
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i != 5; })
   };
@@ -928,9 +928,9 @@ TYPED_TEST(TypedScatterListsTest, NullListsOfStructs)
 
   auto expected_strings = cudf::test::strings_column_wrapper{
     {
-      "eight", "eight", "eight",
+      "eight", "", "eight",
       "one",   "one",
-      "nine",  "nine",  "nine", "nine",
+      "nine",  "",  "nine", "nine",
       "three", "three",
       "five",  "five"
     },

--- a/cpp/tests/copying/scatter_list_tests.cpp
+++ b/cpp/tests/copying/scatter_list_tests.cpp
@@ -651,7 +651,7 @@ TYPED_TEST(TypedScatterListsTest, ListsOfStructsWithNullMembers)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(expected_lists->view(), scatter_result->get_column(0));
 }
 
-TYPED_TEST(TypedScatterListsTest, ListsOfNullgitStructs)
+TYPED_TEST(TypedScatterListsTest, ListsOfNullStructs)
 {
   using T               = TypeParam;
   using offsets_column  = cudf::test::fixed_width_column_wrapper<cudf::size_type>;

--- a/cpp/tests/copying/scatter_tests.cpp
+++ b/cpp/tests/copying/scatter_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -512,12 +512,12 @@ TYPED_TEST(BooleanMaskScatter, WithNull)
 {
   using T = TypeParam;
   cudf::test::fixed_width_column_wrapper<T, int32_t> source_col1({1, 5, 6, 8, 9}, {1, 0, 1, 0, 1});
-  cudf::test::strings_column_wrapper source_col2({"This", "is", "cudf", "test", "column"},
+  cudf::test::strings_column_wrapper source_col2({"This", "", "", "test", ""},
                                                  {true, false, false, true, false});
   cudf::test::fixed_width_column_wrapper<T, int32_t> target_col1({2, 2, 3, 4, 11, 12, 7, 7, 10, 10},
                                                                  {1, 1, 0, 1, 1, 1, 1, 1, 1, 0});
   cudf::test::strings_column_wrapper target_col2(
-    {"a", "bc", "cd", "ef", "gh", "ij", "jk", "lm", "no", "pq"},
+    {"a", "bc", "", "ef", "gh", "ij", "jk", "lm", "no", ""},
     {true, true, false, true, true, true, true, true, true, false});
   cudf::test::fixed_width_column_wrapper<bool> mask(
     {true, false, false, false, true, true, false, true, true, false});
@@ -525,7 +525,7 @@ TYPED_TEST(BooleanMaskScatter, WithNull)
   cudf::test::fixed_width_column_wrapper<T, int32_t> expected_col1({1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
                                                                    {1, 1, 0, 1, 0, 1, 1, 0, 1, 0});
   cudf::test::strings_column_wrapper expected_col2(
-    {"This", "bc", "cd", "ef", "is", "cudf", "jk", "test", "column", "pq"},
+    {"This", "bc", "", "ef", "", "", "jk", "test", "", ""},
     {true, true, false, true, false, false, true, true, false, false});
   auto source_table   = cudf::table_view({source_col1, source_col2});
   auto target_table   = cudf::table_view({target_col1, target_col2});
@@ -556,12 +556,12 @@ TEST_F(BooleanMaskScatterString, NoNUll)
 
 TEST_F(BooleanMaskScatterString, WithNUll)
 {
-  cudf::test::strings_column_wrapper source({"This", "cudf"}, {false, true});
-  cudf::test::strings_column_wrapper target({"is", "is", "a", "udf", "api"},
+  cudf::test::strings_column_wrapper source({"", "cudf"}, {false, true});
+  cudf::test::strings_column_wrapper target({"is", "", "", "udf", "api"},
                                             {true, false, false, true, true});
   cudf::test::fixed_width_column_wrapper<bool> mask({true, false, false, true, false});
 
-  cudf::test::strings_column_wrapper expected({"This", "is", "a", "cudf", "api"},
+  cudf::test::strings_column_wrapper expected({"", "", "", "cudf", "api"},
                                               {false, false, false, true, true});
   auto source_table   = cudf::table_view({source});
   auto target_table   = cudf::table_view({target});
@@ -693,7 +693,7 @@ TYPED_TEST(BooleanMaskScalarScatter, WithNull)
   cudf::test::fixed_width_column_wrapper<T, int32_t> target_col1({2, 2, 3, 4, 11, 12, 7, 7, 10, 10},
                                                                  {1, 1, 0, 1, 1, 1, 1, 1, 1, 0});
   cudf::test::strings_column_wrapper target_col2(
-    {"a", "bc", "cd", "ef", "gh", "ij", "jk", "lm", "no", "pq"},
+    {"a", "bc", "", "ef", "gh", "ij", "jk", "lm", "no", ""},
     {true, true, false, true, true, true, true, true, true, false});
   cudf::test::fixed_width_column_wrapper<bool> mask(
     {true, false, false, false, true, true, false, true, true, false});
@@ -701,7 +701,7 @@ TYPED_TEST(BooleanMaskScalarScatter, WithNull)
   cudf::test::fixed_width_column_wrapper<T, int32_t> expected_col1(
     {11, 2, 3, 4, 11, 11, 7, 11, 11, 10}, {0, 1, 0, 1, 0, 0, 1, 0, 0, 0});
   cudf::test::strings_column_wrapper expected_col2(
-    {"cudf", "bc", "cd", "ef", "cudf", "cudf", "jk", "cudf", "cudf", "pq"},
+    {"cudf", "bc", "", "ef", "cudf", "cudf", "jk", "cudf", "cudf", ""},
     {true, true, false, true, true, true, true, true, true, false});
   auto target_table   = cudf::table_view({target_col1, target_col2});
   auto expected_table = cudf::table_view({expected_col1, expected_col2});
@@ -738,11 +738,11 @@ TEST_F(BooleanMaskScatterScalarString, WithNUll)
   scalar->set_valid_async(true);
   std::vector<std::reference_wrapper<const cudf::scalar>> scalar_vect;
   scalar_vect.emplace_back(*scalar);
-  cudf::test::strings_column_wrapper target({"is", "is", "a", "udf", "api"},
+  cudf::test::strings_column_wrapper target({"is", "", "", "udf", "api"},
                                             {true, false, false, true, true});
   cudf::test::fixed_width_column_wrapper<bool> mask({true, false, true, true, false});
 
-  cudf::test::strings_column_wrapper expected({"cudf", "is", "cudf", "cudf", "api"},
+  cudf::test::strings_column_wrapper expected({"cudf", "", "cudf", "cudf", "api"},
                                               {true, false, true, true, true});
   auto target_table   = cudf::table_view({target});
   auto expected_table = cudf::table_view({expected});

--- a/cpp/tests/encode/encode_tests.cpp
+++ b/cpp/tests/encode/encode_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf_test/base_fixture.hpp>
@@ -88,9 +88,9 @@ TEST_F(EncodeStringTest, SimpleNoNulls)
 
 TEST_F(EncodeStringTest, SimpleWithNulls)
 {
-  cudf::test::strings_column_wrapper input{{"a", "b", "c", "d", "a"}, {1, 0, 1, 1, 0}};
+  cudf::test::strings_column_wrapper input{{"a", "", "c", "d", ""}, {1, 0, 1, 1, 0}};
   cudf::test::fixed_width_column_wrapper<cudf::size_type> expect{0, 3, 1, 2, 3};
-  cudf::test::strings_column_wrapper expect_keys{{"a", "c", "d", "0"}, {1, 1, 1, 0}};
+  cudf::test::strings_column_wrapper expect_keys{{"a", "c", "d", ""}, {1, 1, 1, 0}};
   auto const result = cudf::encode(cudf::table_view({input}));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.first->view().column(0), expect_keys);
@@ -99,9 +99,9 @@ TEST_F(EncodeStringTest, SimpleWithNulls)
 
 TEST_F(EncodeStringTest, UnorderedWithNulls)
 {
-  cudf::test::strings_column_wrapper input{{"ef", "a", "c", "d", "ef", "a"}, {1, 0, 1, 1, 0, 1}};
+  cudf::test::strings_column_wrapper input{{"ef", "", "c", "d", "", "a"}, {1, 0, 1, 1, 0, 1}};
   cudf::test::fixed_width_column_wrapper<cudf::size_type> expect{3, 4, 1, 2, 4, 0};
-  cudf::test::strings_column_wrapper expect_keys{{"a", "c", "d", "ef", "0"}, {1, 1, 1, 1, 0}};
+  cudf::test::strings_column_wrapper expect_keys{{"a", "c", "d", "ef", ""}, {1, 1, 1, 1, 0}};
   auto const result = cudf::encode(cudf::table_view({input}));
 
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.first->view().column(0), expect_keys);

--- a/cpp/tests/groupby/argmax_tests.cpp
+++ b/cpp/tests/groupby/argmax_tests.cpp
@@ -130,7 +130,7 @@ TEST_F(groupby_argmax_string_test, zero_valid_values)
   using R = cudf::size_type;
 
   cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
-  cudf::test::strings_column_wrapper vals({"año", "bit", "₹1"}, cudf::test::iterators::all_nulls());
+  cudf::test::strings_column_wrapper vals({"", "", ""}, cudf::test::iterators::all_nulls());
 
   cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
   cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, cudf::test::iterators::all_nulls());

--- a/cpp/tests/groupby/argmin_tests.cpp
+++ b/cpp/tests/groupby/argmin_tests.cpp
@@ -131,7 +131,7 @@ TEST_F(groupby_argmin_string_test, zero_valid_values)
   using R = cudf::size_type;
 
   cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
-  cudf::test::strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
+  cudf::test::strings_column_wrapper vals({"", "", ""}, all_nulls());
 
   cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
   cudf::test::fixed_width_column_wrapper<R> expect_vals({0}, all_nulls());

--- a/cpp/tests/groupby/max_tests.cpp
+++ b/cpp/tests/groupby/max_tests.cpp
@@ -143,7 +143,7 @@ TEST_F(groupby_max_string_test, basic)
 TEST_F(groupby_max_string_test, zero_valid_values)
 {
   cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
-  cudf::test::strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
+  cudf::test::strings_column_wrapper vals({"", "", ""}, all_nulls());
 
   cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
   cudf::test::strings_column_wrapper expect_vals({""}, all_nulls());

--- a/cpp/tests/groupby/min_tests.cpp
+++ b/cpp/tests/groupby/min_tests.cpp
@@ -139,7 +139,7 @@ TEST_F(groupby_min_string_test, basic)
 TEST_F(groupby_min_string_test, zero_valid_values)
 {
   cudf::test::fixed_width_column_wrapper<K> keys{1, 1, 1};
-  cudf::test::strings_column_wrapper vals({"año", "bit", "₹1"}, all_nulls());
+  cudf::test::strings_column_wrapper vals({"", "", ""}, all_nulls());
 
   cudf::test::fixed_width_column_wrapper<K> expect_keys{1};
   cudf::test::strings_column_wrapper expect_vals({""}, all_nulls());

--- a/cpp/tests/groupby/structs_tests.cpp
+++ b/cpp/tests/groupby/structs_tests.cpp
@@ -127,7 +127,7 @@ TYPED_TEST(groupby_structs_test, structs_with_null_rows)
   auto expected_values   = fwcw<R> {    6,   19,   17,      3  };
   auto expected_member_0 = fwcw<M0>{ {  1,    2,    3,   null  }, null_at(3)};
   auto expected_member_1 = fwcw<M1>{ { 11,   22,   33,   null  }, null_at(3)};
-  auto expected_member_2 = cudf::test::strings_column_wrapper { {"11", "22", "33", "null" }, null_at(3)};
+  auto expected_member_2 = cudf::test::strings_column_wrapper { {"11", "22", "33", "" }, null_at(3)};
   auto expected_keys     = cudf::test::structs_column_wrapper{{expected_member_0, expected_member_1, expected_member_2}, null_at(3)};
   // clang-format on
 
@@ -157,7 +157,7 @@ TYPED_TEST(groupby_structs_test, structs_with_nulls_in_rows_and_members)
   auto expected_values   = fwcw<R> {    9,   14,    10,     7,     1,      4  };
   auto expected_member_0 = fwcw<M0>{{   1,    2,     3,     3,  null,   null  }, nulls_at({4,5})};
   auto expected_member_1 = fwcw<M1>{{  11,   22,    33,  null,    22,   null  }, nulls_at({3,5})};
-  auto expected_member_2 = cudf::test::strings_column_wrapper {{ "11", "22",  "33",  "33",  "22", "null" }, null_at(5)};
+  auto expected_member_2 = cudf::test::strings_column_wrapper {{ "11", "22",  "33",  "33",  "22", "" }, null_at(5)};
   auto expected_keys     = cudf::test::structs_column_wrapper{{expected_member_0, expected_member_1, expected_member_2}, null_at(5)};
   // clang-format on
 
@@ -192,7 +192,7 @@ TYPED_TEST(groupby_structs_test, null_members_differ_from_null_structs)
   auto expected_values   = fwcw<R> {    9,   14,    17,      1,      4  };
   auto expected_member_0 = fwcw<M0>{ {  1,    2,     3,   null,   null  }, nulls_at({3,4})};
   auto expected_member_1 = fwcw<M1>{ { 11,   22,    33,   null,   null  }, nulls_at({3,4})};
-  auto expected_member_2 = cudf::test::strings_column_wrapper { {"11", "22",  "33", "null", "null" }, nulls_at({3,4})};
+  auto expected_member_2 = cudf::test::strings_column_wrapper { {"11", "22",  "33", "", "" }, nulls_at({3,4})};
   auto expected_keys     = cudf::test::structs_column_wrapper{{expected_member_0, expected_member_1, expected_member_2}, null_at(4)};
   // clang-format on
 
@@ -210,7 +210,7 @@ TYPED_TEST(groupby_structs_test, structs_of_structs)
   auto values            = fwcw<V> {    0,      1,    2,    3,    4,    5,    6,    7,    8,    9 };
   auto struct_0_member_0 = fwcw<M0>{{   1,   null,    3,    1,    2,    2,    1,    3,    3,    2 }, null_at(1)};
   auto struct_0_member_1 = fwcw<M1>{{  11,   null,   33,   11,   22,   22,   11,   33,   33,   22 }, null_at(1)};
-  auto struct_0_member_2 = cudf::test::strings_column_wrapper {{ "11", "null", "33", "11", "22", "22", "11", "33", "33", "22"}, null_at(1)};
+  auto struct_0_member_2 = cudf::test::strings_column_wrapper {{ "11", "", "33", "11", "22", "22", "11", "33", "33", "22"}, null_at(1)};
   // clang-format on
 
   auto struct_0 = cudf::test::structs_column_wrapper{
@@ -226,7 +226,7 @@ TYPED_TEST(groupby_structs_test, structs_of_structs)
   auto expected_values            = fwcw<R> {    9,   14,    17,      1,      4  };
   auto expected_member_0          = fwcw<M0>{ {  1,    2,     3,   null,   null  }, nulls_at({3,4})};
   auto expected_member_1          = fwcw<M1>{ { 11,   22,    33,   null,   null  }, nulls_at({3,4})};
-  auto expected_member_2          = cudf::test::strings_column_wrapper { {"11", "22",  "33", "null", "null" }, nulls_at({3,4})};
+  auto expected_member_2          = cudf::test::strings_column_wrapper { {"11", "22",  "33", "", "" }, nulls_at({3,4})};
   auto expected_structs           = cudf::test::structs_column_wrapper{{expected_member_0, expected_member_1, expected_member_2}, null_at(4)};
   auto expected_struct_1_member_1 = fwcw<M1>{    8,    7,     6,      9,      0  };
   auto expected_keys              = cudf::test::structs_column_wrapper{{expected_structs, expected_struct_1_member_1}};
@@ -276,7 +276,7 @@ TYPED_TEST(groupby_structs_test, all_null_input)
   auto expected_values   = fwcw<R> {    45 };
   auto expected_member_0 = fwcw<M0>{ null };
   auto expected_member_1 = fwcw<M1>{ null };
-  auto expected_member_2 = cudf::test::strings_column_wrapper {"null"};
+  auto expected_member_2 = cudf::test::strings_column_wrapper {""};
   auto expected_keys     = cudf::test::structs_column_wrapper{{expected_member_0, expected_member_1, expected_member_2}, all_nulls()};
   // clang-format on
 

--- a/cpp/tests/interop/from_arrow_device_test.cpp
+++ b/cpp/tests/interop/from_arrow_device_test.cpp
@@ -253,8 +253,7 @@ TEST_F(FromArrowDeviceTest, StructColumn)
     cudf::test::strings_column_wrapper{
       "Samuel Vimes", "Carrot Ironfoundersson", "Angua von Überwald"}
       .release();
-  auto str_col2 =
-    cudf::test::strings_column_wrapper{{"CUDF", "ROCKS", "EVERYWHERE"}, {0, 1, 0}}.release();
+  auto str_col2 = cudf::test::strings_column_wrapper{{"", "ROCKS", ""}, {0, 1, 0}}.release();
   int num_rows{str_col->size()};
   auto int_col = cudf::test::fixed_width_column_wrapper<int32_t, int32_t>{{48, 27, 25}}.release();
   auto int_col2 =

--- a/cpp/tests/interop/from_arrow_test.cpp
+++ b/cpp/tests/interop/from_arrow_test.cpp
@@ -237,8 +237,7 @@ TEST_F(FromArrowTest, StructColumn)
       "Samuel Vimes", "Carrot Ironfoundersson", "Angua von Überwald"}
       .release();
   auto str_col2 =
-    cudf::test::strings_column_wrapper{{"CUDF", "ROCKS", "EVERYWHERE"}, {false, true, false}}
-      .release();
+    cudf::test::strings_column_wrapper{{"", "ROCKS", ""}, {false, true, false}}.release();
   int num_rows{str_col->size()};
   auto int_col = cudf::test::fixed_width_column_wrapper<int32_t, int32_t>{{48, 27, 25}}.release();
   auto int_col2 =

--- a/cpp/tests/io/cudftable_test.cpp
+++ b/cpp/tests/io/cudftable_test.cpp
@@ -129,7 +129,7 @@ TEST_F(CudftableTest, MultiColumnCompound)
 
   cudf::test::fixed_width_column_wrapper<int32_t> struct_col1{{1, 2, 3, 4},
                                                               {true, false, true, true}};
-  cudf::test::strings_column_wrapper struct_col2{{"a", "b", "c", "d"}, {true, true, false, true}};
+  cudf::test::strings_column_wrapper struct_col2{{"a", "b", "", "d"}, {true, true, false, true}};
   cudf::test::structs_column_wrapper struct_col{{struct_col1, struct_col2},
                                                 {true, true, true, false}};
 

--- a/cpp/tests/json/json_tests.cpp
+++ b/cpp/tests/json/json_tests.cpp
@@ -443,7 +443,7 @@ TEST_F(JsonPathTests, GetJsonObjectNullInputs)
 {
   {
     std::string str(R"({"a" : "b"})");
-    cudf::test::strings_column_wrapper input({str, str, str, str}, {true, false, true, false});
+    cudf::test::strings_column_wrapper input({str, "", str, ""}, {true, false, true, false});
 
     std::string_view json_path("$.a");
     auto result_raw = cudf::get_json_object(cudf::strings_column_view(input), json_path);

--- a/cpp/tests/merge/merge_test.cpp
+++ b/cpp/tests/merge/merge_test.cpp
@@ -720,16 +720,14 @@ TEST_F(MergeTest, KeysWithNulls)
 
 TEST_F(MergeTest, Structs)
 {
-  // clang-format off
-
   cudf::test::fixed_width_column_wrapper<int> t0_col0{0, 2, 4, 6, 8};
-    cudf::test::strings_column_wrapper t0_scol0{"abc", "def", "ghi", "jkl", "mno"};
-    cudf::test::fixed_width_column_wrapper<float> t0_scol1{1, 2, 3, 4, 5};
+  cudf::test::strings_column_wrapper t0_scol0{"abc", "def", "ghi", "jkl", "mno"};
+  cudf::test::fixed_width_column_wrapper<float> t0_scol1{1, 2, 3, 4, 5};
   cudf::test::structs_column_wrapper t0_col1({t0_scol0, t0_scol1});
 
   cudf::test::fixed_width_column_wrapper<int> t1_col0{1, 3, 5, 7, 9};
-    cudf::test::strings_column_wrapper t1_scol0{"pqr", "stu", "vwx", "yzz", "000"};
-    cudf::test::fixed_width_column_wrapper<float> t1_scol1{-1, -2, -3, -4, -5};
+  cudf::test::strings_column_wrapper t1_scol0{"pqr", "stu", "vwx", "yzz", "000"};
+  cudf::test::fixed_width_column_wrapper<float> t1_scol1{-1, -2, -3, -4, -5};
   cudf::test::structs_column_wrapper t1_col1({t1_scol0, t1_scol1});
 
   cudf::table_view t0({t0_col0, t0_col1});
@@ -738,29 +736,26 @@ TEST_F(MergeTest, Structs)
   auto result = cudf::merge({t0, t1}, {0}, {cudf::order::ASCENDING});
 
   cudf::test::fixed_width_column_wrapper<int> e_col0{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    cudf::test::strings_column_wrapper e_scol0{"abc", "pqr", "def", "stu", "ghi", "vwx", "jkl", "yzz", "mno", "000"};
-    cudf::test::fixed_width_column_wrapper<float> e_scol1{1, -1, 2, -2, 3, -3, 4, -4, 5, -5};
+  cudf::test::strings_column_wrapper e_scol0{
+    "abc", "pqr", "def", "stu", "ghi", "vwx", "jkl", "yzz", "mno", "000"};
+  cudf::test::fixed_width_column_wrapper<float> e_scol1{1, -1, 2, -2, 3, -3, 4, -4, 5, -5};
   cudf::test::structs_column_wrapper e_col1({e_scol0, e_scol1});
 
   cudf::table_view expected({e_col0, e_col1});
 
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected, *result);
-
-  // clang-format on
 }
 
 TEST_F(MergeTest, StructsWithNulls)
 {
-  // clang-format off
-
   cudf::test::fixed_width_column_wrapper<int> t0_col0{0, 2, 4, 6, 8};
-    cudf::test::strings_column_wrapper t0_scol0{{"abc", "def", "ghi", "jkl", "mno"}, {1, 1, 0, 0, 1}};
-    cudf::test::fixed_width_column_wrapper<float> t0_scol1{{1, 2, 3, 4, 5}, {0, 1, 0, 0, 1}};
+  cudf::test::strings_column_wrapper t0_scol0{{"abc", "def", "", "", "mno"}, {1, 1, 0, 0, 1}};
+  cudf::test::fixed_width_column_wrapper<float> t0_scol1{{1, 2, 3, 4, 5}, {0, 1, 0, 0, 1}};
   cudf::test::structs_column_wrapper t0_col1({t0_scol0, t0_scol1}, {1, 0, 1, 0, 0});
 
   cudf::test::fixed_width_column_wrapper<int> t1_col0{1, 3, 5, 7, 9};
-    cudf::test::strings_column_wrapper t1_scol0{"pqr", "stu", "vwx", "yzz", "000"};
-    cudf::test::fixed_width_column_wrapper<float> t1_scol1{{-1, -2, -3, -4, -5}, {1, 1, 1, 0, 0}};
+  cudf::test::strings_column_wrapper t1_scol0{"pqr", "stu", "vwx", "yzz", "000"};
+  cudf::test::fixed_width_column_wrapper<float> t1_scol1{{-1, -2, -3, -4, -5}, {1, 1, 1, 0, 0}};
   cudf::test::structs_column_wrapper t1_col1({t1_scol0, t1_scol1}, {1, 1, 1, 1, 0});
 
   cudf::table_view t0({t0_col0, t0_col1});
@@ -769,99 +764,96 @@ TEST_F(MergeTest, StructsWithNulls)
   auto result = cudf::merge({t0, t1}, {0}, {cudf::order::ASCENDING});
 
   cudf::test::fixed_width_column_wrapper<int> e_col0{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    cudf::test::strings_column_wrapper e_scol0{{"abc", "pqr", "def", "stu", "ghi", "vwx", "jkl", "yzz", "mno", "000"},
-                                               {1,     1,     0,      1,    0,     1,     0,     1,     0,     1}};
-    cudf::test::fixed_width_column_wrapper<float> e_scol1{{1, -1, 2, -2, 3, -3, 4, -4, 5, -5},
-                                                          {0,  1, 0,  1, 0,  1, 0,  0, 0,  0}};
+  cudf::test::strings_column_wrapper e_scol0{
+    {"abc", "pqr", "", "stu", "", "vwx", "", "yzz", "", "000"}, {1, 1, 0, 1, 0, 1, 0, 1, 0, 1}};
+  cudf::test::fixed_width_column_wrapper<float> e_scol1{{1, -1, 2, -2, 3, -3, 4, -4, 5, -5},
+                                                        {0, 1, 0, 1, 0, 1, 0, 0, 0, 0}};
   cudf::test::structs_column_wrapper e_col1({e_scol0, e_scol1}, {1, 1, 0, 1, 1, 1, 0, 1, 0, 0});
 
   cudf::table_view expected({e_col0, e_col1});
 
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected, *result);
-
-  // clang-format on
 }
 
 TEST_F(MergeTest, StructsNested)
 {
-  // clang-format off
-
   cudf::test::fixed_width_column_wrapper<int> t0_col0{8, 6, 4, 2, 0};
-    cudf::test::strings_column_wrapper t0_scol0{"mno", "jkl", "ghi", "def", "abc"};
-    cudf::test::fixed_width_column_wrapper<float> t0_scol1{5, 4, 3, 2, 1};
-      cudf::test::strings_column_wrapper t0_sscol0{"5555", "4444", "333", "22", "1"};
-      cudf::test::fixed_width_column_wrapper<float> t0_sscol1{50, 40, 30, 20, 10};
-    cudf::test::structs_column_wrapper t0_scol2({t0_sscol0, t0_sscol1});
+  cudf::test::strings_column_wrapper t0_scol0{"mno", "jkl", "ghi", "def", "abc"};
+  cudf::test::fixed_width_column_wrapper<float> t0_scol1{5, 4, 3, 2, 1};
+  cudf::test::strings_column_wrapper t0_sscol0{"5555", "4444", "333", "22", "1"};
+  cudf::test::fixed_width_column_wrapper<float> t0_sscol1{50, 40, 30, 20, 10};
+  cudf::test::structs_column_wrapper t0_scol2({t0_sscol0, t0_sscol1});
   cudf::test::structs_column_wrapper t0_col1({t0_scol0, t0_scol1, t0_scol2});
 
   cudf::test::fixed_width_column_wrapper<int> t1_col0{9, 7, 5, 3, 1};
-    cudf::test::strings_column_wrapper t1_scol0{"000", "yzz", "vwx", "stu", "pqr"};
-    cudf::test::fixed_width_column_wrapper<float> t1_scol1{-5, -4, -3, -2, -1};
-      cudf::test::strings_column_wrapper t1_sscol0{"-5555", "-4444", "-333", "-22", "-1"};
-      cudf::test::fixed_width_column_wrapper<float> t1_sscol1{-50, -40, -30, -20, -10};
-    cudf::test::structs_column_wrapper t1_scol2({t1_sscol0, t1_sscol1});
+  cudf::test::strings_column_wrapper t1_scol0{"000", "yzz", "vwx", "stu", "pqr"};
+  cudf::test::fixed_width_column_wrapper<float> t1_scol1{-5, -4, -3, -2, -1};
+  cudf::test::strings_column_wrapper t1_sscol0{"-5555", "-4444", "-333", "-22", "-1"};
+  cudf::test::fixed_width_column_wrapper<float> t1_sscol1{-50, -40, -30, -20, -10};
+  cudf::test::structs_column_wrapper t1_scol2({t1_sscol0, t1_sscol1});
   cudf::test::structs_column_wrapper t1_col1({t1_scol0, t1_scol1, t1_scol2});
 
-  cudf::table_view t0({t0_col0 , t0_col1});
-  cudf::table_view t1({t1_col0 , t1_col1});
+  cudf::table_view t0({t0_col0, t0_col1});
+  cudf::table_view t1({t1_col0, t1_col1});
 
   auto result = cudf::merge({t0, t1}, {0}, {cudf::order::DESCENDING});
 
   cudf::test::fixed_width_column_wrapper<int> e_col0{9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
-    cudf::test::strings_column_wrapper e_scol0{"000", "mno", "yzz", "jkl", "vwx", "ghi", "stu", "def", "pqr", "abc"};
-    cudf::test::fixed_width_column_wrapper<float> e_scol1{-5, 5, -4, 4, -3, 3, -2, 2, -1, 1};
-      cudf::test::strings_column_wrapper e_sscol0{"-5555", "5555", "-4444", "4444", "-333", "333", "-22", "22", "-1", "1"};
-      cudf::test::fixed_width_column_wrapper<float> e_sscol1{-50, 50, -40, 40, -30, 30, -20, 20, -10, 10};
-    cudf::test::structs_column_wrapper e_scol2({e_sscol0, e_sscol1});
+  cudf::test::strings_column_wrapper e_scol0{
+    "000", "mno", "yzz", "jkl", "vwx", "ghi", "stu", "def", "pqr", "abc"};
+  cudf::test::fixed_width_column_wrapper<float> e_scol1{-5, 5, -4, 4, -3, 3, -2, 2, -1, 1};
+  cudf::test::strings_column_wrapper e_sscol0{
+    "-5555", "5555", "-4444", "4444", "-333", "333", "-22", "22", "-1", "1"};
+  cudf::test::fixed_width_column_wrapper<float> e_sscol1{
+    -50, 50, -40, 40, -30, 30, -20, 20, -10, 10};
+  cudf::test::structs_column_wrapper e_scol2({e_sscol0, e_sscol1});
   cudf::test::structs_column_wrapper e_col1({e_scol0, e_scol1, e_scol2});
 
   cudf::table_view expected({e_col0, e_col1});
 
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected, *result);
-
-  // clang-format on
 }
 
 TEST_F(MergeTest, StructsNestedWithNulls)
 {
-  // clang-format off
-
   cudf::test::fixed_width_column_wrapper<int> t0_col0{8, 6, 4, 2, 0};
-    cudf::test::strings_column_wrapper t0_scol0{"mno", "jkl", "ghi", "def", "abc"};
-    cudf::test::fixed_width_column_wrapper<float> t0_scol1{{5, 4, 3, 2, 1}, {1, 1, 0, 1, 1}};
-      cudf::test::strings_column_wrapper t0_sscol0{{"5555", "4444", "333", "22", "1"}, {1, 0, 1, 1, 0}};
-      cudf::test::fixed_width_column_wrapper<float> t0_sscol1{50, 40, 30, 20, 10};
-    cudf::test::structs_column_wrapper t0_scol2({t0_sscol0, t0_sscol1}, {0, 0, 1, 1, 1});
+  cudf::test::strings_column_wrapper t0_scol0{"mno", "jkl", "ghi", "def", "abc"};
+  cudf::test::fixed_width_column_wrapper<float> t0_scol1{{5, 4, 3, 2, 1}, {1, 1, 0, 1, 1}};
+  cudf::test::strings_column_wrapper t0_sscol0{{"5555", "", "333", "22", ""}, {1, 0, 1, 1, 0}};
+  cudf::test::fixed_width_column_wrapper<float> t0_sscol1{50, 40, 30, 20, 10};
+  cudf::test::structs_column_wrapper t0_scol2({t0_sscol0, t0_sscol1}, {0, 0, 1, 1, 1});
   cudf::test::structs_column_wrapper t0_col1({t0_scol0, t0_scol1, t0_scol2}, {0, 0, 1, 1, 1});
 
   cudf::test::fixed_width_column_wrapper<int> t1_col0{9, 7, 5, 3, 1};
-    cudf::test::strings_column_wrapper t1_scol0{"000", "yzz", "vwx", "stu", "pqr"};
-    cudf::test::fixed_width_column_wrapper<float> t1_scol1{{-5, -4, -3, -2, -1}, {1, 1, 1, 0, 1}};
-      cudf::test::strings_column_wrapper t1_sscol0{{"-5555", "-4444", "-333", "-22", "-1"}, {1, 1, 1, 1, 1}};
-      cudf::test::fixed_width_column_wrapper<float> t1_sscol1{-50, -40, -30, -20, -10};
-    cudf::test::structs_column_wrapper t1_scol2({t1_sscol0, t1_sscol1}, {1, 1, 1, 1, 0});
+  cudf::test::strings_column_wrapper t1_scol0{"000", "yzz", "vwx", "stu", "pqr"};
+  cudf::test::fixed_width_column_wrapper<float> t1_scol1{{-5, -4, -3, -2, -1}, {1, 1, 1, 0, 1}};
+  cudf::test::strings_column_wrapper t1_sscol0{{"-5555", "-4444", "-333", "-22", "-1"},
+                                               {1, 1, 1, 1, 1}};
+  cudf::test::fixed_width_column_wrapper<float> t1_sscol1{-50, -40, -30, -20, -10};
+  cudf::test::structs_column_wrapper t1_scol2({t1_sscol0, t1_sscol1}, {1, 1, 1, 1, 0});
   cudf::test::structs_column_wrapper t1_col1({t1_scol0, t1_scol1, t1_scol2});
 
-  cudf::table_view t0({t0_col0 , t0_col1});
-  cudf::table_view t1({t1_col0 , t1_col1});
+  cudf::table_view t0({t0_col0, t0_col1});
+  cudf::table_view t1({t1_col0, t1_col1});
 
   auto result = cudf::merge({t0, t1}, {0}, {cudf::order::DESCENDING});
 
   cudf::test::fixed_width_column_wrapper<int> e_col0{9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
-    cudf::test::strings_column_wrapper e_scol0{"000", "mno", "yzz", "jkl", "vwx", "ghi", "stu", "def", "pqr", "abc"};
-    cudf::test::fixed_width_column_wrapper<float> e_scol1{{-5, 5, -4, 4, -3, 3, -2, 2, -1, 1},
-                                                          { 1, 1,  1, 1,  1, 0,  0, 1,  1, 1}};
-      cudf::test::strings_column_wrapper e_sscol0{{"-5555", "5555", "-4444", "4444", "-333", "333", "-22", "22", "-1", "1"},
-                                                  {  1,      0,       1,      0,       1,     1,      1,    1,     0,   0}};
-      cudf::test::fixed_width_column_wrapper<float> e_sscol1{-50, 50, -40, 40, -30, 30, -20, 20, -10, 10};
-    cudf::test::structs_column_wrapper e_scol2({e_sscol0, e_sscol1}, {1, 0, 1, 0, 1, 1, 1, 1, 0, 1});
-  cudf::test::structs_column_wrapper e_col1({e_scol0, e_scol1, e_scol2}, {1, 0, 1, 0, 1, 1, 1, 1, 1, 1});
+  cudf::test::strings_column_wrapper e_scol0{
+    "000", "mno", "yzz", "jkl", "vwx", "ghi", "stu", "def", "pqr", "abc"};
+  cudf::test::fixed_width_column_wrapper<float> e_scol1{{-5, 5, -4, 4, -3, 3, -2, 2, -1, 1},
+                                                        {1, 1, 1, 1, 1, 0, 0, 1, 1, 1}};
+  cudf::test::strings_column_wrapper e_sscol0{
+    {"-5555", "", "-4444", "", "-333", "333", "-22", "22", "", ""}, {1, 0, 1, 0, 1, 1, 1, 1, 0, 0}};
+  cudf::test::fixed_width_column_wrapper<float> e_sscol1{
+    -50, 50, -40, 40, -30, 30, -20, 20, -10, 10};
+  cudf::test::structs_column_wrapper e_scol2({e_sscol0, e_sscol1}, {1, 0, 1, 0, 1, 1, 1, 1, 0, 1});
+  cudf::test::structs_column_wrapper e_col1({e_scol0, e_scol1, e_scol2},
+                                            {1, 0, 1, 0, 1, 1, 1, 1, 1, 1});
 
   cudf::table_view expected({e_col0, e_col1});
 
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected, *result);
-
-  // clang-format on
 }
 
 using lcw = cudf::test::lists_column_wrapper<int32_t>;

--- a/cpp/tests/rolling/grouped_rolling_test.cpp
+++ b/cpp/tests/rolling/grouped_rolling_test.cpp
@@ -651,7 +651,7 @@ using GroupedRollingTestStrings = GroupedRollingTest<cudf::string_view>;
 
 TEST_F(GroupedRollingTestStrings, StringsUnsupportedOperators)
 {
-  cudf::test::strings_column_wrapper input{{"This", "is", "not", "a", "string", "type"},
+  cudf::test::strings_column_wrapper input{{"This", "is", "not", "", "string", ""},
                                            {true, true, true, false, true, false}};
 
   const cudf::size_type DATA_SIZE{static_cast<cudf::column_view>(input).size()};

--- a/cpp/tests/rolling/rolling_test.cpp
+++ b/cpp/tests/rolling/rolling_test.cpp
@@ -1149,7 +1149,7 @@ using RollingTestStrings = RollingTest<cudf::string_view>;
 
 TEST_F(RollingTestStrings, StringsUnsupportedOperators)
 {
-  cudf::test::strings_column_wrapper input{{"This", "is", "not", "a", "string", "type"},
+  cudf::test::strings_column_wrapper input{{"This", "is", "not", "", "string", ""},
                                            {1, 1, 1, 0, 1, 0}};
 
   std::vector<cudf::size_type> window{1};

--- a/cpp/tests/search/search_test.cpp
+++ b/cpp/tests/search/search_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -912,7 +912,7 @@ TEST_F(SearchTest, non_null_column__nullable_values__find_last__nulls_as_largest
   cudf::test::strings_column_wrapper column({"N", "N", "N", "N", "Y", "Y", "Y", "Y"},
                                             {1, 1, 1, 1, 1, 1, 1, 1});
 
-  cudf::test::strings_column_wrapper values({"Y", "Z", "N"}, {1, 0, 1});
+  cudf::test::strings_column_wrapper values({"Y", "", "N"}, {1, 0, 1});
 
   fixed_width_column_wrapper<size_type> expect{8, 8, 4};
 

--- a/cpp/tests/sort/is_sorted_tests.cpp
+++ b/cpp/tests/sort/is_sorted_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -138,13 +138,13 @@ auto empty<cudf::string_view>()
 template <>
 auto nulls_after<cudf::string_view>()
 {
-  return cudf::test::strings_column_wrapper({"identical", "identical"}, {true, false});
+  return cudf::test::strings_column_wrapper({"identical", ""}, {true, false});
 }
 
 template <>
 auto nulls_before<cudf::string_view>()
 {
-  return cudf::test::strings_column_wrapper({"identical", "identical"}, {false, true});
+  return cudf::test::strings_column_wrapper({"", "identical"}, {false, true});
 }
 
 // ----- struct_view {"nestedInt" : {"Int" : 0 }, "float" : 1}

--- a/cpp/tests/sort/sort_test.cpp
+++ b/cpp/tests/sort/sort_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -52,7 +52,7 @@ TYPED_TEST(Sort, WithNullMax)
   using T = TypeParam;
 
   cudf::test::fixed_width_column_wrapper<T> col1{{5, 4, 3, 5, 8, 5}, {1, 1, 0, 1, 1, 1}};
-  cudf::test::strings_column_wrapper col2({"d", "e", "a", "d", "k", "d"}, {1, 1, 0, 1, 1, 1});
+  cudf::test::strings_column_wrapper col2({"d", "e", "", "d", "k", "d"}, {1, 1, 0, 1, 1, 1});
   cudf::test::fixed_width_column_wrapper<T> col3{{10, 40, 70, 5, 2, 10}, {1, 1, 0, 1, 1, 1}};
   cudf::table_view input{{col1, col2, col3}};
 
@@ -88,7 +88,7 @@ TYPED_TEST(Sort, WithNullMin)
   using T = TypeParam;
 
   cudf::test::fixed_width_column_wrapper<T> col1{{5, 4, 3, 5, 8}, {1, 1, 0, 1, 1}};
-  cudf::test::strings_column_wrapper col2({"d", "e", "a", "d", "k"}, {1, 1, 0, 1, 1});
+  cudf::test::strings_column_wrapper col2({"d", "e", "", "d", "k"}, {1, 1, 0, 1, 1});
   cudf::test::fixed_width_column_wrapper<T> col3{{10, 40, 70, 5, 2}, {1, 1, 0, 1, 1}};
   cudf::table_view input{{col1, col2, col3}};
 
@@ -120,7 +120,7 @@ TYPED_TEST(Sort, WithMixedNullOrder)
   using T = TypeParam;
 
   cudf::test::fixed_width_column_wrapper<T> col1{{5, 4, 3, 5, 8}, {0, 0, 1, 1, 0}};
-  cudf::test::strings_column_wrapper col2({"d", "e", "a", "d", "k"}, {0, 1, 0, 0, 1});
+  cudf::test::strings_column_wrapper col2({"", "e", "", "", "k"}, {0, 1, 0, 0, 1});
   cudf::test::fixed_width_column_wrapper<T> col3{{10, 40, 70, 5, 2}, {1, 0, 1, 0, 1}};
   cudf::table_view input{{col1, col2, col3}};
 
@@ -415,7 +415,7 @@ TYPED_TEST(Sort, WithSlicedStructColumn)
   // clang-format off
   using FWCW = cudf::test::fixed_width_column_wrapper<T, int32_t>;
   std::vector<bool>             string_valids{    1,     1,     1,     1,    1,    1,   1,   0};
-  std::initializer_list<std::string> names = {"bbe", "bbe", "aaa", "abc", "ab", "za", "b", "x"};
+  std::initializer_list<std::string> names = {"bbe", "bbe", "aaa", "abc", "ab", "za", "b", ""};
   auto col2 =                           FWCW{{    1,     1,     0,     0,    0,    2,   1,   3}};
   auto col3 =                           FWCW{{    7,     8,     1,     1,    9,    5,   7,   3}};
   auto col1 = cudf::test::strings_column_wrapper{names.begin(), names.end(), string_valids.begin()};
@@ -479,7 +479,7 @@ TYPED_TEST(Sort, SlicedColumns)
 
   // clang-format off
   std::vector<bool>             string_valids{    1,     1,     1,     1,    1,    1,   1,   0};
-  std::initializer_list<std::string> names = {"bbe", "bbe", "aaa", "abc", "ab", "za", "b", "x"};
+  std::initializer_list<std::string> names = {"bbe", "bbe", "aaa", "abc", "ab", "za", "b", ""};
   auto col2 =                           FWCW{{    7,     8,     1,     1,    9,    5,   7,   3}};
   auto col1 = cudf::test::strings_column_wrapper{names.begin(), names.end(), string_valids.begin()};
   // clang-format on

--- a/cpp/tests/strings/find_multiple_tests.cpp
+++ b/cpp/tests/strings/find_multiple_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -59,7 +59,7 @@ TEST_F(StringsFindMultipleTest, ZeroSizeStringsColumn)
 
 TEST_F(StringsFindMultipleTest, ErrorTest)
 {
-  cudf::test::strings_column_wrapper strings({"this string intentionally left blank"}, {false});
+  cudf::test::strings_column_wrapper strings({""}, {false});
   auto strings_view = cudf::strings_column_view(strings);
 
   auto const zero_size_strings_column = cudf::make_empty_column(cudf::type_id::STRING)->view();

--- a/cpp/tests/text/edit_distance_tests.cpp
+++ b/cpp/tests/text/edit_distance_tests.cpp
@@ -89,7 +89,7 @@ TEST_F(TextEditDistanceTest, ErrorsTest)
   auto tvi     = cudf::strings_column_view(targets);
   EXPECT_THROW(nvtext::edit_distance(svi, tvi), std::invalid_argument);
 
-  auto single = cudf::test::strings_column_wrapper({"pup"}, {0});
+  auto single = cudf::test::strings_column_wrapper({""}, {0});
   auto sv1    = cudf::strings_column_view(single);
   EXPECT_THROW(nvtext::edit_distance(svi, sv1), std::invalid_argument);
 }


### PR DESCRIPTION
## Description
Fixes gtests using `cudf::test::strings_column_wrapper` to not include unsanitized nulls.
This is considered UB for libcudf APIs and it would be best to honor this in our gtests which may be used as example implementation resources.
Cursor found most of these and it is certainly surprising how many it found.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
