### PR TITLE
Refactor cudf-polars test fixtures away from indirect parametrization

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
@@ -228,14 +228,6 @@ class StreamingOptions:
         Env: ``CUDF_POLARS__EXECUTOR__TARGET_PARTITION_SIZE``.
         Default: auto.
         Category: executor.
-    groupby_n_ary
-        Factor by which the number of partitions is decreased when performing
-        a groupby on a partitioned column. For example, with 64 partitions and
-        a factor of 32 the column is first reduced to ``ceil(64 / 32) = 2``
-        partitions.
-        Env: ``CUDF_POLARS__EXECUTOR__GROUPBY_N_ARY``.
-        Default: ``32``.
-        Category: executor.
     dynamic_planning
         Dynamic planning config, dict or
         :class:`~cudf_polars.utils.config.DynamicPlanningOptions`. ``None`` disables.
@@ -336,9 +328,6 @@ class StreamingOptions:
     )
     target_partition_size: int | Unspecified = _opt(
         "executor", "CUDF_POLARS__EXECUTOR__TARGET_PARTITION_SIZE", int
-    )
-    groupby_n_ary: int | Unspecified = _opt(
-        "executor", "CUDF_POLARS__EXECUTOR__GROUPBY_N_ARY", int
     )
     dynamic_planning: dict[str, Any] | DynamicPlanningOptions | None | Unspecified = (
         _opt("executor")
@@ -525,7 +514,6 @@ class StreamingOptions:
             max_rows_per_partition=_get("max_rows_per_partition"),
             broadcast_join_limit=_get("broadcast_join_limit"),
             target_partition_size=target_partition_size,
-            groupby_n_ary=_get("groupby_n_ary"),
             dynamic_planning=dynamic_planning,
             unique_fraction=_get("unique_fraction"),
             raise_on_fail=_get("raise_on_fail"),
@@ -713,16 +701,6 @@ class StreamingOptions:
             help=textwrap.dedent("""\
                 Target IO partition size in bytes. 0 = auto.
                 Env: CUDF_POLARS__EXECUTOR__TARGET_PARTITION_SIZE. Built-in default: auto."""),
-        )
-        g.add_argument(
-            "--groupby-n-ary",
-            dest="groupby_n_ary",
-            default=None,
-            type=int,
-            help=textwrap.dedent("""\
-                Factor by which the number of partitions is decreased during a
-                partitioned groupby (e.g. 64 partitions → ceil(64/32) = 2).
-                Env: CUDF_POLARS__EXECUTOR__GROUPBY_N_ARY. Built-in default: 32."""),
         )
         g.add_argument(
             "--dynamic-planning",

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/options.py
@@ -228,6 +228,14 @@ class StreamingOptions:
         Env: ``CUDF_POLARS__EXECUTOR__TARGET_PARTITION_SIZE``.
         Default: auto.
         Category: executor.
+    groupby_n_ary
+        Factor by which the number of partitions is decreased when performing
+        a groupby on a partitioned column. For example, with 64 partitions and
+        a factor of 32 the column is first reduced to ``ceil(64 / 32) = 2``
+        partitions.
+        Env: ``CUDF_POLARS__EXECUTOR__GROUPBY_N_ARY``.
+        Default: ``32``.
+        Category: executor.
     dynamic_planning
         Dynamic planning config, dict or
         :class:`~cudf_polars.utils.config.DynamicPlanningOptions`. ``None`` disables.
@@ -328,6 +336,9 @@ class StreamingOptions:
     )
     target_partition_size: int | Unspecified = _opt(
         "executor", "CUDF_POLARS__EXECUTOR__TARGET_PARTITION_SIZE", int
+    )
+    groupby_n_ary: int | Unspecified = _opt(
+        "executor", "CUDF_POLARS__EXECUTOR__GROUPBY_N_ARY", int
     )
     dynamic_planning: dict[str, Any] | DynamicPlanningOptions | None | Unspecified = (
         _opt("executor")
@@ -514,6 +525,7 @@ class StreamingOptions:
             max_rows_per_partition=_get("max_rows_per_partition"),
             broadcast_join_limit=_get("broadcast_join_limit"),
             target_partition_size=target_partition_size,
+            groupby_n_ary=_get("groupby_n_ary"),
             dynamic_planning=dynamic_planning,
             unique_fraction=_get("unique_fraction"),
             raise_on_fail=_get("raise_on_fail"),
@@ -701,6 +713,16 @@ class StreamingOptions:
             help=textwrap.dedent("""\
                 Target IO partition size in bytes. 0 = auto.
                 Env: CUDF_POLARS__EXECUTOR__TARGET_PARTITION_SIZE. Built-in default: auto."""),
+        )
+        g.add_argument(
+            "--groupby-n-ary",
+            dest="groupby_n_ary",
+            default=None,
+            type=int,
+            help=textwrap.dedent("""\
+                Factor by which the number of partitions is decreased during a
+                partitioned groupby (e.g. 64 partitions → ceil(64/32) = 2).
+                Env: CUDF_POLARS__EXECUTOR__GROUPBY_N_ARY. Built-in default: 32."""),
         )
         g.add_argument(
             "--dynamic-planning",

--- a/python/cudf_polars/cudf_polars/testing/engine_utils.py
+++ b/python/cudf_polars/cudf_polars/testing/engine_utils.py
@@ -58,7 +58,7 @@ def is_streaming_engine(obj: Any) -> bool:
     """Return ``True`` if ``obj`` is a :class:`StreamingEngine`."""
     try:
         from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
-    except ImportError:
+    except ImportError:  # pragma: no cover; only triggered without rapidsmpf
         return False
     return isinstance(obj, StreamingEngine)
 
@@ -124,7 +124,7 @@ def create_streaming_options(
                 raise_on_fail=True,
                 fallback_mode=StreamingFallbackMode.SILENT,
             )
-        case _:
+        case _:  # pragma: no cover
             raise ValueError(f"Unknown blocksize_mode: {blocksize_mode!r}")
     if overrides is None:
         return baseline
@@ -164,5 +164,5 @@ def build_streaming_engine(
                 executor_options=streaming_options.to_executor_options(),
                 engine_options=streaming_options.to_engine_options(),
             )
-        case _:
+        case _:  # pragma: no cover
             raise AssertionError(f"Unknown streaming backend: {param.engine_name!r}")

--- a/python/cudf_polars/cudf_polars/testing/engine_utils.py
+++ b/python/cudf_polars/cudf_polars/testing/engine_utils.py
@@ -36,12 +36,12 @@ class EngineFixtureParam:
     engine_name
         Backend name (e.g. ``"in-memory"`` or ``"spmd"``).
     blocksize_mode
-        Block size mode, either ``"default"`` or ``"small"``.
+        Block size mode, either ``"medium"`` or ``"small"``.
     """
 
     full_name: str
     engine_name: str
-    blocksize_mode: Literal["default", "small"]
+    blocksize_mode: Literal["medium", "small"]
 
     def __init__(self, full_name: str):
         self.full_name = full_name
@@ -51,7 +51,7 @@ class EngineFixtureParam:
         else:
             # Covers ``"in-memory"`` and bare backend names like ``"spmd"``.
             self.engine_name = full_name
-            self.blocksize_mode = "default"
+            self.blocksize_mode = "medium"
 
 
 def is_streaming_engine(obj: Any) -> bool:
@@ -63,29 +63,8 @@ def is_streaming_engine(obj: Any) -> bool:
     return isinstance(obj, StreamingEngine)
 
 
-def get_blocksize_mode(obj: pl.GPUEngine) -> Literal["default", "small"]:
-    """
-    Infer the block size mode used to configure an engine.
-
-    Parameters
-    ----------
-    obj
-        Engine instance to inspect.
-
-    Returns
-    -------
-    ``"small"`` if the engine's executor options match the small-partition
-    configuration (``max_rows_per_partition == 4``), otherwise ``"default"``.
-    Non-streaming engines always return ``"default"``.
-    """
-    if not is_streaming_engine(obj):
-        return "default"
-    executor_options = obj.config.get("executor_options", {})
-    return "small" if executor_options.get("max_rows_per_partition") == 4 else "default"
-
-
 def create_streaming_options(
-    blocksize_mode: Literal["default", "small"],
+    blocksize_mode: Literal["medium", "small"],
     overrides: StreamingOptions | None = None,
 ) -> StreamingOptions:
     """
@@ -94,7 +73,7 @@ def create_streaming_options(
     Parameters
     ----------
     blocksize_mode
-        Block size configuration. ``"default"`` uses moderate partition sizes,
+        Block size configuration. ``"medium"`` uses moderate partition sizes,
         while ``"small"`` uses very small partitions and sets
         ``fallback_mode=SILENT`` to avoid excessive warnings from CPU fallback.
     overrides
@@ -109,7 +88,7 @@ def create_streaming_options(
     from cudf_polars.utils.config import StreamingFallbackMode
 
     match blocksize_mode:
-        case "default":
+        case "medium":
             baseline = StreamingOptions(
                 max_rows_per_partition=50,
                 dynamic_planning={},
@@ -166,3 +145,29 @@ def build_streaming_engine(
             )
         case _:  # pragma: no cover
             raise AssertionError(f"Unknown streaming backend: {param.engine_name!r}")
+
+
+def get_blocksize_mode(obj: pl.GPUEngine) -> Literal["medium", "small"]:
+    """
+    Infer the block size mode for a GPU engine.
+
+    Parameters
+    ----------
+    obj
+        Engine instance to inspect.
+
+    Returns
+    -------
+      - "small": Engine is configured with a reduced ``max_rows_per_partition``.
+      - "medium": Standard configuration, or non-streaming engine.
+    """
+    if not is_streaming_engine(obj):
+        return "medium"
+
+    # The blocksize mode is defined by the `max_rows_per_partition` value.
+    # Get the obj's execution options and compare it with a "small" blocksize.
+    executor_options = obj.config["executor_options"]
+    small_max_rows = create_streaming_options("small").max_rows_per_partition
+    if executor_options.get("max_rows_per_partition") == small_max_rows:
+        return "small"
+    return "medium"

--- a/python/cudf_polars/cudf_polars/testing/engine_utils.py
+++ b/python/cudf_polars/cudf_polars/testing/engine_utils.py
@@ -5,16 +5,57 @@
 
 from __future__ import annotations
 
+import importlib.util
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    from rapidsmpf.communicator.communicator import Communicator
+
     import polars as pl
 
+    from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 
 
+STREAMING_ENGINE_FIXTURE_PARAMS: list[str] = []
+if importlib.util.find_spec("rapidsmpf") is not None:
+    STREAMING_ENGINE_FIXTURE_PARAMS.extend(["spmd", "spmd-small"])
+ALL_ENGINE_FIXTURE_PARAMS = ["in-memory", *STREAMING_ENGINE_FIXTURE_PARAMS]
+
+
+@dataclass
+class EngineFixtureParam:
+    """
+    Decoded engine parametrization identifier.
+
+    Attributes
+    ----------
+    full_name
+        Full parametrization id e.g. "in-memory", "spmd", or "spmd-small".
+    engine_name
+        Backend name (e.g. ``"in-memory"`` or ``"spmd"``).
+    blocksize_mode
+        Block size mode, either ``"default"`` or ``"small"``.
+    """
+
+    full_name: str
+    engine_name: str
+    blocksize_mode: Literal["default", "small"]
+
+    def __init__(self, full_name: str):
+        self.full_name = full_name
+        if full_name.endswith("-small"):
+            self.engine_name = full_name[: -len("-small")]
+            self.blocksize_mode = "small"
+        else:
+            # Covers ``"in-memory"`` and bare backend names like ``"spmd"``.
+            self.engine_name = full_name
+            self.blocksize_mode = "default"
+
+
 def is_streaming_engine(obj: Any) -> bool:
-    """True when ``obj`` is a :class:`StreamingEngine`."""
+    """Return ``True`` if ``obj`` is a :class:`StreamingEngine`."""
     try:
         from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
     except ImportError:
@@ -24,13 +65,18 @@ def is_streaming_engine(obj: Any) -> bool:
 
 def get_blocksize_mode(obj: pl.GPUEngine) -> Literal["default", "small"]:
     """
-    Recover the blocksize mode an engine was configured with.
+    Infer the block size mode used to configure an engine.
 
-    Inspects ``max_rows_per_partition`` in the engine's executor options
-    and returns ``"small"`` if it matches the value set by the
-    ``blocksize_mode == "small"`` branch of ``streaming_engine_factory``,
-    otherwise ``"default"``. Non-streaming engines have no blocksize mode
-    and always return ``"default"``.
+    Parameters
+    ----------
+    obj
+        Engine instance to inspect.
+
+    Returns
+    -------
+    ``"small"`` if the engine's executor options match the small-partition
+    configuration (``max_rows_per_partition == 4``), otherwise ``"default"``.
+    Non-streaming engines always return ``"default"``.
     """
     if not is_streaming_engine(obj):
         return "default"
@@ -40,29 +86,83 @@ def get_blocksize_mode(obj: pl.GPUEngine) -> Literal["default", "small"]:
 
 def create_streaming_options(
     blocksize_mode: Literal["default", "small"],
+    overrides: StreamingOptions | None = None,
 ) -> StreamingOptions:
     """
-    Return the :class:`StreamingOptions` used by tests for ``blocksize_mode``.
+    Create :class:`StreamingOptions` for a block size mode.
 
-    ``"small"`` sets tiny partitions plus ``fallback_mode=SILENT`` so tests
-    that fall back to CPU don't drown the suite in warnings.
+    Parameters
+    ----------
+    blocksize_mode
+        Block size configuration. ``"default"`` uses moderate partition sizes,
+        while ``"small"`` uses very small partitions and sets
+        ``fallback_mode=SILENT`` to avoid excessive warnings from CPU fallback.
+    overrides
+        Optional options to merge on top of the selected baseline. Fields in
+        ``overrides`` take precedence over the baseline.
+
+    Returns
+    -------
+    The merged streaming options.
     """
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
     from cudf_polars.utils.config import StreamingFallbackMode
 
-    if blocksize_mode == "default":
-        return StreamingOptions(
-            max_rows_per_partition=50,
-            dynamic_planning={},
-            target_partition_size=1_000_000,
-            raise_on_fail=True,
-        )
-    if blocksize_mode == "small":
-        return StreamingOptions(
-            max_rows_per_partition=4,
-            dynamic_planning={},
-            target_partition_size=10,
-            raise_on_fail=True,
-            fallback_mode=StreamingFallbackMode.SILENT,
-        )
-    raise ValueError(f"Unknown blocksize_mode: {blocksize_mode!r}")
+    match blocksize_mode:
+        case "default":
+            baseline = StreamingOptions(
+                max_rows_per_partition=50,
+                dynamic_planning={},
+                target_partition_size=1_000_000,
+                raise_on_fail=True,
+            )
+        case "small":
+            baseline = StreamingOptions(
+                max_rows_per_partition=4,
+                dynamic_planning={},
+                target_partition_size=10,
+                raise_on_fail=True,
+                fallback_mode=StreamingFallbackMode.SILENT,
+            )
+        case _:
+            raise ValueError(f"Unknown blocksize_mode: {blocksize_mode!r}")
+    if overrides is None:
+        return baseline
+    return StreamingOptions(**{**baseline.to_dict(), **overrides.to_dict()})
+
+
+def build_streaming_engine(
+    param: EngineFixtureParam,
+    spmd_comm: Communicator,
+    options: StreamingOptions | None = None,
+) -> StreamingEngine:
+    """
+    Build a :class:`StreamingEngine` from an engine fixture parameter.
+
+    Parameters
+    ----------
+    param
+        Decoded engine fixture parameter describing the backend and block size mode.
+    spmd_comm
+        Communicator used when constructing an :class:`SPMDEngine`.
+    options
+        Optional streaming options to merge on top of the baseline selected by
+        ``param.blocksize_mode``.
+
+    Returns
+    -------
+    A streaming engine matching ``param``.
+    """
+    from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
+
+    streaming_options = create_streaming_options(param.blocksize_mode, options)
+    match param.engine_name:
+        case "spmd":
+            return SPMDEngine(
+                comm=spmd_comm,
+                rapidsmpf_options=streaming_options.to_rapidsmpf_options(),
+                executor_options=streaming_options.to_executor_options(),
+                engine_options=streaming_options.to_engine_options(),
+            )
+        case _:
+            raise AssertionError(f"Unknown streaming backend: {param.engine_name!r}")

--- a/python/cudf_polars/cudf_polars/testing/engine_utils.py
+++ b/python/cudf_polars/cudf_polars/testing/engine_utils.py
@@ -164,8 +164,11 @@ def get_blocksize_mode(obj: pl.GPUEngine) -> Literal["medium", "small"]:
     if not is_streaming_engine(obj):
         return "medium"
 
-    # The blocksize mode is defined by the `max_rows_per_partition` value.
-    # Get the obj's execution options and compare it with a "small" blocksize.
+    # ``max_rows_per_partition`` is the defining signal for "small", it is
+    # what triggers multi-partition behavior. Other fields in the small
+    # baseline (``fallback_mode``, ``target_partition_size`` etc.) are
+    # deliberately ignored so callers that override them on top of the
+    # small baseline are still classified as ``"small"``.
     executor_options = obj.config["executor_options"]
     small_max_rows = create_streaming_options("small").max_rows_per_partition
     if executor_options.get("max_rows_per_partition") == small_max_rows:

--- a/python/cudf_polars/cudf_polars/testing/engine_utils.py
+++ b/python/cudf_polars/cudf_polars/testing/engine_utils.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for :class:`polars.GPUEngine` tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    import polars as pl
+
+    from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
+
+
+def is_streaming_engine(obj: Any) -> bool:
+    """True when ``obj`` is a :class:`StreamingEngine`."""
+    try:
+        from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
+    except ImportError:
+        return False
+    return isinstance(obj, StreamingEngine)
+
+
+def get_blocksize_mode(obj: pl.GPUEngine) -> Literal["default", "small"]:
+    """
+    Recover the blocksize mode an engine was configured with.
+
+    Inspects ``max_rows_per_partition`` in the engine's executor options
+    and returns ``"small"`` if it matches the value set by the
+    ``blocksize_mode == "small"`` branch of ``streaming_engine_factory``,
+    otherwise ``"default"``. Non-streaming engines have no blocksize mode
+    and always return ``"default"``.
+    """
+    if not is_streaming_engine(obj):
+        return "default"
+    executor_options = obj.config.get("executor_options", {})
+    return "small" if executor_options.get("max_rows_per_partition") == 4 else "default"
+
+
+def create_streaming_options(
+    blocksize_mode: Literal["default", "small"],
+) -> StreamingOptions:
+    """
+    Return the :class:`StreamingOptions` used by tests for ``blocksize_mode``.
+
+    ``"small"`` sets tiny partitions plus ``fallback_mode=SILENT`` so tests
+    that fall back to CPU don't drown the suite in warnings.
+    """
+    from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
+    from cudf_polars.utils.config import StreamingFallbackMode
+
+    if blocksize_mode == "default":
+        return StreamingOptions(
+            max_rows_per_partition=50,
+            dynamic_planning={},
+            target_partition_size=1_000_000,
+            raise_on_fail=True,
+        )
+    if blocksize_mode == "small":
+        return StreamingOptions(
+            max_rows_per_partition=4,
+            dynamic_planning={},
+            target_partition_size=10,
+            raise_on_fail=True,
+            fallback_mode=StreamingFallbackMode.SILENT,
+        )
+    raise ValueError(f"Unknown blocksize_mode: {blocksize_mode!r}")

--- a/python/cudf_polars/cudf_polars/testing/engine_utils.py
+++ b/python/cudf_polars/cudf_polars/testing/engine_utils.py
@@ -46,7 +46,7 @@ class EngineFixtureParam:
     def __init__(self, full_name: str):
         self.full_name = full_name
         if full_name.endswith("-small"):
-            self.engine_name = full_name[: -len("-small")]
+            self.engine_name = full_name.removesuffix("-small")
             self.blocksize_mode = "small"
         else:
             # Covers ``"in-memory"`` and bare backend names like ``"spmd"``.

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -89,11 +89,13 @@ def spmd_comm() -> Communicator:
 
 @pytest.fixture(params=STREAMING_ENGINE_FIXTURE_PARAMS)
 def _streaming_engine_param(request: pytest.FixtureRequest) -> EngineFixtureParam:
+    """Parametrization helper to run tests for each streaming engine variant."""
     return EngineFixtureParam(full_name=request.param)
 
 
 @pytest.fixture(params=ALL_ENGINE_FIXTURE_PARAMS)
 def _all_engine_param(request: pytest.FixtureRequest) -> EngineFixtureParam:
+    """Parametrization helper to run tests for each engine variant."""
     return EngineFixtureParam(full_name=request.param)
 
 
@@ -102,18 +104,24 @@ def streaming_engine_factory(
     _streaming_engine_param: EngineFixtureParam,
     spmd_comm: Communicator,
 ) -> Generator[Callable[..., StreamingEngine], None, None]:
-    """Yield a callable that constructs and manages :class:`StreamingEngine` lifetimes.
+    """
+    Yield a factory that constructs :class:`StreamingEngine` instances for tests.
 
-    Parametrized over :data:`STREAMING_ENGINE_FIXTURE_PARAMS` (today: ``"spmd"`` and
-    ``"spmd-small"``). Tests pass a :class:`StreamingOptions` describing only
-    the fields they care about; the factory layers the parametrized
-    blocksize baseline underneath and tracks engines for teardown.
+    The fixture is parametrized over :data:`STREAMING_ENGINE_FIXTURE_PARAMS`.
+    Created engines are tracked and automatically shut down after the test.
 
-    Today the factory builds an :class:`SPMDEngine`, but it is typed as the
-    abstract :class:`StreamingEngine` because future variants (``RayEngine``,
-    ``DaskEngine``) will plug in here. Tests that genuinely need
-    SPMDEngine-specific attributes (``comm``, ``context``) should construct
-    an :class:`SPMDEngine` directly using the ``spmd_comm`` fixture.
+    Parameters
+    ----------
+    _streaming_engine_param
+        Parametrized engine descriptor controlling backend and block size mode.
+    spmd_comm
+        Communicator used when constructing SPMD-based engines.
+
+    Yields
+    ------
+    Factory function that creates :class:`StreamingEngine` instances. The
+    factory accepts optional :class:`StreamingOptions`, which are merged on
+    top of the parametrized blocksize baseline.
     """
     engines: list[StreamingEngine] = []
 
@@ -132,11 +140,22 @@ def streaming_engine_factory(
 def streaming_engine(
     streaming_engine_factory: Callable[..., StreamingEngine],
 ) -> StreamingEngine:
-    """Default-configured :class:`StreamingEngine` (no per-test overrides).
+    """
+    Return a default-configured :class:`StreamingEngine`.
 
-    Inherits :func:`streaming_engine_factory`'s parametrization, so tests
-    using this fixture run once per ``(backend, blocksize_mode)``
+    Inherits the parametrization of :func:`streaming_engine_factory`, so
+    tests using this fixture run once per ``(backend, blocksize_mode)``
     combination.
+
+    Parameters
+    ----------
+    streaming_engine_factory
+        Factory fixture used to construct streaming engines.
+
+    Returns
+    -------
+    A streaming engine created with the parametrized baseline and no
+    per-test overrides.
     """
     return streaming_engine_factory()
 
@@ -146,15 +165,24 @@ def engine(
     request: pytest.FixtureRequest,
     _all_engine_param: EngineFixtureParam,
 ) -> Generator[pl.GPUEngine, None, None]:
-    """Yield a :class:`polars.GPUEngine` for each engine variant under test.
+    """
+    Yield a :class:`polars.GPUEngine` for each engine variant under test.
 
-    Iterates over ``"in-memory"`` and (when ``rapidsmpf`` is installed) the
-    streaming variants from :data:`STREAMING_ENGINE_FIXTURE_PARAMS` (``"spmd"`` and
-    ``"spmd-small"``). Streaming engines are built inline via
-    :func:`build_streaming_engine` so that ``engine="in-memory"`` does not
-    pull in :func:`spmd_comm` (which would skip on rapidsmpf-less envs).
+    Parameters
+    ----------
+    request
+        Pytest fixture request object used to access dependent fixtures.
+    _all_engine_param
+        Parametrized engine descriptor covering both in-memory and streaming
+        variants.
 
-    For tests that need a :class:`StreamingEngine` only, use the
+    Yields
+    ------
+    Engine instance matching the parametrized variant.
+
+    Notes
+    -----
+    For tests that require a :class:`StreamingEngine` only, use the
     :func:`streaming_engine` fixture instead.
     """
     if _all_engine_param.engine_name == "in-memory":
@@ -171,11 +199,18 @@ def engine(
 
 @pytest.fixture
 def engine_raise_on_fail() -> pl.GPUEngine:
-    """Yield a default :class:`polars.GPUEngine` with ``raise_on_fail=True``.
+    """
+    Return a default :class:`polars.GPUEngine` with ``raise_on_fail=True``.
 
+    Returns
+    -------
+    In-memory engine configured to raise exceptions on failure.
+
+    Notes
+    -----
     Intended for error-path tests that assert specific exceptions propagate
-    from ``.collect()``. Uses the default (in-memory) executor so errors are
-    not wrapped by a streaming task group.
+    from ``.collect()``. Uses the in-memory executor so errors are not wrapped
+    by a streaming task group.
     """
     return pl.GPUEngine(raise_on_fail=True)
 

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -13,11 +13,11 @@ import cudf_polars.callback
 from cudf_polars.utils.config import StreamingFallbackMode
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
     from rapidsmpf.communicator.communicator import Communicator
 
-    from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
+    from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
 
 
 @pytest.fixture(params=[False, True], ids=["no_nulls", "nulls"], scope="session")
@@ -114,49 +114,68 @@ def blocksize_mode(request: pytest.FixtureRequest) -> Literal["default", "small"
 
 
 @pytest.fixture
-def streaming_engine(
-    request: pytest.FixtureRequest,
+def streaming_engine_factory(
     spmd_comm: Communicator,
     blocksize_mode: Literal["default", "small"],
-) -> Generator[StreamingEngine, None, None]:
-    """Yield an :class:`SPMDEngine` configured for streaming-only tests.
+) -> Generator[Callable[..., SPMDEngine], None, None]:
+    """Yield a callable that constructs and manages :class:`SPMDEngine` lifetimes.
 
-    Options can be overridden via ``indirect`` parametrization by passing
-    a dict with any of the keys ``"executor_options"``,
-    ``"engine_options"``, or ``"rapidsmpf_options"``.
+    Tests pass a :class:`StreamingOptions` describing only the fields they
+    care about; the factory layers test-suite defaults underneath, applies
+    ``blocksize_mode`` adjustments, and enters the engine context manager.
+    All produced engines are torn down at fixture teardown in reverse order.
     """
-    from rapidsmpf.config import Options
-
+    from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
     from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
 
-    params: dict[str, Any] = getattr(request, "param", {}) or {}
-    executor_options: dict[str, Any] = {
-        "max_rows_per_partition": 50,
-        "dynamic_planning": {},
-        "target_partition_size": 1_000_000,
-    }
-    if blocksize_mode == "small":
-        executor_options.update(
-            max_rows_per_partition=4,
-            target_partition_size=10,
-            # We expect many tests to fall back, so silence the warnings
-            fallback_mode=StreamingFallbackMode.SILENT,
+    engines: list[SPMDEngine] = []
+
+    def factory(options: StreamingOptions | None = None) -> SPMDEngine:
+        baseline: dict[str, Any] = {
+            "max_rows_per_partition": 50,
+            "dynamic_planning": {},
+            "target_partition_size": 1_000_000,
+            "raise_on_fail": True,
+        }
+        if blocksize_mode == "small":
+            baseline.update(
+                max_rows_per_partition=4,
+                target_partition_size=10,
+                # We expect many tests to fall back, so silence the warnings
+                fallback_mode=StreamingFallbackMode.SILENT,
+            )
+        if options is not None:
+            baseline.update(options.to_dict())
+
+        merged = StreamingOptions(**baseline)
+        engine = SPMDEngine(
+            comm=spmd_comm,
+            rapidsmpf_options=merged.to_rapidsmpf_options(),
+            executor_options=merged.to_executor_options(),
+            engine_options=merged.to_engine_options(),
         )
-    executor_options.update(params.get("executor_options", {}))
-    rapidsmpf_options = (
-        Options(params.get("rapidsmpf_options"))
-        if "rapidsmpf_options" in params
-        else None
-    )
-    engine_options: dict[str, Any] = {"raise_on_fail": True}
-    engine_options.update(params.get("engine_options", {}))
-    with SPMDEngine(
-        comm=spmd_comm,
-        rapidsmpf_options=rapidsmpf_options,
-        executor_options=executor_options,
-        engine_options=engine_options,
-    ) as engine:
-        yield engine
+        engine.__enter__()
+        engines.append(engine)
+        return engine
+
+    yield factory
+
+    for engine in reversed(engines):
+        engine.__exit__(None, None, None)
+
+
+@pytest.fixture
+def streaming_engine(
+    streaming_engine_factory: Callable[..., SPMDEngine],
+) -> SPMDEngine:
+    """Default-configured :class:`SPMDEngine` (no per-test overrides).
+
+    Kept as a thin wrapper because the ``engine`` fixture's spmd /
+    spmd-small branches resolve it via ``request.getfixturevalue("streaming_engine")``.
+    Tests that need to customize options should use
+    :func:`streaming_engine_factory` directly with a :class:`StreamingOptions`.
+    """
+    return streaming_engine_factory()
 
 
 _ENGINE_PARAMS = ["in-memory"]

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import importlib.util
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 import pytest
 
 import polars as pl
 
 import cudf_polars.callback
-from cudf_polars.utils.config import StreamingFallbackMode
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -37,30 +36,6 @@ def clear_memory_resource_cache():
     cudf_polars.callback.default_memory_resource.cache_clear()
     yield
     cudf_polars.callback.default_memory_resource.cache_clear()
-
-
-def is_streaming_engine(obj: Any) -> bool:
-    """True when ``obj`` is a :class:`StreamingEngine`."""
-    try:
-        from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
-    except ImportError:
-        return False
-    return isinstance(obj, StreamingEngine)
-
-
-def get_blocksize_mode(obj: pl.GPUEngine) -> Literal["default", "small"]:
-    """Recover the blocksize mode an engine was configured with.
-
-    Inspects ``max_rows_per_partition`` in the engine's executor options
-    and returns ``"small"`` if it matches the value set by the
-    ``blocksize_mode == "small"`` branch of ``streaming_engine_factory``,
-    otherwise ``"default"``. Non-streaming engines have no blocksize mode
-    and always return ``"default"``.
-    """
-    if not is_streaming_engine(obj):
-        return "default"
-    executor_options = obj.config.get("executor_options", {})
-    return "small" if executor_options.get("max_rows_per_partition") == 4 else "default"
 
 
 @pytest.fixture(autouse=True)
@@ -146,23 +121,12 @@ def streaming_engine_factory(
     """
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
     from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
+    from cudf_polars.testing.engine_utils import create_streaming_options
 
     engines: list[SPMDEngine] = []
 
     def factory(options: StreamingOptions | None = None) -> StreamingEngine:
-        baseline: dict[str, Any] = {
-            "max_rows_per_partition": 50,
-            "dynamic_planning": {},
-            "target_partition_size": 1_000_000,
-            "raise_on_fail": True,
-        }
-        if blocksize_mode == "small":
-            baseline.update(
-                max_rows_per_partition=4,
-                target_partition_size=10,
-                # We expect many tests to fall back, so silence the warnings
-                fallback_mode=StreamingFallbackMode.SILENT,
-            )
+        baseline = create_streaming_options(blocksize_mode).to_dict()
         if options is not None:
             baseline.update(options.to_dict())
 

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -170,17 +170,6 @@ def engine(
 
 
 @pytest.fixture
-def in_memory_engine() -> pl.GPUEngine:
-    """Yield an in-memory :class:`polars.GPUEngine` with ``raise_on_fail=True``.
-
-    Use this for tests that exercise operations without a multi-partition
-    implementation — the test runs only against the in-memory executor and
-    is not parametrized over streaming variants.
-    """
-    return pl.GPUEngine(executor="in-memory", raise_on_fail=True)
-
-
-@pytest.fixture
 def engine_raise_on_fail() -> pl.GPUEngine:
     """Yield a default :class:`polars.GPUEngine` with ``raise_on_fail=True``.
 
@@ -220,6 +209,14 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     import cudf_polars.testing.asserts
 
+    config.addinivalue_line(
+        "markers",
+        "skip_on_streaming_engine(reason): skip the test for streaming "
+        '``engine`` variants (e.g. ``"spmd"``, ``"spmd-small"``) while '
+        "still letting the in-memory variant run. Use this to track features "
+        "that have no multi-partition implementation",
+    )
+
     # Ray's internal subprocess management leaks `/dev/null` file handles, and
     # distributed's shutdown leaves unclosed sockets. Under Python 3.14 +
     # pytest 9, these surface as unraisable `ResourceWarning`s and — combined
@@ -248,3 +245,23 @@ def pytest_configure(config):
     cudf_polars.testing.asserts.DEFAULT_EXECUTOR = config.getoption("--executor")
     cudf_polars.testing.asserts.DEFAULT_RUNTIME = config.getoption("--runtime")
     cudf_polars.testing.asserts.DEFAULT_CLUSTER = config.getoption("--cluster")
+
+
+def pytest_collection_modifyitems(items):
+    """Apply ``skip_on_streaming_engine`` markers to streaming ``engine`` items."""
+    for item in items:
+        marker = item.get_closest_marker("skip_on_streaming_engine")
+        if marker is None:
+            continue
+        callspec = getattr(item, "callspec", None)
+        if callspec is None:
+            continue
+        engine_param = callspec.params.get("_all_engine_param")
+        if engine_param is None or engine_param == "in-memory":
+            continue
+        reason = (
+            marker.args[0]
+            if marker.args
+            else marker.kwargs.get("reason", "unsupported on streaming engine")
+        )
+        item.add_marker(pytest.mark.skip(reason=reason))

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -10,6 +10,12 @@ import pytest
 import polars as pl
 
 import cudf_polars.callback
+from cudf_polars.testing.engine_utils import (
+    ALL_ENGINE_FIXTURE_PARAMS,
+    STREAMING_ENGINE_FIXTURE_PARAMS,
+    EngineFixtureParam,
+    build_streaming_engine,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -17,6 +23,7 @@ if TYPE_CHECKING:
     from rapidsmpf.communicator.communicator import Communicator
 
     from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
+    from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 
 
 @pytest.fixture(params=[False, True], ids=["no_nulls", "nulls"], scope="session")
@@ -80,22 +87,27 @@ def spmd_comm() -> Communicator:
     return single_communicator(Options(get_environment_variables()), ProgressThread())
 
 
+@pytest.fixture(params=STREAMING_ENGINE_FIXTURE_PARAMS)
+def _streaming_engine_param(request: pytest.FixtureRequest) -> EngineFixtureParam:
+    return EngineFixtureParam(full_name=request.param)
+
+
+@pytest.fixture(params=ALL_ENGINE_FIXTURE_PARAMS)
+def _all_engine_param(request: pytest.FixtureRequest) -> EngineFixtureParam:
+    return EngineFixtureParam(full_name=request.param)
+
+
 @pytest.fixture
 def streaming_engine_factory(
+    _streaming_engine_param: EngineFixtureParam,
     spmd_comm: Communicator,
 ) -> Generator[Callable[..., StreamingEngine], None, None]:
     """Yield a callable that constructs and manages :class:`StreamingEngine` lifetimes.
 
-    Tests pass a :class:`StreamingOptions` describing only the fields they
-    care about; the factory layers the default blocksize baseline
-    underneath and enters the engine context manager. All produced engines
-    are torn down at fixture teardown in reverse order.
-
-    The factory always uses the ``"default"`` blocksize baseline. Tests that
-    need the tiny-partition / silent-fallback path either call the factory
-    with a fully-populated :class:`StreamingOptions` or use the
-    :func:`streaming_engine` fixture (which the ``engine`` fixture's
-    ``"spmd-small"`` variant resolves).
+    Parametrized over :data:`STREAMING_ENGINE_FIXTURE_PARAMS` (today: ``"spmd"`` and
+    ``"spmd-small"``). Tests pass a :class:`StreamingOptions` describing only
+    the fields they care about; the factory layers the parametrized
+    blocksize baseline underneath and tracks engines for teardown.
 
     Today the factory builds an :class:`SPMDEngine`, but it is typed as the
     abstract :class:`StreamingEngine` because future variants (``RayEngine``,
@@ -103,24 +115,10 @@ def streaming_engine_factory(
     SPMDEngine-specific attributes (``comm``, ``context``) should construct
     an :class:`SPMDEngine` directly using the ``spmd_comm`` fixture.
     """
-    from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
-    from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
-    from cudf_polars.testing.engine_utils import create_streaming_options
-
-    engines: list[SPMDEngine] = []
+    engines: list[StreamingEngine] = []
 
     def factory(options: StreamingOptions | None = None) -> StreamingEngine:
-        baseline = create_streaming_options("default").to_dict()
-        if options is not None:
-            baseline.update(options.to_dict())
-
-        merged = StreamingOptions(**baseline)
-        engine = SPMDEngine(
-            comm=spmd_comm,
-            rapidsmpf_options=merged.to_rapidsmpf_options(),
-            executor_options=merged.to_executor_options(),
-            engine_options=merged.to_engine_options(),
-        )
+        engine = build_streaming_engine(_streaming_engine_param, spmd_comm, options)
         engines.append(engine)
         return engine
 
@@ -136,41 +134,39 @@ def streaming_engine(
 ) -> StreamingEngine:
     """Default-configured :class:`StreamingEngine` (no per-test overrides).
 
-    Kept as a thin wrapper because the ``engine`` fixture's spmd /
-    spmd-small branches resolve it via ``request.getfixturevalue("streaming_engine")``.
-    Tests that need to customize options should use
-    :func:`streaming_engine_factory` directly with a :class:`StreamingOptions`.
+    Inherits :func:`streaming_engine_factory`'s parametrization, so tests
+    using this fixture run once per ``(backend, blocksize_mode)``
+    combination.
     """
     return streaming_engine_factory()
 
 
-_ENGINE_PARAMS = ["in-memory"]
-if importlib.util.find_spec("rapidsmpf") is not None:
-    _ENGINE_PARAMS.extend(["spmd", "spmd-small"])
-
-
-@pytest.fixture(params=_ENGINE_PARAMS)
+@pytest.fixture
 def engine(
     request: pytest.FixtureRequest,
+    _all_engine_param: EngineFixtureParam,
 ) -> Generator[pl.GPUEngine, None, None]:
     """Yield a :class:`polars.GPUEngine` for each engine variant under test.
 
-    Use this fixture for tests that support any ``GPUEngine``. The test runs
-    once per available variant: always with the in-memory executor, and, if
-    ``rapidsmpf`` is installed, a streaming :class:`SPMDEngine` at the
-    default blocksize (``"spmd"``) and a second streaming engine with
-    tiny-partition / silent-fallback settings (``"spmd-small"``). The
-    ``"spmd-small"`` variant forces ``blocksize_mode="small"`` via the
-    ``blocksize_mode`` fixture, so every test using ``engine`` exercises
-    multi-partition paths for free.
+    Iterates over ``"in-memory"`` and (when ``rapidsmpf`` is installed) the
+    streaming variants from :data:`STREAMING_ENGINE_FIXTURE_PARAMS` (``"spmd"`` and
+    ``"spmd-small"``). Streaming engines are built inline via
+    :func:`build_streaming_engine` so that ``engine="in-memory"`` does not
+    pull in :func:`spmd_comm` (which would skip on rapidsmpf-less envs).
 
-    For tests that require a ``StreamingEngine``, use the ``streaming_engine``
-    fixture instead.
+    For tests that need a :class:`StreamingEngine` only, use the
+    :func:`streaming_engine` fixture instead.
     """
-    if request.param == "in-memory":
+    if _all_engine_param.engine_name == "in-memory":
         yield pl.GPUEngine(executor="in-memory", raise_on_fail=True)
-    else:
-        yield request.getfixturevalue("streaming_engine")
+        return
+
+    spmd_comm: Communicator = request.getfixturevalue("spmd_comm")
+    engine = build_streaming_engine(_all_engine_param, spmd_comm)
+    try:
+        yield engine
+    finally:
+        engine.shutdown()
 
 
 @pytest.fixture

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -39,15 +39,13 @@ def clear_memory_resource_cache():
     cudf_polars.callback.default_memory_resource.cache_clear()
 
 
-@pytest.fixture
-def using_streaming_engine(engine: pl.GPUEngine) -> bool:
-    """True when the active ``engine`` fixture is a :class:`StreamingEngine`."""
+def is_streaming_engine(obj: Any) -> bool:
+    """True when ``obj`` is a :class:`StreamingEngine`."""
     try:
         from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
-
-        return isinstance(engine, StreamingEngine)
     except ImportError:
         return False
+    return isinstance(obj, StreamingEngine)
 
 
 @pytest.fixture(autouse=True)

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -81,37 +81,21 @@ def spmd_comm() -> Communicator:
 
 
 @pytest.fixture
-def blocksize_mode(request: pytest.FixtureRequest) -> Literal["default", "small"]:
-    """Blocksize mode for the streaming executor.
-
-    Defaults to ``"default"``. Tests can override this via ``indirect``
-    parametrization with ``["default", "small"]`` to run under both the
-    standard and small-partition configurations. In addition, the
-    ``engine="spmd-small"`` variant of the ``engine`` fixture implicitly
-    selects ``"small"`` mode so that every streaming-engine test exercises
-    tiny-partition / fallback paths without per-test opt-in. Explicit
-    indirect parametrization always wins over the implicit engine-derived
-    value.
-    """
-    if hasattr(request, "param"):
-        return request.param
-    callspec = getattr(request.node, "callspec", None)
-    if callspec is not None and callspec.params.get("engine") == "spmd-small":
-        return "small"
-    return "default"
-
-
-@pytest.fixture
 def streaming_engine_factory(
     spmd_comm: Communicator,
-    blocksize_mode: Literal["default", "small"],
 ) -> Generator[Callable[..., StreamingEngine], None, None]:
     """Yield a callable that constructs and manages :class:`StreamingEngine` lifetimes.
 
     Tests pass a :class:`StreamingOptions` describing only the fields they
-    care about; the factory layers test-suite defaults underneath, applies
-    ``blocksize_mode`` adjustments, and enters the engine context manager.
-    All produced engines are torn down at fixture teardown in reverse order.
+    care about; the factory layers the default blocksize baseline
+    underneath and enters the engine context manager. All produced engines
+    are torn down at fixture teardown in reverse order.
+
+    The factory always uses the ``"default"`` blocksize baseline. Tests that
+    need the tiny-partition / silent-fallback path either call the factory
+    with a fully-populated :class:`StreamingOptions` or use the
+    :func:`streaming_engine` fixture (which the ``engine`` fixture's
+    ``"spmd-small"`` variant resolves).
 
     Today the factory builds an :class:`SPMDEngine`, but it is typed as the
     abstract :class:`StreamingEngine` because future variants (``RayEngine``,
@@ -126,7 +110,7 @@ def streaming_engine_factory(
     engines: list[SPMDEngine] = []
 
     def factory(options: StreamingOptions | None = None) -> StreamingEngine:
-        baseline = create_streaming_options(blocksize_mode).to_dict()
+        baseline = create_streaming_options("default").to_dict()
         if options is not None:
             baseline.update(options.to_dict())
 

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -213,6 +213,17 @@ def engine(
 
 
 @pytest.fixture
+def in_memory_engine() -> pl.GPUEngine:
+    """Yield an in-memory :class:`polars.GPUEngine` with ``raise_on_fail=True``.
+
+    Use this for tests that exercise operations without a multi-partition
+    implementation — the test runs only against the in-memory executor and
+    is not parametrized over streaming variants.
+    """
+    return pl.GPUEngine(executor="in-memory", raise_on_fail=True)
+
+
+@pytest.fixture
 def engine_raise_on_fail() -> pl.GPUEngine:
     """Yield a default :class:`polars.GPUEngine` with ``raise_on_fail=True``.
 
@@ -252,14 +263,6 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     import cudf_polars.testing.asserts
 
-    config.addinivalue_line(
-        "markers",
-        "skip_on_streaming_engine(reason): skip the test when the `engine` "
-        "fixture resolves to a streaming engine variant (e.g. 'spmd'). "
-        "Use for tests exercising operations that have no multi-partition "
-        "implementation.",
-    )
-
     # Ray's internal subprocess management leaks `/dev/null` file handles, and
     # distributed's shutdown leaves unclosed sockets. Under Python 3.14 +
     # pytest 9, these surface as unraisable `ResourceWarning`s and — combined
@@ -288,23 +291,3 @@ def pytest_configure(config):
     cudf_polars.testing.asserts.DEFAULT_EXECUTOR = config.getoption("--executor")
     cudf_polars.testing.asserts.DEFAULT_RUNTIME = config.getoption("--runtime")
     cudf_polars.testing.asserts.DEFAULT_CLUSTER = config.getoption("--cluster")
-
-
-def pytest_collection_modifyitems(items):
-    """Apply ``skip_on_streaming_engine`` markers to parametrized ``engine`` items."""
-    for item in items:
-        marker = item.get_closest_marker("skip_on_streaming_engine")
-        if marker is None:
-            continue
-        callspec = getattr(item, "callspec", None)
-        if callspec is None:
-            continue
-        engine_param = callspec.params.get("engine")
-        if engine_param is None or engine_param == "in-memory":
-            continue
-        reason = (
-            marker.args[0]
-            if marker.args
-            else marker.kwargs.get("reason", "unsupported on streaming engine")
-        )
-        item.add_marker(pytest.mark.skip(reason=reason))

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -48,6 +48,21 @@ def is_streaming_engine(obj: Any) -> bool:
     return isinstance(obj, StreamingEngine)
 
 
+def get_blocksize_mode(obj: pl.GPUEngine) -> Literal["default", "small"]:
+    """Recover the blocksize mode an engine was configured with.
+
+    Inspects ``max_rows_per_partition`` in the engine's executor options
+    and returns ``"small"`` if it matches the value set by the
+    ``blocksize_mode == "small"`` branch of ``streaming_engine_factory``,
+    otherwise ``"default"``. Non-streaming engines have no blocksize mode
+    and always return ``"default"``.
+    """
+    if not is_streaming_engine(obj):
+        return "default"
+    executor_options = obj.config.get("executor_options", {})
+    return "small" if executor_options.get("max_rows_per_partition") == 4 else "default"
+
+
 @pytest.fixture(autouse=True)
 def _skip_unless_spmd(request: pytest.FixtureRequest) -> None:
     """Skip tests in SPMD multi-rank mode unless marked with ``pytest.mark.spmd``."""

--- a/python/cudf_polars/tests/conftest.py
+++ b/python/cudf_polars/tests/conftest.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     from rapidsmpf.communicator.communicator import Communicator
 
-    from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
+    from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
 
 
 @pytest.fixture(params=[False, True], ids=["no_nulls", "nulls"], scope="session")
@@ -117,20 +117,26 @@ def blocksize_mode(request: pytest.FixtureRequest) -> Literal["default", "small"
 def streaming_engine_factory(
     spmd_comm: Communicator,
     blocksize_mode: Literal["default", "small"],
-) -> Generator[Callable[..., SPMDEngine], None, None]:
-    """Yield a callable that constructs and manages :class:`SPMDEngine` lifetimes.
+) -> Generator[Callable[..., StreamingEngine], None, None]:
+    """Yield a callable that constructs and manages :class:`StreamingEngine` lifetimes.
 
     Tests pass a :class:`StreamingOptions` describing only the fields they
     care about; the factory layers test-suite defaults underneath, applies
     ``blocksize_mode`` adjustments, and enters the engine context manager.
     All produced engines are torn down at fixture teardown in reverse order.
+
+    Today the factory builds an :class:`SPMDEngine`, but it is typed as the
+    abstract :class:`StreamingEngine` because future variants (``RayEngine``,
+    ``DaskEngine``) will plug in here. Tests that genuinely need
+    SPMDEngine-specific attributes (``comm``, ``context``) should construct
+    an :class:`SPMDEngine` directly using the ``spmd_comm`` fixture.
     """
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
     from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
 
     engines: list[SPMDEngine] = []
 
-    def factory(options: StreamingOptions | None = None) -> SPMDEngine:
+    def factory(options: StreamingOptions | None = None) -> StreamingEngine:
         baseline: dict[str, Any] = {
             "max_rows_per_partition": 50,
             "dynamic_planning": {},
@@ -154,21 +160,20 @@ def streaming_engine_factory(
             executor_options=merged.to_executor_options(),
             engine_options=merged.to_engine_options(),
         )
-        engine.__enter__()
         engines.append(engine)
         return engine
 
     yield factory
 
     for engine in reversed(engines):
-        engine.__exit__(None, None, None)
+        engine.shutdown()
 
 
 @pytest.fixture
 def streaming_engine(
-    streaming_engine_factory: Callable[..., SPMDEngine],
-) -> SPMDEngine:
-    """Default-configured :class:`SPMDEngine` (no per-test overrides).
+    streaming_engine_factory: Callable[..., StreamingEngine],
+) -> StreamingEngine:
+    """Default-configured :class:`StreamingEngine` (no per-test overrides).
 
     Kept as a thin wrapper because the ``engine`` fixture's spmd /
     spmd-small branches resolve it via ``request.getfixturevalue("streaming_engine")``.

--- a/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
+++ b/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
@@ -13,6 +13,7 @@ from cudf_polars.experimental.rapidsmpf.frontend.core import (
     ClusterInfo,
     all_gather_host_data,
 )
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 
 pytestmark = pytest.mark.spmd
 
@@ -74,11 +75,9 @@ def test_cluster_info_cuda_visible_devices_unset(monkeypatch) -> None:
     assert ClusterInfo.local().cuda_visible_devices is None
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"engine_options": {"allow_gpu_sharing": True}}],
-    indirect=True,
-)
-def test_allow_gpu_sharing(streaming_engine) -> None:
+def test_allow_gpu_sharing(streaming_engine_factory) -> None:
     """Engine init succeeds with allow_gpu_sharing=True."""
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(allow_gpu_sharing=True),
+    )
     assert streaming_engine.nranks >= 1

--- a/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
+++ b/python/cudf_polars/tests/experimental/test_all_gather_host_data.py
@@ -14,6 +14,7 @@ from cudf_polars.experimental.rapidsmpf.frontend.core import (
     all_gather_host_data,
 )
 from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
+from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
 
 pytestmark = pytest.mark.spmd
 
@@ -35,14 +36,15 @@ def _struct(rank: int) -> bytes:
 
 
 @pytest.mark.parametrize("make_data", [_empty, _text, _bytearray, _struct])
-def test_all_gather_host_data(streaming_engine, make_data) -> None:
+def test_all_gather_host_data(spmd_comm, make_data) -> None:
     """Each rank sends rank-specific data; results are correct and ordered."""
-    comm = streaming_engine.comm
-    br = streaming_engine.context.br()
-    result = all_gather_host_data(comm, br, op_id=0, data=make_data(comm.rank))
-    assert len(result) == comm.nranks
-    for i, item in enumerate(result):
-        assert item == bytes(make_data(i))
+    with SPMDEngine(comm=spmd_comm) as spmd_engine:
+        comm = spmd_engine.comm
+        br = spmd_engine.context.br()
+        result = all_gather_host_data(comm, br, op_id=0, data=make_data(comm.rank))
+        assert len(result) == comm.nranks
+        for i, item in enumerate(result):
+            assert item == bytes(make_data(i))
 
 
 def test_gather_cluster_info(streaming_engine) -> None:

--- a/python/cudf_polars/tests/experimental/test_allgather.py
+++ b/python/cudf_polars/tests/experimental/test_allgather.py
@@ -13,6 +13,7 @@ from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 import pylibcudf as plc
 
 from cudf_polars.experimental.rapidsmpf.collectives.allgather import AllGatherManager
+from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
 from cudf_polars.experimental.rapidsmpf.utils import allgather_reduce
 
 
@@ -52,8 +53,9 @@ async def _test_allgather(engine) -> None:
     assert col.type().id().value == plc.types.TypeId.INT32.value
 
 
-def test_allgather(streaming_engine) -> None:
-    asyncio.run(_test_allgather(streaming_engine))
+def test_allgather(spmd_comm) -> None:
+    with SPMDEngine(comm=spmd_comm) as engine:
+        asyncio.run(_test_allgather(engine))
 
 
 async def _test_allgather_reduce(engine) -> None:
@@ -70,5 +72,6 @@ async def _test_allgather_reduce(engine) -> None:
     assert results == (10, 20, 30)  # Single rank, so sums are just the local values
 
 
-def test_allgather_reduce(streaming_engine) -> None:
-    asyncio.run(_test_allgather_reduce(streaming_engine))
+def test_allgather_reduce(spmd_comm) -> None:
+    with SPMDEngine(comm=spmd_comm) as engine:
+        asyncio.run(_test_allgather_reduce(engine))

--- a/python/cudf_polars/tests/experimental/test_dataframescan.py
+++ b/python/cudf_polars/tests/experimental/test_dataframescan.py
@@ -12,6 +12,7 @@ import polars as pl
 from cudf_polars import Translator
 from cudf_polars.dsl.traversal import traversal
 from cudf_polars.experimental.parallel import lower_ir_graph
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.experimental.statistics import collect_statistics
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.utils.config import ConfigOptions
@@ -33,16 +34,12 @@ def df():
     )
 
 
-@pytest.mark.parametrize(
-    "max_rows_per_partition,streaming_engine",
-    [
-        (1_000, {"executor_options": {"max_rows_per_partition": 1_000}}),
-        (1_000_000, {"executor_options": {"max_rows_per_partition": 1_000_000}}),
-    ],
-    indirect=["streaming_engine"],
-)
-def test_parallel_dataframescan(df, max_rows_per_partition, streaming_engine):
-    total_row_count = len(df.collect())
+@pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
+def test_parallel_dataframescan(df, streaming_engine_factory, max_rows_per_partition):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=max_rows_per_partition),
+    )
+    total_row_count = len(df.collect(engine=streaming_engine))
     assert_gpu_result_equal(df, engine=streaming_engine)
 
     # Check partitioning (throwaway engine — no cluster/runtime needed)
@@ -63,12 +60,10 @@ def test_parallel_dataframescan(df, max_rows_per_partition, streaming_engine):
         assert count == 1
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"max_rows_per_partition": 1_000}}],
-    indirect=True,
-)
-def test_dataframescan_concat(df, streaming_engine):
+def test_dataframescan_concat(df, streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=1_000),
+    )
     df2 = pl.concat([df, df])
     assert_gpu_result_equal(df2, engine=streaming_engine)
 
@@ -79,8 +74,10 @@ def test_join_in_memory_lazy_stable_id_pickle():
         executor="streaming",
         executor_options={"max_rows_per_partition": 1_000},
     )
-    left = pl.LazyFrame({"k": [1, 2, 3], "x": [10, 20, 30]}).collect().lazy()
-    right = pl.LazyFrame({"k": [2, 3, 4], "y": [1, 2, 3]}).collect().lazy()
+    left = (
+        pl.LazyFrame({"k": [1, 2, 3], "x": [10, 20, 30]}).collect(engine=engine).lazy()
+    )
+    right = pl.LazyFrame({"k": [2, 3, 4], "y": [1, 2, 3]}).collect(engine=engine).lazy()
     qir = Translator(left.join(right, on="k")._ldf.visit(), engine).translate_ir()
     config_options = ConfigOptions.from_polars_engine(engine)
     ir, _ = lower_ir_graph(qir, config_options, collect_statistics(qir, config_options))

--- a/python/cudf_polars/tests/experimental/test_distinct.py
+++ b/python/cudf_polars/tests/experimental/test_distinct.py
@@ -8,6 +8,7 @@ import pytest
 
 import polars as pl
 
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
@@ -37,13 +38,11 @@ def test_dynamic_distinct_basic(df, streaming_engine, subset, keep):
     assert_gpu_result_equal(q, engine=streaming_engine, check_row_order=False)
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"target_partition_size": 100_000_000}}],
-    indirect=True,
-)
-def test_dynamic_distinct_tree_strategy(df, streaming_engine):
+def test_dynamic_distinct_tree_strategy(df, streaming_engine_factory):
     """Test that small output uses tree reduction (high target_partition_size)."""
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(target_partition_size=100_000_000),
+    )
     subset = ("y",)
     q = df.unique(subset=subset, keep="any", maintain_order=False)
     # With keep="any", non-subset columns are non-deterministic, so only check subset
@@ -51,13 +50,11 @@ def test_dynamic_distinct_tree_strategy(df, streaming_engine):
     assert_gpu_result_equal(q, engine=streaming_engine, check_row_order=False)
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"target_partition_size": 1000}}],
-    indirect=True,
-)
-def test_dynamic_distinct_shuffle_strategy(streaming_engine):
+def test_dynamic_distinct_shuffle_strategy(streaming_engine_factory):
     """Test that large output uses shuffle (low target_partition_size)."""
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(target_partition_size=1000),
+    )
     df = pl.LazyFrame({"x": range(1000), "y": range(1000)})
     q = df.unique(subset=None, keep="any", maintain_order=False)
     assert_gpu_result_equal(q, engine=streaming_engine, check_row_order=False)

--- a/python/cudf_polars/tests/experimental/test_empty_channels.py
+++ b/python/cudf_polars/tests/experimental/test_empty_channels.py
@@ -5,34 +5,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
 import pytest
 
 import polars as pl
 
-from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.testing.asserts import assert_gpu_result_equal
-
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
-    from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
 
 
 @pytest.fixture
-def engine(
-    request: pytest.FixtureRequest,
-) -> Generator[StreamingEngine, None, None]:
+def engine(streaming_engine_factory):
     """StreamingEngine with empty-channel-specific defaults (small partitions)."""
-    params: dict[str, Any] = getattr(request, "param", {})
-    executor_options = {
-        "max_rows_per_partition": 2,
-        "dynamic_planning": {},
-        **params.get("executor_options", {}),
-    }
-    with SPMDEngine(executor_options=executor_options) as engine:
-        yield engine
+    return streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=2),
+    )
 
 
 def test_empty_dataframe_source(engine):

--- a/python/cudf_polars/tests/experimental/test_filter.py
+++ b/python/cudf_polars/tests/experimental/test_filter.py
@@ -13,8 +13,10 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 @pytest.fixture
 def engine(streaming_engine_factory):
+    # ``fallback_mode="warn"`` overrides the small-blocksize baseline (which
+    # sets SILENT) so ``test_filter_non_pointwise`` can assert on the warning.
     return streaming_engine_factory(
-        StreamingOptions(max_rows_per_partition=3),
+        StreamingOptions(max_rows_per_partition=3, fallback_mode="warn"),
     )
 
 

--- a/python/cudf_polars/tests/experimental/test_filter.py
+++ b/python/cudf_polars/tests/experimental/test_filter.py
@@ -3,33 +3,19 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
 import pytest
 
 import polars as pl
 
-from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.testing.asserts import assert_gpu_result_equal
-
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
-    from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
 
 
 @pytest.fixture
-def engine(
-    request: pytest.FixtureRequest,
-) -> Generator[StreamingEngine, None, None]:
-    params: dict[str, Any] = getattr(request, "param", {})
-    executor_options = {
-        "max_rows_per_partition": 3,
-        "dynamic_planning": {},
-        **params.get("executor_options", {}),
-    }
-    with SPMDEngine(executor_options=executor_options) as engine:
-        yield engine
+def engine(streaming_engine_factory):
+    return streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=3),
+    )
 
 
 @pytest.fixture(scope="module")

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -12,6 +12,7 @@ import pytest
 import polars as pl
 
 from cudf_polars.experimental.rapidsmpf.collectives.shuffle import ShuffleManager
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
@@ -41,24 +42,20 @@ def test_dynamic_groupby_basic(df, streaming_engine, keys, agg):
     assert_gpu_result_equal(q, engine=streaming_engine, check_row_order=False)
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"target_partition_size": 100_000_000}}],
-    indirect=True,
-)
-def test_dynamic_groupby_tree_strategy(df, streaming_engine):
+def test_dynamic_groupby_tree_strategy(df, streaming_engine_factory):
     """Test that small output uses tree reduction (high target_partition_size)."""
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(target_partition_size=100_000_000),
+    )
     q = df.group_by("key2").agg(pl.col("value").sum())
     assert_gpu_result_equal(q, engine=streaming_engine, check_row_order=False)
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"target_partition_size": 1000}}],
-    indirect=True,
-)
-def test_dynamic_groupby_shuffle_strategy(streaming_engine):
+def test_dynamic_groupby_shuffle_strategy(streaming_engine_factory):
     """Test that large output uses shuffle (low target_partition_size)."""
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(target_partition_size=1000),
+    )
     df = pl.LazyFrame({"key": range(1000), "value": range(1000)})
     q = df.group_by("key").agg(pl.col("value").sum())
     assert_gpu_result_equal(q, engine=streaming_engine, check_row_order=False)
@@ -108,12 +105,10 @@ def test_groupby(df, streaming_engine, op, keys):
 
 @pytest.mark.parametrize("op", ["sum", "mean", "len"])
 @pytest.mark.parametrize("keys", [("y",), ("y", "z")])
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"max_rows_per_partition": int(1e9)}}],
-    indirect=True,
-)
-def test_groupby_single_partitions(df, streaming_engine, op, keys):
+def test_groupby_single_partitions(df, streaming_engine_factory, op, keys):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=int(1e9)),
+    )
     q = getattr(df.group_by(*keys), op)()
     assert_gpu_result_equal(q, engine=streaming_engine, check_row_order=False)
 
@@ -135,17 +130,11 @@ def test_groupby_std_var_ddof(df, engine, agg, ddof):
     assert_gpu_result_equal(q, engine=engine, check_row_order=False)
 
 
-@pytest.mark.parametrize(
-    "fallback_mode,streaming_engine",
-    [
-        ("silent", {"executor_options": {"fallback_mode": "silent"}}),
-        ("raise", {"executor_options": {"fallback_mode": "raise"}}),
-        ("warn", {"executor_options": {"fallback_mode": "warn"}}),
-        ("foo", {"executor_options": {"fallback_mode": "foo"}}),
-    ],
-    indirect=["streaming_engine"],
-)
-def test_groupby_fallback(df, fallback_mode, streaming_engine):
+@pytest.mark.parametrize("fallback_mode", ["silent", "raise", "warn", "foo"])
+def test_groupby_fallback(df, fallback_mode, streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(fallback_mode=fallback_mode),
+    )
     match = "Failed to decompose groupby aggs"
 
     q = df.group_by("y").median()
@@ -246,12 +235,10 @@ def test_groupby_on_equality(streaming_engine) -> None:
         [1, None, None, None],
     ],
 )
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"max_rows_per_partition": 2}}],
-    indirect=True,
-)
-def test_mean_partitioned(values: list[int | None], streaming_engine) -> None:
+def test_mean_partitioned(values: list[int | None], streaming_engine_factory) -> None:
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=2),
+    )
     df = pl.LazyFrame(
         {
             "key1": [1, 1, 2, 2],
@@ -281,20 +268,14 @@ def test_groupby_literal_key(df, streaming_engine):
 
 @pytest.mark.parametrize("op", ["sum", "mean", "len", "count"])
 @pytest.mark.parametrize("keys", [("y",), ("y", "z")])
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [
-        {
-            "executor_options": {
-                "max_rows_per_partition": 4,
-                "unique_fraction": {"z": 0.5},
-                "groupby_n_ary": 8,
-            }
-        }
-    ],
-    indirect=True,
-)
-def test_groupby_agg_config_options(df, op, keys, streaming_engine):
+def test_groupby_agg_config_options(df, op, keys, streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(
+            max_rows_per_partition=4,
+            unique_fraction={"z": 0.5},
+            groupby_n_ary=8,
+        ),
+    )
     agg = getattr(pl.col("x"), op)()
     if op in ("sum", "mean"):
         agg = agg.round(2)  # Unary test coverage
@@ -302,22 +283,18 @@ def test_groupby_agg_config_options(df, op, keys, streaming_engine):
     assert_gpu_result_equal(q, engine=streaming_engine, check_row_order=False)
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"target_partition_size": 1}}],
-    indirect=True,
-)
-def test_groupby_count_type_mismatch(df, streaming_engine):
+def test_groupby_count_type_mismatch(df, streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(target_partition_size=1),
+    )
     q = df.group_by("key", maintain_order=True).agg(pl.col("value").count())
     assert_gpu_result_equal(q, engine=streaming_engine, check_row_order=False)
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"target_partition_size": 10, "max_rows_per_partition": 5}}],
-    indirect=True,
-)
-def test_shuffle_reduce_insert_finished_called_on_oom(streaming_engine):
+def test_shuffle_reduce_insert_finished_called_on_oom(streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(target_partition_size=10, max_rows_per_partition=5),
+    )
     # Tests that an exception raised inside insert_hash() must not leave the
     # C++ ShufflerAsync without insert_finished() being called.
 

--- a/python/cudf_polars/tests/experimental/test_groupby.py
+++ b/python/cudf_polars/tests/experimental/test_groupby.py
@@ -273,7 +273,6 @@ def test_groupby_agg_config_options(df, op, keys, streaming_engine_factory):
         StreamingOptions(
             max_rows_per_partition=4,
             unique_fraction={"z": 0.5},
-            groupby_n_ary=8,
         ),
     )
     agg = getattr(pl.col("x"), op)()

--- a/python/cudf_polars/tests/experimental/test_join.py
+++ b/python/cudf_polars/tests/experimental/test_join.py
@@ -14,6 +14,7 @@ from cudf_polars.dsl.ir import Cache, Join
 from cudf_polars.dsl.traversal import traversal
 from cudf_polars.experimental.base import PartitionInfo
 from cudf_polars.experimental.parallel import lower_ir_graph
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.experimental.rapidsmpf.join import _use_pwise_join
 from cudf_polars.experimental.shuffle import Shuffle
 from cudf_polars.experimental.statistics import collect_statistics
@@ -45,27 +46,25 @@ def right():
 
 @pytest.mark.parametrize("how", ["inner", "left", "right", "full"])
 @pytest.mark.parametrize(
-    "streaming_engine",
+    "options",
     [
-        {"executor_options": {"max_rows_per_partition": 3, "broadcast_join_limit": 2}},
-        {"executor_options": {"max_rows_per_partition": 5, "broadcast_join_limit": 2}},
+        StreamingOptions(max_rows_per_partition=3, broadcast_join_limit=2),
+        StreamingOptions(max_rows_per_partition=5, broadcast_join_limit=2),
     ],
-    indirect=True,
 )
-def test_dynamic_join_how(left, right, streaming_engine, how):
+def test_dynamic_join_how(left, right, streaming_engine_factory, options, how):
     """Dynamic join path: all join types including Right and Full."""
+    streaming_engine = streaming_engine_factory(options)
     q = left.join(right, on="y", how=how)
     assert_gpu_result_equal(q, engine=streaming_engine, check_row_order=False)
 
 
 @pytest.mark.parametrize("how", ["right", "full"])
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"max_rows_per_partition": 3, "broadcast_join_limit": 2}}],
-    indirect=True,
-)
-def test_dynamic_join_right_full_reverse(left, right, streaming_engine, how):
+def test_dynamic_join_right_full_reverse(left, right, streaming_engine_factory, how):
     """Dynamic join path: Right/Full with reversed left/right (stress ordering)."""
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=3, broadcast_join_limit=2),
+    )
     # Reverse so "right" frame is larger; exercises right-side preservation
     q = right.join(left, on="y", how=how)
     assert_gpu_result_equal(q, engine=streaming_engine, check_row_order=False)
@@ -76,12 +75,10 @@ def test_dynamic_join_right_full_reverse(left, right, streaming_engine, how):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"max_rows_per_partition": 2, "broadcast_join_limit": 1}}],
-    indirect=True,
-)
-def test_join_then_shuffle(left, right, streaming_engine):
+def test_join_then_shuffle(left, right, streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=2, broadcast_join_limit=1),
+    )
     q = left.join(right, on="y", how="inner").select(
         pl.col("x").sum(),
         pl.col("xx").mean(),
@@ -92,33 +89,15 @@ def test_join_then_shuffle(left, right, streaming_engine):
 
 
 @pytest.mark.parametrize("reverse", [True, False])
-@pytest.mark.parametrize(
-    "max_rows_per_partition,streaming_engine",
-    [
-        (
-            3,
-            {
-                "executor_options": {
-                    "max_rows_per_partition": 3,
-                    "fallback_mode": "warn",
-                    "dynamic_planning": None,
-                }
-            },
+@pytest.mark.parametrize("max_rows_per_partition", [3, 9])
+def test_join_conditional(reverse, max_rows_per_partition, streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(
+            max_rows_per_partition=max_rows_per_partition,
+            fallback_mode="warn",
+            dynamic_planning=None,
         ),
-        (
-            9,
-            {
-                "executor_options": {
-                    "max_rows_per_partition": 9,
-                    "fallback_mode": "warn",
-                    "dynamic_planning": None,
-                }
-            },
-        ),
-    ],
-    indirect=["streaming_engine"],
-)
-def test_join_conditional(reverse, max_rows_per_partition, streaming_engine):
+    )
     left = pl.LazyFrame({"x": range(15), "y": [1, 2, 3] * 5})
     right = pl.LazyFrame({"xx": range(9), "yy": [2, 4, 3] * 3})
     if reverse:
@@ -141,35 +120,20 @@ def test_join_conditional(reverse, max_rows_per_partition, streaming_engine):
 @pytest.mark.parametrize("how", ["inner", "left", "right", "full", "semi", "anti"])
 @pytest.mark.parametrize("reverse", [True, False])
 @pytest.mark.parametrize(
-    "streaming_engine",
+    "options",
     [
-        {"executor_options": {"max_rows_per_partition": 1, "broadcast_join_limit": 1}},
-        {"executor_options": {"max_rows_per_partition": 1, "broadcast_join_limit": 16}},
-        {"executor_options": {"max_rows_per_partition": 5, "broadcast_join_limit": 1}},
-        {"executor_options": {"max_rows_per_partition": 5, "broadcast_join_limit": 16}},
-        {"executor_options": {"max_rows_per_partition": 10, "broadcast_join_limit": 1}},
-        {
-            "executor_options": {
-                "max_rows_per_partition": 10,
-                "broadcast_join_limit": 16,
-            }
-        },
-        {
-            "executor_options": {
-                "max_rows_per_partition": 15,
-                "broadcast_join_limit": 1,
-            }
-        },
-        {
-            "executor_options": {
-                "max_rows_per_partition": 15,
-                "broadcast_join_limit": 16,
-            }
-        },
+        StreamingOptions(max_rows_per_partition=1, broadcast_join_limit=1),
+        StreamingOptions(max_rows_per_partition=1, broadcast_join_limit=16),
+        StreamingOptions(max_rows_per_partition=5, broadcast_join_limit=1),
+        StreamingOptions(max_rows_per_partition=5, broadcast_join_limit=16),
+        StreamingOptions(max_rows_per_partition=10, broadcast_join_limit=1),
+        StreamingOptions(max_rows_per_partition=10, broadcast_join_limit=16),
+        StreamingOptions(max_rows_per_partition=15, broadcast_join_limit=1),
+        StreamingOptions(max_rows_per_partition=15, broadcast_join_limit=16),
     ],
-    indirect=True,
 )
-def test_join(left, right, how, reverse, streaming_engine):
+def test_join(left, right, how, reverse, streaming_engine_factory, options):
+    streaming_engine = streaming_engine_factory(options)
     if reverse:
         left, right = right, left
 
@@ -192,20 +156,14 @@ def test_join(left, right, how, reverse, streaming_engine):
 
 
 @pytest.mark.parametrize("zlice", [(0, 2), (2, 2), (-2, None)])
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [
-        {
-            "executor_options": {
-                "max_rows_per_partition": 3,
-                "broadcast_join_limit": 100,
-                "fallback_mode": "warn",
-            }
-        }
-    ],
-    indirect=True,
-)
-def test_join_and_slice(zlice, streaming_engine):
+def test_join_and_slice(zlice, streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(
+            max_rows_per_partition=3,
+            broadcast_join_limit=100,
+            fallback_mode="warn",
+        ),
+    )
     left = pl.LazyFrame(
         {
             "a": [1, 2, 3, 1, None],
@@ -244,20 +202,14 @@ def test_join_and_slice(zlice, streaming_engine):
 
 
 @pytest.mark.parametrize("how", ["inner", "semi", "left", "right"])
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [
-        {
-            "executor_options": {
-                "max_rows_per_partition": 2,
-                "broadcast_join_limit": 1,
-                "target_partition_size": 10,
-            }
-        }
-    ],
-    indirect=True,
-)
-def test_bloom_filter_join(how, streaming_engine):
+def test_bloom_filter_join(how, streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(
+            max_rows_per_partition=2,
+            broadcast_join_limit=1,
+            target_partition_size=10,
+        ),
+    )
     dim = pl.LazyFrame({"key": range(10), "val": range(10)})
     fact = pl.LazyFrame({"key": range(200), "data": range(200)})
     left, right = (dim, fact) if how == "right" else (fact, dim)
@@ -268,22 +220,16 @@ def test_bloom_filter_join(how, streaming_engine):
 @pytest.mark.parametrize(
     "maintain_order", ["left_right", "right_left", "left", "right"]
 )
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [
-        {
-            "executor_options": {
-                "max_rows_per_partition": 3,
-                "broadcast_join_limit": 1,
-                "fallback_mode": "warn",
-            }
-        }
-    ],
-    indirect=True,
-)
 def test_join_maintain_order_fallback_streaming(
-    left, right, maintain_order, streaming_engine
+    left, right, maintain_order, streaming_engine_factory
 ):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(
+            max_rows_per_partition=3,
+            broadcast_join_limit=1,
+            fallback_mode="warn",
+        ),
+    )
     q = left.join(right, on="y", how="inner", maintain_order=maintain_order)
 
     with pytest.warns(

--- a/python/cudf_polars/tests/experimental/test_metadata.py
+++ b/python/cudf_polars/tests/experimental/test_metadata.py
@@ -18,6 +18,7 @@ from cudf_polars.containers import DataType
 from cudf_polars.dsl import expr
 from cudf_polars.dsl.ir import GroupBy, HStack, Projection, Select
 from cudf_polars.experimental.rapidsmpf.core import evaluate_logical_plan
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.experimental.rapidsmpf.utils import (
     NormalizedPartitioning,
     maybe_remap_partitioning,
@@ -48,30 +49,27 @@ def right() -> pl.LazyFrame:
 
 
 @pytest.mark.parametrize(
-    "streaming_engine",
+    "options",
     [
-        {
-            "executor_options": {
-                "max_rows_per_partition": 1,
-                "broadcast_join_limit": 2,
-                "dynamic_planning": None,
-            }
-        },
-        {
-            "executor_options": {
-                "max_rows_per_partition": 1,
-                "broadcast_join_limit": 10,
-                "dynamic_planning": None,
-            }
-        },
+        StreamingOptions(
+            max_rows_per_partition=1,
+            broadcast_join_limit=2,
+            dynamic_planning=None,
+        ),
+        StreamingOptions(
+            max_rows_per_partition=1,
+            broadcast_join_limit=10,
+            dynamic_planning=None,
+        ),
     ],
-    indirect=True,
 )
 def test_rapidsmpf_join_metadata(
     left: pl.LazyFrame,
     right: pl.LazyFrame,
-    streaming_engine,
+    streaming_engine_factory,
+    options,
 ) -> None:
+    streaming_engine = streaming_engine_factory(options)
     config_options = ConfigOptions.from_polars_engine(streaming_engine)
     broadcast_join_limit = config_options.executor.broadcast_join_limit
     q = left.join(
@@ -80,8 +78,8 @@ def test_rapidsmpf_join_metadata(
         how="left",
     ).filter(pl.col("x") > pl.col("zz"))
     ir = Translator(q._ldf.visit(), streaming_engine).translate_ir()
-    left_count = left.collect().height
-    right_count = right.collect().height
+    left_count = left.collect(engine=streaming_engine).height
+    right_count = right.collect(engine=streaming_engine).height
 
     metadata_collector = evaluate_logical_plan(
         ir, config_options, collect_metadata=True

--- a/python/cudf_polars/tests/experimental/test_parallel.py
+++ b/python/cudf_polars/tests/experimental/test_parallel.py
@@ -15,6 +15,7 @@ from cudf_polars import Translator
 from cudf_polars.dsl.expressions.base import Col, NamedExpr
 from cudf_polars.dsl.traversal import traversal
 from cudf_polars.experimental.parallel import lower_ir_graph
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.experimental.statistics import collect_statistics
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.utils.config import ConfigOptions
@@ -132,20 +133,14 @@ def test_pickle_conditional_join_args():
         pickle.loads(pickle.dumps(node._non_child_args))
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [
-        {
-            "executor_options": {
-                "max_rows_per_partition": 2,
-                "broadcast_join_limit": 2,
-                "unique_fraction": {"a": 1.0},
-            }
-        }
-    ],
-    indirect=True,
-)
-def test_preserve_partitioning(streaming_engine):
+def test_preserve_partitioning(streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(
+            max_rows_per_partition=2,
+            broadcast_join_limit=2,
+            unique_fraction={"a": 1.0},
+        ),
+    )
     left = pl.LazyFrame({"a": [1, 2, 3, 4] * 5, "b": range(20)})
     right = pl.LazyFrame({"a": [3, 4, 5, 6, 7] * 4, "c": range(20)})
     q = (

--- a/python/cudf_polars/tests/experimental/test_parallel.py
+++ b/python/cudf_polars/tests/experimental/test_parallel.py
@@ -54,7 +54,10 @@ def test_rename_concat(streaming_engine) -> None:
     assert_gpu_result_equal(q, engine=streaming_engine)
 
 
-def test_fallback_on_concat_zlice(streaming_engine) -> None:
+def test_fallback_on_concat_zlice(streaming_engine_factory) -> None:
+    # Pin ``fallback_mode="warn"`` so the spmd-small baseline (which sets
+    # ``SILENT``) doesn't suppress the warning this test asserts on.
+    streaming_engine = streaming_engine_factory(StreamingOptions(fallback_mode="warn"))
     q = pl.concat(
         [
             pl.LazyFrame({"a": [1, 2]}),

--- a/python/cudf_polars/tests/experimental/test_rolling.py
+++ b/python/cudf_polars/tests/experimental/test_rolling.py
@@ -3,35 +3,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
 import pytest
 
 import polars as pl
 
-from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.utils.versions import POLARS_VERSION_LT_136
 
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
-    from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
-
 
 @pytest.fixture
-def engine(
-    request: pytest.FixtureRequest,
-) -> Generator[StreamingEngine, None, None]:
-    params: dict[str, Any] = getattr(request, "param", {})
-    executor_options = {
-        "max_rows_per_partition": 3,
-        "fallback_mode": "warn",
-        "dynamic_planning": {},
-        **params.get("executor_options", {}),
-    }
-    with SPMDEngine(executor_options=executor_options) as engine:
-        yield engine
+def engine(streaming_engine_factory):
+    return streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=3, fallback_mode="warn"),
+    )
 
 
 def test_rolling_datetime(request, engine):
@@ -61,12 +46,10 @@ def test_rolling_datetime(request, engine):
         assert_gpu_result_equal(q, engine=engine)
 
 
-@pytest.mark.parametrize(
-    "engine",
-    [{"executor_options": {"max_rows_per_partition": 1}}],
-    indirect=True,
-)
-def test_over_in_filter_unsupported(engine) -> None:
+def test_over_in_filter_unsupported(streaming_engine_factory) -> None:
+    engine = streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=1, fallback_mode="warn"),
+    )
     q = pl.concat(
         [
             pl.LazyFrame({"k": ["x", "y"], "v": [3, 2]}),

--- a/python/cudf_polars/tests/experimental/test_scan.py
+++ b/python/cudf_polars/tests/experimental/test_scan.py
@@ -9,6 +9,7 @@ import polars as pl
 
 from cudf_polars import Translator
 from cudf_polars.experimental.parallel import lower_ir_graph
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.experimental.statistics import collect_statistics
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.testing.io import make_partitioned_source
@@ -40,17 +41,13 @@ def test_parallel_scan(tmp_path, df, fmt, scan_fn, streaming_engine):
     assert_gpu_result_equal(q, engine=streaming_engine)
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [
-        {
-            "executor_options": {"target_partition_size": 1_000},
-            "engine_options": {"parquet_options": {"use_rapidsmpf_native": True}},
-        }
-    ],
-    indirect=True,
-)
-def test_scan_parquet_use_rapidsmpf_native(tmp_path, df, streaming_engine):
+def test_scan_parquet_use_rapidsmpf_native(tmp_path, df, streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(
+            target_partition_size=1_000,
+            parquet_options={"use_rapidsmpf_native": True},
+        ),
+    )
     make_partitioned_source(df, tmp_path, "parquet", n_files=1)
     assert_gpu_result_equal(pl.scan_parquet(tmp_path), engine=streaming_engine)
 
@@ -60,24 +57,22 @@ def test_scan_parquet_use_rapidsmpf_native(tmp_path, df, streaming_engine):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"target_partition_size": 1_000}}],
-    indirect=True,
-)
-def test_split_scan_aligns_to_row_group_boundaries(tmp_path, df, streaming_engine):
+def test_split_scan_aligns_to_row_group_boundaries(
+    tmp_path, df, streaming_engine_factory
+):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(target_partition_size=1_000),
+    )
     make_partitioned_source(df, tmp_path, "parquet", n_files=1, row_group_size=10)
     q = pl.scan_parquet(tmp_path)
     assert_gpu_result_equal(q, engine=streaming_engine)
 
 
 @pytest.mark.parametrize("mask", [None, pl.col("x") < 1_000])
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [{"executor_options": {"target_partition_size": 1_000}}],
-    indirect=True,
-)
-def test_split_scan_predicate(tmp_path, df, mask, streaming_engine):
+def test_split_scan_predicate(tmp_path, df, mask, streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(target_partition_size=1_000),
+    )
     make_partitioned_source(df, tmp_path, "parquet", n_files=1)
     q = pl.scan_parquet(tmp_path)
     if mask is not None:
@@ -86,16 +81,13 @@ def test_split_scan_predicate(tmp_path, df, mask, streaming_engine):
 
 
 @pytest.mark.parametrize("n_files", [2, 3])
-@pytest.mark.parametrize(
-    "blocksize,streaming_engine",
-    [
-        (1_000, {"executor_options": {"target_partition_size": 1_000}}),
-        (10_000, {"executor_options": {"target_partition_size": 10_000}}),
-        (1_000_000, {"executor_options": {"target_partition_size": 1_000_000}}),
-    ],
-    indirect=["streaming_engine"],
-)
-def test_target_partition_size(tmp_path, df, blocksize, n_files, streaming_engine):
+@pytest.mark.parametrize("blocksize", [1_000, 10_000, 1_000_000])
+def test_target_partition_size(
+    tmp_path, df, blocksize, n_files, streaming_engine_factory
+):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(target_partition_size=blocksize),
+    )
     make_partitioned_source(df, tmp_path, "parquet", n_files=n_files)
     q = pl.scan_parquet(tmp_path)
     assert_gpu_result_equal(q, engine=streaming_engine)

--- a/python/cudf_polars/tests/experimental/test_select.py
+++ b/python/cudf_polars/tests/experimental/test_select.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import contextlib
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -17,7 +16,7 @@ from cudf_polars import Translator
 from cudf_polars.containers import DataType
 from cudf_polars.dsl import expr
 from cudf_polars.dsl.ir import HStack, Projection, Select
-from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.experimental.select import _inline_hstack_false, _sub_expr
 from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
@@ -28,25 +27,12 @@ from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_134,
 )
 
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
-    from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
-
 
 @pytest.fixture
-def engine(
-    request: pytest.FixtureRequest,
-) -> Generator[StreamingEngine, None, None]:
-    params: dict[str, Any] = getattr(request, "param", {})
-    executor_options = {
-        "max_rows_per_partition": 3,
-        "fallback_mode": "warn",
-        "dynamic_planning": {},
-        **params.get("executor_options", {}),
-    }
-    with SPMDEngine(executor_options=executor_options) as engine:
-        yield engine
+def engine(streaming_engine_factory):
+    return streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=3, fallback_mode="warn"),
+    )
 
 
 @pytest.fixture(scope="module")
@@ -67,17 +53,11 @@ def test_select(df, engine):
     assert_gpu_result_equal(query, engine=engine)
 
 
-@pytest.mark.parametrize(
-    "fallback_mode,engine",
-    [
-        ("silent", {"executor_options": {"fallback_mode": "silent"}}),
-        ("raise", {"executor_options": {"fallback_mode": "raise"}}),
-        ("warn", {"executor_options": {"fallback_mode": "warn"}}),
-        ("foo", {"executor_options": {"fallback_mode": "foo"}}),
-    ],
-    indirect=["engine"],
-)
-def test_select_reduce_fallback(df, fallback_mode, engine):
+@pytest.mark.parametrize("fallback_mode", ["silent", "raise", "warn", "foo"])
+def test_select_reduce_fallback(df, streaming_engine_factory, fallback_mode):
+    engine = streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=3, fallback_mode=fallback_mode),
+    )
     match = "This selection is not supported for multiple partitions."
 
     query = df.select(

--- a/python/cudf_polars/tests/experimental/test_shuffler.py
+++ b/python/cudf_polars/tests/experimental/test_shuffler.py
@@ -12,6 +12,7 @@ from rapidsmpf.streaming.cudf.channel_metadata import (
 
 import polars as pl
 
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.experimental.rapidsmpf.utils import (
     _is_already_partitioned,
 )
@@ -19,26 +20,14 @@ from cudf_polars.testing.asserts import assert_gpu_result_equal
 
 
 @pytest.mark.parametrize(
-    "streaming_engine",
+    "options",
     [
-        {
-            "executor_options": {
-                "max_rows_per_partition": 1,
-                "broadcast_join_limit": 2,
-                "shuffle_method": "rapidsmpf",
-            }
-        },
-        {
-            "executor_options": {
-                "max_rows_per_partition": 5,
-                "broadcast_join_limit": 2,
-                "shuffle_method": "rapidsmpf",
-            }
-        },
+        StreamingOptions(max_rows_per_partition=1, broadcast_join_limit=2),
+        StreamingOptions(max_rows_per_partition=5, broadcast_join_limit=2),
     ],
-    indirect=True,
 )
-def test_join_rapidsmpf(streaming_engine) -> None:
+def test_join_rapidsmpf(streaming_engine_factory, options) -> None:
+    streaming_engine = streaming_engine_factory(options)
     left = pl.LazyFrame(
         {
             "x": range(15),
@@ -58,24 +47,14 @@ def test_join_rapidsmpf(streaming_engine) -> None:
 
 
 @pytest.mark.parametrize(
-    "streaming_engine",
+    "options",
     [
-        {
-            "executor_options": {
-                "max_rows_per_partition": 1,
-                "shuffle_method": "rapidsmpf",
-            }
-        },
-        {
-            "executor_options": {
-                "max_rows_per_partition": 5,
-                "shuffle_method": "rapidsmpf",
-            }
-        },
+        StreamingOptions(max_rows_per_partition=1),
+        StreamingOptions(max_rows_per_partition=5),
     ],
-    indirect=True,
 )
-def test_sort_rapidsmpf(streaming_engine) -> None:
+def test_sort_rapidsmpf(streaming_engine_factory, options) -> None:
+    streaming_engine = streaming_engine_factory(options)
     df = pl.LazyFrame(
         {
             "x": range(15),

--- a/python/cudf_polars/tests/experimental/test_sink.py
+++ b/python/cudf_polars/tests/experimental/test_sink.py
@@ -9,6 +9,7 @@ import pytest
 
 import polars as pl
 
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.testing.asserts import assert_sink_result_equal
 from cudf_polars.utils.config import ConfigOptions
 
@@ -27,22 +28,19 @@ def df():
 @pytest.mark.parametrize("mkdir", [True, False])
 @pytest.mark.parametrize("data_page_size", [None, 256_000])
 @pytest.mark.parametrize("row_group_size", [None, 1_000])
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [
-        {"executor_options": {"max_rows_per_partition": 1_000}},
-        {"executor_options": {"max_rows_per_partition": 1_000_000}},
-    ],
-    indirect=True,
-)
+@pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
 def test_sink_parquet_single_file(
     df,
+    streaming_engine_factory,
     tmp_path,
     mkdir,
     data_page_size,
     row_group_size,
-    streaming_engine,
+    max_rows_per_partition,
 ):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=max_rows_per_partition),
+    )
     assert_sink_result_equal(
         df,
         tmp_path / "test_sink.parquet",
@@ -58,35 +56,22 @@ def test_sink_parquet_single_file(
 @pytest.mark.parametrize("mkdir", [True, False])
 @pytest.mark.parametrize("data_page_size", [None, 256_000])
 @pytest.mark.parametrize("row_group_size", [None, 1_000])
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [
-        {
-            "executor_options": {
-                "max_rows_per_partition": 1_000,
-                "sink_to_directory": True,
-            }
-        },
-        {
-            "executor_options": {
-                "max_rows_per_partition": 1_000_000,
-                "sink_to_directory": True,
-            }
-        },
-    ],
-    indirect=True,
-)
+@pytest.mark.parametrize("max_rows_per_partition", [1_000, 1_000_000])
 def test_sink_parquet_directory(
     df,
+    streaming_engine_factory,
     tmp_path,
     mkdir,
     data_page_size,
     row_group_size,
-    streaming_engine,
+    max_rows_per_partition,
 ):
-    max_rows_per_partition = streaming_engine.config["executor_options"][
-        "max_rows_per_partition"
-    ]
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(
+            max_rows_per_partition=max_rows_per_partition,
+            sink_to_directory=True,
+        ),
+    )
     assert_sink_result_equal(
         df,
         tmp_path / "test_sink.parquet",
@@ -99,7 +84,9 @@ def test_sink_parquet_directory(
     )
 
     check_path = Path(tmp_path / "test_sink_gpu.parquet")
-    expected_file_count = df.collect().height // max_rows_per_partition
+    expected_file_count = (
+        df.collect(engine=streaming_engine).height // max_rows_per_partition
+    )
     assert check_path.is_dir()
     if expected_file_count > 1:
         assert len(list(check_path.iterdir())) == expected_file_count

--- a/python/cudf_polars/tests/experimental/test_spilling.py
+++ b/python/cudf_polars/tests/experimental/test_spilling.py
@@ -17,6 +17,7 @@ from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 
 import pylibcudf as plc
 
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.experimental.rapidsmpf.utils import (
     make_spill_function,
 )
@@ -37,24 +38,29 @@ def create_test_table(nbytes: int, stream: Stream) -> plc.Table:
 
 
 @pytest.mark.parametrize(
-    "streaming_engine,spilled_host_mem_type",
+    "pinned_memory,spilled_host_mem_type",
     [
         pytest.param(
-            {"rapidsmpf_options": {"pinned_memory": "true"}},
+            True,
             MemoryType.PINNED_HOST,
             marks=pytest.mark.skipif(
                 not is_pinned_memory_resources_supported(),
                 reason="Pinned memory requires CUDA 12.6+ driver and runtime",
             ),
         ),
-        ({"rapidsmpf_options": {"pinned_memory": "false"}}, MemoryType.HOST),
+        (False, MemoryType.HOST),
     ],
-    indirect=["streaming_engine"],
 )
 def test_make_spill_function(
-    streaming_engine: SPMDEngine, spilled_host_mem_type: MemoryType
+    streaming_engine_factory,
+    *,
+    pinned_memory: bool,
+    spilled_host_mem_type: MemoryType,
 ) -> None:
     """Test that spilling prioritizes longest queues and newest messages."""
+    streaming_engine: SPMDEngine = streaming_engine_factory(
+        StreamingOptions(pinned_memory=pinned_memory),
+    )
     context = streaming_engine.context
 
     if spilled_host_mem_type == MemoryType.PINNED_HOST:

--- a/python/cudf_polars/tests/experimental/test_spilling.py
+++ b/python/cudf_polars/tests/experimental/test_spilling.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
+from rapidsmpf.config import Options
 from rapidsmpf.memory.buffer import MemoryType
 from rapidsmpf.memory.pinned_memory_resource import is_pinned_memory_resources_supported
 from rapidsmpf.streaming.core.message import Message
@@ -17,15 +18,13 @@ from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 
 import pylibcudf as plc
 
-from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
+from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
 from cudf_polars.experimental.rapidsmpf.utils import (
     make_spill_function,
 )
 
 if TYPE_CHECKING:
     from rmm.pylibrmm.stream import Stream
-
-    from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
 
 
 def create_test_table(nbytes: int, stream: Stream) -> plc.Table:
@@ -52,106 +51,109 @@ def create_test_table(nbytes: int, stream: Stream) -> plc.Table:
     ],
 )
 def test_make_spill_function(
-    streaming_engine_factory,
+    spmd_comm,
     *,
     pinned_memory: bool,
     spilled_host_mem_type: MemoryType,
 ) -> None:
     """Test that spilling prioritizes longest queues and newest messages."""
-    streaming_engine: SPMDEngine = streaming_engine_factory(
-        StreamingOptions(pinned_memory=pinned_memory),
-    )
-    context = streaming_engine.context
+    with SPMDEngine(
+        comm=spmd_comm,
+        rapidsmpf_options=Options({"pinned_memory": str(pinned_memory).lower()}),
+    ) as spmd_engine:
+        context = spmd_engine.context
 
-    if spilled_host_mem_type == MemoryType.PINNED_HOST:
-        assert streaming_engine.context.br().pinned_mr is not None
-        other_host_mem_type = MemoryType.HOST
-    else:
-        assert streaming_engine.context.br().pinned_mr is None
-        other_host_mem_type = MemoryType.PINNED_HOST
+        if spilled_host_mem_type == MemoryType.PINNED_HOST:
+            assert spmd_engine.context.br().pinned_mr is not None
+            other_host_mem_type = MemoryType.HOST
+        else:
+            assert spmd_engine.context.br().pinned_mr is None
+            other_host_mem_type = MemoryType.PINNED_HOST
 
-    # Create 3 spillable message containers simulating fanout buffers
-    # Buffer 0: Fast consumer (2 messages)
-    # Buffer 1: Slow consumer (5 messages) <- should spill from here first
-    # Buffer 2: Medium consumer (3 messages)
-    buffers = [SpillableMessages(context.br()) for _ in range(3)]
-    messages_per_buffer = [2, 5, 3]
+        # Create 3 spillable message containers simulating fanout buffers
+        # Buffer 0: Fast consumer (2 messages)
+        # Buffer 1: Slow consumer (5 messages) <- should spill from here first
+        # Buffer 2: Medium consumer (3 messages)
+        buffers = [SpillableMessages(context.br()) for _ in range(3)]
+        messages_per_buffer = [2, 5, 3]
 
-    # Track message IDs for each buffer
-    message_ids: dict[int, list[int]] = {}
+        # Track message IDs for each buffer
+        message_ids: dict[int, list[int]] = {}
 
-    # Populate buffers with messages
-    stream = context.get_stream_from_pool()
-    for buffer_idx, (sm, count) in enumerate(
-        zip(buffers, messages_per_buffer, strict=False)
-    ):
-        message_ids[buffer_idx] = []
-        for msg_idx in range(count):
-            # Create 1MB messages
-            table = create_test_table(1024 * 1024, stream)
-            chunk = TableChunk.from_pylibcudf_table(
-                table, stream, exclusive_view=True, br=context.br()
+        # Populate buffers with messages
+        stream = context.get_stream_from_pool()
+        for buffer_idx, (sm, count) in enumerate(
+            zip(buffers, messages_per_buffer, strict=False)
+        ):
+            message_ids[buffer_idx] = []
+            for msg_idx in range(count):
+                # Create 1MB messages
+                table = create_test_table(1024 * 1024, stream)
+                chunk = TableChunk.from_pylibcudf_table(
+                    table, stream, exclusive_view=True, br=context.br()
+                )
+                msg = Message(msg_idx, chunk)
+                mid = sm.insert(msg)
+                message_ids[buffer_idx].append(mid)
+
+        # Register spill function
+        spill_func = make_spill_function(buffers, context)
+        func_id = context.br().spill_manager.add_spill_function(spill_func, priority=0)
+
+        try:
+            # Manually trigger spilling of 3MB
+            # Expected: Buffer 1 (longest) should spill newest messages first
+            amount_to_spill = 3 * 1024 * 1024
+            actual_spilled = context.br().spill_manager.spill(amount_to_spill)
+
+            # Allow some tolerance
+            assert actual_spilled >= amount_to_spill * 0.95
+
+            # Verify Buffer 1 (longest queue): newest 3 messages should be spilled
+            buffer_1_descs = buffers[1].get_content_descriptions()
+            for i in range(3, 5):  # Messages 3, 4 (newest)
+                mid = message_ids[1][i]
+                desc = buffer_1_descs[mid]
+                # Should be in HOST memory (spilled)
+                assert desc.content_sizes[spilled_host_mem_type] > 0
+                assert desc.content_sizes[other_host_mem_type] == 0
+                assert desc.content_sizes[MemoryType.DEVICE] == 0
+
+            # Buffer 1: oldest messages should still be in device
+            for i in range(2):  # Messages 0, 1 (oldest)
+                mid = message_ids[1][i]
+                desc = buffer_1_descs[mid]
+                # Should still be in DEVICE memory
+                assert desc.content_sizes[MemoryType.DEVICE] > 0
+                assert desc.content_sizes[spilled_host_mem_type] == 0
+                assert desc.content_sizes[other_host_mem_type] == 0
+
+            # Buffer 0 (shortest queue): all messages should still be on device
+            buffer_0_descs = buffers[0].get_content_descriptions()
+            for mid in message_ids[0]:
+                desc = buffer_0_descs[mid]
+                assert desc.content_sizes[MemoryType.DEVICE] > 0
+                assert desc.content_sizes[spilled_host_mem_type] == 0
+                assert desc.content_sizes[other_host_mem_type] == 0
+
+            # Verify we can extract and make available a spilled message
+            spilled_mid = message_ids[1][4]  # Newest message from longest queue
+            spilled_msg = buffers[1].extract(mid=spilled_mid)
+
+            chunk = TableChunk.from_message(spilled_msg, br=context.br())
+            assert not chunk.is_available()  # Should be on host
+
+            # Make it available should bring it back to device
+            cost = chunk.make_available_cost()
+            assert cost > 0
+            res, _ = context.br().reserve(
+                MemoryType.DEVICE, cost, allow_overbooking=True
             )
-            msg = Message(msg_idx, chunk)
-            mid = sm.insert(msg)
-            message_ids[buffer_idx].append(mid)
+            chunk_available = chunk.make_available(res)
 
-    # Register spill function
-    spill_func = make_spill_function(buffers, context)
-    func_id = context.br().spill_manager.add_spill_function(spill_func, priority=0)
+            assert chunk_available.is_available()
+            # Verify we got a valid table back
+            assert chunk_available.table_view().num_rows() > 0
 
-    try:
-        # Manually trigger spilling of 3MB
-        # Expected: Buffer 1 (longest) should spill newest messages first
-        amount_to_spill = 3 * 1024 * 1024
-        actual_spilled = context.br().spill_manager.spill(amount_to_spill)
-
-        # Allow some tolerance
-        assert actual_spilled >= amount_to_spill * 0.95
-
-        # Verify Buffer 1 (longest queue): newest 3 messages should be spilled
-        buffer_1_descs = buffers[1].get_content_descriptions()
-        for i in range(3, 5):  # Messages 3, 4 (newest)
-            mid = message_ids[1][i]
-            desc = buffer_1_descs[mid]
-            # Should be in HOST memory (spilled)
-            assert desc.content_sizes[spilled_host_mem_type] > 0
-            assert desc.content_sizes[other_host_mem_type] == 0
-            assert desc.content_sizes[MemoryType.DEVICE] == 0
-
-        # Buffer 1: oldest messages should still be in device
-        for i in range(2):  # Messages 0, 1 (oldest)
-            mid = message_ids[1][i]
-            desc = buffer_1_descs[mid]
-            # Should still be in DEVICE memory
-            assert desc.content_sizes[MemoryType.DEVICE] > 0
-            assert desc.content_sizes[spilled_host_mem_type] == 0
-            assert desc.content_sizes[other_host_mem_type] == 0
-
-        # Buffer 0 (shortest queue): all messages should still be on device
-        buffer_0_descs = buffers[0].get_content_descriptions()
-        for mid in message_ids[0]:
-            desc = buffer_0_descs[mid]
-            assert desc.content_sizes[MemoryType.DEVICE] > 0
-            assert desc.content_sizes[spilled_host_mem_type] == 0
-            assert desc.content_sizes[other_host_mem_type] == 0
-
-        # Verify we can extract and make available a spilled message
-        spilled_mid = message_ids[1][4]  # Newest message from longest queue
-        spilled_msg = buffers[1].extract(mid=spilled_mid)
-
-        chunk = TableChunk.from_message(spilled_msg, br=context.br())
-        assert not chunk.is_available()  # Should be on host
-
-        # Make it available should bring it back to device
-        cost = chunk.make_available_cost()
-        assert cost > 0
-        res, _ = context.br().reserve(MemoryType.DEVICE, cost, allow_overbooking=True)
-        chunk_available = chunk.make_available(res)
-
-        assert chunk_available.is_available()
-        # Verify we got a valid table back
-        assert chunk_available.table_view().num_rows() > 0
-
-    finally:
-        context.br().spill_manager.remove_spill_function(func_id)
+        finally:
+            context.br().spill_manager.remove_spill_function(func_id)

--- a/python/cudf_polars/tests/experimental/test_stats.py
+++ b/python/cudf_polars/tests/experimental/test_stats.py
@@ -18,6 +18,7 @@ from cudf_polars.experimental.io import (
     ParquetSourceInfo,
     _clear_source_info_cache,
 )
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.experimental.statistics import collect_statistics
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.testing.io import make_lazy_frame, make_partitioned_source
@@ -155,19 +156,10 @@ def test_dataframe_round_trip() -> None:
 
 
 @pytest.mark.parametrize("kind", ["parquet", "csv", "frame"])
-@pytest.mark.parametrize(
-    "streaming_engine",
-    [
-        {
-            "executor_options": {
-                "target_partition_size": 10_000,
-                "max_rows_per_partition": 1_000,
-            }
-        }
-    ],
-    indirect=True,
-)
-def test_stats_planning(tmp_path, kind, streaming_engine):
+def test_stats_planning(tmp_path, kind, streaming_engine_factory):
+    streaming_engine = streaming_engine_factory(
+        StreamingOptions(target_partition_size=10_000, max_rows_per_partition=1_000),
+    )
     sales = pl.DataFrame(
         {
             "order_id": [1, 2, 3, 4, 5, 6],

--- a/python/cudf_polars/tests/experimental/test_unique.py
+++ b/python/cudf_polars/tests/experimental/test_unique.py
@@ -3,38 +3,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal
 
-from cudf_polars.experimental.rapidsmpf.frontend.spmd import SPMDEngine
+from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 from cudf_polars.testing.asserts import assert_gpu_result_equal
-
-if TYPE_CHECKING:
-    from collections.abc import Generator
-
-    from rapidsmpf.communicator.communicator import Communicator
-
-    from cudf_polars.experimental.rapidsmpf.frontend.core import StreamingEngine
 
 
 @pytest.fixture
-def engine(
-    request: pytest.FixtureRequest,
-    spmd_comm: Communicator,
-) -> Generator[StreamingEngine, None, None]:
-    params: dict[str, Any] = getattr(request, "param", {})
-    executor_options = {
-        "max_rows_per_partition": 50,
-        "fallback_mode": "warn",
-        "dynamic_planning": {},
-        **params.get("executor_options", {}),
-    }
-    with SPMDEngine(comm=spmd_comm, executor_options=executor_options) as engine:
-        yield engine
+def engine(streaming_engine_factory):
+    return streaming_engine_factory(
+        StreamingOptions(fallback_mode="warn"),
+    )
 
 
 @pytest.fixture(scope="module")
@@ -52,15 +34,13 @@ def df():
 @pytest.mark.parametrize("subset", [None, ("y",), ("y", "z")])
 @pytest.mark.parametrize("keep", ["first", "last", "any", "none"])
 @pytest.mark.parametrize("maintain_order", [True, False])
-@pytest.mark.parametrize(
-    "cardinality,engine",
-    [
-        ({}, {"executor_options": {"unique_fraction": {}}}),
-        ({"y": 0.7}, {"executor_options": {"unique_fraction": {"y": 0.7}}}),
-    ],
-    indirect=["engine"],
-)
-def test_unique(df, keep, subset, maintain_order, cardinality, engine):
+@pytest.mark.parametrize("cardinality", [{}, {"y": 0.7}])
+def test_unique(
+    df, streaming_engine_factory, keep, subset, maintain_order, cardinality
+):
+    engine = streaming_engine_factory(
+        StreamingOptions(unique_fraction=cardinality, fallback_mode="warn"),
+    )
     q = df.unique(subset=subset, keep=keep, maintain_order=maintain_order)
     check_row_order = maintain_order
     if keep == "any" and subset:
@@ -70,20 +50,14 @@ def test_unique(df, keep, subset, maintain_order, cardinality, engine):
     assert_gpu_result_equal(q, engine=engine, check_row_order=check_row_order)
 
 
-@pytest.mark.parametrize(
-    "engine",
-    [
-        {
-            "executor_options": {
-                "unique_fraction": {"y": 1.0},
-                "fallback_mode": "raise",
-                "dynamic_planning": None,
-            }
-        }
-    ],
-    indirect=True,
-)
-def test_unique_fallback(df, engine):
+def test_unique_fallback(df, streaming_engine_factory):
+    engine = streaming_engine_factory(
+        StreamingOptions(
+            unique_fraction={"y": 1.0},
+            fallback_mode="raise",
+            dynamic_planning=None,
+        ),
+    )
     q = df.unique(keep="first", maintain_order=True)
     with pytest.raises(
         NotImplementedError,
@@ -93,26 +67,15 @@ def test_unique_fallback(df, engine):
 
 
 @pytest.mark.parametrize("maintain_order", [True, False])
-@pytest.mark.parametrize(
-    "cardinality,engine",
-    [
-        (
-            {},
-            {"executor_options": {"max_rows_per_partition": 4, "unique_fraction": {}}},
+@pytest.mark.parametrize("cardinality", [{}, {"y": 0.5}])
+def test_unique_select(df, streaming_engine_factory, maintain_order, cardinality):
+    engine = streaming_engine_factory(
+        StreamingOptions(
+            max_rows_per_partition=4,
+            unique_fraction=cardinality,
+            fallback_mode="warn",
         ),
-        (
-            {"y": 0.5},
-            {
-                "executor_options": {
-                    "max_rows_per_partition": 4,
-                    "unique_fraction": {"y": 0.5},
-                }
-            },
-        ),
-    ],
-    indirect=["engine"],
-)
-def test_unique_select(df, maintain_order, cardinality, engine):
+    )
     q = df.select(pl.col("y").unique(maintain_order=maintain_order))
     if cardinality == {"y": 0.5} and maintain_order:
         with pytest.warns(
@@ -125,12 +88,10 @@ def test_unique_select(df, maintain_order, cardinality, engine):
 
 @pytest.mark.parametrize("keep", ["first", "last", "any"])
 @pytest.mark.parametrize("zlice", ["head", "tail"])
-@pytest.mark.parametrize(
-    "engine",
-    [{"executor_options": {"max_rows_per_partition": 4}}],
-    indirect=True,
-)
-def test_unique_head_tail(keep, zlice, engine):
+def test_unique_head_tail(keep, zlice, streaming_engine_factory):
+    engine = streaming_engine_factory(
+        StreamingOptions(max_rows_per_partition=4, fallback_mode="warn"),
+    )
     data = [0, 1, 2, 3, 4, 5, 6, 7, 3, 4, 5, 6, 7, 8, 9, 10]
     df = pl.LazyFrame({"x": data})
     q = df.unique(subset=None, keep=keep, maintain_order=True)
@@ -139,7 +100,7 @@ def test_unique_head_tail(keep, zlice, engine):
     # See: https://github.com/pola-rs/polars/issues/22470
     assert_frame_equal(
         getattr(q, zlice)().collect(engine=engine),
-        getattr(expect, zlice)().collect(),
+        getattr(expect, zlice)().collect(engine=engine),
     )
 
 

--- a/python/cudf_polars/tests/expressions/test_booleanfunction.py
+++ b/python/cudf_polars/tests/expressions/test_booleanfunction.py
@@ -13,6 +13,7 @@ from cudf_polars.testing.asserts import (
     assert_ir_translation_raises,
 )
 from cudf_polars.utils.versions import POLARS_VERSION_LT_132
+from tests.conftest import is_streaming_engine
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -81,9 +82,8 @@ def test_boolean_function_unary(
     *,
     has_nans: bool,
     has_nulls: bool,
-    using_streaming_engine: bool,
 ) -> None:
-    if using_streaming_engine:
+    if is_streaming_engine(engine):
         pytest.skip(
             "Avoiding possible segfault with cuda 12.9 builds https://github.com/rapidsai/cudf/issues/21828"
         )
@@ -170,10 +170,8 @@ def test_boolean_isbetween(engine: pl.GPUEngine, closed, bounds):
     "expr", [pl.any_horizontal("*"), pl.all_horizontal("*")], ids=["any", "all"]
 )
 @pytest.mark.parametrize("wide", [False, True], ids=["narrow", "wide"])
-def test_boolean_horizontal(
-    engine: pl.GPUEngine, expr, has_nulls, wide, using_streaming_engine
-):
-    if using_streaming_engine:
+def test_boolean_horizontal(engine: pl.GPUEngine, expr, has_nulls, wide):
+    if is_streaming_engine(engine):
         pytest.skip(
             "Avoiding possible segfault with cuda 12.9 builds https://github.com/rapidsai/cudf/issues/21828"
         )

--- a/python/cudf_polars/tests/expressions/test_booleanfunction.py
+++ b/python/cudf_polars/tests/expressions/test_booleanfunction.py
@@ -12,8 +12,8 @@ from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
     assert_ir_translation_raises,
 )
+from cudf_polars.testing.engine_utils import is_streaming_engine
 from cudf_polars.utils.versions import POLARS_VERSION_LT_132
-from tests.conftest import is_streaming_engine
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/python/cudf_polars/tests/expressions/test_rolling.py
+++ b/python/cudf_polars/tests/expressions/test_rolling.py
@@ -298,10 +298,11 @@ def test_over_ternary(engine: pl.GPUEngine, df):
     assert_gpu_result_equal(q, engine=engine)
 
 
-@pytest.mark.skip_on_streaming_engine(
-    "GroupedWindow not supported for multiple partitions"
-)
-def test_over_broadcast_input_row_group_indices_aligned(engine: pl.GPUEngine):
+def test_over_broadcast_input_row_group_indices_aligned(
+    in_memory_engine: pl.GPUEngine,
+):
+    # GroupedWindow not supported for multiple partitions, so this test only
+    # exercises the in-memory engine.
     num_rows, num_groups = 512, 64
 
     df = pl.LazyFrame(
@@ -312,7 +313,7 @@ def test_over_broadcast_input_row_group_indices_aligned(engine: pl.GPUEngine):
     )
     q = df.select(pl.col("x").sum().over("g"))
 
-    assert_gpu_result_equal(q, engine=engine)
+    assert_gpu_result_equal(q, engine=in_memory_engine)
 
 
 @pytest.mark.parametrize("method", ["ordinal", "dense", "min", "max", "average"])

--- a/python/cudf_polars/tests/expressions/test_rolling.py
+++ b/python/cudf_polars/tests/expressions/test_rolling.py
@@ -298,11 +298,10 @@ def test_over_ternary(engine: pl.GPUEngine, df):
     assert_gpu_result_equal(q, engine=engine)
 
 
-def test_over_broadcast_input_row_group_indices_aligned(
-    in_memory_engine: pl.GPUEngine,
-):
-    # GroupedWindow not supported for multiple partitions, so this test only
-    # exercises the in-memory engine.
+@pytest.mark.skip_on_streaming_engine(
+    "GroupedWindow not supported for multiple partitions"
+)
+def test_over_broadcast_input_row_group_indices_aligned(engine: pl.GPUEngine):
     num_rows, num_groups = 512, 64
 
     df = pl.LazyFrame(
@@ -313,7 +312,7 @@ def test_over_broadcast_input_row_group_indices_aligned(
     )
     q = df.select(pl.col("x").sum().over("g"))
 
-    assert_gpu_result_equal(q, engine=in_memory_engine)
+    assert_gpu_result_equal(q, engine=engine)
 
 
 @pytest.mark.parametrize("method", ["ordinal", "dense", "min", "max", "average"])

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -21,6 +21,7 @@ from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_136,
     POLARS_VERSION_LT_138,
 )
+from tests.conftest import is_streaming_engine
 
 
 @pytest.fixture
@@ -661,8 +662,8 @@ def test_string_zfill_forbidden_chars():
         ),
     ],
 )
-def test_string_pad_start(engine: pl.GPUEngine, width, char, using_streaming_engine):
-    if using_streaming_engine:
+def test_string_pad_start(engine: pl.GPUEngine, width, char):
+    if is_streaming_engine(engine):
         pytest.skip(
             "Avoiding possible segfault with cuda 12.9 builds https://github.com/rapidsai/cudf/issues/21828"
         )

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -14,6 +14,7 @@ from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
     assert_ir_translation_raises,
 )
+from cudf_polars.testing.engine_utils import is_streaming_engine
 from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_131,
     POLARS_VERSION_LT_132,
@@ -21,7 +22,6 @@ from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_136,
     POLARS_VERSION_LT_138,
 )
-from tests.conftest import is_streaming_engine
 
 
 @pytest.fixture

--- a/python/cudf_polars/tests/test_dataframescan.py
+++ b/python/cudf_polars/tests/test_dataframescan.py
@@ -14,6 +14,7 @@ from cudf_polars.testing.asserts import (
     assert_ir_translation_raises,
 )
 from cudf_polars.utils.versions import POLARS_VERSION_LT_138
+from tests.conftest import is_streaming_engine
 
 
 @pytest.mark.parametrize(
@@ -87,12 +88,10 @@ def test_dataframescan_with_decimals(engine: pl.GPUEngine):
     POLARS_VERSION_LT_138,
     reason="height parameter added in Polars 1.38",
 )
-def test_dataframescan_zero_width_with_rows(
-    engine: pl.GPUEngine, request, using_streaming_engine
-):
+def test_dataframescan_zero_width_with_rows(engine: pl.GPUEngine, request):
     request.applymarker(
         pytest.mark.xfail(
-            using_streaming_engine,
+            is_streaming_engine(engine),
             reason="https://github.com/rapidsai/cudf/issues/21644",
         )
     )

--- a/python/cudf_polars/tests/test_dataframescan.py
+++ b/python/cudf_polars/tests/test_dataframescan.py
@@ -13,8 +13,8 @@ from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
     assert_ir_translation_raises,
 )
+from cudf_polars.testing.engine_utils import is_streaming_engine
 from cudf_polars.utils.versions import POLARS_VERSION_LT_138
-from tests.conftest import is_streaming_engine
 
 
 @pytest.mark.parametrize(

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -21,7 +21,7 @@ from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_136,
     POLARS_VERSION_LT_1321,
 )
-from tests.conftest import is_streaming_engine
+from tests.conftest import get_blocksize_mode, is_streaming_engine
 
 
 @pytest.fixture
@@ -304,12 +304,13 @@ def test_groupby_nested_list_struct_raises(dtype):
 @pytest.mark.parametrize("nkeys", [1, 2, 4])
 def test_groupby_maintain_order_random(
     engine: pl.GPUEngine,
-    blocksize_mode,
     nrows,
     nkeys,
     with_nulls,
 ):
-    if nrows > 30 and (blocksize_mode == "small" or is_streaming_engine(engine)):
+    if nrows > 30 and (
+        get_blocksize_mode(engine) == "small" or is_streaming_engine(engine)
+    ):
         pytest.skip("streaming executor too slow for large n_rows")
     key_names = [f"key{key}" for key in range(nkeys)]
     rng = random.Random(2)

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -15,13 +15,13 @@ from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
     assert_ir_translation_raises,
 )
+from cudf_polars.testing.engine_utils import get_blocksize_mode, is_streaming_engine
 from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_132,
     POLARS_VERSION_LT_134,
     POLARS_VERSION_LT_136,
     POLARS_VERSION_LT_1321,
 )
-from tests.conftest import get_blocksize_mode, is_streaming_engine
 
 
 @pytest.fixture

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -412,7 +412,7 @@ def test_groupby_sum_all_null_group_returns_null(engine: pl.GPUEngine):
     ids=["sum", "mean", "median", "quantile-0.5"],
 )
 def test_groupby_aggs_keep_unsupported_as_null(
-    engine: pl.GPUEngine, using_streaming_engine, request, df: pl.LazyFrame, agg_expr
+    engine: pl.GPUEngine, request, df: pl.LazyFrame, agg_expr
 ) -> None:
     request.applymarker(
         pytest.mark.xfail(
@@ -425,7 +425,7 @@ def test_groupby_aggs_keep_unsupported_as_null(
             condition="quantile" in str(agg_expr)
             and not POLARS_VERSION_LT_132
             and POLARS_VERSION_LT_134
-            and using_streaming_engine,
+            and is_streaming_engine(engine),
             reason="Decimal precision mismatch (9 vs 38)",
         )
     )

--- a/python/cudf_polars/tests/test_groupby.py
+++ b/python/cudf_polars/tests/test_groupby.py
@@ -21,6 +21,7 @@ from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_136,
     POLARS_VERSION_LT_1321,
 )
+from tests.conftest import is_streaming_engine
 
 
 @pytest.fixture
@@ -142,12 +143,11 @@ def test_groupby_sorted_keys(
     df: pl.LazyFrame,
     keys,
     exprs,
-    using_streaming_engine,
     request,
 ):
     request.applymarker(
         pytest.mark.xfail(
-            using_streaming_engine,
+            is_streaming_engine(engine),
             strict=False,
             reason="https://github.com/rapidsai/cudf/issues/21642 -  no deterministic sort for keys",
         )
@@ -308,9 +308,8 @@ def test_groupby_maintain_order_random(
     nrows,
     nkeys,
     with_nulls,
-    using_streaming_engine,
 ):
-    if nrows > 30 and (blocksize_mode == "small" or using_streaming_engine):
+    if nrows > 30 and (blocksize_mode == "small" or is_streaming_engine(engine)):
         pytest.skip("streaming executor too slow for large n_rows")
     key_names = [f"key{key}" for key in range(nkeys)]
     rng = random.Random(2)

--- a/python/cudf_polars/tests/test_join.py
+++ b/python/cudf_polars/tests/test_join.py
@@ -165,20 +165,19 @@ def test_join_literal_key(engine: pl.GPUEngine, left, right, left_on, right_on):
     ],
 )
 @pytest.mark.parametrize("zlice", [None, (0, 5)])
-@pytest.mark.skip_on_streaming_engine(
-    "ConditionalJoin not supported for multiple partitions"
-)
-def test_join_where(engine: pl.GPUEngine, left, right, conditions, zlice):
+def test_join_where(in_memory_engine: pl.GPUEngine, left, right, conditions, zlice):
+    # ConditionalJoin not supported for multiple partitions, so this test
+    # only exercises the in-memory engine.
     q = left.join_where(right, *conditions)
 
-    assert_gpu_result_equal(q, engine=engine, check_row_order=False)
+    assert_gpu_result_equal(q, engine=in_memory_engine, check_row_order=False)
 
     if zlice is not None:
         q_len = q.slice(*zlice).select(pl.len())
         # Can't compare result, since row order is not guaranteed and
         # therefore we only check the length
 
-        assert_gpu_result_equal(q_len, engine=engine)
+        assert_gpu_result_equal(q_len, engine=in_memory_engine)
 
 
 def test_cross_join_empty_right_table(engine: pl.GPUEngine, request):
@@ -308,12 +307,11 @@ def test_join_maintain_order_with_slice(
         (pl.Decimal(15, 2), pl.Float64),
     ],
 )
-@pytest.mark.skip_on_streaming_engine(
-    "ConditionalJoin not supported for multiple partitions"
-)
 def test_cross_join_filter_with_decimals(
-    engine: pl.GPUEngine, request, expr, left_dtype, right_dtype
+    in_memory_engine: pl.GPUEngine, request, expr, left_dtype, right_dtype
 ):
+    # ConditionalJoin not supported for multiple partitions, so this test
+    # only exercises the in-memory engine.
     request.applymarker(
         pytest.mark.xfail(
             POLARS_VERSION_LT_132
@@ -347,7 +345,7 @@ def test_cross_join_filter_with_decimals(
 
     q = left.join(right, how="cross").filter(expr)
 
-    assert_gpu_result_equal(q, engine=engine, check_row_order=False)
+    assert_gpu_result_equal(q, engine=in_memory_engine, check_row_order=False)
 
 
 def test_conditional_join_predicate_pickle():

--- a/python/cudf_polars/tests/test_join.py
+++ b/python/cudf_polars/tests/test_join.py
@@ -165,19 +165,20 @@ def test_join_literal_key(engine: pl.GPUEngine, left, right, left_on, right_on):
     ],
 )
 @pytest.mark.parametrize("zlice", [None, (0, 5)])
-def test_join_where(in_memory_engine: pl.GPUEngine, left, right, conditions, zlice):
-    # ConditionalJoin not supported for multiple partitions, so this test
-    # only exercises the in-memory engine.
+@pytest.mark.skip_on_streaming_engine(
+    "ConditionalJoin not supported for multiple partitions"
+)
+def test_join_where(engine: pl.GPUEngine, left, right, conditions, zlice):
     q = left.join_where(right, *conditions)
 
-    assert_gpu_result_equal(q, engine=in_memory_engine, check_row_order=False)
+    assert_gpu_result_equal(q, engine=engine, check_row_order=False)
 
     if zlice is not None:
         q_len = q.slice(*zlice).select(pl.len())
         # Can't compare result, since row order is not guaranteed and
         # therefore we only check the length
 
-        assert_gpu_result_equal(q_len, engine=in_memory_engine)
+        assert_gpu_result_equal(q_len, engine=engine)
 
 
 def test_cross_join_empty_right_table(engine: pl.GPUEngine, request):
@@ -307,11 +308,12 @@ def test_join_maintain_order_with_slice(
         (pl.Decimal(15, 2), pl.Float64),
     ],
 )
+@pytest.mark.skip_on_streaming_engine(
+    "ConditionalJoin not supported for multiple partitions"
+)
 def test_cross_join_filter_with_decimals(
-    in_memory_engine: pl.GPUEngine, request, expr, left_dtype, right_dtype
+    engine: pl.GPUEngine, request, expr, left_dtype, right_dtype
 ):
-    # ConditionalJoin not supported for multiple partitions, so this test
-    # only exercises the in-memory engine.
     request.applymarker(
         pytest.mark.xfail(
             POLARS_VERSION_LT_132
@@ -345,7 +347,7 @@ def test_cross_join_filter_with_decimals(
 
     q = left.join(right, how="cross").filter(expr)
 
-    assert_gpu_result_equal(q, engine=in_memory_engine, check_row_order=False)
+    assert_gpu_result_equal(q, engine=engine, check_row_order=False)
 
 
 def test_conditional_join_predicate_pickle():

--- a/python/cudf_polars/tests/test_join.py
+++ b/python/cudf_polars/tests/test_join.py
@@ -15,8 +15,8 @@ from cudf_polars.containers import DataType
 from cudf_polars.dsl import expr as ir_expr
 from cudf_polars.dsl.ir import ConditionalJoin
 from cudf_polars.testing.asserts import assert_gpu_result_equal
+from cudf_polars.testing.engine_utils import is_streaming_engine
 from cudf_polars.utils.versions import POLARS_VERSION_LT_132
-from tests.conftest import is_streaming_engine
 
 
 @pytest.fixture(params=[False, True], ids=["nulls_not_equal", "nulls_equal"])

--- a/python/cudf_polars/tests/test_join.py
+++ b/python/cudf_polars/tests/test_join.py
@@ -16,6 +16,7 @@ from cudf_polars.dsl import expr as ir_expr
 from cudf_polars.dsl.ir import ConditionalJoin
 from cudf_polars.testing.asserts import assert_gpu_result_equal
 from cudf_polars.utils.versions import POLARS_VERSION_LT_132
+from tests.conftest import is_streaming_engine
 
 
 @pytest.fixture(params=[False, True], ids=["nulls_not_equal", "nulls_equal"])
@@ -80,12 +81,11 @@ def test_non_coalesce_join(
     how,
     nulls_equal,
     join_expr,
-    using_streaming_engine,
     request,
 ):
     request.applymarker(
         pytest.mark.xfail(
-            using_streaming_engine,
+            is_streaming_engine(engine),
             strict=False,
             reason="Non deterministic sort/join on nulls",
         )

--- a/python/cudf_polars/tests/test_mapfunction.py
+++ b/python/cudf_polars/tests/test_mapfunction.py
@@ -13,6 +13,7 @@ from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
     assert_ir_translation_raises,
 )
+from cudf_polars.testing.engine_utils import get_blocksize_mode
 from cudf_polars.utils.versions import POLARS_VERSION_LT_131, POLARS_VERSION_LT_135
 
 
@@ -115,7 +116,7 @@ def test_unique_hash():
     assert hash(ir_a) != hash(ir_b)
 
 
-def test_set_sorted_then_inner_join(engine: pl.GPUEngine, blocksize_mode, request):
+def test_set_sorted_then_inner_join(engine: pl.GPUEngine, request):
     request.applymarker(
         pytest.mark.xfail(
             condition=not POLARS_VERSION_LT_135,
@@ -124,7 +125,7 @@ def test_set_sorted_then_inner_join(engine: pl.GPUEngine, blocksize_mode, reques
     )
     request.applymarker(
         pytest.mark.xfail(
-            condition=blocksize_mode == "small" and POLARS_VERSION_LT_135,
+            condition=get_blocksize_mode(engine) == "small" and POLARS_VERSION_LT_135,
             reason="set_sorted join result order differs in polars < 1.35",
         )
     )

--- a/python/cudf_polars/tests/test_merge_sorted.py
+++ b/python/cudf_polars/tests/test_merge_sorted.py
@@ -7,7 +7,7 @@ import pytest
 import polars as pl
 
 from cudf_polars.testing.asserts import assert_gpu_result_equal
-from tests.conftest import is_streaming_engine
+from cudf_polars.testing.engine_utils import is_streaming_engine
 
 
 @pytest.mark.parametrize("descending", [True, False])

--- a/python/cudf_polars/tests/test_merge_sorted.py
+++ b/python/cudf_polars/tests/test_merge_sorted.py
@@ -7,15 +7,14 @@ import pytest
 import polars as pl
 
 from cudf_polars.testing.asserts import assert_gpu_result_equal
+from tests.conftest import is_streaming_engine
 
 
 @pytest.mark.parametrize("descending", [True, False])
-def test_merge_sorted_without_nulls(
-    engine: pl.GPUEngine, descending, request, using_streaming_engine
-):
+def test_merge_sorted_without_nulls(engine: pl.GPUEngine, descending, request):
     request.applymarker(
         pytest.mark.xfail(
-            not using_streaming_engine and descending,
+            not is_streaming_engine(engine) and descending,
             reason="https://github.com/pola-rs/polars/issues/21511",
         )
     )

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -23,6 +23,7 @@ from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_135,
     POLARS_VERSION_LT_138,
 )
+from tests.conftest import is_streaming_engine
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -713,11 +714,11 @@ def test_scan_tiny_file_not_compressed(engine: pl.GPUEngine, tmp_path):
 )
 @pytest.mark.parametrize("custom_engine", [None, NO_CHUNK_ENGINE])
 def test_scan_parquet_zero_width_with_limit(
-    engine: pl.GPUEngine, tmp_path, custom_engine, request, using_streaming_engine
+    engine: pl.GPUEngine, tmp_path, custom_engine, request
 ):
     request.applymarker(
         pytest.mark.xfail(
-            using_streaming_engine and custom_engine is None,
+            is_streaming_engine(engine) and custom_engine is None,
             reason="https://github.com/rapidsai/cudf/issues/21644",
         )
     )

--- a/python/cudf_polars/tests/test_scan.py
+++ b/python/cudf_polars/tests/test_scan.py
@@ -17,13 +17,13 @@ from cudf_polars.testing.asserts import (
     assert_gpu_result_equal,
     assert_ir_translation_raises,
 )
+from cudf_polars.testing.engine_utils import is_streaming_engine
 from cudf_polars.testing.io import make_partitioned_source
 from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_131,
     POLARS_VERSION_LT_135,
     POLARS_VERSION_LT_138,
 )
-from tests.conftest import is_streaming_engine
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/python/cudf_polars/tests/test_sink.py
+++ b/python/cudf_polars/tests/test_sink.py
@@ -11,6 +11,7 @@ from cudf_polars.testing.asserts import (
     assert_sink_result_equal,
 )
 from cudf_polars.utils.versions import POLARS_VERSION_LT_138
+from tests.conftest import get_blocksize_mode
 
 
 @pytest.fixture(scope="module")
@@ -29,7 +30,6 @@ def df():
 @pytest.mark.parametrize("separator", [",", "|"])
 def test_sink_csv(
     engine: pl.GPUEngine,
-    blocksize_mode,
     df,
     tmp_path,
     include_header,
@@ -37,7 +37,7 @@ def test_sink_csv(
     line_terminator,
     separator,
 ):
-    if line_terminator == "\n\n" and blocksize_mode == "small":
+    if line_terminator == "\n\n" and get_blocksize_mode(engine) == "small":
         # We end up with an extra row per partition.
         pytest.skip("Multi-line terminator not supported with small blocksize")
     assert_sink_result_equal(

--- a/python/cudf_polars/tests/test_sink.py
+++ b/python/cudf_polars/tests/test_sink.py
@@ -10,8 +10,8 @@ from cudf_polars.testing.asserts import (
     assert_sink_ir_translation_raises,
     assert_sink_result_equal,
 )
+from cudf_polars.testing.engine_utils import get_blocksize_mode
 from cudf_polars.utils.versions import POLARS_VERSION_LT_138
-from tests.conftest import get_blocksize_mode
 
 
 @pytest.fixture(scope="module")

--- a/python/cudf_polars/tests/testing/test_engine_utils.py
+++ b/python/cudf_polars/tests/testing/test_engine_utils.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from cudf_polars.testing.engine_utils import (
+    EngineFixtureParam,
+    create_streaming_options,
+)
+
+
+def test_engine_fixture_param_in_memory():
+    param = EngineFixtureParam("in-memory")
+    assert param.engine_name == "in-memory"
+    assert param.blocksize_mode == "default"
+
+
+def test_engine_fixture_param_default_blocksize():
+    param = EngineFixtureParam("spmd")
+    assert param.engine_name == "spmd"
+    assert param.blocksize_mode == "default"
+
+
+def test_engine_fixture_param_small_blocksize():
+    param = EngineFixtureParam("spmd-small")
+    assert param.engine_name == "spmd"
+    assert param.blocksize_mode == "small"
+
+
+def test_create_streaming_options_default():
+    pytest.importorskip("rapidsmpf")
+    opts = create_streaming_options("default")
+    assert opts.max_rows_per_partition == 50
+    assert opts.target_partition_size == 1_000_000
+    assert opts.raise_on_fail is True
+
+
+def test_create_streaming_options_small():
+    pytest.importorskip("rapidsmpf")
+    opts = create_streaming_options("small")
+    assert opts.max_rows_per_partition == 4
+    assert opts.target_partition_size == 10
+
+
+def test_create_streaming_options_overrides_merge():
+    """Overrides take precedence over the blocksize baseline."""
+    pytest.importorskip("rapidsmpf")
+    from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
+
+    overrides = StreamingOptions(max_rows_per_partition=999)
+    merged = create_streaming_options("default", overrides)
+    # Override wins.
+    assert merged.max_rows_per_partition == 999
+    # Untouched baseline field is preserved.
+    assert merged.target_partition_size == 1_000_000

--- a/python/cudf_polars/tests/testing/test_engine_utils.py
+++ b/python/cudf_polars/tests/testing/test_engine_utils.py
@@ -14,13 +14,13 @@ from cudf_polars.testing.engine_utils import (
 def test_engine_fixture_param_in_memory():
     param = EngineFixtureParam("in-memory")
     assert param.engine_name == "in-memory"
-    assert param.blocksize_mode == "default"
+    assert param.blocksize_mode == "medium"
 
 
-def test_engine_fixture_param_default_blocksize():
+def test_engine_fixture_param_medium_blocksize():
     param = EngineFixtureParam("spmd")
     assert param.engine_name == "spmd"
-    assert param.blocksize_mode == "default"
+    assert param.blocksize_mode == "medium"
 
 
 def test_engine_fixture_param_small_blocksize():
@@ -29,9 +29,9 @@ def test_engine_fixture_param_small_blocksize():
     assert param.blocksize_mode == "small"
 
 
-def test_create_streaming_options_default():
+def test_create_streaming_options_medium():
     pytest.importorskip("rapidsmpf")
-    opts = create_streaming_options("default")
+    opts = create_streaming_options("medium")
     assert opts.max_rows_per_partition == 50
     assert opts.target_partition_size == 1_000_000
     assert opts.raise_on_fail is True
@@ -50,7 +50,7 @@ def test_create_streaming_options_overrides_merge():
     from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
 
     overrides = StreamingOptions(max_rows_per_partition=999)
-    merged = create_streaming_options("default", overrides)
+    merged = create_streaming_options("medium", overrides)
     # Override wins.
     assert merged.max_rows_per_partition == 999
     # Untouched baseline field is preserved.


### PR DESCRIPTION
Replaces the brittle `@pytest.mark.parametrize("streaming_engine", [...], indirect=True)` pattern, where tests construct ad hoc option dicts, with a small set of orthogonal fixtures driven by `StreamingOptions`.

Tests that need custom configuration can now use `streaming_engine_factory(options)`, which is parametrized over backends, accepts a `StreamingOptions`, and manages engine lifetimes.

Moves the fixture infrastructure into a reusable `cudf_polars/testing/engine_utils.py` module, making it easy to add new engine variants (e.g. `RayEngine`, `DaskEngine`) by appending a single entry to a list.

Also exposes `groupby_n_ary` on `StreamingOptions` (field, docstring, CLI flag, argparse hookup) so it can be configured via the typed interface used in tests.