### PR TITLE
Reset check-nightly-ci max days without success

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -76,8 +76,7 @@ jobs:
         with:
           repo: ${{ github.repository }}
           target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
-          # TODO: Fix nightly CI and remove this line
-          max-days-without-success: 40
+          max-days-without-success: 14
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
## Description
Resets the check-nightly-ci max-days-without-success value. The nightly builds appear to be succeeding again.
Undoes temporary change #22264 

Previously it was set to 1 week which had problems around holidays where failures sometimes could not be addressed for several consecutive days. It was changed to 30 days at one point but that is half an entire release and so seemed to generous. 
Setting it to now to 14 days as a middle ground for now.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
