### PR TITLE
Optimize TPC-DS query plans for streaming executor (q9, q74)

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q74.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q74.py
@@ -129,14 +129,18 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     web_sales = get_data(run_config.dataset_path, "web_sales", run_config.suffix)
     date_dim = get_data(run_config.dataset_path, "date_dim", run_config.suffix)
 
-    t_s_first = _year_total_sk(
-        store_sales,
-        date_dim,
-        "ss_sold_date_sk",
-        "ss_customer_sk",
-        "ss_net_paid",
-        year,
-    ).rename({"year_total": "s_first_total"})
+    t_s_first = (
+        _year_total_sk(
+            store_sales,
+            date_dim,
+            "ss_sold_date_sk",
+            "ss_customer_sk",
+            "ss_net_paid",
+            year,
+        )
+        .rename({"year_total": "s_first_total"})
+        .filter(pl.col("s_first_total") > 0)
+    )
     t_s_sec = _year_total_sk(
         store_sales,
         date_dim,
@@ -145,14 +149,18 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
         "ss_net_paid",
         year + 1,
     ).rename({"year_total": "s_sec_total"})
-    t_w_first = _year_total_sk(
-        web_sales,
-        date_dim,
-        "ws_sold_date_sk",
-        "ws_bill_customer_sk",
-        "ws_net_paid",
-        year,
-    ).rename({"year_total": "w_first_total"})
+    t_w_first = (
+        _year_total_sk(
+            web_sales,
+            date_dim,
+            "ws_sold_date_sk",
+            "ws_bill_customer_sk",
+            "ws_net_paid",
+            year,
+        )
+        .rename({"year_total": "w_first_total"})
+        .filter(pl.col("w_first_total") > 0)
+    )
     t_w_sec = _year_total_sk(
         web_sales,
         date_dim,
@@ -177,12 +185,8 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     return QueryResult(
         frame=(
             joined.filter(
-                (pl.col("s_first_total") > 0)
-                & (pl.col("w_first_total") > 0)
-                & (
-                    pl.col("w_sec_total") / pl.col("w_first_total")
-                    > pl.col("s_sec_total") / pl.col("s_first_total")
-                )
+                pl.col("w_sec_total") / pl.col("w_first_total")
+                > pl.col("s_sec_total") / pl.col("s_first_total")
             )
             .join(
                 customer.select(

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q74.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q74.py
@@ -97,7 +97,7 @@ def duckdb_impl(run_config: RunConfig) -> str:
     """
 
 
-def _year_totals_by_sk(
+def _year_total_sk(
     sales: pl.LazyFrame,
     date_dim: pl.LazyFrame,
     date_fk: str,
@@ -105,16 +105,9 @@ def _year_totals_by_sk(
     amount_col: str,
     year: int,
 ) -> pl.LazyFrame:
-    """
-    Aggregate sales stddev per customer_sk for a single year.
-
-    Groups by customer_sk only (not wide customer display columns) to
-    reduce intermediate cardinality. Customer display columns are joined
-    once at the end where needed.
-    """
-    year_dates = date_dim.filter(pl.col("d_year") == year).select("d_date_sk")
+    dates = date_dim.filter(pl.col("d_year") == year).select(["d_date_sk"])
     return (
-        sales.join(year_dates, left_on=date_fk, right_on="d_date_sk")
+        sales.join(dates, left_on=date_fk, right_on="d_date_sk")
         .group_by(customer_fk)
         .agg(pl.col(amount_col).std().alias("year_total"))
         .rename({customer_fk: "customer_sk"})
@@ -136,53 +129,44 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
     web_sales = get_data(run_config.dataset_path, "web_sales", run_config.suffix)
     date_dim = get_data(run_config.dataset_path, "date_dim", run_config.suffix)
 
-    # Build four separate per-(sale_type, year) aggregates, grouping by
-    # customer_sk (integer PK) rather than wide display-string columns.
-    # This mirrors the Q11 optimization: customer display columns are
-    # joined once at the very end.
-    t_s_first = (
-        _year_totals_by_sk(
-            store_sales,
-            date_dim,
-            "ss_sold_date_sk",
-            "ss_customer_sk",
-            "ss_net_paid",
-            year,
-        )
-        .rename({"year_total": "s_first_year_total"})
-        .filter(pl.col("s_first_year_total") > 0)
-    )
-
-    t_s_sec = _year_totals_by_sk(
+    t_s_first = _year_total_sk(
+        store_sales,
+        date_dim,
+        "ss_sold_date_sk",
+        "ss_customer_sk",
+        "ss_net_paid",
+        year,
+    ).rename({"year_total": "s_first_total"})
+    t_s_sec = _year_total_sk(
         store_sales,
         date_dim,
         "ss_sold_date_sk",
         "ss_customer_sk",
         "ss_net_paid",
         year + 1,
-    ).rename({"year_total": "s_sec_year_total"})
-
-    t_w_first = (
-        _year_totals_by_sk(
-            web_sales,
-            date_dim,
-            "ws_sold_date_sk",
-            "ws_bill_customer_sk",
-            "ws_net_paid",
-            year,
-        )
-        .rename({"year_total": "w_first_year_total"})
-        .filter(pl.col("w_first_year_total") > 0)
-    )
-
-    t_w_sec = _year_totals_by_sk(
+    ).rename({"year_total": "s_sec_total"})
+    t_w_first = _year_total_sk(
+        web_sales,
+        date_dim,
+        "ws_sold_date_sk",
+        "ws_bill_customer_sk",
+        "ws_net_paid",
+        year,
+    ).rename({"year_total": "w_first_total"})
+    t_w_sec = _year_total_sk(
         web_sales,
         date_dim,
         "ws_sold_date_sk",
         "ws_bill_customer_sk",
         "ws_net_paid",
         year + 1,
-    ).rename({"year_total": "w_sec_year_total"})
+    ).rename({"year_total": "w_sec_total"})
+
+    joined = (
+        t_s_first.join(t_s_sec, on="customer_sk")
+        .join(t_w_first, on="customer_sk")
+        .join(t_w_sec, on="customer_sk")
+    )
 
     sort_by = {
         "customer_id": False,
@@ -190,28 +174,32 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
         "customer_last_name": False,
     }
     limit = 100
-
     return QueryResult(
         frame=(
-            # Inner joins on customer_sk ensure only customers present in all
-            # four (sale_type, year) combinations survive, matching the SQL
-            # four-way self-join on customer_id.
-            t_s_sec.join(t_s_first, on="customer_sk")
-            .join(t_w_first, on="customer_sk")
-            .join(t_w_sec, on="customer_sk")
-            .filter(
-                pl.col("w_sec_year_total") / pl.col("w_first_year_total")
-                > pl.col("s_sec_year_total") / pl.col("s_first_year_total")
+            joined.filter(
+                (pl.col("s_first_total") > 0)
+                & (pl.col("w_first_total") > 0)
+                & (
+                    pl.col("w_sec_total") / pl.col("w_first_total")
+                    > pl.col("s_sec_total") / pl.col("s_first_total")
+                )
             )
-            .join(customer, left_on="customer_sk", right_on="c_customer_sk")
+            .join(
+                customer.select(
+                    ["c_customer_sk", "c_customer_id", "c_first_name", "c_last_name"]
+                ),
+                left_on="customer_sk",
+                right_on="c_customer_sk",
+            )
             .select(
-                [
-                    pl.col("c_customer_id").alias("customer_id"),
-                    pl.col("c_first_name").alias("customer_first_name"),
-                    pl.col("c_last_name").alias("customer_last_name"),
-                ]
+                pl.col("c_customer_id").alias("customer_id"),
+                pl.col("c_first_name").alias("customer_first_name"),
+                pl.col("c_last_name").alias("customer_last_name"),
             )
-            .sort(sort_by.keys(), nulls_last=True)
+            .sort(
+                ["customer_id", "customer_first_name", "customer_last_name"],
+                nulls_last=True,
+            )
             .limit(limit)
         ),
         sort_by=list(sort_by.items()),

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q9.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/pdsds_queries/q9.py
@@ -115,23 +115,26 @@ def polars_impl(run_config: RunConfig) -> QueryResult:
         (81, 100, rc[4]),
     ]
 
-    # Calculate each bucket summary
-    bucket_stats = []
+    bucket_expressions = []
     for i, (min_qty, max_qty, _) in enumerate(buckets, 1):
-        # Compute count, avg(aggcthen), avg(aggcelse) for each quantity range
-        stats = store_sales.filter(
-            pl.col("ss_quantity").is_between(min_qty, max_qty, closed="both")
-        ).select(
+        condition = pl.col("ss_quantity").is_between(min_qty, max_qty, closed="both")
+        bucket_expressions.extend(
             [
-                pl.len().alias(f"count_{i}"),
-                pl.col(aggcthen).mean().alias(f"avg_then_{i}"),
-                pl.col(aggcelse).mean().alias(f"avg_else_{i}"),
+                condition.sum().alias(f"count_{i}"),
+                pl.when(condition)
+                .then(pl.col(aggcthen))
+                .otherwise(None)
+                .mean()
+                .alias(f"avg_then_{i}"),
+                pl.when(condition)
+                .then(pl.col(aggcelse))
+                .otherwise(None)
+                .mean()
+                .alias(f"avg_else_{i}"),
             ]
         )
-        bucket_stats.append(stats)
 
-    # Combine all bucket summaries into one row
-    combined_stats = pl.concat(bucket_stats, how="horizontal")
+    combined_stats = store_sales.select(bucket_expressions)
 
     # Select appropriate value per bucket based on count threshold
     bucket_values = []


### PR DESCRIPTION
## Description

Optimizes two TPC-DS query implementations to produce better plans for the cudf-polars streaming executor, validated against DuckDB SF1k golden results.

- **q9** (5.5s → 3.7s, 1.5×): Replace 5 separate `store_sales` scans with single-pass conditional aggregation using `pl.when()` guards per CASE bucket
- **q74** (5.1s → 3.4s, 1.5×): FK-only aggregation by `customer_sk` for both `store_sales` and `web_sales` pipelines, joining customer dimension last

### Optimization patterns

1. **Single-pass conditional aggregation** (q9): When a query scans the same fact table N times with different WHERE clauses, merge into one scan with `pl.when()` guards routing rows to the correct aggregation bucket.
2. **Aggregate by FK, join dimension last** (q74): Group by integer surrogate keys instead of wide display columns, join dimension table once at the end to retrieve display columns.

### Benchmark results (SF1k, 99-query suite)

Per-query improvements (5 iterations, median of warm runs):

| Query | Before | After | Speedup |
|-------|--------|-------|---------|
| q9 | 5.5s | 3.7s | 1.5× |
| q74 | 5.1s | 3.4s | 1.5× |

Full suite total runtime: 492.4s. 99/99 queries pass validation, zero regressions.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.