### PR TITLE
Skip flaky upstream polars deadlock test

### DIFF
--- a/python/cudf_polars/cudf_polars/testing/plugin.py
+++ b/python/cudf_polars/cudf_polars/testing/plugin.py
@@ -245,6 +245,8 @@ TESTS_TO_SKIP: Mapping[str, str] = {
     "tests/unit/io/test_delta.py::test_scan_delta_extract_table_statistics_df": "schemas mismatch: dtypes different",
     "tests/unit/io/test_partition.py::test_sink_partitioned_no_columns_in_file_25535[scan_parquet-sink_parquet]": "Incorrect row count. Related to https://github.com/rapidsai/cudf/issues/21428",
     "tests/unit/operations/test_group_by.py::test_unique_head_tail_26429[0]": "ZeroDivisionError: division by zero",
+    # Flaky deadlock test, may occur on rtxpro6000 only
+    "tests/unit/io/test_lazy_parquet.py::test_scan_parquet_in_mem_to_streaming_dispatch_deadlock_22641": "Flaky deadlock, may occur on rtxpro6000 only",
 }
 
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Example of the failure: https://github.com/rapidsai/cudf/actions/runs/24489500301/job/71681935545?pr=14162


<details>

```
=================================== FAILURES ===================================
________ test_scan_parquet_in_mem_to_streaming_dispatch_deadlock_22641 _________
[gw2] linux -- Python 3.14.4 /pyenv/versions/3.14.4/bin/python
Traceback (most recent call last):
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/runner.py", line 341, in from_call
    result: TResult | None = func()
                             ~~~~^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/runner.py", line 242, in <lambda>
    lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
            ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/threadexception.py", line 92, in pytest_runtest_call
    yield from thread_exception_runtest_hook()
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/threadexception.py", line 68, in thread_exception_runtest_hook
    yield
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/unraisableexception.py", line 95, in pytest_runtest_call
    yield from unraisable_exception_runtest_hook()
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/unraisableexception.py", line 70, in unraisable_exception_runtest_hook
    yield
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/logging.py", line 848, in pytest_runtest_call
    yield from self._runtest_for(item, "call")
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/logging.py", line 831, in _runtest_for
    yield
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/capture.py", line 879, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 53, in run_old_style_hookwrapper
    return result.get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_result.py", line 103, in get_result
    raise exc.with_traceback(tb)
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
    res = yield
          ^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/skipping.py", line 257, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/runner.py", line 174, in pytest_runtest_call
    item.runtest()
    ~~~~~~~~~~~~^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/python.py", line 1627, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/pyenv/versions/3.14.4/lib/python3.14/site-packages/_pytest/python.py", line 159, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/__w/cudf/cudf/polars/py-polars/tests/unit/io/test_lazy_parquet.py", line 955, in test_scan_parquet_in_mem_to_streaming_dispatch_deadlock_22641
        out = subprocess.check_output(
              ~~~~~~~~~~~~~~~~~~~~~~~^
            [
            ^
    ...<74 lines>...
            stderr=subprocess.STDOUT,
            ^^^^^^^^^^^^^^^^^^^^^^^^^
        )
        ^
  File "/pyenv/versions/3.14.4/lib/python3.14/subprocess.py", line 473, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               **kwargs).stdout
               ^^^^^^^^^
  File "/pyenv/versions/3.14.4/lib/python3.14/subprocess.py", line 578, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/pyenv/versions/3.14.4/bin/python', '-c', 'import os\n\nos.environ["POLARS_MAX_THREADS"] = "1"\nos.environ["POLARS_VERBOSE"] = "1"\n\nimport io\nimport sys\nfrom threading import Thread\n\nimport polars as pl\n\nassert pl.thread_pool_size() == 1\n\nf = io.BytesIO()\npl.DataFrame({"x": 1}).write_parquet(f)\n\nq = (\n    pl.scan_parquet(f)\n    .filter(pl.sum_horizontal(pl.col("x"), pl.col("x"), pl.col("x")) >= 0)\n    .join(pl.scan_parquet(f), on="x", how="left")\n)\n\nresults = [\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n]\n\n\ndef run():\n    # Also test just a single scan\n    pl.scan_parquet(f).collect()\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[0] = q.collect()\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[1] = pl.concat([q, q, q]).collect().head(1)\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[2] = pl.collect_all([q, q, q])[0]\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[3] = pl.collect_all(3 * [pl.concat(3 * [q])])[0].head(1)\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[4] = q.collect(background=True).fetch_blocking()\n\n\nt = Thread(target=run, daemon=True)\nt.start()\nt.join(5)\n\nassert [x.equals(pl.DataFrame({"x": 1})) for x in results] == [\n    True,\n    True,\n    True,\n    True,\n    True,\n]\n\nprint("OK", end="", file=sys.stderr)\n']' returned non-zero exit status 1.
=========================== short test summary info ============================
FAILED py-polars/tests/unit/io/test_lazy_parquet.py::test_scan_parquet_in_mem_to_streaming_dispatch_deadlock_22641 - subprocess.CalledProcessError: Command '['/pyenv/versions/3.14.4/bin/python', '-c', 'import os\n\nos.environ["POLARS_MAX_THREADS"] = "1"\nos.environ["POLARS_VERBOSE"] = "1"\n\nimport io\nimport sys\nfrom threading import Thread\n\nimport polars as pl\n\nassert pl.thread_pool_size() == 1\n\nf = io.BytesIO()\npl.DataFrame({"x": 1}).write_parquet(f)\n\nq = (\n    pl.scan_parquet(f)\n    .filter(pl.sum_horizontal(pl.col("x"), pl.col("x"), pl.col("x")) >= 0)\n    .join(pl.scan_parquet(f), on="x", how="left")\n)\n\nresults = [\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n]\n\n\ndef run():\n    # Also test just a single scan\n    pl.scan_parquet(f).collect()\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[0] = q.collect()\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[1] = pl.concat([q, q, q]).collect().head(1)\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[2] = pl.collect_all([q, q, q])[0]\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[3] = pl.collect_all(3 * [pl.concat(3 * [q])])[0].head(1)\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[4] = q.collect(background=True).fetch_blocking()\n\n\nt = Thread(target=run, daemon=True)\nt.start()\nt.join(5)\n\nassert [x.equals(pl.DataFrame({"x": 1})) for x in results] == [\n    True,\n    True,\n    True,\n    True,\n    True,\n]\n\nprint("OK", end="", file=sys.stderr)\n']' returned non-zero exit status 1.
===== 1 failed, 32588 passed, 51 skipped, 95 xfailed in 1231.24s (0:20:31) =====
```

</details>

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
