### PR TITLE
Address cuml RandomForestClassifier(max_depth=) deprecation

### DIFF
--- a/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_cuml.py
+++ b/python/cudf/cudf_pandas_tests/third_party_integration_tests/tests/test_cuml.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 import cupy as cp
 import numpy as np
@@ -94,7 +94,9 @@ def test_random_forest(binary_classification_data):
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, random_state=42
     )
-    model = RandomForestClassifier(n_estimators=100, n_bins=len(X_train))
+    model = RandomForestClassifier(
+        n_estimators=100, n_bins=len(X_train), max_depth=16
+    )
     model.fit(X_train, y_train)
     preds = model.predict(X_test)
     return preds.values


### PR DESCRIPTION
## Description
xref https://github.com/rapidsai/cuml/pull/7958

(IIUC, 16 was the previous default)

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
