### PR TITLE
Update to clang 20.1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
                "python/dask_cudf/dask_cudf"]
         pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v20.1.4
+    rev: v20.1.8
     hooks:
       - id: clang-format
         types_or: [c, c++, cuda]

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -12,8 +12,8 @@ dependencies:
 - breathe>=4.35.0
 - c-compiler
 - cachetools
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cramjam
 - cuda-cudart-dev

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -12,8 +12,8 @@ dependencies:
 - breathe>=4.35.0
 - c-compiler
 - cachetools
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cramjam
 - cuda-cudart-dev

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -12,8 +12,8 @@ dependencies:
 - breathe>=4.35.0
 - c-compiler
 - cachetools
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cramjam
 - cuda-cudart-dev

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -12,8 +12,8 @@ dependencies:
 - breathe>=4.35.0
 - c-compiler
 - cachetools
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cramjam
 - cuda-cudart-dev

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -694,8 +694,8 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - clang==20.1.4
-          - clang-tools==20.1.4
+          - clang==20.1.8
+          - clang-tools==20.1.8
   iwyu:
     common:
       - output_types: conda


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/267

This PR updates the clang version to 20.1.8.
