### PR TITLE
[Multi-GPU Polars] Remove all `pytest.skip` calls for unavailable GPU.

### DIFF
--- a/python/cudf_polars/tests/experimental/test_dask.py
+++ b/python/cudf_polars/tests/experimental/test_dask.py
@@ -13,7 +13,7 @@ import polars as pl
 
 from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.testing.asserts import assert_gpu_result_equal
-from cudf_polars.utils.config import DaskContext, MemoryResourceConfig
+from cudf_polars.utils.config import DaskContext
 
 distributed = pytest.importorskip("distributed")
 
@@ -26,15 +26,12 @@ if TYPE_CHECKING:
 @pytest.fixture(scope="module")
 def engine() -> Iterator[DaskEngine]:
     """Create one Dask/GPU cluster shared across the test module."""
-    try:
-        with DaskEngine(
-            # Small partition size so tests exercise the multi-partition code path
-            # deterministically, regardless of input size.
-            executor_options={"max_rows_per_partition": 10},
-        ) as engine:
-            yield engine
-    except Exception as e:
-        pytest.skip(f"Dask GPU cluster unavailable: {e}")
+    with DaskEngine(
+        # Small partition size so tests exercise the multi-partition code path
+        # deterministically, regardless of input size.
+        executor_options={"max_rows_per_partition": 10},
+    ) as engine:
+        yield engine
 
 
 pytestmark = [
@@ -55,11 +52,8 @@ pytestmark = [
 def test_from_options() -> None:
     """DaskEngine.from_options with default StreamingOptions creates a valid engine."""
     opts = StreamingOptions(fallback_mode="silent")
-    try:
-        with DaskEngine.from_options(opts) as engine:
-            assert engine.nranks >= 1
-    except Exception as e:
-        pytest.skip(f"Dask GPU cluster unavailable: {e}")
+    with DaskEngine.from_options(opts) as engine:
+        assert engine.nranks >= 1
 
 
 def test_yields_engine(engine: DaskEngine) -> None:
@@ -92,14 +86,11 @@ def test_gather_cluster_info(engine: DaskEngine) -> None:
 def test_from_options_creates_engine() -> None:
     """DaskEngine.from_options produces a working engine and runs a query."""
     opts = StreamingOptions(max_rows_per_partition=10, fallback_mode="silent")
-    try:
-        with DaskEngine.from_options(opts) as eng:
-            assert isinstance(eng, pl.GPUEngine)
-            assert eng.nranks >= 1
-            lf = pl.LazyFrame({"a": [1, 2, 3]})
-            assert_gpu_result_equal(lf, engine=eng, check_row_order=False)
-    except Exception as e:
-        pytest.skip(f"Dask GPU cluster unavailable: {e}")
+    with DaskEngine.from_options(opts) as eng:
+        assert isinstance(eng, pl.GPUEngine)
+        assert eng.nranks >= 1
+        lf = pl.LazyFrame({"a": [1, 2, 3]})
+        assert_gpu_result_equal(lf, engine=eng, check_row_order=False)
 
 
 def test_scan(engine: DaskEngine) -> None:
@@ -145,21 +136,6 @@ def test_join(engine: DaskEngine) -> None:
         engine=engine,
         check_row_order=False,
     )
-
-
-def test_memory_resource_config() -> None:
-    """DaskEngine workers use the MR from memory_resource_config when provided."""
-    opts = StreamingOptions(
-        fallback_mode="silent",
-        memory_resource_config=MemoryResourceConfig(
-            qualname="rmm.mr.CudaMemoryResource"
-        ),
-    )
-    try:
-        with DaskEngine.from_options(opts) as engine:
-            assert engine.nranks >= 1
-    except Exception as e:
-        pytest.skip(f"Dask GPU cluster unavailable: {e}")
 
 
 def test_empty_dataframe(engine: DaskEngine) -> None:

--- a/python/cudf_polars/tests/experimental/test_ray.py
+++ b/python/cudf_polars/tests/experimental/test_ray.py
@@ -12,10 +12,7 @@ from rapidsmpf.bootstrap import is_running_with_rrun
 
 import polars as pl
 
-from cudf_polars.experimental.rapidsmpf.frontend.options import (
-    StreamingOptions,
-)
-from cudf_polars.utils.config import MemoryResourceConfig, RayContext
+from cudf_polars.utils.config import RayContext
 
 ray = pytest.importorskip("ray")
 from cudf_polars.experimental.rapidsmpf.frontend.ray import RayEngine  # noqa: E402
@@ -27,16 +24,13 @@ if TYPE_CHECKING:
 @pytest.fixture(scope="module")
 def engine() -> Iterator[RayEngine]:
     """Create one Ray cluster + GPU actors shared across the test session."""
-    try:
-        with RayEngine(
-            # Use a small partition size so tests exercise the multi-partition
-            # code path deterministically, regardless of input size.
-            executor_options={"max_rows_per_partition": 10},
-            ray_init_options={"include_dashboard": False},
-        ) as engine:
-            yield engine
-    except RuntimeError as e:
-        pytest.skip(f"Ray GPU cluster unavailable: {e}")
+    with RayEngine(
+        # Use a small partition size so tests exercise the multi-partition
+        # code path deterministically, regardless of input size.
+        executor_options={"max_rows_per_partition": 10},
+        ray_init_options={"include_dashboard": False},
+    ) as engine:
+        yield engine
 
 
 pytestmark = [
@@ -172,21 +166,6 @@ def test_join(engine: RayEngine) -> None:
     assert result.shape == (n, 3)
     assert result["val_left"].to_list() == list(range(n))
     assert result["val_right"].to_list() == [x * 2 for x in range(n)]
-
-
-def test_memory_resource_config() -> None:
-    """RayEngine actors use the MR from memory_resource_config when provided."""
-    opts = StreamingOptions(
-        fallback_mode="silent",
-        memory_resource_config=MemoryResourceConfig(
-            qualname="rmm.mr.CudaMemoryResource"
-        ),
-    )
-    try:
-        with RayEngine.from_options(opts) as engine:
-            assert engine.nranks >= 1
-    except Exception as e:
-        pytest.skip(f"Ray GPU cluster unavailable: {e}")
 
 
 def test_empty_dataframe(engine: RayEngine) -> None:


### PR DESCRIPTION
These tests should fail hard if no GPUs are available.


