### PR TITLE
Fix more use-after-free cases found in libcudf

### DIFF
--- a/cpp/src/interop/to_arrow_host.cu
+++ b/cpp/src/interop/to_arrow_host.cu
@@ -90,6 +90,7 @@ struct dispatch_to_arrow_host {
                             : column.null_mask(),
       bitmap->buffer.size_bytes,
       stream));
+    stream.synchronize();  // ensures the bitmap is not destroyed before the copy is completed
     return NANOARROW_OK;
   }
 

--- a/cpp/src/io/json/host_tree_algorithms.cu
+++ b/cpp/src/io/json/host_tree_algorithms.cu
@@ -847,7 +847,7 @@ std::
                  column_categories.cbegin(),
                  expected_types.begin(),
                  [](auto exp, auto cat) { return exp == NUM_NODE_CLASSES ? cat : exp; });
-  cudf::detail::cuda_memcpy_async<NodeT>(d_column_tree.node_categories, expected_types, stream);
+  cudf::detail::cuda_memcpy<NodeT>(d_column_tree.node_categories, expected_types, stream);
 
   return {is_pruned, is_mixed_pruned, columns};
 }

--- a/cpp/src/io/orc/reader_impl_chunking.cu
+++ b/cpp/src/io/orc/reader_impl_chunking.cu
@@ -527,6 +527,7 @@ void reader_impl::load_next_stripe_data(read_mode mode)
     CUDF_CUDA_TRY(
       cudf::detail::memcpy_async(dev_dst, host_buffer->data(), host_buffer->size(), _stream));
   }
+  _stream.synchronize();
 
   for (auto& task : device_read_tasks) {  // if there were device reads
     CUDF_EXPECTS(task.first.get() == task.second, "Unexpected discrepancy in bytes read.");

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -1463,6 +1463,7 @@ encoded_footer_statistics finish_statistic_blobs(Footer const& footer,
     file_blobs[i].assign(stat_begin, stat_end);
   }
 
+  stream.synchronize();  // makes sure num_file_blobs is copied before going out of scope
   return {std::move(stripe_blobs), std::move(file_blobs)};
 }
 

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -1463,7 +1463,6 @@ encoded_footer_statistics finish_statistic_blobs(Footer const& footer,
     file_blobs[i].assign(stat_begin, stat_end);
   }
 
-  stream.synchronize();  // makes sure num_file_blobs is copied before going out of scope
   return {std::move(stripe_blobs), std::move(file_blobs)};
 }
 

--- a/cpp/src/io/parquet/reader_impl.cpp
+++ b/cpp/src/io/parquet/reader_impl.cpp
@@ -189,8 +189,7 @@ void reader_impl::decode_page_data(read_mode mode, size_t skip_rows, size_t num_
     std::fill(
       host_offsets_vector.begin(), host_offsets_vector.end(), std::numeric_limits<size_t>::max());
     // Initialize the initial string offsets vector from the host vector
-    initial_str_offsets =
-      cudf::detail::make_device_uvector_async(host_offsets_vector, _stream, _mr);
+    initial_str_offsets = cudf::detail::make_device_uvector(host_offsets_vector, _stream, _mr);
     chunk_nested_str_data.host_to_device_async(_stream);
   }
 

--- a/cpp/src/io/parquet/reader_impl_chunking_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_chunking_utils.cu
@@ -715,8 +715,8 @@ rmm::device_uvector<size_t> compute_decompression_scratch_sizes(
     return cudf::io::detail::get_decompression_scratch_size(d);
   });
 
-  rmm::device_uvector<size_t> d_temp_cost = cudf::detail::make_device_uvector_async(
-    temp_cost, stream, cudf::get_current_device_resource_ref());
+  rmm::device_uvector<size_t> d_temp_cost =
+    cudf::detail::make_device_uvector(temp_cost, stream, cudf::get_current_device_resource_ref());
 
   std::array codecs{compression_type::BROTLI,
                     compression_type::GZIP,

--- a/cpp/src/io/parquet/reader_impl_preprocess_utils.cu
+++ b/cpp/src/io/parquet/reader_impl_preprocess_utils.cu
@@ -327,6 +327,7 @@ void fill_in_page_info(host_span<ColumnChunkDesc> chunks,
                    iter,
                    iter + num_pages,
                    copy_page_info{d_page_indexes, pages});
+  stream.synchronize();  // ensures the page_indexes is not destroyed before the copy is completed
 }
 
 std::string encoding_to_string(Encoding encoding)

--- a/cpp/src/io/parquet/stats_filter_helpers.hpp
+++ b/cpp/src/io/parquet/stats_filter_helpers.hpp
@@ -250,6 +250,7 @@ class stats_caster_base {
       auto d_chars   = cudf::detail::make_device_uvector_async(host_chars, stream, mr);
       auto d_offsets = cudf::detail::make_device_uvector_async(offsets, stream, mr);
       auto d_sizes   = cudf::detail::make_device_uvector_async(sizes, stream, mr);
+      stream.synchronize();  // ensures the vectors are not destroyed before the copy is completed
       return {std::move(d_chars), std::move(d_offsets), std::move(d_sizes)};
     }
 

--- a/cpp/src/jit/helpers.hpp
+++ b/cpp/src/jit/helpers.hpp
@@ -67,7 +67,7 @@ column_views_to_device(std::span<ColumnView const> views,
   }
 
   rmm::device_uvector<DeviceView> device_array{handles.size(), stream, mr};
-  cudf::detail::cuda_memcpy_async<DeviceView>(device_array, host_array, stream);
+  cudf::detail::cuda_memcpy<DeviceView>(device_array, host_array, stream);
 
   return std::make_tuple(std::move(handles), std::move(device_array));
 }

--- a/cpp/src/join/sort_merge_join.cu
+++ b/cpp/src/join/sort_merge_join.cu
@@ -903,6 +903,7 @@ sort_merge_join::left_join(table_view const& left,
         sizes[1]   = preprocessed_right_indices->size();
 
         batched_copy(input_iterators.begin(), output_iterators.begin(), sizes.begin(), 2, stream);
+        stream.synchronize();  // ensures the vectors are not destroyed before the copy is completed
       }
 
       // Append filtered null rows with JoinNoMatch for right side

--- a/cpp/src/reshape/table_to_array.cu
+++ b/cpp/src/reshape/table_to_array.cu
@@ -67,6 +67,7 @@ void table_to_array_impl(table_view const& input,
 
   cudf::detail::batched_memcpy_async(
     d_srcs.begin(), d_dsts.begin(), sizes, num_columns, stream.value());
+  stream.synchronize();  // ensures h_srcs and h_dsts are not destroyed before the copy is done
 }
 
 struct table_to_array_dispatcher {

--- a/cpp/src/strings/convert/convert_datetime.cu
+++ b/cpp/src/strings/convert/convert_datetime.cu
@@ -154,8 +154,8 @@ struct format_compiler {
     }
 
     // copy format_items to device memory
-    d_items = cudf::detail::make_device_uvector_async(
-      items, stream, cudf::get_current_device_resource_ref());
+    d_items =
+      cudf::detail::make_device_uvector(items, stream, cudf::get_current_device_resource_ref());
   }
 
   device_span<format_item const> format_items() { return device_span<format_item const>(d_items); }

--- a/cpp/src/strings/filter_chars.cu
+++ b/cpp/src/strings/filter_chars.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -123,8 +123,8 @@ std::unique_ptr<column> filter_characters(
     characters_to_filter.begin(), characters_to_filter.end(), htable.begin(), [](auto entry) {
       return char_range{entry.first, entry.second};
     });
-  rmm::device_uvector<char_range> table = cudf::detail::make_device_uvector_async(
-    htable, stream, cudf::get_current_device_resource_ref());
+  rmm::device_uvector<char_range> table =
+    cudf::detail::make_device_uvector(htable, stream, cudf::get_current_device_resource_ref());
 
   auto d_strings = column_device_view::create(strings.parent(), stream);
 

--- a/cpp/src/strings/regex/regexec.cpp
+++ b/cpp/src/strings/regex/regexec.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.  All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.  All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -106,7 +106,7 @@ std::unique_ptr<reprog_device, std::function<void(reprog_device*)>> reprog_devic
   d_prog->_prog_size = memsize + sizeof(reprog_device);
 
   // copy flat prog to device memory
-  cudf::detail::cuda_memcpy_async<u_char>(*d_buffer, h_buffer, stream);
+  cudf::detail::cuda_memcpy<u_char>(*d_buffer, h_buffer, stream);
 
   // build deleter to cleanup device memory
   auto deleter = [d_buffer](reprog_device* t) {

--- a/cpp/src/strings/replace/backref_re.cu
+++ b/cpp/src/strings/replace/backref_re.cu
@@ -108,7 +108,7 @@ std::unique_ptr<column> replace_with_backrefs(strings_column_view const& input,
   // parse the repl string for back-ref indicators
   auto group_count = std::min(99, d_prog->group_counts());  // group count should NOT exceed 99
   auto const parse_result                    = parse_backrefs(replacement, group_count);
-  rmm::device_uvector<backref_type> backrefs = cudf::detail::make_device_uvector_async(
+  rmm::device_uvector<backref_type> backrefs = cudf::detail::make_device_uvector(
     parse_result.second, stream, cudf::get_current_device_resource_ref());
   string_scalar repl_scalar(
     parse_result.first, true, stream, cudf::get_current_device_resource_ref());

--- a/cpp/src/strings/replace/multi_re.cu
+++ b/cpp/src/strings/replace/multi_re.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -171,7 +171,7 @@ std::unique_ptr<column> replace_re(strings_column_view const& input,
                    return *prog;
                  });
   auto d_progs =
-    cudf::detail::make_device_uvector_async(progs, stream, cudf::get_current_device_resource_ref());
+    cudf::detail::make_device_uvector(progs, stream, cudf::get_current_device_resource_ref());
 
   auto const d_strings = column_device_view::create(input.parent(), stream);
   auto const d_repls   = column_device_view::create(replacements.parent(), stream);

--- a/cpp/src/strings/search/contains_multiple.cu
+++ b/cpp/src/strings/search/contains_multiple.cu
@@ -244,7 +244,7 @@ std::unique_ptr<table> contains_multiple(strings_column_view const& input,
       });
     auto host_results_pointers =
       std::vector<bool*>(host_results_pointer_iter, host_results_pointer_iter + results.size());
-    return cudf::detail::make_device_uvector_async(host_results_pointers, stream, mr);
+    return cudf::detail::make_device_uvector(host_results_pointers, stream, mr);
   }();
 
   constexpr cudf::thread_index_type block_size = 256;

--- a/cpp/src/strings/translate.cu
+++ b/cpp/src/strings/translate.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -96,8 +96,8 @@ std::unique_ptr<column> translate(strings_column_view const& strings,
     return lhs.first < rhs.first;
   });
   // copy translate table to device memory
-  rmm::device_uvector<translate_table> table = cudf::detail::make_device_uvector_async(
-    htable, stream, cudf::get_current_device_resource_ref());
+  rmm::device_uvector<translate_table> table =
+    cudf::detail::make_device_uvector(htable, stream, cudf::get_current_device_resource_ref());
 
   auto d_strings = column_device_view::create(strings.parent(), stream);
 

--- a/cpp/src/transform/transform.cu
+++ b/cpp/src/transform/transform.cu
@@ -314,7 +314,7 @@ auto to_args(std::span<input_column_view const> inputs,
       out);
   }
 
-  auto d_args = detail::make_device_uvector_async(h_args, stream, mr);
+  auto d_args = detail::make_device_uvector(h_args, stream, mr);
 
   return std::make_tuple(std::move(d_args), std::move(handles));
 }


### PR DESCRIPTION
## Description
Fixes several use-after-free potential issues where host/device memory are copied and the source may be freed before the async copy has finished.

Follow on to #22321 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
