### PR TITLE
Ensure insert_finished() is called on error paths for streaming collectives

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/allgather.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/allgather.py
@@ -22,6 +22,62 @@ if TYPE_CHECKING:
     from rmm.pylibrmm.stream import Stream
 
 
+class AllGatherInserter:
+    """
+    Context manager for the insert phase of an AllGather operation.
+
+    Obtained via :meth:`AllGatherManager.inserting`. On exit, signals
+    the end of insertion to all ranks by calling ``insert_finished()``.
+
+    Parameters
+    ----------
+    manager: AllGatherManager
+        The AllGather manager to insert into.
+    """
+
+    def __init__(self, manager: AllGatherManager):
+        self._manager = manager
+
+    def insert(self, sequence_number: int, chunk: TableChunk) -> None:
+        """
+        Insert a chunk into the AllGather.
+
+        Parameters
+        ----------
+        sequence_number: int
+            The sequence number of the chunk to insert.
+        chunk: TableChunk
+            The table chunk to insert. Need not be GPU-resident; if spilled,
+            it will be made available internally.
+        """
+        chunk = chunk.make_available_and_spill(
+            self._manager.context.br(), allow_overbooking=True
+        )
+        self._manager.allgather.insert(
+            sequence_number,
+            # TODO: Avoid unnecessary copies.
+            # See https://github.com/rapidsai/rapidsmpf/issues/933
+            PackedData.from_cudf_packed_columns(
+                pack(
+                    chunk.table_view(),
+                    chunk.stream,
+                    mr=self._manager.context.br().device_mr,
+                ),
+                chunk.stream,
+                self._manager.context.br(),
+            ),
+        )
+        del chunk
+
+    def __enter__(self) -> AllGatherInserter:
+        """Enter the context manager."""
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Exit the context manager, calling ``insert_finished()``."""
+        self._manager.allgather.insert_finished()
+
+
 class AllGatherManager:
     """
     AllGather manager.
@@ -40,48 +96,9 @@ class AllGatherManager:
         self.context = context
         self.allgather = AllGather(self.context, comm, op_id)
 
-    def insert(self, sequence_number: int, chunk: TableChunk) -> None:
-        """
-        Insert a chunk into the AllGatherContext.
-
-        Parameters
-        ----------
-        sequence_number: int
-            The sequence number of the chunk to insert.
-        chunk: TableChunk
-            The table chunk to insert. Need not be GPU-resident; if spilled,
-            it will be made available internally.
-        """
-        chunk = chunk.make_available_and_spill(
-            self.context.br(), allow_overbooking=True
-        )
-        self.allgather.insert(
-            sequence_number,
-            # TODO: Avoid unnecessary copies.
-            # See https://github.com/rapidsai/rapidsmpf/issues/933
-            PackedData.from_cudf_packed_columns(
-                pack(
-                    chunk.table_view(),
-                    chunk.stream,
-                    mr=self.context.br().device_mr,
-                ),
-                chunk.stream,
-                self.context.br(),
-            ),
-        )
-        del chunk
-
-    def insert_finished(self) -> None:
-        """Insert finished into the AllGatherManager."""
-        self.allgather.insert_finished()
-
-    def __enter__(self) -> AllGatherManager:
-        """Enter the context manager."""
-        return self
-
-    def __exit__(self, *args: object) -> None:
-        """Exit the context manager, calling ``insert_finished()``."""
-        self.insert_finished()
+    def inserting(self) -> AllGatherInserter:
+        """Return a context manager for the insert phase."""
+        return AllGatherInserter(self)
 
     async def extract_concatenated(
         self, stream: Stream, *, ordered: bool = True

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/allgather.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/allgather.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from rapidsmpf.integrations.cudf.partition import unpack_and_concat
@@ -15,8 +14,6 @@ from rapidsmpf.streaming.coll.allgather import AllGather
 from pylibcudf.contiguous_split import pack
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.streaming.core.context import Context
     from rapidsmpf.streaming.cudf.table_chunk import TableChunk
@@ -78,13 +75,13 @@ class AllGatherManager:
         """Insert finished into the AllGatherManager."""
         self.allgather.insert_finished()
 
-    @contextmanager
-    def inserting(self) -> Iterator[None]:
-        """Context manager that guarantees ``insert_finished()`` is called."""
-        try:
-            yield
-        finally:
-            self.insert_finished()
+    def __enter__(self) -> AllGatherManager:
+        """Enter the context manager."""
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Exit the context manager, calling ``insert_finished()``."""
+        self.insert_finished()
 
     async def extract_concatenated(
         self, stream: Stream, *, ordered: bool = True

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/allgather.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/allgather.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from rapidsmpf.integrations.cudf.partition import unpack_and_concat
@@ -14,6 +15,8 @@ from rapidsmpf.streaming.coll.allgather import AllGather
 from pylibcudf.contiguous_split import pack
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.streaming.core.context import Context
     from rapidsmpf.streaming.cudf.table_chunk import TableChunk
@@ -74,6 +77,14 @@ class AllGatherManager:
     def insert_finished(self) -> None:
         """Insert finished into the AllGatherManager."""
         self.allgather.insert_finished()
+
+    @contextmanager
+    def inserting(self) -> Iterator[None]:
+        """Context manager that guarantees ``insert_finished()`` is called."""
+        try:
+            yield
+        finally:
+            self.insert_finished()
 
     async def extract_concatenated(
         self, stream: Stream, *, ordered: bool = True

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/allgather.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/allgather.py
@@ -22,62 +22,6 @@ if TYPE_CHECKING:
     from rmm.pylibrmm.stream import Stream
 
 
-class AllGatherInserter:
-    """
-    Context manager for the insert phase of an AllGather operation.
-
-    Obtained via :meth:`AllGatherManager.inserting`. On exit, signals
-    the end of insertion to all ranks by calling ``insert_finished()``.
-
-    Parameters
-    ----------
-    manager: AllGatherManager
-        The AllGather manager to insert into.
-    """
-
-    def __init__(self, manager: AllGatherManager):
-        self._manager = manager
-
-    def insert(self, sequence_number: int, chunk: TableChunk) -> None:
-        """
-        Insert a chunk into the AllGather.
-
-        Parameters
-        ----------
-        sequence_number: int
-            The sequence number of the chunk to insert.
-        chunk: TableChunk
-            The table chunk to insert. Need not be GPU-resident; if spilled,
-            it will be made available internally.
-        """
-        chunk = chunk.make_available_and_spill(
-            self._manager.context.br(), allow_overbooking=True
-        )
-        self._manager.allgather.insert(
-            sequence_number,
-            # TODO: Avoid unnecessary copies.
-            # See https://github.com/rapidsai/rapidsmpf/issues/933
-            PackedData.from_cudf_packed_columns(
-                pack(
-                    chunk.table_view(),
-                    chunk.stream,
-                    mr=self._manager.context.br().device_mr,
-                ),
-                chunk.stream,
-                self._manager.context.br(),
-            ),
-        )
-        del chunk
-
-    def __enter__(self) -> AllGatherInserter:
-        """Enter the context manager."""
-        return self
-
-    def __exit__(self, *args: object) -> None:
-        """Exit the context manager, calling ``insert_finished()``."""
-        self._manager.allgather.insert_finished()
-
-
 class AllGatherManager:
     """
     AllGather manager.
@@ -92,13 +36,68 @@ class AllGatherManager:
         Pre-allocated operation ID for this operation.
     """
 
+    class Inserter:
+        """
+        Context manager for the insert phase of an AllGather operation.
+
+        Obtained via :meth:`AllGatherManager.inserting`. On exit, signals
+        the end of insertion to all ranks by calling ``insert_finished()``.
+
+        Parameters
+        ----------
+        manager: AllGatherManager
+            The AllGather manager to insert into.
+        """
+
+        def __init__(self, manager: AllGatherManager):
+            self._manager = manager
+
+        def insert(self, sequence_number: int, chunk: TableChunk) -> None:
+            """
+            Insert a chunk into the AllGather.
+
+            Parameters
+            ----------
+            sequence_number: int
+                The sequence number of the chunk to insert.
+            chunk: TableChunk
+                The table chunk to insert. Need not be GPU-resident; if spilled,
+                it will be made available internally.
+            """
+            chunk = chunk.make_available_and_spill(
+                self._manager.context.br(), allow_overbooking=True
+            )
+            self._manager.allgather.insert(
+                sequence_number,
+                # TODO: Avoid unnecessary copies.
+                # See https://github.com/rapidsai/rapidsmpf/issues/933
+                PackedData.from_cudf_packed_columns(
+                    pack(
+                        chunk.table_view(),
+                        chunk.stream,
+                        mr=self._manager.context.br().device_mr,
+                    ),
+                    chunk.stream,
+                    self._manager.context.br(),
+                ),
+            )
+            del chunk
+
+        def __enter__(self) -> AllGatherManager.Inserter:
+            """Enter the context manager."""
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            """Exit the context manager, calling ``insert_finished()``."""
+            self._manager.allgather.insert_finished()
+
     def __init__(self, context: Context, comm: Communicator, op_id: int):
         self.context = context
         self.allgather = AllGather(self.context, comm, op_id)
 
-    def inserting(self) -> AllGatherInserter:
+    def inserting(self) -> AllGatherManager.Inserter:
         """Return a context manager for the insert phase."""
-        return AllGatherInserter(self)
+        return AllGatherManager.Inserter(self)
 
     async def extract_concatenated(
         self, stream: Stream, *, ordered: bool = True

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from rapidsmpf.integrations.cudf.partition import (
@@ -37,8 +36,6 @@ from cudf_polars.experimental.rapidsmpf.utils import (
 from cudf_polars.experimental.shuffle import Shuffle
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
-
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
@@ -120,13 +117,13 @@ class ShuffleManager:
         """Insert finished into the ShuffleManager."""
         await self.shuffler.insert_finished(self.context)
 
-    @asynccontextmanager
-    async def inserting(self) -> AsyncIterator[None]:
-        """Context manager that guarantees ``insert_finished()`` is called."""
-        try:
-            yield
-        finally:
-            await self.insert_finished()
+    async def __aenter__(self) -> ShuffleManager:
+        """Enter the context manager."""
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Exit the context manager, calling ``insert_finished()``."""
+        await self.insert_finished()
 
     def extract_chunk(self, sequence_number: int, stream: Stream) -> plc.Table:
         """
@@ -233,13 +230,11 @@ async def _global_shuffle(
     )
     await send_metadata(ch_out, context, output_metadata)
 
-    # Create ShuffleManager instance
-    shuffle = ShuffleManager(context, comm, num_partitions, collective_id)
     # When input is duplicated, only rank 0 should contribute data.
     # Other ranks still participate in the shuffle protocol.
     skip_insert = metadata_in.duplicated and comm.rank != 0
 
-    async with shuffle.inserting():
+    async with ShuffleManager(context, comm, num_partitions, collective_id) as shuffle:
         while (msg := await ch_in.recv(context)) is not None:
             if not skip_insert:
                 shuffle.insert_hash(

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -47,6 +47,54 @@ if TYPE_CHECKING:
     from cudf_polars.experimental.rapidsmpf.core import SubNetGenerator
 
 
+class ShuffleInserter:
+    """
+    Context manager for the insert phase of a shuffle operation.
+
+    Obtained via :meth:`ShuffleManager.inserting`. On exit, signals
+    the end of insertion to all ranks by calling ``insert_finished()``.
+
+    Parameters
+    ----------
+    manager: ShuffleManager
+        The shuffle manager to insert into.
+    """
+
+    def __init__(self, manager: ShuffleManager):
+        self._manager = manager
+
+    def insert_hash(self, chunk: TableChunk, columns_to_hash: tuple[int, ...]) -> None:
+        """Partition chunk by hash and insert into the shuffler."""
+        self._manager.shuffler.insert(
+            py_partition_and_pack(
+                table=chunk.table_view(),
+                columns_to_hash=columns_to_hash,
+                num_partitions=self._manager.num_partitions,
+                stream=chunk.stream,
+                br=self._manager.context.br(),
+            )
+        )
+
+    def insert_split(self, chunk: TableChunk, splits: list[int]) -> None:
+        """Split chunk at the given indices and insert into the shuffler."""
+        self._manager.shuffler.insert(
+            py_split_and_pack(
+                table=chunk.table_view(),
+                splits=splits,
+                stream=chunk.stream,
+                br=self._manager.context.br(),
+            )
+        )
+
+    async def __aenter__(self) -> ShuffleInserter:
+        """Enter the context manager."""
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Exit the context manager, calling ``insert_finished()``."""
+        await self._manager.shuffler.insert_finished(self._manager.context)
+
+
 class ShuffleManager:
     """
     ShufflerAsync manager.
@@ -86,44 +134,13 @@ class ShuffleManager:
             partition_assignment=partition_assignment,
         )
 
+    def inserting(self) -> ShuffleInserter:
+        """Return a context manager for the insert phase."""
+        return ShuffleInserter(self)
+
     def local_partitions(self) -> list[int]:
         """Get the local partition IDs for this rank."""
         return self.shuffler.local_partitions()
-
-    def insert_hash(self, chunk: TableChunk, columns_to_hash: tuple[int, ...]) -> None:
-        """Partition chunk by hash and insert into the shuffler."""
-        self.shuffler.insert(
-            py_partition_and_pack(
-                table=chunk.table_view(),
-                columns_to_hash=columns_to_hash,
-                num_partitions=self.num_partitions,
-                stream=chunk.stream,
-                br=self.context.br(),
-            )
-        )
-
-    def insert_split(self, chunk: TableChunk, splits: list[int]) -> None:
-        """Split chunk at the given indices and insert into the shuffler."""
-        self.shuffler.insert(
-            py_split_and_pack(
-                table=chunk.table_view(),
-                splits=splits,
-                stream=chunk.stream,
-                br=self.context.br(),
-            )
-        )
-
-    async def insert_finished(self) -> None:
-        """Insert finished into the ShuffleManager."""
-        await self.shuffler.insert_finished(self.context)
-
-    async def __aenter__(self) -> ShuffleManager:
-        """Enter the context manager."""
-        return self
-
-    async def __aexit__(self, *args: object) -> None:
-        """Exit the context manager, calling ``insert_finished()``."""
-        await self.insert_finished()
 
     def extract_chunk(self, sequence_number: int, stream: Stream) -> plc.Table:
         """
@@ -234,10 +251,11 @@ async def _global_shuffle(
     # Other ranks still participate in the shuffle protocol.
     skip_insert = metadata_in.duplicated and comm.rank != 0
 
-    async with ShuffleManager(context, comm, num_partitions, collective_id) as shuffle:
+    shuffle = ShuffleManager(context, comm, num_partitions, collective_id)
+    async with shuffle.inserting() as inserter:
         while (msg := await ch_in.recv(context)) is not None:
             if not skip_insert:
-                shuffle.insert_hash(
+                inserter.insert_hash(
                     TableChunk.from_message(
                         msg, br=context.br()
                     ).make_available_and_spill(context.br(), allow_overbooking=True),

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -47,54 +47,6 @@ if TYPE_CHECKING:
     from cudf_polars.experimental.rapidsmpf.core import SubNetGenerator
 
 
-class ShuffleInserter:
-    """
-    Context manager for the insert phase of a shuffle operation.
-
-    Obtained via :meth:`ShuffleManager.inserting`. On exit, signals
-    the end of insertion to all ranks by calling ``insert_finished()``.
-
-    Parameters
-    ----------
-    manager: ShuffleManager
-        The shuffle manager to insert into.
-    """
-
-    def __init__(self, manager: ShuffleManager):
-        self._manager = manager
-
-    def insert_hash(self, chunk: TableChunk, columns_to_hash: tuple[int, ...]) -> None:
-        """Partition chunk by hash and insert into the shuffler."""
-        self._manager.shuffler.insert(
-            py_partition_and_pack(
-                table=chunk.table_view(),
-                columns_to_hash=columns_to_hash,
-                num_partitions=self._manager.num_partitions,
-                stream=chunk.stream,
-                br=self._manager.context.br(),
-            )
-        )
-
-    def insert_split(self, chunk: TableChunk, splits: list[int]) -> None:
-        """Split chunk at the given indices and insert into the shuffler."""
-        self._manager.shuffler.insert(
-            py_split_and_pack(
-                table=chunk.table_view(),
-                splits=splits,
-                stream=chunk.stream,
-                br=self._manager.context.br(),
-            )
-        )
-
-    async def __aenter__(self) -> ShuffleInserter:
-        """Enter the context manager."""
-        return self
-
-    async def __aexit__(self, *args: object) -> None:
-        """Exit the context manager, calling ``insert_finished()``."""
-        await self._manager.shuffler.insert_finished(self._manager.context)
-
-
 class ShuffleManager:
     """
     ShufflerAsync manager.
@@ -115,6 +67,55 @@ class ShuffleManager:
         partition IDs and concatenation order matches global order.
     """
 
+    class Inserter:
+        """
+        Context manager for the insert phase of a shuffle operation.
+
+        Obtained via :meth:`ShuffleManager.inserting`. On exit, signals
+        the end of insertion to all ranks by calling ``insert_finished()``.
+
+        Parameters
+        ----------
+        manager: ShuffleManager
+            The shuffle manager to insert into.
+        """
+
+        def __init__(self, manager: ShuffleManager):
+            self._manager = manager
+
+        def insert_hash(
+            self, chunk: TableChunk, columns_to_hash: tuple[int, ...]
+        ) -> None:
+            """Partition chunk by hash and insert into the shuffler."""
+            self._manager.shuffler.insert(
+                py_partition_and_pack(
+                    table=chunk.table_view(),
+                    columns_to_hash=columns_to_hash,
+                    num_partitions=self._manager.num_partitions,
+                    stream=chunk.stream,
+                    br=self._manager.context.br(),
+                )
+            )
+
+        def insert_split(self, chunk: TableChunk, splits: list[int]) -> None:
+            """Split chunk at the given indices and insert into the shuffler."""
+            self._manager.shuffler.insert(
+                py_split_and_pack(
+                    table=chunk.table_view(),
+                    splits=splits,
+                    stream=chunk.stream,
+                    br=self._manager.context.br(),
+                )
+            )
+
+        async def __aenter__(self) -> ShuffleManager.Inserter:
+            """Enter the context manager."""
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            """Exit the context manager, calling ``insert_finished()``."""
+            await self._manager.shuffler.insert_finished(self._manager.context)
+
     def __init__(
         self,
         context: Context,
@@ -134,9 +135,9 @@ class ShuffleManager:
             partition_assignment=partition_assignment,
         )
 
-    def inserting(self) -> ShuffleInserter:
+    def inserting(self) -> ShuffleManager.Inserter:
         """Return a context manager for the insert phase."""
-        return ShuffleInserter(self)
+        return ShuffleManager.Inserter(self)
 
     def local_partitions(self) -> list[int]:
         """Get the local partition IDs for this rank."""

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from rapidsmpf.integrations.cudf.partition import (
@@ -36,6 +37,8 @@ from cudf_polars.experimental.rapidsmpf.utils import (
 from cudf_polars.experimental.shuffle import Shuffle
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.streaming.core.channel import Channel
     from rapidsmpf.streaming.core.context import Context
@@ -116,6 +119,14 @@ class ShuffleManager:
     async def insert_finished(self) -> None:
         """Insert finished into the ShuffleManager."""
         await self.shuffler.insert_finished(self.context)
+
+    @asynccontextmanager
+    async def inserting(self) -> AsyncIterator[None]:
+        """Context manager that guarantees ``insert_finished()`` is called."""
+        try:
+            yield
+        finally:
+            await self.insert_finished()
 
     def extract_chunk(self, sequence_number: int, stream: Stream) -> plc.Table:
         """
@@ -228,16 +239,15 @@ async def _global_shuffle(
     # Other ranks still participate in the shuffle protocol.
     skip_insert = metadata_in.duplicated and comm.rank != 0
 
-    while (msg := await ch_in.recv(context)) is not None:
-        if not skip_insert:
-            shuffle.insert_hash(
-                TableChunk.from_message(msg, br=context.br()).make_available_and_spill(
-                    context.br(), allow_overbooking=True
-                ),
-                columns_to_hash,
-            )
-
-    await shuffle.insert_finished()
+    async with shuffle.inserting():
+        while (msg := await ch_in.recv(context)) is not None:
+            if not skip_insert:
+                shuffle.insert_hash(
+                    TableChunk.from_message(
+                        msg, br=context.br()
+                    ).make_available_and_spill(context.br(), allow_overbooking=True),
+                    columns_to_hash,
+                )
 
     for partition_id in shuffle.shuffler.local_partitions():
         stream = ir_context.get_cuda_stream()

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
@@ -134,8 +134,8 @@ async def _compute_sort_boundaries(
             exclusive_view=True,
             br=context.br(),
         )
-        allgather.insert(comm.rank, chunk)
-        allgather.insert_finished()
+        with allgather.inserting():
+            allgather.insert(comm.rank, chunk)
         concat_table = await allgather.extract_concatenated(stream, ordered=True)
         return _get_final_sort_boundaries(
             DataFrame.from_table(
@@ -296,33 +296,32 @@ async def _insert_chunks_into_shuffle(
     local_sort_ir = ir.children[0]
     assert isinstance(local_sort_ir, Sort), "ShuffleSorted must have a Sort child."
 
-    for msg in chunk_store:
-        if skip_insert:
-            continue
-        seq_num = msg.sequence_number
-        available_chunk = TableChunk.from_message(
-            msg, br=context.br()
-        ).make_available_and_spill(context.br(), allow_overbooking=True)
-        tbl = available_chunk.table_view()
-        sort_cols_tbl = plc.Table([tbl.columns()[i] for i in by_indices])
+    async with shuffle.inserting():
+        for msg in chunk_store:
+            if skip_insert:
+                continue
+            seq_num = msg.sequence_number
+            available_chunk = TableChunk.from_message(
+                msg, br=context.br()
+            ).make_available_and_spill(context.br(), allow_overbooking=True)
+            tbl = available_chunk.table_view()
+            sort_cols_tbl = plc.Table([tbl.columns()[i] for i in by_indices])
 
-        stream = get_joined_cuda_stream(
-            ir_context.get_cuda_stream,
-            upstreams=(available_chunk.stream, sort_boundaries_df.stream),
-        )
+            stream = get_joined_cuda_stream(
+                ir_context.get_cuda_stream,
+                upstreams=(available_chunk.stream, sort_boundaries_df.stream),
+            )
 
-        splits = find_sort_splits(
-            sort_cols_tbl,
-            sort_boundaries_df.table,
-            seq_num,
-            column_order,
-            null_order,
-            stream=stream,
-            chunk_relative=True,
-        )
-        shuffle.insert_split(available_chunk, splits)
-
-    await shuffle.insert_finished()
+            splits = find_sort_splits(
+                sort_cols_tbl,
+                sort_boundaries_df.table,
+                seq_num,
+                column_order,
+                null_order,
+                stream=stream,
+                chunk_relative=True,
+            )
+            shuffle.insert_split(available_chunk, splits)
 
     post_sort_ir = local_sort_ir
     if local_sort_ir.stable:

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
@@ -127,14 +127,13 @@ async def _compute_sort_boundaries(
     stream = local_boundaries_df.stream
 
     if allgather_id is not None:
-        allgather = AllGatherManager(context, comm, allgather_id)
         chunk = TableChunk.from_pylibcudf_table(
             local_boundaries_df.table,
             stream,
             exclusive_view=True,
             br=context.br(),
         )
-        with allgather.inserting():
+        with AllGatherManager(context, comm, allgather_id) as allgather:
             allgather.insert(comm.rank, chunk)
         concat_table = await allgather.extract_concatenated(stream, ordered=True)
         return _get_final_sort_boundaries(
@@ -285,18 +284,17 @@ async def _insert_chunks_into_shuffle(
     null_order = list(ir.null_order)
     by_indices = names_to_indices(tuple(by), ir.schema)
 
-    shuffle = ShuffleManager(
+    skip_insert = metadata_in.duplicated and comm.rank != 0
+    local_sort_ir = ir.children[0]
+    assert isinstance(local_sort_ir, Sort), "ShuffleSorted must have a Sort child."
+
+    async with ShuffleManager(
         context,
         comm,
         num_partitions,
         collective_ids.pop(),
         partition_assignment=PartitionAssignment.CONTIGUOUS,
-    )
-    skip_insert = metadata_in.duplicated and comm.rank != 0
-    local_sort_ir = ir.children[0]
-    assert isinstance(local_sort_ir, Sort), "ShuffleSorted must have a Sort child."
-
-    async with shuffle.inserting():
+    ) as shuffle:
         for msg in chunk_store:
             if skip_insert:
                 continue

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
@@ -133,8 +133,9 @@ async def _compute_sort_boundaries(
             exclusive_view=True,
             br=context.br(),
         )
-        with AllGatherManager(context, comm, allgather_id) as allgather:
-            allgather.insert(comm.rank, chunk)
+        allgather = AllGatherManager(context, comm, allgather_id)
+        with allgather.inserting() as inserter:
+            inserter.insert(comm.rank, chunk)
         concat_table = await allgather.extract_concatenated(stream, ordered=True)
         return _get_final_sort_boundaries(
             DataFrame.from_table(
@@ -288,13 +289,14 @@ async def _insert_chunks_into_shuffle(
     local_sort_ir = ir.children[0]
     assert isinstance(local_sort_ir, Sort), "ShuffleSorted must have a Sort child."
 
-    async with ShuffleManager(
+    shuffle = ShuffleManager(
         context,
         comm,
         num_partitions,
         collective_ids.pop(),
         partition_assignment=PartitionAssignment.CONTIGUOUS,
-    ) as shuffle:
+    )
+    async with shuffle.inserting() as inserter:
         for msg in chunk_store:
             if skip_insert:
                 continue
@@ -319,7 +321,7 @@ async def _insert_chunks_into_shuffle(
                 stream=stream,
                 chunk_relative=True,
             )
-            shuffle.insert_split(available_chunk, splits)
+            inserter.insert_split(available_chunk, splits)
 
     post_sort_ir = local_sort_ir
     if local_sort_ir.stable:

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
@@ -163,8 +163,10 @@ def allgather_polars_dataframe(
 
     # Bulk AllGather: each rank contributes once (sequence_number=0)
     allgather = AllGather(comm, op_id, ctx.br())
-    allgather.insert(0, packed_data)
-    allgather.insert_finished()
+    try:
+        allgather.insert(0, packed_data)
+    finally:
+        allgather.insert_finished()
     results = allgather.wait_and_extract(ordered=True)
 
     # Deserialize and concatenate each rank's contribution

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
@@ -307,8 +307,9 @@ async def _tree_reduce(
     await send_metadata(ch_out, context, metadata_out)
 
     if need_allgather:
-        with AllGatherManager(context, comm, collective_id) as allgather:
-            allgather.insert(
+        allgather = AllGatherManager(context, comm, collective_id)
+        with allgather.inserting() as inserter:
+            inserter.insert(
                 0,
                 _enforce_schema(
                     aggregated, decomposed.reduction_ir.schema, context.br()
@@ -427,13 +428,14 @@ async def _shuffle_reduce(
     )
     await send_metadata(ch_out, context, metadata_out)
 
-    async with ShuffleManager(
+    shuffle = ShuffleManager(
         shuffle_context,
         shuffle_comm,
         modulus,
         collective_id,
-    ) as shuffle:
-        shuffle.insert_hash(
+    )
+    async with shuffle.inserting() as inserter:
+        inserter.insert_hash(
             _enforce_schema(
                 aggregated,
                 decomposed.reduction_ir.schema,
@@ -451,7 +453,7 @@ async def _shuffle_reduce(
                 ch_in,
                 target_partition_size,
             )
-            shuffle.insert_hash(
+            inserter.insert_hash(
                 _enforce_schema(
                     aggregated, decomposed.reduction_ir.schema, context.br()
                 ),

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
@@ -307,9 +307,7 @@ async def _tree_reduce(
     await send_metadata(ch_out, context, metadata_out)
 
     if need_allgather:
-        allgather = AllGatherManager(context, comm, collective_id)
-
-        with allgather.inserting():
+        with AllGatherManager(context, comm, collective_id) as allgather:
             allgather.insert(
                 0,
                 _enforce_schema(
@@ -429,14 +427,12 @@ async def _shuffle_reduce(
     )
     await send_metadata(ch_out, context, metadata_out)
 
-    shuffle = ShuffleManager(
+    async with ShuffleManager(
         shuffle_context,
         shuffle_comm,
         modulus,
         collective_id,
-    )
-
-    async with shuffle.inserting():
+    ) as shuffle:
         shuffle.insert_hash(
             _enforce_schema(
                 aggregated,

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
@@ -309,12 +309,13 @@ async def _tree_reduce(
     if need_allgather:
         allgather = AllGatherManager(context, comm, collective_id)
 
-        allgather.insert(
-            0,
-            _enforce_schema(aggregated, decomposed.reduction_ir.schema, context.br()),
-        )
-
-        allgather.insert_finished()
+        with allgather.inserting():
+            allgather.insert(
+                0,
+                _enforce_schema(
+                    aggregated, decomposed.reduction_ir.schema, context.br()
+                ),
+            )
 
         stream = ir_context.get_cuda_stream()
         aggregated = await evaluate_chunk(
@@ -435,31 +436,32 @@ async def _shuffle_reduce(
         collective_id,
     )
 
-    shuffle.insert_hash(
-        _enforce_schema(
-            aggregated,
-            decomposed.reduction_ir.schema,
-            context.br(),
-        ),
-        decomposed.shuffle_indices,
-    )
-    del aggregated
-
-    while not input_drained:
-        aggregated, input_drained, _ = await _local_aggregation(
-            context,
-            decomposed,
-            ir_context,
-            ch_in,
-            target_partition_size,
-        )
+    async with shuffle.inserting():
         shuffle.insert_hash(
-            _enforce_schema(aggregated, decomposed.reduction_ir.schema, context.br()),
+            _enforce_schema(
+                aggregated,
+                decomposed.reduction_ir.schema,
+                context.br(),
+            ),
             decomposed.shuffle_indices,
         )
         del aggregated
 
-    await shuffle.insert_finished()
+        while not input_drained:
+            aggregated, input_drained, _ = await _local_aggregation(
+                context,
+                decomposed,
+                ir_context,
+                ch_in,
+                target_partition_size,
+            )
+            shuffle.insert_hash(
+                _enforce_schema(
+                    aggregated, decomposed.reduction_ir.schema, context.br()
+                ),
+                decomposed.shuffle_indices,
+            )
+            del aggregated
     extract_irs = [decomposed.reduction_ir] + (
         [decomposed.select_ir] if decomposed.select_ir else []
     )

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
@@ -190,9 +190,9 @@ async def _collect_small_side_for_broadcast(
     dfs: list[DataFrame] = []
     if need_allgather:
         allgather = AllGatherManager(context, comm, collective_id)
-        for s_id in range(len(chunks)):
-            allgather.insert(s_id, chunks.pop(0))
-        allgather.insert_finished()
+        with allgather.inserting():
+            for s_id in range(len(chunks)):
+                allgather.insert(s_id, chunks.pop(0))
         stream = ir_context.get_cuda_stream()
         dfs = [
             DataFrame.from_table(

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
@@ -189,9 +189,10 @@ async def _collect_small_side_for_broadcast(
 
     dfs: list[DataFrame] = []
     if need_allgather:
-        with AllGatherManager(context, comm, collective_id) as allgather:
+        allgather = AllGatherManager(context, comm, collective_id)
+        with allgather.inserting() as inserter:
             for s_id in range(len(chunks)):
-                allgather.insert(s_id, chunks.pop(0))
+                inserter.insert(s_id, chunks.pop(0))
         stream = ir_context.get_cuda_stream()
         dfs = [
             DataFrame.from_table(

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
@@ -189,8 +189,7 @@ async def _collect_small_side_for_broadcast(
 
     dfs: list[DataFrame] = []
     if need_allgather:
-        allgather = AllGatherManager(context, comm, collective_id)
-        with allgather.inserting():
+        with AllGatherManager(context, comm, collective_id) as allgather:
             for s_id in range(len(chunks)):
                 allgather.insert(s_id, chunks.pop(0))
         stream = ir_context.get_cuda_stream()

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
@@ -143,10 +143,9 @@ async def concatenate_node(
             if tracer is not None and output_duplicated:
                 tracer.set_duplicated()
 
-            allgather = AllGatherManager(context, comm, collective_id)
             stream = context.get_stream_from_pool()
             seq_num = 0
-            with allgather.inserting():
+            with AllGatherManager(context, comm, collective_id) as allgather:
                 while (msg := await ch_in.recv(context)) is not None:
                     allgather.insert(
                         seq_num, TableChunk.from_message(msg, br=context.br())

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
@@ -146,11 +146,13 @@ async def concatenate_node(
             allgather = AllGatherManager(context, comm, collective_id)
             stream = context.get_stream_from_pool()
             seq_num = 0
-            while (msg := await ch_in.recv(context)) is not None:
-                allgather.insert(seq_num, TableChunk.from_message(msg, br=context.br()))
-                seq_num += 1
-                del msg
-            allgather.insert_finished()
+            with allgather.inserting():
+                while (msg := await ch_in.recv(context)) is not None:
+                    allgather.insert(
+                        seq_num, TableChunk.from_message(msg, br=context.br())
+                    )
+                    seq_num += 1
+                    del msg
 
             # Extract concatenated result
             result_table = await allgather.extract_concatenated(stream)

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
@@ -145,9 +145,10 @@ async def concatenate_node(
 
             stream = context.get_stream_from_pool()
             seq_num = 0
-            with AllGatherManager(context, comm, collective_id) as allgather:
+            allgather = AllGatherManager(context, comm, collective_id)
+            with allgather.inserting() as inserter:
                 while (msg := await ch_in.recv(context)) is not None:
-                    allgather.insert(
+                    inserter.insert(
                         seq_num, TableChunk.from_message(msg, br=context.br())
                     )
                     seq_num += 1

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
@@ -1066,8 +1066,10 @@ async def allgather_reduce(
     packed = PackedData.from_host_bytes(data, context.br())
 
     allgather = AllGather(context, comm, op_id)
-    allgather.insert(0, packed)
-    allgather.insert_finished()
+    try:
+        allgather.insert(0, packed)
+    finally:
+        allgather.insert_finished()
 
     results = await allgather.extract_all(context, ordered=False)
 

--- a/python/cudf_polars/tests/experimental/test_allgather.py
+++ b/python/cudf_polars/tests/experimental/test_allgather.py
@@ -30,14 +30,14 @@ async def _test_allgather(engine) -> None:
 
     # Insert tables into AllGatherManager
     allgather = AllGatherManager(context, comm, 0)
-    for i, table in enumerate(tables):
-        allgather.insert(
-            i,
-            TableChunk.from_pylibcudf_table(
-                table, stream, exclusive_view=True, br=context.br()
-            ),
-        )
-    allgather.insert_finished()
+    with allgather.inserting() as inserter:
+        for i, table in enumerate(tables):
+            inserter.insert(
+                i,
+                TableChunk.from_pylibcudf_table(
+                    table, stream, exclusive_view=True, br=context.br()
+                ),
+            )
 
     # Extract concatenated result
     result = await allgather.extract_concatenated(stream, ordered=True)

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -11,7 +11,7 @@ import pytest
 
 import polars as pl
 
-from cudf_polars.experimental.rapidsmpf.collectives.shuffle import ShuffleManager
+from cudf_polars.experimental.rapidsmpf.collectives.shuffle import ShuffleInserter
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
@@ -319,7 +319,7 @@ def test_shuffle_reduce_insert_finished_called_on_oom(engine):
 
     df = pl.LazyFrame({"a": range(10), "b": range(10)})
     with (
-        patch.object(ShuffleManager, "insert_hash", foo),
+        patch.object(ShuffleInserter, "insert_hash", foo),
         pytest.raises(ExceptionGroup) as exc_info,
     ):
         df.group_by("a").agg(pl.col("b").sum()).collect(engine=engine)

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -11,7 +11,7 @@ import pytest
 
 import polars as pl
 
-from cudf_polars.experimental.rapidsmpf.collectives.shuffle import ShuffleInserter
+from cudf_polars.experimental.rapidsmpf.collectives.shuffle import ShuffleManager
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
@@ -319,7 +319,7 @@ def test_shuffle_reduce_insert_finished_called_on_oom(engine):
 
     df = pl.LazyFrame({"a": range(10), "b": range(10)})
     with (
-        patch.object(ShuffleInserter, "insert_hash", foo),
+        patch.object(ShuffleManager.Inserter, "insert_hash", foo),
         pytest.raises(ExceptionGroup) as exc_info,
     ):
         df.group_by("a").agg(pl.col("b").sum()).collect(engine=engine)

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -5,11 +5,13 @@
 from __future__ import annotations
 
 import contextlib
+from unittest.mock import patch
 
 import pytest
 
 import polars as pl
 
+from cudf_polars.experimental.rapidsmpf.collectives.shuffle import ShuffleManager
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
@@ -301,3 +303,24 @@ def test_groupby_agg_config_options(df, op, keys, engine):
 def test_groupby_count_type_mismatch(df, engine):
     q = df.group_by("key", maintain_order=True).agg(pl.col("value").count())
     assert_gpu_result_equal(q, engine=engine, check_row_order=False)
+
+
+@pytest.mark.parametrize(
+    "engine",
+    [{"executor_options": {"target_partition_size": 10, "max_rows_per_partition": 5}}],
+    indirect=True,
+)
+def test_shuffle_reduce_insert_finished_called_on_oom(engine):
+    # Tests that an exception raised inside insert_hash() must not leave the
+    # C++ ShufflerAsync without insert_finished() being called.
+
+    def foo(*args, **kwargs):
+        raise MemoryError("OOM in insert_hash()")
+
+    df = pl.LazyFrame({"a": range(10), "b": range(10)})
+    with (
+        patch.object(ShuffleManager, "insert_hash", foo),
+        pytest.raises(ExceptionGroup) as exc_info,
+    ):
+        df.group_by("a").agg(pl.col("b").sum()).collect(engine=engine)
+    assert any("OOM in insert_hash" in str(e) for e in exc_info.value.exceptions)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Adds `inserting()` context managers to ShuffleManager and AllGatherManager that guarantee insert_finished() is called in a finally block.

Before if we raised an exception while inserting into one of the rapidsmpf collective managers (`ShufflerManager` or `AllGatherManager`), then we never called `insert_finished` which is required to let the other ranks know that insertion is complete. Without it, the C++ destructors of `ShufflerAsync`/`AllGather` segfault.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
