### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/.github/workflows/compute-sanitizer-run.yaml
+++ b/.github/workflows/compute-sanitizer-run.yaml
@@ -1,16 +1,7 @@
-name: Compute Sanitizer Run
+name: Compute Sanitizer
+run-name: "Compute Sanitizer ${{ inputs.tool_name }}"
 
 on:
-  workflow_call:
-    inputs:
-      tool_name:
-        required: true
-        type: string
-        description: "Compute sanitizer tool to run (memcheck, racecheck, initcheck, synccheck)"
-      test_names:
-        required: true
-        type: string
-        description: "JSON array of test names to run"
   workflow_dispatch:
     inputs:
       tool_name:
@@ -23,13 +14,31 @@ on:
           - initcheck
           - synccheck
       test_names:
-        required: true
+        required: false
         type: string
-        description: "JSON array of test names to run"
+        description: "JSON array of test names to run (discovers all tests if empty)"
+        default: ""
 
 jobs:
+  discover-sanitizer-tests:
+    if: ${{ inputs.test_names == '' }}
+    runs-on: linux-amd64-cpu4
+    container:
+      image: rapidsai/ci-conda:26.06-latest
+    outputs:
+      tests: ${{ steps.find-tests.outputs.tests }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Discover test executables
+        id: find-tests
+        shell: bash
+        run: |
+          ./ci/discover_libcudf_tests.sh
   run-sanitizer-tests:
     name: Run ${{ inputs.tool_name }} on ${{ matrix.test_name }}
+    needs: discover-sanitizer-tests
+    if: ${{ !cancelled() }}
     runs-on: linux-amd64-gpu-l4-latest-1
     container:
       image: rapidsai/ci-conda:26.06-latest
@@ -38,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_name: ${{ fromJson(inputs.test_names) }}
+        test_name: ${{ fromJson(inputs.test_names || needs.discover-sanitizer-tests.outputs.tests) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/compute-sanitizer-trigger.yaml
+++ b/.github/workflows/compute-sanitizer-trigger.yaml
@@ -1,6 +1,6 @@
-name: Compute Sanitizer Trigger
+name: Trigger Compute Sanitizer
 
-# This workflow runs all compute-sanitizer tools on all libcudf tests weekly.
+# This workflow triggers compute-sanitizer runs for all libcudf tests weekly.
 # WARNING: This is very resource intensive and runs hundreds of GPU jobs.
 # For targeted testing, manually trigger compute-sanitizer-run.yaml with specific tool_name and test_names.
 
@@ -10,31 +10,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  discover-sanitizer-tests:
-    runs-on: linux-amd64-cpu4
-    container:
-      image: rapidsai/ci-conda:26.06-latest
-    outputs:
-      tests: ${{ steps.find-tests.outputs.tests }}
+  trigger-racecheck:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      - name: Discover test executables
-        id: find-tests
-        shell: bash
+      - uses: actions/checkout@v5
+      - name: Trigger racecheck
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          ./ci/discover_libcudf_tests.sh
-  run-sanitizer-tests-racecheck:
-    name: compute-sanitizer racecheck tests
-    needs: discover-sanitizer-tests
-    uses: ./.github/workflows/compute-sanitizer-run.yaml
-    with:
-      tool_name: "racecheck"
-      test_names: ${{ needs.discover-sanitizer-tests.outputs.tests }}
-  run-sanitizer-tests-synccheck:
-    name: compute-sanitizer synccheck tests
-    needs: discover-sanitizer-tests
-    uses: ./.github/workflows/compute-sanitizer-run.yaml
-    with:
-      tool_name: "synccheck"
-      test_names: ${{ needs.discover-sanitizer-tests.outputs.tests }}
+          gh workflow run compute-sanitizer-run.yaml \
+            -f tool_name="racecheck"
+  trigger-synccheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Trigger synccheck
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run compute-sanitizer-run.yaml \
+            -f tool_name="synccheck"

--- a/cpp/src/bitmask/null_mask.cu
+++ b/cpp/src/bitmask/null_mask.cu
@@ -739,7 +739,7 @@ void set_all_valid_null_masks(column_view const& input,
                               rmm::cuda_stream_view stream,
                               rmm::device_async_resource_ref mr)
 {
-  if (input.nullable()) {
+  if (input.nullable() && output.size() > 0) {
     auto mask = detail::create_null_mask(output.size(), mask_state::ALL_VALID, stream, mr);
     output.set_null_mask(std::move(mask), 0);
 

--- a/python/cudf_polars/cudf_polars/dsl/expressions/aggregation.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/aggregation.py
@@ -59,7 +59,11 @@ class Agg(Expr):
             req = plc.aggregation.median()
         elif name == "n_unique":
             # TODO: datatype of result
-            req = plc.aggregation.nunique(null_handling=plc.types.NullPolicy.INCLUDE)
+            req = plc.aggregation.nunique(
+                null_handling=plc.types.NullPolicy.EXCLUDE
+                if options
+                else plc.types.NullPolicy.INCLUDE
+            )
         elif name == "first" or name == "last":
             req = None
         elif name == "mean":

--- a/python/cudf_polars/cudf_polars/dsl/nodebase.py
+++ b/python/cudf_polars/cudf_polars/dsl/nodebase.py
@@ -18,6 +18,15 @@ __all__: list[str] = ["Node"]
 T = TypeVar("T", bound="Node[Any]")
 
 
+def _expand_hashable(obj: Any) -> Any:
+    """Expand nested Node instances to their hashable form."""
+    if isinstance(obj, Node):
+        return _expand_hashable(obj.get_hashable())
+    elif isinstance(obj, tuple):
+        return tuple(_expand_hashable(x) for x in obj)
+    return obj
+
+
 class Node(Generic[T]):
     """
     An abstract node type.
@@ -103,7 +112,7 @@ class Node(Generic[T]):
         try:
             return self._stable_hash_value
         except AttributeError:
-            content = repr(self.get_hashable()).encode("utf-8")
+            content = repr(_expand_hashable(self)).encode("utf-8")
             self._stable_hash_value = int(hashlib.md5(content).hexdigest()[:8], 16)
             return self._stable_hash_value
 

--- a/python/cudf_polars/cudf_polars/dsl/utils/aggregations.py
+++ b/python/cudf_polars/cudf_polars/dsl/utils/aggregations.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """Utilities for rewriting aggregations."""
@@ -167,6 +167,16 @@ def decompose_single_agg(
             child = agg.children[0]
         else:
             (child,) = agg.children
+        # Fuse drop_nulls().n_unique() into nunique(null_handling=EXCLUDE)
+        # rather than materializing a filtered intermediate column.
+        if (
+            agg.name == "n_unique"
+            and isinstance(child, expr.UnaryFunction)
+            and child.name == "drop_nulls"
+        ):
+            (child,) = child.children
+            agg = expr.Agg(agg.dtype, "n_unique", (True,), agg.context, child)
+            named_expr = named_expr.reconstruct(agg)
         needs_masking = agg.name in {"min", "max"} and plc.traits.is_floating_point(
             child.dtype.plc_type
         )

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -10,9 +10,15 @@ import pytest
 import polars as pl
 
 from cudf_polars import Translator
+from cudf_polars.dsl.traversal import traversal
 from cudf_polars.experimental.parallel import lower_ir_graph
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.utils.config import ConfigOptions
+
+
+def _assert_stable_ids_match(orig, loaded) -> None:
+    for a, b in zip(traversal([orig]), traversal([loaded]), strict=True):
+        assert a.get_stable_id() == b.get_stable_id()
 
 
 @pytest.fixture(scope="module")
@@ -63,6 +69,21 @@ def test_dataframescan_concat(df, engine):
     assert_gpu_result_equal(df2, engine=engine)
 
 
+def test_join_in_memory_lazy_stable_id_pickle():
+    engine = pl.GPUEngine(
+        raise_on_fail=True,
+        executor="streaming",
+        executor_options={"max_rows_per_partition": 1_000},
+    )
+    left = pl.LazyFrame({"k": [1, 2, 3], "x": [10, 20, 30]}).collect().lazy()
+    right = pl.LazyFrame({"k": [2, 3, 4], "y": [1, 2, 3]}).collect().lazy()
+    ir, _, _ = lower_ir_graph(
+        Translator(left.join(right, on="k")._ldf.visit(), engine).translate_ir(),
+        ConfigOptions.from_polars_engine(engine),
+    )
+    _assert_stable_ids_match(ir, pickle.loads(pickle.dumps(ir)))
+
+
 def test_dataframescan_pickle(df):
     _engine = pl.GPUEngine(
         raise_on_fail=True,
@@ -79,3 +100,4 @@ def test_dataframescan_pickle(df):
     # Verify the unpickled IR is equivalent
     assert type(unpickled_ir) is type(ir)
     assert unpickled_ir.schema == ir.schema
+    _assert_stable_ids_match(ir, unpickled_ir)

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -328,6 +328,13 @@ def test_groupby_nunique(df: pl.LazyFrame, column):
     assert_gpu_result_equal(q, check_row_order=False)
 
 
+@pytest.mark.parametrize("column", ["int", "string", "uint16_with_null"])
+def test_groupby_nunique_drop_nulls(df: pl.LazyFrame, column):
+    q = df.group_by("key1").agg(pl.col(column).drop_nulls().n_unique())
+
+    assert_gpu_result_equal(q, check_row_order=False)
+
+
 def test_groupby_null_count(df: pl.LazyFrame):
     q = df.group_by("key1").agg(pl.col("uint16_with_null").null_count())
 


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.