### PR TITLE
Increase tolerance in `test_groupby_categorical_key`

### DIFF
--- a/python/dask_cudf/dask_cudf/tests/test_groupby.py
+++ b/python/dask_cudf/dask_cudf/tests/test_groupby.py
@@ -533,7 +533,7 @@ def test_groupby_categorical_key():
         .groupby("name", sort=True, observed=True)
         .agg({"x": ["mean", "max"], "y": ["mean", "count"]})
     )
-    dd.assert_eq(expect, got)
+    dd.assert_eq(expect, got, atol=1e-3)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

The test compares a parallel Dask cuDF groupby mean against a single-pass pandas groupby mean, which can produce slightly different results due to reduction order. Add `atol=1e-3` to avoid intermittent failures, as observed primarily in CI with Python 3.14.

