### PR TITLE
Fix `sort_values` when `return_indexer=True`

### DIFF
--- a/python/cudf/cudf/core/_compat.py
+++ b/python/cudf/cudf/core/_compat.py
@@ -4,5 +4,5 @@
 import pandas as pd
 from packaging import version
 
-PANDAS_CURRENT_SUPPORTED_VERSION = version.parse("3.0.1")
+PANDAS_CURRENT_SUPPORTED_VERSION = version.parse("3.0.2")
 PANDAS_VERSION = version.parse(pd.__version__)

--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -2832,20 +2832,13 @@ class RangeIndex(Index):
             raise ValueError(f"invalid na_position: {na_position}")
 
         sorted_index = self
-        indexer = RangeIndex(range(len(self)))
-
-        sorted_index = self
-        if ascending:
-            if self.step < 0:
-                sorted_index = self[::-1]
-                indexer = indexer[::-1]
-        else:
-            if self.step > 0:
-                sorted_index = self[::-1]
-                indexer = indexer = indexer[::-1]
+        if (ascending and self.step < 0) or (not ascending and self.step > 0):
+            sorted_index = self[::-1]
 
         if return_indexer:
-            return sorted_index, indexer
+            return sorted_index, self.argsort(
+                ascending=ascending, na_position=na_position
+            )
         else:
             return sorted_index
 


### PR DESCRIPTION
## Description
 Root cause: RangeIndex.sort_values was returning a RangeIndex object as the indexer when     
  return_indexer=True, instead of a cupy.ndarray (as the base Index.sort_values does via
  argsort()). This caused assert_eq to fail when comparing a numpy.ndarray (from pandas)       
  against a RangeIndex (from cuDF's to_pandas() conversion), since numpy_array == pd.RangeIndex
   evaluates element-wise and can't be used as a boolean.

  Fix in python/cudf/cudf/core/index.py: Replaced the manual RangeIndex-based indexer logic    
  with a call to self.argsort(ascending=ascending, na_position=na_position), which already
  correctly returns a cupy.ndarray. The sorted index logic was also simplified equivalently.   
                                

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
