### PR TITLE
Try out rapids-cmake PR #1007

### DIFF
--- a/cmake/rapids_config.cmake
+++ b/cmake/rapids_config.cmake
@@ -34,6 +34,9 @@ endif()
 if(NOT rapids-cmake-branch)
   set(rapids-cmake-branch "${RAPIDS_BRANCH}")
 endif()
+
+set(rapids-cmake-branch "bug/find_package_redirect_support")
+set(rapids-cmake-repo "robertmaynard/rapids-cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/RAPIDS.cmake")
 
 # Don't use sccache-dist for CMake's compiler tests


### PR DESCRIPTION
## Description
Validate that https://github.com/rapidsai/rapids-cmake/pull/1007 doesn't introduce regressions to CUDF builds like https://github.com/rapidsai/rapids-cmake/pull/998 did.

