### PR TITLE
Enable --collect-traces with new frontends

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
@@ -9,6 +9,7 @@ import argparse
 import dataclasses
 import importlib
 import io
+import itertools
 import json
 import logging
 import os
@@ -59,6 +60,7 @@ except ImportError:
 
 try:
     from cudf_polars.dsl.ir import IRExecutionContext
+    from cudf_polars.dsl.tracing import Scope
     from cudf_polars.dsl.translate import Translator
     from cudf_polars.experimental.benchmarks.asserts import (
         ValidationError,
@@ -76,6 +78,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from cudf_polars.experimental.explain import SerializablePlan
+    from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 
 
@@ -816,7 +819,6 @@ def run_polars_query_iteration(
     engine: pl.GPUEngine | None,
     expected: pl.DataFrame | None,
     query_result: Any,
-    client: Any,
     prepare_validation_result: Callable[[pl.DataFrame], pl.DataFrame] | None = None,
     result_casts: list[pl.Expr] | None = None,
 ) -> SuccessRecord:
@@ -874,8 +876,7 @@ def run_polars_query(
     benchmark: Any,
     run_config: RunConfig,
     args: argparse.Namespace,
-    engine: pl.GPUEngine | None,
-    client: Any,
+    engine: StreamingEngine | None,
     numeric_type: str,
     date_type: str,
     validation_files: dict[int, Path] | None,
@@ -935,8 +936,8 @@ def run_polars_query(
     for i in range(args.iterations):
         if _HAS_STRUCTLOG and run_config.collect_traces:
             setup_logging(q_id, i)
-            if client is not None:
-                client.run(setup_logging, q_id, i)
+            if engine is not None:
+                engine._run(setup_logging, q_id, i)
 
         try:
             record = run_polars_query_iteration(
@@ -948,7 +949,6 @@ def run_polars_query(
                 engine=engine,
                 expected=expected,
                 query_result=query_result,
-                client=client,
                 prepare_validation_result=prepare_validation_result,
                 result_casts=casts if casts else None,
             )
@@ -992,8 +992,7 @@ def _run_query_loop(
     benchmark: Any,
     args: argparse.Namespace,
     run_config: RunConfig,
-    engine: pl.GPUEngine | None,
-    client: Any,
+    engine: StreamingEngine | None,
     numeric_type: str,
     date_type: str,
     validation_files: dict[int, Path] | None,
@@ -1018,7 +1017,6 @@ def _run_query_loop(
                 run_config=run_config,
                 args=args,
                 engine=engine,
-                client=client,
                 numeric_type=numeric_type,
                 date_type=date_type,
                 validation_files=validation_files,
@@ -1086,10 +1084,6 @@ def run_polars_spmd(
     """Run benchmark queries using SPMD execution via the ``rrun`` launcher."""
     from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
 
-    if run_config.collect_traces:
-        raise NotImplementedError(
-            "--collect-traces is not yet supported with --frontend spmd"
-        )
     executor_options = get_executor_options(run_config, benchmark=benchmark)
     # "runtime" and "cluster" are reserved — SPMDEngine sets them
     executor_options.pop("runtime", None)
@@ -1122,7 +1116,6 @@ def run_polars_spmd(
             args,
             run_config,
             engine,
-            None,
             numeric_type,
             date_type,
             validation_files,
@@ -1131,6 +1124,9 @@ def run_polars_spmd(
         if engine.rank > 0:
             sys.exit(1 if (query_failures or validation_failures) else 0)
         run_config = dataclasses.replace(run_config, records=dict(records), plans=plans)
+        run_config = _consolidate_logs(
+            run_config, engine=engine, gather_client_logs=False
+        )
         _finalize_benchmark_run(args, run_config, validation_failures, query_failures)
 
 
@@ -1146,10 +1142,6 @@ def run_polars_ray(
     """Run benchmark queries using Ray actor-based distributed execution."""
     from cudf_polars.experimental.rapidsmpf.frontend.ray import RayEngine
 
-    if run_config.collect_traces:
-        raise NotImplementedError(
-            "--collect-traces is not yet supported with --frontend ray."
-        )
     executor_options = get_executor_options(run_config, benchmark=benchmark)
     # "runtime", "cluster" are reserved — RayEngine sets them
     executor_options.pop("runtime", None)
@@ -1176,12 +1168,13 @@ def run_polars_ray(
             args,
             run_config,
             engine,
-            None,
             numeric_type,
             date_type,
             validation_files,
         )
-    run_config = dataclasses.replace(run_config, records=dict(records), plans=plans)
+        run_config = dataclasses.replace(run_config, records=dict(records), plans=plans)
+        run_config = _consolidate_logs(run_config, engine=engine)
+
     _finalize_benchmark_run(args, run_config, validation_failures, query_failures)
 
 
@@ -1199,10 +1192,6 @@ def run_polars_dask(
 
     from cudf_polars.experimental.rapidsmpf.frontend.dask import DaskEngine
 
-    if run_config.collect_traces:
-        raise NotImplementedError(
-            "--collect-traces is not yet supported with --frontend dask."
-        )
     executor_options = get_executor_options(run_config, benchmark=benchmark)
     # "runtime", "cluster" are reserved — DaskEngine sets them
     executor_options.pop("runtime", None)
@@ -1236,15 +1225,17 @@ def run_polars_dask(
                 args,
                 run_config,
                 engine,
-                None,
                 numeric_type,
                 date_type,
                 validation_files,
             )
+            run_config = dataclasses.replace(
+                run_config, records=dict(records), plans=plans
+            )
+            run_config = _consolidate_logs(run_config, engine)
     finally:
         if dask_client is not None:
             dask_client.close()
-    run_config = dataclasses.replace(run_config, records=dict(records), plans=plans)
     _finalize_benchmark_run(args, run_config, validation_failures, query_failures)
 
 
@@ -1321,6 +1312,62 @@ def setup_logging(query_id: int, iteration: int) -> None:
             wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
             cache_logger_on_first_use=True,
         )
+
+
+def _consolidate_logs(
+    run_config: RunConfig, engine: StreamingEngine, *, gather_client_logs: bool = True
+) -> RunConfig:
+    """Merge structlog traces from the local process and Dask workers into run_config."""
+    if not (_HAS_STRUCTLOG and run_config.collect_traces):
+        return run_config
+
+    def gather_logs() -> str:
+        logger = logging.getLogger()
+        return logger.handlers[0].stream.getvalue()  # type: ignore[attr-defined]
+
+    # worker logs + client logs.
+    # all_logs = "\n".join(engine._run(gather_logs))
+    all_logs = "\n".join(engine._run(gather_logs))
+    if gather_client_logs:
+        all_logs += "\n" + gather_logs()
+
+    parsed_logs = [json.loads(log) for log in all_logs.splitlines() if log]
+    # Some other log records can end up in here. Filter those out.
+    scope_values = {s.value for s in Scope}
+    parsed_logs = [log for log in parsed_logs if log.get("scope") in scope_values]
+    # Now we want to augment the existing Records with the trace data.
+
+    def group_key(x: dict) -> int:
+        return x["query_id"]
+
+    def sort_key(x: dict) -> tuple[int, int]:
+        return x["query_id"], x["iteration"]
+
+    grouped = itertools.groupby(
+        sorted(parsed_logs, key=sort_key),
+        key=group_key,
+    )
+
+    for query_id, run_logs_group in grouped:
+        run_logs = list(run_logs_group)
+        by_iteration = [
+            list(x)
+            for _, x in itertools.groupby(run_logs, key=lambda x: x["iteration"])
+        ]
+        run_records = run_config.records[query_id]
+        assert len(by_iteration) == len(run_records)  # same number of iterations
+        all_traces = [list(iteration) for iteration in by_iteration]
+
+        new_records: list[SuccessRecord | FailedRecord] = []
+        for rec, traces in zip(run_records, all_traces, strict=True):
+            if rec.status == "success":
+                new_records.append(dataclasses.replace(rec, traces=traces))
+            else:
+                new_records.append(rec)
+
+        run_config.records[query_id] = new_records
+
+    return run_config
 
 
 PDSDS_TABLE_NAMES: list[str] = [

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
@@ -1325,8 +1325,6 @@ def _consolidate_logs(
         logger = logging.getLogger()
         return logger.handlers[0].stream.getvalue()  # type: ignore[attr-defined]
 
-    # worker logs + client logs.
-    # all_logs = "\n".join(engine._run(gather_logs))
     all_logs = "\n".join(engine._run(gather_logs))
     if gather_client_logs:
         all_logs += "\n" + gather_logs()

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
@@ -183,7 +183,22 @@ class StreamingEngine(pl.GPUEngine):
         self.shutdown()
 
     def _run(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> list[T]:
-        """Execute a function on all ranks."""
+        """
+        Execute a function on all ranks.
+
+        Parameters
+        ----------
+        func
+            Function to execute.
+        args
+            Arguments to pass to the function.
+        kwargs
+            Keyword arguments to pass to the function.
+
+        Returns
+        -------
+        List of results from calling ``func``, one per rank.
+        """
         raise NotImplementedError
 
 

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/core.py
@@ -8,7 +8,7 @@ import contextlib
 import dataclasses
 import os
 import socket
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 import cuda.core
 from rapidsmpf.coll import AllGather
@@ -26,7 +26,7 @@ from cudf_polars.experimental.rapidsmpf.utils import empty_table_chunk
 from cudf_polars.experimental.utils import _concat
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
+    from collections.abc import Callable, MutableMapping
     from concurrent.futures import ThreadPoolExecutor
 
     from rapidsmpf.communicator.communicator import Communicator
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
     from cudf_polars.experimental.base import PartitionInfo, StatsCollector
     from cudf_polars.experimental.parallel import ConfigOptions
     from cudf_polars.utils.config import StreamingExecutor
+
+
+T = TypeVar("T")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -178,6 +181,10 @@ class StreamingEngine(pl.GPUEngine):
     def __exit__(self, *_: object) -> None:
         """Exit the context manager, calling :meth:`shutdown`."""
         self.shutdown()
+
+    def _run(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> list[T]:
+        """Execute a function on all ranks."""
+        raise NotImplementedError
 
 
 def execute_ir_on_rank(

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/dask.py
@@ -44,7 +44,7 @@ from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
 from cudf_polars.utils.config import DaskContext
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
+    from collections.abc import Callable, MutableMapping
 
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.streaming.cudf.channel_metadata import ChannelMetadata
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from cudf_polars.dsl.ir import IR
     from cudf_polars.experimental.base import PartitionInfo, StatsCollector
     from cudf_polars.experimental.parallel import ConfigOptions
+    from cudf_polars.experimental.rapidsmpf.frontend.core import T
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
     from cudf_polars.utils.config import MemoryResourceConfig, StreamingExecutor
 
@@ -663,6 +664,9 @@ class DaskEngine(StreamingEngine):
         List of :class:`ClusterInfo`, one per rank.
         """
         return list(self._dask_ctx.client.run(ClusterInfo.local).values())
+
+    def _run(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> list[T]:
+        return list(self._dask_ctx.client.run(func, *args, **kwargs).values())
 
     def shutdown(self) -> None:
         """

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
@@ -41,7 +41,7 @@ from cudf_polars.utils.config import RayContext
 
 if TYPE_CHECKING:
     import uuid
-    from collections.abc import MutableMapping
+    from collections.abc import Callable, MutableMapping
 
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.streaming.cudf.channel_metadata import ChannelMetadata
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from cudf_polars.dsl.ir import IR
     from cudf_polars.experimental.base import PartitionInfo, StatsCollector
     from cudf_polars.experimental.parallel import ConfigOptions
+    from cudf_polars.experimental.rapidsmpf.frontend.core import T
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
     from cudf_polars.utils.config import MemoryResourceConfig, StreamingExecutor
 
@@ -356,6 +357,9 @@ class RankActor:
             collect_metadata=collect_metadata,
         )
 
+    def _run(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        return func(*args, **kwargs)
+
 
 def get_num_gpus_in_ray_cluster() -> int:
     """
@@ -600,6 +604,11 @@ class RayEngine(StreamingEngine):
         List of :class:`ClusterInfo`, one per rank.
         """
         return ray.get([rank.get_info.remote() for rank in self.rank_actors])
+
+    def _run(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> list[T]:
+        return ray.get(
+            [rank._run.remote(func, *args, **kwargs) for rank in self.rank_actors]
+        )
 
     def shutdown(self) -> None:
         """

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/spmd.py
@@ -45,7 +45,7 @@ from cudf_polars.utils.config import SPMDContext
 
 if TYPE_CHECKING:
     import uuid
-    from collections.abc import MutableMapping
+    from collections.abc import Callable, MutableMapping
 
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.streaming.cudf.channel_metadata import ChannelMetadata
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from cudf_polars.dsl.ir import IR
     from cudf_polars.experimental.base import PartitionInfo, StatsCollector
     from cudf_polars.experimental.parallel import ConfigOptions
+    from cudf_polars.experimental.rapidsmpf.frontend.core import T
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
     from cudf_polars.utils.config import MemoryResourceConfig, StreamingExecutor
 
@@ -521,3 +522,10 @@ class SPMDEngine(StreamingEngine):
         self._comm = None
         self._ctx = None
         super().shutdown()
+
+    def _run(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> list[T]:
+        data = json.dumps(func(*args, **kwargs)).encode()
+        with reserve_op_id() as op_id:
+            results = all_gather_host_data(self.comm, self.context.br(), op_id, data)
+
+        return [json.loads(r) for r in results]

--- a/python/cudf_polars/tests/experimental/test_dask.py
+++ b/python/cudf_polars/tests/experimental/test_dask.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -142,3 +143,8 @@ def test_empty_dataframe(engine: DaskEngine) -> None:
         {"a": pl.Series([], dtype=pl.Int32), "b": pl.Series([], dtype=pl.Float64)}
     )
     assert_gpu_result_equal(lf, engine=engine)
+
+
+def test_run(engine: DaskEngine) -> None:
+    result = engine._run(os.getpid)
+    assert len(set(result)) == engine.nranks

--- a/python/cudf_polars/tests/experimental/test_ray.py
+++ b/python/cudf_polars/tests/experimental/test_ray.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -174,3 +175,8 @@ def test_empty_dataframe(engine: RayEngine) -> None:
     assert result.shape == (0, 2)
     assert result.columns == ["a", "b"]
     assert result.dtypes == [pl.Int32, pl.Float64]
+
+
+def test_run(engine: RayEngine) -> None:
+    result = engine._run(os.getpid)
+    assert len(set(result)) == engine.nranks

--- a/python/cudf_polars/tests/experimental/test_spmd.py
+++ b/python/cudf_polars/tests/experimental/test_spmd.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -284,3 +285,10 @@ def test_comm_and_context_unavailable_after_shutdown(spmd_comm: Communicator) ->
         _ = engine.comm
     with pytest.raises(RuntimeError, match="shutdown"):
         _ = engine.context
+
+
+def test_run(spmd_comm):
+    with SPMDEngine(comm=spmd_comm) as engine:
+        result = engine._run(os.getpid)
+
+    assert result == [os.getpid()]


### PR DESCRIPTION
This updates our new frontend-based pdsh benchmark runner to support `--collect-traces`. Our trace collection requires

1. Configuring a python Logger on each process (easiest done via some python code)
2. Collecting logging at the end of each iteration (eastiest done via some python code)

The old method used Dask's `Client.run` method to execute arbitrary python code on each worker. This PR adds a (private) `StreamingEngine._run` method.

- The Dask frontend uses `self._dask_ctx.client.run`
- The Ray frontend uses a new `ActorHandle._run` wrapper method
- The SPMD frontend uses `all_gather_host_data` on json serializable result
