### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/ndsh_data_generator.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,6 @@
 
 #include <cudf_test/column_wrapper.hpp>
 
-#include <cudf/ast/detail/operators.cuh>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/binaryop.hpp>
 #include <cudf/filling.hpp>

--- a/cpp/benchmarks/common/ndsh_data_generator/table_helpers.cpp
+++ b/cpp/benchmarks/common/ndsh_data_generator/table_helpers.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,6 @@
 #include <benchmarks/common/nvtx_ranges.hpp>
 
 #include <cudf/aggregation.hpp>
-#include <cudf/ast/detail/operators.cuh>
 #include <cudf/ast/expressions.hpp>
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>

--- a/cpp/benchmarks/io/csv/csv_reader_options.cpp
+++ b/cpp/benchmarks/io/csv/csv_reader_options.cpp
@@ -8,7 +8,6 @@
 #include <benchmarks/io/cuio_common.hpp>
 #include <benchmarks/io/nvbench_helpers.hpp>
 
-#include <cudf/detail/utilities/default_stream.hpp>
 #include <cudf/detail/utilities/integer_utils.hpp>
 #include <cudf/io/csv.hpp>
 

--- a/cpp/benchmarks/search/contains_table.cpp
+++ b/cpp/benchmarks/search/contains_table.cpp
@@ -1,13 +1,13 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <benchmarks/common/generate_input.hpp>
 #include <benchmarks/common/memory_stats.hpp>
 
-#include <cudf/detail/search.hpp>
 #include <cudf/lists/list_view.hpp>
+#include <cudf/search.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
@@ -41,12 +41,7 @@ static void nvbench_contains_table(nvbench::state& state, nvbench::type_list<Typ
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
     auto const stream_view = rmm::cuda_stream_view{launch.get_stream()};
     [[maybe_unused]] auto const result =
-      cudf::detail::contains(haystack->view(),
-                             needles->view(),
-                             cudf::null_equality::EQUAL,
-                             cudf::nan_equality::ALL_EQUAL,
-                             stream_view,
-                             cudf::get_current_device_resource_ref());
+      cudf::contains(haystack->view().column(0), needles->view().column(0), stream_view);
   });
 
   state.add_buffer_size(

--- a/cpp/benchmarks/string/factory.cpp
+++ b/cpp/benchmarks/string/factory.cpp
@@ -1,14 +1,14 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <benchmarks/common/generate_input.hpp>
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/strings/detail/utilities.hpp>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/strings/strings_column_view.hpp>
+#include <cudf/strings/utilities.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/device_uvector.hpp>
@@ -29,8 +29,7 @@ static void bench_factory(nvbench::state& state)
   auto const sv     = cudf::strings_column_view(column->view());
 
   auto stream    = cudf::get_default_stream();
-  auto mr        = cudf::get_current_device_resource_ref();
-  auto d_strings = cudf::strings::detail::create_string_vector_from_column(sv, stream, mr);
+  auto d_strings = cudf::strings::create_string_vector_from_column(sv);
 
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
   auto const data_size = column->alloc_size();

--- a/cpp/benchmarks/type_dispatcher/type_dispatcher.cu
+++ b/cpp/benchmarks/type_dispatcher/type_dispatcher.cu
@@ -1,11 +1,10 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_view.hpp>
-#include <cudf/detail/utilities/cuda.cuh>
 #include <cudf/detail/utilities/grid_1d.cuh>
 #include <cudf/filling.hpp>
 #include <cudf/scalar/scalar_factories.hpp>

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
@@ -28,8 +28,6 @@ import nvtx
 
 import polars as pl
 
-import rmm.mr
-
 __all__: list[str] = [
     "COUNT_DTYPE",
     "QueryResult",
@@ -1085,7 +1083,6 @@ def run_polars_spmd(
     # "runtime" and "cluster" are reserved — SPMDEngine sets them
     executor_options.pop("runtime", None)
     executor_options.pop("cluster", None)
-    rmm.mr.set_current_device_resource(rmm.mr.CudaAsyncMemoryResource())
     engine_options = {
         **run_config.streaming_options.to_engine_options(),
         "parquet_options": parquet_options,

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from cudf_polars.experimental.base import PartitionInfo, StatsCollector
     from cudf_polars.experimental.parallel import ConfigOptions
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
-    from cudf_polars.utils.config import StreamingExecutor
+    from cudf_polars.utils.config import MemoryResourceConfig, StreamingExecutor
 
 
 @dataclasses.dataclass
@@ -66,6 +66,7 @@ def _setup_root(
     rapidsmpf_options_as_bytes: bytes,
     *,
     uid: str,
+    memory_resource_config: MemoryResourceConfig | None = None,
     dask_worker: distributed.Worker | None = None,
 ) -> bytes:
     """
@@ -84,6 +85,9 @@ def _setup_root(
     uid
         Unique identifier for this cluster instance, used to namespace the
         per-worker attribute so multiple contexts can coexist on a worker.
+    memory_resource_config
+        Optional RMM memory resource configuration. If ``None``, defaults to
+        :class:`rmm.mr.CudaAsyncMemoryResource`.
     dask_worker
         Injected by ``distributed`` when called via :meth:`distributed.Client.run`.
 
@@ -93,7 +97,12 @@ def _setup_root(
     """
     assert dask_worker is not None
     options = Options.deserialize(rapidsmpf_options_as_bytes)
-    mr = RmmResourceAdaptor(rmm.mr.CudaAsyncMemoryResource())
+    base_mr = (
+        memory_resource_config.create_memory_resource()
+        if memory_resource_config is not None
+        else rmm.mr.CudaAsyncMemoryResource()
+    )
+    mr = RmmResourceAdaptor(base_mr)
     statistics = Statistics.from_options(mr, options)
     comm = new_communicator(
         nranks=nranks,
@@ -119,6 +128,7 @@ def _setup_worker(
     executor_options: dict[str, object],
     *,
     uid: str,
+    memory_resource_config: MemoryResourceConfig | None = None,
     dask_worker: distributed.Worker | None = None,
 ) -> None:
     """
@@ -140,6 +150,9 @@ def _setup_worker(
     uid
         Unique identifier for this cluster instance, used to namespace the
         per-worker attribute so multiple contexts can coexist on a worker.
+    memory_resource_config
+        Optional RMM memory resource configuration. If ``None``, defaults to
+        :class:`rmm.mr.CudaAsyncMemoryResource`.
     dask_worker
         Injected by ``distributed`` when called via :meth:`distributed.Client.run`.
     """
@@ -150,7 +163,12 @@ def _setup_worker(
 
     if mp_ctx is None:
         # Non-root worker: create communicator now.
-        mr = RmmResourceAdaptor(rmm.mr.CudaAsyncMemoryResource())
+        base_mr = (
+            memory_resource_config.create_memory_resource()
+            if memory_resource_config is not None
+            else rmm.mr.CudaAsyncMemoryResource()
+        )
+        mr = RmmResourceAdaptor(base_mr)
         statistics = Statistics.from_options(mr, options)
         root_addr = ucx_api.UCXAddress.create_from_buffer(root_ucxx_address_as_bytes)
         comm = new_communicator(
@@ -437,6 +455,10 @@ class DaskEngine(StreamingEngine):
 
         check_reserved_keys(executor_options, engine_options)
 
+        mr_config: MemoryResourceConfig | None = engine_options.get(
+            "memory_resource_config", None
+        )
+
         rapidsmpf_options = (
             rapidsmpf_options
             if rapidsmpf_options is not None
@@ -464,7 +486,7 @@ class DaskEngine(StreamingEngine):
 
         # Phase 1: initialize root communicator on one worker.
         root_result = dask_client.run(
-            functools.partial(_setup_root, uid=uid),
+            functools.partial(_setup_root, uid=uid, memory_resource_config=mr_config),
             nranks,
             rapidsmpf_options_as_bytes,
             workers=[root_worker],
@@ -474,7 +496,7 @@ class DaskEngine(StreamingEngine):
         # Phase 2: complete bootstrap on all workers concurrently.
         # All workers call barrier() so they must all run simultaneously.
         dask_client.run(
-            functools.partial(_setup_worker, uid=uid),
+            functools.partial(_setup_worker, uid=uid, memory_resource_config=mr_config),
             root_ucxx_address_as_bytes,
             nranks,
             rapidsmpf_options_as_bytes,

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
@@ -15,12 +15,13 @@ from typing import TYPE_CHECKING, Any, Literal
 from rapidsmpf.config import Options
 from rapidsmpf.utils.string import parse_boolean
 
+from cudf_polars.utils.config import MemoryResourceConfig
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from cudf_polars.utils.config import (
         DynamicPlanningOptions,
-        MemoryResourceConfig,
         ParquetOptions,
     )
 
@@ -115,6 +116,11 @@ def _category_opts(
         else:
             result[f.name] = v
     return result
+
+
+def _parse_memory_resource_config(value: str) -> MemoryResourceConfig:
+    """Argparse ``type`` callback: parse a JSON string into a :class:`MemoryResourceConfig`."""
+    return MemoryResourceConfig(**json.loads(value))
 
 
 @dataclasses.dataclass
@@ -300,9 +306,7 @@ class StreamingOptions:
     # ---- Engine ----
     raise_on_fail: bool | Unspecified = _opt("engine")
     parquet_options: dict[str, Any] | ParquetOptions | Unspecified = _opt("engine")
-    memory_resource_config: dict[str, Any] | MemoryResourceConfig | Unspecified = _opt(
-        "engine"
-    )
+    memory_resource_config: MemoryResourceConfig | Unspecified = _opt("engine")
     cuda_stream_policy: (
         Literal["default", "new", "pool"] | dict[str, Any] | Unspecified
     ) = _opt("engine", "CUDF_POLARS__CUDA_STREAM_POLICY")
@@ -686,7 +690,7 @@ class StreamingOptions:
             "--memory-resource-config",
             dest="memory_resource_config",
             default=None,
-            type=json.loads,
+            type=_parse_memory_resource_config,
             help=textwrap.dedent("""\
                 RMM memory resource configuration as a JSON object.
                 Env: CUDF_POLARS__MEMORY_RESOURCE_CONFIG__*."""),

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from cudf_polars.experimental.base import PartitionInfo, StatsCollector
     from cudf_polars.experimental.parallel import ConfigOptions
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
-    from cudf_polars.utils.config import StreamingExecutor
+    from cudf_polars.utils.config import MemoryResourceConfig, StreamingExecutor
 
 
 def evaluate_pipeline_ray_mode(
@@ -176,8 +176,14 @@ class RankActor:
         nranks: int,
         rapidsmpf_options_as_bytes: bytes,
         num_py_executors: int,
+        memory_resource_config: MemoryResourceConfig | None = None,
     ) -> None:
-        self._mr = RmmResourceAdaptor(rmm.mr.CudaAsyncMemoryResource())
+        base_mr = (
+            memory_resource_config.create_memory_resource()
+            if memory_resource_config is not None
+            else rmm.mr.CudaAsyncMemoryResource()
+        )
+        self._mr = RmmResourceAdaptor(base_mr)
         self._rapidsmpf_options: Options = Options.deserialize(
             rapidsmpf_options_as_bytes
         )
@@ -449,6 +455,10 @@ class RayEngine(StreamingEngine):
 
         check_reserved_keys(executor_options, engine_options)
 
+        mr_config: MemoryResourceConfig | None = engine_options.get(
+            "memory_resource_config", None
+        )
+
         rapidsmpf_options = (
             rapidsmpf_options
             if rapidsmpf_options is not None
@@ -479,6 +489,7 @@ class RayEngine(StreamingEngine):
                         int,
                         executor_options.get("num_py_executors", 1),
                     ),
+                    memory_resource_config=mr_config,
                 )
                 for _ in range(num_gpus)
             ]

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from cudf_polars.experimental.base import PartitionInfo, StatsCollector
     from cudf_polars.experimental.parallel import ConfigOptions
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
-    from cudf_polars.utils.config import StreamingExecutor
+    from cudf_polars.utils.config import MemoryResourceConfig, StreamingExecutor
 
 
 def evaluate_pipeline_spmd_mode(
@@ -328,7 +328,15 @@ class SPMDEngine(StreamingEngine):
             if rapidsmpf_options is not None
             else Options(get_environment_variables())
         )
-        mr = RmmResourceAdaptor(rmm.mr.get_current_device_resource())
+        mr_config: MemoryResourceConfig | None = engine_options.get(
+            "memory_resource_config", None
+        )
+        base_mr = (
+            mr_config.create_memory_resource()
+            if mr_config is not None
+            else rmm.mr.get_current_device_resource()
+        )
+        mr = RmmResourceAdaptor(base_mr)
         if comm is None:
             if bootstrap.is_running_with_rrun():
                 comm = bootstrap.create_ucxx_comm(
@@ -337,7 +345,10 @@ class SPMDEngine(StreamingEngine):
                     options=rapidsmpf_options,
                 )
             else:
-                comm = single_communicator(rapidsmpf_options, ProgressThread())
+                comm = single_communicator(
+                    progress_thread=ProgressThread(),
+                    options=rapidsmpf_options,
+                )
         # else: caller-provided comm; the caller retains ownership
 
         py_executor = ThreadPoolExecutor(

--- a/python/cudf_polars/docs/cudf-polars-mp.md
+++ b/python/cudf_polars/docs/cudf-polars-mp.md
@@ -96,6 +96,44 @@ opts = StreamingOptions.from_dict({
 })
 ```
 
+### Memory resource configuration
+
+Use `memory_resource_config` to control the RMM memory resource used by the
+engine. It accepts a `MemoryResourceConfig` object that specifies the fully
+qualified class name and optional constructor arguments:
+
+```python
+from cudf_polars.utils.config import MemoryResourceConfig
+
+opts = StreamingOptions(
+    memory_resource_config=MemoryResourceConfig(
+        qualname="rmm.mr.CudaAsyncMemoryResource",
+    ),
+)
+```
+
+Nested resources (e.g. a pool wrapping a managed resource) are supported:
+
+```python
+opts = StreamingOptions(
+    memory_resource_config=MemoryResourceConfig(
+        qualname="rmm.mr.PoolMemoryResource",
+        options={
+            "upstream_mr": {
+                "qualname": "rmm.mr.ManagedMemoryResource",
+            },
+        },
+    ),
+)
+```
+
+When no `memory_resource_config` is provided:
+
+- **SPMDEngine** uses `rmm.mr.get_current_device_resource()` (the in-process
+  default — useful when user code has already configured a resource).
+benchm- **DaskEngine** and **RayEngine** default to `rmm.mr.CudaAsyncMemoryResource()`
+  (workers start in a fresh process with no pre-configured resource).
+
 ---
 
 ## Ray execution mode
@@ -601,7 +639,6 @@ Prefer `SPMDEngine.from_options()` with a `StreamingOptions` object (see
 fine-grained control, the `__init__` parameters accept raw dicts:
 
 ```python
-import rmm
 from rapidsmpf.config import Options
 
 with SPMDEngine(
@@ -615,12 +652,12 @@ with SPMDEngine(
     ...
 ```
 
-**Memory resource:** `SPMDEngine` captures `rmm.mr.get_current_device_resource()`
-at construction, wraps it in `RmmResourceAdaptor` (so libcudf temporary allocations and the
-RapidsMPF `Context` share the same resource), sets the wrapped resource as current, and
-restores the original resource on shutdown. To use a custom allocator, call
-`rmm.mr.set_current_device_resource(your_mr)` **before** constructing `SPMDEngine`.
-Do not pre-wrap it in `RmmResourceAdaptor`.
+**Memory resource:** All engines accept a `memory_resource_config` option (via
+`StreamingOptions` or `engine_options`) that controls the RMM memory resource.
+See [Memory resource configuration](#memory-resource-configuration) for details.
+When no config is provided, `SPMDEngine` falls back to
+`rmm.mr.get_current_device_resource()`, while `DaskEngine` and `RayEngine`
+default to `rmm.mr.CudaAsyncMemoryResource()`.
 
 `comm` is an already-bootstrapped communicator. When provided, the bootstrap step
 is skipped and the caller retains ownership (see

--- a/python/cudf_polars/tests/experimental/test_dask.py
+++ b/python/cudf_polars/tests/experimental/test_dask.py
@@ -12,12 +12,12 @@ from rapidsmpf.bootstrap import is_running_with_rrun
 import polars as pl
 
 from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
-from cudf_polars.utils.config import DaskContext
+from cudf_polars.testing.asserts import assert_gpu_result_equal
+from cudf_polars.utils.config import DaskContext, MemoryResourceConfig
 
 distributed = pytest.importorskip("distributed")
 
 from cudf_polars.experimental.rapidsmpf.frontend.dask import DaskEngine  # noqa: E402
-from cudf_polars.testing.asserts import assert_gpu_result_equal  # noqa: E402
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -50,6 +50,16 @@ pytestmark = [
 # ---------------------------------------------------------------------------
 # GPU tests — share a single Dask cluster for the whole module
 # ---------------------------------------------------------------------------
+
+
+def test_from_options() -> None:
+    """DaskEngine.from_options with default StreamingOptions creates a valid engine."""
+    opts = StreamingOptions(fallback_mode="silent")
+    try:
+        with DaskEngine.from_options(opts) as engine:
+            assert engine.nranks >= 1
+    except Exception as e:
+        pytest.skip(f"Dask GPU cluster unavailable: {e}")
 
 
 def test_yields_engine(engine: DaskEngine) -> None:
@@ -135,6 +145,21 @@ def test_join(engine: DaskEngine) -> None:
         engine=engine,
         check_row_order=False,
     )
+
+
+def test_memory_resource_config() -> None:
+    """DaskEngine workers use the MR from memory_resource_config when provided."""
+    opts = StreamingOptions(
+        fallback_mode="silent",
+        memory_resource_config=MemoryResourceConfig(
+            qualname="rmm.mr.CudaMemoryResource"
+        ),
+    )
+    try:
+        with DaskEngine.from_options(opts) as engine:
+            assert engine.nranks >= 1
+    except Exception as e:
+        pytest.skip(f"Dask GPU cluster unavailable: {e}")
 
 
 def test_empty_dataframe(engine: DaskEngine) -> None:

--- a/python/cudf_polars/tests/experimental/test_options.py
+++ b/python/cudf_polars/tests/experimental/test_options.py
@@ -14,6 +14,7 @@ from cudf_polars.experimental.rapidsmpf.frontend.options import (
     StreamingOptions,
     Unspecified,
 )
+from cudf_polars.utils.config import MemoryResourceConfig
 
 # ---------------------------------------------------------------------------
 # Sentinel
@@ -136,30 +137,47 @@ def test_rapidsmpf_options_env_var_absent(monkeypatch: pytest.MonkeyPatch) -> No
     assert "log" not in StreamingOptions().to_rapidsmpf_options().get_strings()
 
 
-@pytest.mark.spmd
-def test_spmd_engine_from_options_creates_engine() -> None:
-    """from_options with default StreamingOptions creates a valid SPMDEngine."""
-    pytest.importorskip("rapidsmpf")
-    from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
-
-    opts = StreamingOptions(fallback_mode="silent", raise_on_fail=True)
-    with SPMDEngine.from_options(opts) as engine:
-        assert engine.nranks >= 1
+# ---------------------------------------------------------------------------
+# memory_resource_config forwarding
+# ---------------------------------------------------------------------------
 
 
-# distributed's shutdown leaves unclosed sockets; suppress the noise.
-@pytest.mark.filterwarnings("ignore::ResourceWarning")
-def test_dask_engine_from_options_creates_engine() -> None:
-    """DaskEngine.from_options with default StreamingOptions creates a valid engine."""
-    pytest.importorskip("distributed")
-    from cudf_polars.experimental.rapidsmpf.frontend.dask import DaskEngine
+def test_parse_memory_resource_config() -> None:
+    """_parse_memory_resource_config converts a JSON string to MemoryResourceConfig."""
+    from cudf_polars.experimental.rapidsmpf.frontend.options import (
+        _parse_memory_resource_config,
+    )
 
-    opts = StreamingOptions(fallback_mode="silent")
-    try:
-        with DaskEngine.from_options(opts) as engine:
-            assert engine.nranks >= 1
-    except Exception as e:
-        pytest.skip(f"Dask GPU cluster unavailable: {e}")
+    config = _parse_memory_resource_config('{"qualname": "rmm.mr.CudaMemoryResource"}')
+    assert isinstance(config, MemoryResourceConfig)
+    assert config.qualname == "rmm.mr.CudaMemoryResource"
+
+
+def test_from_argparse_memory_resource_config_passthrough() -> None:
+    """MemoryResourceConfig instances pass through _from_argparse unchanged."""
+    config = MemoryResourceConfig(qualname="rmm.mr.CudaMemoryResource")
+    ns = argparse.Namespace(memory_resource_config=config)
+    opts = StreamingOptions._from_argparse(ns)
+    assert opts.memory_resource_config is config
+
+
+def test_cli_memory_resource_config_roundtrip() -> None:
+    """--memory-resource-config JSON roundtrips through CLI parsing."""
+    parser = argparse.ArgumentParser()
+    StreamingOptions._add_cli_args(parser)
+    args = parser.parse_args(
+        ["--memory-resource-config", '{"qualname": "rmm.mr.CudaAsyncMemoryResource"}']
+    )
+    opts = StreamingOptions._from_argparse(args)
+    assert isinstance(opts.memory_resource_config, MemoryResourceConfig)
+    assert opts.memory_resource_config.qualname == "rmm.mr.CudaAsyncMemoryResource"
+
+
+def test_memory_resource_config_in_engine_options() -> None:
+    """memory_resource_config is included in to_engine_options() when set."""
+    config = MemoryResourceConfig(qualname="rmm.mr.CudaMemoryResource")
+    opts = StreamingOptions(memory_resource_config=config)
+    assert opts.to_engine_options()["memory_resource_config"] is config
 
 
 # ---------------------------------------------------------------------------

--- a/python/cudf_polars/tests/experimental/test_ray.py
+++ b/python/cudf_polars/tests/experimental/test_ray.py
@@ -8,15 +8,16 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+from rapidsmpf.bootstrap import is_running_with_rrun
 
 import polars as pl
 
-from cudf_polars.utils.config import RayContext
+from cudf_polars.experimental.rapidsmpf.frontend.options import (
+    StreamingOptions,
+)
+from cudf_polars.utils.config import MemoryResourceConfig, RayContext
 
 ray = pytest.importorskip("ray")
-
-from rapidsmpf.bootstrap import is_running_with_rrun  # noqa: E402
-
 from cudf_polars.experimental.rapidsmpf.frontend.ray import RayEngine  # noqa: E402
 
 if TYPE_CHECKING:
@@ -171,6 +172,21 @@ def test_join(engine: RayEngine) -> None:
     assert result.shape == (n, 3)
     assert result["val_left"].to_list() == list(range(n))
     assert result["val_right"].to_list() == [x * 2 for x in range(n)]
+
+
+def test_memory_resource_config() -> None:
+    """RayEngine actors use the MR from memory_resource_config when provided."""
+    opts = StreamingOptions(
+        fallback_mode="silent",
+        memory_resource_config=MemoryResourceConfig(
+            qualname="rmm.mr.CudaMemoryResource"
+        ),
+    )
+    try:
+        with RayEngine.from_options(opts) as engine:
+            assert engine.nranks >= 1
+    except Exception as e:
+        pytest.skip(f"Ray GPU cluster unavailable: {e}")
 
 
 def test_empty_dataframe(engine: RayEngine) -> None:

--- a/python/cudf_polars/tests/experimental/test_spmd.py
+++ b/python/cudf_polars/tests/experimental/test_spmd.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 from rapidsmpf.bootstrap import is_running_with_rrun
@@ -15,10 +16,12 @@ import polars as pl
 import rmm.mr
 
 from cudf_polars.experimental.rapidsmpf.collectives.common import reserve_op_id
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.experimental.rapidsmpf.frontend.spmd import (
     SPMDEngine,
     allgather_polars_dataframe,
 )
+from cudf_polars.utils.config import MemoryResourceConfig
 
 if TYPE_CHECKING:
     from rapidsmpf.communicator.communicator import Communicator
@@ -32,6 +35,13 @@ def test_yields_context_and_engine(spmd_comm: Communicator) -> None:
         assert engine.comm is not None
         assert engine.context is not None
         assert isinstance(engine, pl.GPUEngine)
+
+
+def test_from_options() -> None:
+    """from_options with default StreamingOptions creates a valid SPMDEngine."""
+    opts = StreamingOptions(fallback_mode="silent", raise_on_fail=True)
+    with SPMDEngine.from_options(opts) as engine:
+        assert engine.nranks >= 1
 
 
 def test_single_communicator_outside_rrun() -> None:
@@ -247,6 +257,23 @@ def test_shutdown_idempotent(spmd_comm: Communicator) -> None:
     engine = SPMDEngine(comm=spmd_comm)
     engine.shutdown()
     engine.shutdown()
+
+
+def test_memory_resource_config() -> None:
+    """SPMDEngine uses the MR from memory_resource_config when provided."""
+    config = MemoryResourceConfig(qualname="rmm.mr.CudaMemoryResource")
+    opts = StreamingOptions(
+        fallback_mode="silent",
+        memory_resource_config=config,
+    )
+    with patch.object(
+        MemoryResourceConfig,
+        "create_memory_resource",
+        wraps=config.create_memory_resource,
+    ) as mock_create:
+        with SPMDEngine.from_options(opts) as engine:
+            assert engine.nranks >= 1
+        mock_create.assert_called_once()
 
 
 def test_comm_and_context_unavailable_after_shutdown(spmd_comm: Communicator) -> None:


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.