### PR TITLE
Record `engine_name` in cudf-polars benchamrks

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_legacy.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_legacy.py
@@ -243,12 +243,14 @@ class PackageVersions:
     polars: str
     python: str
     rapidsmpf: str | VersionInfo | None
+    duckdb: str | None
 
     @classmethod
     def collect(cls) -> PackageVersions:
         """Collect the versions of the software used to run the query."""
         packages = [
             "cudf_polars",
+            "duckdb",
             "polars",
             "rapidsmpf",
         ]

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_legacy.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_legacy.py
@@ -349,6 +349,7 @@ def _infer_scale_factor(name: str, path: str | Path, suffix: str) -> int | float
 class RunConfig:
     """Results for a PDS-H or PDS-DS query run."""
 
+    engine_name: Literal["polars-cpu", "cudf-polars", "duckdb"]
     queries: list[int]
     suffix: str
     executor: ExecutorType
@@ -484,7 +485,19 @@ class RunConfig:
         else:
             validation_method = None
 
+        engine_name: Literal["polars-cpu", "cudf-polars", "duckdb"]
+        if args.engine == "duckdb":
+            engine_name = "duckdb"
+        elif args.engine == "polars":
+            if executor == "cpu":
+                engine_name = "polars-cpu"
+            else:
+                engine_name = "cudf-polars"
+        else:
+            raise ValueError(f"Invalid engine: {args.engine}")
+
         return cls(
+            engine_name=engine_name,
             queries=args.query,
             executor=executor,
             cluster=cluster,

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
@@ -254,12 +254,14 @@ class PackageVersions:
     polars: str
     python: str
     rapidsmpf: str | VersionInfo | None
+    duckdb: str | None
 
     @classmethod
     def collect(cls) -> PackageVersions:
         """Collect the versions of the software used to run the query."""
         packages = [
             "cudf_polars",
+            "duckdb",
             "polars",
             "rapidsmpf",
         ]

--- a/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
+++ b/python/cudf_polars/cudf_polars/experimental/benchmarks/utils_new_frontends.py
@@ -377,6 +377,7 @@ def _infer_scale_factor(name: str, path: str | Path, suffix: str) -> int | float
 class RunConfig:
     """Benchmark run configuration for SPMD / Ray / DuckDB frontends."""
 
+    engine_name: Literal["polars-cpu", "cudf-polars", "duckdb"]
     # Query selection & dataset
     queries: list[int]
     query_set: str
@@ -502,7 +503,19 @@ class RunConfig:
         else:
             validation_method = None
 
+        engine_name: Literal["polars-cpu", "cudf-polars", "duckdb"]
+        if args.engine == "duckdb":
+            engine_name = "duckdb"
+        elif args.engine == "polars":
+            if args.executor == "cpu":
+                engine_name = "polars-cpu"
+            else:
+                engine_name = "cudf-polars"
+        else:
+            raise ValueError(f"Invalid engine: {args.engine}")
+
         return cls(
+            engine_name=engine_name,
             queries=args.query,
             query_set=name,
             dataset_path=path,
@@ -527,6 +540,7 @@ class RunConfig:
         """Serialize the run config to a dictionary."""
         opts = self.streaming_options
         result: dict[str, Any] = {
+            "engine_name": self.engine_name,
             "queries": self.queries,
             "query_set": self.query_set,
             "dataset_path": str(self.dataset_path),


### PR DESCRIPTION
## Description

This adds a new field `engine_name` to our pdsh and pdsds benchmark output. It can be one of `polars-cpu`, `duckdb`, or `cudf-polars`.
