### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
@@ -1,6 +1,6 @@
 /*
  *
- *  SPDX-FileCopyrightText: Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ *  SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *  SPDX-License-Identifier: Apache-2.0
  *
  */
@@ -624,6 +624,28 @@ public class ColumnWriterOptions {
    */
   public ColumnWriterOptions[] getChildColumnOptions() {
     return childColumnOptions;
+  }
+
+  /**
+   * Returns true if this column is a binary (byte array) column in Parquet.
+   */
+  public boolean isBinary() {
+    return isBinary;
+  }
+
+  /**
+   * Returns true if a Parquet field ID was set on this column.
+   */
+  public boolean hasParquetFieldId() {
+    return hasParquetFieldId;
+  }
+
+  /**
+   * Return the Parquet field ID for this column. The value is only meaningful when
+   * {@link #hasParquetFieldId()} returns true.
+   */
+  public int getParquetFieldId() {
+    return parquetFieldId;
   }
 
   public static class StructColumnWriterOptions extends ColumnWriterOptions {


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.