### PR TITLE
[JAVA] Fix ColumnWriterOptions parquet field id placement on outer list/binary/map

### DIFF
--- a/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
@@ -568,11 +568,14 @@ public class ColumnWriterOptions {
    * named 'value'. The caller of this method doesn't need to worry about this as this method will
    * take care of this without the knowledge of the caller.
    *
-   * @param isNullable     is the returned map nullable.
+   * @param isNullable     is the returned map nullable. Primitive {@code boolean} (not
+   *                       {@code Boolean}) so a {@code null} can't slip through and trigger an
+   *                       unexpected {@link NullPointerException} when forwarded to
+   *                       {@link #listBuilder(String, boolean, int)}.
    * @param parquetFieldId the Parquet field ID to attach to the outer (list) column.
    */
   public static ColumnWriterOptions mapColumn(String name, ColumnWriterOptions key,
-                                              ColumnWriterOptions value, Boolean isNullable,
+                                              ColumnWriterOptions value, boolean isNullable,
                                               int parquetFieldId) {
     if (key.isNullable) {
       throw new IllegalArgumentException("key column can not be nullable");

--- a/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
+++ b/java/src/main/java/ai/rapids/cudf/ColumnWriterOptions.java
@@ -46,6 +46,8 @@ public class ColumnWriterOptions {
     assert(builder.children.size() == 1) : "Lists can only have one child";
     this.columnName = builder.name;
     this.isNullable = builder.isNullable;
+    this.hasParquetFieldId = builder.hasParquetFieldId;
+    this.parquetFieldId = builder.parquetFieldId;
     // we are adding the child twice even though lists have one child only because the way the cudf
     // has implemented this it requires two children to be set for the list, but it drops the
     // first one. This is something that is a lower priority and might be fixed in future
@@ -144,10 +146,13 @@ public class ColumnWriterOptions {
     }
 
     protected ColumnWriterOptions withBinary(String name, boolean isNullable, int parquetFieldId) {
-      ColumnWriterOptions opt = listBuilder(name, isNullable)
+      // The parquet field id must be attached to the outer list (the column the writer emits as
+      // BINARY), not to the inner BINARY_DATA child, because the writer drops the inner child when
+      // flattening the list-as-binary into a parquet primitive.
+      ColumnWriterOptions opt = listBuilder(name, isNullable, parquetFieldId)
           // The name here does not matter. It will not be included in the final file
           // This is just to get the metadata to line up properly for the C++ APIs
-          .withColumn(false, "BINARY_DATA", parquetFieldId)
+          .withColumns(false, "BINARY_DATA")
           .build();
       opt.isBinary = true;
       return opt;
@@ -557,6 +562,31 @@ public class ColumnWriterOptions {
   }
 
   /**
+   * Add a Map Column to the schema with a Parquet field ID set on the outer list.
+   * <p>
+   * Maps are List columns with a Struct named 'key_value' with a child named 'key' and a child
+   * named 'value'. The caller of this method doesn't need to worry about this as this method will
+   * take care of this without the knowledge of the caller.
+   *
+   * @param isNullable     is the returned map nullable.
+   * @param parquetFieldId the Parquet field ID to attach to the outer (list) column.
+   */
+  public static ColumnWriterOptions mapColumn(String name, ColumnWriterOptions key,
+                                              ColumnWriterOptions value, Boolean isNullable,
+                                              int parquetFieldId) {
+    if (key.isNullable) {
+      throw new IllegalArgumentException("key column can not be nullable");
+    }
+    StructColumnWriterOptions struct = structBuilder("key_value").build();
+    struct.childColumnOptions = new ColumnWriterOptions[]{key, value};
+    ColumnWriterOptions opt = listBuilder(name, isNullable, parquetFieldId)
+        .withStructColumn(struct)
+        .build();
+    opt.isMap = true;
+    return opt;
+  }
+
+  /**
    * Creates a ListBuilder for column called 'name'
    */
   public static ListBuilder listBuilder(String name) {
@@ -568,6 +598,13 @@ public class ColumnWriterOptions {
    */
   public static ListBuilder listBuilder(String name, boolean isNullable) {
     return new ListBuilder(name, isNullable);
+  }
+
+  /**
+   * Creates a ListBuilder for column called 'name' with a Parquet field ID set on the list itself.
+   */
+  public static ListBuilder listBuilder(String name, boolean isNullable, int parquetFieldId) {
+    return new ListBuilder(name, isNullable, parquetFieldId);
   }
 
   /**
@@ -677,6 +714,10 @@ public class ColumnWriterOptions {
   public static class ListBuilder extends NestedBuilder<ListBuilder, ListColumnWriterOptions> {
     public ListBuilder(String name, boolean isNullable) {
       super(name, isNullable);
+    }
+
+    public ListBuilder(String name, boolean isNullable, int parquetFieldId) {
+      super(name, isNullable, parquetFieldId);
     }
 
     public ListColumnWriterOptions build() {

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -29,6 +29,7 @@ import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.Type;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -9563,10 +9564,45 @@ public class TableTest extends CudfTestBase {
         assertEquals(1, schema.getFields().get(0).getId().intValue());
         assertEquals(2, schema.getFields().get(1).getId().intValue());
         assertEquals(3, schema.getFields().get(2).getId().intValue());
+
+        // No nested descendant must inherit the outer id (catches "id placed on
+        // both outer and inner" regressions, including the original bug where
+        // withBinary(...id) attached the id to the inner BINARY_DATA child).
+        assertNoNestedIdEquals(schema.getFields().get(0), 1);
+        assertNoNestedIdEquals(schema.getFields().get(1), 2);
+        assertNoNestedIdEquals(schema.getFields().get(2), 3);
+
+        // The explicit child id on the LIST<INT> "element" must be preserved.
+        Type listElement = findDescendantByName(schema.getFields().get(1), "element");
+        assertNotNull(listElement);
+        assertEquals(22, listElement.getId().intValue());
       }
     } finally {
       tempFile.delete();
     }
+  }
+
+  private static void assertNoNestedIdEquals(Type type, int outerId) {
+    if (type.isPrimitive()) return;
+    for (Type child : type.asGroupType().getFields()) {
+      if (child.getId() != null) {
+        assertNotEquals(outerId, child.getId().intValue(),
+            "Field " + child.getName() + " unexpectedly inherited outer id " + outerId);
+      }
+      assertNoNestedIdEquals(child, outerId);
+    }
+  }
+
+  private static Type findDescendantByName(Type type, String name) {
+    if (type.isPrimitive()) {
+      return name.equals(type.getName()) ? type : null;
+    }
+    for (Type child : type.asGroupType().getFields()) {
+      if (name.equals(child.getName())) return child;
+      Type found = findDescendantByName(child, name);
+      if (found != null) return found;
+    }
+    return null;
   }
 
   /** Return a column where DECIMAL64 has been up-casted to DECIMAL128 */

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -9605,6 +9605,67 @@ public class TableTest extends CudfTestBase {
     return null;
   }
 
+  @Test
+  void testParquetWriteFieldIdOnNestedArrayOfBinaryAndString() throws IOException {
+    // Regression test for cudf #22347: the original Spark-Rapids/Iceberg
+    // failure ("Missing required field ... optional binary element is not in
+    // the store") came from array<binary> / array<string> columns where
+    // iceberg looks the leaf up by its parquet field id. Lock that nested path
+    // down here in addition to the top-level cases.
+    ParquetWriterOptions options = ParquetWriterOptions.builder()
+        .withListColumn(listBuilder("arr_bin", true, 10)
+            .withBinaryColumn("element", true, 11)
+            .build())
+        .withListColumn(listBuilder("arr_str", true, 20)
+            .withColumn(true, "element", 21)
+            .build())
+        .build();
+
+    File tempFile = File.createTempFile("test-field-id-nested", ".parquet");
+    try {
+      HostColumnVector.ListType binEl = new HostColumnVector.ListType(true,
+          new HostColumnVector.BasicType(false, DType.UINT8));
+      HostColumnVector.ListType arrBinType = new HostColumnVector.ListType(true, binEl);
+      HostColumnVector.ListType arrStrType = new HostColumnVector.ListType(true,
+          new HostColumnVector.BasicType(true, DType.STRING));
+
+      try (ColumnVector arrBinCol = ColumnVector.fromLists(arrBinType,
+               Arrays.asList(asList("ABC"), asList("DEF")),
+               Arrays.asList(asList("GHI")));
+           ColumnVector arrStrCol = ColumnVector.fromLists(arrStrType,
+               Arrays.asList("a", "b"),
+               Arrays.asList("c"));
+           Table t0 = new Table(arrBinCol, arrStrCol)) {
+        try (TableWriter writer = Table.writeParquetChunked(options, tempFile.getAbsoluteFile())) {
+          writer.write(t0);
+        }
+      }
+
+      try (ParquetFileReader reader = ParquetFileReader.open(HadoopInputFile.fromPath(
+          new Path(tempFile.getAbsolutePath()), new Configuration()))) {
+        MessageType schema = reader.getFooter().getFileMetaData().getSchema();
+        // Outer LIST ids must land on the outer list groups.
+        assertEquals(10, schema.getFields().get(0).getId().intValue());
+        assertEquals(20, schema.getFields().get(1).getId().intValue());
+
+        // Outer ids must not leak into nested descendants.
+        assertNoNestedIdEquals(schema.getFields().get(0), 10);
+        assertNoNestedIdEquals(schema.getFields().get(1), 20);
+
+        // Inner element ids must reach the leaf — this is the iceberg lookup
+        // path that broke before the fix on array<binary>.
+        Type binElement = findDescendantByName(schema.getFields().get(0), "element");
+        assertNotNull(binElement);
+        assertEquals(11, binElement.getId().intValue());
+        Type strElement = findDescendantByName(schema.getFields().get(1), "element");
+        assertNotNull(strElement);
+        assertEquals(21, strElement.getId().intValue());
+      }
+    } finally {
+      tempFile.delete();
+    }
+  }
+
   /** Return a column where DECIMAL64 has been up-casted to DECIMAL128 */
   private ColumnVector castDecimal64To128(ColumnView c) {
     DType dtype = c.getType();

--- a/java/src/test/java/ai/rapids/cudf/TableTest.java
+++ b/java/src/test/java/ai/rapids/cudf/TableTest.java
@@ -9514,6 +9514,61 @@ public class TableTest extends CudfTestBase {
     }
   }
 
+  @Test
+  void testParquetWriteFieldIdOnOuterListBinaryAndMap() throws IOException {
+    // Regression test for cudf #22347: parquet field IDs supplied via
+    // withBinaryColumn(name, nullable, id), listBuilder(name, nullable, id) and
+    // mapColumn(name, key, value, isNullable, id) must end up on the outer
+    // (list/map) column on disk, not on the inner element/key_value child.
+    ParquetWriterOptions options = ParquetWriterOptions.builder()
+        .withBinaryColumn("_c0", true, 1)
+        .withListColumn(listBuilder("_c1", true, 2)
+            .withColumn(false, "element", 22)
+            .build())
+        .withMapColumn(mapColumn("_c2",
+            new ColumnWriterOptions("key", false),
+            new ColumnWriterOptions("value"),
+            true, 3))
+        .build();
+
+    File tempFile = File.createTempFile("test-field-id-outer", ".parquet");
+    try {
+      List<Byte> bin1 = asList("ABC");
+      List<Byte> bin2 = asList("DEF");
+      HostColumnVector.ListType binType = new HostColumnVector.ListType(true,
+          new HostColumnVector.BasicType(false, DType.UINT8));
+      HostColumnVector.ListType listOfInt = new HostColumnVector.ListType(true,
+          new HostColumnVector.BasicType(false, DType.INT32));
+      HostColumnVector.StructType kvType = new HostColumnVector.StructType(true,
+          Arrays.asList(new HostColumnVector.BasicType(true, DType.STRING),
+                        new HostColumnVector.BasicType(true, DType.STRING)));
+      HostColumnVector.ListType mapType = new HostColumnVector.ListType(true, kvType);
+
+      try (ColumnVector binCol = ColumnVector.fromLists(binType, bin1, bin2);
+           ColumnVector listCol = ColumnVector.fromLists(listOfInt,
+               Arrays.asList(1, 2, 3), Arrays.asList(4, 5));
+           ColumnVector mapCol = ColumnVector.fromLists(mapType,
+               Arrays.asList(new HostColumnVector.StructData(Arrays.asList("a", "b"))),
+               Arrays.asList(new HostColumnVector.StructData(Arrays.asList("c", "d"))));
+           Table t0 = new Table(binCol, listCol, mapCol)) {
+        try (TableWriter writer = Table.writeParquetChunked(options, tempFile.getAbsoluteFile())) {
+          writer.write(t0);
+        }
+      }
+
+      try (ParquetFileReader reader = ParquetFileReader.open(HadoopInputFile.fromPath(
+          new Path(tempFile.getAbsolutePath()), new Configuration()))) {
+        MessageType schema = reader.getFooter().getFileMetaData().getSchema();
+        // The id supplied to the API must land on the outer (BINARY/LIST/MAP) column.
+        assertEquals(1, schema.getFields().get(0).getId().intValue());
+        assertEquals(2, schema.getFields().get(1).getId().intValue());
+        assertEquals(3, schema.getFields().get(2).getId().intValue());
+      }
+    } finally {
+      tempFile.delete();
+    }
+  }
+
   /** Return a column where DECIMAL64 has been up-casted to DECIMAL128 */
   private ColumnVector castDecimal64To128(ColumnView c) {
     DType dtype = c.getType();


### PR DESCRIPTION
## Description

Fixes #22347.

`ColumnWriterOptions.NestedBuilder.withBinary(name, nullable, parquetFieldId)` placed the supplied `parquetFieldId` on the inner `BINARY_DATA` child of the list-marked-as-binary, not on the outer list. When the parquet writer flattens the list-marked-as-binary into a `BINARY` primitive, the inner child is dropped, so the caller-supplied field id never reached the on-disk column. This broke iceberg readback in spark-rapids (`Missing required field: _c8`, `optional binary element is not in the store`) since iceberg looks columns up by parquet field id.

There was also no public API to set a parquet field id on the outer LIST or MAP column at all, so spark-rapids was setting `parquetFieldId` / `isBinary` reflectively. [PR review feedback](https://github.com/NVIDIA/spark-rapids/pull/14611#discussion_r3129182230) asked us to upstream a proper API.

## Changes

This is **Solution 2** from the issue — symmetrical with the existing `structBuilder(name, nullable, parquetFieldId)`:

- `ColumnWriterOptions(ListBuilder)` now copies `hasParquetFieldId` / `parquetFieldId` from the builder (was a latent gap — set on the builder, dropped on `build()`).
- `withBinary(name, nullable, parquetFieldId)` attaches the id to the outer list and drops it from the inner `BINARY_DATA` child, so the on-disk BINARY column carries the caller-supplied id.
- New `ListBuilder(name, nullable, parquetFieldId)` constructor and `listBuilder(name, nullable, parquetFieldId)` factory.
- New `mapColumn(name, key, value, isNullable, parquetFieldId)` factory.

These let spark-rapids (and any other consumer) set parquet field ids on outer LIST / MAP / top-level BINARY columns without reflection.

Native parquet writer logic does not need to change — the outer-list field id is already what the writer reads when emitting the on-disk BINARY column, per the issue's compatibility note.

## Test

Added `TableTest#testParquetWriteFieldIdOnOuterListBinaryAndMap` — writes a parquet file with one BINARY, one LIST<INT>, and one MAP<STRING,STRING> column (each with a distinct field id) and asserts the on-disk schema places the id on the outer column.

Verified via the spark-rapids-jni docker test wrapper:

```
./build/build-in-docker test \
  -DCMAKE_CUDA_ARCHITECTURES=NATIVE \
  -DCPP_PARALLEL_LEVEL=32 \
  -Dsubmodule.check.skip=true \
  -Dtest=ai.rapids.cudf.TableTest#testParquetWriteFieldIdOnOuterListBinaryAndMap
```

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)