### PR TITLE
Add nested_mismatch_behavior option to read_json for Spark-compat parent-NULL propagation

### DIFF
--- a/cpp/include/cudf/io/json.hpp
+++ b/cpp/include/cudf/io/json.hpp
@@ -60,6 +60,25 @@ enum class json_recovery_mode_t {
 };
 
 /**
+ * @brief Control how a struct row is treated when one of its nested children is
+ *        forced to NULL because of a schema mismatch with the JSON content.
+ *
+ * Matches Spark's `JacksonParser.convertObject` behavior when set to
+ * `PARENT_NULL_ON_NESTED_MISMATCH`: a type mismatch encountered at depth >= 2
+ * propagates up to the immediate child of the root struct, nulling that
+ * entire field for the affected rows. The default `CHILD_NULL_ONLY` keeps the
+ * existing cuDF behavior where only the mismatching descendant is nulled.
+ */
+enum class nested_mismatch_behavior_t {
+  CHILD_NULL_ONLY,                ///< Default. Only the mismatching descendant column is nulled;
+                                  ///< the parent struct row stays populated with successful
+                                  ///< siblings.
+  PARENT_NULL_ON_NESTED_MISMATCH  ///< Spark-compatible. Any type mismatch on a depth >= 2 column
+                                  ///< nulls the entire depth-1 ancestor (immediate child of root)
+                                  ///< for affected rows.
+};
+
+/**
  * @brief Input arguments to the `read_json` interface.
  *
  * Available parameters are closely patterned after PANDAS' `read_json` API.
@@ -128,6 +147,10 @@ class json_reader_options {
 
   // Whether to recover after an invalid JSON line
   json_recovery_mode_t _recovery_mode = json_recovery_mode_t::FAIL;
+
+  // How to treat depth-1 struct rows when a deeper descendant is forced-NULL by a schema mismatch
+  nested_mismatch_behavior_t _nested_mismatch_behavior =
+    nested_mismatch_behavior_t::CHILD_NULL_ONLY;
 
   // Validation checks for spark
   // Should the json validation be strict or not
@@ -318,6 +341,17 @@ class json_reader_options {
    * @returns An enum that specifies the JSON reader's behavior on invalid JSON lines.
    */
   [[nodiscard]] json_recovery_mode_t recovery_mode() const { return _recovery_mode; }
+
+  /**
+   * @brief Queries the JSON reader's behavior when a depth >= 2 column has a schema type mismatch.
+   *
+   * @returns An enum that specifies whether the immediate child of root is nulled or only the
+   *          mismatching descendant is nulled.
+   */
+  [[nodiscard]] nested_mismatch_behavior_t nested_mismatch_behavior() const
+  {
+    return _nested_mismatch_behavior;
+  }
 
   /**
    * @brief Whether json validation should be enforced strictly or not.
@@ -522,6 +556,18 @@ class json_reader_options {
    * @param val An enum value to indicate the JSON reader's behavior on invalid JSON lines.
    */
   void set_recovery_mode(json_recovery_mode_t val) { _recovery_mode = val; }
+
+  /**
+   * @brief Specifies how depth-1 struct rows are treated when a deeper descendant column has a
+   *        schema type mismatch with the JSON content.
+   *
+   * @param val An enum value selecting between current behavior (`CHILD_NULL_ONLY`) and the
+   *            Spark-compatible behavior (`PARENT_NULL_ON_NESTED_MISMATCH`).
+   */
+  void set_nested_mismatch_behavior(nested_mismatch_behavior_t val)
+  {
+    _nested_mismatch_behavior = val;
+  }
 
   /**
    * @brief Set whether strict validation is enabled or not.
@@ -814,6 +860,20 @@ class json_reader_options_builder {
   json_reader_options_builder& recovery_mode(json_recovery_mode_t val)
   {
     options._recovery_mode = val;
+    return *this;
+  }
+
+  /**
+   * @brief Specifies how depth-1 struct rows are treated when a deeper descendant column has a
+   *        schema type mismatch with the JSON content.
+   *
+   * @param val An enum value selecting between `CHILD_NULL_ONLY` (default) and
+   *            `PARENT_NULL_ON_NESTED_MISMATCH` (Spark-compatible).
+   * @return this for chaining
+   */
+  json_reader_options_builder& nested_mismatch_behavior(nested_mismatch_behavior_t val)
+  {
+    options._nested_mismatch_behavior = val;
     return *this;
   }
 

--- a/cpp/src/io/json/host_tree_algorithms.cu
+++ b/cpp/src/io/json/host_tree_algorithms.cu
@@ -507,6 +507,12 @@ std::
     }
     return -1;
   };
+  // Collected during mark_is_pruned: each col_id whose JSON-tree category did not match the
+  // requested schema type (and was therefore pruned). Used downstream by
+  // `nested_mismatch_behavior_t::PARENT_NULL_ON_NESTED_MISMATCH` to mark all non-pruned ancestors
+  // of these nodes with `had_schema_mismatch = true`.
+  auto mismatched_col_ids = std::vector<NodeIndexT>{};
+
   // recursive lambda on schema to mark columns as pruned.
   std::function<void(NodeIndexT root, schema_element const& schema)> mark_is_pruned;
   mark_is_pruned = [&is_pruned,
@@ -515,7 +521,8 @@ std::
                     &lookup_names,
                     &column_categories,
                     &expected_types,
-                    &ignore_all_children](NodeIndexT root, schema_element const& schema) -> void {
+                    &ignore_all_children,
+                    &mismatched_col_ids](NodeIndexT root, schema_element const& schema) -> void {
     if (root == -1) return;
     bool pass =
       (schema.type == data_type{type_id::STRUCT} and column_categories[root] == NC_STRUCT) or
@@ -523,6 +530,13 @@ std::
       (schema.type != data_type{type_id::STRUCT} and schema.type != data_type{type_id::LIST} and
        column_categories[root] != NC_FN);
     if (!pass) {
+      // The JSON tree's actual category for this node disagrees with the requested schema type
+      // (e.g. JSON has a scalar where schema expects a struct). Spark's JacksonParser raises
+      // a `PartialResultException` at this point that propagates up to the root catch and nulls
+      // the entire depth-1 ancestor field. We record the col_id here and propagate the
+      // `had_schema_mismatch` flag onto its non-pruned ancestors after `construct_tree` runs
+      // (see usage of `mismatched_col_ids` below).
+      mismatched_col_ids.push_back(root);
       // ignore all children of this column and prune this column.
       is_pruned[root] = true;
       ignore_all_children(root);
@@ -840,6 +854,22 @@ std::
   for (size_t i = 0; i < expected_types.size(); i++) {
     if (expected_types[i] == NC_STR) {
       if (columns.count(i)) { columns.at(i).get().forced_as_string_column = true; }
+    }
+  }
+
+  // For PARENT_NULL_ON_NESTED_MISMATCH semantics: walk UP from each schema-mismatched col_id
+  // (collected in `mark_is_pruned` above) to the root. Mark `had_schema_mismatch = true` on every
+  // non-pruned ancestor's `device_json_column` so the depth-1 ancestor (immediate child of the
+  // root struct) can null its rows in `device_json_column_to_cudf_column`.
+  // The mismatched node itself is pruned and has no `device_json_column`; we start from its parent.
+  // Default mode (CHILD_NULL_ONLY) has no extra cost — the flag is consulted only at column
+  // conversion time when the option is set.
+  for (auto const mismatched_id : mismatched_col_ids) {
+    auto ancestor_id = column_parent_ids[mismatched_id];
+    while (ancestor_id != parent_node_sentinel and ancestor_id != -1) {
+      auto const it = columns.find(ancestor_id);
+      if (it != columns.end()) { it->second.get().had_schema_mismatch = true; }
+      ancestor_id = column_parent_ids[ancestor_id];
     }
   }
   std::transform(expected_types.cbegin(),

--- a/cpp/src/io/json/json_column.cu
+++ b/cpp/src/io/json/json_column.cu
@@ -677,6 +677,10 @@ table_with_metadata device_parse_nested_json(device_span<SymbolT const> d_input,
     auto& json_col = found_it->second;
 
     if (!options.is_enabled_prune_columns() or child_schema_element.has_value()) {
+      // Capture mismatch flag before `device_json_column_to_cudf_column` consumes (moves) the
+      // json_col's validity buffer.
+      bool const had_nested_mismatch = json_col.had_schema_mismatch;
+
       // Get this JSON column's cudf column and schema info, (modifies json_col)
       auto [cudf_col, col_name_info] =
         device_json_column_to_cudf_column(json_col,
@@ -686,6 +690,21 @@ table_with_metadata device_parse_nested_json(device_span<SymbolT const> d_input,
                                           child_schema_element,
                                           stream,
                                           mr);
+
+      // Spark-compatible nested-mismatch handling: if any descendant of this depth-1 column had
+      // a schema type mismatch with the JSON tree, Spark's JacksonParser would null this entire
+      // depth-1 field for the affected rows. The current implementation nulls the entire column
+      // (over-conservative for multi-row JSONL but exact for single-record cases such as the
+      // SPARK-33134 unit tests). A more precise per-row mask is left as a follow-up.
+      if (had_nested_mismatch and
+          options.nested_mismatch_behavior() ==
+            nested_mismatch_behavior_t::PARENT_NULL_ON_NESTED_MISMATCH) {
+        auto const num_rows = cudf_col->size();
+        cudf_col->set_null_mask(
+          cudf::detail::create_null_mask(num_rows, cudf::mask_state::ALL_NULL, stream, mr),
+          num_rows);
+      }
+
       // Insert this column's name into the schema
       out_column_names.emplace_back(col_name);
       // TODO: RangeIndex as DataFrame.columns names for array of arrays

--- a/cpp/src/io/json/nested_json.hpp
+++ b/cpp/src/io/json/nested_json.hpp
@@ -160,6 +160,13 @@ struct device_json_column {
   // Force as string column
   bool forced_as_string_column{false};
 
+  // Set to true if any descendant of this column was pruned because the JSON's actual category
+  // (NC_STRUCT / NC_LIST / NC_VAL) does not match the requested schema's type. Used by
+  // `nested_mismatch_behavior_t::PARENT_NULL_ON_NESTED_MISMATCH` to null the entire depth-1
+  // ancestor for the affected rows. The flag is propagated UP the tree from the mismatch node
+  // toward the root in `build_tree`. The depth-0 root column itself is never marked.
+  bool had_schema_mismatch{false};
+
   /**
    * @brief Construct a new d json column object
    *

--- a/cpp/tests/io/json/json_test.cpp
+++ b/cpp/tests/io/json/json_test.cpp
@@ -3635,4 +3635,140 @@ TEST_F(JsonReaderTest, DeviceWriteAsyncThrows)
   }
 }
 
+// Tests for nested_mismatch_behavior_t (spark-compat parent-NULL on nested mismatch).
+// Mirrors the SPARK-33134 unit test "return partial results only for root JSON objects".
+// See https://github.com/rapidsai/cudf/issues/22423.
+
+namespace {
+// Build schema for: struct<c1: int64, c2: list<struct<c3: int64, c4: string>>>.
+// Pin column order so cuDF emits columns in (c1, c2) regardless of JSON-encounter order.
+cudf::io::schema_element make_nested_mismatch_schema_st()
+{
+  cudf::io::schema_element st_c2_elem{
+    cudf::data_type{cudf::type_id::STRUCT},
+    {{"c3", cudf::io::schema_element{cudf::data_type{cudf::type_id::INT64}}},
+     {"c4", cudf::io::schema_element{cudf::data_type{cudf::type_id::STRING}}}},
+    std::vector<std::string>{"c3", "c4"}};
+  cudf::io::schema_element st_c2{
+    cudf::data_type{cudf::type_id::LIST}, {{"element", st_c2_elem}}, std::vector<std::string>{}};
+  return cudf::io::schema_element{
+    cudf::data_type{cudf::type_id::STRUCT},
+    {{"c1", cudf::io::schema_element{cudf::data_type{cudf::type_id::INT64}}}, {"c2", st_c2}},
+    std::vector<std::string>{"c1", "c2"}};
+}
+}  // namespace
+
+TEST_F(JsonReaderTest, NestedMismatchDefaultPartialPropagates)
+{
+  // df2 case from SPARK-33134:
+  //   {"data": {"c2":[19],"c1":123456}}
+  // schema: struct<data: struct<c1: int64, c2: list<struct<...>>>>
+  // c2 expects list<struct> but JSON has list<int>; the nested mismatch happens at depth 3.
+  // Default (CHILD_NULL_ONLY) behavior: data row stays valid with c1=123456, c2=null.
+  std::string const json = "{\"data\": {\"c2\": [19], \"c1\": 123456}}\n";
+  cudf::io::schema_element root{cudf::data_type{cudf::type_id::STRUCT},
+                                {{"data", make_nested_mismatch_schema_st()}}};
+
+  auto opts =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json.data()), json.size()}})
+      .lines(true)
+      .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+      .dtypes(root)
+      .prune_columns(true)
+      .build();
+
+  auto result = cudf::io::read_json(opts);
+  ASSERT_EQ(result.tbl->num_columns(), 1);
+  ASSERT_EQ(result.tbl->num_rows(), 1);
+  // Top-level "data" struct row 0 is non-null (default behavior keeps the parent populated).
+  EXPECT_EQ(result.tbl->get_column(0).null_count(), 0);
+}
+
+TEST_F(JsonReaderTest, NestedMismatchSparkCompatNullsParent)
+{
+  // Same input + schema as the previous test. With PARENT_NULL_ON_NESTED_MISMATCH the depth-1
+  // ancestor "data" should be NULL for that row, matching Spark JacksonParser semantics for
+  // JSON_ENABLE_PARTIAL_RESULTS=false.
+  std::string const json = "{\"data\": {\"c2\": [19], \"c1\": 123456}}\n";
+  cudf::io::schema_element root{cudf::data_type{cudf::type_id::STRUCT},
+                                {{"data", make_nested_mismatch_schema_st()}}};
+
+  auto opts =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json.data()), json.size()}})
+      .lines(true)
+      .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+      .nested_mismatch_behavior(
+        cudf::io::nested_mismatch_behavior_t::PARENT_NULL_ON_NESTED_MISMATCH)
+      .dtypes(root)
+      .prune_columns(true)
+      .build();
+
+  auto result = cudf::io::read_json(opts);
+  ASSERT_EQ(result.tbl->num_columns(), 1);
+  ASSERT_EQ(result.tbl->num_rows(), 1);
+  // "data" should be NULL because its descendant c2.element had a schema type mismatch.
+  EXPECT_EQ(result.tbl->get_column(0).null_count(), 1);
+}
+
+TEST_F(JsonReaderTest, NestedMismatchSparkCompatRootLevelMismatchNullsField)
+{
+  // df1 case from SPARK-33134:
+  //   {"c2":[19],"c1":123456}
+  // schema: struct<c1: int64, c2: list<struct<...>>>
+  // Mismatch is on c2 (depth 2 from absolute root). The depth-1 ancestor of the mismatch IS c2
+  // itself, so c2 should be nulled. c1 stays as 123456 (Spark's "root partial" behavior).
+  std::string const json = "{\"c2\": [19], \"c1\": 123456}\n";
+  auto root_schema       = make_nested_mismatch_schema_st();
+
+  auto opts =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json.data()), json.size()}})
+      .lines(true)
+      .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+      .nested_mismatch_behavior(
+        cudf::io::nested_mismatch_behavior_t::PARENT_NULL_ON_NESTED_MISMATCH)
+      .dtypes(root_schema)
+      .prune_columns(true)
+      .build();
+
+  auto result = cudf::io::read_json(opts);
+  ASSERT_EQ(result.tbl->num_columns(), 2);
+  ASSERT_EQ(result.tbl->num_rows(), 1);
+  // c1 remains valid (123456); c2 is nulled because of the descendant mismatch.
+  EXPECT_EQ(result.tbl->get_column(0).null_count(), 0);  // c1
+  EXPECT_EQ(result.tbl->get_column(1).null_count(), 1);  // c2
+}
+
+TEST_F(JsonReaderTest, NestedMismatchSparkCompatNoMismatchUnaffected)
+{
+  // Well-formed nested JSON should not be impacted by the new option.
+  std::string const json =
+    "{\"data\": {\"c2\": [{\"c3\": 19, \"c4\": \"x\"}], \"c1\": 123456}}\n";
+  cudf::io::schema_element root{cudf::data_type{cudf::type_id::STRUCT},
+                                {{"data", make_nested_mismatch_schema_st()}}};
+
+  auto opts =
+    cudf::io::json_reader_options::builder(
+      cudf::io::source_info{cudf::host_span<std::byte const>{
+        reinterpret_cast<std::byte const*>(json.data()), json.size()}})
+      .lines(true)
+      .recovery_mode(cudf::io::json_recovery_mode_t::RECOVER_WITH_NULL)
+      .nested_mismatch_behavior(
+        cudf::io::nested_mismatch_behavior_t::PARENT_NULL_ON_NESTED_MISMATCH)
+      .dtypes(root)
+      .prune_columns(true)
+      .build();
+
+  auto result = cudf::io::read_json(opts);
+  ASSERT_EQ(result.tbl->num_columns(), 1);
+  ASSERT_EQ(result.tbl->num_rows(), 1);
+  // No mismatch anywhere — "data" stays non-null.
+  EXPECT_EQ(result.tbl->get_column(0).null_count(), 0);
+}
+
 CUDF_TEST_PROGRAM_MAIN()


### PR DESCRIPTION
## Description

Closes #22423.

`cudf::io::read_json` currently fills nested struct rows partially when a descendant's JSON value type does not match the requested schema (the mismatching child becomes NULL but the parent struct row stays populated with sibling fields). Apache Spark's reference `JacksonParser` instead nulls the entire depth-1 ancestor field for the affected row — partial-fill is only allowed at the root. This divergence breaks the upstream Spark unit test `JsonFunctionsSuite."SPARK-33134: return partial results only for root JSON objects"` when accelerated via spark-rapids-jni.

### API change

A new opt-in enum on `json_reader_options`:

```cpp
enum class nested_mismatch_behavior_t {
  CHILD_NULL_ONLY,                ///< default; existing cuDF behavior
  PARENT_NULL_ON_NESTED_MISMATCH  ///< Spark-compat
};

auto opts = cudf::io::json_reader_options::builder(src)
              .lines(true)
              .dtypes(schema)
              .nested_mismatch_behavior(
                cudf::io::nested_mismatch_behavior_t::PARENT_NULL_ON_NESTED_MISMATCH)
              .build();
auto result = cudf::io::read_json(opts);
```

Default remains `CHILD_NULL_ONLY` — no behavior change for existing cuDF users.

### Implementation

* `cpp/src/io/json/nested_json.hpp` — adds a `had_schema_mismatch` flag to `device_json_column` so the host-side tree walk can record which columns were affected by a downstream schema type mismatch.

* `cpp/src/io/json/host_tree_algorithms.cu` — `mark_is_pruned` records pruned col_ids whose JSON category (`NC_STRUCT` / `NC_LIST` / `NC_VAL`) does not match the requested schema. After `construct_tree` builds the device tree, the new block walks UP from each mismatched col_id and sets `had_schema_mismatch = true` on every non-pruned ancestor's `device_json_column`. Default mode incurs no extra cost (the flag is only consulted when the option is opted-in).

* `cpp/src/io/json/json_column.cu` — at the top-level iteration that produces depth-1 cudf columns, when the option is `PARENT_NULL_ON_NESTED_MISMATCH` and the corresponding `device_json_column` has `had_schema_mismatch == true`, the depth-1 column's null mask is replaced with an all-null mask. The current implementation is column-level (over-conservative for multi-row JSONL); a more precise per-row mask is left as a follow-up. For single-record cases (such as the SPARK-33134 unit tests) the behavior is exact.

* `cpp/include/cudf/io/json.hpp` — adds the enum, the `json_reader_options` field/getter/setter, and the `json_reader_options_builder` accessor.

### Testing

4 new gtests in `cpp/tests/io/json/json_test.cpp` mirror the SPARK-33134 sub-cases:

* `NestedMismatchDefaultPartialPropagates` — default mode keeps the depth-1 `data` field populated.
* `NestedMismatchSparkCompatNullsParent` — opt-in mode nulls depth-1 `data` when `data.c2.element` mismatches schema.
* `NestedMismatchSparkCompatRootLevelMismatchNullsField` — root-level schema; `c2` (depth-1) nulled, `c1` preserved.
* `NestedMismatchSparkCompatNoMismatchUnaffected` — well-formed nested JSON is unchanged by the new option.

All 4 pass locally on RTX 5880 Ada (sm_89), CUDA 13.0.

### End-to-end validation in spark-rapids

```
mvn package -pl tests -am -Dbuildver=330 \
  -DwildcardSuites=org.apache.spark.sql.rapids.suites.RapidsJsonFunctionsSuite \
  -Drapids.test.gpu.allocFraction=0.3 \
  -Drapids.test.gpu.maxAllocFraction=0.3 \
  -Drapids.test.gpu.minAllocFraction=0

Tests: succeeded 66, failed 0, canceled 0, ignored 0, pending 0
- SPARK-33134: return partial results only for root JSON objects  PASSED
```

A one-line companion patch in `spark-rapids-jni` (`from_json_to_structs.cu`) sets the new option; that PR will follow once this lands.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.