### PR TITLE
Fix `MultiIndex` getitem

### DIFF
--- a/python/cudf/cudf/core/multiindex.py
+++ b/python/cudf/cudf/core/multiindex.py
@@ -1018,7 +1018,7 @@ class MultiIndex(Index):
 
     @_performance_tracking
     def __getitem__(self, index):
-        flatten = isinstance(index, int)
+        flatten = is_integer(index)
 
         if isinstance(index, slice):
             start, stop, step = index.indices(len(self))


### PR DESCRIPTION
## Description
Replace the type check with cudf's existing `is_integer` (which delegates
to `pandas.api.types.is_integer`) — it returns True for Python ints and
all numpy integer scalars, and False for bool, exactly matching the cases
that should be treated as scalar positional indexers.

    flatten = is_integer(index)

(`is_integer` was already imported at the top of the module.)

This Fixes: 
```python
72 occurrences of
    "TypeError: unsupported format string passed to MultiIndex.__format__"

    tests/frame/test_stack_unstack.py::TestDataFrameReshape::test_unstack_nan_index_repeats
```
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
