### PR TITLE
fix(cmake): exclude kvikio from install, build static, and fix some export issues introduced in 22263

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1002,8 +1002,8 @@ add_dependencies(cudf jitify_preprocess_run)
 target_link_libraries(
   cudf
   PUBLIC CCCL::CCCL rapids_logger::rapids_logger rmm::rmm $<BUILD_LOCAL_INTERFACE:BS::thread_pool>
-  PRIVATE $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp> $<BUILD_LOCAL_INTERFACE:cuco::cuco> ZLIB::ZLIB nvcomp::nvcomp
-          kvikio::kvikio nanoarrow::nanoarrow zstd
+  PRIVATE $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp> $<BUILD_LOCAL_INTERFACE:cuco::cuco> ZLIB::ZLIB
+          nvcomp::nvcomp kvikio::kvikio nanoarrow::nanoarrow zstd
 )
 
 # Add Conda library, and include paths if specified

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1002,7 +1002,7 @@ add_dependencies(cudf jitify_preprocess_run)
 target_link_libraries(
   cudf
   PUBLIC CCCL::CCCL rapids_logger::rapids_logger rmm::rmm $<BUILD_LOCAL_INTERFACE:BS::thread_pool>
-  PRIVATE $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp> cuco::cuco ZLIB::ZLIB nvcomp::nvcomp
+  PRIVATE $<BUILD_LOCAL_INTERFACE:nvtx3::nvtx3-cpp> $<BUILD_LOCAL_INTERFACE:cuco::cuco> ZLIB::ZLIB nvcomp::nvcomp
           kvikio::kvikio nanoarrow::nanoarrow zstd
 )
 

--- a/cpp/cmake/thirdparty/get_croaring.cmake
+++ b/cpp/cmake/thirdparty/get_croaring.cmake
@@ -7,6 +7,12 @@
 
 # Use CPM to clone CRoaring and set up the necessary targets and include directories.
 function(find_and_configure_roaring VERSION)
+  if(NOT BUILD_SHARED_LIBS)
+    set(_exclude_from_all EXCLUDE_FROM_ALL FALSE)
+  else()
+    set(_exclude_from_all EXCLUDE_FROM_ALL TRUE)
+  endif()
+
   rapids_cpm_find(
     roaring ${VERSION}
     GLOBAL_TARGETS roaring
@@ -14,7 +20,7 @@ function(find_and_configure_roaring VERSION)
     GIT_REPOSITORY https://github.com/RoaringBitmap/CRoaring.git
     GIT_TAG v${VERSION}
     GIT_SHALLOW TRUE
-    EXCLUDE_FROM_ALL TRUE
+    ${_exclude_from_all}
     OPTIONS "ROARING_BUILD_STATIC ON"
             "BUILD_SHARED_LIBS OFF"
             "ENABLE_ROARING_TESTS OFF"

--- a/cpp/cmake/thirdparty/get_croaring.cmake
+++ b/cpp/cmake/thirdparty/get_croaring.cmake
@@ -7,11 +7,7 @@
 
 # Use CPM to clone CRoaring and set up the necessary targets and include directories.
 function(find_and_configure_roaring VERSION)
-  if(NOT BUILD_SHARED_LIBS)
-    set(_exclude_from_all EXCLUDE_FROM_ALL FALSE)
-  else()
-    set(_exclude_from_all EXCLUDE_FROM_ALL TRUE)
-  endif()
+  set(_exclude_from_all EXCLUDE_FROM_ALL ${BUILD_SHARED_LIBS})
 
   rapids_cpm_find(
     roaring ${VERSION}

--- a/cpp/cmake/thirdparty/get_croaring.cmake
+++ b/cpp/cmake/thirdparty/get_croaring.cmake
@@ -19,8 +19,7 @@ function(find_and_configure_roaring VERSION)
     CPM_ARGS
     GIT_REPOSITORY https://github.com/RoaringBitmap/CRoaring.git
     GIT_TAG v${VERSION}
-    GIT_SHALLOW TRUE
-    ${_exclude_from_all}
+    GIT_SHALLOW TRUE ${_exclude_from_all}
     OPTIONS "ROARING_BUILD_STATIC ON"
             "BUILD_SHARED_LIBS OFF"
             "ENABLE_ROARING_TESTS OFF"

--- a/cpp/cmake/thirdparty/get_flatbuffers.cmake
+++ b/cpp/cmake/thirdparty/get_flatbuffers.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/cpp/cmake/thirdparty/get_flatbuffers.cmake
+++ b/cpp/cmake/thirdparty/get_flatbuffers.cmake
@@ -7,12 +7,7 @@
 
 # Use CPM to find or clone flatbuffers
 function(find_and_configure_flatbuffers VERSION)
-
-  if(NOT BUILD_SHARED_LIBS)
-    set(_exclude_from_all EXCLUDE_FROM_ALL FALSE)
-  else()
-    set(_exclude_from_all EXCLUDE_FROM_ALL TRUE)
-  endif()
+  set(_exclude_from_all EXCLUDE_FROM_ALL ${BUILD_SHARED_LIBS})
 
   rapids_cpm_find(
     flatbuffers ${VERSION}

--- a/cpp/cmake/thirdparty/get_kvikio.cmake
+++ b/cpp/cmake/thirdparty/get_kvikio.cmake
@@ -7,11 +7,7 @@
 
 # This function finds KvikIO
 function(find_and_configure_kvikio VERSION)
-  if(NOT BUILD_SHARED_LIBS)
-    set(_exclude_from_all EXCLUDE_FROM_ALL FALSE)
-  else()
-    set(_exclude_from_all EXCLUDE_FROM_ALL TRUE)
-  endif()
+  set(_exclude_from_all EXCLUDE_FROM_ALL ${BUILD_SHARED_LIBS})
 
   rapids_cpm_find(
     kvikio ${VERSION}

--- a/cpp/cmake/thirdparty/get_kvikio.cmake
+++ b/cpp/cmake/thirdparty/get_kvikio.cmake
@@ -7,6 +7,11 @@
 
 # This function finds KvikIO
 function(find_and_configure_kvikio VERSION)
+  if(NOT BUILD_SHARED_LIBS)
+    set(_exclude_from_all EXCLUDE_FROM_ALL FALSE)
+  else()
+    set(_exclude_from_all EXCLUDE_FROM_ALL TRUE)
+  endif()
 
   rapids_cpm_find(
     kvikio ${VERSION}
@@ -15,7 +20,7 @@ function(find_and_configure_kvikio VERSION)
     GIT_REPOSITORY https://github.com/rapidsai/kvikio.git
     GIT_TAG "${RAPIDS_BRANCH}"
     GIT_SHALLOW TRUE SOURCE_SUBDIR cpp
-    EXCLUDE_FROM_ALL TRUE
+    ${_exclude_from_all}
     OPTIONS "KvikIO_BUILD_EXAMPLES OFF" "KvikIO_REMOTE_SUPPORT ${CUDF_KVIKIO_REMOTE_IO}"
             "BUILD_SHARED_LIBS OFF"
   )

--- a/cpp/cmake/thirdparty/get_kvikio.cmake
+++ b/cpp/cmake/thirdparty/get_kvikio.cmake
@@ -19,8 +19,7 @@ function(find_and_configure_kvikio VERSION)
     CPM_ARGS
     GIT_REPOSITORY https://github.com/rapidsai/kvikio.git
     GIT_TAG "${RAPIDS_BRANCH}"
-    GIT_SHALLOW TRUE SOURCE_SUBDIR cpp
-    ${_exclude_from_all}
+    GIT_SHALLOW TRUE SOURCE_SUBDIR cpp ${_exclude_from_all}
     OPTIONS "KvikIO_BUILD_EXAMPLES OFF" "KvikIO_REMOTE_SUPPORT ${CUDF_KVIKIO_REMOTE_IO}"
             "BUILD_SHARED_LIBS OFF"
   )

--- a/cpp/cmake/thirdparty/get_kvikio.cmake
+++ b/cpp/cmake/thirdparty/get_kvikio.cmake
@@ -15,7 +15,9 @@ function(find_and_configure_kvikio VERSION)
     GIT_REPOSITORY https://github.com/rapidsai/kvikio.git
     GIT_TAG "${RAPIDS_BRANCH}"
     GIT_SHALLOW TRUE SOURCE_SUBDIR cpp
+    EXCLUDE_FROM_ALL TRUE
     OPTIONS "KvikIO_BUILD_EXAMPLES OFF" "KvikIO_REMOTE_SUPPORT ${CUDF_KVIKIO_REMOTE_IO}"
+            "BUILD_SHARED_LIBS OFF"
   )
 
 endfunction()

--- a/cpp/cmake/thirdparty/get_nanoarrow.cmake
+++ b/cpp/cmake/thirdparty/get_nanoarrow.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/cpp/cmake/thirdparty/get_nanoarrow.cmake
+++ b/cpp/cmake/thirdparty/get_nanoarrow.cmake
@@ -7,11 +7,7 @@
 
 # This function finds nanoarrow and sets any additional necessary environment variables.
 function(find_and_configure_nanoarrow)
-  if(NOT BUILD_SHARED_LIBS)
-    set(_exclude_from_all EXCLUDE_FROM_ALL FALSE)
-  else()
-    set(_exclude_from_all EXCLUDE_FROM_ALL TRUE)
-  endif()
+  set(_exclude_from_all EXCLUDE_FROM_ALL ${BUILD_SHARED_LIBS})
 
   rapids_cpm_find(
     nanoarrow 0.7.0

--- a/cpp/cmake/thirdparty/get_zstd.cmake
+++ b/cpp/cmake/thirdparty/get_zstd.cmake
@@ -7,11 +7,7 @@
 
 # Use CPM to find or clone libzstd
 function(find_and_configure_zstd)
-  if(NOT BUILD_SHARED_LIBS)
-    set(_exclude_from_all EXCLUDE_FROM_ALL FALSE)
-  else()
-    set(_exclude_from_all EXCLUDE_FROM_ALL TRUE)
-  endif()
+  set(_exclude_from_all EXCLUDE_FROM_ALL ${BUILD_SHARED_LIBS})
 
   set(CPM_DOWNLOAD_zstd ON)
   rapids_cpm_find(

--- a/cpp/cmake/thirdparty/get_zstd.cmake
+++ b/cpp/cmake/thirdparty/get_zstd.cmake
@@ -7,6 +7,11 @@
 
 # Use CPM to find or clone libzstd
 function(find_and_configure_zstd)
+  if(NOT BUILD_SHARED_LIBS)
+    set(_exclude_from_all EXCLUDE_FROM_ALL FALSE)
+  else()
+    set(_exclude_from_all EXCLUDE_FROM_ALL TRUE)
+  endif()
 
   set(CPM_DOWNLOAD_zstd ON)
   rapids_cpm_find(
@@ -16,7 +21,7 @@ function(find_and_configure_zstd)
     GIT_REPOSITORY https://github.com/facebook/zstd.git
     GIT_TAG v1.5.7
     GIT_SHALLOW FALSE SOURCE_SUBDIR build/cmake
-    EXCLUDE_FROM_ALL TRUE
+    ${_exclude_from_all}
     OPTIONS "ZSTD_BUILD_STATIC ON" "ZSTD_BUILD_SHARED OFF" "ZSTD_BUILD_TESTS OFF"
             "ZSTD_BUILD_PROGRAMS OFF" "BUILD_SHARED_LIBS OFF"
   )

--- a/cpp/cmake/thirdparty/get_zstd.cmake
+++ b/cpp/cmake/thirdparty/get_zstd.cmake
@@ -20,8 +20,7 @@ function(find_and_configure_zstd)
     CPM_ARGS
     GIT_REPOSITORY https://github.com/facebook/zstd.git
     GIT_TAG v1.5.7
-    GIT_SHALLOW FALSE SOURCE_SUBDIR build/cmake
-    ${_exclude_from_all}
+    GIT_SHALLOW FALSE SOURCE_SUBDIR build/cmake ${_exclude_from_all}
     OPTIONS "ZSTD_BUILD_STATIC ON" "ZSTD_BUILD_SHARED OFF" "ZSTD_BUILD_TESTS OFF"
             "ZSTD_BUILD_PROGRAMS OFF" "BUILD_SHARED_LIBS OFF"
   )


### PR DESCRIPTION
## Description

When kvikio is built as part of the cudf build, we should always be building the static library. There is no reason to ship it as a separate DSO that could interfere with other dependency resolution or be bundled into packages. 

However, we do need the static library to be bundled when libcudf itself is built as a static library because in that case anything built against libcudf will also require libkvikio to be present. This case was overlooked in #22263 for zstd and croaring, which also need the same conditional exclusion to ensure they are present for static builds. That is now resolved in this PR. Since cuco is header-only, the same requirement does not apply, so we simply mark it as `BUILD_LOCAL_INTERFACE` to avoid it being exported to consumer's dependency sets.

Contributes to #18728.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.