### PR TITLE
Avoid pytz in test_holidays_within_dates

### DIFF
--- a/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
+++ b/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
@@ -28,7 +28,6 @@ from nbconvert.preprocessors import ExecutePreprocessor
 from numba import (
     vectorize,
 )
-from pytz import utc
 
 from rmm import RMMError
 
@@ -1449,10 +1448,10 @@ def test_holidays_within_dates(holiday, start, expected):
     # Verify that timezone info is preserved.
     assert list(
         holiday.dates(
-            utc.localize(xpd.Timestamp(start)),
-            utc.localize(xpd.Timestamp(start)),
+            xpd.Timestamp(start, tz="UTC"),
+            xpd.Timestamp(start, tz="UTC"),
         )
-    ) == [utc.localize(dt) for dt in expected]
+    ) == [dt.tz_localize("UTC") for dt in expected]
 
 
 @pytest.mark.serial


### PR DESCRIPTION
## Description
I noticed in https://github.com/rapidsai/cudf/pull/22137 that the CI errors when running `python/cudf/cudf_pandas_tests` because it uses `pytz` which used to be transitively installed via pandas, but now this is an optional dependency in pandas 3.

This test shouldn't need to use `pytz` regardless.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
