### PR TITLE
Remove verbose from bind() in favor of exceptions in cudf-polars

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/hardware_binding.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/hardware_binding.py
@@ -43,10 +43,9 @@ class HardwareBindingPolicy:
         subsequent calls to :func:`bind_to_gpu` are no-ops. When
         ``False``, binding is attempted on every call.
     raise_on_fail
-        When ``True``, binding failures raise an exception. Currently
-        ``rrun.bind()`` only prints warnings to stderr on per-subsystem
-        failures; setting this flag enables ``verbose=True`` so those
-        warnings are visible.
+        When ``True``, binding failures (e.g. CPU affinity, NUMA memory
+        policy, or topology discovery) raise an exception.  When
+        ``False`` (the default), failures are silently ignored.
     """
 
     skip_under_rrun: bool = True
@@ -95,14 +94,12 @@ def bind_to_gpu(policy: HardwareBindingPolicy) -> None:
 
 def _do_bind(policy: HardwareBindingPolicy) -> None:
     """Execute the actual bind call according to *policy*."""
-    verbose = policy.raise_on_fail
-    # TODO(rapidsmpf): rrun.bind() does not currently report per-subsystem
-    # failures programmatically — it only prints warnings to stderr when
-    # verbose=True. When a return value or exception is available, check it
-    # here and raise if policy.raise_on_fail is True.
-    # See: https://github.com/rapidsai/rapidsmpf/issues/963
     try:
-        bind(verbose=verbose)
+        try:
+            bind()
+        except RuntimeError:
+            # CUDA_VISIBLE_DEVICES is unset; fall back to GPU 0.
+            bind(gpu_id=0)
     except RuntimeError:
-        # CUDA_VISIBLE_DEVICES is unset; fall back to GPU 0.
-        bind(gpu_id=0, verbose=verbose)
+        if policy.raise_on_fail:
+            raise

--- a/python/cudf_polars/tests/experimental/test_bind_to_gpu.py
+++ b/python/cudf_polars/tests/experimental/test_bind_to_gpu.py
@@ -112,28 +112,54 @@ def test_bind_falls_back_to_gpu_0() -> None:
             bind_to_gpu(HardwareBindingPolicy())
             assert mock_bind.call_count == 2
             assert mock_bind.call_args_list == [
-                call(verbose=False),
-                call(gpu_id=0, verbose=False),
+                call(),
+                call(gpu_id=0),
             ]
 
     _run_in_subprocess(body)
 
 
-def test_bind_raise_on_fail_sets_verbose() -> None:
-    """raise_on_fail=True forwards verbose=True to bind()."""
+def test_bind_raise_on_fail_propagates_exception() -> None:
+    """raise_on_fail=True lets RuntimeError from bind() propagate."""
 
     def body() -> None:
         _reset_bind_state()
+        mock_bind = MagicMock(
+            side_effect=RuntimeError("binding failed")
+        )
         with patch(
-            "cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind"
-        ) as mock_bind:
+            "cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind",
+            mock_bind,
+        ):
             from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
                 HardwareBindingPolicy,
                 bind_to_gpu,
             )
 
-            bind_to_gpu(HardwareBindingPolicy(raise_on_fail=True))
-            mock_bind.assert_called_once_with(verbose=True)
+            with pytest.raises(RuntimeError, match="binding failed"):
+                bind_to_gpu(HardwareBindingPolicy(raise_on_fail=True))
+
+    _run_in_subprocess(body)
+
+
+def test_bind_raise_on_fail_false_suppresses_exception() -> None:
+    """raise_on_fail=False silently ignores RuntimeError from bind()."""
+
+    def body() -> None:
+        _reset_bind_state()
+        mock_bind = MagicMock(
+            side_effect=RuntimeError("binding failed")
+        )
+        with patch(
+            "cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind",
+            mock_bind,
+        ):
+            from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+                HardwareBindingPolicy,
+                bind_to_gpu,
+            )
+
+            bind_to_gpu(HardwareBindingPolicy(raise_on_fail=False))
 
     _run_in_subprocess(body)
 

--- a/python/cudf_polars/tests/experimental/test_bind_to_gpu.py
+++ b/python/cudf_polars/tests/experimental/test_bind_to_gpu.py
@@ -124,9 +124,7 @@ def test_bind_raise_on_fail_propagates_exception() -> None:
 
     def body() -> None:
         _reset_bind_state()
-        mock_bind = MagicMock(
-            side_effect=RuntimeError("binding failed")
-        )
+        mock_bind = MagicMock(side_effect=RuntimeError("binding failed"))
         with patch(
             "cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind",
             mock_bind,
@@ -147,9 +145,7 @@ def test_bind_raise_on_fail_false_suppresses_exception() -> None:
 
     def body() -> None:
         _reset_bind_state()
-        mock_bind = MagicMock(
-            side_effect=RuntimeError("binding failed")
-        )
+        mock_bind = MagicMock(side_effect=RuntimeError("binding failed"))
         with patch(
             "cudf_polars.experimental.rapidsmpf.frontend.hardware_binding.bind",
             mock_bind,


### PR DESCRIPTION
## Description

Adapt cudf-polars to the updated `rrun.bind()` API which now raises `RuntimeError` on failure instead of optionally printing to stderr. The `_do_bind()` helper catches or propagates the exception based on `policy.raise_on_fail`.

Requires https://github.com/rapidsai/rapidsmpf/pull/971