### PR TITLE
Fix partitioning metadata preservation for ``GroupBy``

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
@@ -39,6 +39,7 @@ from cudf_polars.experimental.rapidsmpf.utils import (
     empty_table_chunk,
     evaluate_batch,
     evaluate_chunk,
+    maybe_remap_partitioning,
     process_children,
     recv_metadata,
     send_metadata,
@@ -685,13 +686,20 @@ async def groupby_actor(
         if fully_partitioned or fallback_case:
             if tracer is not None:
                 tracer.decision = "chunkwise"
+            metadata_out = ChannelMetadata(
+                local_count=metadata_in.local_count,
+                partitioning=maybe_remap_partitioning(
+                    ir, metadata_in.partitioning, child_ir=ir.children[0]
+                ),
+                duplicated=metadata_in.duplicated,
+            )
             await chunkwise_evaluate(
                 context,
                 ir,
                 ir_context,
                 ch_out,
                 ch_in,
-                metadata_in,
+                metadata_out,
                 tracer=tracer,
             )
             return

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
@@ -35,7 +35,7 @@ import rmm.mr
 import cudf_polars.dsl.tracing
 from cudf_polars.containers import DataFrame
 from cudf_polars.dsl.expr import Col, NamedExpr
-from cudf_polars.dsl.ir import Cache, Filter, HStack, Join, Projection, Select
+from cudf_polars.dsl.ir import Cache, Filter, GroupBy, HStack, Join, Projection, Select
 from cudf_polars.dsl.tracing import Scope
 from cudf_polars.experimental.utils import _concat
 
@@ -258,6 +258,13 @@ def maybe_remap_partitioning(
         return Partitioning(
             inter_rank=_remap_scheme_select(ir, partitioning.inter_rank),
             local=_remap_scheme_select(ir, partitioning.local),
+        )
+    if isinstance(ir, GroupBy):
+        return Partitioning(
+            inter_rank=_remap_scheme_simple(
+                ir, partitioning.inter_rank, ir.children[0]
+            ),
+            local=_remap_scheme_simple(ir, partitioning.local, ir.children[0]),
         )
     if isinstance(ir, (Cache, Join, Projection, Filter)):
         child = child_ir if child_ir is not None else ir.children[0]

--- a/python/cudf_polars/tests/experimental/test_metadata.py
+++ b/python/cudf_polars/tests/experimental/test_metadata.py
@@ -16,7 +16,7 @@ import polars as pl
 from cudf_polars import Translator
 from cudf_polars.containers import DataType
 from cudf_polars.dsl import expr
-from cudf_polars.dsl.ir import HStack, Projection, Select
+from cudf_polars.dsl.ir import GroupBy, HStack, Projection, Select
 from cudf_polars.experimental.rapidsmpf.core import evaluate_logical_plan
 from cudf_polars.experimental.rapidsmpf.utils import (
     NormalizedPartitioning,
@@ -269,6 +269,34 @@ def test_remap_partitioning_select_preserves_keys(engine) -> None:
     assert result is not None
     assert result.inter_rank is not None
     assert result.inter_rank.column_indices == (0, 1)
+    assert result.inter_rank.modulus == 8
+    assert result.local == "inherit"
+
+
+def test_remap_partitioning_groupby(engine) -> None:
+    """Hash indices refer to the groupby input child; remap to groupby output columns."""
+    q = (
+        pl.LazyFrame({"a": [1], "b": [2], "c": [3]})
+        .group_by("a", "b")
+        .agg(pl.col("c").sum())
+    )
+    ir = Translator(q._ldf.visit(), engine).translate_ir()
+    while isinstance(ir, (Select, Projection)):
+        ir = ir.children[0]
+    assert isinstance(ir, GroupBy)
+
+    gb = ir
+    key_names = tuple(ne.name for ne in gb.keys)
+    child_cols = list(gb.children[0].schema.keys())
+    input_indices = tuple(child_cols.index(n) for n in key_names)
+    out_cols = list(gb.schema.keys())
+    expected = tuple(out_cols.index(n) for n in key_names)
+
+    part = Partitioning(inter_rank=HashScheme(input_indices, 8), local="inherit")
+    result = maybe_remap_partitioning(gb, part)
+    assert result is not None
+    assert result.inter_rank is not None
+    assert result.inter_rank.column_indices == expected
     assert result.inter_rank.modulus == 8
     assert result.local == "inherit"
 


### PR DESCRIPTION
## Description
We currently pass through partitioning metadata "as is" - Even when the column indices have changed. This PR updates `maybe_remap_partitioning` to handle `GroupBy`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
