### PR TITLE
Forward-merge main into pandas3

### DIFF
--- a/python/cudf/cudf/pandas/_benchmarks/utils.py
+++ b/python/cudf/cudf/pandas/_benchmarks/utils.py
@@ -742,6 +742,7 @@ def run_pandas(
         query_failures.extend(result.iteration_failures)
         if result.validation_failed:
             validation_failures.append(q_id)
+        records[q_id].extend(result.query_records)
 
     run_config = dataclasses.replace(run_config, records=dict(records))
 


### PR DESCRIPTION
Forward-merge triggered by automated cron job to keep `pandas3` up-to-date with `main`.

If this PR has conflicts, it will remain open for manual resolution.

See [forward-merger docs](https://docs.rapids.ai/maintainers/forward-merger/) for more info.