### PR TITLE
[Multi-GPU Polars] Reduce DaskEngine local cluster log verbosity

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
@@ -589,8 +589,9 @@ class DaskEngine(StreamingEngine):
                 }
             # Set scheduler/client log level to WARNING in the main
             # process (is INFO by default).
-            logging.getLogger("distributed").setLevel(logging.WARNING)
-            owned_cluster = distributed.SpecCluster(workers=worker_spec)
+            owned_cluster = distributed.SpecCluster(
+                workers=worker_spec, silence_logs=logging.WARNING
+            )
             owned_client = distributed.Client(owned_cluster)
             dask_client = owned_client
 

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import functools
+import logging
 import os
 import socket
 import uuid
@@ -578,11 +579,17 @@ class DaskEngine(StreamingEngine):
                     "cls": distributed.Nanny,
                     "options": {
                         "nthreads": 1,
+                        # Set worker subprocess log level to WARNING
+                        # (is INFO by default).
+                        "silence_logs": logging.WARNING,
                         "env": {
                             "CUDA_VISIBLE_DEVICES": gpu_ids[i],
                         },
                     },
                 }
+            # Set scheduler/client log level to WARNING in the main
+            # process (is INFO by default).
+            logging.getLogger("distributed").setLevel(logging.WARNING)
             owned_cluster = distributed.SpecCluster(workers=worker_spec)
             owned_client = distributed.Client(owned_cluster)
             dask_client = owned_client


### PR DESCRIPTION
When `DaskEngine` creates a local cluster, set the `distributed` logger level to `WARNING` (default is `INFO`) to reduce noisy startup and shutdown logs.

This does not affect user-provided clusters.