### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/cpp/include/cudf/datetime.hpp
+++ b/cpp/include/cudf/datetime.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -177,9 +177,9 @@ std::unique_ptr<cudf::column> add_calendrical_months(
 /**
  * @brief  Check if the year of the given date is a leap year
  *
- * `output[i] == true` if year of `column[i]` is a leap year
- * `output[i] == false` if year of `column[i]` is not a leap year
- * `output[i] is null` if `column[i]` is null
+ * `output[i] == true` if year of `column[i]` is a leap year, otherwise `output[i] == false`.
+ *
+ * Any null input rows return corresponding null entries in the output columns.
  *
  * @param column cudf::column_view of the input datetime values
  * @param stream CUDA stream used for device memory operations and kernel launches
@@ -196,8 +196,9 @@ std::unique_ptr<cudf::column> is_leap_year(
 /**
  * @brief Extract the number of days in the month
  *
- * output[i] contains the number of days in the month of date `column[i]`
- * output[i] is null if `column[i]` is null
+ * `output[i]` contains the number of days in the month of date `column[i]`.
+ *
+ * Any null input rows return corresponding null entries in the output columns.
  *
  * @throw cudf::logic_error if input column datatype is not a TIMESTAMP
  *
@@ -214,8 +215,10 @@ std::unique_ptr<cudf::column> days_in_month(
 /**
  * @brief  Returns the quarter of the date
  *
- * `output[i]` will be a value from {1, 2, 3, 4} corresponding to the quarter of month given by
- * `column[i]`. It will be null if the input row at `column[i]` is null.
+ * `output[i]` will be a value from `{1, 2, 3, 4}` corresponding to the quarter of month given by
+ * `column[i]`.
+ *
+ * Any null input rows return corresponding null entries in the output columns.
  *
  * @throw cudf::logic_error if input column datatype is not a TIMESTAMP
  *

--- a/cpp/include/cudf/strings/find.hpp
+++ b/cpp/include/cudf/strings/find.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -164,7 +164,7 @@ std::unique_ptr<column> contains(
  * @brief Returns a column of boolean values for each string where true indicates
  * the corresponding target string was found within that string in the provided column.
  *
- * The 'output[i] = true` if string `targets[i]` is found inside `input[i]` otherwise
+ * `output[i] = true` if string `targets[i]` is found inside `input[i]` otherwise
  * `output[i] = false`.
  * If `target[i]` is an empty string, true is returned for `output[i]`.
  * If `target[i]` is null, false is returned for `output[i]`.

--- a/cpp/tests/ast/transform_tests.cpp
+++ b/cpp/tests/ast/transform_tests.cpp
@@ -14,6 +14,7 @@
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/detail/iterator.cuh>
+#include <cudf/filling.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/transform.hpp>
@@ -275,18 +276,19 @@ TYPED_TEST(TransformTest, BasicAdditionLarge)
 {
   using Executor = TypeParam;
 
-  auto a     = cuda::counting_iterator<int32_t>{0};
-  auto col   = column_wrapper<int32_t>(a, a + 2000);
-  auto table = cudf::table_view{{col, col}};
+  auto zero = cudf::numeric_scalar<int32_t>(0);
+  auto two  = cudf::numeric_scalar<int32_t>(2);
+
+  auto col   = cudf::sequence(2000, zero);
+  auto table = cudf::table_view{{col->view(), col->view()}};
 
   auto col_ref    = cudf::ast::column_reference(0);
   auto expression = cudf::ast::operation(cudf::ast::ast_operator::ADD, col_ref, col_ref);
 
-  auto b        = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i * 2; });
-  auto expected = column_wrapper<int32_t>(b, b + 2000);
+  auto expected = cudf::sequence(2000, zero, two);
   auto result   = Executor::compute_column(table, expression);
 
-  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), verbosity);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected->view(), result->view(), verbosity);
 }
 
 TYPED_TEST(TransformTest, LessComparator)
@@ -309,12 +311,14 @@ TYPED_TEST(TransformTest, LessComparator)
 
 TYPED_TEST(TransformTest, LessComparatorLarge)
 {
-  auto a         = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i * 2; });
-  auto b         = cuda::counting_iterator<int32_t>{500};
+  auto zero   = cudf::numeric_scalar<int32_t>(0);
+  auto two    = cudf::numeric_scalar<int32_t>(2);
+  auto five_h = cudf::numeric_scalar<int32_t>(500);
+
   using Executor = TypeParam;
-  auto c_0       = column_wrapper<int32_t>(a, a + 2000);
-  auto c_1       = column_wrapper<int32_t>(b, b + 2000);
-  auto table     = cudf::table_view{{c_0, c_1}};
+  auto c_0       = cudf::sequence(2000, zero, two);
+  auto c_1       = cudf::sequence(2000, five_h);
+  auto table     = cudf::table_view{{c_0->view(), c_1->view()}};
 
   auto col_ref_0  = cudf::ast::column_reference(0);
   auto col_ref_1  = cudf::ast::column_reference(1);
@@ -357,14 +361,15 @@ TYPED_TEST(TransformTest, MultiLevelTreeArithmetic)
 
 TYPED_TEST(TransformTest, MultiLevelTreeArithmeticLarge)
 {
-  auto a         = cuda::counting_iterator<int32_t>{0};
-  auto b         = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i + 1; });
-  auto c         = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i * 2; });
+  auto zero = cudf::numeric_scalar<int32_t>(0);
+  auto one  = cudf::numeric_scalar<int32_t>(1);
+  auto two  = cudf::numeric_scalar<int32_t>(2);
+
   using Executor = TypeParam;
-  auto c_0       = column_wrapper<int32_t>(a, a + 2000);
-  auto c_1       = column_wrapper<int32_t>(b, b + 2000);
-  auto c_2       = column_wrapper<int32_t>(c, c + 2000);
-  auto table     = cudf::table_view{{c_0, c_1, c_2}};
+  auto c_0       = cudf::sequence(2000, zero);
+  auto c_1       = cudf::sequence(2000, one);
+  auto c_2       = cudf::sequence(2000, zero, two);
+  auto table     = cudf::table_view{{c_0->view(), c_1->view(), c_2->view()}};
 
   auto col_ref_0 = cudf::ast::column_reference(0);
   auto col_ref_1 = cudf::ast::column_reference(1);

--- a/cpp/tests/io/cudftable_test.cpp
+++ b/cpp/tests/io/cudftable_test.cpp
@@ -11,9 +11,11 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/dictionary/dictionary_factories.hpp>
+#include <cudf/filling.hpp>
 #include <cudf/io/data_sink.hpp>
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/experimental/cudftable.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
@@ -141,18 +143,17 @@ TEST_F(CudftableTest, LargeTable)
 {
   constexpr int num_rows = 23'456'789;
 
-  auto sequence = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return i; });
-  cudf::test::fixed_width_column_wrapper<int32_t> col1(sequence, sequence + num_rows);
-  cudf::test::fixed_width_column_wrapper<double> col2(sequence, sequence + num_rows);
+  auto col1 = cudf::sequence(num_rows, cudf::numeric_scalar<int32_t>(0));
+  auto col2 = cudf::sequence(num_rows, cudf::numeric_scalar<double>(0.0));
 
-  auto const expected = cudf::table_view{{col1, col2}};
+  auto const expected = cudf::table_view{{col1->view(), col2->view()}};
   run_test(expected);
 }
 
 TEST_F(CudftableTest, AllNullColumn)
 {
-  auto all_nulls = cudf::detail::make_counting_transform_iterator(0, [](auto i) { return false; });
-  cudf::test::fixed_width_column_wrapper<int32_t> col({1, 2, 3, 4, 5}, all_nulls);
+  cudf::test::fixed_width_column_wrapper<int32_t> col({1, 2, 3, 4, 5},
+                                                      cudf::test::iterators::all_nulls());
 
   auto const expected = cudf::table_view{{col}};
   run_test(expected);

--- a/python/cudf_polars/cudf_polars/experimental/select.py
+++ b/python/cudf_polars/cudf_polars/experimental/select.py
@@ -59,8 +59,12 @@ def _hstack_chain_to_select(ir: Select) -> Select | None:
 
     col_defs: dict[str, expr.Expr] = {}
     for hstack in reversed(hstack_chain):
+        # with_columns semantics: snapshot so expressions see the input frame,
+        # not each other's outputs. CSE placeholders use col_defs directly since
+        # later placeholders may reference earlier ones.
+        defs = dict(col_defs) if hstack.should_broadcast else col_defs
         for ne in hstack.columns:
-            col_defs[ne.name] = _sub_expr(ne.value, col_defs)
+            col_defs[ne.name] = _sub_expr(ne.value, defs)
 
     new_exprs = tuple(
         expr.NamedExpr(ne.name, _sub_expr(ne.value, col_defs)) for ne in ir.exprs

--- a/python/cudf_polars/cudf_polars/testing/plugin.py
+++ b/python/cudf_polars/cudf_polars/testing/plugin.py
@@ -245,6 +245,8 @@ TESTS_TO_SKIP: Mapping[str, str] = {
     "tests/unit/io/test_delta.py::test_scan_delta_extract_table_statistics_df": "schemas mismatch: dtypes different",
     "tests/unit/io/test_partition.py::test_sink_partitioned_no_columns_in_file_25535[scan_parquet-sink_parquet]": "Incorrect row count. Related to https://github.com/rapidsai/cudf/issues/21428",
     "tests/unit/operations/test_group_by.py::test_unique_head_tail_26429[0]": "ZeroDivisionError: division by zero",
+    # Flaky deadlock test, may occur on rtxpro6000 only
+    "tests/unit/io/test_lazy_parquet.py::test_scan_parquet_in_mem_to_streaming_dispatch_deadlock_22641": "Flaky deadlock, may occur on rtxpro6000 only",
 }
 
 

--- a/python/cudf_polars/tests/experimental/test_hstack.py
+++ b/python/cudf_polars/tests/experimental/test_hstack.py
@@ -136,3 +136,17 @@ def test_cse_agg_shared_decomposition(engine, comm_subexpr_elim):
     assert len(repartitions) == 1
     assert len(repartitions[0].children[0].exprs) == 1
     assert_gpu_result_equal(q, engine=engine, collect_kwargs={"optimizations": opts})
+
+
+def test_hstack_with_cse_and_column_override(engine):
+    # When a with_columns overrides a column and a CSE placeholder is hoisted,
+    # other expressions in the same with_columns must still see the original
+    # column, not the overridden value.
+    df = pl.LazyFrame({"a": [1, 3, 2], "b": [4, 4, 6], "z": [7.0, 8.0, 9.0]})
+    q = df.with_columns(
+        a=(1 + 3 * pl.col("a")) * (1 / pl.col("a")),
+        c=pl.col("a") + pl.col("b") / 2,
+        e=((pl.col("a") > pl.col("b")) & (pl.col("a") >= pl.col("z"))).cast(pl.Int64),
+        k=2 // pl.col("a"),
+    )
+    assert_gpu_result_equal(q, engine=engine)


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.