### PR TITLE
Rename GroupedRollingWindow as GroupedWindow

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 """
 DSL nodes for the polars expression language.
@@ -26,7 +26,7 @@ from cudf_polars.dsl.expressions.binaryop import BinOp
 from cudf_polars.dsl.expressions.boolean import BooleanFunction
 from cudf_polars.dsl.expressions.datetime import TemporalFunction
 from cudf_polars.dsl.expressions.literal import Literal, LiteralColumn
-from cudf_polars.dsl.expressions.rolling import GroupedRollingWindow, RollingWindow
+from cudf_polars.dsl.expressions.rolling import RollingWindow, WindowExpr
 from cudf_polars.dsl.expressions.selection import Filter, Gather
 from cudf_polars.dsl.expressions.slicing import Slice
 from cudf_polars.dsl.expressions.sorting import Sort, SortBy
@@ -47,7 +47,6 @@ __all__ = [
     "Expr",
     "Filter",
     "Gather",
-    "GroupedRollingWindow",
     "Len",
     "Literal",
     "LiteralColumn",
@@ -61,4 +60,5 @@ __all__ = [
     "TemporalFunction",
     "Ternary",
     "UnaryFunction",
+    "WindowExpr",
 ]

--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -26,7 +26,7 @@ from cudf_polars.dsl.expressions.binaryop import BinOp
 from cudf_polars.dsl.expressions.boolean import BooleanFunction
 from cudf_polars.dsl.expressions.datetime import TemporalFunction
 from cudf_polars.dsl.expressions.literal import Literal, LiteralColumn
-from cudf_polars.dsl.expressions.rolling import RollingWindow, WindowExpr
+from cudf_polars.dsl.expressions.rolling import GroupedWindow, RollingWindow
 from cudf_polars.dsl.expressions.selection import Filter, Gather
 from cudf_polars.dsl.expressions.slicing import Slice
 from cudf_polars.dsl.expressions.sorting import Sort, SortBy
@@ -47,6 +47,7 @@ __all__ = [
     "Expr",
     "Filter",
     "Gather",
+    "GroupedWindow",
     "Len",
     "Literal",
     "LiteralColumn",
@@ -60,5 +61,4 @@ __all__ = [
     "TemporalFunction",
     "Ternary",
     "UnaryFunction",
-    "WindowExpr",
 ]

--- a/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from cudf_polars.typing import ClosedInterval, Duration
 
-__all__ = ["RollingWindow", "WindowExpr", "to_request"]
+__all__ = ["GroupedWindow", "RollingWindow", "to_request"]
 
 
 @dataclass(frozen=True)
@@ -206,7 +206,7 @@ class RollingWindow(Expr):  # pragma: no cover; polars >1.36 uses AExpr::Rolling
         return Column(result, dtype=self.dtype)
 
 
-class WindowExpr(Expr):
+class GroupedWindow(Expr):
     """
     Compute a window ``.over(...)`` aggregation and broadcast to rows.
 
@@ -845,7 +845,7 @@ class WindowExpr(Expr):
                     rank_by_cols_for_scan = self._gather_columns(
                         by_cols, order_index, stream=df.stream
                     )
-                    local = WindowExpr._sorted_grouper(rank_by_cols_for_scan)
+                    local = GroupedWindow._sorted_grouper(rank_by_cols_for_scan)
                     names, dtypes, tables = self._apply_unary_op(
                         RankOp(
                             named_exprs=[ne],

--- a/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # TODO: remove need for this
 # ruff: noqa: D101
-"""Rolling DSL nodes."""
+"""Rolling and Window DSL nodes."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from cudf_polars.typing import ClosedInterval, Duration
 
-__all__ = ["GroupedRollingWindow", "RollingWindow", "to_request"]
+__all__ = ["RollingWindow", "WindowExpr", "to_request"]
 
 
 @dataclass(frozen=True)
@@ -206,7 +206,7 @@ class RollingWindow(Expr):  # pragma: no cover; polars >1.36 uses AExpr::Rolling
         return Column(result, dtype=self.dtype)
 
 
-class GroupedRollingWindow(Expr):
+class WindowExpr(Expr):
     """
     Compute a window ``.over(...)`` aggregation and broadcast to rows.
 
@@ -845,7 +845,7 @@ class GroupedRollingWindow(Expr):
                     rank_by_cols_for_scan = self._gather_columns(
                         by_cols, order_index, stream=df.stream
                     )
-                    local = GroupedRollingWindow._sorted_grouper(rank_by_cols_for_scan)
+                    local = WindowExpr._sorted_grouper(rank_by_cols_for_scan)
                     names, dtypes, tables = self._apply_unary_op(
                         RankOp(
                             named_exprs=[ne],

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -904,6 +904,9 @@ def _(
         return replace([named_post_agg.value], replacements)[0]
     elif isinstance(node.options, plrs._expr_nodes.WindowMapping):
         # pl.col("a").over(...)
+        # Note: pl.col("a").rolling(...).over("g") also lands here. But
+        # is not supported in polars < 1.39 since the AExpr::Rolling was
+        # not exposed until polars 1.39.
         with set_expr_context(translator, ExecutionContext.WINDOW):
             agg = translator.translate_expr(n=node.function, schema=schema)
         name_gen = unique_names(schema)
@@ -948,7 +951,7 @@ def _(
             )
         ]
         children = (*by_exprs, *((order_by_expr,) if has_order_by else ()), *child_deps)
-        return expr.GroupedRollingWindow(
+        return expr.WindowExpr(
             dtype,
             (mapping, has_order_by, descending, nulls_last),
             named_aggs,

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -951,7 +951,7 @@ def _(
             )
         ]
         children = (*by_exprs, *((order_by_expr,) if has_order_by else ()), *child_deps)
-        return expr.WindowExpr(
+        return expr.GroupedWindow(
             dtype,
             (mapping, has_order_by, descending, nulls_last),
             named_aggs,

--- a/python/cudf_polars/cudf_polars/experimental/select.py
+++ b/python/cudf_polars/cudf_polars/experimental/select.py
@@ -42,7 +42,7 @@ def _hstack_chain_to_select(ir: Select) -> Select | None:
 
     Only fires when the chain has HStack(should_broadcast=False). Pure HStack(True)
     chains are left for rec(child) — their col refs may live in non-traversable expr
-    internals (e.g. WindowExpr.named_aggs) that _sub_expr cannot reach.
+    internals (e.g. GroupedWindow.named_aggs) that _sub_expr cannot reach.
     """
     hstack_chain: list[HStack] = []
     current: IR = ir.children[0]

--- a/python/cudf_polars/cudf_polars/experimental/select.py
+++ b/python/cudf_polars/cudf_polars/experimental/select.py
@@ -42,7 +42,7 @@ def _hstack_chain_to_select(ir: Select) -> Select | None:
 
     Only fires when the chain has HStack(should_broadcast=False). Pure HStack(True)
     chains are left for rec(child) — their col refs may live in non-traversable expr
-    internals (e.g. GroupedRollingWindow.named_aggs) that _sub_expr cannot reach.
+    internals (e.g. WindowExpr.named_aggs) that _sub_expr cannot reach.
     """
     hstack_chain: list[HStack] = []
     current: IR = ir.children[0]

--- a/python/cudf_polars/cudf_polars/experimental/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/utils.py
@@ -10,7 +10,7 @@ from functools import reduce
 from itertools import chain
 from typing import TYPE_CHECKING
 
-from cudf_polars.dsl.expr import Col, Expr, GroupedRollingWindow, UnaryFunction
+from cudf_polars.dsl.expr import Col, Expr, UnaryFunction, WindowExpr
 from cudf_polars.dsl.ir import Union
 from cudf_polars.dsl.traversal import traversal
 from cudf_polars.experimental.base import PartitionInfo
@@ -141,8 +141,8 @@ def _get_unique_fractions(
 
 
 def _contains_over(exprs: Sequence[Expr]) -> bool:
-    """Return True if any expression in 'exprs' contains an over(...) (ie. GroupedRollingWindow)."""
-    return any(isinstance(e, GroupedRollingWindow) for e in traversal(exprs))
+    """Return True if any expression contains a window expression."""
+    return any(isinstance(e, WindowExpr) for e in traversal(exprs))
 
 
 def _contains_unsupported_fill_strategy(exprs: Sequence[Expr]) -> bool:

--- a/python/cudf_polars/cudf_polars/experimental/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/utils.py
@@ -10,7 +10,7 @@ from functools import reduce
 from itertools import chain
 from typing import TYPE_CHECKING
 
-from cudf_polars.dsl.expr import Col, Expr, UnaryFunction, WindowExpr
+from cudf_polars.dsl.expr import Col, Expr, GroupedWindow, UnaryFunction
 from cudf_polars.dsl.ir import Union
 from cudf_polars.dsl.traversal import traversal
 from cudf_polars.experimental.base import PartitionInfo
@@ -142,7 +142,7 @@ def _get_unique_fractions(
 
 def _contains_over(exprs: Sequence[Expr]) -> bool:
     """Return True if any expression contains a window expression."""
-    return any(isinstance(e, WindowExpr) for e in traversal(exprs))
+    return any(isinstance(e, GroupedWindow) for e in traversal(exprs))
 
 
 def _contains_unsupported_fill_strategy(exprs: Sequence[Expr]) -> bool:

--- a/python/cudf_polars/tests/dsl/test_nodebase.py
+++ b/python/cudf_polars/tests/dsl/test_nodebase.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
             expr.Col(DataType(pl.Int64()), "foo"),
             expr.Literal(DataType(pl.Int64()), 1),
         ),
-        expr.GroupedRollingWindow(
+        expr.WindowExpr(
             DataType(pl.Float64),
             ("groups_to_rows", True, False, False),
             [

--- a/python/cudf_polars/tests/dsl/test_nodebase.py
+++ b/python/cudf_polars/tests/dsl/test_nodebase.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
             expr.Col(DataType(pl.Int64()), "foo"),
             expr.Literal(DataType(pl.Int64()), 1),
         ),
-        expr.WindowExpr(
+        expr.GroupedWindow(
             DataType(pl.Float64),
             ("groups_to_rows", True, False, False),
             [


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The old expression name is not accurately encapsulate what the expression does. There's nothing "rolling" specific about it. Of course, you can do a `rolling(...).over(...)` calculation, but that is one of many. What `over` does is more like a [`window function`](https://www.postgresql.org/docs/current/tutorial-window.html) in SQL.

Preparatory PR for https://github.com/rapidsai/cudf/issues/22047
xref #21749 
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
