### PR TITLE
Avoid oversubscribing the CPU in cudf-polars tests

### DIFF
--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -56,6 +56,13 @@ fi
 
 DESELECTED_TESTS_STR=$(printf -- " --deselect %s" "${DESELECTED_TESTS[@]}")
 
+# Avoid oversubscribing the CPU
+num_cpus=$(nproc)
+export POLARS_MAX_THREADS=$(( num_cpus / 8 ))
+if (( POLARS_MAX_THREADS < 1 )); then
+    export POLARS_MAX_THREADS=1
+fi
+
 # Don't quote the `DESELECTED_...` variable because `pytest` can't handle
 # multiple quoted arguments inline
 # shellcheck disable=SC2086

--- a/ci/run_cudf_polars_polars_tests.sh
+++ b/ci/run_cudf_polars_polars_tests.sh
@@ -57,8 +57,9 @@ fi
 DESELECTED_TESTS_STR=$(printf -- " --deselect %s" "${DESELECTED_TESTS[@]}")
 
 # Avoid oversubscribing the CPU
+num_processes=8
 num_cpus=$(nproc)
-export POLARS_MAX_THREADS=$(( num_cpus / 8 ))
+export POLARS_MAX_THREADS=$(( num_cpus / num_processes ))
 if (( POLARS_MAX_THREADS < 1 )); then
     export POLARS_MAX_THREADS=1
 fi
@@ -72,7 +73,7 @@ python -m pytest \
        --cache-clear \
        -m "" \
        -p cudf_polars.testing.inject_gpu_engine \
-       -n 8 \
+       -n ${num_processes} \
        --dist=worksteal \
        -vv \
        --tb=native \

--- a/ci/run_cudf_polars_pytests.sh
+++ b/ci/run_cudf_polars_pytests.sh
@@ -4,6 +4,13 @@
 
 set -euo pipefail
 
+# Avoid oversubscribing the CPU
+num_cpus=$(nproc)
+export POLARS_MAX_THREADS=$(( num_cpus / 8 ))
+if (( POLARS_MAX_THREADS < 1 )); then
+    export POLARS_MAX_THREADS=1
+fi
+
 # It is essential to cd into python/cudf_polars as `pytest-xdist` + `coverage` seem to work only at this directory level.
 # Support invoking run_cudf_polars_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cudf_polars/

--- a/ci/run_cudf_polars_pytests.sh
+++ b/ci/run_cudf_polars_pytests.sh
@@ -4,13 +4,6 @@
 
 set -euo pipefail
 
-# Avoid oversubscribing the CPU
-num_cpus=$(nproc)
-export POLARS_MAX_THREADS=$(( num_cpus / 8 ))
-if (( POLARS_MAX_THREADS < 1 )); then
-    export POLARS_MAX_THREADS=1
-fi
-
 # It is essential to cd into python/cudf_polars as `pytest-xdist` + `coverage` seem to work only at this directory level.
 # Support invoking run_cudf_polars_pytests.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/cudf_polars/

--- a/ci/test_cudf_polars_experimental.sh
+++ b/ci/test_cudf_polars_experimental.sh
@@ -50,10 +50,18 @@ EXITCODE=0
 trap set_exitcode ERR
 set +e
 
+# Avoid oversubscribing the CPU
+num_processes=8
+num_cpus=$(nproc)
+export POLARS_MAX_THREADS=$(( num_cpus / num_processes ))
+if (( POLARS_MAX_THREADS < 1 )); then
+    export POLARS_MAX_THREADS=1
+fi
+
 rapids-logger "Running cudf_polars experimental tests (non-ci-blocking)"
 timeout 30m ./ci/run_cudf_polars_experimental_pytests.sh \
     --no-cov \
-    --numprocesses=8 \
+    --numprocesses=${num_processes} \
     --dist=worksteal \
     -v \
     --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars-rapidsmpf.xml"

--- a/ci/test_python_other.sh
+++ b/ci/test_python_other.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -41,10 +41,18 @@ timeout 30m ./ci/run_custreamz_pytests.sh \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/custreamz-coverage.xml" \
   --cov-report=term
 
+# Avoid oversubscribing the CPU
+num_processes=8
+num_cpus=$(nproc)
+export POLARS_MAX_THREADS=$(( num_cpus / num_processes ))
+if (( POLARS_MAX_THREADS < 1 )); then
+    export POLARS_MAX_THREADS=1
+fi
+
 rapids-logger "pytest cudf-polars"
 timeout 30m ./ci/run_cudf_polars_pytests.sh \
   --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars.xml" \
-  --numprocesses=8 \
+  --numprocesses=${num_processes} \
   --dist=worksteal \
   --cov-config=./pyproject.toml \
   --cov=cudf_polars \

--- a/ci/test_wheel_cudf_polars.sh
+++ b/ci/test_wheel_cudf_polars.sh
@@ -39,6 +39,14 @@ rapids-logger "Run cudf_polars tests"
 available_polars_versions=$(python -m pip index versions polars --json | jq '.versions')
 POLARS_VERSIONS=$(python ci/utils/filter_package_versions.py dependencies.yaml run_cudf_polars polars "$available_polars_versions")
 
+# Avoid oversubscribing the CPU
+num_processes=8
+num_cpus=$(nproc)
+export POLARS_MAX_THREADS=$(( num_cpus / num_processes ))
+if (( POLARS_MAX_THREADS < 1 )); then
+    export POLARS_MAX_THREADS=1
+fi
+
 # shellcheck disable=SC2317
 function set_exitcode()
 {
@@ -73,7 +81,7 @@ for version in "${VERSIONS[@]}"; do
 
     timeout 1h ./ci/run_cudf_polars_pytests.sh \
         "${COVERAGE_ARGS[@]}" \
-        --numprocesses=8 \
+        --numprocesses=${num_processes} \
         --dist=worksteal \
         --junitxml="${RAPIDS_TESTS_DIR}/junit-cudf-polars-${version}.xml"
 


### PR DESCRIPTION
This limits the number of CPU threads polars uses in our test suite. We limit it to `number of CPUs / 8`, since our CI scripts use 8 test processes.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
