### PR TITLE
[Multi-GPU Polars] Unify `num_py_executors` default

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
@@ -257,8 +257,8 @@ def _setup_worker(
     rmm.mr.set_current_device_resource(ctx.br().device_mr)
     py_executor = ThreadPoolExecutor(
         max_workers=cast(
-            int | None,
-            executor_options.get("num_py_executors"),
+            int,
+            executor_options.get("num_py_executors", 8),
         ),
         thread_name_prefix="dask-executor",
     )

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
@@ -206,7 +206,7 @@ class StreamingOptions:
     num_py_executors
         Workers for the internal Python ``ThreadPoolExecutor``.
         Env: ``CUDF_POLARS__EXECUTOR__NUM_PY_EXECUTORS``.
-        Default: ``1``.
+        Default: ``8``.
         Category: executor.
     fallback_mode
         Fallback behavior (``"warn"``, ``"raise"``, ``"silent"``).

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
@@ -503,7 +503,7 @@ class RayEngine(StreamingEngine):
                     rapidsmpf_options_as_bytes=rapidsmpf_options_as_bytes,
                     num_py_executors=cast(
                         int,
-                        executor_options.get("num_py_executors", 1),
+                        executor_options.get("num_py_executors", 8),
                     ),
                     hardware_binding=hw_binding,
                     memory_resource_config=mr_config,

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
@@ -373,7 +373,7 @@ class SPMDEngine(StreamingEngine):
         # else: caller-provided comm; the caller retains ownership
 
         py_executor = ThreadPoolExecutor(
-            max_workers=cast(int, executor_options.get("num_py_executors", 1)),
+            max_workers=cast(int, executor_options.get("num_py_executors", 8)),
             thread_name_prefix="spmd-executor",
         )
         exit_stack = contextlib.ExitStack()

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -691,8 +691,7 @@ class StreamingExecutor:
         regular pageable host memory.
     num_py_executors
         Maximum number of workers for the Python ThreadPoolExecutor used by
-        the rapidsmpf runtime. Default is None, which uses ThreadPoolExecutor's
-        default behavior. This option is only used by the "rapidsmpf" runtime.
+        the rapidsmpf runtime. Default is 8.
 
     Notes
     -----
@@ -786,9 +785,9 @@ class StreamingExecutor:
             f"{_env_prefix}__SPILL_TO_PINNED_MEMORY", bool, default=False
         )
     )
-    num_py_executors: int | None = dataclasses.field(
+    num_py_executors: int = dataclasses.field(
         default_factory=_make_default_factory(
-            f"{_env_prefix}__NUM_PY_EXECUTORS", int, default=None
+            f"{_env_prefix}__NUM_PY_EXECUTORS", int, default=8
         )
     )
     spmd_context: SPMDContext | None = None
@@ -890,8 +889,8 @@ class StreamingExecutor:
             raise TypeError("max_io_threads must be an int")
         if not isinstance(self.spill_to_pinned_memory, bool):
             raise TypeError("spill_to_pinned_memory must be bool")
-        if not isinstance(self.num_py_executors, (int, type(None))):
-            raise TypeError("num_py_executors must be int or None")
+        if not isinstance(self.num_py_executors, int):
+            raise TypeError("num_py_executors must be an int")
 
         # RapidsMPF spill is only supported for distributed clusters for now.
         # This is because the spilling API is still within the RMPF-Dask integration.

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -898,7 +898,7 @@ def test_num_py_executors_default() -> None:
         )
     )
     assert config.executor.name == "streaming"
-    assert config.executor.num_py_executors is None
+    assert config.executor.num_py_executors == 8
 
 
 def test_num_py_executors_from_executor_options() -> None:


### PR DESCRIPTION
Unify the default `num_py_executors` to `8` across all streaming engines (single-GPU, SPMD, Ray, Dask). Previously, the default varied: `None` for single-GPU and Dask, and `1` for SPMD and Ray.

I think `8` is a reasonable default, since the Python thread pool primarily drives the actor network and threads often block on C++ calls that release the GIL. That said, once the new engines stabilize, we should run a benchmark sweep across configurations to validate and potentially refine this default.

For now, having a consistent default across all engines is the main goal.
