### PR TITLE
Add call to reset_current_device_resource in gtests fixtures

### DIFF
--- a/cpp/include/cudf_test/testing_main.hpp
+++ b/cpp/include/cudf_test/testing_main.hpp
@@ -21,6 +21,7 @@
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/managed_memory_resource.hpp>
+#include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
@@ -260,10 +261,12 @@ inline void init_cudf_test(int argc, char** argv, cudf::test::config const& conf
       auto rc = RUN_ALL_TESTS();                                                                 \
       std::cout << "Peak memory usage " << mr.get_bytes_counter().peak << " bytes" << std::endl; \
       cudf::teardown();                                                                          \
+      rmm::mr::reset_current_device_resource();                                                  \
       return rc;                                                                                 \
     } else {                                                                                     \
       auto rc = RUN_ALL_TESTS();                                                                 \
       cudf::teardown();                                                                          \
+      rmm::mr::reset_current_device_resource();                                                  \
       return rc;                                                                                 \
     }                                                                                            \
   }

--- a/cpp/tests/large_strings/large_strings_fixture.cpp
+++ b/cpp/tests/large_strings/large_strings_fixture.cpp
@@ -123,7 +123,9 @@ int main(int argc, char** argv)
     cudf::set_current_device_resource(mr);
     auto rc = RUN_ALL_TESTS();
     std::cout << "Peak memory usage " << mr.get_bytes_counter().peak << " bytes" << std::endl;
+    rmm::mr::reset_current_device_resource();
     return rc;
   }
+  rmm::mr::reset_current_device_resource();
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Description
Follow on to https://github.com/rapidsai/cudf/pull/22257 to reset the memory resource used by gtests before exiting the `main()` of the process. This can help prevent a potential segfault and even if that is fixed can possibly prevent a memory leak making it easier to detect those in future debugging efforts.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
