### PR TITLE
Use simpler iterators instead of make_counting_transform_iterator

### DIFF
--- a/cpp/tests/copying/gather_tests.cpp
+++ b/cpp/tests/copying/gather_tests.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/random.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
@@ -20,6 +21,8 @@
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
 
+#include <cuda/iterator>
+
 #include <numeric>
 
 template <typename T>
@@ -31,17 +34,13 @@ TYPED_TEST(GatherTest, IdentityTest)
 {
   constexpr cudf::size_type source_size{1000};
 
-  auto data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto data = cuda::counting_iterator{0};
   cudf::test::fixed_width_column_wrapper<TypeParam> source_column(data, data + source_size);
   cudf::test::fixed_width_column_wrapper<int32_t> gather_map(data, data + source_size);
 
   cudf::table_view source_table({source_column});
 
   std::unique_ptr<cudf::table> result = cudf::gather(source_table, gather_map);
-
-  for (auto i = 0; i < source_table.num_columns(); ++i) {
-    CUDF_TEST_EXPECT_COLUMNS_EQUAL(source_table.column(i), result->view().column(i));
-  }
 
   CUDF_TEST_EXPECT_TABLES_EQUAL(source_table, result->view());
 }
@@ -50,7 +49,7 @@ TYPED_TEST(GatherTest, ReverseIdentityTest)
 {
   constexpr cudf::size_type source_size{1000};
 
-  auto data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto data = cuda::counting_iterator{0};
   auto reversed_data =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return source_size - 1 - i; });
 
@@ -74,7 +73,7 @@ TYPED_TEST(GatherTest, EveryOtherNullOdds)
   constexpr cudf::size_type source_size{1000};
 
   // Every other element is valid
-  auto data     = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto data     = cuda::counting_iterator{0};
   auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
 
   cudf::test::fixed_width_column_wrapper<TypeParam> source_column(
@@ -90,8 +89,8 @@ TYPED_TEST(GatherTest, EveryOtherNullOdds)
 
   std::unique_ptr<cudf::table> result = cudf::gather(source_table, gather_map);
 
-  auto expect_data  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return 0; });
-  auto expect_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return 0; });
+  auto expect_data  = cuda::constant_iterator{0};
+  auto expect_valid = cudf::test::iterators::all_nulls();
   cudf::test::fixed_width_column_wrapper<TypeParam> expect_column(
     expect_data, expect_data + source_size / 2, expect_valid);
 
@@ -105,7 +104,7 @@ TYPED_TEST(GatherTest, EveryOtherNullEvens)
   constexpr cudf::size_type source_size{1000};
 
   // Every other element is valid
-  auto data     = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto data     = cuda::counting_iterator{0};
   auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
 
   cudf::test::fixed_width_column_wrapper<TypeParam> source_column(
@@ -124,7 +123,7 @@ TYPED_TEST(GatherTest, EveryOtherNullEvens)
 
   auto expect_data =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i * 2 + 1; });
-  auto expect_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return 1; });
+  auto expect_valid = cudf::test::iterators::no_nulls();
   cudf::test::fixed_width_column_wrapper<TypeParam> expect_column(
     expect_data, expect_data + source_size / 2, expect_valid);
 
@@ -138,8 +137,8 @@ TYPED_TEST(GatherTest, AllNull)
   constexpr cudf::size_type source_size{1000};
 
   // Every element is invalid
-  auto data     = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return 0; });
+  auto data     = cuda::counting_iterator{0};
+  auto validity = cudf::test::iterators::all_nulls();
 
   // Create a gather map that gathers to random locations
   std::vector<cudf::size_type> host_map_data(source_size);
@@ -166,7 +165,7 @@ TYPED_TEST(GatherTest, MultiColReverseIdentityTest)
 
   constexpr cudf::size_type n_cols = 3;
 
-  auto data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto data = cuda::counting_iterator{0};
   auto reversed_data =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return source_size - 1 - i; });
 
@@ -202,7 +201,7 @@ TYPED_TEST(GatherTest, MultiColNulls)
 
   constexpr cudf::size_type n_cols = 3;
 
-  auto data     = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto data     = cuda::counting_iterator{0};
   auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
 
   std::vector<cudf::test::fixed_width_column_wrapper<TypeParam>> source_column_wrappers;

--- a/cpp/tests/copying/sample_tests.cpp
+++ b/cpp/tests/copying/sample_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,10 +8,11 @@
 #include <cudf_test/table_utilities.hpp>
 
 #include <cudf/copying.hpp>
-#include <cudf/detail/iterator.cuh>
 #include <cudf/sorting.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/table/table_view.hpp>
+
+#include <cuda/iterator>
 
 struct SampleTest : public cudf::test::BaseFixture {};
 
@@ -31,7 +32,7 @@ TEST_F(SampleTest, FailCaseRowMultipleSampling)
 TEST_F(SampleTest, RowMultipleSamplingDisallowed)
 {
   cudf::size_type const n_samples = 1024;
-  auto data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto data                       = cuda::counting_iterator{0};
   cudf::test::fixed_width_column_wrapper<int16_t> col1(data, data + n_samples);
 
   cudf::table_view input({col1});
@@ -47,7 +48,7 @@ TEST_F(SampleTest, RowMultipleSamplingDisallowed)
 TEST_F(SampleTest, TestReproducibilityWithSeed)
 {
   cudf::size_type const n_samples = 1024;
-  auto data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto data                       = cuda::counting_iterator{0};
   cudf::test::fixed_width_column_wrapper<int16_t> col1(data, data + n_samples);
 
   cudf::table_view input({col1});
@@ -76,7 +77,7 @@ TEST_P(SampleBasicTest, CombinationOfParameters)
   cudf::size_type const table_size   = 1024;
   auto const [n_samples, multi_smpl] = GetParam();
 
-  auto data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto data = cuda::counting_iterator{0};
   cudf::test::fixed_width_column_wrapper<int16_t> col1(data, data + table_size);
   cudf::test::fixed_width_column_wrapper<float> col2(data, data + table_size);
 

--- a/cpp/tests/copying/scatter_tests.cpp
+++ b/cpp/tests/copying/scatter_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,6 +11,8 @@
 #include <cudf/copying.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/scalar/scalar_factories.hpp>
+
+#include <cuda/iterator>
 
 #include <stdexcept>
 
@@ -405,11 +407,11 @@ TYPED_TEST(ScatterDataTypeTests, ScatterSourceNullsLarge)
 
   cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> source({0, 0, 0, 0}, {0, 0, 0, 0});
   cudf::test::fixed_width_column_wrapper<int32_t> scatter_map({0, 1, 2, 3});
-  auto target_data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto target_data = cuda::counting_iterator{0};
   cudf::test::fixed_width_column_wrapper<TypeParam, typename decltype(target_data)::value_type>
     target(target_data, target_data + N);
 
-  auto expect_data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto expect_data = cuda::counting_iterator{0};
   auto expect_valid =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i > 3; });
   cudf::test::fixed_width_column_wrapper<TypeParam, typename decltype(expect_data)::value_type>

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -8,6 +8,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
@@ -673,7 +674,7 @@ void split_empty_output_strings_column_value(SplitFunc Split,
 template <typename SplitFunc, typename CompareFunc>
 void split_null_input_strings_column_value(SplitFunc Split, CompareFunc Compare)
 {
-  auto no_valids = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return false; });
+  auto no_valids = cudf::test::iterators::all_nulls();
   auto valids =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
 
@@ -2005,11 +2006,11 @@ TEST_F(ContiguousSplitTableCornerCases, MixedColumnTypes)
 
   std::vector<std::unique_ptr<cudf::column>> cols;
 
-  auto iter0 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i); });
+  auto iter0 = cuda::counting_iterator{0};
   auto c0    = cudf::test::fixed_width_column_wrapper<int>(iter0, iter0 + 10, valids);
   cols.push_back(c0.release());
 
-  auto iter1 = cudf::detail::make_counting_transform_iterator(10, [](auto i) { return (i); });
+  auto iter1 = cuda::counting_iterator{10};
   auto c1    = cudf::test::fixed_width_column_wrapper<int>(iter1, iter1 + 10, valids);
   cols.push_back(c1.release());
 
@@ -2019,7 +2020,7 @@ TEST_F(ContiguousSplitTableCornerCases, MixedColumnTypes)
   auto c3 = cudf::test::strings_column_wrapper(strings[1].begin(), strings[1].end(), valids);
   cols.push_back(c3.release());
 
-  auto iter4 = cudf::detail::make_counting_transform_iterator(20, [](auto i) { return (i); });
+  auto iter4 = cuda::counting_iterator{20};
   auto c4    = cudf::test::fixed_width_column_wrapper<int>(iter4, iter4 + 10, valids);
   cols.push_back(c4.release());
 
@@ -2054,7 +2055,7 @@ TEST_F(ContiguousSplitTableCornerCases, MixedColumnTypesChunked)
 
   std::vector<std::unique_ptr<cudf::column>> cols;
 
-  auto iter0 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i); });
+  auto iter0 = cuda::counting_iterator{0};
   auto c0    = cudf::test::fixed_width_column_wrapper<int>(iter0, iter0 + num_rows, valids);
   cols.push_back(c0.release());
 
@@ -2086,7 +2087,7 @@ TEST_F(ContiguousSplitTableCornerCases, MixedColumnTypesSingleRowChunked)
 
   std::vector<std::unique_ptr<cudf::column>> cols;
 
-  auto iter0 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i); });
+  auto iter0 = cuda::counting_iterator{0};
   auto c0    = cudf::test::fixed_width_column_wrapper<int32_t>(iter0, iter0 + num_rows, valids);
   cols.push_back(c0.release());
 

--- a/cpp/tests/groupby/tdigest_tests.cpp
+++ b/cpp/tests/groupby/tdigest_tests.cpp
@@ -721,12 +721,9 @@ TEST_F(TDigestMergeTest, AllValuesAreNull)
   // See `aggregate_result_functor::operator()<aggregation::TDIGEST>` for details.
   auto const keys      = cudf::test::fixed_width_column_wrapper<int32_t>{{0, 0, 1, 1, 2}};
   auto const keys_view = cudf::column_view(keys);
-  auto val_elems  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
-  auto val_valids = cudf::detail::make_counting_transform_iterator(0, [](auto i) {
-    // All values are null
-    return false;
-  });
-  auto const vals = cudf::test::fixed_width_column_wrapper<int32_t>{
+  auto val_elems       = cuda::counting_iterator(0);
+  auto val_valids      = cudf::test::iterators::all_nulls();
+  auto const vals      = cudf::test::fixed_width_column_wrapper<int32_t>{
     val_elems, val_elems + keys_view.size(), val_valids};
 
   auto const delta = 1000;

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/random.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/testing_main.hpp>
@@ -1662,7 +1663,7 @@ TEST_F(CsvReaderTest, MultiColumnWithWriter)
   auto const result_sliced_view = result_table.select(non_float64s);
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(input_sliced_view, result_sliced_view);
 
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto validity = cudf::test::iterators::no_nulls();
   double tol{1.0e-6};
   auto float64_col_idx = non_float64s.size();
   check_float_column(

--- a/cpp/tests/io/orc_chunked_reader_test.cu
+++ b/cpp/tests/io/orc_chunked_reader_test.cu
@@ -956,7 +956,7 @@ TEST_F(OrcChunkedReaderTest, TestChunkedReadNullCount)
 {
   auto constexpr num_rows = 100'000;
 
-  auto const sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return 1; });
+  auto const sequence = cuda::constant_iterator(1);
   auto const validity =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 4 != 3; });
   std::vector<std::unique_ptr<cudf::column>> cols;

--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -170,7 +170,7 @@ struct SkipRowTest {
                                              int file_num_rows,
                                              int read_num_rows)
   {
-    auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+    auto sequence = cuda::counting_iterator{0};
     column_wrapper<int32_t, typename decltype(sequence)::value_type> input_col(
       sequence, sequence + file_num_rows);
     table_view input_table({input_col});
@@ -224,7 +224,7 @@ struct SkipRowTest {
 
 TYPED_TEST(OrcWriterNumericTypeTest, SingleColumn)
 {
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
 
   constexpr auto num_rows = 100;
   column_wrapper<TypeParam, typename decltype(sequence)::value_type> col(sequence,
@@ -245,7 +245,7 @@ TYPED_TEST(OrcWriterNumericTypeTest, SingleColumn)
 
 TYPED_TEST(OrcWriterNumericTypeTest, SingleColumnWithNulls)
 {
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
   auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 2); });
 
   constexpr auto num_rows = 100;
@@ -460,7 +460,7 @@ TEST_F(OrcWriterTest, MultiColumnWithNulls)
 
 TEST_F(OrcWriterTest, ReadZeroRows)
 {
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
 
   constexpr auto num_rows = 10;
   column_wrapper<int64_t, typename decltype(sequence)::value_type> col(sequence,
@@ -998,7 +998,7 @@ TEST_F(OrcReaderTest, CombinedSkipRowTest)
 
 TEST_F(OrcStatisticsTest, Basic)
 {
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
   auto ts_sequence =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i - 4) * 1000002; });
   auto dec_sequence =
@@ -1373,9 +1373,8 @@ TEST_P(OrcWriterTestStripes, StripeSize)
   constexpr auto num_rows            = 1000000;
   auto const [size_bytes, size_rows] = GetParam();
 
-  auto const seq_col = random_values<int>(num_rows);
-  auto const validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto const seq_col  = random_values<int>(num_rows);
+  auto const validity = cudf::test::iterators::no_nulls();
   column_wrapper<int64_t> col{seq_col.begin(), seq_col.end(), validity};
 
   std::vector<std::unique_ptr<column>> cols;
@@ -1858,7 +1857,7 @@ TEST_F(OrcWriterTest, EmptyRowGroup)
 
 TEST_F(OrcWriterTest, NoNullsAsNonNullable)
 {
-  auto valids = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto valids = cudf::test::iterators::no_nulls();
   column_wrapper<int32_t> col{{1, 2, 3}, valids};
   table_view expected({col});
 

--- a/cpp/tests/io/parquet_chunked_reader_test.cu
+++ b/cpp/tests/io/parquet_chunked_reader_test.cu
@@ -1100,7 +1100,7 @@ TEST_F(ParquetChunkedReaderTest, TestChunkedReadNullCount)
 {
   auto constexpr num_rows = 100'000;
 
-  auto const sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return 1; });
+  auto const sequence = cuda::constant_iterator{1};
   auto const validity =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 4 != 3; });
   cudf::test::fixed_width_column_wrapper<int32_t> col{sequence, sequence + num_rows, validity};

--- a/cpp/tests/io/parquet_v2_test.cpp
+++ b/cpp/tests/io/parquet_v2_test.cpp
@@ -899,7 +899,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexNullColumn)
   auto col2_data = random_values<int32_t>(num_rows);
 
   // col1 is all nulls
-  auto valids = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return false; });
+  auto valids = cudf::test::iterators::all_nulls();
   auto col1 =
     cudf::test::fixed_width_column_wrapper<int32_t>(col1_data.begin(), col1_data.end(), valids);
   auto col2 = cudf::test::fixed_width_column_wrapper<int32_t>(col2_data.begin(), col2_data.end());
@@ -1401,7 +1401,7 @@ TEST_P(ParquetV2Test, CheckEncodings)
   // data should be PLAIN for v1, DELTA_BINARY_PACKED for v2
   auto col1_data = random_values<int32_t>(num_rows);
   // data should be PLAIN_DICTIONARY for v1, PLAIN and RLE_DICTIONARY for v2
-  auto col2_data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return 1; });
+  auto col2_data = cuda::constant_iterator{1};
 
   cudf::test::fixed_width_column_wrapper<bool> col0{col0_data, col0_data + num_rows, validity};
   column_wrapper<int32_t> col1{col1_data.begin(), col1_data.end(), validity};

--- a/cpp/tests/iterator/value_iterator_test_strings.cu
+++ b/cpp/tests/iterator/value_iterator_test_strings.cu
@@ -4,6 +4,8 @@
  */
 #include "iterator_tests.cuh"
 
+#include <cudf_test/iterator_utilities.hpp>
+
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
@@ -17,7 +19,7 @@
 
 auto strings_to_string_views(std::vector<std::string>& input_strings)
 {
-  auto all_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto all_valid = cudf::test::iterators::no_nulls();
   std::vector<char> chars;
   std::vector<int32_t> offsets;
   std::tie(chars, offsets) = cudf::test::detail::make_chars_and_offsets(

--- a/cpp/tests/jit/row_ir.cpp
+++ b/cpp/tests/jit/row_ir.cpp
@@ -11,8 +11,9 @@
 #include <cudf_test/testing_main.hpp>
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/iterator.cuh>
 #include <cudf/transform.hpp>
+
+#include <cuda/iterator>
 
 #include <algorithm>
 #include <cctype>
@@ -247,8 +248,7 @@ TEST_F(RowIRCudaCodeGenTest, AstConversionBasic)
 
   auto column = cudf::test::fixed_width_column_wrapper<int32_t>({69, 69, 69, 69, 69, 69}).release();
 
-  auto expected_iter =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return 69 + 42; });
+  auto expected_iter = cuda::constant_iterator{69 + 42};
   auto expected =
     cudf::test::fixed_width_column_wrapper<int32_t>(expected_iter, expected_iter + column->size());
 

--- a/cpp/tests/lists/explode_tests.cpp
+++ b/cpp/tests/lists/explode_tests.cpp
@@ -127,8 +127,7 @@ TEST_F(ExplodeTest, Nulls)
 
   auto valids =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
-  auto always_valid =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto always_valid = cudf::test::iterators::no_nulls();
 
   LCW a({LCW{1, 2, 7}, LCW{null}, LCW{0, 3}}, valids);
   FCW b({100, 200, 300}, valids);
@@ -223,8 +222,7 @@ TEST_F(ExplodeTest, NestedNulls)
 
   auto valids =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
-  auto always_valid =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto always_valid = cudf::test::iterators::no_nulls();
 
   LCW a({LCW{LCW{1, 2}, LCW{7, 6, 5}}, LCW{LCW{null}}, LCW{LCW{0, 3}, LCW{5}, LCW{2, 1}}}, valids);
   FCW b({100, null, 300}, valids);
@@ -646,7 +644,7 @@ TEST_F(ExplodeOuterTest, AllNulls)
 
   constexpr auto null = 0;
 
-  auto non_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return false; });
+  auto non_valid = cudf::test::iterators::all_nulls();
 
   LCW a({LCW{null}, LCW{null}, LCW{null}}, non_valid);
   FCW b({100, 200, 300});

--- a/cpp/tests/merge/merge_test.cpp
+++ b/cpp/tests/merge/merge_test.cpp
@@ -13,7 +13,6 @@
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/detail/iterator.cuh>
 #include <cudf/merge.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/table/table.hpp>
@@ -194,7 +193,7 @@ TYPED_TEST(MergeTest_, SingleTableInput)
 {
   cudf::size_type inputRows = 40;
 
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
   cudf::test::fixed_width_column_wrapper<TypeParam, typename decltype(sequence)::value_type>
     colWrap1(sequence, sequence + inputRows);
 
@@ -241,7 +240,7 @@ TYPED_TEST(MergeTest_, MergeWithEmptyColumn)
 
   cudf::size_type inputRows = 40;
 
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
   cudf::test::fixed_width_column_wrapper<TypeParam, typename decltype(sequence)::value_type>
     leftColWrap1(sequence, sequence + inputRows);
   columnFactoryT rightColWrap1{};  // wrapper of empty column <- this might require a (sequence,

--- a/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
+++ b/cpp/tests/stream_compaction/apply_boolean_mask_tests.cpp
@@ -19,6 +19,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
+#include <cuda/iterator>
 #include <cuda/std/functional>
 
 struct ApplyBooleanMask : public cudf::test::BaseFixture {};
@@ -246,9 +247,8 @@ TEST_F(ApplyBooleanMask, CorrectNullCount)
 {
   cudf::size_type inputRows = 471234;
 
-  auto seq1 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
-  auto valid_seq1 =
-    cudf::detail::make_counting_transform_iterator(0, [](auto row) { return true; });
+  auto seq1       = cuda::counting_iterator{0};
+  auto valid_seq1 = cudf::test::iterators::no_nulls();
   cudf::test::fixed_width_column_wrapper<int64_t, typename decltype(seq1)::value_type> col1(
     seq1, seq1 + inputRows, valid_seq1);
 

--- a/cpp/tests/streams/copying_test.cpp
+++ b/cpp/tests/streams/copying_test.cpp
@@ -24,7 +24,7 @@ TEST_F(CopyingTest, Gather)
 {
   constexpr cudf::size_type source_size{1000};
 
-  auto data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto data = cuda::counting_iterator{0};
   cudf::test::fixed_width_column_wrapper<int32_t> source_column(data, data + source_size);
   cudf::test::fixed_width_column_wrapper<int32_t> gather_map(data, data + source_size);
 
@@ -293,7 +293,7 @@ TEST_F(CopyingTest, Sample)
   auto const n_samples             = 10;
   auto const multi_smpl            = cudf::sample_with_replacement::FALSE;
 
-  auto data = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto data = cuda::counting_iterator{0};
   cudf::test::fixed_width_column_wrapper<int16_t> col1(data, data + table_size);
 
   cudf::table_view input({col1});

--- a/cpp/tests/streams/merge_test.cpp
+++ b/cpp/tests/streams/merge_test.cpp
@@ -56,7 +56,7 @@ TYPED_TEST(MergeTest_, SingleTableInput)
 {
   cudf::size_type inputRows = 40;
 
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
   cudf::test::fixed_width_column_wrapper<TypeParam, typename decltype(sequence)::value_type>
     colWrap1(sequence, sequence + inputRows);
 

--- a/cpp/tests/streams/transform_test.cpp
+++ b/cpp/tests/streams/transform_test.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/default_stream.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/testing_main.hpp>
 
 #include <cudf/ast/expressions.hpp>
@@ -21,7 +22,7 @@ void test_udf(char const* udf,
               cudf::size_type size,
               cudf::udf_source_type source_type)
 {
-  auto all_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto all_valid = cudf::test::iterators::no_nulls();
   auto data_iter = cudf::detail::make_counting_transform_iterator(0, data_init);
   cudf::test::fixed_width_column_wrapper<dtype, typename decltype(data_iter)::value_type> in(
     data_iter, data_iter + size, all_valid);

--- a/cpp/tests/transform/bools_to_mask_test.cpp
+++ b/cpp/tests/transform/bools_to_mask_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,9 +9,9 @@
 #include <cudf_test/testing_main.hpp>
 
 #include <cudf/column/column.hpp>
-#include <cudf/detail/iterator.cuh>
 #include <cudf/transform.hpp>
 
+#include <cuda/iterator>
 #include <thrust/host_vector.h>
 
 struct MaskToNullTest : public cudf::test::BaseFixture {
@@ -21,7 +21,7 @@ struct MaskToNullTest : public cudf::test::BaseFixture {
       input.begin(), input.end(), val.begin());
     std::transform(val.begin(), val.end(), input.begin(), input.begin(), std::logical_and<>());
 
-    auto sample = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+    auto sample = cuda::counting_iterator{0};
 
     cudf::test::fixed_width_column_wrapper<int32_t> expected(
       sample, sample + input.size(), input.begin());
@@ -37,7 +37,7 @@ struct MaskToNullTest : public cudf::test::BaseFixture {
   {
     cudf::test::fixed_width_column_wrapper<bool> input_column(input.begin(), input.end());
 
-    auto sample = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+    auto sample = cuda::counting_iterator{0};
     cudf::test::fixed_width_column_wrapper<int32_t> expected(
       sample, sample + input.size(), input.begin());
 

--- a/cpp/tests/transform/integration/unary_transform_test.cpp
+++ b/cpp/tests/transform/integration/unary_transform_test.cpp
@@ -25,6 +25,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/random.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -121,7 +122,7 @@ void test_udf(std::string const& udf,
               cudf::size_type size,
               cudf::udf_source_type source_type)
 {
-  auto all_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto all_valid = cudf::test::iterators::no_nulls();
   auto data_iter = cudf::detail::make_counting_transform_iterator(0, data_init);
 
   cudf::test::fixed_width_column_wrapper<dtype, typename decltype(data_iter)::value_type> in(

--- a/cpp/tests/unary/cast_tests.cpp
+++ b/cpp/tests/unary/cast_tests.cpp
@@ -627,7 +627,7 @@ TYPED_TEST(FixedPointTests, CastToIntLarge)
   using fp_wrapper = cudf::test::fixed_point_column_wrapper<RepType>;
   using fw_wrapper = cudf::test::fixed_width_column_wrapper<int32_t>;
 
-  auto begin  = cudf::detail::make_counting_transform_iterator(0, [](int i) { return RepType{i}; });
+  auto begin  = cuda::counting_iterator<RepType>{0};
   auto begin2 = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return 10 * i; });
   auto const input    = fp_wrapper{begin, begin + 2000, scale_type{1}};
   auto const expected = fw_wrapper(begin2, begin2 + 2000);
@@ -728,7 +728,7 @@ TYPED_TEST(FixedPointTests, CastFromIntLarge)
   using fw_wrapper = cudf::test::fixed_width_column_wrapper<int32_t>;
 
   auto begin  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return 1000 * i; });
-  auto begin2 = cudf::detail::make_counting_transform_iterator(0, [](int i) { return RepType{i}; });
+  auto begin2 = cuda::counting_iterator<RepType>{0};
   auto const input    = fw_wrapper(begin, begin + 2000);
   auto const expected = fp_wrapper{begin2, begin2 + 2000, scale_type{3}};
   auto const result   = cudf::cast(input, make_fixed_point_data_type<decimalXX>(3));

--- a/cpp/tests/utilities_tests/column_utilities_tests.cpp
+++ b/cpp/tests/utilities_tests/column_utilities_tests.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/random.hpp>
 #include <cudf_test/testing_main.hpp>
 #include <cudf_test/type_lists.hpp>
@@ -133,7 +134,7 @@ TEST_F(ColumnUtilitiesEquivalenceTest, DoubleTest)
 
 TEST_F(ColumnUtilitiesEquivalenceTest, NullabilityTest)
 {
-  auto all_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto all_valid = cudf::test::iterators::no_nulls();
   cudf::test::fixed_width_column_wrapper<double> col1{1, 2, 3};
   cudf::test::fixed_width_column_wrapper<double> col2({1, 2, 3}, all_valid);
 
@@ -220,7 +221,7 @@ TEST_F(ColumnUtilitiesListsTest, Equivalence)
 {
   // list<int>, nullable vs. non-nullable
   {
-    auto all_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+    auto all_valid = cudf::test::iterators::no_nulls();
     cudf::test::lists_column_wrapper<int> a{{1, 2, 3}, {5, 6}, {8, 9}, {10}, {14, 15}};
     cudf::test::lists_column_wrapper<int> b{{{1, 2, 3}, {5, 6}, {8, 9}, {10}, {14, 15}}, all_valid};
 
@@ -237,7 +238,7 @@ TEST_F(ColumnUtilitiesListsTest, Equivalence)
 
   // list<list<int>>, nullable vs. non-nullable
   {
-    auto all_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+    auto all_valid = cudf::test::iterators::no_nulls();
     cudf::test::lists_column_wrapper<int> a{{{1, 2, 3}, {5, 6}}, {{8, 9}, {10}}, {{14, 15}}};
     cudf::test::lists_column_wrapper<int> b{{{{1, 2, 3}, {5, 6}}, {{8, 9}, {10}}, {{14, 15}}},
                                             all_valid};

--- a/cpp/tests/utilities_tests/column_wrapper_tests.cpp
+++ b/cpp/tests/utilities_tests/column_wrapper_tests.cpp
@@ -1,15 +1,18 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/random.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/detail/iterator.cuh>
+
+#include <cuda/iterator>
 
 template <typename T>
 struct FixedWidthColumnWrapperTest : public cudf::test::BaseFixture,
@@ -25,7 +28,7 @@ TYPED_TEST_SUITE(FixedWidthColumnWrapperTest, cudf::test::FixedWidthTypes);
 
 TYPED_TEST(FixedWidthColumnWrapperTest, EmptyIterator)
 {
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
   cudf::test::fixed_width_column_wrapper<TypeParam, typename decltype(sequence)::value_type> col(
     sequence, sequence);
   cudf::column_view view = col;
@@ -50,7 +53,7 @@ TYPED_TEST(FixedWidthColumnWrapperTest, EmptyList)
 
 TYPED_TEST(FixedWidthColumnWrapperTest, NonNullableIteratorConstructor)
 {
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
 
   auto size = this->size();
 
@@ -80,9 +83,9 @@ TYPED_TEST(FixedWidthColumnWrapperTest, NonNullableListConstructor)
 
 TYPED_TEST(FixedWidthColumnWrapperTest, NullableIteratorConstructorAllValid)
 {
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
 
-  auto all_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto all_valid = cudf::test::iterators::no_nulls();
 
   auto size = this->size();
 
@@ -99,7 +102,7 @@ TYPED_TEST(FixedWidthColumnWrapperTest, NullableIteratorConstructorAllValid)
 
 TYPED_TEST(FixedWidthColumnWrapperTest, NullableListConstructorAllValid)
 {
-  auto all_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto all_valid = cudf::test::iterators::no_nulls();
 
   cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> col({1, 2, 3, 4, 5}, all_valid);
   cudf::column_view view = col;
@@ -113,9 +116,9 @@ TYPED_TEST(FixedWidthColumnWrapperTest, NullableListConstructorAllValid)
 
 TYPED_TEST(FixedWidthColumnWrapperTest, NullableIteratorConstructorAllNull)
 {
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
 
-  auto all_null = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return false; });
+  auto all_null = cudf::test::iterators::all_nulls();
 
   auto size = this->size();
 
@@ -133,7 +136,7 @@ TYPED_TEST(FixedWidthColumnWrapperTest, NullableIteratorConstructorAllNull)
 
 TYPED_TEST(FixedWidthColumnWrapperTest, NullableListConstructorAllNull)
 {
-  auto all_null = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return false; });
+  auto all_null = cudf::test::iterators::all_nulls();
 
   cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> col({1, 2, 3, 4, 5}, all_null);
   cudf::column_view view = col;
@@ -183,7 +186,7 @@ TYPED_TEST(FixedWidthColumnWrapperTest, NullablePairListConstructorAllNullMatch)
 
 TYPED_TEST(FixedWidthColumnWrapperTest, ReleaseWrapperAllValid)
 {
-  auto all_valid = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return true; });
+  auto all_valid = cudf::test::iterators::no_nulls();
 
   cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> col({1, 2, 3, 4, 5}, all_valid);
   auto colPtr            = col.release();
@@ -198,7 +201,7 @@ TYPED_TEST(FixedWidthColumnWrapperTest, ReleaseWrapperAllValid)
 
 TYPED_TEST(FixedWidthColumnWrapperTest, ReleaseWrapperAllNull)
 {
-  auto all_null = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return false; });
+  auto all_null = cudf::test::iterators::all_nulls();
 
   cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> col({1, 2, 3, 4, 5}, all_null);
   auto colPtr            = col.release();

--- a/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
+++ b/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
@@ -17,7 +17,6 @@
 #include <rmm/device_buffer.hpp>
 
 #include <cuda/iterator>
-#include <thrust/iterator/transform_iterator.h>
 
 struct ListColumnWrapperTest : public cudf::test::BaseFixture {};
 template <typename T>
@@ -158,7 +157,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListFromIterator)
   // Children :
   //    0, 1, 2, 3, 4
   //
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
 
   cudf::test::lists_column_wrapper<T, typename decltype(sequence)::value_type> list{sequence,
                                                                                     sequence + 5};
@@ -192,7 +191,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListFromIteratorWithValidity)
   // Children :
   //    0, NULL, 2, NULL, 4
   //
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
+  auto sequence = cuda::counting_iterator{0};
 
   cudf::test::lists_column_wrapper<T, typename decltype(sequence)::value_type> list{
     sequence, sequence + 5, valids};


### PR DESCRIPTION
## Description
Replaces some calls to `cudf::detail::make_counting_transform_iterator` with simpler available and appropriately scoped versions.
This includes patterns like this:
- `make_counting_transform_iterator(0, [](auto i) { return i; });` -> `cuda::counting_iterator{0};`
- `make_counting_transform_iterator(0, [](auto i) { return 0; });` -> `cuda::constant_iterator{0};` 
- `make_counting_transform_iterator(0, [](auto i) { return false; });` -> `cudf::test::iterators::all_nulls()` 

This is to help improve analysis of what `detail` functions are being used outside of internal libcudf source.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
