### PR TITLE
Fix reading of large CSV files (>64MB) 

### DIFF
--- a/cpp/src/io/csv/csv_gpu.cu
+++ b/cpp/src/io/csv/csv_gpu.cu
@@ -736,7 +736,8 @@ CUDF_KERNEL void __launch_bounds__(rowofs_block_dim)
         ctx = make_char_context(ROW_CTX_NONE, ROW_CTX_QUOTE, ROW_CTX_NONE);
       }
     } else {
-      if (cur <= end && cur == data_end) {
+      bool const is_last_chunk = data_end_off <= data.size();
+      if (is_last_chunk && cur <= end && cur == data_end) {
         // Add a newline at data end (need the extra row offset to infer length of previous row)
         ctx = make_char_context(ROW_CTX_EOF, ROW_CTX_EOF, ROW_CTX_EOF, 1, 1, 1);
       } else {

--- a/cpp/tests/io/csv_test.cpp
+++ b/cpp/tests/io/csv_test.cpp
@@ -12,9 +12,12 @@
 #include <cudf_test/testing_main.hpp>
 #include <cudf_test/type_lists.hpp>
 
+#include <cudf/aggregation.hpp>
 #include <cudf/detail/iterator.cuh>
 #include <cudf/io/csv.hpp>
 #include <cudf/io/datasource.hpp>
+#include <cudf/reduction.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/strings/convert/convert_datetime.hpp>
 #include <cudf/strings/convert/convert_fixed_point.hpp>
 #include <cudf/strings/strings_column_view.hpp>
@@ -1305,6 +1308,49 @@ TEST_F(CsvReaderTest, TypeInferenceEmptyDelimitedFields)
   expect_column_data_equal(std::vector<int64_t>{1, 4}, result_view.column(0));
   expect_column_data_equal(std::vector<std::string>{"", ""}, result_view.column(1));
   expect_column_data_equal(std::vector<int64_t>{3, 6}, result_view.column(2));
+}
+
+TEST_F(CsvReaderTest, MultiChunkRowCount)
+{
+  // TODO: add reader option to set chunk size and use it here
+  constexpr size_t chunk_threshold = 64ull * 1024 * 1024;
+  std::string const row            = "123,456,789\n";
+  size_t const num_rows            = (chunk_threshold / row.size()) + 1024;
+
+  std::string buffer;
+  buffer.reserve(num_rows * row.size());
+  for (size_t i = 0; i < num_rows; ++i) {
+    buffer.append(row);
+  }
+
+  cudf::io::csv_reader_options const in_opts =
+    cudf::io::csv_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(buffer.data()), buffer.size()}})
+      .header(-1);
+  auto const result      = cudf::io::read_csv(in_opts);
+  auto const result_view = result.tbl->view();
+
+  ASSERT_EQ(result_view.num_columns(), 3);
+  EXPECT_EQ(static_cast<size_t>(result_view.num_rows()), num_rows);
+  EXPECT_EQ(result_view.column(0).type().id(), type_id::INT64);
+  EXPECT_EQ(result_view.column(1).type().id(), type_id::INT64);
+  EXPECT_EQ(result_view.column(2).type().id(), type_id::INT64);
+
+  // All rows are identical, so verifying min == max == expected
+  auto const i64       = cudf::data_type{cudf::type_id::INT64};
+  auto const min_agg   = cudf::make_min_aggregation<cudf::reduce_aggregation>();
+  auto const max_agg   = cudf::make_max_aggregation<cudf::reduce_aggregation>();
+  auto const all_equal = [&](cudf::column_view const& col, int64_t expected) {
+    using scalar_t = cudf::numeric_scalar<int64_t>;
+    auto const min = cudf::reduce(col, *min_agg, i64);
+    auto const max = cudf::reduce(col, *max_agg, i64);
+    return static_cast<scalar_t const&>(*min).value() == expected &&
+           static_cast<scalar_t const&>(*max).value() == expected;
+  };
+  EXPECT_TRUE(all_equal(result_view.column(0), 123));
+  EXPECT_TRUE(all_equal(result_view.column(1), 456));
+  EXPECT_TRUE(all_equal(result_view.column(2), 789));
 }
 
 TEST_F(CsvReaderTest, TypeInferenceThousands)


### PR DESCRIPTION
## Description
Fixes a regression in #22237 where reading a CSV larger than the internal 64 MiB chunk size dropped all rows past the first chunk. Root cause is a misuse of a clamped value to determine the EOF state.

This PR fixes the EOF transition so it only happens in the last chunk.

Also added a large test - all previous CSV tests were below the chunk threshold.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
