### PR TITLE
fix(cmake): exclude zstd, roaring, and cuco from install

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1081,8 +1081,8 @@ if(CUDF_BUILD_TESTUTIL)
   )
 
   target_link_libraries(
-    cudftestutil INTERFACE cuco::cuco Threads::Threads cudf cudftest_default_stream
-                           $<TARGET_NAME_IF_EXISTS:conda_env>
+    cudftestutil INTERFACE $<BUILD_LOCAL_INTERFACE:cuco::cuco> Threads::Threads cudf
+                           cudftest_default_stream $<TARGET_NAME_IF_EXISTS:conda_env>
   )
 
   target_include_directories(

--- a/cpp/cmake/thirdparty/get_croaring.cmake
+++ b/cpp/cmake/thirdparty/get_croaring.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -14,6 +14,7 @@ function(find_and_configure_roaring VERSION)
     GIT_REPOSITORY https://github.com/RoaringBitmap/CRoaring.git
     GIT_TAG v${VERSION}
     GIT_SHALLOW TRUE
+    EXCLUDE_FROM_ALL TRUE
     OPTIONS "ROARING_BUILD_STATIC ON"
             "BUILD_SHARED_LIBS OFF"
             "ENABLE_ROARING_TESTS OFF"

--- a/cpp/cmake/thirdparty/get_cucollections.cmake
+++ b/cpp/cmake/thirdparty/get_cucollections.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -9,7 +9,7 @@
 function(find_and_configure_cucollections)
   include(${rapids-cmake-dir}/cpm/cuco.cmake)
 
-  rapids_cpm_cuco(BUILD_EXPORT_SET cudf-exports INSTALL_EXPORT_SET cudf-exports)
+  rapids_cpm_cuco(BUILD_EXPORT_SET cudf-exports)
 endfunction()
 
 find_and_configure_cucollections()

--- a/cpp/cmake/thirdparty/get_zstd.cmake
+++ b/cpp/cmake/thirdparty/get_zstd.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -16,6 +16,7 @@ function(find_and_configure_zstd)
     GIT_REPOSITORY https://github.com/facebook/zstd.git
     GIT_TAG v1.5.7
     GIT_SHALLOW FALSE SOURCE_SUBDIR build/cmake
+    EXCLUDE_FROM_ALL TRUE
     OPTIONS "ZSTD_BUILD_STATIC ON" "ZSTD_BUILD_SHARED OFF" "ZSTD_BUILD_TESTS OFF"
             "ZSTD_BUILD_PROGRAMS OFF" "BUILD_SHARED_LIBS OFF"
   )


### PR DESCRIPTION
## Description

Exclude private dependencies from the install tree to reduce wheel bloat.

- **zstd**: Add `EXCLUDE_FROM_ALL TRUE` to `get_zstd.cmake` to prevent zstd's install rules from running
- **roaring**: Add `EXCLUDE_FROM_ALL TRUE` to `get_croaring.cmake` to prevent CRoaring's install rules from running
- **cuco**: Remove `INSTALL_EXPORT_SET cudf-exports` from `get_cucollections.cmake` — the rapids-cmake cuco wrapper correctly honors `INSTALL_CUCO ${to_install}`, so removing the export set causes `to_install=OFF` which disables cuco's install rules

These dependencies are linked as `PRIVATE` and their headers are only used in `detail/` headers, so they should not be part of the installed package.

Contributes to #18728.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.