### PR TITLE
cudf-polars: add `RayEngine._reset()`

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
@@ -136,6 +136,18 @@ def evaluate_pipeline_ray_mode(
     return pl.concat(dfs), metadata_collector or None
 
 
+def _build_mr(
+    memory_resource_config: MemoryResourceConfig | None,
+) -> RmmResourceAdaptor:
+    """Construct a new ``RmmResourceAdaptor`` from a memory-resource config."""
+    base_mr = (
+        memory_resource_config.create_memory_resource()
+        if memory_resource_config is not None
+        else rmm.mr.CudaAsyncMemoryResource()
+    )
+    return RmmResourceAdaptor(base_mr)
+
+
 @ray.remote(
     max_restarts=0,
     max_task_retries=0,
@@ -181,12 +193,10 @@ class RankActor:
         memory_resource_config: MemoryResourceConfig | None,
     ) -> None:
         bind_to_gpu(hardware_binding)
-        base_mr = (
-            memory_resource_config.create_memory_resource()
-            if memory_resource_config is not None
-            else rmm.mr.CudaAsyncMemoryResource()
+        self._memory_resource_config: MemoryResourceConfig | None = (
+            memory_resource_config
         )
-        self._mr = RmmResourceAdaptor(base_mr)
+        self._mr = _build_mr(self._memory_resource_config)
         self._rapidsmpf_options: Options = Options.deserialize(
             rapidsmpf_options_as_bytes
         )
@@ -250,6 +260,50 @@ class RankActor:
         )
         # Set the current RMM device resource so all temporary allocations
         # in libcudf also use the same memory resource.
+        rmm.mr.set_current_device_resource(self._ctx.br().device_mr)
+
+    def reset(
+        self,
+        *,
+        rapidsmpf_options_as_bytes: bytes,
+        memory_resource_config: MemoryResourceConfig | None,
+    ) -> None:
+        """
+        Rebuild the streaming Context and RMM resource with new options.
+
+        Keeps the UCXX communicator and Python thread-pool executor alive, replacing
+        only the rapidsmpf :class:`Context` and the :class:`RmmResourceAdaptor`. Used
+        by :meth:`RayEngine._reset` to amortize actor startup and UCX bootstrap costs
+        across engines that differ only in streaming options.
+
+        The memory resource is rebuilt from ``memory_resource_config``, dropping
+        any accumulated pool memory. Pass the same value to keep the configuration
+        stable, or a different one to replace it. ``None`` creates a fresh
+        ``rmm.mr.CudaAsyncMemoryResource``.
+
+        Must be called collectively on all actors. A barrier ensures no rank tears
+        down its Context while peers may still be using it.
+
+        Parameters
+        ----------
+        rapidsmpf_options_as_bytes
+            Serialized :class:`Options` to install.
+        memory_resource_config
+            Memory-resource configuration to apply.
+        """
+        if self._ctx is None:
+            raise RuntimeError("reset() requires setup_worker() to have run")
+        assert self._comm is not None
+        # Collective: all ranks idle before any rank tears down its Context.
+        barrier(self._comm)
+        self._ctx.shutdown()
+        self._ctx = None
+        self._memory_resource_config = memory_resource_config
+        self._mr = _build_mr(self._memory_resource_config)
+        self._rapidsmpf_options = Options.deserialize(rapidsmpf_options_as_bytes)
+        self._ctx = Context.from_options(
+            self._comm.logger, self._mr, self._rapidsmpf_options
+        )
         rmm.mr.set_current_device_resource(self._ctx.br().device_mr)
 
     def shutdown(self) -> None:
@@ -578,6 +632,93 @@ class RayEngine(StreamingEngine):
             exit_stack.close()
             raise
 
+    def _reset(
+        self,
+        *,
+        rapidsmpf_options: Options | None = None,
+        executor_options: dict[str, Any] | None = None,
+        engine_options: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Reset the engine with new options.
+
+        Fast path for consecutive ``RayEngine`` uses that differ only in
+        streaming options. Avoids Ray actor startup and UCX bootstrap.
+
+        Replaces engine state in full, similar to :meth:`__init__`.
+        ``StreamingEngine`` revalidates invariants on each reset, so callers
+        must pass required options (for example, ``allow_gpu_sharing=True``
+        when ``num_ranks > 1``).
+
+        The following inputs are fixed at construction time and cannot change:
+          - ``num_ranks``
+          - ``num_py_executors``
+          - ``hardware_binding``
+          - ``ray_init_options``
+
+        Parameters
+        ----------
+        rapidsmpf_options
+            New :class:`Options` for each actor's ``Context``. Defaults to
+            ``Options(get_environment_variables())`` if ``None``.
+        executor_options
+            Polars ``GPUEngine`` executor options. ``None`` is treated as
+            an empty dict.
+        engine_options
+            Polars ``GPUEngine`` options. ``memory_resource_config`` is
+            forwarded to actors. ``None`` is treated as an empty dict.
+        """
+        if self._rank_actors is None:
+            raise RuntimeError("Cannot reset a shut-down engine")
+
+        executor_options = executor_options or {}
+        engine_options = engine_options or {}
+        check_reserved_keys(executor_options, engine_options)
+
+        mr_config: MemoryResourceConfig | None = engine_options.get(
+            "memory_resource_config", None
+        )
+
+        rapidsmpf_options = (
+            rapidsmpf_options
+            if rapidsmpf_options is not None
+            else Options(get_environment_variables())
+        )
+        rapidsmpf_options.insert_if_absent({"num_streaming_threads": "4"})
+        rapidsmpf_options_as_bytes = rapidsmpf_options.serialize()
+
+        # Reset all actor Contexts collectively. ``ray.get`` blocks until
+        # every actor's reset returns; the per-actor barrier inside
+        # :meth:`RankActor.reset` synchronizes the teardown across ranks.
+        ray.get(
+            [
+                rank.reset.remote(
+                    rapidsmpf_options_as_bytes=rapidsmpf_options_as_bytes,
+                    memory_resource_config=mr_config,
+                )
+                for rank in self._rank_actors
+            ]
+        )
+
+        # Re-run ``StreamingEngine.__init__`` on the existing instance to
+        # reconfigure the polars ``GPUEngine`` layer (``self.config``,
+        # ``self.device``, etc.) with the new options. Pass the existing
+        # ``self._exit_stack`` so any registered shutdown callbacks
+        # (e.g. ``ray.shutdown`` if this engine bootstrapped Ray itself)
+        # remain registered.
+        StreamingEngine.__init__(
+            self,
+            nranks=len(self._rank_actors),
+            executor_options={
+                **executor_options,
+                "runtime": "rapidsmpf",
+                "cluster": "ray",
+                "ray_context": RayContext(self._rank_actors),
+            },
+            engine_options=engine_options,
+            exit_stack=self._exit_stack,
+        )
+
     @classmethod
     def from_options(
         cls,
@@ -680,6 +821,12 @@ class RayEngine(StreamingEngine):
             return  # already shut down; idempotent
         exceptions: list[Exception] = []
         try:
+            # If Ray is no longer initialized (for example, if ``ray.shutdown()`` was
+            # called before ``RayEngine.shutdown()``), the actors are gone as well.
+            # Calling ``.remote()`` in this state would trigger Ray's ``auto_init_hook``
+            # and start a new cluster.
+            if not ray.is_initialized():
+                return
             refs = [a.shutdown.remote() for a in self._rank_actors]
             for ref in refs:
                 try:

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
@@ -675,6 +675,20 @@ class RayEngine(StreamingEngine):
         engine_options = engine_options or {}
         check_reserved_keys(executor_options, engine_options)
 
+        # Reject keys that cannot be changed.
+        _disallowed_exec = {"num_py_executors"} & executor_options.keys()
+        if _disallowed_exec:
+            raise ValueError(
+                f"executor_options keys {sorted(_disallowed_exec)} cannot be "
+                "changed via _reset(). Construct a fresh RayEngine instead."
+            )
+        _disallowed_engine = {"hardware_binding"} & engine_options.keys()
+        if _disallowed_engine:
+            raise ValueError(
+                f"engine_options keys {sorted(_disallowed_engine)} cannot be "
+                "changed via _reset(). Construct a fresh RayEngine instead."
+            )
+
         mr_config: MemoryResourceConfig | None = engine_options.get(
             "memory_resource_config", None
         )

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
@@ -136,18 +136,6 @@ def evaluate_pipeline_ray_mode(
     return pl.concat(dfs), metadata_collector or None
 
 
-def _build_mr(
-    memory_resource_config: MemoryResourceConfig | None,
-) -> RmmResourceAdaptor:
-    """Construct a new ``RmmResourceAdaptor`` from a memory-resource config."""
-    base_mr = (
-        memory_resource_config.create_memory_resource()
-        if memory_resource_config is not None
-        else rmm.mr.CudaAsyncMemoryResource()
-    )
-    return RmmResourceAdaptor(base_mr)
-
-
 @ray.remote(
     max_restarts=0,
     max_task_retries=0,
@@ -193,10 +181,12 @@ class RankActor:
         memory_resource_config: MemoryResourceConfig | None,
     ) -> None:
         bind_to_gpu(hardware_binding)
-        self._memory_resource_config: MemoryResourceConfig | None = (
-            memory_resource_config
+        base_mr = (
+            memory_resource_config.create_memory_resource()
+            if memory_resource_config is not None
+            else rmm.mr.CudaAsyncMemoryResource()
         )
-        self._mr = _build_mr(self._memory_resource_config)
+        self._mr = RmmResourceAdaptor(base_mr)
         self._rapidsmpf_options: Options = Options.deserialize(
             rapidsmpf_options_as_bytes
         )
@@ -262,34 +252,29 @@ class RankActor:
         # in libcudf also use the same memory resource.
         rmm.mr.set_current_device_resource(self._ctx.br().device_mr)
 
-    def reset(
-        self,
-        *,
-        rapidsmpf_options_as_bytes: bytes,
-        memory_resource_config: MemoryResourceConfig | None,
-    ) -> None:
+    def reset(self, *, rapidsmpf_options_as_bytes: bytes) -> None:
         """
-        Rebuild the streaming Context and RMM resource with new options.
+        Rebuild the streaming Context with new options.
 
-        Keeps the UCXX communicator and Python thread-pool executor alive, replacing
-        only the rapidsmpf :class:`Context` and the :class:`RmmResourceAdaptor`. Used
-        by :meth:`RayEngine._reset` to amortize actor startup and UCX bootstrap costs
-        across engines that differ only in streaming options.
+        Keeps the UCXX communicator, the :class:`RmmResourceAdaptor`,
+        and the Python thread-pool executor alive — only the rapidsmpf
+        :class:`Context` is replaced. Used by :meth:`RayEngine._reset`
+        to amortize actor startup and UCX bootstrap costs across engines
+        that differ only in streaming options.
 
-        The memory resource is rebuilt from ``memory_resource_config``, dropping
-        any accumulated pool memory. Pass the same value to keep the configuration
-        stable, or a different one to replace it. ``None`` creates a fresh
-        ``rmm.mr.CudaAsyncMemoryResource``.
+        The RMM resource is *not* rebuilt: UCX maps CUDA IPC buffers
+        against it (notably for pool memory resources) and never
+        releases those mappings during the application lifetime, so a
+        rebuilt MR would silently leak pool memory. Construct a fresh
+        :class:`RayEngine` if you need to swap the memory resource.
 
-        Must be called collectively on all actors. A barrier ensures no rank tears
-        down its Context while peers may still be using it.
+        Must be called collectively on all actors. A barrier ensures no
+        rank tears down its Context while peers may still be using it.
 
         Parameters
         ----------
         rapidsmpf_options_as_bytes
             Serialized :class:`Options` to install.
-        memory_resource_config
-            Memory-resource configuration to apply.
         """
         if self._ctx is None:
             raise RuntimeError("reset() requires setup_worker() to have run")
@@ -298,8 +283,6 @@ class RankActor:
         barrier(self._comm)
         self._ctx.shutdown()
         self._ctx = None
-        self._memory_resource_config = memory_resource_config
-        self._mr = _build_mr(self._memory_resource_config)
         self._rapidsmpf_options = Options.deserialize(rapidsmpf_options_as_bytes)
         self._ctx = Context.from_options(
             self._comm.logger, self._mr, self._rapidsmpf_options
@@ -652,8 +635,12 @@ class RayEngine(StreamingEngine):
 
         The following inputs are fixed at construction time and cannot change:
           - ``num_ranks``
-          - ``num_py_executors``
-          - ``hardware_binding``
+          - ``num_py_executors`` (in ``executor_options``)
+          - ``hardware_binding`` (in ``engine_options``)
+          - ``memory_resource_config`` (in ``engine_options``) — the RMM
+            resource is kept alive across resets because UCX never
+            releases CUDA IPC buffer mappings, so a rebuilt MR would
+            silently leak pool memory
           - ``ray_init_options``
 
         Parameters
@@ -665,8 +652,8 @@ class RayEngine(StreamingEngine):
             Polars ``GPUEngine`` executor options. ``None`` is treated as
             an empty dict.
         engine_options
-            Polars ``GPUEngine`` options. ``memory_resource_config`` is
-            forwarded to actors. ``None`` is treated as an empty dict.
+            Polars ``GPUEngine`` options. ``None`` is treated as an empty
+            dict.
         """
         if self._rank_actors is None:
             raise RuntimeError("Cannot reset a shut-down engine")
@@ -682,16 +669,15 @@ class RayEngine(StreamingEngine):
                 f"executor_options keys {sorted(_disallowed_exec)} cannot be "
                 "changed via _reset(). Construct a fresh RayEngine instead."
             )
-        _disallowed_engine = {"hardware_binding"} & engine_options.keys()
+        _disallowed_engine = {
+            "hardware_binding",
+            "memory_resource_config",
+        } & engine_options.keys()
         if _disallowed_engine:
             raise ValueError(
                 f"engine_options keys {sorted(_disallowed_engine)} cannot be "
                 "changed via _reset(). Construct a fresh RayEngine instead."
             )
-
-        mr_config: MemoryResourceConfig | None = engine_options.get(
-            "memory_resource_config", None
-        )
 
         rapidsmpf_options = (
             rapidsmpf_options
@@ -704,11 +690,12 @@ class RayEngine(StreamingEngine):
         # Reset all actor Contexts collectively. ``ray.get`` blocks until
         # every actor's reset returns; the per-actor barrier inside
         # :meth:`RankActor.reset` synchronizes the teardown across ranks.
+        # Each actor rebuilds its MR from the ``memory_resource_config``
+        # it was constructed with — see :meth:`RankActor.reset`.
         ray.get(
             [
                 rank.reset.remote(
                     rapidsmpf_options_as_bytes=rapidsmpf_options_as_bytes,
-                    memory_resource_config=mr_config,
                 )
                 for rank in self._rank_actors
             ]

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
@@ -287,7 +287,6 @@ class RankActor:
         self._ctx = Context.from_options(
             self._comm.logger, self._mr, self._rapidsmpf_options
         )
-        rmm.mr.set_current_device_resource(self._ctx.br().device_mr)
 
     def shutdown(self) -> None:
         """
@@ -687,8 +686,8 @@ class RayEngine(StreamingEngine):
         # Reset all actor Contexts collectively. ``ray.get`` blocks until
         # every actor's reset returns; the per-actor barrier inside
         # :meth:`RankActor.reset` synchronizes the teardown across ranks.
-        # Each actor rebuilds its MR from the ``memory_resource_config``
-        # it was constructed with — see :meth:`RankActor.reset`.
+        # The per-actor RMM resource is kept alive across resets — see
+        # :meth:`RankActor.reset`.
         ray.get(
             [
                 rank.reset.remote(

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/frontend/ray.py
@@ -637,10 +637,7 @@ class RayEngine(StreamingEngine):
           - ``num_ranks``
           - ``num_py_executors`` (in ``executor_options``)
           - ``hardware_binding`` (in ``engine_options``)
-          - ``memory_resource_config`` (in ``engine_options``) — the RMM
-            resource is kept alive across resets because UCX never
-            releases CUDA IPC buffer mappings, so a rebuilt MR would
-            silently leak pool memory
+          - ``memory_resource_config`` (in ``engine_options``)
           - ``ray_init_options``
 
         Parameters

--- a/python/cudf_polars/tests/experimental/test_ray.py
+++ b/python/cudf_polars/tests/experimental/test_ray.py
@@ -313,6 +313,13 @@ def test_reset_rejects_construction_time_engine_options(
                 "hardware_binding": HardwareBindingPolicy(enabled=False),
             },
         )
+    with pytest.raises(ValueError, match="memory_resource_config"):
+        reset_engine._reset(
+            engine_options={
+                "allow_gpu_sharing": True,
+                "memory_resource_config": None,
+            },
+        )
 
 
 def test_shutdown_skips_when_ray_not_initialized() -> None:

--- a/python/cudf_polars/tests/experimental/test_ray.py
+++ b/python/cudf_polars/tests/experimental/test_ray.py
@@ -287,6 +287,34 @@ def test_reset_after_shutdown_raises() -> None:
         engine._reset()
 
 
+def test_reset_rejects_construction_time_executor_options(
+    reset_engine: RayEngine,
+) -> None:
+    """``_reset`` rejects ``executor_options`` keys read at actor construction."""
+    with pytest.raises(ValueError, match="num_py_executors"):
+        reset_engine._reset(
+            executor_options={"num_py_executors": 4},
+            engine_options={"allow_gpu_sharing": True},
+        )
+
+
+def test_reset_rejects_construction_time_engine_options(
+    reset_engine: RayEngine,
+) -> None:
+    """``_reset`` rejects ``engine_options`` keys read at actor construction."""
+    from cudf_polars.experimental.rapidsmpf.frontend.hardware_binding import (
+        HardwareBindingPolicy,
+    )
+
+    with pytest.raises(ValueError, match="hardware_binding"):
+        reset_engine._reset(
+            engine_options={
+                "allow_gpu_sharing": True,
+                "hardware_binding": HardwareBindingPolicy(enabled=False),
+            },
+        )
+
+
 def test_shutdown_skips_when_ray_not_initialized() -> None:
     """``shutdown`` short-circuits if ``ray.is_initialized()`` is ``False``."""
     engine = RayEngine(

--- a/python/cudf_polars/tests/experimental/test_ray.py
+++ b/python/cudf_polars/tests/experimental/test_ray.py
@@ -21,6 +21,8 @@ from cudf_polars.experimental.rapidsmpf.frontend.ray import RayEngine  # noqa: E
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+NUM_RANKS = 2
+
 
 @pytest.fixture(scope="module")
 def engine() -> Iterator[RayEngine]:
@@ -29,6 +31,8 @@ def engine() -> Iterator[RayEngine]:
         # Use a small partition size so tests exercise the multi-partition
         # code path deterministically, regardless of input size.
         executor_options={"max_rows_per_partition": 10},
+        engine_options={"allow_gpu_sharing": True},
+        num_ranks=NUM_RANKS,
         ray_init_options={"include_dashboard": False},
     ) as engine:
         yield engine
@@ -76,9 +80,9 @@ def test_raises_inside_rrun() -> None:
 def test_num_ranks_requires_allow_gpu_sharing() -> None:
     """num_ranks requires engine_options['allow_gpu_sharing']=True."""
     with pytest.raises(ValueError, match="allow_gpu_sharing"):
-        RayEngine(num_ranks=2)
+        RayEngine(num_ranks=NUM_RANKS)
     with pytest.raises(ValueError, match="allow_gpu_sharing"):
-        RayEngine(num_ranks=2, engine_options={"allow_gpu_sharing": False})
+        RayEngine(num_ranks=NUM_RANKS, engine_options={"allow_gpu_sharing": False})
 
 
 def test_num_ranks_must_be_positive() -> None:
@@ -206,3 +210,98 @@ def test_num_ranks_oversubscribes() -> None:
         assert len(engine.rank_actors) == n
         result = pl.LazyFrame({"a": [1, 2, 3, 4]}).collect(engine=engine)
         assert sorted(result["a"].to_list()) == [1, 2, 3, 4]
+
+
+@pytest.fixture(scope="module")
+def reset_engine() -> Iterator[RayEngine]:
+    """Module-scoped engine for reset tests — independent of ``engine``.
+
+    These tests exercise :meth:`RayEngine._reset` (which mutates the
+    engine in-place) and the shutdown guard. A dedicated fixture keeps
+    those mutations from leaking into the other tests.
+    """
+    with RayEngine(
+        executor_options={"max_rows_per_partition": 10},
+        engine_options={"allow_gpu_sharing": True},
+        num_ranks=NUM_RANKS,
+        ray_init_options={"include_dashboard": False},
+    ) as e:
+        yield e
+
+
+def test_reset_keeps_actors_alive(reset_engine: RayEngine) -> None:
+    """``_reset`` must not respawn rank actor processes."""
+    actors_before = list(reset_engine.rank_actors)
+    pids_before = reset_engine._run(os.getpid)
+
+    reset_engine._reset(
+        executor_options={"max_rows_per_partition": 7},
+        engine_options={"allow_gpu_sharing": True},
+    )
+
+    actors_after = list(reset_engine.rank_actors)
+    pids_after = reset_engine._run(os.getpid)
+
+    # The Python ``ActorHandle`` objects are the same instances …
+    assert all(a is b for a, b in zip(actors_before, actors_after, strict=True))
+    # … and the actors are running in the same OS processes.
+    assert pids_before == pids_after
+
+
+def test_reset_updates_executor_options(reset_engine: RayEngine) -> None:
+    """``_reset`` updates the polars-layer config to the new options."""
+    reset_engine._reset(
+        executor_options={"max_rows_per_partition": 42},
+        engine_options={"allow_gpu_sharing": True},
+    )
+
+    opts = reset_engine.config["executor_options"]
+    assert opts["max_rows_per_partition"] == 42
+    # Reserved keys are still injected by ``_reset``.
+    assert opts["runtime"] == "rapidsmpf"
+    assert opts["cluster"] == "ray"
+    assert isinstance(opts["ray_context"], RayContext)
+    assert opts["ray_context"].rank_actors == reset_engine.rank_actors
+
+
+def test_reset_collects_after_options_change(reset_engine: RayEngine) -> None:
+    """The engine still drives a real query after ``_reset``."""
+    reset_engine._reset(
+        executor_options={"max_rows_per_partition": 3},
+        engine_options={"allow_gpu_sharing": True},
+    )
+    result = pl.LazyFrame({"a": [1, 2, 3, 4, 5]}).collect(engine=reset_engine)
+    assert sorted(result["a"].to_list()) == [1, 2, 3, 4, 5]
+
+
+def test_reset_after_shutdown_raises() -> None:
+    """``_reset`` after ``shutdown`` raises ``RuntimeError``."""
+    engine = RayEngine(
+        executor_options={"max_rows_per_partition": 10},
+        engine_options={"allow_gpu_sharing": True},
+        num_ranks=NUM_RANKS,
+        ray_init_options={"include_dashboard": False},
+    )
+    engine.shutdown()
+    with pytest.raises(RuntimeError, match="shut-down"):
+        engine._reset()
+
+
+def test_shutdown_skips_when_ray_not_initialized() -> None:
+    """``shutdown`` short-circuits if ``ray.is_initialized()`` is ``False``."""
+    engine = RayEngine(
+        executor_options={"max_rows_per_partition": 10},
+        engine_options={"allow_gpu_sharing": True},
+        num_ranks=NUM_RANKS,
+        ray_init_options={"include_dashboard": False},
+    )
+    try:
+        with patch("ray.is_initialized", return_value=False):
+            engine.shutdown()  # must not raise, must not auto-init
+        # The exit stack is closed; rank_actors is cleared.
+        assert engine._rank_actors is None
+    finally:
+        # Defensive: if the guard somehow didn't fire, make sure the
+        # actors are released so the next test's fixture isn't blocked.
+        if engine._rank_actors is not None:
+            engine.shutdown()


### PR DESCRIPTION
This PR introduces `RayEngine._reset()`, which allows reusing existing actor processes while updating per-rank state.

Constructing a `RayEngine` is expensive. Each instance spawns one Ray actor per rank (Python startup, imports, CUDA context creation) and bootstraps a UCXX communicator. In contrast:

* `SPMDEngine` reuses a session-scoped communicator, so construction is cheap.
* `DaskEngine` connects to long-lived workers, so construction is cheap.
* `RayEngine` always creates fresh actors, there is no reuse.

This is not an issue in production, where a single engine is typically reused across many queries. It is costly in tests, where we parametrize over many `StreamingOptions` variants and rebuild the engine repeatedly, paying the full startup cost each time.

With this change, test suite runtime with `RayEngine` **drops from hours to minutes!**
