### PR TITLE
Rename build/probe to right/left in hash_join and distinct_hash_join

### DIFF
--- a/cpp/benchmarks/join/distinct_join.cu
+++ b/cpp/benchmarks/join/distinct_join.cu
@@ -18,11 +18,11 @@ void nvbench_distinct_inner_join(nvbench::state& state,
 {
   auto dtypes = cycle_dtypes(get_type_or_group(static_cast<int32_t>(DataType)), num_keys);
 
-  auto join = [](cudf::table_view const& probe_input,
-                 cudf::table_view const& build_input,
+  auto join = [](cudf::table_view const& left_input,
+                 cudf::table_view const& right_input,
                  cudf::null_equality compare_nulls) {
-    auto hj_obj = cudf::distinct_hash_join{build_input, compare_nulls, LOAD_FACTOR};
-    return hj_obj.inner_join(probe_input);
+    auto hj_obj = cudf::distinct_hash_join{right_input, compare_nulls, LOAD_FACTOR};
+    return hj_obj.inner_join(left_input);
   };
 
   BM_join<Nullable, join_t::HASH, NullEquality>(state, dtypes, join);
@@ -36,11 +36,11 @@ void nvbench_distinct_left_join(nvbench::state& state,
 {
   auto dtypes = cycle_dtypes(get_type_or_group(static_cast<int32_t>(DataType)), num_keys);
 
-  auto join = [](cudf::table_view const& probe_input,
-                 cudf::table_view const& build_input,
+  auto join = [](cudf::table_view const& left_input,
+                 cudf::table_view const& right_input,
                  cudf::null_equality compare_nulls) {
-    auto hj_obj = cudf::distinct_hash_join{build_input, compare_nulls, LOAD_FACTOR};
-    return hj_obj.left_join(probe_input);
+    auto hj_obj = cudf::distinct_hash_join{right_input, compare_nulls, LOAD_FACTOR};
+    return hj_obj.left_join(left_input);
   };
 
   BM_join<Nullable, join_t::HASH, NullEquality>(state, dtypes, join);

--- a/cpp/include/cudf/detail/join/distinct_hash_join.cuh
+++ b/cpp/include/cudf/detail/join/distinct_hash_join.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/include/cudf/detail/join/distinct_hash_join.cuh
+++ b/cpp/include/cudf/detail/join/distinct_hash_join.cuh
@@ -25,14 +25,14 @@ using cudf::detail::row::lhs_index_type;
 using cudf::detail::row::rhs_index_type;
 
 /**
- * @brief A custom comparator used for the build table insertion
+ * @brief A custom comparator used for the right table insertion
  */
 struct always_not_equal {
   __device__ constexpr bool operator()(
     cuco::pair<hash_value_type, rhs_index_type> const&,
     cuco::pair<hash_value_type, rhs_index_type> const&) const noexcept
   {
-    // All build table keys are distinct thus `false` no matter what
+    // All right table keys are distinct thus `false` no matter what
     return false;
   }
 };
@@ -76,11 +76,11 @@ struct primitive_comparator_adapter {
 };
 
 /**
- * @brief Distinct hash join that builds hash table in creation and probes results in subsequent
- * `*_join` member functions.
+ * @brief Distinct hash join that builds a hash table with the right table on construction and
+ * probes results in subsequent `*_join` member functions.
  *
- * This class enables the distinct hash join scheme that builds hash table once, and probes as many
- * times as needed (possibly in parallel).
+ * This class enables the distinct hash join scheme that builds with the right table once and
+ * probes with many left tables (possibly in parallel).
  */
 class distinct_hash_join {
  public:
@@ -104,15 +104,15 @@ class distinct_hash_join {
   };
 
   /**
-   * @brief Constructor that internally builds the hash table based on the given `build` table.
+   * @brief Constructor that internally builds the hash table from the given `right` table.
    *
-   * @throw cudf::logic_error if the number of columns in `build` table is 0.
+   * @throw cudf::logic_error if the number of columns in `right` table is 0.
    *
-   * @param build The build table, from which the hash table is built
+   * @param right The right table, from which the hash table is built
    * @param compare_nulls Controls whether null join-key values should match or not.
    * @param stream CUDA stream used for device memory operations and kernel launches.
    */
-  distinct_hash_join(cudf::table_view const& build,
+  distinct_hash_join(cudf::table_view const& right,
                      cudf::null_equality compare_nulls,
                      rmm::cuda_stream_view stream);
 
@@ -121,7 +121,7 @@ class distinct_hash_join {
    *
    * @param load_factor The hash table occupancy ratio in (0,1]. A value of 0.5 means 50% occupancy.
    */
-  distinct_hash_join(cudf::table_view const& build,
+  distinct_hash_join(cudf::table_view const& right,
                      cudf::null_equality compare_nulls,
                      double load_factor,
                      rmm::cuda_stream_view stream);
@@ -131,7 +131,7 @@ class distinct_hash_join {
    */
   std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
             std::unique_ptr<rmm::device_uvector<size_type>>>
-  inner_join(cudf::table_view const& probe,
+  inner_join(cudf::table_view const& left,
              rmm::cuda_stream_view stream,
              rmm::device_async_resource_ref mr) const;
 
@@ -139,7 +139,7 @@ class distinct_hash_join {
    * @copydoc cudf::distinct_hash_join::left_join
    */
   std::unique_ptr<rmm::device_uvector<size_type>> left_join(
-    cudf::table_view const& probe,
+    cudf::table_view const& left,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const;
 
@@ -156,11 +156,11 @@ class distinct_hash_join {
                                            rmm::mr::polymorphic_allocator<char>,
                                            cuco_storage_type>;
 
-  bool _has_nested_columns;  ///< True if nested columns are present in build and probe tables
+  bool _has_nested_columns;  ///< True if nested columns are present in right and left tables
   cudf::null_equality _nulls_equal;  ///< Whether to consider nulls as equal
-  cudf::table_view _build;           ///< Input table to build the hash map
+  cudf::table_view _right;           ///< Input table to build the hash map
   std::shared_ptr<cudf::detail::row::equality::preprocessed_table>
-    _preprocessed_build;        ///< Input table preprocssed for row operators
-  hash_table_type _hash_table;  ///< Hash table built on `_build`
+    _preprocessed_right;        ///< Input table preprocssed for row operators
+  hash_table_type _hash_table;  ///< Hash table built on `_right`
 };
 }  // namespace cudf::detail

--- a/cpp/include/cudf/detail/join/hash_join.hpp
+++ b/cpp/include/cudf/detail/join/hash_join.hpp
@@ -29,8 +29,8 @@ class preprocessed_table;
 namespace cudf {
 namespace detail {
 /**
- * @brief Hash join that builds hash table in creation and probes results in subsequent `*_join`
- * member functions.
+ * @brief Hash join that builds a hash table with the right table on construction and probes
+ * results in subsequent `*_join` member functions.
  *
  * User-defined hash function can be passed via the template parameter `Hasher`
  *
@@ -50,17 +50,17 @@ class hash_join {
   hash_join& operator=(hash_join&&)      = delete;
 
   /**
-   * @brief Constructor that internally builds the hash table based on the given `build` table.
+   * @brief Constructor that internally builds the hash table from the given `right` table.
    *
-   * @throw cudf::logic_error if the number of columns in `build` table is 0.
+   * @throw cudf::logic_error if the number of columns in `right` table is 0.
    *
-   * @param build The build table, from which the hash table is built.
-   * @param has_nulls Flag to indicate if the there exists any nulls in the `build` table or
-   *        any `probe` table that will be used later for join.
+   * @param right The right table, from which the hash table is built.
+   * @param has_nulls Flag to indicate if the there exists any nulls in the `right` table or
+   *        any `left` table that will be used later for join.
    * @param compare_nulls Controls whether null join-key values should match or not.
    * @param stream CUDA stream used for device memory operations and kernel launches.
    */
-  hash_join(cudf::table_view const& build,
+  hash_join(cudf::table_view const& right,
             bool has_nulls,
             cudf::null_equality compare_nulls,
             rmm::cuda_stream_view stream);
@@ -70,7 +70,7 @@ class hash_join {
    *
    * @param load_factor The hash table occupancy ratio in (0,1]. A value of 0.5 means 50% occupancy.
    */
-  hash_join(cudf::table_view const& build,
+  hash_join(cudf::table_view const& right,
             bool has_nulls,
             cudf::null_equality compare_nulls,
             double load_factor,
@@ -81,7 +81,7 @@ class hash_join {
    */
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
-  inner_join(cudf::table_view const& probe,
+  inner_join(cudf::table_view const& left,
              std::optional<std::size_t> output_size,
              rmm::cuda_stream_view stream,
              rmm::device_async_resource_ref mr) const;
@@ -91,7 +91,7 @@ class hash_join {
    */
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
-  left_join(cudf::table_view const& probe,
+  left_join(cudf::table_view const& left,
             std::optional<std::size_t> output_size,
             rmm::cuda_stream_view stream,
             rmm::device_async_resource_ref mr) const;
@@ -101,7 +101,7 @@ class hash_join {
    */
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
-  full_join(cudf::table_view const& probe,
+  full_join(cudf::table_view const& left,
             std::optional<std::size_t> output_size,
             rmm::cuda_stream_view stream,
             rmm::device_async_resource_ref mr) const;
@@ -109,19 +109,19 @@ class hash_join {
   /**
    * @copydoc cudf::hash_join::inner_join_size
    */
-  [[nodiscard]] std::size_t inner_join_size(cudf::table_view const& probe,
+  [[nodiscard]] std::size_t inner_join_size(cudf::table_view const& left,
                                             rmm::cuda_stream_view stream) const;
 
   /**
    * @copydoc cudf::hash_join::left_join_size
    */
-  [[nodiscard]] std::size_t left_join_size(cudf::table_view const& probe,
+  [[nodiscard]] std::size_t left_join_size(cudf::table_view const& left,
                                            rmm::cuda_stream_view stream) const;
 
   /**
    * @copydoc cudf::hash_join::full_join_size
    */
-  [[nodiscard]] std::size_t full_join_size(cudf::table_view const& probe,
+  [[nodiscard]] std::size_t full_join_size(cudf::table_view const& left,
                                            rmm::cuda_stream_view stream,
                                            rmm::device_async_resource_ref mr) const;
 
@@ -129,7 +129,7 @@ class hash_join {
    * @copydoc cudf::hash_join::inner_join_match_context
    */
   [[nodiscard]] cudf::join_match_context inner_join_match_context(
-    cudf::table_view const& probe,
+    cudf::table_view const& left,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const;
 
@@ -137,7 +137,7 @@ class hash_join {
    * @copydoc cudf::hash_join::left_join_match_context
    */
   [[nodiscard]] cudf::join_match_context left_join_match_context(
-    cudf::table_view const& probe,
+    cudf::table_view const& left,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const;
 
@@ -145,39 +145,39 @@ class hash_join {
    * @copydoc cudf::hash_join::full_join_match_context
    */
   [[nodiscard]] cudf::join_match_context full_join_match_context(
-    cudf::table_view const& probe,
+    cudf::table_view const& left,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const;
 
  private:
   bool const _is_empty;   ///< true if `_hash_table` is empty
-  bool const _has_nulls;  ///< true if nulls are present in either build table or any probe table
+  bool const _has_nulls;  ///< true if nulls are present in either right table or any left table
   cudf::null_equality const _nulls_equal;  ///< whether to consider nulls as equal
-  cudf::table_view _build;                 ///< input table to build the hash map
+  cudf::table_view _right;                 ///< input table to build the hash map
   std::shared_ptr<cudf::detail::row::equality::preprocessed_table>
-    _preprocessed_build;        ///< input table preprocssed for row operators
+    _preprocessed_right;        ///< input table preprocssed for row operators
   std::unique_ptr<impl> _impl;  ///< CUDA hash table implementation
 
   [[nodiscard]] std::unique_ptr<rmm::device_uvector<size_type>> make_match_counts(
     join_kind join,
-    cudf::table_view const& probe,
+    cudf::table_view const& left,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const;
 
   template <join_kind Join>
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
-  join_retrieve(cudf::table_view const& probe,
+  join_retrieve(cudf::table_view const& left,
                 std::optional<std::size_t> output_size,
                 rmm::cuda_stream_view stream,
                 rmm::device_async_resource_ref mr) const;
 
   template <join_kind Join>
-  [[nodiscard]] std::size_t join_size(cudf::table_view const& probe,
+  [[nodiscard]] std::size_t join_size(cudf::table_view const& left,
                                       rmm::cuda_stream_view stream) const;
 
   template <join_kind Join>
-  [[nodiscard]] std::size_t join_size(cudf::table_view const& probe,
+  [[nodiscard]] std::size_t join_size(cudf::table_view const& left,
                                       rmm::cuda_stream_view stream,
                                       rmm::device_async_resource_ref mr) const;
 };

--- a/cpp/include/cudf/join/distinct_hash_join.hpp
+++ b/cpp/include/cudf/join/distinct_hash_join.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/include/cudf/join/distinct_hash_join.hpp
+++ b/cpp/include/cudf/join/distinct_hash_join.hpp
@@ -33,13 +33,13 @@ class distinct_hash_join;
 }  // namespace detail
 
 /**
- * @brief Distinct hash join that builds hash table in creation and probes results in subsequent
- * `*_join` member functions
+ * @brief Distinct hash join that builds a hash table with the right table on construction and
+ * probes results in subsequent `*_join` member functions
  *
- * This class enables the distinct hash join scheme that builds hash table once, and probes as many
- * times as needed (possibly in parallel).
+ * This class enables the distinct hash join scheme that builds with the right table once and
+ * probes with many left tables (possibly in parallel).
  *
- * @note Behavior is undefined if the build table contains duplicates.
+ * @note Behavior is undefined if the right table contains duplicates.
  * @note All NaNs are considered as equal
  */
 class distinct_hash_join {
@@ -54,17 +54,17 @@ class distinct_hash_join {
   /**
    * @brief Constructs a distinct hash join object for subsequent probe calls
    *
-   * @throw cudf::logic_error if the build table has no columns
+   * @throw cudf::logic_error if the right table has no columns
    * @throw std::invalid_argument if load_factor is not greater than 0 and less than or equal to 1
    *
-   * @param build The build table that contains distinct elements
+   * @param right The right table that contains distinct elements
    * @param compare_nulls Controls whether null join-key values should match or not
    * @param load_factor The desired ratio of filled slots to total slots in the hash table, must be
    * in range (0,1]. For example, 0.5 indicates a target of 50% occupancy. Note that the actual
    * occupancy achieved may be slightly lower than the specified value.
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  distinct_hash_join(cudf::table_view const& build,
+  distinct_hash_join(cudf::table_view const& right,
                      null_equality compare_nulls  = null_equality::EQUAL,
                      double load_factor           = 0.5,
                      rmm::cuda_stream_view stream = cudf::get_default_stream());
@@ -73,39 +73,39 @@ class distinct_hash_join {
    * @brief Returns the row indices that can be used to construct the result of performing
    * an inner join between two tables. @see cudf::inner_join().
    *
-   * @param probe The probe table, from which the keys are probed
+   * @param left The left table, from which the keys are probed
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the returned indices' device memory.
    *
-   * @return A pair of columns [`probe_indices`, `build_indices`] that can be used to
+   * @return A pair of columns [`left_indices`, `right_indices`] that can be used to
    * construct the result of performing an inner join between two tables
-   * with `build` and `probe` as the join keys.
+   * with `left` and `right` as the join keys.
    */
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
-  inner_join(cudf::table_view const& probe,
+  inner_join(cudf::table_view const& left,
              rmm::cuda_stream_view stream      = cudf::get_default_stream(),
              rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
-   * @brief Returns the build table indices that can be used to construct the result of performing
+   * @brief Returns the right table indices that can be used to construct the result of performing
    * a left join between two tables.
    *
-   * @note For a given row index `i` of the probe table, the resulting `build_indices[i]` contains
-   * the row index of the matched row from the build table if there is a match. Otherwise, contains
+   * @note For a given row index `i` of the left table, the resulting `right_indices[i]` contains
+   * the row index of the matched row from the right table if there is a match. Otherwise, contains
    * `JoinNoMatch`.
    *
-   * @param probe The probe table, from which the keys are probed
+   * @param left The left table, from which the keys are probed
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the returned table and columns' device
    * memory.
    *
-   * @return A `build_indices` column that can be used to construct the result of
-   * performing a left join between two tables with `build` and `probe` as the join
+   * @return A `right_indices` column that can be used to construct the result of
+   * performing a left join between two tables with `left` and `right` as the join
    * keys.
    */
   [[nodiscard]] std::unique_ptr<rmm::device_uvector<size_type>> left_join(
-    cudf::table_view const& probe,
+    cudf::table_view const& left,
     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 

--- a/cpp/include/cudf/join/hash_join.hpp
+++ b/cpp/include/cudf/join/hash_join.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/include/cudf/join/hash_join.hpp
+++ b/cpp/include/cudf/join/hash_join.hpp
@@ -45,8 +45,8 @@ class hash_join;
 }  // namespace detail
 
 /**
- * @brief The enum class to specify if any of the input join tables (`build` table and any later
- * `probe` table) has nulls.
+ * @brief The enum class to specify if any of the input join tables (`right` table and any later
+ * `left` table) has nulls.
  *
  * This is used upon hash_join object construction to specify the existence of nulls in all the
  * possible input tables. If such null existence is unknown, `YES` should be used as the default
@@ -55,11 +55,11 @@ class hash_join;
 enum class nullable_join : bool { YES, NO };
 
 /**
- * @brief Hash join that builds hash table in creation and probes results in subsequent `*_join`
- * member functions.
+ * @brief Hash join that builds a hash table with the right table on construction and probes
+ * results in subsequent `*_join` member functions.
  *
- * This class enables the hash join scheme that builds hash table once, and probes as many times as
- * needed (possibly in parallel).
+ * This class enables the hash join scheme that builds with the right table once and probes
+ * with many left tables (possibly in parallel).
  */
 class hash_join {
  public:
@@ -76,16 +76,16 @@ class hash_join {
   /**
    * @brief Construct a hash join object for subsequent probe calls.
    *
-   * @note The `hash_join` object must not outlive the table viewed by `build`, else behavior is
+   * @note The `hash_join` object must not outlive the table viewed by `right`, else behavior is
    * undefined.
    *
-   * @throws std::invalid_argument if the build table has no columns
+   * @throws std::invalid_argument if the right table has no columns
    *
-   * @param build The build table, from which the hash table is built
+   * @param right The right table, from which the hash table is built
    * @param compare_nulls Controls whether null join-key values should match or not
    * @param stream CUDA stream used for device memory operations and kernel launches
    */
-  hash_join(cudf::table_view const& build,
+  hash_join(cudf::table_view const& right,
             null_equality compare_nulls,
             rmm::cuda_stream_view stream = cudf::get_default_stream());
 
@@ -94,12 +94,12 @@ class hash_join {
    *
    * @throws std::invalid_argument if load_factor is not greater than 0 and less than or equal to 1
    *
-   * @param has_nulls Flag to indicate if there exists any nulls in the `build` table or
-   *                  any `probe` table that will be used later for join
+   * @param has_nulls Flag to indicate if there exists any nulls in the `right` table or
+   *                  any `left` table that will be used later for join
    * @param load_factor The hash table occupancy ratio in (0,1]. A value of 0.5 means 50% desired
    * occupancy.
    */
-  hash_join(cudf::table_view const& build,
+  hash_join(cudf::table_view const& right,
             nullable_join has_nulls,
             null_equality compare_nulls,
             double load_factor,
@@ -110,22 +110,22 @@ class hash_join {
    * an inner join between two tables. @see cudf::inner_join(). Behavior is undefined if the
    * provided `output_size` is smaller than the actual output size.
    *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * @throw std::invalid_argument If the input left table has nulls while this hash_join object was
    * not constructed with null check.
    *
-   * @param probe The probe table, from which the tuples are probed
+   * @param left The left table, from which the tuples are probed
    * @param output_size Optional value which allows users to specify the exact output size
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the returned table and columns' device
    * memory.
    *
    * @return A pair of columns [`left_indices`, `right_indices`] that can be used to construct
-   * the result of performing an inner join between two tables with `build` and `probe`
+   * the result of performing an inner join between two tables with `left` and `right`
    * as the join keys .
    */
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
-  inner_join(cudf::table_view const& probe,
+  inner_join(cudf::table_view const& left,
              std::optional<std::size_t> output_size = {},
              rmm::cuda_stream_view stream           = cudf::get_default_stream(),
              rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
@@ -135,22 +135,22 @@ class hash_join {
    * a left join between two tables. @see cudf::left_join(). Behavior is undefined if the
    * provided `output_size` is smaller than the actual output size.
    *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * @throw std::invalid_argument If the input left table has nulls while this hash_join object was
    * not constructed with null check.
    *
-   * @param probe The probe table, from which the tuples are probed
+   * @param left The left table, from which the tuples are probed
    * @param output_size Optional value which allows users to specify the exact output size
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the returned table and columns' device
    * memory.
    *
    * @return A pair of columns [`left_indices`, `right_indices`] that can be used to construct
-   * the result of performing a left join between two tables with `build` and `probe`
+   * the result of performing a left join between two tables with `left` and `right`
    * as the join keys.
    */
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
-  left_join(cudf::table_view const& probe,
+  left_join(cudf::table_view const& left,
             std::optional<std::size_t> output_size = {},
             rmm::cuda_stream_view stream           = cudf::get_default_stream(),
             rmm::device_async_resource_ref mr      = cudf::get_current_device_resource_ref()) const;
@@ -160,151 +160,151 @@ class hash_join {
    * a full join between two tables. @see cudf::full_join(). Behavior is undefined if the
    * provided `output_size` is smaller than the actual output size.
    *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * @throw std::invalid_argument If the input left table has nulls while this hash_join object was
    * not constructed with null check.
    *
-   * @param probe The probe table, from which the tuples are probed
+   * @param left The left table, from which the tuples are probed
    * @param output_size Optional value which allows users to specify the exact output size
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the returned table and columns' device
    * memory.
    *
    * @return A pair of columns [`left_indices`, `right_indices`] that can be used to construct
-   * the result of performing a full join between two tables with `build` and `probe`
+   * the result of performing a full join between two tables with `left` and `right`
    * as the join keys .
    */
   [[nodiscard]] std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                           std::unique_ptr<rmm::device_uvector<size_type>>>
-  full_join(cudf::table_view const& probe,
+  full_join(cudf::table_view const& left,
             std::optional<std::size_t> output_size = {},
             rmm::cuda_stream_view stream           = cudf::get_default_stream(),
             rmm::device_async_resource_ref mr      = cudf::get_current_device_resource_ref()) const;
 
   /**
    * Returns the exact number of matches (rows) when performing an inner join with the specified
-   * probe table.
+   * left table.
    *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * @throw std::invalid_argument If the input left table has nulls while this hash_join object was
    * not constructed with null check.
    *
-   * @param probe The probe table, from which the tuples are probed
+   * @param left The left table, from which the tuples are probed
    * @param stream CUDA stream used for device memory operations and kernel launches
    *
    * @return The exact number of output when performing an inner join between two tables with
-   * `build` and `probe` as the join keys .
+   * `left` and `right` as the join keys .
    */
   [[nodiscard]] std::size_t inner_join_size(
-    cudf::table_view const& probe, rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+    cudf::table_view const& left, rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
 
   /**
-   * Returns the exact number of matches (rows) when performing a left join with the specified probe
+   * Returns the exact number of matches (rows) when performing a left join with the specified left
    * table.
    *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * @throw std::invalid_argument If the input left table has nulls while this hash_join object was
    * not constructed with null check.
    *
-   * @param probe The probe table, from which the tuples are probed
+   * @param left The left table, from which the tuples are probed
    * @param stream CUDA stream used for device memory operations and kernel launches
    *
-   * @return The exact number of output when performing a left join between two tables with `build`
-   * and `probe` as the join keys .
+   * @return The exact number of output when performing a left join between two tables with `left`
+   * and `right` as the join keys .
    */
   [[nodiscard]] std::size_t left_join_size(
-    cudf::table_view const& probe, rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
+    cudf::table_view const& left, rmm::cuda_stream_view stream = cudf::get_default_stream()) const;
 
   /**
-   * Returns the exact number of matches (rows) when performing a full join with the specified probe
+   * Returns the exact number of matches (rows) when performing a full join with the specified left
    * table.
    *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * @throw std::invalid_argument If the input left table has nulls while this hash_join object was
    * not constructed with null check.
    *
-   * @param probe The probe table, from which the tuples are probed
+   * @param left The left table, from which the tuples are probed
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the intermediate table and columns' device
    * memory.
    *
-   * @return The exact number of output when performing a full join between two tables with `build`
-   * and `probe` as the join keys .
+   * @return The exact number of output when performing a full join between two tables with `left`
+   * and `right` as the join keys .
    */
   [[nodiscard]] std::size_t full_join_size(
-    cudf::table_view const& probe,
+    cudf::table_view const& left,
     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
-   * @brief Returns context information about matches between the probe and build tables.
+   * @brief Returns context information about matches between the left and right tables.
    *
-   * This method computes, for each row in the probe table, how many matching rows exist in
-   * the build table according to inner join semantics, and returns the number of matches through a
+   * This method computes, for each row in the left table, how many matching rows exist in
+   * the right table according to inner join semantics, and returns the number of matches through a
    * join_match_context object.
    *
    * This is particularly useful for:
    * - Determining the total size of a potential join result without materializing it
    * - Planning partitioned join operations for large datasets
    *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * @throw std::invalid_argument If the input left table has nulls while this hash_join object was
    * not constructed with null check.
    *
-   * @param probe The probe table to join with the pre-processed build table
+   * @param left The left table to join with the pre-processed right table
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the result device memory
    *
-   * @return A join_match_context object containing the probe table view and a device vector
-   *         of match counts for each row in the probe table
+   * @return A join_match_context object containing the left table view and a device vector
+   *         of match counts for each row in the left table
    */
   [[nodiscard]] cudf::join_match_context inner_join_match_context(
-    cudf::table_view const& probe,
+    cudf::table_view const& left,
     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
-   * @brief Returns context information about matches between the probe and build tables.
+   * @brief Returns context information about matches between the left and right tables.
    *
-   * This method computes, for each row in the probe table, how many matching rows exist in
-   * the build table according to left join semantics, and returns the number of matches through a
+   * This method computes, for each row in the left table, how many matching rows exist in
+   * the right table according to left join semantics, and returns the number of matches through a
    * join_match_context object.
    *
-   * For left join, every row in the probe table will have at least one match (either with a
-   * matching row from the build table or with a null placeholder).
+   * For left join, every row in the left table will have at least one match (either with a
+   * matching row from the right table or with a null placeholder).
    *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * @throw std::invalid_argument If the input left table has nulls while this hash_join object was
    * not constructed with null check.
    *
-   * @param probe The probe table to join with the pre-processed build table
+   * @param left The left table to join with the pre-processed right table
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the result device memory
    *
-   * @return A join_match_context object containing the probe table view and a device vector
-   *         of match counts for each row in the probe table
+   * @return A join_match_context object containing the left table view and a device vector
+   *         of match counts for each row in the left table
    */
   [[nodiscard]] cudf::join_match_context left_join_match_context(
-    cudf::table_view const& probe,
+    cudf::table_view const& left,
     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 
   /**
-   * @brief Returns context information about matches between the probe and build tables.
+   * @brief Returns context information about matches between the left and right tables.
    *
-   * This method computes, for each row in the probe table, how many matching rows exist in
-   * the build table according to full join semantics, and returns the number of matches through a
+   * This method computes, for each row in the left table, how many matching rows exist in
+   * the right table according to full join semantics, and returns the number of matches through a
    * join_match_context object.
    *
-   * For full join, this includes matches for probe table rows, and the result may need to be
-   * combined with unmatched rows from the build table to get the complete picture.
+   * For full join, this includes matches for left table rows, and the result may need to be
+   * combined with unmatched rows from the right table to get the complete picture.
    *
-   * @throw std::invalid_argument If the input probe table has nulls while this hash_join object was
+   * @throw std::invalid_argument If the input left table has nulls while this hash_join object was
    * not constructed with null check.
    *
-   * @param probe The probe table to join with the pre-processed build table
+   * @param left The left table to join with the pre-processed right table
    * @param stream CUDA stream used for device memory operations and kernel launches
    * @param mr Device memory resource used to allocate the result device memory
    *
-   * @return A join_match_context object containing the probe table view and a device vector
-   *         of match counts for each row in the probe table
+   * @return A join_match_context object containing the left table view and a device vector
+   *         of match counts for each row in the left table
    */
   [[nodiscard]] cudf::join_match_context full_join_match_context(
-    cudf::table_view const& probe,
+    cudf::table_view const& left,
     rmm::cuda_stream_view stream      = cudf::get_default_stream(),
     rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref()) const;
 

--- a/cpp/src/join/distinct_hash_join.cu
+++ b/cpp/src/join/distinct_hash_join.cu
@@ -268,7 +268,7 @@ distinct_hash_join::inner_join(cudf::table_view const& left,
 
     auto const left_row_hasher = cudf::detail::row::hash::row_hasher{preprocessed_left};
     auto const d_left_hasher   = left_row_hasher.device_hasher(nullate::DYNAMIC{has_nulls});
-    auto const iter             = cudf::detail::make_counting_transform_iterator(
+    auto const iter            = cudf::detail::make_counting_transform_iterator(
       0, build_keys_fn<lhs_index_type>{d_left_hasher});
 
     if (_has_nested_columns) {
@@ -371,7 +371,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> distinct_hash_join::left_join(
 
       auto const left_row_hasher = cudf::detail::row::hash::row_hasher{preprocessed_left};
       auto const d_left_hasher   = left_row_hasher.device_hasher(nullate::DYNAMIC{has_nulls});
-      auto const iter             = cudf::detail::make_counting_transform_iterator(
+      auto const iter            = cudf::detail::make_counting_transform_iterator(
         0, build_keys_fn<lhs_index_type>{d_left_hasher});
 
       if (_has_nested_columns) {

--- a/cpp/src/join/distinct_hash_join.cu
+++ b/cpp/src/join/distinct_hash_join.cu
@@ -103,7 +103,7 @@ struct output_fn {
  * @param hash_table The hash table to search in
  * @param iter Iterator over hash values
  * @param d_equal Equality comparator
- * @param probe The probe table
+ * @param left The left table
  * @param hasher Hash function
  * @param nulls_equal Null equality setting
  * @param found_begin Output iterator for found indices
@@ -117,27 +117,27 @@ template <typename HashTableType,
 void find_matches_in_hash_table(HashTableType const& hash_table,
                                 IterType iter,
                                 EqualType const& d_equal,
-                                cudf::table_view const& probe,
+                                cudf::table_view const& left,
                                 Hasher hasher,
                                 cudf::null_equality nulls_equal,
                                 FoundIterator found_begin,
                                 rmm::cuda_stream_view stream)
 {
-  auto const probe_table_num_rows = probe.num_rows();
-  // If `idx` is within the range `[0, probe_table_num_rows)` and `found_indices[idx]` is not
+  auto const left_table_num_rows = left.num_rows();
+  // If `idx` is within the range `[0, left_table_num_rows)` and `found_indices[idx]` is not
   // equal to `cudf::JoinNoMatch`, then `idx` has a match in the hash set.
-  if (nulls_equal == cudf::null_equality::EQUAL or (not cudf::nullable(probe))) {
+  if (nulls_equal == cudf::null_equality::EQUAL or (not cudf::nullable(left))) {
     hash_table.find_async(
-      iter, iter + probe_table_num_rows, d_equal, hasher, found_begin, stream.value());
+      iter, iter + left_table_num_rows, d_equal, hasher, found_begin, stream.value());
   } else {
     auto stencil = cuda::counting_iterator<size_type>{0};
     auto const row_bitmask =
-      cudf::detail::bitmask_and(probe, stream, cudf::get_current_device_resource_ref()).first;
+      cudf::detail::bitmask_and(left, stream, cudf::get_current_device_resource_ref()).first;
     auto const pred =
       cudf::detail::row_is_valid{reinterpret_cast<bitmask_type const*>(row_bitmask.data())};
 
     hash_table.find_if_async(iter,
-                             iter + probe_table_num_rows,
+                             iter + left_table_num_rows,
                              stencil,
                              pred,
                              d_equal,
@@ -149,22 +149,22 @@ void find_matches_in_hash_table(HashTableType const& hash_table,
 
 }  // namespace
 
-distinct_hash_join::distinct_hash_join(cudf::table_view const& build,
+distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
                                        cudf::null_equality compare_nulls,
                                        rmm::cuda_stream_view stream)
-  : distinct_hash_join{build, compare_nulls, CUCO_DESIRED_LOAD_FACTOR, stream}
+  : distinct_hash_join{right, compare_nulls, CUCO_DESIRED_LOAD_FACTOR, stream}
 {
 }
 
-distinct_hash_join::distinct_hash_join(cudf::table_view const& build,
+distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
                                        cudf::null_equality compare_nulls,
                                        double load_factor,
                                        rmm::cuda_stream_view stream)
-  : _has_nested_columns{cudf::has_nested_columns(build)},
+  : _has_nested_columns{cudf::has_nested_columns(right)},
     _nulls_equal{compare_nulls},
-    _build{build},
-    _preprocessed_build{cudf::detail::row::equality::preprocessed_table::create(_build, stream)},
-    _hash_table{cuco::extent{static_cast<std::size_t>(build.num_rows())},
+    _right{right},
+    _preprocessed_right{cudf::detail::row::equality::preprocessed_table::create(_right, stream)},
+    _hash_table{cuco::extent{static_cast<std::size_t>(right.num_rows())},
                 load_factor,
                 cuco::empty_key{cuco::pair{std::numeric_limits<hash_value_type>::max(),
                                            rhs_index_type{cudf::JoinNoMatch}}},
@@ -176,41 +176,41 @@ distinct_hash_join::distinct_hash_join(cudf::table_view const& build,
                 stream.value()}
 {
   CUDF_FUNC_RANGE();
-  CUDF_EXPECTS(0 != this->_build.num_columns(), "Hash join build table is empty");
+  CUDF_EXPECTS(0 != this->_right.num_columns(), "Hash join right table is empty");
   CUDF_EXPECTS(load_factor > 0 && load_factor <= 1,
                "Invalid load factor: must be greater than 0 and less than or equal to 1.",
                std::invalid_argument);
 
-  size_type const build_table_num_rows{_build.num_rows()};
+  size_type const right_table_num_rows{_right.num_rows()};
 
-  if (build_table_num_rows == 0) { return; }
+  if (right_table_num_rows == 0) { return; }
 
   auto const build_hash_table = [&](auto iter) {
-    if (this->_nulls_equal == cudf::null_equality::EQUAL or (not cudf::nullable(build))) {
-      this->_hash_table.insert_async(iter, iter + build_table_num_rows, stream.value());
+    if (this->_nulls_equal == cudf::null_equality::EQUAL or (not cudf::nullable(right))) {
+      this->_hash_table.insert_async(iter, iter + right_table_num_rows, stream.value());
     } else {
       auto stencil = cuda::counting_iterator<size_type>{0};
       auto const row_bitmask =
-        cudf::detail::bitmask_and(_build, stream, cudf::get_current_device_resource_ref()).first;
+        cudf::detail::bitmask_and(_right, stream, cudf::get_current_device_resource_ref()).first;
       auto const pred =
         cudf::detail::row_is_valid{reinterpret_cast<bitmask_type const*>(row_bitmask.data())};
 
       // insert valid rows
       this->_hash_table.insert_if_async(
-        iter, iter + build_table_num_rows, stencil, pred, stream.value());
+        iter, iter + right_table_num_rows, stencil, pred, stream.value());
     }
   };
 
-  if (cudf::detail::is_primitive_row_op_compatible(_build)) {
+  if (cudf::detail::is_primitive_row_op_compatible(_right)) {
     auto const d_hasher = cudf::detail::row::primitive::row_hasher{nullate::DYNAMIC{has_nulls},
-                                                                   this->_preprocessed_build};
+                                                                   this->_preprocessed_right};
 
     auto const iter = cudf::detail::make_counting_transform_iterator(
       0, primitive_keys_fn<rhs_index_type>{d_hasher});
 
     build_hash_table(iter);
   } else {
-    auto const row_hasher = detail::row::hash::row_hasher{this->_preprocessed_build};
+    auto const row_hasher = detail::row::hash::row_hasher{this->_preprocessed_right};
     auto const d_hasher   = row_hasher.device_hasher(nullate::DYNAMIC{has_nulls});
 
     auto const iter =
@@ -222,54 +222,54 @@ distinct_hash_join::distinct_hash_join(cudf::table_view const& build,
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-distinct_hash_join::inner_join(cudf::table_view const& probe,
+distinct_hash_join::inner_join(cudf::table_view const& left,
                                rmm::cuda_stream_view stream,
                                rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"distinct_hash_join::inner_join"};
 
-  size_type const probe_table_num_rows{probe.num_rows()};
+  size_type const left_table_num_rows{left.num_rows()};
 
   // If output size is zero, return immediately
-  if (probe_table_num_rows == 0) {
+  if (left_table_num_rows == 0) {
     return std::pair(std::make_unique<rmm::device_uvector<size_type>>(0, stream, mr),
                      std::make_unique<rmm::device_uvector<size_type>>(0, stream, mr));
   }
 
-  auto build_indices =
-    std::make_unique<rmm::device_uvector<size_type>>(probe_table_num_rows, stream, mr);
-  auto probe_indices =
-    std::make_unique<rmm::device_uvector<size_type>>(probe_table_num_rows, stream, mr);
+  auto right_indices =
+    std::make_unique<rmm::device_uvector<size_type>>(left_table_num_rows, stream, mr);
+  auto left_indices =
+    std::make_unique<rmm::device_uvector<size_type>>(left_table_num_rows, stream, mr);
 
-  auto found_indices = rmm::device_uvector<size_type>(probe_table_num_rows, stream);
+  auto found_indices = rmm::device_uvector<size_type>(left_table_num_rows, stream);
   auto const found_begin =
     thrust::make_transform_output_iterator(found_indices.begin(), output_fn{});
 
-  auto preprocessed_probe = cudf::detail::row::equality::preprocessed_table::create(probe, stream);
-  if (cudf::detail::is_primitive_row_op_compatible(_build)) {
+  auto preprocessed_left = cudf::detail::row::equality::preprocessed_table::create(left, stream);
+  if (cudf::detail::is_primitive_row_op_compatible(_right)) {
     auto const d_hasher =
-      cudf::detail::row::primitive::row_hasher{nullate::DYNAMIC{has_nulls}, preprocessed_probe};
+      cudf::detail::row::primitive::row_hasher{nullate::DYNAMIC{has_nulls}, preprocessed_left};
     auto const d_equal = cudf::detail::row::primitive::row_equality_comparator{
-      nullate::DYNAMIC{has_nulls}, preprocessed_probe, _preprocessed_build, _nulls_equal};
+      nullate::DYNAMIC{has_nulls}, preprocessed_left, _preprocessed_right, _nulls_equal};
     auto const iter = cudf::detail::make_counting_transform_iterator(
       0, primitive_keys_fn<lhs_index_type>{d_hasher});
 
     find_matches_in_hash_table(this->_hash_table,
                                iter,
                                primitive_comparator_adapter{d_equal},
-                               probe,
+                               left,
                                hasher{},
                                _nulls_equal,
                                found_begin,
                                stream);
   } else {
     auto const two_table_equal =
-      cudf::detail::row::equality::two_table_comparator(preprocessed_probe, _preprocessed_build);
+      cudf::detail::row::equality::two_table_comparator(preprocessed_left, _preprocessed_right);
 
-    auto const probe_row_hasher = cudf::detail::row::hash::row_hasher{preprocessed_probe};
-    auto const d_probe_hasher   = probe_row_hasher.device_hasher(nullate::DYNAMIC{has_nulls});
+    auto const left_row_hasher = cudf::detail::row::hash::row_hasher{preprocessed_left};
+    auto const d_left_hasher   = left_row_hasher.device_hasher(nullate::DYNAMIC{has_nulls});
     auto const iter             = cudf::detail::make_counting_transform_iterator(
-      0, build_keys_fn<lhs_index_type>{d_probe_hasher});
+      0, build_keys_fn<lhs_index_type>{d_left_hasher});
 
     if (_has_nested_columns) {
       auto const device_comparator =
@@ -277,7 +277,7 @@ distinct_hash_join::inner_join(cudf::table_view const& probe,
       find_matches_in_hash_table(this->_hash_table,
                                  iter,
                                  comparator_adapter{device_comparator},
-                                 probe,
+                                 left,
                                  hasher{},
                                  _nulls_equal,
                                  found_begin,
@@ -288,7 +288,7 @@ distinct_hash_join::inner_join(cudf::table_view const& probe,
       find_matches_in_hash_table(this->_hash_table,
                                  iter,
                                  comparator_adapter{device_comparator},
-                                 probe,
+                                 left,
                                  hasher{},
                                  _nulls_equal,
                                  found_begin,
@@ -303,10 +303,10 @@ distinct_hash_join::inner_join(cudf::table_view const& probe,
         return cuda::std::tuple{*(found_iter + idx), idx};
       }));
   auto const output_begin =
-    thrust::make_zip_iterator(build_indices->begin(), probe_indices->begin());
+    thrust::make_zip_iterator(right_indices->begin(), left_indices->begin());
   auto const output_end =
     cudf::detail::copy_if(tuple_iter,
-                          tuple_iter + probe_table_num_rows,
+                          tuple_iter + left_table_num_rows,
                           found_indices.begin(),
                           output_begin,
                           cuda::proclaim_return_type<bool>(
@@ -314,38 +314,38 @@ distinct_hash_join::inner_join(cudf::table_view const& probe,
                           stream);
   auto const actual_size = std::distance(output_begin, output_end);
 
-  build_indices->resize(actual_size, stream);
-  probe_indices->resize(actual_size, stream);
+  right_indices->resize(actual_size, stream);
+  left_indices->resize(actual_size, stream);
 
-  return {std::move(probe_indices), std::move(build_indices)};
+  return {std::move(left_indices), std::move(right_indices)};
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> distinct_hash_join::left_join(
-  cudf::table_view const& probe,
+  cudf::table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"distinct_hash_join::left_join"};
 
-  size_type const probe_table_num_rows{probe.num_rows()};
+  size_type const left_table_num_rows{left.num_rows()};
 
   // If output size is zero, return empty
-  if (probe_table_num_rows == 0) {
+  if (left_table_num_rows == 0) {
     return std::make_unique<rmm::device_uvector<size_type>>(0, stream, mr);
   }
 
-  auto build_indices =
-    std::make_unique<rmm::device_uvector<size_type>>(probe_table_num_rows, stream, mr);
+  auto right_indices =
+    std::make_unique<rmm::device_uvector<size_type>>(left_table_num_rows, stream, mr);
   auto const output_begin =
-    thrust::make_transform_output_iterator(build_indices->begin(), output_fn{});
+    thrust::make_transform_output_iterator(right_indices->begin(), output_fn{});
 
-  auto preprocessed_probe = cudf::detail::row::equality::preprocessed_table::create(probe, stream);
+  auto preprocessed_left = cudf::detail::row::equality::preprocessed_table::create(left, stream);
 
-  if (cudf::detail::is_primitive_row_op_compatible(_build)) {
+  if (cudf::detail::is_primitive_row_op_compatible(_right)) {
     auto const d_hasher =
-      cudf::detail::row::primitive::row_hasher{nullate::DYNAMIC{has_nulls}, preprocessed_probe};
+      cudf::detail::row::primitive::row_hasher{nullate::DYNAMIC{has_nulls}, preprocessed_left};
     auto const d_equal = cudf::detail::row::primitive::row_equality_comparator{
-      nullate::DYNAMIC{has_nulls}, preprocessed_probe, _preprocessed_build, _nulls_equal};
+      nullate::DYNAMIC{has_nulls}, preprocessed_left, _preprocessed_right, _nulls_equal};
 
     auto const iter = cudf::detail::make_counting_transform_iterator(
       0, primitive_keys_fn<lhs_index_type>{d_hasher});
@@ -353,26 +353,26 @@ std::unique_ptr<rmm::device_uvector<size_type>> distinct_hash_join::left_join(
     find_matches_in_hash_table(this->_hash_table,
                                iter,
                                primitive_comparator_adapter{d_equal},
-                               probe,
+                               left,
                                hasher{},
                                _nulls_equal,
                                output_begin,
                                stream);
   } else {
-    // If build table is empty, return probe table
-    if (this->_build.num_rows() == 0) {
+    // If right table is empty, return left table
+    if (this->_right.num_rows() == 0) {
       thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                   build_indices->begin(),
-                   build_indices->end(),
+                   right_indices->begin(),
+                   right_indices->end(),
                    cudf::JoinNoMatch);
     } else {
       auto const two_table_equal =
-        cudf::detail::row::equality::two_table_comparator(preprocessed_probe, _preprocessed_build);
+        cudf::detail::row::equality::two_table_comparator(preprocessed_left, _preprocessed_right);
 
-      auto const probe_row_hasher = cudf::detail::row::hash::row_hasher{preprocessed_probe};
-      auto const d_probe_hasher   = probe_row_hasher.device_hasher(nullate::DYNAMIC{has_nulls});
+      auto const left_row_hasher = cudf::detail::row::hash::row_hasher{preprocessed_left};
+      auto const d_left_hasher   = left_row_hasher.device_hasher(nullate::DYNAMIC{has_nulls});
       auto const iter             = cudf::detail::make_counting_transform_iterator(
-        0, build_keys_fn<lhs_index_type>{d_probe_hasher});
+        0, build_keys_fn<lhs_index_type>{d_left_hasher});
 
       if (_has_nested_columns) {
         auto const device_comparator =
@@ -380,7 +380,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> distinct_hash_join::left_join(
         find_matches_in_hash_table(this->_hash_table,
                                    iter,
                                    comparator_adapter{device_comparator},
-                                   probe,
+                                   left,
                                    hasher{},
                                    _nulls_equal,
                                    output_begin,
@@ -391,7 +391,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> distinct_hash_join::left_join(
         find_matches_in_hash_table(this->_hash_table,
                                    iter,
                                    comparator_adapter{device_comparator},
-                                   probe,
+                                   left,
                                    hasher{},
                                    _nulls_equal,
                                    output_begin,
@@ -399,34 +399,34 @@ std::unique_ptr<rmm::device_uvector<size_type>> distinct_hash_join::left_join(
       }
     }
   }
-  return build_indices;
+  return right_indices;
 }
 }  // namespace detail
 
 distinct_hash_join::~distinct_hash_join() = default;
 
-distinct_hash_join::distinct_hash_join(cudf::table_view const& build,
+distinct_hash_join::distinct_hash_join(cudf::table_view const& right,
                                        null_equality compare_nulls,
                                        double load_factor,
                                        rmm::cuda_stream_view stream)
-  : _impl{std::make_unique<impl_type>(build, compare_nulls, load_factor, stream)}
+  : _impl{std::make_unique<impl_type>(right, compare_nulls, load_factor, stream)}
 {
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-distinct_hash_join::inner_join(cudf::table_view const& probe,
+distinct_hash_join::inner_join(cudf::table_view const& left,
                                rmm::cuda_stream_view stream,
                                rmm::device_async_resource_ref mr) const
 {
-  return _impl->inner_join(probe, stream, mr);
+  return _impl->inner_join(left, stream, mr);
 }
 
 std::unique_ptr<rmm::device_uvector<size_type>> distinct_hash_join::left_join(
-  cudf::table_view const& probe,
+  cudf::table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
-  return _impl->left_join(probe, stream, mr);
+  return _impl->left_join(left, stream, mr);
 }
 }  // namespace cudf

--- a/cpp/src/join/hash_join/common.cuh
+++ b/cpp/src/join/hash_join/common.cuh
@@ -24,17 +24,17 @@ using hash_table_t     = typename cudf::detail::hash_join<hash_join_hasher>::imp
 
 bool is_trivial_join(table_view const& left, table_view const& right, join_kind join_type);
 
-void validate_hash_join_probe(table_view const& build, table_view const& probe, bool has_nulls);
+void validate_hash_join_probe(table_view const& right, table_view const& left, bool has_nulls);
 
 std::unique_ptr<rmm::device_uvector<size_type>> make_join_match_counts(
-  table_view const& build,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_build,
+  table_view const& right,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_right,
   cudf::detail::hash_table_t const& hash_table,
   bool is_empty,
   bool has_nulls,
   null_equality compare_nulls,
   join_kind join,
-  table_view const& probe,
+  table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr);
 

--- a/cpp/src/join/hash_join/dispatch.cuh
+++ b/cpp/src/join/hash_join/dispatch.cuh
@@ -42,7 +42,7 @@ class pair_equal {
 };
 
 /**
- * @brief Extracts the build-side row index from a cuco hash table slot.
+ * @brief Extracts the right-side row index from a cuco hash table slot.
  */
 struct output_fn {
   __device__ constexpr cudf::size_type operator()(
@@ -75,34 +75,34 @@ class primitive_pair_equal {
 
 template <typename Fn>
 decltype(auto) dispatch_join_comparator(
-  table_view const& build_table,
-  table_view const& probe_table,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_build,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_probe,
+  table_view const& right_table,
+  table_view const& left_table,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_right,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
   bool has_nulls,
   null_equality compare_nulls,
   Fn&& fn)
 {
-  auto const probe_nulls = cudf::nullate::DYNAMIC{has_nulls};
+  auto const left_nulls = cudf::nullate::DYNAMIC{has_nulls};
 
-  if (cudf::detail::is_primitive_row_op_compatible(build_table)) {
-    auto const d_hasher = cudf::detail::row::primitive::row_hasher{probe_nulls, preprocessed_probe};
+  if (cudf::detail::is_primitive_row_op_compatible(right_table)) {
+    auto const d_hasher = cudf::detail::row::primitive::row_hasher{left_nulls, preprocessed_left};
     auto const d_equal  = cudf::detail::row::primitive::row_equality_comparator{
-      probe_nulls, preprocessed_probe, preprocessed_build, compare_nulls};
+      left_nulls, preprocessed_left, preprocessed_right, compare_nulls};
     return std::forward<Fn>(fn)(primitive_pair_equal{d_equal}, d_hasher);
   }
 
   auto const d_hasher =
-    cudf::detail::row::hash::row_hasher{preprocessed_probe}.device_hasher(probe_nulls);
+    cudf::detail::row::hash::row_hasher{preprocessed_left}.device_hasher(left_nulls);
   auto const row_comparator =
-    cudf::detail::row::equality::two_table_comparator{preprocessed_probe, preprocessed_build};
+    cudf::detail::row::equality::two_table_comparator{preprocessed_left, preprocessed_right};
 
-  if (cudf::detail::has_nested_columns(probe_table)) {
-    auto const d_equal = row_comparator.equal_to<true>(probe_nulls, compare_nulls);
+  if (cudf::detail::has_nested_columns(left_table)) {
+    auto const d_equal = row_comparator.equal_to<true>(left_nulls, compare_nulls);
     return std::forward<Fn>(fn)(pair_equal{d_equal}, d_hasher);
   }
 
-  auto const d_equal = row_comparator.equal_to<false>(probe_nulls, compare_nulls);
+  auto const d_equal = row_comparator.equal_to<false>(left_nulls, compare_nulls);
   return std::forward<Fn>(fn)(pair_equal{d_equal}, d_hasher);
 }
 

--- a/cpp/src/join/hash_join/full_join_match_context.cpp
+++ b/cpp/src/join/hash_join/full_join_match_context.cpp
@@ -17,8 +17,7 @@ cudf::join_match_context hash_join<Hasher>::full_join_match_context(
   rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"hash_join::full_join_match_context"};
-  return cudf::join_match_context{left,
-                                  make_match_counts(join_kind::FULL_JOIN, left, stream, mr)};
+  return cudf::join_match_context{left, make_match_counts(join_kind::FULL_JOIN, left, stream, mr)};
 }
 
 template cudf::join_match_context cudf::hash_join::impl_type::full_join_match_context(

--- a/cpp/src/join/hash_join/full_join_match_context.cpp
+++ b/cpp/src/join/hash_join/full_join_match_context.cpp
@@ -12,17 +12,17 @@ namespace cudf::detail {
 
 template <typename Hasher>
 cudf::join_match_context hash_join<Hasher>::full_join_match_context(
-  cudf::table_view const& probe,
+  cudf::table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"hash_join::full_join_match_context"};
-  return cudf::join_match_context{probe,
-                                  make_match_counts(join_kind::FULL_JOIN, probe, stream, mr)};
+  return cudf::join_match_context{left,
+                                  make_match_counts(join_kind::FULL_JOIN, left, stream, mr)};
 }
 
 template cudf::join_match_context cudf::hash_join::impl_type::full_join_match_context(
-  cudf::table_view const& probe,
+  cudf::table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const;
 

--- a/cpp/src/join/hash_join/full_join_retrieve.cu
+++ b/cpp/src/join/hash_join/full_join_retrieve.cu
@@ -10,17 +10,17 @@ namespace cudf::detail {
 template <typename Hasher>
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-hash_join<Hasher>::full_join(cudf::table_view const& probe,
+hash_join<Hasher>::full_join(cudf::table_view const& left,
                              std::optional<std::size_t> output_size,
                              rmm::cuda_stream_view stream,
                              rmm::device_async_resource_ref mr) const
 {
-  return this->template join_retrieve<join_kind::FULL_JOIN>(probe, output_size, stream, mr);
+  return this->template join_retrieve<join_kind::FULL_JOIN>(left, output_size, stream, mr);
 }
 
 template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                    std::unique_ptr<rmm::device_uvector<size_type>>>
-hash_join<hash_join_hasher>::full_join(cudf::table_view const& probe,
+hash_join<hash_join_hasher>::full_join(cudf::table_view const& left,
                                        std::optional<std::size_t> output_size,
                                        rmm::cuda_stream_view stream,
                                        rmm::device_async_resource_ref mr) const;

--- a/cpp/src/join/hash_join/full_join_size.cu
+++ b/cpp/src/join/hash_join/full_join_size.cu
@@ -8,15 +8,15 @@
 namespace cudf::detail {
 
 template <typename Hasher>
-std::size_t hash_join<Hasher>::full_join_size(cudf::table_view const& probe,
+std::size_t hash_join<Hasher>::full_join_size(cudf::table_view const& left,
                                               rmm::cuda_stream_view stream,
                                               rmm::device_async_resource_ref mr) const
 {
-  return this->template join_size<join_kind::FULL_JOIN>(probe, stream, mr);
+  return this->template join_size<join_kind::FULL_JOIN>(left, stream, mr);
 }
 
 template std::size_t hash_join<hash_join_hasher>::full_join_size(
-  cudf::table_view const& probe,
+  cudf::table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const;
 

--- a/cpp/src/join/hash_join/full_join_size_impl.cu
+++ b/cpp/src/join/hash_join/full_join_size_impl.cu
@@ -53,20 +53,20 @@ std::size_t compute_left_join_complement_size(cudf::device_span<size_type const>
 }  // namespace
 
 std::size_t get_full_join_size(
-  cudf::table_view const& build_table,
-  cudf::table_view const& probe_table,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_build,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_probe,
+  cudf::table_view const& right_table,
+  cudf::table_view const& left_table,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_right,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
   cudf::detail::hash_table_t const& hash_table,
   bool has_nulls,
   null_equality compare_nulls,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  std::size_t join_size = compute_join_output_size<join_kind::LEFT_JOIN>(build_table,
-                                                                         probe_table,
-                                                                         preprocessed_build,
-                                                                         preprocessed_probe,
+  std::size_t join_size = compute_join_output_size<join_kind::LEFT_JOIN>(right_table,
+                                                                         left_table,
+                                                                         preprocessed_right,
+                                                                         preprocessed_left,
                                                                          hash_table,
                                                                          has_nulls,
                                                                          compare_nulls,
@@ -79,18 +79,18 @@ std::size_t get_full_join_size(
   auto const out_build_begin =
     thrust::make_transform_output_iterator(right_indices->begin(), output_fn{});
 
-  retrieve_left_join_build_indices(build_table,
-                                   probe_table,
-                                   preprocessed_build,
-                                   preprocessed_probe,
+  retrieve_left_join_build_indices(right_table,
+                                   left_table,
+                                   preprocessed_right,
+                                   preprocessed_left,
                                    hash_table,
                                    has_nulls,
                                    compare_nulls,
                                    out_build_begin,
                                    stream);
 
-  auto const left_table_row_count  = probe_table.num_rows();
-  auto const right_table_row_count = build_table.num_rows();
+  auto const left_table_row_count  = left_table.num_rows();
+  auto const right_table_row_count = right_table.num_rows();
 
   return join_size + compute_left_join_complement_size(
                        *right_indices, left_table_row_count, right_table_row_count, stream);

--- a/cpp/src/join/hash_join/hash_join.cu
+++ b/cpp/src/join/hash_join/hash_join.cu
@@ -43,81 +43,81 @@ bool is_trivial_join(table_view const& left, table_view const& right, join_kind 
   return false;
 }
 
-void validate_hash_join_probe(table_view const& build, table_view const& probe, bool has_nulls)
+void validate_hash_join_probe(table_view const& right, table_view const& left, bool has_nulls)
 {
-  CUDF_EXPECTS(0 != probe.num_columns(), "Hash join probe table is empty", std::invalid_argument);
-  CUDF_EXPECTS(build.num_columns() == probe.num_columns(),
+  CUDF_EXPECTS(0 != left.num_columns(), "Hash join left table is empty", std::invalid_argument);
+  CUDF_EXPECTS(right.num_columns() == left.num_columns(),
                "Mismatch in number of columns to be joined on",
                std::invalid_argument);
-  CUDF_EXPECTS(has_nulls || !cudf::has_nested_nulls(probe),
-               "Probe table has nulls while build table was not hashed with null check.",
+  CUDF_EXPECTS(has_nulls || !cudf::has_nested_nulls(left),
+               "Left table has nulls while right table was not hashed with null check.",
                std::invalid_argument);
-  CUDF_EXPECTS(cudf::have_same_types(build, probe),
+  CUDF_EXPECTS(cudf::have_same_types(right, left),
                "Mismatch in joining column data types",
                cudf::data_type_error);
 }
 
 namespace {
 void build_hash_join(
-  cudf::table_view const& build,
-  std::shared_ptr<detail::row::equality::preprocessed_table> const& preprocessed_build,
+  cudf::table_view const& right,
+  std::shared_ptr<detail::row::equality::preprocessed_table> const& preprocessed_right,
   cudf::detail::hash_table_t& hash_table,
   bool has_nested_nulls,
   null_equality nulls_equal,
   [[maybe_unused]] bitmask_type const* bitmask,
   rmm::cuda_stream_view stream)
 {
-  CUDF_EXPECTS(0 != build.num_columns(), "Selected build dataset is empty", std::invalid_argument);
-  CUDF_EXPECTS(0 != build.num_rows(), "Build side table has no rows", std::invalid_argument);
+  CUDF_EXPECTS(0 != right.num_columns(), "Selected right dataset is empty", std::invalid_argument);
+  CUDF_EXPECTS(0 != right.num_rows(), "Right side table has no rows", std::invalid_argument);
 
-  auto insert_rows = [&](auto const& build, auto const& d_hasher) {
+  auto insert_rows = [&](auto const& right, auto const& d_hasher) {
     auto const iter = cudf::detail::make_counting_transform_iterator(0, pair_fn{d_hasher});
 
-    if (nulls_equal == cudf::null_equality::EQUAL or not nullable(build)) {
-      hash_table.insert(iter, iter + build.num_rows(), stream.value());
+    if (nulls_equal == cudf::null_equality::EQUAL or not nullable(right)) {
+      hash_table.insert(iter, iter + right.num_rows(), stream.value());
     } else {
       auto const stencil = cuda::counting_iterator<size_type>{0};
       auto const pred    = row_is_valid{bitmask};
 
-      hash_table.insert_if(iter, iter + build.num_rows(), stencil, pred, stream.value());
+      hash_table.insert_if(iter, iter + right.num_rows(), stencil, pred, stream.value());
     }
   };
 
   auto const nulls = nullate::DYNAMIC{has_nested_nulls};
 
-  if (cudf::detail::is_primitive_row_op_compatible(build)) {
-    auto const d_hasher = cudf::detail::row::primitive::row_hasher{nulls, preprocessed_build};
+  if (cudf::detail::is_primitive_row_op_compatible(right)) {
+    auto const d_hasher = cudf::detail::row::primitive::row_hasher{nulls, preprocessed_right};
 
-    insert_rows(build, d_hasher);
+    insert_rows(right, d_hasher);
   } else {
-    auto const row_hash = detail::row::hash::row_hasher{preprocessed_build};
+    auto const row_hash = detail::row::hash::row_hasher{preprocessed_right};
     auto const d_hasher = row_hash.device_hasher(nulls);
 
-    insert_rows(build, d_hasher);
+    insert_rows(right, d_hasher);
   }
 }
 }  // namespace
 
 template <typename Hasher>
-hash_join<Hasher>::hash_join(cudf::table_view const& build,
+hash_join<Hasher>::hash_join(cudf::table_view const& right,
                              bool has_nulls,
                              cudf::null_equality compare_nulls,
                              rmm::cuda_stream_view stream)
-  : hash_join{build, has_nulls, compare_nulls, CUCO_DESIRED_LOAD_FACTOR, stream}
+  : hash_join{right, has_nulls, compare_nulls, CUCO_DESIRED_LOAD_FACTOR, stream}
 {
 }
 
 template <typename Hasher>
-hash_join<Hasher>::hash_join(cudf::table_view const& build,
+hash_join<Hasher>::hash_join(cudf::table_view const& right,
                              bool has_nulls,
                              cudf::null_equality compare_nulls,
                              double load_factor,
                              rmm::cuda_stream_view stream)
   : _has_nulls(has_nulls),
-    _is_empty{build.num_rows() == 0},
+    _is_empty{right.num_rows() == 0},
     _nulls_equal{compare_nulls},
     _impl{std::make_unique<impl>(impl{typename impl::hash_table_t{
-      cuco::extent{static_cast<size_t>(build.num_rows())},
+      cuco::extent{static_cast<size_t>(right.num_rows())},
       load_factor,
       cuco::empty_key{cuco::pair{std::numeric_limits<hash_value_type>::max(), cudf::JoinNoMatch}},
       {},
@@ -126,11 +126,11 @@ hash_join<Hasher>::hash_join(cudf::table_view const& build,
       {},
       rmm::mr::polymorphic_allocator<char>{},
       stream.value()}})},
-    _build{build},
-    _preprocessed_build{cudf::detail::row::equality::preprocessed_table::create(_build, stream)}
+    _right{right},
+    _preprocessed_right{cudf::detail::row::equality::preprocessed_table::create(_right, stream)}
 {
   CUDF_FUNC_RANGE();
-  CUDF_EXPECTS(0 != build.num_columns(), "Hash join build table is empty", std::invalid_argument);
+  CUDF_EXPECTS(0 != right.num_columns(), "Hash join right table is empty", std::invalid_argument);
   CUDF_EXPECTS(load_factor > 0 && load_factor <= 1,
                "Invalid load factor: must be greater than 0 and less than or equal to 1.",
                std::invalid_argument);
@@ -138,9 +138,9 @@ hash_join<Hasher>::hash_join(cudf::table_view const& build,
   if (_is_empty) { return; }
 
   auto const row_bitmask =
-    cudf::detail::bitmask_and(build, stream, cudf::get_current_device_resource_ref()).first;
-  cudf::detail::build_hash_join(_build,
-                                _preprocessed_build,
+    cudf::detail::bitmask_and(right, stream, cudf::get_current_device_resource_ref()).first;
+  cudf::detail::build_hash_join(_right,
+                                _preprocessed_right,
                                 _impl->_hash_table,
                                 _has_nulls,
                                 _nulls_equal,
@@ -148,12 +148,12 @@ hash_join<Hasher>::hash_join(cudf::table_view const& build,
                                 stream);
 }
 
-template hash_join<hash_join_hasher>::hash_join(cudf::table_view const& build,
+template hash_join<hash_join_hasher>::hash_join(cudf::table_view const& right,
                                                 bool has_nulls,
                                                 cudf::null_equality compare_nulls,
                                                 rmm::cuda_stream_view stream);
 
-template hash_join<hash_join_hasher>::hash_join(cudf::table_view const& build,
+template hash_join<hash_join_hasher>::hash_join(cudf::table_view const& right,
                                                 bool has_nulls,
                                                 cudf::null_equality compare_nulls,
                                                 double load_factor,
@@ -170,93 +170,93 @@ namespace cudf {
 
 hash_join::~hash_join() = default;
 
-hash_join::hash_join(cudf::table_view const& build,
+hash_join::hash_join(cudf::table_view const& right,
                      null_equality compare_nulls,
                      rmm::cuda_stream_view stream)
   : hash_join(
-      build, nullable_join::YES, compare_nulls, cudf::detail::CUCO_DESIRED_LOAD_FACTOR, stream)
+      right, nullable_join::YES, compare_nulls, cudf::detail::CUCO_DESIRED_LOAD_FACTOR, stream)
 {
 }
 
-hash_join::hash_join(cudf::table_view const& build,
+hash_join::hash_join(cudf::table_view const& right,
                      nullable_join has_nulls,
                      null_equality compare_nulls,
                      double load_factor,
                      rmm::cuda_stream_view stream)
   : _impl{std::make_unique<impl_type const>(
-      build, has_nulls == nullable_join::YES, compare_nulls, load_factor, stream)}
+      right, has_nulls == nullable_join::YES, compare_nulls, load_factor, stream)}
 {
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-hash_join::inner_join(cudf::table_view const& probe,
+hash_join::inner_join(cudf::table_view const& left,
                       std::optional<std::size_t> output_size,
                       rmm::cuda_stream_view stream,
                       rmm::device_async_resource_ref mr) const
 {
-  return _impl->inner_join(probe, output_size, stream, mr);
+  return _impl->inner_join(left, output_size, stream, mr);
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-hash_join::left_join(cudf::table_view const& probe,
+hash_join::left_join(cudf::table_view const& left,
                      std::optional<std::size_t> output_size,
                      rmm::cuda_stream_view stream,
                      rmm::device_async_resource_ref mr) const
 {
-  return _impl->left_join(probe, output_size, stream, mr);
+  return _impl->left_join(left, output_size, stream, mr);
 }
 
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-hash_join::full_join(cudf::table_view const& probe,
+hash_join::full_join(cudf::table_view const& left,
                      std::optional<std::size_t> output_size,
                      rmm::cuda_stream_view stream,
                      rmm::device_async_resource_ref mr) const
 {
-  return _impl->full_join(probe, output_size, stream, mr);
+  return _impl->full_join(left, output_size, stream, mr);
 }
 
-std::size_t hash_join::inner_join_size(cudf::table_view const& probe,
+std::size_t hash_join::inner_join_size(cudf::table_view const& left,
                                        rmm::cuda_stream_view stream) const
 {
-  return _impl->inner_join_size(probe, stream);
+  return _impl->inner_join_size(left, stream);
 }
 
-std::size_t hash_join::left_join_size(cudf::table_view const& probe,
+std::size_t hash_join::left_join_size(cudf::table_view const& left,
                                       rmm::cuda_stream_view stream) const
 {
-  return _impl->left_join_size(probe, stream);
+  return _impl->left_join_size(left, stream);
 }
 
-std::size_t hash_join::full_join_size(cudf::table_view const& probe,
+std::size_t hash_join::full_join_size(cudf::table_view const& left,
                                       rmm::cuda_stream_view stream,
                                       rmm::device_async_resource_ref mr) const
 {
-  return _impl->full_join_size(probe, stream, mr);
+  return _impl->full_join_size(left, stream, mr);
 }
 
 cudf::join_match_context hash_join::inner_join_match_context(
-  cudf::table_view const& probe,
+  cudf::table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
-  return _impl->inner_join_match_context(probe, stream, mr);
+  return _impl->inner_join_match_context(left, stream, mr);
 }
 
-cudf::join_match_context hash_join::left_join_match_context(cudf::table_view const& probe,
+cudf::join_match_context hash_join::left_join_match_context(cudf::table_view const& left,
                                                             rmm::cuda_stream_view stream,
                                                             rmm::device_async_resource_ref mr) const
 {
-  return _impl->left_join_match_context(probe, stream, mr);
+  return _impl->left_join_match_context(left, stream, mr);
 }
 
-cudf::join_match_context hash_join::full_join_match_context(cudf::table_view const& probe,
+cudf::join_match_context hash_join::full_join_match_context(cudf::table_view const& left,
                                                             rmm::cuda_stream_view stream,
                                                             rmm::device_async_resource_ref mr) const
 {
-  return _impl->full_join_match_context(probe, stream, mr);
+  return _impl->full_join_match_context(left, stream, mr);
 }
 
 }  // namespace cudf

--- a/cpp/src/join/hash_join/inner_join_match_context.cpp
+++ b/cpp/src/join/hash_join/inner_join_match_context.cpp
@@ -12,17 +12,17 @@ namespace cudf::detail {
 
 template <typename Hasher>
 cudf::join_match_context hash_join<Hasher>::inner_join_match_context(
-  cudf::table_view const& probe,
+  cudf::table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"hash_join::inner_join_match_context"};
-  return cudf::join_match_context{probe,
-                                  make_match_counts(join_kind::INNER_JOIN, probe, stream, mr)};
+  return cudf::join_match_context{left,
+                                  make_match_counts(join_kind::INNER_JOIN, left, stream, mr)};
 }
 
 template cudf::join_match_context cudf::hash_join::impl_type::inner_join_match_context(
-  cudf::table_view const& probe,
+  cudf::table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const;
 

--- a/cpp/src/join/hash_join/inner_join_match_context.cpp
+++ b/cpp/src/join/hash_join/inner_join_match_context.cpp
@@ -17,8 +17,7 @@ cudf::join_match_context hash_join<Hasher>::inner_join_match_context(
   rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"hash_join::inner_join_match_context"};
-  return cudf::join_match_context{left,
-                                  make_match_counts(join_kind::INNER_JOIN, left, stream, mr)};
+  return cudf::join_match_context{left, make_match_counts(join_kind::INNER_JOIN, left, stream, mr)};
 }
 
 template cudf::join_match_context cudf::hash_join::impl_type::inner_join_match_context(

--- a/cpp/src/join/hash_join/inner_join_retrieve.cu
+++ b/cpp/src/join/hash_join/inner_join_retrieve.cu
@@ -10,17 +10,17 @@ namespace cudf::detail {
 template <typename Hasher>
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-hash_join<Hasher>::inner_join(cudf::table_view const& probe,
+hash_join<Hasher>::inner_join(cudf::table_view const& left,
                               std::optional<std::size_t> output_size,
                               rmm::cuda_stream_view stream,
                               rmm::device_async_resource_ref mr) const
 {
-  return this->template join_retrieve<join_kind::INNER_JOIN>(probe, output_size, stream, mr);
+  return this->template join_retrieve<join_kind::INNER_JOIN>(left, output_size, stream, mr);
 }
 
 template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                    std::unique_ptr<rmm::device_uvector<size_type>>>
-hash_join<hash_join_hasher>::inner_join(cudf::table_view const& probe,
+hash_join<hash_join_hasher>::inner_join(cudf::table_view const& left,
                                         std::optional<std::size_t> output_size,
                                         rmm::cuda_stream_view stream,
                                         rmm::device_async_resource_ref mr) const;

--- a/cpp/src/join/hash_join/inner_join_size.cu
+++ b/cpp/src/join/hash_join/inner_join_size.cu
@@ -8,13 +8,13 @@
 namespace cudf::detail {
 
 template <typename Hasher>
-std::size_t hash_join<Hasher>::inner_join_size(cudf::table_view const& probe,
+std::size_t hash_join<Hasher>::inner_join_size(cudf::table_view const& left,
                                                rmm::cuda_stream_view stream) const
 {
-  return this->template join_size<join_kind::INNER_JOIN>(probe, stream);
+  return this->template join_size<join_kind::INNER_JOIN>(left, stream);
 }
 
 template std::size_t hash_join<hash_join_hasher>::inner_join_size(
-  cudf::table_view const& probe, rmm::cuda_stream_view stream) const;
+  cudf::table_view const& left, rmm::cuda_stream_view stream) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/left_join_match_context.cpp
+++ b/cpp/src/join/hash_join/left_join_match_context.cpp
@@ -17,8 +17,7 @@ cudf::join_match_context hash_join<Hasher>::left_join_match_context(
   rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"hash_join::left_join_match_context"};
-  return cudf::join_match_context{left,
-                                  make_match_counts(join_kind::LEFT_JOIN, left, stream, mr)};
+  return cudf::join_match_context{left, make_match_counts(join_kind::LEFT_JOIN, left, stream, mr)};
 }
 
 template cudf::join_match_context cudf::hash_join::impl_type::left_join_match_context(

--- a/cpp/src/join/hash_join/left_join_match_context.cpp
+++ b/cpp/src/join/hash_join/left_join_match_context.cpp
@@ -12,17 +12,17 @@ namespace cudf::detail {
 
 template <typename Hasher>
 cudf::join_match_context hash_join<Hasher>::left_join_match_context(
-  cudf::table_view const& probe,
+  cudf::table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
   cudf::scoped_range range{"hash_join::left_join_match_context"};
-  return cudf::join_match_context{probe,
-                                  make_match_counts(join_kind::LEFT_JOIN, probe, stream, mr)};
+  return cudf::join_match_context{left,
+                                  make_match_counts(join_kind::LEFT_JOIN, left, stream, mr)};
 }
 
 template cudf::join_match_context cudf::hash_join::impl_type::left_join_match_context(
-  cudf::table_view const& probe,
+  cudf::table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const;
 

--- a/cpp/src/join/hash_join/left_join_retrieve.cu
+++ b/cpp/src/join/hash_join/left_join_retrieve.cu
@@ -10,17 +10,17 @@ namespace cudf::detail {
 template <typename Hasher>
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-hash_join<Hasher>::left_join(cudf::table_view const& probe,
+hash_join<Hasher>::left_join(cudf::table_view const& left,
                              std::optional<std::size_t> output_size,
                              rmm::cuda_stream_view stream,
                              rmm::device_async_resource_ref mr) const
 {
-  return this->template join_retrieve<join_kind::LEFT_JOIN>(probe, output_size, stream, mr);
+  return this->template join_retrieve<join_kind::LEFT_JOIN>(left, output_size, stream, mr);
 }
 
 template std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
                    std::unique_ptr<rmm::device_uvector<size_type>>>
-hash_join<hash_join_hasher>::left_join(cudf::table_view const& probe,
+hash_join<hash_join_hasher>::left_join(cudf::table_view const& left,
                                        std::optional<std::size_t> output_size,
                                        rmm::cuda_stream_view stream,
                                        rmm::device_async_resource_ref mr) const;

--- a/cpp/src/join/hash_join/left_join_size.cu
+++ b/cpp/src/join/hash_join/left_join_size.cu
@@ -8,13 +8,13 @@
 namespace cudf::detail {
 
 template <typename Hasher>
-std::size_t hash_join<Hasher>::left_join_size(cudf::table_view const& probe,
+std::size_t hash_join<Hasher>::left_join_size(cudf::table_view const& left,
                                               rmm::cuda_stream_view stream) const
 {
-  return this->template join_size<join_kind::LEFT_JOIN>(probe, stream);
+  return this->template join_size<join_kind::LEFT_JOIN>(left, stream);
 }
 
 template std::size_t hash_join<hash_join_hasher>::left_join_size(
-  cudf::table_view const& probe, rmm::cuda_stream_view stream) const;
+  cudf::table_view const& left, rmm::cuda_stream_view stream) const;
 
 }  // namespace cudf::detail

--- a/cpp/src/join/hash_join/match_context.cu
+++ b/cpp/src/join/hash_join/match_context.cu
@@ -25,19 +25,19 @@ struct clamp_zero_to_one {
 }  // namespace
 
 std::unique_ptr<rmm::device_uvector<size_type>> make_join_match_counts(
-  table_view const& build,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_build,
+  table_view const& right,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_right,
   cudf::detail::hash_table_t const& hash_table,
   bool is_empty,
   bool has_nulls,
   null_equality compare_nulls,
   join_kind join,
-  table_view const& probe,
+  table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
   auto match_counts =
-    std::make_unique<rmm::device_uvector<size_type>>(probe.num_rows(), stream, mr);
+    std::make_unique<rmm::device_uvector<size_type>>(left.num_rows(), stream, mr);
 
   if (is_empty) {
     thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
@@ -47,19 +47,19 @@ std::unique_ptr<rmm::device_uvector<size_type>> make_join_match_counts(
     return match_counts;
   }
 
-  CUDF_EXPECTS(has_nulls || !cudf::has_nested_nulls(probe),
-               "Probe table has nulls while build table was not hashed with null check.",
+  CUDF_EXPECTS(has_nulls || !cudf::has_nested_nulls(left),
+               "Left table has nulls while right table was not hashed with null check.",
                std::invalid_argument);
 
-  auto const preprocessed_probe =
-    cudf::detail::row::equality::preprocessed_table::create(probe, stream);
-  auto const probe_table_num_rows = probe.num_rows();
+  auto const preprocessed_left =
+    cudf::detail::row::equality::preprocessed_table::create(left, stream);
+  auto const left_table_num_rows = left.num_rows();
 
   auto count_matches = [&](auto equality, auto d_hasher) {
     auto const iter = cudf::detail::make_counting_transform_iterator(0, pair_fn{d_hasher});
     if (join == join_kind::INNER_JOIN) {
       hash_table.count_each(iter,
-                            iter + probe_table_num_rows,
+                            iter + left_table_num_rows,
                             equality,
                             hash_table.hash_function(),
                             match_counts->begin(),
@@ -69,7 +69,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> make_join_match_counts(
       auto const output =
         thrust::make_transform_output_iterator(match_counts->begin(), clamp_zero_to_one{});
       hash_table.count_each(iter,
-                            iter + probe_table_num_rows,
+                            iter + left_table_num_rows,
                             equality,
                             hash_table.hash_function(),
                             output,
@@ -78,7 +78,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> make_join_match_counts(
   };
 
   dispatch_join_comparator(
-    build, probe, preprocessed_build, preprocessed_probe, has_nulls, compare_nulls, count_matches);
+    right, left, preprocessed_right, preprocessed_left, has_nulls, compare_nulls, count_matches);
 
   return match_counts;
 }
@@ -86,18 +86,18 @@ std::unique_ptr<rmm::device_uvector<size_type>> make_join_match_counts(
 template <typename Hasher>
 std::unique_ptr<rmm::device_uvector<size_type>> hash_join<Hasher>::make_match_counts(
   join_kind join,
-  cudf::table_view const& probe,
+  cudf::table_view const& left,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr) const
 {
-  return make_join_match_counts(_build,
-                                _preprocessed_build,
+  return make_join_match_counts(_right,
+                                _preprocessed_right,
                                 _impl->_hash_table,
                                 _is_empty,
                                 _has_nulls,
                                 _nulls_equal,
                                 join,
-                                probe,
+                                left,
                                 stream,
                                 mr);
 }

--- a/cpp/src/join/hash_join/match_context.cu
+++ b/cpp/src/join/hash_join/match_context.cu
@@ -36,8 +36,7 @@ std::unique_ptr<rmm::device_uvector<size_type>> make_join_match_counts(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
-  auto match_counts =
-    std::make_unique<rmm::device_uvector<size_type>>(left.num_rows(), stream, mr);
+  auto match_counts = std::make_unique<rmm::device_uvector<size_type>>(left.num_rows(), stream, mr);
 
   if (is_empty) {
     thrust::fill(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),

--- a/cpp/src/join/hash_join/retrieve_impl.cuh
+++ b/cpp/src/join/hash_join/retrieve_impl.cuh
@@ -23,10 +23,10 @@ template <join_kind Join>
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
 probe_join_hash_table(
-  cudf::table_view const& build_table,
-  cudf::table_view const& probe_table,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_build,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_probe,
+  cudf::table_view const& right_table,
+  cudf::table_view const& left_table,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_right,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
   cudf::detail::hash_table_t const& hash_table,
   bool has_nulls,
   null_equality compare_nulls,
@@ -41,10 +41,10 @@ probe_join_hash_table(
 
   std::size_t const join_size = output_size
                                   ? *output_size
-                                  : compute_join_output_size<size_join>(build_table,
-                                                                        probe_table,
-                                                                        preprocessed_build,
-                                                                        preprocessed_probe,
+                                  : compute_join_output_size<size_join>(right_table,
+                                                                        left_table,
+                                                                        preprocessed_right,
+                                                                        preprocessed_left,
                                                                         hash_table,
                                                                         has_nulls,
                                                                         compare_nulls,
@@ -60,7 +60,7 @@ probe_join_hash_table(
   cudf::prefetch::detail::prefetch(*left_indices, stream);
   cudf::prefetch::detail::prefetch(*right_indices, stream);
 
-  auto const probe_table_num_rows = probe_table.num_rows();
+  auto const left_table_num_rows = left_table.num_rows();
   auto const out_probe_begin =
     thrust::make_transform_output_iterator(left_indices->begin(), output_fn{});
   auto const out_build_begin =
@@ -70,7 +70,7 @@ probe_join_hash_table(
     auto const iter = cudf::detail::make_counting_transform_iterator(0, pair_fn{d_hasher});
     if constexpr (Join == join_kind::INNER_JOIN) {
       hash_table.retrieve(iter,
-                          iter + probe_table_num_rows,
+                          iter + left_table_num_rows,
                           equality,
                           hash_table.hash_function(),
                           out_probe_begin,
@@ -79,7 +79,7 @@ probe_join_hash_table(
     } else {
       [[maybe_unused]] auto out_probe_end = hash_table
                                               .retrieve_outer(iter,
-                                                              iter + probe_table_num_rows,
+                                                              iter + left_table_num_rows,
                                                               equality,
                                                               hash_table.hash_function(),
                                                               out_probe_begin,
@@ -95,10 +95,10 @@ probe_join_hash_table(
     }
   };
 
-  dispatch_join_comparator(build_table,
-                           probe_table,
-                           preprocessed_build,
-                           preprocessed_probe,
+  dispatch_join_comparator(right_table,
+                           left_table,
+                           preprocessed_right,
+                           preprocessed_left,
                            has_nulls,
                            compare_nulls,
                            retrieve_results);
@@ -108,22 +108,22 @@ probe_join_hash_table(
 
 template <typename RightOutputIterator>
 void retrieve_left_join_build_indices(
-  cudf::table_view const& build_table,
-  cudf::table_view const& probe_table,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_build,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_probe,
+  cudf::table_view const& right_table,
+  cudf::table_view const& left_table,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_right,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
   cudf::detail::hash_table_t const& hash_table,
   bool has_nulls,
   null_equality compare_nulls,
   RightOutputIterator out_build_begin,
   rmm::cuda_stream_view stream)
 {
-  auto const probe_table_num_rows = probe_table.num_rows();
+  auto const left_table_num_rows = left_table.num_rows();
 
   auto retrieve_results = [&](auto equality, auto d_hasher) {
     auto const iter = cudf::detail::make_counting_transform_iterator(0, pair_fn{d_hasher});
     hash_table.retrieve_outer(iter,
-                              iter + probe_table_num_rows,
+                              iter + left_table_num_rows,
                               equality,
                               hash_table.hash_function(),
                               cuda::make_discard_iterator(),
@@ -131,10 +131,10 @@ void retrieve_left_join_build_indices(
                               stream.value());
   };
 
-  dispatch_join_comparator(build_table,
-                           probe_table,
-                           preprocessed_build,
-                           preprocessed_probe,
+  dispatch_join_comparator(right_table,
+                           left_table,
+                           preprocessed_right,
+                           preprocessed_left,
                            has_nulls,
                            compare_nulls,
                            retrieve_results);
@@ -144,36 +144,36 @@ template <typename Hasher>
 template <join_kind Join>
 std::pair<std::unique_ptr<rmm::device_uvector<size_type>>,
           std::unique_ptr<rmm::device_uvector<size_type>>>
-hash_join<Hasher>::join_retrieve(cudf::table_view const& probe,
+hash_join<Hasher>::join_retrieve(cudf::table_view const& left,
                                  std::optional<std::size_t> output_size,
                                  rmm::cuda_stream_view stream,
                                  rmm::device_async_resource_ref mr) const
 {
   CUDF_FUNC_RANGE();
 
-  validate_hash_join_probe(_build, probe, _has_nulls);
+  validate_hash_join_probe(_right, left, _has_nulls);
 
   if constexpr (Join == join_kind::INNER_JOIN) {
-    if (is_trivial_join(probe, _build, Join)) {
+    if (is_trivial_join(left, _right, Join)) {
       return std::pair(std::make_unique<rmm::device_uvector<size_type>>(0, stream, mr),
                        std::make_unique<rmm::device_uvector<size_type>>(0, stream, mr));
     }
   } else {
-    if (_is_empty) { return get_trivial_left_join_indices(probe, stream, mr); }
+    if (_is_empty) { return get_trivial_left_join_indices(left, stream, mr); }
 
-    if (is_trivial_join(probe, _build, Join)) {
+    if (is_trivial_join(left, _right, Join)) {
       return std::pair(std::make_unique<rmm::device_uvector<size_type>>(0, stream, mr),
                        std::make_unique<rmm::device_uvector<size_type>>(0, stream, mr));
     }
   }
 
-  auto const preprocessed_probe =
-    cudf::detail::row::equality::preprocessed_table::create(probe, stream);
+  auto const preprocessed_left =
+    cudf::detail::row::equality::preprocessed_table::create(left, stream);
 
-  auto join_indices = cudf::detail::probe_join_hash_table<Join>(_build,
-                                                                probe,
-                                                                _preprocessed_build,
-                                                                preprocessed_probe,
+  auto join_indices = cudf::detail::probe_join_hash_table<Join>(_right,
+                                                                left,
+                                                                _preprocessed_right,
+                                                                preprocessed_left,
                                                                 _impl->_hash_table,
                                                                 _has_nulls,
                                                                 _nulls_equal,
@@ -183,7 +183,7 @@ hash_join<Hasher>::join_retrieve(cudf::table_view const& probe,
 
   if constexpr (Join == join_kind::FULL_JOIN) {
     auto complement_indices = detail::get_left_join_indices_complement(
-      join_indices.second, probe.num_rows(), _build.num_rows(), stream, mr);
+      join_indices.second, left.num_rows(), _right.num_rows(), stream, mr);
     return detail::concatenate_vector_pairs(join_indices, complement_indices, stream);
   } else {
     return join_indices;

--- a/cpp/src/join/hash_join/size_impl.cuh
+++ b/cpp/src/join/hash_join/size_impl.cuh
@@ -13,10 +13,10 @@
 namespace cudf::detail {
 
 std::size_t get_full_join_size(
-  cudf::table_view const& build_table,
-  cudf::table_view const& probe_table,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_build,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_probe,
+  cudf::table_view const& right_table,
+  cudf::table_view const& left_table,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_right,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
   cudf::detail::hash_table_t const& hash_table,
   bool has_nulls,
   null_equality compare_nulls,
@@ -25,10 +25,10 @@ std::size_t get_full_join_size(
 
 template <join_kind Join>
 std::size_t compute_join_output_size(
-  table_view const& build_table,
-  table_view const& probe_table,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_build,
-  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_probe,
+  table_view const& right_table,
+  table_view const& left_table,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_right,
+  std::shared_ptr<cudf::detail::row::equality::preprocessed_table> const& preprocessed_left,
   cudf::detail::hash_table_t const& hash_table,
   bool has_nulls,
   cudf::null_equality nulls_equal,
@@ -36,34 +36,34 @@ std::size_t compute_join_output_size(
 {
   static_assert(Join == join_kind::INNER_JOIN || Join == join_kind::LEFT_JOIN);
 
-  if (build_table.num_rows() == 0) {
-    return Join == join_kind::INNER_JOIN ? 0 : probe_table.num_rows();
+  if (right_table.num_rows() == 0) {
+    return Join == join_kind::INNER_JOIN ? 0 : left_table.num_rows();
   }
 
-  auto const probe_table_num_rows = probe_table.num_rows();
+  auto const left_table_num_rows = left_table.num_rows();
 
   return dispatch_join_comparator(
-    build_table,
-    probe_table,
-    preprocessed_build,
-    preprocessed_probe,
+    right_table,
+    left_table,
+    preprocessed_right,
+    preprocessed_left,
     has_nulls,
     nulls_equal,
     [&](auto equality, auto d_hasher) {
       auto const iter = cudf::detail::make_counting_transform_iterator(0, pair_fn{d_hasher});
       if constexpr (Join == join_kind::LEFT_JOIN) {
         return hash_table.count_outer(
-          iter, iter + probe_table_num_rows, equality, hash_table.hash_function(), stream.value());
+          iter, iter + left_table_num_rows, equality, hash_table.hash_function(), stream.value());
       } else {
         return hash_table.count(
-          iter, iter + probe_table_num_rows, equality, hash_table.hash_function(), stream.value());
+          iter, iter + left_table_num_rows, equality, hash_table.hash_function(), stream.value());
       }
     });
 }
 
 template <typename Hasher>
 template <join_kind Join>
-std::size_t hash_join<Hasher>::join_size(cudf::table_view const& probe,
+std::size_t hash_join<Hasher>::join_size(cudf::table_view const& left,
                                          rmm::cuda_stream_view stream) const
 {
   static_assert(Join == join_kind::INNER_JOIN || Join == join_kind::LEFT_JOIN);
@@ -73,20 +73,20 @@ std::size_t hash_join<Hasher>::join_size(cudf::table_view const& probe,
   if constexpr (Join == join_kind::INNER_JOIN) {
     if (_is_empty) { return 0; }
   } else {
-    if (_is_empty) { return probe.num_rows(); }
+    if (_is_empty) { return left.num_rows(); }
   }
 
-  CUDF_EXPECTS(_has_nulls || !cudf::has_nested_nulls(probe),
-               "Probe table has nulls while build table was not hashed with null check.",
+  CUDF_EXPECTS(_has_nulls || !cudf::has_nested_nulls(left),
+               "Left table has nulls while right table was not hashed with null check.",
                std::invalid_argument);
 
-  auto const preprocessed_probe =
-    cudf::detail::row::equality::preprocessed_table::create(probe, stream);
+  auto const preprocessed_left =
+    cudf::detail::row::equality::preprocessed_table::create(left, stream);
 
-  return cudf::detail::compute_join_output_size<Join>(_build,
-                                                      probe,
-                                                      _preprocessed_build,
-                                                      preprocessed_probe,
+  return cudf::detail::compute_join_output_size<Join>(_right,
+                                                      left,
+                                                      _preprocessed_right,
+                                                      preprocessed_left,
                                                       _impl->_hash_table,
                                                       _has_nulls,
                                                       _nulls_equal,
@@ -95,7 +95,7 @@ std::size_t hash_join<Hasher>::join_size(cudf::table_view const& probe,
 
 template <typename Hasher>
 template <join_kind Join>
-std::size_t hash_join<Hasher>::join_size(cudf::table_view const& probe,
+std::size_t hash_join<Hasher>::join_size(cudf::table_view const& left,
                                          rmm::cuda_stream_view stream,
                                          rmm::device_async_resource_ref mr) const
 {
@@ -103,19 +103,19 @@ std::size_t hash_join<Hasher>::join_size(cudf::table_view const& probe,
 
   CUDF_FUNC_RANGE();
 
-  if (_is_empty) { return probe.num_rows(); }
+  if (_is_empty) { return left.num_rows(); }
 
-  CUDF_EXPECTS(_has_nulls || !cudf::has_nested_nulls(probe),
-               "Probe table has nulls while build table was not hashed with null check.",
+  CUDF_EXPECTS(_has_nulls || !cudf::has_nested_nulls(left),
+               "Left table has nulls while right table was not hashed with null check.",
                std::invalid_argument);
 
-  auto const preprocessed_probe =
-    cudf::detail::row::equality::preprocessed_table::create(probe, stream);
+  auto const preprocessed_left =
+    cudf::detail::row::equality::preprocessed_table::create(left, stream);
 
-  return cudf::detail::get_full_join_size(_build,
-                                          probe,
-                                          _preprocessed_build,
-                                          preprocessed_probe,
+  return cudf::detail::get_full_join_size(_right,
+                                          left,
+                                          _preprocessed_right,
+                                          preprocessed_left,
                                           _impl->_hash_table,
                                           _has_nulls,
                                           _nulls_equal,

--- a/cpp/tests/join/distinct_join_tests.cpp
+++ b/cpp/tests/join/distinct_join_tests.cpp
@@ -357,7 +357,7 @@ TEST_F(DistinctJoinTest, InnerJoinWithStructsAndNulls)
   this->compare_to_reference(right.view(), left.view(), result, gold.view());
 }
 
-TEST_F(DistinctJoinTest, EmptyBuildTableInnerJoin)
+TEST_F(DistinctJoinTest, EmptyRightTableInnerJoin)
 {
   column_wrapper<int32_t> col0_0;
   column_wrapper<int32_t> col0_1;
@@ -380,7 +380,7 @@ TEST_F(DistinctJoinTest, EmptyBuildTableInnerJoin)
   this->compare_to_reference(right.view(), left.view(), result, right.view());
 }
 
-TEST_F(DistinctJoinTest, EmptyBuildTableLeftJoin)
+TEST_F(DistinctJoinTest, EmptyRightTableLeftJoin)
 {
   column_wrapper<int32_t> col0_0;
   column_wrapper<int32_t> col0_1;
@@ -405,7 +405,7 @@ TEST_F(DistinctJoinTest, EmptyBuildTableLeftJoin)
     right.view(), left.view(), gather_map, left.view(), cudf::out_of_bounds_policy::NULLIFY);
 }
 
-TEST_F(DistinctJoinTest, EmptyProbeTableInnerJoin)
+TEST_F(DistinctJoinTest, EmptyLeftTableInnerJoin)
 {
   column_wrapper<int32_t> col0_0{{2, 2, 0, 4, 3}};
   column_wrapper<int32_t> col0_1{{1, 0, 1, 2, 1}, {true, false, true, true, true}};
@@ -428,7 +428,7 @@ TEST_F(DistinctJoinTest, EmptyProbeTableInnerJoin)
   this->compare_to_reference(right.view(), left.view(), result, left.view());
 }
 
-TEST_F(DistinctJoinTest, EmptyProbeTableLeftJoin)
+TEST_F(DistinctJoinTest, EmptyLeftTableLeftJoin)
 {
   column_wrapper<int32_t> col0_0{{2, 2, 0, 4, 3}};
   column_wrapper<int32_t> col0_1{{1, 0, 1, 2, 1}, {true, false, true, true, true}};

--- a/cpp/tests/join/distinct_join_tests.cpp
+++ b/cpp/tests/join/distinct_join_tests.cpp
@@ -39,8 +39,8 @@ std::unique_ptr<rmm::device_uvector<cudf::size_type>> get_left_indices(cudf::siz
 
 struct DistinctJoinTest : public cudf::test::BaseFixture {
   void compare_to_reference(
-    cudf::table_view const& build_table,
-    cudf::table_view const& probe_table,
+    cudf::table_view const& right_table,
+    cudf::table_view const& left_table,
     std::pair<std::unique_ptr<rmm::device_uvector<cudf::size_type>>,
               std::unique_ptr<rmm::device_uvector<cudf::size_type>>> const& result,
     cudf::table_view const& expected_table,
@@ -54,8 +54,8 @@ struct DistinctJoinTest : public cudf::test::BaseFixture {
     auto build_indices_col = cudf::column_view{build_indices_span};
     auto probe_indices_col = cudf::column_view{probe_indices_span};
 
-    auto joined_cols = cudf::gather(probe_table, probe_indices_col, oob_policy)->release();
-    auto right_cols  = cudf::gather(build_table, build_indices_col, oob_policy)->release();
+    auto joined_cols = cudf::gather(left_table, probe_indices_col, oob_policy)->release();
+    auto right_cols  = cudf::gather(right_table, build_indices_col, oob_policy)->release();
 
     joined_cols.insert(joined_cols.end(),
                        std::make_move_iterator(right_cols.begin()),
@@ -76,19 +76,19 @@ TEST_F(DistinctJoinTest, IntegerInnerJoin)
 
   auto const init = cudf::numeric_scalar<int32_t>{0};
 
-  auto build = cudf::sequence(size, init, cudf::numeric_scalar<int32_t>{1});
-  auto probe = cudf::sequence(size, init, cudf::numeric_scalar<int32_t>{2});
+  auto right = cudf::sequence(size, init, cudf::numeric_scalar<int32_t>{1});
+  auto left = cudf::sequence(size, init, cudf::numeric_scalar<int32_t>{2});
 
-  auto build_table = cudf::table_view{{build->view()}};
-  auto probe_table = cudf::table_view{{probe->view()}};
+  auto right_table = cudf::table_view{{right->view()}};
+  auto left_table = cudf::table_view{{left->view()}};
 
-  auto distinct_join = cudf::distinct_hash_join{build_table};
+  auto distinct_join = cudf::distinct_hash_join{right_table};
 
-  auto result = distinct_join.inner_join(probe_table);
+  auto result = distinct_join.inner_join(left_table);
 
   auto constexpr gold_size = size / 2;
   auto gold                = cudf::sequence(gold_size, init, cudf::numeric_scalar<int32_t>{2});
-  this->compare_to_reference(build_table, probe_table, result, cudf::table_view{{gold->view()}});
+  this->compare_to_reference(right_table, left_table, result, cudf::table_view{{gold->view()}});
 }
 
 TEST_F(DistinctJoinTest, InnerJoinNoNulls)
@@ -109,11 +109,11 @@ TEST_F(DistinctJoinTest, InnerJoinNoNulls)
   cols1.push_back(col1_1.release());
   cols1.push_back(col1_2.release());
 
-  Table build(std::move(cols0));
-  Table probe(std::move(cols1));
+  Table right(std::move(cols0));
+  Table left(std::move(cols1));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.inner_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.inner_join(left.view());
 
   column_wrapper<int32_t> col_gold_0{{1, 2}};
   strcol_wrapper col_gold_1({"s0", "s0"});
@@ -130,7 +130,7 @@ TEST_F(DistinctJoinTest, InnerJoinNoNulls)
   cols_gold.push_back(col_gold_5.release());
   Table gold(std::move(cols_gold));
 
-  this->compare_to_reference(build.view(), probe.view(), result, gold.view());
+  this->compare_to_reference(right.view(), left.view(), result, gold.view());
 }
 
 TEST_F(DistinctJoinTest, PrimitiveInnerJoinNoNulls)
@@ -151,11 +151,11 @@ TEST_F(DistinctJoinTest, PrimitiveInnerJoinNoNulls)
   cols1.push_back(col1_1.release());
   cols1.push_back(col1_2.release());
 
-  Table build(std::move(cols0));
-  Table probe(std::move(cols1));
+  Table right(std::move(cols0));
+  Table left(std::move(cols1));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.inner_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.inner_join(left.view());
 
   column_wrapper<int32_t> col_gold_0{{1, 2}};
   column_wrapper<int32_t> col_gold_1({0, 0});
@@ -172,7 +172,7 @@ TEST_F(DistinctJoinTest, PrimitiveInnerJoinNoNulls)
   cols_gold.push_back(col_gold_5.release());
   Table gold(std::move(cols_gold));
 
-  this->compare_to_reference(build.view(), probe.view(), result, gold.view());
+  this->compare_to_reference(right.view(), left.view(), result, gold.view());
 }
 
 TEST_F(DistinctJoinTest, InnerJoinWithNulls)
@@ -193,8 +193,8 @@ TEST_F(DistinctJoinTest, InnerJoinWithNulls)
   cols1.push_back(col1_1.release());
   cols1.push_back(col1_2.release());
 
-  Table build(std::move(cols0));
-  Table probe(std::move(cols1));
+  Table right(std::move(cols0));
+  Table left(std::move(cols1));
 
   // Create gold table once
   column_wrapper<int32_t> col_gold_0{{3, 2}};
@@ -217,10 +217,10 @@ TEST_F(DistinctJoinTest, InnerJoinWithNulls)
 
   for (auto load_factor : load_factors) {
     auto distinct_join =
-      cudf::distinct_hash_join{build.view(), cudf::null_equality::EQUAL, load_factor};
-    auto result = distinct_join.inner_join(probe.view());
+      cudf::distinct_hash_join{right.view(), cudf::null_equality::EQUAL, load_factor};
+    auto result = distinct_join.inner_join(left.view());
 
-    this->compare_to_reference(build.view(), probe.view(), result, gold.view());
+    this->compare_to_reference(right.view(), left.view(), result, gold.view());
   }
 }
 
@@ -242,8 +242,8 @@ TEST_F(DistinctJoinTest, PrimitiveInnerJoinWithNulls)
   cols1.push_back(col1_1.release());
   cols1.push_back(col1_2.release());
 
-  Table build(std::move(cols0));
-  Table probe(std::move(cols1));
+  Table right(std::move(cols0));
+  Table left(std::move(cols1));
 
   // Create gold table once
   column_wrapper<int32_t> col_gold_0{{3, 2}};
@@ -266,10 +266,10 @@ TEST_F(DistinctJoinTest, PrimitiveInnerJoinWithNulls)
 
   for (auto load_factor : load_factors) {
     auto distinct_join =
-      cudf::distinct_hash_join{build.view(), cudf::null_equality::EQUAL, load_factor};
-    auto result = distinct_join.inner_join(probe.view());
+      cudf::distinct_hash_join{right.view(), cudf::null_equality::EQUAL, load_factor};
+    auto result = distinct_join.inner_join(left.view());
 
-    this->compare_to_reference(build.view(), probe.view(), result, gold.view());
+    this->compare_to_reference(right.view(), left.view(), result, gold.view());
   }
 }
 
@@ -316,11 +316,11 @@ TEST_F(DistinctJoinTest, InnerJoinWithStructsAndNulls)
   cols1.push_back(col1_2.release());
   cols1.push_back(col1_3.release());
 
-  Table probe(std::move(cols0));
-  Table build(std::move(cols1));
+  Table left(std::move(cols0));
+  Table right(std::move(cols1));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.inner_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.inner_join(left.view());
 
   column_wrapper<int32_t> col_gold_0{{3, 2}};
   strcol_wrapper col_gold_1({"s1", "s0"}, {true, true});
@@ -354,7 +354,7 @@ TEST_F(DistinctJoinTest, InnerJoinWithStructsAndNulls)
   cols_gold.push_back(col_gold_7.release());
   Table gold(std::move(cols_gold));
 
-  this->compare_to_reference(build.view(), probe.view(), result, gold.view());
+  this->compare_to_reference(right.view(), left.view(), result, gold.view());
 }
 
 TEST_F(DistinctJoinTest, EmptyBuildTableInnerJoin)
@@ -371,13 +371,13 @@ TEST_F(DistinctJoinTest, EmptyBuildTableInnerJoin)
   cols1.push_back(col1_0.release());
   cols1.push_back(col1_1.release());
 
-  Table build(std::move(cols0));
-  Table probe(std::move(cols1));
+  Table right(std::move(cols0));
+  Table left(std::move(cols1));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.inner_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.inner_join(left.view());
 
-  this->compare_to_reference(build.view(), probe.view(), result, build.view());
+  this->compare_to_reference(right.view(), left.view(), result, right.view());
 }
 
 TEST_F(DistinctJoinTest, EmptyBuildTableLeftJoin)
@@ -394,15 +394,15 @@ TEST_F(DistinctJoinTest, EmptyBuildTableLeftJoin)
   cols1.push_back(col1_0.release());
   cols1.push_back(col1_1.release());
 
-  Table build(std::move(cols0));
-  Table probe(std::move(cols1));
+  Table right(std::move(cols0));
+  Table left(std::move(cols1));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.left_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.left_join(left.view());
   auto gather_map    = std::pair{get_left_indices(result->size()), std::move(result)};
 
   this->compare_to_reference(
-    build.view(), probe.view(), gather_map, probe.view(), cudf::out_of_bounds_policy::NULLIFY);
+    right.view(), left.view(), gather_map, left.view(), cudf::out_of_bounds_policy::NULLIFY);
 }
 
 TEST_F(DistinctJoinTest, EmptyProbeTableInnerJoin)
@@ -419,13 +419,13 @@ TEST_F(DistinctJoinTest, EmptyProbeTableInnerJoin)
   cols1.push_back(col1_0.release());
   cols1.push_back(col1_1.release());
 
-  Table build(std::move(cols0));
-  Table probe(std::move(cols1));
+  Table right(std::move(cols0));
+  Table left(std::move(cols1));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.inner_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.inner_join(left.view());
 
-  this->compare_to_reference(build.view(), probe.view(), result, probe.view());
+  this->compare_to_reference(right.view(), left.view(), result, left.view());
 }
 
 TEST_F(DistinctJoinTest, EmptyProbeTableLeftJoin)
@@ -442,15 +442,15 @@ TEST_F(DistinctJoinTest, EmptyProbeTableLeftJoin)
   cols1.push_back(col1_0.release());
   cols1.push_back(col1_1.release());
 
-  Table build(std::move(cols0));
-  Table probe(std::move(cols1));
+  Table right(std::move(cols0));
+  Table left(std::move(cols1));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.left_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.left_join(left.view());
   auto gather_map    = std::pair{get_left_indices(result->size()), std::move(result)};
 
   this->compare_to_reference(
-    build.view(), probe.view(), gather_map, probe.view(), cudf::out_of_bounds_policy::NULLIFY);
+    right.view(), left.view(), gather_map, left.view(), cudf::out_of_bounds_policy::NULLIFY);
 }
 
 TEST_F(DistinctJoinTest, LeftJoinNoNulls)
@@ -467,8 +467,8 @@ TEST_F(DistinctJoinTest, LeftJoinNoNulls)
   cols1.push_back(col1_0.release());
   cols1.push_back(col1_1.release());
 
-  Table probe(std::move(cols0));
-  Table build(std::move(cols1));
+  Table left(std::move(cols0));
+  Table right(std::move(cols1));
 
   column_wrapper<int32_t> col_gold_0({3, 1, 2, 0, 3});
   strcol_wrapper col_gold_1({"s0", "s1", "s2", "s4", "s1"});
@@ -481,12 +481,12 @@ TEST_F(DistinctJoinTest, LeftJoinNoNulls)
   cols_gold.push_back(col_gold_3.release());
   Table gold(std::move(cols_gold));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.left_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.left_join(left.view());
   auto gather_map    = std::pair{get_left_indices(result->size()), std::move(result)};
 
   this->compare_to_reference(
-    build.view(), probe.view(), gather_map, gold.view(), cudf::out_of_bounds_policy::NULLIFY);
+    right.view(), left.view(), gather_map, gold.view(), cudf::out_of_bounds_policy::NULLIFY);
 }
 
 TEST_F(DistinctJoinTest, PrimitiveLeftJoinNoNulls)
@@ -503,8 +503,8 @@ TEST_F(DistinctJoinTest, PrimitiveLeftJoinNoNulls)
   cols1.push_back(col1_0.release());
   cols1.push_back(col1_1.release());
 
-  Table probe(std::move(cols0));
-  Table build(std::move(cols1));
+  Table left(std::move(cols0));
+  Table right(std::move(cols1));
 
   column_wrapper<int32_t> col_gold_0({3, 1, 2, 0, 3});
   column_wrapper<int32_t> col_gold_1({0, 1, 2, 4, 1});
@@ -517,12 +517,12 @@ TEST_F(DistinctJoinTest, PrimitiveLeftJoinNoNulls)
   cols_gold.push_back(col_gold_3.release());
   Table gold(std::move(cols_gold));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.left_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.left_join(left.view());
   auto gather_map    = std::pair{get_left_indices(result->size()), std::move(result)};
 
   this->compare_to_reference(
-    build.view(), probe.view(), gather_map, gold.view(), cudf::out_of_bounds_policy::NULLIFY);
+    right.view(), left.view(), gather_map, gold.view(), cudf::out_of_bounds_policy::NULLIFY);
 }
 
 TEST_F(DistinctJoinTest, LeftJoinWithNulls)
@@ -539,11 +539,11 @@ TEST_F(DistinctJoinTest, LeftJoinWithNulls)
   cols1.push_back(col1_0.release());
   cols1.push_back(col1_1.release());
 
-  Table probe(std::move(cols0));
-  Table build(std::move(cols1));
+  Table left(std::move(cols0));
+  Table right(std::move(cols1));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.left_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.left_join(left.view());
   auto gather_map    = std::pair{get_left_indices(result->size()), std::move(result)};
 
   column_wrapper<int32_t> col_gold_0{{3, 1, 2, 0, 2}, {true, true, true, true, true}};
@@ -559,7 +559,7 @@ TEST_F(DistinctJoinTest, LeftJoinWithNulls)
   Table gold(std::move(cols_gold));
 
   this->compare_to_reference(
-    build.view(), probe.view(), gather_map, gold.view(), cudf::out_of_bounds_policy::NULLIFY);
+    right.view(), left.view(), gather_map, gold.view(), cudf::out_of_bounds_policy::NULLIFY);
 }
 
 TEST_F(DistinctJoinTest, PrimitiveLeftJoinWithNulls)
@@ -576,11 +576,11 @@ TEST_F(DistinctJoinTest, PrimitiveLeftJoinWithNulls)
   cols1.push_back(col1_0.release());
   cols1.push_back(col1_1.release());
 
-  Table probe(std::move(cols0));
-  Table build(std::move(cols1));
+  Table left(std::move(cols0));
+  Table right(std::move(cols1));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.left_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.left_join(left.view());
   auto gather_map    = std::pair{get_left_indices(result->size()), std::move(result)};
 
   column_wrapper<int32_t> col_gold_0{{3, 1, 2, 0, 2}, {true, true, true, true, true}};
@@ -596,7 +596,7 @@ TEST_F(DistinctJoinTest, PrimitiveLeftJoinWithNulls)
   Table gold(std::move(cols_gold));
 
   this->compare_to_reference(
-    build.view(), probe.view(), gather_map, gold.view(), cudf::out_of_bounds_policy::NULLIFY);
+    right.view(), left.view(), gather_map, gold.view(), cudf::out_of_bounds_policy::NULLIFY);
 }
 
 TEST_F(DistinctJoinTest, LeftJoinWithStructsAndNulls)
@@ -621,11 +621,11 @@ TEST_F(DistinctJoinTest, LeftJoinWithStructsAndNulls)
   cols0.push_back(col0.release());
   cols1.push_back(col1.release());
 
-  Table probe(std::move(cols0));
-  Table build(std::move(cols1));
+  Table left(std::move(cols0));
+  Table right(std::move(cols1));
 
-  auto distinct_join = cudf::distinct_hash_join{build.view()};
-  auto result        = distinct_join.left_join(probe.view());
+  auto distinct_join = cudf::distinct_hash_join{right.view()};
+  auto result        = distinct_join.left_join(left.view());
   auto gather_map    = std::pair{get_left_indices(result->size()), std::move(result)};
 
   auto col0_gold_names_col = strcol_wrapper{
@@ -658,7 +658,7 @@ TEST_F(DistinctJoinTest, LeftJoinWithStructsAndNulls)
   Table gold(std::move(cols_gold));
 
   this->compare_to_reference(
-    build.view(), probe.view(), gather_map, gold.view(), cudf::out_of_bounds_policy::NULLIFY);
+    right.view(), left.view(), gather_map, gold.view(), cudf::out_of_bounds_policy::NULLIFY);
 }
 
 TEST_F(DistinctJoinTest, InvalidLoadFactor)
@@ -699,14 +699,14 @@ TEST_F(DistinctJoinTest, DistinctLargeExtentOverflowPrevention)
   auto const init = cudf::numeric_scalar<cudf::size_type>{0};
   auto build_col  = cudf::sequence(table_size, init, cudf::numeric_scalar<cudf::size_type>{1});
 
-  auto build_table = cudf::table_view{{build_col->view()}};
+  auto right_table = cudf::table_view{{build_col->view()}};
   cudf::table empty_probe_table{};
 
   // This should succeed with size_t extent - would have failed with int32_t extent
   // in scenarios approaching the overflow boundary
   EXPECT_NO_THROW({
     auto distinct_join = cudf::distinct_hash_join(
-      build_table, cudf::null_equality::EQUAL, load_factor, cudf::get_default_stream());
+      right_table, cudf::null_equality::EQUAL, load_factor, cudf::get_default_stream());
     auto result = distinct_join.inner_join(empty_probe_table);
   });
 }

--- a/cpp/tests/join/distinct_join_tests.cpp
+++ b/cpp/tests/join/distinct_join_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -77,10 +77,10 @@ TEST_F(DistinctJoinTest, IntegerInnerJoin)
   auto const init = cudf::numeric_scalar<int32_t>{0};
 
   auto right = cudf::sequence(size, init, cudf::numeric_scalar<int32_t>{1});
-  auto left = cudf::sequence(size, init, cudf::numeric_scalar<int32_t>{2});
+  auto left  = cudf::sequence(size, init, cudf::numeric_scalar<int32_t>{2});
 
   auto right_table = cudf::table_view{{right->view()}};
-  auto left_table = cudf::table_view{{left->view()}};
+  auto left_table  = cudf::table_view{{left->view()}};
 
   auto distinct_join = cudf::distinct_hash_join{right_table};
 

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -2894,7 +2894,7 @@ struct JoinTestLists : public cudf::test::BaseFixture {
             cudf::out_of_bounds_policy oob_policy)
   {
     auto const right_tv = cudf::table_view{{right}};
-    auto const left_tv = cudf::table_view{{left}};
+    auto const left_tv  = cudf::table_view{{left}};
 
     auto const [left_result_map, right_result_map] =
       join_func(right_tv,

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -2401,7 +2401,7 @@ TEST_F(JoinTest, HashJoinFullMatchContext)
   }
 }
 
-TEST_F(JoinTest, HashJoinMatchContextEmptyBuild)
+TEST_F(JoinTest, HashJoinMatchContextEmptyRight)
 {
   // Test match context with empty right table
   column_wrapper<int32_t> col0_0{{3, 1, 2}};

--- a/cpp/tests/join/join_tests.cpp
+++ b/cpp/tests/join/join_tests.cpp
@@ -2403,7 +2403,7 @@ TEST_F(JoinTest, HashJoinFullMatchContext)
 
 TEST_F(JoinTest, HashJoinMatchContextEmptyBuild)
 {
-  // Test match context with empty build table
+  // Test match context with empty right table
   column_wrapper<int32_t> col0_0{{3, 1, 2}};
   column_wrapper<int32_t> col1_0{};  // Empty
 
@@ -2855,7 +2855,7 @@ struct JoinTestLists : public cudf::test::BaseFixture {
       [],        3
       [5, 6]     4
   */
-  lcw build{{{0}, {1}, {{2, 0}, null_at(1)}, {}, {5, 6}}, null_at(0)};
+  lcw right{{{0}, {1}, {{2, 0}, null_at(1)}, {}, {5, 6}}, null_at(0)};
 
   /*
     [
@@ -2868,7 +2868,7 @@ struct JoinTestLists : public cudf::test::BaseFixture {
       [6]        6
     ]
   */
-  lcw probe{{{1}, {3}, {0}, {}, {{2, 0}, null_at(1)}, {5}, {6}}, null_at(2)};
+  lcw left{{{1}, {3}, {0}, {}, {{2, 0}, null_at(1)}, {5}, {6}}, null_at(2)};
 
   auto column_view_from_device_uvector(rmm::device_uvector<cudf::size_type> const& vector)
   {
@@ -2893,23 +2893,23 @@ struct JoinTestLists : public cudf::test::BaseFixture {
             JoinFunc join_func,
             cudf::out_of_bounds_policy oob_policy)
   {
-    auto const build_tv = cudf::table_view{{build}};
-    auto const probe_tv = cudf::table_view{{probe}};
+    auto const right_tv = cudf::table_view{{right}};
+    auto const left_tv = cudf::table_view{{left}};
 
     auto const [left_result_map, right_result_map] =
-      join_func(build_tv,
-                probe_tv,
+      join_func(right_tv,
+                left_tv,
                 nulls_equal,
                 cudf::get_default_stream(),
                 cudf::get_current_device_resource_ref());
 
     auto const left_result_table =
-      sort_and_gather(build_tv, column_view_from_device_uvector(*left_result_map), oob_policy);
+      sort_and_gather(right_tv, column_view_from_device_uvector(*left_result_map), oob_policy);
     auto const right_result_table =
-      sort_and_gather(probe_tv, column_view_from_device_uvector(*right_result_map), oob_policy);
+      sort_and_gather(left_tv, column_view_from_device_uvector(*right_result_map), oob_policy);
 
-    auto const left_gold_table  = sort_and_gather(build_tv, left_gold_map, oob_policy);
-    auto const right_gold_table = sort_and_gather(probe_tv, right_gold_map, oob_policy);
+    auto const left_gold_table  = sort_and_gather(right_tv, left_gold_map, oob_policy);
+    auto const right_gold_table = sort_and_gather(left_tv, right_gold_map, oob_policy);
 
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*left_result_table, *left_gold_table);
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*right_result_table, *right_gold_table);


### PR DESCRIPTION
## Description
There have been prior discussions about unifying the join interfaces to avoid, or at least reduce, the mixed use of probe/build and left/right terminology, which can be confusing.

This is the first PR in a series that renames join operations to replace the probe/build terminology with left/right. The probe/build roles are not deterministic and can vary depending on the algorithm, whereas left/right provides a consistent and unambiguous reference, minimizing confusion. This PR applies the renaming to `hash_join` and `distinct_hash_join`. There are no functional changes, only naming updates.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
