### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/allgather.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/allgather.py
@@ -36,44 +36,68 @@ class AllGatherManager:
         Pre-allocated operation ID for this operation.
     """
 
+    class Inserter:
+        """
+        Context manager for the insert phase of an AllGather operation.
+
+        Obtained via :meth:`AllGatherManager.inserting`. On exit, signals
+        the end of insertion to all ranks by calling ``insert_finished()``.
+
+        Parameters
+        ----------
+        manager: AllGatherManager
+            The AllGather manager to insert into.
+        """
+
+        def __init__(self, manager: AllGatherManager):
+            self._manager = manager
+
+        def insert(self, sequence_number: int, chunk: TableChunk) -> None:
+            """
+            Insert a chunk into the AllGather.
+
+            Parameters
+            ----------
+            sequence_number: int
+                The sequence number of the chunk to insert.
+            chunk: TableChunk
+                The table chunk to insert. Need not be GPU-resident; if spilled,
+                it will be made available internally.
+            """
+            chunk = chunk.make_available_and_spill(
+                self._manager.context.br(), allow_overbooking=True
+            )
+            self._manager.allgather.insert(
+                sequence_number,
+                # TODO: Avoid unnecessary copies.
+                # See https://github.com/rapidsai/rapidsmpf/issues/933
+                PackedData.from_cudf_packed_columns(
+                    pack(
+                        chunk.table_view(),
+                        chunk.stream,
+                        mr=self._manager.context.br().device_mr,
+                    ),
+                    chunk.stream,
+                    self._manager.context.br(),
+                ),
+            )
+            del chunk
+
+        def __enter__(self) -> AllGatherManager.Inserter:
+            """Enter the context manager."""
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            """Exit the context manager, calling ``insert_finished()``."""
+            self._manager.allgather.insert_finished()
+
     def __init__(self, context: Context, comm: Communicator, op_id: int):
         self.context = context
         self.allgather = AllGather(self.context, comm, op_id)
 
-    def insert(self, sequence_number: int, chunk: TableChunk) -> None:
-        """
-        Insert a chunk into the AllGatherContext.
-
-        Parameters
-        ----------
-        sequence_number: int
-            The sequence number of the chunk to insert.
-        chunk: TableChunk
-            The table chunk to insert. Need not be GPU-resident; if spilled,
-            it will be made available internally.
-        """
-        chunk = chunk.make_available_and_spill(
-            self.context.br(), allow_overbooking=True
-        )
-        self.allgather.insert(
-            sequence_number,
-            # TODO: Avoid unnecessary copies.
-            # See https://github.com/rapidsai/rapidsmpf/issues/933
-            PackedData.from_cudf_packed_columns(
-                pack(
-                    chunk.table_view(),
-                    chunk.stream,
-                    mr=self.context.br().device_mr,
-                ),
-                chunk.stream,
-                self.context.br(),
-            ),
-        )
-        del chunk
-
-    def insert_finished(self) -> None:
-        """Insert finished into the AllGatherManager."""
-        self.allgather.insert_finished()
+    def inserting(self) -> AllGatherManager.Inserter:
+        """Return a context manager for the insert phase."""
+        return AllGatherManager.Inserter(self)
 
     async def extract_concatenated(
         self, stream: Stream, *, ordered: bool = True

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -67,6 +67,55 @@ class ShuffleManager:
         partition IDs and concatenation order matches global order.
     """
 
+    class Inserter:
+        """
+        Context manager for the insert phase of a shuffle operation.
+
+        Obtained via :meth:`ShuffleManager.inserting`. On exit, signals
+        the end of insertion to all ranks by calling ``insert_finished()``.
+
+        Parameters
+        ----------
+        manager: ShuffleManager
+            The shuffle manager to insert into.
+        """
+
+        def __init__(self, manager: ShuffleManager):
+            self._manager = manager
+
+        def insert_hash(
+            self, chunk: TableChunk, columns_to_hash: tuple[int, ...]
+        ) -> None:
+            """Partition chunk by hash and insert into the shuffler."""
+            self._manager.shuffler.insert(
+                py_partition_and_pack(
+                    table=chunk.table_view(),
+                    columns_to_hash=columns_to_hash,
+                    num_partitions=self._manager.num_partitions,
+                    stream=chunk.stream,
+                    br=self._manager.context.br(),
+                )
+            )
+
+        def insert_split(self, chunk: TableChunk, splits: list[int]) -> None:
+            """Split chunk at the given indices and insert into the shuffler."""
+            self._manager.shuffler.insert(
+                py_split_and_pack(
+                    table=chunk.table_view(),
+                    splits=splits,
+                    stream=chunk.stream,
+                    br=self._manager.context.br(),
+                )
+            )
+
+        async def __aenter__(self) -> ShuffleManager.Inserter:
+            """Enter the context manager."""
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            """Exit the context manager, calling ``insert_finished()``."""
+            await self._manager.shuffler.insert_finished(self._manager.context)
+
     def __init__(
         self,
         context: Context,
@@ -86,36 +135,13 @@ class ShuffleManager:
             partition_assignment=partition_assignment,
         )
 
+    def inserting(self) -> ShuffleManager.Inserter:
+        """Return a context manager for the insert phase."""
+        return ShuffleManager.Inserter(self)
+
     def local_partitions(self) -> list[int]:
         """Get the local partition IDs for this rank."""
         return self.shuffler.local_partitions()
-
-    def insert_hash(self, chunk: TableChunk, columns_to_hash: tuple[int, ...]) -> None:
-        """Partition chunk by hash and insert into the shuffler."""
-        self.shuffler.insert(
-            py_partition_and_pack(
-                table=chunk.table_view(),
-                columns_to_hash=columns_to_hash,
-                num_partitions=self.num_partitions,
-                stream=chunk.stream,
-                br=self.context.br(),
-            )
-        )
-
-    def insert_split(self, chunk: TableChunk, splits: list[int]) -> None:
-        """Split chunk at the given indices and insert into the shuffler."""
-        self.shuffler.insert(
-            py_split_and_pack(
-                table=chunk.table_view(),
-                splits=splits,
-                stream=chunk.stream,
-                br=self.context.br(),
-            )
-        )
-
-    async def insert_finished(self) -> None:
-        """Insert finished into the ShuffleManager."""
-        await self.shuffler.insert_finished(self.context)
 
     def extract_chunk(self, sequence_number: int, stream: Stream) -> plc.Table:
         """
@@ -222,22 +248,20 @@ async def _global_shuffle(
     )
     await send_metadata(ch_out, context, output_metadata)
 
-    # Create ShuffleManager instance
-    shuffle = ShuffleManager(context, comm, num_partitions, collective_id)
     # When input is duplicated, only rank 0 should contribute data.
     # Other ranks still participate in the shuffle protocol.
     skip_insert = metadata_in.duplicated and comm.rank != 0
 
-    while (msg := await ch_in.recv(context)) is not None:
-        if not skip_insert:
-            shuffle.insert_hash(
-                TableChunk.from_message(msg, br=context.br()).make_available_and_spill(
-                    context.br(), allow_overbooking=True
-                ),
-                columns_to_hash,
-            )
-
-    await shuffle.insert_finished()
+    shuffle = ShuffleManager(context, comm, num_partitions, collective_id)
+    async with shuffle.inserting() as inserter:
+        while (msg := await ch_in.recv(context)) is not None:
+            if not skip_insert:
+                inserter.insert_hash(
+                    TableChunk.from_message(
+                        msg, br=context.br()
+                    ).make_available_and_spill(context.br(), allow_overbooking=True),
+                    columns_to_hash,
+                )
 
     for partition_id in shuffle.shuffler.local_partitions():
         stream = ir_context.get_cuda_stream()

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/sort.py
@@ -127,15 +127,15 @@ async def _compute_sort_boundaries(
     stream = local_boundaries_df.stream
 
     if allgather_id is not None:
-        allgather = AllGatherManager(context, comm, allgather_id)
         chunk = TableChunk.from_pylibcudf_table(
             local_boundaries_df.table,
             stream,
             exclusive_view=True,
             br=context.br(),
         )
-        allgather.insert(comm.rank, chunk)
-        allgather.insert_finished()
+        allgather = AllGatherManager(context, comm, allgather_id)
+        with allgather.inserting() as inserter:
+            inserter.insert(comm.rank, chunk)
         concat_table = await allgather.extract_concatenated(stream, ordered=True)
         return _get_final_sort_boundaries(
             DataFrame.from_table(
@@ -285,6 +285,10 @@ async def _insert_chunks_into_shuffle(
     null_order = list(ir.null_order)
     by_indices = names_to_indices(tuple(by), ir.schema)
 
+    skip_insert = metadata_in.duplicated and comm.rank != 0
+    local_sort_ir = ir.children[0]
+    assert isinstance(local_sort_ir, Sort), "ShuffleSorted must have a Sort child."
+
     shuffle = ShuffleManager(
         context,
         comm,
@@ -292,37 +296,32 @@ async def _insert_chunks_into_shuffle(
         collective_ids.pop(),
         partition_assignment=PartitionAssignment.CONTIGUOUS,
     )
-    skip_insert = metadata_in.duplicated and comm.rank != 0
-    local_sort_ir = ir.children[0]
-    assert isinstance(local_sort_ir, Sort), "ShuffleSorted must have a Sort child."
+    async with shuffle.inserting() as inserter:
+        for msg in chunk_store:
+            if skip_insert:
+                continue
+            seq_num = msg.sequence_number
+            available_chunk = TableChunk.from_message(
+                msg, br=context.br()
+            ).make_available_and_spill(context.br(), allow_overbooking=True)
+            tbl = available_chunk.table_view()
+            sort_cols_tbl = plc.Table([tbl.columns()[i] for i in by_indices])
 
-    for msg in chunk_store:
-        if skip_insert:
-            continue
-        seq_num = msg.sequence_number
-        available_chunk = TableChunk.from_message(
-            msg, br=context.br()
-        ).make_available_and_spill(context.br(), allow_overbooking=True)
-        tbl = available_chunk.table_view()
-        sort_cols_tbl = plc.Table([tbl.columns()[i] for i in by_indices])
+            stream = get_joined_cuda_stream(
+                ir_context.get_cuda_stream,
+                upstreams=(available_chunk.stream, sort_boundaries_df.stream),
+            )
 
-        stream = get_joined_cuda_stream(
-            ir_context.get_cuda_stream,
-            upstreams=(available_chunk.stream, sort_boundaries_df.stream),
-        )
-
-        splits = find_sort_splits(
-            sort_cols_tbl,
-            sort_boundaries_df.table,
-            seq_num,
-            column_order,
-            null_order,
-            stream=stream,
-            chunk_relative=True,
-        )
-        shuffle.insert_split(available_chunk, splits)
-
-    await shuffle.insert_finished()
+            splits = find_sort_splits(
+                sort_cols_tbl,
+                sort_boundaries_df.table,
+                seq_num,
+                column_order,
+                null_order,
+                stream=stream,
+                chunk_relative=True,
+            )
+            inserter.insert_split(available_chunk, splits)
 
     post_sort_ir = local_sort_ir
     if local_sort_ir.stable:

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
@@ -257,8 +257,8 @@ def _setup_worker(
     rmm.mr.set_current_device_resource(ctx.br().device_mr)
     py_executor = ThreadPoolExecutor(
         max_workers=cast(
-            int | None,
-            executor_options.get("num_py_executors"),
+            int,
+            executor_options.get("num_py_executors", 8),
         ),
         thread_name_prefix="dask-executor",
     )

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
@@ -206,7 +206,7 @@ class StreamingOptions:
     num_py_executors
         Workers for the internal Python ``ThreadPoolExecutor``.
         Env: ``CUDF_POLARS__EXECUTOR__NUM_PY_EXECUTORS``.
-        Default: ``1``.
+        Default: ``8``.
         Category: executor.
     fallback_mode
         Fallback behavior (``"warn"``, ``"raise"``, ``"silent"``).

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
@@ -503,7 +503,7 @@ class RayEngine(StreamingEngine):
                     rapidsmpf_options_as_bytes=rapidsmpf_options_as_bytes,
                     num_py_executors=cast(
                         int,
-                        executor_options.get("num_py_executors", 1),
+                        executor_options.get("num_py_executors", 8),
                     ),
                     hardware_binding=hw_binding,
                     memory_resource_config=mr_config,

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
@@ -373,7 +373,7 @@ class SPMDEngine(StreamingEngine):
         # else: caller-provided comm; the caller retains ownership
 
         py_executor = ThreadPoolExecutor(
-            max_workers=cast(int, executor_options.get("num_py_executors", 1)),
+            max_workers=cast(int, executor_options.get("num_py_executors", 8)),
             thread_name_prefix="spmd-executor",
         )
         exit_stack = contextlib.ExitStack()

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
@@ -167,8 +167,10 @@ def allgather_polars_dataframe(
 
     # Bulk AllGather: each rank contributes once (sequence_number=0)
     allgather = AllGather(comm, op_id, ctx.br())
-    allgather.insert(0, packed_data)
-    allgather.insert_finished()
+    try:
+        allgather.insert(0, packed_data)
+    finally:
+        allgather.insert_finished()
     results = allgather.wait_and_extract(ordered=True)
 
     # Deserialize and concatenate each rank's contribution

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
@@ -308,13 +308,13 @@ async def _tree_reduce(
 
     if need_allgather:
         allgather = AllGatherManager(context, comm, collective_id)
-
-        allgather.insert(
-            0,
-            _enforce_schema(aggregated, decomposed.reduction_ir.schema, context.br()),
-        )
-
-        allgather.insert_finished()
+        with allgather.inserting() as inserter:
+            inserter.insert(
+                0,
+                _enforce_schema(
+                    aggregated, decomposed.reduction_ir.schema, context.br()
+                ),
+            )
 
         stream = ir_context.get_cuda_stream()
         aggregated = await evaluate_chunk(
@@ -434,32 +434,32 @@ async def _shuffle_reduce(
         modulus,
         collective_id,
     )
-
-    shuffle.insert_hash(
-        _enforce_schema(
-            aggregated,
-            decomposed.reduction_ir.schema,
-            context.br(),
-        ),
-        decomposed.shuffle_indices,
-    )
-    del aggregated
-
-    while not input_drained:
-        aggregated, input_drained, _ = await _local_aggregation(
-            context,
-            decomposed,
-            ir_context,
-            ch_in,
-            target_partition_size,
-        )
-        shuffle.insert_hash(
-            _enforce_schema(aggregated, decomposed.reduction_ir.schema, context.br()),
+    async with shuffle.inserting() as inserter:
+        inserter.insert_hash(
+            _enforce_schema(
+                aggregated,
+                decomposed.reduction_ir.schema,
+                context.br(),
+            ),
             decomposed.shuffle_indices,
         )
         del aggregated
 
-    await shuffle.insert_finished()
+        while not input_drained:
+            aggregated, input_drained, _ = await _local_aggregation(
+                context,
+                decomposed,
+                ir_context,
+                ch_in,
+                target_partition_size,
+            )
+            inserter.insert_hash(
+                _enforce_schema(
+                    aggregated, decomposed.reduction_ir.schema, context.br()
+                ),
+                decomposed.shuffle_indices,
+            )
+            del aggregated
     extract_irs = [decomposed.reduction_ir] + (
         [decomposed.select_ir] if decomposed.select_ir else []
     )

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/join.py
@@ -190,9 +190,9 @@ async def _collect_small_side_for_broadcast(
     dfs: list[DataFrame] = []
     if need_allgather:
         allgather = AllGatherManager(context, comm, collective_id)
-        for s_id in range(len(chunks)):
-            allgather.insert(s_id, chunks.pop(0))
-        allgather.insert_finished()
+        with allgather.inserting() as inserter:
+            for s_id in range(len(chunks)):
+                inserter.insert(s_id, chunks.pop(0))
         stream = ir_context.get_cuda_stream()
         dfs = [
             DataFrame.from_table(

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/repartition.py
@@ -143,14 +143,16 @@ async def concatenate_node(
             if tracer is not None and output_duplicated:
                 tracer.set_duplicated()
 
-            allgather = AllGatherManager(context, comm, collective_id)
             stream = context.get_stream_from_pool()
             seq_num = 0
-            while (msg := await ch_in.recv(context)) is not None:
-                allgather.insert(seq_num, TableChunk.from_message(msg, br=context.br()))
-                seq_num += 1
-                del msg
-            allgather.insert_finished()
+            allgather = AllGatherManager(context, comm, collective_id)
+            with allgather.inserting() as inserter:
+                while (msg := await ch_in.recv(context)) is not None:
+                    inserter.insert(
+                        seq_num, TableChunk.from_message(msg, br=context.br())
+                    )
+                    seq_num += 1
+                    del msg
 
             # Extract concatenated result
             result_table = await allgather.extract_concatenated(stream)

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
@@ -1066,8 +1066,10 @@ async def allgather_reduce(
     packed = PackedData.from_host_bytes(data, context.br())
 
     allgather = AllGather(context, comm, op_id)
-    allgather.insert(0, packed)
-    allgather.insert_finished()
+    try:
+        allgather.insert(0, packed)
+    finally:
+        allgather.insert_finished()
 
     results = await allgather.extract_all(context, ordered=False)
 

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -691,8 +691,7 @@ class StreamingExecutor:
         regular pageable host memory.
     num_py_executors
         Maximum number of workers for the Python ThreadPoolExecutor used by
-        the rapidsmpf runtime. Default is None, which uses ThreadPoolExecutor's
-        default behavior. This option is only used by the "rapidsmpf" runtime.
+        the rapidsmpf runtime. Default is 8.
 
     Notes
     -----
@@ -786,9 +785,9 @@ class StreamingExecutor:
             f"{_env_prefix}__SPILL_TO_PINNED_MEMORY", bool, default=False
         )
     )
-    num_py_executors: int | None = dataclasses.field(
+    num_py_executors: int = dataclasses.field(
         default_factory=_make_default_factory(
-            f"{_env_prefix}__NUM_PY_EXECUTORS", int, default=None
+            f"{_env_prefix}__NUM_PY_EXECUTORS", int, default=8
         )
     )
     spmd_context: SPMDContext | None = None
@@ -890,8 +889,8 @@ class StreamingExecutor:
             raise TypeError("max_io_threads must be an int")
         if not isinstance(self.spill_to_pinned_memory, bool):
             raise TypeError("spill_to_pinned_memory must be bool")
-        if not isinstance(self.num_py_executors, (int, type(None))):
-            raise TypeError("num_py_executors must be int or None")
+        if not isinstance(self.num_py_executors, int):
+            raise TypeError("num_py_executors must be an int")
 
         # RapidsMPF spill is only supported for distributed clusters for now.
         # This is because the spilling API is still within the RMPF-Dask integration.

--- a/python/cudf_polars/tests/experimental/test_allgather.py
+++ b/python/cudf_polars/tests/experimental/test_allgather.py
@@ -30,14 +30,14 @@ async def _test_allgather(engine) -> None:
 
     # Insert tables into AllGatherManager
     allgather = AllGatherManager(context, comm, 0)
-    for i, table in enumerate(tables):
-        allgather.insert(
-            i,
-            TableChunk.from_pylibcudf_table(
-                table, stream, exclusive_view=True, br=context.br()
-            ),
-        )
-    allgather.insert_finished()
+    with allgather.inserting() as inserter:
+        for i, table in enumerate(tables):
+            inserter.insert(
+                i,
+                TableChunk.from_pylibcudf_table(
+                    table, stream, exclusive_view=True, br=context.br()
+                ),
+            )
 
     # Extract concatenated result
     result = await allgather.extract_concatenated(stream, ordered=True)

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -5,11 +5,13 @@
 from __future__ import annotations
 
 import contextlib
+from unittest.mock import patch
 
 import pytest
 
 import polars as pl
 
+from cudf_polars.experimental.rapidsmpf.collectives.shuffle import ShuffleManager
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
@@ -301,3 +303,24 @@ def test_groupby_agg_config_options(df, op, keys, engine):
 def test_groupby_count_type_mismatch(df, engine):
     q = df.group_by("key", maintain_order=True).agg(pl.col("value").count())
     assert_gpu_result_equal(q, engine=engine, check_row_order=False)
+
+
+@pytest.mark.parametrize(
+    "engine",
+    [{"executor_options": {"target_partition_size": 10, "max_rows_per_partition": 5}}],
+    indirect=True,
+)
+def test_shuffle_reduce_insert_finished_called_on_oom(engine):
+    # Tests that an exception raised inside insert_hash() must not leave the
+    # C++ ShufflerAsync without insert_finished() being called.
+
+    def foo(*args, **kwargs):
+        raise MemoryError("OOM in insert_hash()")
+
+    df = pl.LazyFrame({"a": range(10), "b": range(10)})
+    with (
+        patch.object(ShuffleManager.Inserter, "insert_hash", foo),
+        pytest.raises(ExceptionGroup) as exc_info,
+    ):
+        df.group_by("a").agg(pl.col("b").sum()).collect(engine=engine)
+    assert any("OOM in insert_hash" in str(e) for e in exc_info.value.exceptions)

--- a/python/cudf_polars/tests/test_config.py
+++ b/python/cudf_polars/tests/test_config.py
@@ -898,7 +898,7 @@ def test_num_py_executors_default() -> None:
         )
     )
     assert config.executor.name == "streaming"
-    assert config.executor.num_py_executors is None
+    assert config.executor.num_py_executors == 8
 
 
 def test_num_py_executors_from_executor_options() -> None:


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.