### PR TITLE
Unwrap ShuffleSorted, Repartition IR during single partition Sort

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/sort.py
+++ b/python/cudf_polars/cudf_polars/experimental/sort.py
@@ -571,8 +571,9 @@ def _(
             f"Falling back to shuffle_method={shuffle_method}.",
             config_options,
         )
-
-    if partition_info[child].count == 1 and not _dynamic_planning_on(config_options):
+    if partition_info[child].count == 1 or not _dynamic_planning_on(config_options):
+        while isinstance(child, (ShuffleSorted, Repartition)):
+            child = child.children[0]
         single_part_node = ir.reconstruct([child])
         partition_info[single_part_node] = partition_info[child]
         return single_part_node, partition_info

--- a/python/cudf_polars/cudf_polars/testing/plugin.py
+++ b/python/cudf_polars/cudf_polars/testing/plugin.py
@@ -392,15 +392,6 @@ RAPIDSMPF_ONLY_EXPECTED_FAILURES: Mapping[str, str] = {
     "tests/unit/sql/test_joins.py::test_join_on_reversed_constraint_order[df12-df22-(df1.a + df1.a) = df2.b-df2.b = (df1.a + df1.a)-expected2-schema2]": "https://github.com/rapidsai/cudf/issues/22105",
     "tests/unit/sql/test_joins.py::test_join_on_unqualified_expressions[df11-df21-x + y = sum-expected1-schema1]": "https://github.com/rapidsai/cudf/issues/22105",
     "tests/unit/sql/test_joins.py::test_join_on_unqualified_expressions[df12-df22-LENGTH(name) = len-expected2-schema2]": "https://github.com/rapidsai/cudf/issues/22105",
-    "tests/unit/sql/test_qualify.py::test_qualify_constraints[above_avg]": "https://github.com/rapidsai/cudf/issues/22050",
-    "tests/unit/sql/test_qualify.py::test_qualify_constraints[equals_max]": "https://github.com/rapidsai/cudf/issues/22050",
-    "tests/unit/sql/test_qualify.py::test_qualify_constraints[compound_expr]": "https://github.com/rapidsai/cudf/issues/22050",
-    "tests/unit/sql/test_qualify.py::test_qualify_distinct": "https://github.com/rapidsai/cudf/issues/22050",
-    "tests/unit/sql/test_qualify.py::test_qualify_matches_all_rows[sum_window]": "https://github.com/rapidsai/cudf/issues/22050",
-    "tests/unit/sql/test_qualify.py::test_qualify_matches_all_rows[count_window]": "https://github.com/rapidsai/cudf/issues/22050",
-    "tests/unit/sql/test_qualify.py::test_qualify_multiple_clauses": "https://github.com/rapidsai/cudf/issues/22050",
-    "tests/unit/sql/test_qualify.py::test_qualify_with_internal_cumulative_sum": "https://github.com/rapidsai/cudf/issues/22050",
-    "tests/unit/sql/test_qualify.py::test_qualify_with_where_clause": "https://github.com/rapidsai/cudf/issues/22050",
 }
 
 


### PR DESCRIPTION
## Description
closes https://github.com/rapidsai/cudf/issues/22050

1. I took the liberty to change the `and` to `or` in the prior `if partition_info[child].count == 1 and not _dynamic_planning_on(config_options)` as IMO even with dynamic planning if a child only has 1 partition (e.g. small data) we should continue constructing a single partition node?
2. As shown in https://github.com/rapidsai/cudf/issues/22050, `sort_actor` assumes we have this `ShuffleSorted(Sort(...))` structure, while we can end up with a more complex nesting involving `Repartition(Sort(...))`. Claude suggested solutions of a) unraveling this nesting during lowering and b) make `sort_actor` more flexible to this nesting and I chose a). Open to other solutions

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
