### PR TITLE
Run conda, cudf_polars CI tests with Ray

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -385,13 +385,15 @@ jobs:
       build_type: pull-request
       script: "ci/test_python_cudf.sh"
   conda-python-other-tests:
-    # Tests for dask_cudf, custreamz, cudf_kafka are separated for CI parallelism
+    # Tests for dask_cudf, cudf_polars, custreamz, cudf_kafka are separated for CI parallelism
     needs: [conda-python-build-noarch, changed-files]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
     with:
       build_type: pull-request
+      # https://github.com/rapidsai/cudf/pull/22381/changes#r3196736965
+      container-options: "--cap-add CAP_SYS_PTRACE --shm-size=8g --ulimit=nofile=1000000:1000000"
       script: "ci/test_python_other.sh"
   conda-java-tests:
     needs: [conda-cpp-build, changed-files]

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -86,6 +86,7 @@ dependencies:
 - rapids-dask-dependency==26.6.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
 - rapidsmpf==26.6.*,>=0.0.0a0
+- ray>=2.55.1
 - rich
 - rmm==26.6.*,>=0.0.0a0
 - s3fs>=2022.3.0

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -86,7 +86,7 @@ dependencies:
 - rapids-dask-dependency==26.6.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
 - rapidsmpf==26.6.*,>=0.0.0a0
-- ray>=2.55.1
+- ray-default>=2.55.1
 - rich
 - rmm==26.6.*,>=0.0.0a0
 - s3fs>=2022.3.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -86,6 +86,7 @@ dependencies:
 - rapids-dask-dependency==26.6.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
 - rapidsmpf==26.6.*,>=0.0.0a0
+- ray>=2.55.1
 - rich
 - rmm==26.6.*,>=0.0.0a0
 - s3fs>=2022.3.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -86,7 +86,7 @@ dependencies:
 - rapids-dask-dependency==26.6.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
 - rapidsmpf==26.6.*,>=0.0.0a0
-- ray>=2.55.1
+- ray-default>=2.55.1
 - rich
 - rmm==26.6.*,>=0.0.0a0
 - s3fs>=2022.3.0

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -86,6 +86,7 @@ dependencies:
 - rapids-dask-dependency==26.6.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
 - rapidsmpf==26.6.*,>=0.0.0a0
+- ray>=2.55.1
 - rich
 - rmm==26.6.*,>=0.0.0a0
 - s3fs>=2022.3.0

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -86,7 +86,7 @@ dependencies:
 - rapids-dask-dependency==26.6.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
 - rapidsmpf==26.6.*,>=0.0.0a0
-- ray>=2.55.1
+- ray-default>=2.55.1
 - rich
 - rmm==26.6.*,>=0.0.0a0
 - s3fs>=2022.3.0

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -86,6 +86,7 @@ dependencies:
 - rapids-dask-dependency==26.6.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
 - rapidsmpf==26.6.*,>=0.0.0a0
+- ray>=2.55.1
 - rich
 - rmm==26.6.*,>=0.0.0a0
 - s3fs>=2022.3.0

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -86,7 +86,7 @@ dependencies:
 - rapids-dask-dependency==26.6.*,>=0.0.0a0
 - rapids-logger==0.2.*,>=0.0.0a0
 - rapidsmpf==26.6.*,>=0.0.0a0
-- ray>=2.55.1
+- ray-default>=2.55.1
 - rich
 - rmm==26.6.*,>=0.0.0a0
 - s3fs>=2022.3.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -26,6 +26,7 @@ files:
       - depends_on_numba_cuda
       - depends_on_rapids_logger
       - depends_on_rapidsmpf
+      - depends_on_ray
       - depends_on_rmm
       - develop
       - docs
@@ -160,6 +161,7 @@ files:
       - depends_on_cudf_kafka
       - depends_on_custreamz
       - depends_on_cudf_polars
+      - depends_on_ray
   test_java:
     output: none
     includes:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1302,7 +1302,10 @@ dependencies:
               - *rapidsmpf_unsuffixed
   depends_on_ray:
     common:
-      - output_types: [conda, requirements, pyproject]
+      - output_types: conda
+        packages:
+          - ray-default>=2.55.1
+      - output_types: [requirements, pyproject]
         packages:
           - ray>=2.55.1
   depends_on_rapids_logger:


### PR DESCRIPTION
## Description
Follow up to https://github.com/rapidsai/cudf/pull/22381

Adds `depends_on_ray` to `test_python_other` so the `conda-python-tests-other` job, which runs cudf_polars tests too,  exercises the `RayEngine` as well.

Also adds `depends_on_ray` to the `all` so ray is included in the `conda/environments/` yamls

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
