### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
           polars,
           "numpy",
           pyarrow-stubs,
+          "pyarrow<24.0.0",  # https://github.com/rapidsai/cudf/issues/22229
           pytest,
           types-cachetools,
           "rmm-cu12==26.6.*,>=0.0.0a0; sys_platform=='linux'",

--- a/ci/run_cudf_benchmark_smoketests.sh
+++ b/ci/run_cudf_benchmark_smoketests.sh
@@ -1,11 +1,25 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 
-# Support customizing the ctests' install location
-cd "${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/benchmarks/libcudf/";
+# Support customizing the benchmarks' install location
+# First, try the installed location (CI/conda environments)
+installed_benchmark_location="${INSTALL_PREFIX:-${CONDA_PREFIX:-/usr}}/bin/benchmarks/libcudf/"
+# Fall back to the build directory (devcontainer environments)
+devcontainers_benchmark_location="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../cpp/build/latest/benchmarks/"
+
+if [[ -d "${installed_benchmark_location}" ]]; then
+    cd "${installed_benchmark_location}"
+elif [[ -d "${devcontainers_benchmark_location}" ]]; then
+    cd "${devcontainers_benchmark_location}"
+else
+    echo "Error: Benchmark location not found. Searched:" >&2
+    echo "  - ${installed_benchmark_location}" >&2
+    echo "  - ${devcontainers_benchmark_location}" >&2
+    exit 1
+fi
 
 # Ensure that benchmarks are runnable
 # Run a small nvbench benchmark

--- a/cpp/benchmarks/common/memory_stats.hpp
+++ b/cpp/benchmarks/common/memory_stats.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,14 +15,12 @@ namespace cudf {
 class memory_stats_logger {
  public:
   memory_stats_logger()
-    : existing_mr(cudf::get_current_device_resource_ref()),
-      statistics_mr(
-        rmm::mr::statistics_resource_adaptor<rmm::device_async_resource_ref>(existing_mr))
+    : existing_mr(cudf::get_current_device_resource_ref()), statistics_mr(existing_mr)
   {
-    cudf::set_current_device_resource_ref(&statistics_mr);
+    cudf::set_current_device_resource(statistics_mr);
   }
 
-  ~memory_stats_logger() { cudf::set_current_device_resource_ref(existing_mr); }
+  ~memory_stats_logger() { cudf::set_current_device_resource(existing_mr); }
 
   [[nodiscard]] size_t peak_memory_usage() const noexcept
   {
@@ -31,7 +29,7 @@ class memory_stats_logger {
 
  private:
   rmm::device_async_resource_ref existing_mr;
-  rmm::mr::statistics_resource_adaptor<rmm::device_async_resource_ref> statistics_mr;
+  rmm::mr::statistics_resource_adaptor statistics_mr;
 };
 
 }  // namespace cudf

--- a/cpp/benchmarks/fixture/nvbench_fixture.hpp
+++ b/cpp/benchmarks/fixture/nvbench_fixture.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,9 +14,10 @@
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/managed_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
+
+#include <cuda/memory_resource>
 
 #include <string>
 
@@ -34,30 +35,25 @@ static std::string cuio_host_mem_param{
  * Initializes the default memory resource to use the RMM pool device resource.
  */
 struct nvbench_base_fixture {
-  inline auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
+  inline auto make_cuda() { return rmm::mr::cuda_memory_resource{}; }
 
   inline auto make_pool()
   {
-    return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-      make_cuda(), rmm::percent_of_free_device_memory(50));
+    return rmm::mr::pool_memory_resource{make_cuda(), rmm::percent_of_free_device_memory(50)};
   }
 
-  inline auto make_async() { return std::make_shared<rmm::mr::cuda_async_memory_resource>(); }
+  inline auto make_async() { return rmm::mr::cuda_async_memory_resource{}; }
 
-  inline auto make_managed() { return std::make_shared<rmm::mr::managed_memory_resource>(); }
+  inline auto make_managed() { return rmm::mr::managed_memory_resource{}; }
 
-  inline auto make_arena()
-  {
-    return rmm::mr::make_owning_wrapper<rmm::mr::arena_memory_resource>(make_cuda());
-  }
+  inline auto make_arena() { return rmm::mr::arena_memory_resource{make_cuda()}; }
 
   inline auto make_managed_pool()
   {
-    return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-      make_managed(), rmm::percent_of_free_device_memory(50));
+    return rmm::mr::pool_memory_resource{make_managed(), rmm::percent_of_free_device_memory(50)};
   }
 
-  inline std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(
+  inline cuda::mr::any_resource<cuda::mr::device_accessible> create_memory_resource(
     std::string const& mode)
   {
     if (mode == "cuda") return make_cuda();
@@ -101,7 +97,7 @@ struct nvbench_base_fixture {
     }
 
     mr = create_memory_resource(rmm_mode);
-    cudf::set_current_device_resource(mr.get());
+    cudf::set_current_device_resource(mr);
     std::cout << "RMM memory resource = " << rmm_mode << "\n";
 
     cudf::set_pinned_memory_resource(create_cuio_host_memory_resource(cuio_host_mode));
@@ -114,7 +110,7 @@ struct nvbench_base_fixture {
     cudf::set_pinned_memory_resource(this->make_cuio_host_pinned());
   }
 
-  std::shared_ptr<rmm::mr::device_memory_resource> mr;
+  cuda::mr::any_resource<cuda::mr::device_accessible> mr;
   std::string rmm_mode{"pool"};
 
   std::string cuio_host_mode{"pinned_pool"};

--- a/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_composer.cpp
+++ b/cpp/benchmarks/io/parquet/experimental/hybrid_scan/hybrid_scan_composer.cpp
@@ -106,8 +106,7 @@ std::vector<cudf::size_type> apply_row_group_filters(
       bloom_filter_byte_ranges.size()) {
     // Fetch 32-byte aligned bloom filter data buffers from the input file buffer
     auto constexpr bloom_filter_alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
-    auto aligned_mr = rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>(
-      mr, bloom_filter_alignment);
+    auto aligned_mr = rmm::mr::aligned_resource_adaptor(mr, bloom_filter_alignment);
     auto [bloom_filter_buffers, bloom_filter_data, bloom_read_tasks] =
       cudf::io::parquet::fetch_byte_ranges_to_device_async(
         datasource, bloom_filter_byte_ranges, stream, aligned_mr);

--- a/cpp/benchmarks/ndsh/utilities.cpp
+++ b/cpp/benchmarks/ndsh/utilities.cpp
@@ -22,7 +22,6 @@
 #include <cudf/utilities/default_stream.hpp>
 
 #include <rmm/mr/managed_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <algorithm>
@@ -388,12 +387,6 @@ void write_to_parquet_device_buffer(std::unique_ptr<cudf::table> const& table,
   cudf::io::write_parquet(options, stream);
 }
 
-inline auto make_managed_pool()
-{
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-    std::make_shared<rmm::mr::managed_memory_resource>(), rmm::percent_of_free_device_memory(50));
-}
-
 void generate_parquet_data_sources(double scale_factor,
                                    std::vector<std::string> const& table_names,
                                    std::unordered_map<std::string, cuio_source_sink_pair>& sources)
@@ -403,9 +396,9 @@ void generate_parquet_data_sources(double scale_factor,
   // Set the memory resource to the managed pool
   auto old_mr = cudf::get_current_device_resource_ref();
   // TODO: if old_mr is already managed pool or managed, don't create new one.
-  using managed_pool_mr_t           = decltype(make_managed_pool());
-  managed_pool_mr_t managed_pool_mr = make_managed_pool();
-  cudf::set_current_device_resource_ref(managed_pool_mr.get());
+  rmm::mr::pool_memory_resource managed_pool_mr{rmm::mr::managed_memory_resource{},
+                                                rmm::percent_of_free_device_memory(50)};
+  cudf::set_current_device_resource(managed_pool_mr);
   // drawback: if already pool takes 50% of free memory, we are left with 50% of 50% of free memory
 
   std::unordered_set<std::string> const requested_table_names = [&table_names]() {
@@ -469,5 +462,5 @@ void generate_parquet_data_sources(double scale_factor,
   }
 
   // Restore the original memory resource
-  cudf::set_current_device_resource_ref(old_mr);
+  cudf::set_current_device_resource(old_mr);
 }

--- a/cpp/examples/basic/src/process_csv.cpp
+++ b/cpp/examples/basic/src/process_csv.cpp
@@ -67,18 +67,18 @@ int main(int argc, char** argv)
 {
   // Construct a CUDA memory resource using RAPIDS Memory Manager (RMM)
   // This is the default memory resource for libcudf for allocating device memory.
-  rmm::mr::cuda_memory_resource cuda_mr{};
   // Construct a memory pool using the CUDA memory resource
   // Using a memory pool for device memory allocations is important for good performance in libcudf.
   // The pool defaults to allocating half of the available GPU memory.
-  rmm::mr::pool_memory_resource mr{&cuda_mr, rmm::percent_of_free_device_memory(50)};
+  rmm::mr::pool_memory_resource mr{rmm::mr::cuda_memory_resource{},
+                                   rmm::percent_of_free_device_memory(50)};
 
   // Set the pool resource to be used by default for all device memory allocations
   // Note: It is the user's responsibility to ensure the `mr` object stays alive for the duration of
   // it being set as the default
   // Also, call this before the first libcudf API call to ensure all data is allocated by the same
   // memory resource.
-  cudf::set_current_device_resource(&mr);
+  cudf::set_current_device_resource(mr);
 
   // Read data
   auto stock_table_with_metadata = read_csv("4stock_5day.csv");

--- a/cpp/examples/billion_rows/brc.cpp
+++ b/cpp/examples/billion_rows/brc.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "common.hpp"
@@ -34,9 +34,8 @@ int main(int argc, char const** argv)
 
   auto const mr_name = std::string("pool");
   auto resource      = create_memory_resource(mr_name);
-  auto stats_mr =
-    rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource>(resource.get());
-  rmm::mr::set_current_device_resource(&stats_mr);
+  auto stats_mr      = rmm::mr::statistics_resource_adaptor{resource};
+  rmm::mr::set_current_device_resource(stats_mr);
   auto stream = cudf::get_default_stream();
 
   auto start = std::chrono::steady_clock::now();

--- a/cpp/examples/billion_rows/brc_chunks.cpp
+++ b/cpp/examples/billion_rows/brc_chunks.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "common.hpp"
@@ -56,9 +56,8 @@ int main(int argc, char const** argv)
 
   auto const mr_name = std::string("pool");
   auto resource      = create_memory_resource(mr_name);
-  auto stats_mr =
-    rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource>(resource.get());
-  rmm::mr::set_current_device_resource(&stats_mr);
+  auto stats_mr      = rmm::mr::statistics_resource_adaptor{resource};
+  rmm::mr::set_current_device_resource(stats_mr);
   auto stream = cudf::get_default_stream();
 
   std::filesystem::path p = input_file;

--- a/cpp/examples/billion_rows/brc_pipeline.cpp
+++ b/cpp/examples/billion_rows/brc_pipeline.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "common.hpp"
@@ -104,9 +104,8 @@ int main(int argc, char const** argv)
 
   auto const mr_name = std::string("pool");
   auto resource      = create_memory_resource(mr_name);
-  auto stats_mr =
-    rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource>(resource.get());
-  rmm::mr::set_current_device_resource(&stats_mr);
+  auto stats_mr      = rmm::mr::statistics_resource_adaptor{resource};
+  rmm::mr::set_current_device_resource(stats_mr);
   auto stream = cudf::get_default_stream();
 
   std::filesystem::path p = input_file;

--- a/cpp/examples/billion_rows/common.hpp
+++ b/cpp/examples/billion_rows/common.hpp
@@ -1,36 +1,26 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
 
 #include <string>
 
 /**
- * @brief Create CUDA memory resource
- */
-auto make_cuda_mr() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
-
-/**
- * @brief Create a pool device memory resource
- */
-auto make_pool_mr()
-{
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-    make_cuda_mr(), rmm::percent_of_free_device_memory(50));
-}
-
-/**
  * @brief Create memory resource for libcudf functions
  */
-std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(std::string const& name)
+cuda::mr::any_resource<cuda::mr::device_accessible> create_memory_resource(std::string const& name)
 {
-  if (name == "pool") { return make_pool_mr(); }
-  return make_cuda_mr();
+  rmm::mr::cuda_memory_resource cuda_mr{};
+  if (name == "pool") {
+    return rmm::mr::pool_memory_resource{cuda_mr, rmm::percent_of_free_device_memory(50)};
+  }
+  return cuda_mr;
 }

--- a/cpp/examples/hybrid_scan_io/common_utils.cpp
+++ b/cpp/examples/hybrid_scan_io/common_utils.cpp
@@ -13,7 +13,6 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <cuda/iterator>
@@ -35,13 +34,13 @@ bool get_boolean(std::string input)
   return input == "ON" or input == "TRUE" or input == "YES" or input == "Y" or input == "T";
 }
 
-std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(bool is_pool_used)
+cuda::mr::any_resource<cuda::mr::device_accessible> create_memory_resource(bool is_pool_used)
 {
   if (is_pool_used) {
-    return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-      std::make_shared<rmm::mr::cuda_memory_resource>(), rmm::percent_of_free_device_memory(80));
+    return rmm::mr::pool_memory_resource{rmm::mr::cuda_memory_resource{},
+                                         rmm::percent_of_free_device_memory(80)};
   }
-  return std::make_shared<rmm::mr::cuda_async_memory_resource>();
+  return rmm::mr::cuda_async_memory_resource{};
 }
 
 cudf::ast::operation create_filter_expression(std::string const& column_name,

--- a/cpp/examples/hybrid_scan_io/common_utils.hpp
+++ b/cpp/examples/hybrid_scan_io/common_utils.hpp
@@ -14,7 +14,11 @@
 #include <cudf/table/table_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/cuda_async_memory_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
 
 #include <string>
 #include <vector>
@@ -38,7 +42,7 @@
  * @param pool Whether to use a pool memory resource.
  * @return Memory resource instance
  */
-std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(bool is_pool_used);
+cuda::mr::any_resource<cuda::mr::device_accessible> create_memory_resource(bool is_pool_used);
 
 /**
  * @brief Create a filter expression of the form `column_name == literal` for string type point

--- a/cpp/examples/hybrid_scan_io/hybrid_scan_composer.cpp
+++ b/cpp/examples/hybrid_scan_io/hybrid_scan_composer.cpp
@@ -177,8 +177,7 @@ std::vector<cudf::size_type> apply_row_group_filters(
       bloom_filter_byte_ranges.size()) {
     // Fetch 32-byte aligned bloom filter data buffers from the input file buffer
     auto constexpr bloom_filter_alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
-    auto aligned_mr = rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>(
-      temp_mr, bloom_filter_alignment);
+    auto aligned_mr = rmm::mr::aligned_resource_adaptor(temp_mr, bloom_filter_alignment);
     if (verbose) { std::cout << "READER: Filter row groups with bloom filters...\n"; }
     timer.reset();
     nvtxRangePush("fetch_bloom_filter_byte_ranges");

--- a/cpp/examples/hybrid_scan_io/hybrid_scan_io.cpp
+++ b/cpp/examples/hybrid_scan_io/hybrid_scan_io.cpp
@@ -10,7 +10,6 @@
 
 #include <cudf/table/table_view.hpp>
 
-#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 
 #include <filesystem>
@@ -112,9 +111,8 @@ int main(int argc, char const** argv)
   auto constexpr is_pool_used = false;
   auto stream                 = cudf::get_default_stream();
   auto resource               = create_memory_resource(is_pool_used);
-  auto stats_mr =
-    rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource>(resource.get());
-  rmm::mr::set_current_device_resource(&stats_mr);
+  auto stats_mr               = rmm::mr::statistics_resource_adaptor{resource};
+  rmm::mr::set_current_device_resource(stats_mr);
 
   // Create filter expression
   auto const column_reference = cudf::ast::column_name_reference(column_name);

--- a/cpp/examples/hybrid_scan_io/hybrid_scan_multifile_single_step.cpp
+++ b/cpp/examples/hybrid_scan_io/hybrid_scan_multifile_single_step.cpp
@@ -14,7 +14,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream_pool.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 
 #include <ranges>
@@ -146,9 +145,8 @@ int main(int argc, char const** argv)
   auto resource               = create_memory_resource(is_pool_used);
   auto stream_pool = rmm::cuda_stream_pool(1 + num_threads, rmm::cuda_stream::flags::non_blocking);
   auto default_stream = stream_pool.get_stream();
-  auto stats_mr =
-    rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource>(resource.get());
-  rmm::mr::set_current_device_resource(&stats_mr);
+  auto stats_mr       = rmm::mr::statistics_resource_adaptor{resource};
+  rmm::mr::set_current_device_resource(stats_mr);
 
   // List of input sources from the input_paths string.
   auto const input_sources = [&]() {

--- a/cpp/examples/hybrid_scan_io/hybrid_scan_multifile_two_step.cpp
+++ b/cpp/examples/hybrid_scan_io/hybrid_scan_multifile_two_step.cpp
@@ -14,7 +14,6 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream_pool.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 
 #include <ranges>
@@ -152,9 +151,8 @@ int main(int argc, char const** argv)
   auto resource               = create_memory_resource(is_pool_used);
   auto stream_pool = rmm::cuda_stream_pool(1 + num_threads, rmm::cuda_stream::flags::non_blocking);
   auto default_stream = stream_pool.get_stream();
-  auto stats_mr =
-    rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource>(resource.get());
-  rmm::mr::set_current_device_resource(&stats_mr);
+  auto stats_mr       = rmm::mr::statistics_resource_adaptor{resource};
+  rmm::mr::set_current_device_resource(stats_mr);
 
   // Create filter expressions (one per thread; reused circularly if needed)
   auto const column_reference = cudf::ast::column_name_reference(column_name);

--- a/cpp/examples/hybrid_scan_io/hybrid_scan_pipeline.cpp
+++ b/cpp/examples/hybrid_scan_io/hybrid_scan_pipeline.cpp
@@ -362,8 +362,8 @@ int main(int argc, char const** argv)
     rmm::cuda_stream_pool(1 + num_partitions, rmm::cuda_stream::flags::non_blocking);
   auto default_stream = stream_pool.get_stream();
   auto mr             = create_memory_resource(is_pool_used);
-  auto stats_mr = rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource>(mr.get());
-  rmm::mr::set_current_device_resource(&stats_mr);
+  auto stats_mr       = rmm::mr::statistics_resource_adaptor{mr};
+  rmm::mr::set_current_device_resource(stats_mr);
 
   // Create io source
   auto const data_source = io_source{input_filepath, io_source_type, default_stream};

--- a/cpp/examples/nested_types/deduplication.cpp
+++ b/cpp/examples/nested_types/deduplication.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,9 +17,10 @@
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
 
 #include <iostream>
 #include <string>
@@ -44,12 +45,11 @@
  * @param pool Whether to use a pool memory resource.
  * @return Memory resource instance
  */
-std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(bool pool)
+cuda::mr::any_resource<cuda::mr::device_accessible> create_memory_resource(bool pool)
 {
-  auto cuda_mr = std::make_shared<rmm::mr::cuda_memory_resource>();
+  rmm::mr::cuda_memory_resource cuda_mr{};
   if (pool) {
-    return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-      cuda_mr, rmm::percent_of_free_device_memory(50));
+    return rmm::mr::pool_memory_resource{cuda_mr, rmm::percent_of_free_device_memory(50)};
   }
   return cuda_mr;
 }
@@ -181,7 +181,7 @@ int main(int argc, char const** argv)
 
   auto pool     = mr_name == "pool";
   auto resource = create_memory_resource(pool);
-  cudf::set_current_device_resource(resource.get());
+  cudf::set_current_device_resource(resource);
 
   std::cout << "Reading " << input_filepath << "..." << std::endl;
   // read input file

--- a/cpp/examples/parquet_inspect/parquet_inspect.cpp
+++ b/cpp/examples/parquet_inspect/parquet_inspect.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -74,8 +74,8 @@ int main(int argc, char const** argv)
 
   auto const stream           = cudf::get_default_stream();
   auto constexpr is_pool_used = false;
-  auto const mr               = create_memory_resource(is_pool_used);
-  cudf::set_current_device_resource(mr.get());
+  auto mr                     = create_memory_resource(is_pool_used);
+  cudf::set_current_device_resource(mr);
 
   // Read parquet footer metadata
   auto [metadata, has_page_index] = read_parquet_file_metadata(input_filepath);

--- a/cpp/examples/parquet_inspect/parquet_inspect_utils.cpp
+++ b/cpp/examples/parquet_inspect/parquet_inspect_utils.cpp
@@ -20,15 +20,12 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <cuda/iterator>
 
 #include <filesystem>
 #include <fstream>
-#include <memory>
 #include <numeric>
 
 /**
@@ -194,13 +191,13 @@ auto make_page_data_list_column(cudf::host_span<T const> data,
 
 }  // namespace
 
-std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(bool is_pool_used)
+cuda::mr::any_resource<cuda::mr::device_accessible> create_memory_resource(bool is_pool_used)
 {
   if (is_pool_used) {
-    return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-      std::make_shared<rmm::mr::cuda_memory_resource>(), rmm::percent_of_free_device_memory(50));
+    return rmm::mr::pool_memory_resource{rmm::mr::cuda_memory_resource{},
+                                         rmm::percent_of_free_device_memory(50)};
   }
-  return std::make_shared<rmm::mr::cuda_async_memory_resource>();
+  return rmm::mr::cuda_async_memory_resource{};
 }
 
 std::tuple<cudf::io::parquet::FileMetaData, bool> read_parquet_file_metadata(

--- a/cpp/examples/parquet_inspect/parquet_inspect_utils.hpp
+++ b/cpp/examples/parquet_inspect/parquet_inspect_utils.hpp
@@ -10,7 +10,11 @@
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/cuda_async_memory_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
 
 /**
  * @file parquet_inspect_utils.hpp
@@ -23,7 +27,7 @@
  * @param pool Whether to use a pool memory resource.
  * @return Memory resource instance
  */
-std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(bool is_pool_used);
+cuda::mr::any_resource<cuda::mr::device_accessible> create_memory_resource(bool is_pool_used);
 
 /**
  * @brief Reads parquet metadata (FileMetaData struct) from a file

--- a/cpp/examples/parquet_io/common_utils.cpp
+++ b/cpp/examples/parquet_io/common_utils.cpp
@@ -11,7 +11,6 @@
 #include <cudf/table/table_view.hpp>
 
 #include <rmm/mr/cuda_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <chrono>
@@ -24,12 +23,11 @@
  *
  */
 
-std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(bool is_pool_used)
+cuda::mr::any_resource<cuda::mr::device_accessible> create_memory_resource(bool is_pool_used)
 {
-  auto cuda_mr = std::make_shared<rmm::mr::cuda_memory_resource>();
+  rmm::mr::cuda_memory_resource cuda_mr{};
   if (is_pool_used) {
-    return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-      cuda_mr, rmm::percent_of_free_device_memory(50));
+    return rmm::mr::pool_memory_resource{cuda_mr, rmm::percent_of_free_device_memory(50)};
   }
   return cuda_mr;
 }

--- a/cpp/examples/parquet_io/common_utils.hpp
+++ b/cpp/examples/parquet_io/common_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,9 +9,12 @@
 #include <cudf/table/table_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
 
-#include <memory>
+#include <cuda/memory_resource>
+
 #include <string>
 
 /**
@@ -26,7 +29,7 @@
  * @param pool Whether to use a pool memory resource.
  * @return Memory resource instance
  */
-std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(bool is_pool_used);
+cuda::mr::any_resource<cuda::mr::device_accessible> create_memory_resource(bool is_pool_used);
 
 /**
  * @brief Get encoding type from the keyword

--- a/cpp/examples/parquet_io/parquet_io.cpp
+++ b/cpp/examples/parquet_io/parquet_io.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -129,7 +129,7 @@ int main(int argc, char const** argv)
   // Create and use a memory pool
   bool constexpr is_pool_used = true;
   auto resource               = create_memory_resource(is_pool_used);
-  cudf::set_current_device_resource(resource.get());
+  cudf::set_current_device_resource(resource);
 
   // Read input parquet file
   // We do not want to time the initial read time as it may include

--- a/cpp/examples/parquet_io/parquet_io_multithreaded.cpp
+++ b/cpp/examples/parquet_io/parquet_io_multithreaded.cpp
@@ -13,7 +13,6 @@
 #include <cudf/table/table_view.hpp>
 
 #include <rmm/cuda_stream_pool.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 
 #include <cuda/iterator>
@@ -358,9 +357,8 @@ int32_t main(int argc, char const** argv)
   auto resource               = create_memory_resource(is_pool_used);
   auto default_stream         = cudf::get_default_stream();
   auto stream_pool = rmm::cuda_stream_pool(thread_count, rmm::cuda_stream::flags::non_blocking);
-  auto stats_mr =
-    rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource>(resource.get());
-  rmm::mr::set_current_device_resource(&stats_mr);
+  auto stats_mr    = rmm::mr::statistics_resource_adaptor{resource};
+  rmm::mr::set_current_device_resource(stats_mr);
 
   // List of input sources from the input_paths string.
   auto const input_sources = extract_input_sources(

--- a/cpp/examples/string_transforms/common.hpp
+++ b/cpp/examples/string_transforms/common.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -17,14 +17,11 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
 
 #include <chrono>
 #include <iostream>
-#include <memory>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -37,37 +34,6 @@
  */
 std::tuple<std::unique_ptr<cudf::column>, std::vector<int32_t>> transform(
   cudf::table_view const& table);
-
-/**
- * @brief Create CUDA memory resource
- */
-auto make_cuda_mr() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
-
-/**
- * @brief Create a pool device memory resource
- */
-auto make_pool_mr()
-{
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-    make_cuda_mr(), rmm::percent_of_free_device_memory(50));
-}
-
-auto make_async_mr() { return std::make_shared<rmm::mr::cuda_async_memory_resource>(); }
-
-/**
- * @brief Create memory resource for libcudf functions
- */
-std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(std::string const& name)
-{
-  if (name == "pool" || name == "pool-stats") {
-    return make_pool_mr();
-  } else if (name == "async" || name == "async-stats") {
-    return make_async_mr();
-  } else if (name == "cuda" || name == "cuda-stats") {
-    return make_cuda_mr();
-  }
-  CUDF_FAIL("Unrecognized memory resource name: " + name, std::invalid_argument);
-}
 
 void write_csv(cudf::table_view const& tbl_view,
                std::string const& file_path,
@@ -105,17 +71,28 @@ int main(int argc, char const** argv)
     std::string{argc > 4 ? std::string(argv[4]) : std::string("cuda")};
   auto const enable_stats = memory_resource_name.ends_with("-stats");
 
-  auto resource = create_memory_resource(memory_resource_name);
-  auto stream   = cudf::get_default_stream();
+  auto stream = cudf::get_default_stream();
 
-  rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource> stats_adaptor{
-    resource.get()};
+  rmm::mr::cuda_memory_resource cuda_mr{};
+  rmm::mr::pool_memory_resource pool_mr{cuda_mr, rmm::percent_of_free_device_memory(50)};
+  rmm::mr::cuda_async_memory_resource async_mr{};
 
-  if (enable_stats) {
-    cudf::set_current_device_resource(&stats_adaptor);
+  auto const base_name = enable_stats
+                           ? memory_resource_name.substr(0, memory_resource_name.size() - 6)
+                           : memory_resource_name;
+  if (base_name == "pool") {
+    cudf::set_current_device_resource(pool_mr);
+  } else if (base_name == "async") {
+    cudf::set_current_device_resource(async_mr);
+  } else if (base_name == "cuda") {
+    cudf::set_current_device_resource(cuda_mr);
   } else {
-    cudf::set_current_device_resource(resource.get());
+    CUDF_FAIL("Unrecognized memory resource name: " + memory_resource_name, std::invalid_argument);
   }
+
+  rmm::mr::statistics_resource_adaptor stats_adaptor{cudf::get_current_device_resource_ref()};
+
+  if (enable_stats) { cudf::set_current_device_resource(stats_adaptor); }
 
   cudf::io::csv_reader_options in_opts =
     cudf::io::csv_reader_options::builder(cudf::io::source_info{in_csv}).header(0);

--- a/cpp/examples/strings/common.hpp
+++ b/cpp/examples/strings/common.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,13 +14,10 @@
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <chrono>
 #include <iostream>
-#include <memory>
 #include <string>
 
 /**
@@ -42,29 +39,6 @@ std::unique_ptr<cudf::column> redact_strings(cudf::column_view const& names,
                                              cudf::column_view const& visibilities);
 
 /**
- * @brief Create CUDA memory resource
- */
-auto make_cuda_mr() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
-
-/**
- * @brief Create a pool device memory resource
- */
-auto make_pool_mr()
-{
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-    make_cuda_mr(), rmm::percent_of_free_device_memory(50));
-}
-
-/**
- * @brief Create memory resource for libcudf functions
- */
-std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(std::string const& name)
-{
-  if (name == "pool") { return make_pool_mr(); }
-  return make_cuda_mr();
-}
-
-/**
  * @brief Main for strings examples
  *
  * Command line parameters:
@@ -81,8 +55,13 @@ int main(int argc, char const** argv)
   }
 
   auto const mr_name = std::string{argc > 2 ? std::string(argv[2]) : std::string("cuda")};
-  auto resource      = create_memory_resource(mr_name);
-  cudf::set_current_device_resource(resource.get());
+  rmm::mr::cuda_memory_resource cuda_mr{};
+  rmm::mr::pool_memory_resource pool_mr{cuda_mr, rmm::percent_of_free_device_memory(50)};
+  if (mr_name == "pool") {
+    cudf::set_current_device_resource(pool_mr);
+  } else {
+    cudf::set_current_device_resource(cuda_mr);
+  }
 
   auto const csv_file   = std::string{argv[1]};
   auto const csv_result = [csv_file] {

--- a/cpp/include/cudf/column/column.hpp
+++ b/cpp/include/cudf/column/column.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -44,7 +44,7 @@ class column {
    * @brief Construct a new column object by deep copying the contents of
    *`other`.
    *
-   * Uses the specified `stream` and device_memory_resource for all allocations
+   * Uses the specified `stream` and device memory resource for all allocations
    * and copies.
    *
    * @param other The `column` to copy

--- a/cpp/include/cudf/detail/utilities/host_vector.hpp
+++ b/cpp/include/cudf/detail/utilities/host_vector.hpp
@@ -140,7 +140,7 @@ class rmm_host_allocator {
   inline pointer allocate(size_type cnt)
   {
     if (cnt > this->max_size()) { throw std::bad_alloc(); }  // end if
-    auto const result = mr.allocate(stream, cnt * sizeof(value_type));
+    auto const result = mr.allocate(stream, cnt * sizeof(value_type), alignof(value_type));
     // Synchronize to ensure the memory is allocated before thrust::host_vector initialization
     // TODO: replace thrust::host_vector with a type that does not require synchronization
     stream.synchronize();
@@ -159,7 +159,7 @@ class rmm_host_allocator {
    */
   inline void deallocate(pointer p, size_type cnt) noexcept
   {
-    mr.deallocate(stream, p, cnt * sizeof(value_type));
+    mr.deallocate(stream, p, cnt * sizeof(value_type), alignof(value_type));
   }
 
   /**

--- a/cpp/include/cudf/detail/utilities/vector_factories.hpp
+++ b/cpp/include/cudf/detail/utilities/vector_factories.hpp
@@ -22,6 +22,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <type_traits>
 #include <vector>

--- a/cpp/include/cudf/replace.hpp
+++ b/cpp/include/cudf/replace.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -271,7 +271,7 @@ std::unique_ptr<column> clamp(
  * @throws cudf::logic_error if column does not have floating point data type.
  * @param[in] input column_view of floating-point elements to copy and normalize
  * @param stream CUDA stream used for device memory operations and kernel launches
- * @param[in] mr device_memory_resource allocator for allocating output data
+ * @param[in] mr Device memory resource for allocating output data
  *
  * @returns new column with the modified data
  */

--- a/cpp/include/cudf/table/table.hpp
+++ b/cpp/include/cudf/table/table.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -37,7 +37,7 @@ class table {
   /**
    * @brief Construct a new table by copying the contents of another table.
    *
-   * Uses the specified `stream` and device_memory_resource for all allocations
+   * Uses the specified `stream` and device memory resource for all allocations
    * and copies.
    *
    * @param other The table to copy

--- a/cpp/include/cudf/utilities/memory_resource.hpp
+++ b/cpp/include/cudf/utilities/memory_resource.hpp
@@ -1,14 +1,15 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
 
 namespace cudf {
 
@@ -25,42 +26,61 @@ namespace cudf {
  */
 inline rmm::device_async_resource_ref get_current_device_resource_ref()
 {
-  // For now, match current behavior which is to return current resource pointer
-  return rmm::mr::get_current_device_resource();
+  return rmm::mr::get_current_device_resource_ref();
 }
 
 /**
  * @brief Set the current device memory resource.
  *
  * @param mr The new device memory resource.
- * @return The previous device memory resource.
+ * @return An owning any_resource holding the previous resource.
  */
-inline rmm::mr::device_memory_resource* set_current_device_resource(
-  rmm::mr::device_memory_resource* mr)
+inline cuda::mr::any_resource<cuda::mr::device_accessible> set_current_device_resource(
+  cuda::mr::any_resource<cuda::mr::device_accessible> mr)
 {
-  return rmm::mr::set_current_device_resource(mr);
+  return rmm::mr::set_current_device_resource(std::move(mr));
 }
 
 /**
  * @brief Set the current device memory resource reference.
  *
+ * @deprecated Use `set_current_device_resource` instead.
+ *
+ * The object referenced by `mr` must outlive the last use of the resource, otherwise behavior is
+ * undefined. It is the caller's responsibility to maintain the lifetime of the resource object.
+ *
  * @param mr The new device memory resource reference.
- * @return The previous device memory resource reference.
+ * @return An owning any_resource holding the previous resource.
  */
-inline rmm::device_async_resource_ref set_current_device_resource_ref(
-  rmm::device_async_resource_ref mr)
+[[deprecated("Use set_current_device_resource instead.")]]  //
+inline cuda::mr::any_resource<cuda::mr::device_accessible>
+set_current_device_resource_ref(rmm::device_async_resource_ref mr)
 {
-  return rmm::mr::set_current_device_resource_ref(mr);
+  return set_current_device_resource(cuda::mr::any_resource<cuda::mr::device_accessible>{mr});
+}
+
+/**
+ * @brief Reset the current device memory resource to the initial resource.
+ *
+ * @return An owning any_resource holding the previous resource.
+ */
+inline cuda::mr::any_resource<cuda::mr::device_accessible> reset_current_device_resource()
+{
+  return rmm::mr::reset_current_device_resource();
 }
 
 /**
  * @brief Reset the current device memory resource reference to the initial resource.
  *
- * @return The previous device memory resource reference.
+ * @deprecated Use `reset_current_device_resource` instead.
+ *
+ * @return An owning any_resource holding the previous resource.
  */
-inline rmm::device_async_resource_ref reset_current_device_resource_ref()
+[[deprecated("Use reset_current_device_resource instead.")]]  //
+inline cuda::mr::any_resource<cuda::mr::device_accessible>
+reset_current_device_resource_ref()
 {
-  return rmm::mr::reset_current_device_resource_ref();
+  return reset_current_device_resource();
 }
 
 /** @} */  // end of group

--- a/cpp/include/cudf/utilities/roaring_bitmap.hpp
+++ b/cpp/include/cudf/utilities/roaring_bitmap.hpp
@@ -13,7 +13,7 @@
 #include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <cuda/std/cstddef>
 

--- a/cpp/include/cudf_test/base_fixture.hpp
+++ b/cpp/include/cudf_test/base_fixture.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,9 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/traits.hpp>
 
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
 
 namespace CUDF_EXPORT cudf {
 namespace test {
@@ -26,13 +28,13 @@ namespace test {
  * ```
  */
 class BaseFixture : public ::testing::Test {
-  rmm::device_async_resource_ref _mr{cudf::get_current_device_resource_ref()};
+  cuda::mr::any_resource<cuda::mr::device_accessible> _mr{cudf::get_current_device_resource_ref()};
 
  public:
   /**
-   * @brief Returns pointer to `device_memory_resource` that should be used for
+   * @brief Returns reference to `device_async_resource_ref` that should be used for
    * all tests inheriting from this fixture
-   * @return pointer to memory resource
+   * @return reference to memory resource
    */
   rmm::device_async_resource_ref mr() { return _mr; }
 };
@@ -47,15 +49,15 @@ class BaseFixture : public ::testing::Test {
  */
 template <typename T>
 class BaseFixtureWithParam : public ::testing::TestWithParam<T> {
-  rmm::device_async_resource_ref _mr{cudf::get_current_device_resource_ref()};
+  cuda::mr::any_resource<cuda::mr::device_accessible> _mr{cudf::get_current_device_resource_ref()};
 
  public:
   /**
-   * @brief Returns pointer to `device_memory_resource` that should be used for
+   * @brief Returns reference to `device_async_resource_ref` that should be used for
    * all tests inheriting from this fixture
-   * @return pointer to memory resource
+   * @return reference to memory resource
    */
-  [[nodiscard]] rmm::device_async_resource_ref mr() const { return _mr; }
+  [[nodiscard]] rmm::device_async_resource_ref mr() { return _mr; }
 };
 
 /**

--- a/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
+++ b/cpp/include/cudf_test/stream_checking_resource_adaptor.hpp
@@ -8,8 +8,14 @@
 
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
 
+#include <cuda/memory_resource>
+#include <cuda/stream_ref>
+
+#include <cstddef>
 #include <iostream>
 
 namespace cudf::test {
@@ -17,30 +23,28 @@ namespace cudf::test {
 /**
  * @brief Resource that verifies that the default stream is not used in any allocation.
  */
-class stream_checking_resource_adaptor final : public rmm::mr::device_memory_resource {
+class stream_checking_resource_adaptor final {
  public:
   /**
    * @brief Construct a new adaptor.
-   *
-   * @throws `cudf::logic_error` if `upstream == nullptr`
    *
    * @param upstream The resource used for allocating/deallocating device memory
    * @param error_on_invalid_stream Whether to error on invalid streams
    * @param check_default_stream Whether to check for the default stream
    */
-  stream_checking_resource_adaptor(rmm::device_async_resource_ref upstream,
+  stream_checking_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                                    bool error_on_invalid_stream,
                                    bool check_default_stream)
-    : upstream_{upstream},
+    : upstream_{std::move(upstream)},
       error_on_invalid_stream_{error_on_invalid_stream},
       check_default_stream_{check_default_stream}
   {
   }
 
   stream_checking_resource_adaptor()                                                   = delete;
-  ~stream_checking_resource_adaptor() override                                         = default;
-  stream_checking_resource_adaptor(stream_checking_resource_adaptor const&)            = delete;
-  stream_checking_resource_adaptor& operator=(stream_checking_resource_adaptor const&) = delete;
+  ~stream_checking_resource_adaptor()                                                  = default;
+  stream_checking_resource_adaptor(stream_checking_resource_adaptor const&)            = default;
+  stream_checking_resource_adaptor& operator=(stream_checking_resource_adaptor const&) = default;
   stream_checking_resource_adaptor(stream_checking_resource_adaptor&&) noexcept        = default;
   stream_checking_resource_adaptor& operator=(stream_checking_resource_adaptor&&) noexcept =
     default;
@@ -52,59 +56,55 @@ class stream_checking_resource_adaptor final : public rmm::mr::device_memory_res
    */
   [[nodiscard]] rmm::device_async_resource_ref get_upstream_resource() const noexcept
   {
-    return upstream_;
+    return rmm::device_async_resource_ref{
+      const_cast<cuda::mr::any_resource<cuda::mr::device_accessible>&>(upstream_)};
+  }
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+  {
+    return upstream_.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  }
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    upstream_.deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+  }
+
+  void* allocate(cuda::stream_ref stream,
+                 std::size_t bytes,
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+  {
+    verify_stream(rmm::cuda_stream_view{stream.get()});
+    return upstream_.allocate(stream, bytes, alignment);
+  }
+
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    verify_stream(rmm::cuda_stream_view{stream.get()});
+    upstream_.deallocate(stream, ptr, bytes, alignment);
+  }
+
+  bool operator==(stream_checking_resource_adaptor const& other) const noexcept
+  {
+    return get_upstream_resource() == other.get_upstream_resource();
+  }
+
+  bool operator!=(stream_checking_resource_adaptor const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  friend void get_property(stream_checking_resource_adaptor const&,
+                           cuda::mr::device_accessible) noexcept
+  {
   }
 
  private:
-  /**
-   * @brief Allocates memory of size at least `bytes` using the upstream
-   * resource as long as it fits inside the allocation limit.
-   *
-   * The returned pointer has at least 256B alignment.
-   *
-   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
-   * by the upstream resource.
-   * @throws `cudf::logic_error` if attempted on a default stream
-   *
-   * @param bytes The size, in bytes, of the allocation
-   * @param stream Stream on which to perform the allocation
-   * @return Pointer to the newly allocated memory
-   */
-  void* do_allocate(std::size_t bytes, rmm::cuda_stream_view stream) override
-  {
-    verify_stream(stream);
-    return upstream_.allocate(stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  }
-
-  /**
-   * @brief Free allocation of size `bytes` pointed to by `ptr`
-   *
-   * @throws `cudf::logic_error` if attempted on a default stream
-   *
-   * @param ptr Pointer to be deallocated
-   * @param bytes Size of the allocation
-   * @param stream Stream on which to perform the deallocation
-   */
-  void do_deallocate(void* ptr, std::size_t bytes, rmm::cuda_stream_view stream) noexcept override
-  {
-    verify_stream(stream);
-    upstream_.deallocate(stream, ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  }
-
-  /**
-   * @brief Compare the upstream resource to another.
-   *
-   * @param other The other resource to compare to
-   * @return Whether or not the two resources are equivalent
-   */
-  [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
-  {
-    if (this == &other) { return true; }
-    auto cast = dynamic_cast<stream_checking_resource_adaptor const*>(&other);
-    if (cast == nullptr) { return false; }
-    return get_upstream_resource() == cast->get_upstream_resource();
-  }
-
   /**
    * @brief Throw an error if the provided stream is invalid.
    *
@@ -133,7 +133,7 @@ class stream_checking_resource_adaptor final : public rmm::mr::device_memory_res
     }
   }
 
-  rmm::device_async_resource_ref
+  cuda::mr::any_resource<cuda::mr::device_accessible>
     upstream_;                    // the upstream resource used for satisfying allocation requests
   bool error_on_invalid_stream_;  // If true, throw an exception when the wrong stream is detected.
                                   // If false, simply print to stdout.
@@ -141,5 +141,9 @@ class stream_checking_resource_adaptor final : public rmm::mr::device_memory_res
                                // If false, throw an exception when anything other than
                                // cudf::test::get_default_stream() is observed.
 };
+
+static_assert(
+  cuda::mr::resource_with<stream_checking_resource_adaptor, cuda::mr::device_accessible>,
+  "stream_checking_resource_adaptor does not satisfy the cuda::mr::resource concept");
 
 }  // namespace cudf::test

--- a/cpp/include/cudf_test/testing_main.hpp
+++ b/cpp/include/cudf_test/testing_main.hpp
@@ -21,9 +21,12 @@
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/managed_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
+#include <rmm/mr/pinned_host_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
 
 #include <iostream>
 
@@ -36,33 +39,70 @@ struct config {
   std::string stream_error_mode;
 };
 
+// Wrapper that adds host_accessible + device_accessible properties to a pool_memory_resource.
+// pool_memory_resource doesn't propagate the host_accessible property from its pinned upstream
+// through its type, so this shim is needed to satisfy the host_device_async_resource_ref
+// required by set_pinned_memory_resource.
+struct pinned_pool {
+  rmm::mr::pinned_host_memory_resource pinned_mr;
+  rmm::mr::pool_memory_resource pool_mr;
+
+  explicit pinned_pool(std::size_t pool_size)
+    : pool_mr{rmm::device_async_resource_ref{pinned_mr}, pool_size}
+  {
+  }
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+  {
+    return pool_mr.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  }
+  void deallocate_sync(void* p,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    pool_mr.deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, p, bytes, alignment);
+  }
+  void* allocate(cuda::stream_ref s,
+                 std::size_t bytes,
+                 std::size_t a = rmm::CUDA_ALLOCATION_ALIGNMENT)
+  {
+    return pool_mr.allocate(s, bytes, a);
+  }
+  void deallocate(cuda::stream_ref s,
+                  void* p,
+                  std::size_t bytes,
+                  std::size_t a = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    pool_mr.deallocate(s, p, bytes, a);
+  }
+  bool operator==(pinned_pool const& o) const noexcept { return &pool_mr == &o.pool_mr; }
+  bool operator!=(pinned_pool const& o) const noexcept { return &pool_mr != &o.pool_mr; }
+  friend void get_property(pinned_pool const&, cuda::mr::device_accessible) noexcept {}
+  friend void get_property(pinned_pool const&, cuda::mr::host_accessible) noexcept {}
+};
+
 /// MR factory functions
-inline auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
+inline auto make_cuda() { return rmm::mr::cuda_memory_resource{}; }
 
-inline auto make_async() { return std::make_shared<rmm::mr::cuda_async_memory_resource>(); }
+inline auto make_async() { return rmm::mr::cuda_async_memory_resource{}; }
 
-inline auto make_managed() { return std::make_shared<rmm::mr::managed_memory_resource>(); }
+inline auto make_managed() { return rmm::mr::managed_memory_resource{}; }
 
 inline auto make_pool()
 {
   auto const [free, total] = rmm::available_device_memory();
   auto const min_alloc =
     rmm::align_down(std::min(free, total / 10), rmm::CUDA_ALLOCATION_ALIGNMENT);
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda(), min_alloc);
+  return rmm::mr::pool_memory_resource{rmm::mr::cuda_memory_resource{}, min_alloc};
 }
 
-inline auto make_arena()
-{
-  return rmm::mr::make_owning_wrapper<rmm::mr::arena_memory_resource>(make_cuda());
-}
+inline auto make_arena() { return rmm::mr::arena_memory_resource{rmm::mr::cuda_memory_resource{}}; }
 
 inline auto make_binning()
 {
-  auto pool = make_pool();
   // Add a binning_memory_resource with fixed-size bins of sizes 256, 512, 1024, 2048 and 4096KiB
   // Larger allocations will use the pool resource
-  auto mr = rmm::mr::make_owning_wrapper<rmm::mr::binning_memory_resource>(pool, 18, 22);
-  return mr;
+  return rmm::mr::binning_memory_resource{make_pool(), 18, 22};
 }
 
 /**
@@ -77,10 +117,10 @@ inline auto make_binning()
  * @throw cudf::logic_error if the `allocation_mode` is unsupported.
  *
  * @param allocation_mode String identifies which resource type.
- *        Accepted types are "pool", "cuda", and "managed" only.
+ *        Accepted types are "pool", "cuda", "async", "arena", "binning", and "managed".
  * @return Memory resource instance
  */
-inline std::shared_ptr<rmm::mr::device_memory_resource> create_memory_resource(
+inline cuda::mr::any_resource<cuda::mr::device_accessible> create_memory_resource(
   std::string const& allocation_mode)
 {
   if (allocation_mode == "binning") return make_binning();
@@ -147,20 +187,14 @@ inline auto parse_cudf_test_opts(int argc, char** argv)
 }
 
 /**
- * @brief Sets up stream mode memory resource adaptor
- *
- * The resource adaptor is only set as the current device resource if the
- * stream mode is enabled.
- *
- * The caller must keep the return object alive for the life of the test runs.
+ * @brief Sets up the memory resource for the test run.
  *
  * @param config Command line options returned by parse_cudf_test_opts
- * @return Memory resource adaptor
  */
 inline auto make_memory_resource_adaptor(cudf::test::config const& config)
 {
   auto resource = cudf::test::create_memory_resource(config.rmm_mode);
-  cudf::set_current_device_resource(resource.get());
+  cudf::set_current_device_resource(resource);
   return resource;
 }
 
@@ -170,33 +204,28 @@ inline auto make_memory_resource_adaptor(cudf::test::config const& config)
  * The resource adaptor is only set as the current device resource if the
  * stream mode is enabled.
  *
- * The caller must keep the return object alive for the life of the test runs.
- *
  * @param config Command line options returned by parse_cudf_test_opts
- * @return Memory resource adaptor
  */
-inline auto make_stream_mode_adaptor(cudf::test::config const& config)
+inline void make_stream_mode_adaptor(cudf::test::config const& config)
 {
-  auto resource                      = cudf::get_current_device_resource_ref();
-  auto const error_on_invalid_stream = (config.stream_error_mode == "error");
-  auto const check_default_stream    = (config.stream_mode == "new_cudf_default");
-  auto adaptor                       = cudf::test::stream_checking_resource_adaptor(
-    resource, error_on_invalid_stream, check_default_stream);
   if ((config.stream_mode == "new_cudf_default") || (config.stream_mode == "new_testing_default")) {
-    cudf::set_current_device_resource(&adaptor);
+    auto const error_on_invalid_stream = (config.stream_error_mode == "error");
+    auto const check_default_stream    = (config.stream_mode == "new_cudf_default");
+    auto resource                      = cudf::reset_current_device_resource();
+    auto adaptor                       = cudf::test::stream_checking_resource_adaptor(
+      resource, error_on_invalid_stream, check_default_stream);
+    cudf::set_current_device_resource(adaptor);
   }
-  return adaptor;
 }
 
 /**
- * @brief Should be called in every test program that uses rmm allocators since it maintains the
- * lifespan of the rmm default memory resource. this function parses the command line to customize
- * test behavior, like the allocation mode used for creating the default memory resource.
+ * @brief Should be called in every test program that uses rmm allocators.
+ * Parses the command line to customize test behavior, like the allocation mode
+ * used for creating the default memory resource.
  *
  */
 inline void init_cudf_test(int argc, char** argv, cudf::test::config const& config_override = {})
 {
-  // static lifetime to keep rmm resource alive till tests end
   auto const cmd_opts       = parse_cudf_test_opts(argc, argv);
   cudf::test::config config = config_override;
   if (config.rmm_mode.empty()) { config.rmm_mode = cmd_opts["rmm_mode"].as<std::string>(); }
@@ -209,8 +238,8 @@ inline void init_cudf_test(int argc, char** argv, cudf::test::config const& conf
     config.stream_error_mode = cmd_opts["stream_error_mode"].as<std::string>();
   }
 
-  [[maybe_unused]] static auto mr      = make_memory_resource_adaptor(config);
-  [[maybe_unused]] static auto adaptor = make_stream_mode_adaptor(config);
+  make_memory_resource_adaptor(config);
+  make_stream_mode_adaptor(config);
 }
 
 /**
@@ -226,9 +255,8 @@ inline void init_cudf_test(int argc, char** argv, cudf::test::config const& conf
     ::testing::InitGoogleTest(&argc, argv);                                                      \
     init_cudf_test(argc, argv);                                                                  \
     if (std::getenv("GTEST_CUDF_MEMORY_PEAK")) {                                                 \
-      auto mr = rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource>(           \
-        cudf::get_current_device_resource_ref());                                                \
-      cudf::set_current_device_resource(&mr);                                                    \
+      auto mr = rmm::mr::statistics_resource_adaptor(cudf::get_current_device_resource_ref());   \
+      cudf::set_current_device_resource(mr);                                                     \
       auto rc = RUN_ALL_TESTS();                                                                 \
       std::cout << "Peak memory usage " << mr.get_bytes_counter().peak << " bytes" << std::endl; \
       cudf::teardown();                                                                          \

--- a/cpp/src/io/parquet/experimental/deletion_vectors.cu
+++ b/cpp/src/io/parquet/experimental/deletion_vectors.cu
@@ -12,6 +12,8 @@
 #include <cudf/utilities/roaring_bitmap.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/exec_policy.hpp>
 #include <rmm/mr/polymorphic_allocator.hpp>
 #include <rmm/resource_ref.hpp>
 

--- a/cpp/src/io/parquet/predicate_pushdown.cpp
+++ b/cpp/src/io/parquet/predicate_pushdown.cpp
@@ -248,8 +248,8 @@ aggregate_reader_metadata::filter_row_groups(
   }
 
   // Aligned resource adaptor to allocate bloom filter buffers with
-  auto aligned_mr = rmm::mr::aligned_resource_adaptor<rmm::device_async_resource_ref>(
-    cudf::get_current_device_resource_ref(), get_bloom_filter_alignment());
+  auto aligned_mr = rmm::mr::aligned_resource_adaptor(cudf::get_current_device_resource_ref(),
+                                                      get_bloom_filter_alignment());
 
   // Read a vector of bloom filter bitset device buffers for all columns with equality
   // predicate(s) across all row groups

--- a/cpp/src/io/utilities/output_builder.cuh
+++ b/cpp/src/io/utilities/output_builder.cuh
@@ -12,6 +12,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/exec_policy.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <thrust/copy.h>
 

--- a/cpp/src/rolling/detail/lead_lag_nested.cuh
+++ b/cpp/src/rolling/detail/lead_lag_nested.cuh
@@ -75,7 +75,7 @@ is_null_index_predicate_impl<GatherMapIter> is_null_index_predicate(size_type in
  * @param[in] row_offset Lead/Lag offset, indicating which row after/before
  *                       the current row is to be returned
  * @param[in] stream CUDA stream for device memory operations/allocations
- * @param[in] mr device_memory_resource for device memory allocations
+ * @param[in] mr Device memory resource used to allocate the returned table's device memory
  */
 template <typename PrecedingIter, typename FollowingIter>
 std::unique_ptr<column> compute_lead_lag_for_nested(aggregation::Kind op,

--- a/cpp/src/rolling/detail/optimized_unbounded_window.hpp
+++ b/cpp/src/rolling/detail/optimized_unbounded_window.hpp
@@ -10,6 +10,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
 
 namespace cudf {
 

--- a/cpp/src/utilities/host_memory.cpp
+++ b/cpp/src/utilities/host_memory.cpp
@@ -3,20 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// clang-format off
-// Forward declaring this type with hidden visibility supersedes the upstream
-// declaration and therefore hides instantiations in this file. This prevents
-// the specific symbol conflict observed in
-// https://github.com/rapidsai/rmm/issues/2219 between nvcomp's instantiation
-// of pool_memory_resource<pinned_host_memory_resource> and libcudf's, but it
-// does not fix the broader issues around rmm's symbol visibility that are
-// raised in that issue. Those will be fixed upstream at a later date.
-namespace rmm::mr {
-template <typename Upstream>
-class pool_memory_resource;
-}
-// clang-format on
-
 #include "io/utilities/getenv_or.hpp"
 
 #include <cudf/detail/utilities/stream_pool.hpp>
@@ -26,9 +12,9 @@ class pool_memory_resource;
 #include <cudf/utilities/pinned_memory.hpp>
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <algorithm>
 #include <atomic>
@@ -42,9 +28,14 @@ namespace cudf {
 
 namespace {
 
-class pinned_pool_with_fallback_memory_resource : public rmm::mr::device_memory_resource {
+class pinned_pool_with_fallback_memory_resource {
   using upstream_mr    = rmm::mr::pinned_host_memory_resource;
-  using host_pooled_mr = rmm::mr::pool_memory_resource<upstream_mr>;
+  using host_pooled_mr = rmm::mr::pool_memory_resource;
+
+  struct fallback_state {
+    mutable std::shared_mutex mutex;
+    std::unordered_set<void*> allocations;
+  };
 
  private:
   upstream_mr upstream_mr_{};
@@ -54,9 +45,8 @@ class pinned_pool_with_fallback_memory_resource : public rmm::mr::device_memory_
   host_pooled_mr* pool_{nullptr};
   cuda::stream_ref stream_{cudf::detail::global_cuda_stream_pool().get_stream().value()};
 
-  // Hash set to track fallback allocations
-  mutable std::shared_mutex fallback_allocations_mutex_;
-  std::unordered_set<void*> fallback_allocations_;
+  // Wrapped in shared_ptr so the outer class is copyable (required by any_resource)
+  std::shared_ptr<fallback_state> fallback_{std::make_shared<fallback_state>()};
 
  public:
   pinned_pool_with_fallback_memory_resource(size_t initial_size, size_t max_size)
@@ -86,49 +76,69 @@ class pinned_pool_with_fallback_memory_resource : public rmm::mr::device_memory_
   {
   }
 
- private:
-  void* do_allocate(std::size_t bytes, rmm::cuda_stream_view stream) override
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+  {
+    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  }
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+  }
+
+  void* allocate(cuda::stream_ref stream,
+                 std::size_t bytes,
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
     try {
-      return pool_->allocate(stream, bytes);
+      return pool_->allocate(stream, bytes, alignment);
     } catch (...) {
       CUDF_LOG_INFO("Pinned pool exhausted, falling back to new pinned allocation for %zu bytes",
                     bytes);
       // fall back to upstream
-      auto* ptr = upstream_mr_.allocate(stream, bytes);
+      auto* ptr = upstream_mr_.allocate(stream, bytes, alignment);
 
       {
-        std::unique_lock lock(fallback_allocations_mutex_);
-        fallback_allocations_.insert(ptr);
+        std::unique_lock lock(fallback_->mutex);
+        fallback_->allocations.insert(ptr);
       }
 
       return ptr;
     }
   }
 
-  void do_deallocate(void* ptr, std::size_t bytes, rmm::cuda_stream_view stream) noexcept override
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
     bool is_fallback{false};
     {
-      std::shared_lock lock(fallback_allocations_mutex_);
-      is_fallback = fallback_allocations_.find(ptr) != fallback_allocations_.end();
+      std::shared_lock lock(fallback_->mutex);
+      is_fallback = fallback_->allocations.find(ptr) != fallback_->allocations.end();
     }
 
     if (is_fallback) {
       {
-        std::unique_lock lock(fallback_allocations_mutex_);
-        fallback_allocations_.erase(ptr);
+        std::unique_lock lock(fallback_->mutex);
+        fallback_->allocations.erase(ptr);
       }
-      upstream_mr_.deallocate(stream, ptr, bytes);
+      upstream_mr_.deallocate(stream, ptr, bytes, alignment);
     } else {
-      pool_->deallocate(stream, ptr, bytes);
+      pool_->deallocate(stream, ptr, bytes, alignment);
     }
   }
 
-  [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
+  bool operator==(pinned_pool_with_fallback_memory_resource const& other) const noexcept
   {
-    auto const* other_ptr = dynamic_cast<pinned_pool_with_fallback_memory_resource const*>(&other);
-    return other_ptr != nullptr && pool_ == other_ptr->pool_ && stream_ == other_ptr->stream_;
+    return pool_ == other.pool_ && stream_ == other.stream_;
+  }
+
+  bool operator!=(pinned_pool_with_fallback_memory_resource const& other) const noexcept
+  {
+    return !(*this == other);
   }
 };
 

--- a/cpp/tests/io/experimental/hybrid_scan_composer.cpp
+++ b/cpp/tests/io/experimental/hybrid_scan_composer.cpp
@@ -104,8 +104,8 @@ auto apply_hybrid_scan_filters(cudf::io::datasource& datasource,
   bloom_filtered_row_group_indices.reserve(current_row_group_indices.size());
   if (bloom_filter_byte_ranges.size()) {
     // Fetch 32 byte aligned bloom filter data buffers from the input file buffer
-    auto aligned_mr = rmm::mr::aligned_resource_adaptor<rmm::device_async_resource_ref>(
-      cudf::get_current_device_resource_ref(), bloom_filter_alignment);
+    auto aligned_mr = rmm::mr::aligned_resource_adaptor(cudf::get_current_device_resource_ref(),
+                                                        bloom_filter_alignment);
 
     auto [bloom_filter_buffers, bloom_filter_data, bloom_read_tasks] =
       cudf::io::parquet::fetch_byte_ranges_to_device_async(
@@ -169,7 +169,7 @@ std::tuple<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>> hybrid_sc
   bool case_sensitive_names,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
-  rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>& aligned_mr)
+  rmm::mr::aligned_resource_adaptor& aligned_mr)
 {
   // Create reader options with empty source info
   cudf::io::parquet_reader_options options = cudf::io::parquet_reader_options::builder()
@@ -238,7 +238,7 @@ std::tuple<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>> chunked_h
   bool case_sensitive_names,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
-  rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>& aligned_mr)
+  rmm::mr::aligned_resource_adaptor& aligned_mr)
 {
   // Create reader options with empty source info
   cudf::io::parquet_reader_options options = cudf::io::parquet_reader_options::builder()

--- a/cpp/tests/io/experimental/hybrid_scan_composer.hpp
+++ b/cpp/tests/io/experimental/hybrid_scan_composer.hpp
@@ -34,7 +34,7 @@ std::tuple<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>> hybrid_sc
   bool case_sensitive_names,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
-  rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>& aligned_mr);
+  rmm::mr::aligned_resource_adaptor& aligned_mr);
 
 /**
  * @brief Read parquet file with the hybrid scan reader
@@ -56,7 +56,7 @@ std::tuple<std::unique_ptr<cudf::table>, std::unique_ptr<cudf::table>> chunked_h
   bool case_sensitive_names,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
-  rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>& aligned_mr);
+  rmm::mr::aligned_resource_adaptor& aligned_mr);
 
 /**
  * @brief Read parquet file with the hybrid scan reader in a single step

--- a/cpp/tests/io/experimental/hybrid_scan_test.cpp
+++ b/cpp/tests/io/experimental/hybrid_scan_test.cpp
@@ -129,8 +129,8 @@ void test_hybrid_scan(std::vector<cudf::column_view> const& columns,
 
   auto stream     = cudf::get_default_stream();
   auto mr         = cudf::get_current_device_resource_ref();
-  auto aligned_mr = rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>(
-    cudf::get_current_device_resource_ref(), bloom_filter_alignment);
+  auto aligned_mr = rmm::mr::aligned_resource_adaptor(cudf::get_current_device_resource_ref(),
+                                                      bloom_filter_alignment);
 
   auto datasource     = cudf::io::datasource::create(cudf::host_span<std::byte const>(
     reinterpret_cast<std::byte const*>(parquet_buffer.data()), parquet_buffer.size()));
@@ -210,7 +210,7 @@ std::unique_ptr<cudf::table> test_hybrid_scan_column_selection(
   bool case_sensitive_names,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr,
-  rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>& aligned_mr)
+  rmm::mr::aligned_resource_adaptor& aligned_mr)
 {
   auto datasource     = cudf::io::datasource::create(cudf::host_span<std::byte const>(
     reinterpret_cast<std::byte const*>(parquet_buffer.data()), parquet_buffer.size()));
@@ -303,8 +303,8 @@ TEST_F(HybridScanTest, FilterRowGroupsOnlyAndScanSelectColumns)
 
   auto stream     = cudf::get_default_stream();
   auto mr         = cudf::get_current_device_resource_ref();
-  auto aligned_mr = rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>(
-    cudf::get_current_device_resource_ref(), bloom_filter_alignment);
+  auto aligned_mr = rmm::mr::aligned_resource_adaptor(cudf::get_current_device_resource_ref(),
+                                                      bloom_filter_alignment);
   auto constexpr case_sensitive_names = false;
 
   // No column selection (all columns)
@@ -371,8 +371,8 @@ TEST_F(HybridScanTest, FilterDataPagesOnlyAndScanAllColumns)
 
   auto stream     = cudf::get_default_stream();
   auto mr         = cudf::get_current_device_resource_ref();
-  auto aligned_mr = rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>(
-    cudf::get_current_device_resource_ref(), bloom_filter_alignment);
+  auto aligned_mr = rmm::mr::aligned_resource_adaptor(cudf::get_current_device_resource_ref(),
+                                                      bloom_filter_alignment);
   auto constexpr case_sensitive_names = false;
 
   auto const payload_column_indices = std::vector<cudf::size_type>{1, 2};
@@ -747,8 +747,8 @@ TEST_F(HybridScanTest, ExtendedFilterExpressions)
 
   auto stream     = cudf::get_default_stream();
   auto mr         = cudf::get_current_device_resource_ref();
-  auto aligned_mr = rmm::mr::aligned_resource_adaptor<rmm::mr::device_memory_resource>(
-    cudf::get_current_device_resource_ref(), bloom_filter_alignment);
+  auto aligned_mr = rmm::mr::aligned_resource_adaptor(cudf::get_current_device_resource_ref(),
+                                                      bloom_filter_alignment);
 
   // Create datasource from buffer
   auto const datasource     = cudf::io::datasource::create(cudf::host_span<std::byte const>(

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -28,8 +28,10 @@
 #include <cudf/utilities/pinned_memory.hpp>
 
 #include <rmm/mr/pinned_host_memory_resource.hpp>
+#include <rmm/mr/pool_memory_resource.hpp>
 
 #include <cuda/iterator>
+#include <cuda/memory_resource>
 
 #include <fstream>
 #include <limits>
@@ -2135,9 +2137,7 @@ TEST_F(JsonReaderTest, JSONLinesRecoveringSync)
 {
   // Set up host pinned memory pool to avoid implicit synchronizations to test for any potential
   // races due to missing host-device synchronizations
-  using host_pooled_mr = rmm::mr::pool_memory_resource<rmm::mr::pinned_host_memory_resource>;
-  auto pinned_mr       = std::make_shared<rmm::mr::pinned_host_memory_resource>();
-  host_pooled_mr mr{pinned_mr.get(), size_t{128} * 1024 * 1024};
+  cudf::test::pinned_pool mr{size_t{128} * 1024 * 1024};
 
   // Set new resource
   auto last_mr = cudf::set_pinned_memory_resource(mr);

--- a/cpp/tests/io/text/data_chunk_source_test.cpp
+++ b/cpp/tests/io/text/data_chunk_source_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,8 +10,6 @@
 
 #include <cudf/io/text/data_chunk_source_factories.hpp>
 #include <cudf/io/text/detail/bgzip_utils.hpp>
-
-#include <rmm/mr/pinned_host_memory_resource.hpp>
 
 #include <fstream>
 #include <random>
@@ -30,9 +28,7 @@ std::string chunk_to_host(cudf::io::text::device_data_chunk const& chunk)
 
 void test_source(std::string const& content, cudf::io::text::data_chunk_source const& source)
 {
-  using host_pooled_mr  = rmm::mr::pool_memory_resource<rmm::mr::pinned_host_memory_resource>;
-  auto static pinned_mr = std::make_shared<rmm::mr::pinned_host_memory_resource>();
-  host_pooled_mr mr{pinned_mr.get(), size_t{128} * 1024 * 1024};
+  static cudf::test::pinned_pool mr{size_t{128} * 1024 * 1024};
   auto last_mr = cudf::set_pinned_memory_resource(mr);
 
   auto stream = cudf::get_default_stream();

--- a/cpp/tests/large_strings/large_strings_fixture.cpp
+++ b/cpp/tests/large_strings/large_strings_fixture.cpp
@@ -119,9 +119,8 @@ int main(int argc, char** argv)
   auto lsd = cudf::test::StringsLargeTest::get_ls_data();
 
   if (std::getenv("GTEST_CUDF_MEMORY_PEAK")) {
-    auto mr = rmm::mr::statistics_resource_adaptor<rmm::mr::device_memory_resource>(
-      cudf::get_current_device_resource_ref());
-    cudf::set_current_device_resource(&mr);
+    auto mr = rmm::mr::statistics_resource_adaptor(cudf::get_current_device_resource_ref());
+    cudf::set_current_device_resource(mr);
     auto rc = RUN_ALL_TESTS();
     std::cout << "Peak memory usage " << mr.get_bytes_counter().peak << " bytes" << std::endl;
     return rc;

--- a/cpp/tests/utilities_tests/pinned_memory_tests.cpp
+++ b/cpp/tests/utilities_tests/pinned_memory_tests.cpp
@@ -8,15 +8,13 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_wrapper.hpp>
 #include <cudf_test/table_utilities.hpp>
+#include <cudf_test/testing_main.hpp>
 
 #include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/pinned_memory.hpp>
 #include <cudf/utilities/span.hpp>
-
-#include <rmm/mr/pinned_host_memory_resource.hpp>
-#include <rmm/mr/pool_memory_resource.hpp>
 
 #include <cuda/iterator>
 
@@ -50,9 +48,7 @@ TEST_F(PinnedMemoryTest, MemoryResourceGetAndSet)
     ::testing::AddGlobalTestEnvironment(new cudf::test::TempDirTestEnvironment));
 
   // pinned/pooled host memory resource
-  using host_pooled_mr = rmm::mr::pool_memory_resource<rmm::mr::pinned_host_memory_resource>;
-  auto pinned_mr       = std::make_shared<rmm::mr::pinned_host_memory_resource>();
-  host_pooled_mr mr{pinned_mr.get(), 4 * 1024 * 1024};
+  cudf::test::pinned_pool mr{4 * 1024 * 1024};
 
   // set new resource
   auto last_mr = cudf::get_pinned_memory_resource();

--- a/java/src/main/java/ai/rapids/cudf/RmmDeviceMemoryResource.java
+++ b/java/src/main/java/ai/rapids/cudf/RmmDeviceMemoryResource.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 package ai.rapids.cudf;
@@ -11,7 +11,7 @@ package ai.rapids.cudf;
  */
 public interface RmmDeviceMemoryResource extends AutoCloseable {
   /**
-   * Returns a pointer to the underlying C++ class that implements rmm::mr::device_memory_resource
+   * Returns a pointer to the underlying C++ class that implements an RMM device memory resource
    */
   long getHandle();
 

--- a/java/src/main/native/include/jni_cccl_any_resource.hpp
+++ b/java/src/main/native/include/jni_cccl_any_resource.hpp
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cuda/memory_resource>
+
+#include <jni.h>
+
+namespace cudf::jni {
+
+inline jlong make_jni_resource(cuda::mr::any_resource<cuda::mr::device_accessible> resource)
+{
+  return reinterpret_cast<jlong>(
+    new cuda::mr::any_resource<cuda::mr::device_accessible>(std::move(resource)));
+}
+
+inline cuda::mr::any_resource<cuda::mr::device_accessible>& get_resource(jlong handle)
+{
+  return *reinterpret_cast<cuda::mr::any_resource<cuda::mr::device_accessible>*>(handle);
+}
+
+inline void delete_jni_resource(jlong handle)
+{
+  delete reinterpret_cast<cuda::mr::any_resource<cuda::mr::device_accessible>*>(handle);
+}
+
+}  // namespace cudf::jni

--- a/java/src/main/native/src/RmmJni.cpp
+++ b/java/src/main/native/src/RmmJni.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "cudf_jni_apis.hpp"
+#include "jni_cccl_any_resource.hpp"
 
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/pinned_memory.hpp>
@@ -17,9 +18,12 @@
 #include <rmm/mr/limiting_resource_adaptor.hpp>
 #include <rmm/mr/logging_resource_adaptor.hpp>
 #include <rmm/mr/managed_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
+#include <rmm/mr/tracking_resource_adaptor.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
 
 #include <atomic>
 #include <ctime>
@@ -27,96 +31,51 @@
 #include <iostream>
 #include <limits>
 #include <mutex>
-
-using rmm::mr::device_memory_resource;
-using rmm::mr::logging_resource_adaptor;
-using rmm_pinned_pool_t = rmm::mr::pool_memory_resource<rmm::mr::pinned_host_memory_resource>;
+#include <unordered_map>
 
 namespace {
+
+using cudf::jni::delete_jni_resource;
+using cudf::jni::get_resource;
+using cudf::jni::make_jni_resource;
 
 constexpr char const* RMM_EXCEPTION_CLASS = "ai/rapids/cudf/RmmException";
 
 /**
- * @brief Base class so we can template tracking_resource_adaptor but
- * still hold all instances of it without issues.
+ * @brief Implementation class for tracking resource adaptor.
+ * This class is not copyable due to atomic/mutex members.
+ * Owns the upstream resource via any_resource.
  */
-class base_tracking_resource_adaptor : public device_memory_resource {
+class tracking_resource_adaptor_impl {
  public:
-  virtual std::size_t get_total_allocated() = 0;
-
-  virtual std::size_t get_max_total_allocated() = 0;
-
-  virtual void reset_scoped_max_total_allocated(std::size_t initial_value) = 0;
-
-  virtual std::size_t get_scoped_max_total_allocated() = 0;
-};
-
-/**
- * @brief An RMM device memory resource that delegates to another resource
- * while tracking the amount of memory allocated.
- *
- * @tparam Upstream Type of memory resource that will be wrapped.
- * @tparam size_align The size to which all allocation requests are
- * aligned. Must be a value >= 1.
- */
-template <typename Upstream>
-class tracking_resource_adaptor final : public base_tracking_resource_adaptor {
- public:
-  /**
-   * @brief Constructs a new tracking resource adaptor that delegates to
-   * `mr` for all allocation operations while tracking the amount of memory
-   * allocated.
-   *
-   * @param mr The resource to use for memory allocation operations.
-   * @param size_alignment The alignment to which the `mr` resource will
-   * round up all memory allocation size requests.
-   */
-  tracking_resource_adaptor(Upstream* mr, std::size_t size_alignment)
-    : resource{mr}, size_align{size_alignment}
+  tracking_resource_adaptor_impl(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+                                 std::size_t size_alignment)
+    : upstream_{std::move(upstream)}, size_align{size_alignment}
   {
   }
 
-  Upstream* get_wrapped_resource() { return resource; }
+  std::size_t get_total_allocated() { return total_allocated.load(); }
 
-  std::size_t get_total_allocated() override { return total_allocated.load(); }
+  std::size_t get_max_total_allocated() { return max_total_allocated; }
 
-  std::size_t get_max_total_allocated() override { return max_total_allocated; }
-
-  void reset_scoped_max_total_allocated(std::size_t initial_value) override
+  void reset_scoped_max_total_allocated(std::size_t initial_value)
   {
     std::scoped_lock lock(max_total_allocated_mutex);
     scoped_allocated           = initial_value;
     scoped_max_total_allocated = initial_value;
   }
 
-  std::size_t get_scoped_max_total_allocated() override
+  std::size_t get_scoped_max_total_allocated()
   {
     std::scoped_lock lock(max_total_allocated_mutex);
     return scoped_max_total_allocated;
   }
 
- private:
-  Upstream* const resource;
-  std::size_t const size_align;
-  // sum of what is currently allocated
-  std::atomic_size_t total_allocated{0};
-
-  // the maximum total allocated for the lifetime of this class
-  std::size_t max_total_allocated{0};
-
-  // the sum of what is currently outstanding from the last
-  // `reset_scoped_max_total_allocated` call. This can be negative.
-  std::atomic_long scoped_allocated{0};
-
-  // the maximum total allocated relative to the last
-  // `reset_scoped_max_total_allocated` call.
-  long scoped_max_total_allocated{0};
-
-  std::mutex max_total_allocated_mutex;
-
-  void* do_allocate(std::size_t num_bytes, rmm::cuda_stream_view stream) override
+  void* allocate(cuda::stream_ref stream,
+                 std::size_t num_bytes,
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    auto const result = resource->allocate(stream, num_bytes, size_align);
+    auto const result = upstream_.allocate(stream, num_bytes, size_align);
     if (result) {
       total_allocated += num_bytes;
       scoped_allocated += num_bytes;
@@ -127,29 +86,133 @@ class tracking_resource_adaptor final : public base_tracking_resource_adaptor {
     return result;
   }
 
-  void do_deallocate(void* p, std::size_t size, rmm::cuda_stream_view stream) noexcept override
+  void deallocate(cuda::stream_ref stream,
+                  void* p,
+                  std::size_t size,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    resource->deallocate(stream, p, size, size_align);
+    upstream_.deallocate(stream, p, size, size_align);
     if (p) {
       total_allocated -= size;
       scoped_allocated -= size;
     }
   }
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+  {
+    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  }
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+  }
+
+  bool operator==(tracking_resource_adaptor_impl const& other) const noexcept
+  {
+    return this == &other;
+  }
+
+  friend void get_property(tracking_resource_adaptor_impl const&,
+                           cuda::mr::device_accessible) noexcept
+  {
+  }
+
+ private:
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream_;
+  std::size_t const size_align;
+  // sum of what is currently allocated
+  std::atomic_size_t total_allocated{0};
+  // the maximum total allocated for the lifetime of this class
+  std::size_t max_total_allocated{0};
+  // the sum of what is currently outstanding from the last
+  // `reset_scoped_max_total_allocated` call. This can be negative.
+  std::atomic_long scoped_allocated{0};
+  // the maximum total allocated relative to the last
+  // `reset_scoped_max_total_allocated` call.
+  long scoped_max_total_allocated{0};
+  std::mutex max_total_allocated_mutex;
 };
+static_assert(cuda::mr::resource_with<tracking_resource_adaptor_impl, cuda::mr::device_accessible>);
 
 /**
- * @brief An RMM device memory resource adaptor that delegates to the wrapped resource
- * for most operations but will call Java to handle certain situations (e.g.: allocation failure).
+ * @brief Tracking resource adaptor with reference-counted shared ownership.
+ * This wrapper holds a shared_ptr to the impl and forwards resource operations.
+ * It satisfies the CCCL resource concept and is copyable for use with any_resource.
  */
-class java_event_handler_memory_resource : public device_memory_resource {
+class tracking_resource_adaptor {
  public:
-  java_event_handler_memory_resource(JNIEnv* env,
-                                     jobject jhandler,
-                                     jlongArray jalloc_thresholds,
-                                     jlongArray jdealloc_thresholds,
-                                     device_memory_resource* resource_to_wrap,
-                                     base_tracking_resource_adaptor* tracker)
-    : resource(resource_to_wrap), tracker(tracker)
+  tracking_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+                            std::size_t size_alignment)
+    : impl_{std::make_shared<tracking_resource_adaptor_impl>(std::move(upstream), size_alignment)}
+  {
+  }
+
+  void* allocate(cuda::stream_ref stream,
+                 std::size_t bytes,
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+  {
+    return impl_->allocate(stream, bytes, alignment);
+  }
+
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    impl_->deallocate(stream, ptr, bytes, alignment);
+  }
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+  {
+    return impl_->allocate_sync(bytes, alignment);
+  }
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    impl_->deallocate_sync(ptr, bytes, alignment);
+  }
+
+  bool operator==(tracking_resource_adaptor const& other) const noexcept
+  {
+    return impl_ == other.impl_;
+  }
+
+  friend void get_property(tracking_resource_adaptor const&, cuda::mr::device_accessible) noexcept
+  {
+  }
+
+  std::size_t get_total_allocated() { return impl_->get_total_allocated(); }
+  std::size_t get_max_total_allocated() { return impl_->get_max_total_allocated(); }
+  void reset_scoped_max_total_allocated(std::size_t initial_value)
+  {
+    impl_->reset_scoped_max_total_allocated(initial_value);
+  }
+  std::size_t get_scoped_max_total_allocated() { return impl_->get_scoped_max_total_allocated(); }
+
+ private:
+  std::shared_ptr<tracking_resource_adaptor_impl> impl_;
+};
+static_assert(cuda::mr::resource_with<tracking_resource_adaptor, cuda::mr::device_accessible>);
+
+/**
+ * @brief Implementation class for java event handler memory resource.
+ * This class holds all the non-copyable JNI state and is wrapped in a shared_ptr.
+ */
+class java_event_handler_memory_resource_impl {
+ public:
+  java_event_handler_memory_resource_impl(
+    JNIEnv* env,
+    jobject jhandler,
+    jlongArray jalloc_thresholds,
+    jlongArray jdealloc_thresholds,
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+    tracking_resource_adaptor tracker)
+    : upstream_{std::move(upstream)}, tracker_(std::move(tracker))
   {
     if (env->GetJavaVM(&jvm) < 0) { throw std::runtime_error("GetJavaVM failed"); }
 
@@ -180,7 +243,7 @@ class java_event_handler_memory_resource : public device_memory_resource {
     handler_obj = cudf::jni::add_global_ref(env, jhandler);
   }
 
-  virtual ~java_event_handler_memory_resource()
+  virtual ~java_event_handler_memory_resource_impl()
   {
     // This should normally be called by a JVM thread. If the JVM environment is missing then this
     // is likely being triggered by the C++ runtime during shutdown. In that case the JVM may
@@ -192,19 +255,71 @@ class java_event_handler_memory_resource : public device_memory_resource {
     handler_obj = nullptr;
   }
 
-  device_memory_resource* get_wrapped_resource() { return resource; }
+  virtual void* allocate(cuda::stream_ref stream,
+                         std::size_t num_bytes,
+                         std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+  {
+    std::size_t total_before;
+    void* result;
+    // a non-zero retry_count signifies that the `on_alloc_fail`
+    // callback is being invoked while re-attempting an allocation
+    // that had previously failed.
+    int retry_count = 0;
+    while (true) {
+      try {
+        total_before = tracker_.get_total_allocated();
+        result       = upstream_.allocate(stream, num_bytes, alignment);
+        break;
+      } catch (rmm::out_of_memory const& e) {
+        if (!on_alloc_fail(num_bytes, retry_count++)) { throw; }
+      }
+    }
+    auto total_after = tracker_.get_total_allocated();
 
- private:
-  device_memory_resource* const resource;
-  base_tracking_resource_adaptor* const tracker;
+    try {
+      check_for_threshold_callback(total_before,
+                                   total_after,
+                                   alloc_thresholds,
+                                   on_alloc_threshold_method,
+                                   "onAllocThreshold",
+                                   total_after);
+    } catch (std::exception const& e) {
+      // Free the allocation as app will think the exception means the memory was not allocated.
+      upstream_.deallocate(stream, result, num_bytes, alignment);
+      throw;
+    }
+
+    return result;
+  }
+
+  virtual void deallocate(cuda::stream_ref stream,
+                          void* p,
+                          std::size_t size,
+                          std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    auto total_before = tracker_.get_total_allocated();
+    upstream_.deallocate(stream, p, size, alignment);
+    auto total_after = tracker_.get_total_allocated();
+    check_for_threshold_callback(total_after,
+                                 total_before,
+                                 dealloc_thresholds,
+                                 on_dealloc_threshold_method,
+                                 "onDeallocThreshold",
+                                 total_after);
+  }
+
+ protected:
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream_;
+  tracking_resource_adaptor tracker_;
   jmethodID on_alloc_fail_method;
   bool use_old_alloc_fail_interface;
   jmethodID on_alloc_threshold_method;
   jmethodID on_dealloc_threshold_method;
-
   // sorted memory thresholds to trigger callbacks
   std::vector<std::size_t> alloc_thresholds{};
   std::vector<std::size_t> dealloc_thresholds{};
+  JavaVM* jvm;
+  jobject handler_obj;
 
   static void update_thresholds(JNIEnv* env,
                                 std::vector<std::size_t>& thresholds,
@@ -229,7 +344,6 @@ class java_event_handler_memory_resource : public device_memory_resource {
                                       on_alloc_fail_method,
                                       static_cast<jlong>(num_bytes),
                                       static_cast<jint>(retry_count));
-
     } else {
       result =
         env->CallBooleanMethod(handler_obj, on_alloc_fail_method, static_cast<jlong>(num_bytes));
@@ -252,76 +366,33 @@ class java_event_handler_memory_resource : public device_memory_resource {
       auto it = std::find_if(thresholds.begin(), thresholds.end(), [=](std::size_t t) -> bool {
         return low < t && high >= t;
       });
-      if (it != thresholds.end()) {  // throw Java exception, but not C++ exception
+      if (it != thresholds.end()) {
         JNIEnv* env = cudf::jni::get_jni_env(jvm);
         env->CallVoidMethod(handler_obj, callback_method, current_total);
       }
     }
   }
-
- protected:
-  JavaVM* jvm;
-  jobject handler_obj;
-
-  void* do_allocate(std::size_t num_bytes, rmm::cuda_stream_view stream) override
-  {
-    std::size_t total_before;
-    void* result;
-    // a non-zero retry_count signifies that the `on_alloc_fail`
-    // callback is being invoked while re-attempting an allocation
-    // that had previously failed.
-    int retry_count = 0;
-    while (true) {
-      try {
-        total_before = tracker->get_total_allocated();
-        result       = resource->allocate(stream, num_bytes);
-        break;
-      } catch (rmm::out_of_memory const& e) {
-        if (!on_alloc_fail(num_bytes, retry_count++)) { throw; }
-      }
-    }
-    auto total_after = tracker->get_total_allocated();
-
-    try {
-      check_for_threshold_callback(total_before,
-                                   total_after,
-                                   alloc_thresholds,
-                                   on_alloc_threshold_method,
-                                   "onAllocThreshold",
-                                   total_after);
-    } catch (std::exception const& e) {
-      // Free the allocation as app will think the exception means the memory was not allocated.
-      resource->deallocate(stream, result, num_bytes);
-      throw;
-    }
-
-    return result;
-  }
-
-  void do_deallocate(void* p, std::size_t size, rmm::cuda_stream_view stream) noexcept override
-  {
-    auto total_before = tracker->get_total_allocated();
-    resource->deallocate(stream, p, size);
-    auto total_after = tracker->get_total_allocated();
-    check_for_threshold_callback(total_after,
-                                 total_before,
-                                 dealloc_thresholds,
-                                 on_dealloc_threshold_method,
-                                 "onDeallocThreshold",
-                                 total_after);
-  }
 };
 
-class java_debug_event_handler_memory_resource final : public java_event_handler_memory_resource {
+/**
+ * @brief Debug implementation that adds allocation/deallocation callbacks.
+ */
+class java_debug_event_handler_memory_resource_impl final
+  : public java_event_handler_memory_resource_impl {
  public:
-  java_debug_event_handler_memory_resource(JNIEnv* env,
-                                           jobject jhandler,
-                                           jlongArray jalloc_thresholds,
-                                           jlongArray jdealloc_thresholds,
-                                           device_memory_resource* resource_to_wrap,
-                                           base_tracking_resource_adaptor* tracker)
-    : java_event_handler_memory_resource(
-        env, jhandler, jalloc_thresholds, jdealloc_thresholds, resource_to_wrap, tracker)
+  java_debug_event_handler_memory_resource_impl(
+    JNIEnv* env,
+    jobject jhandler,
+    jlongArray jalloc_thresholds,
+    jlongArray jdealloc_thresholds,
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+    tracking_resource_adaptor tracker)
+    : java_event_handler_memory_resource_impl(env,
+                                              jhandler,
+                                              jalloc_thresholds,
+                                              jdealloc_thresholds,
+                                              std::move(upstream),
+                                              std::move(tracker))
   {
     jclass cls = env->GetObjectClass(jhandler);
     if (cls == nullptr) { throw cudf::jni::jni_exception("class not found"); }
@@ -335,11 +406,29 @@ class java_debug_event_handler_memory_resource final : public java_event_handler
     }
   }
 
+  void* allocate(cuda::stream_ref stream,
+                 std::size_t num_bytes,
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) override
+  {
+    void* result = java_event_handler_memory_resource_impl::allocate(stream, num_bytes, alignment);
+    on_allocated_callback(num_bytes);
+    return result;
+  }
+
+  void deallocate(cuda::stream_ref stream,
+                  void* p,
+                  std::size_t size,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept override
+  {
+    java_event_handler_memory_resource_impl::deallocate(stream, p, size, alignment);
+    on_deallocated_callback(size);
+  }
+
  private:
   jmethodID on_allocated_method;
   jmethodID on_deallocated_method;
 
-  void on_allocated_callback(std::size_t num_bytes, rmm::cuda_stream_view stream)
+  void on_allocated_callback(std::size_t num_bytes)
   {
     JNIEnv* env = cudf::jni::get_jni_env(jvm);
     env->CallVoidMethod(handler_obj, on_allocated_method, num_bytes);
@@ -348,30 +437,85 @@ class java_debug_event_handler_memory_resource final : public java_event_handler
     }
   }
 
-  void on_deallocated_callback(void* p, std::size_t size, rmm::cuda_stream_view stream)
+  void on_deallocated_callback(std::size_t size)
   {
     JNIEnv* env = cudf::jni::get_jni_env(jvm);
     env->CallVoidMethod(handler_obj, on_deallocated_method, size);
   }
-
-  void* do_allocate(std::size_t num_bytes, rmm::cuda_stream_view stream) override
-  {
-    void* result = java_event_handler_memory_resource::do_allocate(num_bytes, stream);
-    on_allocated_callback(num_bytes, stream);
-    return result;
-  }
-
-  void do_deallocate(void* p, std::size_t size, rmm::cuda_stream_view stream) noexcept override
-  {
-    java_event_handler_memory_resource::do_deallocate(p, size, stream);
-    on_deallocated_callback(p, size, stream);
-  }
 };
+
+/**
+ * @brief Copyable wrapper for java event handler that holds shared_ptr to impl.
+ * Satisfies CCCL resource concept for use with device_async_resource_ref.
+ */
+class java_event_handler_memory_resource {
+ public:
+  java_event_handler_memory_resource(JNIEnv* env,
+                                     jobject jhandler,
+                                     jlongArray jalloc_thresholds,
+                                     jlongArray jdealloc_thresholds,
+                                     cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+                                     tracking_resource_adaptor tracker,
+                                     bool enable_debug)
+    : impl_(enable_debug
+              ? std::make_shared<java_debug_event_handler_memory_resource_impl>(
+                  env, jhandler, jalloc_thresholds, jdealloc_thresholds, upstream, tracker)
+              : std::make_shared<java_event_handler_memory_resource_impl>(env,
+                                                                          jhandler,
+                                                                          jalloc_thresholds,
+                                                                          jdealloc_thresholds,
+                                                                          std::move(upstream),
+                                                                          std::move(tracker)))
+  {
+  }
+
+  void* allocate(cuda::stream_ref stream,
+                 std::size_t bytes,
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+  {
+    return impl_->allocate(stream, bytes, alignment);
+  }
+
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    impl_->deallocate(stream, ptr, bytes, alignment);
+  }
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+  {
+    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  }
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+  }
+
+  bool operator==(java_event_handler_memory_resource const& other) const noexcept
+  {
+    return impl_ == other.impl_;
+  }
+
+  friend void get_property(java_event_handler_memory_resource const&,
+                           cuda::mr::device_accessible) noexcept
+  {
+  }
+
+ private:
+  std::shared_ptr<java_event_handler_memory_resource_impl> impl_;
+};
+static_assert(
+  cuda::mr::resource_with<java_event_handler_memory_resource, cuda::mr::device_accessible>);
 
 inline auto& prior_cudf_pinned_mr()
 {
-  static rmm::host_device_async_resource_ref _prior_cudf_pinned_mr =
-    cudf::get_pinned_memory_resource();
+  static cuda::mr::resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible>
+    _prior_cudf_pinned_mr = cudf::get_pinned_memory_resource();
   return _prior_cudf_pinned_mr;
 }
 
@@ -385,26 +529,23 @@ inline auto& prior_cudf_pinned_mr()
  *
  * Most of this comes directly from `pinned_host_memory_resource` in RMM.
  */
-class pinned_fallback_host_memory_resource : public rmm::mr::device_memory_resource {
+class pinned_fallback_host_memory_resource {
  public:
-  pinned_fallback_host_memory_resource(rmm_pinned_pool_t* pool_) : pool{pool_}
+  pinned_fallback_host_memory_resource(rmm::mr::pool_memory_resource pool_) : pool{pool_}
   {
-    auto pool_size = pool->pool_size();
-    pool_begin     = pool->allocate_sync(pool_size);
+    auto pool_size = pool.pool_size();
+    pool_begin     = pool.allocate_sync(pool_size);
     pool_end       = static_cast<void*>(static_cast<uint8_t*>(pool_begin) + pool_size);
-    pool->deallocate_sync(pool_begin, pool_size);
+    pool.deallocate_sync(pool_begin, pool_size);
   }
 
- private:
-  rmm_pinned_pool_t* pool;
-  void* pool_begin;
-  void* pool_end;
-
-  void* do_allocate(std::size_t bytes, rmm::cuda_stream_view stream) override
+  void* allocate(cuda::stream_ref stream,
+                 std::size_t bytes,
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    if (bytes <= pool->pool_size()) {
+    if (bytes <= pool.pool_size()) {
       try {
-        return pool->allocate(stream, bytes);
+        return pool.allocate(stream, bytes, alignment);
       } catch (...) {
         // If the pool is exhausted, fall back to the upstream memory resource
       }
@@ -412,19 +553,33 @@ class pinned_fallback_host_memory_resource : public rmm::mr::device_memory_resou
     return prior_cudf_pinned_mr().allocate(stream, bytes);
   }
 
-  void do_deallocate(void* ptr, std::size_t bytes, rmm::cuda_stream_view stream) noexcept override
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    if (bytes <= pool->pool_size() && ptr >= pool_begin && ptr < pool_end) {
-      pool->deallocate(stream, ptr, bytes);
+    if (bytes <= pool.pool_size() && ptr >= pool_begin && ptr < pool_end) {
+      pool.deallocate(stream, ptr, bytes, alignment);
     } else {
       prior_cudf_pinned_mr().deallocate(stream, ptr, bytes);
     }
   }
 
-  [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    auto const* other_ptr = dynamic_cast<pinned_fallback_host_memory_resource const*>(&other);
-    return other_ptr != nullptr && pool == other_ptr->pool;
+    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  }
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  {
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+  }
+
+  bool operator==(pinned_fallback_host_memory_resource const& other) const noexcept
+  {
+    return pool == other.pool;
   }
 
   /**
@@ -446,6 +601,11 @@ class pinned_fallback_host_memory_resource : public rmm::mr::device_memory_resou
                            cuda::mr::host_accessible) noexcept
   {
   }
+
+ private:
+  rmm::mr::pool_memory_resource pool;
+  void* pool_begin;
+  void* pool_end;
 };
 
 // carryover from RMM pinned_host_memory_resource
@@ -553,8 +713,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newCudaMemoryResource(JNIEnv* en
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto ret = new rmm::mr::cuda_memory_resource();
-    return reinterpret_cast<jlong>(ret);
+    return make_jni_resource(rmm::mr::cuda_memory_resource{});
   }
   JNI_CATCH(env, 0);
 }
@@ -566,8 +725,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releaseCudaMemoryResource(JNIEnv*
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr = reinterpret_cast<rmm::mr::cuda_memory_resource*>(ptr);
-    delete mr;
+    delete_jni_resource(ptr);
   }
   JNI_CATCH(env, );
 }
@@ -577,8 +735,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newManagedMemoryResource(JNIEnv*
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto ret = new rmm::mr::managed_memory_resource();
-    return reinterpret_cast<jlong>(ret);
+    return make_jni_resource(rmm::mr::managed_memory_resource{});
   }
   JNI_CATCH(env, 0);
 }
@@ -590,8 +747,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releaseManagedMemoryResource(JNIE
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr = reinterpret_cast<rmm::mr::managed_memory_resource*>(ptr);
-    delete mr;
+    delete_jni_resource(ptr);
   }
   JNI_CATCH(env, );
 }
@@ -603,10 +759,9 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newPoolMemoryResource(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto wrapped = reinterpret_cast<rmm::mr::device_memory_resource*>(child);
-    auto ret =
-      new rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>(wrapped, init, max);
-    return reinterpret_cast<jlong>(ret);
+    auto upstream = get_resource(child);
+    return make_jni_resource(rmm::mr::pool_memory_resource{
+      upstream, static_cast<std::size_t>(init), static_cast<std::size_t>(max)});
   }
   JNI_CATCH(env, 0);
 }
@@ -618,9 +773,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releasePoolMemoryResource(JNIEnv*
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr =
-      reinterpret_cast<rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>*>(ptr);
-    delete mr;
+    delete_jni_resource(ptr);
   }
   JNI_CATCH(env, );
 }
@@ -632,10 +785,9 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newArenaMemoryResource(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto wrapped = reinterpret_cast<rmm::mr::device_memory_resource*>(child);
-    auto ret     = new rmm::mr::arena_memory_resource<rmm::mr::device_memory_resource>(
-      wrapped, init, dump_on_oom);
-    return reinterpret_cast<jlong>(ret);
+    auto upstream = get_resource(child);
+    return make_jni_resource(rmm::mr::arena_memory_resource{
+      upstream, static_cast<std::size_t>(init), static_cast<bool>(dump_on_oom)});
   }
   JNI_CATCH(env, 0);
 }
@@ -647,9 +799,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releaseArenaMemoryResource(JNIEnv
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr =
-      reinterpret_cast<rmm::mr::arena_memory_resource<rmm::mr::device_memory_resource>*>(ptr);
-    delete mr;
+    delete_jni_resource(ptr);
   }
   JNI_CATCH(env, );
 }
@@ -665,9 +815,7 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newCudaAsyncMemoryResource(
       fabric ? std::optional{rmm::mr::cuda_async_memory_resource::allocation_handle_type::fabric}
              : std::nullopt;
 
-    auto ret = new rmm::mr::cuda_async_memory_resource(init, release, handle_type);
-
-    return reinterpret_cast<jlong>(ret);
+    return make_jni_resource(rmm::mr::cuda_async_memory_resource{init, release, handle_type});
   }
   JNI_CATCH(env, 0);
 }
@@ -679,8 +827,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releaseCudaAsyncMemoryResource(JN
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr = reinterpret_cast<rmm::mr::cuda_async_memory_resource*>(ptr);
-    delete mr;
+    delete_jni_resource(ptr);
   }
   JNI_CATCH(env, );
 }
@@ -692,10 +839,9 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newLimitingResourceAdaptor(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto wrapped = reinterpret_cast<rmm::mr::device_memory_resource*>(child);
-    auto ret     = new rmm::mr::limiting_resource_adaptor<rmm::mr::device_memory_resource>(
-      wrapped, limit, align);
-    return reinterpret_cast<jlong>(ret);
+    auto upstream = get_resource(child);
+    return make_jni_resource(rmm::mr::limiting_resource_adaptor{
+      upstream, static_cast<std::size_t>(limit), static_cast<std::size_t>(align)});
   }
   JNI_CATCH(env, 0);
 }
@@ -707,9 +853,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releaseLimitingResourceAdaptor(JN
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr =
-      reinterpret_cast<rmm::mr::limiting_resource_adaptor<rmm::mr::device_memory_resource>*>(ptr);
-    delete mr;
+    delete_jni_resource(ptr);
   }
   JNI_CATCH(env, );
 }
@@ -721,27 +865,20 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newLoggingResourceAdaptor(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto wrapped = reinterpret_cast<rmm::mr::device_memory_resource*>(child);
+    auto upstream = get_resource(child);
     switch (type) {
       case 1:  // File
       {
         cudf::jni::native_jstring path(env, jpath);
-        auto ret = new logging_resource_adaptor<rmm::mr::device_memory_resource>(
-          wrapped, path.get(), auto_flush);
-        return reinterpret_cast<jlong>(ret);
+        return make_jni_resource(
+          rmm::mr::logging_resource_adaptor{upstream, path.get(), static_cast<bool>(auto_flush)});
       }
       case 2:  // stdout
-      {
-        auto ret = new logging_resource_adaptor<rmm::mr::device_memory_resource>(
-          wrapped, std::cout, auto_flush);
-        return reinterpret_cast<jlong>(ret);
-      }
+        return make_jni_resource(
+          rmm::mr::logging_resource_adaptor{upstream, std::cout, static_cast<bool>(auto_flush)});
       case 3:  // stderr
-      {
-        auto ret = new logging_resource_adaptor<rmm::mr::device_memory_resource>(
-          wrapped, std::cerr, auto_flush);
-        return reinterpret_cast<jlong>(ret);
-      }
+        return make_jni_resource(
+          rmm::mr::logging_resource_adaptor{upstream, std::cerr, static_cast<bool>(auto_flush)});
       default: throw std::logic_error("unsupported logging location type");
     }
   }
@@ -755,12 +892,15 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releaseLoggingResourceAdaptor(JNI
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr =
-      reinterpret_cast<rmm::mr::logging_resource_adaptor<rmm::mr::device_memory_resource>*>(ptr);
-    delete mr;
+    delete_jni_resource(ptr);
   }
   JNI_CATCH(env, );
 }
+
+// Map to store tracking adaptors for metrics access.
+// tracking_resource_adaptor is copyable (via shared_ptr to impl), so copies share state.
+std::mutex tracking_adaptor_map_mutex;
+std::unordered_map<jlong, tracking_resource_adaptor> tracking_adaptor_map;
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newTrackingResourceAdaptor(JNIEnv* env,
                                                                            jclass clazz,
@@ -771,9 +911,15 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newTrackingResourceAdaptor(JNIEn
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto wrapped = reinterpret_cast<rmm::mr::device_memory_resource*>(child);
-    auto ret     = new tracking_resource_adaptor<rmm::mr::device_memory_resource>(wrapped, align);
-    return reinterpret_cast<jlong>(ret);
+    auto upstream = get_resource(child);
+    auto adaptor  = tracking_resource_adaptor(upstream, static_cast<std::size_t>(align));
+    auto handle   = make_jni_resource(adaptor);
+    // Store a copy in map for metrics access (copies share impl via shared_ptr)
+    {
+      std::lock_guard<std::mutex> lock(tracking_adaptor_map_mutex);
+      tracking_adaptor_map.emplace(handle, adaptor);
+    }
+    return handle;
   }
   JNI_CATCH(env, 0);
 }
@@ -785,10 +931,24 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releaseTrackingResourceAdaptor(JN
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr = reinterpret_cast<tracking_resource_adaptor<rmm::mr::device_memory_resource>*>(ptr);
-    delete mr;
+    {
+      std::lock_guard<std::mutex> lock(tracking_adaptor_map_mutex);
+      tracking_adaptor_map.erase(ptr);
+    }
+    delete_jni_resource(ptr);
   }
   JNI_CATCH(env, );
+}
+
+// Helper to get tracking adaptor from the map
+inline tracking_resource_adaptor& get_tracking_adaptor(jlong handle)
+{
+  std::lock_guard<std::mutex> lock(tracking_adaptor_map_mutex);
+  auto it = tracking_adaptor_map.find(handle);
+  if (it == tracking_adaptor_map.end()) {
+    throw std::runtime_error("tracking adaptor not found for handle");
+  }
+  return it->second;
 }
 
 JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_nativeGetTotalBytesAllocated(JNIEnv* env,
@@ -799,8 +959,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_nativeGetTotalBytesAllocated(JNI
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr = reinterpret_cast<tracking_resource_adaptor<rmm::mr::device_memory_resource>*>(ptr);
-    return mr->get_total_allocated();
+    auto& mr = get_tracking_adaptor(ptr);
+    return mr.get_total_allocated();
   }
   JNI_CATCH(env, 0);
 }
@@ -813,8 +973,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_nativeGetMaxTotalBytesAllocated(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr = reinterpret_cast<tracking_resource_adaptor<rmm::mr::device_memory_resource>*>(ptr);
-    return mr->get_max_total_allocated();
+    auto& mr = get_tracking_adaptor(ptr);
+    return mr.get_max_total_allocated();
   }
   JNI_CATCH(env, 0);
 }
@@ -828,8 +988,8 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_nativeResetScopedMaxTotalBytesAll
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr = reinterpret_cast<tracking_resource_adaptor<rmm::mr::device_memory_resource>*>(ptr);
-    mr->reset_scoped_max_total_allocated(init);
+    auto& mr = get_tracking_adaptor(ptr);
+    mr.reset_scoped_max_total_allocated(init);
   }
   JNI_CATCH(env, );
 }
@@ -842,8 +1002,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_nativeGetScopedMaxTotalBytesAllo
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr = reinterpret_cast<tracking_resource_adaptor<rmm::mr::device_memory_resource>*>(ptr);
-    return mr->get_scoped_max_total_allocated();
+    auto& mr = get_tracking_adaptor(ptr);
+    return mr.get_scoped_max_total_allocated();
   }
   JNI_CATCH(env, 0);
 }
@@ -862,17 +1022,10 @@ Java_ai_rapids_cudf_Rmm_newEventHandlerResourceAdaptor(JNIEnv* env,
   JNI_NULL_CHECK(env, tracker, "tracker is null", 0);
   JNI_TRY
   {
-    auto wrapped = reinterpret_cast<rmm::mr::device_memory_resource*>(child);
-    auto t = reinterpret_cast<tracking_resource_adaptor<rmm::mr::device_memory_resource>*>(tracker);
-    if (enable_debug) {
-      auto ret = new java_debug_event_handler_memory_resource(
-        env, handler_obj, jalloc_thresholds, jdealloc_thresholds, wrapped, t);
-      return reinterpret_cast<jlong>(ret);
-    } else {
-      auto ret = new java_event_handler_memory_resource(
-        env, handler_obj, jalloc_thresholds, jdealloc_thresholds, wrapped, t);
-      return reinterpret_cast<jlong>(ret);
-    }
+    auto upstream = get_resource(child);
+    auto t        = get_tracking_adaptor(tracker);
+    return make_jni_resource(java_event_handler_memory_resource(
+      env, handler_obj, jalloc_thresholds, jdealloc_thresholds, upstream, t, enable_debug));
   }
   JNI_CATCH(env, 0);
 }
@@ -883,13 +1036,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releaseEventHandlerResourceAdapto
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    if (enable_debug) {
-      auto mr = reinterpret_cast<java_debug_event_handler_memory_resource*>(ptr);
-      delete mr;
-    } else {
-      auto mr = reinterpret_cast<java_event_handler_memory_resource*>(ptr);
-      delete mr;
-    }
+    delete_jni_resource(ptr);
   }
   JNI_CATCH(env, );
 }
@@ -901,8 +1048,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_setCurrentDeviceResourceInternal(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto mr = reinterpret_cast<rmm::mr::device_memory_resource*>(new_handle);
-    cudf::set_current_device_resource(mr);
+    cudf::set_current_device_resource(get_resource(new_handle));
   }
   JNI_CATCH(env, );
 }
@@ -915,7 +1061,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_newPinnedPoolMemoryResource(JNIE
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto pool = new rmm_pinned_pool_t(new rmm::mr::pinned_host_memory_resource(), init, max);
+    auto pool =
+      new rmm::mr::pool_memory_resource(rmm::mr::pinned_host_memory_resource{}, init, max);
     return reinterpret_cast<jlong>(pool);
   }
   JNI_CATCH(env, 0);
@@ -928,10 +1075,10 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_setCudfPinnedPoolMemoryResource(J
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto pool = reinterpret_cast<rmm_pinned_pool_t*>(pool_ptr);
+    auto pool = reinterpret_cast<rmm::mr::pool_memory_resource*>(pool_ptr);
     // create a pinned fallback pool that will allocate pinned memory
     // if the regular pinned pool is exhausted
-    pinned_fallback_mr.reset(new pinned_fallback_host_memory_resource(pool));
+    pinned_fallback_mr.reset(new pinned_fallback_host_memory_resource(*pool));
     prior_cudf_pinned_mr() = cudf::set_pinned_memory_resource(*pinned_fallback_mr);
   }
   JNI_CATCH(env, );
@@ -948,7 +1095,7 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_releasePinnedPoolMemoryResource(J
     // if we didn't overwrite it with setCudfPinnedPoolMemoryResource
     cudf::set_pinned_memory_resource(prior_cudf_pinned_mr());
     pinned_fallback_mr.reset();
-    delete reinterpret_cast<rmm_pinned_pool_t*>(pool_ptr);
+    delete reinterpret_cast<rmm::mr::pool_memory_resource*>(pool_ptr);
   }
   JNI_CATCH(env, );
 }
@@ -961,8 +1108,8 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Rmm_allocFromPinnedPool(JNIEnv* env,
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto pool = reinterpret_cast<rmm_pinned_pool_t*>(pool_ptr);
-    void* ret = pool->allocate(cudf::get_default_stream(), size);
+    auto pool = reinterpret_cast<rmm::mr::pool_memory_resource*>(pool_ptr);
+    void* ret = pool->allocate(cudf::get_default_stream(), size, rmm::CUDA_ALLOCATION_ALIGNMENT);
     return reinterpret_cast<jlong>(ret);
   }
   JNI_CATCH_BEGIN(env, 0)
@@ -978,9 +1125,9 @@ JNIEXPORT void JNICALL Java_ai_rapids_cudf_Rmm_freeFromPinnedPool(
   JNI_TRY
   {
     cudf::jni::auto_set_device(env);
-    auto pool  = reinterpret_cast<rmm_pinned_pool_t*>(pool_ptr);
+    auto pool  = reinterpret_cast<rmm::mr::pool_memory_resource*>(pool_ptr);
     void* cptr = reinterpret_cast<void*>(ptr);
-    pool->deallocate(cudf::get_default_stream(), cptr, size);
+    pool->deallocate(cudf::get_default_stream(), cptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   }
   JNI_CATCH(env, );
 }

--- a/java/src/main/native/src/TableJni.cpp
+++ b/java/src/main/native/src/TableJni.cpp
@@ -6,6 +6,7 @@
 #include "csv_chunked_writer.hpp"
 #include "cudf_jni_apis.hpp"
 #include "dtype_utils.hpp"
+#include "jni_cccl_any_resource.hpp"
 #include "jni_compiled_expr.hpp"
 #include "jni_utils.hpp"
 #include "jni_writer_data_sink.hpp"
@@ -46,7 +47,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 #include <cudf/utilities/span.hpp>
 
-#include <rmm/mr/device_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <arrow/api.h>
 #include <arrow/c/bridge.h>
@@ -4312,9 +4313,10 @@ JNIEXPORT jlong JNICALL Java_ai_rapids_cudf_Table_makeChunkedPack(
     cudf::table_view* n_table = reinterpret_cast<cudf::table_view*>(input_table);
     // `temp_mr` is the memory resource that `cudf::chunked_pack` will use to create temporary
     // and scratch memory only.
-    auto temp_mr = memoryResourceHandle != 0
-                     ? reinterpret_cast<rmm::mr::device_memory_resource*>(memoryResourceHandle)
-                     : cudf::get_current_device_resource_ref();
+    rmm::device_async_resource_ref temp_mr =
+      memoryResourceHandle != 0
+        ? rmm::device_async_resource_ref{cudf::jni::get_resource(memoryResourceHandle)}
+        : cudf::get_current_device_resource_ref();
     auto chunked_pack =
       cudf::chunked_pack::create(*n_table, bounce_buffer_size, cudf::get_default_stream(), temp_mr);
     return reinterpret_cast<jlong>(chunked_pack.release());

--- a/python/pylibcudf/pylibcudf/libcudf/binaryop.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/binaryop.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t
 from libcpp cimport bool
@@ -11,7 +11,7 @@ from pylibcudf.libcudf.scalar.scalar cimport scalar
 from pylibcudf.libcudf.types cimport data_type
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/binaryop.hpp" namespace "cudf" nogil:
@@ -58,7 +58,7 @@ cdef extern from "cudf/binaryop.hpp" namespace "cudf" nogil:
         binary_operator op,
         data_type output_type,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] binary_operation (
@@ -67,7 +67,7 @@ cdef extern from "cudf/binaryop.hpp" namespace "cudf" nogil:
         binary_operator op,
         data_type output_type,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] binary_operation (
@@ -76,7 +76,7 @@ cdef extern from "cudf/binaryop.hpp" namespace "cudf" nogil:
         binary_operator op,
         data_type output_type,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] binary_operation (
@@ -85,7 +85,7 @@ cdef extern from "cudf/binaryop.hpp" namespace "cudf" nogil:
         const string& op,
         data_type output_type,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
 cdef extern from "cudf/binaryop.hpp" namespace "cudf::binops" nogil:

--- a/python/pylibcudf/pylibcudf/libcudf/column/column.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/column/column.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -12,7 +12,7 @@ from pylibcudf.libcudf.types cimport data_type, size_type
 
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/column/column.hpp" namespace "cudf" nogil:
@@ -26,13 +26,13 @@ cdef extern from "cudf/column/column.hpp" namespace "cudf" nogil:
         column(
             const column& other,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         column(
             column_view view,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         size_type size() except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/column/column_factories.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/column/column_factories.pxd
@@ -14,7 +14,7 @@ from pylibcudf.libcudf.types cimport (
 
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/column/column_factories.hpp" namespace "cudf" nogil:
@@ -23,7 +23,7 @@ cdef extern from "cudf/column/column_factories.hpp" namespace "cudf" nogil:
         size_type size,
         mask_state state,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_numeric_column(
@@ -32,7 +32,7 @@ cdef extern from "cudf/column/column_factories.hpp" namespace "cudf" nogil:
         device_buffer mask,
         size_type null_count,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_fixed_point_column(
@@ -40,7 +40,7 @@ cdef extern from "cudf/column/column_factories.hpp" namespace "cudf" nogil:
         size_type size,
         mask_state state,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_fixed_point_column(
         data_type type,
@@ -48,14 +48,14 @@ cdef extern from "cudf/column/column_factories.hpp" namespace "cudf" nogil:
         device_buffer mask,
         size_type null_count,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_timestamp_column(
         data_type type,
         size_type size,
         mask_state state,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_timestamp_column(
         data_type type,
@@ -63,14 +63,14 @@ cdef extern from "cudf/column/column_factories.hpp" namespace "cudf" nogil:
         device_buffer mask,
         size_type null_count,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_duration_column(
         data_type type,
         size_type size,
         mask_state state,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_duration_column(
         data_type type,
@@ -78,14 +78,14 @@ cdef extern from "cudf/column/column_factories.hpp" namespace "cudf" nogil:
         device_buffer mask,
         size_type null_count,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_fixed_width_column(
         data_type type,
         size_type size,
         mask_state state,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_fixed_width_column(
         data_type type,
@@ -93,27 +93,27 @@ cdef extern from "cudf/column/column_factories.hpp" namespace "cudf" nogil:
         device_buffer mask,
         size_type null_count,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_column_from_scalar(
         const scalar& s,
         size_type size,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_dictionary_from_scalar(
         const scalar& s,
         size_type size,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_dictionary_column(
         unique_ptr[column] keys_column,
         unique_ptr[column] indices_column,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] make_empty_column(
         type_id id

--- a/python/pylibcudf/pylibcudf/libcudf/concatenate.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/concatenate.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from libcpp.vector cimport vector
@@ -9,7 +9,7 @@ from pylibcudf.libcudf.utilities.span cimport host_span
 
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/concatenate.hpp" namespace "cudf" nogil:
@@ -25,10 +25,10 @@ cdef extern from "cudf/concatenate.hpp" namespace "cudf" nogil:
     cdef unique_ptr[column] concatenate(
         const vector[column_view] columns,
         cuda_stream_view stream,
-        device_memory_resource *mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[table] concatenate(
         const vector[table_view] tables,
         cuda_stream_view stream,
-        device_memory_resource *mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/contiguous_split.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/contiguous_split.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport uint8_t
 from libc.stddef cimport size_t
@@ -11,7 +11,7 @@ from pylibcudf.libcudf.types cimport size_type
 from pylibcudf.libcudf.utilities.span cimport device_span
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/contiguous_split.hpp" namespace "cudf" nogil:
@@ -33,7 +33,7 @@ cdef extern from "cudf/contiguous_split.hpp" namespace "cudf" nogil:
             const table_view & input,
             size_t user_buffer_size,
             cuda_stream_view stream,
-            device_memory_resource *temp_mr,
+            device_async_resource_ref temp_mr,
         ) except +libcudf_exception_handler
 
     cdef struct contiguous_split_result:
@@ -44,13 +44,13 @@ cdef extern from "cudf/contiguous_split.hpp" namespace "cudf" nogil:
         table_view input_table,
         vector[size_type] splits,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef packed_columns pack (
         const table_view& input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef table_view unpack (

--- a/python/pylibcudf/pylibcudf/libcudf/copying.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/copying.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t, int64_t, uint8_t
 from libcpp cimport bool
@@ -18,7 +18,7 @@ from pylibcudf.libcudf.types cimport size_type
 
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 ctypedef const scalar constscalar
 
@@ -32,7 +32,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         const column_view& gather_map,
         out_of_bounds_policy policy,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] shift(
@@ -40,7 +40,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         size_type offset,
         const scalar& fill_values,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] scatter (
@@ -48,7 +48,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         const column_view& scatter_map,
         const table_view& target_table,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] scatter (
@@ -56,7 +56,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         const column_view& indices,
         const table_view& target,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cpdef enum class mask_allocation_policy(int32_t):
@@ -72,7 +72,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         const column_view& input_column,
         mask_allocation_policy policy,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] allocate_like (
@@ -80,7 +80,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         size_type size,
         mask_allocation_policy policy,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] empty_like (
@@ -103,7 +103,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         size_type input_end,
         size_type target_begin,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef vector[column_view] slice (
@@ -135,7 +135,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         const column_view& rhs,
         const column_view& boolean_mask,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] copy_if_else (
@@ -143,7 +143,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         const column_view& rhs,
         const column_view& boolean_mask,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] copy_if_else (
@@ -151,7 +151,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         const scalar& rhs,
         const column_view boolean_mask,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] copy_if_else (
@@ -159,7 +159,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         const scalar& rhs,
         const column_view boolean_mask,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] boolean_mask_scatter (
@@ -167,7 +167,7 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         const table_view& target,
         const column_view& boolean_mask,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] boolean_mask_scatter (
@@ -175,14 +175,14 @@ cdef extern from "cudf/copying.hpp" namespace "cudf" nogil:
         const table_view& target,
         const column_view& boolean_mask,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[scalar] get_element (
         const column_view& input,
         size_type index,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cpdef enum class sample_with_replacement(bool):

--- a/python/pylibcudf/pylibcudf/libcudf/datetime.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/datetime.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from libc.stdint cimport int32_t, uint8_t
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport scalar
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/datetime.hpp" namespace "cudf::datetime" nogil:
@@ -28,7 +28,7 @@ cdef extern from "cudf/datetime.hpp" namespace "cudf::datetime" nogil:
         const column_view& column,
         datetime_component component,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cpdef enum class rounding_frequency(int32_t):
@@ -43,53 +43,53 @@ cdef extern from "cudf/datetime.hpp" namespace "cudf::datetime" nogil:
     cdef unique_ptr[column] ceil_datetimes(
         const column_view& column, rounding_frequency freq,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[column] floor_datetimes(
         const column_view& column, rounding_frequency freq,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[column] round_datetimes(
         const column_view& column, rounding_frequency freq,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] add_calendrical_months(
         const column_view& timestamps,
         const column_view& months,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[column] add_calendrical_months(
         const column_view& timestamps,
         const scalar& months,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[column] day_of_year(
         const column_view& column,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[column] is_leap_year(
         const column_view& column,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[column] last_day_of_month(
         const column_view& column,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[column] extract_quarter(
         const column_view& column,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[column] days_in_month(
         const column_view& column,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/filling.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/filling.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -13,7 +13,7 @@ from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.table.table_view cimport table_view
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/filling.hpp" namespace "cudf" nogil:
@@ -23,7 +23,7 @@ cdef extern from "cudf/filling.hpp" namespace "cudf" nogil:
         size_type end,
         const scalar & value,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef void fill_in_place(
@@ -38,14 +38,14 @@ cdef extern from "cudf/filling.hpp" namespace "cudf" nogil:
         const table_view & input,
         const column_view & count,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] repeat(
         const table_view & input,
         size_type count,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] sequence(
@@ -53,7 +53,7 @@ cdef extern from "cudf/filling.hpp" namespace "cudf" nogil:
         const scalar & init,
         const scalar & step,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] calendrical_month_sequence(
@@ -61,5 +61,5 @@ cdef extern from "cudf/filling.hpp" namespace "cudf" nogil:
         const scalar& init,
         size_type months,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/groupby.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/groupby.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.functional cimport reference_wrapper
@@ -25,7 +25,7 @@ from pylibcudf.libcudf.types cimport (
 )
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 # workaround for https://github.com/cython/cython/issues/3885
 ctypedef const scalar constscalar
@@ -68,7 +68,7 @@ cdef extern from "cudf/groupby.hpp" \
         ] aggregate(
             const vector[aggregation_request]& requests,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         pair[
@@ -77,7 +77,7 @@ cdef extern from "cudf/groupby.hpp" \
         ] scan(
             const vector[scan_request]& requests,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         pair[
@@ -88,18 +88,18 @@ cdef extern from "cudf/groupby.hpp" \
             const vector[size_type] offset,
             const vector[reference_wrapper[constscalar]] fill_values,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         groups get_groups(
             table_view values,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         pair[unique_ptr[table], unique_ptr[table]] replace_nulls(
             const table_view& values,
             const vector[replace_policy] replace_policy,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/hash.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/hash.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport uint32_t, uint64_t
 from libcpp.memory cimport unique_ptr
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.table.table_view cimport table_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/hashing.hpp" namespace "cudf::hashing" nogil:
@@ -16,64 +16,64 @@ cdef extern from "cudf/hashing.hpp" namespace "cudf::hashing" nogil:
         const table_view& input,
         const uint32_t seed,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] murmurhash3_x64_128(
         const table_view& input,
         const uint64_t seed,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] md5(
         const table_view& input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] sha1(
         const table_view& input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] sha224(
         const table_view& input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] sha256(
         const table_view& input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] sha384(
         const table_view& input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] sha512(
         const table_view& input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] xxhash_32(
         const table_view& input,
         const uint32_t seed,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] xxhash_64(
         const table_view& input,
         const uint64_t seed,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
 cdef extern from "cudf/hashing.hpp" namespace "cudf" nogil:

--- a/python/pylibcudf/pylibcudf/libcudf/interop.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/interop.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t
 from libcpp.memory cimport shared_ptr, unique_ptr
@@ -13,7 +13,7 @@ from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.table.table_view cimport table_view
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "dlpack/dlpack.h" nogil:
@@ -41,13 +41,13 @@ cdef extern from "cudf/interop.hpp" namespace "cudf" \
     cdef unique_ptr[table] from_dlpack(
         const DLManagedTensor* managed_tensor,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     DLManagedTensor* to_dlpack(
         const table_view& input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef cppclass column_metadata:
@@ -66,18 +66,18 @@ cdef extern from "cudf/interop.hpp" namespace "cudf::interop" \
             ArrowSchema&& schema,
             ArrowArray&& array,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
         arrow_column(
             ArrowSchema&& schema,
             ArrowDeviceArray&& array,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
         arrow_column(
             ArrowArrayStream&& stream,
             cuda_stream_view cuda_stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
         column_view view() except +libcudf_exception_handler
 
@@ -85,13 +85,13 @@ cdef extern from "cudf/interop.hpp" namespace "cudf::interop" \
         arrow_table(
             ArrowArrayStream&& stream,
             cuda_stream_view cuda_stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
         arrow_table(
             ArrowSchema&& schema,
             ArrowDeviceArray&& array,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
         table_view view() except +libcudf_exception_handler
 

--- a/python/pylibcudf/pylibcudf/libcudf/io/avro.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/avro.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 cimport pylibcudf.libcudf.io.types as cudf_io_types
 from libcpp.string cimport string
@@ -6,7 +6,7 @@ from libcpp.vector cimport vector
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/io/avro.hpp" namespace "cudf::io" nogil:
@@ -50,5 +50,5 @@ cdef extern from "cudf/io/avro.hpp" namespace "cudf::io" nogil:
     cdef cudf_io_types.table_with_metadata read_avro(
         avro_reader_options &options,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/io/csv.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/csv.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 cimport pylibcudf.libcudf.io.types as cudf_io_types
 cimport pylibcudf.libcudf.table.table_view as cudf_table_view
@@ -11,7 +11,7 @@ from libcpp.vector cimport vector
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.types cimport data_type, size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 cdef extern from "cudf/io/csv.hpp" \
         namespace "cudf::io" nogil:
@@ -264,7 +264,7 @@ cdef extern from "cudf/io/csv.hpp" \
     cdef cudf_io_types.table_with_metadata read_csv(
         csv_reader_options &options,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef cppclass csv_writer_options:

--- a/python/pylibcudf/pylibcudf/libcudf/io/hybrid_scan.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/hybrid_scan.pxd
@@ -16,7 +16,7 @@ from pylibcudf.libcudf.io.types cimport table_with_metadata
 from pylibcudf.libcudf.types cimport size_type
 from pylibcudf.libcudf.utilities.span cimport device_span, host_span
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 ctypedef const uint8_t const_uint8_t
 ctypedef const size_type const_size_type
@@ -89,7 +89,7 @@ cdef extern from "cudf/io/experimental/hybrid_scan.hpp" \
             host_span[const_size_type] row_group_indices,
             const parquet_reader_options& options,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         vector[byte_range_info] filter_column_chunks_byte_ranges(
@@ -104,7 +104,7 @@ cdef extern from "cudf/io/experimental/hybrid_scan.hpp" \
             use_data_page_mask mask_data_pages,
             const parquet_reader_options& options,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         vector[byte_range_info] payload_column_chunks_byte_ranges(
@@ -119,7 +119,7 @@ cdef extern from "cudf/io/experimental/hybrid_scan.hpp" \
             use_data_page_mask mask_data_pages,
             const parquet_reader_options& options,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         vector[byte_range_info] all_column_chunks_byte_ranges(
@@ -132,7 +132,7 @@ cdef extern from "cudf/io/experimental/hybrid_scan.hpp" \
             host_span[const_device_span_const_uint8_t] column_chunk_data,
             const parquet_reader_options& options,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         void setup_chunking_for_filter_columns(
@@ -144,7 +144,7 @@ cdef extern from "cudf/io/experimental/hybrid_scan.hpp" \
             host_span[const_device_span_const_uint8_t] column_chunk_data,
             const parquet_reader_options& options,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         table_with_metadata materialize_filter_columns_chunk(
@@ -160,7 +160,7 @@ cdef extern from "cudf/io/experimental/hybrid_scan.hpp" \
             host_span[const_device_span_const_uint8_t] column_chunk_data,
             const parquet_reader_options& options,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
         table_with_metadata materialize_payload_columns_chunk(

--- a/python/pylibcudf/pylibcudf/libcudf/io/json.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/json.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 cimport pylibcudf.libcudf.io.types as cudf_io_types
 cimport pylibcudf.libcudf.table.table_view as cudf_table_view
@@ -12,7 +12,7 @@ from libcpp.vector cimport vector
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.types cimport data_type, size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/io/json.hpp" namespace "cudf::io" nogil:
@@ -159,7 +159,7 @@ cdef extern from "cudf/io/json.hpp" namespace "cudf::io" nogil:
     cdef cudf_io_types.table_with_metadata read_json(
         json_reader_options &options,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef cppclass json_writer_options:

--- a/python/pylibcudf/pylibcudf/libcudf/io/orc.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/orc.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 cimport pylibcudf.libcudf.io.types as cudf_io_types
 cimport pylibcudf.libcudf.table.table_view as cudf_table_view
@@ -12,7 +12,7 @@ from libcpp.vector cimport vector
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.types cimport data_type, size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/io/orc.hpp" namespace "cudf::io" nogil:
@@ -81,7 +81,7 @@ cdef extern from "cudf/io/orc.hpp" namespace "cudf::io" nogil:
     cdef cudf_io_types.table_with_metadata read_orc(
         orc_reader_options opts,
         cuda_stream_view stream,
-        device_memory_resource* mr,
+        device_async_resource_ref mr,
     ) except +libcudf_exception_handler
 
     cdef cppclass orc_writer_options:

--- a/python/pylibcudf/pylibcudf/libcudf/io/parquet.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/parquet.pxd
@@ -23,7 +23,7 @@ from pylibcudf.libcudf.io.types cimport (
 from pylibcudf.libcudf.table.table_view cimport table_view
 from pylibcudf.libcudf.types cimport data_type, size_type, type_id
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/io/parquet.hpp" namespace "cudf::io" nogil:
@@ -125,7 +125,7 @@ cdef extern from "cudf/io/parquet.hpp" namespace "cudf::io" nogil:
     cdef table_with_metadata read_parquet(
         parquet_reader_options args,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef cppclass parquet_writer_options_base:
@@ -304,14 +304,14 @@ cdef extern from "cudf/io/parquet.hpp" namespace "cudf::io" nogil:
             size_t chunk_read_limit,
             const parquet_reader_options& options,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
         chunked_parquet_reader(
             size_t chunk_read_limit,
             size_t pass_read_limit,
             const parquet_reader_options& options,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
         bool has_next() except +libcudf_exception_handler
         table_with_metadata read_chunk() except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/io/text.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/text.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int64_t, uint64_t
 from libcpp cimport bool
@@ -7,7 +7,7 @@ from libcpp.string cimport string
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.column.column cimport column
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/io/text/byte_range_info.hpp" \
@@ -64,5 +64,5 @@ cdef extern from "cudf/io/text/multibyte_split.hpp" \
         string delimiter,
         parse_options options,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/io/timezone.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/io/timezone.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -7,7 +7,7 @@ from libcpp.string cimport string
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.table.table cimport table
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/timezone.hpp" namespace "cudf" nogil:
@@ -15,5 +15,5 @@ cdef extern from "cudf/timezone.hpp" namespace "cudf" nogil:
         optional[string] tzif_dir,
         string timezone_name,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/join.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/join.pxd
@@ -14,7 +14,7 @@ from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.table.table_view cimport table_view
 from pylibcudf.libcudf.types cimport null_equality, size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 from rmm.librmm.device_uvector cimport device_uvector
 from pylibcudf.libcudf.utilities.span cimport device_span
@@ -29,7 +29,7 @@ cdef extern from "cudf/join/join.hpp" namespace "cudf" nogil:
         const table_view right_keys,
         null_equality nulls_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_pair_type left_join(
@@ -37,7 +37,7 @@ cdef extern from "cudf/join/join.hpp" namespace "cudf" nogil:
         const table_view right_keys,
         null_equality nulls_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_pair_type full_join(
@@ -45,7 +45,7 @@ cdef extern from "cudf/join/join.hpp" namespace "cudf" nogil:
         const table_view right_keys,
         null_equality nulls_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_pair_type inner_join(
@@ -53,7 +53,7 @@ cdef extern from "cudf/join/join.hpp" namespace "cudf" nogil:
         const table_view right_keys,
         null_equality nulls_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_pair_type left_join(
@@ -61,7 +61,7 @@ cdef extern from "cudf/join/join.hpp" namespace "cudf" nogil:
         const table_view right_keys,
         null_equality nulls_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_pair_type full_join(
@@ -69,14 +69,14 @@ cdef extern from "cudf/join/join.hpp" namespace "cudf" nogil:
         const table_view right_keys,
         null_equality nulls_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] cross_join(
         const table_view left,
         const table_view right,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
 cdef extern from "cudf/join/conditional_join.hpp" namespace "cudf" nogil:
@@ -85,7 +85,7 @@ cdef extern from "cudf/join/conditional_join.hpp" namespace "cudf" nogil:
         const table_view right,
         const expression binary_predicate,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_pair_type conditional_inner_join(
@@ -94,7 +94,7 @@ cdef extern from "cudf/join/conditional_join.hpp" namespace "cudf" nogil:
         const expression binary_predicate,
         optional[size_t] output_size,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_pair_type conditional_left_join(
@@ -102,7 +102,7 @@ cdef extern from "cudf/join/conditional_join.hpp" namespace "cudf" nogil:
         const table_view right,
         const expression binary_predicate,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_pair_type conditional_left_join(
@@ -111,7 +111,7 @@ cdef extern from "cudf/join/conditional_join.hpp" namespace "cudf" nogil:
         const expression binary_predicate,
         optional[size_t] output_size,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_pair_type conditional_full_join(
@@ -119,7 +119,7 @@ cdef extern from "cudf/join/conditional_join.hpp" namespace "cudf" nogil:
         const table_view right,
         const expression binary_predicate,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_type conditional_left_semi_join(
@@ -127,7 +127,7 @@ cdef extern from "cudf/join/conditional_join.hpp" namespace "cudf" nogil:
         const table_view right,
         const expression binary_predicate,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_type conditional_left_semi_join(
@@ -136,7 +136,7 @@ cdef extern from "cudf/join/conditional_join.hpp" namespace "cudf" nogil:
         const expression binary_predicate,
         optional[size_t] output_size,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_type conditional_left_anti_join(
@@ -144,7 +144,7 @@ cdef extern from "cudf/join/conditional_join.hpp" namespace "cudf" nogil:
         const table_view right,
         const expression binary_predicate,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_type conditional_left_anti_join(
@@ -153,7 +153,7 @@ cdef extern from "cudf/join/conditional_join.hpp" namespace "cudf" nogil:
         const expression binary_predicate,
         optional[size_t] output_size,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
 cdef extern from "cudf/join/mixed_join.hpp" namespace "cudf" nogil:
@@ -166,7 +166,7 @@ cdef extern from "cudf/join/mixed_join.hpp" namespace "cudf" nogil:
         null_equality compare_nulls,
         output_size_data_type output_size_data,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_pair_type mixed_left_join(
@@ -178,7 +178,7 @@ cdef extern from "cudf/join/mixed_join.hpp" namespace "cudf" nogil:
         null_equality compare_nulls,
         output_size_data_type output_size_data,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_pair_type mixed_full_join(
@@ -190,7 +190,7 @@ cdef extern from "cudf/join/mixed_join.hpp" namespace "cudf" nogil:
         null_equality compare_nulls,
         output_size_data_type output_size_data,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_type mixed_left_semi_join(
@@ -201,7 +201,7 @@ cdef extern from "cudf/join/mixed_join.hpp" namespace "cudf" nogil:
         const expression binary_predicate,
         null_equality compare_nulls,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef gather_map_type mixed_left_anti_join(
@@ -212,7 +212,7 @@ cdef extern from "cudf/join/mixed_join.hpp" namespace "cudf" nogil:
         const expression binary_predicate,
         null_equality compare_nulls,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
 cdef extern from "cudf/join/filtered_join.hpp" namespace "cudf" nogil:
@@ -236,10 +236,10 @@ cdef extern from "cudf/join/filtered_join.hpp" namespace "cudf" nogil:
         gather_map_type semi_join(
             const table_view probe,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
         gather_map_type anti_join(
             const table_view probe,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/json.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/json.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -9,7 +9,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport scalar, string_scalar
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/json/json.hpp" namespace "cudf" nogil:
@@ -31,5 +31,5 @@ cdef extern from "cudf/json/json.hpp" namespace "cudf" nogil:
         string_scalar json_path,
         get_json_object_options options,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/labeling.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/labeling.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport int
 from libcpp.memory cimport unique_ptr
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/labeling/label_bins.hpp" namespace "cudf" nogil:
@@ -22,5 +22,5 @@ cdef extern from "cudf/labeling/label_bins.hpp" namespace "cudf" nogil:
         const column_view &right_edges,
         inclusive right_inclusive,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/lists/combine.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/lists/combine.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from libc.stdint cimport int32_t
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.table.table_view cimport table_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/lists/combine.hpp" namespace \
@@ -22,18 +22,18 @@ cdef extern from "cudf/lists/combine.hpp" namespace \
         const table_view input_table,
         concatenate_null_policy null_policy,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] concatenate_list_elements(
         const table_view input_table,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] concatenate_list_elements(
         const column_view input_table,
         concatenate_null_policy null_policy,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/lists/contains.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/lists/contains.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t
 from libcpp.memory cimport unique_ptr
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.lists.lists_column_view cimport lists_column_view
 from pylibcudf.libcudf.scalar.scalar cimport scalar
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/lists/contains.hpp" namespace "cudf::lists" nogil:
@@ -21,20 +21,20 @@ cdef extern from "cudf/lists/contains.hpp" namespace "cudf::lists" nogil:
         const lists_column_view& lists,
         const scalar& search_key,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] contains(
         const lists_column_view& lists,
         const column_view& search_keys,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] contains_nulls(
         const lists_column_view& lists,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] index_of(
@@ -42,7 +42,7 @@ cdef extern from "cudf/lists/contains.hpp" namespace "cudf::lists" nogil:
         const scalar& search_key,
         duplicate_find_option find_option,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] index_of(
@@ -50,5 +50,5 @@ cdef extern from "cudf/lists/contains.hpp" namespace "cudf::lists" nogil:
         const column_view& search_keys,
         duplicate_find_option find_option,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/lists/count_elements.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/lists/count_elements.pxd
@@ -1,16 +1,16 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.lists.lists_column_view cimport lists_column_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/lists/count_elements.hpp" namespace "cudf::lists" nogil:
     cdef unique_ptr[column] count_elements(
         const lists_column_view&,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/lists/explode.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/lists/explode.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.table.table_view cimport table_view
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/lists/explode.hpp" namespace "cudf" nogil:
@@ -14,5 +14,5 @@ cdef extern from "cudf/lists/explode.hpp" namespace "cudf" nogil:
         const table_view,
         size_type explode_column_idx,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/lists/extract.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/lists/extract.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.column.column cimport column, column_view
 from pylibcudf.libcudf.lists.lists_column_view cimport lists_column_view
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/lists/extract.hpp" namespace "cudf::lists" nogil:
@@ -14,11 +14,11 @@ cdef extern from "cudf/lists/extract.hpp" namespace "cudf::lists" nogil:
         const lists_column_view&,
         size_type,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[column] extract_list_element(
         const lists_column_view&,
         const column_view&,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/lists/filling.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/lists/filling.pxd
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/lists/filling.hpp" namespace "cudf::lists" nogil:
@@ -13,7 +13,7 @@ cdef extern from "cudf/lists/filling.hpp" namespace "cudf::lists" nogil:
         const column_view& starts,
         const column_view& sizes,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] sequences(
@@ -21,5 +21,5 @@ cdef extern from "cudf/lists/filling.hpp" namespace "cudf::lists" nogil:
         const column_view& steps,
         const column_view& sizes,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/lists/gather.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/lists/gather.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.copying cimport out_of_bounds_policy
 from pylibcudf.libcudf.lists.lists_column_view cimport lists_column_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 cdef extern from "cudf/lists/gather.hpp" namespace "cudf::lists" nogil:
     cdef unique_ptr[column] segmented_gather(
@@ -14,5 +14,5 @@ cdef extern from "cudf/lists/gather.hpp" namespace "cudf::lists" nogil:
         const lists_column_view& gather_map_list,
         out_of_bounds_policy bounds_policy,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/lists/reverse.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/lists/reverse.pxd
@@ -1,16 +1,16 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.lists.lists_column_view cimport lists_column_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/lists/reverse.hpp" namespace "cudf::lists" nogil:
     cdef unique_ptr[column] reverse(
         const lists_column_view& lists_column,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/lists/set_operations.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/lists/set_operations.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.lists.lists_column_view cimport lists_column_view
 from pylibcudf.libcudf.types cimport nan_equality, null_equality
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/lists/set_operations.hpp" namespace "cudf::lists" nogil:
@@ -16,7 +16,7 @@ cdef extern from "cudf/lists/set_operations.hpp" namespace "cudf::lists" nogil:
         null_equality nulls_equal,
         nan_equality nans_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] have_overlap(
@@ -25,7 +25,7 @@ cdef extern from "cudf/lists/set_operations.hpp" namespace "cudf::lists" nogil:
         null_equality nulls_equal,
         nan_equality nans_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] intersect_distinct(
@@ -34,7 +34,7 @@ cdef extern from "cudf/lists/set_operations.hpp" namespace "cudf::lists" nogil:
         null_equality nulls_equal,
         nan_equality nans_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] union_distinct(
@@ -43,5 +43,5 @@ cdef extern from "cudf/lists/set_operations.hpp" namespace "cudf::lists" nogil:
         null_equality nulls_equal,
         nan_equality nans_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/lists/sorting.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/lists/sorting.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.lists.lists_column_view cimport lists_column_view
 from pylibcudf.libcudf.types cimport null_order, order
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/lists/sorting.hpp" namespace "cudf::lists" nogil:
@@ -15,7 +15,7 @@ cdef extern from "cudf/lists/sorting.hpp" namespace "cudf::lists" nogil:
         order column_order,
         null_order null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] stable_sort_lists(
@@ -23,5 +23,5 @@ cdef extern from "cudf/lists/sorting.hpp" namespace "cudf::lists" nogil:
         order column_order,
         null_order null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/lists/stream_compaction.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/lists/stream_compaction.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.lists.lists_column_view cimport lists_column_view
 from pylibcudf.libcudf.stream_compaction cimport duplicate_keep_option
 from pylibcudf.libcudf.types cimport nan_equality, null_equality
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/lists/stream_compaction.hpp" \
@@ -16,7 +16,7 @@ cdef extern from "cudf/lists/stream_compaction.hpp" \
         const lists_column_view& lists_column,
         const lists_column_view& boolean_mask,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] distinct(
@@ -25,5 +25,5 @@ cdef extern from "cudf/lists/stream_compaction.hpp" \
         nan_equality nans_equal,
         duplicate_keep_option keep_option,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/merge.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/merge.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 cimport pylibcudf.libcudf.types as libcudf_types
 from libcpp.memory cimport unique_ptr
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.table.table_view cimport table_view
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/merge.hpp" namespace "cudf" nogil:
@@ -18,5 +18,5 @@ cdef extern from "cudf/merge.hpp" namespace "cudf" nogil:
         vector[libcudf_types.order] column_order,
         vector[libcudf_types.null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/null_mask.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/null_mask.pxd
@@ -9,14 +9,14 @@ from pylibcudf.libcudf.types cimport bitmask_type, mask_state, size_type
 
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/null_mask.hpp" namespace "cudf" nogil:
     cdef device_buffer copy_bitmask (
         column_view view,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef device_buffer copy_bitmask (
@@ -24,7 +24,7 @@ cdef extern from "cudf/null_mask.hpp" namespace "cudf" nogil:
         size_type begin_bit,
         size_type end_bit,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef size_t bitmask_allocation_size_bytes (
@@ -36,19 +36,19 @@ cdef extern from "cudf/null_mask.hpp" namespace "cudf" nogil:
         size_type size,
         mask_state state,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef pair[device_buffer, size_type] bitmask_and(
         table_view view,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     )
 
     cdef pair[device_buffer, size_type] bitmask_or(
         table_view view,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     )
 
     cdef size_type null_count(

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/byte_pair_encode.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/byte_pair_encode.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "nvtext/byte_pair_encoding.hpp" namespace "nvtext" nogil:
@@ -18,7 +18,7 @@ cdef extern from "nvtext/byte_pair_encoding.hpp" namespace "nvtext" nogil:
     cdef unique_ptr[bpe_merge_pairs] load_merge_pairs(
         const column_view &merge_pairs,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] byte_pair_encoding(
@@ -26,5 +26,5 @@ cdef extern from "nvtext/byte_pair_encoding.hpp" namespace "nvtext" nogil:
         const bpe_merge_pairs &merge_pairs,
         const string_scalar &separator,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/deduplicate.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/deduplicate.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from libcpp.memory cimport unique_ptr
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 from rmm.librmm.device_uvector cimport device_uvector
 
@@ -20,7 +20,7 @@ cdef extern from "nvtext/deduplicate.hpp" namespace "nvtext" nogil:
         column_view source_strings,
         size_type min_width,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] resolve_duplicates(
@@ -28,7 +28,7 @@ cdef extern from "nvtext/deduplicate.hpp" namespace "nvtext" nogil:
         column_view indices,
         size_type min_width,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] resolve_duplicates_pair(
@@ -38,5 +38,5 @@ cdef extern from "nvtext/deduplicate.hpp" namespace "nvtext" nogil:
         column_view indices2,
         size_type min_width,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/edit_distance.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/edit_distance.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "nvtext/edit_distance.hpp" namespace "nvtext" nogil:
@@ -16,11 +16,11 @@ cdef extern from "nvtext/edit_distance.hpp" namespace "nvtext" nogil:
         const column_view & strings,
         const column_view & targets,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] edit_distance_matrix(
         const column_view & strings,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/generate_ngrams.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/generate_ngrams.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport uint32_t
 from libcpp.memory cimport unique_ptr
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "nvtext/generate_ngrams.hpp" namespace "nvtext" nogil:
@@ -18,14 +18,14 @@ cdef extern from "nvtext/generate_ngrams.hpp" namespace "nvtext" nogil:
         size_type ngrams,
         const string_scalar & separator,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] generate_character_ngrams(
         const column_view &strings,
         size_type ngrams,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] hash_character_ngrams(
@@ -33,5 +33,5 @@ cdef extern from "nvtext/generate_ngrams.hpp" namespace "nvtext" nogil:
         size_type ngrams,
         uint32_t seed,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/jaccard.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/jaccard.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "nvtext/jaccard.hpp" namespace "nvtext" nogil:
@@ -16,5 +16,5 @@ cdef extern from "nvtext/jaccard.hpp" namespace "nvtext" nogil:
         const column_view &input2,
         size_type width,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/minhash.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/minhash.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport uint32_t, uint64_t
 from libcpp.memory cimport unique_ptr
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport numeric_scalar
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "nvtext/minhash.hpp" namespace "nvtext" nogil:
@@ -20,7 +20,7 @@ cdef extern from "nvtext/minhash.hpp" namespace "nvtext" nogil:
         const column_view &b,
         const size_type width,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] minhash64(
@@ -30,7 +30,7 @@ cdef extern from "nvtext/minhash.hpp" namespace "nvtext" nogil:
         const column_view &b,
         const size_type width,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] minhash_ngrams(
@@ -40,7 +40,7 @@ cdef extern from "nvtext/minhash.hpp" namespace "nvtext" nogil:
         const column_view &a,
         const column_view &b,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] minhash64_ngrams(
@@ -50,5 +50,5 @@ cdef extern from "nvtext/minhash.hpp" namespace "nvtext" nogil:
         const column_view &a,
         const column_view &b,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/ngrams_tokenize.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/ngrams_tokenize.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "nvtext/ngrams_tokenize.hpp" namespace "nvtext" nogil:
@@ -18,5 +18,5 @@ cdef extern from "nvtext/ngrams_tokenize.hpp" namespace "nvtext" nogil:
         const string_scalar & delimiter,
         const string_scalar & separator,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/normalize.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/normalize.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -6,7 +6,7 @@ from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "nvtext/normalize.hpp" namespace "nvtext" nogil:
@@ -14,7 +14,7 @@ cdef extern from "nvtext/normalize.hpp" namespace "nvtext" nogil:
     cdef unique_ptr[column] normalize_spaces(
         const column_view & strings,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef struct character_normalizer:
@@ -24,12 +24,12 @@ cdef extern from "nvtext/normalize.hpp" namespace "nvtext" nogil:
         bool do_lower_case,
         const column_view & strings,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] normalize_characters(
         const column_view & strings,
         const character_normalizer & normalizer,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/replace.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/replace.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "nvtext/replace.hpp" namespace "nvtext" nogil:
@@ -18,7 +18,7 @@ cdef extern from "nvtext/replace.hpp" namespace "nvtext" nogil:
         const column_view & replacements,
         const string_scalar & delimiter,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] filter_tokens(
@@ -27,5 +27,5 @@ cdef extern from "nvtext/replace.hpp" namespace "nvtext" nogil:
         const string_scalar & replacement,
         const string_scalar & delimiter,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/stemmer.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/stemmer.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t
 from libcpp cimport bool
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "nvtext/stemmer.hpp" namespace "nvtext" nogil:
@@ -19,7 +19,7 @@ cdef extern from "nvtext/stemmer.hpp" namespace "nvtext" nogil:
     cdef unique_ptr[column] porter_stemmer_measure(
         const column_view & strings,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] is_letter(

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/tokenize.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/tokenize.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "nvtext/tokenize.hpp" namespace "nvtext" nogil:
@@ -16,34 +16,34 @@ cdef extern from "nvtext/tokenize.hpp" namespace "nvtext" nogil:
         const column_view & strings,
         const string_scalar & delimiter,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] tokenize(
         const column_view & strings,
         const column_view & delimiters,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] count_tokens(
         const column_view & strings,
         const string_scalar & delimiter,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] count_tokens(
         const column_view & strings,
         const column_view & delimiters,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] character_tokenize(
         const column_view & strings,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] detokenize(
@@ -51,7 +51,7 @@ cdef extern from "nvtext/tokenize.hpp" namespace "nvtext" nogil:
         const column_view & row_indices,
         const string_scalar & separator,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef struct tokenize_vocabulary:
@@ -60,7 +60,7 @@ cdef extern from "nvtext/tokenize.hpp" namespace "nvtext" nogil:
     cdef unique_ptr[tokenize_vocabulary] load_vocabulary(
         const column_view & strings,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] tokenize_with_vocabulary(
@@ -69,5 +69,5 @@ cdef extern from "nvtext/tokenize.hpp" namespace "nvtext" nogil:
         const string_scalar & delimiter,
         size_type default_id,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/nvtext/wordpiece_tokenize.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/nvtext/wordpiece_tokenize.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "nvtext/wordpiece_tokenize.hpp" namespace "nvtext" nogil:
@@ -17,7 +17,7 @@ cdef extern from "nvtext/wordpiece_tokenize.hpp" namespace "nvtext" nogil:
     cdef unique_ptr[wordpiece_vocabulary] load_wordpiece_vocabulary(
         const column_view & strings,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] wordpiece_tokenize(
@@ -25,5 +25,5 @@ cdef extern from "nvtext/wordpiece_tokenize.hpp" namespace "nvtext" nogil:
         const wordpiece_vocabulary & vocabulary,
         size_type max_tokens_per_row,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/partitioning.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/partitioning.pxd
@@ -12,7 +12,7 @@ from pylibcudf.libcudf.hash cimport DEFAULT_HASH_SEED
 from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.table.table_view cimport table_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 cdef extern from "cudf/partitioning.hpp" namespace "cudf" nogil:
     cpdef enum class hash_id(int32_t):
@@ -29,7 +29,7 @@ cdef extern from "cudf/partitioning.hpp" namespace "cudf" nogil:
         hash_id hash_function,
         uint32_t seed,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef pair[unique_ptr[table], vector[libcudf_types.size_type]] \
@@ -40,7 +40,7 @@ cdef extern from "cudf/partitioning.hpp" namespace "cudf" nogil:
         hash_id hash_function,
         uint32_t seed,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef pair[unique_ptr[table], vector[libcudf_types.size_type]] \
@@ -49,7 +49,7 @@ cdef extern from "cudf/partitioning.hpp" namespace "cudf" nogil:
         const column_view& partition_map,
         int num_partitions,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef pair[unique_ptr[table], vector[libcudf_types.size_type]] \
@@ -58,5 +58,5 @@ cdef extern from "cudf/partitioning.hpp" namespace "cudf" nogil:
         int num_partitions,
         int start_partition,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/quantiles.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/quantiles.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -16,7 +16,7 @@ from pylibcudf.libcudf.types cimport (
     sorted,
 )
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/quantiles.hpp" namespace "cudf" nogil:
@@ -28,7 +28,7 @@ cdef extern from "cudf/quantiles.hpp" namespace "cudf" nogil:
         column_view ordered_indices,
         bool exact,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] quantiles (
@@ -39,5 +39,5 @@ cdef extern from "cudf/quantiles.hpp" namespace "cudf" nogil:
         vector[order] column_order,
         vector[null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/reduce.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/reduce.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.functional cimport reference_wrapper
@@ -12,7 +12,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport scalar
 from pylibcudf.libcudf.types cimport data_type, null_policy
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 ctypedef const scalar constscalar
 
@@ -23,7 +23,7 @@ cdef extern from "cudf/reduction.hpp" namespace "cudf" nogil:
         data_type output_type,
         optional[reference_wrapper[constscalar]] init,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cpdef enum class scan_type(bool):
@@ -36,13 +36,13 @@ cdef extern from "cudf/reduction.hpp" namespace "cudf" nogil:
         scan_type inclusive,
         null_policy null_handling,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef pair[unique_ptr[scalar], unique_ptr[scalar]] minmax(
         const column_view& col,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
 

--- a/python/pylibcudf/pylibcudf/libcudf/replace.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/replace.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -10,7 +10,7 @@ from pylibcudf.libcudf.column.column_view cimport (
 )
 from pylibcudf.libcudf.scalar.scalar cimport scalar
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/replace.hpp" namespace "cudf" nogil:
@@ -23,46 +23,46 @@ cdef extern from "cudf/replace.hpp" namespace "cudf" nogil:
         column_view source_column,
         column_view replacement_column,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] replace_nulls(
         column_view source_column,
         scalar replacement,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] replace_nulls(
         column_view source_column,
         replace_policy replace_policy,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] find_and_replace_all(
         column_view source_column,
         column_view values_to_replace,
         column_view replacement_values,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] clamp(
         column_view source_column,
         scalar lo, scalar lo_replace,
         scalar hi, scalar hi_replace,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] clamp(
         column_view source_column,
         scalar lo, scalar hi,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] normalize_nans_and_zeros(
         column_view source_column,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef void normalize_nans_and_zeros(
         mutable_column_view source_column,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/reshape.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/reshape.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -9,7 +9,7 @@ from pylibcudf.libcudf.types cimport size_type, data_type
 from pylibcudf.libcudf.utilities.span cimport device_span
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 cdef extern from "cuda/functional" namespace "cuda::std":
     cdef cppclass byte:
@@ -20,13 +20,13 @@ cdef extern from "cudf/reshape.hpp" namespace "cudf" nogil:
     cdef unique_ptr[column] interleave_columns(
         table_view source_table,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[table] tile(
         table_view source_table,
         size_type count,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef void table_to_array(
         table_view input_table,

--- a/python/pylibcudf/pylibcudf/libcudf/rolling.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/rolling.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -13,7 +13,7 @@ from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.table.table_view cimport table_view
 from pylibcudf.libcudf.types cimport data_type, null_order, order, size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/rolling.hpp" namespace "cudf" nogil:
@@ -45,7 +45,7 @@ cdef extern from "cudf/rolling.hpp" namespace "cudf" nogil:
         range_window_type following,
         vector[rolling_request]& requests,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] rolling_window(
@@ -55,7 +55,7 @@ cdef extern from "cudf/rolling.hpp" namespace "cudf" nogil:
         size_type min_periods,
         rolling_aggregation& agg,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] rolling_window(
         column_view source,
@@ -64,7 +64,7 @@ cdef extern from "cudf/rolling.hpp" namespace "cudf" nogil:
         size_type min_periods,
         rolling_aggregation& agg,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef pair[unique_ptr[column], unique_ptr[column]] make_range_windows(
         const table_view& group_keys,
@@ -74,7 +74,7 @@ cdef extern from "cudf/rolling.hpp" namespace "cudf" nogil:
         range_window_type preceding,
         range_window_type following,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     bool is_valid_rolling_aggregation(

--- a/python/pylibcudf/pylibcudf/libcudf/round.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/round.pxd
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/round.hpp" namespace "cudf" nogil:
@@ -21,7 +21,7 @@ cdef extern from "cudf/round.hpp" namespace "cudf" nogil:
         int32_t decimal_places,
         rounding_method method,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] round_decimal (
@@ -29,5 +29,5 @@ cdef extern from "cudf/round.hpp" namespace "cudf" nogil:
         int32_t decimal_places,
         rounding_method method,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/scalar/scalar.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/scalar/scalar.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t, int64_t
 from libcpp cimport bool
@@ -9,7 +9,7 @@ from pylibcudf.libcudf.fixed_point.fixed_point cimport scale_type
 from pylibcudf.libcudf.table.table_view cimport table_view
 from pylibcudf.libcudf.types cimport data_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/scalar/scalar.hpp" namespace "cudf" nogil:

--- a/python/pylibcudf/pylibcudf/libcudf/scalar/scalar_factories.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/scalar/scalar_factories.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
@@ -10,48 +10,48 @@ from pylibcudf.libcudf.fixed_point.fixed_point cimport scale_type
 from pylibcudf.libcudf.types cimport int128 as int128_t
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/scalar/scalar_factories.hpp" namespace "cudf" nogil:
     cdef unique_ptr[scalar] make_string_scalar(
         const string & _string,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[scalar] make_fixed_width_scalar[T](
         T value,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[scalar] make_fixed_point_scalar[T](
         int128_t value,
         scale_type scale,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[scalar] make_numeric_scalar(
         data_type type_,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[scalar] make_timestamp_scalar(
         data_type type_,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[scalar] make_empty_scalar_like(
         const column_view &,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[scalar] make_duration_scalar(
         data_type type_,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef unique_ptr[scalar] make_default_constructed_scalar(
         data_type type_,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/search.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/search.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 cimport pylibcudf.libcudf.types as libcudf_types
 from libcpp.memory cimport unique_ptr
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.table.table_view cimport table_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/search.hpp" namespace "cudf" nogil:
@@ -19,7 +19,7 @@ cdef extern from "cudf/search.hpp" namespace "cudf" nogil:
         vector[libcudf_types.order] column_order,
         vector[libcudf_types.null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] upper_bound(
@@ -28,12 +28,12 @@ cdef extern from "cudf/search.hpp" namespace "cudf" nogil:
         vector[libcudf_types.order] column_order,
         vector[libcudf_types.null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] contains(
         column_view haystack,
         column_view needles,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/sorting.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/sorting.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from libcpp cimport bool
@@ -18,7 +18,7 @@ from pylibcudf.libcudf.types cimport (
     size_type
 )
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
@@ -27,7 +27,7 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         vector[order] column_order,
         vector[null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] stable_sorted_order(
@@ -35,7 +35,7 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         vector[order] column_order,
         vector[null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] rank(
@@ -46,7 +46,7 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         null_order null_precedence,
         bool percentage,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef bool is_sorted(
@@ -63,7 +63,7 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         vector[order] column_order,
         vector[null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] stable_segmented_sort_by_key(
@@ -73,7 +73,7 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         vector[order] column_order,
         vector[null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] sort_by_key(
@@ -82,7 +82,7 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         vector[order] column_order,
         vector[null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] stable_sort_by_key(
@@ -91,7 +91,7 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         vector[order] column_order,
         vector[null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] sort(
@@ -99,7 +99,7 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         vector[order] column_order,
         vector[null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] stable_sort(
@@ -107,7 +107,7 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         vector[order] column_order,
         vector[null_order] null_precedence,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] top_k(
@@ -115,7 +115,7 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         size_type k,
         order sort_order,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] top_k_order(
@@ -123,5 +123,5 @@ cdef extern from "cudf/sorting.hpp" namespace "cudf" nogil:
         size_type k,
         order sort_order,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/stream_compaction.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/stream_compaction.pxd
@@ -15,7 +15,7 @@ from pylibcudf.libcudf.types cimport (
     size_type,
 )
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/stream_compaction.hpp" namespace "cudf" nogil:
@@ -30,7 +30,7 @@ cdef extern from "cudf/stream_compaction.hpp" namespace "cudf" nogil:
         vector[size_type] keys,
         size_type keep_threshold,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] drop_nans(
@@ -38,14 +38,14 @@ cdef extern from "cudf/stream_compaction.hpp" namespace "cudf" nogil:
         vector[size_type] keys,
         size_type keep_threshold,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] apply_boolean_mask(
         table_view source_table,
         column_view boolean_mask,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] unique(
@@ -54,7 +54,7 @@ cdef extern from "cudf/stream_compaction.hpp" namespace "cudf" nogil:
         duplicate_keep_option keep,
         null_equality nulls_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] distinct(
@@ -64,7 +64,7 @@ cdef extern from "cudf/stream_compaction.hpp" namespace "cudf" nogil:
         null_equality nulls_equal,
         nan_equality nans_equals,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] distinct_indices(
@@ -73,7 +73,7 @@ cdef extern from "cudf/stream_compaction.hpp" namespace "cudf" nogil:
         null_equality nulls_equal,
         nan_equality nans_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] stable_distinct(
@@ -83,7 +83,7 @@ cdef extern from "cudf/stream_compaction.hpp" namespace "cudf" nogil:
         null_equality nulls_equal,
         nan_equality nans_equal,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[table] filter(
@@ -91,5 +91,5 @@ cdef extern from "cudf/stream_compaction.hpp" namespace "cudf" nogil:
         const expression& predicate_expr,
         table_view filter_table,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/attributes.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/attributes.pxd
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/attributes.hpp" namespace "cudf::strings" nogil:
@@ -13,14 +13,14 @@ cdef extern from "cudf/strings/attributes.hpp" namespace "cudf::strings" nogil:
     cdef unique_ptr[column] count_characters(
         column_view source_strings,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] count_bytes(
         column_view source_strings,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] code_points(
         column_view source_strings,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/capitalize.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/capitalize.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.strings.char_types cimport string_character_types
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/capitalize.hpp" namespace "cudf::strings" nogil:
@@ -15,17 +15,17 @@ cdef extern from "cudf/strings/capitalize.hpp" namespace "cudf::strings" nogil:
         const column_view & strings,
         const string_scalar & delimiters,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] title(
         const column_view & strings,
         string_character_types sequence_type,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
         ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] is_title(
         const column_view & strings,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/case.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/case.pxd
@@ -1,25 +1,25 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/case.hpp" namespace "cudf::strings" nogil:
     cdef unique_ptr[column] to_lower(
         const column_view & strings,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] to_upper(
         const column_view & strings,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] swapcase(
         const column_view & strings,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/char_types.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/char_types.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport uint32_t
 from libcpp.memory cimport unique_ptr
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/char_types/char_types.hpp" \
@@ -30,7 +30,7 @@ cdef extern from "cudf/strings/char_types/char_types.hpp" \
         string_character_types types,
         string_character_types verify_types,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] filter_characters_of_type(
         column_view source_strings,
@@ -38,4 +38,4 @@ cdef extern from "cudf/strings/char_types/char_types.hpp" \
         string_scalar replacement,
         string_character_types types_to_keep,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/combine.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/combine.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from libcpp cimport int
@@ -9,7 +9,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.table.table_view cimport table_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/combine.hpp" namespace "cudf::strings" nogil:
@@ -28,7 +28,7 @@ cdef extern from "cudf/strings/combine.hpp" namespace "cudf::strings" nogil:
         string_scalar narep,
         separator_on_nulls separate_nulls,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] concatenate(
         table_view strings_columns,
@@ -37,14 +37,14 @@ cdef extern from "cudf/strings/combine.hpp" namespace "cudf::strings" nogil:
         string_scalar col_narep,
         separator_on_nulls separate_nulls,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] join_strings(
         column_view input,
         string_scalar separator,
         string_scalar narep,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] join_list_elements(
         column_view lists_strings_column,
@@ -54,7 +54,7 @@ cdef extern from "cudf/strings/combine.hpp" namespace "cudf::strings" nogil:
         separator_on_nulls separate_nulls,
         output_if_empty_list empty_list_policy,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] join_list_elements(
         column_view lists_strings_column,
@@ -63,4 +63,4 @@ cdef extern from "cudf/strings/combine.hpp" namespace "cudf::strings" nogil:
         separator_on_nulls separate_nulls,
         output_if_empty_list empty_list_policy,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/contains.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/contains.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.strings.regex_program cimport regex_program
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/contains.hpp" namespace "cudf::strings" nogil:
@@ -17,30 +17,30 @@ cdef extern from "cudf/strings/contains.hpp" namespace "cudf::strings" nogil:
         column_view source_strings,
         regex_program,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] count_re(
         column_view source_strings,
         regex_program,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] matches_re(
         column_view source_strings,
         regex_program,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] like(
         column_view source_strings,
         string pattern,
         string escape_character,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] like(
         column_view source_strings,
         column_view patterns,
         string_scalar escape_character,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_booleans.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_booleans.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/convert/convert_booleans.hpp" namespace \
@@ -16,11 +16,11 @@ cdef extern from "cudf/strings/convert/convert_booleans.hpp" namespace \
         column_view input,
         string_scalar true_string,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] from_booleans(
         column_view booleans,
         string_scalar true_string,
         string_scalar false_string,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_datetime.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_datetime.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport data_type
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/convert/convert_datetime.hpp" namespace \
@@ -18,17 +18,17 @@ cdef extern from "cudf/strings/convert/convert_datetime.hpp" namespace \
         data_type timestamp_type,
         string format,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] from_timestamps(
         column_view timestamps,
         string format,
         column_view names,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] is_timestamp(
         column_view input_col,
         string format,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_durations.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_durations.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport data_type
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/convert/convert_durations.hpp" namespace \
@@ -18,10 +18,10 @@ cdef extern from "cudf/strings/convert/convert_durations.hpp" namespace \
         data_type duration_type,
         const string & format,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] from_durations(
         const column_view & durations,
         const string & format,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_fixed_point.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_fixed_point.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport data_type
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/convert/convert_fixed_point.hpp" namespace \
@@ -16,16 +16,16 @@ cdef extern from "cudf/strings/convert/convert_fixed_point.hpp" namespace \
         column_view input,
         data_type output_type,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] from_fixed_point(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] is_fixed_point(
         column_view input,
         data_type decimal_type,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_floats.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_floats.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport data_type
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/convert/convert_floats.hpp" namespace \
@@ -16,15 +16,15 @@ cdef extern from "cudf/strings/convert/convert_floats.hpp" namespace \
         column_view strings,
         data_type output_type,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] from_floats(
         column_view floats,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] is_float(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_integers.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_integers.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport data_type
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/convert/convert_integers.hpp" namespace \
@@ -16,39 +16,39 @@ cdef extern from "cudf/strings/convert/convert_integers.hpp" namespace \
         column_view input,
         data_type output_type,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] from_integers(
         column_view integers,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] is_integer(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] is_integer(
         column_view input,
         data_type int_type,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] hex_to_integers(
         column_view input,
         data_type output_type,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] is_hex(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] integers_to_hex(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_ipv4.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_ipv4.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/convert/convert_ipv4.hpp" namespace \
@@ -14,15 +14,15 @@ cdef extern from "cudf/strings/convert/convert_ipv4.hpp" namespace \
     cdef unique_ptr[column] ipv4_to_integers(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] integers_to_ipv4(
         column_view integers,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] is_ipv4(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_lists.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_lists.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/convert/convert_lists.hpp" namespace \
@@ -18,4 +18,4 @@ cdef extern from "cudf/strings/convert/convert_lists.hpp" namespace \
         string_scalar na_rep,
         column_view separators,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_urls.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/convert/convert_urls.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/convert/convert_urls.hpp" namespace \
@@ -14,9 +14,9 @@ cdef extern from "cudf/strings/convert/convert_urls.hpp" namespace \
     cdef unique_ptr[column] url_encode(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] url_decode(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/extract.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/extract.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.strings.regex_program cimport regex_program
 from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/extract.hpp" namespace "cudf::strings" nogil:
@@ -17,17 +17,17 @@ cdef extern from "cudf/strings/extract.hpp" namespace "cudf::strings" nogil:
         column_view input,
         regex_program prog,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] extract_all_record(
         column_view input,
         regex_program prog,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] extract_single(
         column_view input,
         regex_program prog,
         size_type group,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/find.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/find.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/find.hpp" namespace "cudf::strings" nogil:
@@ -17,37 +17,37 @@ cdef extern from "cudf/strings/find.hpp" namespace "cudf::strings" nogil:
         column_view source_strings,
         string_scalar target,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] contains(
         column_view source_strings,
         column_view target_strings,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] ends_with(
         column_view source_strings,
         string_scalar target,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] ends_with(
         column_view source_strings,
         column_view target_strings,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] starts_with(
         column_view source_strings,
         string_scalar target,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] starts_with(
         column_view source_strings,
         column_view target_strings,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] find(
         column_view source_strings,
@@ -55,14 +55,14 @@ cdef extern from "cudf/strings/find.hpp" namespace "cudf::strings" nogil:
         size_type start,
         size_type stop,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] find(
         column_view source_strings,
         column_view target,
         size_type start,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] rfind(
         column_view source_strings,
@@ -70,4 +70,4 @@ cdef extern from "cudf/strings/find.hpp" namespace "cudf::strings" nogil:
         size_type start,
         size_type stop,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/find_multiple.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/find_multiple.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.table.table cimport table
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/find_multiple.hpp" namespace "cudf::strings" \
@@ -16,10 +16,10 @@ cdef extern from "cudf/strings/find_multiple.hpp" namespace "cudf::strings" \
         column_view input,
         column_view targets,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] find_multiple(
         column_view input,
         column_view targets,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/findall.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/findall.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.strings.regex_program cimport regex_program
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/findall.hpp" namespace "cudf::strings" nogil:
@@ -15,10 +15,10 @@ cdef extern from "cudf/strings/findall.hpp" namespace "cudf::strings" nogil:
         column_view input,
         regex_program prog,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] find_re(
         column_view input,
         regex_program prog,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/padding.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/padding.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t
 from libcpp.memory cimport unique_ptr
@@ -10,7 +10,7 @@ from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.strings.side_type cimport side_type
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/padding.hpp" namespace "cudf::strings" nogil:
@@ -21,16 +21,16 @@ cdef extern from "cudf/strings/padding.hpp" namespace "cudf::strings" nogil:
         side_type side,
         string fill_char,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] zfill(
         column_view input,
         size_type width,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] zfill_by_widths(
         column_view input,
         column_view widths,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/repeat.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/repeat.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport size_type
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/repeat_strings.hpp" namespace "cudf::strings" \
@@ -17,12 +17,12 @@ cdef extern from "cudf/strings/repeat_strings.hpp" namespace "cudf::strings" \
         column_view input,
         size_type repeat_times,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] repeat_strings(
         column_view input,
         column_view repeat_times,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/replace.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/replace.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t
 from libcpp.memory cimport unique_ptr
@@ -9,7 +9,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/replace.hpp" namespace "cudf::strings" nogil:
@@ -19,7 +19,7 @@ cdef extern from "cudf/strings/replace.hpp" namespace "cudf::strings" nogil:
         size_type start,
         size_type stop,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] replace(
         column_view source_strings,
@@ -27,11 +27,11 @@ cdef extern from "cudf/strings/replace.hpp" namespace "cudf::strings" nogil:
         string_scalar repl,
         int32_t maxrepl,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] replace_multiple(
         column_view source_strings,
         column_view target_strings,
         column_view repl_strings,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/replace_re.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/replace_re.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
@@ -12,7 +12,7 @@ from pylibcudf.libcudf.strings.regex_program cimport regex_program
 from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/replace_re.hpp" namespace "cudf::strings" nogil:
@@ -23,7 +23,7 @@ cdef extern from "cudf/strings/replace_re.hpp" namespace "cudf::strings" nogil:
         string_scalar replacement,
         size_type max_replace_count,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] replace_re(
         column_view input,
@@ -31,11 +31,11 @@ cdef extern from "cudf/strings/replace_re.hpp" namespace "cudf::strings" nogil:
         column_view replacements,
         regex_flags flags,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] replace_with_backrefs(
         column_view input,
         regex_program prog,
         string replacement,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/reverse.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/reverse.pxd
@@ -1,15 +1,15 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
 from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 cdef extern from "cudf/strings/reverse.hpp" namespace "cudf::strings" nogil:
     cdef unique_ptr[column] reverse(
         column_view source_strings,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/split/partition.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/split/partition.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from libcpp.string cimport string
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.table.table cimport table
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/split/partition.hpp" namespace \
@@ -18,10 +18,10 @@ cdef extern from "cudf/strings/split/partition.hpp" namespace \
         column_view input,
         string_scalar delimiter,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[table] rpartition(
         column_view input,
         string_scalar delimiter,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/split/split.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/split/split.pxd
@@ -10,7 +10,7 @@ from pylibcudf.libcudf.strings.regex_program cimport regex_program
 from pylibcudf.libcudf.table.table cimport table
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/split/split.hpp" namespace \
@@ -21,35 +21,35 @@ cdef extern from "cudf/strings/split/split.hpp" namespace \
         string_scalar delimiter,
         size_type maxsplit,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[table] rsplit(
         column_view strings_column,
         string_scalar delimiter,
         size_type maxsplit,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] split_record(
         column_view strings,
         string_scalar delimiter,
         size_type maxsplit,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] rsplit_record(
         column_view strings,
         string_scalar delimiter,
         size_type maxsplit,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] split_part(
         column_view strings,
         string_scalar delimiter,
         size_type index,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
 
 cdef extern from "cudf/strings/split/split_re.hpp" namespace \
@@ -60,25 +60,25 @@ cdef extern from "cudf/strings/split/split_re.hpp" namespace \
         regex_program prog,
         size_type maxsplit,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[table] rsplit_re(
         const column_view& input,
         regex_program prog,
         size_type maxsplit,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] split_record_re(
         const column_view& input,
         regex_program prog,
         size_type maxsplit,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef unique_ptr[column] rsplit_record_re(
         const column_view& input,
         regex_program prog,
         size_type maxsplit,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/strip.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/strip.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.strings.side_type cimport side_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/strip.hpp" namespace "cudf::strings" nogil:
@@ -17,4 +17,4 @@ cdef extern from "cudf/strings/strip.hpp" namespace "cudf::strings" nogil:
         side_type side,
         string_scalar to_strip,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/substring.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/substring.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.scalar.scalar cimport numeric_scalar
 from pylibcudf.libcudf.types cimport size_type
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/slice.hpp" namespace "cudf::strings" nogil:
@@ -18,7 +18,7 @@ cdef extern from "cudf/strings/slice.hpp" namespace "cudf::strings" nogil:
         numeric_scalar[size_type] end,
         numeric_scalar[size_type] step,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] slice_strings(
@@ -26,5 +26,5 @@ cdef extern from "cudf/strings/slice.hpp" namespace "cudf::strings" nogil:
         column_view starts,
         column_view stops,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/translate.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/translate.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
@@ -10,7 +10,7 @@ from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.scalar.scalar cimport string_scalar
 from pylibcudf.libcudf.types cimport char_utf8
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/translate.hpp" namespace "cudf::strings" nogil:
@@ -19,7 +19,7 @@ cdef extern from "cudf/strings/translate.hpp" namespace "cudf::strings" nogil:
         column_view input,
         vector[pair[char_utf8, char_utf8]] chars_table,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cpdef enum class filter_type(bool):
@@ -32,4 +32,4 @@ cdef extern from "cudf/strings/translate.hpp" namespace "cudf::strings" nogil:
         filter_type keep_characters,
         string_scalar replacement,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/strings/wrap.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/strings/wrap.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from pylibcudf.exception_handler cimport libcudf_exception_handler
@@ -6,7 +6,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/strings/wrap.hpp" namespace "cudf::strings" nogil:
@@ -15,4 +15,4 @@ cdef extern from "cudf/strings/wrap.hpp" namespace "cudf::strings" nogil:
         column_view input,
         size_type width,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/table/table.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/table/table.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from libcpp.vector cimport vector
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.table.table_view cimport mutable_table_view, table_view
 from pylibcudf.libcudf.types cimport size_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/table/table.hpp" namespace "cudf" nogil:
@@ -15,12 +15,12 @@ cdef extern from "cudf/table/table.hpp" namespace "cudf" nogil:
         table(
             const table&,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
         table(
             table_view,
             cuda_stream_view stream,
-            device_memory_resource* mr
+            device_async_resource_ref mr
         ) except +libcudf_exception_handler
         size_type num_columns() except +libcudf_exception_handler
         size_type num_rows() except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/transform.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/transform.pxd
@@ -17,14 +17,14 @@ from pylibcudf.libcudf.types cimport null_aware, output_nullability
 
 from rmm.librmm.device_buffer cimport device_buffer
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/transform.hpp" namespace "cudf" nogil:
     cdef pair[unique_ptr[device_buffer], size_type] bools_to_mask (
         const column_view& input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] mask_to_bools (
@@ -32,19 +32,19 @@ cdef extern from "cudf/transform.hpp" namespace "cudf" nogil:
         size_type begin_bit,
         size_type end_bit,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef pair[unique_ptr[device_buffer], size_type] nans_to_nulls(
         const column_view& input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] column_nans_to_nulls(
         const column_view& input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] transform(
@@ -56,32 +56,32 @@ cdef extern from "cudf/transform.hpp" namespace "cudf" nogil:
         null_aware is_null_aware,
         output_nullability null_policy,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef pair[unique_ptr[table], unique_ptr[column]] encode(
         table_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef pair[unique_ptr[column], table_view] one_hot_encode(
         column_view input_column,
         column_view categories,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] compute_column(
         const table_view table,
         const expression& expr,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
 
     cdef unique_ptr[column] compute_column_jit(
         const table_view table,
         const expression& expr,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/transpose.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/transpose.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libcpp.memory cimport unique_ptr
 from libcpp.pair cimport pair
@@ -7,7 +7,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.table.table_view cimport table_view
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/transpose.hpp" namespace "cudf" nogil:
@@ -17,5 +17,5 @@ cdef extern from "cudf/transpose.hpp" namespace "cudf" nogil:
     ] transpose(
         table_view input_table,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler

--- a/python/pylibcudf/pylibcudf/libcudf/unary.pxd
+++ b/python/pylibcudf/pylibcudf/libcudf/unary.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 from libc.stdint cimport int32_t
 from libcpp cimport bool
@@ -8,7 +8,7 @@ from pylibcudf.libcudf.column.column cimport column
 from pylibcudf.libcudf.column.column_view cimport column_view
 from pylibcudf.libcudf.types cimport data_type
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "cudf/unary.hpp" namespace "cudf" nogil:
@@ -43,31 +43,31 @@ cdef extern from "cudf/unary.hpp" namespace "cudf" nogil:
         column_view input,
         unary_operator op,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
 
     cdef extern unique_ptr[column] is_null(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef extern unique_ptr[column] is_valid(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef extern unique_ptr[column] cast(
         column_view input,
         data_type out_type,
         cuda_stream_view stream,
-        device_memory_resource* mr) except +libcudf_exception_handler
+        device_async_resource_ref mr) except +libcudf_exception_handler
     cdef extern bool is_supported_cast(data_type from_, data_type to) noexcept
     cdef extern unique_ptr[column] is_nan(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler
     cdef extern unique_ptr[column] is_not_nan(
         column_view input,
         cuda_stream_view stream,
-        device_memory_resource* mr
+        device_async_resource_ref mr
     ) except +libcudf_exception_handler


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.