### PR TITLE
Remove unnecessary older pandas checks in pandas 3

### DIFF
--- a/python/cudf/cudf/_typing.py
+++ b/python/cudf/cudf/_typing.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, Union
 
 import numpy as np
 import pandas as pd
-from packaging.version import parse
+from pandas.api.typing import NoDefault  # noqa: F401
 
 import pylibcudf as plc
 
@@ -53,8 +53,3 @@ MultiColumnAggType = Union[  # noqa: UP007
 ]
 
 Axis = Literal[0, 1, "index", "columns"]
-
-if parse(pd.__version__) >= parse("3.0.0"):
-    from pandas.api.typing import NoDefault
-else:
-    NoDefault = Any

--- a/python/cudf/cudf/tests/conftest.py
+++ b/python/cudf/cudf/tests/conftest.py
@@ -15,7 +15,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from packaging.version import parse
 
 import rmm  # noqa: F401
 
@@ -449,39 +448,24 @@ def all_supported_types_as_str(request):
     return request.param
 
 
-pandas_nullables_types_with_scalars = [
-    (1, pd.Int8Dtype()),
-    (1, pd.Int16Dtype()),
-    (1, pd.Int32Dtype()),
-    (1, pd.Int64Dtype()),
-    (1, pd.UInt8Dtype()),
-    (1, pd.UInt16Dtype()),
-    (1, pd.UInt32Dtype()),
-    (1, pd.UInt64Dtype()),
-    (1.5, pd.Float32Dtype()),
-    (1.5, pd.Float64Dtype()),
-    (True, pd.BooleanDtype()),
-]
-if parse(pd.__version__) >= parse("2.3.0"):
-    pandas_nullables_types_with_scalars.extend(
-        [
-            ("a", pd.StringDtype(na_value=np.nan, storage="python")),
-            ("a", pd.StringDtype(na_value=pd.NA, storage="python")),
-            ("a", pd.StringDtype(na_value=np.nan, storage="pyarrow")),
-            ("a", pd.StringDtype(na_value=pd.NA, storage="pyarrow")),
-        ]
-    )
-else:
-    pandas_nullables_types_with_scalars.extend(
-        [
-            ("a", pd.StringDtype(storage="python")),
-            ("a", pd.StringDtype(storage="pyarrow")),
-        ]
-    )
-
-
 @pytest.fixture(
-    params=pandas_nullables_types_with_scalars,
+    params=[
+        (1, pd.Int8Dtype()),
+        (1, pd.Int16Dtype()),
+        (1, pd.Int32Dtype()),
+        (1, pd.Int64Dtype()),
+        (1, pd.UInt8Dtype()),
+        (1, pd.UInt16Dtype()),
+        (1, pd.UInt32Dtype()),
+        (1, pd.UInt64Dtype()),
+        (1.5, pd.Float32Dtype()),
+        (1.5, pd.Float64Dtype()),
+        (True, pd.BooleanDtype()),
+        ("a", pd.StringDtype(na_value=np.nan, storage="python")),
+        ("a", pd.StringDtype(na_value=pd.NA, storage="python")),
+        ("a", pd.StringDtype(na_value=np.nan, storage="pyarrow")),
+        ("a", pd.StringDtype(na_value=pd.NA, storage="pyarrow")),
+    ],
     ids=lambda x: repr(x[1]),
 )
 def all_supported_pandas_nullable_extension_dtypes(request):

--- a/python/cudf/cudf/tests/dataframe/indexing/test_setitem.py
+++ b/python/cudf/cudf/tests/dataframe/indexing/test_setitem.py
@@ -9,10 +9,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq
 from cudf.testing._utils import assert_exceptions_equal, expect_warning_if
 
@@ -687,8 +683,7 @@ def test_tupleize_cols_False_set():
 def test_dataframe_assign_scalar(request, col_data, assign_val):
     request.applymarker(
         pytest.mark.xfail(
-            condition=PANDAS_VERSION >= PANDAS_CURRENT_SUPPORTED_VERSION
-            and len(col_data) == 0,
+            condition=len(col_data) == 0,
             reason="https://github.com/pandas-dev/pandas/issues/56679",
         )
     )

--- a/python/cudf/cudf/tests/dataframe/methods/test_interpolate.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_interpolate.py
@@ -1,10 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.testing import assert_eq
 from cudf.testing._utils import assert_exceptions_equal
 
@@ -33,10 +32,6 @@ def test_interpolate_dataframe(data):
     assert_eq(expect, got)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Does not fail on older versions of pandas",
-)
 def test_interpolate_dataframe_error_cases():
     data = {"A": ["a", "b", "c"], "B": ["d", "e", "f"]}
     kwargs = {"axis": 0, "method": "linear"}

--- a/python/cudf/cudf/tests/dataframe/methods/test_pct_change.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_pct_change.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -6,17 +6,9 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="warning not present in older pandas versions",
-)
 @pytest.mark.parametrize(
     "data",
     [

--- a/python/cudf/cudf/tests/dataframe/methods/test_reductions.py
+++ b/python/cudf/cudf/tests/dataframe/methods/test_reductions.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.testing import assert_eq
 from cudf.testing._utils import expect_warning_if
 
@@ -133,10 +132,6 @@ def test_any_all_axis_none(data, op):
     assert expected == actual
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Warning not given on older versions of pandas",
-)
 def test_reductions_axis_none(request, reduction_methods):
     if reduction_methods == "quantile":
         pytest.skip(f"pandas {reduction_methods} doesn't support axis=None")

--- a/python/cudf/cudf/tests/dataframe/test_np_ufuncs.py
+++ b/python/cudf/cudf/tests/dataframe/test_np_ufuncs.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import operator
@@ -10,19 +10,10 @@ import pytest
 from packaging.version import parse
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq
 from cudf.testing._utils import set_random_null_mask_inplace
 
 
-# Skip matmul since it requires aligned shapes.
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="warning not present in older pandas versions",
-)
 @pytest.mark.parametrize("has_nulls", [True, False])
 @pytest.mark.parametrize("indexed", [True, False])
 def test_ufunc_dataframe(request, numpy_ufunc, has_nulls, indexed):

--- a/python/cudf/cudf/tests/general_functions/test_api_types.py
+++ b/python/cudf/cudf/tests/general_functions/test_api_types.py
@@ -8,7 +8,6 @@ from pandas.api import types as pd_types  # noqa: TID251
 
 import cudf
 from cudf.api import types
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 
 
 @pytest.mark.parametrize(
@@ -484,22 +483,8 @@ def test_is_integer(obj, expect):
         (pd.Series(dtype="int"), False),
         (pd.Series(dtype="float"), False),
         (pd.Series(dtype="complex"), False),
-        pytest.param(
-            pd.Series(dtype="str"),
-            True,
-            marks=pytest.mark.skipif(
-                PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-                reason="bug in previous pandas versions",
-            ),
-        ),
-        pytest.param(
-            pd.Series(dtype="unicode"),
-            True,
-            marks=pytest.mark.skipif(
-                PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-                reason="bug in previous pandas versions",
-            ),
-        ),
+        (pd.Series(dtype="str"), True),
+        (pd.Series(dtype="unicode"), True),
         (pd.Series(dtype="datetime64[s]"), False),
         (pd.Series(dtype="timedelta64[s]"), False),
         (pd.Series(dtype="category"), False),
@@ -951,10 +936,6 @@ def test_is_decimal_dtype(obj, expect):
     assert types.is_decimal_dtype(obj) == expect
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="inconsistent warnings in older pandas versions",
-)
 @pytest.mark.parametrize(
     "obj",
     (

--- a/python/cudf/cudf/tests/general_functions/test_date_range.py
+++ b/python/cudf/cudf/tests/general_functions/test_date_range.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -7,10 +7,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq
 
 
@@ -93,10 +89,6 @@ def test_date_range_start_end_periods(start, end, periods):
     )
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="https://github.com/pandas-dev/pandas/issues/46877",
-)
 def test_date_range_end_freq_periods(end, freq, periods):
     if isinstance(freq, str):
         _gfreq = _pfreq = freq
@@ -177,10 +169,6 @@ def test_date_range_raise_unsupported(freqstr_unsupported, case):
         cudf.date_range(start=s, end=e, freq=freq)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_date_range_start_freq_periods(start, freq, periods):
     if isinstance(freq, str):
         _gfreq = _pfreq = freq
@@ -208,10 +196,6 @@ def test_daterange_pandas_compatibility():
     assert_eq(expected, actual)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_date_range_start_end_freq(start, end, freq):
     if isinstance(freq, str):
         _gfreq = _pfreq = freq

--- a/python/cudf/cudf/tests/groupby/test_agg.py
+++ b/python/cudf/cudf/tests/groupby/test_agg.py
@@ -8,10 +8,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.core.dtypes import ListDtype, StructDtype
 from cudf.testing import assert_eq, assert_groupby_results_equal
 
@@ -211,13 +207,6 @@ def test_groupby_agg_decimal(groupby_reduction_methods, request):
             groupby_reduction_methods in ["prod", "mean"],
             raises=pd.errors.DataError,
             reason=f"{groupby_reduction_methods} not supported with Decimals in pandas",
-        )
-    )
-    request.applymarker(
-        pytest.mark.xfail(
-            groupby_reduction_methods in ["idxmax", "idxmin"]
-            and PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-            reason=f"{groupby_reduction_methods} not supported with Decimals in an older version of pandas",
         )
     )
     rng = np.random.default_rng(seed=0)

--- a/python/cudf/cudf/tests/groupby/test_apply.py
+++ b/python/cudf/cudf/tests/groupby/test_apply.py
@@ -10,10 +10,6 @@ import pytest
 
 import cudf
 from cudf import DataFrame
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.core.udf._ops import arith_ops, comparison_ops, unary_ops
 from cudf.core.udf.groupby_typing import SUPPORTED_GROUPBY_NUMPY_TYPES
 from cudf.core.udf.utils import UDFError, precompiled
@@ -42,10 +38,6 @@ def test_groupby_as_index_apply(as_index, engine):
     assert_groupby_results_equal(pdf, gdf, as_index=as_index, by="y")
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply():
     rng = np.random.default_rng(seed=0)
     nelem = 20
@@ -89,10 +81,6 @@ def f3(df, k, L, m):
 
 @pytest.mark.parametrize(
     "func,args", [(f1, (42,)), (f2, (42, 119)), (f3, (42, 119, 212.1))]
-)
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
 )
 def test_groupby_apply_args(func, args):
     rng = np.random.default_rng(seed=0)
@@ -224,10 +212,6 @@ def groupby_apply_jit_reductions_test_inner(func, data, dtype):
     "func", ["min", "max", "sum", "mean", "var", "std", "idxmin", "idxmax"]
 )
 @pytest.mark.parametrize("dataset", ["small", "large", "nans"])
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Include groups missing on old versions of pandas",
-)
 def test_groupby_apply_jit_unary_reductions(
     request, func, dtype, dataset, groupby_jit_datasets
 ):
@@ -275,10 +259,6 @@ def groupby_apply_jit_reductions_special_vals_inner(
 
 
 # test unary index reductions for special values
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def groupby_apply_jit_idx_reductions_special_vals_inner(
     func, data, dtype, special_val
 ):
@@ -304,10 +284,6 @@ def groupby_apply_jit_idx_reductions_special_vals_inner(
 @pytest.mark.parametrize("func", ["min", "max", "sum", "mean", "var", "std"])
 @pytest.mark.parametrize("special_val", [np.nan, np.inf, -np.inf])
 @pytest.mark.parametrize("dataset", ["small", "large", "nans"])
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Include groups missing on old versions of pandas",
-)
 def test_groupby_apply_jit_reductions_special_vals(
     func, dtype, dataset, groupby_jit_datasets, special_val
 ):
@@ -335,10 +311,6 @@ def test_groupby_apply_jit_reductions_special_vals(
     ],
 )
 @pytest.mark.parametrize("dataset", ["small", "large", "nans"])
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="include_groups keyword new in pandas 2.2",
-)
 def test_groupby_apply_jit_idx_reductions_special_vals(
     func, dataset, groupby_jit_datasets, special_val
 ):
@@ -348,10 +320,6 @@ def test_groupby_apply_jit_idx_reductions_special_vals(
     )
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply_jit_sum_integer_overflow():
     max = np.iinfo("int32").max
 
@@ -386,10 +354,6 @@ def test_groupby_apply_jit_sum_integer_overflow():
         "large",
     ],
 )
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply_jit_correlation(dataset, groupby_jit_datasets, dtype):
     dataset = groupby_jit_datasets[dataset].copy(deep=True)
 
@@ -416,10 +380,6 @@ def test_groupby_apply_jit_correlation(dataset, groupby_jit_datasets, dtype):
 
 
 @pytest.mark.parametrize("dtype", ["int32", "int64"])
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply_jit_correlation_zero_variance(dtype):
     # pearson correlation is undefined when the variance of either
     # variable is zero. This test ensures that the jit implementation
@@ -478,10 +438,6 @@ def test_groupby_apply_jit_no_df_ops(groupby_jit_data_small):
 
 
 @pytest.mark.parametrize("dtype", ["uint8", "str"])
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply_unsupported_dtype(dtype):
     df = cudf.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
     df["b"] = df["b"].astype(dtype)
@@ -510,10 +466,6 @@ def test_groupby_apply_unsupported_dtype(dtype):
         lambda df: df["val1"].mean() + df["val2"].std(),
     ],
 )
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply_jit_basic(func, groupby_jit_data_small):
     run_groupby_apply_jit_test(groupby_jit_data_small, func, ["key1", "key2"])
 
@@ -533,20 +485,12 @@ def f3(df, k, L, m):
 @pytest.mark.parametrize(
     "func,args", [(f1, (42,)), (f2, (42, 119)), (f3, (42, 119, 212.1))]
 )
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply_jit_args(func, args, groupby_jit_data_small):
     run_groupby_apply_jit_test(
         groupby_jit_data_small, func, ["key1", "key2"], *args
     )
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply_jit_block_divergence():
     # https://github.com/rapidsai/cudf/issues/12686
     df = cudf.DataFrame(
@@ -564,10 +508,6 @@ def test_groupby_apply_jit_block_divergence():
     run_groupby_apply_jit_test(df, diverging_block, ["a"])
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply_caching():
     # Make sure similar functions that differ
     # by simple things like constants actually
@@ -604,10 +544,6 @@ def test_groupby_apply_caching():
     assert precompiled.currsize == 3
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply_no_bytecode_fallback():
     # tests that a function which contains no bytecode
     # attribute, but would still be executable using
@@ -626,10 +562,6 @@ def test_groupby_apply_no_bytecode_fallback():
     assert_groupby_results_equal(expect, got)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply_return_col_from_df():
     # tests a UDF that consists of purely colwise
     # ops, such as `lambda group: group.x + group.y`
@@ -655,10 +587,6 @@ def test_groupby_apply_return_col_from_df():
 
 
 @pytest.mark.parametrize("func", [lambda group: group.sum()])
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_groupby_apply_return_df(func):
     # tests a UDF that reduces over a dataframe
     # and produces a series with the original column names
@@ -698,10 +626,6 @@ def test_groupby_apply_return_reindexed_series(as_index):
     assert_groupby_results_equal(expect, got)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Include groups missing on old versions of pandas",
-)
 def test_groupby_apply_noempty_group():
     pdf = pd.DataFrame(
         {"a": [1, 1, 2, 2], "b": [1, 2, 1, 2], "c": [1, 2, 3, 4]}
@@ -751,10 +675,6 @@ def create_test_groupby_apply_return_scalars_params():
 
 @pytest.mark.parametrize(
     "func,args", create_test_groupby_apply_return_scalars_params()
-)
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
 )
 def test_groupby_apply_return_scalars(func, args):
     pdf = pd.DataFrame(
@@ -813,10 +733,6 @@ def create_test_groupby_apply_return_series_dataframe_params():
 
 @pytest.mark.parametrize(
     "func,args", create_test_groupby_apply_return_series_dataframe_params()
-)
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Include groups missing on old versions of pandas",
 )
 def test_groupby_apply_return_series_dataframe(func, args):
     pdf = pd.DataFrame(
@@ -965,10 +881,6 @@ def test_groupby_group_keys(group_keys, by):
 @pytest.mark.parametrize(
     "apply_op",
     ["sum", "min", "max", "idxmax"],
-)
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
 )
 def test_group_by_empty_apply(request, dtype, apply_op):
     request.applymarker(

--- a/python/cudf/cudf/tests/groupby/test_reductions.py
+++ b/python/cudf/cudf/tests/groupby/test_reductions.py
@@ -6,10 +6,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq, assert_groupby_results_equal, assert_neq
 from cudf.testing._utils import assert_exceptions_equal
 
@@ -872,10 +868,6 @@ def test_group_by_pandas_sort_order(groups, sort):
         )
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_group_by_empty_reduction(
     all_supported_types_as_str, groupby_reduction_methods, request
 ):

--- a/python/cudf/cudf/tests/groupby/test_resample.py
+++ b/python/cudf/cudf/tests/groupby/test_resample.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.testing import assert_eq
 
 
@@ -174,10 +173,6 @@ def test_resampling_frequency_conversion(in_freq, sampling_freq, out_freq):
     assert got.index.dtype == np.dtype(f"datetime64[{out_freq}]")
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_resampling_downsampling_ms():
     pdf = pd.DataFrame(
         {

--- a/python/cudf/cudf/tests/indexes/multiindex/methods/test_get_indexer.py
+++ b/python/cudf/cudf/tests/indexes/multiindex/methods/test_get_indexer.py
@@ -1,14 +1,10 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq
 from cudf.testing._utils import assert_exceptions_equal
 
@@ -61,10 +57,6 @@ def test_get_indexer_multi_numeric_deviate(key, method):
 
 
 @pytest.mark.parametrize("method", ["ffill", "bfill"])
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_get_indexer_multi_error(method):
     pi = pd.MultiIndex.from_tuples(
         [(2, 1, 1), (1, 2, 3), (1, 2, 1), (1, 1, 10), (1, 1, 1), (2, 2, 1)]

--- a/python/cudf/cudf/tests/indexes/test_interval.py
+++ b/python/cudf/cudf/tests/indexes/test_interval.py
@@ -7,7 +7,6 @@ import pytest
 from packaging.version import parse
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.core.index import IntervalIndex, interval_range
 from cudf.testing import assert_eq
 
@@ -299,26 +298,18 @@ def test_interval_index_from_breaks(closed):
     [
         (0.0, None, 0.2, 5),
         (0.0, 1.0, None, 5),
-        pytest.param(
+        (
             0.0,
             1.0,
             0.2,
             None,
-            marks=pytest.mark.skipif(
-                condition=PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-                reason="https://github.com/pandas-dev/pandas/pull/54477",
-            ),
         ),
         (None, 1.0, 0.2, 5),
-        pytest.param(
+        (
             0.0,
             1.0,
             0.1,
             None,
-            marks=pytest.mark.xfail(
-                condition=PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-                reason="https://github.com/pandas-dev/pandas/pull/54477",
-            ),
         ),
         (0.0, 1.0, None, 10),
         (0.0, None, 0.25, 4),

--- a/python/cudf/cudf/tests/input_output/test_avro.py
+++ b/python/cudf/cudf/tests/input_output/test_avro.py
@@ -12,7 +12,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.testing import assert_eq
 from cudf.testing.dataset_generator import rand_dataframe
 
@@ -294,10 +293,6 @@ def get_days_from_epoch(date: datetime.date | None) -> int | None:
 
 
 @pytest.mark.parametrize("namespace", [None, "root_ns"])
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas (datetime(9999, ...) too large)",
-)
 def test_can_parse_avro_date_logical_type(namespace, nullable, prepend_null):
     avro_type = {"logicalType": "date", "type": "int"}
     if nullable:

--- a/python/cudf/cudf/tests/input_output/test_csv.py
+++ b/python/cudf/cudf/tests/input_output/test_csv.py
@@ -15,10 +15,6 @@ import pytest
 
 import cudf
 from cudf import read_csv
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq
 from cudf.testing._utils import assert_exceptions_equal
 
@@ -291,10 +287,6 @@ def test_csv_reader_dtype_extremes(use_names, numeric_extremes_dataframe):
     assert_eq(gdf, pdf)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="https://github.com/pandas-dev/pandas/issues/52449",
-)
 def test_csv_reader_skiprows_skipfooter(tmp_path, pd_mixed_dataframe):
     fname = tmp_path / "tmp_csvreader_file5.csv"
 

--- a/python/cudf/cudf/tests/input_output/test_json.py
+++ b/python/cudf/cudf/tests/input_output/test_json.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.testing import assert_eq
 from cudf.testing._utils import (
     DATETIME_TYPES,
@@ -335,10 +334,6 @@ def json_input(request, tmp_path):
         return Path(fname).as_uri()
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="warning not present in older pandas versions",
-)
 @pytest.mark.filterwarnings("ignore:Using CPU")
 def test_json_lines_basic(json_input, engine):
     can_warn = isinstance(json_input, str) and not json_input.endswith(".json")
@@ -363,10 +358,6 @@ def test_nonexistent_json_correct_error(engine):
         cudf.read_json(json_input, engine=engine)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="warning not present in older pandas versions",
-)
 @pytest.mark.filterwarnings("ignore:Using CPU")
 def test_json_lines_multiple(tmp_path, json_input, engine):
     if engine == "pandas":
@@ -390,10 +381,6 @@ def test_json_lines_multiple(tmp_path, json_input, engine):
         np.testing.assert_array_equal(pd_df[pd_col], cu_df[cu_col].to_numpy())
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="warning not present in older pandas versions",
-)
 def test_json_read_directory(tmp_path, json_input, engine):
     if engine == "pandas":
         pytest.skip("pandas engine does not support directories")
@@ -1166,10 +1153,6 @@ class TestNestedJsonReaderCommon:
         df = cudf.concat(chunks, ignore_index=True)
         assert expected.to_arrow().equals(df.to_arrow())
 
-    @pytest.mark.skipif(
-        PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-        reason="https://github.com/pandas-dev/pandas/pull/57439",
-    )
     def test_order_nested_json_reader(self, tag, data):
         expected = pd.read_json(StringIO(data), lines=True)
         target = cudf.read_json(StringIO(data), lines=True)

--- a/python/cudf/cudf/tests/input_output/test_orc.py
+++ b/python/cudf/cudf/tests/input_output/test_orc.py
@@ -16,7 +16,6 @@ from packaging import version
 from pyarrow import orc
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.io.orc import (
     ORCWriter,
     is_supported_read_orc,
@@ -142,10 +141,6 @@ def test_orc_reader_filepath_or_buffer(path_or_buf, src):
     assert_eq(expect, got)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Bug in older version of pandas",
-)
 def test_orc_reader_trailing_nulls(datadir):
     path = datadir / "TestOrcFile.nulls-at-end-snappy.orc"
     expect = pd.read_orc(path)
@@ -1664,19 +1659,7 @@ def run_orc_columns_and_index_param(index_obj, index, columns):
 
 @pytest.mark.parametrize("index_obj", [None, [10, 11, 12], ["x", "y", "z"]])
 @pytest.mark.parametrize("index", [True, False, None])
-@pytest.mark.parametrize(
-    "columns",
-    [
-        None,
-        pytest.param(
-            [],
-            marks=pytest.mark.skipif(
-                PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-                reason="Bug in older version of pandas",
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("columns", [None, []])
 def test_orc_columns_and_index_param(index_obj, index, columns):
     run_orc_columns_and_index_param(index_obj, index, columns)
 

--- a/python/cudf/cudf/tests/input_output/test_parquet.py
+++ b/python/cudf/cudf/tests/input_output/test_parquet.py
@@ -22,7 +22,6 @@ from packaging import version
 from pyarrow import parquet as pq
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.io.parquet import (
     ParquetDatasetWriter,
     ParquetWriter,
@@ -3201,10 +3200,6 @@ def test_parquet_reader_rle_boolean(datadir):
 #                a list column in a schema, the cudf reader was confusing
 #                nesting information between a list column and a subsequent
 #                string column, ultimately causing a crash.
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Older versions of pandas do not have DataFrame.map()",
-)
 def test_parquet_reader_one_level_list2(datadir):
     # we are reading in a file containing binary types, but cudf returns
     # those as strings. so we have to massage the pandas data to get

--- a/python/cudf/cudf/tests/private_objects/test_column.py
+++ b/python/cudf/cudf/tests/private_objects/test_column.py
@@ -9,10 +9,6 @@ import pyarrow as pa
 import pytest
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.core.column.column import _can_values_be_equal, as_column
 from cudf.core.column.decimal import (
     Decimal32Column,
@@ -454,10 +450,6 @@ def test_string_int_to_ipv4_dtype_fail(numeric_types_as_str):
         gsr._column.int2ip()
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas.",
-)
 def test_datetime_can_cast_safely():
     sr = cudf.Series(
         ["1679-01-01", "2000-01-31", "2261-01-01"], dtype="datetime64[ms]"

--- a/python/cudf/cudf/tests/reshape/test_join.py
+++ b/python/cudf/cudf/tests/reshape/test_join.py
@@ -7,7 +7,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.testing import assert_eq
 from cudf.testing._utils import (
     assert_exceptions_equal,
@@ -135,10 +134,6 @@ def test_dataframe_join_how(aa, bb, how):
                 assert direct_equal or nanfilled_equal, msg
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="bug in older version of pandas",
-)
 def test_dataframe_join_suffix():
     rng = np.random.default_rng(seed=0)
 

--- a/python/cudf/cudf/tests/series/accessors/test_dt.py
+++ b/python/cudf/cudf/tests/series/accessors/test_dt.py
@@ -9,10 +9,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq
 
 
@@ -184,10 +180,6 @@ def test_round(datetime_types_as_str, resolution):
     assert_eq(expect, got)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="https://github.com/pandas-dev/pandas/issues/52761",
-)
 @pytest.mark.parametrize(
     "resolution", ["D", "h", "min", "min", "s", "ms", "us", "ns"]
 )
@@ -210,10 +202,6 @@ def test_floor(datetime_types_as_str, resolution):
     assert_eq(expect, got)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="https://github.com/pandas-dev/pandas/issues/52761",
-)
 @pytest.mark.parametrize(
     "resolution", ["D", "h", "min", "min", "s", "ms", "us", "ns"]
 )

--- a/python/cudf/cudf/tests/series/accessors/test_str.py
+++ b/python/cudf/cudf/tests/series/accessors/test_str.py
@@ -13,7 +13,6 @@ import pytest
 import cudf
 from cudf import concat
 from cudf.api.extensions import no_default
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.testing import assert_eq
 from cudf.testing._utils import (
     assert_exceptions_equal,
@@ -1157,16 +1156,7 @@ def test_string_compiled_re(ps_gs, pat, repl):
     ],
 )
 @pytest.mark.parametrize("pat", ["", " ", "a", "abc", "cat", "$", "\n"])
-@pytest.mark.parametrize(
-    "na",
-    [
-        None
-        if PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION
-        else no_default,
-        True,
-        False,
-    ],
-)
+@pytest.mark.parametrize("na", [no_default, True, False])
 def test_string_str_match(data, pat, na):
     ps = pd.Series(data)
     gs = cudf.Series(data)
@@ -2390,16 +2380,7 @@ def test_string_replace_n(n):
     "flags,flags_raise",
     [(0, 0), (re.MULTILINE | re.DOTALL, 0), (re.I, 0), (re.I | re.DOTALL, 0)],
 )
-@pytest.mark.parametrize(
-    "na",
-    [
-        None
-        if PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION
-        else no_default,
-        True,
-        False,
-    ],
-)
+@pytest.mark.parametrize("na", [no_default, True, False])
 def test_string_contains(ps_gs, pat, regex, flags, flags_raise, na):
     ps, gs = ps_gs
 

--- a/python/cudf/cudf/tests/series/indexing/test_iloc.py
+++ b/python/cudf/cudf/tests/series/indexing/test_iloc.py
@@ -7,7 +7,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.testing import assert_eq
 from cudf.testing._utils import assert_exceptions_equal
 
@@ -137,10 +136,6 @@ def test_series_iloc():
     )
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="warning not present in older pandas versions",
-)
 @pytest.mark.parametrize(
     "key, value",
     [

--- a/python/cudf/cudf/tests/series/methods/test_apply.py
+++ b/python/cudf/cudf/tests/series/methods/test_apply.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.core.udf.utils import precompiled
 from cudf.testing import assert_eq
 
@@ -139,7 +138,6 @@ def test_masked_udf_scalar_args_binops_multiple_series(
                 operator.gt,
                 operator.ge,
             ]
-            and PANDAS_VERSION >= PANDAS_CURRENT_SUPPORTED_VERSION
             and data.dtype.kind != "b",
             reason="https://github.com/pandas-dev/pandas/issues/57390",
         )
@@ -184,7 +182,6 @@ def test_series_apply_basic(data, name):
 
 
 @pytest.mark.xfail(
-    PANDAS_VERSION >= PANDAS_CURRENT_SUPPORTED_VERSION,
     reason="https://github.com/pandas-dev/pandas/issues/57390",
 )
 def test_series_apply_null_conditional():
@@ -208,7 +205,6 @@ def test_series_arith_masked_vs_masked(arithmetic_op):
 
 
 @pytest.mark.xfail(
-    PANDAS_VERSION >= PANDAS_CURRENT_SUPPORTED_VERSION,
     reason="https://github.com/pandas-dev/pandas/issues/57390",
 )
 def test_series_compare_masked_vs_masked(comparison_op):
@@ -269,7 +265,6 @@ def test_series_arith_masked_vs_constant_reflected(
 
 
 @pytest.mark.xfail(
-    PANDAS_VERSION >= PANDAS_CURRENT_SUPPORTED_VERSION,
     reason="https://github.com/pandas-dev/pandas/issues/57390",
 )
 def test_series_masked_is_null_conditional():

--- a/python/cudf/cudf/tests/series/methods/test_astype.py
+++ b/python/cudf/cudf/tests/series/methods/test_astype.py
@@ -11,7 +11,6 @@ import pyarrow as pa
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.core.column.decimal import Decimal32Column, Decimal64Column
 from cudf.core.column.numerical import NumericalColumn
 from cudf.testing import assert_eq
@@ -346,10 +345,6 @@ def test_timedelta_astype_unicode_dtype_pandas_compat():
         "timedelta64[ms]",
         "timedelta64[s]",
     ],
-)
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Bug in older pandas versions",
 )
 def test_timedelta_astype_str_pandas_compat(data, min_unit, unit):
     ptd = pd.to_timedelta(data).astype(unit)

--- a/python/cudf/cudf/tests/series/methods/test_cov_corr.py
+++ b/python/cudf/cudf/tests/series/methods/test_cov_corr.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -8,7 +8,6 @@ import pyarrow as pa
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.testing import assert_eq
 from cudf.testing._utils import expect_warning_if
 
@@ -83,10 +82,6 @@ def test_cov1d(data1, data2):
         np.array([5]),
     ],
 )
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Warnings missing on older pandas (scipy version seems unrelated?)",
-)
 def test_corr1d(data1, data2, corr_method):
     if corr_method == "spearman":
         # Pandas uses scipy.stats.spearmanr code-path
@@ -145,10 +140,6 @@ def test_corr1d(data1, data2, corr_method):
         [1, 2, 3, 4],
         [10, 1, 3, 5],
     ],
-)
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
 )
 def test_cov_corr_datetime_timedelta(data1, data2, temporal_types_as_str):
     gsr1 = cudf.Series(data1, dtype=temporal_types_as_str)

--- a/python/cudf/cudf/tests/series/methods/test_isin.py
+++ b/python/cudf/cudf/tests/series/methods/test_isin.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 from cudf.testing import assert_eq
 
 
@@ -50,10 +49,6 @@ def test_isin_numeric(data, values):
     assert_eq(got, expected)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Warning newly introduced in pandas-2.2.0",
-)
 @pytest.mark.parametrize(
     "data",
     [

--- a/python/cudf/cudf/tests/series/methods/test_replace.py
+++ b/python/cudf/cudf/tests/series/methods/test_replace.py
@@ -8,10 +8,6 @@ import pandas as pd
 import pytest
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq
 from cudf.testing._utils import (
     assert_exceptions_equal,
@@ -284,7 +280,6 @@ def test_numeric_series_replace_dtype(
             pd.Series(["one", "two", "three"], dtype="category"),
             {"to_replace": "one", "value": "two", "inplace": True},
             marks=pytest.mark.xfail(
-                condition=PANDAS_VERSION >= PANDAS_CURRENT_SUPPORTED_VERSION,
                 reason="https://github.com/pandas-dev/pandas/issues/43232"
                 "https://github.com/pandas-dev/pandas/issues/53358",
             ),

--- a/python/cudf/cudf/tests/series/test_binops.py
+++ b/python/cudf/cudf/tests/series/test_binops.py
@@ -14,10 +14,6 @@ import pyarrow as pa
 import pytest
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq
 from cudf.testing._utils import (
     _decimal_series,
@@ -1396,8 +1392,7 @@ def test_operator_func_series_and_scalar_logical(
 ):
     request.applymarker(
         pytest.mark.xfail(
-            PANDAS_VERSION >= PANDAS_CURRENT_SUPPORTED_VERSION
-            and fill_value == 1.0
+            fill_value == 1.0
             and scalar is np.nan
             and (
                 has_nulls
@@ -1567,8 +1562,7 @@ def test_datetime_dateoffset_binaryop(
 ):
     request.applymarker(
         pytest.mark.xfail(
-            PANDAS_VERSION >= PANDAS_CURRENT_SUPPORTED_VERSION
-            and dtype in {"datetime64[ms]", "datetime64[s]"}
+            dtype in {"datetime64[ms]", "datetime64[s]"}
             and frequency == "microseconds"
             and n_periods == 0,
             reason="https://github.com/pandas-dev/pandas/issues/57448",
@@ -1638,10 +1632,6 @@ def test_datetime_dateoffset_binaryop(
     "ignore:Discarding nonzero nanoseconds:UserWarning"
 )
 @pytest.mark.parametrize("op", [operator.add, operator.sub])
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_datetime_dateoffset_binaryop_multiple(kwargs, op):
     gsr = cudf.Series(
         [

--- a/python/cudf/cudf/tests/series/test_constructors.py
+++ b/python/cudf/cudf/tests/series/test_constructors.py
@@ -14,10 +14,6 @@ import pytest
 from packaging.version import parse
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.core.buffer.spill_manager import get_global_manager
 from cudf.core.column.column import as_column
 from cudf.errors import MixedTypeError
@@ -1275,10 +1271,6 @@ def test_datetime_array_timeunit_cast(dtype):
 
 
 @pytest.mark.parametrize("timeunit", ["D", "W", "M", "Y"])
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_datetime_scalar_timeunit_cast(timeunit):
     testscalar = np.datetime64("2016-11-20", timeunit)
 
@@ -1299,10 +1291,6 @@ def test_datetime_scalar_timeunit_cast(timeunit):
     assert_eq(pdf, gdf, check_dtype=True)
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="Fails in older versions of pandas",
-)
 def test_datetime_string_to_datetime_resolution_loss_raises():
     data = ["2020-01-01 00:00:00.00001"]
     dtype = "datetime64[s]"

--- a/python/cudf/cudf/tests/series/test_np_ufuncs.py
+++ b/python/cudf/cudf/tests/series/test_np_ufuncs.py
@@ -9,18 +9,10 @@ import numpy as np
 import pytest
 
 import cudf
-from cudf.core._compat import (
-    PANDAS_CURRENT_SUPPORTED_VERSION,
-    PANDAS_VERSION,
-)
 from cudf.testing import assert_eq
 from cudf.testing._utils import set_random_null_mask_inplace
 
 
-@pytest.mark.skipif(
-    PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-    reason="warning not present in older pandas versions",
-)
 @pytest.mark.parametrize("has_nulls", [True, False])
 @pytest.mark.parametrize("indexed", [True, False])
 def test_ufunc_series(request, numpy_ufunc, has_nulls, indexed):

--- a/python/cudf/cudf/tests/test_doctests.py
+++ b/python/cudf/cudf/tests/test_doctests.py
@@ -10,7 +10,6 @@ import pytest
 from packaging import version
 
 import cudf
-from cudf.core._compat import PANDAS_CURRENT_SUPPORTED_VERSION, PANDAS_VERSION
 
 pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
 _SKIP_DOCTESTS = frozenset(
@@ -121,10 +120,6 @@ class TestDoctests:
         "docstring",
         _all_doctests,
         ids=lambda docstring: docstring.name,
-    )
-    @pytest.mark.skipif(
-        PANDAS_VERSION < PANDAS_CURRENT_SUPPORTED_VERSION,
-        reason="Doctests not expected to pass on older versions of pandas",
     )
     def test_docstring(self, docstring, monkeypatch, tmp_path):
         if docstring.name in _SKIP_DOCTESTS:


### PR DESCRIPTION
## Description
* Removes `pytest.mark.skipif` and misc "older" pandas version checking in tests
* Removes pandas < 3 version checks in cuDF itself

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
