### PR TITLE
Handle 0-row input in `ContainsAny`, `JsonDecode`, and `JsonEncode`

### DIFF
--- a/ci/run_cudf_polars_experimental_pytests.sh
+++ b/ci/run_cudf_polars_experimental_pytests.sh
@@ -11,10 +11,10 @@ set -euo pipefail
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cudf_polars/
 
 echo "Running the full cudf-polars test suite with both the in-memory and spmd engine"
-timeout 10m python -m pytest --cache-clear "$@" tests --ignore=tests/experimental/legacy
+python -m pytest --cache-clear "$@" tests --ignore=tests/experimental/legacy
 
 echo "Running experimental legacy tests with the 'rapidsmpf' runtime and a 'distributed' cluster"
-timeout 10m python -m pytest --cache-clear "$@" "tests/experimental/legacy" \
+python -m pytest --cache-clear "$@" "tests/experimental/legacy" \
     --executor streaming \
     --cluster distributed \
     --runtime rapidsmpf

--- a/ci/test_cudf_polars_experimental.sh
+++ b/ci/test_cudf_polars_experimental.sh
@@ -51,7 +51,7 @@ trap set_exitcode ERR
 set +e
 
 rapids-logger "Running cudf_polars experimental tests (non-ci-blocking)"
-timeout 15m ./ci/run_cudf_polars_experimental_pytests.sh \
+timeout 30m ./ci/run_cudf_polars_experimental_pytests.sh \
     --no-cov \
     --numprocesses=8 \
     --dist=worksteal \

--- a/python/cudf_polars/cudf_polars/dsl/expressions/string.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/string.py
@@ -21,6 +21,7 @@ from cudf_polars.containers import Column
 from cudf_polars.dsl.expressions.base import ExecutionContext, Expr
 from cudf_polars.dsl.expressions.literal import Literal, LiteralColumn
 from cudf_polars.dsl.utils.reshape import broadcast
+from cudf_polars.utils.dtypes import make_empty_column
 from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_132,
     POLARS_VERSION_LT_136,
@@ -489,6 +490,14 @@ class StringFunction(Expr):
             child, arg = self.children
             plc_column = child.evaluate(df, context=context).obj
             plc_targets = arg.evaluate(df, context=context).obj
+            if plc_column.size() == 0:
+                # contains_multiple launches a kernel with grid_1d sized
+                # against the input rows, which asserts num_blocks > 0.
+                # Skip the kernel call on empty input.
+                return Column(
+                    make_empty_column(self.dtype, df.stream),
+                    dtype=self.dtype,
+                )
             if ascii_case_insensitive:
                 plc_column = plc.strings.case.to_lower(plc_column, stream=df.stream)
                 plc_targets = plc.strings.case.to_lower(plc_targets, stream=df.stream)
@@ -574,6 +583,14 @@ class StringFunction(Expr):
             return Column(plc_column, dtype=self.dtype)
         elif self.name is StringFunction.Name.JsonDecode:
             plc_column = self.children[0].evaluate(df, context=context).obj
+            if plc_column.size() == 0:
+                # read_json_from_string_column raises
+                # "Generated token count exceeds the expected token count"
+                # on empty input. Return a typed empty struct column directly.
+                return Column(
+                    make_empty_column(self.dtype, df.stream),
+                    dtype=self.dtype,
+                )
             plc_table_with_metadata = plc.io.json.read_json_from_string_column(
                 plc_column,
                 plc.Scalar.from_py("\n", stream=df.stream),

--- a/python/cudf_polars/cudf_polars/dsl/expressions/struct.py
+++ b/python/cudf_polars/cudf_polars/dsl/expressions/struct.py
@@ -16,6 +16,7 @@ import pylibcudf as plc
 
 from cudf_polars.containers import Column
 from cudf_polars.dsl.expressions.base import ExecutionContext, Expr
+from cudf_polars.utils.dtypes import make_empty_column
 
 if TYPE_CHECKING:
     from typing import Self
@@ -109,6 +110,14 @@ class StructFunction(Expr):
         elif self.name == StructFunction.Name.JsonEncode:
             # Once https://github.com/rapidsai/cudf/issues/19338 is implemented,
             # we can use do this conversion on host.
+            if column.size == 0:
+                # write_json emits no lines for an empty input, which makes
+                # from_iterable_of_py unable to infer a dtype. Skip the
+                # round-trip and return a typed empty column.
+                return Column(
+                    make_empty_column(self.dtype, df.stream),
+                    dtype=self.dtype,
+                )
             buff = StringIO()
             target = plc.io.SinkInfo([buff])
             table = plc.Table(column.obj.children())

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
@@ -38,6 +38,7 @@ from cudf_polars.dsl.expr import Col, NamedExpr
 from cudf_polars.dsl.ir import Cache, Filter, GroupBy, HStack, Join, Projection, Select
 from cudf_polars.dsl.tracing import Scope
 from cudf_polars.experimental.utils import _concat
+from cudf_polars.utils.dtypes import make_empty_column
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Coroutine, Iterator
@@ -53,7 +54,7 @@ if TYPE_CHECKING:
     from cudf_polars.dsl.ir import IR, IRExecutionContext
     from cudf_polars.experimental.rapidsmpf.dispatch import SubNetGenerator
     from cudf_polars.experimental.rapidsmpf.tracing import ActorTracer
-    from cudf_polars.typing import DataType, Schema
+    from cudf_polars.typing import Schema
 
 
 @contextlib.contextmanager
@@ -863,38 +864,6 @@ def process_children(
     return nodes, channels
 
 
-def _make_empty_column(dtype: DataType, stream: Stream) -> plc.Column:
-    """
-    Create an empty (0-row) column, including for nested types.
-
-    ``plc.column_factories.make_empty_column`` rejects LIST and STRUCT,
-    so we build those by hand with the correct child structure.
-
-    Parameters
-    ----------
-    dtype
-        The cudf-polars DataType (carries child-type metadata for nested types).
-    stream
-        CUDA stream for any device allocations.
-    """
-    if dtype.id() == plc.TypeId.LIST:
-        offsets = plc.Column.from_scalar(
-            plc.Scalar.from_py(0, plc.DataType(plc.TypeId.INT32), stream=stream),
-            1,
-            stream=stream,
-        )
-        child = _make_empty_column(dtype.children[0], stream)
-        return plc.Column(dtype.plc_type, 0, None, None, 0, 0, [offsets, child])
-
-    if dtype.id() == plc.TypeId.STRUCT:
-        children = [
-            _make_empty_column(child_dtype, stream) for child_dtype in dtype.children
-        ]
-        return plc.Column(dtype.plc_type, 0, None, None, 0, 0, children)
-
-    return plc.column_factories.make_empty_column(dtype.plc_type, stream=stream)
-
-
 def empty_table_chunk(ir: IR, context: Context, stream: Stream) -> TableChunk:
     """
     Make an empty table chunk.
@@ -912,7 +881,7 @@ def empty_table_chunk(ir: IR, context: Context, stream: Stream) -> TableChunk:
     -------
     The empty table chunk.
     """
-    empty_columns = [_make_empty_column(dtype, stream) for dtype in ir.schema.values()]
+    empty_columns = [make_empty_column(dtype, stream) for dtype in ir.schema.values()]
     empty_table = plc.Table(empty_columns)
 
     return TableChunk.from_pylibcudf_table(

--- a/python/cudf_polars/cudf_polars/utils/dtypes.py
+++ b/python/cudf_polars/cudf_polars/utils/dtypes.py
@@ -1,9 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """Datatype utilities."""
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pylibcudf as plc
 from pylibcudf.traits import (
@@ -13,10 +15,48 @@ from pylibcudf.traits import (
     is_numeric_not_bool,
 )
 
+if TYPE_CHECKING:
+    from rmm.pylibrmm.stream import Stream
+
+    from cudf_polars.containers import DataType
+
 __all__ = [
     "can_cast",
     "is_order_preserving_cast",
+    "make_empty_column",
 ]
+
+
+def make_empty_column(dtype: DataType, stream: Stream) -> plc.Column:
+    """
+    Create an empty (0-row) column, including for nested types.
+
+    ``plc.column_factories.make_empty_column`` rejects LIST and STRUCT,
+    so we build those by hand with the correct child structure.
+
+    Parameters
+    ----------
+    dtype
+        The cudf-polars DataType (carries child-type metadata for nested types).
+    stream
+        CUDA stream for any device allocations.
+    """
+    if dtype.id() == plc.TypeId.LIST:
+        offsets = plc.Column.from_scalar(
+            plc.Scalar.from_py(0, plc.DataType(plc.TypeId.INT32), stream=stream),
+            1,
+            stream=stream,
+        )
+        child = make_empty_column(dtype.children[0], stream)
+        return plc.Column(dtype.plc_type, 0, None, None, 0, 0, [offsets, child])
+
+    if dtype.id() == plc.TypeId.STRUCT:
+        children = [
+            make_empty_column(child_dtype, stream) for child_dtype in dtype.children
+        ]
+        return plc.Column(dtype.plc_type, 0, None, None, 0, 0, children)
+
+    return plc.column_factories.make_empty_column(dtype.plc_type, stream=stream)
 
 
 def can_cast(from_: plc.DataType, to: plc.DataType) -> bool:

--- a/python/cudf_polars/tests/expressions/test_stringfunction.py
+++ b/python/cudf_polars/tests/expressions/test_stringfunction.py
@@ -764,6 +764,15 @@ def test_contains_any(engine: pl.GPUEngine, ldf, ascii_case_insensitive):
     assert_gpu_result_equal(q, engine=engine)
 
 
+def test_contains_any_empty(engine: pl.GPUEngine):
+    # libcudf's ``contains_multiple`` asserts ``num_blocks > 0`` and crashes
+    # on a zero-row input, so the expression short-circuits to an empty
+    # bool column.
+    ldf = pl.LazyFrame({"a": pl.Series([], dtype=pl.String)})
+    q = ldf.select(pl.col("a").str.contains_any(["a", "b"]))
+    assert_gpu_result_equal(q, engine=engine)
+
+
 def test_count_matches(engine: pl.GPUEngine, ldf):
     q = ldf.select(pl.col("a").str.count_matches("a"))
     assert_gpu_result_equal(q, engine=engine)
@@ -814,6 +823,16 @@ def test_json_decode(engine: pl.GPUEngine, ldf_jsonlike):
     if POLARS_VERSION_LT_133:
         q = ldf_jsonlike.select(pl.col("a").str.json_decode(None))  # type: ignore[arg-type]
         assert_ir_translation_raises(q, NotImplementedError)
+
+
+def test_json_decode_empty(engine: pl.GPUEngine):
+    # libcudf's ``read_json_from_string_column`` raises
+    # "Generated token count exceeds the expected token count" on a
+    # zero-row input, so the expression short-circuits to an empty
+    # struct column with the requested schema.
+    ldf = pl.LazyFrame({"a": pl.Series([], dtype=pl.String)})
+    q = ldf.select(pl.col("a").str.json_decode(pl.Struct({"a": pl.Int64()})))
+    assert_gpu_result_equal(q, engine=engine)
 
 
 @pytest.mark.parametrize("dtype", [pl.Int64(), pl.Float64()])

--- a/python/cudf_polars/tests/expressions/test_struct.py
+++ b/python/cudf_polars/tests/expressions/test_struct.py
@@ -69,6 +69,23 @@ def test_json_encode(engine: pl.GPUEngine, request, ldf):
     assert_gpu_result_equal(q, engine=engine)
 
 
+def test_json_encode_empty(engine: pl.GPUEngine, request):
+    # ``write_json`` emits no lines for a zero-row input, so the
+    # ``from_iterable_of_py(buff.split())`` round-trip cannot infer a
+    # dtype. The expression short-circuits to an empty string column.
+    request.applymarker(
+        pytest.mark.xfail(
+            condition=POLARS_VERSION_LT_131,
+            reason="not supported until polars 1.31",
+        )
+    )
+    ldf = pl.LazyFrame(
+        {"a": pl.Series([], dtype=pl.Struct({"b": pl.String, "d": pl.String}))}
+    )
+    q = ldf.select(pl.col("a").struct.json_encode())
+    assert_gpu_result_equal(q, engine=engine)
+
+
 def test_rename_fields(engine: pl.GPUEngine, request, ldf):
     request.applymarker(
         pytest.mark.xfail(

--- a/python/cudf_polars/tests/utils/test_make_empty_column.py
+++ b/python/cudf_polars/tests/utils/test_make_empty_column.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for _make_empty_column supporting nested types."""
+"""Tests for make_empty_column, including nested types."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ import pylibcudf as plc
 from rmm.pylibrmm.stream import DEFAULT_STREAM
 
 from cudf_polars.containers import DataType
-from cudf_polars.experimental.rapidsmpf.utils import _make_empty_column
+from cudf_polars.utils.dtypes import make_empty_column
 
 
 @pytest.mark.parametrize(
@@ -28,7 +28,7 @@ from cudf_polars.experimental.rapidsmpf.utils import _make_empty_column
 )
 def test_flat_types(polars_dtype):
     dtype = DataType(polars_dtype)
-    col = _make_empty_column(dtype, DEFAULT_STREAM)
+    col = make_empty_column(dtype, DEFAULT_STREAM)
     assert col.size() == 0
     assert col.null_count() == 0
     assert col.type() == dtype.plc_type
@@ -40,7 +40,7 @@ def test_flat_types(polars_dtype):
 )
 def test_list_type(inner):
     dtype = DataType(pl.List(inner))
-    col = _make_empty_column(dtype, DEFAULT_STREAM)
+    col = make_empty_column(dtype, DEFAULT_STREAM)
 
     assert col.size() == 0
     assert col.null_count() == 0
@@ -57,7 +57,7 @@ def test_list_type(inner):
 
 def test_nested_list_type():
     dtype = DataType(pl.List(pl.List(pl.Int32())))
-    col = _make_empty_column(dtype, DEFAULT_STREAM)
+    col = make_empty_column(dtype, DEFAULT_STREAM)
 
     assert col.size() == 0
     assert col.type().id() == plc.TypeId.LIST
@@ -73,7 +73,7 @@ def test_nested_list_type():
 
 def test_struct_type():
     dtype = DataType(pl.Struct({"a": pl.Int64, "b": pl.String}))
-    col = _make_empty_column(dtype, DEFAULT_STREAM)
+    col = make_empty_column(dtype, DEFAULT_STREAM)
 
     assert col.size() == 0
     assert col.null_count() == 0
@@ -88,7 +88,7 @@ def test_struct_type():
 
 def test_struct_with_list_field():
     dtype = DataType(pl.Struct({"x": pl.Int64, "y": pl.List(pl.String)}))
-    col = _make_empty_column(dtype, DEFAULT_STREAM)
+    col = make_empty_column(dtype, DEFAULT_STREAM)
 
     assert col.size() == 0
     assert col.type().id() == plc.TypeId.STRUCT
@@ -104,7 +104,7 @@ def test_struct_with_list_field():
 
 def test_list_of_struct():
     dtype = DataType(pl.List(pl.Struct({"a": pl.Int32, "b": pl.Float64})))
-    col = _make_empty_column(dtype, DEFAULT_STREAM)
+    col = make_empty_column(dtype, DEFAULT_STREAM)
 
     assert col.size() == 0
     assert col.type().id() == plc.TypeId.LIST


### PR DESCRIPTION
Three string/struct expressions in cudf-polars crash when given an empty (0-row) input column. This change fixes each case by short-circuiting to a typed empty column when the input has zero rows. It also promotes the existing `_make_empty_column` helper out of the experimental rapidsmpf module so it can be reused by non-experimental DSL code.

**How to reproduce**

Each issue reproduces on the in-memory engine with no multi-rank involvement:

```python
import polars as pl

# ContainsAny
pl.LazyFrame({"s": pl.Series([], dtype=pl.String)}).select(
    pl.col("s").str.contains_any(["a"])
).collect(engine="gpu")

# JsonDecode
pl.LazyFrame({"s": pl.Series([], dtype=pl.String)}).select(
    pl.col("s").str.json_decode(dtype=pl.Struct({"a": pl.Int64}))
).collect(engine="gpu")

# JsonEncode
pl.LazyFrame({"s": pl.Series([], dtype=pl.Struct({"a": pl.Int64}))}).select(
    pl.col("s").struct.json_encode()
).collect(engine="gpu")
```

These were originally surfaced by multi-rank Ray tests where one rank receives an empty partition, but the bugs are not multi-rank specific. Any 0-row input, such as a fully filtered chunk or an empty `LazyFrame`, will trigger them.