### PR TITLE
Ignore ResourceWarning from stumpy for Python 3.14

### DIFF
--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_stumpy.py
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_stumpy.py
@@ -36,6 +36,8 @@ def test_1d_time_series():
 @pytest.mark.filterwarnings(
     "ignore::numba.cuda.core.errors.NumbaPerformanceWarning"
 )
+# https://github.com/stumpy-dev/stumpy/issues/1134
+@pytest.mark.filterwarnings("ignore:Implicitly cleaning up:ResourceWarning")
 def test_1d_gpu():
     rng = np.random.default_rng(42)
     your_time_series = rng.random(10000)


### PR DESCRIPTION
## Description
As described in https://github.com/stumpy-dev/stumpy/issues/1134, stumpy is creating a temporary file that is never closed. IIRC in Python 3.14, ResourceWarnings arise in more places now

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
