### PR TITLE
Fix regression in `eval` frame fetching

### DIFF
--- a/python/cudf/cudf/pandas/_wrappers/pandas.py
+++ b/python/cudf/cudf/pandas/_wrappers/pandas.py
@@ -1297,13 +1297,16 @@ except ImportError:
     pass
 
 
-def _find_user_frame():
+def _find_user_frame(level=0):
     frame = inspect.currentframe()
+    skip = 0
     while frame:
         modname = frame.f_globals.get("__name__", "")
         # TODO: Remove "nvtx." entry once we cross nvtx-0.2.11 as minimum version
         if modname == "__main__" or not modname.startswith(("cudf.", "nvtx.")):
-            return frame
+            if skip == level:
+                return frame
+            skip += 1
         frame = frame.f_back
     raise RuntimeError("Could not find the user's frame.")
 
@@ -1327,7 +1330,7 @@ register_proxy_func(getitem)(getitem)
 
 
 def _get_eval_locals_and_globals(level, local_dict=None, global_dict=None):
-    frame = _find_user_frame()
+    frame = _find_user_frame(level=level)
     local_dict = dict(frame.f_locals) if local_dict is None else local_dict
     global_dict = dict(frame.f_globals) if global_dict is None else global_dict
     return local_dict, global_dict


### PR DESCRIPTION
## Description
Fixes a regression in `cudf.pandas`'s `pd.eval` / `DataFrame.eval` / `DataFrame.query` proxies where the `level` argument was being ignored when resolving the user's frame for locals/globals.

### Root cause
`cudf.pandas` replaces `pd.eval` (and `DataFrame.eval`/`query`) with a proxy
that captures the caller's locals/globals and forwards them explicitly to the
real pandas implementation. That proxy used `_find_user_frame()` which walked
up the stack and returned the *first* frame whose module wasn't `cudf.*` or
`nvtx.*` — but it ignored the `level` argument entirely.

When user code calls `pd.eval(..., level=n)` (or wraps `pd.eval` in a helper
that bumps `level`, as pandas' own `TestMath.eval` does with `level + 1`), the
real `pd.eval` semantics are "look `n` frames above my caller." Because
`_find_user_frame` always returned the innermost user frame, the captured
locals came from the wrong scope, producing spurious
`UndefinedVariableError: name '<x>' is not defined` failures for expressions
referring to variables defined further up the stack.

### Fix
`_find_user_frame` now accepts a `level` argument and skips `level` user
frames before returning, and `_get_eval_locals_and_globals` threads the
`level` through. This matches pandas' own scope-lookup semantics.

### Test impact (pandas test suite)

| Metric | `pandas3` | This PR | Delta |
|---|---|---|---|
| **Failed** | 3711 | 3623 | **-88** ✓ |
| **Passed** | 203926 | 204014 | **+88** ✓ |
| Skipped | 7361 | 7361 | 0 |
| XFailed | 6283 | 6283 | 0 |
| XPassed | 77 | 77 | 0 |
| Warnings | 7305 | 7305 | 0 |
| **Total** | **221358** | **221358** | 0 |
| **Duration** | 1963.33s (32:43) | 3302.73s (55:02) | **+1339.40s (+68.2%)** |

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.