### PR TITLE
[Multi-GPU Polars] Add GPU sharing detection

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
@@ -48,7 +48,7 @@ class ClusterInfo:
     Attributes
     ----------
     pid
-        Process ID.
+        Process ID of the current rank.
     hostname
         Hostname of the machine running this rank.
     cuda_visible_devices
@@ -123,7 +123,7 @@ class StreamingEngine(pl.GPUEngine):
             executor_options=executor_options,
             **engine_options,
         )
-        if nranks > 1 and not engine_options.get("allow_gpu_sharing", False):
+        if nranks > 1 and engine_options.get("allow_gpu_sharing", False) is False:
             uuids = [info.gpu_uuid for info in self.gather_cluster_info()]
             if len(uuids) != len(set(uuids)):
                 raise RuntimeError(

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
@@ -5,8 +5,15 @@
 from __future__ import annotations
 
 import contextlib
+import dataclasses
+import os
+import socket
 from typing import TYPE_CHECKING, Any, Self
 
+import cuda.core
+from rapidsmpf.coll import AllGather
+from rapidsmpf.memory.packed_data import PackedData
+from rapidsmpf.statistics import Statistics
 from rapidsmpf.streaming.core.actor import run_actor_network
 from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 
@@ -23,6 +30,7 @@ if TYPE_CHECKING:
     from concurrent.futures import ThreadPoolExecutor
 
     from rapidsmpf.communicator.communicator import Communicator
+    from rapidsmpf.memory.buffer_resource import BufferResource
     from rapidsmpf.streaming.core.context import Context
     from rapidsmpf.streaming.cudf.channel_metadata import ChannelMetadata
 
@@ -30,6 +38,146 @@ if TYPE_CHECKING:
     from cudf_polars.experimental.base import PartitionInfo, StatsCollector
     from cudf_polars.experimental.parallel import ConfigOptions
     from cudf_polars.utils.config import StreamingExecutor
+
+
+@dataclasses.dataclass(frozen=True)
+class ClusterInfo:
+    """
+    Diagnostic information about a single rank in the cluster.
+
+    Attributes
+    ----------
+    pid
+        Process ID.
+    hostname
+        Hostname of the machine running this rank.
+    cuda_visible_devices
+        Value of ``CUDA_VISIBLE_DEVICES``, or ``None`` if unset.
+    gpu_uuid
+        UUID of the current CUDA device.
+    """
+
+    pid: int
+    hostname: str
+    cuda_visible_devices: str | None
+    gpu_uuid: str
+
+    @classmethod
+    def local(cls) -> ClusterInfo:
+        """
+        Build a :class:`ClusterInfo` for the current process and GPU.
+
+        Returns
+        -------
+        Diagnostic information for this rank.
+        """
+        return cls(
+            pid=os.getpid(),
+            hostname=socket.gethostname(),
+            cuda_visible_devices=os.environ.get("CUDA_VISIBLE_DEVICES"),
+            gpu_uuid=cuda.core.Device().uuid,
+        )
+
+
+class StreamingEngine(pl.GPUEngine):
+    """
+    Base class for multi-GPU Polars engines.
+
+    The engine manages the lifecycle of a streaming execution and can
+    be used as a context manager. On exit, :meth:`shutdown` is called.
+
+    Notes
+    -----
+    The engine must be created and shut down on the same thread. In particular,
+    destruction and context manager exit must occur on the thread that created
+    the instance.
+
+    Parameters
+    ----------
+    nranks
+        Number of ranks (workers or GPUs) in the cluster.
+    executor_options
+        Executor-specific options (e.g. ``max_rows_per_partition``).
+    engine_options
+        Engine-specific keyword arguments (e.g. ``raise_on_fail``,
+        ``parquet_options``).
+    exit_stack
+        A :class:`contextlib.ExitStack` whose registered contexts are closed
+        when :meth:`shutdown` is called. If ``None``, an empty stack is created.
+    """
+
+    def __init__(
+        self,
+        *,
+        nranks: int,
+        executor_options: dict[str, Any],
+        engine_options: dict[str, Any],
+        exit_stack: contextlib.ExitStack | None = None,
+    ):
+        self._nranks = nranks
+        self._exit_stack: contextlib.ExitStack | None = (
+            exit_stack or contextlib.ExitStack()
+        )
+        super().__init__(
+            executor="streaming",
+            executor_options=executor_options,
+            **engine_options,
+        )
+        if nranks > 1 and not engine_options.get("allow_gpu_sharing", False):
+            uuids = [info.gpu_uuid for info in self.gather_cluster_info()]
+            if len(uuids) != len(set(uuids)):
+                raise RuntimeError(
+                    "Multiple ranks share the same GPU (UUID collision detected). "
+                    f"UUIDs: {uuids}. Set allow_gpu_sharing=True to allow this."
+                )
+
+    @property
+    def nranks(self) -> int:
+        """
+        Number of ranks (for example GPUs or workers) in the cluster.
+
+        Local execution without a cluster returns 1.
+
+        Returns
+        -------
+        Number of ranks.
+        """
+        return self._nranks
+
+    def gather_cluster_info(self) -> list[ClusterInfo]:
+        """
+        Collect diagnostic information from every rank.
+
+        Returns
+        -------
+        List of :class:`ClusterInfo`, one per rank.
+        """
+        raise NotImplementedError
+
+    def shutdown(self) -> None:
+        """
+        Shut down engine and release all owned resources.
+
+        Idempotent: safe to call more than once. Must be called on the same
+        thread that created the engine.
+        """
+        if self._exit_stack is None:
+            return  # already shut down
+        try:
+            self._exit_stack.close()
+        finally:
+            self._exit_stack = None
+            self.device = None
+            self.memory_resource = None
+            self.config = {}
+
+    def __enter__(self) -> Self:
+        """Enter the context manager, returning ``self``."""
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        """Exit the context manager, calling :meth:`shutdown`."""
+        self.shutdown()
 
 
 def execute_ir_on_rank(
@@ -160,85 +308,47 @@ def check_reserved_keys(
         raise TypeError(f"engine_options may not contain reserved keys: {bad}")
 
 
-class StreamingEngine(pl.GPUEngine):
+def all_gather_host_data(
+    comm: Communicator,
+    br: BufferResource,
+    op_id: int,
+    data: bytes | bytearray,
+) -> list[bytes]:
     """
-    Base class for multi-GPU Polars engines.
+    Gather host data from every rank using an AllGather collective.
 
-    The engine manages the lifecycle of a streaming execution and can
-    be used as a context manager. On exit, :meth:`shutdown` is called.
+    Each rank contributes a buffer of host bytes; every rank receives back
+    an ordered list containing the contributions from all ranks (index *i*
+    holds the bytes sent by rank *i*).
 
-    Notes
-    -----
-    The engine must be created and shut down on the same thread. In particular,
-    destruction and context manager exit must occur on the thread that created
-    the instance.
+    This function is **blocking**: all ranks must call it, and each rank
+    waits until the collective completes. The input buffer is **copied**
+    into device memory and cannot be stream-ordered.
 
     Parameters
     ----------
-    nranks
-        Number of ranks (workers or GPUs) in the cluster.
-    executor_options
-        Executor-specific options (e.g. ``max_rows_per_partition``).
-    engine_options
-        Engine-specific keyword arguments (e.g. ``raise_on_fail``,
-        ``parquet_options``).
-    exit_stack
-        A :class:`contextlib.ExitStack` whose registered contexts are closed
-        when :meth:`shutdown` is called. If ``None``, an empty stack is created.
+    comm
+        The communicator shared by all participating ranks.
+    br
+        Buffer resource for memory allocation.
+    op_id
+        Unique operation identifier for this collective.
+    data
+        Host-side buffer to broadcast from this rank.  Accepts any object
+        that implements the buffer protocol (``bytes``, ``bytearray``,
+        ``memoryview``, etc.).
+
+    Returns
+    -------
+    List of bytes, one element per rank, ordered by rank index.
     """
-
-    def __init__(
-        self,
-        *,
-        nranks: int,
-        executor_options: dict[str, Any],
-        engine_options: dict[str, Any],
-        exit_stack: contextlib.ExitStack | None = None,
-    ):
-        self._nranks = nranks
-        self._exit_stack: contextlib.ExitStack | None = (
-            exit_stack or contextlib.ExitStack()
-        )
-        super().__init__(
-            executor="streaming",
-            executor_options=executor_options,
-            **engine_options,
-        )
-
-    @property
-    def nranks(self) -> int:
-        """
-        Number of ranks (for example GPUs or workers) in the cluster.
-
-        Local execution without a cluster returns 1.
-
-        Returns
-        -------
-        Number of ranks.
-        """
-        return self._nranks
-
-    def shutdown(self) -> None:
-        """
-        Shut down engine and release all owned resources.
-
-        Idempotent: safe to call more than once. Must be called on the same
-        thread that created the engine.
-        """
-        if self._exit_stack is None:
-            return  # already shut down
-        try:
-            self._exit_stack.close()
-        finally:
-            self._exit_stack = None
-            self.device = None
-            self.memory_resource = None
-            self.config = {}
-
-    def __enter__(self) -> Self:
-        """Enter the context manager, returning ``self``."""
-        return self
-
-    def __exit__(self, *_: object) -> None:
-        """Exit the context manager, calling :meth:`shutdown`."""
-        self.shutdown()
+    allgather = AllGather(
+        comm=comm,
+        op_id=op_id,
+        br=br,
+        statistics=Statistics(enable=False),
+    )
+    allgather.insert(0, PackedData.from_host_bytes(data, br))
+    allgather.insert_finished()
+    results = allgather.wait_and_extract(ordered=True)
+    return [r.to_host_bytes() for r in results]

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
@@ -318,12 +318,12 @@ def all_gather_host_data(
     Gather host data from every rank using an AllGather collective.
 
     Each rank contributes a buffer of host bytes; every rank receives back
-    an ordered list containing the contributions from all ranks (index *i*
-    holds the bytes sent by rank *i*).
+    an ordered list containing the contributions from all ranks (index `i`
+    holds the bytes sent by rank `i`).
 
-    This function is **blocking**: all ranks must call it, and each rank
-    waits until the collective completes. The input buffer is **copied**
-    into device memory and cannot be stream-ordered.
+    This function is blocking: all ranks must call it, and each rank
+    waits until the collective completes. The input buffer is copied
+    and cannot be stream-ordered.
 
     Parameters
     ----------

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
@@ -8,7 +8,6 @@ import contextlib
 import dataclasses
 import functools
 import os
-import socket
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
@@ -32,6 +31,7 @@ import polars as pl
 import rmm.mr
 
 from cudf_polars.experimental.rapidsmpf.frontend.core import (
+    ClusterInfo,
     StreamingEngine,
     check_reserved_keys,
     execute_ir_on_rank,
@@ -646,30 +646,15 @@ class DaskEngine(StreamingEngine):
             raise RuntimeError("dask_context is not available after shutdown")
         return self._dask_context
 
-    def gather_cluster_info(self) -> list[dict]:
+    def gather_cluster_info(self) -> list[ClusterInfo]:
         """
-        Collect diagnostic information from every Dask worker.
+        Collect diagnostic information from every rank.
 
         Returns
         -------
-        List of info dicts, one per worker. Each dict contains
-        ``pid``, ``hostname``, and ``cuda_visible_devices``.
-
-        Examples
-        --------
-        >>> with DaskEngine() as engine:  # doctest: +SKIP
-        ...     for info in engine.gather_cluster_info():
-        ...         print(info)
+        List of :class:`ClusterInfo`, one per rank.
         """
-
-        def _get_info() -> dict:
-            return {
-                "pid": os.getpid(),
-                "hostname": socket.gethostname(),
-                "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
-            }
-
-        return list(self._dask_ctx.client.run(_get_info).values())
+        return list(self._dask_ctx.client.run(ClusterInfo.local).values())
 
     def shutdown(self) -> None:
         """

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
@@ -265,6 +265,11 @@ class StreamingOptions:
         e.g. ``'{"enabled": false}'``).
         Default: ``HardwareBindingPolicy()``.
         Category: engine.
+    allow_gpu_sharing
+        When ``False`` (default), the engine raises if multiple ranks share the same physical GPU.
+        Env: ``CUDF_POLARS__ALLOW_GPU_SHARING``.
+        Default: ``False``.
+        Category: engine.
 
     Examples
     --------
@@ -332,6 +337,9 @@ class StreamingOptions:
     )
     hardware_binding: HardwareBindingPolicy | Unspecified = _opt(
         "engine", "CUDF_POLARS__HARDWARE_BINDING", _parse_hardware_binding
+    )
+    allow_gpu_sharing: bool | Unspecified = _opt(
+        "engine", "CUDF_POLARS__ALLOW_GPU_SHARING", parse_boolean
     )
 
     # ------------------------------------------------------------------

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import os
-import socket
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
 
@@ -29,6 +28,7 @@ import polars as pl
 import rmm.mr
 
 from cudf_polars.experimental.rapidsmpf.frontend.core import (
+    ClusterInfo,
     StreamingEngine,
     check_reserved_keys,
     execute_ir_on_rank,
@@ -281,7 +281,7 @@ class RankActor:
         self._mr = None
         ray.actor.exit_actor()
 
-    def get_info(self) -> dict[str, Any]:
+    def get_info(self) -> ClusterInfo:
         """
         Return diagnostic information about actor placement.
 
@@ -289,12 +289,7 @@ class RankActor:
         -------
         Diagnostic information about this actor's placement and state.
         """
-        return {
-            "pid": os.getpid(),
-            "hostname": socket.gethostname(),
-            "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
-            "node_id": ray.get_runtime_context().get_node_id(),
-        }
+        return ClusterInfo.local()
 
     def evaluate_polars_ir(
         self,
@@ -596,20 +591,13 @@ class RayEngine(StreamingEngine):
             raise RuntimeError("rank_actors is not available after shutdown")
         return self._rank_actors
 
-    def gather_cluster_info(self) -> list[dict]:
+    def gather_cluster_info(self) -> list[ClusterInfo]:
         """
-        Collect diagnostic information from every rank actor.
+        Collect diagnostic information from every rank.
 
         Returns
         -------
-        List of info dicts (see :meth:`RankActor.get_info`), one per rank
-        in rank order.
-
-        Examples
-        --------
-        >>> with RayEngine() as engine:  # doctest: +SKIP
-        ...     for i, info in enumerate(engine.gather_cluster_info()):
-        ...         print(f"rank {i}: {info}")
+        List of :class:`ClusterInfo`, one per rank.
         """
         return ray.get([rank.get_info.remote() for rank in self.rank_actors])
 

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import contextlib
+import dataclasses
+import json
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
 
@@ -26,8 +28,11 @@ import pylibcudf as plc
 import rmm.mr
 from pylibcudf.contiguous_split import pack
 
+from cudf_polars.experimental.rapidsmpf.collectives.common import reserve_op_id
 from cudf_polars.experimental.rapidsmpf.frontend.core import (
+    ClusterInfo,
     StreamingEngine,
+    all_gather_host_data,
     check_reserved_keys,
     execute_ir_on_rank,
 )
@@ -488,6 +493,19 @@ class SPMDEngine(StreamingEngine):
         if self._ctx is None:
             raise RuntimeError("context is not available after shutdown")
         return self._ctx
+
+    def gather_cluster_info(self) -> list[ClusterInfo]:
+        """
+        Collect diagnostic information from every rank.
+
+        Returns
+        -------
+        List of :class:`ClusterInfo`, one per rank.
+        """
+        data = json.dumps(dataclasses.asdict(ClusterInfo.local())).encode()
+        with reserve_op_id() as op_id:
+            results = all_gather_host_data(self.comm, self.context.br(), op_id, data)
+        return [ClusterInfo(**json.loads(r)) for r in results]
 
     def shutdown(self) -> None:
         """

--- a/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
+++ b/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
@@ -68,7 +68,7 @@ def test_gather_cluster_info(engine) -> None:
     for info in infos:
         assert isinstance(info, ClusterInfo)
         assert info.pid > 0
-        assert len(info.hostname) > 0
+        assert isinstance(info.hostname, str)
         assert info.cuda_visible_devices is None or isinstance(
             info.cuda_visible_devices, str
         )

--- a/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
+++ b/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for all_gather_host_data."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from cudf_polars.experimental.rapidsmpf.frontend.core import (
+    ClusterInfo,
+    all_gather_host_data,
+)
+
+pytestmark = pytest.mark.spmd
+
+
+def test_roundtrip_bytes(engine) -> None:
+    """Each rank contributes a bytes object and gets back all contributions."""
+    comm = engine.comm
+    br = engine.context.br()
+    data = b"hello from rank"
+    result = all_gather_host_data(comm, br, op_id=0, data=data)
+    assert len(result) == comm.nranks
+    for item in result:
+        assert item == data
+
+
+def test_empty_bytes(engine) -> None:
+    """Gathering empty bytes from every rank works."""
+    comm = engine.comm
+    br = engine.context.br()
+    result = all_gather_host_data(comm, br, op_id=1, data=b"")
+    assert len(result) == comm.nranks
+    for item in result:
+        assert item == b""
+
+
+def test_structured_data(engine) -> None:
+    """Struct-packed integers survive the gather round-trip."""
+    comm = engine.comm
+    br = engine.context.br()
+    value = 12345678901234
+    data = struct.pack("q", value)
+    result = all_gather_host_data(comm, br, op_id=2, data=data)
+    assert len(result) == comm.nranks
+    for item in result:
+        assert struct.unpack("q", item)[0] == value
+
+
+def test_bytearray_input(engine) -> None:
+    """A bytearray input is accepted and gathered correctly."""
+    comm = engine.comm
+    br = engine.context.br()
+    data = bytearray(b"bytearray input")
+    result = all_gather_host_data(comm, br, op_id=3, data=data)
+    assert len(result) == comm.nranks
+    for item in result:
+        assert item == bytes(data)
+
+
+def test_gather_cluster_info(engine) -> None:
+    """SPMDEngine.gather_cluster_info returns ClusterInfo for each rank."""
+    infos = engine.gather_cluster_info()
+    assert len(infos) == engine.nranks
+    for info in infos:
+        assert isinstance(info, ClusterInfo)
+        assert info.pid > 0
+        assert len(info.hostname) > 0
+        assert len(info.gpu_uuid) > 0
+    # Each rank runs in its own process.
+    assert len({info.pid for info in infos}) == engine.nranks
+    # Without allow_gpu_sharing, all UUIDs must be unique (enforced at init).
+    assert len({info.gpu_uuid for info in infos}) == engine.nranks
+
+
+@pytest.mark.parametrize(
+    "engine",
+    [{"engine_options": {"allow_gpu_sharing": True}}],
+    indirect=True,
+)
+def test_allow_gpu_sharing(engine) -> None:
+    """Engine init succeeds with allow_gpu_sharing=True."""
+    assert engine.nranks >= 1

--- a/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
+++ b/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
@@ -17,15 +17,15 @@ from cudf_polars.experimental.rapidsmpf.frontend.core import (
 pytestmark = pytest.mark.spmd
 
 
-def test_roundtrip_bytes(engine) -> None:
-    """Each rank contributes a bytes object and gets back all contributions."""
+def test_per_rank_data(engine) -> None:
+    """Each rank sends its rank index; results are ordered by rank."""
     comm = engine.comm
     br = engine.context.br()
-    data = b"hello from rank"
-    result = all_gather_host_data(comm, br, op_id=0, data=data)
+    data = struct.pack("i", comm.rank)
+    result = all_gather_host_data(comm, br, op_id=4, data=data)
     assert len(result) == comm.nranks
-    for item in result:
-        assert item == data
+    for i, item in enumerate(result):
+        assert struct.unpack("i", item)[0] == i
 
 
 def test_empty_bytes(engine) -> None:
@@ -69,11 +69,28 @@ def test_gather_cluster_info(engine) -> None:
         assert isinstance(info, ClusterInfo)
         assert info.pid > 0
         assert len(info.hostname) > 0
-        assert len(info.gpu_uuid) > 0
+        assert info.cuda_visible_devices is None or isinstance(
+            info.cuda_visible_devices, str
+        )
+        assert isinstance(info.gpu_uuid, str)
     # Each rank runs in its own process.
     assert len({info.pid for info in infos}) == engine.nranks
     # Without allow_gpu_sharing, all UUIDs must be unique (enforced at init).
     assert len({info.gpu_uuid for info in infos}) == engine.nranks
+
+
+def test_cluster_info_cuda_visible_devices(monkeypatch) -> None:
+    """ClusterInfo.local() picks up CUDA_VISIBLE_DEVICES from the environment."""
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,7")
+    info = ClusterInfo.local()
+    assert info.cuda_visible_devices == "3,7"
+
+
+def test_cluster_info_cuda_visible_devices_unset(monkeypatch) -> None:
+    """ClusterInfo.local() returns None when CUDA_VISIBLE_DEVICES is not set."""
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    info = ClusterInfo.local()
+    assert info.cuda_visible_devices is None
 
 
 @pytest.mark.parametrize(

--- a/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
+++ b/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
@@ -17,48 +17,31 @@ from cudf_polars.experimental.rapidsmpf.frontend.core import (
 pytestmark = pytest.mark.spmd
 
 
-def test_per_rank_data(engine) -> None:
-    """Each rank sends its rank index; results are ordered by rank."""
+def _empty(rank: int) -> bytes:
+    return b""
+
+
+def _text(rank: int) -> bytes:
+    return f"hello from rank {rank}".encode()
+
+
+def _bytearray(rank: int) -> bytearray:
+    return bytearray(f"ba-rank-{rank}".encode())
+
+
+def _struct(rank: int) -> bytes:
+    return struct.pack("qi", 12345678901234 + rank, rank)
+
+
+@pytest.mark.parametrize("make_data", [_empty, _text, _bytearray, _struct])
+def test_all_gather_host_data(engine, make_data) -> None:
+    """Each rank sends rank-specific data; results are correct and ordered."""
     comm = engine.comm
     br = engine.context.br()
-    data = struct.pack("i", comm.rank)
-    result = all_gather_host_data(comm, br, op_id=4, data=data)
+    result = all_gather_host_data(comm, br, op_id=0, data=make_data(comm.rank))
     assert len(result) == comm.nranks
     for i, item in enumerate(result):
-        assert struct.unpack("i", item)[0] == i
-
-
-def test_empty_bytes(engine) -> None:
-    """Gathering empty bytes from every rank works."""
-    comm = engine.comm
-    br = engine.context.br()
-    result = all_gather_host_data(comm, br, op_id=1, data=b"")
-    assert len(result) == comm.nranks
-    for item in result:
-        assert item == b""
-
-
-def test_structured_data(engine) -> None:
-    """Struct-packed integers survive the gather round-trip."""
-    comm = engine.comm
-    br = engine.context.br()
-    value = 12345678901234
-    data = struct.pack("q", value)
-    result = all_gather_host_data(comm, br, op_id=2, data=data)
-    assert len(result) == comm.nranks
-    for item in result:
-        assert struct.unpack("q", item)[0] == value
-
-
-def test_bytearray_input(engine) -> None:
-    """A bytearray input is accepted and gathered correctly."""
-    comm = engine.comm
-    br = engine.context.br()
-    data = bytearray(b"bytearray input")
-    result = all_gather_host_data(comm, br, op_id=3, data=data)
-    assert len(result) == comm.nranks
-    for item in result:
-        assert item == bytes(data)
+        assert item == bytes(make_data(i))
 
 
 def test_gather_cluster_info(engine) -> None:
@@ -82,15 +65,13 @@ def test_gather_cluster_info(engine) -> None:
 def test_cluster_info_cuda_visible_devices(monkeypatch) -> None:
     """ClusterInfo.local() picks up CUDA_VISIBLE_DEVICES from the environment."""
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,7")
-    info = ClusterInfo.local()
-    assert info.cuda_visible_devices == "3,7"
+    assert ClusterInfo.local().cuda_visible_devices == "3,7"
 
 
 def test_cluster_info_cuda_visible_devices_unset(monkeypatch) -> None:
     """ClusterInfo.local() returns None when CUDA_VISIBLE_DEVICES is not set."""
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-    info = ClusterInfo.local()
-    assert info.cuda_visible_devices is None
+    assert ClusterInfo.local().cuda_visible_devices is None
 
 
 @pytest.mark.parametrize(

--- a/python/cudf_polars/tests/experimental/test_dask.py
+++ b/python/cudf_polars/tests/experimental/test_dask.py
@@ -71,16 +71,14 @@ def test_executor_options_forwarded(engine: DaskEngine) -> None:
 
 
 def test_gather_cluster_info(engine: DaskEngine) -> None:
-    """gather_cluster_info returns one info dict per rank with expected fields."""
+    """gather_cluster_info returns one ClusterInfo per rank with expected fields."""
     infos = engine.gather_cluster_info()
     assert len(infos) == engine.nranks
     for info in infos:
-        assert "pid" in info
-        assert "hostname" in info
-        assert "cuda_visible_devices" in info
-        assert isinstance(info["pid"], int)
+        assert isinstance(info.pid, int)
+        assert isinstance(info.hostname, str)
     # Each worker runs in its own process.
-    assert len({info["pid"] for info in infos}) == engine.nranks
+    assert len({info.pid for info in infos}) == engine.nranks
 
 
 def test_from_options_creates_engine() -> None:

--- a/python/cudf_polars/tests/experimental/test_ray.py
+++ b/python/cudf_polars/tests/experimental/test_ray.py
@@ -101,17 +101,14 @@ def test_executor_options_forwarded(
 
 
 def test_gather_cluster_info(engine: RayEngine) -> None:
-    """gather_cluster_info returns one info dict per rank with expected fields."""
+    """gather_cluster_info returns one ClusterInfo per rank with expected fields."""
     infos = engine.gather_cluster_info()
     assert len(infos) == engine.nranks
     for info in infos:
-        assert "node_id" in info
-        assert "hostname" in info
-        assert "pid" in info
-        assert "cuda_visible_devices" in info
-        assert isinstance(info["pid"], int)
+        assert isinstance(info.hostname, str)
+        assert isinstance(info.pid, int)
     # Each actor runs in its own process.
-    assert len({info["pid"] for info in infos}) == engine.nranks
+    assert len({info.pid for info in infos}) == engine.nranks
 
 
 def test_scan(engine: RayEngine) -> None:


### PR DESCRIPTION
Introduces detection of unintended GPU sharing across ranks. This works across all new engines (Ray, Dask, and SPMD) and is independent of how the cluster is created, whether via `rrun`, manual setup, or local execution.

Adds an `allow_gpu_sharing` engine option (default: `False`). When running with multiple ranks, initialization fails if two ranks report the same GPU UUID, unless explicitly enabled.
