### PR TITLE
Pin polars version in type-checking environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [
-          polars,
+          "polars>=1.30,<1.39",
           "numpy",
           pyarrow-stubs,
           "pyarrow<24.0.0",  # https://github.com/rapidsai/cudf/issues/22229


### PR DESCRIPTION
## Description

This fixes the CI failure seen at https://github.com/rapidsai/cudf/actions/runs/24802055547/job/72587066869?pr=22254

```
python/cudf_polars/cudf_polars/containers/dataframe.py:140: error: Argument 1 to "DataFrame" has incompatible type "_ObjectWithArrowMetadata"; expected "Mapping[str, Iterable[Any] | Series | PyArrowArray | PyArrowChunkedArray | NumpyArray | PandasSeries | PandasIndex | ArrowArrayExportable | ArrowStreamExportable | int | float | Decimal | date | time | datetime | timedelta | str | bool | bytes | None] | Iterable[Any] | NumpyArray | PyArrowTable | PandasDataFrame | ArrowArrayExportable | ArrowStreamExportable | TorchTensor | DataFrame | None"  [arg-type]
```

For future reference (once we support polars 1.40.1) this change seems to satisfy mypy on this line

```diff
diff --git a/python/cudf_polars/cudf_polars/containers/dataframe.py b/python/cudf_polars/cudf_polars/containers/dataframe.py
index d96e96cc99..fe52d5d777 100644
--- a/python/cudf_polars/cudf_polars/containers/dataframe.py
+++ b/python/cudf_polars/cudf_polars/containers/dataframe.py
@@ -73,7 +73,7 @@ class _ObjectWithArrowMetadata:
         self.stream = stream
 
     def __arrow_c_array__(
-        self, requested_schema: None = None
+        self, requested_schema: object | None = None
     ) -> tuple[CapsuleType, CapsuleType]:
         return self.obj._to_schema(self.metadata), self.obj._to_host_array(
             stream=self.stream
```