### PR TITLE
Fix custreamz tests for pandas 3

### DIFF
--- a/python/custreamz/custreamz/tests/test_dataframes.py
+++ b/python/custreamz/custreamz/tests/test_dataframes.py
@@ -619,7 +619,7 @@ def test_windowing_n(func, n, getter):
 
 
 @pytest.mark.parametrize("func", [lambda x: x.sum(), lambda x: x.mean()])
-@pytest.mark.parametrize("value", ["10h", "1d"])
+@pytest.mark.parametrize("value", ["10h", "1D"])
 @pytest.mark.parametrize("getter", [lambda df: df, lambda df: df.x])
 @pytest.mark.parametrize(
     "grouper", [lambda a: "y", lambda a: a.index, lambda a: ["y"]]
@@ -843,7 +843,7 @@ def test_rolling_aggs_with_start_state(stream):
     )
 
     stream = Stream()
-    example = cudf.DataFrame({"name": [], "amount": []})
+    example = cudf.DataFrame({"name": [], "amount": []}, dtype="float64")
     sdf = DataFrame(stream, example=example)
     output1 = (
         sdf.rolling(2, with_state=True, start=output0[-1][0])


### PR DESCRIPTION
## Description
* `"d"` is deprecated in pandas 3 in favor of `"D"`
* An empty `cudf.DataFrame` defaults to string type to match pandas 3. The applicable test expects subsequent data to be numeric type.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
