### PR TITLE
fix(ci): use sha for the only allowlisted version of action-add-assignees

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     if: ${{ ! github.event.pull_request.merged }}
     steps:
-      - uses: actions-ecosystem/action-add-assignees@ce5019e63cc4f35aba27308dc88d19c8f3686747 # v1.0.0
+      - uses: actions-ecosystem/action-add-assignees@59970ef501a38f91ea9afa2993b44162e33b3eac # v1
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           assignees: ${{ github.actor }}

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     if: ${{ ! github.event.pull_request.merged }}
     steps:
-      - uses: actions-ecosystem/action-add-assignees@59970ef501a38f91ea9afa2993b44162e33b3eac # v1
+      - uses: actions-ecosystem/action-add-assignees@ce5019e63cc4f35aba27308dc88d19c8f3686747 # v1
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           assignees: ${{ github.actor }}


### PR DESCRIPTION
## Description

I can't tell if this is right, because that repo has weird tags:

```
🐚 git ls-remote https://github.com/actions-ecosystem/action-add-assignees refs/tags/*
59970ef501a38f91ea9afa2993b44162e33b3eac        refs/tags/v1
ce5019e63cc4f35aba27308dc88d19c8f3686747        refs/tags/v1^{}
60aa57ae61b8fc53785076d0fc7327a6ef3a06fd        refs/tags/v1.0.0
ce5019e63cc4f35aba27308dc88d19c8f3686747        refs/tags/v1.0.0^{}
48956ae0c11159427139404f968c4686dd245cfd        refs/tags/v1.0.1
a5b84af721c4a621eb9c7a4a95ec20a90d0b88e9        refs/tags/v1.0.1^{}
```

Only the `@v1` mutable ref is allow-listed in the org-wide actions settings, so maybe the tag pointing to `v1.0.0` messes it up?  

The action that allowed is listed as:

`actions-ecosystem/action-add-assignee@v1`

It is unclear to me if that `@v1` will allow a commit SHA that points to the same location that the `@v1` tag points.  I would've thought so, but the current SHA on `main` _does_ point to the same location:

```
󰕈 gforsyth  …/action-add-assignees   main   13:29 
🐚 git checkout v1
HEAD is now at ce5019e Update action.yml (#3)

󰕈 gforsyth  …/action-add-assignees   HEAD   13:29 
🐚 git rev-parse HEAD
ce5019e63cc4f35aba27308dc88d19c8f3686747
```

It's possible (and what this PR currently changes) that the _commented_ tag corresponding to that SHA is causing the issue here, since `v1.0.0` isn't explicitly allowed (despite being the same commit):

```
* ce5019e - (HEAD, tag: v1.0.0, tag: v1) Update action.yml (#3) (6 years ago) <micnncim>
```

The other option is that the `@v1` only allows resolving the SHA of that git tag object itself (the tag, not what it points to), which is `59970ef501a38f91ea9afa2993b44162e33b3eac`.  Does the SHA of a tag object change if the tag is mutated to point to a different commit?  I don't know.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
