### PR TITLE
Fix lists::segmented_gather to return empty for empty input

### DIFF
--- a/cpp/src/lists/copying/segmented_gather.cu
+++ b/cpp/src/lists/copying/segmented_gather.cu
@@ -35,6 +35,7 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& value_column,
   CUDF_EXPECTS(!gather_map.has_nulls(), "Gather map contains nulls", std::invalid_argument);
   CUDF_EXPECTS(value_column.size() == gather_map.size(),
                "Gather map and list column should be same size");
+  if (value_column.is_empty()) { return empty_like(value_column.parent()); }
 
   auto const gather_map_sliced_child = gather_map.get_sliced_child(stream);
   auto const gather_map_size         = gather_map_sliced_child.size();

--- a/cpp/tests/copying/segmented_gather_list_tests.cpp
+++ b/cpp/tests/copying/segmented_gather_list_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf_test/base_fixture.hpp>
@@ -108,6 +108,17 @@ TYPED_TEST(SegmentedGatherTest, GatherNothing)
     EXPECT_EQ(cudf::lists_column_view(cudf::lists_column_view(lcv.child()).child()).child().size(),
               0);
   }
+}
+
+using SegmentedGatherTestSingle = SegmentedGatherTest<int32_t>;
+TEST_F(SegmentedGatherTestSingle, GatherEmpty)
+{
+  auto const list       = LCW<int32_t>{};
+  auto const gather_map = LCW<cudf::size_type>{};
+  auto const expected   = LCW<int32_t>{};
+  auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                                     cudf::lists_column_view{gather_map});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 }
 
 TYPED_TEST(SegmentedGatherTest, GatherNulls)


### PR DESCRIPTION
## Description
Adds a check to the list column segmented gather function to handle empty input by returning an empty result.
Also adds a gtest for this condition.

Closes #22112 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
