### PR TITLE
Fix missing rapidsmpf hiding real `ImportError` in benchmark scripts

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds.py
@@ -13,14 +13,13 @@ and may be modified or removed at any time.
 
 from __future__ import annotations
 
-import contextlib
 import importlib
 import os
 from typing import TYPE_CHECKING, ClassVar
 
 import polars as pl
 
-with contextlib.suppress(ImportError):
+try:
     from cudf_polars.experimental.benchmarks.utils import (
         COUNT_DTYPE,
         build_parser,
@@ -28,6 +27,9 @@ with contextlib.suppress(ImportError):
         run_duckdb,
         run_polars,
     )
+except ImportError as e:
+    if e.name is not None and not e.name.startswith("cudf_polars"):
+        raise
 
 if TYPE_CHECKING:
     from types import ModuleType

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py
@@ -30,7 +30,9 @@ try:
         run_duckdb,
         run_polars,
     )
-except ImportError:
+except ImportError as e:
+    if e.name is not None and not e.name.startswith("cudf_polars"):
+        raise
     # We want to be able to import pdsh in a CPU-only environment.
     COUNT_DTYPE = None  # type: ignore[assignment]
 

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_legacy.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_legacy.py
@@ -26,7 +26,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, assert_never
 
 import nvtx
-from rapidsmpf.config import Options, get_environment_variables
 
 import polars as pl
 
@@ -737,6 +736,7 @@ def initialize_dask_cluster(run_config: RunConfig, args: argparse.Namespace):  #
 
     if run_config.shuffle != "tasks":
         try:
+            from rapidsmpf.config import Options, get_environment_variables
             from rapidsmpf.integrations.dask import bootstrap_dask_cluster
 
             bootstrap_dask_cluster(


### PR DESCRIPTION
## Description

`utils_legacy.py` imported `rapidsmpf.config` at the module top level, which raised `ImportError` when `rapidsmpf` was not installed. This error propagated through `utils.py` into `pdsh.py` and `pdsds.py`, where overly broad `except ImportError` blocks silently swallowed it, leaving `build_parser` and other names undefined. Running the benchmark scripts then failed with a confusing `NameError` instead of the real cause:

```python
$ python python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py --help
Traceback (most recent call last):
  File "/usr/src/cudf/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsh.py", line 1797, in <module>
    parser = build_parser(num_queries=22)
             ^^^^^^^^^^^^
NameError: name 'build_parser' is not defined
```

Move the `rapidsmpf.config` import into `initialize_dask_cluster` (the only call-site) and tighten the `ImportError` guards in `pdsh.py` and `pdsds.py` to only suppress `cudf_polars`-related import failures.