### PR TITLE
fix(ci): remove `needs` dependency on job that doesn't exist in test yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -187,7 +187,6 @@ jobs:
       container_image: "rapidsai/ci-conda:26.06-latest"
       script: ci/test_narwhals.sh
   streams-build:
-    needs: checks
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}


### PR DESCRIPTION
#22150 broke nightly tests because one of the newly added jobs is waiting for the `check` job that only exists in `pr.yaml`.
