### PR TITLE
Add ray run_constraints in cudf_polars conda recipe

### DIFF
--- a/conda/recipes/cudf-polars/recipe.yaml
+++ b/conda/recipes/cudf-polars/recipe.yaml
@@ -43,6 +43,8 @@ requirements:
     - if: cuda_major == "12"
       then: cuda-python >=12.9.2,<13.0
       else: cuda-python >=13.0.1,<14.0
+  run_constraints:
+    - ray >=2.55.1
   ignore_run_exports:
     by_name:
       - cuda-version

--- a/conda/recipes/cudf-polars/recipe.yaml
+++ b/conda/recipes/cudf-polars/recipe.yaml
@@ -44,7 +44,7 @@ requirements:
       then: cuda-python >=12.9.2,<13.0
       else: cuda-python >=13.0.1,<14.0
   run_constraints:
-    - ray >=2.55.1
+    - ray-default >=2.55.1
   ignore_run_exports:
     by_name:
       - cuda-version


### PR DESCRIPTION
## Description
Address a follow up review in https://github.com/rapidsai/cudf/pull/22381#discussion_r3203910796 now that ray is an optional runtime dependency in cudf_polars

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
