### PR TITLE
Add ``LocalRepartitioner`` utility

### DIFF
--- a/python/cudf_polars/cudf_polars/dsl/ir.py
+++ b/python/cudf_polars/cudf_polars/dsl/ir.py
@@ -45,8 +45,7 @@ from cudf_polars.dsl.utils.windows import (
 from cudf_polars.utils import dtypes
 from cudf_polars.utils.cuda_stream import (
     get_cuda_stream,
-    get_joined_cuda_stream,
-    join_cuda_streams,
+    stream_ordered_after,
 )
 from cudf_polars.utils.versions import (
     POLARS_VERSION_LT_131,
@@ -128,36 +127,11 @@ class IRExecutionContext:
         Yields
         ------
         A CUDA stream that is downstream of the given dataframes.
-
-        Notes
-        -----
-        This context manager provides two useful guarantees when working with
-        objects holding references to stream-ordered objects:
-
-        1. The stream yield upon entering the context manager is *downstream* of
-           all the input dataframes.  This ensures that you can safely perform
-           stream-ordered operations on any input using the yielded stream.
-        2. The stream-ordered CUDA deallocation of the inputs happens *after* the
-           context manager exits. This ensures that all stream-ordered operations
-           submitted inside the context manager can complete before the memory
-           referenced by the inputs is deallocated.
-
-        Note that this does (deliberately) disconnect the dropping of the Python
-        object (by its refcount dropping to 0) from the actual stream-ordered
-        deallocation of the CUDA memory. This is precisely what we need to ensure
-        that the inputs are valid long enough for the stream-ordered operations to
-        complete.
         """
-        result_stream = get_joined_cuda_stream(
+        with stream_ordered_after(
             self.get_cuda_stream, upstreams=[df.stream for df in dfs]
-        )
-
-        yield result_stream
-
-        # ensure that the inputs are downstream of result_stream (so that deallocation happens after the result is ready)
-        join_cuda_streams(
-            downstreams=[df.stream for df in dfs], upstreams=[result_stream]
-        )
+        ) as result_stream:
+            yield result_stream
 
 
 _BINOPS = {

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -25,6 +25,8 @@ from rapidsmpf.streaming.cudf.channel_metadata import (
 )
 from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 
+import pylibcudf as plc
+
 from cudf_polars.dsl.expr import Col
 from cudf_polars.experimental.rapidsmpf.dispatch import (
     generate_ir_sub_network,
@@ -44,7 +46,6 @@ if TYPE_CHECKING:
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.streaming.core.channel import Channel
 
-    import pylibcudf as plc
     from rmm.pylibrmm.stream import Stream
 
     from cudf_polars.dsl.ir import IR, IRExecutionContext
@@ -107,6 +108,39 @@ class ShuffleManager:
                 py_split_and_pack(
                     table=chunk.table_view(),
                     splits=splits,
+                    stream=chunk.stream,
+                    br=self._manager.context.br(),
+                )
+            )
+
+        def insert_index(self, chunk: TableChunk, partition_col: int) -> None:
+            """
+            Partition chunk by a pre-computed integer column and insert.
+
+            Parameters
+            ----------
+            chunk
+                The chunk to partition.
+            partition_col
+                Index of the integer column whose values give the target
+                local partition ID for each row. The partition column is
+                consumed as routing metadata and stripped from the payload.
+                Callers should not expect it in the output.
+            """
+            table = chunk.table_view()
+            cols = table.columns()
+            partition_map = cols[partition_col]
+            payload = plc.Table([c for i, c in enumerate(cols) if i != partition_col])
+            reordered, offsets = plc.partitioning.partition(
+                payload,
+                partition_map,
+                self._manager.num_partitions,
+                stream=chunk.stream,
+            )
+            self._manager.shuffler.insert(
+                py_split_and_pack(
+                    table=reordered,
+                    splits=list(offsets[1:-1]),
                     stream=chunk.stream,
                     br=self._manager.context.br(),
                 )
@@ -241,6 +275,29 @@ class LocalRepartitioner:
                         table, stream, exclusive_view=True, br=self._br
                     ),
                     columns_to_hash,
+                )
+
+    async def insert_chunks_index(self, *, partition_col: int, stream: Stream) -> None:
+        """
+        Re-partition items by a pre-computed integer partition column.
+
+        Parameters
+        ----------
+        partition_col
+            Index of the integer column whose values give the target
+            local partition ID for each row. The partition column is
+            consumed as routing metadata and stripped from the payload.
+            Callers should not expect it in the output.
+        stream
+            CUDA stream for the unpack operation.
+        """
+        async with self._local_shuffle.inserting() as inserter:
+            for table in self._iter_chunks(stream):
+                inserter.insert_index(
+                    TableChunk.from_pylibcudf_table(
+                        table, stream, exclusive_view=True, br=self._br
+                    ),
+                    partition_col,
                 )
 
     def local_partitions(self) -> list[int]:

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -26,6 +26,7 @@ from rapidsmpf.streaming.cudf.channel_metadata import (
 from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 
 import pylibcudf as plc
+import pylibcudf.partitioning
 
 from cudf_polars.dsl.expr import Col
 from cudf_polars.experimental.rapidsmpf.dispatch import (
@@ -39,6 +40,7 @@ from cudf_polars.experimental.rapidsmpf.utils import (
     send_metadata,
 )
 from cudf_polars.experimental.shuffle import Shuffle
+from cudf_polars.utils.cuda_stream import get_joined_cuda_stream
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -113,35 +115,36 @@ class ShuffleManager:
                 )
             )
 
-        def insert_index(self, chunk: TableChunk, partition_col: int) -> None:
+        def insert_index(self, chunk: TableChunk, partition_map: TableChunk) -> None:
             """
-            Partition chunk by a pre-computed integer column and insert.
+            Partition chunk by a separate single-column partition-map and insert.
 
             Parameters
             ----------
             chunk
-                The chunk to partition.
-            partition_col
-                Index of the integer column whose values give the target
-                local partition ID for each row. The partition column is
-                consumed as routing metadata and stripped from the payload.
-                Callers should not expect it in the output.
+                The payload chunk to partition. Its schema is preserved
+                unchanged in the shuffler output.
+            partition_map
+                Single-column ``TableChunk`` whose integer values give the
+                target partition ID for each row. Must be row-aligned with
+                ``chunk``.
             """
-            table = chunk.table_view()
-            cols = table.columns()
-            partition_map = cols[partition_col]
-            payload = plc.Table([c for i, c in enumerate(cols) if i != partition_col])
+            stream = get_joined_cuda_stream(
+                self._manager.context.get_stream_from_pool,
+                upstreams=(chunk.stream, partition_map.stream),
+            )
+            partition_map_col = partition_map.table_view().columns()[0]
             reordered, offsets = plc.partitioning.partition(
-                payload,
-                partition_map,
+                chunk.table_view(),
+                partition_map_col,
                 self._manager.num_partitions,
-                stream=chunk.stream,
+                stream=stream,
             )
             self._manager.shuffler.insert(
                 py_split_and_pack(
                     table=reordered,
                     splits=list(offsets[1:-1]),
-                    stream=chunk.stream,
+                    stream=stream,
                     br=self._manager.context.br(),
                 )
             )
@@ -277,27 +280,45 @@ class LocalRepartitioner:
                     columns_to_hash,
                 )
 
-    async def insert_chunks_index(self, *, partition_col: int, stream: Stream) -> None:
+    async def insert_chunks_index(
+        self,
+        *,
+        partition_col: int,
+        stream: Stream,
+        drop_partition_col: bool = True,
+    ) -> None:
         """
-        Re-partition items by a pre-computed integer partition column.
+        Re-partition items by a pre-computed integer column in the received data.
 
         Parameters
         ----------
         partition_col
             Index of the integer column whose values give the target
-            local partition ID for each row. The partition column is
-            consumed as routing metadata and stripped from the payload.
-            Callers should not expect it in the output.
+            local partition ID for each row.
         stream
             CUDA stream for the unpack operation.
+        drop_partition_col
+            If ``True`` (default), the partition column is stripped from the
+            payload before inserting. If ``False``, it is kept in the output.
         """
         async with self._local_shuffle.inserting() as inserter:
             for table in self._iter_chunks(stream):
+                cols = table.columns()
+                payload = plc.Table(
+                    [
+                        c
+                        for i, c in enumerate(cols)
+                        if not drop_partition_col or i != partition_col
+                    ]
+                )
+                partition_map = plc.Table([cols[partition_col]])
                 inserter.insert_index(
                     TableChunk.from_pylibcudf_table(
-                        table, stream, exclusive_view=True, br=self._br
+                        payload, stream, exclusive_view=True, br=self._br
                     ),
-                    partition_col,
+                    TableChunk.from_pylibcudf_table(
+                        partition_map, stream, exclusive_view=True, br=self._br
+                    ),
                 )
 
     def local_partitions(self) -> list[int]:

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -25,8 +25,6 @@ from rapidsmpf.streaming.cudf.channel_metadata import (
 )
 from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 
-import pylibcudf as plc
-
 from cudf_polars.dsl.expr import Col
 from cudf_polars.experimental.rapidsmpf.dispatch import (
     generate_ir_sub_network,
@@ -39,7 +37,6 @@ from cudf_polars.experimental.rapidsmpf.utils import (
     send_metadata,
 )
 from cudf_polars.experimental.shuffle import Shuffle
-from cudf_polars.experimental.sort import find_sort_splits
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -47,9 +44,9 @@ if TYPE_CHECKING:
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.streaming.core.channel import Channel
 
+    import pylibcudf as plc
     from rmm.pylibrmm.stream import Stream
 
-    from cudf_polars.containers import DataFrame
     from cudf_polars.dsl.ir import IR, IRExecutionContext
     from cudf_polars.experimental.rapidsmpf.core import SubNetGenerator
 
@@ -190,7 +187,7 @@ class ShuffleManager:
         return self.shuffler.extract(partition_id)
 
 
-class LocalShuffle:
+class LocalRepartitioner:
     """
     Local re-partitioner that wraps a completed :class:`ShuffleManager`.
 
@@ -227,7 +224,16 @@ class LocalShuffle:
     async def insert_chunks_hash(
         self, *, columns_to_hash: tuple[int, ...], stream: Stream
     ) -> None:
-        """Re-partition items by hash of the given columns."""
+        """
+        Re-partition items by hash of the given columns.
+
+        Parameters
+        ----------
+        columns_to_hash
+            Tuple of column indices to use for hashing.
+        stream
+            CUDA stream for the unpack operation.
+        """
         async with self._local_shuffle.inserting() as inserter:
             for table in self._iter_chunks(stream):
                 inserter.insert_hash(
@@ -235,35 +241,6 @@ class LocalShuffle:
                         table, stream, exclusive_view=True, br=self._br
                     ),
                     columns_to_hash,
-                )
-
-    async def insert_chunks_boundaries(
-        self,
-        *,
-        sort_boundaries_df: DataFrame,
-        by_indices: tuple[int, ...],
-        column_order: list,
-        null_order: list,
-        stream: Stream,
-    ) -> None:
-        """Re-partition items by sort boundaries."""
-        async with self._local_shuffle.inserting() as inserter:
-            for seq_num, table in enumerate(self._iter_chunks(stream)):
-                sort_cols_tbl = plc.Table([table.columns()[i] for i in by_indices])
-                splits = find_sort_splits(
-                    sort_cols_tbl,
-                    sort_boundaries_df.table,
-                    seq_num,
-                    column_order,
-                    null_order,
-                    stream=stream,
-                    chunk_relative=True,
-                )
-                inserter.insert_split(
-                    TableChunk.from_pylibcudf_table(
-                        table, stream, exclusive_view=True, br=self._br
-                    ),
-                    splits,
                 )
 
     def local_partitions(self) -> list[int]:

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from rapidsmpf.communicator.single import new_communicator as single_comm
+from rapidsmpf.config import Options, get_environment_variables
 from rapidsmpf.integrations.cudf.partition import (
     partition_and_pack as py_partition_and_pack,
     split_and_pack as py_split_and_pack,
@@ -14,6 +16,7 @@ from rapidsmpf.integrations.cudf.partition import (
 from rapidsmpf.shuffler import PartitionAssignment
 from rapidsmpf.streaming.coll.shuffler import ShufflerAsync
 from rapidsmpf.streaming.core.actor import define_actor
+from rapidsmpf.streaming.core.context import Context
 from rapidsmpf.streaming.core.message import Message
 from rapidsmpf.streaming.cudf.channel_metadata import (
     ChannelMetadata,
@@ -21,6 +24,8 @@ from rapidsmpf.streaming.cudf.channel_metadata import (
     Partitioning,
 )
 from rapidsmpf.streaming.cudf.table_chunk import TableChunk
+
+import pylibcudf as plc
 
 from cudf_polars.dsl.expr import Col
 from cudf_polars.experimental.rapidsmpf.dispatch import (
@@ -34,15 +39,17 @@ from cudf_polars.experimental.rapidsmpf.utils import (
     send_metadata,
 )
 from cudf_polars.experimental.shuffle import Shuffle
+from cudf_polars.experimental.sort import find_sort_splits
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from rapidsmpf.communicator.communicator import Communicator
     from rapidsmpf.streaming.core.channel import Channel
-    from rapidsmpf.streaming.core.context import Context
 
-    import pylibcudf as plc
     from rmm.pylibrmm.stream import Stream
 
+    from cudf_polars.containers import DataFrame
     from cudf_polars.dsl.ir import IR, IRExecutionContext
     from cudf_polars.experimental.rapidsmpf.core import SubNetGenerator
 
@@ -53,15 +60,15 @@ class ShuffleManager:
 
     Parameters
     ----------
-    context: Context
+    context
         The streaming context.
-    comm: Communicator
+    comm
         The communicator.
-    num_partitions: int
+    num_partitions
         The number of partitions to shuffle into.
-    collective_id: int
+    collective_id
         The collective ID.
-    partition_assignment: PartitionAssignment, optional
+    partition_assignment, optional
         How to assign partition IDs to ranks: ROUND_ROBIN (default) or
         CONTIGUOUS. Use CONTIGUOUS for sort so each rank gets adjacent
         partition IDs and concatenation order matches global order.
@@ -76,7 +83,7 @@ class ShuffleManager:
 
         Parameters
         ----------
-        manager: ShuffleManager
+        manager
             The shuffle manager to insert into.
         """
 
@@ -126,7 +133,9 @@ class ShuffleManager:
         partition_assignment: PartitionAssignment = PartitionAssignment.ROUND_ROBIN,
     ):
         self.context = context
+        self.comm = comm
         self.num_partitions = num_partitions
+        self.collective_id = collective_id
         self.shuffler = ShufflerAsync(
             context,
             comm,
@@ -143,32 +152,136 @@ class ShuffleManager:
         """Get the local partition IDs for this rank."""
         return self.shuffler.local_partitions()
 
-    def extract_chunk(self, sequence_number: int, stream: Stream) -> plc.Table:
+    def extract_chunk(self, partition_id: int, stream: Stream) -> plc.Table:
         """
         Extract a chunk from the ShuffleManager.
 
         Parameters
         ----------
-        sequence_number: int
-            The sequence number of the chunk to extract.
-        stream: Stream
+        partition_id
+            The partition ID of the chunk to extract.
+        stream
             The stream to use for chunk extraction.
 
         Returns
         -------
         The extracted table.
-
-        Raises
-        ------
-        KeyError
-            If the requested sequence number has already been extracted.
         """
-        partition_chunks = self.shuffler.extract(sequence_number)
         return py_unpack_and_concat(
-            partitions=partition_chunks,
+            partitions=self.shuffler.extract(partition_id),
             stream=stream,
             br=self.context.br(),
         )
+
+    def extract_pieces(self, partition_id: int) -> list:
+        """
+        Extract raw packed items for a partition without unpacking.
+
+        Parameters
+        ----------
+        partition_id
+            The partition ID to extract.
+
+        Returns
+        -------
+        list[PackedData]
+            Raw packed items for the partition.
+        """
+        return self.shuffler.extract(partition_id)
+
+
+class LocalShuffle:
+    """
+    Local re-partitioner that wraps a completed :class:`ShuffleManager`.
+
+    Parameters
+    ----------
+    shuffle
+        Completed inter-rank :class:`ShuffleManager` (insertion phase done).
+        Must own exactly one global partition.
+    local_count
+        Number of local output partitions to produce.
+    """
+
+    def __init__(self, shuffle: ShuffleManager, local_count: int) -> None:
+        self._global_shuffle = shuffle
+        self._br = shuffle.context.br()
+        options = Options(get_environment_variables())
+        local_comm = single_comm(options, shuffle.comm.progress_thread)
+        local_ctx = Context(local_comm.logger, self._br, options)
+        self._local_shuffle = ShuffleManager(
+            local_ctx,
+            local_comm,
+            local_count,
+            shuffle.collective_id,
+        )
+
+    def _iter_chunks(self, stream: Stream) -> Generator[plc.Table, None, None]:
+        for partition_id in self._global_shuffle.local_partitions():
+            for piece in self._global_shuffle.extract_pieces(partition_id):
+                # TODO: batch pieces up to target_partition_size before unpacking
+                table = py_unpack_and_concat([piece], stream=stream, br=self._br)
+                if table.num_rows() > 0:
+                    yield table
+
+    async def insert_chunks_hash(
+        self, *, columns_to_hash: tuple[int, ...], stream: Stream
+    ) -> None:
+        """Re-partition items by hash of the given columns."""
+        async with self._local_shuffle.inserting() as inserter:
+            for table in self._iter_chunks(stream):
+                inserter.insert_hash(
+                    TableChunk.from_pylibcudf_table(
+                        table, stream, exclusive_view=True, br=self._br
+                    ),
+                    columns_to_hash,
+                )
+
+    async def insert_chunks_boundaries(
+        self,
+        *,
+        sort_boundaries_df: DataFrame,
+        by_indices: tuple[int, ...],
+        column_order: list,
+        null_order: list,
+        stream: Stream,
+    ) -> None:
+        """Re-partition items by sort boundaries."""
+        async with self._local_shuffle.inserting() as inserter:
+            for seq_num, table in enumerate(self._iter_chunks(stream)):
+                sort_cols_tbl = plc.Table([table.columns()[i] for i in by_indices])
+                splits = find_sort_splits(
+                    sort_cols_tbl,
+                    sort_boundaries_df.table,
+                    seq_num,
+                    column_order,
+                    null_order,
+                    stream=stream,
+                    chunk_relative=True,
+                )
+                inserter.insert_split(
+                    TableChunk.from_pylibcudf_table(
+                        table, stream, exclusive_view=True, br=self._br
+                    ),
+                    splits,
+                )
+
+    def local_partitions(self) -> list[int]:
+        """Return the local partition IDs."""
+        return self._local_shuffle.local_partitions()
+
+    def extract_chunk(self, partition_id: int, stream: Stream) -> plc.Table:
+        """
+        Extract the table for *partition_id* from the local shuffle.
+
+        Parameters
+        ----------
+        partition_id
+            The local partition to extract.
+        stream
+            CUDA stream for the unpack operation.
+        """
+        return self._local_shuffle.extract_chunk(partition_id, stream)
 
 
 async def _global_shuffle(
@@ -241,7 +354,7 @@ async def _global_shuffle(
                     columns_to_hash,
                 )
 
-    for partition_id in shuffle.shuffler.local_partitions():
+    for partition_id in shuffle.local_partitions():
         stream = ir_context.get_cuda_stream()
         await ch_out.send(
             context,

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -258,7 +258,7 @@ class LocalRepartitioner:
                 if table.num_rows() > 0:
                     yield table
 
-    async def insert_chunks_hash(
+    async def repartition_by_hash(
         self, *, columns_to_hash: tuple[int, ...], stream: Stream
     ) -> None:
         """
@@ -280,7 +280,7 @@ class LocalRepartitioner:
                     columns_to_hash,
                 )
 
-    async def insert_chunks_index(
+    async def repartition_by_index(
         self,
         *,
         partition_col: int,

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/collectives/shuffle.py
@@ -40,12 +40,13 @@ from cudf_polars.experimental.rapidsmpf.utils import (
     send_metadata,
 )
 from cudf_polars.experimental.shuffle import Shuffle
-from cudf_polars.utils.cuda_stream import get_joined_cuda_stream
+from cudf_polars.utils.cuda_stream import stream_ordered_after
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
     from rapidsmpf.communicator.communicator import Communicator
+    from rapidsmpf.memory.packed_data import PackedData
     from rapidsmpf.streaming.core.channel import Channel
 
     from rmm.pylibrmm.stream import Stream
@@ -129,25 +130,25 @@ class ShuffleManager:
                 target partition ID for each row. Must be row-aligned with
                 ``chunk``.
             """
-            stream = get_joined_cuda_stream(
+            with stream_ordered_after(
                 self._manager.context.get_stream_from_pool,
                 upstreams=(chunk.stream, partition_map.stream),
-            )
-            partition_map_col = partition_map.table_view().columns()[0]
-            reordered, offsets = plc.partitioning.partition(
-                chunk.table_view(),
-                partition_map_col,
-                self._manager.num_partitions,
-                stream=stream,
-            )
-            self._manager.shuffler.insert(
-                py_split_and_pack(
-                    table=reordered,
-                    splits=list(offsets[1:-1]),
+            ) as stream:
+                partition_map_col = partition_map.table_view().columns()[0]
+                reordered, offsets = plc.partitioning.partition(
+                    chunk.table_view(),
+                    partition_map_col,
+                    self._manager.num_partitions,
                     stream=stream,
-                    br=self._manager.context.br(),
                 )
-            )
+                self._manager.shuffler.insert(
+                    py_split_and_pack(
+                        table=reordered,
+                        splits=list(offsets[1:-1]),
+                        stream=stream,
+                        br=self._manager.context.br(),
+                    )
+                )
 
         async def __aenter__(self) -> ShuffleManager.Inserter:
             """Enter the context manager."""
@@ -207,7 +208,7 @@ class ShuffleManager:
             br=self.context.br(),
         )
 
-    def extract_pieces(self, partition_id: int) -> list:
+    def extract_pieces(self, partition_id: int) -> list[PackedData]:
         """
         Extract raw packed items for a partition without unpacking.
 
@@ -232,7 +233,7 @@ class LocalRepartitioner:
     ----------
     shuffle
         Completed inter-rank :class:`ShuffleManager` (insertion phase done).
-        Must own exactly one global partition.
+        The repartitioner consumes whatever local partitions this rank owns.
     local_count
         Number of local output partitions to produce.
     """

--- a/python/cudf_polars/cudf_polars/utils/cuda_stream.py
+++ b/python/cudf_polars/cudf_polars/utils/cuda_stream.py
@@ -5,13 +5,14 @@
 
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING
 
 import pylibcudf as plc
 from rmm.pylibrmm.stream import DEFAULT_STREAM
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Generator, Sequence
 
     from pylibcudf.utils import CudaStreamLike
     from rmm.pylibrmm.stream import Stream
@@ -61,3 +62,48 @@ def get_joined_cuda_stream(
     downstream = get_cuda_stream()
     join_cuda_streams(downstreams=(downstream,), upstreams=upstreams)
     return downstream
+
+
+@contextlib.contextmanager
+def stream_ordered_after(
+    get_cuda_stream: Callable[[], Stream],
+    upstreams: Sequence[CudaStreamLike],
+) -> Generator[Stream, None, None]:
+    """
+    Get a joined CUDA stream with safe stream ordering for deallocation of inputs.
+
+    Parameters
+    ----------
+    get_cuda_stream
+        A zero-argument callable that returns a CUDA stream.
+    upstreams
+        The streams being provided to stream-ordered operations.
+
+    Yields
+    ------
+    A CUDA stream that is downstream of the given streams.
+
+    Notes
+    -----
+    This context manager provides two useful guarantees when working with
+    objects holding references to stream-ordered objects:
+
+    1. The stream yield upon entering the context manager is *downstream* of
+       all the input streams.  This ensures that you can safely perform
+       stream-ordered operations on any input using the yielded stream.
+    2. The stream-ordered CUDA deallocation of the inputs happens *after* the
+       context manager exits. This ensures that all stream-ordered operations
+       submitted inside the context manager can complete before the memory
+       referenced by the inputs is deallocated.
+
+    Note that this does (deliberately) disconnect the dropping of the Python
+    object (by its refcount dropping to 0) from the actual stream-ordered
+    deallocation of the CUDA memory. This is precisely what we need to ensure
+    that the inputs are valid long enough for the stream-ordered operations to
+    complete.
+    """
+    downstream = get_joined_cuda_stream(get_cuda_stream, upstreams=upstreams)
+    try:
+        yield downstream
+    finally:
+        join_cuda_streams(downstreams=upstreams, upstreams=(downstream,))

--- a/python/cudf_polars/tests/experimental/test_shuffler.py
+++ b/python/cudf_polars/tests/experimental/test_shuffler.py
@@ -222,17 +222,16 @@ def test_local_repartitioner_index(spmd_engine, local_count) -> None:
     context = spmd_engine.context
     comm = spmd_engine.comm
 
-    # "rank_part" routes each row to a rank via insert_index (global phase).
-    # "local_part" routes each row to a local partition via insert_chunks_index.
-    # Both columns are stripped; output has only "val".
-    pl_df = pl.DataFrame(
+    # Payload: "local_part" routes locally, "val" is the data.
+    # Routing for the global phase ("rank_part") is kept separate.
+    pl_payload = pl.DataFrame(
         {
-            "rank_part": [i % comm.nranks for i in range(12)],
             "local_part": [i % local_count for i in range(12)],
             "val": list(range(12)),
         }
     )
-    # Output schema after both routing columns are stripped.
+    pl_rank_part = pl.DataFrame({"rank_part": [i % comm.nranks for i in range(12)]})
+    # Output schema after local_part is also stripped by insert_chunks_index.
     out_col_names = ["val"]
     out_dtypes = [DataType(pl.Int32())]
 
@@ -240,24 +239,26 @@ def test_local_repartitioner_index(spmd_engine, local_count) -> None:
 
     async def _run() -> None:
         stream = context.get_stream_from_pool()
-        cudf_df = DataFrame.from_polars(pl_df, stream)
+        payload_df = DataFrame.from_polars(pl_payload, stream)
+        rank_part_df = DataFrame.from_polars(pl_rank_part, stream)
 
         with reserve_op_id() as op_id:
-            # Global phase: route by rank_part (col 0), which is stripped.
-            # After this shuffle each rank holds rows where rank_part == rank,
-            # and the remaining schema is {"local_part": Int32, "val": Int32}.
+            # Global phase: route payload by rank_part (separate chunk).
+            # After shuffle each rank holds {"local_part": Int32, "val": Int32}.
             shuffle = ShuffleManager(
                 context, comm, num_partitions=comm.nranks, collective_id=op_id
             )
             async with shuffle.inserting() as inserter:
                 inserter.insert_index(
                     TableChunk.from_pylibcudf_table(
-                        cudf_df.table, stream, exclusive_view=True, br=context.br()
+                        payload_df.table, stream, exclusive_view=True, br=context.br()
                     ),
-                    partition_col=0,
+                    TableChunk.from_pylibcudf_table(
+                        rank_part_df.table, stream, exclusive_view=True, br=context.br()
+                    ),
                 )
 
-            # Local phase: route by local_part (now col 0 after rank_part stripped).
+            # Local phase: route by local_part (col 0 of the received data), strip it.
             local = LocalRepartitioner(shuffle, local_count=local_count)
             await local.insert_chunks_index(partition_col=0, stream=stream)
 

--- a/python/cudf_polars/tests/experimental/test_shuffler.py
+++ b/python/cudf_polars/tests/experimental/test_shuffler.py
@@ -212,3 +212,88 @@ def test_local_repartitioner_hash(spmd_engine, local_count) -> None:
 
     # All 4 distinct key values must appear somewhere across all ranks.
     assert set(global_df["key"].unique().to_list()) == {0, 1, 2, 3}
+
+
+@pytest.mark.spmd
+@pytest.mark.parametrize("local_count", [1, 2, 4])
+def test_local_repartitioner_index(spmd_engine, local_count) -> None:
+    # Two-phase index routing: insert_index globally, insert_chunks_index locally.
+    # Each row carries explicit routing columns so we can verify end-to-end placement.
+    context = spmd_engine.context
+    comm = spmd_engine.comm
+
+    # "rank_part" routes each row to a rank via insert_index (global phase).
+    # "local_part" routes each row to a local partition via insert_chunks_index.
+    # Both columns are stripped; output has only "val".
+    pl_df = pl.DataFrame(
+        {
+            "rank_part": [i % comm.nranks for i in range(12)],
+            "local_part": [i % local_count for i in range(12)],
+            "val": list(range(12)),
+        }
+    )
+    # Output schema after both routing columns are stripped.
+    out_col_names = ["val"]
+    out_dtypes = [DataType(pl.Int32())]
+
+    results: list[tuple[int, pl.DataFrame]] = []
+
+    async def _run() -> None:
+        stream = context.get_stream_from_pool()
+        cudf_df = DataFrame.from_polars(pl_df, stream)
+
+        with reserve_op_id() as op_id:
+            # Global phase: route by rank_part (col 0), which is stripped.
+            # After this shuffle each rank holds rows where rank_part == rank,
+            # and the remaining schema is {"local_part": Int32, "val": Int32}.
+            shuffle = ShuffleManager(
+                context, comm, num_partitions=comm.nranks, collective_id=op_id
+            )
+            async with shuffle.inserting() as inserter:
+                inserter.insert_index(
+                    TableChunk.from_pylibcudf_table(
+                        cudf_df.table, stream, exclusive_view=True, br=context.br()
+                    ),
+                    partition_col=0,
+                )
+
+            # Local phase: route by local_part (now col 0 after rank_part stripped).
+            local = LocalRepartitioner(shuffle, local_count=local_count)
+            await local.insert_chunks_index(partition_col=0, stream=stream)
+
+            for pid in local.local_partitions():
+                tbl = local.extract_chunk(pid, stream)
+                results.append(
+                    (
+                        pid,
+                        DataFrame.from_table(
+                            tbl, out_col_names, out_dtypes, stream
+                        ).to_polars(),
+                    )
+                )
+
+    asyncio.run(_run())
+
+    # Each rank produces exactly local_count partitions.
+    assert len(results) == local_count
+
+    # Both routing columns are stripped; output has only "val".
+    for _, df in results:
+        assert df.columns == ["val"]
+
+    # Routing: val=v must land in local partition v % local_count (== local_part).
+    for pid, df in results:
+        for val in df["val"].to_list():
+            assert val % local_count == pid
+
+    # Global: every inserted row survives.
+    local_df = (
+        pl.concat([df for _, df in results])
+        if results
+        else pl.DataFrame(schema={"val": pl.Int32})
+    )
+    with reserve_op_id() as op_id:
+        global_df = allgather_polars_dataframe(
+            engine=spmd_engine, local_df=local_df, op_id=op_id
+        )
+    assert global_df.height == 12 * comm.nranks

--- a/python/cudf_polars/tests/experimental/test_shuffler.py
+++ b/python/cudf_polars/tests/experimental/test_shuffler.py
@@ -3,16 +3,26 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from rapidsmpf.streaming.cudf.channel_metadata import (
     ChannelMetadata,
     HashScheme,
     Partitioning,
 )
+from rapidsmpf.streaming.cudf.table_chunk import TableChunk
 
 import polars as pl
 
+from cudf_polars.containers import DataFrame, DataType
+from cudf_polars.experimental.rapidsmpf.collectives.common import reserve_op_id
+from cudf_polars.experimental.rapidsmpf.collectives.shuffle import (
+    LocalRepartitioner,
+    ShuffleManager,
+)
 from cudf_polars.experimental.rapidsmpf.frontend.options import StreamingOptions
+from cudf_polars.experimental.rapidsmpf.frontend.spmd import allgather_polars_dataframe
 from cudf_polars.experimental.rapidsmpf.utils import (
     _is_already_partitioned,
 )
@@ -130,3 +140,75 @@ def test_is_already_partitioned():
         ),
     )
     assert _is_already_partitioned(metadata_local, columns, modulus, nranks) is False
+
+
+@pytest.mark.spmd
+@pytest.mark.parametrize("local_count", [1, 2, 4])
+def test_local_repartitioner_hash(spmd_engine, local_count) -> None:
+    # Test LocalRepartitioner with hash partitioning
+    context = spmd_engine.context
+    comm = spmd_engine.comm
+
+    # 12 rows, 4 distinct key values (3 rows per key)
+    pl_df = pl.DataFrame({"key": list(range(4)) * 3, "val": list(range(12))})
+    col_names = pl_df.columns
+    dtypes = [DataType(dt) for dt in pl_df.dtypes]
+
+    results: list[tuple[int, pl.DataFrame]] = []
+
+    async def _run() -> None:
+        stream = context.get_stream_from_pool()
+        cudf_df = DataFrame.from_polars(pl_df, stream)
+        with reserve_op_id() as op_id:
+            shuffle = ShuffleManager(
+                context, comm, num_partitions=comm.nranks, collective_id=op_id
+            )
+            async with shuffle.inserting() as inserter:
+                inserter.insert_hash(
+                    TableChunk.from_pylibcudf_table(
+                        cudf_df.table, stream, exclusive_view=True, br=context.br()
+                    ),
+                    columns_to_hash=(0,),
+                )
+
+            local = LocalRepartitioner(shuffle, local_count=local_count)
+            await local.insert_chunks_hash(columns_to_hash=(0,), stream=stream)
+
+            for pid in local.local_partitions():
+                tbl = local.extract_chunk(pid, stream)
+                results.append(
+                    (
+                        pid,
+                        DataFrame.from_table(
+                            tbl, col_names, dtypes, stream
+                        ).to_polars(),
+                    )
+                )
+
+    asyncio.run(_run())
+
+    # Each rank must produce exactly local_count output partitions.
+    assert len(results) == local_count
+
+    # Hash is deterministic locally: same key always lands in the same local partition.
+    key_to_pid: dict[int, int] = {}
+    for pid, df in results:
+        for key_val in df["key"].to_list():
+            assert key_to_pid.setdefault(key_val, pid) == pid
+
+    # AllGather across ranks to verify global invariants.
+    local_df = (
+        pl.concat([df for _, df in results])
+        if results
+        else pl.DataFrame(schema={"key": pl.Int32, "val": pl.Int32})
+    )
+    with reserve_op_id() as op_id:
+        global_df = allgather_polars_dataframe(
+            engine=spmd_engine, local_df=local_df, op_id=op_id
+        )
+
+    # Every rank inserts 12 rows; all must survive the shuffle + local repartition.
+    assert global_df.height == 12 * comm.nranks
+
+    # All 4 distinct key values must appear somewhere across all ranks.
+    assert set(global_df["key"].unique().to_list()) == {0, 1, 2, 3}

--- a/python/cudf_polars/tests/experimental/test_shuffler.py
+++ b/python/cudf_polars/tests/experimental/test_shuffler.py
@@ -145,11 +145,9 @@ def test_is_already_partitioned():
 @pytest.mark.spmd
 @pytest.mark.parametrize("local_count", [1, 2, 4])
 def test_local_repartitioner_hash(spmd_engine, local_count) -> None:
-    # Test LocalRepartitioner with hash partitioning
     context = spmd_engine.context
     comm = spmd_engine.comm
 
-    # 12 rows, 4 distinct key values (3 rows per key)
     pl_df = pl.DataFrame({"key": list(range(4)) * 3, "val": list(range(12))})
     col_names = pl_df.columns
     dtypes = [DataType(dt) for dt in pl_df.dtypes]
@@ -172,7 +170,7 @@ def test_local_repartitioner_hash(spmd_engine, local_count) -> None:
                 )
 
             local = LocalRepartitioner(shuffle, local_count=local_count)
-            await local.insert_chunks_hash(columns_to_hash=(0,), stream=stream)
+            await local.repartition_by_hash(columns_to_hash=(0,), stream=stream)
 
             for pid in local.local_partitions():
                 tbl = local.extract_chunk(pid, stream)
@@ -187,43 +185,29 @@ def test_local_repartitioner_hash(spmd_engine, local_count) -> None:
 
     asyncio.run(_run())
 
-    # Each rank must produce exactly local_count output partitions.
     assert len(results) == local_count
 
-    # Hash is deterministic locally: same key always lands in the same local partition.
+    # Same key always lands in the same local partition.
     key_to_pid: dict[int, int] = {}
     for pid, df in results:
         for key_val in df["key"].to_list():
             assert key_to_pid.setdefault(key_val, pid) == pid
 
-    # AllGather across ranks to verify global invariants.
-    local_df = (
-        pl.concat([df for _, df in results])
-        if results
-        else pl.DataFrame(schema={"key": pl.Int32, "val": pl.Int32})
-    )
+    # AllGather across ranks: every rank inserts 12 rows, all must survive.
+    local_df = pl.concat([df for _, df in results])
     with reserve_op_id() as op_id:
         global_df = allgather_polars_dataframe(
             engine=spmd_engine, local_df=local_df, op_id=op_id
         )
-
-    # Every rank inserts 12 rows; all must survive the shuffle + local repartition.
     assert global_df.height == 12 * comm.nranks
-
-    # All 4 distinct key values must appear somewhere across all ranks.
-    assert set(global_df["key"].unique().to_list()) == {0, 1, 2, 3}
 
 
 @pytest.mark.spmd
 @pytest.mark.parametrize("local_count", [1, 2, 4])
 def test_local_repartitioner_index(spmd_engine, local_count) -> None:
-    # Two-phase index routing: insert_index globally, insert_chunks_index locally.
-    # Each row carries explicit routing columns so we can verify end-to-end placement.
     context = spmd_engine.context
     comm = spmd_engine.comm
 
-    # Payload: "local_part" routes locally, "val" is the data.
-    # Routing for the global phase ("rank_part") is kept separate.
     pl_payload = pl.DataFrame(
         {
             "local_part": [i % local_count for i in range(12)],
@@ -231,7 +215,6 @@ def test_local_repartitioner_index(spmd_engine, local_count) -> None:
         }
     )
     pl_rank_part = pl.DataFrame({"rank_part": [i % comm.nranks for i in range(12)]})
-    # Output schema after local_part is also stripped by insert_chunks_index.
     out_col_names = ["val"]
     out_dtypes = [DataType(pl.Int32())]
 
@@ -243,8 +226,6 @@ def test_local_repartitioner_index(spmd_engine, local_count) -> None:
         rank_part_df = DataFrame.from_polars(pl_rank_part, stream)
 
         with reserve_op_id() as op_id:
-            # Global phase: route payload by rank_part (separate chunk).
-            # After shuffle each rank holds {"local_part": Int32, "val": Int32}.
             shuffle = ShuffleManager(
                 context, comm, num_partitions=comm.nranks, collective_id=op_id
             )
@@ -258,9 +239,8 @@ def test_local_repartitioner_index(spmd_engine, local_count) -> None:
                     ),
                 )
 
-            # Local phase: route by local_part (col 0 of the received data), strip it.
             local = LocalRepartitioner(shuffle, local_count=local_count)
-            await local.insert_chunks_index(partition_col=0, stream=stream)
+            await local.repartition_by_index(partition_col=0, stream=stream)
 
             for pid in local.local_partitions():
                 tbl = local.extract_chunk(pid, stream)
@@ -275,24 +255,16 @@ def test_local_repartitioner_index(spmd_engine, local_count) -> None:
 
     asyncio.run(_run())
 
-    # Each rank produces exactly local_count partitions.
     assert len(results) == local_count
-
-    # Both routing columns are stripped; output has only "val".
-    for _, df in results:
-        assert df.columns == ["val"]
 
     # Routing: val=v must land in local partition v % local_count (== local_part).
     for pid, df in results:
+        assert df.columns == ["val"]
         for val in df["val"].to_list():
             assert val % local_count == pid
 
     # Global: every inserted row survives.
-    local_df = (
-        pl.concat([df for _, df in results])
-        if results
-        else pl.DataFrame(schema={"val": pl.Int32})
-    )
+    local_df = pl.concat([df for _, df in results])
     with reserve_op_id() as op_id:
         global_df = allgather_polars_dataframe(
             engine=spmd_engine, local_df=local_df, op_id=op_id


### PR DESCRIPTION
## Description
- Useful for two-stage shuffling (shuffle data into one partition on each rank, and then locally repartition into multiple chunks)
- (Probably) useful for the reverse shuffle needed in https://github.com/rapidsai/cudf/pull/22191 (cc @Matt711)

**Typical Usge***
1. Wrap the `ShuffleManager` in a `LocalRepartitioner` **after** insertion is finished (and before extracting chunks). 
2. Call `LocalRepartitioner.repartition_by_hash` or `repartition_by_index` to dictate how the local partition(s) should be **re**-partitioned locally.
3. Use `LocalRepartitioner.local_partitions()` and `LocalRepartitioner.extract_chunk()` in the same way we do with `ShuffleManager`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
