### PR TITLE
Temporarily increase max days without success to 40 days

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -75,7 +75,7 @@ jobs:
           repo: ${{ github.repository }}
           target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
           # TODO: Fix nightly CI and remove this line
-          max-days-without-success: 30
+          max-days-without-success: 40
   changed-files:
     secrets: inherit
     needs: telemetry-setup

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -595,10 +595,11 @@ jobs:
       node_type: "gpu-l4-latest-1"
       container_image: "rapidsai/ci-conda:26.06-latest"
       script: ci/test_narwhals.sh
-  spark-rapids-jni:
-    needs: changed-files
-    uses: ./.github/workflows/spark-rapids-jni.yaml
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
+  # TODO: Re-enable. Temporarily disabling as it seems to be missing RMM->CCCL changes.
+  # spark-rapids-jni:
+  #   needs: changed-files
+  #   uses: ./.github/workflows/spark-rapids-jni.yaml
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
   streams-build:
     needs: checks
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -595,11 +595,10 @@ jobs:
       node_type: "gpu-l4-latest-1"
       container_image: "rapidsai/ci-conda:26.06-latest"
       script: ci/test_narwhals.sh
-  # TODO: Re-enable. Temporarily disabling as it seems to be missing RMM->CCCL changes.
-  # spark-rapids-jni:
-  #   needs: changed-files
-  #   uses: ./.github/workflows/spark-rapids-jni.yaml
-  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
+  spark-rapids-jni:
+    needs: changed-files
+    uses: ./.github/workflows/spark-rapids-jni.yaml
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
   streams-build:
     needs: checks
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main

--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
@@ -1764,17 +1764,19 @@ def test_concat_decimal_non_numeric(
 def test_concat_struct_column():
     s1 = cudf.Series([{"a": 5}, {"c": "hello"}, {"b": 7}])
     s2 = cudf.Series([{"a": 5, "c": "hello", "b": 7}])
-    expected = cudf.Series(
-        [
-            {"a": 5, "b": None, "c": None},
-            {"a": None, "b": None, "c": "hello"},
-            {"a": None, "b": 7, "c": None},
-            {"a": 5, "b": 7, "c": "hello"},
-        ],
-        index=[0, 1, 2, 0],
-    )
-    s = cudf.concat([s1, s2])
-    assert_eq(s, expected, check_index_type=True)
+    result = cudf.concat([s1, s2])
+    # Field order depends on pyarrow's type inference (alphabetical
+    # before pyarrow 23, insertion-order after), so derive the
+    # expected output from s1's inferred dtype rather than hardcoding.
+    fields = list(s1.dtype.fields)
+    expected_data = [
+        {f: (5 if f == "a" else None) for f in fields},
+        {f: ("hello" if f == "c" else None) for f in fields},
+        {f: (7 if f == "b" else None) for f in fields},
+        {f: (5 if f == "a" else "hello" if f == "c" else 7) for f in fields},
+    ]
+    expected = cudf.Series(expected_data, index=[0, 1, 2, 0])
+    assert_eq(result, expected, check_index_type=True)
 
 
 @pytest.mark.parametrize(

--- a/python/cudf/cudf/tests/reshape/test_concat.py
+++ b/python/cudf/cudf/tests/reshape/test_concat.py
@@ -1768,6 +1768,7 @@ def test_concat_struct_column():
     # Field order depends on pyarrow's type inference (alphabetical
     # before pyarrow 23, insertion-order after), so derive the
     # expected output from s1's inferred dtype rather than hardcoding.
+    # See https://github.com/apache/arrow/pull/48813
     fields = list(s1.dtype.fields)
     expected_data = [
         {f: (5 if f == "a" else None) for f in fields},


### PR DESCRIPTION
## Description
Two changes are included:

1. Give more room for CI fixes.
2. Fix `test_concat_struct_column` to take into account `pa.array()` bug from https://github.com/apache/arrow/pull/48813​ fixed since PyArrow 23.