### PR TITLE
Fix stable ID for ``DataFrameScan``

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/nodebase.py
+++ b/python/cudf_polars/cudf_polars/dsl/nodebase.py
@@ -18,6 +18,17 @@ __all__: list[str] = ["Node"]
 T = TypeVar("T", bound="Node[Any]")
 
 
+def _expand_hashable(obj: Any) -> Any:
+    """Expand nested Node instances to their hashable form."""
+    if isinstance(obj, Node):
+        return _expand_hashable(obj.get_hashable())
+    elif isinstance(obj, (tuple, list)):
+        return tuple(_expand_hashable(x) for x in obj)
+    elif isinstance(obj, dict):
+        return tuple(sorted((k, _expand_hashable(v)) for k, v in obj.items()))
+    return obj
+
+
 class Node(Generic[T]):
     """
     An abstract node type.
@@ -103,7 +114,7 @@ class Node(Generic[T]):
         try:
             return self._stable_hash_value
         except AttributeError:
-            content = repr(self.get_hashable()).encode("utf-8")
+            content = repr(_expand_hashable(self)).encode("utf-8")
             self._stable_hash_value = int(hashlib.md5(content).hexdigest()[:8], 16)
             return self._stable_hash_value
 

--- a/python/cudf_polars/cudf_polars/dsl/nodebase.py
+++ b/python/cudf_polars/cudf_polars/dsl/nodebase.py
@@ -22,10 +22,8 @@ def _expand_hashable(obj: Any) -> Any:
     """Expand nested Node instances to their hashable form."""
     if isinstance(obj, Node):
         return _expand_hashable(obj.get_hashable())
-    elif isinstance(obj, (tuple, list)):
+    elif isinstance(obj, tuple):
         return tuple(_expand_hashable(x) for x in obj)
-    elif isinstance(obj, dict):
-        return tuple(sorted((k, _expand_hashable(v)) for k, v in obj.items()))
     return obj
 
 

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -10,6 +10,7 @@ import pytest
 import polars as pl
 
 from cudf_polars import Translator
+from cudf_polars.dsl.traversal import traversal
 from cudf_polars.experimental.parallel import lower_ir_graph
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.utils.config import ConfigOptions
@@ -63,6 +64,23 @@ def test_dataframescan_concat(df, engine):
     assert_gpu_result_equal(df2, engine=engine)
 
 
+def test_join_in_memory_lazy_stable_id_pickle():
+    """Join over collect().lazy() uses DataFrameScan children; IDs must survive pickle."""
+    left = pl.LazyFrame({"k": [1, 2, 3], "x": [10, 20, 30]}).collect().lazy()
+    right = pl.LazyFrame({"k": [2, 3, 4], "y": [1, 2, 3]}).collect().lazy()
+    q = left.join(right, on="k", how="inner")
+    _engine = pl.GPUEngine(
+        raise_on_fail=True,
+        executor="streaming",
+        executor_options={"max_rows_per_partition": 1_000},
+    )
+    ir = Translator(q._ldf.visit(), _engine).translate_ir()
+    ir, _, _ = lower_ir_graph(ir, ConfigOptions.from_polars_engine(_engine))
+    ir2 = pickle.loads(pickle.dumps(ir))
+    for orig, loaded in zip(traversal([ir]), traversal([ir2]), strict=True):
+        assert orig.get_stable_id() == loaded.get_stable_id()
+
+
 def test_dataframescan_pickle(df):
     _engine = pl.GPUEngine(
         raise_on_fail=True,
@@ -79,3 +97,7 @@ def test_dataframescan_pickle(df):
     # Verify the unpickled IR is equivalent
     assert type(unpickled_ir) is type(ir)
     assert unpickled_ir.schema == ir.schema
+
+    # Stable IDs must match after unpickle (plan logging vs distributed workers).
+    for orig, loaded in zip(traversal([ir]), traversal([unpickled_ir]), strict=True):
+        assert orig.get_stable_id() == loaded.get_stable_id()

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -85,15 +85,19 @@ def test_join_in_memory_lazy_stable_id_pickle():
 
 
 def test_dataframescan_pickle(df):
-    engine = pl.GPUEngine(
+    _engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
         executor_options={"max_rows_per_partition": 1_000},
     )
-    qir = Translator(df._ldf.visit(), engine).translate_ir()
-    ir, _, _ = lower_ir_graph(qir, ConfigOptions.from_polars_engine(engine))
+    qir = Translator(df._ldf.visit(), _engine).translate_ir()
+    ir, _, _ = lower_ir_graph(qir, ConfigOptions.from_polars_engine(_engine))
 
-    clone = pickle.loads(pickle.dumps(ir))
-    assert type(clone) is type(ir)
-    assert clone.schema == ir.schema
-    _assert_stable_ids_match(ir, clone)
+    # Pickle and unpickle the IR (which contains DataFrameScan)
+    pickled = pickle.dumps(ir)
+    unpickled_ir = pickle.loads(pickled)
+
+    # Verify the unpickled IR is equivalent
+    assert type(unpickled_ir) is type(ir)
+    assert unpickled_ir.schema == ir.schema
+    _assert_stable_ids_match(ir, unpickled_ir)

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -16,6 +16,11 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.utils.config import ConfigOptions
 
 
+def _assert_stable_ids_match(orig, loaded) -> None:
+    for a, b in zip(traversal([orig]), traversal([loaded]), strict=True):
+        assert a.get_stable_id() == b.get_stable_id()
+
+
 @pytest.fixture(scope="module")
 def df():
     return pl.LazyFrame(
@@ -65,39 +70,30 @@ def test_dataframescan_concat(df, engine):
 
 
 def test_join_in_memory_lazy_stable_id_pickle():
-    """Join over collect().lazy() uses DataFrameScan children; IDs must survive pickle."""
-    left = pl.LazyFrame({"k": [1, 2, 3], "x": [10, 20, 30]}).collect().lazy()
-    right = pl.LazyFrame({"k": [2, 3, 4], "y": [1, 2, 3]}).collect().lazy()
-    q = left.join(right, on="k", how="inner")
-    _engine = pl.GPUEngine(
+    engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
         executor_options={"max_rows_per_partition": 1_000},
     )
-    ir = Translator(q._ldf.visit(), _engine).translate_ir()
-    ir, _, _ = lower_ir_graph(ir, ConfigOptions.from_polars_engine(_engine))
-    ir2 = pickle.loads(pickle.dumps(ir))
-    for orig, loaded in zip(traversal([ir]), traversal([ir2]), strict=True):
-        assert orig.get_stable_id() == loaded.get_stable_id()
+    left = pl.LazyFrame({"k": [1, 2, 3], "x": [10, 20, 30]}).collect().lazy()
+    right = pl.LazyFrame({"k": [2, 3, 4], "y": [1, 2, 3]}).collect().lazy()
+    ir, _, _ = lower_ir_graph(
+        Translator(left.join(right, on="k")._ldf.visit(), engine).translate_ir(),
+        ConfigOptions.from_polars_engine(engine),
+    )
+    _assert_stable_ids_match(ir, pickle.loads(pickle.dumps(ir)))
 
 
 def test_dataframescan_pickle(df):
-    _engine = pl.GPUEngine(
+    engine = pl.GPUEngine(
         raise_on_fail=True,
         executor="streaming",
         executor_options={"max_rows_per_partition": 1_000},
     )
-    qir = Translator(df._ldf.visit(), _engine).translate_ir()
-    ir, _, _ = lower_ir_graph(qir, ConfigOptions.from_polars_engine(_engine))
+    qir = Translator(df._ldf.visit(), engine).translate_ir()
+    ir, _, _ = lower_ir_graph(qir, ConfigOptions.from_polars_engine(engine))
 
-    # Pickle and unpickle the IR (which contains DataFrameScan)
-    pickled = pickle.dumps(ir)
-    unpickled_ir = pickle.loads(pickled)
-
-    # Verify the unpickled IR is equivalent
-    assert type(unpickled_ir) is type(ir)
-    assert unpickled_ir.schema == ir.schema
-
-    # Stable IDs must match after unpickle (plan logging vs distributed workers).
-    for orig, loaded in zip(traversal([ir]), traversal([unpickled_ir]), strict=True):
-        assert orig.get_stable_id() == loaded.get_stable_id()
+    clone = pickle.loads(pickle.dumps(ir))
+    assert type(clone) is type(ir)
+    assert clone.schema == ir.schema
+    _assert_stable_ids_match(ir, clone)


### PR DESCRIPTION
## Description
cuDF-Polars tracing infrastructure relies on the concept of "stable ID" for each IR node. This ID is **not** currently stable for `DataFrameScan`. This PR adds a simple `_expand_hashable` helper utility to correct this.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
