### PR TITLE
Add UTF-8 non-ASCII tests for JSON reader

### DIFF
--- a/cpp/tests/io/json/json_chunked_reader.cpp
+++ b/cpp/tests/io/json/json_chunked_reader.cpp
@@ -155,6 +155,70 @@ TEST_P(JsonReaderTest, ReadCompleteFiles)
   CUDF_TEST_EXPECT_TABLES_EQUIVALENT(result.tbl->view(), expected_result->view());
 }
 
+TEST_P(JsonReaderTest, ByteRange_SingleSource_UTF8)
+{
+  cudf::io::compression_type const comptype = GetParam();
+
+  // Non-ASCII UTF-8 in string values and field names.
+  // Byte-range splits may land inside multi-byte UTF-8 sequences; the chunked reader
+  // must handle this correctly.
+  std::string const json_string = R"({"name": "résumé", "val": 1})"
+                                  "\n"
+                                  R"({"name": "日本語", "val": 2})"
+                                  "\n"
+                                  R"({"name": "emoji: 😀", "val": 3})"
+                                  "\n"
+                                  R"({"name": "café ☕ 𝄞", "val": 4})"
+                                  "\n";
+
+  std::vector<std::uint8_t> cdata;
+  if (comptype != cudf::io::compression_type::NONE) {
+    cdata = cudf::io::detail::compress(
+      comptype,
+      cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(json_string.data()),
+                                     json_string.size()));
+  } else
+    cdata = std::vector<uint8_t>(
+      reinterpret_cast<uint8_t const*>(json_string.data()),
+      reinterpret_cast<uint8_t const*>(json_string.data()) + json_string.size());
+
+  cudf::io::json_reader_options json_lines_options =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json_string.c_str()), json_string.size()}})
+      .compression(cudf::io::compression_type::NONE)
+      .lines(true);
+  cudf::io::json_reader_options cjson_lines_options =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<uint8_t>(cdata.data(), cdata.size())})
+      .compression(comptype)
+      .lines(true);
+
+  cudf::io::table_with_metadata current_reader_table = cudf::io::read_json(cjson_lines_options);
+
+  auto datasources  = cudf::io::datasource::create(json_lines_options.get_source().host_buffers());
+  auto cdatasources = cudf::io::datasource::create(cjson_lines_options.get_source().host_buffers());
+
+  // Chunk sizes chosen to hit mid-character byte boundaries in multi-byte UTF-8 sequences
+  for (auto chunk_size : {7, 10, 15, 20, 30, 40, 50, 80, 100}) {
+    auto const tables = split_byte_range_reading(datasources,
+                                                 cdatasources,
+                                                 json_lines_options,
+                                                 cjson_lines_options,
+                                                 chunk_size,
+                                                 cudf::get_default_stream(),
+                                                 cudf::get_current_device_resource_ref());
+
+    auto table_views = std::vector<cudf::table_view>(tables.size());
+    std::transform(tables.begin(), tables.end(), table_views.begin(), [](auto& table) {
+      return table.tbl->view();
+    });
+    auto result = cudf::concatenate(table_views);
+
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(current_reader_table.tbl->view(), result->view());
+  }
+}
+
 TEST_P(JsonReaderTest, ByteRange_MultiSource)
 {
   cudf::io::compression_type const comptype = GetParam();
@@ -229,6 +293,85 @@ TEST_P(JsonReaderTest, ByteRange_MultiSource)
 
     // Verify that the data read via chunked reader matches the data read via nested JSON reader
     // cannot use EQUAL due to concatenate removing null mask
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(current_reader_table.tbl->view(), result->view());
+  }
+}
+
+TEST_P(JsonReaderTest, ByteRange_MultiSource_UTF8)
+{
+  cudf::io::compression_type const comptype = GetParam();
+
+  // Multi-source byte-range reading with non-ASCII UTF-8 content.
+  // Each source file contains the same UTF-8-rich JSON lines; byte-range splits
+  // across multiple sources may land inside multi-byte sequences.
+  std::string const json_string = R"({"città": "München", "id": 1})"
+                                  "\n"
+                                  R"({"città": "Zürich", "id": 2})"
+                                  "\n"
+                                  R"({"città": "東京", "id": 3})"
+                                  "\n"
+                                  R"({"città": "São Paulo", "id": 4})"
+                                  "\n";
+
+  std::vector<std::uint8_t> cdata;
+  if (comptype != cudf::io::compression_type::NONE) {
+    cdata = cudf::io::detail::compress(
+      comptype,
+      cudf::host_span<uint8_t const>(reinterpret_cast<uint8_t const*>(json_string.data()),
+                                     json_string.size()));
+  } else
+    cdata = std::vector<uint8_t>(
+      reinterpret_cast<uint8_t const*>(json_string.data()),
+      reinterpret_cast<uint8_t const*>(json_string.data()) + json_string.size());
+
+  auto cfilename = temp_env->get_temp_dir() + "cByteRangeMultiSourceUTF8.json";
+  {
+    std::ofstream outfile(cfilename, std::ofstream::out);
+    std::copy(cdata.begin(), cdata.end(), std::ostreambuf_iterator<char>(outfile));
+  }
+
+  constexpr int num_sources = 5;
+  std::vector<std::string> cfilepaths(num_sources, cfilename);
+  std::vector<cudf::host_span<char const>> hostbufs(
+    num_sources,
+    cudf::host_span<char const>(reinterpret_cast<char const*>(json_string.data()),
+                                json_string.size()));
+
+  cudf::io::json_reader_options json_lines_options =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{
+        cudf::host_span<cudf::host_span<char const>>(hostbufs.data(), hostbufs.size())})
+      .compression(cudf::io::compression_type::NONE)
+      .lines(true);
+  cudf::io::json_reader_options cjson_lines_options =
+    cudf::io::json_reader_options::builder(cudf::io::source_info{cfilepaths})
+      .lines(true)
+      .compression(comptype)
+      .recovery_mode(cudf::io::json_recovery_mode_t::FAIL);
+
+  cudf::io::table_with_metadata current_reader_table = cudf::io::read_json(cjson_lines_options);
+
+  std::vector<std::unique_ptr<cudf::io::datasource>> cdatasources;
+  for (auto& fp : cfilepaths) {
+    cdatasources.emplace_back(cudf::io::datasource::create(fp));
+  }
+  auto datasources = cudf::io::datasource::create(json_lines_options.get_source().host_buffers());
+
+  for (auto chunk_size : {7, 10, 15, 20, 40, 50, 100, 200, 500, 1000}) {
+    auto const tables = split_byte_range_reading(datasources,
+                                                 cdatasources,
+                                                 json_lines_options,
+                                                 cjson_lines_options,
+                                                 chunk_size,
+                                                 cudf::get_default_stream(),
+                                                 cudf::get_current_device_resource_ref());
+
+    auto table_views = std::vector<cudf::table_view>(tables.size());
+    std::transform(tables.begin(), tables.end(), table_views.begin(), [](auto& table) {
+      return table.tbl->view();
+    });
+    auto result = cudf::concatenate(table_views);
+
     CUDF_TEST_EXPECT_TABLES_EQUIVALENT(current_reader_table.tbl->view(), result->view());
   }
 }

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -3581,6 +3581,261 @@ TEST_F(JsonBatchedReaderTest, EmptyLastBatch)
                                  cudf::test::strings_column_wrapper{{"b", "b", "b", "b"}});
 }
 
+TEST_F(JsonBatchedReaderTest, UTF8StringValues)
+{
+  // Batched reading with non-ASCII UTF-8 strings.
+  // Each line is ~30-50 bytes; setting batch size to 40 forces batch boundaries
+  // that fall mid-record, exercising the delimiter search across UTF-8 content.
+  std::string const data = R"({"v": "résumé"})"
+                           "\n"
+                           R"({"v": "日本語"})"
+                           "\n"
+                           R"({"v": "emoji: 😀"})"
+                           "\n"
+                           R"({"v": "café ☕"})"
+                           "\n";
+
+  // Read without batching as reference
+  auto opts_full = cudf::io::json_reader_options::builder(
+                     cudf::io::source_info{cudf::host_span<std::byte const>{
+                       reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+                     .lines(true)
+                     .build();
+  auto const expected = cudf::io::read_json(opts_full);
+
+  // Force multiple batches with a small batch size
+  for (auto batch_size : {25, 30, 40, 50, 60}) {
+    this->set_batch_size(batch_size);
+    auto opts = cudf::io::json_reader_options::builder(
+                  cudf::io::source_info{cudf::host_span<std::byte const>{
+                    reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+                  .lines(true)
+                  .build();
+    auto const result = cudf::io::read_json(opts);
+
+    EXPECT_EQ(result.tbl->num_rows(), expected.tbl->num_rows());
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected.tbl->view(), result.tbl->view());
+  }
+}
+
+TEST_F(JsonBatchedReaderTest, UTF8FieldNamesAndMixedTypes)
+{
+  // Batched reading with non-ASCII field names and mixed column types
+  std::string const data = R"({"名前": "Alice", "スコア": 95.5})"
+                           "\n"
+                           R"({"名前": "Böb", "スコア": 87.3})"
+                           "\n"
+                           R"({"名前": "Ché", "スコア": 91.0})"
+                           "\n"
+                           R"({"名前": "Dörte", "スコア": 88.8})"
+                           "\n";
+
+  auto opts_full = cudf::io::json_reader_options::builder(
+                     cudf::io::source_info{cudf::host_span<std::byte const>{
+                       reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+                     .lines(true)
+                     .build();
+  auto const expected = cudf::io::read_json(opts_full);
+
+  for (auto batch_size : {30, 45, 60, 80}) {
+    this->set_batch_size(batch_size);
+    auto opts = cudf::io::json_reader_options::builder(
+                  cudf::io::source_info{cudf::host_span<std::byte const>{
+                    reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+                  .lines(true)
+                  .build();
+    auto const result = cudf::io::read_json(opts);
+
+    EXPECT_EQ(result.tbl->num_rows(), expected.tbl->num_rows());
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected.tbl->view(), result.tbl->view());
+  }
+}
+
+TEST_F(JsonBatchedReaderTest, UTF8RecoveryMode)
+{
+  // Batched reading with recovery mode and non-ASCII content
+  std::string const data = R"({"v": "café"})"
+                           "\n"
+                           R"({"v": bad})"
+                           "\n"
+                           R"({"v": "naïve"})"
+                           "\n"
+                           R"({"v": "über"})"
+                           "\n";
+
+  auto opts_full = cudf::io::json_reader_options::builder(
+                     cudf::io::source_info{cudf::host_span<std::byte const>{
+                       reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+                     .lines(true)
+                     .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+                     .build();
+  auto const expected = cudf::io::read_json(opts_full);
+
+  for (auto batch_size : {20, 35, 50}) {
+    this->set_batch_size(batch_size);
+    auto opts = cudf::io::json_reader_options::builder(
+                  cudf::io::source_info{cudf::host_span<std::byte const>{
+                    reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+                  .lines(true)
+                  .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+                  .build();
+    auto const result = cudf::io::read_json(opts);
+
+    EXPECT_EQ(result.tbl->num_rows(), expected.tbl->num_rows());
+    CUDF_TEST_EXPECT_TABLES_EQUIVALENT(expected.tbl->view(), result.tbl->view());
+  }
+}
+
+// Tests for non-ASCII UTF-8 input handling.
+// The PdaSymbolToSymbolGroupId operator casts char (signed) to int32_t, producing negative indices
+// for bytes 0x80-0xFF. The one-sided min() clamp in tos_sg_to_pda_sgid[] lookup does not guard
+// against negative values, causing an OOB read from __constant__ memory.
+
+TEST_F(JsonReaderTest, UTF8StringValues)
+{
+  // Two-byte (Latin), three-byte (CJK), and four-byte (emoji) UTF-8 sequences in string values
+  std::string const data = R"({"col0": "résumé", "col1": 1})"
+                           "\n"
+                           R"({"col0": "日本語テスト", "col1": 2})"
+                           "\n"
+                           R"({"col0": "emoji: 😀🎉", "col1": 3})"
+                           "\n"
+                           R"({"col0": "mixed: café ☕ 𝄞", "col1": 4})"
+                           "\n";
+
+  cudf::io::json_reader_options const in_opts =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+      .lines(true);
+
+  auto const result = cudf::io::read_json(in_opts);
+
+  EXPECT_EQ(result.tbl->num_columns(), 2);
+  EXPECT_EQ(result.tbl->num_rows(), 4);
+  EXPECT_EQ(result.tbl->get_column(0).type().id(), cudf::type_id::STRING);
+  EXPECT_EQ(result.metadata.schema_info[0].name, "col0");
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(0),
+                                 cudf::test::strings_column_wrapper(
+                                   {"résumé", "日本語テスト", "emoji: 😀🎉", "mixed: café ☕ 𝄞"}));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(1), int64_wrapper{{1, 2, 3, 4}});
+}
+
+TEST_F(JsonReaderTest, UTF8FieldNames)
+{
+  // Non-ASCII characters in JSON field names
+  std::string const data = R"({"名前": "Alice", "年齢": 30})"
+                           "\n"
+                           R"({"名前": "Bob", "年齢": 25})"
+                           "\n";
+
+  cudf::io::json_reader_options const in_opts =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+      .lines(true);
+
+  auto const result = cudf::io::read_json(in_opts);
+
+  EXPECT_EQ(result.tbl->num_columns(), 2);
+  EXPECT_EQ(result.tbl->num_rows(), 2);
+  EXPECT_EQ(result.metadata.schema_info[0].name, "名前");
+  EXPECT_EQ(result.metadata.schema_info[1].name, "年齢");
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(0),
+                                 cudf::test::strings_column_wrapper({"Alice", "Bob"}));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(1), int64_wrapper{{30, 25}});
+}
+
+TEST_F(JsonReaderTest, UTF8NestedStructsAndLists)
+{
+  // Non-ASCII in nested structures: struct values, list elements, and field names
+  std::string const data = R"({"obj": {"clé": "données"}, "arr": ["α", "β", "γ"]})"
+                           "\n"
+                           R"({"obj": {"clé": "über"}, "arr": ["δ", "ε"]})"
+                           "\n";
+
+  cudf::io::json_reader_options const in_opts =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+      .lines(true);
+
+  auto const result = cudf::io::read_json(in_opts);
+
+  EXPECT_EQ(result.tbl->num_columns(), 2);
+  EXPECT_EQ(result.tbl->num_rows(), 2);
+  EXPECT_EQ(result.metadata.schema_info[0].name, "obj");
+  EXPECT_EQ(result.metadata.schema_info[1].name, "arr");
+}
+
+TEST_F(JsonReaderTest, UTF8AllBytePatterns)
+{
+  // Exercise all UTF-8 byte lengths: 1-byte (ASCII), 2-byte, 3-byte, 4-byte
+  // This ensures every high-bit-set lead byte (0xC0-0xF4) and continuation byte (0x80-0xBF)
+  // is exercised in the PDA symbol group lookup.
+  std::string const data = R"({"s": "A"})"  // 1-byte: U+0041
+                           "\n"
+                           R"({"s": "ñ"})"  // 2-byte: U+00F1 = 0xC3 0xB1
+                           "\n"
+                           R"({"s": "€"})"  // 3-byte: U+20AC = 0xE2 0x82 0xAC
+                           "\n"
+                           R"({"s": "𐍈"})"  // 4-byte: U+10348 = 0xF0 0x90 0x8D 0x88
+                           "\n"
+                           R"({"s": "Ω"})"  // 2-byte: U+03A9 = 0xCE 0xA9
+                           "\n"
+                           R"({"s": "한"})"  // 3-byte: U+D55C = 0xED 0x95 0x9C
+                           "\n"
+                           R"({"s": "𝄞"})"  // 4-byte: U+1D11E = 0xF0 0x9D 0x84 0x9E
+                           "\n";
+
+  cudf::io::json_reader_options const in_opts =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+      .lines(true);
+
+  auto const result = cudf::io::read_json(in_opts);
+
+  EXPECT_EQ(result.tbl->num_columns(), 1);
+  EXPECT_EQ(result.tbl->num_rows(), 7);
+  EXPECT_EQ(result.tbl->get_column(0).type().id(), cudf::type_id::STRING);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(
+    result.tbl->get_column(0),
+    cudf::test::strings_column_wrapper({"A", "ñ", "€", "𐍈", "Ω", "한", "𝄞"}));
+}
+
+TEST_F(JsonReaderTest, UTF8RecoveryMode)
+{
+  // Non-ASCII input with recovery mode enabled (JSON lines with errors)
+  std::string const data = R"({"v": "café"})"
+                           "\n"
+                           R"({"v": invalid})"
+                           "\n"
+                           R"({"v": "naïve"})"
+                           "\n";
+
+  cudf::io::json_reader_options const in_opts =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(data.data()), data.size()}})
+      .lines(true)
+      .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL);
+
+  auto const result = cudf::io::read_json(in_opts);
+
+  EXPECT_EQ(result.tbl->num_columns(), 1);
+  EXPECT_EQ(result.tbl->num_rows(), 3);
+  EXPECT_EQ(result.tbl->get_column(0).type().id(), cudf::type_id::STRING);
+
+  // The invalid line should produce a null; valid UTF-8 lines should parse correctly
+  cudf::test::strings_column_wrapper expected({"café", "", "naïve"},
+                                              cudf::test::iterators::nulls_at({1}));
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(result.tbl->get_column(0), expected);
+}
+
 TEST_F(JsonReaderTest, DeviceReadAsyncThrows)
 {
   // Create simple JSON data


### PR DESCRIPTION
## Description

Add tests exercising the JSON reader with non-ASCII UTF-8 input to expose an OOB read in `PdaSymbolToSymbolGroupId` where signed char values `(0x80-0xFF)` produce negative indices into the `tos_sg_to_pda_sgid` lookup table.

**Reference**: https://github.com/rapidsai/adi-glasswing/issues/22

### Tests added:
- `JsonReaderTest`: UTF-8 string values, field names, nested structs/lists, all byte-length patterns (2/3/4-byte), and recovery mode
- `JsonBatchedReaderTest`: batched reading with UTF-8 content at various batch sizes, including recovery mode
- `json_chunked_reader`: single-source and multi-source byte-range reading with UTF-8 content across all compression types

### Test results:
- **11 tests fail**:
  - Recovery mode fails to detect invalid lines (nullable mismatch)
  - Token count estimation overflows (`"Generated token count exceeds the expected token count"`)
  - Schema inference becomes inconsistent across byte-range chunks (`"Mismatch in table columns to concatenate"`)
  - Batch size validation triggers spuriously (`"A single JSON line cannot be larger than the batch size limit"`)

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
