### PR TITLE
Pass writable numpy array to pytorch third party test with pandas 3

### DIFF
--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_pytorch.py
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_pytorch.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
@@ -140,4 +140,4 @@ def test_torch_tensor_ctor():
 
 def test_torch_tensor_from_numpy():
     s = pd.Series(range(5))
-    return torch.from_numpy(s.values)
+    return torch.from_numpy(s.to_numpy(copy=True))


### PR DESCRIPTION
## Description
This appears to be the only failing test in the `third-party-integration-tests-cudf-pandas` job

`Series.values` is now a read only numpy array in pandas 3. Appears `torch.from_numpy` warns if passed a read-only array.

We can more explicitly call `to_numpy(copy=True)` to ensure we pass a writable array

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
