### PR TITLE
Multi-rank sinks: enforce directory output for streaming engines

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
@@ -239,6 +239,13 @@ class StreamingOptions:
         Env: ``CUDF_POLARS__EXECUTOR__UNIQUE_FRACTION``.
         Default: ``{}``.
         Category: executor.
+    sink_to_directory
+        Whether multi-partition sink operations should write to a directory
+        rather than a single file. The ``spmd``/``ray``/``dask`` engines
+        always use ``True``; passing ``False`` raises ``ValueError``.
+        Env: ``CUDF_POLARS__EXECUTOR__SINK_TO_DIRECTORY``.
+        Default: ``True`` (forced by the streaming engines).
+        Category: executor.
     raise_on_fail
         Raise instead of falling back to CPU.
         Default: ``False``.
@@ -327,6 +334,9 @@ class StreamingOptions:
     )
     unique_fraction: dict[str, float] | Unspecified = _opt(
         "executor", "CUDF_POLARS__EXECUTOR__UNIQUE_FRACTION", json.loads
+    )
+    sink_to_directory: bool | Unspecified = _opt(
+        "executor", "CUDF_POLARS__EXECUTOR__SINK_TO_DIRECTORY", parse_boolean
     )
     # ---- Engine ----
     raise_on_fail: bool | Unspecified = _opt("engine")

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/io.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/io.py
@@ -814,7 +814,9 @@ async def sink_node(
             rank_width = math.ceil(math.log10(comm.nranks))
             rank_str = str(comm.rank).zfill(rank_width)
             path_root = f"{path_root}.{rank_str}"
-        count_width = math.ceil(math.log10(metadata.local_count))
+        # local_count may be 0 when a rank receives no partitions
+        # (e.g. more ranks than input files); log10(0) is undefined.
+        count_width = math.ceil(math.log10(max(metadata.local_count, 1)))
         count_width = max(count_width, 6)
 
         if ir.sink_to_directory:

--- a/python/cudf_polars/cudf_polars/utils/config.py
+++ b/python/cudf_polars/cudf_polars/utils/config.py
@@ -687,10 +687,10 @@ class StreamingExecutor:
         Default is 50% of device memory on the client process.
         This argument is only used by the "rapidsmpf" runtime.
     sink_to_directory
-        Whether multi-partition sink operations should write to a directory
-        rather than a single file. By default, this will be set to True for
-        the 'distributed' cluster and False otherwise. The 'distributed'
-        cluster does not currently support ``sink_to_directory=False``.
+        Whether multi-partition sink operations write to a directory rather
+        than a single file. For the distributed, spmd, ray, and dask clusters
+        this is always True; setting it to False raises a ValueError.
+        Defaults to False for the single-GPU cluster.
     dynamic_planning
         Options controlling dynamic shuffle planning. See
         :class:`~cudf_polars.utils.config.DynamicPlanningOptions` for more.
@@ -872,10 +872,10 @@ class StreamingExecutor:
                 DynamicPlanningOptions(**self.dynamic_planning),
             )
 
-        if self.cluster == "distributed":
+        if self.cluster in ("distributed", "spmd", "ray", "dask"):
             if self.sink_to_directory is False:
                 raise ValueError(
-                    "The distributed cluster requires sink_to_directory=True"
+                    f"The {self.cluster} cluster requires sink_to_directory=True"
                 )
             object.__setattr__(self, "sink_to_directory", True)
         elif self.sink_to_directory is None:

--- a/python/cudf_polars/tests/experimental/test_io_multirank.py
+++ b/python/cudf_polars/tests/experimental/test_io_multirank.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+"""IO tests for the streaming engines."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from rapidsmpf.bootstrap import is_running_with_rrun
+
+import polars as pl
+
+from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
+from cudf_polars.testing.asserts import assert_sink_result_equal
+from cudf_polars.utils.config import Cluster, StreamingExecutor
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from rapidsmpf.communicator.communicator import Communicator
+
+    from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
+
+# Runs the spmd variant even under rrun with nranks > 1. The ray/dask
+# variants skip themselves in that environment.
+pytestmark = [
+    pytest.mark.spmd,
+    pytest.mark.filterwarnings("ignore::ResourceWarning"),
+]
+
+
+@pytest.fixture(scope="module")
+def df() -> pl.LazyFrame:
+    return pl.LazyFrame(
+        {
+            "x": range(30_000),
+            "y": [1, 2, None] * 10_000,
+            "z": ["ẅ", "a", "z", "123", "abcd"] * 6_000,
+        }
+    )
+
+
+@pytest.fixture(params=["spmd", "ray", "dask"])
+def engine(
+    request: pytest.FixtureRequest,
+    spmd_comm: Communicator,
+) -> Iterator[StreamingEngine]:
+    """Yield each supported streaming engine."""
+    backend = request.param
+    executor_options = {"max_rows_per_partition": 1_000}
+
+    if backend == "spmd":
+        with SPMDEngine(
+            comm=spmd_comm,
+            executor_options=executor_options,
+        ) as eng:
+            yield eng
+        return
+
+    if is_running_with_rrun():
+        pytest.skip(f"{backend}Engine must not be created from within an rrun cluster")
+
+    if backend == "ray":
+        pytest.importorskip("ray", reason="ray is not installed")
+        from cudf_polars.experimental.rapidsmpf.frontend.ray import RayEngine
+
+        with RayEngine(
+            executor_options=executor_options,
+            ray_init_options={"include_dashboard": False},
+        ) as eng:
+            yield eng
+        return
+
+    assert backend == "dask"
+    pytest.importorskip("distributed", reason="distributed is not installed")
+    from cudf_polars.experimental.rapidsmpf.frontend.dask import DaskEngine
+
+    with DaskEngine(executor_options=executor_options) as eng:
+        yield eng
+
+
+def test_sink_parquet_directory(
+    engine: StreamingEngine, df: pl.LazyFrame, tmp_path: Path
+) -> None:
+    """Streaming engines always sink to a directory of partition files."""
+    path = tmp_path / "out.parquet"
+    assert_sink_result_equal(df, path, engine=engine)
+
+    gpu_path = path.with_name(f"{path.stem}_gpu{path.suffix}")
+    assert gpu_path.is_dir()
+    assert any(gpu_path.iterdir())
+
+
+def test_sink_parquet_empty_rank(engine: StreamingEngine, tmp_path: Path) -> None:
+    """A rank that receives no partitions."""
+    lazydf = pl.LazyFrame({"x": [1]})
+    path = tmp_path / "tiny.parquet"
+    assert_sink_result_equal(lazydf, path, engine=engine)
+
+    gpu_path = path.with_name(f"{path.stem}_gpu{path.suffix}")
+    assert gpu_path.is_dir()
+
+
+@pytest.mark.parametrize(
+    "cluster",
+    [Cluster.SPMD, Cluster.RAY, Cluster.DASK, Cluster.DISTRIBUTED],
+)
+def test_sink_to_directory_false_raises(cluster: Cluster) -> None:
+    """Explicit ``sink_to_directory=False`` is rejected for every multi-rank cluster."""
+    with pytest.raises(
+        ValueError,
+        match=rf"The {cluster.value} cluster requires sink_to_directory=True",
+    ):
+        StreamingExecutor(cluster=cluster, sink_to_directory=False)

--- a/python/cudf_polars/tests/experimental/test_options.py
+++ b/python/cudf_polars/tests/experimental/test_options.py
@@ -76,6 +76,16 @@ def test_executor_options_num_py_executors() -> None:
     assert result["num_py_executors"] == 4
 
 
+@pytest.mark.parametrize("value", [True, False])
+def test_executor_options_sink_to_directory(*, value: bool) -> None:
+    result = StreamingOptions(sink_to_directory=value).to_executor_options()
+    assert result["sink_to_directory"] is value
+
+
+def test_executor_options_sink_to_directory_absent_when_unspecified() -> None:
+    assert "sink_to_directory" not in StreamingOptions().to_executor_options()
+
+
 # ---------------------------------------------------------------------------
 # to_engine_options
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
* Align `RayEngine`, `DaskEngine`, and `SPMDEngine` with the legacy distributed cluster sink contract: `sink_to_directory` is always `True`, and passing `False` raises a `ValueError`. This prevents silent data corruption from multiple ranks writing to the same `ir.sink.path`.
* Promote `sink_to_directory` to a first-class `StreamingOptions` executor field (env: `CUDF_POLARS__EXECUTOR__SINK_TO_DIRECTORY`).
* Fix a `math.log10(0)` crash in `rapidsmpf/io.py` when a rank receives zero partitions, for example when there are fewer input files than ranks.
