### PR TITLE
Relax ``NormalizedPartitioning.from_keys``

### DIFF
--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/groupby.py
@@ -676,7 +676,7 @@ async def groupby_actor(
             keys=_key_indices(ir, ir.children[0].schema),
         )
         require_tree = _require_tree(ir)
-        fully_partitioned = bool(partitioning)
+        fully_partitioned = partitioning.is_strictly_partitioned()
         fallback_case = (
             # NOTE: This criteria means that we fell back
             # to one partition at lowering time.

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
@@ -755,8 +755,10 @@ class NormalizedPartitioning:
             Number of ranks.
         keys
             Key column descriptors. Pass sequence of ``int`` values
-            (column indices) for hash-only matching. Pass a sequence of
-            ``OrderKey`` instances for ordered matching.
+            (column indices) to match by column index only (both
+            ``HashScheme`` and ``OrderScheme``). Pass a sequence of
+            ``OrderKey`` instances to match ``OrderScheme`` with full
+            order/null-order semantics.
         allow_subset
             If True, the metadata keys may be a prefix of ``keys``.
 
@@ -813,15 +815,17 @@ class NormalizedPartitioning:
             return target == current
 
         def _order_keys_match(scheme: OrderScheme) -> bool:
-            if not order_based:
-                return False  # hash-only caller; ORDER metadata is a mismatch
             if allow_subset:
-                n = min(len(scheme.keys), len(keys))
+                n = min(len(scheme.keys), len(key_indices))
             else:
-                if len(scheme.keys) != len(keys):
+                if len(scheme.keys) != len(key_indices):
                     return False
-                n = len(keys)
-            return all(ok == k for ok, k in zip(scheme.keys[:n], keys[:n], strict=True))
+                n = len(key_indices)
+            if order_based:
+                return all(
+                    ok == k for ok, k in zip(scheme.keys[:n], keys[:n], strict=True)
+                )
+            return tuple(k.column_index for k in scheme.keys[:n]) == key_indices[:n]
 
         def _keys_match(
             scheme: object,

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
@@ -816,16 +816,16 @@ class NormalizedPartitioning:
 
         def _order_keys_match(scheme: OrderScheme) -> bool:
             if allow_subset:
-                n = min(len(scheme.keys), len(key_indices))
+                n = len(scheme.keys)
+                if n > len(key_indices):
+                    return False
             else:
                 if len(scheme.keys) != len(key_indices):
                     return False
                 n = len(key_indices)
             if order_based:
-                return all(
-                    ok == k for ok, k in zip(scheme.keys[:n], keys[:n], strict=True)
-                )
-            return tuple(k.column_index for k in scheme.keys[:n]) == key_indices[:n]
+                return all(ok == k for ok, k in zip(scheme.keys, keys[:n], strict=True))
+            return tuple(k.column_index for k in scheme.keys) == key_indices[:n]
 
         def _keys_match(
             scheme: object,

--- a/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
+++ b/python/cudf_polars/cudf_polars/experimental/rapidsmpf/utils.py
@@ -825,7 +825,10 @@ class NormalizedPartitioning:
                 n = len(key_indices)
             if order_based:
                 return all(ok == k for ok, k in zip(scheme.keys, keys[:n], strict=True))
-            return tuple(k.column_index for k in scheme.keys) == key_indices[:n]
+            return all(
+                k.column_index == k_idx
+                for k, k_idx in zip(scheme.keys, key_indices[:n], strict=True)
+            )
 
         def _keys_match(
             scheme: object,

--- a/python/cudf_polars/tests/experimental/test_metadata.py
+++ b/python/cudf_polars/tests/experimental/test_metadata.py
@@ -514,7 +514,7 @@ def _make_order_scheme(context, *, key_index=0, values=(100, 200), strict=False)
             True,
             False,
         ),
-        ((0,), True, False),  # plain int → hash-only, won't match OrderScheme
+        ((0,), True, True),  # plain int → matches OrderScheme by column index
     ],
 )
 def test_from_keys_order_scheme(spmd_engine, keys, strict, should_match):

--- a/python/cudf_polars/tests/experimental/test_metadata.py
+++ b/python/cudf_polars/tests/experimental/test_metadata.py
@@ -481,14 +481,17 @@ def test_remap_partitioning_reorder_columns_projection(streaming_engine) -> None
     assert result.inter_rank.modulus == 8
 
 
-def _make_order_scheme(context, *, key_index=0, values=(100, 200), strict=False):
+def _make_order_scheme(context, *, key_indices=(0,), values=(100, 200), strict=False):
     stream = context.get_stream_from_pool()
-    df = DataFrame.from_polars(pl.DataFrame({"k": list(values)}), stream)
+    df = DataFrame.from_polars(
+        pl.DataFrame({f"k{i}": list(values) for i in key_indices}), stream
+    )
     chunk = TableChunk.from_pylibcudf_table(
         df.table, stream, exclusive_view=False, br=context.br()
     )
-    key = OrderKey(key_index, plc.types.Order.ASCENDING, plc.types.NullOrder.BEFORE)
-    return OrderScheme([key], chunk, strict_boundaries=strict)
+    asc, before = plc.types.Order.ASCENDING, plc.types.NullOrder.BEFORE
+    keys = [OrderKey(i, asc, before) for i in key_indices]
+    return OrderScheme(keys, chunk, strict_boundaries=strict)
 
 
 @pytest.mark.parametrize(
@@ -553,7 +556,8 @@ def test_is_aligned_with_order_scheme(spmd_engine):
 
 
 def test_from_keys_order_scheme_single_rank(spmd_engine):
-    keys = (OrderKey(0, plc.types.Order.ASCENDING, plc.types.NullOrder.BEFORE),)
+    asc, before = plc.types.Order.ASCENDING, plc.types.NullOrder.BEFORE
+    keys = (OrderKey(0, asc, before),)
     local_scheme = _make_order_scheme(spmd_engine.context, strict=True)
     # Single-rank: local OrderScheme promoted to inter-rank
     part = Partitioning(inter_rank=None, local=local_scheme)
@@ -563,11 +567,19 @@ def test_from_keys_order_scheme_single_rank(spmd_engine):
     # Multi-rank without inter-rank OrderScheme → no partitioning
     result_multi = NormalizedPartitioning.from_keys(part, nranks=4, keys=keys)
     assert result_multi.inter_rank_scheme is None
+    # Reversed prefix: scheme has 2 keys, query has 1 → must not match
+    scheme_2key = _make_order_scheme(
+        spmd_engine.context, key_indices=(0, 1), strict=True
+    )
+    part_2key = Partitioning(inter_rank=scheme_2key, local="inherit")
+    result_rev = NormalizedPartitioning.from_keys(part_2key, nranks=4, keys=keys)
+    assert result_rev.inter_rank_scheme is None
 
 
 def test_remap_partitioning_order_scheme_select(spmd_engine, engine):
     part = Partitioning(
-        inter_rank=_make_order_scheme(spmd_engine.context, key_index=0), local="inherit"
+        inter_rank=_make_order_scheme(spmd_engine.context, key_indices=(0,)),
+        local="inherit",
     )
     result = maybe_remap_partitioning(_make_select_ir(engine, ("b", "a")), part)
     assert result is not None
@@ -577,7 +589,8 @@ def test_remap_partitioning_order_scheme_select(spmd_engine, engine):
 
 def test_remap_partitioning_order_scheme_drops_key(spmd_engine, engine):
     part = Partitioning(
-        inter_rank=_make_order_scheme(spmd_engine.context, key_index=0), local="inherit"
+        inter_rank=_make_order_scheme(spmd_engine.context, key_indices=(0,)),
+        local="inherit",
     )
     result = maybe_remap_partitioning(_make_select_ir(engine, ("b",)), part)
     assert result is not None

--- a/python/cudf_polars/tests/experimental/test_metadata.py
+++ b/python/cudf_polars/tests/experimental/test_metadata.py
@@ -574,6 +574,9 @@ def test_from_keys_order_scheme_single_rank(spmd_engine):
     part_2key = Partitioning(inter_rank=scheme_2key, local="inherit")
     result_rev = NormalizedPartitioning.from_keys(part_2key, nranks=4, keys=keys)
     assert result_rev.inter_rank_scheme is None
+    # Same check via Sequence[int] path
+    result_rev_int = NormalizedPartitioning.from_keys(part_2key, nranks=4, keys=(0,))
+    assert result_rev_int.inter_rank_scheme is None
 
 
 def test_remap_partitioning_order_scheme_select(spmd_engine, engine):


### PR DESCRIPTION
## Description
- Part of https://github.com/rapidsai/cudf/issues/22128
- Relaxes some unnecessary assumptions in `NormalizedPartitioning.from_keys` so that we can take advantage of `OrderScheme` metadata in `GroupBy`. This will become relevant after https://github.com/rapidsai/cudf/pull/22477 is merged. 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
