### PR TITLE
Fix potential malformed headers in parquet delta decoder

### DIFF
--- a/cpp/src/io/parquet/delta_binary.cuh
+++ b/cpp/src/io/parquet/delta_binary.cuh
@@ -151,7 +151,7 @@ struct delta_binary_decoder {
     current_value_idx = 0;
     error             = false;
 
-    if (mini_block_count == 0 || block_size == 0 || (block_size % mini_block_count) != 0) {
+    if (mini_block_count == 0 or block_size == 0 or (block_size % mini_block_count) != 0) {
       error         = true;
       value_count   = 0;
       values_per_mb = 1;

--- a/cpp/src/io/parquet/delta_binary.cuh
+++ b/cpp/src/io/parquet/delta_binary.cuh
@@ -91,7 +91,7 @@ struct delta_binary_decoder {
   uint32_t cur_mb;               // index of the current mini-block within the block
   uint8_t const* cur_mb_start;   // pointer to the start of the current mini-block data
   uint8_t const* cur_bitwidths;  // pointer to the bitwidth array in the block
-  bool error;                    // whether to catch malformed headers
+  bool error;                    // flag to catch malformed headers
 
   zigzag128_t value[delta_rolling_buf_size];  // circular buffer of delta values
 

--- a/cpp/src/io/parquet/delta_binary.cuh
+++ b/cpp/src/io/parquet/delta_binary.cuh
@@ -91,6 +91,7 @@ struct delta_binary_decoder {
   uint32_t cur_mb;               // index of the current mini-block within the block
   uint8_t const* cur_mb_start;   // pointer to the start of the current mini-block data
   uint8_t const* cur_bitwidths;  // pointer to the bitwidth array in the block
+  bool error;                    // whether to catch malformed headers
 
   zigzag128_t value[delta_rolling_buf_size];  // circular buffer of delta values
 
@@ -148,7 +149,20 @@ struct delta_binary_decoder {
     last_value       = first_value;
 
     current_value_idx = 0;
-    values_per_mb     = block_size / mini_block_count;
+    error             = false;
+
+    if (mini_block_count == 0 || block_size == 0 || (block_size % mini_block_count) != 0) {
+      error         = true;
+      value_count   = 0;
+      values_per_mb = 1;
+      block_start   = d_end;
+      cur_mb        = 0;
+      cur_mb_start  = d_end;
+      cur_bitwidths = d_end;
+      return;
+    }
+
+    values_per_mb = block_size / mini_block_count;
 
     // init the first mini-block
     block_start = d_start;

--- a/cpp/src/io/parquet/delta_binary.cuh
+++ b/cpp/src/io/parquet/delta_binary.cuh
@@ -151,6 +151,7 @@ struct delta_binary_decoder {
     current_value_idx = 0;
     error             = false;
 
+    // Validate header against the DELTA_BINARY_PACKED spec invariants
     if (mini_block_count == 0 or block_size == 0 or (block_size % mini_block_count) != 0) {
       error         = true;
       value_count   = 0;

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -365,6 +365,13 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
   if (block.thread_rank() == 0) { db->init_binary_block(s->data_start, s->data_end); }
   block.sync();
 
+  // Exit if the DELTA_BINARY_PACKED header is malformed
+  if (db->error) {
+    set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
+              error_code);
+    return;
+  }
+
   auto const batch_size = db->values_per_mb;
   if (batch_size > max_delta_mini_block_size) {
     set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
@@ -378,6 +385,9 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
 
   while (s->error == 0 &&
          (s->input_value_count < s->num_input_values || s->src_pos < s->nz_count)) {
+    int const prev_input_value_count = s->input_value_count;
+    uint32_t const prev_src_pos      = s->src_pos;
+
     uint32_t target_pos;
     uint32_t const src_pos = s->src_pos;
 
@@ -432,6 +442,13 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
     }
 
     block.sync();
+
+    // Ensure we advanced position and input value count in this iteration.
+    if (s->input_value_count == prev_input_value_count and s->src_pos == prev_src_pos) {
+      cg::invoke_one(block, [&] { s->set_error_code(decode_error::DELTA_PARAMS_UNSUPPORTED); });
+      block.sync();
+      break;
+    }
   }
 
   if (has_repetition) {
@@ -545,6 +562,13 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     dba->init(s->data_start, s->data_end, s->page.start_val, s->page.temp_string_buf);
   }
   block.sync();
+
+  // Propagate malformed-header errors from either underlying DELTA_BINARY_PACKED decoder.
+  if (prefix_db->error || suffix_db->error) {
+    set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
+              error_code);
+    return;
+  }
 
   // assert that prefix and suffix have same mini-block size
   if (prefix_db->values_per_mb != suffix_db->values_per_mb or
@@ -758,6 +782,12 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
     page_string_data = db->find_end_of_block(s->data_start, s->data_end);
   }
   block.sync();
+
+  // Propagate malformed-header errors from the underlying DELTA_BINARY_PACKED decoder
+  if (db->error) {
+    set_error(static_cast<int32_t>(decode_error::DELTA_PARAMS_UNSUPPORTED), error_code);
+    return;
+  }
 
   int const leaf_level_index = s->col.max_nesting_depth - 1;
 

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -564,7 +564,7 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   block.sync();
 
   // Propagate malformed-header errors from either underlying DELTA_BINARY_PACKED decoder.
-  if (prefix_db->error || suffix_db->error) {
+  if (prefix_db->error or suffix_db->error) {
     set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
               error_code);
     return;

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -772,8 +772,9 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   }
   block.sync();
 
-  // Propagate malformed-header errors from the underlying DELTA_BINARY_PACKED decoder
-  if (db->error) {
+  // sanity check to make sure we can process this page
+  auto const batch_size = db->values_per_mb;
+  if (db->error or batch_size > max_delta_mini_block_size) {
     if (block.thread_rank() == 0) {
       set_error(static_cast<int32_t>(decode_error::DELTA_PARAMS_UNSUPPORTED), error_code);
     }
@@ -782,12 +783,6 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
   int const leaf_level_index = s->col.max_nesting_depth - 1;
 
-  // sanity check to make sure we can process this page
-  auto const batch_size = db->values_per_mb;
-  if (batch_size > max_delta_mini_block_size) {
-    set_error(static_cast<int32_t>(decode_error::DELTA_PARAMS_UNSUPPORTED), error_code);
-    return;
-  }
   // db->init_binary_block below resets db->values_per_mb
   block.sync();
   // if this is a bounds page, then we need to decode up to the first mini-block

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -365,17 +365,12 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
   if (block.thread_rank() == 0) { db->init_binary_block(s->data_start, s->data_end); }
   block.sync();
 
-  // Exit if the DELTA_BINARY_PACKED header is malformed
-  if (db->error) {
-    set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
-              error_code);
-    return;
-  }
-
   auto const batch_size = db->values_per_mb;
-  if (batch_size > max_delta_mini_block_size) {
-    set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
-              error_code);
+  if (db->error or batch_size > max_delta_mini_block_size) {
+    if (block.thread_rank() == 0) {
+      set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
+                error_code);
+    }
     return;
   }
 
@@ -385,9 +380,6 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
 
   while (s->error == 0 &&
          (s->input_value_count < s->num_input_values || s->src_pos < s->nz_count)) {
-    int const prev_input_value_count = s->input_value_count;
-    uint32_t const prev_src_pos      = s->src_pos;
-
     uint32_t target_pos;
     uint32_t const src_pos = s->src_pos;
 
@@ -442,13 +434,6 @@ CUDF_KERNEL void __launch_bounds__(decode_delta_binary_block_size)
     }
 
     block.sync();
-
-    // Ensure we advanced position and input value count in this iteration.
-    if (s->input_value_count == prev_input_value_count and s->src_pos == prev_src_pos) {
-      cg::invoke_one(block, [&] { s->set_error_code(decode_error::DELTA_PARAMS_UNSUPPORTED); });
-      block.sync();
-      break;
-    }
   }
 
   if (has_repetition) {
@@ -565,8 +550,10 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
   // Propagate malformed-header errors from either underlying DELTA_BINARY_PACKED decoder.
   if (prefix_db->error or suffix_db->error) {
-    set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
-              error_code);
+    if (block.thread_rank() == 0) {
+      set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
+                error_code);
+    }
     return;
   }
 
@@ -586,8 +573,10 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   // sanity check to make sure we can process this page
   auto const batch_size = prefix_db->values_per_mb;
   if (batch_size > max_delta_mini_block_size) {
-    set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
-              error_code);
+    if (block.thread_rank() == 0) {
+      set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
+                error_code);
+    }
     return;
   }
 
@@ -785,7 +774,9 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
 
   // Propagate malformed-header errors from the underlying DELTA_BINARY_PACKED decoder
   if (db->error) {
-    set_error(static_cast<int32_t>(decode_error::DELTA_PARAMS_UNSUPPORTED), error_code);
+    if (block.thread_rank() == 0) {
+      set_error(static_cast<int32_t>(decode_error::DELTA_PARAMS_UNSUPPORTED), error_code);
+    }
     return;
   }
 

--- a/cpp/src/io/parquet/page_delta_decode.cu
+++ b/cpp/src/io/parquet/page_delta_decode.cu
@@ -776,7 +776,8 @@ CUDF_KERNEL void __launch_bounds__(decode_block_size)
   auto const batch_size = db->values_per_mb;
   if (db->error or batch_size > max_delta_mini_block_size) {
     if (block.thread_rank() == 0) {
-      set_error(static_cast<int32_t>(decode_error::DELTA_PARAMS_UNSUPPORTED), error_code);
+      set_error(static_cast<kernel_error::value_type>(decode_error::DELTA_PARAMS_UNSUPPORTED),
+                error_code);
     }
     return;
   }


### PR DESCRIPTION
## Description

This PR checks for potential malformed headers in Parquet delta decoder and propagates it in decoders.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
