### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/cpp/include/cudf_test/iterator_utilities.hpp
+++ b/cpp/include/cudf_test/iterator_utilities.hpp
@@ -106,6 +106,50 @@ template <typename Iter>
 [[maybe_unused]] static auto no_nulls() { return cuda::make_constant_iterator(true); }
 
 /**
+ * @brief Bool iterator for marking null elements at every multiple of n.
+ *
+ * The returned iterator yields `false` (to mark `null`) at indices 0, n, 2n, ...,
+ * and yields `true` (to mark valid rows) for all other indices. E.g.
+ *
+ * @code
+ * auto iter = nulls_at_multiples_of(3);
+ * iter[0] == false; // i.e. Invalid (null) row at index 0.
+ * iter[1] == true;  // i.e. Valid row at index 1.
+ * iter[2] == true;  // i.e. Valid row at index 2.
+ * iter[3] == false; // i.e. Invalid (null) row at index 3.
+ * @endcode
+ *
+ * @param n The period at which nulls occur (nulls at indices 0, n, 2n, ...)
+ * @return auto Validity iterator
+ */
+[[maybe_unused]] static auto nulls_at_multiples_of(cudf::size_type n)
+{
+  return cudf::detail::make_counting_transform_iterator(0, [n](auto i) { return (i % n) != 0; });
+}
+
+/**
+ * @brief Bool iterator for marking valid elements only at multiples of n, null elsewhere.
+ *
+ * The returned iterator yields `true` (to mark valid rows) at indices 0, n, 2n, ...,
+ * and yields `false` (to mark `null`) for all other indices. E.g.
+ *
+ * @code
+ * auto iter = valids_at_multiples_of(3);
+ * iter[0] == true;  // i.e. Valid row at index 0.
+ * iter[1] == false; // i.e. Invalid (null) row at index 1.
+ * iter[2] == false; // i.e. Invalid (null) row at index 2.
+ * iter[3] == true;  // i.e. Valid row at index 3.
+ * @endcode
+ *
+ * @param n The period at which valid elements occur (valid at indices 0, n, 2n, ...)
+ * @return auto Validity iterator
+ */
+[[maybe_unused]] static auto valids_at_multiples_of(cudf::size_type n)
+{
+  return cudf::detail::make_counting_transform_iterator(0, [n](auto i) { return (i % n) == 0; });
+}
+
+/**
  * @brief Bool iterator for marking null elements from pointers of data
  *
  * The returned iterator yields `false` (to mark `null`) at the indices corresponding to the

--- a/cpp/src/copying/sample.cu
+++ b/cpp/src/copying/sample.cu
@@ -61,7 +61,7 @@ std::unique_ptr<table> sample(table_view const& input,
                                           cudf::get_current_device_resource_ref());
     auto gather_map_mutable_view = gather_map->mutable_view();
     // Shuffle all the row indices
-    thrust::shuffle_copy(rmm::exec_policy_nosync(stream),
+    thrust::shuffle_copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          cuda::counting_iterator<size_type>{0},
                          cuda::counting_iterator<size_type>{num_rows},
                          gather_map_mutable_view.begin<size_type>(),

--- a/cpp/src/copying/scatter.cu
+++ b/cpp/src/copying/scatter.cu
@@ -116,7 +116,7 @@ struct column_scalar_scatterer_impl {
     auto scalar_iter =
       thrust::make_permutation_iterator(scalar_impl->data(), cuda::make_constant_iterator(0));
 
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     scalar_iter,
                     scalar_iter + scatter_rows,
                     scatter_iter,
@@ -194,7 +194,7 @@ struct column_scalar_scatterer_impl<dictionary32, MapIterator> {
     auto new_indices = std::make_unique<column>(dict_view.get_indices_annotated(), stream, mr);
     auto target_iter = indexalator_factory::make_output_iterator(new_indices->mutable_view());
 
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     scalar_iter,
                     scalar_iter + scatter_rows,
                     scatter_iter,
@@ -390,7 +390,7 @@ std::unique_ptr<column> boolean_mask_scatter(column_view const& input,
                                            cudf::get_current_device_resource_ref());
   auto mutable_indices = indices->mutable_view();
 
-  thrust::sequence(rmm::exec_policy_nosync(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    mutable_indices.begin<size_type>(),
                    mutable_indices.end<size_type>(),
                    0);

--- a/cpp/src/copying/shift.cu
+++ b/cpp/src/copying/shift.cu
@@ -131,7 +131,11 @@ struct shift_functor {
         return out_of_bounds(size, src_idx) ? *fill : input.element<T>(src_idx);
       };
 
-    thrust::transform(rmm::exec_policy_nosync(stream), index_begin, index_end, data, func_value);
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      index_begin,
+                      index_end,
+                      data,
+                      func_value);
 
     return output;
   }

--- a/cpp/src/dictionary/detail/concatenate.cu
+++ b/cpp/src/dictionary/detail/concatenate.cu
@@ -158,7 +158,7 @@ struct dispatch_compute_indices {
     auto result_itr =
       cudf::detail::indexalator_factory::make_output_iterator(result->mutable_view());
     // new indices values are computed by matching the concatenated keys to the new key set
-    thrust::lower_bound(rmm::exec_policy_nosync(stream),
+    thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         begin,
                         end,
                         all_itr,
@@ -240,7 +240,7 @@ std::unique_ptr<column> concatenate(host_span<column_view const> columns,
     }));
   // the indices offsets (pair.second) are for building the map
   thrust::lower_bound(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     children_offsets.begin() + 1,
     children_offsets.end(),
     indices_itr,

--- a/cpp/src/dictionary/detail/merge.cu
+++ b/cpp/src/dictionary/detail/merge.cu
@@ -40,7 +40,7 @@ std::unique_ptr<column> merge(dictionary_column_view const& lcol,
     cudf::detail::indexalator_factory::make_output_iterator(indices_column->mutable_view());
 
   // merge the input indices columns into the output column
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     row_order.begin(),
                     row_order.end(),
                     output_iter,

--- a/cpp/src/dictionary/encode.cu
+++ b/cpp/src/dictionary/encode.cu
@@ -98,7 +98,7 @@ std::unique_ptr<column> encode(column_view const& input,
   // and keep track of the indices of the unique values
   auto d_indices = rmm::device_uvector<size_type>(input.size(), stream);
   auto d_input   = column_device_view::create(input, stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     d_indices.begin(),
@@ -109,7 +109,9 @@ std::unique_ptr<column> encode(column_view const& input,
   keys_indices.resize(cuda::std::distance(keys_indices.begin(), keys_end), stream);
 
   // sort the keys_indices so we can use lower-bound on them
-  thrust::sort(rmm::exec_policy_nosync(stream), keys_indices.begin(), keys_indices.end());
+  thrust::sort(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+               keys_indices.begin(),
+               keys_indices.end());
 
   // use keys_indices to retrieve the keys
   auto const oob_policy   = cudf::out_of_bounds_policy::DONT_CHECK;
@@ -122,7 +124,7 @@ std::unique_ptr<column> encode(column_view const& input,
   // call lower-bound with keys_indices and d_indices to get the output indices_column
   auto d_result =
     cudf::detail::indexalator_factory::make_output_iterator(indices_column->mutable_view());
-  thrust::lower_bound(rmm::exec_policy_nosync(stream),
+  thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       keys_indices.begin(),
                       keys_indices.end(),
                       d_indices.begin(),

--- a/cpp/src/dictionary/remove_keys.cu
+++ b/cpp/src/dictionary/remove_keys.cu
@@ -67,7 +67,7 @@ std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_
   auto map_itr =
     cudf::detail::indexalator_factory::make_output_iterator(map_indices->mutable_view());
   // init to max to identify new nulls
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                map_itr,
                map_itr + keys_view.size(),
                max_size);  // all valid indices are less than this value
@@ -82,7 +82,9 @@ std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_
                                                stream,
                                                cudf::get_current_device_resource_ref());
       auto itr = cudf::detail::indexalator_factory::make_output_iterator(positions->mutable_view());
-      thrust::sequence(rmm::exec_policy_nosync(stream), itr, itr + keys_view.size());
+      thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       itr,
+                       itr + keys_view.size());
       return positions;
     }();
     // copy the non-removed keys ( keys_to_keep_fn(idx)==true )
@@ -96,7 +98,7 @@ std::unique_ptr<column> remove_keys_fn(dictionary_column_view const& dictionary_
       cudf::detail::indexalator_factory::make_input_iterator(keys_positions->view());
     // build indices mapper
     // Example scatter([0,1,2][0,2,4][max,max,max,max,max]) => [0,max,1,max,2]
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     positions_itr,
                     positions_itr + filtered_view.size(),
                     filtered_itr,
@@ -177,7 +179,9 @@ std::unique_ptr<column> remove_unused_keys(dictionary_column_view const& diction
   auto const matches = [&] {
     // build keys index to verify against indices values
     rmm::device_uvector<int32_t> keys_positions(keys_size, stream);
-    thrust::sequence(rmm::exec_policy_nosync(stream), keys_positions.begin(), keys_positions.end());
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     keys_positions.begin(),
+                     keys_positions.end());
     // wrap the indices for comparison in contains()
     column_view keys_positions_view(
       data_type{type_id::INT32}, keys_size, keys_positions.data(), nullptr, 0);

--- a/cpp/src/dictionary/search.cu
+++ b/cpp/src/dictionary/search.cu
@@ -73,7 +73,11 @@ struct find_index_fn {
     auto keys_view   = column_device_view::create(input.keys(), stream);
     auto const begin = keys_view->begin<Element>();
     auto const end   = keys_view->end<Element>();
-    auto const iter  = thrust::find(rmm::exec_policy_nosync(stream), begin, end, find_key);
+    auto const iter =
+      thrust::find(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   begin,
+                   end,
+                   find_key);
     return type_dispatcher(input.indices().type(),
                            dispatch_scalar_index{},
                            cuda::std::distance(begin, iter),

--- a/cpp/src/dictionary/set_keys.cu
+++ b/cpp/src/dictionary/set_keys.cu
@@ -90,8 +90,11 @@ struct set_keys_dispatch_fn {
     auto indices_map = rmm::device_uvector<size_type>(old_keys.size(), stream);
     create_indices_map_fn<T, decltype(keys_itr)> map_fn{
       *d_old_keys, keys_itr, keys_itr + new_keys.size(), d_sorted_indices};
-    thrust::transform(
-      rmm::exec_policy_nosync(stream), iota, iota + old_keys.size(), indices_map.begin(), map_fn);
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      iota,
+                      iota + old_keys.size(),
+                      indices_map.begin(),
+                      map_fn);
 
     // map the old indices to the new set
     auto indices_column = cudf::make_numeric_column(
@@ -100,8 +103,11 @@ struct set_keys_dispatch_fn {
       cudf::detail::indexalator_factory::make_output_iterator(indices_column->mutable_view());
     auto d_input = cudf::column_device_view::create(input.parent(), stream);
     apply_indices_map_fn apply_fn{*d_input, indices_map.data()};
-    thrust::transform(
-      rmm::exec_policy_nosync(stream), iota, iota + input.size(), d_new_indices, apply_fn);
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      iota,
+                      iota + input.size(),
+                      d_new_indices,
+                      apply_fn);
 
     // compute the nulls (any indices < 0)
     auto d_indices = cudf::detail::indexalator_factory::make_input_iterator(indices_column->view());

--- a/cpp/src/interop/from_arrow_device.cu
+++ b/cpp/src/interop/from_arrow_device.cu
@@ -190,7 +190,7 @@ dispatch_tuple_t dispatch_from_arrow_device::operator()<cudf::string_view>(
     // build strings into gather input form
     auto d_indices =
       rmm::device_uvector<cudf::strings::detail::string_index_pair>(size, stream, mr);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<cudf::size_type>{offset},
                       cuda::counting_iterator<cudf::size_type>{offset + size},
                       d_indices.begin(),

--- a/cpp/src/interop/from_arrow_host.cu
+++ b/cpp/src/interop/from_arrow_host.cu
@@ -375,10 +375,11 @@ std::tuple<std::unique_ptr<column>, int64_t, int64_t> copy_offsets_column(
   if (offset != 0) {
     auto begin = result->mutable_view().template begin<OffsetType>();
     auto end   = begin + offsets->length;
-    thrust::transform(
-      rmm::exec_policy_nosync(stream), begin, end, begin, [offset] __device__(auto o) {
-        return o - offset;
-      });
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      begin,
+                      end,
+                      begin,
+                      [offset] __device__(auto o) { return o - offset; });
   }
   return std::tuple{std::move(result), offset, length};
 }

--- a/cpp/src/interop/from_arrow_host_strings.cu
+++ b/cpp/src/interop/from_arrow_host_strings.cu
@@ -99,7 +99,7 @@ std::unique_ptr<column> from_arrow_stringview(ArrowSchemaView const* schema,
   // create indices to string fragments for the make_strings_column gather
   auto d_indices = rmm::device_uvector<string_index_pair>(input->length, stream, mr);
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator{static_cast<cudf::size_type>(input->length)},
     d_indices.begin(),

--- a/cpp/src/interop/to_arrow_host.cu
+++ b/cpp/src/interop/to_arrow_host.cu
@@ -434,7 +434,7 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
 
   // count the number of long-ish strings -- ones that cannot be inlined
   auto const num_longer_strings = thrust::count_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator<cudf::size_type>{col.size()},
     [d_offsets] __device__(auto idx) {
@@ -483,13 +483,13 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
       0, cuda::proclaim_return_type<int64_t>([] __device__(auto idx) {
         return (idx + 1) * max_size;
       }));
-    thrust::lower_bound(rmm::exec_policy_nosync(stream),
+    thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         d_offsets,
                         d_offsets + longer_strings.size(),
                         bound_itr,
                         bound_itr + num_buffers,
                         buffer_indices.begin());
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       buffer_indices.begin(),
                       buffer_indices.end(),
                       buffer_offsets.begin(),
@@ -513,7 +513,7 @@ unique_device_array_t to_arrow_host_stringview(cudf::strings_column_view const& 
 
   // now build BinaryView objects from the strings in device memory
   auto d_items = rmm::device_uvector<ArrowBinaryView>(col.size(), stream);
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<cudf::size_type>{0},
                      col.size(),
                      strings_to_binary_view{*d_strings, d_offsets, buffer_offsets, d_items.data()});

--- a/cpp/src/io/avro/reader_impl.cu
+++ b/cpp/src/io/avro/reader_impl.cu
@@ -189,7 +189,7 @@ rmm::device_buffer decompress_data(datasource& source,
       cudf::detail::hostdevice_vector<device_span<uint8_t>>(meta.block_list.size(), stream);
     auto inflate_stats =
       cudf::detail::hostdevice_vector<codec_exec_result>(meta.block_list.size(), stream);
-    thrust::fill(rmm::exec_policy_nosync(stream),
+    thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  inflate_stats.d_begin(),
                  inflate_stats.d_end(),
                  codec_exec_result{0, codec_status::FAILURE});
@@ -293,7 +293,7 @@ rmm::device_buffer decompress_data(datasource& source,
 
     rmm::device_buffer decompressed_data(uncompressed_data_size, stream);
     rmm::device_uvector<device_span<uint8_t>> decompressed_blocks(num_blocks, stream);
-    thrust::tabulate(rmm::exec_policy_nosync(stream),
+    thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      decompressed_blocks.begin(),
                      decompressed_blocks.end(),
                      [off  = uncompressed_offsets.device_ptr(),
@@ -303,7 +303,7 @@ rmm::device_buffer decompress_data(datasource& source,
                      });
 
     rmm::device_uvector<codec_exec_result> decomp_results(num_blocks, stream);
-    thrust::fill(rmm::exec_policy_nosync(stream),
+    thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  decomp_results.begin(),
                  decomp_results.end(),
                  codec_exec_result{0, codec_status::FAILURE});
@@ -315,14 +315,14 @@ rmm::device_buffer decompress_data(datasource& source,
                max_decomp_block_size,
                uncompressed_data_size,
                stream);
-    CUDF_EXPECTS(thrust::equal(rmm::exec_policy_nosync(stream),
-                               uncompressed_sizes.d_begin(),
-                               uncompressed_sizes.d_end(),
-                               decomp_results.begin(),
-                               [] __device__(auto const& size, auto const& result) {
-                                 return size == result.bytes_written and
-                                        result.status == codec_status::SUCCESS;
-                               }),
+    CUDF_EXPECTS(thrust::equal(
+                   rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   uncompressed_sizes.d_begin(),
+                   uncompressed_sizes.d_end(),
+                   decomp_results.begin(),
+                   [] __device__(auto const& size, auto const& result) {
+                     return size == result.bytes_written and result.status == codec_status::SUCCESS;
+                   }),
                  "Error during Snappy decompression");
 
     // Update blocks offsets & sizes to refer to uncompressed data

--- a/cpp/src/io/comp/compression.cu
+++ b/cpp/src/io/comp/compression.cu
@@ -5,6 +5,8 @@
 
 #include "compression.hpp"
 
+#include <cudf/utilities/memory_resource.hpp>
+
 #include <rmm/exec_policy.hpp>
 
 #include <cuda/functional>
@@ -20,7 +22,7 @@ writer_compression_statistics collect_compression_statistics(
 {
   // bytes_written on success
   auto const output_size_successful = thrust::transform_reduce(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     results.begin(),
     results.end(),
     cuda::proclaim_return_type<size_t>([] __device__(codec_exec_result const& res) {
@@ -35,7 +37,7 @@ writer_compression_statistics collect_compression_statistics(
     auto const zipped_end = zipped_begin + inputs.size();
 
     return thrust::transform_reduce(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       zipped_begin,
       zipped_end,
       cuda::proclaim_return_type<size_t>([status] __device__(auto tup) {

--- a/cpp/src/io/comp/gpuinflate.cu
+++ b/cpp/src/io/comp/gpuinflate.cu
@@ -1263,11 +1263,13 @@ sorted_codec_parameters sort_tasks(device_span<device_span<uint8_t const> const>
 {
   CUDF_FUNC_RANGE();
   rmm::device_uvector<std::size_t> order(inputs.size(), stream, mr);
-  thrust::sequence(rmm::exec_policy_nosync(stream), order.begin(), order.end());
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   order.begin(),
+                   order.end());
 
   // Precompute costs to avoid repeated computation during sorting
   rmm::device_uvector<double> costs(inputs.size(), stream, mr);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     thrust::make_zip_iterator(inputs.begin(), outputs.begin()),
                     thrust::make_zip_iterator(inputs.end(), outputs.end()),
                     costs.begin(),
@@ -1277,7 +1279,7 @@ sorted_codec_parameters sort_tasks(device_span<device_span<uint8_t const> const>
                       return cost_model::task_device_cost(input.size(), output.size(), task_type);
                     });
 
-  thrust::sort(rmm::exec_policy_nosync(stream),
+  thrust::sort(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                order.begin(),
                order.end(),
                [costs = costs.data()] __device__(std::size_t a, std::size_t b) {
@@ -1285,14 +1287,14 @@ sorted_codec_parameters sort_tasks(device_span<device_span<uint8_t const> const>
                });
 
   auto sorted_inputs = rmm::device_uvector<device_span<uint8_t const>>(inputs.size(), stream, mr);
-  thrust::gather(rmm::exec_policy_nosync(stream),
+  thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  order.begin(),
                  order.end(),
                  inputs.begin(),
                  sorted_inputs.begin());
 
   auto sorted_outputs = rmm::device_uvector<device_span<uint8_t>>(outputs.size(), stream, mr);
-  thrust::gather(rmm::exec_policy_nosync(stream),
+  thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  order.begin(),
                  order.end(),
                  outputs.begin(),
@@ -1403,7 +1405,7 @@ void copy_results_to_original_order(device_span<codec_exec_result const> sorted_
                                     device_span<std::size_t const> order,
                                     rmm::cuda_stream_view stream)
 {
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   sorted_results.begin(),
                   sorted_results.end(),
                   order.begin(),

--- a/cpp/src/io/comp/nvcomp_adapter.cu
+++ b/cpp/src/io/comp/nvcomp_adapter.cu
@@ -5,6 +5,7 @@
 #include "nvcomp_adapter.cuh"
 
 #include <cudf/detail/utilities/integer_utils.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/exec_policy.hpp>
 
@@ -28,7 +29,7 @@ batched_args create_batched_nvcomp_args(device_span<device_span<uint8_t const> c
   // Prepare the input vectors
   auto ins_it = thrust::make_zip_iterator(input_data_ptrs.begin(), input_data_sizes.begin());
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     inputs.begin(),
     inputs.end(),
     ins_it,
@@ -37,7 +38,7 @@ batched_args create_batched_nvcomp_args(device_span<device_span<uint8_t const> c
   // Prepare the output vectors
   auto outs_it = thrust::make_zip_iterator(output_data_ptrs.begin(), output_data_sizes.begin());
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     outputs.begin(),
     outputs.end(),
     outs_it,
@@ -57,7 +58,7 @@ std::pair<rmm::device_uvector<void const*>, rmm::device_uvector<size_t>> create_
 
   auto ins_it = thrust::make_zip_iterator(input_data_ptrs.begin(), input_data_sizes.begin());
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     inputs.begin(),
     inputs.end(),
     ins_it,
@@ -72,7 +73,7 @@ void update_compression_results(device_span<nvcompStatus_t const> nvcomp_stats,
                                 rmm::cuda_stream_view stream)
 {
   thrust::transform_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     nvcomp_stats.begin(),
     nvcomp_stats.end(),
     actual_output_sizes.begin(),
@@ -92,7 +93,7 @@ void update_compression_results(device_span<size_t const> actual_output_sizes,
                                 rmm::cuda_stream_view stream)
 {
   thrust::transform_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     actual_output_sizes.begin(),
     actual_output_sizes.end(),
     results.begin(),
@@ -109,7 +110,7 @@ void skip_unsupported_inputs(device_span<size_t> input_sizes,
   if (max_valid_input_size.has_value()) {
     auto status_size_it = thrust::make_zip_iterator(input_sizes.begin(), results.begin());
     thrust::transform_if(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       results.begin(),
       results.end(),
       input_sizes.begin(),
@@ -125,13 +126,16 @@ void skip_unsupported_inputs(device_span<size_t> input_sizes,
 std::pair<size_t, size_t> max_chunk_and_total_input_size(device_span<size_t const> input_sizes,
                                                          rmm::cuda_stream_view stream)
 {
-  auto const max = thrust::reduce(rmm::exec_policy_nosync(stream),
-                                  input_sizes.begin(),
-                                  input_sizes.end(),
-                                  0ul,
-                                  cuda::maximum<size_t>());
+  auto const max =
+    thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   input_sizes.begin(),
+                   input_sizes.end(),
+                   0ul,
+                   cuda::maximum<size_t>());
   auto const sum =
-    thrust::reduce(rmm::exec_policy_nosync(stream), input_sizes.begin(), input_sizes.end());
+    thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   input_sizes.begin(),
+                   input_sizes.end());
   return {max, sum};
 }
 

--- a/cpp/src/io/csv/csv_gpu.cu
+++ b/cpp/src/io/csv/csv_gpu.cu
@@ -781,7 +781,7 @@ size_t __host__ count_blank_rows(cudf::io::parse_options_view const& opts,
   auto const comment  = opts.comment != '\0' ? opts.comment : newline;
   auto const carriage = (opts.skipblanklines && opts.terminator == '\n') ? '\r' : comment;
   return thrust::count_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     row_offsets.begin(),
     row_offsets.end(),
     [data = data, newline, comment, carriage] __device__(uint64_t const pos) {
@@ -800,7 +800,7 @@ device_span<uint64_t> __host__ remove_blank_rows(cudf::io::parse_options_view co
   auto const comment  = options.comment != '\0' ? options.comment : newline;
   auto const carriage = (options.skipblanklines && options.terminator == '\n') ? '\r' : comment;
   auto new_end        = thrust::remove_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     row_offsets.begin(),
     row_offsets.end(),
     [data = data, d_size, newline, comment, carriage] __device__(uint64_t const pos) {

--- a/cpp/src/io/csv/durations.cu
+++ b/cpp/src/io/csv/durations.cu
@@ -187,7 +187,7 @@ struct dispatch_from_durations_fn {
     auto chars_data = rmm::device_uvector<char>(chars_bytes, stream, mr);
     auto d_chars    = chars_data.data();
 
-    thrust::for_each_n(rmm::exec_policy_nosync(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        cuda::counting_iterator<size_type>{0},
                        strings_count,
                        duration_to_string_fn<T>{d_column, d_new_offsets, d_chars});

--- a/cpp/src/io/csv/reader_impl.cu
+++ b/cpp/src/io/csv/reader_impl.cu
@@ -992,7 +992,10 @@ table_with_metadata read_csv(cudf::io::datasource* source,
 
         // Count how many rows were quoted to determine the fast path
         auto const num_quoted = thrust::count(
-          rmm::exec_policy_nosync(col_stream), is_quoted.begin(), is_quoted.end(), true);
+          rmm::exec_policy_nosync(col_stream, cudf::get_current_device_resource_ref()),
+          is_quoted.begin(),
+          is_quoted.end(),
+          true);
         if (num_quoted == 0) {
           // Fast path: no rows were quoted, skip replacement entirely
           out_columns[col_idx] = make_column(*buffer, nullptr, std::nullopt, col_stream);

--- a/cpp/src/io/fst/logical_stack.cuh
+++ b/cpp/src/io/fst/logical_stack.cuh
@@ -9,6 +9,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/device_buffer.hpp>
@@ -537,7 +538,7 @@ void sparse_stack_op_to_top_of_stack(StackSymbolItT d_symbols,
     stream));
 
   // Fill the output tape with read-symbol
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                thrust::device_ptr<StackSymbolT>{d_top_of_stack},
                thrust::device_ptr<StackSymbolT>{d_top_of_stack + num_symbols_out},
                read_symbol);
@@ -548,7 +549,7 @@ void sparse_stack_op_to_top_of_stack(StackSymbolItT d_symbols,
 
   // Scatter the stack symbols to the output tape (spots that are not scattered to have been
   // pre-filled with the read-symbol)
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   kv_op_to_stack_sym_it,
                   kv_op_to_stack_sym_it + num_symbols_in,
                   d_symbol_positions_db.Current(),

--- a/cpp/src/io/json/column_tree_construction.cu
+++ b/cpp/src/io/json/column_tree_construction.cu
@@ -135,11 +135,12 @@ std::tuple<compressed_sparse_row, column_tree_properties> reduce_to_column_tree(
   rmm::device_uvector<NodeIndexT> rev_mapped_col_ids(num_columns, stream);
   rmm::device_uvector<NodeIndexT> reordering_index(unpermuted_col_ids.size(), stream);
 
-  thrust::sequence(
-    rmm::exec_policy_nosync(stream), reordering_index.begin(), reordering_index.end());
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   reordering_index.begin(),
+                   reordering_index.end());
   // Reorder nodes and column ids in level-wise fashion
   thrust::sort_by_key(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     reordering_index.begin(),
     reordering_index.end(),
     mapped_col_ids.begin(),
@@ -149,9 +150,10 @@ std::tuple<compressed_sparse_row, column_tree_properties> reduce_to_column_tree(
   {
     auto mapped_col_ids_copy = cudf::detail::make_device_uvector_async(
       mapped_col_ids, stream, cudf::get_current_device_resource_ref());
-    thrust::sequence(
-      rmm::exec_policy_nosync(stream), rev_mapped_col_ids.begin(), rev_mapped_col_ids.end());
-    thrust::sort_by_key(rmm::exec_policy_nosync(stream),
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     rev_mapped_col_ids.begin(),
+                     rev_mapped_col_ids.end());
+    thrust::sort_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         mapped_col_ids_copy.begin(),
                         mapped_col_ids_copy.end(),
                         rev_mapped_col_ids.begin());
@@ -163,7 +165,7 @@ std::tuple<compressed_sparse_row, column_tree_properties> reduce_to_column_tree(
   rmm::device_uvector<row_offset_t> max_row_offsets(num_columns, stream);
   rmm::device_uvector<NodeT> column_categories(num_columns, stream);
   thrust::copy_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     thrust::make_zip_iterator(thrust::make_permutation_iterator(
                                 unpermuted_tree.parent_node_ids.begin(), reordering_index.begin()),
                               thrust::make_permutation_iterator(unpermuted_max_row_offsets.begin(),
@@ -189,8 +191,10 @@ std::tuple<compressed_sparse_row, column_tree_properties> reduce_to_column_tree(
     // Note that the first element of csr_parent_col_ids is -1 (parent_node_sentinel)
     // children adjacency
 
-    auto num_non_leaf_columns = thrust::unique_count(
-      rmm::exec_policy_nosync(stream), parent_col_ids.begin() + 1, parent_col_ids.end());
+    auto num_non_leaf_columns =
+      thrust::unique_count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           parent_col_ids.begin() + 1,
+                           parent_col_ids.end());
     rmm::device_uvector<NodeIndexT> non_leaf_nodes(num_non_leaf_columns, stream);
     rmm::device_uvector<NodeIndexT> non_leaf_nodes_children(num_non_leaf_columns, stream);
     cudf::detail::reduce_by_key_async(parent_col_ids.begin() + 1,
@@ -201,7 +205,7 @@ std::tuple<compressed_sparse_row, column_tree_properties> reduce_to_column_tree(
                                       cuda::std::plus<NodeIndexT>(),
                                       stream);
 
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     non_leaf_nodes_children.begin(),
                     non_leaf_nodes_children.end(),
                     non_leaf_nodes.begin(),
@@ -209,7 +213,7 @@ std::tuple<compressed_sparse_row, column_tree_properties> reduce_to_column_tree(
 
     if (num_columns > 1) {
       thrust::transform_inclusive_scan(
-        rmm::exec_policy_nosync(stream),
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
         thrust::make_zip_iterator(cuda::counting_iterator<NodeIndexT>{1}, row_idx.begin() + 1),
         thrust::make_zip_iterator(cuda::counting_iterator<NodeIndexT>{1} + num_columns,
                                   row_idx.end()),
@@ -235,15 +239,19 @@ std::tuple<compressed_sparse_row, column_tree_properties> reduce_to_column_tree(
                                      device_span<NodeIndexT const> parent_col_ids,
                                      device_span<NodeIndexT const> row_idx) {
     rmm::device_uvector<NodeIndexT> col_idx((num_columns - 1) * 2, stream);
-    thrust::fill(rmm::exec_policy_nosync(stream), col_idx.begin(), col_idx.end(), -1);
+    thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                 col_idx.begin(),
+                 col_idx.end(),
+                 -1);
     // excluding root node, construct scatter map
     rmm::device_uvector<NodeIndexT> map(num_columns - 1, stream);
-    thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                  parent_col_ids.begin() + 1,
-                                  parent_col_ids.end(),
-                                  cuda::make_constant_iterator(1),
-                                  map.begin());
-    thrust::for_each_n(rmm::exec_policy_nosync(stream),
+    thrust::inclusive_scan_by_key(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      parent_col_ids.begin() + 1,
+      parent_col_ids.end(),
+      cuda::make_constant_iterator(1),
+      map.begin());
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        cuda::counting_iterator<NodeIndexT>{1},
                        num_columns - 1,
                        [row_idx        = row_idx.begin(),
@@ -255,14 +263,14 @@ std::tuple<compressed_sparse_row, column_tree_properties> reduce_to_column_tree(
                          else
                            map[i - 1] += row_idx[parent_col_id];
                        });
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<NodeIndexT>{1},
                     cuda::counting_iterator<NodeIndexT>{1} + num_columns - 1,
                     map.begin(),
                     col_idx.begin());
 
     // Skip the parent of root node
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     parent_col_ids.begin() + 1,
                     parent_col_ids.end(),
                     row_idx.begin() + 1,

--- a/cpp/src/io/json/host_tree_algorithms.cu
+++ b/cpp/src/io/json/host_tree_algorithms.cu
@@ -61,7 +61,7 @@ rmm::device_uvector<NodeIndexT> get_values_column_indices(TreeDepthT const row_a
     row_array_children_level, d_tree.node_levels, d_tree.parent_node_ids, stream);
   auto col_id_location = thrust::make_permutation_iterator(col_ids.begin(), level2_nodes.begin());
   rmm::device_uvector<NodeIndexT> values_column_indices(num_columns, stream);
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   level2_indices.begin(),
                   level2_indices.end(),
                   col_id_location,
@@ -89,7 +89,7 @@ std::vector<std::string> copy_strings_to_host_sync(
   rmm::device_uvector<size_type> string_lengths(num_strings, stream);
   auto d_offset_pairs = thrust::make_zip_iterator(node_range_begin.begin(), node_range_end.begin());
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     d_offset_pairs,
     d_offset_pairs + num_strings,
     thrust::make_zip_iterator(string_offsets.begin(), string_lengths.begin()),
@@ -163,11 +163,14 @@ rmm::device_uvector<uint8_t> is_all_nulls_each_column(device_span<SymbolT const>
   auto const num_nodes = col_ids.size();
   auto const num_cols  = d_column_tree.node_categories.size();
   rmm::device_uvector<uint8_t> is_all_nulls(num_cols, stream);
-  thrust::fill(rmm::exec_policy_nosync(stream), is_all_nulls.begin(), is_all_nulls.end(), true);
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+               is_all_nulls.begin(),
+               is_all_nulls.end(),
+               true);
 
   auto parse_opt = parsing_options(options, stream);
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     num_nodes,
     [options           = parse_opt.view(),
@@ -307,11 +310,14 @@ void make_device_json_column(device_span<SymbolT const> input,
 
   // sort by {col_id} on {node_ids} stable
   rmm::device_uvector<NodeIndexT> node_ids(col_ids.size(), stream);
-  thrust::sequence(rmm::exec_policy_nosync(stream), node_ids.begin(), node_ids.end());
-  thrust::stable_sort_by_key(rmm::exec_policy_nosync(stream),
-                             sorted_col_ids.begin(),
-                             sorted_col_ids.end(),
-                             node_ids.begin());
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   node_ids.begin(),
+                   node_ids.end());
+  thrust::stable_sort_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    sorted_col_ids.begin(),
+    sorted_col_ids.end(),
+    node_ids.begin());
 
   NodeIndexT const row_array_parent_col_id =
     get_row_array_parent_col_id(col_ids, is_enabled_lines, stream);
@@ -428,14 +434,17 @@ std::
       col.string_offsets.resize(max_row_offsets[i] + 1, stream);
       col.string_lengths.resize(max_row_offsets[i] + 1, stream);
       thrust::fill(
-        rmm::exec_policy_nosync(stream),
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
         thrust::make_zip_iterator(col.string_offsets.begin(), col.string_lengths.begin()),
         thrust::make_zip_iterator(col.string_offsets.end(), col.string_lengths.end()),
         cuda::std::make_tuple(0, 0));
     } else if (column_category == NC_LIST) {
       col.child_offsets.resize(max_row_offsets[i] + 2, stream);
       thrust::uninitialized_fill(
-        rmm::exec_policy_nosync(stream), col.child_offsets.begin(), col.child_offsets.end(), 0);
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        col.child_offsets.begin(),
+        col.child_offsets.end(),
+        0);
     }
     col.num_rows = max_row_offsets[i] + 1;
     col.validity =
@@ -876,7 +885,7 @@ void scatter_offsets(tree_meta_t const& tree,
 
   // 3. scatter string offsets to respective columns, set validity bits
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     num_nodes,
     [column_categories = d_column_tree.node_categories.begin(),
@@ -939,7 +948,7 @@ void scatter_offsets(tree_meta_t const& tree,
   auto const num_list_children = cuda::std::distance(
     thrust::make_zip_iterator(node_ids.begin(), parent_col_ids.begin()), list_children_end);
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     num_list_children,
     [node_ids          = node_ids.begin(),
@@ -959,12 +968,13 @@ void scatter_offsets(tree_meta_t const& tree,
       }
     });
 
-  thrust::stable_sort_by_key(rmm::exec_policy_nosync(stream),
-                             parent_col_ids.begin(),
-                             parent_col_ids.begin() + num_list_children,
-                             node_ids.begin());
+  thrust::stable_sort_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    parent_col_ids.begin(),
+    parent_col_ids.begin() + num_list_children,
+    node_ids.begin());
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     num_list_children,
     [node_ids        = node_ids.begin(),
@@ -991,17 +1001,19 @@ void scatter_offsets(tree_meta_t const& tree,
   for (auto& [id, col_ref] : columns) {
     auto& col = col_ref.get();
     if (col.type == json_col_t::StringColumn) {
-      thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
-                             col.string_offsets.begin(),
-                             col.string_offsets.end(),
-                             col.string_offsets.begin(),
-                             cuda::maximum<json_column::row_offset_t>{});
+      thrust::inclusive_scan(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        col.string_offsets.begin(),
+        col.string_offsets.end(),
+        col.string_offsets.begin(),
+        cuda::maximum<json_column::row_offset_t>{});
     } else if (col.type == json_col_t::ListColumn) {
-      thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
-                             col.child_offsets.begin(),
-                             col.child_offsets.end(),
-                             col.child_offsets.begin(),
-                             cuda::maximum<json_column::row_offset_t>{});
+      thrust::inclusive_scan(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        col.child_offsets.begin(),
+        col.child_offsets.end(),
+        col.child_offsets.begin(),
+        cuda::maximum<json_column::row_offset_t>{});
     }
   }
   stream.synchronize();

--- a/cpp/src/io/json/json_column.cu
+++ b/cpp/src/io/json/json_column.cu
@@ -102,15 +102,17 @@ reduce_to_column_tree(tree_meta_t const& tree,
   CUDF_FUNC_RANGE();
 
   // 1. column count for allocation
-  auto const num_columns = thrust::unique_count(
-    rmm::exec_policy_nosync(stream), sorted_col_ids.begin(), sorted_col_ids.end());
+  auto const num_columns =
+    thrust::unique_count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                         sorted_col_ids.begin(),
+                         sorted_col_ids.end());
 
   // 2. reduce_by_key {col_id}, {row_offset}, max.
   rmm::device_uvector<NodeIndexT> unique_col_ids(num_columns, stream);
   rmm::device_uvector<size_type> max_row_offsets(num_columns, stream);
   auto ordered_row_offsets =
     thrust::make_permutation_iterator(row_offsets.begin(), ordered_node_ids.begin());
-  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         sorted_col_ids.begin(),
                         sorted_col_ids.end(),
                         ordered_row_offsets,
@@ -122,7 +124,7 @@ reduce_to_column_tree(tree_meta_t const& tree,
   // 3. reduce_by_key {col_id}, {node_categories} - custom opp (*+v=*, v+v=v, *+#=E)
   rmm::device_uvector<NodeT> column_categories(num_columns, stream);
   thrust::reduce_by_key(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     sorted_col_ids.begin(),
     sorted_col_ids.end(),
     thrust::make_permutation_iterator(tree.node_categories.begin(), ordered_node_ids.begin()),
@@ -153,15 +155,16 @@ reduce_to_column_tree(tree_meta_t const& tree,
   rmm::device_uvector<SymbolOffsetT> col_range_begin(num_columns, stream);  // Field names
   rmm::device_uvector<SymbolOffsetT> col_range_end(num_columns, stream);
   rmm::device_uvector<size_type> unique_node_ids(num_columns, stream);
-  thrust::unique_by_key_copy(rmm::exec_policy_nosync(stream),
-                             sorted_col_ids.begin(),
-                             sorted_col_ids.end(),
-                             ordered_node_ids.begin(),
-                             cuda::make_discard_iterator(),
-                             unique_node_ids.begin());
+  thrust::unique_by_key_copy(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    sorted_col_ids.begin(),
+    sorted_col_ids.end(),
+    ordered_node_ids.begin(),
+    cuda::make_discard_iterator(),
+    unique_node_ids.begin());
 
   thrust::copy_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     thrust::make_zip_iterator(
       thrust::make_permutation_iterator(tree.node_levels.begin(), unique_node_ids.begin()),
       thrust::make_permutation_iterator(tree.parent_node_ids.begin(), unique_node_ids.begin()),
@@ -175,7 +178,7 @@ reduce_to_column_tree(tree_meta_t const& tree,
 
   // convert parent_node_ids to parent_col_ids
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     parent_col_ids.begin(),
     parent_col_ids.end(),
     parent_col_ids.begin(),
@@ -203,7 +206,7 @@ reduce_to_column_tree(tree_meta_t const& tree,
     auto list_parents_children_max_row_offsets =
       cudf::detail::make_zeroed_device_uvector_async<NodeIndexT>(
         static_cast<std::size_t>(num_columns), stream, cudf::get_current_device_resource_ref());
-    thrust::for_each(rmm::exec_policy_nosync(stream),
+    thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      unique_col_ids.begin(),
                      unique_col_ids.end(),
                      [column_categories = column_categories.begin(),
@@ -221,7 +224,7 @@ reduce_to_column_tree(tree_meta_t const& tree,
                      });
 
     thrust::gather_if(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       parent_col_ids.begin(),
       parent_col_ids.end(),
       parent_col_ids.begin(),
@@ -236,7 +239,7 @@ reduce_to_column_tree(tree_meta_t const& tree,
   // copy lists' max_row_offsets to children.
   // all structs should have same size.
   thrust::transform_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     unique_col_ids.begin(),
     unique_col_ids.end(),
     max_row_offsets.begin(),
@@ -262,7 +265,7 @@ reduce_to_column_tree(tree_meta_t const& tree,
 
   // For Struct and List (to avoid copying entire strings when mixed type as string is enabled)
   thrust::transform_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     col_range_begin.begin(),
     col_range_begin.end(),
     column_categories.begin(),
@@ -551,7 +554,7 @@ table_with_metadata device_parse_nested_json(device_span<SymbolT const> d_input,
   device_json_column root_column(stream, mr);
   root_column.type = json_col_t::ListColumn;
   root_column.child_offsets.resize(2, stream);
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                root_column.child_offsets.begin(),
                root_column.child_offsets.end(),
                0);

--- a/cpp/src/io/json/json_normalization.cu
+++ b/cpp/src/io/json/json_normalization.cu
@@ -345,10 +345,12 @@ std::
     col_lengths, stream, cudf::get_current_device_resource_ref());
   std::size_t inbuf_lengths_size = inbuf_lengths.size();
   size_type inbuf_size =
-    thrust::reduce(rmm::exec_policy_nosync(stream), inbuf_lengths.begin(), inbuf_lengths.end());
+    thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   inbuf_lengths.begin(),
+                   inbuf_lengths.end());
   rmm::device_uvector<char> inbuf(inbuf_size, stream);
   rmm::device_uvector<size_type> inbuf_offsets(inbuf_lengths_size, stream);
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          inbuf_lengths.begin(),
                          inbuf_lengths.end(),
                          inbuf_offsets.begin(),
@@ -409,7 +411,7 @@ std::
   // now these indices need to be removed
   // TODO: is there a better way to do this?
   thrust::for_each(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     outbuf_indices.begin(),
     outbuf_indices.end(),
     [inbuf_offsets_begin = inbuf_offsets.begin(),
@@ -423,19 +425,19 @@ std::
 
   auto stencil = cudf::detail::make_zeroed_device_uvector_async<bool>(
     static_cast<std::size_t>(inbuf_size), stream, cudf::get_current_device_resource_ref());
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   cuda::make_constant_iterator(true),
                   cuda::make_constant_iterator(true) + num_deletions,
                   outbuf_indices.begin(),
                   stencil.begin());
-  thrust::remove_if(rmm::exec_policy_nosync(stream),
+  thrust::remove_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     inbuf.begin(),
                     inbuf.end(),
                     stencil.begin(),
                     cuda::std::identity{});
   inbuf.resize(inbuf_size - num_deletions, stream);
 
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          inbuf_lengths.begin(),
                          inbuf_lengths.end(),
                          inbuf_offsets.begin(),

--- a/cpp/src/io/json/json_tree.cu
+++ b/cpp/src/io/json/json_tree.cu
@@ -160,8 +160,13 @@ std::pair<rmm::device_uvector<KeyType>, rmm::device_uvector<IndexType>> stable_s
     nullptr, temp_storage_bytes, keys_buffer, order_buffer, keys.size());
   rmm::device_buffer d_temp_storage(temp_storage_bytes, stream);
 
-  thrust::copy(rmm::exec_policy_nosync(stream), keys.begin(), keys.end(), keys_buffer1.begin());
-  thrust::sequence(rmm::exec_policy_nosync(stream), order_buffer1.begin(), order_buffer1.end());
+  thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+               keys.begin(),
+               keys.end(),
+               keys_buffer1.begin());
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   order_buffer1.begin(),
+                   order_buffer1.end());
 
   cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
                                   temp_storage_bytes,
@@ -195,7 +200,7 @@ void propagate_first_sibling_to_other(cudf::device_span<TreeDepthT const> node_l
   // instead of gather, using permutation_iterator, which is ~17% faster
 
   thrust::inclusive_scan_by_key(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     sorted_node_levels.begin(),
     sorted_node_levels.end(),
     thrust::make_permutation_iterator(parent_node_ids.begin(), sorted_order.begin()),
@@ -246,11 +251,17 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
   };
 
   // Look for ErrorBegin and report the point of error.
-  if (auto const error_count = thrust::count(
-        rmm::exec_policy_nosync(stream), tokens.begin(), tokens.end(), token_t::ErrorBegin);
+  if (auto const error_count =
+        thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      tokens.begin(),
+                      tokens.end(),
+                      token_t::ErrorBegin);
       error_count > 0) {
-    auto const error_location = thrust::find(
-      rmm::exec_policy_nosync(stream), tokens.begin(), tokens.end(), token_t::ErrorBegin);
+    auto const error_location =
+      thrust::find(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   tokens.begin(),
+                   tokens.end(),
+                   token_t::ErrorBegin);
     auto error_index = cudf::detail::make_host_vector<SymbolOffsetT>(
       device_span<SymbolOffsetT const>{
         token_indices.data() + cuda::std::distance(tokens.begin(), error_location), 1},
@@ -273,8 +284,10 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
         [does_push, does_pop] __device__(PdaTokenT const token) -> size_type {
           return does_push(token) - does_pop(token);
         }));
-    thrust::exclusive_scan(
-      rmm::exec_policy_nosync(stream), push_pop_it, push_pop_it + num_tokens, token_levels.begin());
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           push_pop_it,
+                           push_pop_it + num_tokens,
+                           token_levels.begin());
 
     auto const node_levels_end = cudf::detail::copy_if(token_levels.begin(),
                                                        token_levels.end(),
@@ -323,7 +336,7 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
     };
 
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       node_token_ids.begin(),
       node_token_ids.end(),
       parent_node_ids.begin(),
@@ -415,7 +428,7 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
     cudf::detail::copy_if_async(
       zipped_in_it, zipped_in_it + num_tokens, tokens.begin(), zipped_out_it, is_nested, stream);
 
-    thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            token_levels.begin(),
                            token_levels.end(),
                            token_levels.begin());
@@ -436,7 +449,7 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
     // initialize first child parent token ids
     // translate token ids to node id using similar binary search.
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<NodeIndexT>{0},
       cuda::counting_iterator<NodeIndexT>{0} + num_nested,
       parent_node_ids.begin(),
@@ -468,7 +481,7 @@ tree_meta_t get_tree_representation(device_span<PdaTokenT const> tokens,
         return i + 1;
       });
     auto stencil = thrust::make_transform_iterator(token_id.begin(), is_nested_end{tokens.data()});
-    thrust::scatter_if(rmm::exec_policy_nosync(stream),
+    thrust::scatter_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        token_indices_it,
                        token_indices_it + num_nested,
                        parent_node_ids.begin(),
@@ -495,7 +508,7 @@ std::pair<size_t, rmm::device_uvector<size_type>> remapped_field_nodes_after_uni
   rmm::device_uvector<size_type> offsets(num_keys, stream);
   rmm::device_uvector<size_type> lengths(num_keys, stream);
   auto offset_length_it = thrust::make_zip_iterator(offsets.begin(), lengths.begin());
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     keys.begin(),
                     keys.end(),
                     offset_length_it,
@@ -582,11 +595,12 @@ rmm::device_uvector<size_type> hash_node_type_with_field_name(device_span<Symbol
 {
   CUDF_FUNC_RANGE();
 
-  auto const num_nodes  = d_tree.node_categories.size();
-  auto const num_fields = thrust::count(rmm::exec_policy_nosync(stream),
-                                        d_tree.node_categories.begin(),
-                                        d_tree.node_categories.end(),
-                                        node_t::NC_FN);
+  auto const num_nodes = d_tree.node_categories.size();
+  auto const num_fields =
+    thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                  d_tree.node_categories.begin(),
+                  d_tree.node_categories.end(),
+                  node_t::NC_FN);
 
   auto const d_hasher = cuda::proclaim_return_type<
     typename cudf::hashing::detail::default_hash<cudf::string_view>::result_type>(
@@ -687,7 +701,7 @@ rmm::device_uvector<size_type> hash_node_type_with_field_name(device_span<Symbol
 
   // convert field nodes to node indices, and other nodes to enum value.
   rmm::device_uvector<size_type> node_type(num_nodes, stream);
-  thrust::tabulate(rmm::exec_policy_nosync(stream),
+  thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    node_type.begin(),
                    node_type.end(),
                    [node_categories = d_tree.node_categories.data(),
@@ -712,11 +726,12 @@ get_array_children_indices(TreeDepthT row_array_children_level,
   // exclusive scan by key (on key their parent_node_id, because we need indices in each row.
   // parent_node_id for each row will be same).
   // -> return their indices and their node id
-  auto const num_nodes  = node_levels.size();
-  auto num_level2_nodes = thrust::count(rmm::exec_policy_nosync(stream),
-                                        node_levels.begin(),
-                                        node_levels.end(),
-                                        row_array_children_level);
+  auto const num_nodes = node_levels.size();
+  auto num_level2_nodes =
+    thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                  node_levels.begin(),
+                  node_levels.end(),
+                  row_array_children_level);
   rmm::device_uvector<NodeIndexT> level2_nodes(num_level2_nodes, stream);
   rmm::device_uvector<NodeIndexT> level2_indices(num_level2_nodes, stream);
   cudf::detail::copy_if_async(
@@ -728,11 +743,12 @@ get_array_children_indices(TreeDepthT row_array_children_level,
     stream);
   auto level2_parent_nodes =
     thrust::make_permutation_iterator(parent_node_ids.begin(), level2_nodes.cbegin());
-  thrust::exclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                level2_parent_nodes,
-                                level2_parent_nodes + num_level2_nodes,
-                                cuda::make_constant_iterator(NodeIndexT{1}),
-                                level2_indices.begin());
+  thrust::exclusive_scan_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    level2_parent_nodes,
+    level2_parent_nodes + num_level2_nodes,
+    cuda::make_constant_iterator(NodeIndexT{1}),
+    level2_indices.begin());
   return std::make_pair(std::move(level2_nodes), std::move(level2_indices));
 }
 
@@ -783,7 +799,7 @@ std::pair<rmm::device_uvector<size_type>, rmm::device_uvector<size_type>> hash_n
     // memory usage could be reduced by using different data structure (hashmap)
     // or alternate method to hash it at node_type
     list_indices.resize(num_nodes, stream);
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     level2_indices.cbegin(),
                     level2_indices.cend(),
                     level2_nodes.cbegin(),
@@ -815,7 +831,10 @@ std::pair<rmm::device_uvector<size_type>, rmm::device_uvector<size_type>> hash_n
   };
 
   rmm::device_uvector<hash_value_type> node_hash(num_nodes, stream);
-  thrust::tabulate(rmm::exec_policy_nosync(stream), node_hash.begin(), node_hash.end(), d_hasher);
+  thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   node_hash.begin(),
+                   node_hash.end(),
+                   d_hasher);
   auto const d_hashed_cache = [node_hash = node_hash.begin()] __device__(auto node_id) {
     return node_hash[node_id];
   };
@@ -928,8 +947,10 @@ std::pair<rmm::device_uvector<NodeIndexT>, rmm::device_uvector<NodeIndexT>> gene
                           mr);
   }();
 
-  thrust::sort(rmm::exec_policy_nosync(stream), unique_keys.begin(), unique_keys.end());
-  thrust::lower_bound(rmm::exec_policy_nosync(stream),
+  thrust::sort(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+               unique_keys.begin(),
+               unique_keys.end());
+  thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       unique_keys.begin(),
                       unique_keys.end(),
                       col_id.begin(),
@@ -937,7 +958,7 @@ std::pair<rmm::device_uvector<NodeIndexT>, rmm::device_uvector<NodeIndexT>> gene
                       col_id.begin());
 
   rmm::device_uvector<size_type> parent_col_id(num_nodes, stream, mr);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     d_tree.parent_node_ids.begin(),
                     d_tree.parent_node_ids.end(),
                     parent_col_id.begin(),
@@ -979,7 +1000,9 @@ rmm::device_uvector<size_type> compute_row_offsets(rmm::device_uvector<NodeIndex
   auto const num_nodes = d_tree.node_categories.size();
 
   rmm::device_uvector<size_type> scatter_indices(num_nodes, stream);
-  thrust::sequence(rmm::exec_policy_nosync(stream), scatter_indices.begin(), scatter_indices.end());
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   scatter_indices.begin(),
+                   scatter_indices.end());
 
   // array of arrays
   NodeIndexT const row_array_parent_level = is_enabled_lines ? 0 : 1;
@@ -996,7 +1019,7 @@ rmm::device_uvector<size_type> compute_row_offsets(rmm::device_uvector<NodeIndex
 
   // Extract only list children. (nodes who's parent is a list/root)
   auto const list_parent_end =
-    thrust::remove_if(rmm::exec_policy_nosync(stream),
+    thrust::remove_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       thrust::make_zip_iterator(parent_col_id.begin(), scatter_indices.begin()),
                       thrust::make_zip_iterator(parent_col_id.end(), scatter_indices.end()),
                       d_tree.parent_node_ids.begin(),
@@ -1004,23 +1027,25 @@ rmm::device_uvector<size_type> compute_row_offsets(rmm::device_uvector<NodeIndex
   auto const num_list_parent = cuda::std::distance(
     thrust::make_zip_iterator(parent_col_id.begin(), scatter_indices.begin()), list_parent_end);
 
-  thrust::stable_sort_by_key(rmm::exec_policy_nosync(stream),
-                             parent_col_id.begin(),
-                             parent_col_id.begin() + num_list_parent,
-                             scatter_indices.begin());
+  thrust::stable_sort_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    parent_col_id.begin(),
+    parent_col_id.begin() + num_list_parent,
+    scatter_indices.begin());
 
   rmm::device_uvector<size_type> row_offsets(num_nodes, stream, mr);
   // TODO is it possible to generate list child_offsets too here?
   // write only 1st child offset to parent node id child_offsets?
-  thrust::exclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                parent_col_id.begin(),
-                                parent_col_id.begin() + num_list_parent,
-                                cuda::make_constant_iterator<size_type>(1),
-                                row_offsets.begin());
+  thrust::exclusive_scan_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    parent_col_id.begin(),
+    parent_col_id.begin() + num_list_parent,
+    cuda::make_constant_iterator<size_type>(1),
+    row_offsets.begin());
 
   // Using scatter instead of sort.
   auto& temp_storage = parent_col_id;  // reuse parent_col_id as temp storage
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   row_offsets.begin(),
                   row_offsets.begin() + num_list_parent,
                   scatter_indices.begin(),
@@ -1029,7 +1054,7 @@ rmm::device_uvector<size_type> compute_row_offsets(rmm::device_uvector<NodeIndex
 
   // Propagate row offsets to non-list leaves from list's immediate children node by recursion
   thrust::transform_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<std::size_t>{0},
     cuda::counting_iterator{num_nodes},
     row_offsets.begin(),

--- a/cpp/src/io/json/nested_json_gpu.cu
+++ b/cpp/src/io/json/nested_json_gpu.cu
@@ -1543,11 +1543,11 @@ std::pair<rmm::device_uvector<PdaTokenT>, rmm::device_uvector<SymbolOffsetT>> pr
   auto const num_total_tokens = d_num_selected_tokens.value(stream);
   rmm::device_uvector<PdaTokenT> tokens_out{num_total_tokens, stream, mr};
   rmm::device_uvector<SymbolOffsetT> token_indices_out{num_total_tokens, stream, mr};
-  thrust::copy(rmm::exec_policy_nosync(stream),
+  thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                filtered_tokens_out.end() - num_total_tokens,
                filtered_tokens_out.end(),
                tokens_out.data());
-  thrust::copy(rmm::exec_policy_nosync(stream),
+  thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                filtered_token_indices_out.end() - num_total_tokens,
                filtered_token_indices_out.end(),
                token_indices_out.data());

--- a/cpp/src/io/json/process_tokens.cu
+++ b/cpp/src/io/json/process_tokens.cu
@@ -282,7 +282,7 @@ void validate_token_stream(device_span<char const> d_input,
       [d_invalid = d_invalid.begin()] __device__(size_type i, bool x) -> void {
         if (x) { d_invalid[i] = true; }
       }));
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     count_it,
                     count_it + num_tokens,
                     conditional_invalidout_it,
@@ -302,12 +302,13 @@ void validate_token_stream(device_span<char const> d_input,
       return {static_cast<token_t>(tokens[i]), tokens[i] == token_t::LineEnd};
     });
 
-  thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                   count_it,
-                                   count_it + num_tokens,
-                                   conditional_output_it,
-                                   transform_op,
-                                   binary_op);  // in-place scan
+  thrust::transform_inclusive_scan(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    count_it,
+    count_it + num_tokens,
+    conditional_output_it,
+    transform_op,
+    binary_op);  // in-place scan
 }
 }  // namespace detail
 }  // namespace cudf::io::json

--- a/cpp/src/io/json/read_json.cu
+++ b/cpp/src/io/json/read_json.cu
@@ -190,7 +190,10 @@ size_type find_first_delimiter(device_span<char const> d_data,
                                rmm::cuda_stream_view stream)
 {
   auto const first_delimiter_position =
-    thrust::find(rmm::exec_policy_nosync(stream), d_data.begin(), d_data.end(), delimiter);
+    thrust::find(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                 d_data.begin(),
+                 d_data.end(),
+                 delimiter);
   return first_delimiter_position != d_data.end()
            ? static_cast<size_type>(cuda::std::distance(d_data.begin(), first_delimiter_position))
            : -1;
@@ -339,7 +342,10 @@ get_record_range_raw_input(host_span<std::unique_ptr<datasource>> sources,
     auto rev_it_begin = cuda::std::make_reverse_iterator(bufsubspan.end());
     auto rev_it_end   = cuda::std::make_reverse_iterator(bufsubspan.begin());
     auto const second_last_delimiter_it =
-      thrust::find(rmm::exec_policy_nosync(stream), rev_it_begin, rev_it_end, delimiter);
+      thrust::find(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   rev_it_begin,
+                   rev_it_end,
+                   delimiter);
     CUDF_EXPECTS(second_last_delimiter_it != rev_it_end,
                  "A single JSON line cannot be larger than the batch size limit");
     auto const last_line_size =
@@ -710,7 +716,7 @@ device_span<char> ingest_raw_input(device_span<char> buffer,
     auto const delimiter_source = cuda::make_constant_iterator(delimiter);
     auto const d_delimiter_map  = cudf::detail::make_device_uvector_async(
       delimiter_map, stream, cudf::get_current_device_resource_ref());
-    thrust::scatter(rmm::exec_policy_nosync(stream),
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     delimiter_source,
                     delimiter_source + d_delimiter_map.size(),
                     d_delimiter_map.data(),

--- a/cpp/src/io/json/write_json.cu
+++ b/cpp/src/io/json/write_json.cu
@@ -310,13 +310,13 @@ std::unique_ptr<column> struct_to_strings(table_view const& strings_columns,
                                          include_nulls,
                                          d_strviews.begin()};
     // scatter row_prefix, row_suffix, column_name:, value, value_separator as string_views
-    thrust::for_each(rmm::exec_policy_nosync(stream),
+    thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      cuda::counting_iterator<size_type>{total_rows},
                      scatter_fn);
   } else {
     thrust::for_each(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<size_type>{0},
       cuda::counting_iterator<size_type>{num_rows},
       [d_strviews = d_strviews.begin(), row_prefix, row_suffix, num_strviews_per_row] __device__(
@@ -335,15 +335,16 @@ std::unique_ptr<column> struct_to_strings(table_view const& strings_columns,
                                               -> size_type { return idx / tbl.num_columns(); }));
     auto validity_iterator =
       cudf::detail::make_counting_transform_iterator(0, validity_fn{*tbl_device_view});
-    thrust::exclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                  row_num,
-                                  row_num + total_rows,
-                                  validity_iterator,
-                                  d_str_separator.begin(),
-                                  false,
-                                  cuda::std::equal_to<size_type>{},
-                                  cuda::std::logical_or<bool>{});
-    thrust::for_each(rmm::exec_policy_nosync(stream),
+    thrust::exclusive_scan_by_key(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      row_num,
+      row_num + total_rows,
+      validity_iterator,
+      d_str_separator.begin(),
+      false,
+      cuda::std::equal_to<size_type>{},
+      cuda::std::logical_or<bool>{});
+    thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      cuda::counting_iterator<size_type>{total_rows},
                      [write_separator = d_str_separator.begin(),
@@ -370,7 +371,7 @@ std::unique_ptr<column> struct_to_strings(table_view const& strings_columns,
     0, cuda::proclaim_return_type<size_type>([num_strviews_per_row] __device__(size_type const i) {
       return i * num_strviews_per_row;
     }));
-  thrust::gather(rmm::exec_policy_nosync(stream),
+  thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  d_strview_offsets,
                  d_strview_offsets + row_string_offsets.size(),
                  old_offsets.begin<size_type>(),
@@ -477,7 +478,7 @@ std::unique_ptr<column> join_list_of_strings(lists_column_view const& lists_stri
         auto const length = offsets[idx + 1] - offsets[idx];
         return length == 0 ? 2 : (2 + length + length - 1);
       }));
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          num_strings_per_list,
                          num_strings_per_list + num_offsets,
                          d_strview_offsets.begin());
@@ -486,7 +487,7 @@ std::unique_ptr<column> join_list_of_strings(lists_column_view const& lists_stri
   rmm::device_uvector<string_view> d_strviews(total_strings, stream);
   // scatter null_list and list_prefix, list_suffix
   auto col_device_view = cudf::column_device_view::create(lists_strings.parent(), stream);
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cuda::counting_iterator<size_type>{0},
                    cuda::counting_iterator<size_type>{num_lists},
                    [col = *col_device_view,
@@ -508,7 +509,7 @@ std::unique_ptr<column> join_list_of_strings(lists_column_view const& lists_stri
   auto labels = cudf::lists::detail::generate_labels(
     lists_strings, num_strings, stream, cudf::get_current_device_resource_ref());
   auto d_strings_children = cudf::column_device_view::create(strings_children, stream);
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cuda::counting_iterator<size_type>{0},
                    cuda::counting_iterator<size_type>{num_strings},
                    scatter_fn{*col_device_view,
@@ -525,7 +526,7 @@ std::unique_ptr<column> join_list_of_strings(lists_column_view const& lists_stri
   // gather from offset and create a new string column
   auto old_offsets = strings_column_view(joined_col->view()).offsets();
   rmm::device_uvector<size_type> row_string_offsets(num_offsets, stream, mr);
-  thrust::gather(rmm::exec_policy_nosync(stream),
+  thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                  d_strview_offsets.begin(),
                  d_strview_offsets.end(),
                  old_offsets.begin<size_type>(),

--- a/cpp/src/io/orc/reader_impl_chunking.cu
+++ b/cpp/src/io/orc/reader_impl_chunking.cu
@@ -431,7 +431,7 @@ void reader_impl::preprocess_file(read_mode mode)
 
   // Compute the prefix sum of stripes' data sizes.
   total_stripe_sizes.host_to_device_async(_stream);
-  thrust::inclusive_scan(rmm::exec_policy_nosync(_stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                          total_stripe_sizes.d_begin(),
                          total_stripe_sizes.d_end(),
                          total_stripe_sizes.d_begin(),
@@ -702,7 +702,7 @@ void reader_impl::load_next_stripe_data(read_mode mode)
 
   // Compute the prefix sum of stripe data sizes and rows.
   stripe_decomp_sizes.host_to_device_async(_stream);
-  thrust::inclusive_scan(rmm::exec_policy_nosync(_stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                          stripe_decomp_sizes.d_begin(),
                          stripe_decomp_sizes.d_end(),
                          stripe_decomp_sizes.d_begin(),

--- a/cpp/src/io/orc/reader_impl_decode.cu
+++ b/cpp/src/io/orc/reader_impl_decode.cu
@@ -142,7 +142,7 @@ rmm::device_buffer decompress_stripe_data(
   rmm::device_uvector<device_span<uint8_t>> inflate_out(
     num_compressed_blocks + num_uncompressed_blocks, stream);
   rmm::device_uvector<codec_exec_result> inflate_res(num_compressed_blocks, stream);
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                inflate_res.begin(),
                inflate_res.end(),
                codec_exec_result{0, codec_status::FAILURE});
@@ -192,7 +192,7 @@ rmm::device_buffer decompress_stripe_data(
 
   // Check if any block has been failed to decompress.
   // Not using `thrust::any` or `thrust::count_if` to defer stream sync.
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cuda::counting_iterator<std::size_t>{0},
                    cuda::counting_iterator{inflate_res.size()},
                    [results           = inflate_res.begin(),
@@ -308,7 +308,7 @@ void update_null_mask(cudf::detail::hostdevice_2dvector<column_desc>& chunks,
         uint32_t* dst_idx_ptr = dst_idx.data();
         // Copy child valid bits from child column to valid indexes, this will merge both child
         // and parent null masks
-        thrust::for_each(rmm::exec_policy_nosync(stream),
+        thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          cuda::counting_iterator<std::size_t>{0},
                          cuda::counting_iterator<std::size_t>{0} + dst_idx.size(),
                          [child_valid_map_base, dst_idx_ptr, merged_mask] __device__(auto idx) {
@@ -450,7 +450,7 @@ void scan_null_counts(cudf::detail::hostdevice_2dvector<column_desc> const& chun
   auto const d_prefix_sums_to_update = cudf::detail::make_device_uvector_async(
     prefix_sums_to_update, stream, cudf::get_current_device_resource_ref());
 
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    d_prefix_sums_to_update.begin(),
                    d_prefix_sums_to_update.end(),
                    [num_stripes, chunks = chunks.device_view()] __device__(auto const& idx_psums) {
@@ -585,7 +585,7 @@ struct list_buffer_data {
 void generate_offsets_for_list(host_span<list_buffer_data> buff_data, rmm::cuda_stream_view stream)
 {
   for (auto& list_data : buff_data) {
-    thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            list_data.data,
                            list_data.data + list_data.size,
                            list_data.data);
@@ -630,7 +630,7 @@ std::vector<range> find_table_splits(table_view const& input,
     cudf::detail::hostdevice_vector<cumulative_size>(d_segmented_sizes->size(), stream);
 
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator{d_segmented_sizes->size()},
     segmented_sizes.d_begin(),
@@ -645,7 +645,7 @@ std::vector<range> find_table_splits(table_view const& input,
                              static_cast<std::size_t>(size)};
     });
 
-  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          segmented_sizes.d_begin(),
                          segmented_sizes.d_end(),
                          segmented_sizes.d_begin(),

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -409,8 +409,10 @@ void persisted_statistics::persist(int num_table_rows,
       string_length_functor{num_chunks,
                             intermediate_stats.stripe_stat_chunks.data(),
                             intermediate_stats.stripe_stat_merge.device_ptr()});
-    thrust::exclusive_scan(
-      rmm::exec_policy_nosync(stream), iter, iter + offsets.size(), offsets.begin());
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           iter,
+                           iter + offsets.size(),
+                           offsets.begin());
 
     // pull size back to host
     auto const total_string_pool_size = offsets.element(num_chunks * 2, stream);
@@ -713,7 +715,7 @@ std::vector<std::vector<rowgroup_rows>> calculate_aligned_rowgroup_bounds(
 
   // One thread per column, per stripe
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_t>{0},
     orc_table.num_columns() * segmentation.num_stripes(),
     [columns = device_span<orc_column_device_view const>{orc_table.d_columns},
@@ -888,7 +890,7 @@ encoded_data encode_columns(orc_table_view const& orc_table,
   // TODO (future): pass columns separately from chunks (to skip this step)
   // and remove info from chunks that is common for the entire column
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_t>{0},
     chunks.count(),
     [chunks = chunks.device_view(),
@@ -1147,7 +1149,7 @@ void set_stat_desc_leaf_cols(device_span<orc_column_device_view const> columns,
                              device_span<stats_column_desc> stat_desc,
                              rmm::cuda_stream_view stream)
 {
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cuda::counting_iterator<size_t>{0},
                    cuda::counting_iterator{stat_desc.size()},
                    [=] __device__(auto idx) { stat_desc[idx].leaf_column = &columns[idx]; });
@@ -1692,7 +1694,7 @@ void pushdown_lists_null_mask(orc_column_view const& col,
 
   // Reset bits where a null list element has rows in the child column
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<uint32_t>{0},
     col.size(),
     [d_columns, col_idx = col.index(), parent_pd_mask, out_mask] __device__(auto& idx) {
@@ -1753,7 +1755,7 @@ pushdown_null_masks init_pushdown_null_masks(orc_table_view& orc_table,
         pd_masks.emplace_back(num_bitmask_words(col.size()), stream);
         mask_ptrs.push_back({pd_masks.back().data()});
 
-        thrust::transform(rmm::exec_policy_nosync(stream),
+        thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           null_mask,
                           null_mask + pd_masks.back().size(),
                           parent_pd_mask,
@@ -1775,7 +1777,7 @@ pushdown_null_masks init_pushdown_null_masks(orc_table_view& orc_table,
   auto const d_mask_ptrs = cudf::detail::make_device_uvector_async(
     mask_ptrs, stream, cudf::get_current_device_resource_ref());
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_t>{0},
     orc_table.num_columns(),
     [cols = device_span<orc_column_device_view>{orc_table.d_columns},
@@ -1924,7 +1926,7 @@ hostdevice_2dvector<rowgroup_rows> calculate_rowgroup_bounds(orc_table_view cons
   hostdevice_2dvector<rowgroup_rows> rowgroup_bounds(
     num_rowgroups, orc_table.num_columns(), stream);
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_t>{0},
     num_rowgroups,
     [cols      = device_span<orc_column_device_view const>{orc_table.d_columns},
@@ -1975,7 +1977,7 @@ encoder_decimal_info decimal_chunk_sizes(orc_table_view& orc_table,
       auto& current_sizes =
         elem_sizes.insert({orc_col.index(), rmm::device_uvector<uint32_t>(orc_col.size(), stream)})
           .first->second;
-      thrust::tabulate(rmm::exec_policy_nosync(stream),
+      thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        current_sizes.begin(),
                        current_sizes.end(),
                        [d_cols  = device_span<orc_column_device_view const>{orc_table.d_columns},
@@ -2014,7 +2016,7 @@ encoder_decimal_info decimal_chunk_sizes(orc_table_view& orc_table,
   std::map<uint32_t, cudf::detail::host_vector<uint32_t>> rg_sizes;
   for (auto const& [col_idx, esizes] : elem_sizes) {
     // Copy last elem in each row group - equal to row group size
-    thrust::tabulate(rmm::exec_policy_nosync(stream),
+    thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      d_tmp_rowgroup_sizes.begin(),
                      d_tmp_rowgroup_sizes.end(),
                      [src       = esizes.data(),
@@ -2265,21 +2267,25 @@ stripe_dictionaries build_dictionaries(orc_table_view& orc_table,
 
       // Sort the dictionary data and create a mapping from the sorted order to the original
       thrust::sequence(
-        rmm::exec_policy_nosync(current_stream), sd.data_order.begin(), sd.data_order.end());
-      thrust::sort_by_key(rmm::exec_policy_nosync(current_stream),
-                          sd.data.begin(),
-                          sd.data.end(),
-                          sd.data_order.begin(),
-                          string_rows_less{orc_table.d_columns, sd.column_idx});
+        rmm::exec_policy_nosync(current_stream, cudf::get_current_device_resource_ref()),
+        sd.data_order.begin(),
+        sd.data_order.end());
+      thrust::sort_by_key(
+        rmm::exec_policy_nosync(current_stream, cudf::get_current_device_resource_ref()),
+        sd.data.begin(),
+        sd.data.end(),
+        sd.data_order.begin(),
+        string_rows_less{orc_table.d_columns, sd.column_idx});
 
       // Create the inverse permutation - i.e. the mapping from the original order to the sorted
       auto order_copy = cudf::detail::make_device_uvector_async<uint32_t>(
         sd.data_order, current_stream, cudf::get_current_device_resource_ref());
-      thrust::scatter(rmm::exec_policy_nosync(current_stream),
-                      cuda::counting_iterator<uint32_t>{0},
-                      cuda::counting_iterator{static_cast<uint32_t>(sd.data_order.size())},
-                      order_copy.begin(),
-                      sd.data_order.begin());
+      thrust::scatter(
+        rmm::exec_policy_nosync(current_stream, cudf::get_current_device_resource_ref()),
+        cuda::counting_iterator<uint32_t>{0},
+        cuda::counting_iterator{static_cast<uint32_t>(sd.data_order.size())},
+        order_copy.begin(),
+        sd.data_order.begin());
 
       stream_idx = (stream_idx + 1) % streams.size();
     }
@@ -2297,7 +2303,7 @@ stripe_dictionaries build_dictionaries(orc_table_view& orc_table,
                                                 rmm::cuda_stream_view stream)
 {
   auto const longest_stream = thrust::max_element(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     ss.data(),
     ss.data() + ss.count(),
     cuda::proclaim_return_type<bool>([] __device__(auto const& lhs, auto const& rhs) {
@@ -2429,7 +2435,7 @@ auto convert_table_to_orc_data(table_view const& input,
   rmm::device_uvector<uint8_t> compressed_data(compressed_bfr_size, stream);
   cudf::detail::hostdevice_vector<codec_exec_result> comp_results(num_compressed_blocks, stream);
   std::optional<writer_compression_statistics> compression_stats;
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                comp_results.d_begin(),
                comp_results.d_end(),
                codec_exec_result{0, codec_status::FAILURE});

--- a/cpp/src/io/parquet/bloom_filter_reader.cu
+++ b/cpp/src/io/parquet/bloom_filter_reader.cu
@@ -77,7 +77,7 @@ struct bloom_filter_caster {
 
     // Query literal in bloom filters from each column chunk (row group).
     thrust::tabulate(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       results_span.begin(),
       results_span.end(),
       [filter_span          = bloom_filter_spans.data(),

--- a/cpp/src/io/parquet/experimental/deletion_vectors.cu
+++ b/cpp/src/io/parquet/experimental/deletion_vectors.cu
@@ -126,7 +126,7 @@ std::unique_ptr<cudf::column> compute_row_index_column(
   if (row_group_offsets.empty()) {
     auto row_indices      = rmm::device_buffer(num_rows * sizeof(size_t), stream, mr);
     auto row_indices_iter = static_cast<size_t*>(row_indices.data());
-    thrust::sequence(rmm::exec_policy_nosync(stream),
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      row_indices_iter,
                      row_indices_iter + num_rows,
                      start_row.value_or(size_t{0}));
@@ -151,10 +151,16 @@ std::unique_ptr<cudf::column> compute_row_index_column(
 
   auto row_indices      = rmm::device_buffer(num_rows * sizeof(size_t), stream, mr);
   auto row_indices_iter = static_cast<size_t*>(row_indices.data());
-  thrust::fill(rmm::exec_policy_nosync(stream), row_indices_iter, row_indices_iter + num_rows, 1);
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+               row_indices_iter,
+               row_indices_iter + num_rows,
+               1);
 
   auto row_group_keys = rmm::device_uvector<size_type>(num_rows, stream);
-  thrust::fill(rmm::exec_policy_nosync(stream), row_group_keys.begin(), row_group_keys.end(), 0);
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+               row_group_keys.begin(),
+               row_group_keys.end(),
+               0);
 
   // Scatter row group offsets and row group indices (or span indices) to their corresponding
   // row group span offsets
@@ -165,25 +171,26 @@ std::unique_ptr<cudf::column> compute_row_index_column(
   auto in_iter =
     thrust::make_zip_iterator(d_row_group_offsets.begin(), cuda::counting_iterator<size_type>{0});
   auto out_iter = thrust::make_zip_iterator(row_indices_iter, row_group_keys.begin());
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   in_iter,
                   in_iter + num_row_groups,
                   d_row_group_span_offsets.begin(),
                   out_iter);
 
   // Fill in the the rest of the row group span indices
-  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          row_group_keys.begin(),
                          row_group_keys.end(),
                          row_group_keys.begin(),
                          cuda::maximum<cudf::size_type>());
 
   // Segmented inclusive scan to compute the rest of the row indices
-  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                row_group_keys.begin(),
-                                row_group_keys.end(),
-                                row_indices_iter,
-                                row_indices_iter);
+  thrust::inclusive_scan_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    row_group_keys.begin(),
+    row_group_keys.end(),
+    row_indices_iter,
+    row_indices_iter);
 
   return std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::UINT64},
                                         num_rows,

--- a/cpp/src/io/parquet/experimental/hybrid_scan_preprocess.cu
+++ b/cpp/src/io/parquet/experimental/hybrid_scan_preprocess.cu
@@ -46,7 +46,7 @@ void decode_dictionary_page_headers(cudf::detail::hostdevice_span<ColumnChunkDes
   CUDF_FUNC_RANGE();
 
   rmm::device_uvector<chunk_page_info> chunk_page_info(chunks.size(), stream);
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cuda::counting_iterator<cuda::std::size_t>{0},
                    cuda::counting_iterator{chunks.size()},
                    [cpi = chunk_page_info.begin(), pages = pages.device_begin()] __device__(
@@ -62,7 +62,7 @@ void decode_dictionary_page_headers(cudf::detail::hostdevice_span<ColumnChunkDes
   }
 
   // Setup dictionary page for each chunk
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    pages.device_begin(),
                    pages.device_end(),
                    [chunks = chunks.device_begin()] __device__(PageInfo const& p) {
@@ -292,7 +292,7 @@ void hybrid_scan_reader_impl::update_row_mask(cudf::column_view const& in_row_ma
 
   // Update output row mask such that out_row_mask[i] = true, iff in_row_mask[i] is valid and true.
   // This is inline with the masking behavior of cudf::detail::apply_boolean_mask.
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator{total_rows},
                     out_row_mask.begin<bool>() + out_row_mask_offset,

--- a/cpp/src/io/parquet/experimental/page_index_filter.cu
+++ b/cpp/src/io/parquet/experimental/page_index_filter.cu
@@ -92,7 +92,7 @@ struct page_stats_caster : public stats_caster_base {
     auto output_data = rmm::device_buffer(cudf::size_of(dtype) * total_rows, stream, mr);
 
     // For each row index, copy over the min/max page stat value from the corresponding page.
-    thrust::gather(rmm::exec_policy_nosync(stream),
+    thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    page_indices.begin(),
                    page_indices.end(),
                    input_column.template begin<T>(),
@@ -197,7 +197,7 @@ struct page_stats_caster : public stats_caster_base {
     // Buffer for row-level string sizes (output).
     auto row_str_sizes = rmm::device_uvector<std::size_t>(total_rows, stream, mr);
     // Gather string sizes from page to row level
-    thrust::gather(rmm::exec_policy_nosync(stream),
+    thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    page_indices.begin(),
                    page_indices.end(),
                    page_str_sizes.begin(),
@@ -239,7 +239,7 @@ struct page_stats_caster : public stats_caster_base {
     // Buffer for row-level string offsets (output).
     auto row_str_offsets =
       cudf::detail::make_zeroed_device_uvector_async<cudf::size_type>(total_rows + 1, stream, mr);
-    thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            row_str_sizes.begin(),
                            row_str_sizes.end(),
                            row_str_offsets.begin() + 1);
@@ -1078,7 +1078,7 @@ thrust::host_vector<bool> aggregate_reader_metadata::compute_data_page_mask(
   // Make sure all row_mask elements contain valid values even if they are nulls
   if constexpr (cuda::std::is_same_v<ColumnView, cudf::mutable_column_view>) {
     if (row_mask.nullable() and row_mask.null_count() > 0) {
-      thrust::for_each(rmm::exec_policy_nosync(stream),
+      thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        cuda::counting_iterator{row_mask_offset},
                        cuda::counting_iterator{row_mask_offset + total_rows},
                        [row_mask  = row_mask.template begin<bool>(),
@@ -1121,7 +1121,7 @@ thrust::host_vector<bool> aggregate_reader_metadata::compute_data_page_mask(
     [&](auto const prev_level) {
       auto const current_level_size = cudf::util::div_rounding_up_safe(prev_level_size, 2);
       thrust::for_each(
-        rmm::exec_policy_nosync(stream),
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
         cuda::counting_iterator<cudf::size_type>{0},
         cuda::counting_iterator{current_level_size},
         build_fenwick_tree_level_functor{
@@ -1137,7 +1137,7 @@ thrust::host_vector<bool> aggregate_reader_metadata::compute_data_page_mask(
     cudf::host_span<cudf::size_type const>{page_row_offsets}, stream);
   auto page_offsets = cudf::detail::make_device_uvector_async(pinned_page_offsets, stream, mr);
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator{num_ranges},
     device_data_page_mask.begin(),

--- a/cpp/src/io/parquet/experimental/page_index_filter_utils.cu
+++ b/cpp/src/io/parquet/experimental/page_index_filter_utils.cu
@@ -204,7 +204,7 @@ rmm::device_uvector<size_type> compute_page_indices_async(
     cudf::detail::make_zeroed_device_uvector_async<cudf::size_type>(total_rows, stream, mr);
 
   // Scatter page indices across the their first row's index
-  thrust::scatter_if(rmm::exec_policy_nosync(stream),
+  thrust::scatter_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      cuda::counting_iterator{static_cast<size_type>(row_counts.size())},
                      row_offsets.begin(),
@@ -213,7 +213,7 @@ rmm::device_uvector<size_type> compute_page_indices_async(
 
   // Inclusive scan with maximum to replace zeros with the (increasing) page index it belongs to.
   // Page indices are scattered at their first row's index.
-  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          page_indices.begin(),
                          page_indices.end(),
                          page_indices.begin(),

--- a/cpp/src/io/parquet/page_hdr.cu
+++ b/cpp/src/io/parquet/page_hdr.cu
@@ -930,7 +930,7 @@ void decode_page_headers_with_pgidx(cudf::device_span<ColumnChunkDesc const> chu
                                     kernel_error::pointer error_code,
                                     rmm::cuda_stream_view stream)
 {
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cuda::counting_iterator<cudf::size_type>{0},
                    cuda::counting_iterator{static_cast<cudf::size_type>(pages.size())},
                    decode_page_headers_with_pgidx_fn{.colchunks          = chunks,

--- a/cpp/src/io/parquet/page_string_decode.cu
+++ b/cpp/src/io/parquet/page_string_decode.cu
@@ -1011,19 +1011,20 @@ void compute_page_string_sizes_pass2(cudf::detail::hostdevice_span<PageInfo> pag
     // now do an exclusive scan over the temp_string_sizes to get offsets for each
     // page's chunk of the temp buffer
     rmm::device_uvector<int64_t> page_string_offsets(pages.size(), stream);
-    thrust::transform_exclusive_scan(rmm::exec_policy_nosync(stream),
-                                     pages.device_begin(),
-                                     pages.device_end(),
-                                     page_string_offsets.begin(),
-                                     page_sizes,
-                                     0L,
-                                     cuda::std::plus<int64_t>{});
+    thrust::transform_exclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      pages.device_begin(),
+      pages.device_end(),
+      page_string_offsets.begin(),
+      page_sizes,
+      0L,
+      cuda::std::plus<int64_t>{});
 
     // allocate the temp space
     temp_string_buf.resize(total_size, stream);
 
     // now use the offsets array to set each page's temp_string_buf pointers
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       pages.device_begin(),
                       pages.device_end(),
                       page_string_offsets.begin(),

--- a/cpp/src/io/parquet/reader_impl_chunking.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking.cu
@@ -240,7 +240,7 @@ void reader_impl::setup_next_subpass(read_mode mode)
       rmm::device_uvector<page_span> page_indices(
         num_columns, _stream, cudf::get_current_device_resource_ref());
       auto iter = cuda::counting_iterator<size_t>{0};
-      thrust::transform(rmm::exec_policy_nosync(_stream),
+      thrust::transform(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                         iter,
                         iter + num_columns,
                         page_indices.begin(),
@@ -255,13 +255,14 @@ void reader_impl::setup_next_subpass(read_mode mode)
     rmm::device_uvector<cumulative_page_info> c_info(pass.pages.size(), _stream);
     auto page_keys = make_page_key_iterator(pass.pages);
     auto page_size = thrust::make_transform_iterator(pass.pages.d_begin(), get_page_input_size{});
-    thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(_stream),
-                                  page_keys,
-                                  page_keys + pass.pages.size(),
-                                  page_size,
-                                  c_info.begin(),
-                                  cuda::std::equal_to{},
-                                  cumulative_page_sum{});
+    thrust::inclusive_scan_by_key(
+      rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
+      page_keys,
+      page_keys + pass.pages.size(),
+      page_size,
+      c_info.begin(),
+      cuda::std::equal_to{},
+      cumulative_page_sum{});
 
     // include scratch space needed for decompression and string offset buffers.
     // for certain codecs (eg ZSTD) this an be considerable.
@@ -279,7 +280,7 @@ void reader_impl::setup_next_subpass(read_mode mode)
 
     auto iter               = cuda::counting_iterator<size_t>{0};
     auto const pass_max_row = pass.skip_rows + pass.num_rows;
-    thrust::for_each(rmm::exec_policy_nosync(_stream),
+    thrust::for_each(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                      iter,
                      iter + pass.pages.size(),
                      set_row_index{pass.chunks, pass.pages, c_info, pass_max_row});
@@ -312,15 +313,16 @@ void reader_impl::setup_next_subpass(read_mode mode)
     subpass.page_src_index = rmm::device_uvector<size_t>(total_pages, _stream);
     auto iter              = cuda::counting_iterator<size_t>{0};
     rmm::device_uvector<size_t> dst_offsets(num_columns + 1, _stream);
-    thrust::transform_exclusive_scan(rmm::exec_policy_nosync(_stream),
-                                     iter,
-                                     iter + num_columns + 1,
-                                     dst_offsets.begin(),
-                                     get_span_size_by_index{page_indices},
-                                     0,
-                                     cuda::std::plus<size_t>{});
+    thrust::transform_exclusive_scan(
+      rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
+      iter,
+      iter + num_columns + 1,
+      dst_offsets.begin(),
+      get_span_size_by_index{page_indices},
+      0,
+      cuda::std::plus<size_t>{});
     thrust::for_each(
-      rmm::exec_policy_nosync(_stream),
+      rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
       iter,
       iter + total_pages,
       copy_subpass_page{
@@ -566,20 +568,21 @@ void reader_impl::compute_output_chunks_for_subpass()
   auto page_input =
     thrust::make_transform_iterator(subpass.pages.device_begin(), get_page_output_size{});
   auto page_keys = make_page_key_iterator(subpass.pages);
-  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(_stream),
-                                page_keys,
-                                page_keys + subpass.pages.size(),
-                                page_input,
-                                c_info.begin(),
-                                cuda::std::equal_to{},
-                                cumulative_page_sum{});
+  thrust::inclusive_scan_by_key(
+    rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
+    page_keys,
+    page_keys + subpass.pages.size(),
+    page_input,
+    c_info.begin(),
+    cuda::std::equal_to{},
+    cumulative_page_sum{});
   auto iter = cuda::counting_iterator<size_t>{0};
   // cap the max row in all pages by the max row we expect in the subpass. input chunking
   // can cause "dangling" row counts where for example, only 1 column has a page whose
   // maximum row is beyond our expected subpass max row, which will cause an out of
   // bounds index in compute_page_splits_by_row.
   auto const subpass_max_row = subpass.skip_rows + subpass.num_rows;
-  thrust::for_each(rmm::exec_policy_nosync(_stream),
+  thrust::for_each(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                    iter,
                    iter + subpass.pages.size(),
                    set_row_index{pass.chunks, subpass.pages, c_info, subpass_max_row});

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -259,8 +259,11 @@ adjust_cumulative_sizes(device_span<cumulative_page_info const> c_info,
     rmm::device_uvector<size_t> indices(c_info.size(), stream);
     rmm::device_uvector<size_t> sort_order(c_info.size(), stream);
 
-    thrust::sequence(rmm::exec_policy_nosync(stream), indices.begin(), indices.end(), 0);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     indices.begin(),
+                     indices.end(),
+                     0);
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       c_info.begin(),
                       c_info.end(),
                       end_row_indices.begin(),
@@ -289,7 +292,7 @@ adjust_cumulative_sizes(device_span<cumulative_page_info const> c_info,
                                     sizeof(size_t) * 8,
                                     stream.value());
 
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       sort_order.begin(),
                       sort_order.end(),
                       c_info_sorted.begin(),
@@ -298,7 +301,7 @@ adjust_cumulative_sizes(device_span<cumulative_page_info const> c_info,
 
   // page keys grouped by split.
   rmm::device_uvector<int32_t> page_keys_by_split{c_info.size(), stream};
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     c_info_sorted.begin(),
                     c_info_sorted.end(),
                     page_keys_by_split.begin(),
@@ -319,8 +322,10 @@ adjust_cumulative_sizes(device_span<cumulative_page_info const> c_info,
                                  .second;
 
   size_t const num_unique_keys = key_offsets_end - key_offsets.begin();
-  thrust::exclusive_scan(
-    rmm::exec_policy_nosync(stream), key_offsets.begin(), key_offsets.end(), key_offsets.begin());
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                         key_offsets.begin(),
+                         key_offsets.end(),
+                         key_offsets.begin());
 
   // adjust the cumulative info such that for each row count, the size includes any pages that span
   // that row count. this is so that if we have this case:
@@ -333,7 +338,7 @@ adjust_cumulative_sizes(device_span<cumulative_page_info const> c_info,
   // page.
   //
   rmm::device_uvector<cumulative_page_info> aggregated_info(c_info.size(), stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     c_info_sorted.begin(),
                     c_info_sorted.end(),
                     aggregated_info.begin(),
@@ -382,7 +387,7 @@ std::tuple<rmm::device_uvector<page_span>, size_t, size_t> compute_next_subpass(
   auto page_row_index =
     cudf::detail::make_counting_transform_iterator(0, get_page_end_row_index{c_info});
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     iter,
     iter + num_columns,
     page_bounds.begin(),
@@ -583,10 +588,11 @@ std::vector<row_range> compute_page_splits_by_row(device_span<cumulative_page_in
   auto const d_comp_out = cudf::detail::make_device_uvector_async(
     comp_out, stream, cudf::get_current_device_resource_ref());
   rmm::device_uvector<codec_exec_result> comp_res(num_comp_pages, stream);
-  thrust::uninitialized_fill(rmm::exec_policy_nosync(stream),
-                             comp_res.begin(),
-                             comp_res.end(),
-                             codec_exec_result{0, codec_status::FAILURE});
+  thrust::uninitialized_fill(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    comp_res.begin(),
+    comp_res.end(),
+    codec_exec_result{0, codec_status::FAILURE});
 
   int32_t start_pos = 0;
   for (auto const& codec : codecs) {
@@ -693,13 +699,14 @@ rmm::device_uvector<size_t> compute_decompression_scratch_sizes(
   // per-codec page counts and decompression sizes
   rmm::device_uvector<decompression_info> decomp_info(pages.size(), stream);
   auto decomp_iter = cuda::make_transform_iterator(pages.begin(), get_decomp_info{chunks});
-  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                page_keys,
-                                page_keys + pages.size(),
-                                decomp_iter,
-                                decomp_info.begin(),
-                                cuda::std::equal_to<int32_t>{},
-                                decomp_sum{});
+  thrust::inclusive_scan_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    page_keys,
+    page_keys + pages.size(),
+    decomp_iter,
+    decomp_info.begin(),
+    cuda::std::equal_to<int32_t>{},
+    decomp_sum{});
 
   // retrieve to host so we can get compression scratch sizes
   auto temp_cost     = cudf::detail::make_pinned_vector_async<size_t>(pages.size(), stream);
@@ -733,7 +740,7 @@ rmm::device_uvector<size_t> compute_decompression_scratch_sizes(
       rmm::device_uvector<device_span<uint8_t const>> temp_spans(pages.size(), stream);
       auto iter = cuda::counting_iterator{size_t{0}};
       thrust::for_each(
-        rmm::exec_policy_nosync(stream),
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
         iter,
         iter + pages.size(),
         [pages      = pages.begin(),
@@ -780,7 +787,7 @@ rmm::device_uvector<size_t> compute_decompression_scratch_sizes(
         auto const adjustment_ratio = static_cast<double>(total_temp_size_ex) / total_temp_size;
 
         // Apply the adjustment ratio to each page's temporary cost
-        thrust::for_each(rmm::exec_policy_nosync(stream),
+        thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          cuda::counting_iterator{size_t{0}},
                          cuda::counting_iterator{pages.size()},
                          [pages           = pages.begin(),
@@ -810,7 +817,7 @@ void include_scratch_size(device_span<size_t const> temp_cost,
                           rmm::cuda_stream_view stream)
 {
   auto iter = cuda::counting_iterator{size_t{0}};
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    iter,
                    iter + c_info.size(),
                    [temp_cost = temp_cost.begin(), c_info = c_info.begin()] __device__(size_t i) {
@@ -899,7 +906,7 @@ rmm::device_uvector<size_t> compute_string_offset_sizes(device_span<ColumnChunkD
 {
   rmm::device_uvector<size_t> string_offset_sizes(pages.size(), stream, mr);
 
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     pages.begin(),
                     pages.end(),
                     string_offset_sizes.begin(),
@@ -918,7 +925,7 @@ rmm::device_uvector<size_t> compute_level_decode_sizes(device_span<ColumnChunkDe
 {
   rmm::device_uvector<size_t> level_decode_sizes(pages.size(), stream, mr);
 
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     pages.begin(),
                     pages.end(),
                     level_decode_sizes.begin(),

--- a/cpp/src/io/parquet/reader_impl_preprocess.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess.cu
@@ -57,9 +57,11 @@ void reader_impl::build_string_dict_indices()
 
   // compute number of indices per chunk and a summed total
   rmm::device_uvector<size_t> str_dict_index_count(pass.chunks.size() + 1, _stream);
-  thrust::fill(
-    rmm::exec_policy_nosync(_stream), str_dict_index_count.begin(), str_dict_index_count.end(), 0);
-  thrust::for_each(rmm::exec_policy_nosync(_stream),
+  thrust::fill(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
+               str_dict_index_count.begin(),
+               str_dict_index_count.end(),
+               0);
+  thrust::for_each(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                    pass.pages.d_begin(),
                    pass.pages.d_end(),
                    set_str_dict_index_count{str_dict_index_count, pass.chunks});
@@ -74,7 +76,7 @@ void reader_impl::build_string_dict_indices()
 
   // convert to offsets
   rmm::device_uvector<size_t>& str_dict_index_offsets = str_dict_index_count;
-  thrust::exclusive_scan(rmm::exec_policy_nosync(_stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                          str_dict_index_offsets.begin(),
                          str_dict_index_offsets.end(),
                          str_dict_index_offsets.begin(),
@@ -86,7 +88,7 @@ void reader_impl::build_string_dict_indices()
 
   auto iter = cuda::counting_iterator<size_t>{0};
   thrust::for_each(
-    rmm::exec_policy_nosync(_stream),
+    rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
     iter,
     iter + pass.chunks.size(),
     set_str_dict_index_ptr{pass.str_dict_index.data(), str_dict_index_offsets, pass.chunks});
@@ -421,7 +423,7 @@ void reader_impl::compute_page_string_offset_indices(size_t skip_rows, size_t nu
   auto const num_pages = subpass.pages.size();
   rmm::device_uvector<size_t> d_page_offset_counts(num_pages, _stream);
 
-  thrust::transform(rmm::exec_policy_nosync(_stream),
+  thrust::transform(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_t>{0},
                     cuda::counting_iterator<size_t>{num_pages},
                     d_page_offset_counts.begin(),
@@ -429,7 +431,7 @@ void reader_impl::compute_page_string_offset_indices(size_t skip_rows, size_t nu
 
   // Compute prefix sum (exclusive scan) to get indices for each page
   subpass.page_string_offset_indices = rmm::device_uvector<size_t>(num_pages, _stream);
-  thrust::exclusive_scan(rmm::exec_policy_nosync(_stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                          d_page_offset_counts.begin(),
                          d_page_offset_counts.end(),
                          subpass.page_string_offset_indices.begin());
@@ -661,31 +663,32 @@ void reader_impl::generate_list_column_row_counts(is_estimate_row_counts is_esti
   // absolute row index for the whole file. chunk_row in PageInfo is relative to the beginning of
   // the chunk. so in the kernels, chunk.start_row + page.chunk_row gives us the absolute row index
   if (is_estimate_row_counts == is_estimate_row_counts::YES) {
-    thrust::for_each(rmm::exec_policy_nosync(_stream),
+    thrust::for_each(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                      pass.pages.d_begin(),
                      pass.pages.d_end(),
                      set_list_row_count_estimate{pass.chunks});
     auto key_input  = thrust::make_transform_iterator(pass.pages.d_begin(), get_page_chunk_idx{});
     auto page_input = thrust::make_transform_iterator(pass.pages.d_begin(), get_page_num_rows{});
-    thrust::exclusive_scan_by_key(rmm::exec_policy_nosync(_stream),
-                                  key_input,
-                                  key_input + pass.pages.size(),
-                                  page_input,
-                                  chunk_row_output_iter{pass.pages.device_ptr()});
+    thrust::exclusive_scan_by_key(
+      rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
+      key_input,
+      key_input + pass.pages.size(),
+      page_input,
+      chunk_row_output_iter{pass.pages.device_ptr()});
 
     // To compensate for the list row size estimates, force the row count on the last page for each
     // column chunk (each rowgroup) such that it ends on the real known row count. this is so that
     // as we march through the subpasses, we will find that every column cleanly ends up the
     // expected row count at the row group boundary and our split computations work correctly.
     auto iter = cuda::counting_iterator<size_t>{0};
-    thrust::for_each(rmm::exec_policy_nosync(_stream),
+    thrust::for_each(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                      iter,
                      iter + pass.pages.size(),
                      set_final_row_count{pass.pages, pass.chunks});
   } else {
     // If column indexes are available, we don't need to estimate PageInfo::num_rows for lists and
     // can instead translate known PageInfo::chunk_row to PageInfo::num_rows
-    thrust::for_each(rmm::exec_policy_nosync(_stream),
+    thrust::for_each(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_t>{0},
                      cuda::counting_iterator{pass.pages.size()},
                      compute_page_num_rows_from_chunk_rows{pass.pages, pass.chunks});
@@ -767,7 +770,7 @@ void reader_impl::preprocess_subpass_pages(read_mode mode, size_t chunk_read_lim
   // copy our now-correct row counts  back to the base pages stored in the pass.
   // only need to do this if we are not processing the whole pass in one subpass
   if (!subpass.single_subpass) {
-    thrust::for_each(rmm::exec_policy_nosync(_stream),
+    thrust::for_each(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                      iter,
                      iter + subpass.pages.size(),
                      update_pass_num_rows{pass.pages, subpass.pages, subpass.page_src_index});
@@ -780,16 +783,17 @@ void reader_impl::preprocess_subpass_pages(read_mode mode, size_t chunk_read_lim
   // gives us the absolute row index
   auto key_input  = thrust::make_transform_iterator(pass.pages.d_begin(), get_page_chunk_idx{});
   auto page_input = thrust::make_transform_iterator(pass.pages.d_begin(), get_page_num_rows{});
-  thrust::exclusive_scan_by_key(rmm::exec_policy_nosync(_stream),
-                                key_input,
-                                key_input + pass.pages.size(),
-                                page_input,
-                                chunk_row_output_iter{pass.pages.device_ptr()});
+  thrust::exclusive_scan_by_key(
+    rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
+    key_input,
+    key_input + pass.pages.size(),
+    page_input,
+    chunk_row_output_iter{pass.pages.device_ptr()});
 
   // copy chunk_row into the subpass pages
   // only need to do this if we are not processing the whole pass in one subpass
   if (!subpass.single_subpass) {
-    thrust::for_each(rmm::exec_policy_nosync(_stream),
+    thrust::for_each(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                      iter,
                      iter + subpass.pages.size(),
                      update_subpass_chunk_row{pass.pages, subpass.pages, subpass.page_src_index});
@@ -828,7 +832,7 @@ void reader_impl::preprocess_subpass_pages(read_mode mode, size_t chunk_read_lim
                                       _stream);
     }
     // set str_bytes_all
-    thrust::for_each(rmm::exec_policy_nosync(_stream),
+    thrust::for_each(rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
                      subpass.pages.device_begin(),
                      subpass.pages.device_end(),
                      set_str_bytes_all{});
@@ -995,7 +999,7 @@ void reader_impl::allocate_columns(read_mode mode, size_t skip_rows, size_t num_
       // Number of keys processed in this iteration
       auto const num_keys_this_iter = std::min<size_t>(num_keys_per_iter, num_keys - key_start);
       thrust::transform(
-        rmm::exec_policy_nosync(_stream),
+        rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
         cuda::counting_iterator<size_t>{key_start},
         cuda::counting_iterator<size_t>{key_start + num_keys_this_iter},
         size_input.begin(),
@@ -1016,15 +1020,16 @@ void reader_impl::allocate_columns(read_mode mode, size_t skip_rows, size_t num_
                                   _stream);
 
       // For nested hierarchies, compute per-page start offset
-      thrust::exclusive_scan_by_key(rmm::exec_policy_nosync(_stream),
-                                    reduction_keys,
-                                    reduction_keys + num_keys_this_iter,
-                                    size_input.cbegin(),
-                                    start_offset_output_iterator{subpass.pages.device_begin(),
-                                                                 key_start,
-                                                                 d_cols_info.data(),
-                                                                 max_depth,
-                                                                 subpass.pages.size()});
+      thrust::exclusive_scan_by_key(
+        rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
+        reduction_keys,
+        reduction_keys + num_keys_this_iter,
+        size_input.cbegin(),
+        start_offset_output_iterator{subpass.pages.device_begin(),
+                                     key_start,
+                                     d_cols_info.data(),
+                                     max_depth,
+                                     subpass.pages.size()});
       // Increment the key_start
       key_start += num_keys_this_iter;
     }
@@ -1086,11 +1091,12 @@ cudf::detail::host_vector<size_t> reader_impl::calculate_page_string_offsets()
                                                   page_to_string_size{pass.chunks.d_begin()});
 
   // do scan by key to calculate string offsets for each page
-  thrust::exclusive_scan_by_key(rmm::exec_policy_nosync(_stream),
-                                page_keys,
-                                page_keys + subpass.pages.size(),
-                                val_iter,
-                                page_offset_output_iter{subpass.pages.device_ptr()});
+  thrust::exclusive_scan_by_key(
+    rmm::exec_policy_nosync(_stream, cudf::get_current_device_resource_ref()),
+    page_keys,
+    page_keys + subpass.pages.size(),
+    val_iter,
+    page_offset_output_iter{subpass.pages.device_ptr()});
 
   // now sum up page sizes
   rmm::device_uvector<int> reduce_keys(d_col_sizes.size(), _stream);

--- a/cpp/src/io/parquet/reader_impl_preprocess_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess_utils.cu
@@ -323,8 +323,10 @@ void fill_in_page_info(host_span<ColumnChunkDesc> chunks,
     page_indexes, stream, cudf::get_current_device_resource_ref());
 
   auto iter = cuda::counting_iterator<size_type>{0};
-  thrust::for_each(
-    rmm::exec_policy_nosync(stream), iter, iter + num_pages, copy_page_info{d_page_indexes, pages});
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   iter,
+                   iter + num_pages,
+                   copy_page_info{d_page_indexes, pages});
 }
 
 std::string encoding_to_string(Encoding encoding)
@@ -399,7 +401,7 @@ cudf::detail::hostdevice_vector<PageInfo> sort_pages(device_span<PageInfo const>
   // We also need to preserve key-relative page ordering, so we need to use a stable sort.
   rmm::device_uvector<int32_t> page_keys{unsorted_pages.size(), stream};
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     unsorted_pages.begin(),
     unsorted_pages.end(),
     page_keys.begin(),
@@ -410,14 +412,18 @@ cudf::detail::hostdevice_vector<PageInfo> sort_pages(device_span<PageInfo const>
   // started generating kernels using too much shared memory when trying to sort the pages
   // directly.
   rmm::device_uvector<int32_t> sort_indices(unsorted_pages.size(), stream);
-  thrust::sequence(rmm::exec_policy_nosync(stream), sort_indices.begin(), sort_indices.end(), 0);
-  thrust::stable_sort_by_key(rmm::exec_policy_nosync(stream),
-                             page_keys.begin(),
-                             page_keys.end(),
-                             sort_indices.begin(),
-                             cuda::std::less<int>());
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   sort_indices.begin(),
+                   sort_indices.end(),
+                   0);
+  thrust::stable_sort_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    page_keys.begin(),
+    page_keys.end(),
+    sort_indices.begin(),
+    cuda::std::less<int>());
   auto pass_pages = cudf::detail::hostdevice_vector<PageInfo>(unsorted_pages.size(), stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     sort_indices.begin(),
                     sort_indices.end(),
                     pass_pages.d_begin(),
@@ -437,7 +443,7 @@ void decode_page_headers(pass_intermediate_data& pass,
   auto iter = cuda::counting_iterator<size_t>{0};
   rmm::device_uvector<size_type> chunk_page_offsets(pass.chunks.size() + 1, stream);
   thrust::transform_exclusive_scan(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     iter,
     iter + pass.chunks.size() + 1,
     chunk_page_offsets.begin(),
@@ -449,7 +455,7 @@ void decode_page_headers(pass_intermediate_data& pass,
     size_type{0},
     cuda::std::plus<size_type>{});
   rmm::device_uvector<chunk_page_info> d_chunk_page_info(pass.chunks.size(), stream);
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    iter,
                    iter + pass.chunks.size(),
                    [cpi                = d_chunk_page_info.begin(),
@@ -577,13 +583,13 @@ void decode_page_headers(pass_intermediate_data& pass,
                                  .second;
   auto const num_page_counts = page_counts_end - page_counts.begin();
   pass.page_offsets          = rmm::device_uvector<size_type>(num_page_counts + 1, stream);
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          page_counts.begin(),
                          page_counts.begin() + num_page_counts + 1,
                          pass.page_offsets.begin());
 
   // setup dict_page for each chunk if necessary
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    pass.pages.d_begin(),
                    pass.pages.d_end(),
                    [chunks = pass.chunks.d_begin()] __device__(PageInfo const& p) {

--- a/cpp/src/io/parquet/writer_impl.cu
+++ b/cpp/src/io/parquet/writer_impl.cu
@@ -1517,7 +1517,7 @@ void encode_pages(hostdevice_2dvector<EncColumnChunk>& chunks,
   rmm::device_uvector<device_span<uint8_t const>> comp_in(max_comp_pages, stream);
   rmm::device_uvector<device_span<uint8_t>> comp_out(max_comp_pages, stream);
   rmm::device_uvector<codec_exec_result> comp_res(max_comp_pages, stream);
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                comp_res.begin(),
                comp_res.end(),
                codec_exec_result{0, codec_status::FAILURE});
@@ -2058,9 +2058,15 @@ auto convert_table_to_parquet_data(table_input_metadata& table_meta,
   rmm::device_uvector<uint32_t> rep_level_histogram(rep_histogram_bfr_size, stream);
 
   thrust::uninitialized_fill(
-    rmm::exec_policy_nosync(stream), def_level_histogram.begin(), def_level_histogram.end(), 0);
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    def_level_histogram.begin(),
+    def_level_histogram.end(),
+    0);
   thrust::uninitialized_fill(
-    rmm::exec_policy_nosync(stream), rep_level_histogram.begin(), rep_level_histogram.end(), 0);
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    rep_level_histogram.begin(),
+    rep_level_histogram.end(),
+    0);
 
   // This contains stats for both the pages and the rowgroups. TODO: make them separate.
   rmm::device_uvector<statistics_chunk> page_stats(num_stats_bfr, stream);

--- a/cpp/src/io/text/bgzip_data_chunk_source.cu
+++ b/cpp/src/io/text/bgzip_data_chunk_source.cu
@@ -140,7 +140,7 @@ class bgzip_data_chunk_reader : public data_chunk_reader {
       auto span_it =
         thrust::make_zip_iterator(d_compressed_spans.begin(), d_decompressed_spans.begin());
       thrust::transform(
-        rmm::exec_policy_nosync(stream),
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
         offset_it,
         offset_it + num_blocks(),
         span_it,

--- a/cpp/src/io/text/multibyte_split.cu
+++ b/cpp/src/io/text/multibyte_split.cu
@@ -453,15 +453,15 @@ std::unique_ptr<cudf::column> multibyte_split(cudf::io::text::data_chunk_source 
           return new_offsets_unclamped;
         }
         // if we are in the last chunk, we need to find the first out-of-bounds offset
-        auto const it = cuda::counting_iterator<output_offset>{};
-        auto const end_loc =
-          *thrust::find_if(rmm::exec_policy_nosync(scan_stream),
-                           it,
-                           it + new_offsets_unclamped,
-                           cuda::proclaim_return_type<bool>(
-                             [row_offsets, byte_range_end] __device__(output_offset i) {
-                               return row_offsets[i] >= byte_range_end;
-                             }));
+        auto const it      = cuda::counting_iterator<output_offset>{};
+        auto const end_loc = *thrust::find_if(
+          rmm::exec_policy_nosync(scan_stream, cudf::get_current_device_resource_ref()),
+          it,
+          it + new_offsets_unclamped,
+          cuda::proclaim_return_type<bool>(
+            [row_offsets, byte_range_end] __device__(output_offset i) {
+              return row_offsets[i] >= byte_range_end;
+            }));
         // if we had no out-of-bounds offset, we copy all offsets
         if (end_loc == new_offsets_unclamped) { return end_loc; }
         // otherwise we copy only up to (including) the first out-of-bounds delimiter
@@ -483,7 +483,10 @@ std::unique_ptr<cudf::column> multibyte_split(cudf::io::text::data_chunk_source 
           chunk->data() + std::min<byte_offset>(sentinel - chunk_offset, chunk->size());
         auto const output_size = end - begin;
         auto char_output       = char_storage.next_output(scan_stream);
-        thrust::copy(rmm::exec_policy_nosync(scan_stream), begin, end, char_output.begin());
+        thrust::copy(rmm::exec_policy_nosync(scan_stream, cudf::get_current_device_resource_ref()),
+                     begin,
+                     end,
+                     char_output.begin());
         char_storage.advance_output(output_size, scan_stream);
       }
 
@@ -528,7 +531,7 @@ std::unique_ptr<cudf::column> multibyte_split(cudf::io::text::data_chunk_source 
   };
   if (insert_begin) { set_offset_value(0, 0); }
   if (insert_end) { set_offset_value(offsets->size() - 1, chars_bytes); }
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     global_offsets.begin(),
                     global_offsets.end(),
                     offsets_itr + insert_begin,

--- a/cpp/src/io/utilities/column_utils.cuh
+++ b/cpp/src/io/utilities/column_utils.cuh
@@ -49,7 +49,7 @@ rmm::device_uvector<column_device_view> create_leaf_column_device_views(
 
   auto iter = cuda::counting_iterator<size_type>{0};
   thrust::for_each(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     iter,
     iter + parent_table_device_view.num_columns(),
     [col_desc, parent_col_view = parent_table_device_view, leaf_columns] __device__(

--- a/cpp/src/io/utilities/data_casting.cu
+++ b/cpp/src/io/utilities/data_casting.cu
@@ -800,7 +800,7 @@ static std::unique_ptr<column> parse_string(string_view_pair_it str_tuples,
   //  CUDF_FUNC_RANGE();
 
   auto const max_length = thrust::transform_reduce(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     str_tuples,
     str_tuples + col_size,
     cuda::proclaim_return_type<std::size_t>([] __device__(auto t) { return t.second; }),
@@ -813,7 +813,7 @@ static std::unique_ptr<column> parse_string(string_view_pair_it str_tuples,
 
   auto single_thread_fn = string_parse<decltype(str_tuples)>{
     str_tuples, static_cast<bitmask_type*>(null_mask.data()), null_count_data, options, d_sizes};
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      col_size,
                      single_thread_fn);
@@ -866,7 +866,7 @@ static std::unique_ptr<column> parse_string(string_view_pair_it str_tuples,
   single_thread_fn.d_chars   = d_chars;
   single_thread_fn.d_offsets = d_offsets;
 
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      col_size,
                      single_thread_fn);
@@ -944,7 +944,7 @@ std::unique_ptr<column> parse_data(
 
   // use `ConvertFunctor` to convert non-string values
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     col_size,
     [str_tuples, col = *output_dv_ptr, options, col_type, null_count_data] __device__(

--- a/cpp/src/io/utilities/output_builder.cuh
+++ b/cpp/src/io/utilities/output_builder.cuh
@@ -328,8 +328,11 @@ class output_builder {
     rmm::device_uvector<T> output{size(), stream, mr};
     auto output_it = output.begin();
     for (auto const& chunk : _chunks) {
-      output_it = thrust::copy(
-        rmm::exec_policy_nosync(stream), chunk.begin(), chunk.begin() + chunk.size(), output_it);
+      output_it =
+        thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     chunk.begin(),
+                     chunk.begin() + chunk.size(),
+                     output_it);
     }
     return output;
   }

--- a/cpp/src/lists/copying/segmented_gather.cu
+++ b/cpp/src/lists/copying/segmented_gather.cu
@@ -35,6 +35,7 @@ std::unique_ptr<column> segmented_gather(lists_column_view const& value_column,
   CUDF_EXPECTS(!gather_map.has_nulls(), "Gather map contains nulls", std::invalid_argument);
   CUDF_EXPECTS(value_column.size() == gather_map.size(),
                "Gather map and list column should be same size");
+  if (value_column.is_empty()) { return empty_like(value_column.parent()); }
 
   auto const gather_map_sliced_child = gather_map.get_sliced_child(stream);
   auto const gather_map_size         = gather_map_sliced_child.size();

--- a/cpp/src/merge/merge.cu
+++ b/cpp/src/merge/merge.cu
@@ -253,7 +253,7 @@ index_vector generate_merged_indices(table_view const& left_table,
 
     auto ineq_op = detail::row_lexicographic_tagged_comparator<true>(
       *lhs_device_view, *rhs_device_view, d_column_order, d_null_precedence);
-    thrust::merge(rmm::exec_policy_nosync(stream),
+    thrust::merge(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   left_begin,
                   left_begin + left_size,
                   right_begin,
@@ -263,7 +263,7 @@ index_vector generate_merged_indices(table_view const& left_table,
   } else {
     auto ineq_op = detail::row_lexicographic_tagged_comparator<false>(
       *lhs_device_view, *rhs_device_view, d_column_order, {});
-    thrust::merge(rmm::exec_policy_nosync(stream),
+    thrust::merge(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   left_begin,
                   left_begin + left_size,
                   right_begin,
@@ -304,7 +304,7 @@ index_vector generate_merged_indices_nested(table_view const& left_table,
 
   auto const total_counter = cuda::counting_iterator<cudf::size_type>{0};
   thrust::for_each(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     total_counter,
     total_counter + total_size,
     [merged = merged_indices.data(), left = left_indices_begin, left_size, right_size] __device__(
@@ -389,7 +389,7 @@ struct column_merger {
     // and "gather" into merged_view.data()[indx_merged]
     // from lcol or rcol, depending on side;
     //
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       row_order_.begin(),
                       row_order_.end(),
                       merged_view.begin<Element>(),

--- a/cpp/src/partitioning/partitioning.cu
+++ b/cpp/src/partitioning/partitioning.cu
@@ -480,7 +480,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
   // Compute partition number for each row
   if (is_power_two(num_partitions)) {
     auto const partitioner = bitwise_partitioner<hash_value_type>(num_partitions);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>(0),
                       cuda::counting_iterator<size_type>(num_rows),
                       row_partition_numbers.begin(),
@@ -489,7 +489,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
                       });
   } else {
     auto const partitioner = modulo_partitioner<hash_value_type>(num_partitions);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>(0),
                       cuda::counting_iterator<size_type>(num_rows),
                       row_partition_numbers.begin(),
@@ -532,8 +532,10 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
 
   // Exclusive scan on histogram to get partition offsets.
   // histogram has num_partitions+1 elements; after scan, histogram[num_partitions] = num_rows.
-  thrust::exclusive_scan(
-    rmm::exec_policy_nosync(stream), histogram.begin(), histogram.end(), histogram.begin());
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                         histogram.begin(),
+                         histogram.end(),
+                         histogram.begin());
 
   // Copy partition offsets to pinned host memory asynchronously
   auto const pinned_offsets = cudf::detail::make_pinned_vector_async(histogram, stream);
@@ -541,7 +543,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table_g
   // Build scatter map: atomically increment partition offsets
   rmm::device_uvector<size_type> scatter_map(num_rows, stream);
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     row_partition_numbers.begin(),
     row_partition_numbers.end(),
     scatter_map.begin(),
@@ -663,7 +665,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
 
   // Compute exclusive scan of all blocks' partition sizes in-place to determine
   // the starting point for each blocks portion of each partition in the output
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          block_partition_sizes.begin(),
                          block_partition_sizes.end(),
                          scanned_block_partition_sizes.data());
@@ -671,7 +673,7 @@ std::pair<std::unique_ptr<table>, std::vector<size_type>> hash_partition_table(
   // Compute exclusive scan of size of each partition to determine offset
   // location of each partition in final output.
   // TODO This can be done independently on a separate stream
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          global_partition_sizes.begin(),
                          global_partition_sizes.end(),
                          global_partition_sizes.begin());
@@ -799,8 +801,10 @@ struct dispatch_map_type {
 
     // `histogram` was created with an extra entry at the end such that an
     // exclusive scan will put the total number of rows at the end
-    thrust::exclusive_scan(
-      rmm::exec_policy_nosync(stream), histogram.begin(), histogram.end(), histogram.begin());
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           histogram.begin(),
+                           histogram.end(),
+                           histogram.begin());
 
     // Copy offsets to host before the transform below modifies the histogram
     auto const partition_offsets = cudf::detail::make_std_vector(histogram, stream);
@@ -811,7 +815,7 @@ struct dispatch_map_type {
 
     // For each `partition_map[i]`, atomically increment the corresponding
     // partition offset to determine `i`s location in the output
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       partition_map.begin<MapType>(),
                       partition_map.end<MapType>(),
                       scatter_map.begin(),

--- a/cpp/src/partitioning/round_robin.cu
+++ b/cpp/src/partitioning/round_robin.cu
@@ -87,8 +87,9 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
 
   if (num_partitions == nrows) {
     rmm::device_uvector<cudf::size_type> partition_offsets(num_partitions + 1, stream);
-    thrust::sequence(
-      rmm::exec_policy_nosync(stream), partition_offsets.begin(), partition_offsets.end());
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     partition_offsets.begin(),
+                     partition_offsets.end());
 
     auto uniq_tbl = cudf::detail::gather(input,
                                          rotated_iter_begin,
@@ -130,12 +131,15 @@ std::pair<std::unique_ptr<cudf::table>, std::vector<cudf::size_type>> degenerate
 
     // offsets (part 2: compute partition offsets):
     rmm::device_uvector<cudf::size_type> partition_offsets(num_partitions + 1, stream);
-    thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            nedges_iter_begin,
                            nedges_iter_begin + num_partitions,
                            partition_offsets.begin());
     // Add the total row count as the last offset
-    thrust::fill_n(rmm::exec_policy_nosync(stream), partition_offsets.end() - 1, 1, nrows);
+    thrust::fill_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   partition_offsets.end() - 1,
+                   1,
+                   nrows);
 
     return std::pair{std::move(uniq_tbl), cudf::detail::make_std_vector(partition_offsets, stream)};
   }

--- a/cpp/src/quantiles/quantile.cu
+++ b/cpp/src/quantiles/quantile.cu
@@ -82,7 +82,7 @@ struct quantile_functor {
     if (!cudf::is_dictionary(input.type())) {
       auto sorted_data =
         thrust::make_permutation_iterator(input.data<StorageType>(), ordered_indices);
-      thrust::transform(rmm::exec_policy_nosync(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         q_device.begin(),
                         q_device.end(),
                         d_output->template begin<StorageResult>(),
@@ -94,7 +94,7 @@ struct quantile_functor {
     } else {
       auto sorted_data = thrust::make_permutation_iterator(
         dictionary::detail::make_dictionary_iterator<T>(*d_input), ordered_indices);
-      thrust::transform(rmm::exec_policy_nosync(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         q_device.begin(),
                         q_device.end(),
                         d_output->template begin<StorageResult>(),

--- a/cpp/src/quantiles/tdigest/tdigest.cu
+++ b/cpp/src/quantiles/tdigest/tdigest.cu
@@ -199,11 +199,12 @@ std::unique_ptr<column> compute_approx_percentiles(tdigest_column_view const& in
           offsets_begin,
           cuda::std::prev(thrust::upper_bound(thrust::seq, offsets_begin, offsets_end, i)));
       }));
-  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                keys,
-                                keys + weight.size(),
-                                weight.begin<double>(),
-                                cumulative_weights->mutable_view().begin<double>());
+  thrust::inclusive_scan_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    keys,
+    keys + weight.size(),
+    weight.begin<double>(),
+    cumulative_weights->mutable_view().begin<double>());
 
   auto percentiles_cdv = column_device_view::create(percentiles, stream);
 
@@ -288,20 +289,20 @@ std::unique_ptr<column> make_empty_tdigests_column(size_type num_rows,
 {
   auto offsets = cudf::make_fixed_width_column(
     data_type(type_id::INT32), num_rows + 1, mask_state::UNALLOCATED, stream, mr);
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                offsets->mutable_view().begin<size_type>(),
                offsets->mutable_view().end<size_type>(),
                0);
 
   auto min_col = cudf::make_numeric_column(
     data_type(type_id::FLOAT64), num_rows, mask_state::UNALLOCATED, stream, mr);
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                min_col->mutable_view().begin<double>(),
                min_col->mutable_view().end<double>(),
                0);
   auto max_col = cudf::make_numeric_column(
     data_type(type_id::FLOAT64), num_rows, mask_state::UNALLOCATED, stream, mr);
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                max_col->mutable_view().begin<double>(),
                max_col->mutable_view().end<double>(),
                0);
@@ -354,7 +355,7 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
                                 [] __device__(auto const x) { return x == 0; },
                                 stream) == static_cast<std::size_t>(input.size());
   auto row_size_iter = cuda::make_constant_iterator(all_empty_rows ? 0 : percentiles.size());
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          row_size_iter,
                          row_size_iter + input.size() + 1,
                          offsets->mutable_view().begin<size_type>());
@@ -376,8 +377,11 @@ std::unique_ptr<column> percentile_approx(tdigest_column_view const& input,
       detail::size_begin(tdv),
       cuda::proclaim_return_type<size_type>(
         [] __device__(size_type tdigest_size) -> size_type { return tdigest_size == 0; }));
-    auto const null_count = thrust::reduce(
-      rmm::exec_policy_nosync(stream), tdigest_is_empty, tdigest_is_empty + tdv.size(), 0);
+    auto const null_count =
+      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     tdigest_is_empty,
+                     tdigest_is_empty + tdv.size(),
+                     0);
     if (null_count == 0) {
       return std::pair<rmm::device_buffer, size_type>{rmm::device_buffer{}, null_count};
     }

--- a/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
+++ b/cpp/src/quantiles/tdigest/tdigest_aggregation.cu
@@ -652,7 +652,7 @@ size_t compute_simple_cluster_count(int delta,
   // worst-case sizes
   auto iter = cuda::counting_iterator<cudf::size_type>{0};
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     iter,
     iter + num_groups,
     group_num_clusters.begin(),
@@ -665,8 +665,9 @@ size_t compute_simple_cluster_count(int delta,
     }));
 
   // total size
-  return thrust::reduce(
-    rmm::exec_policy_nosync(stream), group_num_clusters.begin(), group_num_clusters.end());
+  return thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        group_num_clusters.begin(),
+                        group_num_clusters.end());
 }
 
 /**
@@ -683,7 +684,7 @@ void compute_cluster_starts(cluster_info& cinfo, rmm::cuda_stream_view stream)
       [group_num_clusters = cinfo.num_clusters.begin(), num_groups] __device__(size_type index) {
         return index == num_groups ? 0 : group_num_clusters[index];
       }));
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          cluster_size,
                          cluster_size + num_groups + 1,
                          cinfo.cluster_start.begin(),
@@ -827,8 +828,9 @@ cluster_info generate_group_cluster_info(int delta,
   // Note: group_cluster_start does not need to be updated.
   cinfo.total_clusters =
     (simple_mem_usage <= max_simple_cluster_usage)
-      ? thrust::reduce(
-          rmm::exec_policy_nosync(stream), cinfo.num_clusters.begin(), cinfo.num_clusters.end())
+      ? thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       cinfo.num_clusters.begin(),
+                       cinfo.num_clusters.end())
       : allocated_clusters;
 
   stream.synchronize();
@@ -860,7 +862,9 @@ std::unique_ptr<column> build_output_column(size_type num_rows,
     if (!has_nulls) { return 0; }
     auto iter = cudf::detail::make_counting_transform_iterator(
       0, cuda::proclaim_return_type<size_type>(is_stub_digest));
-    return thrust::reduce(rmm::exec_policy_nosync(stream), iter, iter + num_rows);
+    return thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                          iter,
+                          iter + num_rows);
   }();
 
   // if there are no stub tdigests, we can return immediately.
@@ -879,7 +883,7 @@ std::unique_ptr<column> build_output_column(size_type num_rows,
   auto remove_stubs = [&](column_view const& col, size_type num_stubs) {
     auto result = cudf::make_numeric_column(
       data_type{type_id::FLOAT64}, col.size() - num_stubs, mask_state::UNALLOCATED, stream, mr);
-    thrust::remove_copy_if(rmm::exec_policy_nosync(stream),
+    thrust::remove_copy_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            col.begin<double>(),
                            col.end<double>(),
                            cuda::counting_iterator<cudf::size_type>{0},
@@ -894,7 +898,7 @@ std::unique_ptr<column> build_output_column(size_type num_rows,
   // adjust offsets.
   rmm::device_uvector<size_type> sizes(num_rows, stream);
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator<cudf::size_type>{0} + num_rows,
     sizes.begin(),
@@ -906,7 +910,7 @@ std::unique_ptr<column> build_output_column(size_type num_rows,
       [sizes = sizes.begin(), is_stub_digest, num_rows] __device__(size_type i) {
         return i == num_rows || is_stub_digest(i) ? 0 : sizes[i];
       }));
-  thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          iter,
                          iter + num_rows + 1,
                          offsets->mutable_view().begin<size_type>(),
@@ -1042,7 +1046,7 @@ std::unique_ptr<column> compute_tdigests(int delta,
     mean_col.begin<double>(), weight_col.begin<double>(), cuda::make_discard_iterator()));
 
   auto const num_values = std::distance(centroids_begin, centroids_end);
-  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         keys,
                         keys + num_values,              // keys
                         centroids_begin,                // values
@@ -1163,7 +1167,7 @@ struct typed_group_tdigest {
     auto max_col = cudf::make_numeric_column(
       data_type{type_id::FLOAT64}, num_groups, mask_state::UNALLOCATED, stream, mr);
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<cudf::size_type>{0},
       cuda::counting_iterator<cudf::size_type>{0} + num_groups,
       thrust::make_zip_iterator(cuda::std::make_tuple(min_col->mutable_view().begin<double>(),
@@ -1242,7 +1246,7 @@ struct typed_reduce_tdigest {
     auto max_col = cudf::make_numeric_column(
       data_type{type_id::FLOAT64}, 1, mask_state::UNALLOCATED, stream, mr);
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<cudf::size_type>{0},
       cuda::counting_iterator<cudf::size_type>{0} + 1,
       thrust::make_zip_iterator(cuda::std::make_tuple(min_col->mutable_view().begin<double>(),
@@ -1440,7 +1444,7 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
     thrust::make_transform_iterator(thrust::make_zip_iterator(cuda::std::make_tuple(
                                       tdv.min_begin(), cudf::tdigest::detail::size_begin(tdv))),
                                     tdigest_min{});
-  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         group_labels,
                         group_labels + num_group_labels,
                         min_iter,
@@ -1455,7 +1459,7 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
     thrust::make_transform_iterator(thrust::make_zip_iterator(cuda::std::make_tuple(
                                       tdv.max_begin(), cudf::tdigest::detail::size_begin(tdv))),
                                     tdigest_max{});
-  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         group_labels,
                         group_labels + num_group_labels,
                         max_iter,
@@ -1472,13 +1476,13 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
     0,
     group_num_clusters_func<decltype(group_offsets)>{group_offsets,
                                                      tdigest_offsets.begin<size_type>()});
-  thrust::replace_if(rmm::exec_policy_nosync(stream),
+  thrust::replace_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      merged_min_col->mutable_view().begin<double>(),
                      merged_min_col->mutable_view().end<double>(),
                      group_num_clusters,
                      group_is_empty{},
                      0);
-  thrust::replace_if(rmm::exec_policy_nosync(stream),
+  thrust::replace_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      merged_max_col->mutable_view().begin<double>(),
                      merged_max_col->mutable_view().end<double>(),
                      group_num_clusters,
@@ -1499,17 +1503,18 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
   // generate group keys for all centroids in the entire column
   rmm::device_uvector<size_type> group_keys(num_centroids, stream, temp_mr);
   auto iter = cuda::counting_iterator<cudf::size_type>{0};
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     iter,
                     iter + num_centroids,
                     group_keys.begin(),
                     group_key_func<decltype(group_labels)>{
                       group_labels, tdigest_offsets.begin<size_type>(), tdigest_offsets.size()});
-  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                group_keys.begin(),
-                                group_keys.begin() + num_centroids,
-                                merged_weights.begin(),
-                                cumulative_weights.begin());
+  thrust::inclusive_scan_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    group_keys.begin(),
+    group_keys.begin() + num_centroids,
+    merged_weights.begin(),
+    cumulative_weights.begin());
 
   auto const delta = max_centroids;
 
@@ -1525,7 +1530,7 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
       auto pinned_mr = cudf::get_pinned_memory_resource();
 
       rmm::device_uvector<size_type> _p_group_offsets(num_groups + 1, stream, pinned_mr);
-      thrust::copy(rmm::exec_policy_nosync(stream),
+      thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    group_offsets,
                    group_offsets + _p_group_offsets.size(),
                    _p_group_offsets.begin());
@@ -1534,13 +1539,13 @@ std::unique_ptr<column> merge_tdigests(tdigest_column_view const& tdv,
       rmm::device_uvector<double> p_cumulative_weights(cumulative_weights, stream, pinned_mr);
 
       rmm::device_uvector<size_type> p_tdigest_offsets(tdigest_offsets.size(), stream, pinned_mr);
-      thrust::copy(rmm::exec_policy_nosync(stream),
+      thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    tdigest_offsets.begin<size_type>(),
                    tdigest_offsets.begin<size_type>() + p_tdigest_offsets.size(),
                    p_tdigest_offsets.begin());
 
       rmm::device_uvector<size_type> _p_group_labels(num_group_labels, stream, pinned_mr);
-      thrust::copy(rmm::exec_policy_nosync(stream),
+      thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    group_labels,
                    group_labels + num_group_labels,
                    _p_group_labels.begin());

--- a/cpp/src/reductions/all.cu
+++ b/cpp/src/reductions/all.cu
@@ -58,7 +58,7 @@ struct all_fn {
     }();
     auto d_result =
       cudf::detail::device_scalar<int32_t>(1, stream, cudf::get_current_device_resource_ref());
-    thrust::for_each_n(rmm::exec_policy_nosync(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        cuda::counting_iterator<size_type>{0},
                        input.size(),
                        all_true_fn<decltype(iter)>{iter, d_result.data()});

--- a/cpp/src/reductions/any.cu
+++ b/cpp/src/reductions/any.cu
@@ -58,7 +58,7 @@ struct any_fn {
     }();
     auto d_result =
       cudf::detail::device_scalar<int32_t>(0, stream, cudf::get_current_device_resource_ref());
-    thrust::for_each_n(rmm::exec_policy_nosync(stream),
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        cuda::counting_iterator<size_type>{0},
                        input.size(),
                        any_true_fn<decltype(iter)>{iter, d_result.data()});

--- a/cpp/src/reductions/distinct_count.cu
+++ b/cpp/src/reductions/distinct_count.cu
@@ -101,7 +101,7 @@ struct has_nans {
   {
     auto input_device_view = cudf::column_device_view::create(input, stream);
     auto device_view       = *input_device_view;
-    return thrust::any_of(rmm::exec_policy_nosync(stream),
+    return thrust::any_of(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           cuda::counting_iterator<cudf::size_type>{0},
                           cuda::counting_iterator<cudf::size_type>{input.size()},
                           check_for_nan<T>(device_view));

--- a/cpp/src/reductions/extrema_utils.cuh
+++ b/cpp/src/reductions/extrema_utils.cuh
@@ -65,10 +65,16 @@ class arg_minmax_dispatcher {
     auto const pos = [&] {
       if constexpr (K == aggregation::ARGMIN) {
         return thrust::min_element(
-          rmm::exec_policy_nosync(stream), it, it + size, std::forward<Args>(args)...);
+          rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+          it,
+          it + size,
+          std::forward<Args>(args)...);
       } else {
         return thrust::max_element(
-          rmm::exec_policy_nosync(stream), it, it + size, std::forward<Args>(args)...);
+          rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+          it,
+          it + size,
+          std::forward<Args>(args)...);
       }
     }();
     return static_cast<size_type>(cuda::std::distance(it, pos));

--- a/cpp/src/reductions/histogram.cu
+++ b/cpp/src/reductions/histogram.cu
@@ -133,10 +133,11 @@ compute_row_frequencies(table_view const& input,
 
   // Construct a vector to store reduced counts and init to zero
   rmm::device_uvector<histogram_count_type> reduction_results(num_rows, stream, mr);
-  thrust::uninitialized_fill(rmm::exec_policy_nosync(stream),
-                             reduction_results.begin(),
-                             reduction_results.end(),
-                             histogram_count_type{0});
+  thrust::uninitialized_fill(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    reduction_results.begin(),
+    reduction_results.end(),
+    histogram_count_type{0});
 
   // Construct a hash set
   auto row_set =
@@ -156,7 +157,7 @@ compute_row_frequencies(table_view const& input,
   // Compute frequencies (aka distinct counts) for the input rows.
   // Note that we consider null and NaNs as always equal.
   thrust::for_each(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<std::size_t>{0},
     cuda::counting_iterator<std::size_t>{num_rows},
     [set_ref = row_set_ref,

--- a/cpp/src/reductions/nth_element.cu
+++ b/cpp/src/reductions/nth_element.cu
@@ -41,13 +41,16 @@ std::unique_ptr<cudf::scalar> nth_element(column_view const& col,
                                       }));
     rmm::device_uvector<size_type> null_skipped_index(col.size(), stream);
     // null skipped index for valids only.
-    thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            bitmask_iterator,
                            bitmask_iterator + col.size(),
                            null_skipped_index.begin());
 
-    auto n_pos = thrust::upper_bound(
-      rmm::exec_policy_nosync(stream), null_skipped_index.begin(), null_skipped_index.end(), n);
+    auto n_pos =
+      thrust::upper_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                          null_skipped_index.begin(),
+                          null_skipped_index.end(),
+                          n);
     auto null_skipped_n = n_pos - null_skipped_index.begin();
     return cudf::detail::get_element(col, null_skipped_n, stream, mr);
   } else {

--- a/cpp/src/reductions/scan/ewm.cu
+++ b/cpp/src/reductions/scan/ewm.cu
@@ -141,11 +141,12 @@ rmm::device_uvector<cudf::size_type> null_roll_up(column_view const& input,
     cuda::proclaim_return_type<int>([] __device__(int valid) -> int { return 1 - valid; }));
 
   // valid mask {1, 0, 1, 0, 0, 1} leads to output array {0, 0, 1, 0, 1, 2}
-  thrust::inclusive_scan_by_key(rmm::exec_policy_nosync(stream),
-                                invalid_it,
-                                invalid_it + input.size() - 1,
-                                invalid_it,
-                                std::next(output.begin()));
+  thrust::inclusive_scan_by_key(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    invalid_it,
+    invalid_it + input.size() - 1,
+    invalid_it,
+    std::next(output.begin()));
   return output;
 }
 
@@ -165,49 +166,53 @@ rmm::device_uvector<T> compute_ewma_adjust(column_view const& input,
     auto data =
       thrust::make_zip_iterator(cuda::std::make_tuple(valid_it, nullcnt.begin(), input.begin<T>()));
 
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     data,
-                                     data + input.size(),
-                                     pairs.begin(),
-                                     ewma_adjust_nulls_functor<T, true>{beta},
-                                     recurrence_functor<T>{});
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      data,
+      data + input.size(),
+      pairs.begin(),
+      ewma_adjust_nulls_functor<T, true>{beta},
+      recurrence_functor<T>{});
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       pairs.begin(),
                       pairs.end(),
                       output.begin(),
                       [] __device__(pair_type<T> pair) -> T { return pair.second; });
 
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     data,
-                                     data + input.size(),
-                                     pairs.begin(),
-                                     ewma_adjust_nulls_functor<T, false>{beta},
-                                     recurrence_functor<T>{});
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      data,
+      data + input.size(),
+      pairs.begin(),
+      ewma_adjust_nulls_functor<T, false>{beta},
+      recurrence_functor<T>{});
 
   } else {
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     input.begin<T>(),
-                                     input.end<T>(),
-                                     pairs.begin(),
-                                     ewma_adjust_no_nulls_functor<T, true>{beta},
-                                     recurrence_functor<T>{});
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      input.begin<T>(),
+      input.end<T>(),
+      pairs.begin(),
+      ewma_adjust_no_nulls_functor<T, true>{beta},
+      recurrence_functor<T>{});
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       pairs.begin(),
                       pairs.end(),
                       output.begin(),
                       [] __device__(pair_type<T> pair) -> T { return pair.second; });
     auto itr = cuda::counting_iterator<size_type>{0};
 
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     itr,
-                                     itr + input.size(),
-                                     pairs.begin(),
-                                     ewma_adjust_no_nulls_functor<T, false>{beta},
-                                     recurrence_functor<T>{});
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      itr,
+      itr + input.size(),
+      pairs.begin(),
+      ewma_adjust_no_nulls_functor<T, false>{beta},
+      recurrence_functor<T>{});
   }
 
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     pairs.begin(),
     pairs.end(),
     output.begin(),
@@ -239,12 +244,13 @@ rmm::device_uvector<T> compute_ewma_noadjust(column_view const& input,
   if (!input.has_nulls()) {
     auto data = thrust::make_zip_iterator(
       cuda::std::make_tuple(input.begin<T>(), cuda::counting_iterator<size_type>{0}));
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     data,
-                                     data + input.size(),
-                                     pairs.begin(),
-                                     ewma_noadjust_no_nulls_functor<T>{beta},
-                                     recurrence_functor<T>{});
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      data,
+      data + input.size(),
+      pairs.begin(),
+      ewma_noadjust_no_nulls_functor<T>{beta},
+      recurrence_functor<T>{});
 
   } else {
     auto device_view = column_device_view::create(input, stream);
@@ -253,16 +259,17 @@ rmm::device_uvector<T> compute_ewma_noadjust(column_view const& input,
     auto data = thrust::make_zip_iterator(cuda::std::make_tuple(
       input.begin<T>(), cuda::counting_iterator<size_type>{0}, valid_it, nullcnt.begin()));
 
-    thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                     data,
-                                     data + input.size(),
-                                     pairs.begin(),
-                                     ewma_noadjust_nulls_functor<T>{beta},
-                                     recurrence_functor<T>());
+    thrust::transform_inclusive_scan(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      data,
+      data + input.size(),
+      pairs.begin(),
+      ewma_noadjust_nulls_functor<T>{beta},
+      recurrence_functor<T>());
   }
 
   // copy the second elements to the output for now
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     pairs.begin(),
                     pairs.end(),
                     output.begin(),

--- a/cpp/src/reductions/scan/rank_scan.cu
+++ b/cpp/src/reductions/scan/rank_scan.cu
@@ -67,7 +67,7 @@ std::unique_ptr<column> rank_generator(column_view const& order_by,
   auto mutable_ranks = ranks->mutable_view();
 
   auto const comparator_helper = [&](auto const device_comparator) {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>(0),
                       cuda::counting_iterator<size_type>(order_by.size()),
                       mutable_ranks.begin<size_type>(),
@@ -85,7 +85,7 @@ std::unique_ptr<column> rank_generator(column_view const& order_by,
     comparator_helper(device_comparator);
   }
 
-  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          mutable_ranks.begin<size_type>(),
                          mutable_ranks.end<size_type>(),
                          mutable_ranks.begin<size_type>(),
@@ -133,7 +133,7 @@ std::unique_ptr<column> inclusive_one_normalized_percent_rank_scan(
   auto percent_rank_result = cudf::make_fixed_width_column(
     data_type{type_to_id<result_type>()}, rank_view.size(), mask_state::UNALLOCATED, stream, mr);
 
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     rank_view.begin<size_type>(),
                     rank_view.end<size_type>(),
                     percent_rank_result->mutable_view().begin<result_type>(),

--- a/cpp/src/reductions/scan/scan_exclusive.cu
+++ b/cpp/src/reductions/scan/scan_exclusive.cu
@@ -60,7 +60,7 @@ struct scan_dispatcher {
 
     // CUB 2.0.0 requires that the binary operator returns the same type as the identity.
     auto const binary_op = cudf::detail::cast_functor<T>(Op{});
-    thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            begin,
                            begin + input.size(),
                            output.data<T>(),

--- a/cpp/src/reductions/scan/scan_inclusive.cu
+++ b/cpp/src/reductions/scan/scan_inclusive.cu
@@ -44,11 +44,12 @@ std::pair<rmm::device_buffer, size_type> mask_scan(column_view const& input_view
   auto valid_itr = detail::make_validity_iterator(*d_input);
 
   auto first_null_position = [&] {
-    size_type const first_null = thrust::find_if_not(rmm::exec_policy_nosync(stream),
-                                                     valid_itr,
-                                                     valid_itr + input_view.size(),
-                                                     cuda::std::identity{}) -
-                                 valid_itr;
+    size_type const first_null =
+      thrust::find_if_not(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                          valid_itr,
+                          valid_itr + input_view.size(),
+                          cuda::std::identity{}) -
+      valid_itr;
     size_type const exclusive_offset = (inclusive == scan_type::EXCLUSIVE) ? 1 : 0;
     return std::min(input_view.size(), first_null + exclusive_offset);
   }();
@@ -78,7 +79,7 @@ struct scan_functor {
 
     // CUB 2.0.0 requires that the binary operator returns the same type as the identity.
     auto const binary_op = cudf::detail::cast_functor<T>(Op{});
-    thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            begin,
                            begin + input_view.size(),
                            result.data<T>(),
@@ -133,8 +134,10 @@ struct scan_functor<Op, T> {
         return static_cast<size_type>(mask == nullptr || bit_is_set(mask, idx));
       }));
 
-    thrust::inclusive_scan(
-      rmm::exec_policy_nosync(stream), begin, begin + input_view.size(), result.data<size_type>());
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           begin,
+                           begin + input_view.size(),
+                           result.data<size_type>());
 
     CUDF_CHECK_CUDA(stream.value());
     return output_column;

--- a/cpp/src/reductions/segmented/counts.cu
+++ b/cpp/src/reductions/segmented/counts.cu
@@ -35,7 +35,10 @@ rmm::device_uvector<size_type> segmented_counts(bitmask_type const* null_mask,
 
   rmm::device_uvector<size_type> valid_counts(num_segments, stream, mr);
   thrust::adjacent_difference(
-    rmm::exec_policy_nosync(stream), offsets.begin() + 1, offsets.end(), valid_counts.begin());
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    offsets.begin() + 1,
+    offsets.end(),
+    valid_counts.begin());
   return valid_counts;
 }
 

--- a/cpp/src/reductions/segmented/nunique.cu
+++ b/cpp/src/reductions/segmented/nunique.cu
@@ -64,7 +64,7 @@ std::unique_ptr<cudf::column> segmented_nunique(column_view const& col,
       *d_col, row_equal, null_handling, offsets.data(), labels.data()};
 
     auto identifiers = rmm::device_uvector<size_type>(col.size(), stream);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{col.size()},
                       identifiers.begin(),

--- a/cpp/src/reductions/segmented/simple.cuh
+++ b/cpp/src/reductions/segmented/simple.cuh
@@ -235,17 +235,18 @@ std::unique_ptr<column> fixed_point_segmented_reduction(
                                                   stream,
                                                   cudf::get_current_device_resource_ref());
 
-      auto const max_count = thrust::reduce(rmm::exec_policy_nosync(stream),
-                                            counts.begin(),
-                                            counts.end(),
-                                            size_type{0},
-                                            cuda::maximum<size_type>{});
+      auto const max_count =
+        thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       counts.begin(),
+                       counts.end(),
+                       size_type{0},
+                       cuda::maximum<size_type>{});
 
       auto const new_scale = numeric::scale_type{col.type().scale() * max_count};
 
       // adjust values in each segment to match the new scale
       auto const d_col = column_device_view::create(col, stream);
-      thrust::transform(rmm::exec_policy_nosync(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         d_col->begin<InputType>(),
                         d_col->end<InputType>(),
                         d_col->begin<InputType>(),

--- a/cpp/src/reductions/simple.cuh
+++ b/cpp/src/reductions/simple.cuh
@@ -312,12 +312,13 @@ struct same_element_type_dispatcher {
     // We will do reduction to find the ARGMIN/ARGMAX index, then return the element at that index.
     auto const binop_generator =
       cudf::reduction::detail::arg_minmax_binop_generator::create<Op>(input, stream);
-    auto const binary_op  = cudf::detail::cast_functor<size_type>(binop_generator.binop());
-    auto const minmax_idx = thrust::reduce(rmm::exec_policy_nosync(stream),
-                                           cuda::counting_iterator<cudf::size_type>{0},
-                                           cuda::counting_iterator{input.size()},
-                                           size_type{0},
-                                           binary_op);
+    auto const binary_op = cudf::detail::cast_functor<size_type>(binop_generator.binop());
+    auto const minmax_idx =
+      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     cuda::counting_iterator<cudf::size_type>{0},
+                     cuda::counting_iterator{input.size()},
+                     size_type{0},
+                     binary_op);
 
     return cudf::detail::get_element(input, minmax_idx, stream, mr);
   }

--- a/cpp/src/reductions/sum_with_overflow.cu
+++ b/cpp/src/reductions/sum_with_overflow.cu
@@ -138,21 +138,23 @@ std::unique_ptr<cudf::scalar> sum_with_overflow(
 
   if (col.has_nulls()) {
     // Use null-aware transform functor
-    result = thrust::transform_reduce(rmm::exec_policy_nosync(stream),
-                                      counting_iter,
-                                      counting_iter + col.size(),
-                                      null_aware_to_sum_overflow{dcol_ptr},
-                                      initial_value,
-                                      overflow_sum_op{});
+    result = thrust::transform_reduce(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      counting_iter,
+      counting_iter + col.size(),
+      null_aware_to_sum_overflow{dcol_ptr},
+      initial_value,
+      overflow_sum_op{});
   } else {
     // Use direct iterator for non-null case
     auto input_iter = dcol->begin<int64_t>();
-    result          = thrust::transform_reduce(rmm::exec_policy_nosync(stream),
-                                      input_iter,
-                                      input_iter + col.size(),
-                                      to_sum_overflow{},
-                                      initial_value,
-                                      overflow_sum_op{});
+    result          = thrust::transform_reduce(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      input_iter,
+      input_iter + col.size(),
+      to_sum_overflow{},
+      initial_value,
+      overflow_sum_op{});
   }
 
   // Create result struct scalar with {sum: int64_t, overflow: bool}

--- a/cpp/src/reductions/unique_count.cu
+++ b/cpp/src/reductions/unique_count.cu
@@ -33,21 +33,24 @@ cudf::size_type unique_count(table_view const& keys,
     // the comparator speeds up compile-time significantly without much degradation in
     // runtime performance over using the comparator directly in thrust::count_if.
     auto d_results = rmm::device_uvector<bool>(keys.num_rows(), stream);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{keys.num_rows()},
                       d_results.begin(),
                       [comp] __device__(auto i) { return (i == 0 or not comp(i, i - 1)); });
 
     return static_cast<size_type>(
-      thrust::count(rmm::exec_policy_nosync(stream), d_results.begin(), d_results.end(), true));
+      thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    d_results.begin(),
+                    d_results.end(),
+                    true));
   } else {
     auto const comp =
       row_comp.equal_to<false>(nullate::DYNAMIC{has_nested_nulls(keys)}, nulls_equal);
     // Using thrust::copy_if with the comparator directly will compile more slowly but
     // improves runtime by up to 2x over the transform/count approach above.
     return thrust::count_if(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::counting_iterator<cudf::size_type>{0},
       cuda::counting_iterator<cudf::size_type>{keys.num_rows()},
       [comp] __device__(cudf::size_type i) { return (i == 0 or not comp(i, i - 1)); });

--- a/cpp/src/reductions/unique_count_column.cu
+++ b/cpp/src/reductions/unique_count_column.cu
@@ -68,7 +68,7 @@ cudf::size_type unique_count(column_view const& input,
     cudf::detail::row::equality::nan_equal_physical_equality_comparator{});
 
   return thrust::count_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator<cudf::size_type>{num_rows},
     [count_nulls, nan_is_null, should_check_nan, device_view, comp] __device__(cudf::size_type i) {

--- a/cpp/src/replace/clamp.cu
+++ b/cpp/src/replace/clamp.cu
@@ -88,7 +88,7 @@ std::unique_ptr<cudf::column> clamp_string_column(strings_column_view const& inp
   auto fn = clamp_strings_fn<OptionalScalarIterator, ReplaceScalarIterator>{
     d_input, lo_itr, lo_replace_itr, hi_itr, hi_replace_itr};
   rmm::device_uvector<cudf::strings::detail::string_index_pair> indices(input.size(), stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     indices.begin(),
@@ -170,7 +170,7 @@ std::unique_ptr<cudf::column> clamp_dictionary_column(dictionary_column_view con
 
   auto fn = clamp_dictionary_fn<T, OptionalIterator, ReplaceIterator>{
     *d_input, lo_itr, lo_index_itr, hi_itr, hi_index_itr};
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     indices_itr,
@@ -226,7 +226,7 @@ std::unique_ptr<cudf::column> clamper(column_view const& input,
 
   auto input_pair_iterator =
     make_optional_iterator<T>(*input_device_view, nullate::DYNAMIC{input.has_nulls()});
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     input_pair_iterator,
                     input_pair_iterator + input.size(),
                     scalar_zip_itr,

--- a/cpp/src/replace/nans.cu
+++ b/cpp/src/replace/nans.cu
@@ -147,7 +147,7 @@ struct normalize_nans_and_zeros_kernel_forwarder {
                   rmm::cuda_stream_view stream)
     requires(std::is_floating_point_v<T>)
   {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<cudf::size_type>{0},
                       cuda::counting_iterator{in.size()},
                       out.head<T>(),

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -217,7 +217,7 @@ struct replace_nulls_scalar_kernel_forwarder {
     auto device_in   = cudf::column_device_view::create(input, stream);
 
     auto func = replace_nulls_functor<col_type>{s1.data()};
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       input.data<col_type>(),
                       input.data<col_type>() + input.size(),
                       cudf::detail::make_validity_iterator(*device_in),
@@ -281,13 +281,19 @@ std::unique_ptr<cudf::column> replace_nulls_policy_impl(cudf::column_view const&
 
   auto func = cudf::detail::replace_policy_functor();
   if (replace_policy == cudf::replace_policy::PRECEDING) {
-    thrust::inclusive_scan(
-      rmm::exec_policy_nosync(stream), in_begin, in_begin + input.size(), gm_begin, func);
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           in_begin,
+                           in_begin + input.size(),
+                           gm_begin,
+                           func);
   } else {
     auto in_rbegin = cuda::std::make_reverse_iterator(in_begin + input.size());
     auto gm_rbegin = cuda::std::make_reverse_iterator(gm_begin + gather_map.size());
-    thrust::inclusive_scan(
-      rmm::exec_policy_nosync(stream), in_rbegin, in_rbegin + input.size(), gm_rbegin, func);
+    thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                           in_rbegin,
+                           in_rbegin + input.size(),
+                           gm_rbegin,
+                           func);
   }
 
   auto output = cudf::detail::gather(cudf::table_view({input}),

--- a/cpp/src/rolling/detail/lead_lag_nested.cuh
+++ b/cpp/src/rolling/detail/lead_lag_nested.cuh
@@ -133,7 +133,7 @@ std::unique_ptr<column> compute_lead_lag_for_nested(aggregation::Kind op,
   auto const input_size = input.size();
   auto const null_index = input.size();
   if (op == aggregation::LEAD) {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       gather_map.begin<size_type>(),
@@ -142,7 +142,7 @@ std::unique_ptr<column> compute_lead_lag_for_nested(aggregation::Kind op,
                           return (row_offset > following[i]) ? null_index : (i + row_offset);
                         }));
   } else {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       gather_map.begin<size_type>(),

--- a/cpp/src/rolling/detail/nth_element.cuh
+++ b/cpp/src/rolling/detail/nth_element.cuh
@@ -147,8 +147,10 @@ std::unique_ptr<column> nth_element(size_type n,
       n, input, preceding, following, min_periods, stream});
 
   auto gather_map = rmm::device_uvector<size_type>(input.size(), stream);
-  thrust::copy(
-    rmm::exec_policy_nosync(stream), gather_iter, gather_iter + input.size(), gather_map.begin());
+  thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+               gather_iter,
+               gather_iter + input.size(),
+               gather_map.begin());
 
   auto gathered = cudf::detail::gather(table_view{{input}},
                                        gather_map,

--- a/cpp/src/rolling/detail/range_utils.cuh
+++ b/cpp/src/rolling/detail/range_utils.cuh
@@ -456,7 +456,7 @@ struct range_window_clamper {
                         mutable_column_view& result,
                         rmm::cuda_stream_view stream) const
   {
-    thrust::copy_n(rmm::exec_policy_nosync(stream),
+    thrust::copy_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cudf::detail::make_counting_transform_iterator(
                      0, unbounded_distance_functor{grouping, direction}),
                    size,
@@ -472,7 +472,7 @@ struct range_window_clamper {
                           mutable_column_view& result,
                           rmm::cuda_stream_view stream) const
   {
-    thrust::copy_n(rmm::exec_policy_nosync(stream),
+    thrust::copy_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cudf::detail::make_counting_transform_iterator(
                      0, current_row_distance_functor{grouping, direction, order, begin}),
                    size,
@@ -489,7 +489,7 @@ struct range_window_clamper {
                       mutable_column_view& result,
                       rmm::cuda_stream_view stream) const
   {
-    thrust::copy_n(rmm::exec_policy_nosync(stream),
+    thrust::copy_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cudf::detail::make_counting_transform_iterator(
                      0,
                      bounded_distance_functor<Grouping, OrderbyT, DeltaT, WindowType>{

--- a/cpp/src/rolling/detail/rolling_collect_list.cu
+++ b/cpp/src/rolling/detail/rolling_collect_list.cu
@@ -50,10 +50,13 @@ std::unique_ptr<column> get_list_child_to_list_row_mapping(cudf::column_view con
                                                  stream,
                                                  cudf::get_current_device_resource_ref());
   auto per_row_mapping_begin = per_row_mapping->mutable_view().template begin<size_type>();
-  thrust::fill_n(rmm::exec_policy_nosync(stream), per_row_mapping_begin, num_child_rows, 0);
+  thrust::fill_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                 per_row_mapping_begin,
+                 num_child_rows,
+                 0);
 
   auto const begin = cuda::counting_iterator<size_type>{0};
-  thrust::scatter_if(rmm::exec_policy_nosync(stream),
+  thrust::scatter_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      begin,
                      begin + offsets.size() - 1,
                      offsets.begin<size_type>(),
@@ -71,7 +74,7 @@ std::unique_ptr<column> get_list_child_to_list_row_mapping(cudf::column_view con
   // For the case with an empty list at index 2:
   //   scatter result == [0, 0, 1, 0, 0, 3, 0, 0, 4, 0, 0, 5, 0]
   //   inclusive_scan == [0, 0, 1, 1, 1, 3, 3, 3, 4, 4, 4, 5, 5]
-  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          per_row_mapping_begin,
                          per_row_mapping_begin + num_child_rows,
                          per_row_mapping_begin,
@@ -134,7 +137,7 @@ std::pair<std::unique_ptr<column>, std::unique_ptr<column>> purge_null_entries(
                                            stream,
                                            cudf::get_current_device_resource_ref());
 
-  thrust::tabulate(rmm::exec_policy_nosync(stream),
+  thrust::tabulate(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    new_sizes->mutable_view().template begin<size_type>(),
                    new_sizes->mutable_view().template end<size_type>(),
                    [d_gather_map  = gather_map.template begin<size_type>(),

--- a/cpp/src/rolling/detail/rolling_collect_list.cuh
+++ b/cpp/src/rolling/detail/rolling_collect_list.cuh
@@ -61,7 +61,7 @@ std::unique_ptr<column> create_collect_offsets(size_type input_size,
   // But if min_periods=3, rows at indices 0 and 4 have too few observations, and must return
   // null. The sizes at these positions must be 0, i.e.
   //  prec + foll = [0,3,3,3,0]
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     preceding_begin,
                     preceding_begin + input_size,
                     following_begin,
@@ -110,7 +110,7 @@ std::unique_ptr<column> create_collect_gather_map(column_view const& child_offse
                                             stream,
                                             cudf::get_current_device_resource_ref());
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     cuda::counting_iterator<size_type>{per_row_mapping.size()},
     gather_map->mutable_view().template begin<size_type>(),

--- a/cpp/src/rolling/grouped_rolling.cu
+++ b/cpp/src/rolling/grouped_rolling.cu
@@ -307,11 +307,12 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
           return nulls_per_group[i] < (d_offsets[i + 1] - d_offsets[i]) &&
                  d_orderby.is_null_nocheck(d_offsets[i]);
         }));
-    auto is_before = thrust::reduce(rmm::exec_policy_nosync(stream),
-                                    it,
-                                    it + offsets.size() - 1,
-                                    false,
-                                    cuda::std::logical_or<>{});
+    auto is_before =
+      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     it,
+                     it + offsets.size() - 1,
+                     false,
+                     cuda::std::logical_or<>{});
     return is_before ? null_order::BEFORE : null_order::AFTER;
   } else {
     // Sort order is DESCENDING
@@ -328,11 +329,12 @@ std::unique_ptr<table> grouped_range_rolling_window(table_view const& group_keys
           return nulls_per_group[i] < (d_offsets[i + 1] - d_offsets[i]) &&
                  d_orderby.is_null_nocheck(d_offsets[i + 1] - 1);
         }));
-    auto is_before = thrust::reduce(rmm::exec_policy_nosync(stream),
-                                    it,
-                                    it + offsets.size() - 1,
-                                    false,
-                                    cuda::std::logical_or<>{});
+    auto is_before =
+      thrust::reduce(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     it,
+                     it + offsets.size() - 1,
+                     false,
+                     cuda::std::logical_or<>{});
     return is_before ? null_order::BEFORE : null_order::AFTER;
   }
 }

--- a/cpp/src/search/contains_scalar.cu
+++ b/cpp/src/search/contains_scalar.cu
@@ -116,7 +116,7 @@ struct contains_scalar_dispatch {
     // runtime performance over using the comparator in a transform iterator with thrust::count_if.
     auto d_results = rmm::device_uvector<bool>(haystack.size(), stream);
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       begin,
       end,
       d_results.begin(),
@@ -127,8 +127,10 @@ struct contains_scalar_dispatch {
         return d_comp(idx, rhs_index_type{0});  // compare haystack[idx] == needle[0].
       });
 
-    return thrust::count(
-             rmm::exec_policy_nosync(stream), d_results.begin(), d_results.end(), true) > 0;
+    return thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                         d_results.begin(),
+                         d_results.end(),
+                         true) > 0;
   }
 };
 

--- a/cpp/src/search/search_ordered.cu
+++ b/cpp/src/search/search_ordered.cu
@@ -67,7 +67,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
   if (cudf::detail::has_nested_columns(haystack) || cudf::detail::has_nested_columns(needles)) {
     auto const d_comparator = comparator.less<true>(nullate::DYNAMIC{has_nulls});
     if (find_first) {
-      thrust::lower_bound(rmm::exec_policy_nosync(stream),
+      thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           haystack_it,
                           haystack_it + haystack.num_rows(),
                           needles_it,
@@ -75,7 +75,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
                           out_it,
                           d_comparator);
     } else {
-      thrust::upper_bound(rmm::exec_policy_nosync(stream),
+      thrust::upper_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           haystack_it,
                           haystack_it + haystack.num_rows(),
                           needles_it,
@@ -86,7 +86,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
   } else {
     auto const d_comparator = comparator.less<false>(nullate::DYNAMIC{has_nulls});
     if (find_first) {
-      thrust::lower_bound(rmm::exec_policy_nosync(stream),
+      thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           haystack_it,
                           haystack_it + haystack.num_rows(),
                           needles_it,
@@ -94,7 +94,7 @@ std::unique_ptr<column> search_ordered(table_view const& haystack,
                           out_it,
                           d_comparator);
     } else {
-      thrust::upper_bound(rmm::exec_policy_nosync(stream),
+      thrust::upper_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           haystack_it,
                           haystack_it + haystack.num_rows(),
                           needles_it,

--- a/cpp/src/sort/is_sorted.cu
+++ b/cpp/src/sort/is_sorted.cu
@@ -39,7 +39,7 @@ bool is_sorted(cudf::table_view const& in,
     // the comparator speeds up compile-time significantly over using the comparator directly
     // in thrust::is_sorted.
     auto d_results = rmm::device_uvector<bool>(in.num_rows(), stream);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{in.num_rows()},
                       d_results.begin(),
@@ -47,15 +47,18 @@ bool is_sorted(cudf::table_view const& in,
                         return (idx == 0) || device_comparator(idx - 1, idx);
                       });
 
-    return thrust::count(
-             rmm::exec_policy_nosync(stream), d_results.begin(), d_results.end(), false) == 0;
+    return thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                         d_results.begin(),
+                         d_results.end(),
+                         false) == 0;
   } else {
     auto const device_comparator = comparator.less<false>(has_nested_nulls(in));
 
-    return thrust::is_sorted(rmm::exec_policy_nosync(stream),
-                             cuda::counting_iterator<size_type>{0},
-                             cuda::counting_iterator<size_type>{in.num_rows()},
-                             device_comparator);
+    return thrust::is_sorted(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      cuda::counting_iterator<size_type>{0},
+      cuda::counting_iterator<size_type>{in.num_rows()},
+      device_comparator);
   }
 }
 

--- a/cpp/src/sort/rank.cu
+++ b/cpp/src/sort/rank.cu
@@ -71,7 +71,7 @@ rmm::device_uvector<size_type> sorted_dense_rank(column_view input_col,
   rmm::device_uvector<size_type> dense_rank_sorted(input_size, stream);
 
   auto const comparator_helper = [&](auto const device_comparator) {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<cudf::size_type>{0},
                       cuda::counting_iterator{input_size},
                       dense_rank_sorted.data(),
@@ -89,7 +89,7 @@ rmm::device_uvector<size_type> sorted_dense_rank(column_view input_col,
     comparator_helper(device_comparator);
   }
 
-  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          dense_rank_sorted.begin(),
                          dense_rank_sorted.end(),
                          dense_rank_sorted.data());
@@ -127,7 +127,7 @@ void tie_break_ranks_transform(cudf::device_span<size_type const> dense_rank_sor
   // algorithm: reduce_by_key(dense_rank, 1, n, reduction_tie_breaker)
   // reduction_tie_breaker = min, max, min_count
   rmm::device_uvector<TieType> tie_sorted(sorted_order_view.size(), stream);
-  thrust::reduce_by_key(rmm::exec_policy_nosync(stream),
+  thrust::reduce_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         dense_rank_sorted.begin(),
                         dense_rank_sorted.end(),
                         tie_iter,
@@ -143,7 +143,7 @@ void tie_break_ranks_transform(cudf::device_span<size_type const> dense_rank_sor
       [tied_rank = tie_sorted.begin(), transformer] __device__(auto dense_pos) {
         return transformer(tied_rank[dense_pos - 1]);
       }));
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   sorted_tied_rank,
                   sorted_tied_rank + input_size,
                   sorted_order_view.begin<size_type>(),
@@ -156,7 +156,7 @@ void rank_first(column_view sorted_order_view,
                 rmm::cuda_stream_view stream)
 {
   // stable sort order ranking (no ties)
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   cuda::counting_iterator<size_type>{1},
                   cuda::counting_iterator<size_type>{rank_mutable_view.size() + 1},
                   sorted_order_view.begin<size_type>(),
@@ -170,7 +170,7 @@ void rank_dense(cudf::device_span<size_type const> dense_rank_sorted,
                 rmm::cuda_stream_view stream)
 {
   // All equal values have same rank and rank always increases by 1 between groups
-  thrust::scatter(rmm::exec_policy_nosync(stream),
+  thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   dense_rank_sorted.begin(),
                   dense_rank_sorted.end(),
                   sorted_order_view.begin<size_type>(),
@@ -342,7 +342,7 @@ std::unique_ptr<column> rank(column_view const& input,
     auto drs            = dense_rank_sorted.data();
     bool const is_dense = (method == rank_method::DENSE);
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       rank_iter,
       rank_iter + input.size(),
       rank_iter,

--- a/cpp/src/sort/segmented_sort.cu
+++ b/cpp/src/sort/segmented_sort.cu
@@ -29,7 +29,7 @@ rmm::device_uvector<size_type> get_segment_indices(size_type num_rows,
   auto offset_begin  = offsets.begin<size_type>();
   auto offset_end    = offsets.end<size_type>();
   auto counting_iter = cuda::counting_iterator<size_type>{0};
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     counting_iter,
                     counting_iter + segment_ids.size(),
                     segment_ids.begin(),

--- a/cpp/src/sort/segmented_top_k.cu
+++ b/cpp/src/sort/segmented_top_k.cu
@@ -105,8 +105,11 @@ std::unique_ptr<column> segmented_top_k_order(column_view const& col,
     size_data_type, total_elements, mask_state::UNALLOCATED, stream, mr);
   auto d_result = result->mutable_view().begin<size_type>();
   // remove the indices marked by resolve_segment_indices
-  thrust::remove_copy(
-    rmm::exec_policy_nosync(stream), d_indices, d_indices + indices->size(), d_result, -1);
+  thrust::remove_copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      d_indices,
+                      d_indices + indices->size(),
+                      d_result,
+                      -1);
 
   auto const num_rows = static_cast<size_type>(offsets->size() - 1);
   return make_lists_column(

--- a/cpp/src/sort/sort_column_impl.cuh
+++ b/cpp/src/sort/sort_column_impl.cuh
@@ -137,8 +137,11 @@ struct column_sorted_order_fn {
     auto itr = cudf::detail::indexalator_factory::make_input_iterator(
       dictionary_column_view(input).indices());
     auto mapped_indices = rmm::device_uvector<size_type>(input.size(), stream);
-    thrust::gather(
-      rmm::exec_policy_nosync(stream), itr, itr + input.size(), map, mapped_indices.begin());
+    thrust::gather(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   itr,
+                   itr + input.size(),
+                   map,
+                   mapped_indices.begin());
 
     // Finally, sort-order the dictionary indices using mapped values
     auto mapped_view = column_view(data_type{type_to_id<size_type>()},

--- a/cpp/src/sort/sort_impl.cuh
+++ b/cpp/src/sort/sort_impl.cuh
@@ -61,7 +61,7 @@ std::unique_ptr<column> sorted_order(table_view input,
   std::unique_ptr<column> sorted_indices = cudf::make_numeric_column(
     data_type(type_to_id<size_type>()), input.num_rows(), mask_state::UNALLOCATED, stream, mr);
   mutable_column_view mutable_indices_view = sorted_indices->mutable_view();
-  thrust::sequence(rmm::exec_policy_nosync(stream),
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    mutable_indices_view.begin<size_type>(),
                    mutable_indices_view.end<size_type>(),
                    0);
@@ -70,12 +70,12 @@ std::unique_ptr<column> sorted_order(table_view input,
     // Compiling `thrust::*sort*` APIs is expensive.
     // Thus, we should optimize that by using constexpr condition to only compile what we need.
     if constexpr (method == sort_method::STABLE) {
-      thrust::stable_sort(rmm::exec_policy_nosync(stream),
+      thrust::stable_sort(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           mutable_indices_view.begin<size_type>(),
                           mutable_indices_view.end<size_type>(),
                           comparator);
     } else {
-      thrust::sort(rmm::exec_policy_nosync(stream),
+      thrust::sort(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    mutable_indices_view.begin<size_type>(),
                    mutable_indices_view.end<size_type>(),
                    comparator);

--- a/cpp/src/sort/sort_radix.cu
+++ b/cpp/src/sort/sort_radix.cu
@@ -86,7 +86,7 @@ struct sort_radix_fn {
     auto pair_out = rmm::device_uvector<float_pair<T>>(input.size(), stream);
     auto d_out    = pair_out.begin();
 
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       d_in,
@@ -111,7 +111,7 @@ struct sort_radix_fn {
       cub::DeviceRadixSort::SortKeysDescending(
         tmp_stg.data(), tmp_bytes, d_in, d_out, n, decomposer, 0, end_bit, sv);
     }
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       d_out,
                       d_out + input.size(),
                       output.begin<T>(),

--- a/cpp/src/sort/sorted_order_radix.cu
+++ b/cpp/src/sort/sorted_order_radix.cu
@@ -68,7 +68,10 @@ struct sorted_order_radix_fn {
     auto output = rmm::device_uvector<T>(input.size(), stream);
     auto d_out  = output.begin();  // not returned
     auto seqs   = rmm::device_uvector<cudf::size_type>(input.size(), stream);
-    thrust::sequence(rmm::exec_policy_nosync(stream), seqs.begin(), seqs.end(), 0);
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     seqs.begin(),
+                     seqs.end(),
+                     0);
     auto dv_in  = seqs.begin();
     auto dv_out = indices.begin<cudf::size_type>();
 
@@ -107,7 +110,7 @@ struct sorted_order_radix_fn {
     auto dv_out   = indices.begin<cudf::size_type>();
 
     auto zip_out = thrust::make_zip_iterator(d_in, dv_in);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       zip_out,

--- a/cpp/src/stream_compaction/distinct_helpers.cu
+++ b/cpp/src/stream_compaction/distinct_helpers.cu
@@ -33,14 +33,15 @@ rmm::device_uvector<size_type> reduce_by_row(distinct_set_t<RowEqual>& set,
   }
 
   auto reduction_results = rmm::device_uvector<size_type>(num_rows, stream, mr);
-  thrust::uninitialized_fill(rmm::exec_policy_nosync(stream),
-                             reduction_results.begin(),
-                             reduction_results.end(),
-                             reduction_init_value(keep));
+  thrust::uninitialized_fill(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    reduction_results.begin(),
+    reduction_results.end(),
+    reduction_init_value(keep));
 
   auto set_ref = set.ref(cuco::op::insert_and_find);
 
-  thrust::for_each(rmm::exec_policy_nosync(stream),
+  thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                    cuda::counting_iterator<cudf::size_type>{0},
                    cuda::counting_iterator{num_rows},
                    [set_ref, keep, reduction_results = reduction_results.begin()] __device__(

--- a/cpp/src/stream_compaction/stable_distinct.cu
+++ b/cpp/src/stream_compaction/stable_distinct.cu
@@ -47,9 +47,12 @@ std::unique_ptr<table> stable_distinct(table_view const& input,
   auto const output_markers = [&] {
     auto markers = rmm::device_uvector<bool>(input.num_rows(), stream);
     thrust::uninitialized_fill(
-      rmm::exec_policy_nosync(stream), markers.begin(), markers.end(), false);
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      markers.begin(),
+      markers.end(),
+      false);
     thrust::scatter(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       cuda::constant_iterator<bool>(true, 0),
       cuda::constant_iterator<bool>(true, static_cast<size_type>(distinct_indices.size())),
       distinct_indices.begin(),

--- a/cpp/src/stream_compaction/unique.cu
+++ b/cpp/src/stream_compaction/unique.cu
@@ -67,7 +67,7 @@ std::unique_ptr<table> unique(table_view const& input,
       auto d_results = rmm::device_uvector<bool>(num_rows, stream);
       auto itr       = cuda::counting_iterator<size_type>{0};
       thrust::transform(
-        rmm::exec_policy_nosync(stream),
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
         itr,
         itr + num_rows,
         d_results.begin(),

--- a/cpp/src/strings/attributes.cu
+++ b/cpp/src/strings/attributes.cu
@@ -80,7 +80,7 @@ std::unique_ptr<column> counts_fn(strings_column_view const& strings,
   auto strings_column = cudf::column_device_view::create(strings.parent(), stream);
   auto d_strings      = *strings_column;
   // fill in the lengths
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator<cudf::size_type>{strings.size()},
                     d_lengths,
@@ -219,7 +219,7 @@ std::unique_ptr<column> code_points(strings_column_view const& input,
   // create offsets vector to account for each string's character length
   rmm::device_uvector<size_type> offsets(input.size() + 1, stream);
   thrust::transform_inclusive_scan(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     cuda::counting_iterator<size_type>{input.size()},
     offsets.begin() + 1,
@@ -241,7 +241,7 @@ std::unique_ptr<column> code_points(strings_column_view const& input,
   // fill column with character code-point values
   auto d_results = results_view.data<int32_t>();
   // now set the ranges from each strings' character values
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      input.size(),
                      code_points_fn{d_column, offsets.data(), d_results});

--- a/cpp/src/strings/capitalize.cu
+++ b/cpp/src/strings/capitalize.cu
@@ -359,7 +359,7 @@ std::unique_ptr<column> is_title(strings_column_view const& input,
                                      stream,
                                      mr);
   auto d_column = column_device_view::create(input.parent(), stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     results->mutable_view().data<bool>(),

--- a/cpp/src/strings/case.cu
+++ b/cpp/src/strings/case.cu
@@ -461,7 +461,7 @@ std::unique_ptr<column> convert_case(strings_column_view const& input,
   {
     rmm::device_uvector<int64_t> sub_offsets(sub_count, stream);
     auto const count_itr = cuda::counting_iterator<int64_t>{0};
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       count_itr,
                       count_itr + sub_count,
                       sub_offsets.data(),
@@ -470,7 +470,7 @@ std::unique_ptr<column> convert_case(strings_column_view const& input,
     // merge them with input offsets
     auto input_offsets =
       cudf::detail::offsetalator_factory::make_input_iterator(input.offsets(), input.offset());
-    thrust::merge(rmm::exec_policy_nosync(stream),
+    thrust::merge(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   input_offsets,
                   input_offsets + input.size() + 1,
                   sub_offsets.begin(),

--- a/cpp/src/strings/char_types/char_types.cu
+++ b/cpp/src/strings/char_types/char_types.cu
@@ -93,7 +93,7 @@ std::unique_ptr<column> all_characters_of_type(strings_column_view const& input,
   auto d_flags = detail::get_character_flags_table(stream);
 
   // set the output values by checking the character types for each string
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     results->mutable_view().data<bool>(),

--- a/cpp/src/strings/convert/convert_booleans.cu
+++ b/cpp/src/strings/convert/convert_booleans.cu
@@ -51,7 +51,7 @@ std::unique_ptr<column> to_booleans(strings_column_view const& input,
   auto results_view = results->mutable_view();
   auto d_results    = results_view.data<bool>();
 
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{strings_count},
                     d_results,

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -408,7 +408,7 @@ struct dispatch_to_timestamps_fn {
   {
     format_compiler compiler(format, stream);
     parse_datetime<T> pfn{d_strings, compiler.format_items(), compiler.subsecond_precision()};
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{results_view.size()},
                       results_view.data<T>(),
@@ -688,7 +688,7 @@ std::unique_ptr<cudf::column> is_timestamp(strings_column_view const& input,
   auto d_results = results->mutable_view().data<bool>();
 
   format_compiler compiler(format, stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{strings_count},
                     d_results,

--- a/cpp/src/strings/convert/convert_durations.cu
+++ b/cpp/src/strings/convert/convert_durations.cu
@@ -651,7 +651,7 @@ struct dispatch_to_durations_fn {
     auto d_items   = compiler.compiled_format_items();
     auto d_results = results_view.data<T>();
     parse_duration<T> pfn{d_strings, d_items, compiler.items_count()};
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{results_view.size()},
                       d_results,

--- a/cpp/src/strings/convert/convert_fixed_point.cu
+++ b/cpp/src/strings/convert/convert_fixed_point.cu
@@ -137,7 +137,7 @@ struct dispatch_to_fixed_point_fn {
     auto d_results = results->mutable_view().data<DecimalType>();
 
     // convert strings into decimal values
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       d_results,
@@ -301,7 +301,7 @@ struct dispatch_is_fixed_point_fn {
     auto d_results = results->mutable_view().data<bool>();
 
     // check strings for valid fixed-point chars
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       d_results,

--- a/cpp/src/strings/convert/convert_floats.cu
+++ b/cpp/src/strings/convert/convert_floats.cu
@@ -63,7 +63,7 @@ struct dispatch_to_floats_fn {
     requires(std::is_floating_point_v<FloatType>)
   {
     auto d_results = output_column.data<FloatType>();
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{strings_column.size()},
                       d_results,
@@ -457,7 +457,7 @@ std::unique_ptr<column> is_float(strings_column_view const& input,
                                      mr);
   auto d_results = results->mutable_view().data<bool>();
   // check strings for valid float chars
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     d_results,

--- a/cpp/src/strings/convert/convert_hex.cu
+++ b/cpp/src/strings/convert/convert_hex.cu
@@ -90,7 +90,7 @@ struct dispatch_hex_to_integers_fn {
     requires(cudf::is_integral_not_bool<IntegerType>())
   {
     auto d_results = output_column.data<IntegerType>();
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{strings_column.size()},
                       d_results,
@@ -230,7 +230,7 @@ std::unique_ptr<column> is_hex(strings_column_view const& strings,
                                      stream,
                                      mr);
   auto d_results = results->mutable_view().data<bool>();
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{strings.size()},
                     d_results,

--- a/cpp/src/strings/convert/convert_integers.cu
+++ b/cpp/src/strings/convert/convert_integers.cu
@@ -117,13 +117,13 @@ struct dispatch_is_integer_fn {
 
     auto d_results = results->mutable_view().data<bool>();
     if (input.has_nulls()) {
-      thrust::transform(rmm::exec_policy_nosync(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         d_column->pair_begin<string_view, true>(),
                         d_column->pair_end<string_view, true>(),
                         d_results,
                         string_to_integer_check_fn<T>{});
     } else {
-      thrust::transform(rmm::exec_policy_nosync(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         d_column->pair_begin<string_view, false>(),
                         d_column->pair_end<string_view, false>(),
                         d_results,
@@ -163,13 +163,13 @@ std::unique_ptr<column> is_integer(strings_column_view const& input,
   auto d_results = results->mutable_view().data<bool>();
   if (input.has_nulls()) {
     thrust::transform(
-      rmm::exec_policy_nosync(stream),
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
       d_column->pair_begin<string_view, true>(),
       d_column->pair_end<string_view, true>(),
       d_results,
       [] __device__(auto const& p) { return p.second ? is_integer(p.first) : false; });
   } else {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       d_column->pair_begin<string_view, false>(),
                       d_column->pair_end<string_view, false>(),
                       d_results,
@@ -243,7 +243,7 @@ struct dispatch_to_integers_fn {
                   rmm::cuda_stream_view stream) const
     requires(cudf::is_integral_not_bool<IntegerType>())
   {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{strings_column.size()},
                       output_column.data<IntegerType>(),

--- a/cpp/src/strings/convert/convert_ipv4.cu
+++ b/cpp/src/strings/convert/convert_ipv4.cu
@@ -81,7 +81,7 @@ std::unique_ptr<column> ipv4_to_integers(strings_column_view const& input,
                                      mr);
   auto d_results = results->mutable_view().data<uint32_t>();
   // fill output column with ipv4 integers
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{strings_count},
                     d_results,
@@ -181,7 +181,7 @@ std::unique_ptr<column> is_ipv4(strings_column_view const& input,
                                      stream,
                                      mr);
   auto d_results = results->mutable_view().data<bool>();
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     d_results,

--- a/cpp/src/strings/convert/int_cast.cu
+++ b/cpp/src/strings/convert/int_cast.cu
@@ -95,7 +95,7 @@ std::unique_ptr<column> cast_to_integer(strings_column_view const& input,
   auto d_results = mutable_column_device_view::create(*results, stream);
 
   auto const type_size = static_cast<size_type>(cudf::size_of(output_type));
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      input.size(),
                      cast_to_integer_fn{*d_strings, *d_results, swap, type_size});
@@ -213,20 +213,20 @@ std::optional<cudf::data_type> integer_cast_type(strings_column_view const& inpu
   if (input.size() == 0) { return std::nullopt; }
   auto d_strings = column_device_view::create(input.parent(), stream);
 
-  auto bits_size =
-    thrust::transform_reduce(rmm::exec_policy_nosync(stream),
-                             cuda::counting_iterator<size_type>{0},
-                             cuda::counting_iterator<size_type>{input.size()},
-                             cuda::proclaim_return_type<size_type>(
-                               [d_strings = *d_strings] __device__(size_type idx) -> size_type {
-                                 if (d_strings.is_null(idx)) { return 0; }
-                                 auto const d_str  = d_strings.element<string_view>(idx);
-                                 auto const bits   = d_str.size_bytes() * CHAR_BIT;
-                                 u_char first_byte = bits > 0 ? d_str.data()[0] : 0;
-                                 return bits - ((first_byte & 0x80) == 0);
-                               }),
-                             size_type{0},
-                             cuda::maximum<size_type>{});
+  auto bits_size = thrust::transform_reduce(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    cuda::counting_iterator<size_type>{0},
+    cuda::counting_iterator<size_type>{input.size()},
+    cuda::proclaim_return_type<size_type>(
+      [d_strings = *d_strings] __device__(size_type idx) -> size_type {
+        if (d_strings.is_null(idx)) { return 0; }
+        auto const d_str  = d_strings.element<string_view>(idx);
+        auto const bits   = d_str.size_bytes() * CHAR_BIT;
+        u_char first_byte = bits > 0 ? d_str.data()[0] : 0;
+        return bits - ((first_byte & 0x80) == 0);
+      }),
+    size_type{0},
+    cuda::maximum<size_type>{});
 
   if (bits_size <= 8) { return data_type{type_id::INT8}; }
   if (bits_size <= 16) {

--- a/cpp/src/strings/copying/concatenate.cu
+++ b/cpp/src/strings/copying/concatenate.cu
@@ -87,12 +87,13 @@ auto create_strings_device_views(host_span<column_view const> views, rmm::cuda_s
   auto d_partition_offsets = rmm::device_uvector<size_t>(views.size() + 1, stream);
   d_partition_offsets.set_element_to_zero_async(0, stream);  // zero first element
 
-  thrust::transform_inclusive_scan(rmm::exec_policy_nosync(stream),
-                                   device_views_ptr,
-                                   device_views_ptr + views.size(),
-                                   std::next(d_partition_offsets.begin()),
-                                   chars_size_transform{},
-                                   cuda::std::plus{});
+  thrust::transform_inclusive_scan(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    device_views_ptr,
+    device_views_ptr + views.size(),
+    std::next(d_partition_offsets.begin()),
+    chars_size_transform{},
+    cuda::std::plus{});
   auto const output_chars_size = d_partition_offsets.back_element(stream);
   stream.synchronize();  // ensure copy of output_chars_size is complete before returning
 

--- a/cpp/src/strings/copying/copy_range.cu
+++ b/cpp/src/strings/copying/copy_range.cu
@@ -91,7 +91,7 @@ std::unique_ptr<column> copy_range(strings_column_view const& source,
   auto chars_data = rmm::device_uvector<char>(chars_bytes, stream, mr);
   auto d_chars    = chars_data.data();
   thrust::for_each(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     cuda::counting_iterator{target.size()},
     [d_source, d_target, source_begin, target_begin, target_end, d_offsets, d_chars] __device__(

--- a/cpp/src/strings/copying/copying.cu
+++ b/cpp/src/strings/copying/copying.cu
@@ -49,7 +49,7 @@ std::unique_ptr<cudf::column> copy_slice(strings_column_view const& input,
       cudf::detail::offsetalator_factory::make_output_iterator(offsets_column->mutable_view());
     auto input_offsets =
       cudf::detail::offsetalator_factory::make_input_iterator(input.offsets(), offsets_offset);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       input_offsets,
                       input_offsets + offsets_column->size(),
                       d_offsets,

--- a/cpp/src/strings/copying/shift.cu
+++ b/cpp/src/strings/copying/shift.cu
@@ -108,7 +108,7 @@ std::unique_ptr<column> shift(strings_column_view const& input,
   auto d_chars = chars.data();
 
   // run kernel to shift all the characters
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<int64_t>{0},
                     cuda::counting_iterator<int64_t>{total_bytes},
                     d_chars,

--- a/cpp/src/strings/filling/fill.cu
+++ b/cpp/src/strings/filling/fill.cu
@@ -63,7 +63,7 @@ std::unique_ptr<column> fill(strings_column_view const& input,
 
   auto fn = fill_fn{*d_strings, begin, end, d_value};
   rmm::device_uvector<string_index_pair> indices(strings_count, stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{strings_count},
                     indices.begin(),

--- a/cpp/src/strings/like.cu
+++ b/cpp/src/strings/like.cu
@@ -323,7 +323,7 @@ std::unique_ptr<column> like(strings_column_view const& input,
   if ((input.size() == input.null_count()) ||
       ((last_offset - first_offset) / (input.size() - input.null_count())) <
         AVG_CHAR_BYTES_THRESHOLD) {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       results->mutable_view().data<bool>(),

--- a/cpp/src/strings/merge/merge.cu
+++ b/cpp/src/strings/merge/merge.cu
@@ -38,7 +38,7 @@ std::unique_ptr<column> merge(strings_column_view const& lhs,
 
   // build vector of strings
   rmm::device_uvector<string_index_pair> indices(strings_count, stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{strings_count},
                     indices.begin(),

--- a/cpp/src/strings/positions.cu
+++ b/cpp/src/strings/positions.cu
@@ -31,7 +31,7 @@ std::unique_ptr<column> create_offsets_from_positions(strings_column_view const&
 
   // first, create a vector of string indices for each position
   auto indices = rmm::device_uvector<size_type>(positions.size(), stream);
-  thrust::upper_bound(rmm::exec_policy_nosync(stream),
+  thrust::upper_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       d_offsets,
                       d_offsets + input.size(),
                       positions.begin(),
@@ -41,13 +41,17 @@ std::unique_ptr<column> create_offsets_from_positions(strings_column_view const&
   // compute position offsets per string
   auto counts = rmm::device_uvector<size_type>(input.size(), stream);
   // memset to zero-out the counts for any null-entries or strings with no positions
-  thrust::uninitialized_fill(rmm::exec_policy_nosync(stream), counts.begin(), counts.end(), 0);
+  thrust::uninitialized_fill(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    counts.begin(),
+    counts.end(),
+    0);
 
   // next, count the number of positions per string
   auto d_counts  = counts.data();
   auto d_indices = indices.data();
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<int64_t>{0},
     positions.size(),
     [d_indices, d_counts] __device__(int64_t idx) {

--- a/cpp/src/strings/repeat_strings.cu
+++ b/cpp/src/strings/repeat_strings.cu
@@ -50,7 +50,7 @@ std::unique_ptr<string_scalar> repeat_string(string_scalar const& input,
   auto buff           = rmm::device_buffer(repeat_times * input.size(), stream, mr);
 
   // Pull data from the input string into each byte of the output string.
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     iter,
                     iter + repeat_times * str_size,
                     static_cast<char*>(buff.data()),

--- a/cpp/src/strings/replace/find_replace.cu
+++ b/cpp/src/strings/replace/find_replace.cu
@@ -64,7 +64,7 @@ std::unique_ptr<cudf::column> find_and_replace_all(
 
   auto indices = rmm::device_uvector<string_index_pair>(input.size(), stream);
 
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     indices.begin(),

--- a/cpp/src/strings/replace/multi.cu
+++ b/cpp/src/strings/replace/multi.cu
@@ -363,7 +363,7 @@ std::unique_ptr<column> replace_character_parallel(strings_column_view const& in
 
   // compute the number of string segments produced by replace in each string
   auto counts = rmm::device_uvector<size_type>(strings_count, stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{strings_count},
                     counts.begin(),
@@ -385,7 +385,7 @@ std::unique_ptr<column> replace_character_parallel(strings_column_view const& in
   auto d_indices = indices.data();
   auto d_sizes   = counts.data();  // reusing this vector to hold output sizes now
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     strings_count,
     [fn,

--- a/cpp/src/strings/replace/replace.cu
+++ b/cpp/src/strings/replace/replace.cu
@@ -311,7 +311,7 @@ std::unique_ptr<column> replace_character_parallel(strings_column_view const& in
 
   // compute the number of string segments produced by replace in each string
   auto counts = rmm::device_uvector<size_type>(strings_count, stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{strings_count},
                     counts.begin(),
@@ -331,7 +331,7 @@ std::unique_ptr<column> replace_character_parallel(strings_column_view const& in
   auto d_indices = indices.data();
   auto d_sizes   = counts.data();  // reusing this vector to hold output sizes now
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     strings_count,
     [fn, d_strings_offsets, d_positions, d_targets_offsets, d_indices, d_sizes] __device__(

--- a/cpp/src/strings/replace/replace_nulls.cu
+++ b/cpp/src/strings/replace/replace_nulls.cu
@@ -54,7 +54,7 @@ std::unique_ptr<column> replace_nulls(strings_column_view const& input,
   // build chars column
   rmm::device_uvector<char> chars(bytes, stream, mr);
   auto d_chars = chars.data();
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      strings_count,
                      [d_strings, d_repl, d_offsets, d_chars] __device__(size_type idx) {

--- a/cpp/src/strings/reverse.cu
+++ b/cpp/src/strings/reverse.cu
@@ -61,7 +61,7 @@ std::unique_ptr<column> reverse(strings_column_view const& input,
   auto d_chars         = result->mutable_view().head<char>();
 
   auto const d_column = column_device_view::create(input.parent(), stream);
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      input.size(),
                      reverse_characters_fn{*d_column, d_offsets, d_chars});

--- a/cpp/src/strings/scan/scan_inclusive.cu
+++ b/cpp/src/strings/scan/scan_inclusive.cu
@@ -78,7 +78,7 @@ std::unique_ptr<column> scan_inclusive(column_view const& input,
 
   // build indices of the scan operation results
   rmm::device_uvector<size_type> result_map(input.size(), stream);
-  thrust::inclusive_scan(rmm::exec_policy_nosync(stream),
+  thrust::inclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                          cuda::counting_iterator<size_type>{0},
                          cuda::counting_iterator<size_type>{input.size()},
                          result_map.begin(),
@@ -89,7 +89,7 @@ std::unique_ptr<column> scan_inclusive(column_view const& input,
     // this prevents un-sanitized null entries in the output
     auto null_itr = cudf::detail::make_counting_transform_iterator(0, null_iterator{mask});
     auto oob_val  = cuda::constant_iterator<size_type>(input.size());
-    thrust::scatter_if(rmm::exec_policy_nosync(stream),
+    thrust::scatter_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        oob_val,
                        oob_val + input.size(),
                        cuda::counting_iterator<size_type>{0},

--- a/cpp/src/strings/search/contains_multiple.cu
+++ b/cpp/src/strings/search/contains_multiple.cu
@@ -216,9 +216,14 @@ std::unique_ptr<table> contains_multiple(strings_column_view const& input,
 
   // remove duplicates to help speed up lower_bound
   auto offsets = rmm::device_uvector<size_type>(targets.size(), stream);
-  thrust::sequence(rmm::exec_policy_nosync(stream), offsets.begin(), offsets.end());
-  auto const end = thrust::unique_by_key(
-    rmm::exec_policy_nosync(stream), first_bytes.begin(), first_bytes.end(), offsets.begin());
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   offsets.begin(),
+                   offsets.end());
+  auto const end =
+    thrust::unique_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                          first_bytes.begin(),
+                          first_bytes.end(),
+                          offsets.begin());
   auto const unique_count =
     static_cast<size_type>(cuda::std::distance(first_bytes.begin(), end.first));
 

--- a/cpp/src/strings/search/find.cu
+++ b/cpp/src/strings/search/find.cu
@@ -178,7 +178,7 @@ void find_utility(strings_column_view const& input,
         *d_strings, target_itr, start, stop, d_results);
   } else {
     // string-per-thread function
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       d_results,
@@ -214,7 +214,7 @@ std::unique_ptr<column> find_fn(strings_column_view const& input,
   if (d_target.empty()) {
     auto d_strings = column_device_view::create(input.parent(), stream);
     auto d_results = results->mutable_view().data<size_type>();
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       d_results,
@@ -384,8 +384,10 @@ std::unique_ptr<column> contains_warp_parallel(strings_column_view const& input,
   // fill the output with `false` unless the `d_target` is empty
   auto results_view = results->mutable_view();
   if (d_target.empty()) {
-    thrust::fill(
-      rmm::exec_policy_nosync(stream), results_view.begin<bool>(), results_view.end<bool>(), true);
+    thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                 results_view.begin<bool>(),
+                 results_view.end<bool>(),
+                 true);
   } else {
     // launch warp per string
     auto const d_strings                   = column_device_view::create(input.parent(), stream);
@@ -448,7 +450,7 @@ std::unique_ptr<column> contains_fn(strings_column_view const& strings,
   auto results_view = results->mutable_view();
   auto d_results    = results_view.data<bool>();
   // set the bool values by evaluating the passed function
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{strings_count},
                     d_results,
@@ -502,7 +504,7 @@ std::unique_ptr<column> contains_fn(strings_column_view const& strings,
   auto d_results    = results_view.data<bool>();
   // set the bool values by evaluating the passed function
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     cuda::counting_iterator<size_type>{strings.size()},
     d_results,

--- a/cpp/src/strings/search/find_multiple.cu
+++ b/cpp/src/strings/search/find_multiple.cu
@@ -54,7 +54,7 @@ std::unique_ptr<column> find_multiple(strings_column_view const& input,
     data_type{type_id::INT32}, total_count, rmm::device_buffer{0, stream, mr}, 0, stream, mr);
 
   // fill output column with position values
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{total_count},
                     results->mutable_view().begin<int32_t>(),

--- a/cpp/src/strings/slice.cu
+++ b/cpp/src/strings/slice.cu
@@ -248,7 +248,7 @@ std::unique_ptr<column> compute_substrings_from_fn(strings_column_view const& in
   auto const d_column = column_device_view::create(input.parent(), stream);
 
   if ((input.chars_size(stream) / (input.size() - input.null_count())) < AVG_CHAR_BYTES_THRESHOLD) {
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       cuda::counting_iterator<size_type>{0},
                       cuda::counting_iterator<size_type>{input.size()},
                       results.begin(),

--- a/cpp/src/strings/split/partition.cu
+++ b/cpp/src/strings/split/partition.cu
@@ -188,7 +188,7 @@ std::unique_ptr<table> partition(strings_column_view const& strings,
   partition_fn partitioner(
     *strings_column, d_delimiter, left_indices, delim_indices, right_indices);
 
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      strings_count,
                      partitioner);
@@ -214,7 +214,7 @@ std::unique_ptr<table> rpartition(strings_column_view const& strings,
   auto right_indices = rmm::device_uvector<string_index_pair>(strings_count, stream);
   rpartition_fn partitioner(
     *strings_column, d_delimiter, left_indices, delim_indices, right_indices);
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      strings_count,
                      partitioner);

--- a/cpp/src/strings/split/split.cu
+++ b/cpp/src/strings/split/split.cu
@@ -158,7 +158,7 @@ std::unique_ptr<table> split_fn(strings_column_view const& input,
 
   // compute the maximum number of tokens for any string
   auto const columns_count = thrust::transform_reduce(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     cuda::counting_iterator<size_type>{input.size()},
     cuda::proclaim_return_type<size_type>([d_offsets] __device__(auto idx) -> size_type {

--- a/cpp/src/strings/split/split.cuh
+++ b/cpp/src/strings/split/split.cuh
@@ -548,7 +548,7 @@ std::pair<std::unique_ptr<column>, rmm::device_uvector<string_index_pair>> split
   auto d_positions     = delimiter_positions.data();
   auto const zero_iter = cuda::counting_iterator<size_type>{0};
   thrust::transform(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     zero_iter,
     zero_iter + input.size(),
     token_counts.begin(),
@@ -570,7 +570,10 @@ std::pair<std::unique_ptr<column>, rmm::device_uvector<string_index_pair>> split
       size_type idx) {
       tokenizer.get_tokens(idx, d_tokens_offsets, d_positions, d_delimiter_offsets, d_tokens);
     };
-  thrust::for_each_n(rmm::exec_policy_nosync(stream), zero_iter, input.size(), get_tokens_fn);
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     zero_iter,
+                     input.size(),
+                     get_tokens_fn);
 
   return std::make_pair(std::move(offsets), std::move(tokens));
 }

--- a/cpp/src/strings/split/split_part.cu
+++ b/cpp/src/strings/split/split_part.cu
@@ -80,7 +80,7 @@ std::unique_ptr<column> split_part_fn(strings_column_view const& input,
 
   // get just the indexed value of each element
   auto d_indices = rmm::device_uvector<string_index_pair>(input.size(), stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     d_indices.begin(),

--- a/cpp/src/strings/split/split_re.cu
+++ b/cpp/src/strings/split/split_re.cu
@@ -208,7 +208,7 @@ std::unique_ptr<table> split_re(strings_column_view const& input,
 
   // the output column count is the maximum number of tokens generated for any input string
   auto const columns_count = thrust::transform_reduce(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<size_type>{0},
     cuda::counting_iterator<size_type>{strings_count},
     cuda::proclaim_return_type<size_type>([d_offsets] __device__(auto const idx) -> size_type {

--- a/cpp/src/strings/strings_column_factories.cu
+++ b/cpp/src/strings/strings_column_factories.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -55,7 +55,7 @@ make_offsets_child_column_batch_async(std::vector<column_string_pairs> const& in
     auto const d_offsets = offsets->mutable_view().template data<OutputType>();
     auto const output_it = cudf::detail::make_sizes_to_offsets_iterator(
       d_offsets, d_offsets + string_count + 1, chars_sizes.data() + idx);
-    thrust::exclusive_scan(rmm::exec_policy_nosync(stream),
+    thrust::exclusive_scan(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                            input_it,
                            input_it + string_count + 1,
                            output_it,
@@ -83,7 +83,10 @@ std::vector<std::unique_ptr<column>> make_strings_column_batch(
 
   rmm::device_uvector<size_type> d_valid_counts(num_columns, stream, mr);
   thrust::uninitialized_fill(
-    rmm::exec_policy_nosync(stream), d_valid_counts.begin(), d_valid_counts.end(), 0);
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    d_valid_counts.begin(),
+    d_valid_counts.end(),
+    0);
 
   for (std::size_t idx = 0; idx < num_columns; ++idx) {
     auto const& string_pairs = input[idx];

--- a/cpp/src/strings/strip.cu
+++ b/cpp/src/strings/strip.cu
@@ -62,7 +62,7 @@ std::unique_ptr<column> strip(strings_column_view const& input,
   auto const d_column = column_device_view::create(input.parent(), stream);
 
   auto result = rmm::device_uvector<string_index_pair>(input.size(), stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     result.begin(),

--- a/cpp/src/strings/utilities.cu
+++ b/cpp/src/strings/utilities.cu
@@ -42,7 +42,7 @@ rmm::device_uvector<string_view> create_string_vector_from_column(
 
   auto strings_vector = rmm::device_uvector<string_view>(input.size(), stream, mr);
 
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<size_type>{0},
                     cuda::counting_iterator<size_type>{input.size()},
                     strings_vector.begin(),

--- a/cpp/src/strings/wrap.cu
+++ b/cpp/src/strings/wrap.cu
@@ -112,7 +112,7 @@ std::unique_ptr<column> wrap(strings_column_view const& strings,
 
   device_execute_functor d_execute_fctr{d_column, d_new_offsets, d_chars, width};
 
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<size_type>{0},
                      strings_count,
                      d_execute_fctr);

--- a/cpp/src/text/bpe/byte_pair_encoding.cu
+++ b/cpp/src/text/bpe/byte_pair_encoding.cu
@@ -369,16 +369,23 @@ std::unique_ptr<cudf::column> byte_pair_encoding(cudf::strings_column_view const
     auto const mp_map = get_bpe_merge_pairs_impl(merge_pairs)->get_mp_table_ref();  // lookup table
     auto const d_chars_span = cudf::device_span<char const>(d_input_chars, chars_size);
     auto up_fn = bpe_unpairable_offsets_fn<decltype(mp_map)>{d_chars_span, first_offset, mp_map};
-    thrust::transform(rmm::exec_policy_nosync(stream), chars_begin, chars_end, d_up_offsets, up_fn);
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      chars_begin,
+                      chars_end,
+                      d_up_offsets,
+                      up_fn);
     auto const up_end =  // remove all but the unpairable offsets
-      thrust::remove(rmm::exec_policy_nosync(stream), d_up_offsets, d_up_offsets + chars_size, 0L);
+      thrust::remove(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     d_up_offsets,
+                     d_up_offsets + chars_size,
+                     0L);
     auto const unpairables = cuda::std::distance(d_up_offsets, up_end);  // number of unpairables
 
     // new string boundaries created by combining unpairable offsets with the existing offsets
     auto tmp_offsets = rmm::device_uvector<int64_t>(unpairables + input.size() + 1, stream);
     auto input_offsets =
       cudf::detail::offsetalator_factory::make_input_iterator(input.offsets(), input.offset());
-    thrust::merge(rmm::exec_policy_nosync(stream),
+    thrust::merge(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   input_offsets,
                   input_offsets + input.size() + 1,
                   d_up_offsets,
@@ -386,7 +393,9 @@ std::unique_ptr<cudf::column> byte_pair_encoding(cudf::strings_column_view const
                   tmp_offsets.begin());
     // remove any adjacent duplicate offsets (i.e. empty or null rows)
     auto const offsets_end =
-      thrust::unique(rmm::exec_policy_nosync(stream), tmp_offsets.begin(), tmp_offsets.end());
+      thrust::unique(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     tmp_offsets.begin(),
+                     tmp_offsets.end());
     auto const offsets_total =
       static_cast<cudf::size_type>(cuda::std::distance(tmp_offsets.begin(), offsets_end));
     tmp_offsets.resize(offsets_total, stream);
@@ -428,7 +437,7 @@ std::unique_ptr<cudf::column> byte_pair_encoding(cudf::strings_column_view const
 
   // this will insert the single-byte separator into positions specified in d_inserts
   auto const sep_char = cuda::constant_iterator<char>(separator.to_string(stream)[0]);
-  thrust::merge_by_key(rmm::exec_policy_nosync(stream),
+  thrust::merge_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                        d_inserts,      // where to insert separator byte
                        copy_end,       //
                        chars_begin,    // all indices

--- a/cpp/src/text/deduplicate.cu
+++ b/cpp/src/text/deduplicate.cu
@@ -173,64 +173,77 @@ std::unique_ptr<cudf::column> resolve_duplicates_fn(
   auto sizes = rmm::device_uvector<int16_t>(indices.size(), stream);
 
   // locate candidate duplicates within the suffix array
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator{static_cast<cudf::size_type>(indices.size())},
                     sizes.begin(),
                     find_adjacent_duplicates_fn{chars_span, min_width, indices.data()});
 
   auto const dup_count =
-    sizes.size() - thrust::count(rmm::exec_policy_nosync(stream), sizes.begin(), sizes.end(), 0);
+    sizes.size() -
+    thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                  sizes.begin(),
+                  sizes.end(),
+                  0);
   auto dup_indices = rmm::device_uvector<cudf::size_type>(dup_count, stream);
 
   // remove the non-candidate entries from indices and sizes
   thrust::remove_copy_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     indices.begin(),
     indices.end(),
     cuda::counting_iterator<cudf::size_type>{0},
     dup_indices.begin(),
     [d_sizes = sizes.data()] __device__(cudf::size_type idx) -> bool { return d_sizes[idx] == 0; });
-  auto end = thrust::remove(rmm::exec_policy_nosync(stream), sizes.begin(), sizes.end(), 0);
+  auto end =
+    thrust::remove(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   sizes.begin(),
+                   sizes.end(),
+                   0);
   sizes.resize(cuda::std::distance(sizes.begin(), end), stream);
 
   // sort the resulting indices/sizes for overlap filtering
-  thrust::sort_by_key(
-    rmm::exec_policy_nosync(stream), dup_indices.begin(), dup_indices.end(), sizes.begin());
+  thrust::sort_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      dup_indices.begin(),
+                      dup_indices.end(),
+                      sizes.begin());
 
   // produce final duplicates for make_strings_column and collapse any overlapping candidates
   auto duplicates =
     rmm::device_uvector<cudf::strings::detail::string_index_pair>(dup_count, stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator{static_cast<cudf::size_type>(dup_indices.size())},
                     duplicates.begin(),
                     collapse_overlaps_fn{chars_span.data(), dup_indices.data(), sizes.data()});
 
   // filter out the remaining non-viable candidates
-  duplicates.resize(cuda::std::distance(duplicates.begin(),
-                                        thrust::remove(rmm::exec_policy_nosync(stream),
-                                                       duplicates.begin(),
-                                                       duplicates.end(),
-                                                       string_index{nullptr, 0})),
-                    stream);
+  duplicates.resize(
+    cuda::std::distance(
+      duplicates.begin(),
+      thrust::remove(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     duplicates.begin(),
+                     duplicates.end(),
+                     string_index{nullptr, 0})),
+    stream);
 
   // sort the result by size descending (should be very fast)
-  thrust::sort(rmm::exec_policy_nosync(stream),
+  thrust::sort(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                duplicates.begin(),
                duplicates.end(),
                [] __device__(auto lhs, auto rhs) -> bool { return lhs.second > rhs.second; });
 
   // ironically remove duplicates from the sorted list
   duplicates.resize(
-    cuda::std::distance(duplicates.begin(),
-                        thrust::unique(rmm::exec_policy_nosync(stream),
-                                       duplicates.begin(),
-                                       duplicates.end(),
-                                       [] __device__(auto lhs, auto rhs) -> bool {
-                                         return cudf::string_view(lhs.first, lhs.second) ==
-                                                cudf::string_view(rhs.first, rhs.second);
-                                       })),
+    cuda::std::distance(
+      duplicates.begin(),
+      thrust::unique(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     duplicates.begin(),
+                     duplicates.end(),
+                     [] __device__(auto lhs, auto rhs) -> bool {
+                       return cudf::string_view(lhs.first, lhs.second) ==
+                              cudf::string_view(rhs.first, rhs.second);
+                     })),
     stream);
 
   return cudf::strings::detail::make_strings_column(
@@ -426,20 +439,31 @@ std::unique_ptr<cudf::column> resolve_duplicates_pair_impl(
   // vectorized lower-bound and upper-bound of prefix strings improves performance of the
   // transform(find_duplicates_fn) by 2x
   auto prefixes = rmm::device_uvector<uint32_t>(indices2.size(), stream);  // 4x input2
-  thrust::transform(
-    rmm::exec_policy_nosync(stream), itr2, end2, prefixes.begin(), string_to_prefix_fn{});
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    itr2,
+                    end2,
+                    prefixes.begin(),
+                    string_to_prefix_fn{});
   auto lb_ids = rmm::device_uvector<cudf::size_type>(indices1.size(), stream);  // 4x input1
-  thrust::lower_bound(
-    rmm::exec_policy_nosync(stream), prefixes.begin(), prefixes.end(), itr1, end1, lb_ids.begin());
+  thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      prefixes.begin(),
+                      prefixes.end(),
+                      itr1,
+                      end1,
+                      lb_ids.begin());
   auto ub_ids = rmm::device_uvector<cudf::size_type>(indices1.size(), stream);  // 4x input1
-  thrust::upper_bound(
-    rmm::exec_policy_nosync(stream), prefixes.begin(), prefixes.end(), itr1, end1, ub_ids.begin());
+  thrust::upper_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      prefixes.begin(),
+                      prefixes.end(),
+                      itr1,
+                      end1,
+                      ub_ids.begin());
 
   // resolve duplicates by searching for input2 with strings from input1
   auto fd_fn =
     find_duplicates_fn{chars_span1, chars_span2, min_width, indices1, indices2, lb_ids, ub_ids};
   auto sizes = rmm::device_uvector<int16_t>(indices1.size(), stream);  // 2x input1
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator{static_cast<cudf::size_type>(sizes.size())},
                     sizes.begin(),
@@ -449,57 +473,70 @@ std::unique_ptr<cudf::column> resolve_duplicates_pair_impl(
   // this means any duplicates in both inputs should be reflected in indices1/sizes;
   // so we should be able to filter/collapse the results using only indices1/sizes
   auto const dup_count =
-    sizes.size() - thrust::count(rmm::exec_policy_nosync(stream), sizes.begin(), sizes.end(), 0);
+    sizes.size() -
+    thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                  sizes.begin(),
+                  sizes.end(),
+                  0);
   auto dup_indices = rmm::device_uvector<cudf::size_type>(dup_count, stream);
 
   // remove the non-candidate entries from indices and sizes
   thrust::remove_copy_if(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     indices1.begin(),
     indices1.end(),
     cuda::counting_iterator<cudf::size_type>{0},
     dup_indices.begin(),
     [d_sizes = sizes.data()] __device__(cudf::size_type idx) -> bool { return d_sizes[idx] == 0; });
-  auto end = thrust::remove(rmm::exec_policy_nosync(stream), sizes.begin(), sizes.end(), 0);
+  auto end =
+    thrust::remove(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   sizes.begin(),
+                   sizes.end(),
+                   0);
   sizes.resize(cuda::std::distance(sizes.begin(), end), stream);
 
   // sort the resulting indices/sizes for overlap filtering
-  thrust::sort_by_key(
-    rmm::exec_policy_nosync(stream), dup_indices.begin(), dup_indices.end(), sizes.begin());
+  thrust::sort_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      dup_indices.begin(),
+                      dup_indices.end(),
+                      sizes.begin());
 
   // produce final duplicates for make_strings_column and collapse any overlapping candidates
   auto duplicates =
     rmm::device_uvector<cudf::strings::detail::string_index_pair>(dup_count, stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator{static_cast<cudf::size_type>(dup_indices.size())},
                     duplicates.begin(),
                     collapse_overlaps_fn{chars_span1.data(), dup_indices.data(), sizes.data()});
 
   // filter out the remaining non-viable candidates
-  duplicates.resize(cuda::std::distance(duplicates.begin(),
-                                        thrust::remove(rmm::exec_policy_nosync(stream),
-                                                       duplicates.begin(),
-                                                       duplicates.end(),
-                                                       string_index{nullptr, 0})),
-                    stream);
+  duplicates.resize(
+    cuda::std::distance(
+      duplicates.begin(),
+      thrust::remove(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     duplicates.begin(),
+                     duplicates.end(),
+                     string_index{nullptr, 0})),
+    stream);
 
   // sort result by size descending (should be very fast)
-  thrust::sort(rmm::exec_policy_nosync(stream),
+  thrust::sort(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                duplicates.begin(),
                duplicates.end(),
                [] __device__(auto lhs, auto rhs) -> bool { return lhs.second > rhs.second; });
 
   // ironically remove duplicates from the sorted list
   duplicates.resize(
-    cuda::std::distance(duplicates.begin(),
-                        thrust::unique(rmm::exec_policy_nosync(stream),
-                                       duplicates.begin(),
-                                       duplicates.end(),
-                                       [] __device__(auto lhs, auto rhs) -> bool {
-                                         return cudf::string_view(lhs.first, lhs.second) ==
-                                                cudf::string_view(rhs.first, rhs.second);
-                                       })),
+    cuda::std::distance(
+      duplicates.begin(),
+      thrust::unique(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     duplicates.begin(),
+                     duplicates.end(),
+                     [] __device__(auto lhs, auto rhs) -> bool {
+                       return cudf::string_view(lhs.first, lhs.second) ==
+                              cudf::string_view(rhs.first, rhs.second);
+                     })),
     stream);
 
   return cudf::strings::detail::make_strings_column(

--- a/cpp/src/text/edit_distance.cu
+++ b/cpp/src/text/edit_distance.cu
@@ -296,7 +296,7 @@ std::unique_ptr<cudf::column> edit_distance(cudf::strings_column_view const& inp
 
   // calculate the size of the compute-buffer
   rmm::device_uvector<std::ptrdiff_t> offsets(input.size() + 1, stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator<cudf::size_type>{input.size()},
                     offsets.begin(),
@@ -393,8 +393,12 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
   auto const n_upper     = (input.size() * (input.size() - 1L)) / 2L;
   auto const output_size = input.size() * input.size();
   rmm::device_uvector<std::ptrdiff_t> offsets(n_upper + 1, stream);
-  thrust::uninitialized_fill(rmm::exec_policy_nosync(stream), offsets.begin(), offsets.end(), 0);
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::uninitialized_fill(
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    offsets.begin(),
+    offsets.end(),
+    0);
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<cudf::size_type>{0},
                      output_size,
                      calculate_matrix_compute_buffer_fn{*d_strings, offsets.data()});
@@ -413,7 +417,7 @@ std::unique_ptr<cudf::column> edit_distance_matrix(cudf::strings_column_view con
     output_type, output_size, rmm::device_buffer{0, stream, mr}, 0, stream, mr);
   auto d_results = results->mutable_view().data<cudf::size_type>();
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     output_size,
     edit_distance_matrix_levenshtein_algorithm{*d_strings, d_buffer, offsets.data(), d_results});

--- a/cpp/src/text/jaccard.cu
+++ b/cpp/src/text/jaccard.cu
@@ -357,10 +357,13 @@ std::pair<rmm::device_uvector<uint32_t>, rmm::device_uvector<int64_t>> hash_subs
     auto const offset_indices = [&] {
       // build a set of indices that point to offsets subsections
       auto sub_offsets = rmm::device_uvector<int64_t>(sort_sections + 1, stream);
-      thrust::sequence(
-        rmm::exec_policy_nosync(stream), sub_offsets.begin(), sub_offsets.end(), 0L, section_size);
+      thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       sub_offsets.begin(),
+                       sub_offsets.end(),
+                       0L,
+                       section_size);
       auto indices = rmm::device_uvector<int64_t>(sub_offsets.size(), stream);
-      thrust::lower_bound(rmm::exec_policy_nosync(stream),
+      thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                           offsets.begin(),
                           offsets.end(),
                           sub_offsets.begin(),
@@ -383,7 +386,7 @@ std::pair<rmm::device_uvector<uint32_t>, rmm::device_uvector<int64_t>> hash_subs
       // shift the offset values so the first offset is 0.
       // This transform can be removed once the bug is fixed.
       auto sort_offsets = rmm::device_uvector<int64_t>(num_segments + 1, stream);
-      thrust::transform(rmm::exec_policy_nosync(stream),
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         offsets.begin() + index1,
                         offsets.begin() + index2 + 1,
                         sort_offsets.begin(),
@@ -463,7 +466,7 @@ std::unique_ptr<cudf::column> jaccard_index(cudf::strings_column_view const& inp
   auto d_results = results->mutable_view().data<float>();
 
   // compute the jaccard using the unique counts and the intersect counts
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator<cudf::size_type>{results->size()},
                     d_results,

--- a/cpp/src/text/minhash.cu
+++ b/cpp/src/text/minhash.cu
@@ -395,7 +395,9 @@ std::pair<cudf::size_type, rmm::device_uvector<cudf::size_type>> partition_input
   rmm::cuda_stream_view stream)
 {
   auto indices = rmm::device_uvector<cudf::size_type>(size, stream);
-  thrust::sequence(rmm::exec_policy_nosync(stream), indices.begin(), indices.end());
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   indices.begin(),
+                   indices.end());
   cudf::size_type threshold_index = threshold_count < size ? size : 0;
 
   // if we counted a split of above/below threshold then
@@ -404,12 +406,21 @@ std::pair<cudf::size_type, rmm::device_uvector<cudf::size_type>> partition_input
     auto sizes = rmm::device_uvector<cudf::size_type>(size, stream);
     auto begin = cuda::counting_iterator<cudf::size_type>{0};
     auto end   = begin + size;
-    thrust::transform(rmm::exec_policy_nosync(stream), begin, end, sizes.data(), tfn);
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      begin,
+                      end,
+                      sizes.data(),
+                      tfn);
     // these 2 are slightly faster than using partition()
-    thrust::sort_by_key(
-      rmm::exec_policy_nosync(stream), sizes.begin(), sizes.end(), indices.begin());
-    auto const lb = thrust::lower_bound(
-      rmm::exec_policy_nosync(stream), sizes.begin(), sizes.end(), wide_row_threshold);
+    thrust::sort_by_key(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        sizes.begin(),
+                        sizes.end(),
+                        indices.begin());
+    auto const lb =
+      thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                          sizes.begin(),
+                          sizes.end(),
+                          wide_row_threshold);
     threshold_index = static_cast<cudf::size_type>(cuda::std::distance(sizes.begin(), lb));
   }
   return {threshold_index, std::move(indices)};

--- a/cpp/src/text/ngrams_tokenize.cu
+++ b/cpp/src/text/ngrams_tokenize.cu
@@ -163,7 +163,7 @@ std::unique_ptr<cudf::column> ngrams_tokenize(cudf::strings_column_view const& s
   rmm::device_uvector<position_pair> token_positions(total_tokens, stream);
   auto d_token_positions = token_positions.data();
   thrust::for_each_n(
-    rmm::exec_policy_nosync(stream),
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
     cuda::counting_iterator<cudf::size_type>{0},
     strings_count,
     string_tokens_positions_fn{d_strings, d_delimiter, d_token_offsets, d_token_positions});
@@ -208,7 +208,7 @@ std::unique_ptr<cudf::column> ngrams_tokenize(cudf::strings_column_view const& s
   // Generate the ngrams into the chars column data buffer.
   // The ngram_builder_fn functor also fills the ngram_sizes vector with the
   // size of each ngram.
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<cudf::size_type>{0},
                      strings_count,
                      ngram_builder_fn{d_strings,

--- a/cpp/src/text/normalize.cu
+++ b/cpp/src/text/normalize.cu
@@ -135,7 +135,7 @@ rmm::device_uvector<codepoint_metadata_type> get_codepoint_metadata(rmm::cuda_st
 {
   auto table_vector = rmm::device_uvector<codepoint_metadata_type>(codepoint_metadata_size, stream);
   auto table        = table_vector.data();
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                table + cp_section1_end,
                table + codepoint_metadata_size,
                codepoint_metadata_default_value);
@@ -159,7 +159,7 @@ rmm::device_uvector<aux_codepoint_data_type> get_aux_codepoint_data(rmm::cuda_st
 {
   auto table_vector = rmm::device_uvector<aux_codepoint_data_type>(aux_codepoint_data_size, stream);
   auto table        = table_vector.data();
-  thrust::fill(rmm::exec_policy_nosync(stream),
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                table + aux_section1_end,
                table + aux_codepoint_data_size,
                aux_codepoint_default_value);
@@ -460,8 +460,13 @@ OutputIterator remove_copy_safe(InputIterator first,
   while (itr != last) {
     auto const copy_end =
       static_cast<std::size_t>(std::distance(itr, last)) <= copy_size ? last : itr + copy_size;
-    result = thrust::remove_copy(rmm::exec_policy_nosync(stream), itr, copy_end, result, value);
-    itr    = copy_end;
+    result =
+      thrust::remove_copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                          itr,
+                          copy_end,
+                          result,
+                          value);
+    itr = copy_end;
   }
   return result;
 }
@@ -477,8 +482,9 @@ Iterator remove_safe(Iterator first, Iterator last, T const& value, rmm::cuda_st
   auto itr    = first;
   while (itr != last) {
     auto end = static_cast<std::size_t>(std::distance(itr, last)) <= size ? last : itr + size;
-    result   = thrust::remove(rmm::exec_policy_nosync(stream), itr, end, value);
-    itr      = end;
+    result   = thrust::remove(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()), itr, end, value);
+    itr = end;
   }
   return result;
 }

--- a/cpp/src/text/replace.cu
+++ b/cpp/src/text/replace.cu
@@ -294,18 +294,21 @@ std::unique_ptr<cudf::column> replace_helper(ReplacerFn replacer,
   {
     rmm::device_uvector<int64_t> sub_offsets(sub_count, stream);
     auto const count_itr = cuda::counting_iterator<int64_t>{0};
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       count_itr,
                       count_itr + sub_count,
                       sub_offsets.data(),
                       sub_offset_fn{input_chars, first_offset, last_offset});
     // remove 0s -- where sub-offset could not be computed
     auto const remove_end =
-      thrust::remove(rmm::exec_policy_nosync(stream), sub_offsets.begin(), sub_offsets.end(), 0L);
+      thrust::remove(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     sub_offsets.begin(),
+                     sub_offsets.end(),
+                     0L);
     sub_count = cuda::std::distance(sub_offsets.begin(), remove_end);
 
     // merge them with input offsets
-    thrust::merge(rmm::exec_policy_nosync(stream),
+    thrust::merge(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   input_offsets,
                   input_offsets + input.size() + 1,
                   sub_offsets.begin(),
@@ -325,7 +328,7 @@ std::unique_ptr<cudf::column> replace_helper(ReplacerFn replacer,
 
   // compute indices to the actual output rows
   auto indices = rmm::device_uvector<cudf::size_type>(tmp_offsets.size(), stream);
-  thrust::upper_bound(rmm::exec_policy_nosync(stream),
+  thrust::upper_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       input_offsets,
                       input_offsets + input.size() + 1,
                       tmp_offsets.begin(),
@@ -334,7 +337,10 @@ std::unique_ptr<cudf::column> replace_helper(ReplacerFn replacer,
 
   // initialize the output row sizes
   auto d_sizes = rmm::device_uvector<cudf::size_type>(input.size(), stream);
-  thrust::fill(rmm::exec_policy_nosync(stream), d_sizes.begin(), d_sizes.end(), 0);
+  thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+               d_sizes.begin(),
+               d_sizes.end(),
+               0);
 
   replacer.d_strings      = *d_tmp_strings;
   replacer.d_indices      = indices.data();

--- a/cpp/src/text/stemmer.cu
+++ b/cpp/src/text/stemmer.cu
@@ -102,7 +102,7 @@ std::unique_ptr<cudf::column> is_letter(cudf::strings_column_view const& strings
                                   mr);
   // set values into output column
   auto strings_column = cudf::column_device_view::create(strings.parent(), stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator<cudf::size_type>{strings.size()},
                     results->mutable_view().data<bool>(),
@@ -218,7 +218,7 @@ std::unique_ptr<cudf::column> porter_stemmer_measure(cudf::strings_column_view c
                                   mr);
   // compute measures into output column
   auto strings_column = cudf::column_device_view::create(strings.parent(), stream);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator<cudf::size_type>{strings.size()},
                     results->mutable_view().data<cudf::size_type>(),

--- a/cpp/src/text/tokenize.cu
+++ b/cpp/src/text/tokenize.cu
@@ -49,7 +49,7 @@ std::unique_ptr<cudf::column> token_count_fn(cudf::size_type strings_count,
                               mr);
   auto d_token_counts = token_counts->mutable_view().data<cudf::size_type>();
   // add the counts to the column
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator<cudf::size_type>{strings_count},
                     d_token_counts,
@@ -80,7 +80,7 @@ std::unique_ptr<cudf::column> tokenize_fn(cudf::size_type strings_count,
   tokenizer.d_offsets =
     cudf::detail::offsetalator_factory::make_input_iterator(token_offsets->view());
   tokenizer.d_tokens = tokens.data();
-  thrust::for_each_n(rmm::exec_policy_nosync(stream),
+  thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                      cuda::counting_iterator<cudf::size_type>{0},
                      strings_count,
                      tokenizer);
@@ -214,8 +214,10 @@ std::unique_ptr<cudf::column> character_tokenize(cudf::strings_column_view const
 
   // create the output chars buffer -- just a copy of the input's chars
   rmm::device_uvector<char> output_chars(chars_bytes, stream, mr);
-  thrust::copy(
-    rmm::exec_policy_nosync(stream), d_chars, d_chars + chars_bytes, output_chars.data());
+  thrust::copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+               d_chars,
+               d_chars + chars_bytes,
+               output_chars.data());
 
   auto output_strings = cudf::make_strings_column(
     num_characters, std::move(offsets_column), output_chars.release(), 0, rmm::device_buffer{});

--- a/cpp/src/text/vocabulary_tokenize.cu
+++ b/cpp/src/text/vocabulary_tokenize.cu
@@ -362,7 +362,7 @@ std::unique_ptr<cudf::column> tokenize_with_vocabulary(cudf::strings_column_view
   if ((input.chars_size(stream) / (input.size() - input.null_count())) < AVG_CHAR_BYTES_THRESHOLD) {
     auto const zero_itr = cuda::counting_iterator<cudf::size_type>{0};
     auto d_sizes        = rmm::device_uvector<cudf::size_type>(input.size(), stream);
-    thrust::transform(rmm::exec_policy_nosync(stream),
+    thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       zero_itr,
                       zero_itr + input.size(),
                       d_sizes.begin(),
@@ -377,7 +377,10 @@ std::unique_ptr<cudf::column> tokenize_with_vocabulary(cudf::strings_column_view
     auto d_offsets = cudf::detail::offsetalator_factory::make_input_iterator(token_offsets->view());
     vocabulary_tokenizer_fn<decltype(map_ref)> tokenizer{
       *d_strings, d_delimiter, map_ref, default_id, d_offsets, d_tokens};
-    thrust::for_each_n(rmm::exec_policy_nosync(stream), zero_itr, input.size(), tokenizer);
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       zero_itr,
+                       input.size(),
+                       tokenizer);
     return cudf::make_lists_column(input.size(),
                                    std::move(token_offsets),
                                    std::move(tokens),
@@ -439,7 +442,7 @@ std::unique_ptr<cudf::column> tokenize_with_vocabulary(cudf::strings_column_view
   auto d_tokens = tokens->mutable_view().data<cudf::size_type>();
 
   transform_tokenizer_fn<decltype(map_ref)> tokenizer{d_delimiter, map_ref, default_id};
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     d_tmp_strings->begin<cudf::string_view>(),
                     d_tmp_strings->end<cudf::string_view>(),
                     d_tokens,

--- a/cpp/src/text/wordpiece_tokenize.cu
+++ b/cpp/src/text/wordpiece_tokenize.cu
@@ -264,7 +264,7 @@ wordpiece_vocabulary::wordpiece_vocabulary(cudf::strings_column_view const& inpu
   // prefetch the [unk] vocab entry
   auto unk_ids = rmm::device_uvector<cudf::size_type>(2, stream);
   auto d_map   = vocab_map->ref(cuco::op::find);
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     zero_itr,
                     zero_itr + unk_ids.size(),
                     unk_ids.begin(),
@@ -536,7 +536,7 @@ rmm::device_uvector<cudf::size_type> compute_all_tokens(
   // merge in the input offsets to identify words starting each row
   auto d_all_edges = [&] {
     auto d_all_edges = rmm::device_uvector<int64_t>(edges_count, stream);
-    thrust::merge(rmm::exec_policy_nosync(stream),
+    thrust::merge(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                   d_offsets,
                   d_offsets + input.size() + 1,
                   d_edges.begin(),
@@ -552,7 +552,10 @@ rmm::device_uvector<cudf::size_type> compute_all_tokens(
 
   auto d_tokens = rmm::device_uvector<cudf::size_type>(chars_size, stream);
   thrust::uninitialized_fill(
-    rmm::exec_policy_nosync(stream), d_tokens.begin(), d_tokens.end(), no_token);
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    d_tokens.begin(),
+    d_tokens.end(),
+    no_token);
 
   cudf::detail::grid_1d grid{static_cast<cudf::size_type>(d_all_edges.size()), 512};
   tokenize_all_kernel<decltype(map_ref), decltype(sub_map_ref)>
@@ -763,7 +766,7 @@ rmm::device_uvector<cudf::size_type> compute_some_tokens(
   auto max_word_offsets = rmm::device_uvector<int64_t>(input.size() + 1, stream);
 
   // compute max word counts for each row
-  thrust::transform(rmm::exec_policy_nosync(stream),
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                     cuda::counting_iterator<cudf::size_type>{0},
                     cuda::counting_iterator<cudf::size_type>{input.size()},
                     max_word_offsets.begin(),
@@ -790,10 +793,16 @@ rmm::device_uvector<cudf::size_type> compute_some_tokens(
       *d_strings, d_input_chars, max_word_offsets.data(), start_words.data(), word_sizes.data());
 
   // remove the non-words
-  auto const end = thrust::remove(
-    rmm::exec_policy_nosync(stream), start_words.begin(), start_words.end(), no_word64);
+  auto const end =
+    thrust::remove(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   start_words.begin(),
+                   start_words.end(),
+                   no_word64);
   auto const check =
-    thrust::remove(rmm::exec_policy_nosync(stream), word_sizes.begin(), word_sizes.end(), no_word);
+    thrust::remove(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   word_sizes.begin(),
+                   word_sizes.end(),
+                   no_word);
 
   auto const total_words = static_cast<int64_t>(cuda::std::distance(start_words.begin(), end));
   // this should only trigger if there is a bug in the code above
@@ -808,7 +817,10 @@ rmm::device_uvector<cudf::size_type> compute_some_tokens(
 
   auto d_tokens = rmm::device_uvector<cudf::size_type>(chars_size, stream);
   thrust::uninitialized_fill(
-    rmm::exec_policy_nosync(stream), d_tokens.begin(), d_tokens.end(), no_token);
+    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+    d_tokens.begin(),
+    d_tokens.end(),
+    no_token);
 
   cudf::detail::grid_1d grid{total_words, 512};
   tokenize_kernel<decltype(map_ref), decltype(sub_map_ref)>
@@ -858,8 +870,11 @@ std::unique_ptr<cudf::column> wordpiece_tokenize(cudf::strings_column_view const
   auto tokens =
     cudf::make_numeric_column(output_type, total_count, cudf::mask_state::UNALLOCATED, stream, mr);
   auto output = tokens->mutable_view().begin<cudf::size_type>();
-  thrust::remove_copy(
-    rmm::exec_policy_nosync(stream), d_tokens.begin(), d_tokens.end(), output, no_token);
+  thrust::remove_copy(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                      d_tokens.begin(),
+                      d_tokens.end(),
+                      output,
+                      no_token);
 
   return cudf::make_lists_column(input.size(),
                                  std::move(token_offsets),

--- a/cpp/tests/bitmask/bitmask_tests.cpp
+++ b/cpp/tests/bitmask/bitmask_tests.cpp
@@ -568,8 +568,7 @@ TEST_F(MergeBitmaskTest, TestBitmaskAnd)
   EXPECT_EQ(result2_null_count, gold_null_count);
   EXPECT_EQ(result3_null_count, gold_null_count);
 
-  auto odd_indices =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto odd_indices = cudf::test::iterators::nulls_at_multiples_of(2);
   auto odd =
     std::get<0>(cudf::test::detail::make_null_mask(odd_indices, odd_indices + input2.num_rows()));
 
@@ -608,8 +607,7 @@ TEST_F(MergeBitmaskTest, TestSegmentedBitmaskAndSingleSegment)
     EXPECT_EQ(result_null_count.size(), 1);
     EXPECT_EQ(result_masks.size(), 1);
     EXPECT_EQ(result_null_count[0], 3);
-    auto odd_indices =
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+    auto odd_indices = cudf::test::iterators::nulls_at_multiples_of(2);
     auto const odd =
       std::get<0>(cudf::test::detail::make_null_mask(odd_indices, odd_indices + num_rows));
     CUDF_TEST_EXPECT_EQUAL_BUFFERS(
@@ -624,8 +622,7 @@ TEST_F(MergeBitmaskTest, TestSegmentedBitmaskAndSingleSegment)
     EXPECT_EQ(result_null_count.size(), 1);
     EXPECT_EQ(result_masks.size(), 1);
     EXPECT_EQ(result_null_count[0], 3);
-    auto odd_indices =
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+    auto odd_indices = cudf::test::iterators::nulls_at_multiples_of(2);
     auto const odd =
       std::get<0>(cudf::test::detail::make_null_mask(odd_indices, odd_indices + num_rows));
     CUDF_TEST_EXPECT_EQUAL_BUFFERS(
@@ -666,8 +663,7 @@ TEST_F(MergeBitmaskTest, TestSegmentedBitmaskAndMultipleSegments)
     EXPECT_EQ(result_masks.size(), 2);
     EXPECT_EQ(result_null_count[0], 3);
     EXPECT_EQ(result_null_count[1], 0);
-    auto odd_indices =
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+    auto odd_indices = cudf::test::iterators::nulls_at_multiples_of(2);
     auto const odd =
       std::get<0>(cudf::test::detail::make_null_mask(odd_indices, odd_indices + num_rows));
     CUDF_TEST_EXPECT_EQUAL_BUFFERS(

--- a/cpp/tests/column/column_test.cpp
+++ b/cpp/tests/column/column_test.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/testing_main.hpp>
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
@@ -610,11 +611,9 @@ TYPED_TEST(ListsColumnTest, ListsSlicedZeroSliceLengthNonNested)
 
 TYPED_TEST(ListsColumnTest, ListsSlicedColumnViewConstructorWithNulls)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
-  auto expect_valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 != 0; });
+  auto expect_valids = cudf::test::iterators::nulls_at_multiples_of(2);
 
   using LCW = cudf::test::lists_column_wrapper<TypeParam>;
 

--- a/cpp/tests/copying/concatenate_tests.cpp
+++ b/cpp/tests/copying/concatenate_tests.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/random.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
@@ -1083,8 +1084,7 @@ TEST_F(ListsColumnTest, ConcatenateEmptyLists)
 
 TEST_F(ListsColumnTest, ConcatenateListsWithNulls)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // nulls in the leaves
   {
@@ -1183,8 +1183,7 @@ TEST_F(ListsColumnTest, ConcatenateNestedEmptyLists)
 
 TEST_F(ListsColumnTest, ConcatenateNestedListsWithNulls)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // nulls in the lists
   {
@@ -1366,8 +1365,7 @@ TEST_F(ListsColumnTest, SlicedColumnsWithNulls)
 {
   using LCW = cudf::test::lists_column_wrapper<int>;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   {
     cudf::test::lists_column_wrapper<int> a{{{{1, 1, 1}, valids}, {2, 2}, {{3, 3}, valids}},

--- a/cpp/tests/copying/copy_tests.cpp
+++ b/cpp/tests/copying/copy_tests.cpp
@@ -449,8 +449,7 @@ struct StringsCopyIfElseTest : public cudf::test::BaseFixture {};
 
 TEST_F(StringsCopyIfElseTest, CopyIfElse)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   std::vector<char const*> h_strings1{"eee", "bb", "", "aa", "bbb", "ééé"};
   cudf::test::strings_column_wrapper strings1(h_strings1.begin(), h_strings1.end(), valids);
@@ -476,8 +475,7 @@ TEST_F(StringsCopyIfElseTest, CopyIfElse)
 
 TEST_F(StringsCopyIfElseTest, CopyIfElseScalarColumn)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   std::vector<char const*> h_string1{"eee"};
   cudf::string_scalar strings1{h_string1[0]};
@@ -504,8 +502,7 @@ TEST_F(StringsCopyIfElseTest, CopyIfElseScalarColumn)
 
 TEST_F(StringsCopyIfElseTest, CopyIfElseColumnScalar)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   std::vector<char const*> h_string1{"eee"};
   cudf::string_scalar strings1{h_string1[0]};
@@ -531,8 +528,7 @@ TEST_F(StringsCopyIfElseTest, CopyIfElseColumnScalar)
 
 TEST_F(StringsCopyIfElseTest, CopyIfElseScalarScalar)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   std::vector<char const*> h_string1{"eee"};
   cudf::string_scalar string1{h_string1[0]};

--- a/cpp/tests/copying/gather_list_tests.cpp
+++ b/cpp/tests/copying/gather_list_tests.cpp
@@ -1,11 +1,12 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/column/column_view.hpp>
@@ -93,8 +94,7 @@ TYPED_TEST(GatherTestListTyped, GatherNulls)
 {
   using T = TypeParam;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<T>
   LCW<T> list{{{1, 2, 3, 4}, valids}, {5}, {{6, 7}, valids}, {{8, 9, 10}, valids}};
@@ -175,8 +175,7 @@ TYPED_TEST(GatherTestListTyped, GatherNestedNulls)
 {
   using T = TypeParam;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<List<T>>
   {
@@ -349,8 +348,7 @@ TYPED_TEST(GatherTestListTyped, GatherSliced)
     CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected1, result1->get_column(0).view());
   }
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<List<List<T>>>
   {

--- a/cpp/tests/copying/gather_tests.cpp
+++ b/cpp/tests/copying/gather_tests.cpp
@@ -74,7 +74,7 @@ TYPED_TEST(GatherTest, EveryOtherNullOdds)
 
   // Every other element is valid
   auto data     = cuda::counting_iterator{0};
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<TypeParam> source_column(
     data, data + source_size, validity);
@@ -105,7 +105,7 @@ TYPED_TEST(GatherTest, EveryOtherNullEvens)
 
   // Every other element is valid
   auto data     = cuda::counting_iterator{0};
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<TypeParam> source_column(
     data, data + source_size, validity);
@@ -202,7 +202,7 @@ TYPED_TEST(GatherTest, MultiColNulls)
   constexpr cudf::size_type n_cols = 3;
 
   auto data     = cuda::counting_iterator{0};
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
   std::vector<cudf::test::fixed_width_column_wrapper<TypeParam>> source_column_wrappers;
   std::vector<cudf::column_view> source_columns;
@@ -226,8 +226,7 @@ TYPED_TEST(GatherTest, MultiColNulls)
   // Expected data
   auto expect_data =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return source_size - i - 1; });
-  auto expect_valid =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i + 1) % 2; });
+  auto expect_valid = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<TypeParam> expect_column(
     expect_data, expect_data + source_size, expect_valid);

--- a/cpp/tests/copying/get_value_tests.cpp
+++ b/cpp/tests/copying/get_value_tests.cpp
@@ -170,10 +170,7 @@ TYPED_TEST(DictionaryGetValueTest, GetNull)
 
 template <typename T>
 struct ListGetFixedWidthValueTest : public cudf::test::BaseFixture {
-  auto odds_valid()
-  {
-    return cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
-  }
+  auto odds_valid() { return nulls_at_multiples_of(2); }
   auto nth_valid(cudf::size_type x)
   {
     return cudf::detail::make_counting_transform_iterator(0, [=](auto i) { return x == i; });
@@ -326,10 +323,7 @@ TYPED_TEST(ListGetFixedWidthValueTest, NestedGetNull)
 }
 
 struct ListGetStringValueTest : public cudf::test::BaseFixture {
-  auto odds_valid()
-  {
-    return cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
-  }
+  auto odds_valid() { return nulls_at_multiples_of(2); }
   auto nth_valid(cudf::size_type x)
   {
     return cudf::detail::make_counting_transform_iterator(0, [=](auto i) { return x == i; });

--- a/cpp/tests/copying/pack_tests.cpp
+++ b/cpp/tests/copying/pack_tests.cpp
@@ -7,6 +7,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
 
 #include <cudf/contiguous_split.hpp>
@@ -131,8 +132,7 @@ std::vector<std::unique_ptr<cudf::column>> generate_lists(bool include_validity)
   using LCW = cudf::test::lists_column_wrapper<int>;
 
   if (include_validity) {
-    auto valids =
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+    auto valids = cudf::test::iterators::valids_at_multiples_of(2);
     cudf::test::lists_column_wrapper<int> list0{{1, 2, 3},
                                                 {4, 5},
                                                 {6},
@@ -506,8 +506,7 @@ TEST_F(PackUnpackTest, NestedSliced)
 {
   // list
   {
-    auto valids =
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+    auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
     using LCW = cudf::test::lists_column_wrapper<int>;
 

--- a/cpp/tests/copying/scatter_struct_tests.cpp
+++ b/cpp/tests/copying/scatter_struct_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -186,14 +186,14 @@ TYPED_TEST(TypedStructScatterTest, ScatterStructOfListsTest)
   auto lists_col_src =
     lists_col{{{5}, {10, 15}, {20, 25, 30}, {35, 40, 45, 50}, {55, 60, 65}, {70, 75}, {80}, {}, {}},
               // Valid for elements 0, 3, 6,...
-              cudf::detail::make_counting_transform_iterator(0, [](auto i) { return !(i % 3); })};
+              valids_at_multiples_of(3)};
   auto const structs_src = structs_col{{lists_col_src}}.release();
 
   // Target data
   auto lists_col_tgt =
     lists_col{{{1}, {2, 3}, {4, 5, 6}, {7, 8}, {9}, {10, 11, 12, 13}, {}, {14}, {15, 16}},
               // Valid for elements 1, 3, 5, 7,...
-              cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })};
+              nulls_at_multiples_of(2)};
   auto const structs_tgt = structs_col{{lists_col_tgt}}.release();
 
   // Expected data

--- a/cpp/tests/copying/segmented_gather_list_tests.cpp
+++ b/cpp/tests/copying/segmented_gather_list_tests.cpp
@@ -125,8 +125,7 @@ TYPED_TEST(SegmentedGatherTest, GatherNulls)
 {
   using T = TypeParam;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<T>
   auto const list = LCW<T>{{{1, 2, 3, 4}, valids}, {5}, {{6, 7}, valids}, {{8, 9, 10}, valids}};
@@ -304,8 +303,7 @@ TYPED_TEST(SegmentedGatherTest, GatherNestedNulls)
 {
   using T = TypeParam;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<List<T>>
   {
@@ -397,8 +395,7 @@ TYPED_TEST(SegmentedGatherTest, GatherSliced)
     }
   }
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<List<List<T>>>
   {
@@ -583,8 +580,7 @@ TEST_F(SegmentedGatherTestFloat, Fails)
                                              cudf::lists_column_view{nonlist_map2}),
                cudf::logic_error);
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
   LCW<int8_t> nulls_map{{{3, 2, 1, 0}, {0}, {0}, {0, 1}}, valids};
 
   // Nulls are not supported in the gather map.

--- a/cpp/tests/copying/segmented_gather_list_tests.cpp
+++ b/cpp/tests/copying/segmented_gather_list_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <cudf_test/base_fixture.hpp>
@@ -108,6 +108,17 @@ TYPED_TEST(SegmentedGatherTest, GatherNothing)
     EXPECT_EQ(cudf::lists_column_view(cudf::lists_column_view(lcv.child()).child()).child().size(),
               0);
   }
+}
+
+using SegmentedGatherTestSingle = SegmentedGatherTest<int32_t>;
+TEST_F(SegmentedGatherTestSingle, GatherEmpty)
+{
+  auto const list       = LCW<int32_t>{};
+  auto const gather_map = LCW<cudf::size_type>{};
+  auto const expected   = LCW<int32_t>{};
+  auto const results    = cudf::lists::segmented_gather(cudf::lists_column_view{list},
+                                                     cudf::lists_column_view{gather_map});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(*results, expected);
 }
 
 TYPED_TEST(SegmentedGatherTest, GatherNulls)

--- a/cpp/tests/copying/slice_tests.cpp
+++ b/cpp/tests/copying/slice_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,6 +8,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -30,8 +31,7 @@ TYPED_TEST(SliceTest, NumericColumnsWithNulls)
 
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<T> col = create_fixed_columns<T>(start, size, valids);
 
@@ -53,8 +53,7 @@ TYPED_TEST(SliceTest, NumericColumnsWithNullsAsColumn)
 
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<T> input = create_fixed_columns<T>(start, size, valids);
 
@@ -77,8 +76,7 @@ TEST_F(SliceStringTest, StringWithNulls)
 {
   std::vector<std::string> strings{
     "", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"};
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
   cudf::test::strings_column_wrapper s(strings.begin(), strings.end(), valids);
 
   std::vector<cudf::size_type> indices{1, 3, 2, 4, 1, 9};
@@ -98,8 +96,7 @@ TEST_F(SliceStringTest, StringWithNullsAsColumn)
 {
   std::vector<std::string> strings{
     "", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"};
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
   cudf::test::strings_column_wrapper s(strings.begin(), strings.end(), valids);
 
   std::vector<cudf::size_type> indices{1, 3, 2, 4, 1, 9};
@@ -179,8 +176,7 @@ TEST_F(SliceListTest, ListsWithNulls)
 {
   using LCW = cudf::test::lists_column_wrapper<int>;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   {
     cudf::test::lists_column_wrapper<int> list{{1, 2, 3},
@@ -265,8 +261,7 @@ TEST_F(SliceCornerCases, EmptyIndices)
 {
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<int8_t> col =
     create_fixed_columns<int8_t>(start, size, valids);
@@ -283,8 +278,7 @@ TEST_F(SliceCornerCases, InvalidSetOfIndices)
 {
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
   cudf::test::fixed_width_column_wrapper<int8_t> col =
     create_fixed_columns<int8_t>(start, size, valids);
   std::vector<cudf::size_type> indices{11, 12};
@@ -296,8 +290,7 @@ TEST_F(SliceCornerCases, ImproperRange)
 {
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<int8_t> col =
     create_fixed_columns<int8_t>(start, size, valids);
@@ -310,8 +303,7 @@ TEST_F(SliceCornerCases, NegativeOffset)
 {
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<int8_t> col =
     create_fixed_columns<int8_t>(start, size, valids);
@@ -331,8 +323,7 @@ TYPED_TEST(SliceTableTest, NumericColumnsWithNulls)
 
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<T>(num_cols, start, col_size, valids);
@@ -353,8 +344,7 @@ struct SliceStringTableTest : public SliceTableTest<std::string> {};
 
 TEST_F(SliceStringTableTest, StringWithNulls)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   std::vector<std::vector<std::string>> strings{
     {{"", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"},
@@ -399,8 +389,7 @@ TEST_F(SliceTableCornerCases, EmptyIndices)
 {
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<int8_t>(num_cols, start, col_size, valids);
@@ -417,8 +406,7 @@ TEST_F(SliceTableCornerCases, InvalidSetOfIndices)
 {
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<int8_t>(num_cols, start, col_size, valids);
@@ -432,8 +420,7 @@ TEST_F(SliceTableCornerCases, ImproperRange)
 {
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<int8_t>(num_cols, start, col_size, valids);
@@ -447,8 +434,7 @@ TEST_F(SliceTableCornerCases, NegativeOffset)
 {
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<int8_t>(num_cols, start, col_size, valids);

--- a/cpp/tests/copying/split_tests.cpp
+++ b/cpp/tests/copying/split_tests.cpp
@@ -165,8 +165,7 @@ TYPED_TEST(SplitTest, SplitEndLessThanSize)
 
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<T> col = create_fixed_columns<T>(start, size, valids);
 
@@ -188,8 +187,7 @@ TYPED_TEST(SplitTest, SplitEndToSize)
 
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<T> col = create_fixed_columns<T>(start, size, valids);
 
@@ -302,8 +300,7 @@ TEST_F(SplitStringTest, StringWithInvalids)
 {
   std::vector<std::string> strings{
     "", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"};
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
   cudf::test::strings_column_wrapper s(strings.begin(), strings.end(), valids);
 
   std::vector<cudf::size_type> splits{2, 5, 9};
@@ -337,8 +334,7 @@ TEST_F(SplitCornerCases, EmptyIndices)
 {
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<int8_t> col =
     create_fixed_columns<int8_t>(start, size, valids);
@@ -355,8 +351,7 @@ TEST_F(SplitCornerCases, InvalidSetOfIndices)
 {
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
   cudf::test::fixed_width_column_wrapper<int8_t> col =
     create_fixed_columns<int8_t>(start, size, valids);
   std::vector<cudf::size_type> splits{11, 12};
@@ -368,8 +363,7 @@ TEST_F(SplitCornerCases, ImproperRange)
 {
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<int8_t> col =
     create_fixed_columns<int8_t>(start, size, valids);
@@ -382,8 +376,7 @@ TEST_F(SplitCornerCases, NegativeValue)
 {
   cudf::size_type start = 0;
   cudf::size_type size  = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids           = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<int8_t> col =
     create_fixed_columns<int8_t>(start, size, valids);
@@ -398,8 +391,7 @@ void split_end_less_than_size(SplitFunc Split, CompareFunc Compare)
 {
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<T>(num_cols, start, col_size, valids);
@@ -422,8 +414,7 @@ void split_end_to_size(SplitFunc Split, CompareFunc Compare)
 {
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<T>(num_cols, start, col_size, valids);
@@ -457,8 +448,7 @@ void split_empty_indices(SplitFunc Split)
 {
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<int8_t>(num_cols, start, col_size, valids);
@@ -476,8 +466,7 @@ void split_invalid_indices(SplitFunc Split)
 {
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<int8_t>(num_cols, start, col_size, valids);
@@ -492,8 +481,7 @@ void split_improper_range(SplitFunc Split)
 {
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<int8_t>(num_cols, start, col_size, valids);
@@ -508,8 +496,7 @@ void split_negative_value(SplitFunc Split)
 {
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<int8_t>(num_cols, start, col_size, valids);
@@ -526,8 +513,7 @@ void split_empty_output_column_value(SplitFunc Split,
 {
   cudf::size_type start    = 0;
   cudf::size_type col_size = 10;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(start, [](auto i) { return i % 2 == 0; });
+  auto valids              = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::size_type num_cols = 5;
   cudf::table src_table    = create_fixed_table<int8_t>(num_cols, start, col_size, valids);
@@ -616,8 +602,7 @@ void split_string_with_invalids(SplitFunc Split,
                                 CompareFunc Compare,
                                 std::vector<cudf::size_type> splits = {2, 5, 9})
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   std::vector<std::vector<std::string>> strings{
     {{"", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"},
@@ -648,8 +633,7 @@ void split_empty_output_strings_column_value(SplitFunc Split,
                                              CompareFunc Compare,
                                              std::vector<cudf::size_type> const& splits = {0, 2, 2})
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   std::vector<std::vector<std::string>> strings{
     {{"", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"},
@@ -674,9 +658,8 @@ void split_empty_output_strings_column_value(SplitFunc Split,
 template <typename SplitFunc, typename CompareFunc>
 void split_null_input_strings_column_value(SplitFunc Split, CompareFunc Compare)
 {
+  auto valids    = cudf::test::iterators::valids_at_multiples_of(2);
   auto no_valids = cudf::test::iterators::all_nulls();
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
 
   std::vector<std::vector<std::string>> strings{
     {{"", "this", "is", "a", "column", "of", "strings", "with", "in", "valid"},
@@ -830,8 +813,7 @@ void split_lists_with_nulls(SplitFunc Split, CompareFunc Compare, bool split = t
 {
   using LCW = cudf::test::lists_column_wrapper<int>;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   {
     cudf::test::lists_column_wrapper<T> list{{1, 2, 3},
@@ -2102,8 +2084,7 @@ TEST_F(ContiguousSplitTableCornerCases, MixedColumnTypesSingleRowChunked)
 
 TEST_F(ContiguousSplitTableCornerCases, PreSplitTable)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   using LCW = cudf::test::lists_column_wrapper<int>;
 

--- a/cpp/tests/groupby/nth_element_tests.cpp
+++ b/cpp/tests/groupby/nth_element_tests.cpp
@@ -20,7 +20,6 @@ struct groupby_nth_element_test : public cudf::test::BaseFixture {};
 
 TYPED_TEST_SUITE(groupby_nth_element_test, cudf::test::AllTypes);
 
-// clang-format off
 TYPED_TEST(groupby_nth_element_test, basic)
 {
   using K = int32_t;
@@ -29,12 +28,12 @@ TYPED_TEST(groupby_nth_element_test, basic)
 
   cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
   cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
-  //keys                                                  {1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
-  //vals                                                  {0, 3, 6, 1, 4, 5, 9, 2, 7, 8};
+  // keys                                                 {1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
+  // vals                                                 {0, 3, 6, 1, 4, 5, 9, 2, 7, 8};
 
   cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
-  //groupby.first()
+  // groupby.first()
   auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0);
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals0({0, 1, 2});
   test_single_agg(keys, vals, expect_keys, expect_vals0, std::move(agg));
@@ -88,12 +87,12 @@ TYPED_TEST(groupby_nth_element_test, negative)
 
   cudf::test::fixed_width_column_wrapper<K> keys{1, 2, 3, 1, 2, 2, 1, 3, 3, 2};
   cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
-  //keys                            {1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
-  //vals                            {0, 3, 6, 1, 4, 5, 9, 2, 7, 8};
+  // keys                                                 {1, 1, 1, 2, 2, 2, 2, 3, 3, 3};
+  // vals                                                 {0, 3, 6, 1, 4, 5, 9, 2, 7, 8};
 
   cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
-  //groupby.last()
+  // groupby.last()
   auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-1);
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals0({6, 9, 8});
   test_single_agg(keys, vals, expect_keys, expect_vals0, std::move(agg));
@@ -161,14 +160,15 @@ TYPED_TEST(groupby_nth_element_test, null_keys_and_values)
   using V = TypeParam;
   using R = V;
 
-  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {true, true, true, true, true, true, true, false, true, true, true});
+  cudf::test::fixed_width_column_wrapper<K> keys(
+    {1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+    {true, true, true, true, true, true, true, false, true, true, true});
   cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                              {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+                                                          {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
 
   cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
-  //keys                                    {1, 1, 1   2,2,2,2    3, 3,    4}
-  //vals                                    {-,3,6,    1,4,-,9,  2,8,      -}
+  // keys   {1, 1, 1   2,2,2,2    3,3,    4}
+  // vals   {-,3,6,    1,4,-,9,   2,8,    -}
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals({-1, 1, 2, -1}, {0, 1, 1, 0});
 
   auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0);
@@ -181,14 +181,15 @@ TYPED_TEST(groupby_nth_element_test, null_keys_and_values_out_of_bounds)
   using V = TypeParam;
   using R = V;
 
-  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
-                                     {true, true, true, true, true, true, true, false, true, true, true});
+  cudf::test::fixed_width_column_wrapper<K> keys(
+    {1, 2, 3, 1, 2, 2, 1, 3, 3, 2, 4},
+    {true, true, true, true, true, true, true, false, true, true, true});
   cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 4},
-                                              {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
-  //                                        {1, 1, 1    2, 2, 2,    3, 3,   4}
+                                                          {0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0});
+  // {1, 1, 1    2, 2, 2,    3, 3,   4}
   cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
-  //                                        {-,3,6,     1,4,-,9,    2,8,    -}
-  //                                         value,     null,       out,    out
+  // {-,3,6,     1,4,-,9,    2,8,    -}
+  //  value,     null,       out,    out
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals({6, -1, -1, -1}, {1, 0, 0, 0});
 
   auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2);
@@ -201,39 +202,46 @@ TYPED_TEST(groupby_nth_element_test, exclude_nulls)
   using V = TypeParam;
   using R = V;
 
-  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
-                                     {true, true, true, true, true, true, true, true, false, true, true, true, true, true});
-  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
-                                              {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys(
+    {1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
+    {true, true, true, true, true, true, true, true, false, true, true, true, true, true});
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals(
+    {0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2}, {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
 
   cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
-  //keys                                    {1, 1, 1    2, 2, 2, 2      3, 3, 3    4}
-  //vals                                    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,   4,-}
-  //                                      0  null,      value,          value,     null
-  //                                      1  value,     value,          value,     null
-  //                                      2  value,     null,           value,     out
-  //null_policy::INCLUDE
+  // keys    {1, 1, 1    2, 2, 2, 2      3, 3, 3    4}
+  // vals    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,   4,-}
+  //       0  null,      value,          value,     null
+  //       1  value,     value,          value,     null
+  //       2  value,     null,           value,     out
+  // null_policy::INCLUDE
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls0({-1, 1, 2, 4}, {0, 1, 1, 1});
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls1({3, 4, 2, -1}, {1, 1, 1, 0});
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls2({6, -1, 8, -1}, {1, 0, 1, 0});
 
-  //null_policy::EXCLUDE
+  // null_policy::EXCLUDE
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals0({3, 1, 2, 4});
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals1({6, 4, 2, -1}, {1, 1, 1, 0});
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals2({-1, 9, 8, -1}, {0, 1, 1, 0});
 
-  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0, cudf::null_policy::INCLUDE);
+  auto agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls0, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(1, cudf::null_policy::INCLUDE);
+  agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(1, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls1, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2, cudf::null_policy::INCLUDE);
+  agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls2, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0, cudf::null_policy::EXCLUDE);
+  agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals0, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(1, cudf::null_policy::EXCLUDE);
+  agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(1, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2, cudf::null_policy::EXCLUDE);
+  agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(2, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg));
 }
 
@@ -243,47 +251,53 @@ TYPED_TEST(groupby_nth_element_test, exclude_nulls_negative_index)
   using V = TypeParam;
   using R = V;
 
-  cudf::test::fixed_width_column_wrapper<K> keys({1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
-                                     {true, true, true, true, true, true, true, true, false, true, true, true, true, true});
-  cudf::test::fixed_width_column_wrapper<V, int32_t> vals({0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2},
-                                              {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
+  cudf::test::fixed_width_column_wrapper<K> keys(
+    {1, 2, 3, 3, 1, 2, 2, 1, 3, 3, 2, 4, 4, 2},
+    {true, true, true, true, true, true, true, true, false, true, true, true, true, true});
+  cudf::test::fixed_width_column_wrapper<V, int32_t> vals(
+    {0, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 4, 4, 2}, {0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0});
 
   cudf::test::fixed_width_column_wrapper<K> expect_keys({1, 2, 3, 4}, no_nulls());
-  //keys                                    {1, 1, 1    2, 2, 2,        3, 3,       4}
-  //vals                                    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,    4,-}
-  //                                      0  null,      value,          value,      value
-  //                                      1  value,     value,          value,      null
-  //                                      2  value,     null,           value,      out
-  //                                      3  out,       value,          out,        out
-  //                                      4  out,       null,           out,        out
+  // keys    {1, 1, 1    2, 2, 2,        3, 3,       4}
+  // vals    {-, 3, 6    1, 4, -, 9, -   2, 2, 8,    4,-}
+  //       0  null,      value,          value,      value
+  //       1  value,     value,          value,      null
+  //       2  value,     null,           value,      out
+  //       3  out,       value,          out,        out
+  //       4  out,       null,           out,        out
 
-  //null_policy::INCLUDE
+  // null_policy::INCLUDE
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls0({6, -1, 8, -1}, {1, 0, 1, 0});
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls1({3, 9, 2, 4});
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_nuls2({-1, -1, 2, -1}, {0, 0, 1, 0});
 
-  //null_policy::EXCLUDE
+  // null_policy::EXCLUDE
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals0({6, 9, 8, 4});
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals1({3, 4, 2, -1}, {1, 1, 1, 0});
   cudf::test::fixed_width_column_wrapper<R, int32_t> expect_vals2({-1, 1, 2, -1}, {0, 1, 1, 0});
 
-  auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-1, cudf::null_policy::INCLUDE);
+  auto agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-1, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls0, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-2, cudf::null_policy::INCLUDE);
+  agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-2, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls1, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-3, cudf::null_policy::INCLUDE);
+  agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-3, cudf::null_policy::INCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_nuls2, std::move(agg));
 
-  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-1, cudf::null_policy::EXCLUDE);
+  agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-1, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals0, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-2, cudf::null_policy::EXCLUDE);
+  agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-2, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals1, std::move(agg));
-  agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-3, cudf::null_policy::EXCLUDE);
+  agg =
+    cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-3, cudf::null_policy::EXCLUDE);
   test_single_agg(keys, vals, expect_keys, expect_vals2, std::move(agg));
 }
 
-struct groupby_nth_element_string_test : public cudf::test::BaseFixture {
-};
+struct groupby_nth_element_string_test : public cudf::test::BaseFixture {};
 
 TEST_F(groupby_nth_element_string_test, basic_string)
 {
@@ -294,7 +308,7 @@ TEST_F(groupby_nth_element_string_test, basic_string)
 
   cudf::test::fixed_width_column_wrapper<K> expect_keys{1, 2, 3};
 
-  //groupby.first()
+  // groupby.first()
   auto agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(0);
   cudf::test::strings_column_wrapper expect_vals0{"ABCD", "1", "2"};
   test_single_agg(keys, vals, expect_keys, expect_vals0, std::move(agg));
@@ -312,7 +326,7 @@ TEST_F(groupby_nth_element_string_test, basic_string)
   cudf::test::strings_column_wrapper expect_vals3{{"", "9", ""}, {false, true, false}};
   test_single_agg(keys, vals, expect_keys, expect_vals3, std::move(agg));
 
-  //groupby.last()
+  // groupby.last()
   agg = cudf::make_nth_element_aggregation<cudf::groupby_aggregation>(-1);
   cudf::test::strings_column_wrapper expect_vals4{"6", "9", "8"};
   test_single_agg(keys, vals, expect_keys, expect_vals4, std::move(agg));
@@ -330,7 +344,6 @@ TEST_F(groupby_nth_element_string_test, basic_string)
   cudf::test::strings_column_wrapper expect_vals7{{"", "1", ""}, {false, true, false}};
   test_single_agg(keys, vals, expect_keys, expect_vals7, std::move(agg));
 }
-// clang-format on
 
 TEST_F(groupby_nth_element_string_test, dictionary)
 {

--- a/cpp/tests/interop/from_arrow_device_test.cpp
+++ b/cpp/tests/interop/from_arrow_device_test.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/debug_utilities.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/nanoarrow_utils.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
@@ -189,9 +190,8 @@ TYPED_TEST(FromArrowDeviceTestDurationsTest, DurationTable)
 
 TEST_F(FromArrowDeviceTest, NestedList)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3 != 0; });
-  auto col = cudf::test::lists_column_wrapper<int64_t>(
+  auto valids = cudf::test::iterators::nulls_at_multiples_of(3);
+  auto col    = cudf::test::lists_column_wrapper<int64_t>(
     {{{{{1, 2}, valids}, {{3, 4}, valids}, {5}}, {{6}, {{7, 8, 9}, valids}}}, valids});
   cudf::table_view expected_table_view({col});
 

--- a/cpp/tests/interop/from_arrow_host_test.cpp
+++ b/cpp/tests/interop/from_arrow_host_test.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/nanoarrow_utils.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
@@ -425,9 +426,8 @@ TYPED_TEST(FromArrowHostDeviceTestDecimalsTest, FixedPointTableLargeNulls)
 
 TEST_F(FromArrowHostDeviceTest, NestedList)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3 != 0; });
-  auto col = cudf::test::lists_column_wrapper<int64_t>(
+  auto valids = cudf::test::iterators::nulls_at_multiples_of(3);
+  auto col    = cudf::test::lists_column_wrapper<int64_t>(
     {{{{{1, 2}, valids}, {{3, 4}, valids}, {5}}, {{6}, {{7, 8, 9}, valids}}}, valids});
   cudf::table_view expected_table_view({col});
 

--- a/cpp/tests/interop/from_arrow_test.cpp
+++ b/cpp/tests/interop/from_arrow_test.cpp
@@ -8,6 +8,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/nanoarrow_utils.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
@@ -199,9 +200,8 @@ TYPED_TEST(FromArrowTestDurationsTest, DurationTable)
 
 TEST_F(FromArrowTest, NestedList)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3 != 0; });
-  auto col = cudf::test::lists_column_wrapper<int64_t>(
+  auto valids = cudf::test::iterators::nulls_at_multiples_of(3);
+  auto col    = cudf::test::lists_column_wrapper<int64_t>(
     {{{{{1, 2}, valids}, {{3, 4}, valids}, {5}}, {{6}, {{7, 8, 9}, valids}}}, valids});
   cudf::table_view expected_table_view({col});
 

--- a/cpp/tests/interop/to_arrow_device_test.cpp
+++ b/cpp/tests/interop/to_arrow_device_test.cpp
@@ -5,6 +5,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/nanoarrow_utils.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -489,9 +490,8 @@ TYPED_TEST(ToArrowDeviceTestDurationsTest, DurationTable)
 
 TEST_F(ToArrowDeviceTest, NestedList)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3 != 0; });
-  auto col = cudf::test::lists_column_wrapper<int64_t>(
+  auto valids = cudf::test::iterators::nulls_at_multiples_of(3);
+  auto col    = cudf::test::lists_column_wrapper<int64_t>(
     {{{{{1, 2}, valids}, {{3, 4}, valids}, {5}}, {{6}, {{7, 8, 9}, valids}}}, valids});
 
   std::vector<std::unique_ptr<cudf::column>> cols;

--- a/cpp/tests/interop/to_arrow_host_test.cpp
+++ b/cpp/tests/interop/to_arrow_host_test.cpp
@@ -5,6 +5,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/nanoarrow_utils.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -373,9 +374,8 @@ TYPED_TEST(ToArrowHostDeviceTestDurationsTest, DurationTable)
 
 TEST_F(ToArrowHostDeviceTest, NestedList)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3 != 0; });
-  auto col = cudf::test::lists_column_wrapper<int64_t>(
+  auto valids = cudf::test::iterators::nulls_at_multiples_of(3);
+  auto col    = cudf::test::lists_column_wrapper<int64_t>(
     {{{{{1, 2}, valids}, {{3, 4}, valids}, {5}}, {{6}, {{7, 8, 9}, valids}}}, valids});
   cudf::table_view input_view({col});
 

--- a/cpp/tests/interop/to_arrow_test.cpp
+++ b/cpp/tests/interop/to_arrow_test.cpp
@@ -8,6 +8,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/testing_main.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -242,9 +243,8 @@ TYPED_TEST(ToArrowTestDurationsTest, DurationTable)
 
 TEST_F(ToArrowTest, NestedList)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3 != 0; });
-  auto col = cudf::test::lists_column_wrapper<int64_t>(
+  auto valids = cudf::test::iterators::nulls_at_multiples_of(3);
+  auto col    = cudf::test::lists_column_wrapper<int64_t>(
     {{{{{1, 2}, valids}, {{3, 4}, valids}, {5}}, {{6}, {{7, 8, 9}, valids}}}, valids});
   cudf::table_view input_view({col});
 

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -349,8 +349,7 @@ TYPED_TEST(CsvFixedPointWriterTest, SingleColumnNegativeScale)
   std::vector<std::string> reference_strings = {
     "1.23", "-8.76", "5.43", "-0.12", "0.25", "-0.23", "-0.27", "0.00", "0.00"};
 
-  auto validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 2 == 0); });
+  auto validity = cudf::test::iterators::valids_at_multiples_of(2);
   cudf::test::strings_column_wrapper strings(
     reference_strings.begin(), reference_strings.end(), validity);
 
@@ -396,8 +395,7 @@ TYPED_TEST(CsvFixedPointWriterTest, SingleColumnPositiveScale)
   std::vector<std::string> reference_strings = {
     "123000", "-876000", "543000", "-12000", "25000", "-23000", "-27000", "0000", "0000"};
 
-  auto validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 2 == 0); });
+  auto validity = cudf::test::iterators::valids_at_multiples_of(2);
   cudf::test::strings_column_wrapper strings(
     reference_strings.begin(), reference_strings.end(), validity);
 

--- a/cpp/tests/io/cudftable_test.cpp
+++ b/cpp/tests/io/cudftable_test.cpp
@@ -5,6 +5,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/testing_main.hpp>
 
@@ -122,8 +123,7 @@ TEST_F(CudftableTest, MultiColumnCompound)
   cudf::test::strings_column_wrapper string_col({"Lorem", "ipsum", "dolor", "sit"},
                                                 {true, false, true, true});
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
   cudf::test::lists_column_wrapper<int32_t> list_col{
     {{1, 2, 3}, valids}, {4, 5}, {}, {{6, 7, 8, 9}, valids}};
 

--- a/cpp/tests/io/orc_test.cpp
+++ b/cpp/tests/io/orc_test.cpp
@@ -68,8 +68,7 @@ std::unique_ptr<cudf::table> create_random_fixed_table(cudf::size_type num_colum
                                                        cudf::size_type num_rows,
                                                        bool include_validity)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
   std::vector<column_wrapper<T>> src_cols(num_columns);
   for (int idx = 0; idx < num_columns; idx++) {
     auto rand_elements =
@@ -246,7 +245,7 @@ TYPED_TEST(OrcWriterNumericTypeTest, SingleColumn)
 TYPED_TEST(OrcWriterNumericTypeTest, SingleColumnWithNulls)
 {
   auto sequence = cuda::counting_iterator{0};
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 2); });
+  auto validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
   constexpr auto num_rows = 100;
   column_wrapper<TypeParam, typename decltype(sequence)::value_type> col(
@@ -405,8 +404,7 @@ TEST_F(OrcWriterTest, MultiColumnWithNulls)
   auto col4_data = random_values<float>(num_rows);
   auto col5_data = random_values<double>(num_rows);
   auto col6_vals = random_values<int32_t>(num_rows);
-  auto col0_mask =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 2); });
+  auto col0_mask = cudf::test::iterators::nulls_at_multiples_of(2);
   auto col1_mask =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i < 2); });
   auto col3_mask =
@@ -415,8 +413,7 @@ TEST_F(OrcWriterTest, MultiColumnWithNulls)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i >= 4 && i <= 6); });
   auto col5_mask =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i > 8); });
-  auto col6_mask =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 3); });
+  auto col6_mask = cudf::test::iterators::nulls_at_multiples_of(3);
 
   bool_col col0{col0_data.begin(), col0_data.end(), col0_mask};
   int8_col col1{col1_data.begin(), col1_data.end(), col1_mask};
@@ -1003,7 +1000,7 @@ TEST_F(OrcStatisticsTest, Basic)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i - 4) * 1000002; });
   auto dec_sequence =
     cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return i * 1001; });
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
   std::vector<char const*> strings{
     "Monday", "Monday", "Friday", "Monday", "Friday", "Friday", "Friday", "Wednesday", "Tuesday"};
@@ -1225,7 +1222,7 @@ TEST_P(OrcWriterTestDecimal, Decimal64)
 
   // Using int16_t because scale causes values to overflow if they already require 32 bits
   auto const vals = random_values<int32_t>(num_rows);
-  auto mask = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 7 == 0; });
+  auto mask       = cudf::test::iterators::valids_at_multiples_of(7);
   dec64_col col{vals.begin(), vals.end(), mask, numeric::scale_type{scale}};
   cudf::table_view tbl({static_cast<cudf::column_view>(col)});
 
@@ -1253,7 +1250,7 @@ TEST_F(OrcWriterTest, Decimal32)
 
   // Using int16_t because scale causes values to overflow if they already require 32 bits
   auto const vals = random_values<int16_t>(num_rows);
-  auto mask = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 13; });
+  auto mask       = cudf::test::iterators::nulls_at_multiples_of(13);
   dec32_col col{vals.begin(), vals.end(), mask, numeric::scale_type{2}};
   cudf::table_view expected({col});
 
@@ -1281,7 +1278,7 @@ TEST_F(OrcStatisticsTest, Overflow)
     0, [](auto i) { return i * (std::numeric_limits<int64_t>::max() / 200); });
   auto not_too_small_seq = cudf::detail::make_counting_transform_iterator(
     0, [](auto i) { return i * (std::numeric_limits<int64_t>::min() / 200); });
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
   column_wrapper<int64_t, typename decltype(too_large_seq)::value_type> col1(
     too_large_seq, too_large_seq + num_rows, validity);
@@ -1457,12 +1454,12 @@ TEST_F(OrcWriterTest, TestMap)
 
   auto keys      = random_values<int>(num_child_rows);
   auto vals      = random_values<float>(num_child_rows);
-  auto vals_mask = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3; });
+  auto vals_mask = cudf::test::iterators::nulls_at_multiples_of(3);
   int32_col keys_col(keys.begin(), keys.end());
   float32_col vals_col{vals.begin(), vals.end(), vals_mask};
   auto s_col = struct_col({keys_col, vals_col}).release();
 
-  auto valids = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto valids = cudf::test::iterators::nulls_at_multiples_of(2);
 
   std::vector<int> row_offsets(num_rows + 1);
   int offset = 0;
@@ -1501,7 +1498,7 @@ TEST_F(OrcReaderTest, NestedColumnSelection)
   auto const num_rows  = 1000;
   auto child_col1_data = random_values<int32_t>(num_rows);
   auto child_col2_data = random_values<int64_t>(num_rows);
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3; });
+  auto validity        = cudf::test::iterators::nulls_at_multiples_of(3);
   int32_col child_col1{child_col1_data.begin(), child_col1_data.end(), validity};
   int64_col child_col2{child_col2_data.begin(), child_col2_data.end(), validity};
   struct_col s_col{child_col1, child_col2};
@@ -1536,7 +1533,7 @@ TEST_F(OrcReaderTest, DecimalOptions)
 {
   constexpr auto num_rows = 10;
   auto col_vals           = random_values<int64_t>(num_rows);
-  auto mask = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3 == 0; });
+  auto mask               = cudf::test::iterators::valids_at_multiples_of(3);
 
   dec128_col col{col_vals.begin(), col_vals.end(), mask, numeric::scale_type{2}};
   table_view expected({col});

--- a/cpp/tests/io/parquet_chunked_writer_test.cpp
+++ b/cpp/tests/io/parquet_chunked_writer_test.cpp
@@ -142,7 +142,7 @@ TEST_F(ParquetChunkedWriterTest, Strings)
 
 TEST_F(ParquetChunkedWriterTest, ListColumn)
 {
-  auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto valids  = cudf::test::iterators::nulls_at_multiples_of(2);
   auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;
@@ -261,7 +261,7 @@ TEST_F(ParquetChunkedWriterTest, ListOfStruct)
 
 TEST_F(ParquetChunkedWriterTest, ListOfStructOfStructOfListOfList)
 {
-  auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto valids  = cudf::test::iterators::nulls_at_multiples_of(2);
   auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;
@@ -413,7 +413,7 @@ TEST_F(ParquetChunkedWriterTest, MismatchedStructure)
 
 TEST_F(ParquetChunkedWriterTest, MismatchedStructureList)
 {
-  auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto valids  = cudf::test::iterators::nulls_at_multiples_of(2);
   auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;
@@ -556,7 +556,7 @@ TEST_F(ParquetChunkedWriterTest, ForcedNullabilityList)
 {
   srand(31337);
 
-  auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto valids  = cudf::test::iterators::nulls_at_multiples_of(2);
   auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;

--- a/cpp/tests/io/parquet_common.cpp
+++ b/cpp/tests/io/parquet_common.cpp
@@ -5,6 +5,8 @@
 
 #include "parquet_common.hpp"
 
+#include <cudf_test/iterator_utilities.hpp>
+
 #include <cudf/io/parquet.hpp>
 #include <cudf/io/parquet_io_utils.hpp>
 
@@ -24,8 +26,7 @@ std::unique_ptr<cudf::table> create_fixed_table(cudf::size_type num_columns,
                                                 bool include_validity,
                                                 Elements elements)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
   std::vector<cudf::test::fixed_width_column_wrapper<T>> src_cols(num_columns);
   for (int idx = 0; idx < num_columns; idx++) {
     if (include_validity) {
@@ -94,8 +95,7 @@ template <typename T>
 std::unique_ptr<cudf::column> make_parquet_list_list_col(
   int skip_rows, int num_rows, int lists_per_row, int list_size, bool include_validity)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0 ? 1 : 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // root list
   std::vector<int> row_offsets(num_rows + 1);

--- a/cpp/tests/io/parquet_deletion_vectors_test.cu
+++ b/cpp/tests/io/parquet_deletion_vectors_test.cu
@@ -6,6 +6,7 @@
 #include "parquet_common.hpp"
 
 #include <cudf_test/base_fixture.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
 
 #include <cudf/io/experimental/deletion_vectors.hpp>
@@ -369,8 +370,7 @@ TYPED_TEST(RoaringBitmapBasicsTest, BitmapSerialization)
   auto constexpr num_keys = 100'000;
   using Key               = TypeParam;
 
-  auto is_even =
-    cudf::detail::make_counting_transform_iterator(0, [](auto const i) { return i % 2 == 0; });
+  auto is_even = [](Key k) { return k % 2 == 0; };
 
   auto serialized_bitmap = std::vector<cuda::std::byte>{};
 
@@ -383,7 +383,7 @@ TYPED_TEST(RoaringBitmapBasicsTest, BitmapSerialization)
 
     std::for_each(
       cuda::counting_iterator<Key>{0}, cuda::counting_iterator<Key>{num_keys}, [&](auto key) {
-        if (is_even[key]) {
+        if (is_even(key)) {
           roaring::api::roaring64_bitmap_add_bulk(roaring64_bitmap, &roaring64_context, key);
         }
       });
@@ -406,7 +406,7 @@ TYPED_TEST(RoaringBitmapBasicsTest, BitmapSerialization)
 
     std::for_each(
       cuda::counting_iterator<Key>{0}, cuda::counting_iterator<Key>{num_keys}, [&](auto key) {
-        if (is_even[key]) {
+        if (is_even(key)) {
           roaring::api::roaring_bitmap_add_bulk(roaring_bitmap, &roaring_context, key);
         }
       });
@@ -445,7 +445,7 @@ TYPED_TEST(RoaringBitmapBasicsTest, BitmapSerialization)
   stream.synchronize();
   EXPECT_TRUE(std::all_of(cuda::counting_iterator<Key>{0},
                           cuda::counting_iterator<Key>{num_keys},
-                          [&](auto key) { return results[key] == is_even[key]; }));
+                          [&](auto key) { return results[key] == is_even(key); }));
 }
 
 // Base test fixture for API tests

--- a/cpp/tests/io/parquet_reader_test.cpp
+++ b/cpp/tests/io/parquet_reader_test.cpp
@@ -1214,8 +1214,7 @@ TEST_F(ParquetReaderTest, NestingOptimizationTest)
 
   constexpr cudf::size_type num_values = (1 << num_nesting_levels) * rows_per_level;
   auto value_iter                      = cuda::counting_iterator<int>{0};
-  auto validity =
-    cudf::detail::make_counting_transform_iterator(0, [](cudf::size_type i) { return i % 2; });
+  auto validity                        = cudf::test::iterators::nulls_at_multiples_of(2);
   cudf::test::fixed_width_column_wrapper<int> values(value_iter, value_iter + num_values, validity);
 
   // ~256k values with num_nesting_levels = 16

--- a/cpp/tests/io/parquet_v2_test.cpp
+++ b/cpp/tests/io/parquet_v2_test.cpp
@@ -109,8 +109,7 @@ TEST_P(ParquetV2Test, MultiColumnWithNulls)
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i >= 40 && i <= 60); });
   auto col5_mask =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i > 80); });
-  auto col6_mask =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 5); });
+  auto col6_mask = cudf::test::iterators::nulls_at_multiples_of(5);
   auto col7_mask =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i != 55); });
 
@@ -272,8 +271,7 @@ TEST_P(ParquetV2Test, SlicedTable)
 
   auto seq_col0 = random_values<int>(num_rows);
   auto seq_col2 = random_values<float>(num_rows);
-  auto validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3 != 0; });
+  auto validity = cudf::test::iterators::nulls_at_multiples_of(3);
 
   column_wrapper<int> col0{seq_col0.begin(), seq_col0.end(), validity};
   column_wrapper<cudf::string_view> col1{strings.begin(), strings.end()};
@@ -290,7 +288,7 @@ TEST_P(ParquetV2Test, SlicedTable)
   // [NULL, [[13],[14,15,16]],  NULL]
   // [[[]]]
   // [NULL, [], NULL, [[]]]
-  auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto valids  = cudf::test::iterators::nulls_at_multiples_of(2);
   auto valids2 = cudf::test::iterators::null_at(3);
   lcw col4{{
              {{{{1, 2, 3, 4}, valids}}, {{{5, 6, 7}, valids}, {8, 9}}},
@@ -383,7 +381,7 @@ TEST_P(ParquetV2Test, ListColumn)
 {
   auto const is_v2 = GetParam();
 
-  auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto valids  = cudf::test::iterators::nulls_at_multiples_of(2);
   auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;
@@ -498,7 +496,7 @@ TEST_P(ParquetV2Test, StructOfList)
   auto ages_col = cudf::test::fixed_width_column_wrapper<int32_t>{
     {48, 27, 25, 31, 351, 351}, {true, true, true, true, true, false}};
 
-  auto valids  = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  auto valids  = cudf::test::iterators::nulls_at_multiples_of(2);
   auto valids2 = cudf::test::iterators::null_at(3);
 
   using lcw = cudf::test::lists_column_wrapper<int32_t>;
@@ -797,8 +795,7 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexNulls)
   auto col5_data = random_values<float>(num_rows);
   auto col6_data = random_values<double>(num_rows);
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // add null values for all but first column
   auto col1 =
@@ -1072,14 +1069,10 @@ TEST_P(ParquetV2Test, CheckColumnOffsetIndexStructNulls)
   auto const expected_hdr_type =
     is_v2 ? cudf::io::parquet::PageType::DATA_PAGE_V2 : cudf::io::parquet::PageType::DATA_PAGE;
 
-  auto validity2 =
-    cudf::detail::make_counting_transform_iterator(0, [](cudf::size_type i) { return i % 2; });
-  auto validity3 = cudf::detail::make_counting_transform_iterator(
-    0, [](cudf::size_type i) { return (i % 3) != 0; });
-  auto validity4 = cudf::detail::make_counting_transform_iterator(
-    0, [](cudf::size_type i) { return (i % 4) != 0; });
-  auto validity5 = cudf::detail::make_counting_transform_iterator(
-    0, [](cudf::size_type i) { return (i % 5) != 0; });
+  auto validity2 = cudf::test::iterators::nulls_at_multiples_of(2);
+  auto validity3 = cudf::test::iterators::nulls_at_multiples_of(3);
+  auto validity4 = cudf::test::iterators::nulls_at_multiples_of(4);
+  auto validity5 = cudf::test::iterators::nulls_at_multiples_of(5);
 
   auto c0 = testdata::ascending<uint32_t>();
 

--- a/cpp/tests/io/parquet_writer_test.cpp
+++ b/cpp/tests/io/parquet_writer_test.cpp
@@ -473,8 +473,7 @@ TEST_F(ParquetWriterTest, DecimalWrite)
   auto seq_col0                      = random_values<int32_t>(num_rows);
   auto seq_col1                      = random_values<int64_t>(num_rows);
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   auto col0 = cudf::test::fixed_point_column_wrapper<int32_t>{
     seq_col0.begin(), seq_col0.end(), valids, numeric::scale_type{5}};
@@ -1532,8 +1531,7 @@ TEST_F(ParquetWriterTest, PreserveNullability)
   auto const col1_data = random_values<int32_t>(num_rows);
 
   auto const col0_validity = cudf::test::iterators::no_nulls();
-  auto const col1_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto const col1_validity = cudf::test::iterators::valids_at_multiples_of(2);
 
   column_wrapper<int32_t> col0{col0_data.begin(), col0_data.end(), col0_validity};
   column_wrapper<int32_t> col1{col1_data.begin(), col1_data.end(), col1_validity};
@@ -1923,8 +1921,7 @@ make_byte_stream_split_table(bool as_struct)
 
     // make as a nested struct
     if (as_struct) {
-      auto valids =
-        cudf::detail::make_counting_transform_iterator(0, [](int i) { return i % 2 == 0; });
+      auto valids                  = cudf::test::iterators::valids_at_multiples_of(2);
       auto [null_mask, null_count] = cudf::test::detail::make_null_mask(valids, valids + num_rows);
 
       std::vector<std::unique_ptr<cudf::column>> table_cols;
@@ -2219,7 +2216,7 @@ TYPED_TEST(ParquetWriterNumericTypeTest, SingleColumnWithNulls)
 {
   auto sequence =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return TypeParam(i); });
-  auto validity = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 2); });
+  auto validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
   constexpr auto num_rows = 100;
   column_wrapper<TypeParam> col(sequence, sequence + num_rows, validity);

--- a/cpp/tests/lists/explode_tests.cpp
+++ b/cpp/tests/lists/explode_tests.cpp
@@ -125,8 +125,7 @@ TEST_F(ExplodeTest, Nulls)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids       = cudf::test::iterators::valids_at_multiples_of(2);
   auto always_valid = cudf::test::iterators::no_nulls();
 
   LCW a({LCW{1, 2, 7}, LCW{null}, LCW{0, 3}}, valids);
@@ -159,8 +158,7 @@ TEST_F(ExplodeTest, NullsInList)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a{
     LCW({1, null, 7}, valids), LCW({5, null, 0, null}, valids), LCW{}, LCW({0, null, 8}, valids)};
@@ -220,8 +218,7 @@ TEST_F(ExplodeTest, NestedNulls)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids       = cudf::test::iterators::valids_at_multiples_of(2);
   auto always_valid = cudf::test::iterators::no_nulls();
 
   LCW a({LCW{LCW{1, 2}, LCW{7, 6, 5}}, LCW{LCW{null}}, LCW{LCW{0, 3}, LCW{5}, LCW{2, 1}}}, valids);
@@ -253,8 +250,7 @@ TEST_F(ExplodeTest, NullsInNested)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a({LCW{LCW({1, null}, valids), LCW{7, 6, 5}},
          LCW{LCW{5, 6}},
@@ -288,8 +284,7 @@ TEST_F(ExplodeTest, NullsInNestedDoubleExplode)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a{LCW{LCW({1, null}, valids), LCW{}, LCW{7, 6, 5}},
         LCW{LCW{5, 6}},
@@ -324,8 +319,7 @@ TEST_F(ExplodeTest, NestedStructs)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a({LCW{LCW({1, null}, valids), LCW{7, 6, 5}},
          LCW{LCW{5, 6}},
@@ -492,8 +486,7 @@ TEST_F(ExplodeTest, SlicedList)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a({LCW{LCW({1, 2}, valids), LCW{7, 6, 5}},
          LCW{LCW{5, 6}},
@@ -613,8 +606,7 @@ TEST_F(ExplodeOuterTest, Nulls)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a({LCW{1, 2, 7}, LCW{null}, LCW{0, 3}}, valids);
   FCW b({100, null, 300}, valids);
@@ -802,8 +794,7 @@ TEST_F(ExplodeOuterTest, NullsInList)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a{
     LCW({1, null, 7}, valids), LCW({5, null, 0, null}, valids), LCW{}, LCW({0, null, 8}, valids)};
@@ -864,8 +855,7 @@ TEST_F(ExplodeOuterTest, NestedNulls)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a({LCW{LCW{1, 2}, LCW{7, 6, 5}}, LCW{LCW{null}}, LCW{LCW{0, 3}, LCW{5}, LCW{2, 1}}}, valids);
   FCW b({100, 200, 300});
@@ -896,8 +886,7 @@ TEST_F(ExplodeOuterTest, NullsInNested)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a({LCW{LCW({1, null}, valids), LCW{7, 6, 5}},
          LCW{LCW{5, 6}},
@@ -931,8 +920,7 @@ TEST_F(ExplodeOuterTest, NullsInNestedDoubleExplode)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a{LCW{LCW({1, null}, valids), LCW{}, LCW{7, 6, 5}},
         LCW{LCW{5, 6}},
@@ -969,8 +957,7 @@ TEST_F(ExplodeOuterTest, NestedStructs)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a({LCW{LCW({1, null}, valids), LCW{7, 6, 5}},
          LCW{LCW{5, 6}},
@@ -1139,8 +1126,7 @@ TEST_F(ExplodeOuterTest, SlicedList)
 
   constexpr auto null = 0;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   LCW a({LCW{LCW({1, null}, valids), LCW{7, 6, 5}},
          LCW{LCW{5, 6}},

--- a/cpp/tests/merge/merge_test.cpp
+++ b/cpp/tests/merge/merge_test.cpp
@@ -687,11 +687,9 @@ TEST_F(MergeTest, KeysWithNulls)
 {
   cudf::size_type nrows = 13200;  // Ensures that thrust::merge uses more than one tile/block
   auto data_iter        = cuda::counting_iterator<int32_t>{0};
-  auto valids1 =
-    cudf::detail::make_counting_transform_iterator(0, [](auto row) { return row % 10 != 0; });
+  auto valids1          = cudf::test::iterators::nulls_at_multiples_of(10);
   cudf::test::fixed_width_column_wrapper<int32_t> data1(data_iter, data_iter + nrows, valids1);
-  auto valids2 =
-    cudf::detail::make_counting_transform_iterator(0, [](auto row) { return row % 15 != 0; });
+  auto valids2 = cudf::test::iterators::nulls_at_multiples_of(15);
   cudf::test::fixed_width_column_wrapper<int32_t> data2(data_iter, data_iter + nrows, valids2);
   auto all_data = cudf::concatenate(std::vector<cudf::column_view>{{data1, data2}});
 

--- a/cpp/tests/quantiles/percentile_approx_test.cpp
+++ b/cpp/tests/quantiles/percentile_approx_test.cpp
@@ -5,6 +5,7 @@
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/tdigest_utilities.hpp>
 #include <cudf_test/type_list_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
@@ -289,7 +290,7 @@ void grouped_test(cudf::data_type input_type, std::vector<std::pair<int, int>> p
 
 std::pair<rmm::device_buffer, cudf::size_type> make_null_mask(cudf::column_view const& col)
 {
-  auto itr = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto itr = cudf::test::iterators::valids_at_multiples_of(2);
   return cudf::test::detail::make_null_mask(itr, itr + col.size());
 }
 

--- a/cpp/tests/replace/replace_nulls_tests.cpp
+++ b/cpp/tests/replace/replace_nulls_tests.cpp
@@ -493,8 +493,7 @@ TYPED_TEST(ReplaceNullsFixedPointTest, ReplaceColumn)
   auto const sz    = std::size_t{1000};
   auto data_begin =
     cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return TypeParam{i, scale}; });
-  auto valid_begin =
-    cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return i % 3 ? 1 : 0; });
+  auto valid_begin = cudf::test::iterators::nulls_at_multiples_of(3);
   auto replace_begin =
     cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return TypeParam{-2, scale}; });
   auto expected_begin = cudf::detail::make_counting_transform_iterator(0, [&](auto i) {
@@ -521,8 +520,7 @@ TYPED_TEST(ReplaceNullsFixedPointTest, ReplaceScalar)
   auto const sz    = std::size_t{1000};
   auto data_begin =
     cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return TypeParam{i, scale}; });
-  auto valid_begin =
-    cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return i % 3 ? 1 : 0; });
+  auto valid_begin    = cudf::test::iterators::nulls_at_multiples_of(3);
   auto expected_begin = cudf::detail::make_counting_transform_iterator(0, [&](auto i) {
     int val = i % 3 ? static_cast<int>(i) : -2;
     return TypeParam{val, scale};
@@ -542,18 +540,15 @@ TYPED_TEST(ReplaceNullsFixedPointTest, ReplacementHasNulls)
   auto const sz    = std::size_t{1000};
   auto data_begin =
     cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return TypeParam{i, scale}; });
-  auto data_valid_begin =
-    cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return i % 3 ? 1 : 0; });
+  auto data_valid_begin = cudf::test::iterators::nulls_at_multiples_of(3);
   auto replace_begin =
     cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return TypeParam{-2, scale}; });
-  auto replace_valid_begin =
-    cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return i % 2 ? 1 : 0; });
-  auto expected_begin = cudf::detail::make_counting_transform_iterator(0, [&](auto i) {
+  auto replace_valid_begin  = cudf::test::iterators::nulls_at_multiples_of(2);
+  auto expected_begin       = cudf::detail::make_counting_transform_iterator(0, [&](auto i) {
     int val = i % 3 ? static_cast<int>(i) : -2;
     return TypeParam{val, scale};
   });
-  auto expected_valid_begin =
-    cudf::detail::make_counting_transform_iterator(0, [&](auto i) { return i % 6 ? 1 : 0; });
+  auto expected_valid_begin = cudf::test::iterators::nulls_at_multiples_of(6);
 
   ReplaceNullsColumn<TypeParam>(cudf::test::fixed_width_column_wrapper<TypeParam>(
                                   data_begin, data_begin + sz, data_valid_begin),

--- a/cpp/tests/reshape/byte_cast_tests.cpp
+++ b/cpp/tests/reshape/byte_cast_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,9 +37,8 @@ TEST_F(ByteCastTest, int16ValuesWithSplit)
 
 TEST_F(ByteCastTest, int16ValuesWithNulls)
 {
-  using limits = std::numeric_limits<int16_t>;
-  auto odd_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  using limits      = std::numeric_limits<int16_t>;
+  auto odd_validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<int16_t> const int16_col(
     {short(0), short(100), short(-100), limits::min(), limits::max()},
@@ -83,9 +82,8 @@ TEST_F(ByteCastTest, int32Values)
 
 TEST_F(ByteCastTest, int32ValuesWithNulls)
 {
-  using limits = std::numeric_limits<int32_t>;
-  auto even_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i + 1) % 2; });
+  using limits       = std::numeric_limits<int32_t>;
+  auto even_validity = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<int32_t> const int32_col(
     {0, 100, -100, limits::min(), limits::max()}, {true, false, true, false, true});
@@ -138,9 +136,8 @@ TEST_F(ByteCastTest, int64ValuesWithSplit)
 
 TEST_F(ByteCastTest, int64ValuesWithNulls)
 {
-  using limits = std::numeric_limits<int64_t>;
-  auto odd_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  using limits      = std::numeric_limits<int64_t>;
+  auto odd_validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<int64_t> const int64_col(
     {long(0), long(100), long(-100), limits::min(), limits::max()},
@@ -199,9 +196,8 @@ TEST_F(ByteCastTest, fp32ValuesWithSplit)
 
 TEST_F(ByteCastTest, fp32ValuesWithNulls)
 {
-  using limits = std::numeric_limits<float>;
-  auto even_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i + 1) % 2; });
+  using limits       = std::numeric_limits<float>;
+  auto even_validity = cudf::test::iterators::valids_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<float> const fp32_col(
     {float(0.0), float(100.0), float(-100.0), limits::min(), limits::max()},
@@ -271,9 +267,8 @@ TEST_F(ByteCastTest, fp64ValuesWithSplit)
 
 TEST_F(ByteCastTest, fp64ValuesWithNulls)
 {
-  using limits = std::numeric_limits<double>;
-  auto odd_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; });
+  using limits      = std::numeric_limits<double>;
+  auto odd_validity = cudf::test::iterators::nulls_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<double> const fp64_col(
     {double(0.0), double(100.0), double(-100.0), limits::min(), limits::max()},

--- a/cpp/tests/streams/io/orc_test.cpp
+++ b/cpp/tests/streams/io/orc_test.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/default_stream.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/testing_main.hpp>
 
 #include <cudf/io/orc.hpp>
@@ -49,16 +50,14 @@ cudf::table construct_table()
     ones_iterator, ones_iterator + num_rows, numeric::scale_type{-12});
 
   cudf::test::lists_column_wrapper<int64_t> col8 = [] {
-    auto col8_mask =
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 2); });
+    auto col8_mask = cudf::test::iterators::nulls_at_multiples_of(2);
     return cudf::test::lists_column_wrapper<int64_t>(
       {{1, 1}, {1, 1, 1}, {}, {1}, {1, 1, 1, 1}, {1, 1, 1, 1, 1}, {}, {1, -1}, {}, {-1, -1}},
       col8_mask);
   }();
 
   cudf::test::structs_column_wrapper col9 = [&ones_iterator] {
-    auto child_col_mask =
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 2); });
+    auto child_col_mask = cudf::test::iterators::nulls_at_multiples_of(2);
     cudf::test::fixed_width_column_wrapper<int32_t> child_col(
       ones_iterator, ones_iterator + num_rows, child_col_mask);
     return cudf::test::structs_column_wrapper{child_col};

--- a/cpp/tests/streams/lists_test.cpp
+++ b/cpp/tests/streams/lists_test.cpp
@@ -1,11 +1,12 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/default_stream.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/testing_main.hpp>
 
 #include <cudf/lists/combine.hpp>
@@ -233,8 +234,7 @@ TEST_F(ListTest, ExplodePosition)
 TEST_F(ListTest, ExplodeOuter)
 {
   constexpr auto null = 0;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids         = cudf::test::iterators::valids_at_multiples_of(2);
   cudf::test::lists_column_wrapper<int32_t> list_col_a{
     cudf::test::lists_column_wrapper<int32_t>({1, null, 7}, valids),
     cudf::test::lists_column_wrapper<int32_t>({5, null, 0, null}, valids),
@@ -248,8 +248,7 @@ TEST_F(ListTest, ExplodeOuter)
 TEST_F(ListTest, ExplodeOuterPosition)
 {
   constexpr auto null = 0;
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids         = cudf::test::iterators::valids_at_multiples_of(2);
   cudf::test::lists_column_wrapper<int32_t> list_col_a{
     cudf::test::lists_column_wrapper<int32_t>({1, null, 7}, valids),
     cudf::test::lists_column_wrapper<int32_t>({5, null, 0, null}, valids),

--- a/cpp/tests/streams/merge_test.cpp
+++ b/cpp/tests/streams/merge_test.cpp
@@ -7,6 +7,7 @@
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/default_stream.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/table_utilities.hpp>
 #include <cudf_test/testing_main.hpp>
 #include <cudf_test/type_lists.hpp>
@@ -83,11 +84,9 @@ TEST_F(MergeTest, KeysWithNulls)
 {
   cudf::size_type nrows = 13200;  // Ensures that thrust::merge uses more than one tile/block
   auto data_iter        = cuda::counting_iterator<int32_t>{0};
-  auto valids1 =
-    cudf::detail::make_counting_transform_iterator(0, [](auto row) { return row % 10 != 0; });
+  auto valids1          = cudf::test::iterators::nulls_at_multiples_of(10);
   cudf::test::fixed_width_column_wrapper<int32_t> data1(data_iter, data_iter + nrows, valids1);
-  auto valids2 =
-    cudf::detail::make_counting_transform_iterator(0, [](auto row) { return row % 15 != 0; });
+  auto valids2 = cudf::test::iterators::nulls_at_multiples_of(15);
   cudf::test::fixed_width_column_wrapper<int32_t> data2(data_iter, data_iter + nrows, valids2);
   auto all_data = cudf::concatenate(std::vector<cudf::column_view>{{data1, data2}},
                                     cudf::test::get_default_stream());

--- a/cpp/tests/structs/structs_column_tests.cpp
+++ b/cpp/tests/structs/structs_column_tests.cpp
@@ -412,17 +412,16 @@ TYPED_TEST(TypedStructColumnWrapperTest, ListOfStructOfList)
 {
   using namespace cudf::test;
 
-  auto list_col = lists_column_wrapper<TypeParam, int32_t>{
-    {{0}, {1}, {}, {3}, {4}, {5, 5}, {6}, {}, {8}, {9}},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })};
+  auto list_col =
+    lists_column_wrapper<TypeParam, int32_t>{{{0}, {1}, {}, {3}, {4}, {5, 5}, {6}, {}, {8}, {9}},
+                                             cudf::test::iterators::nulls_at_multiples_of(2)};
 
   // TODO: Struct<List> cannot be compared with expect_columns_equal(),
   // if the struct has null values. After lists support "equivalence"
   // comparisons, the structs column needs to be modified to add nulls.
   auto struct_of_lists_col = structs_column_wrapper{{list_col}}.release();
 
-  auto list_of_struct_of_list_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3; });
+  auto list_of_struct_of_list_validity = cudf::test::iterators::nulls_at_multiples_of(3);
   auto [null_mask, null_count] =
     detail::make_null_mask(list_of_struct_of_list_validity, list_of_struct_of_list_validity + 5);
   auto list_of_struct_of_list =
@@ -436,8 +435,7 @@ TYPED_TEST(TypedStructColumnWrapperTest, ListOfStructOfList)
   // Compare with expected values.
 
   auto expected_level0_list = lists_column_wrapper<TypeParam, int32_t>{
-    {{}, {3}, {}, {5, 5}, {}, {9}},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })};
+    {{}, {3}, {}, {5, 5}, {}, {9}}, cudf::test::iterators::nulls_at_multiples_of(2)};
 
   auto expected_level2_struct = structs_column_wrapper{{expected_level0_list}}.release();
 
@@ -462,8 +460,7 @@ TYPED_TEST(TypedStructColumnWrapperTest, StructOfListOfStruct)
   using namespace cudf::test;
 
   auto ints_col = fixed_width_column_wrapper<TypeParam, int32_t>{
-    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2; })};
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, cudf::test::iterators::nulls_at_multiples_of(2)};
 
   auto structs_col =
     structs_column_wrapper{
@@ -471,8 +468,7 @@ TYPED_TEST(TypedStructColumnWrapperTest, StructOfListOfStruct)
     }
       .release();
 
-  auto list_validity =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3; });
+  auto list_validity           = cudf::test::iterators::nulls_at_multiples_of(3);
   auto [null_mask, null_count] = detail::make_null_mask(list_validity, list_validity + 5);
 
   auto lists_col =

--- a/cpp/tests/transform/integration/unary_transform_test.cpp
+++ b/cpp/tests/transform/integration/unary_transform_test.cpp
@@ -759,15 +759,9 @@ ret;
   std::vector<float> t_scalar_host = std::vector<float>(1, T);
   std::vector<float> expected_host = std::vector<float>(N, RES);
 
-  auto fourth()
-  {
-    return cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 4) == 0; });
-  }
+  auto fourth() { return cudf::test::iterators::valids_at_multiples_of(4); }
 
-  auto fifth()
-  {
-    return cudf::detail::make_counting_transform_iterator(0, [](auto i) { return (i % 5) == 0; });
-  }
+  auto fifth() { return cudf::test::iterators::valids_at_multiples_of(5); }
 };
 
 TEST_F(NullTest, ColumnNulls)

--- a/cpp/tests/transform/row_bit_count_test.cu
+++ b/cpp/tests/transform/row_bit_count_test.cu
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/column/column.hpp>
@@ -196,7 +197,7 @@ TYPED_TEST(RowBitCountTyped, SimpleTypesWithNulls)
   using T = TypeParam;
 
   auto iter   = cuda::counting_iterator<int>{0};
-  auto valids = cudf::detail::make_counting_transform_iterator(0, [](int i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
   cudf::test::fixed_width_column_wrapper<T> col(iter, iter + 16, valids);
 
   cudf::table_view t({col});

--- a/cpp/tests/unary/unary_ops_test.cpp
+++ b/cpp/tests/unary/unary_ops_test.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/testing_main.hpp>
 #include <cudf_test/type_lists.hpp>
 
@@ -24,8 +25,7 @@ cudf::test::fixed_width_column_wrapper<T> create_fixed_columns(cudf::size_type s
   if (not nullable) {
     return cudf::test::fixed_width_column_wrapper<T>(iter, iter + size);
   } else {
-    auto valids =
-      cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+    auto valids = cudf::test::iterators::valids_at_multiples_of(2);
     return cudf::test::fixed_width_column_wrapper<T>(iter, iter + size, valids);
   }
 }

--- a/cpp/tests/utilities_tests/column_wrapper_tests.cpp
+++ b/cpp/tests/utilities_tests/column_wrapper_tests.cpp
@@ -167,8 +167,7 @@ TYPED_TEST(FixedWidthColumnWrapperTest, NullablePairListConstructorAllNull)
 
 TYPED_TEST(FixedWidthColumnWrapperTest, NullablePairListConstructorAllNullMatch)
 {
-  auto odd_valid =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 != 0; });
+  auto odd_valid = cudf::test::iterators::nulls_at_multiples_of(2);
 
   cudf::test::fixed_width_column_wrapper<TypeParam, int32_t> match_col({1, 2, 3, 4, 5}, odd_valid);
   cudf::column_view match_view = match_col;
@@ -254,8 +253,7 @@ TYPED_TEST(StringsColumnWrapperTest, NullablePairListConstructorAllNull)
 
 TYPED_TEST(StringsColumnWrapperTest, NullablePairListConstructorAllNullMatch)
 {
-  auto odd_valid =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 != 0; });
+  auto odd_valid = cudf::test::iterators::nulls_at_multiples_of(2);
 
   cudf::test::strings_column_wrapper match_col({"a", "string", "", "test", "for", "nulls"},
                                                odd_valid);

--- a/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
+++ b/cpp/tests/utilities_tests/lists_column_wrapper_tests.cpp
@@ -6,6 +6,7 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/column/column_factories.hpp>
@@ -91,8 +92,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListWithValidity)
 {
   using T = TypeParam;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<T>, 1 row
   //
@@ -180,8 +180,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListFromIteratorWithValidity)
 {
   using T = TypeParam;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<int>, 1 row
   //
@@ -295,8 +294,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListOfListsWithValidity)
 {
   using T = TypeParam;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<List<T>>, 1 row
   //
@@ -383,8 +381,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, ListOfListOfListsWithValidity)
 {
   using T = TypeParam;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<List<List<T>>>, 2 rows
   //
@@ -581,8 +578,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, EmptyListsWithValidity)
   // empty lists in lists_column_wrapper documentation
   using LCW = cudf::test::lists_column_wrapper<T, int32_t>;
 
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<T>, 2 rows
   //
@@ -1246,8 +1242,7 @@ TEST_F(ListColumnWrapperTest, ListOfBools)
 
 TEST_F(ListColumnWrapperTest, ListOfBoolsWithValidity)
 {
-  auto valids =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 0; });
+  auto valids = cudf::test::iterators::valids_at_multiples_of(2);
 
   // List<bool>, 3 rows
   //
@@ -1507,15 +1502,14 @@ TYPED_TEST(ListColumnWrapperTestTyped, LargeListsOfStructsWithValidity)
   auto numeric_column = cudf::test::fixed_width_column_wrapper<T, int32_t>{
     cuda::counting_iterator<int32_t>{0},
     cuda::counting_iterator{num_struct_rows},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 1; })};
+    cudf::test::iterators::nulls_at_multiples_of(2)};
 
   auto bool_iterator =
     cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 3 == 0; });
   auto bool_column =
     cudf::test::fixed_width_column_wrapper<bool>(bool_iterator, bool_iterator + num_struct_rows);
 
-  auto struct_validity_iterator =
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 5 == 0; });
+  auto struct_validity_iterator = cudf::test::iterators::valids_at_multiples_of(5);
   auto struct_column =
     cudf::test::structs_column_wrapper{
       {numeric_column, bool_column},
@@ -1541,7 +1535,7 @@ TYPED_TEST(ListColumnWrapperTestTyped, LargeListsOfStructsWithValidity)
   auto expected_numeric_column = cudf::test::fixed_width_column_wrapper<T, int32_t>{
     cuda::counting_iterator<int32_t>{0},
     cuda::counting_iterator{num_struct_rows},
-    cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i % 2 == 1; })};
+    cudf::test::iterators::nulls_at_multiples_of(2)};
 
   auto expected_bool_column =
     cudf::test::fixed_width_column_wrapper<bool>(bool_iterator, bool_iterator + num_struct_rows);

--- a/python/cudf_polars/cudf_polars/dsl/expr.py
+++ b/python/cudf_polars/cudf_polars/dsl/expr.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 """
 DSL nodes for the polars expression language.
@@ -26,7 +26,7 @@ from cudf_polars.dsl.expressions.binaryop import BinOp
 from cudf_polars.dsl.expressions.boolean import BooleanFunction
 from cudf_polars.dsl.expressions.datetime import TemporalFunction
 from cudf_polars.dsl.expressions.literal import Literal, LiteralColumn
-from cudf_polars.dsl.expressions.rolling import GroupedRollingWindow, RollingWindow
+from cudf_polars.dsl.expressions.rolling import GroupedWindow, RollingWindow
 from cudf_polars.dsl.expressions.selection import Filter, Gather
 from cudf_polars.dsl.expressions.slicing import Slice
 from cudf_polars.dsl.expressions.sorting import Sort, SortBy
@@ -47,7 +47,7 @@ __all__ = [
     "Expr",
     "Filter",
     "Gather",
-    "GroupedRollingWindow",
+    "GroupedWindow",
     "Len",
     "Literal",
     "LiteralColumn",

--- a/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/rolling.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # TODO: remove need for this
 # ruff: noqa: D101
-"""Rolling DSL nodes."""
+"""Rolling and Window DSL nodes."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from cudf_polars.typing import ClosedInterval, Duration
 
-__all__ = ["GroupedRollingWindow", "RollingWindow", "to_request"]
+__all__ = ["GroupedWindow", "RollingWindow", "to_request"]
 
 
 @dataclass(frozen=True)
@@ -206,7 +206,7 @@ class RollingWindow(Expr):  # pragma: no cover; polars >1.36 uses AExpr::Rolling
         return Column(result, dtype=self.dtype)
 
 
-class GroupedRollingWindow(Expr):
+class GroupedWindow(Expr):
     """
     Compute a window ``.over(...)`` aggregation and broadcast to rows.
 
@@ -845,7 +845,7 @@ class GroupedRollingWindow(Expr):
                     rank_by_cols_for_scan = self._gather_columns(
                         by_cols, order_index, stream=df.stream
                     )
-                    local = GroupedRollingWindow._sorted_grouper(rank_by_cols_for_scan)
+                    local = GroupedWindow._sorted_grouper(rank_by_cols_for_scan)
                     names, dtypes, tables = self._apply_unary_op(
                         RankOp(
                             named_exprs=[ne],

--- a/python/cudf_polars/cudf_polars/dsl/translate.py
+++ b/python/cudf_polars/cudf_polars/dsl/translate.py
@@ -904,6 +904,9 @@ def _(
         return replace([named_post_agg.value], replacements)[0]
     elif isinstance(node.options, plrs._expr_nodes.WindowMapping):
         # pl.col("a").over(...)
+        # Note: pl.col("a").rolling(...).over("g") also lands here. But
+        # is not supported in polars < 1.39 since the AExpr::Rolling was
+        # not exposed until polars 1.39.
         with set_expr_context(translator, ExecutionContext.WINDOW):
             agg = translator.translate_expr(n=node.function, schema=schema)
         name_gen = unique_names(schema)
@@ -948,7 +951,7 @@ def _(
             )
         ]
         children = (*by_exprs, *((order_by_expr,) if has_order_by else ()), *child_deps)
-        return expr.GroupedRollingWindow(
+        return expr.GroupedWindow(
             dtype,
             (mapping, has_order_by, descending, nulls_last),
             named_aggs,

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
@@ -386,6 +386,7 @@ class RunConfig:
     executor: ExecutorType  # "in-memory" | "streaming" | "cpu"
     frontend: str  # "spmd" | "ray" | "duckdb"
     connect: str | None = None
+    num_gpus: int | None = None
 
     # Run parameters
     iterations: int
@@ -514,6 +515,7 @@ class RunConfig:
             max_io_threads=args.max_io_threads,
             streaming_options=streaming_options,
             connect=args.connect,
+            num_gpus=args.num_gpus,
             validation_method=validation_method,
             extra_info=args.extra_info,
         )
@@ -1159,6 +1161,8 @@ def run_polars_ray(
     ray_init_options: dict[str, Any] = {}
     if run_config.connect is not None:
         ray_init_options["address"] = run_config.connect
+    if run_config.num_gpus is not None:
+        ray_init_options["num_gpus"] = run_config.num_gpus
 
     with RayEngine(
         rapidsmpf_options=run_config.streaming_options.to_rapidsmpf_options(),
@@ -1213,6 +1217,11 @@ def run_polars_dask(
             dask_client = distributed.Client(scheduler_file=run_config.connect)
         else:
             dask_client = distributed.Client(address=run_config.connect)
+
+    if run_config.num_gpus is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(
+            str(i) for i in range(run_config.num_gpus)
+        )
 
     try:
         with DaskEngine(
@@ -1638,6 +1647,14 @@ def build_parser(num_queries: int = 22) -> argparse.ArgumentParser:
             Not supported with --frontend spmd."""),
     )
     parser.add_argument(
+        "--num-gpus",
+        dest="num_gpus",
+        default=None,
+        type=int,
+        help="Number of GPUs for local cluster creation (--frontend ray/dask only). "
+        "Cannot be used with --connect. Defaults to all visible GPUs.",
+    )
+    parser.add_argument(
         "--iterations",
         default=1,
         type=int,
@@ -1770,10 +1787,16 @@ def build_parser(num_queries: int = 22) -> argparse.ArgumentParser:
 
     StreamingOptions._add_cli_args(parser)
 
-    # Trap the legacy --spill-device flag so we can emit a clear error.
+    # Trap legacy flags so we can emit clear errors.
     parser.add_argument(
         "--spill-device",
         dest="spill_device",
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--blocksize",
+        dest="blocksize",
         default=None,
         help=argparse.SUPPRESS,
     )
@@ -1794,7 +1817,13 @@ def parse_args(
     if parsed_args.spill_device is not None:
         parser.error(
             "--spill-device is not supported with --frontend; "
-            "use --spill-device-limit instead."
+            "use --spill-device-limit instead, which takes a "
+            'percentage, not a fraction (e.g. "80%").'
+        )
+    if parsed_args.blocksize is not None:
+        parser.error(
+            "--blocksize is not supported with --frontend; "
+            "use --target-partition-size instead."
         )
 
     if parsed_args.validate_directory and parsed_args.validate:
@@ -1824,6 +1853,19 @@ def run_polars(benchmark: Any, args: argparse.Namespace) -> None:
 
     if run_config.connect is not None and run_config.frontend == "spmd":
         raise ValueError("--connect is not supported with --frontend spmd.")
+
+    if run_config.num_gpus is not None:
+        if run_config.connect is not None:
+            raise ValueError("--num-gpus cannot be used with --connect.")
+        if run_config.frontend not in ("ray", "dask"):
+            raise ValueError(
+                "--num-gpus is only supported with --frontend ray or dask."
+            )
+        if "CUDA_VISIBLE_DEVICES" in os.environ:
+            raise ValueError(
+                "--num-gpus cannot be used when CUDA_VISIBLE_DEVICES is already set. "
+                "Unset CUDA_VISIBLE_DEVICES or use it directly to control GPU visibility."
+            )
 
     parquet_options = {"use_rapidsmpf_native": run_config.native_parquet}
     validation_files = (

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
@@ -385,6 +385,7 @@ class RunConfig:
     # Execution mode
     executor: ExecutorType  # "in-memory" | "streaming" | "cpu"
     frontend: str  # "spmd" | "ray" | "duckdb"
+    connect: str | None = None
 
     # Run parameters
     iterations: int
@@ -512,6 +513,7 @@ class RunConfig:
             native_parquet=args.native_parquet,
             max_io_threads=args.max_io_threads,
             streaming_options=streaming_options,
+            connect=args.connect,
             validation_method=validation_method,
             extra_info=args.extra_info,
         )
@@ -1154,10 +1156,15 @@ def run_polars_ray(
         **run_config.streaming_options.to_engine_options(),
         "parquet_options": parquet_options,
     }
+    ray_init_options: dict[str, Any] = {}
+    if run_config.connect is not None:
+        ray_init_options["address"] = run_config.connect
+
     with RayEngine(
         rapidsmpf_options=run_config.streaming_options.to_rapidsmpf_options(),
         executor_options=executor_options,
         engine_options=engine_options,
+        ray_init_options=ray_init_options,
     ) as engine:
         run_config = dataclasses.replace(run_config, n_workers=engine.nranks)
         records, plans, validation_failures, query_failures = _run_query_loop(
@@ -1184,6 +1191,8 @@ def run_polars_dask(
     validation_files: dict[int, Path] | None,
 ) -> None:
     """Run benchmark queries using Dask distributed execution."""
+    import distributed
+
     from cudf_polars.experimental.rapidsmpf.frontend.dask import DaskEngine
 
     if run_config.collect_traces:
@@ -1198,22 +1207,34 @@ def run_polars_dask(
         **run_config.streaming_options.to_engine_options(),
         "parquet_options": parquet_options,
     }
-    with DaskEngine(
-        rapidsmpf_options=run_config.streaming_options.to_rapidsmpf_options(),
-        executor_options=executor_options,
-        engine_options=engine_options,
-    ) as engine:
-        run_config = dataclasses.replace(run_config, n_workers=engine.nranks)
-        records, plans, validation_failures, query_failures = _run_query_loop(
-            benchmark,
-            args,
-            run_config,
-            engine,
-            None,
-            numeric_type,
-            date_type,
-            validation_files,
-        )
+    dask_client = None
+    if run_config.connect is not None:
+        if Path(run_config.connect).is_file():
+            dask_client = distributed.Client(scheduler_file=run_config.connect)
+        else:
+            dask_client = distributed.Client(address=run_config.connect)
+
+    try:
+        with DaskEngine(
+            rapidsmpf_options=run_config.streaming_options.to_rapidsmpf_options(),
+            executor_options=executor_options,
+            engine_options=engine_options,
+            dask_client=dask_client,
+        ) as engine:
+            run_config = dataclasses.replace(run_config, n_workers=engine.nranks)
+            records, plans, validation_failures, query_failures = _run_query_loop(
+                benchmark,
+                args,
+                run_config,
+                engine,
+                None,
+                numeric_type,
+                date_type,
+                validation_files,
+            )
+    finally:
+        if dask_client is not None:
+            dask_client.close()
     run_config = dataclasses.replace(run_config, records=dict(records), plans=plans)
     _finalize_benchmark_run(args, run_config, validation_failures, query_failures)
 
@@ -1605,6 +1626,18 @@ def build_parser(num_queries: int = 22) -> argparse.ArgumentParser:
                 - duckdb : DuckDB CPU execution"""),
     )
     parser.add_argument(
+        "--connect",
+        dest="connect",
+        default=None,
+        type=str,
+        help=textwrap.dedent("""\
+            Connect to an existing cluster instead of creating a local one.
+            For --frontend dask: a TCP address (e.g. tcp://host:8786) or a
+            scheduler file path. For --frontend ray: a Ray address
+            (e.g. ray://host:10001 or "auto").
+            Not supported with --frontend spmd."""),
+    )
+    parser.add_argument(
         "--iterations",
         default=1,
         type=int,
@@ -1788,6 +1821,10 @@ def run_polars(benchmark: Any, args: argparse.Namespace) -> None:
     """Run the queries using the given benchmark and frontend."""
     vars(args).update({"query_set": benchmark.name})
     run_config = RunConfig.from_args(args)
+
+    if run_config.connect is not None and run_config.frontend == "spmd":
+        raise ValueError("--connect is not supported with --frontend spmd.")
+
     parquet_options = {"use_rapidsmpf_native": run_config.native_parquet}
     validation_files = (
         list_validation_files(args.validate_directory)

--- a/python/cudf_polars/cudf_polars/experimental/expressions.py
+++ b/python/cudf_polars/cudf_polars/experimental/expressions.py
@@ -463,6 +463,23 @@ def _decompose_expr_node(
             config_options,
             names=names,
         )
+    elif isinstance(expr, UnaryFunction) and expr.name == "null_count":
+        columns, input_ir, partition_info = select(
+            [expr],
+            input_ir,
+            partition_info,
+            names=names,
+            repartition=True,
+        )
+        (column,) = columns
+        columns, input_ir, partition_info = select(
+            [Agg(expr.dtype, "sum", None, ExecutionContext.FRAME, column)],
+            input_ir,
+            partition_info,
+            names=names,
+        )
+        (expr,) = columns
+        return expr, input_ir, partition_info
     else:
         # This is an un-supported expression - raise.
         raise NotImplementedError(

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
@@ -14,6 +14,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
 
 import distributed
+import pynvml
 import ucxx._lib.libucxx as ucx_api
 from rapidsmpf import bootstrap
 from rapidsmpf.communicator.ucxx import barrier, get_root_ucxx_address, new_communicator
@@ -35,6 +36,10 @@ from cudf_polars.experimental.rapidsmpf.frontend.core import (
     check_reserved_keys,
     execute_ir_on_rank,
 )
+from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+    HardwareBindingPolicy,
+    bind_to_gpu,
+)
 from cudf_polars.utils.config import DaskContext
 
 if TYPE_CHECKING:
@@ -48,6 +53,57 @@ if TYPE_CHECKING:
     from cudf_polars.experimental.parallel import ConfigOptions
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
     from cudf_polars.utils.config import MemoryResourceConfig, StreamingExecutor
+
+
+def _get_visible_gpu_ids() -> list[str]:
+    """
+    Return the list of visible GPU identifiers.
+
+    Reads ``CUDA_VISIBLE_DEVICES`` if set, otherwise queries NVML for the
+    total device count and returns ``["0", "1", ...]``.
+    """
+    cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if cvd is not None:
+        return [d.strip() for d in cvd.split(",") if d.strip()]
+    pynvml.nvmlInit()
+    return [str(i) for i in range(pynvml.nvmlDeviceGetCount())]
+
+
+_nanny_preload_counter = 0
+
+
+def dask_setup(nanny: distributed.Nanny) -> None:
+    """
+    Nanny preload: assign one GPU per worker via ``CUDA_VISIBLE_DEVICES``.
+
+    The name ``dask_setup`` is required by Dask's preload protocol, it is
+    discovered by name via ``--preload-nanny``. The function runs inside the
+    Nanny process *before* the worker subprocess is spawned, so the
+    environment variable is inherited by the worker.
+
+    GPUs are assigned in a round-robin fashion across workers on the same
+    node. Each worker is bound to a single GPU, but GPUs may be shared across
+    multiple workers if there are more workers than available GPUs.
+
+    Usage::
+
+        dask worker SCHEDULER:8786 --nworkers N --nthreads 1 \
+            --preload-nanny cudf_polars.experimental.rapidsmpf.frontend.dask
+
+    Parameters
+    ----------
+    nanny
+        The :class:`distributed.Nanny` instance (injected by Dask).
+    """
+    if not isinstance(nanny, distributed.Nanny):
+        raise TypeError(
+            "dask_setup() must be used with --preload-nanny, not --preload. "
+            f"Expected a Nanny instance, got {type(nanny).__name__}."
+        )
+    global _nanny_preload_counter  # noqa: PLW0603
+    gpu_ids = _get_visible_gpu_ids()
+    nanny.env["CUDA_VISIBLE_DEVICES"] = gpu_ids[_nanny_preload_counter % len(gpu_ids)]
+    _nanny_preload_counter += 1
 
 
 @dataclasses.dataclass
@@ -66,7 +122,8 @@ def _setup_root(
     rapidsmpf_options_as_bytes: bytes,
     *,
     uid: str,
-    memory_resource_config: MemoryResourceConfig | None = None,
+    hardware_binding: HardwareBindingPolicy,
+    memory_resource_config: MemoryResourceConfig | None,
     dask_worker: distributed.Worker | None = None,
 ) -> bytes:
     """
@@ -85,6 +142,8 @@ def _setup_root(
     uid
         Unique identifier for this cluster instance, used to namespace the
         per-worker attribute so multiple contexts can coexist on a worker.
+    hardware_binding
+        Policy controlling topology-aware hardware binding.
     memory_resource_config
         Optional RMM memory resource configuration. If ``None``, defaults to
         :class:`rmm.mr.CudaAsyncMemoryResource`.
@@ -97,6 +156,7 @@ def _setup_root(
     """
     assert dask_worker is not None
     options = Options.deserialize(rapidsmpf_options_as_bytes)
+    bind_to_gpu(hardware_binding)
     base_mr = (
         memory_resource_config.create_memory_resource()
         if memory_resource_config is not None
@@ -128,7 +188,8 @@ def _setup_worker(
     executor_options: dict[str, object],
     *,
     uid: str,
-    memory_resource_config: MemoryResourceConfig | None = None,
+    hardware_binding: HardwareBindingPolicy,
+    memory_resource_config: MemoryResourceConfig | None,
     dask_worker: distributed.Worker | None = None,
 ) -> None:
     """
@@ -146,15 +207,18 @@ def _setup_worker(
     rapidsmpf_options_as_bytes
         Serialized RapidsMPF options.
     executor_options
-        Additional executor options.
+        Executor options (e.g. ``num_py_executors``).
     uid
         Unique identifier for this cluster instance, used to namespace the
         per-worker attribute so multiple contexts can coexist on a worker.
+    hardware_binding
+        Policy controlling topology-aware hardware binding.
     memory_resource_config
         Optional RMM memory resource configuration. If ``None``, defaults to
         :class:`rmm.mr.CudaAsyncMemoryResource`.
     dask_worker
         Injected by ``distributed`` when called via :meth:`distributed.Client.run`.
+
     """
     assert dask_worker is not None
     options = Options.deserialize(rapidsmpf_options_as_bytes)
@@ -163,6 +227,7 @@ def _setup_worker(
 
     if mp_ctx is None:
         # Non-root worker: create communicator now.
+        bind_to_gpu(hardware_binding)
         base_mr = (
             memory_resource_config.create_memory_resource()
             if memory_resource_config is not None
@@ -384,7 +449,7 @@ class DaskEngine(StreamingEngine):
 
     If ``dask_client`` is provided, it is used directly and its lifetime is
     managed by the caller. If ``dask_client`` is ``None``, a
-    :class:`dask_cuda.LocalCUDACluster` is created automatically (one worker
+    :class:`distributed.LocalCluster` is created automatically (one worker
     per visible GPU) and torn down by :meth:`shutdown`.
 
     Prefer the context-manager form in scripts: it guarantees that workers are
@@ -396,8 +461,8 @@ class DaskEngine(StreamingEngine):
     ----------
     dask_client
         An existing :class:`~distributed.Client` to use. If ``None``, a
-        :class:`~dask_cuda.LocalCUDACluster` and a new client are created and
-        owned by this engine.
+        :class:`~distributed.LocalCluster` (one worker per visible GPU)
+        and a new client are created and owned by this engine.
     rapidsmpf_options
         RapidsMPF options forwarded to every worker. If ``None``, defaults to
         ``Options(get_environment_variables())``.
@@ -433,6 +498,37 @@ class DaskEngine(StreamingEngine):
     >>> engine = DaskEngine()  # doctest: +SKIP
     >>> result = pl.LazyFrame({"a": [1, 2, 3]}).collect(engine=engine)  # doctest: +SKIP
     >>> engine.shutdown()  # doctest: +SKIP
+
+    Notes
+    -----
+    When using a pre-configured cluster that already performs its own hardware
+    binding (e.g. :class:`dask_cuda.LocalCUDACluster`, which pins CPU affinity
+    and sets ``CUDA_VISIBLE_DEVICES`` per worker), disable some or all of the
+    built-in binding to avoid conflicts:
+
+    >>> from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+    ...     HardwareBindingPolicy,
+    ... )
+    >>> with DaskEngine(  # doctest: +SKIP
+    ...     dask_client=dc,
+    ...     engine_options={
+    ...         "hardware_binding": HardwareBindingPolicy(enabled=False),
+    ...     },
+    ... ) as engine:
+    ...     ...
+
+    For manually launched Dask clusters, use the nanny preload to assign
+    one GPU per worker before the worker process spawns::
+
+        dask worker SCHEDULER:8786 --nworkers N --nthreads 1 \
+            --preload-nanny cudf_polars.experimental.rapidsmpf.frontend.dask
+
+    Then connect from the client::
+
+        >>> from distributed import Client  # doctest: +SKIP
+        >>> with Client("SCHEDULER:8786") as dc:  # doctest: +SKIP
+        ...     with DaskEngine(dask_client=dc) as engine:
+        ...         result = lf.collect(engine=engine)
     """
 
     def __init__(
@@ -454,6 +550,7 @@ class DaskEngine(StreamingEngine):
             )
 
         check_reserved_keys(executor_options, engine_options)
+        hw_binding = engine_options.get("hardware_binding", HardwareBindingPolicy())
 
         mr_config: MemoryResourceConfig | None = engine_options.get(
             "memory_resource_config", None
@@ -474,19 +571,36 @@ class DaskEngine(StreamingEngine):
         owned_cluster: Any = None
         owned_client: distributed.Client | None = None
         if dask_client is None:
-            import dask_cuda
-
-            owned_cluster = dask_cuda.LocalCUDACluster()
+            gpu_ids = _get_visible_gpu_ids()
+            worker_spec: dict[str, Any] = {}
+            for i, gpu_id in enumerate(gpu_ids):
+                worker_spec[str(gpu_id)] = {
+                    "cls": distributed.Nanny,
+                    "options": {
+                        "nthreads": 1,
+                        "env": {
+                            "CUDA_VISIBLE_DEVICES": gpu_ids[i],
+                        },
+                    },
+                }
+            owned_cluster = distributed.SpecCluster(workers=worker_spec)
             owned_client = distributed.Client(owned_cluster)
             dask_client = owned_client
 
         workers_info = dask_client.scheduler_info(n_workers=-1)["workers"]
         nranks = len(workers_info)
+        if nranks == 0:
+            raise RuntimeError("No workers found in the Dask cluster.")
         root_worker = next(iter(workers_info))
 
         # Phase 1: initialize root communicator on one worker.
         root_result = dask_client.run(
-            functools.partial(_setup_root, uid=uid, memory_resource_config=mr_config),
+            functools.partial(
+                _setup_root,
+                uid=uid,
+                hardware_binding=hw_binding,
+                memory_resource_config=mr_config,
+            ),
             nranks,
             rapidsmpf_options_as_bytes,
             workers=[root_worker],
@@ -496,7 +610,12 @@ class DaskEngine(StreamingEngine):
         # Phase 2: complete bootstrap on all workers concurrently.
         # All workers call barrier() so they must all run simultaneously.
         dask_client.run(
-            functools.partial(_setup_worker, uid=uid, memory_resource_config=mr_config),
+            functools.partial(
+                _setup_worker,
+                uid=uid,
+                hardware_binding=hw_binding,
+                memory_resource_config=mr_config,
+            ),
             root_ucxx_address_as_bytes,
             nranks,
             rapidsmpf_options_as_bytes,
@@ -604,7 +723,7 @@ class DaskEngine(StreamingEngine):
             Unified streaming configuration.
         dask_client
             An existing :class:`distributed.Client` to use. If ``None``, a
-            :class:`dask_cuda.LocalCUDACluster` is created automatically.
+            :class:`distributed.LocalCluster` is created automatically.
 
         Returns
         -------

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/hardware_binding.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/hardware_binding.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""Topology-aware hardware binding."""
+
+from __future__ import annotations
+
+import dataclasses
+import threading
+
+from rapidsmpf import bootstrap
+from rapidsmpf.rrun.rrun import bind
+
+
+@dataclasses.dataclass(frozen=True)
+class HardwareBindingPolicy:
+    """
+    Policy controlling topology-aware hardware binding.
+
+    Determines whether :func:`rapidsmpf.rrun.rrun.bind` is invoked
+    to pin the calling process to CPU cores, NUMA memory nodes,
+    and network devices local to the worker's GPU.
+
+    The GPU to bind to is resolved from ``CUDA_VISIBLE_DEVICES``.
+    Each frontend is responsible for setting this variable per worker
+    (Dask via the nanny preload or ``SpecCluster``, Ray via
+    ``num_gpus=1`` scheduling, SPMD via ``rrun``). If
+    ``CUDA_VISIBLE_DEVICES`` is unset, binding falls back to GPU 0.
+
+    The default instance (``HardwareBindingPolicy()``) enables
+    binding once per process with soft failure handling.
+
+    Parameters
+    ----------
+    skip_under_rrun
+        When ``True`` (the default), binding is skipped if the process
+        was launched via ``rrun``, because ``rrun`` already performs
+        hardware binding at launch time. If binding is skipped, all
+        other options are ignored.
+    enabled
+        Whether binding is enabled. ``False`` disables all binding.
+    enable_once
+        When ``True``, binding is performed at most once per process;
+        subsequent calls to :func:`bind_to_gpu` are no-ops. When
+        ``False``, binding is attempted on every call.
+    raise_on_fail
+        When ``True``, binding failures raise an exception. Currently
+        ``rrun.bind()`` only prints warnings to stderr on per-subsystem
+        failures; setting this flag enables ``verbose=True`` so those
+        warnings are visible.
+    """
+
+    skip_under_rrun: bool = True
+    enabled: bool = True
+    enable_once: bool = True
+    raise_on_fail: bool = False
+
+
+_bind_lock = threading.Lock()
+_bind_done = False
+
+
+def bind_to_gpu(policy: HardwareBindingPolicy) -> None:
+    """
+    Bind the calling process to resources topologically close to a GPU.
+
+    Thread-safe wrapper around :func:`rapidsmpf.rrun.rrun.bind` governed
+    by *policy*.
+
+    When ``policy.enable_once`` is ``True`` (the default), double-checked
+    locking with a module-level lock guarantees that the underlying
+    ``bind()`` is called **at most once per process**, regardless of how
+    many frontend engines are constructed or from how many threads.
+
+    Parameters
+    ----------
+    policy
+        The :class:`HardwareBindingPolicy` controlling binding behavior.
+    """
+    global _bind_done  # noqa: PLW0603
+    if not policy.enabled:
+        return
+    if policy.skip_under_rrun and bootstrap.is_running_with_rrun():
+        return
+    if policy.enable_once:
+        if _bind_done:
+            return
+        with _bind_lock:
+            if _bind_done:
+                return
+            _do_bind(policy)
+            _bind_done = True
+    else:
+        _do_bind(policy)
+
+
+def _do_bind(policy: HardwareBindingPolicy) -> None:
+    """Execute the actual bind call according to *policy*."""
+    verbose = policy.raise_on_fail
+    # TODO(rapidsmpf): rrun.bind() does not currently report per-subsystem
+    # failures programmatically — it only prints warnings to stderr when
+    # verbose=True. When a return value or exception is available, check it
+    # here and raise if policy.raise_on_fail is True.
+    # See: https://github.com/rapidsai/rapidsmpf/issues/963
+    try:
+        bind(verbose=verbose)
+    except RuntimeError:
+        # CUDA_VISIBLE_DEVICES is unset; fall back to GPU 0.
+        bind(gpu_id=0, verbose=verbose)

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
@@ -15,6 +15,9 @@ from typing import TYPE_CHECKING, Any, Literal
 from rapidsmpf.config import Options
 from rapidsmpf.utils.string import parse_boolean
 
+from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+    HardwareBindingPolicy,
+)
 from cudf_polars.utils.config import MemoryResourceConfig
 
 if TYPE_CHECKING:
@@ -123,6 +126,15 @@ def _parse_memory_resource_config(value: str) -> MemoryResourceConfig:
     return MemoryResourceConfig(**json.loads(value))
 
 
+def _parse_hardware_binding(value: str) -> HardwareBindingPolicy:
+    """
+    Parse a JSON string into a :class:`HardwareBindingPolicy`.
+
+    Examples: ``'{"enabled": false}'``, ``'{"raise_on_fail": true}'``.
+    """
+    return HardwareBindingPolicy(**json.loads(value))
+
+
 @dataclasses.dataclass
 class StreamingOptions:
     """
@@ -131,7 +143,7 @@ class StreamingOptions:
     Options are grouped into three categories:
       - **RapidsMPF**: runtime and memory behavior (e.g. spilling, threading).
       - **Executor**: query execution and partitioning behavior.
-      - **Engine**: Polars integration and IO configuration.
+      - **Engine**: Polars integration, IO configuration, hardware binding.
 
     All fields default to :data:`UNSPECIFIED` and follow this precedence:
       1. Explicit value.
@@ -245,6 +257,14 @@ class StreamingOptions:
         CUDA stream policy (``"default"``, ``"pool"`` or config dict).
         Env: ``CUDF_POLARS__CUDA_STREAM_POLICY``.
         Category: engine.
+    hardware_binding
+        Hardware binding policy. Pass a
+        :class:`~cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.HardwareBindingPolicy`
+        instance for fine-grained control.
+        Env: ``CUDF_POLARS__HARDWARE_BINDING`` (JSON object,
+        e.g. ``'{"enabled": false}'``).
+        Default: ``HardwareBindingPolicy()``.
+        Category: engine.
 
     Examples
     --------
@@ -309,6 +329,9 @@ class StreamingOptions:
     memory_resource_config: MemoryResourceConfig | Unspecified = _opt("engine")
     cuda_stream_policy: Literal["default", "pool"] | dict[str, Any] | Unspecified = (
         _opt("engine", "CUDF_POLARS__CUDA_STREAM_POLICY")
+    )
+    hardware_binding: HardwareBindingPolicy | Unspecified = _opt(
+        "engine", "CUDF_POLARS__HARDWARE_BINDING", _parse_hardware_binding
     )
 
     # ------------------------------------------------------------------
@@ -467,6 +490,7 @@ class StreamingOptions:
             pinned_initial_pool_size=_get("pinned_initial_pool_size"),
             spill_device_limit=_get("spill_device_limit"),
             periodic_spill_check=_get("periodic_spill_check"),
+            hardware_binding=_get("hardware_binding"),
             num_py_executors=_get("num_py_executors"),
             fallback_mode=_get("fallback_mode"),
             max_rows_per_partition=_get("max_rows_per_partition"),
@@ -592,13 +616,24 @@ class StreamingOptions:
                 Env: RAPIDSMPF_PERIODIC_SPILL_CHECK. Built-in default: 1ms."""),
         )
         g.add_argument(
+            "--hardware-binding",
+            dest="hardware_binding",
+            default=None,
+            type=_parse_hardware_binding,
+            help=textwrap.dedent("""\
+                Hardware binding policy as a JSON object
+                (e.g. '{"enabled": false}', '{"raise_on_fail": true}').
+                Env: CUDF_POLARS__HARDWARE_BINDING.
+                Built-in default: enabled with auto GPU detection."""),
+        )
+        g.add_argument(
             "--num-py-executors",
             dest="num_py_executors",
             default=None,
             type=int,
             help=textwrap.dedent("""\
                 Max workers for the Python ThreadPoolExecutor inside RapidsMPF.
-                Env: CUDF_POLARS__EXECUTOR__NUM_PY_EXECUTORS.
+                Env: CUDF_POLARS__NUM_PY_EXECUTORS.
                 Built-in default: 1."""),
         )
         g.add_argument(

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
@@ -33,6 +33,10 @@ from cudf_polars.experimental.rapidsmpf.frontend.core import (
     check_reserved_keys,
     execute_ir_on_rank,
 )
+from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+    HardwareBindingPolicy,
+    bind_to_gpu,
+)
 from cudf_polars.utils.config import RayContext
 
 if TYPE_CHECKING:
@@ -168,6 +172,15 @@ class RankActor:
     num_py_executors
         Maximum number of threads for the actor's Python thread-pool executor.
         ``None`` lets :class:`~concurrent.futures.ThreadPoolExecutor` choose.
+    hardware_binding
+        Policy controlling topology-aware hardware binding.
+
+    Notes
+    -----
+    Calls :func:`~cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind_to_gpu`
+    at construction time, before RMM and communicator initialisation, so that
+    CPU affinity, NUMA memory policy, and ``UCX_NET_DEVICES`` are set as early
+    as possible.
     """
 
     def __init__(
@@ -176,8 +189,10 @@ class RankActor:
         nranks: int,
         rapidsmpf_options_as_bytes: bytes,
         num_py_executors: int,
-        memory_resource_config: MemoryResourceConfig | None = None,
+        hardware_binding: HardwareBindingPolicy,
+        memory_resource_config: MemoryResourceConfig | None,
     ) -> None:
+        bind_to_gpu(hardware_binding)
         base_mr = (
             memory_resource_config.create_memory_resource()
             if memory_resource_config is not None
@@ -454,6 +469,7 @@ class RayEngine(StreamingEngine):
             )
 
         check_reserved_keys(executor_options, engine_options)
+        hw_binding = engine_options.get("hardware_binding", HardwareBindingPolicy())
 
         mr_config: MemoryResourceConfig | None = engine_options.get(
             "memory_resource_config", None
@@ -489,6 +505,7 @@ class RayEngine(StreamingEngine):
                         int,
                         executor_options.get("num_py_executors", 1),
                     ),
+                    hardware_binding=hw_binding,
                     memory_resource_config=mr_config,
                 )
                 for _ in range(num_gpus)

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
@@ -31,6 +31,10 @@ from cudf_polars.experimental.rapidsmpf.frontend.core import (
     check_reserved_keys,
     execute_ir_on_rank,
 )
+from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+    HardwareBindingPolicy,
+    bind_to_gpu,
+)
 from cudf_polars.experimental.rapidsmpf.utils import set_memory_resource
 from cudf_polars.utils.config import SPMDContext
 
@@ -293,6 +297,16 @@ class SPMDEngine(StreamingEngine):
     TypeError
         If ``executor_options`` or ``engine_options`` contains a reserved key.
 
+    Notes
+    -----
+    Calls
+    :func:`~cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind_to_gpu`
+    at construction time, before RMM and communicator initialisation, so that
+    CPU affinity, NUMA memory policy, and ``UCX_NET_DEVICES`` are set as early
+    as possible.  By default, binding is skipped under ``rrun`` (which already
+    performs its own binding) — see
+    :attr:`HardwareBindingPolicy.skip_under_rrun`.
+
     Examples
     --------
     Context-manager style (recommended for scripts):
@@ -322,6 +336,11 @@ class SPMDEngine(StreamingEngine):
         engine_options = engine_options or {}
 
         check_reserved_keys(executor_options, engine_options)
+        hw_binding = cast(
+            HardwareBindingPolicy,
+            engine_options.get("hardware_binding", HardwareBindingPolicy()),
+        )
+        bind_to_gpu(hw_binding)
 
         rapidsmpf_options = (
             rapidsmpf_options

--- a/python/cudf_polars/cudf_polars/experimental/select.py
+++ b/python/cudf_polars/cudf_polars/experimental/select.py
@@ -42,7 +42,7 @@ def _hstack_chain_to_select(ir: Select) -> Select | None:
 
     Only fires when the chain has HStack(should_broadcast=False). Pure HStack(True)
     chains are left for rec(child) — their col refs may live in non-traversable expr
-    internals (e.g. GroupedRollingWindow.named_aggs) that _sub_expr cannot reach.
+    internals (e.g. GroupedWindow.named_aggs) that _sub_expr cannot reach.
     """
     hstack_chain: list[HStack] = []
     current: IR = ir.children[0]

--- a/python/cudf_polars/cudf_polars/experimental/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/utils.py
@@ -10,7 +10,7 @@ from functools import reduce
 from itertools import chain
 from typing import TYPE_CHECKING
 
-from cudf_polars.dsl.expr import Col, Expr, GroupedRollingWindow, UnaryFunction
+from cudf_polars.dsl.expr import Col, Expr, GroupedWindow, UnaryFunction
 from cudf_polars.dsl.ir import Union
 from cudf_polars.dsl.traversal import traversal
 from cudf_polars.experimental.base import PartitionInfo
@@ -141,8 +141,8 @@ def _get_unique_fractions(
 
 
 def _contains_over(exprs: Sequence[Expr]) -> bool:
-    """Return True if any expression in 'exprs' contains an over(...) (ie. GroupedRollingWindow)."""
-    return any(isinstance(e, GroupedRollingWindow) for e in traversal(exprs))
+    """Return True if any expression contains a window expression."""
+    return any(isinstance(e, GroupedWindow) for e in traversal(exprs))
 
 
 def _contains_unsupported_fill_strategy(exprs: Sequence[Expr]) -> bool:

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -1044,6 +1044,7 @@ class ConfigOptions(Generic[ExecutorType]):
             "raise_on_fail",
             "memory_resource_config",
             "cuda_stream_policy",
+            "hardware_binding",
         }
 
         extra_options = set(engine.config.keys()) - valid_options

--- a/python/cudf_polars/docs/cudf-polars-mp.md
+++ b/python/cudf_polars/docs/cudf-polars-mp.md
@@ -43,11 +43,11 @@ This document describes these three execution modes.
 It provides a single typed object covering all configuration knobs across three
 categories:
 
-| Category    | Controls                                                   |
-| ----------- | ---------------------------------------------------------- |
-| `rapidsmpf` | Threads, CUDA streams, spilling, pinned memory, log level  |
-| `executor`  | Partitioning, fallback behavior, dynamic planning          |
-| `engine`    | Polars integration, IO options, RMM memory resource        |
+| Category    | Controls                                                              |
+| ----------- | --------------------------------------------------------------------- |
+| `rapidsmpf` | Threads, CUDA streams, spilling, pinned memory, log level             |
+| `executor`  | Partitioning, fallback behavior, dynamic planning                     |
+| `engine`    | Polars integration, IO, RMM, hardware binding, thread-pool sizing     |
 
 All fields default to `UNSPECIFIED`, which means: use the corresponding
 environment variable if set, otherwise let the underlying library apply its
@@ -131,8 +131,63 @@ When no `memory_resource_config` is provided:
 
 - **SPMDEngine** uses `rmm.mr.get_current_device_resource()` (the in-process
   default — useful when user code has already configured a resource).
-benchm- **DaskEngine** and **RayEngine** default to `rmm.mr.CudaAsyncMemoryResource()`
+- **DaskEngine** and **RayEngine** default to `rmm.mr.CudaAsyncMemoryResource()`
   (workers start in a fresh process with no pre-configured resource).
+
+### Hardware binding
+
+All three engines automatically bind each worker process to the CPU cores,
+NUMA memory nodes, and network devices that are topologically close to the
+worker's GPU. This is done via `rapidsmpf.rrun.rrun.bind()` and improves
+performance by ensuring memory allocations and network traffic stay local to
+the GPU's NUMA node.
+
+Binding is controlled by the `hardware_binding` executor option, which accepts
+a `HardwareBindingPolicy` instance:
+
+```python
+from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+    HardwareBindingPolicy,
+)
+```
+
+The default policy (`HardwareBindingPolicy()`) skips binding when running under `rrun`,
+which already handles binding at launch. Otherwise, it binds once per process based on
+`CUDA_VISIBLE_DEVICES`. If `CUDA_VISIBLE_DEVICES` is unset, binding falls back to GPU 0.
+
+
+| Field             | Default | Description                                                                                                        |
+| ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `skip_under_rrun` | `True`  | Skip binding when launched via `rrun` (which already performs binding). If skipped, all other options are ignored. |
+| `enabled`         | `True`  | Enable or disable hardware binding.                                                                                |
+| `enable_once`     | `True`  | Perform binding at most once per process. Subsequent calls are no-ops.                                             |
+| `raise_on_fail`   | `False` | Surface binding failures by enabling `verbose=True` in `rrun.bind()`.                                              |
+
+
+Examples:
+
+```python
+# Disable binding entirely:
+opts = StreamingOptions(hardware_binding=HardwareBindingPolicy(enabled=False))
+
+# Enable failure reporting:
+opts = StreamingOptions(
+    hardware_binding=HardwareBindingPolicy(raise_on_fail=True),
+)
+```
+
+Via the environment variable (JSON):
+
+```bash
+# Disable binding:
+export CUDF_POLARS__HARDWARE_BINDING='{"enabled": false}'
+```
+
+Via the CLI:
+
+```bash
+python my_script.py --hardware-binding '{"raise_on_fail": true}'
+```
 
 ---
 
@@ -271,10 +326,8 @@ from rapidsmpf.config import Options
 
 with RayEngine(
     rapidsmpf_options=Options(num_streaming_threads=8),
-    executor_options={
-        "max_rows_per_partition": 500_000,
-        "num_py_executors": 2,
-    },
+    executor_options={"num_py_executors": 2},
+    executor_options={"max_rows_per_partition": 500_000},
     engine_options={"raise_on_fail": True},
     ray_init_options={"num_cpus": 4},
 ) as engine:
@@ -324,14 +377,14 @@ Conceptually the system looks like this:
 
 ### Prerequisites
 
-* Dask distributed (`distributed`) and `dask-cuda` installed
+* Dask distributed (`distributed`) installed
 * RapidsMPF and UCXX available on all GPU nodes
 
 ### Running in Dask mode
 
 `DaskEngine` is imported from `cudf_polars.experimental.rapidsmpf.frontend.dask`. On construction it:
 
-1. If `dask_client` is `None`, creates a `dask_cuda.LocalCUDACluster` (one worker per GPU) and a `distributed.Client`
+1. If `dask_client` is `None`, creates a `distributed.LocalCluster` (one worker per visible GPU) and a `distributed.Client`
 2. Bootstraps a UCXX communicator across all workers
 
 `DaskEngine` is a `StreamingEngine` subclass (and therefore a `pl.GPUEngine`) that can be used directly or as a context manager.
@@ -381,6 +434,57 @@ engine.shutdown()
 
 `DaskEngine` raises `RuntimeError` if created inside an `rrun` cluster.
 
+### Hardware binding with pre-configured clusters
+
+When using a pre-configured cluster that already performs its own hardware
+binding — such as `dask_cuda.LocalCUDACluster`, which pins CPU affinity and
+sets `CUDA_VISIBLE_DEVICES` per worker — disable the built-in binding to
+avoid conflicts:
+
+```python
+from cudf_polars.experimental.rapidsmpf.frontend.dask import DaskEngine
+from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+    HardwareBindingPolicy,
+)
+
+with DaskEngine(
+    dask_client=dc,
+    engine_options={
+        "hardware_binding": HardwareBindingPolicy(enabled=False),
+    },
+) as engine:
+    ...
+```
+
+### Manually launched Dask clusters
+
+When launching workers manually (e.g. on a multi-node HPC cluster), use the
+built-in nanny preload to assign one GPU per worker. The preload sets
+`CUDA_VISIBLE_DEVICES` on each worker before the process spawns:
+
+```bash
+# On each node — launch one worker per GPU with a single thread each:
+dask worker SCHEDULER:8786 --nworkers N --nthreads 1 \
+    --preload-nanny cudf_polars.experimental.rapidsmpf.frontend.dask
+```
+
+Then connect from the client:
+
+```python
+from distributed import Client
+from cudf_polars.experimental.rapidsmpf.frontend.dask import DaskEngine
+
+with Client("SCHEDULER:8786") as dc:
+    with DaskEngine(dask_client=dc) as engine:
+        result = lf.collect(engine=engine)
+```
+
+Hardware binding (CPU affinity, NUMA, network) is handled automatically by
+`DaskEngine` via `HardwareBindingPolicy` — the nanny preload only handles
+GPU assignment.
+
+See the [Dask CLI deployment guide][dask-cli] for more on `dask worker` options.
+
 ### Cluster diagnostics
 
 ```python
@@ -406,10 +510,8 @@ from rapidsmpf.config import Options
 
 with DaskEngine(
     rapidsmpf_options=Options(num_streaming_threads=8),
-    executor_options={
-        "max_rows_per_partition": 500_000,
-        "num_py_executors": 2,
-    },
+    executor_options={"num_py_executors": 2},
+    executor_options={"max_rows_per_partition": 500_000},
     engine_options={"raise_on_fail": True},
 ) as engine:
     ...
@@ -643,10 +745,8 @@ from rapidsmpf.config import Options
 
 with SPMDEngine(
     rapidsmpf_options=Options(num_streaming_threads=8),
-    executor_options={
-        "max_rows_per_partition": 500_000,
-        "num_py_executors": 2,
-    },
+    executor_options={"num_py_executors": 2},
+    executor_options={"max_rows_per_partition": 500_000},
     engine_options={"parquet_options": {"use_rapidsmpf_native": True}},
 ) as engine:
     ...
@@ -674,6 +774,7 @@ pass `engine_options={"parquet_options": {"use_rapidsmpf_native": True}}` to ena
 native Parquet reads.
 
 <!-- Reference links -->
+[dask-cli]: https://docs.dask.org/en/latest/deploying-cli.html
 [dask-distributed]: https://distributed.dask.org/
 [spmd-wiki]: https://en.wikipedia.org/wiki/Single_program,_multiple_data
 [ray-docs]: https://docs.ray.io/

--- a/python/cudf_polars/tests/dsl/test_nodebase.py
+++ b/python/cudf_polars/tests/dsl/test_nodebase.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
             expr.Col(DataType(pl.Int64()), "foo"),
             expr.Literal(DataType(pl.Int64()), 1),
         ),
-        expr.GroupedRollingWindow(
+        expr.GroupedWindow(
             DataType(pl.Float64),
             ("groups_to_rows", True, False, False),
             [

--- a/python/cudf_polars/tests/experimental/test_bind_to_gpu.py
+++ b/python/cudf_polars/tests/experimental/test_bind_to_gpu.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for bind_to_gpu() and HardwareBindingPolicy."""
+
+from __future__ import annotations
+
+import multiprocessing
+import traceback
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, call, patch
+
+import distributed
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _run_in_subprocess(target: Callable[[], None]) -> None:
+    """Execute ``target()`` in a forked child process.
+
+    Because each call forks a new child, process-wide side-effects
+    (the ``_bind_done`` flag, CPU affinity, environment variables) never
+    leak between tests or back into the pytest process.
+    """
+    ctx = multiprocessing.get_context("fork")
+    parent_conn, child_conn = ctx.Pipe()
+
+    def _wrapper() -> None:
+        try:
+            target()
+            child_conn.send(None)
+        except BaseException as exc:
+            try:
+                child_conn.send(exc)
+            except Exception:
+                child_conn.send(
+                    RuntimeError(
+                        f"{type(exc).__name__}: {exc}\n"
+                        f"{''.join(traceback.format_tb(exc.__traceback__))}"
+                    )
+                )
+        finally:
+            child_conn.close()
+
+    proc = ctx.Process(target=_wrapper)
+    proc.start()
+    try:
+        proc.join(timeout=30)
+
+        if proc.is_alive():
+            proc.kill()
+            proc.join()
+            raise RuntimeError("Subprocess timed out after 30 seconds")
+
+        if parent_conn.poll():
+            exc = parent_conn.recv()
+            if exc is not None:
+                raise exc
+
+        if proc.exitcode != 0:
+            raise RuntimeError(f"Subprocess exited with code {proc.exitcode}")
+    finally:
+        proc.close()
+
+
+def _reset_bind_state() -> None:
+    """Reset the module-level bind state so each subprocess starts clean."""
+    from cudf_polars.experimental.rapidsmpf.frontend import hardware_binding
+
+    hardware_binding._bind_done = False
+
+
+def test_bind_called_once() -> None:
+    """bind() is called exactly once even when bind_to_gpu() is called twice."""
+
+    def body() -> None:
+        _reset_bind_state()
+        with patch(
+            "cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind"
+        ) as mock_bind:
+            from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+                HardwareBindingPolicy,
+                bind_to_gpu,
+            )
+
+            policy = HardwareBindingPolicy()
+            bind_to_gpu(policy)
+            bind_to_gpu(policy)
+            assert mock_bind.call_count == 1
+
+    _run_in_subprocess(body)
+
+
+def test_bind_falls_back_to_gpu_0() -> None:
+    """When bind() raises RuntimeError, falls back to gpu_id=0."""
+
+    def body() -> None:
+        _reset_bind_state()
+        mock_bind = MagicMock(
+            side_effect=[RuntimeError("no CUDA_VISIBLE_DEVICES"), None]
+        )
+        with patch(
+            "cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind",
+            mock_bind,
+        ):
+            from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+                HardwareBindingPolicy,
+                bind_to_gpu,
+            )
+
+            bind_to_gpu(HardwareBindingPolicy())
+            assert mock_bind.call_count == 2
+            assert mock_bind.call_args_list == [
+                call(verbose=False),
+                call(gpu_id=0, verbose=False),
+            ]
+
+    _run_in_subprocess(body)
+
+
+def test_bind_raise_on_fail_sets_verbose() -> None:
+    """raise_on_fail=True forwards verbose=True to bind()."""
+
+    def body() -> None:
+        _reset_bind_state()
+        with patch(
+            "cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind"
+        ) as mock_bind:
+            from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+                HardwareBindingPolicy,
+                bind_to_gpu,
+            )
+
+            bind_to_gpu(HardwareBindingPolicy(raise_on_fail=True))
+            mock_bind.assert_called_once_with(verbose=True)
+
+    _run_in_subprocess(body)
+
+
+def test_bind_thread_safe() -> None:
+    """Concurrent calls from multiple threads result in exactly one bind() call."""
+
+    def body() -> None:
+        import threading
+
+        _reset_bind_state()
+        with patch(
+            "cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind"
+        ) as mock_bind:
+            from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+                HardwareBindingPolicy,
+                bind_to_gpu,
+            )
+
+            policy = HardwareBindingPolicy()
+            barrier = threading.Barrier(8)
+
+            def _call_bind() -> None:
+                barrier.wait()
+                bind_to_gpu(policy)
+
+            threads = [threading.Thread(target=_call_bind) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert mock_bind.call_count == 1
+
+    _run_in_subprocess(body)
+
+
+def test_bind_done_flag_set() -> None:
+    """_bind_done is True after bind_to_gpu() succeeds."""
+
+    def body() -> None:
+        from cudf_polars.experimental.rapidsmpf.frontend import hardware_binding
+
+        _reset_bind_state()
+        assert not hardware_binding._bind_done
+        with patch("cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind"):
+            hardware_binding.bind_to_gpu(hardware_binding.HardwareBindingPolicy())
+            assert hardware_binding._bind_done
+
+    _run_in_subprocess(body)
+
+
+def test_bind_disabled() -> None:
+    """enabled=False skips binding entirely."""
+
+    def body() -> None:
+        _reset_bind_state()
+        with patch(
+            "cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind"
+        ) as mock_bind:
+            from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+                HardwareBindingPolicy,
+                bind_to_gpu,
+            )
+
+            bind_to_gpu(HardwareBindingPolicy(enabled=False))
+            mock_bind.assert_not_called()
+
+    _run_in_subprocess(body)
+
+
+def test_bind_enable_once_false() -> None:
+    """enable_once=False allows repeated bind() calls."""
+
+    def body() -> None:
+        _reset_bind_state()
+        with patch(
+            "cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind"
+        ) as mock_bind:
+            from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+                HardwareBindingPolicy,
+                bind_to_gpu,
+            )
+
+            policy = HardwareBindingPolicy(enable_once=False)
+            bind_to_gpu(policy)
+            bind_to_gpu(policy)
+            assert mock_bind.call_count == 2
+
+    _run_in_subprocess(body)
+
+
+# ---------------------------------------------------------------------------
+# dask_setup (nanny preload)
+# ---------------------------------------------------------------------------
+
+
+def test_get_visible_gpu_ids_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cudf_polars.experimental.rapidsmpf.frontend.dask import _get_visible_gpu_ids
+
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,1,4")
+    assert _get_visible_gpu_ids() == ["3", "1", "4"]
+
+
+def test_dask_setup_assigns_gpus(monkeypatch: pytest.MonkeyPatch) -> None:
+    """dask_setup assigns round-robin CUDA_VISIBLE_DEVICES to each nanny."""
+    import cudf_polars.experimental.rapidsmpf.frontend.dask as dask_mod
+
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+    monkeypatch.setattr(dask_mod, "_nanny_preload_counter", 0)
+
+    nanny0 = MagicMock(spec=distributed.Nanny)
+    nanny0.env = {}
+    dask_mod.dask_setup(nanny0)
+    assert nanny0.env["CUDA_VISIBLE_DEVICES"] == "0"
+
+    nanny1 = MagicMock(spec=distributed.Nanny)
+    nanny1.env = {}
+    dask_mod.dask_setup(nanny1)
+    assert nanny1.env["CUDA_VISIBLE_DEVICES"] == "1"
+
+
+def test_dask_setup_wraps_around(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Counter wraps around when workers exceed GPUs."""
+    import cudf_polars.experimental.rapidsmpf.frontend.dask as dask_mod
+
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+    monkeypatch.setattr(dask_mod, "_nanny_preload_counter", 0)
+
+    nannies = []
+    for _ in range(4):
+        n = MagicMock(spec=distributed.Nanny)
+        n.env = {}
+        dask_mod.dask_setup(n)
+        nannies.append(n)
+
+    assert nannies[0].env["CUDA_VISIBLE_DEVICES"] == "0"
+    assert nannies[1].env["CUDA_VISIBLE_DEVICES"] == "1"
+    assert nannies[2].env["CUDA_VISIBLE_DEVICES"] == "0"  # wraps
+    assert nannies[3].env["CUDA_VISIBLE_DEVICES"] == "1"  # wraps
+
+
+def test_dask_setup_rejects_worker() -> None:
+    """dask_setup raises TypeError when used with --preload instead of --preload-nanny."""
+    import cudf_polars.experimental.rapidsmpf.frontend.dask as dask_mod
+
+    worker = MagicMock(spec=distributed.Worker)
+    with pytest.raises(TypeError, match="--preload-nanny"):
+        dask_mod.dask_setup(worker)

--- a/python/cudf_polars/tests/experimental/test_options.py
+++ b/python/cudf_polars/tests/experimental/test_options.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 
 import pytest
@@ -323,3 +324,59 @@ def test_to_dict_roundtrip() -> None:
 def test_to_dict_roundtrip_empty() -> None:
     opts = StreamingOptions()
     assert StreamingOptions.from_dict(opts.to_dict()) == opts
+
+
+# ---------------------------------------------------------------------------
+# hardware_binding
+# ---------------------------------------------------------------------------
+
+
+def test_hardware_binding_in_engine_options() -> None:
+    from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+        HardwareBindingPolicy,
+    )
+
+    result = StreamingOptions(
+        hardware_binding=HardwareBindingPolicy(enabled=False)
+    ).to_engine_options()
+    assert result["hardware_binding"] == HardwareBindingPolicy(enabled=False)
+
+
+def test_hardware_binding_env_var_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+        HardwareBindingPolicy,
+    )
+
+    monkeypatch.setenv("CUDF_POLARS__HARDWARE_BINDING", '{"enabled": false}')
+    result = StreamingOptions().to_engine_options()
+    assert result["hardware_binding"] == HardwareBindingPolicy(enabled=False)
+
+
+def test_hardware_binding_cli_json() -> None:
+    from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+        HardwareBindingPolicy,
+    )
+
+    parser = argparse.ArgumentParser()
+    StreamingOptions._add_cli_args(parser)
+    args = parser.parse_args(["--hardware-binding", '{"raise_on_fail": true}'])
+    opts = StreamingOptions._from_argparse(args)
+    assert opts.hardware_binding == HardwareBindingPolicy(raise_on_fail=True)
+
+
+def test_hardware_binding_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CUDF_POLARS__HARDWARE_BINDING", "not json")
+    with pytest.raises(json.JSONDecodeError):
+        StreamingOptions()
+
+
+def test_hardware_binding_cli_disabled() -> None:
+    from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+        HardwareBindingPolicy,
+    )
+
+    parser = argparse.ArgumentParser()
+    StreamingOptions._add_cli_args(parser)
+    args = parser.parse_args(["--hardware-binding", '{"enabled": false}'])
+    opts = StreamingOptions._from_argparse(args)
+    assert opts.hardware_binding == HardwareBindingPolicy(enabled=False)

--- a/python/cudf_polars/tests/experimental/test_select.py
+++ b/python/cudf_polars/tests/experimental/test_select.py
@@ -155,6 +155,7 @@ def test_select_aggs(df, engine, aggs):
         (pl.col("a").drop_nulls().min(),),
         (pl.col("a").drop_nulls().max(),),
         (pl.col("a").drop_nulls().mean(),),
+        (pl.col("a").null_count(),),
     ],
 )
 def test_select_drop_nulls_aggs(engine, aggs):


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.