### PR TITLE
Fix CCCL compilation errors

### DIFF
--- a/cpp/include/cudf/detail/row_operator/lexicographic.cuh
+++ b/cpp/include/cudf/detail/row_operator/lexicographic.cuh
@@ -645,11 +645,6 @@ struct less_comparator
     : weak_ordering_comparator_impl<Comparator, cudf::detail::weak_ordering::LESS>{comparator}
   {
   }
-
-  less_comparator<Comparator>& operator=(less_comparator<Comparator> const& other)
-  {
-    return *this;
-  };
 };
 
 /**

--- a/cpp/include/cudf/detail/row_operator/lexicographic.cuh
+++ b/cpp/include/cudf/detail/row_operator/lexicographic.cuh
@@ -645,6 +645,11 @@ struct less_comparator
     : weak_ordering_comparator_impl<Comparator, cudf::detail::weak_ordering::LESS>{comparator}
   {
   }
+
+  less_comparator<Comparator>& operator=(less_comparator<Comparator> const& other)
+  {
+    return *this;
+  };
 };
 
 /**

--- a/cpp/include/cudf/detail/row_operator/lexicographic.cuh
+++ b/cpp/include/cudf/detail/row_operator/lexicographic.cuh
@@ -588,15 +588,15 @@ class device_row_comparator {
   }
 
  private:
-  table_device_view const _lhs;
-  table_device_view const _rhs;
-  device_span<detail::dremel_device_view const> const _l_dremel;
-  device_span<detail::dremel_device_view const> const _r_dremel;
-  Nullate const _check_nulls;
-  cuda::std::optional<device_span<int const>> const _depth;
-  cuda::std::optional<device_span<order const>> const _column_order;
-  cuda::std::optional<device_span<null_order const>> const _null_precedence;
-  PhysicalElementComparator const _comparator;
+  table_device_view _lhs;
+  table_device_view _rhs;
+  device_span<detail::dremel_device_view const> _l_dremel;
+  device_span<detail::dremel_device_view const> _r_dremel;
+  Nullate _check_nulls;
+  cuda::std::optional<device_span<int const>> _depth;
+  cuda::std::optional<device_span<order const>> _column_order;
+  cuda::std::optional<device_span<null_order const>> _null_precedence;
+  PhysicalElementComparator _comparator;
 };
 
 /**
@@ -624,7 +624,7 @@ struct weak_ordering_comparator_impl {
     cudf::detail::weak_ordering const result = comparator(lhs_index, rhs_index);
     return ((result == values) || ...);
   }
-  Comparator const comparator;
+  Comparator comparator;
 };
 
 /**
@@ -645,11 +645,6 @@ struct less_comparator
     : weak_ordering_comparator_impl<Comparator, cudf::detail::weak_ordering::LESS>{comparator}
   {
   }
-
-  less_comparator<Comparator>& operator=(less_comparator<Comparator> const& other)
-  {
-    return *this;
-  };
 };
 
 /**
@@ -1042,7 +1037,7 @@ struct strong_index_comparator_adapter {
     return cudf::detail::weak_ordering::EQUIVALENT;
   }
 
-  Comparator const comparator;
+  Comparator comparator;
 };
 // @endcond
 

--- a/cpp/src/io/orc/writer_impl.cu
+++ b/cpp/src/io/orc/writer_impl.cu
@@ -2299,16 +2299,21 @@ stripe_dictionaries build_dictionaries(orc_table_view& orc_table,
           std::move(dict_order_owner)};
 }
 
+struct stripe_stream_size_less {
+  __device__ bool operator()(stripe_stream const& lhs, stripe_stream const& rhs) const
+  {
+    return lhs.stream_size < rhs.stream_size;
+  }
+};
+
 [[nodiscard]] uint32_t find_largest_stream_size(device_2dspan<stripe_stream const> ss,
                                                 rmm::cuda_stream_view stream)
 {
-  auto const longest_stream = thrust::max_element(
-    rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-    ss.data(),
-    ss.data() + ss.count(),
-    cuda::proclaim_return_type<bool>([] __device__(auto const& lhs, auto const& rhs) {
-      return lhs.stream_size < rhs.stream_size;
-    }));
+  auto const longest_stream =
+    thrust::max_element(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        ss.data(),
+                        ss.data() + ss.count(),
+                        stripe_stream_size_less{});
 
   auto const h_longest_stream =
     cudf::detail::make_host_vector(device_span<stripe_stream const>{longest_stream, 1}, stream);

--- a/cpp/src/join/sort_merge_join.cu
+++ b/cpp/src/join/sort_merge_join.cu
@@ -42,7 +42,6 @@
 #include <cuda/std/tuple>
 #include <thrust/binary_search.h>
 #include <thrust/for_each.h>
-#include <thrust/iterator/tabulate_output_iterator.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/unique.h>
@@ -232,16 +231,20 @@ merge<LargerIterator, SmallerIterator>::matches_per_row(rmm::cuda_stream_view st
                       match_counts_it,
                       comparator);
 
-  auto match_counts_update_it =
-    thrust::tabulate_output_iterator([match_counts = match_counts.begin()] __device__(
-                                       size_type idx, size_type val) { match_counts[idx] -= val; });
+  rmm::device_uvector<size_type> lower_bounds(larger_numrows, stream, mr);
   thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       smaller_it,
                       smaller_it + smaller_numrows,
                       cudf::detail::row::rhs_iterator(0),
                       cudf::detail::row::rhs_iterator(0) + larger_numrows,
-                      match_counts_update_it,
+                      lower_bounds.begin(),
                       comparator);
+  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    match_counts.begin(),
+                    match_counts.begin() + larger_numrows,
+                    lower_bounds.begin(),
+                    match_counts.begin(),
+                    thrust::minus<size_type>{});
 
   return std::make_unique<rmm::device_uvector<size_type>>(std::move(match_counts));
 }
@@ -318,16 +321,8 @@ merge<LargerIterator, SmallerIterator>::inner(rmm::cuda_stream_view stream,
   cub::DeviceTransform::Fill(smaller_indices.begin(), smaller_indices.size(), 1, stream.value());
 
   {
-    auto const comparator    = tt_comparator->less<true>(nullate::DYNAMIC{has_nulls});
-    auto smaller_tabulate_it = thrust::tabulate_output_iterator(
-      [nonzero_matches = nonzero_matches.begin(),
-       match_offsets   = match_offsets.begin(),
-       smaller_indices = smaller_indices.begin()] __device__(auto idx, auto lb) {
-        auto const lhs_idx   = nonzero_matches[idx];
-        auto const pos       = match_offsets[lhs_idx];
-        smaller_indices[pos] = lb;
-      });
-    auto smaller_it = cuda::transform_iterator(
+    auto const comparator = tt_comparator->less<true>(nullate::DYNAMIC{has_nulls});
+    auto smaller_it       = cuda::transform_iterator(
       sorted_smaller_order_begin,
       cuda::proclaim_return_type<detail::row::lhs_index_type>(
         [] __device__(size_type idx) { return static_cast<detail::row::lhs_index_type>(idx); }));
@@ -335,13 +330,23 @@ merge<LargerIterator, SmallerIterator>::inner(rmm::cuda_stream_view stream,
       nonzero_matches.begin(),
       cuda::proclaim_return_type<detail::row::rhs_index_type>(
         [] __device__(size_type idx) { return static_cast<detail::row::rhs_index_type>(idx); }));
+    rmm::device_uvector<size_type> lb_positions(nonzero_matches.size(), stream, mr);
     thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         smaller_it,
                         smaller_it + smaller_numrows,
                         larger_it,
                         larger_it + nonzero_matches.size(),
-                        smaller_tabulate_it,
+                        lb_positions.begin(),
                         comparator);
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       thrust::counting_iterator<size_type>(0),
+                       nonzero_matches.size(),
+                       [nonzero_matches = nonzero_matches.begin(),
+                        match_offsets   = match_offsets.begin(),
+                        smaller_indices = smaller_indices.begin(),
+                        lb_positions    = lb_positions.begin()] __device__(size_type idx) {
+                         smaller_indices[match_offsets[nonzero_matches[idx]]] = lb_positions[idx];
+                       });
   }
 
   // Use cub API to handle large arrays (> INT32_MAX)
@@ -468,17 +473,8 @@ merge<LargerIterator, SmallerIterator>::left(rmm::cuda_stream_view stream,
     smaller_indices.begin() + left_join_only_matches, inner_join_matches, 1, stream.value());
 
   {
-    auto const comparator    = tt_comparator->less<true>(nullate::DYNAMIC{has_nulls});
-    auto smaller_tabulate_it = thrust::tabulate_output_iterator(
-      [nonzero_matches = nonzero_matches.begin(),
-       match_offsets   = match_offsets.begin(),
-       smaller_indices = smaller_indices.begin() + left_join_only_matches] __device__(auto idx,
-                                                                                      auto lb) {
-        auto const lhs_idx   = nonzero_matches[idx];
-        auto const pos       = match_offsets[lhs_idx];
-        smaller_indices[pos] = lb;
-      });
-    auto smaller_it = cuda::transform_iterator(
+    auto const comparator = tt_comparator->less<true>(nullate::DYNAMIC{has_nulls});
+    auto smaller_it       = cuda::transform_iterator(
       sorted_smaller_order_begin,
       cuda::proclaim_return_type<detail::row::lhs_index_type>(
         [] __device__(size_type idx) { return static_cast<detail::row::lhs_index_type>(idx); }));
@@ -486,13 +482,23 @@ merge<LargerIterator, SmallerIterator>::left(rmm::cuda_stream_view stream,
       nonzero_matches.begin(),
       cuda::proclaim_return_type<detail::row::rhs_index_type>(
         [] __device__(size_type idx) { return static_cast<detail::row::rhs_index_type>(idx); }));
+    rmm::device_uvector<size_type> lb_positions(nonzero_matches.size(), stream, mr);
     thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         smaller_it,
                         smaller_it + smaller_numrows,
                         larger_it,
                         larger_it + nonzero_matches.size(),
-                        smaller_tabulate_it,
+                        lb_positions.begin(),
                         comparator);
+    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                       thrust::counting_iterator<size_type>(0),
+                       nonzero_matches.size(),
+                       [nonzero_matches = nonzero_matches.begin(),
+                        match_offsets   = match_offsets.begin(),
+                        smaller_indices = smaller_indices.begin() + left_join_only_matches,
+                        lb_positions    = lb_positions.begin()] __device__(size_type idx) {
+                         smaller_indices[match_offsets[nonzero_matches[idx]]] = lb_positions[idx];
+                       });
   }
 
   // Use cub API to handle large arrays (> INT32_MAX)

--- a/cpp/src/reductions/extrema_utils.cuh
+++ b/cpp/src/reductions/extrema_utils.cuh
@@ -34,6 +34,7 @@ struct noinline_adapter_fn {
   noinline_adapter_fn(Functor&& f_) : f{std::forward<Functor>(f_)} {}
   template <typename... Args>
   [[nodiscard]] __attribute__((noinline)) __device__ auto operator()(Args&&... args) const
+    -> decltype(f(std::forward<Args>(args)...))
   {
     return f(std::forward<Args>(args)...);
   }

--- a/cpp/src/reductions/extrema_utils.cuh
+++ b/cpp/src/reductions/extrema_utils.cuh
@@ -38,12 +38,6 @@ struct noinline_adapter_fn {
   {
     return f(std::forward<Args>(args)...);
   }
-
-  noinline_adapter_fn<Functor>& operator=(noinline_adapter_fn<Functor> const& other)
-  {
-    this->f = other.f;
-    return *this;
-  };
 };
 
 /**

--- a/cpp/src/reductions/extrema_utils.cuh
+++ b/cpp/src/reductions/extrema_utils.cuh
@@ -38,6 +38,12 @@ struct noinline_adapter_fn {
   {
     return f(std::forward<Args>(args)...);
   }
+
+  noinline_adapter_fn<Functor>& operator=(noinline_adapter_fn<Functor> const& other)
+  {
+    this->f = other.f;
+    return *this;
+  };
 };
 
 /**


### PR DESCRIPTION
## Description
Fixes cuDF compilation failures exposed by a recent CCCL update.

- Row comparators: make row-comparator wrapper types satisfy CCCL algorithms that now require assignable functors.
- Reductions: update `noinline_adapter_fn` to preserve its callable return type and support assignment.
- Sort-merge join: replace `thrust::tabulate_output_iterator` lower-bound outputs with materialized lower-bound buffers.
- ORC writer: switch the `thrust::max_element` predicate to a named device functor to avoid the problematic proclaimed-return-type path.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
