### PR TITLE
Add proxy types for missing offsets 

### DIFF
--- a/python/cudf/cudf/pandas/_wrappers/pandas.py
+++ b/python/cudf/cudf/pandas/_wrappers/pandas.py
@@ -1611,6 +1611,28 @@ BDay = make_final_proxy_type(
     },
 )
 
+BHalfYearBegin = make_final_proxy_type(
+    "BHalfYearBegin",
+    _Unusable,
+    pd.offsets.BHalfYearBegin,
+    fast_to_slow=_Unusable(),
+    slow_to_fast=_Unusable(),
+    additional_attributes={
+        "__hash__": _FastSlowAttribute("__hash__"),
+    },
+)
+
+BHalfYearEnd = make_final_proxy_type(
+    "BHalfYearEnd",
+    _Unusable,
+    pd.offsets.BHalfYearEnd,
+    fast_to_slow=_Unusable(),
+    slow_to_fast=_Unusable(),
+    additional_attributes={
+        "__hash__": _FastSlowAttribute("__hash__"),
+    },
+)
+
 BMonthBegin = make_final_proxy_type(
     "BMonthBegin",
     _Unusable,
@@ -1846,6 +1868,28 @@ FY5253Quarter = make_final_proxy_type(
     "FY5253Quarter",
     _Unusable,
     pd.offsets.FY5253Quarter,
+    fast_to_slow=_Unusable(),
+    slow_to_fast=_Unusable(),
+    additional_attributes={
+        "__hash__": _FastSlowAttribute("__hash__"),
+    },
+)
+
+HalfYearBegin = make_final_proxy_type(
+    "HalfYearBegin",
+    _Unusable,
+    pd.offsets.HalfYearBegin,
+    fast_to_slow=_Unusable(),
+    slow_to_fast=_Unusable(),
+    additional_attributes={
+        "__hash__": _FastSlowAttribute("__hash__"),
+    },
+)
+
+HalfYearEnd = make_final_proxy_type(
+    "HalfYearEnd",
+    _Unusable,
+    pd.offsets.HalfYearEnd,
     fast_to_slow=_Unusable(),
     slow_to_fast=_Unusable(),
     additional_attributes={


### PR DESCRIPTION
## Description
This PR adds proxy types for missing offsets.

## Test results

| Metric | `pandas3` | this PR | Δ |
|---|---:|---:|---:|
| failed | 3,378 | 3,283 | **−95** |
| passed | 210,444 | 210,539 | **+95** |
| skipped | 9,884 | 9,884 | 0 |
| xfailed | 6,110 | 6,110 | 0 |
| xpassed | 78 | 78 | 0 |
| warnings | 7,286 | 7,286 | 0 |
| duration | 2,454.82 s (40:54) | 2,424.58 s (40:24) | −30.24 s |

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.