### PR TITLE
Fix nvbench handling of memory-resource objects

### DIFF
--- a/cpp/benchmarks/fixture/nvbench_fixture.hpp
+++ b/cpp/benchmarks/fixture/nvbench_fixture.hpp
@@ -106,7 +106,8 @@ struct nvbench_base_fixture {
 
   ~nvbench_base_fixture()
   {
-    // Ensure the the pool is freed before the CUDA context is destroyed:
+    // Ensure the the pool is freed before the CUDA context is destroyed
+    rmm::mr::reset_current_device_resource();
     cudf::set_pinned_memory_resource(this->make_cuio_host_pinned());
   }
 


### PR DESCRIPTION
## Description
Adds a call to `rmm::mr::reset_current_device_resource()` in the `nvbench_base_fixture` destructor so RMM can cleanup a static map before the process exists `main()`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
