### PR TITLE
Include find_package_root everywhere it's used

### DIFF
--- a/cpp/cmake/thirdparty/get_flatbuffers.cmake
+++ b/cpp/cmake/thirdparty/get_flatbuffers.cmake
@@ -19,6 +19,7 @@ function(find_and_configure_flatbuffers VERSION EXCLUDE_FROM_ALL)
     OPTIONS "FLATBUFFERS_BUILD_TESTS OFF"
   )
 
+  include("${rapids-cmake-dir}/export/find_package_root.cmake")
   rapids_export_find_package_root(
     BUILD flatbuffers "${flatbuffers_BINARY_DIR}" EXPORT_SET cudf-exports
   )

--- a/cpp/cmake/thirdparty/get_nanoarrow.cmake
+++ b/cpp/cmake/thirdparty/get_nanoarrow.cmake
@@ -19,6 +19,7 @@ function(find_and_configure_nanoarrow BUILD_SHARED EXCLUDE_FROM_ALL)
   )
   if(nanoarrow_ADDED)
     set_target_properties(nanoarrow_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    include("${rapids-cmake-dir}/export/find_package_root.cmake")
     rapids_export_find_package_root(
       BUILD nanoarrow "${nanoarrow_BINARY_DIR}" EXPORT_SET cudf-exports
     )

--- a/cpp/cmake/thirdparty/get_zstd.cmake
+++ b/cpp/cmake/thirdparty/get_zstd.cmake
@@ -37,6 +37,7 @@ function(find_and_configure_zstd)
         PARENT_SCOPE
     )
   endif()
+  include("${rapids-cmake-dir}/export/find_package_root.cmake")
   rapids_export_find_package_root(BUILD zstd "${zstd_BINARY_DIR}" EXPORT_SET cudf-exports)
 
 endfunction()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
https://github.com/rapidsai/cudf/pull/22341/ removed the usage of this function in `get_nvcomp`, which I suspect was previously being relied on to supply the definition for some of these others. We do properly fetch it in `get_arrow.cmake` as well so it's just a matter of when each file is included.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
