### PR TITLE
Pass required `br` argument to `TableChunk.from_pylibcudf_table`

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
@@ -310,9 +310,7 @@ async def _tree_reduce(
 
         allgather.insert(
             0,
-            _enforce_schema(
-                aggregated, decomposed.reduction_ir.schema, context.br()
-            ),
+            _enforce_schema(aggregated, decomposed.reduction_ir.schema, context.br()),
         )
 
         allgather.insert_finished()
@@ -455,9 +453,7 @@ async def _shuffle_reduce(
             target_partition_size,
         )
         shuffle.insert_hash(
-            _enforce_schema(
-                aggregated, decomposed.reduction_ir.schema, context.br()
-            ),
+            _enforce_schema(aggregated, decomposed.reduction_ir.schema, context.br()),
             decomposed.shuffle_indices,
         )
         del aggregated

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
@@ -48,6 +48,7 @@ from cudf_polars.experimental.repartition import Repartition
 
 if TYPE_CHECKING:
     from rapidsmpf.communicator.communicator import Communicator
+    from rapidsmpf.memory.buffer_resource import BufferResource
     from rapidsmpf.streaming.core.channel import Channel
 
     from cudf_polars.dsl.ir import IRExecutionContext
@@ -220,7 +221,7 @@ async def _local_aggregation(
             decomposed.piecewise_ir,
             ir_context=ir_context,
         )
-        chunk = _enforce_schema(chunk, decomposed.piecewise_ir.schema)
+        chunk = _enforce_schema(chunk, decomposed.piecewise_ir.schema, context.br())
         total_size += chunk.data_alloc_size()
         evaluated_chunks.append(chunk)
         if total_size > target_partition_size and len(evaluated_chunks) > 1:
@@ -309,7 +310,9 @@ async def _tree_reduce(
 
         allgather.insert(
             0,
-            _enforce_schema(aggregated, decomposed.reduction_ir.schema),
+            _enforce_schema(
+                aggregated, decomposed.reduction_ir.schema, context.br()
+            ),
         )
 
         allgather.insert_finished()
@@ -437,6 +440,7 @@ async def _shuffle_reduce(
         _enforce_schema(
             aggregated,
             decomposed.reduction_ir.schema,
+            context.br(),
         ),
         decomposed.shuffle_indices,
     )
@@ -451,7 +455,9 @@ async def _shuffle_reduce(
             target_partition_size,
         )
         shuffle.insert_hash(
-            _enforce_schema(aggregated, decomposed.reduction_ir.schema),
+            _enforce_schema(
+                aggregated, decomposed.reduction_ir.schema, context.br()
+            ),
             decomposed.shuffle_indices,
         )
         del aggregated
@@ -484,6 +490,7 @@ async def _shuffle_reduce(
 def _enforce_schema(
     chunk: TableChunk,
     canonical_schema: dict[str, Any],
+    br: BufferResource,
 ) -> TableChunk:
     """Enforce the canonical schema of a TableChunk."""
     tbl = chunk.table_view()
@@ -511,7 +518,7 @@ def _enforce_schema(
         for col, target_plc in zip(cols, target_plcs, strict=True)
     ]
     return TableChunk.from_pylibcudf_table(
-        plc.Table(new_columns), chunk.stream, exclusive_view=True
+        plc.Table(new_columns), chunk.stream, exclusive_view=True, br=br
     )
 
 

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Coroutine, Iterator
 
     from rapidsmpf.communicator.communicator import Communicator
+    from rapidsmpf.memory.buffer_resource import BufferResource
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
     from rapidsmpf.streaming.core.spillable_messages import SpillableMessages
@@ -327,6 +328,7 @@ def _evaluate_chunk_sync(
     chunk: TableChunk,
     ir: IR,
     ir_context: IRExecutionContext,
+    br: BufferResource,
 ) -> TableChunk:
     """
     Apply an IR node's do_evaluate to a table chunk (synchronous).
@@ -342,6 +344,8 @@ def _evaluate_chunk_sync(
         The IR node to evaluate.
     ir_context
         The IR execution context.
+    br
+        The buffer resource for lifetime tracking.
 
     Returns
     -------
@@ -355,7 +359,9 @@ def _evaluate_chunk_sync(
         DataFrame.from_table(chunk.table_view(), names, dtypes, chunk.stream),
         context=ir_context,
     )
-    return TableChunk.from_pylibcudf_table(df.table, df.stream, exclusive_view=True)
+    return TableChunk.from_pylibcudf_table(
+        df.table, df.stream, exclusive_view=True, br=br
+    )
 
 
 async def evaluate_chunk(
@@ -393,7 +399,7 @@ async def evaluate_chunk(
     with opaque_memory_usage(extra):
         for single_ir in irs:
             chunk = await asyncio.to_thread(
-                _evaluate_chunk_sync, chunk, single_ir, ir_context
+                _evaluate_chunk_sync, chunk, single_ir, ir_context, context.br()
             )
         return chunk
 


### PR DESCRIPTION
## Description

https://github.com/rapidsai/rapidsmpf/pull/961 made the `br` (`BufferResource`) parameter of `TableChunk.from_pylibcudf_table` required instead of optional. Two callsites callsites in cudf-polars were not updated and now raise `TypeError: from_pylibcudf_table() needs keyword-only argument br`.