### PR TITLE
Fix more misc cuDF unit tests for pandas 3

### DIFF
--- a/python/cudf/cudf/tests/input_output/test_csv.py
+++ b/python/cudf/cudf/tests/input_output/test_csv.py
@@ -974,16 +974,19 @@ def test_csv_reader_dtype_inference_whitespace():
 def test_csv_reader_empty_dataframe():
     dtypes = ["float64", "int64"]
     buffer = "float_point, integer"
+    dtype = dict(zip(buffer.split(","), dtypes, strict=True))
 
     # should work fine with dtypes
-    df = read_csv(StringIO(buffer), dtype=dtypes)
-    assert df.shape == (0, 2)
-    assert all(df.dtypes == ["float64", "int64"])
+    result = read_csv(StringIO(buffer), dtype=dtype)
+    expected = pd.read_csv(StringIO(buffer), dtype=dtype)
+    assert_eq(result, expected)
 
     # should default to string columns without dtypes
-    df = read_csv(StringIO(buffer))
-    assert df.shape == (0, 2)
-    assert all(df.dtypes == ["object", "object"])
+    result = read_csv(StringIO(buffer))
+    expected = pd.read_csv(StringIO(buffer)).astype(
+        pd.StringDtype(na_value=np.nan)
+    )
+    assert_eq(result, expected)
 
 
 def test_csv_reader_filenotfound(tmp_path):

--- a/python/cudf/cudf/tests/series/test_constructors.py
+++ b/python/cudf/cudf/tests/series/test_constructors.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+from packaging.version import parse
 
 import cudf
 from cudf.core._compat import (
@@ -1577,18 +1578,13 @@ def test_series_constructor_dtype_is_pandas_nullable_extension_type(
 
 def test_series_constructor_dtype_is_pandas_arrowdtype(
     all_supported_pandas_arrowdtypes,
-    request,
 ):
     scalar, dtype = all_supported_pandas_arrowdtypes
-    if PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION:
-        if dtype.kind == "M" and dtype.pyarrow_dtype.tz is not None:
-            pytest.skip(
-                f"RecursionError occurs in older versions of pandas/pyarrow for {dtype}"
-            )
-        elif pa.types.is_decimal(dtype.pyarrow_dtype):
-            pytest.skip(
-                "Decimal types coerced to object in older versions of pandas/pyarrow"
-            )
+    if (
+        pa.types.is_decimal32(dtype.pyarrow_dtype)
+        or pa.types.is_decimal64(dtype.pyarrow_dtype)
+    ) and parse(pa.__version__) < parse("20"):
+        pytest.skip("pyarrow < 19 converts decimal32/64 to object")
     result = cudf.Series([scalar], dtype=dtype)
     expected = pd.Series([scalar], dtype=dtype)
     assert result.dtype == expected.dtype


### PR DESCRIPTION
## Description
* `test_csv_reader_empty_dataframe` was failing as a result type was being compared to object when it should have been compared to `pandas.StringDtype` (the new default)
* `test_series_constructor_dtype_is_pandas_arrowdtype` was failing on the old dependencies job as I believe pyarrow 19 didn't fully convert decimal32/64 correctly in pandas via pyarrow (IIRC I fixed this in pyarrow 20)

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
