### PR TITLE
Pass `dask.datasets.timeseries(seed=)` in tests

### DIFF
--- a/python/dask_cudf/dask_cudf/io/tests/test_csv.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_csv.py
@@ -88,7 +88,9 @@ def test_csv_roundtrip_filepath(tmp_path):
 
 def test_read_csv(tmp_path):
     df = dask.datasets.timeseries(
-        dtypes={"x": int, "y": int}, freq="120s"
+        dtypes={"x": int, "y": int},
+        freq="120s",
+        seed=1,
     ).reset_index(drop=True)
 
     csv_path = str(tmp_path / "data-*.csv")
@@ -117,7 +119,9 @@ def test_raises_FileNotFoundError():
 
 def test_read_csv_w_bytes(tmp_path):
     df = dask.datasets.timeseries(
-        dtypes={"x": int, "y": int}, freq="120s"
+        dtypes={"x": int, "y": int},
+        freq="120s",
+        seed=1,
     ).reset_index(drop=True)
     df = pd.DataFrame(dict(x=np.arange(20), y=np.arange(20)))
     df.to_csv(tmp_path / "data-*.csv", index=False)

--- a/python/dask_cudf/dask_cudf/io/tests/test_json.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_json.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import math
@@ -17,7 +17,9 @@ import dask_cudf
 def test_read_json_backend_dispatch(tmp_path):
     # Test ddf.read_json cudf-backend dispatch
     df1 = dask.datasets.timeseries(
-        dtypes={"x": int, "y": int}, freq="120s"
+        dtypes={"x": int, "y": int},
+        freq="120s",
+        seed=1,
     ).reset_index(drop=True)
     json_path = str(tmp_path / "data-*.json")
     df1.to_json(json_path)
@@ -29,7 +31,9 @@ def test_read_json_backend_dispatch(tmp_path):
 
 def test_read_json(tmp_path):
     df1 = dask.datasets.timeseries(
-        dtypes={"x": int, "y": int}, freq="120s"
+        dtypes={"x": int, "y": int},
+        freq="120s",
+        seed=1,
     ).reset_index(drop=True)
     json_path = str(tmp_path / "data-*.json")
     df1.to_json(json_path)
@@ -99,7 +103,9 @@ def test_read_json_nested(tmp_path):
 
 def test_read_json_aggregate_files(tmp_path):
     df1 = dask.datasets.timeseries(
-        dtypes={"x": int, "y": int}, freq="120s"
+        dtypes={"x": int, "y": int},
+        freq="120s",
+        seed=1,
     ).reset_index(drop=True)
     json_path = str(tmp_path / "data-*.json")
     df1.to_json(json_path)

--- a/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
+++ b/python/dask_cudf/dask_cudf/io/tests/test_parquet.py
@@ -164,7 +164,7 @@ def test_strings(tmpdir):
 
 def test_dask_timeseries_from_pandas(tmpdir):
     fn = str(tmpdir.join("test.parquet"))
-    ddf2 = dask.datasets.timeseries(freq="D")
+    ddf2 = dask.datasets.timeseries(freq="D", seed=1)
     pdf = ddf2.compute()
     pdf.to_parquet(fn, engine="pyarrow")
     read_df = dask_cudf.read_parquet(fn)
@@ -175,7 +175,7 @@ def test_dask_timeseries_from_pandas(tmpdir):
 @pytest.mark.parametrize("divisions", [False, True])
 def test_dask_timeseries_from_dask(tmpdir, index, divisions):
     fn = str(tmpdir)
-    ddf2 = dask.datasets.timeseries(freq="D")
+    ddf2 = dask.datasets.timeseries(freq="D", seed=1)
     ddf2.to_parquet(fn, engine="pyarrow", write_index=index)
     read_df = dask_cudf.read_parquet(
         fn, index=index, calculate_divisions=divisions

--- a/python/dask_cudf/dask_cudf/tests/test_core.py
+++ b/python/dask_cudf/dask_cudf/tests/test_core.py
@@ -369,6 +369,7 @@ def test_repartition_timeseries(start, stop):
         freq="1s",
         partition_freq=start,
         dtypes={"x": int, "y": float},
+        seed=1,
     )
     gdf = pdf.map_partitions(cudf.DataFrame)
 

--- a/python/dask_cudf/dask_cudf/tests/test_distributed.py
+++ b/python/dask_cudf/dask_cudf/tests/test_distributed.py
@@ -51,7 +51,7 @@ def dask_client(worker_id: str):
 @pytest.mark.usefixtures("dask_client")
 @pytest.mark.parametrize("delayed", [True, False])
 def test_basic(delayed):
-    pdf = dask.datasets.timeseries(dtypes={"x": int}).reset_index()
+    pdf = dask.datasets.timeseries(dtypes={"x": int}, seed=1).reset_index()
     gdf = pdf.map_partitions(cudf.DataFrame)
     if delayed:
         gdf = dd.from_delayed(gdf.to_delayed())
@@ -123,6 +123,7 @@ def test_p2p_shuffle():
             start="2000-01-01",
             end="2000-01-08",
             dtypes={"x": int},
+            seed=1,
         )
         .reset_index(drop=True)
         .to_backend("cudf")

--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -518,7 +518,7 @@ def test_groupby_reset_index_string_name():
 
 def test_groupby_categorical_key():
     # See https://github.com/rapidsai/cudf/issues/4608
-    df = dask.datasets.timeseries()
+    df = dask.datasets.timeseries(seed=1)
     gddf = df.to_backend("cudf")
     gddf["name"] = gddf["name"].astype("category")
     ddf = gddf.to_backend("pandas")


### PR DESCRIPTION
## Description
Random data generation in Python tests should have a seed (e.g. see `no-unseeded-default-rng` pre-commit hook) to promote reproducibility.

`dask.datasets.timeseries` can generate random data but isn't covered by this check. This should hopefully avoid flaky failures like in https://github.com/rapidsai/cudf/actions/runs/24686918102/job/72204079317?pr=22221

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
