### PR TITLE
Fix StatsCollector.serialize to use value equality instead of object identity

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/base.py
+++ b/python/cudf_polars/cudf_polars/experimental/base.py
@@ -118,9 +118,9 @@ class StatsCollector:
         traversal of *ir* so that the result is independent of object
         identity.
         """
-        node_to_idx = {id(node): i for i, node in enumerate(traversal([ir]))}
+        node_to_idx = {node: i for i, node in enumerate(traversal([ir]))}
         return [
-            {"index": node_to_idx[id(node)], "info": info.serialize()}
+            {"index": node_to_idx[node], "info": info.serialize()}
             for node, info in self.scan_stats.items()
         ]
 

--- a/python/cudf_polars/tests/experimental/test_stats.py
+++ b/python/cudf_polars/tests/experimental/test_stats.py
@@ -12,6 +12,8 @@ import pytest
 import polars as pl
 
 from cudf_polars import Translator
+from cudf_polars.containers import DataType
+from cudf_polars.dsl.ir import Empty, Projection
 from cudf_polars.experimental.base import SerializedDataSourceInfo, StatsCollector
 from cudf_polars.experimental.io import (
     DataFrameSourceInfo,
@@ -266,3 +268,20 @@ def test_serialize_stats_roundtrip_parquet(
         assert rt.row_count == info.row_count
         for col in ("x", "y", "z"):
             assert rt.column_storage_size(col) == info.column_storage_size(col)
+
+
+def test_serialize_uses_value_equality() -> None:
+    schema = {"x": DataType(pl.Int64())}
+    scan_x = Empty(schema)
+    scan_y = Empty(schema)
+    assert scan_x == scan_y
+    assert scan_x is not scan_y
+
+    root = Projection(schema, scan_y)
+
+    stats = StatsCollector()
+    stats.scan_stats[scan_x] = DataFrameSourceInfo(100)
+
+    result = stats.serialize(root)
+    assert len(result) == 1
+    assert result[0]["index"] >= 0


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Uses node directly as the dict key instead of `id(node)`, so nodes reconstructed on workers (introduced in #22287) are found correctly by value rather than failing with a `KeyError`.
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
