### PR TITLE
Undo some CCCL workarounds fixed in the latest update

### DIFF
--- a/cpp/src/groupby/sort/group_replace_nulls.cu
+++ b/cpp/src/groupby/sort/group_replace_nulls.cu
@@ -15,8 +15,6 @@
 #include <cuda/iterator>
 #include <cuda/std/functional>
 #include <cuda/std/tuple>
-#include <thrust/iterator/discard_iterator.h>
-#include <thrust/iterator/zip_iterator.h>
 #include <thrust/scan.h>
 
 #include <utility>
@@ -36,11 +34,11 @@ std::unique_ptr<column> group_replace_nulls(cudf::column_view const& grouped_val
   auto device_in = cudf::column_device_view::create(grouped_value, stream);
   auto index     = cuda::counting_iterator<cudf::size_type>{0};
   auto valid_it  = cudf::detail::make_validity_iterator(*device_in);
-  auto in_begin  = thrust::make_zip_iterator(cuda::std::make_tuple(index, valid_it));
+  auto in_begin  = cuda::make_zip_iterator(cuda::std::make_tuple(index, valid_it));
 
   rmm::device_uvector<cudf::size_type> gather_map(size, stream);
-  auto gm_begin = thrust::make_zip_iterator(
-    cuda::std::make_tuple(gather_map.begin(), thrust::make_discard_iterator()));
+  auto gm_begin = cuda::make_zip_iterator(
+    cuda::std::make_tuple(gather_map.begin(), cuda::make_discard_iterator()));
 
   auto func = cudf::detail::replace_policy_functor();
   cuda::std::equal_to<cudf::size_type> eq;

--- a/cpp/src/join/sort_merge_join.cu
+++ b/cpp/src/join/sort_merge_join.cu
@@ -231,20 +231,16 @@ merge<LargerIterator, SmallerIterator>::matches_per_row(rmm::cuda_stream_view st
                       match_counts_it,
                       comparator);
 
-  rmm::device_uvector<size_type> lower_bounds(larger_numrows, stream, mr);
+  auto match_counts_update_it =
+    cuda::tabulate_output_iterator([match_counts = match_counts.begin()] __device__(
+                                     size_type idx, size_type val) { match_counts[idx] -= val; });
   thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                       smaller_it,
                       smaller_it + smaller_numrows,
                       cudf::detail::row::rhs_iterator(0),
                       cudf::detail::row::rhs_iterator(0) + larger_numrows,
-                      lower_bounds.begin(),
+                      match_counts_update_it,
                       comparator);
-  thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                    match_counts.begin(),
-                    match_counts.begin() + larger_numrows,
-                    lower_bounds.begin(),
-                    match_counts.begin(),
-                    thrust::minus<size_type>{});
 
   return std::make_unique<rmm::device_uvector<size_type>>(std::move(match_counts));
 }
@@ -321,8 +317,16 @@ merge<LargerIterator, SmallerIterator>::inner(rmm::cuda_stream_view stream,
   cub::DeviceTransform::Fill(smaller_indices.begin(), smaller_indices.size(), 1, stream.value());
 
   {
-    auto const comparator = tt_comparator->less<true>(nullate::DYNAMIC{has_nulls});
-    auto smaller_it       = cuda::transform_iterator(
+    auto const comparator    = tt_comparator->less<true>(nullate::DYNAMIC{has_nulls});
+    auto smaller_tabulate_it = cuda::tabulate_output_iterator(
+      [nonzero_matches = nonzero_matches.begin(),
+       match_offsets   = match_offsets.begin(),
+       smaller_indices = smaller_indices.begin()] __device__(size_type idx, size_type lb) {
+        auto const lhs_idx   = nonzero_matches[idx];
+        auto const pos       = match_offsets[lhs_idx];
+        smaller_indices[pos] = lb;
+      });
+    auto smaller_it = cuda::transform_iterator(
       sorted_smaller_order_begin,
       cuda::proclaim_return_type<detail::row::lhs_index_type>(
         [] __device__(size_type idx) { return static_cast<detail::row::lhs_index_type>(idx); }));
@@ -330,23 +334,13 @@ merge<LargerIterator, SmallerIterator>::inner(rmm::cuda_stream_view stream,
       nonzero_matches.begin(),
       cuda::proclaim_return_type<detail::row::rhs_index_type>(
         [] __device__(size_type idx) { return static_cast<detail::row::rhs_index_type>(idx); }));
-    rmm::device_uvector<size_type> lb_positions(nonzero_matches.size(), stream, mr);
     thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         smaller_it,
                         smaller_it + smaller_numrows,
                         larger_it,
                         larger_it + nonzero_matches.size(),
-                        lb_positions.begin(),
+                        smaller_tabulate_it,
                         comparator);
-    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                       thrust::counting_iterator<size_type>(0),
-                       nonzero_matches.size(),
-                       [nonzero_matches = nonzero_matches.begin(),
-                        match_offsets   = match_offsets.begin(),
-                        smaller_indices = smaller_indices.begin(),
-                        lb_positions    = lb_positions.begin()] __device__(size_type idx) {
-                         smaller_indices[match_offsets[nonzero_matches[idx]]] = lb_positions[idx];
-                       });
   }
 
   // Use cub API to handle large arrays (> INT32_MAX)
@@ -473,8 +467,17 @@ merge<LargerIterator, SmallerIterator>::left(rmm::cuda_stream_view stream,
     smaller_indices.begin() + left_join_only_matches, inner_join_matches, 1, stream.value());
 
   {
-    auto const comparator = tt_comparator->less<true>(nullate::DYNAMIC{has_nulls});
-    auto smaller_it       = cuda::transform_iterator(
+    auto const comparator    = tt_comparator->less<true>(nullate::DYNAMIC{has_nulls});
+    auto smaller_tabulate_it = cuda::tabulate_output_iterator(
+      [nonzero_matches = nonzero_matches.begin(),
+       match_offsets   = match_offsets.begin(),
+       smaller_indices =
+         smaller_indices.begin() + left_join_only_matches] __device__(size_type idx, size_type lb) {
+        auto const lhs_idx   = nonzero_matches[idx];
+        auto const pos       = match_offsets[lhs_idx];
+        smaller_indices[pos] = lb;
+      });
+    auto smaller_it = cuda::transform_iterator(
       sorted_smaller_order_begin,
       cuda::proclaim_return_type<detail::row::lhs_index_type>(
         [] __device__(size_type idx) { return static_cast<detail::row::lhs_index_type>(idx); }));
@@ -482,23 +485,13 @@ merge<LargerIterator, SmallerIterator>::left(rmm::cuda_stream_view stream,
       nonzero_matches.begin(),
       cuda::proclaim_return_type<detail::row::rhs_index_type>(
         [] __device__(size_type idx) { return static_cast<detail::row::rhs_index_type>(idx); }));
-    rmm::device_uvector<size_type> lb_positions(nonzero_matches.size(), stream, mr);
     thrust::lower_bound(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
                         smaller_it,
                         smaller_it + smaller_numrows,
                         larger_it,
                         larger_it + nonzero_matches.size(),
-                        lb_positions.begin(),
+                        smaller_tabulate_it,
                         comparator);
-    thrust::for_each_n(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
-                       thrust::counting_iterator<size_type>(0),
-                       nonzero_matches.size(),
-                       [nonzero_matches = nonzero_matches.begin(),
-                        match_offsets   = match_offsets.begin(),
-                        smaller_indices = smaller_indices.begin() + left_join_only_matches,
-                        lb_positions    = lb_positions.begin()] __device__(size_type idx) {
-                         smaller_indices[match_offsets[nonzero_matches[idx]]] = lb_positions[idx];
-                       });
   }
 
   // Use cub API to handle large arrays (> INT32_MAX)

--- a/cpp/src/replace/nulls.cu
+++ b/cpp/src/replace/nulls.cu
@@ -37,8 +37,6 @@
 
 #include <cuda/iterator>
 #include <cuda/std/tuple>
-#include <thrust/iterator/discard_iterator.h>
-#include <thrust/iterator/zip_iterator.h>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 
@@ -273,11 +271,11 @@ std::unique_ptr<cudf::column> replace_nulls_policy_impl(cudf::column_view const&
   auto device_in = cudf::column_device_view::create(input, stream);
   auto index     = cuda::counting_iterator<cudf::size_type>{0};
   auto valid_it  = cudf::detail::make_validity_iterator(*device_in);
-  auto in_begin  = thrust::make_zip_iterator(cuda::std::make_tuple(index, valid_it));
+  auto in_begin  = cuda::make_zip_iterator(cuda::std::make_tuple(index, valid_it));
 
   rmm::device_uvector<cudf::size_type> gather_map(input.size(), stream);
-  auto gm_begin = thrust::make_zip_iterator(
-    cuda::std::make_tuple(gather_map.begin(), thrust::make_discard_iterator()));
+  auto gm_begin = cuda::make_zip_iterator(
+    cuda::std::make_tuple(gather_map.begin(), cuda::make_discard_iterator()));
 
   auto func = cudf::detail::replace_policy_functor();
   if (replace_policy == cudf::replace_policy::PRECEDING) {


### PR DESCRIPTION
## Description
Fixes in `sort_merge_join.cu` re-enable calls to thrust::lower_bound with a `cuda::tabulate_output_iterator`
Also, the `cuda::discard_iterator` now works with the `cuda::zip_iterator` in all usage patterns in libcudf.
Both of these were fixed by https://github.com/NVIDIA/cccl/pull/8845

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
