### PR TITLE
Fix libcudf gather segfault in set_all_valid_null_masks

### DIFF
--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -739,7 +739,7 @@ void set_all_valid_null_masks(column_view const& input,
                               rmm::cuda_stream_view stream,
                               rmm::device_async_resource_ref mr)
 {
-  if (input.nullable()) {
+  if (input.nullable() && output.size() > 0) {
     auto mask = detail::create_null_mask(output.size(), mask_state::ALL_VALID, stream, mr);
     output.set_null_mask(std::move(mask), 0);
 


### PR DESCRIPTION
## Description
Fixes segfault in `cudf::detail::gather` where the gather results may build an empty strings column. In this case, the `set_all_valid_null_masks` may segfault when then number of children in the `input` and `output` columns do not match. This can happen if the `input` is not empty and not all null (has an offsets child) and when the `output` is empty (no children).
The change adds an additional check since there would be no need to propagate an all-valid null mask to an empty output.

The segfault was found when running the `NDSH_Q09_NVBENCH` on the latest main code.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
