### PR TITLE
Fix cudf interval test for pandas 3 and numpy < 2

### DIFF
--- a/python/cudf/cudf/tests/indexes/test_interval.py
+++ b/python/cudf/cudf/tests/indexes/test_interval.py
@@ -212,6 +212,16 @@ def test_interval_range_periods_freq_start_dtype(periods_t, freq_t, start_t):
     gindex = cudf.interval_range(
         start=start, freq=freq, periods=periods, closed="left"
     )
+    if (
+        parse(np.__version__) < parse("2")
+        and pindex.dtype.subtype != gindex.dtype.subtype
+    ):
+        # NEP 50 in numpy 2 changes pandas' subtype result to match cudf
+        pindex = pindex.astype(
+            pd.IntervalDtype(
+                subtype=gindex.dtype.subtype, closed=pindex.dtype.closed
+            )
+        )
     assert_eq(pindex, gindex)
 
 

--- a/python/cudf/cudf/tests/indexes/test_interval.py
+++ b/python/cudf/cudf/tests/indexes/test_interval.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+from packaging.version import parse
 
 import cudf
 from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
@@ -121,6 +122,14 @@ def test_interval_range_periods_basic_dtype(start_t, end_t, periods_t):
     gindex = cudf.interval_range(
         start=start, end=end, periods=periods, closed="left"
     )
+    if (
+        parse(np.__version__) < parse("2")
+        and pindex.dtype.subtype != gindex.dtype.subtype
+    ):
+        # NEP 50 in numpy 2 changes pandas' subtype result to match cudf
+        pindex = pindex.astype(
+            pd.IntervalDtype(gindex.dtype.subtype, pindex.dtype.closed)
+        )
 
     assert_eq(pindex, gindex)
 
@@ -164,6 +173,16 @@ def test_interval_range_periods_freq_end_dtype(periods_t, freq_t, end_t):
     gindex = cudf.interval_range(
         end=end, freq=freq, periods=periods, closed="left"
     )
+    if (
+        parse(np.__version__) < parse("2")
+        and pindex.dtype.subtype != gindex.dtype.subtype
+    ):
+        # NEP 50 in numpy 2 changes pandas' subtype result to match cudf
+        pindex = pindex.astype(
+            pd.IntervalDtype(
+                subtype=gindex.dtype.subtype, closed=pindex.dtype.closed
+            )
+        )
     assert_eq(pindex, gindex)
 
 


### PR DESCRIPTION
## Description
(Used Claude to investigate)

Some interval tests are sensitive to the NumPy 1.26 vs 2 difference with NEP 50 type promotion rules in `pandas.interval_range` calls when floats with ints could return `float64` vs `float32`. Namely, some parameterizations of `test_interval_range_periods_basic_dtype`, `test_interval_range_periods_freq_end_dtype`, `test_interval_range_periods_freq_start_dtype` fail on the oldest dependencies job in pandas 3 due to this difference.

Since NumPy 1.26 is on the way out soon, this just coerces the pandas result to match cuDF.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
