### PR TITLE
Fix `to_period` parameter

### DIFF
--- a/python/cudf/cudf/core/index.py
+++ b/python/cudf/cudf/core/index.py
@@ -3530,7 +3530,7 @@ class DatetimeIndex(Index):
             self._column.to_julian_date(), name=self.name
         )
 
-    def to_period(self, freq) -> pd.PeriodIndex:
+    def to_period(self, freq=None) -> pd.PeriodIndex:
         return self.to_pandas().to_period(freq=freq)
 
     def normalize(self) -> Self:


### PR DESCRIPTION
## Description
cudf.DatetimeIndex.to_period requires `freq` as a positional argument:

    def to_period(self, freq) -> pd.PeriodIndex:
        return self.to_pandas().to_period(freq=freq)

Pandas's signature is `to_period(freq=None)`. When the index has a freq
attribute set, pandas auto-infers; if not, it raises a clear ValueError.

Calling `idx.to_period()` (no argument) under cudf or cudf.pandas raises:

    TypeError: DatetimeIndex.to_period() missing 1 required positional
        argument: 'freq'


This PR fixes all `tests/plotting/test_datetimelike.py::TestTSPlot::test_*resampling` failures

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
