### PR TITLE
Pass BufferResource in more places

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/nodes.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/nodes.py
@@ -352,7 +352,9 @@ async def fanout_node_unbounded(
         )
 
         # Spillable FIFO buffer for each output channel
-        output_buffers: list[SpillableMessages] = [SpillableMessages() for _ in chs_out]
+        output_buffers: list[SpillableMessages] = [
+            SpillableMessages(br=context.br()) for _ in chs_out
+        ]
         num_outputs = len(chs_out)
 
         # Track message IDs in FIFO order for each output buffer

--- a/python/cudf_polars/tests/experimental/test_spilling.py
+++ b/python/cudf_polars/tests/experimental/test_spilling.py
@@ -68,7 +68,7 @@ def test_make_spill_function(
     # Buffer 0: Fast consumer (2 messages)
     # Buffer 1: Slow consumer (5 messages) <- should spill from here first
     # Buffer 2: Medium consumer (3 messages)
-    buffers = [SpillableMessages() for _ in range(3)]
+    buffers = [SpillableMessages(br=engine.context.br()) for _ in range(3)]
     messages_per_buffer = [2, 5, 3]
 
     # Track message IDs for each buffer


### PR DESCRIPTION
## Description

https://github.com/rapidsai/rapidsmpf/pull/970 changed the API for rapidsmpf's `SpillableMessages` to require a `BufferResource`.
https://github.com/rapidsai/cudf/pull/22164 caught most of them, but not all.

This should fix the errors seen in the (non-blocking) CI jobs like https://github.com/rapidsai/cudf/actions/runs/24686308044/job/72201352845?pr=22220#step:13:13558.

I'll note, this would have been caught if we had rapidsmpf in our type checking environment. But given all the headaches of adding RMM, I'm not brave enough to propose adding that (yet).