### PR TITLE
Import nvcomp CMake configuration from rapids-cmake into cudf

### DIFF
--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -1,24 +1,234 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
 
+# This function contains more branches and statements than cmake-lint allows, because it faithfully
+# ports rapids_cpm_nvcomp() from rapids-cmake. The spacing below is necessary to prevent
+# cmake-format from combining the lint directive with the surrounding comments.
+
+# cmake-lint: disable=R0915,R0912,C0103
+
 # This function finds nvcomp and sets any additional necessary environment variables.
 function(find_and_configure_nvcomp)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "cudf.get_nvcomp")
 
-  include(${rapids-cmake-dir}/cpm/nvcomp.cmake)
-  rapids_cpm_nvcomp(
+  # --- 1. Hardcoded version/URL data (replacing versions.json) ---
+  set(version "5.2.0.10")
+
+  # Always try proprietary binary (matches prior behavior)
+  set(USE_PROPRIETARY_BINARY ON)
+
+  # --- 2. Stage 1: Local search (skip if rapids_cmake_always_download) ---
+  include("${rapids-cmake-dir}/find/package.cmake")
+  if(NOT rapids_cmake_always_download)
+    rapids_find_package(
+      nvcomp ${version}
+      GLOBAL_TARGETS nvcomp::nvcomp
+      BUILD_EXPORT_SET cudf-exports
+      INSTALL_EXPORT_SET cudf-exports
+      FIND_ARGS QUIET
+    )
+    if(nvcomp_FOUND)
+      message(STATUS "Found nvcomp: ${nvcomp_DIR} (found version ${nvcomp_VERSION})")
+    endif()
+  endif()
+
+  # --- 3. Stage 2: Proprietary binary download (if not found and USE_PROPRIETARY_BINARY) ---
+  include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
+  rapids_cmake_install_lib_dir(lib_dir)
+
+  set(nvcomp_proprietary_binary OFF)
+
+  if(USE_PROPRIETARY_BINARY AND NOT nvcomp_FOUND)
+    # Resolve platform key
+    set(platform_key "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
+    string(TOLOWER "${platform_key}" platform_key)
+
+    # Look up URL for this platform (hardcoded)
+    set(nvcomp_url "")
+    if(platform_key STREQUAL "x86_64-linux")
+      set(nvcomp_url
+          "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-\${version}_cuda\${cuda_version_mapping}-archive.tar.xz"
+      )
+    elseif(platform_key STREQUAL "aarch64-linux")
+      set(nvcomp_url
+          "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-\${version}_cuda\${cuda_version_mapping}-archive.tar.xz"
+      )
+    else()
+      message(
+        VERBOSE
+        "nvcomp requested usage of a proprietary_binary but none exist for ${CMAKE_SYSTEM_PROCESSOR}"
+      )
+    endif()
+
+    if(nvcomp_url)
+      # Determine CUDA version mapping
+      find_package(CUDAToolkit REQUIRED)
+      set(cuda_version_mapping "${CUDAToolkit_VERSION_MAJOR}")
+      if(CUDAToolkit_VERSION_MAJOR STREQUAL "12")
+        set(cuda_version_mapping "12")
+      elseif(CUDAToolkit_VERSION_MAJOR STREQUAL "13")
+        set(cuda_version_mapping "13")
+      endif()
+
+      # Evaluate template
+      cmake_language(EVAL CODE "set(nvcomp_url ${nvcomp_url})")
+
+      # Download proprietary binary
+      include(FetchContent)
+      set(pkg_name "nvcomp_proprietary_binary")
+      FetchContent_Declare(${pkg_name} URL ${nvcomp_url})
+      FetchContent_MakeAvailable(${pkg_name})
+      set(nvcomp_ROOT "${nvcomp_proprietary_binary_SOURCE_DIR}")
+      set(nvcomp_proprietary_binary ON)
+    endif()
+
+    # Normalize lib64 layout if needed
+    if(nvcomp_proprietary_binary)
+      if(NOT EXISTS "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp/nvcomp-config.cmake")
+        include(GNUInstallDirs)
+        cmake_path(GET lib_dir PARENT_PATH lib_dir_parent)
+        cmake_path(GET CMAKE_INSTALL_INCLUDEDIR PARENT_PATH include_dir_parent)
+        if(NOT lib_dir_parent STREQUAL include_dir_parent)
+          message(
+            FATAL_ERROR
+              "CMAKE_INSTALL_INCLUDEDIR and CMAKE_INSTALL_LIBDIR must share parent directory"
+          )
+        endif()
+
+        cmake_path(GET lib_dir FILENAME lib_dir_name)
+        set(nvcomp_list_of_target_files
+            "nvcomp-targets-common-release.cmake"
+            "nvcomp-targets-common.cmake"
+            "nvcomp-targets-dynamic-release.cmake"
+            "nvcomp-targets-dynamic.cmake"
+            "nvcomp-targets-release.cmake"
+            "nvcomp-targets-static-release.cmake"
+            "nvcomp-targets-static.cmake"
+        )
+        foreach(filename IN LISTS nvcomp_list_of_target_files)
+          if(EXISTS "${nvcomp_ROOT}/lib/cmake/nvcomp/${filename}")
+            file(READ "${nvcomp_ROOT}/lib/cmake/nvcomp/${filename}" FILE_CONTENTS)
+            string(REPLACE "\$\{_IMPORT_PREFIX\}/lib/" "\$\{_IMPORT_PREFIX\}/${lib_dir_name}/"
+                           FILE_CONTENTS ${FILE_CONTENTS}
+            )
+            file(WRITE "${nvcomp_ROOT}/lib/cmake/nvcomp/${filename}" ${FILE_CONTENTS})
+          endif()
+        endforeach()
+        file(MAKE_DIRECTORY "${nvcomp_ROOT}/${lib_dir_parent}")
+        file(RENAME "${nvcomp_ROOT}/lib/" "${nvcomp_ROOT}/${lib_dir}/")
+        # Move the `include` dir if necessary as well
+        file(RENAME "${nvcomp_ROOT}/include/" "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/")
+      endif()
+
+      # Record the proprietary root dir location
+      set(nvcomp_proprietary_root "${nvcomp_ROOT}")
+      cmake_path(NORMAL_PATH nvcomp_proprietary_root)
+      set(rapids_cpm_nvcomp_proprietary_root
+          "${nvcomp_proprietary_root}"
+          CACHE INTERNAL "nvcomp proprietary root dir location"
+      )
+
+      # Enforce usage of the local download only
+      list(APPEND CMAKE_PREFIX_PATH "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp")
+      unset(CPM_DOWNLOAD_ALL)
+      set(CPM_USE_LOCAL_PACKAGES ON)
+    endif()
+  elseif(DEFINED nvcomp_DIR)
+    # Re-configuration: restore state if nvcomp_DIR points to our proprietary root
+    cmake_path(NORMAL_PATH nvcomp_DIR)
+    if(nvcomp_DIR STREQUAL "${rapids_cpm_nvcomp_proprietary_root}/${lib_dir}/cmake/nvcomp")
+      set(nvcomp_proprietary_binary ON)
+      set(nvcomp_ROOT "${rapids_cpm_nvcomp_proprietary_root}")
+      unset(nvcomp_DIR)
+      unset(nvcomp_DIR CACHE)
+    endif()
+  endif()
+
+  # --- 4. Stage 3: CPM fallback ---
+  include("${rapids-cmake-dir}/cpm/find.cmake")
+  rapids_cpm_find(
+    nvcomp ${version}
+    GLOBAL_TARGETS nvcomp::nvcomp
     BUILD_EXPORT_SET cudf-exports
     INSTALL_EXPORT_SET cudf-exports
-    USE_PROPRIETARY_BINARY ON
+    CPM_ARGS
+    OPTIONS "BUILD_STATIC ON" "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF" "BUILD_EXAMPLES OFF"
   )
 
-  # Per-thread default stream
-  if(TARGET nvcomp AND CUDF_USE_PER_THREAD_DEFAULT_STREAM)
-    target_compile_definitions(nvcomp PRIVATE CUDA_API_PER_THREAD_DEFAULT_STREAM)
+  include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
+  rapids_cpm_display_patch_status(nvcomp)
+
+  # --- 5. Target aliases ---
+  foreach(name IN ITEMS nvcomp nvcomp_cpu nvcomp_cpu_static nvcomp_static)
+    if(NOT TARGET nvcomp::${name} AND TARGET ${name})
+      add_library(nvcomp::${name} ALIAS ${name})
+    endif()
+  endforeach()
+
+  # --- 6. Propagate parent-scope variables ---
+  set(nvcomp_SOURCE_DIR
+      "${nvcomp_SOURCE_DIR}"
+      PARENT_SCOPE
+  )
+  set(nvcomp_BINARY_DIR
+      "${nvcomp_BINARY_DIR}"
+      PARENT_SCOPE
+  )
+  set(nvcomp_ADDED
+      "${nvcomp_ADDED}"
+      PARENT_SCOPE
+  )
+  set(nvcomp_VERSION
+      ${version}
+      PARENT_SCOPE
+  )
+  set(nvcomp_proprietary_binary
+      ${nvcomp_proprietary_binary}
+      PARENT_SCOPE
+  )
+
+  # --- 7. Install rules (if to_install AND nvcomp_proprietary_binary) ---
+  set(to_install ON)
+  if(to_install AND nvcomp_proprietary_binary)
+    include(GNUInstallDirs)
+    install(DIRECTORY "${nvcomp_ROOT}/${lib_dir}/" DESTINATION "${lib_dir}")
+    install(DIRECTORY "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    )
+    if(EXISTS "${nvcomp_ROOT}/${CMAKE_INSTALL_BINDIR}")
+      install(DIRECTORY "${nvcomp_ROOT}/${CMAKE_INSTALL_BINDIR}/"
+              DESTINATION "${CMAKE_INSTALL_BINDIR}"
+      )
+    endif()
+    install(
+      FILES "${nvcomp_ROOT}/NOTICE"
+      DESTINATION info/
+      RENAME NVCOMP_NOTICE
+    )
+    install(
+      FILES "${nvcomp_ROOT}/LICENSE"
+      DESTINATION info/
+      RENAME NVCOMP_LICENSE
+    )
   endif()
+
+  # --- 8. Export tracking ---
+  include("${rapids-cmake-dir}/export/find_package_root.cmake")
+  rapids_export_find_package_root(
+    BUILD nvcomp "${nvcomp_ROOT}"
+    EXPORT_SET cudf-exports
+    CONDITION nvcomp_proprietary_binary
+  )
+
 endfunction()
 
 find_and_configure_nvcomp()
+
+# Per-thread default stream
+if(TARGET nvcomp AND CUDF_USE_PER_THREAD_DEFAULT_STREAM)
+  target_compile_definitions(nvcomp PRIVATE CUDA_API_PER_THREAD_DEFAULT_STREAM)
+endif()

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -17,7 +17,7 @@ function(find_and_configure_nvcomp)
   set(one_value VERSION)
   cmake_parse_arguments(_NVCOMP "${options}" "${one_value}" "" ${ARGN})
 
-  # --- 2. Local search (skip if DOWNLOAD_ONLY) ---
+  # If DOWNLOAD_ONLY is not set, try searching for an existing installation first
   if(NOT _NVCOMP_DOWNLOAD_ONLY)
     include("${rapids-cmake-dir}/find/package.cmake")
     rapids_find_package(
@@ -33,34 +33,33 @@ function(find_and_configure_nvcomp)
     endif()
   endif()
 
-  # --- 3. Proprietary binary download ---
+  # Find and download the platform-specific proprietary binary
   include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
   rapids_cmake_install_lib_dir(lib_dir)
-
-  # Determine CUDA major version for download URL
   find_package(CUDAToolkit REQUIRED)
-  set(cuda_version_mapping "${CUDAToolkit_VERSION_MAJOR}")
 
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     set(nvcomp_url
-        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-${_NVCOMP_VERSION}_cuda${cuda_version_mapping}-archive.tar.xz"
+        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-${_NVCOMP_VERSION}_cuda${CUDAToolkit_VERSION_MAJOR}-archive.tar.xz"
     )
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     set(nvcomp_url
-        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-${_NVCOMP_VERSION}_cuda${cuda_version_mapping}-archive.tar.xz"
+        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-${_NVCOMP_VERSION}_cuda${CUDAToolkit_VERSION_MAJOR}-archive.tar.xz"
     )
   else()
     message(FATAL_ERROR "No nvcomp binary available for ${CMAKE_SYSTEM_PROCESSOR}")
   endif()
 
-  # Download proprietary binary
   include(FetchContent)
   set(pkg_name "nvcomp_proprietary_binary")
   FetchContent_Declare(${pkg_name} URL ${nvcomp_url})
   FetchContent_MakeAvailable(${pkg_name})
   set(nvcomp_ROOT "${nvcomp_proprietary_binary_SOURCE_DIR}")
 
-  # Normalize lib64 layout if needed
+  # The downloaded nvcomp binary always uses `lib`, but some platforms use `lib64` for 64-bit
+  # libraries. If the platform's lib directory is `lib64`, move the contents of the downloaded `lib`
+  # directory to a new `lib64` directory and update the CMake config files to point to the new
+  # location.
   if(NOT EXISTS "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp/nvcomp-config.cmake")
     include(GNUInstallDirs)
     cmake_path(GET lib_dir PARENT_PATH lib_dir_parent)
@@ -96,7 +95,8 @@ function(find_and_configure_nvcomp)
     file(RENAME "${nvcomp_ROOT}/include/" "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/")
   endif()
 
-  # --- 4. Find the downloaded binary ---
+  # Now that the downloaded binary is configured correctly, perform a find_package call to generate
+  # the necessary targets
   include("${rapids-cmake-dir}/find/package.cmake")
   rapids_find_package(
     nvcomp ${_NVCOMP_VERSION}
@@ -107,7 +107,6 @@ function(find_and_configure_nvcomp)
     REQUIRED
   )
 
-  # --- 6. Install rules for downloaded binary ---
   include(GNUInstallDirs)
   install(DIRECTORY "${nvcomp_ROOT}/${lib_dir}/" DESTINATION "${lib_dir}")
   install(DIRECTORY "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/"
@@ -129,7 +128,6 @@ function(find_and_configure_nvcomp)
     RENAME NVCOMP_LICENSE
   )
 
-  # --- 7. Export tracking ---
   include("${rapids-cmake-dir}/export/find_package_root.cmake")
   rapids_export_find_package_root(BUILD nvcomp "${nvcomp_ROOT}" EXPORT_SET cudf-exports)
 

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -13,8 +13,6 @@
 
 # This function finds nvcomp and sets any additional necessary environment variables.
 function(find_and_configure_nvcomp)
-  list(APPEND CMAKE_MESSAGE_CONTEXT "cudf.get_nvcomp")
-
   set(options DOWNLOAD_ONLY)
   cmake_parse_arguments(_NVCOMP "${options}" "" "" ${ARGN})
 
@@ -40,6 +38,10 @@ function(find_and_configure_nvcomp)
   # --- 3. Proprietary binary download ---
   include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
   rapids_cmake_install_lib_dir(lib_dir)
+
+  # Determine CUDA major version for download URL
+  find_package(CUDAToolkit REQUIRED)
+  set(cuda_version_mapping "${CUDAToolkit_VERSION_MAJOR}")
 
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     set(nvcomp_url
@@ -111,17 +113,12 @@ function(find_and_configure_nvcomp)
   # --- 5. Target aliases ---
   foreach(name IN ITEMS nvcomp nvcomp_cpu nvcomp_cpu_static nvcomp_static)
     if(NOT TARGET nvcomp::${name} AND TARGET ${name})
+      message("Got here")
       add_library(nvcomp::${name} ALIAS ${name})
     endif()
   endforeach()
 
-  # --- 6. Propagate parent-scope variables ---
-  set(nvcomp_VERSION
-      ${version}
-      PARENT_SCOPE
-  )
-
-  # --- 7. Install rules for downloaded binary ---
+  # --- 6. Install rules for downloaded binary ---
   include(GNUInstallDirs)
   install(DIRECTORY "${nvcomp_ROOT}/${lib_dir}/" DESTINATION "${lib_dir}")
   install(DIRECTORY "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/"
@@ -143,7 +140,7 @@ function(find_and_configure_nvcomp)
     RENAME NVCOMP_LICENSE
   )
 
-  # --- 8. Export tracking ---
+  # --- 7. Export tracking ---
   include("${rapids-cmake-dir}/export/find_package_root.cmake")
   rapids_export_find_package_root(BUILD nvcomp "${nvcomp_ROOT}" EXPORT_SET cudf-exports)
 

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -6,8 +6,7 @@
 # =============================================================================
 
 # This function finds or downloads nvcomp and sets any additional necessary environment variables.
-# The CPM build-from-source fallback has been removed since nvcomp cannot be built from source. The
-# spacing below is necessary to prevent cmake-format from combining the lint directive with the
+# The spacing below is necessary to prevent cmake-format from combining the lint directive with the
 # surrounding comments.
 
 # cmake-lint: disable=R0915,R0912,C0103
@@ -16,15 +15,15 @@
 function(find_and_configure_nvcomp)
   list(APPEND CMAKE_MESSAGE_CONTEXT "cudf.get_nvcomp")
 
-  # --- 1. Hardcoded version/URL data (replacing versions.json) ---
+  set(options DOWNLOAD_ONLY)
+  cmake_parse_arguments(_NVCOMP "${options}" "" "" ${ARGN})
+
+  # --- 1. Hardcoded version/URL data ---
   set(version "5.2.0.10")
 
-  # Always try proprietary binary (matches prior behavior)
-  set(USE_PROPRIETARY_BINARY ON)
-
-  # --- 2. Stage 1: Local search (skip if rapids_cmake_always_download) ---
-  include("${rapids-cmake-dir}/find/package.cmake")
-  if(NOT rapids_cmake_always_download)
+  # --- 2. Local search (skip if DOWNLOAD_ONLY) ---
+  if(NOT _NVCOMP_DOWNLOAD_ONLY)
+    include("${rapids-cmake-dir}/find/package.cmake")
     rapids_find_package(
       nvcomp ${version}
       GLOBAL_TARGETS nvcomp::nvcomp
@@ -34,123 +33,101 @@ function(find_and_configure_nvcomp)
     )
     if(nvcomp_FOUND)
       message(STATUS "Found nvcomp: ${nvcomp_DIR} (found version ${nvcomp_VERSION})")
+      return()
     endif()
   endif()
-  if(nvcomp_FOUND)
-    return()
-  endif()
 
-  # --- 3. Stage 2: Proprietary binary download (if not found and USE_PROPRIETARY_BINARY) ---
+  # --- 3. Proprietary binary download ---
   include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
   rapids_cmake_install_lib_dir(lib_dir)
 
   set(nvcomp_proprietary_binary OFF)
 
-  if(USE_PROPRIETARY_BINARY AND NOT nvcomp_FOUND)
-    # Resolve platform key
-    set(platform_key "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
-    string(TOLOWER "${platform_key}" platform_key)
+  # Resolve platform key
+  set(platform_key "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
+  string(TOLOWER "${platform_key}" platform_key)
 
-    # Look up URL for this platform (hardcoded)
-    set(nvcomp_url "")
-    if(platform_key STREQUAL "x86_64-linux")
-      set(nvcomp_url
-          "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-\${version}_cuda\${cuda_version_mapping}-archive.tar.xz"
-      )
-    elseif(platform_key STREQUAL "aarch64-linux")
-      set(nvcomp_url
-          "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-\${version}_cuda\${cuda_version_mapping}-archive.tar.xz"
-      )
-    else()
-      message(
-        VERBOSE
-        "nvcomp requested usage of a proprietary_binary but none exist for ${CMAKE_SYSTEM_PROCESSOR}"
-      )
-    endif()
-
-    if(nvcomp_url)
-      # Determine CUDA version mapping
-      find_package(CUDAToolkit REQUIRED)
-      set(cuda_version_mapping "${CUDAToolkit_VERSION_MAJOR}")
-      if(CUDAToolkit_VERSION_MAJOR STREQUAL "12")
-        set(cuda_version_mapping "12")
-      elseif(CUDAToolkit_VERSION_MAJOR STREQUAL "13")
-        set(cuda_version_mapping "13")
-      endif()
-
-      # Evaluate template
-      cmake_language(EVAL CODE "set(nvcomp_url ${nvcomp_url})")
-
-      # Download proprietary binary
-      include(FetchContent)
-      set(pkg_name "nvcomp_proprietary_binary")
-      FetchContent_Declare(${pkg_name} URL ${nvcomp_url})
-      FetchContent_MakeAvailable(${pkg_name})
-      set(nvcomp_ROOT "${nvcomp_proprietary_binary_SOURCE_DIR}")
-      set(nvcomp_proprietary_binary ON)
-    endif()
-
-    # Normalize lib64 layout if needed
-    if(nvcomp_proprietary_binary)
-      if(NOT EXISTS "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp/nvcomp-config.cmake")
-        include(GNUInstallDirs)
-        cmake_path(GET lib_dir PARENT_PATH lib_dir_parent)
-        cmake_path(GET CMAKE_INSTALL_INCLUDEDIR PARENT_PATH include_dir_parent)
-        if(NOT lib_dir_parent STREQUAL include_dir_parent)
-          message(
-            FATAL_ERROR
-              "CMAKE_INSTALL_INCLUDEDIR and CMAKE_INSTALL_LIBDIR must share parent directory"
-          )
-        endif()
-
-        cmake_path(GET lib_dir FILENAME lib_dir_name)
-        set(nvcomp_list_of_target_files
-            "nvcomp-targets-common-release.cmake"
-            "nvcomp-targets-common.cmake"
-            "nvcomp-targets-dynamic-release.cmake"
-            "nvcomp-targets-dynamic.cmake"
-            "nvcomp-targets-release.cmake"
-            "nvcomp-targets-static-release.cmake"
-            "nvcomp-targets-static.cmake"
-        )
-        foreach(filename IN LISTS nvcomp_list_of_target_files)
-          if(EXISTS "${nvcomp_ROOT}/lib/cmake/nvcomp/${filename}")
-            file(READ "${nvcomp_ROOT}/lib/cmake/nvcomp/${filename}" FILE_CONTENTS)
-            string(REPLACE "\$\{_IMPORT_PREFIX\}/lib/" "\$\{_IMPORT_PREFIX\}/${lib_dir_name}/"
-                           FILE_CONTENTS ${FILE_CONTENTS}
-            )
-            file(WRITE "${nvcomp_ROOT}/lib/cmake/nvcomp/${filename}" ${FILE_CONTENTS})
-          endif()
-        endforeach()
-        file(MAKE_DIRECTORY "${nvcomp_ROOT}/${lib_dir_parent}")
-        file(RENAME "${nvcomp_ROOT}/lib/" "${nvcomp_ROOT}/${lib_dir}/")
-        # Move the `include` dir if necessary as well
-        file(RENAME "${nvcomp_ROOT}/include/" "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/")
-      endif()
-
-      # Record the proprietary root dir location
-      set(nvcomp_proprietary_root "${nvcomp_ROOT}")
-      cmake_path(NORMAL_PATH nvcomp_proprietary_root)
-      set(rapids_cpm_nvcomp_proprietary_root
-          "${nvcomp_proprietary_root}"
-          CACHE INTERNAL "nvcomp proprietary root dir location"
-      )
-
-      # Enforce usage of the local download only
-      list(APPEND CMAKE_PREFIX_PATH "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp")
-    endif()
-  elseif(DEFINED nvcomp_DIR)
-    # Re-configuration: restore state if nvcomp_DIR points to our proprietary root
-    cmake_path(NORMAL_PATH nvcomp_DIR)
-    if(nvcomp_DIR STREQUAL "${rapids_cpm_nvcomp_proprietary_root}/${lib_dir}/cmake/nvcomp")
-      set(nvcomp_proprietary_binary ON)
-      set(nvcomp_ROOT "${rapids_cpm_nvcomp_proprietary_root}")
-      unset(nvcomp_DIR)
-      unset(nvcomp_DIR CACHE)
-    endif()
+  # Look up URL for this platform
+  if(platform_key STREQUAL "x86_64-linux")
+    set(nvcomp_url
+        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-\${version}_cuda\${cuda_version_mapping}-archive.tar.xz"
+    )
+  elseif(platform_key STREQUAL "aarch64-linux")
+    set(nvcomp_url
+        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-\${version}_cuda\${cuda_version_mapping}-archive.tar.xz"
+    )
+  else()
+    message(FATAL_ERROR "No nvcomp binary available for ${CMAKE_SYSTEM_PROCESSOR}")
   endif()
 
-  # --- 4. Find proprietary binary + FATAL_ERROR if not found ---
+  # Determine CUDA version mapping
+  find_package(CUDAToolkit REQUIRED)
+  set(cuda_version_mapping "${CUDAToolkit_VERSION_MAJOR}")
+  if(CUDAToolkit_VERSION_MAJOR STREQUAL "12")
+    set(cuda_version_mapping "12")
+  elseif(CUDAToolkit_VERSION_MAJOR STREQUAL "13")
+    set(cuda_version_mapping "13")
+  endif()
+
+  # Evaluate URL template
+  cmake_language(EVAL CODE "set(nvcomp_url ${nvcomp_url})")
+
+  # Download proprietary binary
+  include(FetchContent)
+  set(pkg_name "nvcomp_proprietary_binary")
+  FetchContent_Declare(${pkg_name} URL ${nvcomp_url})
+  FetchContent_MakeAvailable(${pkg_name})
+  set(nvcomp_ROOT "${nvcomp_proprietary_binary_SOURCE_DIR}")
+  set(nvcomp_proprietary_binary ON)
+
+  # Normalize lib64 layout if needed
+  if(NOT EXISTS "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp/nvcomp-config.cmake")
+    include(GNUInstallDirs)
+    cmake_path(GET lib_dir PARENT_PATH lib_dir_parent)
+    cmake_path(GET CMAKE_INSTALL_INCLUDEDIR PARENT_PATH include_dir_parent)
+    if(NOT lib_dir_parent STREQUAL include_dir_parent)
+      message(
+        FATAL_ERROR "CMAKE_INSTALL_INCLUDEDIR and CMAKE_INSTALL_LIBDIR must share parent directory"
+      )
+    endif()
+
+    cmake_path(GET lib_dir FILENAME lib_dir_name)
+    set(nvcomp_list_of_target_files
+        "nvcomp-targets-common-release.cmake"
+        "nvcomp-targets-common.cmake"
+        "nvcomp-targets-dynamic-release.cmake"
+        "nvcomp-targets-dynamic.cmake"
+        "nvcomp-targets-release.cmake"
+        "nvcomp-targets-static-release.cmake"
+        "nvcomp-targets-static.cmake"
+    )
+    foreach(filename IN LISTS nvcomp_list_of_target_files)
+      if(EXISTS "${nvcomp_ROOT}/lib/cmake/nvcomp/${filename}")
+        file(READ "${nvcomp_ROOT}/lib/cmake/nvcomp/${filename}" FILE_CONTENTS)
+        string(REPLACE "\$\{_IMPORT_PREFIX\}/lib/" "\$\{_IMPORT_PREFIX\}/${lib_dir_name}/"
+                       FILE_CONTENTS ${FILE_CONTENTS}
+        )
+        file(WRITE "${nvcomp_ROOT}/lib/cmake/nvcomp/${filename}" ${FILE_CONTENTS})
+      endif()
+    endforeach()
+    file(MAKE_DIRECTORY "${nvcomp_ROOT}/${lib_dir_parent}")
+    file(RENAME "${nvcomp_ROOT}/lib/" "${nvcomp_ROOT}/${lib_dir}/")
+    # Move the `include` dir if necessary as well
+    file(RENAME "${nvcomp_ROOT}/include/" "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/")
+  endif()
+
+  # Record the proprietary root dir location
+  set(nvcomp_proprietary_root "${nvcomp_ROOT}")
+  cmake_path(NORMAL_PATH nvcomp_proprietary_root)
+  set(rapids_cpm_nvcomp_proprietary_root
+      "${nvcomp_proprietary_root}"
+      CACHE INTERNAL "nvcomp proprietary root dir location"
+  )
+
+  list(APPEND CMAKE_PREFIX_PATH "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp")
+
+  # --- 4. Find the downloaded binary + FATAL_ERROR if not found ---
+  include("${rapids-cmake-dir}/find/package.cmake")
   rapids_find_package(
     nvcomp ${version}
     GLOBAL_TARGETS nvcomp::nvcomp

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -41,8 +41,6 @@ function(find_and_configure_nvcomp)
   include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
   rapids_cmake_install_lib_dir(lib_dir)
 
-  set(nvcomp_proprietary_binary OFF)
-
   # Resolve platform key
   set(platform_key "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
   string(TOLOWER "${platform_key}" platform_key)
@@ -73,7 +71,6 @@ function(find_and_configure_nvcomp)
   FetchContent_Declare(${pkg_name} URL ${nvcomp_url})
   FetchContent_MakeAvailable(${pkg_name})
   set(nvcomp_ROOT "${nvcomp_proprietary_binary_SOURCE_DIR}")
-  set(nvcomp_proprietary_binary ON)
 
   # Normalize lib64 layout if needed
   if(NOT EXISTS "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp/nvcomp-config.cmake")
@@ -135,43 +132,32 @@ function(find_and_configure_nvcomp)
       ${version}
       PARENT_SCOPE
   )
-  set(nvcomp_proprietary_binary
-      ${nvcomp_proprietary_binary}
-      PARENT_SCOPE
-  )
 
-  # --- 7. Install rules (if to_install AND nvcomp_proprietary_binary) ---
-  set(to_install ON)
-  if(to_install AND nvcomp_proprietary_binary)
-    include(GNUInstallDirs)
-    install(DIRECTORY "${nvcomp_ROOT}/${lib_dir}/" DESTINATION "${lib_dir}")
-    install(DIRECTORY "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/"
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-    )
-    if(EXISTS "${nvcomp_ROOT}/${CMAKE_INSTALL_BINDIR}")
-      install(DIRECTORY "${nvcomp_ROOT}/${CMAKE_INSTALL_BINDIR}/"
-              DESTINATION "${CMAKE_INSTALL_BINDIR}"
-      )
-    endif()
-    install(
-      FILES "${nvcomp_ROOT}/NOTICE"
-      DESTINATION info/
-      RENAME NVCOMP_NOTICE
-    )
-    install(
-      FILES "${nvcomp_ROOT}/LICENSE"
-      DESTINATION info/
-      RENAME NVCOMP_LICENSE
+  # --- 7. Install rules for downloaded binary ---
+  include(GNUInstallDirs)
+  install(DIRECTORY "${nvcomp_ROOT}/${lib_dir}/" DESTINATION "${lib_dir}")
+  install(DIRECTORY "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/"
+          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  )
+  if(EXISTS "${nvcomp_ROOT}/${CMAKE_INSTALL_BINDIR}")
+    install(DIRECTORY "${nvcomp_ROOT}/${CMAKE_INSTALL_BINDIR}/"
+            DESTINATION "${CMAKE_INSTALL_BINDIR}"
     )
   endif()
+  install(
+    FILES "${nvcomp_ROOT}/NOTICE"
+    DESTINATION info/
+    RENAME NVCOMP_NOTICE
+  )
+  install(
+    FILES "${nvcomp_ROOT}/LICENSE"
+    DESTINATION info/
+    RENAME NVCOMP_LICENSE
+  )
 
   # --- 8. Export tracking ---
   include("${rapids-cmake-dir}/export/find_package_root.cmake")
-  rapids_export_find_package_root(
-    BUILD nvcomp "${nvcomp_ROOT}"
-    EXPORT_SET cudf-exports
-    CONDITION nvcomp_proprietary_binary
-  )
+  rapids_export_find_package_root(BUILD nvcomp "${nvcomp_ROOT}" EXPORT_SET cudf-exports)
 
 endfunction()
 

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -60,14 +60,9 @@ function(find_and_configure_nvcomp)
     message(FATAL_ERROR "No nvcomp binary available for ${CMAKE_SYSTEM_PROCESSOR}")
   endif()
 
-  # Determine CUDA version mapping
+  # Determine CUDA version for download URL
   find_package(CUDAToolkit REQUIRED)
   set(cuda_version_mapping "${CUDAToolkit_VERSION_MAJOR}")
-  if(CUDAToolkit_VERSION_MAJOR STREQUAL "12")
-    set(cuda_version_mapping "12")
-  elseif(CUDAToolkit_VERSION_MAJOR STREQUAL "13")
-    set(cuda_version_mapping "13")
-  endif()
 
   # Evaluate URL template
   cmake_language(EVAL CODE "set(nvcomp_url ${nvcomp_url})")

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -14,16 +14,14 @@
 # This function finds nvcomp and sets any additional necessary environment variables.
 function(find_and_configure_nvcomp)
   set(options DOWNLOAD_ONLY)
-  cmake_parse_arguments(_NVCOMP "${options}" "" "" ${ARGN})
-
-  # --- 1. Hardcoded version/URL data ---
-  set(version "5.2.0.10")
+  set(one_value VERSION)
+  cmake_parse_arguments(_NVCOMP "${options}" "${one_value}" "" ${ARGN})
 
   # --- 2. Local search (skip if DOWNLOAD_ONLY) ---
   if(NOT _NVCOMP_DOWNLOAD_ONLY)
     include("${rapids-cmake-dir}/find/package.cmake")
     rapids_find_package(
-      nvcomp ${version}
+      nvcomp ${_NVCOMP_VERSION}
       GLOBAL_TARGETS nvcomp::nvcomp
       BUILD_EXPORT_SET cudf-exports
       INSTALL_EXPORT_SET cudf-exports
@@ -45,11 +43,11 @@ function(find_and_configure_nvcomp)
 
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     set(nvcomp_url
-        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-${version}_cuda${cuda_version_mapping}-archive.tar.xz"
+        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-${_NVCOMP_VERSION}_cuda${cuda_version_mapping}-archive.tar.xz"
     )
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     set(nvcomp_url
-        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-${version}_cuda${cuda_version_mapping}-archive.tar.xz"
+        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-${_NVCOMP_VERSION}_cuda${cuda_version_mapping}-archive.tar.xz"
     )
   else()
     message(FATAL_ERROR "No nvcomp binary available for ${CMAKE_SYSTEM_PROCESSOR}")
@@ -101,7 +99,7 @@ function(find_and_configure_nvcomp)
   # --- 4. Find the downloaded binary ---
   include("${rapids-cmake-dir}/find/package.cmake")
   rapids_find_package(
-    nvcomp ${version}
+    nvcomp ${_NVCOMP_VERSION}
     GLOBAL_TARGETS nvcomp::nvcomp
     BUILD_EXPORT_SET cudf-exports
     INSTALL_EXPORT_SET cudf-exports
@@ -137,7 +135,7 @@ function(find_and_configure_nvcomp)
 
 endfunction()
 
-find_and_configure_nvcomp()
+find_and_configure_nvcomp(VERSION 5.2.0.10)
 
 # Per-thread default stream
 if(TARGET nvcomp AND CUDF_USE_PER_THREAD_DEFAULT_STREAM)

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -97,7 +97,6 @@ function(find_and_configure_nvcomp)
     # Move the `include` dir if necessary as well
     file(RENAME "${nvcomp_ROOT}/include/" "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/")
   endif()
-  list(APPEND CMAKE_PREFIX_PATH "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp")
 
   # --- 4. Find the downloaded binary ---
   include("${rapids-cmake-dir}/find/package.cmake")

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -41,20 +41,11 @@ function(find_and_configure_nvcomp)
   include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
   rapids_cmake_install_lib_dir(lib_dir)
 
-  # Resolve platform key
-  set(platform_key "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
-  string(TOLOWER "${platform_key}" platform_key)
-
-  # Determine CUDA version for download URL
-  find_package(CUDAToolkit REQUIRED)
-  set(cuda_version_mapping "${CUDAToolkit_VERSION_MAJOR}")
-
-  # Look up URL for this platform
-  if(platform_key STREQUAL "x86_64-linux")
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     set(nvcomp_url
         "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-${version}_cuda${cuda_version_mapping}-archive.tar.xz"
     )
-  elseif(platform_key STREQUAL "aarch64-linux")
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     set(nvcomp_url
         "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-${version}_cuda${cuda_version_mapping}-archive.tar.xz"
     )

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -45,25 +45,22 @@ function(find_and_configure_nvcomp)
   set(platform_key "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
   string(TOLOWER "${platform_key}" platform_key)
 
-  # Look up URL for this platform
-  if(platform_key STREQUAL "x86_64-linux")
-    set(nvcomp_url
-        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-\${version}_cuda\${cuda_version_mapping}-archive.tar.xz"
-    )
-  elseif(platform_key STREQUAL "aarch64-linux")
-    set(nvcomp_url
-        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-\${version}_cuda\${cuda_version_mapping}-archive.tar.xz"
-    )
-  else()
-    message(FATAL_ERROR "No nvcomp binary available for ${CMAKE_SYSTEM_PROCESSOR}")
-  endif()
-
   # Determine CUDA version for download URL
   find_package(CUDAToolkit REQUIRED)
   set(cuda_version_mapping "${CUDAToolkit_VERSION_MAJOR}")
 
-  # Evaluate URL template
-  cmake_language(EVAL CODE "set(nvcomp_url ${nvcomp_url})")
+  # Look up URL for this platform
+  if(platform_key STREQUAL "x86_64-linux")
+    set(nvcomp_url
+        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-${version}_cuda${cuda_version_mapping}-archive.tar.xz"
+    )
+  elseif(platform_key STREQUAL "aarch64-linux")
+    set(nvcomp_url
+        "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-${version}_cuda${cuda_version_mapping}-archive.tar.xz"
+    )
+  else()
+    message(FATAL_ERROR "No nvcomp binary available for ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
 
   # Download proprietary binary
   include(FetchContent)

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -110,15 +110,6 @@ function(find_and_configure_nvcomp)
     # Move the `include` dir if necessary as well
     file(RENAME "${nvcomp_ROOT}/include/" "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/")
   endif()
-
-  # Record the proprietary root dir location
-  set(nvcomp_proprietary_root "${nvcomp_ROOT}")
-  cmake_path(NORMAL_PATH nvcomp_proprietary_root)
-  set(rapids_cpm_nvcomp_proprietary_root
-      "${nvcomp_proprietary_root}"
-      CACHE INTERNAL "nvcomp proprietary root dir location"
-  )
-
   list(APPEND CMAKE_PREFIX_PATH "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp")
 
   # --- 4. Find the downloaded binary + FATAL_ERROR if not found ---

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -110,14 +110,6 @@ function(find_and_configure_nvcomp)
     REQUIRED
   )
 
-  # --- 5. Target aliases ---
-  foreach(name IN ITEMS nvcomp nvcomp_cpu nvcomp_cpu_static nvcomp_static)
-    if(NOT TARGET nvcomp::${name} AND TARGET ${name})
-      message("Got here")
-      add_library(nvcomp::${name} ALIAS ${name})
-    endif()
-  endforeach()
-
   # --- 6. Install rules for downloaded binary ---
   include(GNUInstallDirs)
   install(DIRECTORY "${nvcomp_ROOT}/${lib_dir}/" DESTINATION "${lib_dir}")

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -5,9 +5,10 @@
 # cmake-format: on
 # =============================================================================
 
-# This function contains more branches and statements than cmake-lint allows, because it faithfully
-# ports rapids_cpm_nvcomp() from rapids-cmake. The spacing below is necessary to prevent
-# cmake-format from combining the lint directive with the surrounding comments.
+# This function finds or downloads nvcomp and sets any additional necessary environment variables.
+# The CPM build-from-source fallback has been removed since nvcomp cannot be built from source. The
+# spacing below is necessary to prevent cmake-format from combining the lint directive with the
+# surrounding comments.
 
 # cmake-lint: disable=R0915,R0912,C0103
 
@@ -34,6 +35,9 @@ function(find_and_configure_nvcomp)
     if(nvcomp_FOUND)
       message(STATUS "Found nvcomp: ${nvcomp_DIR} (found version ${nvcomp_VERSION})")
     endif()
+  endif()
+  if(nvcomp_FOUND)
+    return()
   endif()
 
   # --- 3. Stage 2: Proprietary binary download (if not found and USE_PROPRIETARY_BINARY) ---
@@ -134,8 +138,6 @@ function(find_and_configure_nvcomp)
 
       # Enforce usage of the local download only
       list(APPEND CMAKE_PREFIX_PATH "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp")
-      unset(CPM_DOWNLOAD_ALL)
-      set(CPM_USE_LOCAL_PACKAGES ON)
     endif()
   elseif(DEFINED nvcomp_DIR)
     # Re-configuration: restore state if nvcomp_DIR points to our proprietary root
@@ -148,19 +150,17 @@ function(find_and_configure_nvcomp)
     endif()
   endif()
 
-  # --- 4. Stage 3: CPM fallback ---
-  include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(
+  # --- 4. Find proprietary binary + FATAL_ERROR if not found ---
+  rapids_find_package(
     nvcomp ${version}
     GLOBAL_TARGETS nvcomp::nvcomp
     BUILD_EXPORT_SET cudf-exports
     INSTALL_EXPORT_SET cudf-exports
-    CPM_ARGS
-    OPTIONS "BUILD_STATIC ON" "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF" "BUILD_EXAMPLES OFF"
   )
 
-  include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
-  rapids_cpm_display_patch_status(nvcomp)
+  if(NOT nvcomp_FOUND)
+    message(FATAL_ERROR "nvcomp ${version} not found. nvcomp cannot be built from source.")
+  endif()
 
   # --- 5. Target aliases ---
   foreach(name IN ITEMS nvcomp nvcomp_cpu nvcomp_cpu_static nvcomp_static)
@@ -170,18 +170,6 @@ function(find_and_configure_nvcomp)
   endforeach()
 
   # --- 6. Propagate parent-scope variables ---
-  set(nvcomp_SOURCE_DIR
-      "${nvcomp_SOURCE_DIR}"
-      PARENT_SCOPE
-  )
-  set(nvcomp_BINARY_DIR
-      "${nvcomp_BINARY_DIR}"
-      PARENT_SCOPE
-  )
-  set(nvcomp_ADDED
-      "${nvcomp_ADDED}"
-      PARENT_SCOPE
-  )
   set(nvcomp_VERSION
       ${version}
       PARENT_SCOPE

--- a/cpp/cmake/thirdparty/get_nvcomp.cmake
+++ b/cpp/cmake/thirdparty/get_nvcomp.cmake
@@ -112,18 +112,16 @@ function(find_and_configure_nvcomp)
   endif()
   list(APPEND CMAKE_PREFIX_PATH "${nvcomp_ROOT}/${lib_dir}/cmake/nvcomp")
 
-  # --- 4. Find the downloaded binary + FATAL_ERROR if not found ---
+  # --- 4. Find the downloaded binary ---
   include("${rapids-cmake-dir}/find/package.cmake")
   rapids_find_package(
     nvcomp ${version}
     GLOBAL_TARGETS nvcomp::nvcomp
     BUILD_EXPORT_SET cudf-exports
     INSTALL_EXPORT_SET cudf-exports
+    FIND_ARGS
+    REQUIRED
   )
-
-  if(NOT nvcomp_FOUND)
-    message(FATAL_ERROR "nvcomp ${version} not found. nvcomp cannot be built from source.")
-  endif()
 
   # --- 5. Target aliases ---
   foreach(name IN ITEMS nvcomp nvcomp_cpu nvcomp_cpu_static nvcomp_static)


### PR DESCRIPTION
## Description

Import nvcomp's CMake fetch/configure logic from rapids-cmake directly into cudf's `cpp/cmake/thirdparty/get_nvcomp.cmake`, replacing the thin wrapper that previously delegated to `rapids_cpm_nvcomp()`.

### Motivation

1. **No other RAPIDS library uses nvcomp anymore** — kvikio's dependency on nvcomp was recently removed, making cudf the sole consumer of the nvcomp integration in rapids-cmake.

2. **Significant rapids-cmake infrastructure can be removed** — there is substantial proprietary binary handling infrastructure in rapids-cmake (versions.json manifests, proprietary binary download machinery, special-case nvcomp logic) that only existed to serve nvcomp consumers. With cudf owning its own integration, all of that can be cleaned up upstream.

3. **The rapids-cmake implementation is very out of date** — it still contains information and code paths for open-source nvcomp even though nvcomp went closed source years ago and cudf is no longer compatible with the old open-source version. The CPM build-from-source fallback was dead code.

4. **We want to make changes to how we link nvcomp in cudf** — specifically, switching to static linking when downloading the proprietary binary. Owning the integration locally makes these changes straightforward without cross-repo coordination.

5. **We don't want to maintain nvcomp versions in as many places** — by owning the version string in cudf's CMake directly, version bumps are a single-file change rather than requiring coordinated updates across rapids-cmake's versions.json, patch files, and cudf's CMake.

### Changes

The original 8-line wrapper has been replaced with a self-contained ~140-line module that:

- Accepts `VERSION` and `DOWNLOAD_ONLY` parameters
- Tries a local `find_package` first (skipped if `DOWNLOAD_ONLY`)
- Downloads the platform-specific proprietary binary via FetchContent on cache miss
- Normalizes lib/lib64 layout differences
- Finds the downloaded package with `REQUIRED`
- Installs libraries, headers, license files
- Registers export tracking for downstream consumers

Stale abstractions removed:
- `rapids_cmake_always_download` → `DOWNLOAD_ONLY` parameter
- `USE_PROPRIETARY_BINARY` gate (always true on download path)
- `rapids_cpm_nvcomp_proprietary_root` cache variable (only consumer was removed reconfiguration block)
- `cmake_language(EVAL)` for URL construction (was needed for JSON-sourced templates)
- Redundant `nvcomp_FOUND` checks, platform_key indirection, CUDA version mapping branches

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.