### PR TITLE
Support null_count decomposition in multi-partition Select

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/expressions.py
+++ b/python/cudf_polars/cudf_polars/experimental/expressions.py
@@ -463,6 +463,23 @@ def _decompose_expr_node(
             config_options,
             names=names,
         )
+    elif isinstance(expr, UnaryFunction) and expr.name == "null_count":
+        columns, input_ir, partition_info = select(
+            [expr],
+            input_ir,
+            partition_info,
+            names=names,
+            repartition=True,
+        )
+        (column,) = columns
+        columns, input_ir, partition_info = select(
+            [Agg(expr.dtype, "sum", None, ExecutionContext.FRAME, column)],
+            input_ir,
+            partition_info,
+            names=names,
+        )
+        (expr,) = columns
+        return expr, input_ir, partition_info
     else:
         # This is an un-supported expression - raise.
         raise NotImplementedError(

--- a/python/cudf_polars/tests/experimental/test_select.py
+++ b/python/cudf_polars/tests/experimental/test_select.py
@@ -148,6 +148,7 @@ def test_select_aggs(df, engine, aggs):
         (pl.col("a").drop_nulls().min(),),
         (pl.col("a").drop_nulls().max(),),
         (pl.col("a").drop_nulls().mean(),),
+        (pl.col("a").null_count(),),
     ],
 )
 def test_select_drop_nulls_aggs(engine, aggs):


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Supports `null_count` in a select context for multiple partitions.
Contributes to #21749 
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
