### PR TITLE
Expose getters for ColumnWriterOptions isBinary and Parquet field id

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
@@ -1,6 +1,6 @@
 /*
  *
- *  SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ *  SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *  SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -624,6 +624,28 @@ public class ColumnWriterOptions {
    */
   public ColumnWriterOptions[] getChildColumnOptions() {
     return childColumnOptions;
+  }
+
+  /**
+   * Returns true if this column is a binary (byte array) column in Parquet.
+   */
+  public boolean isBinary() {
+    return isBinary;
+  }
+
+  /**
+   * Returns true if a Parquet field ID was set on this column.
+   */
+  public boolean hasParquetFieldId() {
+    return hasParquetFieldId;
+  }
+
+  /**
+   * Return the Parquet field ID for this column. The value is only meaningful when
+   * {@link #hasParquetFieldId()} returns true.
+   */
+  public int getParquetFieldId() {
+    return parquetFieldId;
   }
 
   public static class StructColumnWriterOptions extends ColumnWriterOptions {


### PR DESCRIPTION
## Description

Add public getters on `ColumnWriterOptions` so downstream JVM consumers can read these properties without falling back to reflection on private fields:

- `boolean isBinary()`
- `boolean hasParquetFieldId()`
- `int getParquetFieldId()`

Motivation: spark-rapids currently reaches into these fields via reflection because there is no public accessor. Exposing plain getters removes that reflection hack and avoids breakage whenever the fields are renamed or refactored.

No behavior change — the getters just return the existing package-private state. Non-breaking (adds new public methods only).

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.