### PR TITLE
Preserve partitioning metadata for ``HStack`` nodes

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
@@ -35,7 +35,7 @@ import rmm.mr
 import cudf_polars.dsl.tracing
 from cudf_polars.containers import DataFrame
 from cudf_polars.dsl.expr import Col, NamedExpr
-from cudf_polars.dsl.ir import Cache, Filter, Join, Projection, Select
+from cudf_polars.dsl.ir import Cache, Filter, HStack, Join, Projection, Select
 from cudf_polars.dsl.tracing import Scope
 from cudf_polars.experimental.utils import _concat
 
@@ -211,6 +211,16 @@ def _remap_scheme_simple(
     return scheme  # None or "inherit" passes through unchanged
 
 
+def _hstack_to_select(hstack: HStack) -> Select:
+    """Translate HStack to the equivalent Select node."""
+    col_map = {ne.name: ne for ne in hstack.columns}
+    exprs = tuple(
+        col_map[name] if name in col_map else NamedExpr(name, Col(dtype, name))
+        for name, dtype in hstack.schema.items()
+    )
+    return Select(hstack.schema, exprs, hstack.should_broadcast, hstack.children[0])
+
+
 def maybe_remap_partitioning(
     ir: IR, partitioning: Partitioning | None, *, child_ir: IR | None = None
 ) -> Partitioning | None:
@@ -241,7 +251,10 @@ def maybe_remap_partitioning(
     """
     if partitioning is None:
         return None  # Nothing to preserve
-    if isinstance(ir, Select):
+    if isinstance(ir, (Select, HStack)):
+        if isinstance(ir, HStack):
+            # HStack is a special case of Select
+            ir = _hstack_to_select(ir)
         return Partitioning(
             inter_rank=_remap_scheme_select(ir, partitioning.inter_rank),
             local=_remap_scheme_select(ir, partitioning.local),
@@ -507,11 +520,11 @@ async def chunkwise_evaluate(
     if tracer is not None and metadata.duplicated:
         tracer.set_duplicated()
 
-    seq_num = 0
     received_any = False
     while (msg := await ch_in.recv(context)) is not None:
         received_any = True
         cd = msg.get_content_description()
+        seq_num = msg.sequence_number
         with cudf_polars.dsl.tracing.bound_contextvars(
             content_sizes=cd.content_sizes,
             spillable=cd.spillable,
@@ -524,7 +537,6 @@ async def chunkwise_evaluate(
         if tracer is not None:
             tracer.add_chunk(table=result.table_view())
         await ch_out.send(context, Message(seq_num, result))
-        seq_num += 1
 
     if handle_empty_input and not received_any:
         chunk = empty_table_chunk(ir.children[0], context, ir_context.get_cuda_stream())
@@ -532,7 +544,7 @@ async def chunkwise_evaluate(
         del chunk
         if tracer is not None:
             tracer.add_chunk(table=result.table_view())
-        await ch_out.send(context, Message(seq_num, result))
+        await ch_out.send(context, Message(0, result))
 
     await ch_out.drain(context)
 

--- a/python/cudf_polars/tests/experimental/test_metadata.py
+++ b/python/cudf_polars/tests/experimental/test_metadata.py
@@ -14,8 +14,9 @@ from rapidsmpf.streaming.cudf.channel_metadata import (
 import polars as pl
 
 from cudf_polars import Translator
+from cudf_polars.containers import DataType
 from cudf_polars.dsl import expr
-from cudf_polars.dsl.ir import Projection, Select
+from cudf_polars.dsl.ir import HStack, Projection, Select
 from cudf_polars.experimental.rapidsmpf.core import evaluate_logical_plan
 from cudf_polars.experimental.rapidsmpf.utils import (
     NormalizedPartitioning,
@@ -265,6 +266,25 @@ def test_remap_partitioning_select_none_input(engine) -> None:
 def test_remap_partitioning_select_preserves_keys(engine) -> None:
     part = Partitioning(inter_rank=HashScheme((0, 1), 8), local="inherit")
     result = maybe_remap_partitioning(_make_select_ir(engine, ("a", "b")), part)
+    assert result is not None
+    assert result.inter_rank is not None
+    assert result.inter_rank.column_indices == (0, 1)
+    assert result.inter_rank.modulus == 8
+    assert result.local == "inherit"
+
+
+def test_remap_partitioning_hstack_appends_preserves_keys(engine) -> None:
+    q = pl.LazyFrame({"a": [1], "b": [2], "c": [3]})
+    child = Translator(q._ldf.visit(), engine).translate_ir()
+    d_dtype = DataType(pl.Int64())
+    hstack = HStack(
+        {**child.schema, "d": d_dtype},
+        (expr.NamedExpr("d", expr.Literal(d_dtype, 0)),),
+        should_broadcast=True,
+        df=child,
+    )
+    part = Partitioning(inter_rank=HashScheme((0, 1), 8), local="inherit")
+    result = maybe_remap_partitioning(hstack, part)
     assert result is not None
     assert result.inter_rank is not None
     assert result.inter_rank.column_indices == (0, 1)


### PR DESCRIPTION
## Description
We preserve partitioning metadata for simple `Select` nodes. We can do the same for `HStack`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
