### PR TITLE
Pass BufferResource for stream lifetime in rapidsmpf integration layer

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -231,7 +231,7 @@ async def _global_shuffle(
     while (msg := await ch_in.recv(context)) is not None:
         if not skip_insert:
             shuffle.insert_hash(
-                TableChunk.from_message(msg).make_available_and_spill(
+                TableChunk.from_message(msg, br=context.br()).make_available_and_spill(
                     context.br(), allow_overbooking=True
                 ),
                 columns_to_hash,
@@ -249,6 +249,7 @@ async def _global_shuffle(
                     table=shuffle.extract_chunk(partition_id, stream),
                     stream=stream,
                     exclusive_view=True,
+                    br=context.br(),
                 ),
             ),
         )

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
@@ -132,6 +132,7 @@ async def _compute_sort_boundaries(
             local_boundaries_df.table,
             stream,
             exclusive_view=True,
+            br=context.br(),
         )
         allgather.insert(comm.rank, chunk)
         allgather.insert_finished()
@@ -179,7 +180,7 @@ async def _sample_chunks_for_size_estimate(
         msg = await ch_in.recv(context)
         if msg is None:
             break
-        chunk = TableChunk.from_message(msg).make_available_and_spill(
+        chunk = TableChunk.from_message(msg, br=context.br()).make_available_and_spill(
             context.br(), allow_overbooking=True
         )
         sampled_bytes += chunk.data_alloc_size()
@@ -222,7 +223,7 @@ async def _receive_and_buffer_chunks(
     while (msg := await ch_in.recv(context)) is not None:
         seq_num = msg.sequence_number
         df = chunk_to_frame(
-            TableChunk.from_message(msg).make_available_and_spill(
+            TableChunk.from_message(msg, br=context.br()).make_available_and_spill(
                 context.br(), allow_overbooking=True
             ),
             sort_ir,
@@ -234,6 +235,7 @@ async def _receive_and_buffer_chunks(
                 ).table,
                 df.stream,
                 exclusive_view=True,
+                br=context.br(),
             )
         )
         if sort_ir.stable:
@@ -256,7 +258,9 @@ async def _receive_and_buffer_chunks(
         chunk_store.insert(
             Message(
                 seq_num,
-                TableChunk.from_pylibcudf_table(tbl, df.stream, exclusive_view=True),
+                TableChunk.from_pylibcudf_table(
+                    tbl, df.stream, exclusive_view=True, br=context.br()
+                ),
             )
         )
         del df
@@ -296,9 +300,9 @@ async def _insert_chunks_into_shuffle(
         if skip_insert:
             continue
         seq_num = msg.sequence_number
-        available_chunk = TableChunk.from_message(msg).make_available_and_spill(
-            context.br(), allow_overbooking=True
-        )
+        available_chunk = TableChunk.from_message(
+            msg, br=context.br()
+        ).make_available_and_spill(context.br(), allow_overbooking=True)
         tbl = available_chunk.table_view()
         sort_cols_tbl = plc.Table([tbl.columns()[i] for i in by_indices])
 
@@ -374,7 +378,9 @@ async def _extract_partitions_and_send(
             context,
             Message(
                 partition_id,
-                TableChunk.from_pylibcudf_table(table, stream, exclusive_view=True),
+                TableChunk.from_pylibcudf_table(
+                    table, stream, exclusive_view=True, br=context.br()
+                ),
             ),
         )
 

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/core.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/core.py
@@ -344,7 +344,7 @@ def evaluate_pipeline(
             # use-after-free with stream-ordered allocations
             messages = output.release()
             chunks = [
-                TableChunk.from_message(msg).make_available_and_spill(
+                TableChunk.from_message(msg, br=br).make_available_and_spill(
                     br, allow_overbooking=True
                 )
                 for msg in messages

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
@@ -99,7 +99,7 @@ def execute_ir_on_rank(
 
     messages = output.release()
     chunks = [
-        TableChunk.from_message(msg).make_available_and_spill(
+        TableChunk.from_message(msg, br=ctx.br()).make_available_and_spill(
             ctx.br(), allow_overbooking=True
         )
         for msg in messages

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
@@ -216,7 +216,7 @@ async def _local_aggregation(
         chunks_received += 1
         chunk = await evaluate_chunk(
             context,
-            TableChunk.from_message(msg),
+            TableChunk.from_message(msg, br=context.br()),
             decomposed.piecewise_ir,
             ir_context=ir_context,
         )
@@ -321,6 +321,7 @@ async def _tree_reduce(
                 await allgather.extract_concatenated(stream),
                 stream,
                 exclusive_view=True,
+                br=context.br(),
             ),
             decomposed.reduction_ir,
             ir_context=ir_context,
@@ -465,6 +466,7 @@ async def _shuffle_reduce(
             shuffle.extract_chunk(partition_id, stream),
             stream,
             exclusive_view=True,
+            br=context.br(),
         )
         partition_chunk = await evaluate_chunk(
             context,

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/io.py
@@ -398,6 +398,7 @@ async def read_chunk(
                 df.table,
                 df.stream,
                 exclusive_view=True,
+                br=context.br(),
             ),
         ),
     )
@@ -820,9 +821,9 @@ async def sink_node(
             _prepare_sink_directory(ir.sink.path)
             i = 0
             while (msg := await ch_in.recv(context)) is not None:
-                chunk = TableChunk.from_message(msg).make_available_and_spill(
-                    context.br(), allow_overbooking=True
-                )
+                chunk = TableChunk.from_message(
+                    msg, br=context.br()
+                ).make_available_and_spill(context.br(), allow_overbooking=True)
                 df = chunk_to_frame(chunk, child_ir)
                 part_path = f"{path_root}.{str(i).zfill(count_width)}.{suffix}"
                 await asyncio.to_thread(
@@ -840,9 +841,9 @@ async def sink_node(
             # Write chunks to a single file
             writer_state = None
             while (msg := await ch_in.recv(context)) is not None:
-                chunk = TableChunk.from_message(msg).make_available_and_spill(
-                    context.br(), allow_overbooking=True
-                )
+                chunk = TableChunk.from_message(
+                    msg, br=context.br()
+                ).make_available_and_spill(context.br(), allow_overbooking=True)
                 # Multiple chunks - use chunked writer
                 df = chunk_to_frame(chunk, child_ir)
                 writer_state = await asyncio.to_thread(

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
@@ -180,7 +180,7 @@ async def _collect_small_side_for_broadcast(
     size = 0
     chunks: list[TableChunk] = []
     while (msg := await ch.recv(context)) is not None:
-        chunks.append(TableChunk.from_message(msg))
+        chunks.append(TableChunk.from_message(msg, br=context.br()))
         size += chunks[-1].data_alloc_size()
     row_count = sum(c.shape[0] for c in chunks)
 
@@ -274,7 +274,9 @@ async def _broadcast_join_large_chunk(
         context,
         Message(
             seq_num,
-            TableChunk.from_pylibcudf_table(df.table, df.stream, exclusive_view=True),
+            TableChunk.from_pylibcudf_table(
+                df.table, df.stream, exclusive_view=True, br=context.br()
+            ),
         ),
     )
     del df, large_df
@@ -370,7 +372,7 @@ async def _broadcast_join(
             ch_out,
             small_dfs,
             small_child,
-            TableChunk.from_message(msg).make_available_and_spill(
+            TableChunk.from_message(msg, br=context.br()).make_available_and_spill(
                 context.br(), allow_overbooking=True
             ),
             large_child,
@@ -441,12 +443,12 @@ async def _join_chunks(
             f"Left: {left_msg.sequence_number}, Right: {right_msg.sequence_number}"
         )
 
-        left_chunk = TableChunk.from_message(left_msg).make_available_and_spill(
-            context.br(), allow_overbooking=True
-        )
-        right_chunk = TableChunk.from_message(right_msg).make_available_and_spill(
-            context.br(), allow_overbooking=True
-        )
+        left_chunk = TableChunk.from_message(
+            left_msg, br=context.br()
+        ).make_available_and_spill(context.br(), allow_overbooking=True)
+        right_chunk = TableChunk.from_message(
+            right_msg, br=context.br()
+        ).make_available_and_spill(context.br(), allow_overbooking=True)
 
         input_bytes = sum(
             col.device_buffer_size()
@@ -474,7 +476,7 @@ async def _join_chunks(
             Message(
                 left_msg.sequence_number,
                 TableChunk.from_pylibcudf_table(
-                    df.table, df.stream, exclusive_view=True
+                    df.table, df.stream, exclusive_view=True, br=context.br()
                 ),
             ),
         )
@@ -830,7 +832,7 @@ async def _sample_chunks(
         msg = await ch.recv(context)
         if msg is None:
             break
-        chunk = TableChunk.from_message(msg).make_available_and_spill(
+        chunk = TableChunk.from_message(msg, br=context.br()).make_available_and_spill(
             context.br(), allow_overbooking=True
         )
         sampled_chunks[msg.sequence_number] = chunk

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/nodes.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/nodes.py
@@ -176,7 +176,7 @@ async def default_node_multi(
                     finished_channels.add(ch_idx)
                 else:
                     # Store the new chunk (replacing previous if any)
-                    ready_chunks[ch_idx] = TableChunk.from_message(msg)
+                    ready_chunks[ch_idx] = TableChunk.from_message(msg, br=context.br())
                     chunk_count[ch_idx] += 1
                 del msg
 
@@ -229,6 +229,7 @@ async def default_node_multi(
                         df.table,
                         df.stream,
                         exclusive_view=True,
+                        br=context.br(),
                     ),
                 ),
             )
@@ -280,9 +281,9 @@ async def fanout_node_bounded(
         )
 
         while (msg := await ch_in.recv(context)) is not None:
-            table_chunk = TableChunk.from_message(msg).make_available_and_spill(
-                context.br(), allow_overbooking=True
-            )
+            table_chunk = TableChunk.from_message(
+                msg, br=context.br()
+            ).make_available_and_spill(context.br(), allow_overbooking=True)
             seq_num = msg.sequence_number
             del msg
             for ch_out in chs_out:
@@ -294,6 +295,7 @@ async def fanout_node_bounded(
                             table_chunk.table_view(),
                             table_chunk.stream,
                             exclusive_view=False,
+                            br=context.br(),
                         ),
                     ),
                 )
@@ -584,7 +586,7 @@ async def empty_node(
 
         # Return the output chunk (empty but with correct schema)
         chunk = TableChunk.from_pylibcudf_table(
-            df.table, df.stream, exclusive_view=True
+            df.table, df.stream, exclusive_view=True, br=context.br()
         )
         await ch_out.send(context, Message(0, chunk))
 

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
@@ -147,7 +147,7 @@ async def concatenate_node(
             stream = context.get_stream_from_pool()
             seq_num = 0
             while (msg := await ch_in.recv(context)) is not None:
-                allgather.insert(seq_num, TableChunk.from_message(msg))
+                allgather.insert(seq_num, TableChunk.from_message(msg, br=context.br()))
                 seq_num += 1
                 del msg
             allgather.insert_finished()
@@ -163,7 +163,7 @@ async def concatenate_node(
                 output_chunk = empty_table_chunk(ir, context, stream)
             else:
                 output_chunk = TableChunk.from_pylibcudf_table(
-                    result_table, stream, exclusive_view=True
+                    result_table, stream, exclusive_view=True, br=context.br()
                 )
 
             await ch_out.send(context, Message(0, output_chunk))
@@ -191,7 +191,7 @@ async def concatenate_node(
                     if msg is None:
                         done_receiving = True
                         break
-                    chunks.append(TableChunk.from_message(msg))
+                    chunks.append(TableChunk.from_message(msg, br=context.br()))
 
                 if chunks:
                     chunks, extra = await make_table_chunks_available_or_wait(
@@ -223,7 +223,10 @@ async def concatenate_node(
                         Message(
                             seq_num,
                             TableChunk.from_pylibcudf_table(
-                                df.table, df.stream, exclusive_view=True
+                                df.table,
+                                df.stream,
+                                exclusive_view=True,
+                                br=context.br(),
                             ),
                         ),
                     )

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/union.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/union.py
@@ -87,7 +87,9 @@ async def union_node(
                     context,
                     Message(
                         msg.sequence_number + seq_num_offset,
-                        TableChunk.from_message(msg).make_available_and_spill(
+                        TableChunk.from_message(
+                            msg, br=context.br()
+                        ).make_available_and_spill(
                             context.br(), allow_overbooking=True
                         ),
                     ),

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
@@ -430,7 +430,9 @@ async def concat_batch(
             context=ir_context,
         )
         del batch
-    return TableChunk.from_pylibcudf_table(df.table, df.stream, exclusive_view=True)
+    return TableChunk.from_pylibcudf_table(
+        df.table, df.stream, exclusive_view=True, br=context.br()
+    )
 
 
 async def evaluate_batch(
@@ -518,7 +520,10 @@ async def chunkwise_evaluate(
             sequence_number=msg.sequence_number,
         ):
             result = await evaluate_chunk(
-                context, TableChunk.from_message(msg), ir, ir_context=ir_context
+                context,
+                TableChunk.from_message(msg, br=context.br()),
+                ir,
+                ir_context=ir_context,
             )
         del msg, cd
         if tracer is not None:
@@ -905,6 +910,7 @@ def empty_table_chunk(ir: IR, context: Context, stream: Stream) -> TableChunk:
         empty_table,
         stream,
         exclusive_view=True,
+        br=context.br(),
     )
 
 

--- a/python/cudf_polars/tests/experimental/test_allgather.py
+++ b/python/cudf_polars/tests/experimental/test_allgather.py
@@ -32,7 +32,10 @@ async def _test_allgather(engine) -> None:
     allgather = AllGatherManager(context, comm, 0)
     for i, table in enumerate(tables):
         allgather.insert(
-            i, TableChunk.from_pylibcudf_table(table, stream, exclusive_view=True)
+            i,
+            TableChunk.from_pylibcudf_table(
+                table, stream, exclusive_view=True, br=context.br()
+            ),
         )
     allgather.insert_finished()
 

--- a/python/cudf_polars/tests/experimental/test_spilling.py
+++ b/python/cudf_polars/tests/experimental/test_spilling.py
@@ -83,7 +83,9 @@ def test_make_spill_function(
         for msg_idx in range(count):
             # Create 1MB messages
             table = create_test_table(1024 * 1024, stream)
-            chunk = TableChunk.from_pylibcudf_table(table, stream, exclusive_view=True)
+            chunk = TableChunk.from_pylibcudf_table(
+                table, stream, exclusive_view=True, br=context.br()
+            )
             msg = Message(msg_idx, chunk)
             mid = sm.insert(msg)
             message_ids[buffer_idx].append(mid)
@@ -132,7 +134,7 @@ def test_make_spill_function(
         spilled_mid = message_ids[1][4]  # Newest message from longest queue
         spilled_msg = buffers[1].extract(mid=spilled_mid)
 
-        chunk = TableChunk.from_message(spilled_msg)
+        chunk = TableChunk.from_message(spilled_msg, br=context.br())
         assert not chunk.is_available()  # Should be on host
 
         # Make it available should bring it back to device


### PR DESCRIPTION
## Description

Pass `BufferResource` to rapidsmpf wrapper factory methods (`TableChunk.from_pylibcudf_table`, `from_message`, `from_packed_data`, `PackedDataChunk.from_message`, etc.) at all call sites in the cudf-polars rapidsmpf integration layer. This keeps the `BufferResource` (and its underlying stream and memory resource) alive for the lifetime of the wrapper objects, preventing dangling `cuda_stream_view` references.

Depends on https://github.com/rapidsai/rapidsmpf/pull/960, which adds the optional `br` parameter to these factory methods.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.