### PR TITLE
Pin to `pyarrow<24` in type checking environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
           polars,
           "numpy",
           pyarrow-stubs,
+          "pyarrow<24.0.0",  # https://github.com/rapidsai/cudf/issues/22229
           pytest,
           types-cachetools,
           "rmm-cu12==26.6.*,>=0.0.0a0; sys_platform=='linux'",


### PR DESCRIPTION
## Description

This pins our mypy type checking environment to `pyarrow<24`. It has no effect on our actual runtime dependencies.

This is just to unblock CI. I'll follow up later with a PR addressing the type checking errors.

xref https://github.com/rapidsai/cudf/issues/22229