### PR TITLE
Optimize PDS-DS Q74

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q74.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q74.py
@@ -97,35 +97,27 @@ def duckdb_impl(run_config: RunConfig) -> str:
     """
 
 
-def _year_totals_component(
+def _year_totals_by_sk(
     sales: pl.LazyFrame,
     date_dim: pl.LazyFrame,
-    customer: pl.LazyFrame,
     date_fk: str,
     customer_fk: str,
     amount_col: str,
-    sale_type: str,
     year: int,
 ) -> pl.LazyFrame:
-    dates = date_dim.filter(pl.col("d_year").is_in([year, year + 1])).select(
-        ["d_date_sk", "d_year"]
-    )
-    cust = customer.select(
-        ["c_customer_sk", "c_customer_id", "c_first_name", "c_last_name"]
-    )
+    """
+    Aggregate sales stddev per customer_sk for a single year.
+
+    Groups by customer_sk only (not wide customer display columns) to
+    reduce intermediate cardinality. Customer display columns are joined
+    once at the end where needed.
+    """
+    year_dates = date_dim.filter(pl.col("d_year") == year).select("d_date_sk")
     return (
-        sales.join(dates, left_on=date_fk, right_on="d_date_sk")
-        .join(cust, left_on=customer_fk, right_on="c_customer_sk")
-        .group_by(["c_customer_id", "c_first_name", "c_last_name", "d_year"])
+        sales.join(year_dates, left_on=date_fk, right_on="d_date_sk")
+        .group_by(customer_fk)
         .agg(pl.col(amount_col).std().alias("year_total"))
-        .select(
-            pl.col("c_customer_id").alias("customer_id"),
-            pl.col("c_first_name").alias("customer_first_name"),
-            pl.col("c_last_name").alias("customer_last_name"),
-            pl.col("d_year").alias("year1"),
-            "year_total",
-        )
-        .with_columns(pl.lit(sale_type).alias("sale_type"))
+        .rename({customer_fk: "customer_sk"})
     )
 
 
@@ -144,100 +136,53 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     web_sales = get_data(run_config.dataset_path, "web_sales", run_config.suffix)
     date_dim = get_data(run_config.dataset_path, "date_dim", run_config.suffix)
 
-    year_total = pl.concat(
-        [
-            _year_totals_component(
-                sales=store_sales,
-                date_dim=date_dim,
-                customer=customer,
-                date_fk="ss_sold_date_sk",
-                customer_fk="ss_customer_sk",
-                amount_col="ss_net_paid",
-                sale_type="s",
-                year=year,
-            ),
-            _year_totals_component(
-                sales=web_sales,
-                date_dim=date_dim,
-                customer=customer,
-                date_fk="ws_sold_date_sk",
-                customer_fk="ws_bill_customer_sk",
-                amount_col="ws_net_paid",
-                sale_type="w",
-                year=year,
-            ),
-        ]
+    # Build four separate per-(sale_type, year) aggregates, grouping by
+    # customer_sk (integer PK) rather than wide display-string columns.
+    # This mirrors the Q11 optimization: customer display columns are
+    # joined once at the very end.
+    t_s_first = (
+        _year_totals_by_sk(
+            store_sales,
+            date_dim,
+            "ss_sold_date_sk",
+            "ss_customer_sk",
+            "ss_net_paid",
+            year,
+        )
+        .rename({"year_total": "s_first_year_total"})
+        .filter(pl.col("s_first_year_total") > 0)
     )
 
-    # Polars sum() returns 0 for all-null groups; SQL returns NULL.
-    # See https://github.com/rapidsai/cudf/issues/19560.
-    grouped = (
-        year_total.group_by(
-            ["customer_id", "customer_first_name", "customer_last_name"]
+    t_s_sec = _year_totals_by_sk(
+        store_sales,
+        date_dim,
+        "ss_sold_date_sk",
+        "ss_customer_sk",
+        "ss_net_paid",
+        year + 1,
+    ).rename({"year_total": "s_sec_year_total"})
+
+    t_w_first = (
+        _year_totals_by_sk(
+            web_sales,
+            date_dim,
+            "ws_sold_date_sk",
+            "ws_bill_customer_sk",
+            "ws_net_paid",
+            year,
         )
-        .agg(
-            [
-                pl.when((pl.col("sale_type") == "s") & (pl.col("year1") == year))
-                .then(pl.col("year_total"))
-                .otherwise(None)
-                .count()
-                .alias("s_first_cnt"),
-                pl.when((pl.col("sale_type") == "s") & (pl.col("year1") == year))
-                .then(pl.col("year_total"))
-                .otherwise(None)
-                .sum()
-                .alias("s_first_sum"),
-                pl.when((pl.col("sale_type") == "s") & (pl.col("year1") == year + 1))
-                .then(pl.col("year_total"))
-                .otherwise(None)
-                .count()
-                .alias("s_second_cnt"),
-                pl.when((pl.col("sale_type") == "s") & (pl.col("year1") == year + 1))
-                .then(pl.col("year_total"))
-                .otherwise(None)
-                .sum()
-                .alias("s_second_sum"),
-                pl.when((pl.col("sale_type") == "w") & (pl.col("year1") == year))
-                .then(pl.col("year_total"))
-                .otherwise(None)
-                .count()
-                .alias("w_first_cnt"),
-                pl.when((pl.col("sale_type") == "w") & (pl.col("year1") == year))
-                .then(pl.col("year_total"))
-                .otherwise(None)
-                .sum()
-                .alias("w_first_sum"),
-                pl.when((pl.col("sale_type") == "w") & (pl.col("year1") == year + 1))
-                .then(pl.col("year_total"))
-                .otherwise(None)
-                .count()
-                .alias("w_second_cnt"),
-                pl.when((pl.col("sale_type") == "w") & (pl.col("year1") == year + 1))
-                .then(pl.col("year_total"))
-                .otherwise(None)
-                .sum()
-                .alias("w_second_sum"),
-            ]
-        )
-        .with_columns(
-            pl.when(pl.col("s_first_cnt") > 0)
-            .then(pl.col("s_first_sum"))
-            .otherwise(None)
-            .alias("s_first"),
-            pl.when(pl.col("s_second_cnt") > 0)
-            .then(pl.col("s_second_sum"))
-            .otherwise(None)
-            .alias("s_second"),
-            pl.when(pl.col("w_first_cnt") > 0)
-            .then(pl.col("w_first_sum"))
-            .otherwise(None)
-            .alias("w_first"),
-            pl.when(pl.col("w_second_cnt") > 0)
-            .then(pl.col("w_second_sum"))
-            .otherwise(None)
-            .alias("w_second"),
-        )
+        .rename({"year_total": "w_first_year_total"})
+        .filter(pl.col("w_first_year_total") > 0)
     )
+
+    t_w_sec = _year_totals_by_sk(
+        web_sales,
+        date_dim,
+        "ws_sold_date_sk",
+        "ws_bill_customer_sk",
+        "ws_net_paid",
+        year + 1,
+    ).rename({"year_total": "w_sec_year_total"})
 
     sort_by = {
         "customer_id": False,
@@ -245,15 +190,27 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
         "customer_last_name": False,
     }
     limit = 100
+
     return QueryResult(
         frame=(
-            grouped.filter((pl.col("s_first") > 0) & (pl.col("w_first") > 0))
-            .with_columns(
-                (pl.col("w_second") / pl.col("w_first")).alias("w_ratio"),
-                (pl.col("s_second") / pl.col("s_first")).alias("s_ratio"),
+            # Inner joins on customer_sk ensure only customers present in all
+            # four (sale_type, year) combinations survive, matching the SQL
+            # four-way self-join on customer_id.
+            t_s_sec.join(t_s_first, on="customer_sk")
+            .join(t_w_first, on="customer_sk")
+            .join(t_w_sec, on="customer_sk")
+            .filter(
+                pl.col("w_sec_year_total") / pl.col("w_first_year_total")
+                > pl.col("s_sec_year_total") / pl.col("s_first_year_total")
             )
-            .filter(pl.col("w_ratio") > pl.col("s_ratio"))
-            .select(["customer_id", "customer_first_name", "customer_last_name"])
+            .join(customer, left_on="customer_sk", right_on="c_customer_sk")
+            .select(
+                [
+                    pl.col("c_customer_id").alias("customer_id"),
+                    pl.col("c_first_name").alias("customer_first_name"),
+                    pl.col("c_last_name").alias("customer_last_name"),
+                ]
+            )
             .sort(sort_by.keys(), nulls_last=True)
             .limit(limit)
         ),


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Following the optimization patterns we've been applying manually to the PDS-DS queries: join reordering, filter pushdown, etc.
In this PR,
1. `_year_totals_by_sk` filters date_dim to a single year, joins sales, then groups by `customer_sk` (one integer column). No customer table join yet.                                      
2. 4 separate aggregates: `t_s_first`,`t_s_sec`, `t_w_first`, `t_w_sec`: one per (sale_type, year) combination. `t_s_first` and `t_w_first` get the `> 0` filter applied immediately, eliminating customers who don't qualify early.                                                                                                                                                      
3. Inner joins on customer_sk chain the 4 aggregates. Only customers present in all 4 survive (matches the SQL 4-way self-join semantics).                                            
4. Ratio filter applied directly: no need for the count/sum/CASE workaround since inner joins already handle the "no rows for this category" case.                                     
5. customer joined once at the end to retrieve display columns.                                                                                                                         
          

Went from an OOM on H100 to ~5sec
```
✅ Query 74 - Iteration 0 finished in 7.4573s
✅ Query 74 - Iteration 1 finished in 5.3775s
✅ Query 74 - Iteration 2 finished in 5.4442s
✅ Query 74 - Iteration 3 finished in 4.9556s
✅ Query 74 - Iteration 4 finished in 4.8756s
```
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
