### PR TITLE
Fix CSE HStack lowering to respect with_columns semantics

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/select.py
+++ b/python/cudf_polars/cudf_polars/experimental/select.py
@@ -59,8 +59,17 @@ def _hstack_chain_to_select(ir: Select) -> Select | None:
 
     col_defs: dict[str, expr.Expr] = {}
     for hstack in reversed(hstack_chain):
-        for ne in hstack.columns:
-            col_defs[ne.name] = _sub_expr(ne.value, col_defs)
+        if hstack.should_broadcast:
+            # All expressions in a with_columns see the input frame, not each
+            # other's outputs, so substitute against a snapshot of col_defs.
+            snapshot = dict(col_defs)
+            for ne in hstack.columns:
+                col_defs[ne.name] = _sub_expr(ne.value, snapshot)
+        else:
+            # CSE placeholders may reference earlier placeholders in the same
+            # HStack, so substitute against the accumulated col_defs.
+            for ne in hstack.columns:
+                col_defs[ne.name] = _sub_expr(ne.value, col_defs)
 
     new_exprs = tuple(
         expr.NamedExpr(ne.name, _sub_expr(ne.value, col_defs)) for ne in ir.exprs

--- a/python/cudf_polars/cudf_polars/experimental/select.py
+++ b/python/cudf_polars/cudf_polars/experimental/select.py
@@ -59,17 +59,12 @@ def _hstack_chain_to_select(ir: Select) -> Select | None:
 
     col_defs: dict[str, expr.Expr] = {}
     for hstack in reversed(hstack_chain):
-        if hstack.should_broadcast:
-            # All expressions in a with_columns see the input frame, not each
-            # other's outputs, so substitute against a snapshot of col_defs.
-            snapshot = dict(col_defs)
-            for ne in hstack.columns:
-                col_defs[ne.name] = _sub_expr(ne.value, snapshot)
-        else:
-            # CSE placeholders may reference earlier placeholders in the same
-            # HStack, so substitute against the accumulated col_defs.
-            for ne in hstack.columns:
-                col_defs[ne.name] = _sub_expr(ne.value, col_defs)
+        # with_columns semantics: snapshot so expressions see the input frame,
+        # not each other's outputs. CSE placeholders use col_defs directly since
+        # later placeholders may reference earlier ones.
+        defs = dict(col_defs) if hstack.should_broadcast else col_defs
+        for ne in hstack.columns:
+            col_defs[ne.name] = _sub_expr(ne.value, defs)
 
     new_exprs = tuple(
         expr.NamedExpr(ne.name, _sub_expr(ne.value, col_defs)) for ne in ir.exprs

--- a/python/cudf_polars/tests/experimental/test_hstack.py
+++ b/python/cudf_polars/tests/experimental/test_hstack.py
@@ -138,13 +138,10 @@ def test_cse_agg_shared_decomposition(engine, comm_subexpr_elim):
     assert_gpu_result_equal(q, engine=engine, collect_kwargs={"optimizations": opts})
 
 
-def test_hstack_with_cse_and_column_override():
-    # Polars CSEs col("a").cast(Float64) into a placeholder, producing a CSE
-    # HStack layer beneath the with_columns HStack. When the with_columns
-    # overrides column "a", the substitution map was built incrementally, so
-    # later expressions in the same with_columns (e, k) saw the new "a" instead
-    # of the original. The fix snapshots the substitution map before processing
-    # each with_columns HStack so all its expressions see the same input state.
+def test_hstack_with_cse_and_column_override(engine):
+    # When a with_columns overrides a column and a CSE placeholder is hoisted,
+    # other expressions in the same with_columns must still see the original
+    # column, not the overridden value.
     df = pl.LazyFrame({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]})
     q = df.with_columns(
         a=(1 + 3 * pl.col("a")) * (1 / pl.col("a")),

--- a/python/cudf_polars/tests/experimental/test_hstack.py
+++ b/python/cudf_polars/tests/experimental/test_hstack.py
@@ -136,3 +136,20 @@ def test_cse_agg_shared_decomposition(engine, comm_subexpr_elim):
     assert len(repartitions) == 1
     assert len(repartitions[0].children[0].exprs) == 1
     assert_gpu_result_equal(q, engine=engine, collect_kwargs={"optimizations": opts})
+
+
+def test_hstack_with_cse_and_column_override():
+    # Polars CSEs col("a").cast(Float64) into a placeholder, producing a CSE
+    # HStack layer beneath the with_columns HStack. When the with_columns
+    # overrides column "a", the substitution map was built incrementally, so
+    # later expressions in the same with_columns (e, k) saw the new "a" instead
+    # of the original. The fix snapshots the substitution map before processing
+    # each with_columns HStack so all its expressions see the same input state.
+    df = pl.LazyFrame({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]})
+    q = df.with_columns(
+        a=(1 + 3 * pl.col("a")) * (1 / pl.col("a")),
+        c=pl.col("a") + pl.col("b") / 2,
+        e=((pl.col("a") > pl.col("b")) & (pl.col("a") >= pl.col("z"))).cast(pl.Int64),
+        k=2 // pl.col("a"),
+    )
+    assert_gpu_result_equal(q, engine=engine)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
#21796 introduced `_hstack_chain_to_select` which inlines a chain of HStack nodes into a flat Select by substituting column references. There's a subtle issue though: expressions in the same `with_columns` should all see the original input columns, not each other's outputs. The code was building the substitution map incrementally, so if one expression overrode a column, later expressions in the same `with_columns` would pick up the new value instead of the original.

The fix is to snapshot the substitution map before processing each `with_columns` HStack, so all its expressions substitute against the same input state. CSE placeholder HStacks still use the accumulated map since that's correct for them.

Fixes the narwhals test failure: https://github.com/rapidsai/cudf/actions/runs/24496549828/job/71660468369#step:13:1882

<details>

```
=================================== FAILURES ===================================
________________________ test_expr_binary[polars[lazy]] ________________________
[gw3] linux -- Python 3.14.4 /opt/conda/envs/test/bin/python

constructor = <function polars_lazy_constructor at 0x763e64666c40>

    def test_expr_binary(constructor: Constructor) -> None:
        if "dask" in str(constructor) and DASK_VERSION < (2024, 10):
            pytest.skip()
        data = {"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]}
        df_raw = constructor(data)
        result = nw.from_native(df_raw).with_columns(
            a=(1 + 3 * nw.col("a")) * (1 / nw.col("a")),
            b=nw.col("z") / (2 - nw.col("b")),
            c=nw.col("a") + nw.col("b") / 2,
            d=nw.col("a") - nw.col("b"),
            e=((nw.col("a") > nw.col("b")) & (nw.col("a") >= nw.col("z"))).cast(nw.Int64),
            f=(
                (nw.col("a") < nw.col("b"))
                | (nw.col("a") <= nw.col("z"))
                | (nw.col("a") == 1)
            ).cast(nw.Int64),
            g=nw.col("a") != 1,
            h=(False & (nw.col("a") != 1)),
            i=(False | (nw.col("a") != 1)),
            j=2 ** nw.col("a"),
            k=2 // nw.col("a"),
            l=nw.col("a") // 2,
            m=nw.col("a") ** 2,
        )
        expected = {
            "a": [4, 3.333333, 3.5],
            "b": [-3.5, -4.0, -2.25],
            "z": [7.0, 8.0, 9.0],
            "c": [3, 5, 5],
            "d": [-3, -1, -4],
            "e": [0, 0, 0],
            "f": [1, 1, 1],
            "g": [False, True, True],
            "h": [False, False, False],
            "i": [False, True, True],
            "j": [2, 8, 4],
            "k": [2, 0, 1],
            "l": [0, 1, 1],
            "m": [1, 9, 4],
        }
>       assert_equal_data(result, expected)

tests/expr_and_series/binary_test.py:49: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/utils.py:111: in assert_equal_data
    result = result.collect(**kwargs.get(result.implementation, {}))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
narwhals/dataframe.py:2474: in collect
    return self._dataframe(collect(None, **kwargs), level="full")
                           ^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PolarsLazyFrame, backend = None, kwargs = {'engine': 'gpu'}

    def collect(
        self, backend: _EagerAllowedImpl | None, **kwargs: Any
    ) -> CompliantDataFrameAny:
        try:
            result = self.native.collect(**kwargs)
        except Exception as e:  # noqa: BLE001
>           raise catch_polars_exception(e) from None
E           narwhals.exceptions.NarwhalsError: CUDF failure at: /tmp/conda-bld-output/bld/rattler-build_libcudf/work/cpp/src/replace/replace.cu:293: Columns type mismatch

narwhals/_polars/dataframe.py:721: NarwhalsError
- generated xml file: /tmp/tmp.0ajEKzdGW2/test-results/junit-cudf-polars-narwhals.xml -
=========================== short test summary info ============================
FAILED tests/expr_and_series/binary_test.py::test_expr_binary[polars[lazy]] - narwhals.exceptions.NarwhalsError: CUDF failure at: /tmp/conda-bld-output/bld/rattler-build_libcudf/work/cpp/src/replace/replace.cu:293: Columns type mismatch

```

</details>

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
