### PR TITLE
Allow SeriesApplyKernel to support pd.StringDtype in pandas 3

### DIFF
--- a/python/cudf/cudf/core/udf/scalar_function.py
+++ b/python/cudf/cudf/core/udf/scalar_function.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import cache
@@ -6,6 +6,7 @@ from functools import cache
 from numba import cuda
 from numba.np import numpy_support
 
+from cudf.core.dtype.validators import is_dtype_obj_string
 from cudf.core.udf.api import Masked, pack_return
 from cudf.core.udf.masked_typing import MaskedType
 from cudf.core.udf.strings_typing import string_view
@@ -38,7 +39,7 @@ class SeriesApplyKernel(ApplyKernelBase):
     def _get_frame_type(self):
         return MaskedType(
             string_view
-            if self.frame.dtype == "O"
+            if is_dtype_obj_string(self.frame.dtype)
             else numpy_support.from_dtype(self.frame.dtype)
         )
 


### PR DESCRIPTION
## Description
`SeriesApplyKernel` only checks for `np.dtype("object")` for string type data. In pandas 3, `pd.StringDtype` will normally be the default string type which cuDF follows suit 

This hopefully should allow the pandas 3 branch to pass the `conda-notebook-tests` job. e.g. the current failure https://github.com/rapidsai/cudf/actions/runs/24524831261/job/71697924457?pr=22174#step:13:1256

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
