### PR TITLE
Test different pandas option in test_options_mode for pandas 3

### DIFF
--- a/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
+++ b/python/cudf/cudf_pandas_tests/test_cudf_pandas.py
@@ -496,7 +496,7 @@ def test_groupby_grouper_fallback(dataframe, groupby_udf):
 
 
 def test_options_mode():
-    assert xpd.options.mode.copy_on_write == pd.options.mode.copy_on_write
+    assert xpd.options.mode.string_storage == pd.options.mode.string_storage
 
 
 # Codecov and Profiler interfere with each-other,


### PR DESCRIPTION
## Description
This is the last failing test in the `unit-tests-cudf-pandas` job (since warnings are errors), so hopefully these jobs are green after this PR

`mode.copy_on_write` is deprecated in pandas 3. Using `mode.string_storage` should hopefully be a better longer term option to test

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
